### PR TITLE
fix(mail): preview injected unread messages

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -25,6 +25,11 @@ import (
 // Errors are non-fatal.
 type nudgeFunc func(recipient string) error
 
+const (
+	mailInjectMaxMessages     = 3
+	mailInjectBodyPreviewSize = 240
+)
+
 func newMailNudgeFunc(sender string) nudgeFunc {
 	return func(recipient string) error {
 		target, err := resolveNudgeTarget(recipient, io.Discard)
@@ -232,18 +237,45 @@ func formatInjectOutput(messages []mail.Message) string {
 	var sb strings.Builder
 	sb.WriteString("<system-reminder>\n")
 	fmt.Fprintf(&sb, "You have %d unread message(s).\n\n", len(messages))
-	for _, m := range messages {
+	limit := len(messages)
+	if limit > mailInjectMaxMessages {
+		limit = mailInjectMaxMessages
+		fmt.Fprintf(&sb, "Showing the first %d message(s) here; run 'gc mail inbox' for the full list.\n\n", limit)
+	}
+	for _, m := range messages[:limit] {
 		subject := strings.TrimSpace(m.Subject)
-		body := strings.TrimSpace(m.Body)
+		body, truncated := mailInjectBodyPreview(m.Body)
 		if subject != "" && subject != body {
-			fmt.Fprintf(&sb, "- %s from %s [%s]: %s\n", m.ID, m.From, m.Subject, m.Body)
+			fmt.Fprintf(&sb, "- %s from %s [%s]: %s", m.ID, m.From, subject, body)
 		} else {
-			fmt.Fprintf(&sb, "- %s from %s: %s\n", m.ID, m.From, m.Body)
+			fmt.Fprintf(&sb, "- %s from %s: %s", m.ID, m.From, body)
 		}
+		if truncated {
+			sb.WriteString(" ... [preview truncated]")
+		}
+		sb.WriteByte('\n')
 	}
 	sb.WriteString("\nRun 'gc mail read <id>' for full details, or 'gc mail inbox' to see all.\n")
 	sb.WriteString("</system-reminder>\n")
 	return sb.String()
+}
+
+func mailInjectBodyPreview(body string) (string, bool) {
+	compact := strings.Join(strings.Fields(body), " ")
+	if len(compact) <= mailInjectBodyPreviewSize {
+		return compact, false
+	}
+	cut := 0
+	for i := range compact {
+		if i > mailInjectBodyPreviewSize {
+			break
+		}
+		cut = i
+	}
+	if cut <= 0 {
+		cut = mailInjectBodyPreviewSize
+	}
+	return strings.TrimSpace(compact[:cut]), true
 }
 
 func defaultMailIdentity() string {

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2041,6 +2041,55 @@ func TestMailCheckInjectFormatsMessages(t *testing.T) {
 	}
 }
 
+func TestMailCheckInjectLimitsMessageCount(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	mp.Send("mayor", "worker", "", "first")   //nolint:errcheck
+	mp.Send("deacon", "worker", "", "second") //nolint:errcheck
+	mp.Send("dog", "worker", "", "third")     //nolint:errcheck
+	mp.Send("boot", "worker", "", "fourth")   //nolint:errcheck
+
+	var stdout bytes.Buffer
+	code := doMailCheck(mp, "worker", true, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("doMailCheck = %d, want 0", code)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"4 unread message(s)", "gc-1 from mayor", "gc-2 from deacon", "gc-3 from dog", "Showing the first 3 message(s)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "gc-4") || strings.Contains(out, "fourth") {
+		t.Errorf("stdout should not include the fourth message:\n%s", out)
+	}
+}
+
+func TestMailCheckInjectTruncatesLongBodies(t *testing.T) {
+	store := beads.NewMemStore()
+	mp := beadmail.New(store)
+	longBody := "prefix " + strings.Repeat("x", mailInjectBodyPreviewSize+100)
+	mp.Send("mayor", "worker", "Long body", longBody) //nolint:errcheck
+
+	var stdout bytes.Buffer
+	code := doMailCheck(mp, "worker", true, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("doMailCheck = %d, want 0", code)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Long body") {
+		t.Errorf("stdout missing subject:\n%s", out)
+	}
+	if !strings.Contains(out, "... [preview truncated]") {
+		t.Errorf("stdout missing truncation marker:\n%s", out)
+	}
+	if strings.Contains(out, strings.Repeat("x", mailInjectBodyPreviewSize+80)) {
+		t.Errorf("stdout includes too much of the long body:\n%s", out)
+	}
+}
+
 func TestMailCheckInjectDoesNotCloseBeads(t *testing.T) {
 	store := beads.NewMemStore()
 	mp := beadmail.New(store)


### PR DESCRIPTION
## Summary

- keeps normal mail inbox/check behavior unchanged
- limits `gc mail check --inject` to the first three unread messages
- collapses and truncates injected message bodies to short previews
- preserves message IDs, senders, subjects, and the existing `gc mail read <id>` full-detail hint

## Why

Unread mail injection previously placed every unread message body directly into the prompt. That can make every hook turn expensive when a session has a backlog. This changes injected mail into a notification/preview and leaves full body retrieval as an explicit action.

## Validation

- `go test ./cmd/gc -run 'TestMailCheckInject|TestMailCheckHasMail|TestMailCheckNoMail'`
