### PR TITLE
docs(gastown): trim operational awareness fragment

### DIFF
--- a/examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md
@@ -10,45 +10,15 @@ clear, or new session to restore full context.
 Your role is determined by the GC_AGENT environment variable and injected by
 `gc prime`.
 
-### Dolt Server
-
-Dolt is the data plane for beads (issues, mail, work history). It runs as a
-single server on port 3307 serving all databases. **It is fragile.**
-
-If you detect Dolt trouble (commands hang/timeout, "connection refused",
-"database not found", query latency > 5s, unexpected empty results):
-
-**BEFORE restarting Dolt, collect diagnostics.** Dolt hangs are hard to
-reproduce. A blind restart destroys the evidence. Always:
-
-```bash
-# 1. Capture goroutine dump (safe — does not kill the process)
-kill -QUIT $(cat {{ .CityRoot }}/.gc/runtime/packs/dolt/dolt.pid)
-
-# 2. Capture server status while it's still (mis)behaving
-gc dolt status 2>&1 | tee /tmp/dolt-hang-$(date +%s).log
-
-# 3. THEN escalate with the evidence
-gc mail send mayor -s "Dolt: <describe symptom>" -m "<paste evidence>"
-```
-
-**Do NOT just `gc dolt stop && gc dolt start` without steps 1-2.**
-
-Orphan databases (testdb_*, beads_t*, beads_pt*) accumulate on the production
-server and degrade performance. Use `gc dolt cleanup` to remove them safely.
-**Never use `rm -rf` on Dolt data directories.**
-
 ### Communication: Nudge First, Mail Rarely
 
 Every `gc mail send` creates a permanent bead with a Dolt commit. `gc nudge`
 is ephemeral and costs zero. **Default to nudge for all routine communication.**
 
-**The litmus test:** "If the recipient dies and restarts, do they need this
-message?" If yes -> mail. If no -> nudge.
-
-**Ephemeral protocol messages:** MERGE_READY, MERGE_FAILED, RECOVERY_NEEDED,
-LIFECYCLE:Shutdown, and WORK_DONE are routine signals. Use `gc nudge` — the
-underlying bead state (assignee, status, metadata) is the durable record.
+Use mail only when the recipient must see the message after a restart. Routine
+protocol signals such as MERGE_READY, MERGE_FAILED, RECOVERY_NEEDED,
+LIFECYCLE:Shutdown, and WORK_DONE should be nudges; bead state is the durable
+record.
 
 **When you must mail**, use shell quoting for multi-line messages:
 
@@ -68,9 +38,10 @@ EOF
 - **After processing a message, always archive it** to keep your inbox clean
 - `gc mail reply <id> -s "RE: ..." -m "..."` creates a threaded reply
 
-**Dolt health — your part:**
-- Nudge, don't mail for routine communication
-- Don't create unnecessary beads — file real work, not scratchpads
-- Close your beads — open beads that linger become pollution
-- When Dolt is slow/down: check `gc doctor`, nudge Deacon — don't restart Dolt yourself
+### Dolt health
+
+Do not create scratchpad beads, and close beads when work is done. If bead or
+mail commands hang, time out, or report connection/database errors, check
+`gc doctor` and nudge Deacon with the symptom instead of restarting Dolt
+yourself.
 {{ end }}


### PR DESCRIPTION
## Summary

- trims the globally injected Gastown `operational-awareness` fragment
- removes detailed Dolt runbook prose from every agent prompt while preserving identity, nudge-first communication, mail lifecycle, and Dolt-health guidance
- reduces the fragment from 456 words to 269 words

## Why

This fragment is injected broadly into Gastown agents, so every line removed lowers repeated prompt/context cost without changing command behavior.

## Validation

- `wc -w examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md`
- `go test ./cmd/gc -run TestDoInitGastownWritesCanonicalPackV2Shape`
