### PR TITLE
fix(hook): bound injected work previews

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -185,6 +185,11 @@ func hookQueryEnv(cityPath string, cfg *config.City, a *config.Agent) map[string
 // dir sets the command's working directory.
 type WorkQueryRunner func(command, dir string) (string, error)
 
+const (
+	hookInjectMaxItems = 3
+	hookInjectMaxBytes = 2400
+)
+
 // shellWorkQueryWithEnv runs a work query command via sh -c and returns
 // stdout. If env is non-nil it is used as the subprocess environment
 // (including any rig-scoped BEADS_DIR / GC_RIG_ROOT overrides); otherwise
@@ -265,6 +270,7 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 }
 
 func formatHookInjectReminder(normalizedWork string) string {
+	preview, note := hookInjectWorkPreview(normalizedWork)
 	return fmt.Sprintf(`<system-reminder>
 You have pending work. Pick up the next item:
 
@@ -272,13 +278,58 @@ You have pending work. Pick up the next item:
 %s
 </work-items>
 
+%s
 Use the bead id from the work item:
 - If the item is not assigned to you yet, run `+"`bd update <id> --claim`"+`.
 - Do the requested work.
 - When done, run `+"`bd close <id>`"+`.
 Run `+"`gc hook`"+` to see the full queue.
 </system-reminder>
-`, normalizedWork)
+`, preview, note)
+}
+
+func hookInjectWorkPreview(normalizedWork string) (string, string) {
+	trimmed := strings.TrimSpace(normalizedWork)
+	if trimmed == "" {
+		return "", ""
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &items); err == nil && len(items) > hookInjectMaxItems {
+		previewItems := items[:hookInjectMaxItems]
+		previewBytes, err := json.Marshal(previewItems)
+		if err == nil {
+			preview, truncated := truncateHookInjectPreview(string(previewBytes))
+			note := fmt.Sprintf("Showing %d of %d ready work items here.", len(previewItems), len(items))
+			if truncated {
+				note += " The preview was also truncated by size."
+			}
+			return preview, note
+		}
+	}
+
+	preview, truncated := truncateHookInjectPreview(trimmed)
+	if truncated {
+		return preview, fmt.Sprintf("Showing the first %d bytes of hook output here.", hookInjectMaxBytes)
+	}
+	return preview, ""
+}
+
+func truncateHookInjectPreview(s string) (string, bool) {
+	if len(s) <= hookInjectMaxBytes {
+		return s, false
+	}
+	cut := 0
+	for i := range s {
+		if i > hookInjectMaxBytes {
+			break
+		}
+		cut = i
+	}
+	if cut <= 0 {
+		cut = hookInjectMaxBytes
+	}
+	return strings.TrimSpace(s[:cut]) + "\n... [truncated]", true
 }
 
 func workQueryHasReadyWork(output string) bool {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -116,6 +116,44 @@ func TestHookInjectFormatsOutput(t *testing.T) {
 	}
 }
 
+func TestHookInjectLimitsJSONWorkItems(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return `[{"id":"hw-1","title":"one"},{"id":"hw-2","title":"two"},{"id":"hw-3","title":"three"},{"id":"hw-4","title":"four"}]`, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready --json", "", true, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("doHook(inject, json work) = %d, want 0", code)
+	}
+	out := stdout.String()
+	for _, want := range []string{"hw-1", "hw-2", "hw-3", "Showing 3 of 4 ready work items"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "hw-4") {
+		t.Errorf("stdout should not include fourth work item:\n%s", out)
+	}
+}
+
+func TestHookInjectTruncatesLargePreview(t *testing.T) {
+	runner := func(string, string) (string, error) {
+		return "hw-1 open " + strings.Repeat("x", hookInjectMaxBytes+200), nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("doHook(inject, large work) = %d, want 0", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "... [truncated]") {
+		t.Errorf("stdout missing truncation marker:\n%s", out)
+	}
+	if !strings.Contains(out, "Showing the first") {
+		t.Errorf("stdout missing preview-size note:\n%s", out)
+	}
+}
+
 func TestHookInjectAlwaysExitsZero(t *testing.T) {
 	// Even on command failure, inject mode exits 0.
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }


### PR DESCRIPTION
## Summary

- keeps normal `gc hook` output unchanged
- bounds `gc hook --inject` prompt content to a small preview
- for JSON work-query output, injects only the first three ready work items and notes the total
- adds a byte cap for unusually large hook output and keeps the `gc hook` full-queue hint

## Why

`gc hook --inject` previously embedded the full normalized work queue into the agent prompt while telling the agent to pick up the next item. Large queues could inflate every hook-injected turn. This keeps enough context to start work while making the full queue an explicit pull action.

## Validation

- `go test ./cmd/gc -run 'TestHook'`
