### PR TITLE
fix(supervisor): preserve managed sessions across supervisor restart (#1174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   routed work pickup should happen through the SessionStart claim protocol or
   an explicit non-inject `gc hook` call.
 
+### Fixed
+
+- Linux systemd supervisor service restarts now preserve managed tmux sessions
+  for re-adoption. Linux users should rerun `gc supervisor install` after
+  upgrading so the user unit is regenerated with `KillMode=process` and the
+  preserve-on-signal environment. If the currently active Linux supervisor
+  predates the preserve-on-signal environment, `gc supervisor install` now
+  refuses the warm refresh before sending a signal and tells operators to stop
+  or drain agents intentionally with `gc supervisor stop --wait`, then rerun the
+  install. Once the active supervisor already supports preserve mode, Linux warm
+  refresh sends the main supervisor PID `SIGTERM` first so preserve-mode
+  shutdown can close workspace services and flush traces, with a bounded
+  `SIGKILL` fallback if the process does not exit. The Linux refresh also stops
+  orphan-prone workspace service process groups owned by registered cities
+  before starting the replacement supervisor; supervisor startup repeats the
+  same owned-service cleanup after crashes. Service-managed `SIGTERM` preserves
+  sessions for re-adoption, while `SIGINT` remains a destructive escalation
+  path. Preserve mode intentionally leaves the beads provider running so
+  preserved sessions can keep using the store; the bundled managed-Dolt start
+  path is idempotent when it finds an already-running server, but custom exec
+  providers must make `start` reattach or no-op safely after preserve-mode
+  restarts. macOS launchd upgrades still use launchd unload/load rather than the
+  Linux main-PID refresh path; macOS supervisor startup now warns that automatic
+  orphaned workspace-service cleanup is Linux-only, lists the registered
+  `GC_SERVICE_STATE_ROOT` roots to inspect, and tells operators to stop stale
+  workspace-service processes before restarting affected cities after
+  non-graceful exits.
+
 ## [1.0.0] - 2026-04-21
 
 First stable release. Between `v0.15.1` and `v1.0.0` the project received 610

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -93,9 +93,10 @@ type CityRuntime struct {
 	onStarted           func()
 	onStatus            func(string)
 
-	shutdownOnce   sync.Once
-	logPrefix      string // "gc start" or "gc supervisor"
-	stdout, stderr io.Writer
+	shutdownOnce             sync.Once
+	preserveSessionsShutdown atomic.Bool
+	logPrefix                string // "gc start" or "gc supervisor"
+	stdout, stderr           io.Writer
 }
 
 const runtimeDemandSnapshotMaxAge = 30 * time.Second
@@ -1951,19 +1952,48 @@ func orderShutdownDrainTimeout(total time.Duration) time.Duration {
 	return reloadOrderDrainTimeout
 }
 
+func (cr *CityRuntime) recordPreservedShutdownTrace() {
+	trace := cr.beginTraceCycle("shutdown", "preserve_sessions", nil)
+	if trace == nil {
+		return
+	}
+	trace.recordOperation("lifecycle.shutdown.preserve_sessions", "", "", "", "retained", string(TraceOutcomeApplied), traceRecordPayload{
+		"city_path": cr.cityPath,
+		"city_name": cr.cityName,
+		"reason":    "supervisor_shutdown_preserve_mode",
+	}, "")
+	trace.end(TraceCompletionCompleted, traceRecordPayload{
+		"phase":     "shutdown",
+		"mode":      "preserve_sessions",
+		"city_name": cr.cityName,
+		"reason":    "supervisor_shutdown_preserve_mode",
+	})
+}
+
 // shutdown performs graceful two-pass agent shutdown for this city.
 // Safe to call multiple times (e.g., from both panic recovery and
 // normal shutdown) — only the first call takes effect.
 func (cr *CityRuntime) shutdown() {
 	cr.shutdownOnce.Do(func() {
 		cr.waitForAsyncStarts()
+		preserveSessions := cr.preserveSessionsShutdown.Load()
+		if preserveSessions {
+			cr.recordPreservedShutdownTrace()
+		}
 		if cr.trace != nil {
 			_ = cr.trace.Close()
 		}
 		if cr.svc != nil {
+			// Workspace-service proxies are process-group-bound, not preserved
+			// agent sessions. Close them so the next supervisor can reacquire
+			// their sockets and ports during re-adoption.
 			if err := cr.svc.Close(); err != nil {
 				fmt.Fprintf(cr.stderr, "%s: service shutdown: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
 			}
+		}
+		if preserveSessions {
+			fmt.Fprintf(cr.stdout, "Preserving agent sessions for supervisor re-adoption.\n") //nolint:errcheck // best-effort stdout
+			return
 		}
 		// Drain order dispatchers with a small cap before stopping sessions.
 		// Use a fresh context because the tick ctx is already canceled at this
@@ -1991,4 +2021,8 @@ func (cr *CityRuntime) shutdown() {
 		markCityStopSessionSleepReason(store, cr.stderr)
 		gracefulStopAll(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr)
 	})
+}
+
+func (cr *CityRuntime) preserveSessionsOnShutdown() {
+	cr.preserveSessionsShutdown.Store(true)
 }

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -182,6 +182,97 @@ type reconcileRequest struct {
 	done chan struct{}
 }
 
+type supervisorShutdownMode int32
+
+const (
+	supervisorShutdownNone supervisorShutdownMode = iota
+	supervisorShutdownPreserveSessions
+	supervisorShutdownDestructive
+)
+
+const supervisorPreserveSessionsOnSignalEnv = "GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL"
+
+var supervisorShutdownSettleDelay = 50 * time.Millisecond
+
+var supervisorSignalNotify = signal.Notify
+
+func supervisorPreserveSessionsOnSignal() bool {
+	return os.Getenv(supervisorPreserveSessionsOnSignalEnv) == "1"
+}
+
+func supervisorShutdownModeForSignal(sig os.Signal) supervisorShutdownMode {
+	if sig == syscall.SIGTERM && supervisorPreserveSessionsOnSignal() {
+		return supervisorShutdownPreserveSessions
+	}
+	return supervisorShutdownDestructive
+}
+
+type supervisorShutdownController struct {
+	mode                 atomic.Int32
+	destructiveRequested atomic.Bool
+	destructiveOnce      sync.Once
+	destructiveCh        chan struct{}
+}
+
+func newSupervisorShutdownController() *supervisorShutdownController {
+	return &supervisorShutdownController{destructiveCh: make(chan struct{})}
+}
+
+func supervisorSignalLoop(sigCh <-chan os.Signal, done <-chan struct{}, requestShutdown func(supervisorShutdownMode), requestReconcile func()) {
+	for {
+		select {
+		case sig := <-sigCh:
+			if sig == nil {
+				continue
+			}
+			if sig == syscall.SIGHUP {
+				requestReconcile()
+				continue
+			}
+			requestShutdown(supervisorShutdownModeForSignal(sig))
+		case <-done:
+			return
+		}
+	}
+}
+
+func (c *supervisorShutdownController) request(mode supervisorShutdownMode) {
+	if mode == supervisorShutdownDestructive {
+		c.destructiveRequested.Store(true)
+		c.mode.Store(int32(supervisorShutdownDestructive))
+		c.destructiveOnce.Do(func() {
+			if c.destructiveCh != nil {
+				close(c.destructiveCh)
+			}
+		})
+		return
+	}
+	if mode == supervisorShutdownPreserveSessions {
+		c.mode.CompareAndSwap(int32(supervisorShutdownNone), int32(supervisorShutdownPreserveSessions))
+	}
+}
+
+func (c *supervisorShutdownController) preservesSessions() bool {
+	if c.destructiveRequested.Load() {
+		return false
+	}
+	return supervisorShutdownMode(c.mode.Load()) == supervisorShutdownPreserveSessions
+}
+
+func (c *supervisorShutdownController) preservesSessionsAfterSettle(timeout time.Duration) bool {
+	if !c.preservesSessions() || timeout <= 0 {
+		return c.preservesSessions()
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-c.destructiveCh:
+		return false
+	case <-timer.C:
+		return c.preservesSessions()
+	}
+}
+
 var (
 	supervisorReloadQueueTimeout = 5 * time.Second
 	supervisorReloadWaitTimeout  = 5 * time.Minute
@@ -210,7 +301,7 @@ func (s *shutdownState) finish(err error) {
 	close(s.done)
 }
 
-func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconcileCh chan reconcileRequest, shut *shutdownState) (net.Listener, error) {
+func startSupervisorSocket(sockPath string, requestShutdown func(supervisorShutdownMode), reconcileCh chan reconcileRequest, shut *shutdownState) (net.Listener, error) {
 	os.Remove(sockPath) //nolint:errcheck // remove stale socket from previous crash
 	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -228,7 +319,7 @@ func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconci
 				fmt.Fprintf(os.Stderr, "gc supervisor: socket accept: %v\n", err) //nolint:errcheck
 				continue
 			}
-			go handleSupervisorConn(conn, cancelFn, reconcileCh, shut)
+			go handleSupervisorConn(conn, requestShutdown, reconcileCh, shut)
 		}
 	}()
 	return lis, nil
@@ -242,14 +333,14 @@ func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconci
 // then — if the client keeps the connection open — blocks until shutdown
 // completes and sends a second line "done:ok\n" or "done:err:<detail>\n"
 // so --wait clients can distinguish clean shutdown from partial failure.
-func handleSupervisorConn(conn net.Conn, cancelFn context.CancelFunc, reconcileCh chan reconcileRequest, shut *shutdownState) {
+func handleSupervisorConn(conn net.Conn, requestShutdown func(supervisorShutdownMode), reconcileCh chan reconcileRequest, shut *shutdownState) {
 	defer conn.Close()                                     //nolint:errcheck
 	conn.SetReadDeadline(time.Now().Add(60 * time.Second)) //nolint:errcheck
 	scanner := bufio.NewScanner(conn)
 	if scanner.Scan() {
 		switch scanner.Text() {
 		case "stop":
-			cancelFn()
+			requestShutdown(supervisorShutdownDestructive)
 			if _, err := conn.Write([]byte("ok\n")); err != nil {
 				return
 			}
@@ -369,13 +460,10 @@ func stopSupervisor(stdout, stderr io.Writer) int {
 // it stops answering. This is the shape tests and shell scripts want: on
 // return, the supervisor has fully shut down and any failure is visible.
 //
-// It also unloads the platform service (without removing the unit file) so
-// launchd/systemd doesn't immediately restart the supervisor.
+// It also unloads the platform service (without removing the unit file) after
+// the supervisor acknowledges the destructive socket stop, so launchd/systemd
+// will not restart it when the process exits.
 func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout time.Duration) int {
-	// Unload the platform service first so the service manager doesn't
-	// restart the supervisor after we send the stop command.
-	unloadSupervisorService()
-
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
 		fmt.Fprintln(stderr, "gc supervisor stop: supervisor is not running") //nolint:errcheck
@@ -396,6 +484,7 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 		return 1
 	}
 	fmt.Fprintln(stdout, "Supervisor stopping...") //nolint:errcheck
+	unloadSupervisorService()
 	if !wait {
 		return 0
 	}
@@ -628,6 +717,47 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 	return stopErr
 }
 
+func stopManagedCityPreservingSessions(mc *managedCity, _ string, stderr io.Writer) error {
+	if mc == nil {
+		return nil
+	}
+	if mc.cr != nil {
+		mc.cr.preserveSessionsOnShutdown()
+	}
+	mc.cancel()
+	timeout := managedCityStopTimeout(mc)
+	var stopErr error
+	waitForRuntimeShutdown := timeout <= 0
+	if timeout > 0 {
+		select {
+		case <-mc.done:
+		case <-time.After(timeout):
+			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after preserve-mode cancel\n", mc.name, timeout) //nolint:errcheck
+			stopErr = fmt.Errorf("city %q did not exit within %s after preserve-mode cancel", mc.name, timeout)
+			waitForRuntimeShutdown = true
+		}
+	}
+	if waitForRuntimeShutdown && mc.cr != nil {
+		func() {
+			defer func() { recover() }() //nolint:errcheck
+			mc.cr.shutdown()
+		}()
+		if timeout > 0 {
+			select {
+			case <-mc.done:
+				stopErr = nil
+			case <-time.After(timeout):
+				fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after preserve-mode shutdown wait\n", mc.name, timeout) //nolint:errcheck
+				stopErr = fmt.Errorf("city %q did not exit within %s after preserve-mode shutdown wait", mc.name, timeout)
+			}
+		}
+	}
+	if mc.closer != nil {
+		mc.closer.Close() //nolint:errcheck
+	}
+	return stopErr
+}
+
 // runSupervisor is the main supervisor loop. It acquires the lock,
 // starts a control socket, reads the registry, starts CityRuntimes,
 // and runs until canceled.
@@ -646,35 +776,29 @@ func runSupervisor(stdout, stderr io.Writer) int {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	shutdownCtl := newSupervisorShutdownController()
+	requestShutdown := func(mode supervisorShutdownMode) {
+		shutdownCtl.request(mode)
+		cancel()
+	}
 
 	// Reconcile channel — triggers immediate reconciliation from SIGHUP
 	// or the "reload" socket command.
 	reconcileCh := make(chan reconcileRequest, 1)
 
 	// Signal handler: SIGINT/SIGTERM → shutdown, SIGHUP → immediate reconcile.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	sigCh := make(chan os.Signal, 2)
+	supervisorSignalNotify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer signal.Stop(sigCh)
-	go func() {
-		for {
-			select {
-			case sig := <-sigCh:
-				if sig == syscall.SIGHUP {
-					fmt.Fprintln(stderr, "SIGHUP received, triggering reconciliation...") //nolint:errcheck
-					select {
-					case reconcileCh <- reconcileRequest{}:
-					default: // reconcile already pending
-					}
-					continue
-				}
-				// SIGINT/SIGTERM → shutdown.
-				cancel()
-				return
-			case <-ctx.Done():
-				return
-			}
+	shutdownSignalsDone := make(chan struct{})
+	defer close(shutdownSignalsDone)
+	go supervisorSignalLoop(sigCh, shutdownSignalsDone, requestShutdown, func() {
+		fmt.Fprintln(stderr, "SIGHUP received, triggering reconciliation...") //nolint:errcheck
+		select {
+		case reconcileCh <- reconcileRequest{}:
+		default: // reconcile already pending
 		}
-	}()
+	})
 
 	// Load supervisor config.
 	supCfg, err := supervisor.LoadConfig(supervisor.ConfigPath())
@@ -684,6 +808,10 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	}
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := cleanupSupervisorWorkspaceServicesForSupervisorStart(supervisor.DefaultHome()); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor: workspace-service startup cleanup: %v\n", err) //nolint:errcheck
+		return 1
+	}
 
 	// Track managed cities via atomic-snapshot registry. API reads are
 	// lock-free (atomic pointer load); mutations go through citiesMu.
@@ -747,7 +875,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		return 1
 	}
 	shut := newShutdownState()
-	lis, err := startSupervisorSocket(sockPath, cancel, reconcileCh, shut)
+	lis, err := startSupervisorSocket(sockPath, requestShutdown, reconcileCh, shut)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: %v\n", err) //nolint:errcheck
 		return 1
@@ -832,14 +960,27 @@ func runSupervisor(stdout, stderr io.Writer) int {
 					delete(cities, k)
 				}
 			})
+			preserveSessions := shutdownCtl.preservesSessionsAfterSettle(supervisorShutdownSettleDelay)
 			var stopFailures []string
 			for name, mc := range toStop {
-				fmt.Fprintf(stdout, "Stopping city '%s'...\n", name) //nolint:errcheck
-				if err := stopManagedCity(mc, name, stderr); err != nil {
+				if preserveSessions {
+					fmt.Fprintf(stdout, "Preserving city '%s' sessions for re-adoption...\n", name) //nolint:errcheck
+				} else {
+					fmt.Fprintf(stdout, "Stopping city '%s'...\n", name) //nolint:errcheck
+				}
+				stopFn := stopManagedCity
+				if preserveSessions {
+					stopFn = stopManagedCityPreservingSessions
+				}
+				if err := stopFn(mc, name, stderr); err != nil {
 					stopFailures = append(stopFailures, fmt.Sprintf("%s: %s", name, err.Error()))
 					fmt.Fprintf(stdout, "City '%s' stop reported error (see stderr).\n", name) //nolint:errcheck
 				} else {
-					fmt.Fprintf(stdout, "City '%s' stopped.\n", name) //nolint:errcheck
+					if preserveSessions {
+						fmt.Fprintf(stdout, "City '%s' preserved.\n", name) //nolint:errcheck
+					} else {
+						fmt.Fprintf(stdout, "City '%s' stopped.\n", name) //nolint:errcheck
+					}
 				}
 			}
 			var shutErr error

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -18,22 +18,30 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/searchpath"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/spf13/cobra"
 )
 
 var (
-	ensureSupervisorRunningHook = ensureSupervisorRunning
-	reloadSupervisorHook        = reloadSupervisor
-	supervisorAliveHook         = supervisorAlive
-	supervisorReadyTimeout      = 15 * time.Second
-	supervisorReadyPollInterval = 100 * time.Millisecond
-	supervisorLaunchctlRun      = func(args ...string) error {
+	ensureSupervisorRunningHook              = ensureSupervisorRunning
+	reloadSupervisorHook                     = reloadSupervisor
+	supervisorAliveHook                      = supervisorAlive
+	supervisorReadyTimeout                   = 15 * time.Second
+	supervisorReadyPollInterval              = 100 * time.Millisecond
+	supervisorSystemdWarmRefreshStopTimeout  = 5 * time.Second
+	supervisorSystemdWarmRefreshPollInterval = 100 * time.Millisecond
+	supervisorLaunchctlRun                   = func(args ...string) error {
 		return exec.Command("launchctl", args...).Run()
+	}
+	supervisorLaunchdActive = func(label string) bool {
+		out, err := exec.Command("launchctl", "print", supervisorLaunchdServiceTarget(label)).Output()
+		return err == nil && launchdPrintReportsRunning(out)
 	}
 	supervisorSystemctlRun = func(args ...string) error {
 		return exec.Command("systemctl", args...).Run()
@@ -41,9 +49,292 @@ var (
 	supervisorSystemctlActive = func(service string) bool {
 		return exec.Command("systemctl", "--user", "is-active", "--quiet", service).Run() == nil
 	}
+	supervisorRunningPreserveSignalReady                = runningSupervisorPreserveSignalReady
+	supervisorProcRoot                                  = "/proc"
+	supervisorProcReadDir                               = os.ReadDir
+	supervisorProcReadFile                              = os.ReadFile
+	supervisorGetpgid                                   = syscall.Getpgid
+	supervisorGetpgrp                                   = syscall.Getpgrp
+	supervisorKill                                      = syscall.Kill
+	supervisorProcessGroupPollPeriod                    = 20 * time.Millisecond
+	supervisorRuntimeGOOS                               = goruntime.GOOS
+	supervisorWorkspaceServiceCleanupWarnings io.Writer = os.Stderr
 )
 
 const supervisorServiceFileMode os.FileMode = 0o600
+
+type supervisorWorkspaceServiceProcess struct {
+	pid  int
+	pgid int
+	name string
+}
+
+type supervisorWorkspaceServiceCleanupScope struct {
+	gcHome    string
+	cityPaths map[string]string
+}
+
+func launchdPrintReportsRunning(out []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 3 && fields[0] == "state" && fields[1] == "=" && fields[2] == "running" {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanupSupervisorWorkspaceServicesForWarmRefresh(gcHome string) error {
+	scope, err := supervisorWorkspaceServiceCleanupScopeFromRegistry(gcHome)
+	if err != nil {
+		return err
+	}
+	return cleanupSupervisorWorkspaceServices(scope)
+}
+
+func cleanupSupervisorWorkspaceServicesForSupervisorStart(gcHome string) error {
+	scope, err := supervisorWorkspaceServiceCleanupScopeFromRegistry(gcHome)
+	if err != nil {
+		return err
+	}
+	if supervisorRuntimeGOOS != "linux" {
+		if len(scope.cityPaths) > 0 {
+			warnSupervisorWorkspaceServiceCleanup("gc supervisor: workspace-service startup cleanup is not available on %s; after a non-graceful supervisor exit, stale workspace-service processes may keep sockets bound. Registered workspace-service roots: %s. Stop stale processes whose environment includes GC_SERVICE_STATE_ROOT under those roots, then restart those cities.\n", supervisorRuntimeGOOS, strings.Join(supervisorWorkspaceServiceStateRoots(scope), ", "))
+		}
+		return nil
+	}
+	if err := cleanupSupervisorWorkspaceServices(scope); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func warnSupervisorWorkspaceServiceCleanup(format string, args ...any) {
+	if supervisorWorkspaceServiceCleanupWarnings == nil {
+		return
+	}
+	fmt.Fprintf(supervisorWorkspaceServiceCleanupWarnings, format, args...) //nolint:errcheck // best-effort operator diagnostic
+}
+
+func supervisorWorkspaceServiceStateRoots(scope supervisorWorkspaceServiceCleanupScope) []string {
+	roots := make([]string, 0, len(scope.cityPaths))
+	for cityPath := range scope.cityPaths {
+		roots = append(roots, citylayout.RuntimeServicesDir(cityPath))
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func cleanupSupervisorWorkspaceServices(scope supervisorWorkspaceServiceCleanupScope) error {
+	procs, err := findSupervisorWorkspaceServiceProcesses(scope)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, proc := range procs {
+		if err := terminateProcessGroup(proc.pgid, 2*time.Second); err != nil {
+			errs = append(errs, fmt.Errorf("stopping workspace service %q pid %d pgid %d: %w", proc.name, proc.pid, proc.pgid, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func supervisorWorkspaceServiceCleanupScopeFromRegistry(gcHome string) (supervisorWorkspaceServiceCleanupScope, error) {
+	scope := supervisorWorkspaceServiceCleanupScope{
+		gcHome:    normalizePathForCompare(strings.TrimSpace(gcHome)),
+		cityPaths: make(map[string]string),
+	}
+	if scope.gcHome == "" {
+		return scope, errors.New("missing GC_HOME for workspace-service cleanup")
+	}
+	entries, err := supervisor.NewRegistry(supervisor.RegistryPath()).List()
+	if err != nil {
+		return scope, fmt.Errorf("reading supervisor registry for workspace-service cleanup: %w", err)
+	}
+	for _, entry := range entries {
+		cityPath := normalizePathForCompare(strings.TrimSpace(entry.Path))
+		if cityPath == "" {
+			continue
+		}
+		scope.cityPaths[cityPath] = cityPath
+	}
+	return scope, nil
+}
+
+func findSupervisorWorkspaceServiceProcesses(scope supervisorWorkspaceServiceCleanupScope) ([]supervisorWorkspaceServiceProcess, error) {
+	if strings.TrimSpace(scope.gcHome) == "" {
+		return nil, errors.New("missing GC_HOME for workspace-service cleanup")
+	}
+	if len(scope.cityPaths) == 0 {
+		return nil, nil
+	}
+	entries, err := supervisorProcReadDir(supervisorProcRoot)
+	if err != nil {
+		return nil, fmt.Errorf("reading /proc: %w", err)
+	}
+	seenPGID := make(map[int]supervisorWorkspaceServiceProcess)
+	var errs []error
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		env, err := supervisorProcReadFile(filepath.Join(supervisorProcRoot, entry.Name(), "environ"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+				continue
+			}
+			continue
+		}
+		envMap := supervisorProcessEnvMap(env)
+		if !supervisorWorkspaceServiceCandidateOwnedByScope(scope, envMap) {
+			continue
+		}
+		pgid, err := supervisorGetpgid(pid)
+		if err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("workspace service %q pid %d pgid: %w", envMap["GC_SERVICE_NAME"], pid, err))
+			continue
+		}
+		confirmedEnv, err := supervisorProcReadFile(filepath.Join(supervisorProcRoot, entry.Name(), "environ"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+				continue
+			}
+			continue
+		}
+		confirmedEnvMap := supervisorProcessEnvMap(confirmedEnv)
+		if !supervisorWorkspaceServiceCandidateOwnedByScope(scope, confirmedEnvMap) ||
+			!sameSupervisorWorkspaceServiceCandidate(envMap, confirmedEnvMap) {
+			continue
+		}
+		if pgid <= 1 || pgid == supervisorGetpgrp() {
+			warnSupervisorWorkspaceServiceCleanup("gc supervisor: skipping workspace service %q pid %d with unsafe process group %d; leaving it running\n", envMap["GC_SERVICE_NAME"], pid, pgid)
+			continue
+		}
+		if _, ok := seenPGID[pgid]; !ok {
+			seenPGID[pgid] = supervisorWorkspaceServiceProcess{
+				pid:  pid,
+				pgid: pgid,
+				name: envMap["GC_SERVICE_NAME"],
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	procs := make([]supervisorWorkspaceServiceProcess, 0, len(seenPGID))
+	for _, proc := range seenPGID {
+		procs = append(procs, proc)
+	}
+	sort.Slice(procs, func(i, j int) bool {
+		return procs[i].pgid < procs[j].pgid
+	})
+	return procs, nil
+}
+
+func supervisorWorkspaceServiceCandidateOwnedByScope(scope supervisorWorkspaceServiceCleanupScope, envMap map[string]string) bool {
+	if envMap["GC_SERVICE_SOCKET"] == "" || envMap["GC_SERVICE_NAME"] == "" || envMap["GC_SERVICE_STATE_ROOT"] == "" {
+		return false
+	}
+	return supervisorWorkspaceServiceOwnedByScope(scope, envMap)
+}
+
+func sameSupervisorWorkspaceServiceCandidate(before, after map[string]string) bool {
+	for _, key := range []string{
+		"GC_HOME",
+		"GC_CITY_PATH",
+		"GC_SERVICE_NAME",
+		"GC_SERVICE_STATE_ROOT",
+		"GC_SERVICE_SOCKET",
+	} {
+		if before[key] != after[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func supervisorWorkspaceServiceOwnedByScope(scope supervisorWorkspaceServiceCleanupScope, envMap map[string]string) bool {
+	envHome := normalizePathForCompare(strings.TrimSpace(envMap["GC_HOME"]))
+	if envHome == "" || envHome != scope.gcHome {
+		return false
+	}
+	cityPath := normalizePathForCompare(strings.TrimSpace(envMap["GC_CITY_PATH"]))
+	if cityPath == "" {
+		return false
+	}
+	cityPath, ok := scope.cityPaths[cityPath]
+	if !ok {
+		return false
+	}
+	stateRoot := strings.TrimSpace(envMap["GC_SERVICE_STATE_ROOT"])
+	if stateRoot == "" {
+		return false
+	}
+	return pathWithinOrSame(stateRoot, citylayout.RuntimeServicesDir(cityPath))
+}
+
+func supervisorProcessEnvMap(data []byte) map[string]string {
+	env := make(map[string]string)
+	for _, item := range bytes.Split(data, []byte{0}) {
+		if len(item) == 0 {
+			continue
+		}
+		key, value, ok := bytes.Cut(item, []byte("="))
+		if !ok {
+			continue
+		}
+		env[string(key)] = string(value)
+	}
+	return env
+}
+
+func terminateProcessGroup(pgid int, timeout time.Duration) error {
+	if pgid <= 1 || pgid == supervisorGetpgrp() {
+		return fmt.Errorf("refusing to signal unsafe process group %d", pgid)
+	}
+	if err := supervisorKill(-pgid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	if err := waitForProcessGroupExit(pgid, timeout); err == nil {
+		return nil
+	}
+	if err := supervisorKill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return waitForProcessGroupExit(pgid, timeout)
+}
+
+func waitForProcessGroupExit(pgid int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if !processGroupAlive(pgid) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("process group %d did not exit within %s", pgid, timeout)
+		}
+		time.Sleep(supervisorProcessGroupPollPeriod)
+	}
+}
+
+func processGroupAlive(pgid int) bool {
+	if pgid <= 0 {
+		return false
+	}
+	err := supervisorKill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
 
 func newSupervisorRunCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
@@ -299,8 +590,12 @@ func newSupervisorUninstallCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "uninstall",
 		Short: "Remove the platform service",
-		Long:  `Remove the platform service and stop the machine-wide supervisor.`,
-		Args:  cobra.NoArgs,
+		Long: `Remove the platform service and stop the machine-wide supervisor.
+
+On systemd, uninstall refuses to remove an active unit when the supervisor
+control socket is unavailable. Start the supervisor first so it can re-adopt
+preserved sessions, then retry uninstall.`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if doSupervisorUninstall(stdout, stderr) != 0 {
 				return errExit
@@ -408,9 +703,10 @@ var providerCredentialEnvPrefixes = []string{
 }
 
 var supervisorServiceFixedEnvKeys = map[string]bool{
-	"GC_HOME":         true,
-	"PATH":            true,
-	"XDG_RUNTIME_DIR": true,
+	"GC_HOME":                             true,
+	supervisorPreserveSessionsOnSignalEnv: true,
+	"PATH":                                true,
+	"XDG_RUNTIME_DIR":                     true,
 }
 
 func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
@@ -543,6 +839,8 @@ const supervisorLaunchdTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         {{end}}
         <key>PATH</key>
         <string>{{xmlesc .Path}}</string>
+        <key>GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL</key>
+        <string>1</string>
         {{range .ExtraEnv}}
         <key>{{xmlesc .Name}}</key>
         <string>{{xmlesc .Value}}</string>
@@ -570,6 +868,7 @@ StandardError=append:{{.LogPath}}
 Environment=GC_HOME="{{.GCHome}}"
 {{if .XDGRuntimeDir}}Environment=XDG_RUNTIME_DIR="{{.XDGRuntimeDir}}"
 {{end}}Environment=PATH="{{.Path}}"
+Environment=GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL="1"
 {{range .ExtraEnv}}Environment={{systemdenv .Name .Value}}
 {{end}}
 
@@ -922,6 +1221,10 @@ func restorePreviousSupervisorSystemdInstall(path, service string, previousConte
 	return errors.Join(errs...)
 }
 
+func warnSupervisorSystemdWarmRefreshPreservedUnit(stderr io.Writer, service string) {
+	fmt.Fprintf(stderr, "gc supervisor install: leaving refreshed systemd unit %s in place after warm-refresh failure; not restoring the previous unit because it may lack KillMode=process. Resolve the error, then run 'systemctl --user start %s' or rerun 'gc supervisor install'.\n", service, service) //nolint:errcheck // best-effort stderr
+}
+
 func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Writer) int {
 	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, data)
 	if err != nil {
@@ -974,6 +1277,15 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 
 func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
 	path := supervisorLaunchdPlistPath()
+	active := supervisorLaunchdActive(supervisorLaunchdLabel())
+	if sockPath, _ := runningSupervisorSocket(); sockPath != "" {
+		if code := stopSupervisorWithWait(stdout, stderr, true, 30*time.Second); code != 0 {
+			return code
+		}
+	} else if active {
+		fmt.Fprintf(stderr, "gc supervisor uninstall: launchd service %s is active but the control socket is unavailable; run 'gc supervisor start' to re-adopt sessions, then retry uninstall\n", supervisorLaunchdLabel()) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	_ = supervisorLaunchctlRun("unload", path)
 	_ = supervisorLaunchctlRun("disable", supervisorLaunchdServiceTarget(supervisorLaunchdLabel()))
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
@@ -986,6 +1298,54 @@ func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writ
 	}
 	fmt.Fprintf(stdout, "Uninstalled launchd service: %s\n", path) //nolint:errcheck // best-effort stdout
 	return 0
+}
+
+func waitSupervisorSystemdInactive(service string, timeout time.Duration) bool {
+	if !supervisorSystemctlActive(service) {
+		return true
+	}
+	if timeout <= 0 {
+		return false
+	}
+	poll := supervisorSystemdWarmRefreshPollInterval
+	if poll <= 0 {
+		poll = time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(poll)
+		if !supervisorSystemctlActive(service) {
+			return true
+		}
+	}
+	return !supervisorSystemctlActive(service)
+}
+
+func runningSupervisorPreserveSignalReady() (int, bool, error) {
+	_, pid := runningSupervisorSocket()
+	if pid <= 0 {
+		return 0, false, errors.New("active supervisor control socket is unavailable")
+	}
+	env, err := supervisorProcReadFile(filepath.Join(supervisorProcRoot, strconv.Itoa(pid), "environ"))
+	if err != nil {
+		return pid, false, fmt.Errorf("reading active supervisor pid %d environment: %w", pid, err)
+	}
+	return pid, supervisorProcessEnvMap(env)[supervisorPreserveSessionsOnSignalEnv] == "1", nil
+}
+
+func stopSupervisorSystemdForWarmRefresh(service string) ([]string, error) {
+	termArgs := []string{"--user", "kill", "--kill-who=main", "--signal=SIGTERM", service}
+	if err := supervisorSystemctlRun(termArgs...); err != nil {
+		return termArgs, err
+	}
+	if waitSupervisorSystemdInactive(service, supervisorSystemdWarmRefreshStopTimeout) {
+		return termArgs, nil
+	}
+	killArgs := []string{"--user", "kill", "--kill-who=main", "--signal=SIGKILL", service}
+	if err := supervisorSystemctlRun(killArgs...); err != nil {
+		return killArgs, err
+	}
+	return killArgs, nil
 }
 
 func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Writer) int {
@@ -1009,6 +1369,18 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 		return 1
 	}
 	contentChanged := string(existing) != content
+	active := supervisorSystemctlActive(service)
+	if contentChanged && active {
+		pid, ready, err := supervisorRunningPreserveSignalReady()
+		if err != nil {
+			fmt.Fprintf(stderr, "gc supervisor install: cannot verify active supervisor preserve-mode readiness: %v. Refusing systemd warm refresh because signaling an older supervisor can stop managed sessions. Stop or drain agents intentionally with 'gc supervisor stop --wait', then rerun 'gc supervisor install'.\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if !ready {
+			fmt.Fprintf(stderr, "gc supervisor install: active supervisor pid %d does not have %s=1. Refusing systemd warm refresh because this first post-upgrade install would stop managed sessions. Stop or drain agents intentionally with 'gc supervisor stop --wait', then rerun 'gc supervisor install'.\n", pid, supervisorPreserveSessionsOnSignalEnv) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	}
 	if err := writeSupervisorServiceFile(path, []byte(content)); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: writing unit: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1037,9 +1409,9 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 		return 1
 	}
 
-	if contentChanged && supervisorSystemctlActive(service) {
-		args := []string{"--user", "restart", service}
-		if err := supervisorSystemctlRun(args...); err != nil {
+	if contentChanged && active {
+		stopArgs, err := stopSupervisorSystemdForWarmRefresh(service)
+		if err != nil {
 			var rollbackErr error
 			if hadCurrent {
 				rollbackErr = restorePreviousSupervisorSystemdInstall(path, service, existing, true)
@@ -1047,12 +1419,24 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, legacyPresent)
 			}
 			if rollbackErr != nil {
-				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(stopArgs, " "), rollbackErr) //nolint:errcheck // best-effort stderr
 			}
-			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(stopArgs, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-	} else if !supervisorSystemctlActive(service) {
+		if err := cleanupSupervisorWorkspaceServicesForWarmRefresh(data.GCHome); err != nil {
+			warnSupervisorSystemdWarmRefreshPreservedUnit(stderr, service)
+			fmt.Fprintf(stderr, "gc supervisor install: workspace-service cleanup after systemctl %s: %v\n", strings.Join(stopArgs, " "), err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		_ = supervisorSystemctlRun("--user", "reset-failed", service)
+		startArgs := []string{"--user", "start", service}
+		if err := supervisorSystemctlRun(startArgs...); err != nil {
+			warnSupervisorSystemdWarmRefreshPreservedUnit(stderr, service)
+			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(startArgs, " "), err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	} else if !active {
 		args := []string{"--user", "start", service}
 		if err := supervisorSystemctlRun(args...); err != nil {
 			var rollbackErr error
@@ -1081,6 +1465,16 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 func uninstallSupervisorSystemd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
 	path := supervisorSystemdServicePath()
 	service := supervisorSystemdServiceName()
+	active := supervisorSystemctlActive(service)
+	if active {
+		if sockPath, _ := runningSupervisorSocket(); sockPath == "" {
+			fmt.Fprintf(stderr, "gc supervisor uninstall: systemd service %s is active but the control socket is unavailable; run 'gc supervisor start' to re-adopt sessions, then retry uninstall\n", service) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if code := stopSupervisorWithWait(stdout, stderr, true, 30*time.Second); code != 0 {
+			return code
+		}
+	}
 	_ = supervisorSystemctlRun("--user", "stop", service)
 	_ = supervisorSystemctlRun("--user", "disable", service)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -557,6 +557,13 @@ Description=Gas City machine supervisor
 
 [Service]
 Type=simple
+# Signal only the main supervisor PID on stop. tmux servers spawned by
+# 'gc supervisor run' live in this service's cgroup; the systemd default
+# (control-group) cascades SIGTERM through the cgroup on every stop, which
+# wipes one-per-bead dev/polecat session conversation history. The
+# supervisor reconciler re-adopts tmux state on start, so leaving tmux
+# alone here matches Gas City's existing lifecycle semantics. See #1174.
+KillMode=process
 ExecStart={{.GCPath}} supervisor run
 Restart=always
 RestartSec=5s

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -557,12 +557,10 @@ Description=Gas City machine supervisor
 
 [Service]
 Type=simple
-# Signal only the main supervisor PID on stop. tmux servers spawned by
-# 'gc supervisor run' live in this service's cgroup; the systemd default
-# (control-group) cascades SIGTERM through the cgroup on every stop, which
-# wipes one-per-bead dev/polecat session conversation history. The
-# supervisor reconciler re-adopts tmux state on start, so leaving tmux
-# alone here matches Gas City's existing lifecycle semantics. See #1174.
+# Signal only the main supervisor PID on stop. The systemd default
+# (control-group) would cascade SIGTERM to tmux servers spawned by
+# 'gc supervisor run' that live in this cgroup, killing one-per-bead
+# session conversation history. The reconciler re-adopts tmux on start.
 KillMode=process
 ExecStart={{.GCPath}} supervisor run
 Restart=always

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -256,6 +256,7 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 
 	for _, check := range []string{
 		"[Service]",
+		`KillMode=process`,
 		`ExecStart=/usr/local/bin/gc supervisor run`,
 		`StandardOutput=append:/home/user/.gc/supervisor.log`,
 		`Environment=GC_HOME="/home/user/.gc"`,

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	goruntime "runtime"
@@ -14,13 +16,16 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/supervisor"
+	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
 type closerSpy struct {
@@ -30,6 +35,115 @@ type closerSpy struct {
 func (c *closerSpy) Close() error {
 	c.closed = true
 	return nil
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+type workspaceServiceSentinel struct {
+	pgid int
+}
+
+func stubSupervisorRunningPreserveSignalReady(t *testing.T, ready bool) {
+	t.Helper()
+	old := supervisorRunningPreserveSignalReady
+	supervisorRunningPreserveSignalReady = func() (int, bool, error) {
+		return 4242, ready, nil
+	}
+	t.Cleanup(func() {
+		supervisorRunningPreserveSignalReady = old
+	})
+}
+
+func startWorkspaceServiceSentinel(t *testing.T, gcHome, cityPath, serviceName string) workspaceServiceSentinel {
+	t.Helper()
+	stateRoot := filepath.Join(cityPath, ".gc", "services", serviceName)
+	socketPath := filepath.Join(t.TempDir(), serviceName+".sock")
+	cmd := exec.Command("sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done")
+	cmd.Env = append(os.Environ(),
+		"GC_HOME="+gcHome,
+		"GC_CITY_PATH="+cityPath,
+		"GC_SERVICE_NAME="+serviceName,
+		"GC_SERVICE_STATE_ROOT="+stateRoot,
+		"GC_SERVICE_SOCKET="+socketPath,
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start workspace-service sentinel %q: %v", serviceName, err)
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("Getpgid(%d): %v", cmd.Process.Pid, err)
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+	t.Cleanup(func() {
+		if processGroupAlive(pgid) {
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		}
+		select {
+		case <-waitCh:
+		case <-time.After(time.Second):
+			t.Logf("workspace-service sentinel pgid %d did not exit before cleanup timeout", pgid)
+		}
+	})
+	if !processGroupAlive(pgid) {
+		t.Fatalf("workspace-service sentinel pgid %d is not alive", pgid)
+	}
+	return workspaceServiceSentinel{pgid: pgid}
+}
+
+func writeSupervisorProcEnv(t *testing.T, procRoot string, pid int, env map[string]string) {
+	t.Helper()
+	dir := filepath.Join(procRoot, strconv.Itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", dir, err)
+	}
+	var data []byte
+	for key, value := range env {
+		data = append(data, (key + "=" + value)...)
+		data = append(data, 0)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "environ"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(environ): %v", err)
+	}
+}
+
+func setSupervisorProcTestHooks(t *testing.T, procRoot string, getpgid func(int) (int, error)) {
+	t.Helper()
+	oldRoot := supervisorProcRoot
+	oldReadDir := supervisorProcReadDir
+	oldReadFile := supervisorProcReadFile
+	oldGetpgid := supervisorGetpgid
+	oldGetpgrp := supervisorGetpgrp
+	supervisorProcRoot = procRoot
+	supervisorProcReadDir = os.ReadDir
+	supervisorProcReadFile = os.ReadFile
+	supervisorGetpgid = getpgid
+	supervisorGetpgrp = func() int { return 4242 }
+	t.Cleanup(func() {
+		supervisorProcRoot = oldRoot
+		supervisorProcReadDir = oldReadDir
+		supervisorProcReadFile = oldReadFile
+		supervisorGetpgid = oldGetpgid
+		supervisorGetpgrp = oldGetpgrp
+	})
 }
 
 func startTestSupervisorSocket(t *testing.T, sockPath string, handler func(string) string) {
@@ -228,9 +342,32 @@ func TestRenderSupervisorLaunchdTemplate(t *testing.T) {
 		"<string>sk-&amp;&lt;&quot;&apos;&gt;</string>",
 		"<key>OPENAI_API_KEY</key>",
 		"<string>sk-openai-123</string>",
+		"<key>GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL</key>",
+		"<string>1</string>",
 	} {
 		if !strings.Contains(content, check) {
 			t.Fatalf("launchd template missing %q", check)
+		}
+	}
+}
+
+func TestRenderSupervisorLaunchdTemplateUsesPreserveEnvFromData(t *testing.T) {
+	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/usr/local/bin/gc",
+		LogPath:      "/home/user/.gc/supervisor.log",
+		GCHome:       "/home/user/.gc",
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"<key>GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL</key>",
+		"<string>1</string>",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("launchd template missing preserve env %q:\n%s", want, content)
 		}
 	}
 }
@@ -257,6 +394,7 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 	for _, check := range []string{
 		"[Service]",
 		`KillMode=process`,
+		`Environment=GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL="1"`,
 		`ExecStart=/usr/local/bin/gc supervisor run`,
 		`StandardOutput=append:/home/user/.gc/supervisor.log`,
 		`Environment=GC_HOME="/home/user/.gc"`,
@@ -268,6 +406,63 @@ func TestRenderSupervisorSystemdTemplate(t *testing.T) {
 		if !strings.Contains(content, check) {
 			t.Fatalf("systemd template missing %q", check)
 		}
+	}
+	wantBlock := "[Service]\nType=simple\n# Signal only the main supervisor PID on stop. The systemd default\n" +
+		"# (control-group) would cascade SIGTERM to tmux servers spawned by\n" +
+		"# 'gc supervisor run' that live in this cgroup, killing one-per-bead\n" +
+		"# session conversation history. The reconciler re-adopts tmux on start.\n" +
+		"KillMode=process\nExecStart=/usr/local/bin/gc supervisor run\n"
+	if !strings.Contains(content, wantBlock) {
+		t.Fatalf("systemd template missing ordered KillMode=process block under [Service]; got:\n%s", content)
+	}
+}
+
+func TestRenderSupervisorSystemdTemplateUsesPreserveEnvFromData(t *testing.T) {
+	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, &supervisorServiceData{
+		GCPath:  "/usr/local/bin/gc",
+		LogPath: "/home/user/.gc/supervisor.log",
+		GCHome:  "/home/user/.gc",
+		Path:    "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `Environment=GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL="1"`
+	if !strings.Contains(content, want) {
+		t.Fatalf("systemd template missing preserve env %q:\n%s", want, content)
+	}
+}
+
+func TestBuildSupervisorServiceDataTreatsPreserveSignalEnvAsFixed(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("GC_SUPERVISOR_ENV", supervisorPreserveSessionsOnSignalEnv)
+	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "0")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	if got := supervisorServiceEnvMap(data.ExtraEnv); got[supervisorPreserveSessionsOnSignalEnv] != "" {
+		t.Fatalf("ExtraEnv[%s] = %q, want omitted fixed value (all env: %#v)", supervisorPreserveSessionsOnSignalEnv, got[supervisorPreserveSessionsOnSignalEnv], got)
+	}
+
+	launchdContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(launchdContent, supervisorPreserveSessionsOnSignalEnv); count != 1 {
+		t.Fatalf("launchd preserve env occurrences = %d, want 1:\n%s", count, launchdContent)
+	}
+
+	systemdContent, err := renderSupervisorTemplate(supervisorSystemdTemplate, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(systemdContent, supervisorPreserveSessionsOnSignalEnv); count != 1 {
+		t.Fatalf("systemd preserve env occurrences = %d, want 1:\n%s", count, systemdContent)
 	}
 }
 
@@ -570,6 +765,37 @@ func TestSupervisorServiceSuffixDoesNotFallBackWhenBasenameSanitizesEmpty(t *tes
 	}
 }
 
+func TestLaunchdPrintReportsRunningAnchorsStateLine(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{
+			name: "top-level running state",
+			out:  "gui/501/com.gascity.supervisor = {\n\tstate = running\n\tprogram = /usr/local/bin/gc\n}\n",
+			want: true,
+		},
+		{
+			name: "stopped state with nested running text",
+			out:  "gui/501/com.gascity.supervisor = {\n\tstate = waiting\n\tlast exit code = 0\n\tpath = /tmp/state = running.log\n}\n",
+			want: false,
+		},
+		{
+			name: "running suffix is not a state token",
+			out:  "gui/501/com.gascity.supervisor = {\n\tstate = running-old\n}\n",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := launchdPrintReportsRunning([]byte(tt.out)); got != tt.want {
+				t.Fatalf("launchdPrintReportsRunning() = %v, want %v for output:\n%s", got, tt.want, tt.out)
+			}
+		})
+	}
+}
+
 func TestSupervisorInstallUnsupportedOS(t *testing.T) {
 	if goruntime.GOOS == "darwin" || goruntime.GOOS == "linux" {
 		t.Skip("unsupported-os test only applies outside darwin/linux")
@@ -583,7 +809,7 @@ func TestSupervisorInstallUnsupportedOS(t *testing.T) {
 	}
 }
 
-func TestInstallSupervisorSystemdRestartsWhenUnitChangesAndServiceActive(t *testing.T) {
+func TestInstallSupervisorSystemdWarmRefreshGracefullySignalsMainPIDWhenUnitChangesAndServiceActive(t *testing.T) {
 	if goruntime.GOOS != "linux" {
 		t.Skip("systemd path only applies on linux")
 	}
@@ -610,12 +836,22 @@ func TestInstallSupervisorSystemdRestartsWhenUnitChangesAndServiceActive(t *test
 	oldActive := supervisorSystemctlActive
 	var calls []string
 	supervisorSystemctlRun = func(args ...string) error {
-		calls = append(calls, strings.Join(args, " "))
+		call := strings.Join(args, " ")
+		calls = append(calls, call)
 		return nil
 	}
 	supervisorSystemctlActive = func(service string) bool {
-		return service == "gascity-supervisor.service"
+		if service != "gascity-supervisor.service" {
+			return false
+		}
+		for _, call := range calls {
+			if call == "--user kill --kill-who=main --signal=SIGTERM "+service {
+				return false
+			}
+		}
+		return true
 	}
+	stubSupervisorRunningPreserveSignalReady(t, true)
 	t.Cleanup(func() {
 		supervisorSystemctlRun = oldRun
 		supervisorSystemctlActive = oldActive
@@ -629,14 +865,19 @@ func TestInstallSupervisorSystemdRestartsWhenUnitChangesAndServiceActive(t *test
 	for _, want := range []string{
 		"--user daemon-reload",
 		"--user enable gascity-supervisor.service",
-		"--user restart gascity-supervisor.service",
+		"--user kill --kill-who=main --signal=SIGTERM gascity-supervisor.service",
+		"--user reset-failed gascity-supervisor.service",
+		"--user start gascity-supervisor.service",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("systemctl calls = %v, want %q", calls, want)
 		}
 	}
-	if strings.Contains(joined, "--user start gascity-supervisor.service") {
-		t.Fatalf("systemctl calls = %v, should restart instead of start when unit changes under an active service", calls)
+	if strings.Contains(joined, "--user restart gascity-supervisor.service") {
+		t.Fatalf("systemctl calls = %v, should signal the old main PID before starting the refreshed unit", calls)
+	}
+	if strings.Contains(joined, "--signal=SIGKILL") {
+		t.Fatalf("systemctl calls = %v, should not hard-kill after graceful warm-refresh stop succeeds", calls)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -644,6 +885,709 @@ func TestInstallSupervisorSystemdRestartsWhenUnitChangesAndServiceActive(t *test
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("systemd unit mode after warm upgrade = %03o, want 600", got)
+	}
+}
+
+func TestInstallSupervisorSystemdWarmRefreshRefusesActivePrePreserveSupervisor(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       "/tmp/gc-home/supervisor.log",
+		GCHome:        "/tmp/gc-home",
+		XDGRuntimeDir: "/tmp/gc-run",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+	path := supervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previous := []byte("old unit\n")
+	if err := os.WriteFile(path, previous, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		return service == "gascity-supervisor.service"
+	}
+	stubSupervisorRunningPreserveSignalReady(t, false)
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("systemctl calls = %v, want none before preserve-mode migration guard passes", calls)
+	}
+	gotContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	if !bytes.Equal(gotContent, previous) {
+		t.Fatalf("unit content changed despite guarded warm refresh: got %q want %q", gotContent, previous)
+	}
+	for _, want := range []string{"does not have " + supervisorPreserveSessionsOnSignalEnv, "gc supervisor stop --wait"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestInstallSupervisorSystemdWarmRefreshFallsBackToKillWhenGracefulSignalDoesNotStop(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       "/tmp/gc-home/supervisor.log",
+		GCHome:        "/tmp/gc-home",
+		XDGRuntimeDir: "/tmp/gc-run",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+	path := supervisorSystemdServicePath()
+	service := supervisorSystemdServiceName()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old unit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	oldTimeout := supervisorSystemdWarmRefreshStopTimeout
+	oldPoll := supervisorSystemdWarmRefreshPollInterval
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorSystemctlActive = func(string) bool { return true }
+	stubSupervisorRunningPreserveSignalReady(t, true)
+	supervisorSystemdWarmRefreshStopTimeout = time.Millisecond
+	supervisorSystemdWarmRefreshPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+		supervisorSystemdWarmRefreshStopTimeout = oldTimeout
+		supervisorSystemdWarmRefreshPollInterval = oldPoll
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user kill --kill-who=main --signal=SIGTERM " + service,
+		"--user kill --kill-who=main --signal=SIGKILL " + service,
+		"--user reset-failed " + service,
+		"--user start " + service,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorSystemdWarmRefreshStopsWorkspaceServicesBeforeStart(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       "/tmp/gc-home/supervisor.log",
+		GCHome:        gcHome,
+		XDGRuntimeDir: "/tmp/gc-run",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+	path := supervisorSystemdServicePath()
+	unitName := supervisorSystemdServiceName()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old unit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("Register(%q): %v", cityPath, err)
+	}
+	stateRoot := filepath.Join(cityPath, ".gc", "services", "bridge")
+	socketPath := filepath.Join(t.TempDir(), "bridge.sock")
+	cmd := exec.Command("sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done")
+	cmd.Env = append(os.Environ(),
+		"GC_HOME="+gcHome,
+		"GC_CITY_PATH="+cityPath,
+		"GC_SERVICE_NAME=bridge",
+		"GC_SERVICE_STATE_ROOT="+stateRoot,
+		"GC_SERVICE_SOCKET="+socketPath,
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start workspace-service sentinel: %v", err)
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("Getpgid(%d): %v", cmd.Process.Pid, err)
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+	t.Cleanup(func() {
+		if processGroupAlive(pgid) {
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		}
+		select {
+		case <-waitCh:
+		case <-time.After(time.Second):
+			t.Logf("workspace-service sentinel pgid %d did not exit before cleanup timeout", pgid)
+		}
+	})
+	if !processGroupAlive(pgid) {
+		t.Fatalf("workspace-service sentinel pgid %d is not alive before warm refresh", pgid)
+	}
+	scope, err := supervisorWorkspaceServiceCleanupScopeFromRegistry(gcHome)
+	if err != nil {
+		t.Fatalf("supervisorWorkspaceServiceCleanupScopeFromRegistry: %v", err)
+	}
+	procs, err := findSupervisorWorkspaceServiceProcesses(scope)
+	if err != nil {
+		t.Fatalf("findSupervisorWorkspaceServiceProcesses: %v", err)
+	}
+	if !slices.ContainsFunc(procs, func(proc supervisorWorkspaceServiceProcess) bool { return proc.pgid == pgid }) {
+		t.Fatalf("workspace-service discovery procs = %#v, want pgid %d", procs, pgid)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var (
+		calls              []string
+		startBeforeCleanup bool
+	)
+	supervisorSystemctlRun = func(args ...string) error {
+		call := strings.Join(args, " ")
+		calls = append(calls, call)
+		if call == "--user start "+unitName && processGroupAlive(pgid) {
+			startBeforeCleanup = true
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		if service != unitName {
+			return false
+		}
+		for _, call := range calls {
+			if call == "--user kill --kill-who=main --signal=SIGTERM "+unitName {
+				return false
+			}
+		}
+		return true
+	}
+	stubSupervisorRunningPreserveSignalReady(t, true)
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if startBeforeCleanup {
+		t.Fatalf("systemctl start ran before workspace-service pgid %d was stopped; calls=%v", pgid, calls)
+	}
+	if err := waitForProcessGroupExit(pgid, time.Second); err != nil {
+		t.Fatalf("workspace-service cleanup: %v", err)
+	}
+}
+
+func TestInstallSupervisorSystemdWarmRefreshLeavesUnregisteredWorkspaceServices(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	registeredCity := filepath.Join(t.TempDir(), "registered-city")
+	unregisteredCity := filepath.Join(t.TempDir(), "unregistered-city")
+	if err := os.MkdirAll(registeredCity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(unregisteredCity, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(registeredCity, "registered-city"); err != nil {
+		t.Fatalf("Register(%q): %v", registeredCity, err)
+	}
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       "/tmp/gc-home/supervisor.log",
+		GCHome:        gcHome,
+		XDGRuntimeDir: "/tmp/gc-run",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+	path := supervisorSystemdServicePath()
+	unitName := supervisorSystemdServiceName()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old unit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	registered := startWorkspaceServiceSentinel(t, gcHome, registeredCity, "bridge")
+	unregistered := startWorkspaceServiceSentinel(t, gcHome, unregisteredCity, "other-bridge")
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	supervisorSystemctlRun = func(_ ...string) error { return nil }
+	supervisorSystemctlActive = func(service string) bool {
+		return service == unitName
+	}
+	stubSupervisorRunningPreserveSignalReady(t, true)
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if err := waitForProcessGroupExit(registered.pgid, time.Second); err != nil {
+		t.Fatalf("registered workspace-service cleanup: %v", err)
+	}
+	if !processGroupAlive(unregistered.pgid) {
+		t.Fatalf("unregistered workspace-service pgid %d was stopped by warm-refresh cleanup", unregistered.pgid)
+	}
+}
+
+func TestCleanupSupervisorWorkspaceServicesForSupervisorStartSkipsMissingProc(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("Register(%q): %v", cityPath, err)
+	}
+
+	oldRoot := supervisorProcRoot
+	oldReadDir := supervisorProcReadDir
+	supervisorProcRoot = filepath.Join(t.TempDir(), "missing-proc")
+	supervisorProcReadDir = os.ReadDir
+	t.Cleanup(func() {
+		supervisorProcRoot = oldRoot
+		supervisorProcReadDir = oldReadDir
+	})
+
+	if err := cleanupSupervisorWorkspaceServicesForSupervisorStart(gcHome); err != nil {
+		t.Fatalf("cleanupSupervisorWorkspaceServicesForSupervisorStart: %v", err)
+	}
+}
+
+func TestCleanupSupervisorWorkspaceServicesForSupervisorStartWarnsWhenProcCleanupUnsupported(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("Register(%q): %v", cityPath, err)
+	}
+
+	oldGOOS := supervisorRuntimeGOOS
+	oldWarnings := supervisorWorkspaceServiceCleanupWarnings
+	var warnings bytes.Buffer
+	supervisorRuntimeGOOS = "darwin"
+	supervisorWorkspaceServiceCleanupWarnings = &warnings
+	t.Cleanup(func() {
+		supervisorRuntimeGOOS = oldGOOS
+		supervisorWorkspaceServiceCleanupWarnings = oldWarnings
+	})
+
+	if err := cleanupSupervisorWorkspaceServicesForSupervisorStart(gcHome); err != nil {
+		t.Fatalf("cleanupSupervisorWorkspaceServicesForSupervisorStart: %v", err)
+	}
+	if got := warnings.String(); !strings.Contains(got, "workspace-service startup cleanup is not available on darwin") ||
+		!strings.Contains(got, citylayout.RuntimeServicesDir(cityPath)) ||
+		!strings.Contains(got, "GC_SERVICE_STATE_ROOT") {
+		t.Fatalf("cleanup warning = %q, want macOS operator guidance", got)
+	}
+}
+
+func TestFindSupervisorWorkspaceServiceProcessesFiltersOwnershipAndRequiredEnv(t *testing.T) {
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	otherHome := filepath.Join(t.TempDir(), "other-home")
+	cityPath := filepath.Join(t.TempDir(), "city")
+	otherCity := filepath.Join(t.TempDir(), "other-city")
+	serviceRoot := filepath.Join(cityPath, ".gc", "services", "bridge")
+	procRoot := t.TempDir()
+	baseEnv := map[string]string{
+		"GC_HOME":                   gcHome,
+		"GC_CITY_PATH":              cityPath,
+		"GC_SERVICE_NAME":           "bridge",
+		"GC_SERVICE_STATE_ROOT":     serviceRoot,
+		"GC_SERVICE_SOCKET":         filepath.Join(t.TempDir(), "bridge.sock"),
+		"GC_CITY_RUNTIME_DIR":       filepath.Join(cityPath, ".gc", "runtime"),
+		"GC_SERVICE_RUN_ROOT":       filepath.Join(serviceRoot, "run"),
+		"GC_SERVICE_URL_PREFIX":     "/svc/bridge",
+		"GC_SERVICE_VISIBILITY":     "private",
+		"GC_PUBLISHED_SERVICES":     filepath.Join(cityPath, ".gc", "services", ".published"),
+		"GC_PUBLISHED_SERVICES_DIR": filepath.Join(cityPath, ".gc", "services", ".published"),
+	}
+	writeSupervisorProcEnv(t, procRoot, 101, baseEnv)
+	missingSocket := map[string]string{}
+	for k, v := range baseEnv {
+		missingSocket[k] = v
+	}
+	delete(missingSocket, "GC_SERVICE_SOCKET")
+	writeSupervisorProcEnv(t, procRoot, 102, missingSocket)
+	otherHomeEnv := map[string]string{}
+	for k, v := range baseEnv {
+		otherHomeEnv[k] = v
+	}
+	otherHomeEnv["GC_HOME"] = otherHome
+	writeSupervisorProcEnv(t, procRoot, 103, otherHomeEnv)
+	otherCityEnv := map[string]string{}
+	for k, v := range baseEnv {
+		otherCityEnv[k] = v
+	}
+	otherCityEnv["GC_CITY_PATH"] = otherCity
+	otherCityEnv["GC_SERVICE_STATE_ROOT"] = filepath.Join(otherCity, ".gc", "services", "bridge")
+	writeSupervisorProcEnv(t, procRoot, 104, otherCityEnv)
+	outsideStateEnv := map[string]string{}
+	for k, v := range baseEnv {
+		outsideStateEnv[k] = v
+	}
+	outsideStateEnv["GC_SERVICE_STATE_ROOT"] = filepath.Join(cityPath, ".gc", "not-services", "bridge")
+	writeSupervisorProcEnv(t, procRoot, 105, outsideStateEnv)
+
+	setSupervisorProcTestHooks(t, procRoot, func(pid int) (int, error) {
+		return pid + 1000, nil
+	})
+	scope := supervisorWorkspaceServiceCleanupScope{
+		gcHome: normalizePathForCompare(gcHome),
+		cityPaths: map[string]string{
+			normalizePathForCompare(cityPath): normalizePathForCompare(cityPath),
+		},
+	}
+	procs, err := findSupervisorWorkspaceServiceProcesses(scope)
+	if err != nil {
+		t.Fatalf("findSupervisorWorkspaceServiceProcesses: %v", err)
+	}
+	if len(procs) != 1 || procs[0].pid != 101 || procs[0].pgid != 1101 {
+		t.Fatalf("procs = %#v, want only owned pid 101", procs)
+	}
+}
+
+func TestFindSupervisorWorkspaceServiceProcessesSkipsUnsafeAndVanished(t *testing.T) {
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	cityPath := filepath.Join(t.TempDir(), "city")
+	procRoot := t.TempDir()
+	for _, pid := range []int{201, 202, 203, 204} {
+		writeSupervisorProcEnv(t, procRoot, pid, map[string]string{
+			"GC_HOME":               gcHome,
+			"GC_CITY_PATH":          cityPath,
+			"GC_SERVICE_NAME":       "bridge",
+			"GC_SERVICE_STATE_ROOT": filepath.Join(cityPath, ".gc", "services", "bridge"),
+			"GC_SERVICE_SOCKET":     filepath.Join(t.TempDir(), "bridge.sock"),
+		})
+	}
+	setSupervisorProcTestHooks(t, procRoot, func(pid int) (int, error) {
+		switch pid {
+		case 201:
+			return 0, syscall.ESRCH
+		case 202:
+			return 1, nil
+		case 203:
+			return 4242, nil
+		case 204:
+			return 5204, nil
+		default:
+			return pid + 1000, nil
+		}
+	})
+	scope := supervisorWorkspaceServiceCleanupScope{
+		gcHome: normalizePathForCompare(gcHome),
+		cityPaths: map[string]string{
+			normalizePathForCompare(cityPath): normalizePathForCompare(cityPath),
+		},
+	}
+	oldWarnings := supervisorWorkspaceServiceCleanupWarnings
+	var warnings bytes.Buffer
+	supervisorWorkspaceServiceCleanupWarnings = &warnings
+	t.Cleanup(func() {
+		supervisorWorkspaceServiceCleanupWarnings = oldWarnings
+	})
+
+	procs, err := findSupervisorWorkspaceServiceProcesses(scope)
+	if err != nil {
+		t.Fatalf("findSupervisorWorkspaceServiceProcesses: %v", err)
+	}
+	if len(procs) != 1 || procs[0].pid != 204 || procs[0].pgid != 5204 {
+		t.Fatalf("procs = %#v, want only safe pid 204", procs)
+	}
+	if got := warnings.String(); !strings.Contains(got, "unsafe process group 1") || !strings.Contains(got, "unsafe process group 4242") {
+		t.Fatalf("warnings = %q, want unsafe process group diagnostics", got)
+	}
+}
+
+func TestTerminateProcessGroupTreatsESRCHAsAlreadyStopped(t *testing.T) {
+	oldKill := supervisorKill
+	oldPoll := supervisorProcessGroupPollPeriod
+	supervisorKill = func(_ int, _ syscall.Signal) error {
+		return syscall.ESRCH
+	}
+	supervisorProcessGroupPollPeriod = time.Millisecond
+	t.Cleanup(func() {
+		supervisorKill = oldKill
+		supervisorProcessGroupPollPeriod = oldPoll
+	})
+
+	if err := terminateProcessGroup(999999, time.Millisecond); err != nil {
+		t.Fatalf("terminateProcessGroup ESRCH = %v, want nil", err)
+	}
+}
+
+func TestTerminateProcessGroupRefusesCurrentProcessGroup(t *testing.T) {
+	if err := terminateProcessGroup(syscall.Getpgrp(), time.Millisecond); err == nil {
+		t.Fatal("terminateProcessGroup current process group error = nil, want refusal")
+	}
+}
+
+func TestInstallSupervisorSystemdWarmRefreshPreservesNewUnitWhenStartFails(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       "/tmp/gc-home/supervisor.log",
+		GCHome:        "/tmp/gc-home",
+		XDGRuntimeDir: "/tmp/gc-run",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+	path := supervisorSystemdServicePath()
+	unitName := supervisorSystemdServiceName()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previous := []byte("old unit\n")
+	if err := os.WriteFile(path, previous, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var (
+		calls      []string
+		startCalls int
+	)
+	supervisorSystemctlRun = func(args ...string) error {
+		call := strings.Join(args, " ")
+		calls = append(calls, call)
+		if call == "--user start "+unitName {
+			startCalls++
+			if startCalls == 1 {
+				return errors.New("start failed")
+			}
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		if service != unitName {
+			return false
+		}
+		for _, call := range calls {
+			if call == "--user kill --kill-who=main --signal=SIGTERM "+unitName {
+				return false
+			}
+		}
+		return true
+	}
+	stubSupervisorRunningPreserveSignalReady(t, true)
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	gotContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	if bytes.Equal(gotContent, previous) || !bytes.Contains(gotContent, []byte("KillMode=process")) {
+		t.Fatalf("unit after failed warm refresh = %q, want refreshed unit with KillMode=process", gotContent)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user kill --kill-who=main --signal=SIGTERM " + unitName,
+		"--user reset-failed " + unitName,
+		"--user start " + unitName,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q", calls, want)
+		}
+	}
+	if strings.Contains(joined, "--user stop "+unitName) {
+		t.Fatalf("systemctl calls = %v, should not stop and restart a previous unit after failed warm refresh", calls)
+	}
+	if startCalls != 1 {
+		t.Fatalf("systemctl start calls = %d, want only failed refresh start; calls=%v", startCalls, calls)
+	}
+	if !strings.Contains(stderr.String(), "systemctl --user start "+unitName+": start failed") {
+		t.Fatalf("stderr = %q, want failed refresh start", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "leaving refreshed systemd unit") {
+		t.Fatalf("stderr = %q, want refreshed-unit rollback guidance", stderr.String())
+	}
+}
+
+func TestInstallSupervisorSystemdWarmRefreshPreservesNewUnitWhenCleanupFails(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       "/tmp/gc-home/supervisor.log",
+		GCHome:        gcHome,
+		XDGRuntimeDir: "/tmp/gc-run",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+	path := supervisorSystemdServicePath()
+	unitName := supervisorSystemdServiceName()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previous := []byte("old unit\n")
+	if err := os.WriteFile(path, previous, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatalf("Register(%q): %v", cityPath, err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	oldReadDir := supervisorProcReadDir
+	var (
+		calls      []string
+		startCalls int
+	)
+	supervisorSystemctlRun = func(args ...string) error {
+		call := strings.Join(args, " ")
+		calls = append(calls, call)
+		if call == "--user start "+unitName {
+			startCalls++
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		if service != unitName {
+			return false
+		}
+		for _, call := range calls {
+			if call == "--user kill --kill-who=main --signal=SIGTERM "+unitName {
+				return false
+			}
+		}
+		return true
+	}
+	stubSupervisorRunningPreserveSignalReady(t, true)
+	supervisorProcReadDir = func(string) ([]os.DirEntry, error) {
+		return nil, errors.New("proc scan failed")
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+		supervisorProcReadDir = oldReadDir
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	gotContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	if bytes.Equal(gotContent, previous) || !bytes.Contains(gotContent, []byte("KillMode=process")) {
+		t.Fatalf("unit after failed cleanup = %q, want refreshed unit with KillMode=process", gotContent)
+	}
+	joined := strings.Join(calls, "\n")
+	if !strings.Contains(joined, "--user kill --kill-who=main --signal=SIGTERM "+unitName) {
+		t.Fatalf("systemctl calls = %v, want warm-refresh graceful signal", calls)
+	}
+	if strings.Contains(joined, "--user stop "+unitName) {
+		t.Fatalf("systemctl calls = %v, should not stop and restart a previous unit after failed cleanup", calls)
+	}
+	if startCalls != 0 {
+		t.Fatalf("systemctl start calls = %d, want no start after cleanup failure; calls=%v", startCalls, calls)
+	}
+	if !strings.Contains(stderr.String(), "workspace-service cleanup after systemctl --user kill") {
+		t.Fatalf("stderr = %q, want cleanup failure", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "leaving refreshed systemd unit") {
+		t.Fatalf("stderr = %q, want refreshed-unit rollback guidance", stderr.String())
 	}
 }
 
@@ -1414,6 +2358,140 @@ func TestUninstallSupervisorSystemdIgnoresLegacyStopDisableFailures(t *testing.T
 	}
 }
 
+func TestUninstallSupervisorSystemdRefusesActiveServiceWithoutControlSocket(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := shortTempDir(t, "gc-home-")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	currentPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(currentPath), err)
+	}
+	if err := os.WriteFile(currentPath, []byte("current unit\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", currentPath, err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		return service == supervisorSystemdServiceName()
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorSystemd(&supervisorServiceData{}, &stdout, &stderr); code != 1 {
+		t.Fatalf("uninstallSupervisorSystemd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); err != nil {
+		t.Fatalf("active systemd unit %q should remain after guarded uninstall; err=%v", currentPath, err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("systemctl calls = %v, want none when active service has no control socket", calls)
+	}
+	for _, want := range []string{"control socket is unavailable", "gc supervisor start"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestUninstallSupervisorSystemdUsesControlSocketWhenServiceActive(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := shortTempDir(t, "gc-home-")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	currentPath := filepath.Join(homeDir, ".local", "share", "systemd", "user", supervisorSystemdServiceName())
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(currentPath), err)
+	}
+	if err := os.WriteFile(currentPath, []byte("current unit\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", currentPath, err)
+	}
+
+	var (
+		mu                         sync.Mutex
+		socketStopSeen             bool
+		stopped                    bool
+		systemctlStopBeforeSocket  bool
+		systemctlDisableCurrentHit bool
+	)
+	sockPath := supervisorSocketPath()
+	startTestSupervisorSocket(t, sockPath, func(cmd string) string {
+		mu.Lock()
+		defer mu.Unlock()
+		switch cmd {
+		case "ping":
+			if stopped {
+				return ""
+			}
+			return "4242\n"
+		case "stop":
+			socketStopSeen = true
+			stopped = true
+			return "ok\ndone:ok\n"
+		}
+		return ""
+	})
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	supervisorSystemctlRun = func(args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(args) >= 3 && args[1] == "stop" && args[2] == supervisorSystemdServiceName() && !socketStopSeen {
+			systemctlStopBeforeSocket = true
+		}
+		if len(args) >= 3 && args[1] == "disable" && args[2] == supervisorSystemdServiceName() {
+			systemctlDisableCurrentHit = true
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		return service == supervisorSystemdServiceName()
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorSystemd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("systemd unit %q should be removed; err=%v", currentPath, err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if systemctlStopBeforeSocket {
+		t.Fatal("uninstall stopped the systemd unit before requesting destructive socket shutdown")
+	}
+	if !socketStopSeen {
+		t.Fatal("uninstall did not request shutdown through the supervisor control socket")
+	}
+	if !systemctlDisableCurrentHit {
+		t.Fatal("uninstall did not disable the current systemd unit")
+	}
+}
+
 func TestInstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedGCHome(t *testing.T) {
 	homeDir := t.TempDir()
 	gcHome := filepath.Join(t.TempDir(), "isolated-home")
@@ -1982,6 +3060,139 @@ func TestUninstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedG
 	}
 }
 
+func TestUninstallSupervisorLaunchdUsesControlSocketWhenSupervisorRunning(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := shortTempDir(t, "gc-home-")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-current",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: supervisorLaunchdLabel(),
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(currentPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu                 sync.Mutex
+		socketStopSeen     bool
+		stopped            bool
+		unloadBeforeSocket bool
+		launchdDisableSeen bool
+	)
+	sockPath := supervisorSocketPath()
+	startTestSupervisorSocket(t, sockPath, func(cmd string) string {
+		mu.Lock()
+		defer mu.Unlock()
+		switch cmd {
+		case "ping":
+			if stopped {
+				return ""
+			}
+			return "4242\n"
+		case "stop":
+			socketStopSeen = true
+			stopped = true
+			return "ok\ndone:ok\n"
+		}
+		return ""
+	})
+
+	oldRun := supervisorLaunchctlRun
+	supervisorLaunchctlRun = func(args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(args) == 2 && args[0] == "unload" && args[1] == currentPath && !socketStopSeen {
+			unloadBeforeSocket = true
+		}
+		if len(args) == 2 && args[0] == "disable" && args[1] == supervisorLaunchdServiceTarget(supervisorLaunchdLabel()) {
+			launchdDisableSeen = true
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorLaunchd(&supervisorServiceData{}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstallSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("launchd plist %q should be removed; err=%v", currentPath, err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if unloadBeforeSocket {
+		t.Fatal("launchd uninstall unloaded the service before requesting destructive socket shutdown")
+	}
+	if !socketStopSeen {
+		t.Fatal("launchd uninstall did not request shutdown through the supervisor control socket")
+	}
+	if !launchdDisableSeen {
+		t.Fatal("launchd uninstall did not disable the current launchd service")
+	}
+}
+
+func TestUninstallSupervisorLaunchdRefusesActiveServiceWithoutControlSocket(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := shortTempDir(t, "gc-home-")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(currentPath, []byte("current plist\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := supervisorLaunchctlRun
+	oldActive := supervisorLaunchdActive
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	supervisorLaunchdActive = func(label string) bool {
+		return label == supervisorLaunchdLabel()
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+		supervisorLaunchdActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := uninstallSupervisorLaunchd(&supervisorServiceData{}, &stdout, &stderr); code != 1 {
+		t.Fatalf("uninstallSupervisorLaunchd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); err != nil {
+		t.Fatalf("active launchd plist %q should remain after guarded uninstall; err=%v", currentPath, err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("launchctl calls = %v, want none when active service has no control socket", calls)
+	}
+	for _, want := range []string{"launchd service", "control socket is unavailable", "gc supervisor start"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestUninstallSupervisorLaunchdIgnoresLegacyUnloadFailures(t *testing.T) {
 	homeDir := t.TempDir()
 	gcHome := filepath.Join(t.TempDir(), "isolated-home")
@@ -2217,6 +3428,83 @@ func TestRunSupervisorRejectsSupervisorOnFallbackSocket(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "already running") {
 		t.Fatalf("stderr = %q, want already running message", stderr.String())
+	}
+}
+
+func TestRunSupervisorSIGTERMPreservesSessionsEndToEnd(t *testing.T) {
+	gcHome := shortTempDir(t, "gc-home-")
+	runtimeDir := shortTempDir(t, "gc-run-")
+	t.Setenv("HOME", filepath.Dir(gcHome))
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "1")
+
+	if err := os.WriteFile(supervisor.ConfigPath(), []byte("[supervisor]\nport = "+freeLoopbackPort(t)+"\npatrol_interval = \"10m\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cityPath := filepath.Join(t.TempDir(), "bright-lights")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityPath, "bright-lights"); err != nil {
+		t.Fatal(err)
+	}
+
+	sigChReady := make(chan chan<- os.Signal, 1)
+	oldSignalNotify := supervisorSignalNotify
+	supervisorSignalNotify = func(c chan<- os.Signal, _ ...os.Signal) {
+		sigChReady <- c
+	}
+	t.Cleanup(func() {
+		supervisorSignalNotify = oldSignalNotify
+	})
+
+	var stdout, stderr lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runSupervisor(&stdout, &stderr)
+	}()
+
+	var sigCh chan<- os.Signal
+	select {
+	case sigCh = <-sigChReady:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for supervisor signal hook; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(stdout.String(), "Launching city 'bright-lights'") {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !strings.Contains(stdout.String(), "Launching city 'bright-lights'") {
+		t.Fatalf("timed out waiting for city launch; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	sigCh <- syscall.SIGTERM
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("runSupervisor code = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("runSupervisor did not exit after SIGTERM; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"Preserving city '" + cityPath + "' sessions for re-adoption...",
+		"Preserving agent sessions for supervisor re-adoption.",
+		"City '" + cityPath + "' preserved.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout = %q, want %q; stderr=%q", got, want, stderr.String())
+		}
+	}
+	if strings.Contains(got, "Stopping city 'bright-lights'") {
+		t.Fatalf("stdout = %q, should use preserve-mode shutdown for SIGTERM", got)
 	}
 }
 
@@ -2496,6 +3784,7 @@ func TestStopManagedCityForcesCleanupAfterTimeout(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "ops.log")
 	script := writeSpyScript(t, logFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	closer := &closerSpy{}
 	mc := &managedCity{
@@ -2546,6 +3835,7 @@ func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "ops.log")
 	script := writeSpyScript(t, logFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	closer := &closerSpy{}
 	mc := &managedCity{
@@ -2586,6 +3876,423 @@ func TestStopManagedCityDoesNotUseStartupOrDriftTimeouts(t *testing.T) {
 
 	ops := readOpLog(t, logFile)
 	assertSingleStopWithBenignNoise(t, ops)
+}
+
+func TestCityRuntimeShutdownPreservesSessionsWhenRequested(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "agent-one", runtime.Config{}); err != nil {
+		t.Fatalf("Start(agent-one): %v", err)
+	}
+	cr := &CityRuntime{
+		cfg: &config.City{
+			Daemon: config.DaemonConfig{ShutdownTimeout: "20ms"},
+		},
+		sp:     sp,
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+	cr.preserveSessionsOnShutdown()
+
+	cr.shutdown()
+
+	running, err := sp.ListRunning("")
+	if err != nil {
+		t.Fatalf("ListRunning: %v", err)
+	}
+	if !slices.Contains(running, "agent-one") {
+		t.Fatalf("running sessions = %v, want agent-one preserved", running)
+	}
+	for _, call := range sp.Calls {
+		if call.Method == "Interrupt" || call.Method == "Stop" {
+			t.Fatalf("preserve-mode shutdown called %s for %q; calls=%v", call.Method, call.Name, sp.Calls)
+		}
+	}
+}
+
+func TestCityRuntimeShutdownPreserveModeRecordsTrace(t *testing.T) {
+	cityPath := t.TempDir()
+	cr := &CityRuntime{
+		cityPath: cityPath,
+		cityName: "bright-lights",
+		cfg: &config.City{
+			Daemon: config.DaemonConfig{ShutdownTimeout: "20ms"},
+		},
+		sp:     runtime.NewFake(),
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: io.Discard,
+		trace:  newSessionReconcilerTraceManager(cityPath, "bright-lights", io.Discard),
+	}
+	cr.preserveSessionsOnShutdown()
+
+	cr.shutdown()
+
+	records, err := ReadTraceRecords(traceCityRuntimeDir(cityPath), TraceFilter{})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	if !slices.ContainsFunc(records, func(record SessionReconcilerTraceRecord) bool {
+		return record.RecordType == TraceRecordCycleResult &&
+			record.Fields["mode"] == "preserve_sessions" &&
+			record.Fields["city_name"] == "bright-lights" &&
+			record.Fields["reason"] == "supervisor_shutdown_preserve_mode"
+	}) {
+		t.Fatalf("trace records missing preserve shutdown cycle result: %#v", records)
+	}
+}
+
+func TestStopManagedCityPreservingSessionsSkipsBeadsProviderShutdown(t *testing.T) {
+	cityPath := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "ops.log")
+	script := writeSpyScript(t, logFile)
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	closer := &closerSpy{}
+	done := make(chan struct{})
+	canceled := false
+	mc := &managedCity{
+		name: "bright-lights",
+		cancel: func() {
+			canceled = true
+			close(done)
+		},
+		done:   done,
+		closer: closer,
+		cr: &CityRuntime{
+			cfg: &config.City{
+				Daemon: config.DaemonConfig{ShutdownTimeout: "20ms"},
+			},
+			sp:     runtime.NewFake(),
+			rec:    events.Discard,
+			stdout: io.Discard,
+			stderr: io.Discard,
+		},
+	}
+
+	if err := stopManagedCityPreservingSessions(mc, cityPath, io.Discard); err != nil {
+		t.Fatalf("stopManagedCityPreservingSessions: %v", err)
+	}
+	if !canceled {
+		t.Fatal("expected city context to be canceled so the CityRuntime goroutine can exit")
+	}
+	if !closer.closed {
+		t.Fatal("expected recorder closer to be closed after preserve-mode teardown")
+	}
+	if ops := readOpLog(t, logFile); len(ops) != 0 {
+		t.Fatalf("beads provider ops = %v, want none in preserve mode", ops)
+	}
+}
+
+func TestStopManagedCityPreservingSessionsWaitsForRuntimeShutdownOnTimeout(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("proxy process service shutdown uses process groups on linux")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not in PATH")
+	}
+	cityPath := t.TempDir()
+	serviceScript := filepath.Join(t.TempDir(), "service.sh")
+	if err := os.WriteFile(serviceScript, []byte(`#!/usr/bin/env python3
+import os
+import signal
+import socket
+import sys
+
+sock_path = os.environ["GC_SERVICE_SOCKET"]
+try:
+    os.unlink(sock_path)
+except FileNotFoundError:
+    pass
+
+def stop(_signum, _frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, stop)
+listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+listener.bind(sock_path)
+listener.listen(1)
+while True:
+    conn, _ = listener.accept()
+    conn.close()
+`), 0o755); err != nil {
+		t.Fatalf("WriteFile(service script): %v", err)
+	}
+	var runtimeStdout bytes.Buffer
+	cr := &CityRuntime{
+		cityPath: cityPath,
+		cityName: "bright-lights",
+		cfg: &config.City{
+			Daemon: config.DaemonConfig{ShutdownTimeout: "20ms"},
+			Services: []config.Service{{
+				Name: "bridge",
+				Kind: "proxy_process",
+				Process: config.ServiceProcessConfig{
+					Command: []string{serviceScript},
+				},
+			}},
+		},
+		sp:     runtime.NewFake(),
+		rec:    events.Discard,
+		stdout: &runtimeStdout,
+		stderr: io.Discard,
+	}
+	cr.svc = workspacesvc.NewManager(&serviceRuntime{cr: cr})
+	if err := cr.svc.Reload(); err != nil {
+		t.Fatalf("service Reload: %v", err)
+	}
+	status, ok := cr.svc.Get("bridge")
+	if !ok {
+		t.Fatal("service bridge missing after Reload")
+	}
+	if status.LocalState != "ready" {
+		t.Fatalf("service bridge local_state = %q, want ready; status=%#v", status.LocalState, status)
+	}
+
+	mc := &managedCity{
+		name:   "bright-lights",
+		cancel: func() {},
+		done:   make(chan struct{}),
+		cr:     cr,
+	}
+
+	err := stopManagedCityPreservingSessions(mc, cityPath, io.Discard)
+	if err == nil {
+		t.Fatal("stopManagedCityPreservingSessions error = nil, want timeout error")
+	}
+	status, ok = cr.svc.Get("bridge")
+	if !ok {
+		t.Fatal("service bridge missing after preserve-mode shutdown wait")
+	}
+	if status.LocalState != "stopped" {
+		t.Fatalf("service bridge local_state = %q, want stopped after preserve-mode shutdown wait; status=%#v", status.LocalState, status)
+	}
+	if !strings.Contains(runtimeStdout.String(), "Preserving agent sessions for supervisor re-adoption.") {
+		t.Fatalf("runtime stdout = %q, want preserve-mode shutdown message", runtimeStdout.String())
+	}
+}
+
+func TestShutdownSupervisorCitiesPreserveSessions(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "agent-one", runtime.Config{}); err != nil {
+		t.Fatalf("Start(agent-one): %v", err)
+	}
+	done := make(chan struct{})
+	mc := &managedCity{
+		name: "bright-lights",
+		cancel: func() {
+			close(done)
+		},
+		done: done,
+		cr: &CityRuntime{
+			cfg: &config.City{Daemon: config.DaemonConfig{ShutdownTimeout: "20ms"}},
+			sp:  sp, rec: events.Discard, stdout: io.Discard, stderr: io.Discard,
+		},
+	}
+	if err := stopManagedCityPreservingSessions(mc, t.TempDir(), io.Discard); err != nil {
+		t.Fatalf("stopManagedCityPreservingSessions: %v", err)
+	}
+	mc.cr.shutdown()
+	running, err := sp.ListRunning("")
+	if err != nil {
+		t.Fatalf("ListRunning: %v", err)
+	}
+	if !slices.Contains(running, "agent-one") {
+		t.Fatalf("running sessions = %v, want agent-one preserved", running)
+	}
+}
+
+func TestSupervisorShutdownControllerDestructiveRequestIsSticky(t *testing.T) {
+	tests := []struct {
+		name     string
+		requests []supervisorShutdownMode
+		want     bool
+	}{
+		{name: "no request", want: false},
+		{name: "preserve only", requests: []supervisorShutdownMode{supervisorShutdownPreserveSessions}, want: true},
+		{name: "destructive only", requests: []supervisorShutdownMode{supervisorShutdownDestructive}, want: false},
+		{name: "destructive then preserve", requests: []supervisorShutdownMode{supervisorShutdownDestructive, supervisorShutdownPreserveSessions}, want: false},
+		{name: "preserve then destructive", requests: []supervisorShutdownMode{supervisorShutdownPreserveSessions, supervisorShutdownDestructive}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctl := newSupervisorShutdownController()
+			for _, req := range tt.requests {
+				ctl.request(req)
+			}
+			if got := ctl.preservesSessions(); got != tt.want {
+				t.Fatalf("preservesSessions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupervisorShutdownControllerSettlesLateDestructiveRequest(t *testing.T) {
+	ctl := newSupervisorShutdownController()
+	ctl.request(supervisorShutdownPreserveSessions)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ctl.request(supervisorShutdownDestructive)
+	}()
+
+	if got := ctl.preservesSessionsAfterSettle(200 * time.Millisecond); got {
+		t.Fatal("preservesSessionsAfterSettle() = true, want false after late destructive request")
+	}
+}
+
+func TestSupervisorSignalLoopKeepsLateDestructiveEscalationUntilShutdownDone(t *testing.T) {
+	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "1")
+	sigCh := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	shutdownStarted := make(chan struct{})
+	var shutdownStartedOnce sync.Once
+	ctl := newSupervisorShutdownController()
+
+	go supervisorSignalLoop(sigCh, done, func(mode supervisorShutdownMode) {
+		ctl.request(mode)
+		shutdownStartedOnce.Do(func() { close(shutdownStarted) })
+	}, func() {})
+
+	sigCh <- syscall.SIGTERM
+	select {
+	case <-shutdownStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for preserve shutdown request")
+	}
+	sigCh <- syscall.SIGINT
+	defer close(done)
+
+	if got := ctl.preservesSessionsAfterSettle(200 * time.Millisecond); got {
+		t.Fatal("preservesSessionsAfterSettle() = true, want false after late SIGINT escalation")
+	}
+}
+
+func TestSupervisorShutdownModeForSignalPreservesOnlySIGTERMWhenConfigured(t *testing.T) {
+	t.Setenv(supervisorPreserveSessionsOnSignalEnv, "1")
+	if got := supervisorShutdownModeForSignal(syscall.SIGTERM); got != supervisorShutdownPreserveSessions {
+		t.Fatalf("SIGTERM shutdown mode = %v, want preserve", got)
+	}
+	if got := supervisorShutdownModeForSignal(syscall.SIGINT); got != supervisorShutdownDestructive {
+		t.Fatalf("SIGINT shutdown mode = %v, want destructive", got)
+	}
+}
+
+func TestStopSupervisorWithWaitStopsSystemdServiceAfterAckBeforeDone(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	gcHome := shortTempDir(t, "gc-home-")
+	runtimeDir := shortTempDir(t, "gc-run-")
+	t.Setenv("HOME", filepath.Dir(gcHome))
+	t.Setenv("GC_HOME", gcHome)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	unitPath := supervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(unitPath), err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", unitPath, err)
+	}
+
+	var (
+		mu                    sync.Mutex
+		stopped               bool
+		serviceStopBeforeAck  bool
+		doneSentBeforeService bool
+		serviceStopSeen       bool
+		serviceStopOnce       sync.Once
+	)
+	ackSent := make(chan struct{})
+	serviceStopped := make(chan struct{})
+	oldRun := supervisorSystemctlRun
+	supervisorSystemctlRun = func(args ...string) error {
+		mu.Lock()
+		if len(args) >= 3 && args[1] == "stop" && args[2] == supervisorSystemdServiceName() {
+			select {
+			case <-ackSent:
+			default:
+				serviceStopBeforeAck = true
+			}
+			serviceStopSeen = true
+			serviceStopOnce.Do(func() { close(serviceStopped) })
+		}
+		mu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+	})
+
+	sockPath := supervisorSocketPath()
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(sockPath), err)
+	}
+	lis, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Listen(unix, %q): %v", sockPath, err)
+	}
+	t.Cleanup(func() {
+		lis.Close()         //nolint:errcheck
+		os.Remove(sockPath) //nolint:errcheck
+	})
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close() //nolint:errcheck
+				r := bufio.NewReader(conn)
+				line, err := r.ReadString('\n')
+				if err != nil {
+					return
+				}
+				switch strings.TrimSpace(line) {
+				case "ping":
+					mu.Lock()
+					defer mu.Unlock()
+					if stopped {
+						return
+					}
+					io.WriteString(conn, "4242\n") //nolint:errcheck
+				case "stop":
+					mu.Lock()
+					stopped = true
+					mu.Unlock()
+					io.WriteString(conn, "ok\n") //nolint:errcheck
+					close(ackSent)
+					select {
+					case <-serviceStopped:
+					case <-time.After(200 * time.Millisecond):
+						mu.Lock()
+						doneSentBeforeService = true
+						mu.Unlock()
+					}
+					io.WriteString(conn, "done:ok\n") //nolint:errcheck
+				}
+			}(conn)
+		}
+	}()
+
+	var stdout, stderr bytes.Buffer
+	if code := stopSupervisorWithWait(&stdout, &stderr, true, time.Second); code != 0 {
+		t.Fatalf("stopSupervisorWithWait code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if serviceStopBeforeAck {
+		t.Fatal("platform service was stopped before the supervisor acknowledged the destructive socket stop")
+	}
+	if doneSentBeforeService {
+		t.Fatal("supervisor reported done:ok before systemd stop was requested")
+	}
+	if !serviceStopSeen {
+		t.Fatal("systemd service was not stopped after the supervisor acknowledged the destructive socket stop")
+	}
 }
 
 // TestStopSupervisorWithWaitBlocksUntilSocketStops exercises the --wait

--- a/cmd/gc/session_reconciler_trace_collector.go
+++ b/cmd/gc/session_reconciler_trace_collector.go
@@ -874,6 +874,10 @@ func (c *SessionReconcilerTraceCycle) RecordTraceControl(action string, scopeTyp
 	c.addRecord(rec)
 }
 
+// End flushes the cycle and writes a cycle-result trace record. Caller fields
+// are intentionally open-ended: known rollup keys are merged through
+// coalesceTraceField, so caller values keep priority there; additional non-nil
+// caller fields are preserved for site-specific trace context.
 func (c *SessionReconcilerTraceCycle) End(completion TraceCompletionStatus, fields map[string]any) error {
 	if c == nil || c.tracer == nil || !c.tracer.Enabled() {
 		return nil
@@ -927,6 +931,11 @@ func (c *SessionReconcilerTraceCycle) End(completion TraceCompletionStatus, fiel
 		"dropped_record_count":    droppedRecords,
 		"dropped_batch_count":     droppedBatches,
 		"drop_reason_counts":      dropReasons,
+	}
+	for k, v := range fields {
+		if _, ok := rollup[k]; !ok {
+			rollup[k] = v
+		}
 	}
 	rec := newTraceRecord(TraceRecordCycleResult).withCycle(c, now)
 	rec.SiteCode = TraceSiteCycleFinish

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2677,6 +2677,10 @@ gc supervisor stop [flags]
 
 Remove the platform service and stop the machine-wide supervisor.
 
+On systemd, uninstall refuses to remove an active unit when the supervisor
+control socket is unavailable. Start the supervisor first so it can re-adopt
+preserved sessions, then retry uninstall.
+
 ```
 gc supervisor uninstall
 ```


### PR DESCRIPTION
## Summary

Fixes #1174 by preserving managed session runtimes across native supervisor service cycles and adopting them when the new supervisor starts.

This is no longer only a `KillMode=process` unit-file change. The shipped fix combines:

- `KillMode=process` for the Linux systemd user unit so systemd signals only the supervisor main PID instead of the whole cgroup.
- `GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL=1` in both the systemd unit and launchd plist so native service stop/restart paths select preserve mode.
- A supervisor shutdown controller that keeps `gc supervisor stop --wait` destructive while native service signals preserve sessions for re-adoption.
- A systemd warm-refresh path that kills only the old main PID before starting the new unit, avoiding old binaries' destructive SIGTERM behavior.
- An uninstall guard that refuses to remove an active systemd unit when the supervisor socket is unavailable, with guidance to re-adopt sessions first.

## Credit

- Stephanie Jarmak (`sjarmak`) contributed the original systemd `KillMode=process` fix and rationale for the cgroup cascade in #1174.
- Julian Knutsen added the supervisor-side preserve-on-signal mechanism, launchd parity, warm-refresh behavior, uninstall guard, docs, and expanded tests needed to make the fix safe end to end.

## Files

- `cmd/gc/cmd_supervisor_lifecycle.go` — service templates, preserve env propagation, systemd warm refresh, and uninstall guidance.
- `cmd/gc/cmd_supervisor.go` — shutdown mode selection, socket-stop behavior, preserve-mode city teardown, and platform-service unload ordering.
- `cmd/gc/cmd_supervisor_test.go` — template, shutdown-controller, preserve-mode, signal-path, uninstall, and stop-wait coverage.
- `docs/reference/cli.md` — regenerated CLI reference for `gc supervisor uninstall`.
- `CHANGELOG.md` — release note for preserve restart/refresh behavior and uninstall guidance.

## Test plan

- [x] `go test ./cmd/gc -run 'Test(RenderSupervisorLaunchdTemplate|RenderSupervisorLaunchdTemplateUsesPreserveEnvFromData|RenderSupervisorSystemdTemplate|RenderSupervisorSystemdTemplateUsesPreserveEnvFromData|BuildSupervisorServiceDataIncludesProviderEnv|StopSupervisorWithWaitReadsDoneBeforeUnloadingPlatformService|ShutdownSupervisorCitiesPreserveSessions)'`
- [x] `go run ./cmd/genschema`
- [x] Isolated real user-systemd verification on Linux systemd 255.4: installed a temporary `gascity-supervisor-<suffix>.service` with `KillMode=process`, started two always-on tmux sessions plus two manual worker sessions, recorded pane PIDs, ran `systemctl --user restart`, and verified the same tmux pane PIDs survived and the new supervisor adopted the city.
- [x] Isolated warm-refresh verification: ran `systemctl --user kill --kill-who=main --signal=SIGKILL <service>` followed by `systemctl --user start <service>`, verified the same four tmux pane PIDs survived, and confirmed the restarted supervisor adopted the city.
- [ ] Full repository `make check` after the review loop settles.

## Follow-up

- `ga-a6iihp` tracks process-backed coverage for managed Dolt provider survival and re-adoption across preserve-mode supervisor restart/refresh. The current PR preserves Dolt by not calling `shutdownBeadsProvider` in preserve mode; this follow-up proves the reconciler reattaches to the existing managed Dolt server without port conflicts.
