### PR TITLE
Deliver routed work in Pi before agent turns

### DIFF
--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -340,6 +340,8 @@ func TestMaterializeBuiltinPacksPiHookUsesCurrentExtensionAPI(t *testing.T) {
 		`pi.on("session_compact"`,
 		`pi.on("session_shutdown"`,
 		`pi.on("before_agent_start"`,
+		`const work = run(["hook", "--inject"], ctx.cwd);`,
+		`appendSystemPrompt(event.systemPrompt, [nudges, mail, work])`,
 	} {
 		if !strings.Contains(data, want) {
 			t.Errorf("materialized Pi hook missing current extension API marker %q:\n%s", want, data)
@@ -385,6 +387,38 @@ module.exports = {
 	}
 	if !strings.Contains(data, `pi.on("session_start"`) {
 		t.Fatalf("repaired materialized Pi hook does not use current extension API:\n%s", data)
+	}
+}
+
+func TestMaterializeBuiltinPacksReplacesFactoryPiHookWithoutRoutedWorkInjection(t *testing.T) {
+	dir := t.TempDir()
+	hookPath := materializedPiHookPath(dir)
+	if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(hookPath), err)
+	}
+	stale := []byte(`// Gas City hooks for Pi Coding Agent.
+module.exports = function gascityPiExtension(pi) {
+  pi.on("before_agent_start", (event, ctx) => {
+    const nudges = run(["nudge", "drain", "--inject"], ctx.cwd);
+    const mail = run(["mail", "check", "--inject"], ctx.cwd);
+    return { systemPrompt: [event.systemPrompt, nudges, mail].filter(Boolean).join("\n\n") };
+  });
+};
+`)
+	if err := os.WriteFile(hookPath, stale, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", hookPath, err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	data := readMaterializedPiHook(t, dir)
+	if data == string(stale) {
+		t.Fatal("stale factory-style materialized Pi hook was preserved; expected core pack materialization to repair it")
+	}
+	if !strings.Contains(data, `const work = run(["hook", "--inject"], ctx.cwd);`) {
+		t.Fatalf("repaired materialized Pi hook does not inject routed work in before_agent_start:\n%s", data)
 	}
 }
 

--- a/internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js
@@ -9,10 +9,11 @@
 //   session_start    → gc prime --hook (load context side effects)
 //   session_compact  → gc prime --hook (reload after compaction)
 //   session_shutdown → gc hook --inject on process quit
-//   before_agent_start → gc nudge drain --inject + gc mail check --inject
+//   before_agent_start → gc nudge drain --inject + gc mail check --inject + gc hook --inject
 
 const { execFileSync } = require("node:child_process");
 
+const GC_PI_HOOK_VERSION = 2;
 const PATH_PREFIX = `${process.env.HOME}/go/bin:${process.env.HOME}/.local/bin:`;
 
 function run(args, cwd) {
@@ -54,7 +55,8 @@ module.exports = function gascityPiExtension(pi) {
   pi.on("before_agent_start", (event, ctx) => {
     const nudges = run(["nudge", "drain", "--inject"], ctx.cwd);
     const mail = run(["mail", "check", "--inject"], ctx.cwd);
-    const systemPrompt = appendSystemPrompt(event.systemPrompt, [nudges, mail]);
+    const work = run(["hook", "--inject"], ctx.cwd);
+    const systemPrompt = appendSystemPrompt(event.systemPrompt, [nudges, mail, work]);
     if (systemPrompt !== event.systemPrompt) {
       return { systemPrompt };
     }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -177,6 +177,15 @@ func piHookNeedsUpgrade(existing []byte) bool {
 			return true
 		}
 	}
+	for _, marker := range []string{
+		"GC_PI_HOOK_VERSION = 2",
+		`const work = run(["hook", "--inject"], ctx.cwd);`,
+		`appendSystemPrompt(event.systemPrompt, [nudges, mail, work])`,
+	} {
+		if !strings.Contains(content, marker) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -699,6 +699,8 @@ func TestInstallPiHookUsesCurrentExtensionAPI(t *testing.T) {
 		`pi.on("session_compact"`,
 		`pi.on("session_shutdown"`,
 		`pi.on("before_agent_start"`,
+		`const work = run(["hook", "--inject"], ctx.cwd);`,
+		`appendSystemPrompt(event.systemPrompt, [nudges, mail, work])`,
 	} {
 		if !strings.Contains(data, want) {
 			t.Errorf("Pi hook missing current extension API marker %q:\n%s", want, data)
@@ -738,6 +740,32 @@ module.exports = {
 	}
 	if !strings.Contains(data, `pi.on("session_start"`) {
 		t.Fatalf("upgraded Pi hook does not use current extension API:\n%s", data)
+	}
+}
+
+func TestInstallPiHookUpgradesFactoryHookWithoutRoutedWorkInjection(t *testing.T) {
+	fs := fsys.NewFake()
+	stale := []byte(`// Gas City hooks for Pi Coding Agent.
+module.exports = function gascityPiExtension(pi) {
+  pi.on("before_agent_start", (event, ctx) => {
+    const nudges = run(["nudge", "drain", "--inject"], ctx.cwd);
+    const mail = run(["mail", "check", "--inject"], ctx.cwd);
+    return { systemPrompt: [event.systemPrompt, nudges, mail].filter(Boolean).join("\n\n") };
+  });
+};
+`)
+	fs.Files["/work/.pi/extensions/gc-hooks.js"] = stale
+
+	if err := Install(fs, "/city", "/work", []string{"pi"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := string(fs.Files["/work/.pi/extensions/gc-hooks.js"])
+	if data == string(stale) {
+		t.Fatal("factory-style Pi hook without routed-work injection was preserved; expected managed upgrade")
+	}
+	if !strings.Contains(data, `const work = run(["hook", "--inject"], ctx.cwd);`) {
+		t.Fatalf("upgraded Pi hook does not inject routed work in before_agent_start:\n%s", data)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `gc hook --inject` to the Pi `before_agent_start` hook so routed ready work is delivered into the active model turn, matching Gemini's BeforeAgent nudge/mail/work pattern.
- Add a managed Pi hook version marker and upgrade stale factory-style Gas City Pi hooks that were current enough to load in Pi 0.70+ but still lacked routed-work injection.
- Extend install/materialization tests so Pi hooks must include routed-work delivery, not just current Pi extension API markers.

## Context

This is a follow-up to #1296. That PR fixes Pi 0.70+ extension loading, but a Pi worker can still start and idle if its assignment is available only through `gc hook --inject`. This branch is currently stacked on #1296, so the diff will shrink after #1296 merges.

Refs #1233.

## Validation

- `go test ./internal/hooks ./internal/worker/builtin`
- `go test ./cmd/gc -run '^TestMaterializeBuiltinPacks'`
- `go test ./internal/hooks ./cmd/gc -run 'TestInstallPiHook|TestMaterializeBuiltinPacks.*PiHook'`
- `go vet ./...`
- `pi -e internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js --list-models` with Pi `0.70.2`

## Notes

OpenCode and OMP have a similar-looking split where prompt transforms inject prime/nudges/mail while `gc hook --inject` runs on session deletion. I left those out of this Pi follow-up to keep the scope tight, but they should be reviewed separately for the same routed-work first-turn gap.
