### PR TITLE
docs(guides): add gitignore guidance for cities and rigs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,7 +95,8 @@
         "pages": [
           "guides/index",
           "guides/migrating-to-pack-vnext",
-          "guides/shareable-packs"
+          "guides/shareable-packs",
+          "guides/gitignore"
         ]
       },
       {

--- a/docs/guides/gitignore.md
+++ b/docs/guides/gitignore.md
@@ -1,0 +1,109 @@
+---
+title: Gitignore Guidance
+description: What to commit and what to ignore in Gas City city and rig repositories.
+---
+
+Gas City mixes portable configuration with machine-local runtime state. Keep
+those layers separate in Git: commit the definitions that someone else can reuse,
+and ignore generated state that belongs to one machine, one run, or one local
+bead store.
+
+## City Repositories
+
+A city repository usually owns the Gas City configuration and pack content for
+one environment.
+
+Commit portable and intentional files such as:
+
+- `pack.toml`
+- `city.toml` when it represents shared deployment policy
+- `agents/`, `commands/`, `doctor/`, `formulas/`, `orders/`, and
+  `template-fragments/`
+- `packs/` when the city vendors or authors reusable packs
+- scripts, docs, hooks, and assets that are part of the city definition
+
+Ignore generated or machine-local files such as:
+
+- `.gc/`, including `.gc/site.toml`, session state, services state, and managed
+  agent work directories
+- `.beads/`, including the local bead database and generated `routes.jsonl`
+- `worktrees/` when your city config uses a top-level worktree directory
+- local logs, sockets, editor files, and OS metadata
+
+For a private running city, start with:
+
+```gitignore
+# Gas City machine-local state
+.gc/
+.beads/
+
+# Agent or workflow worktrees, when configured outside .gc/
+worktrees/
+
+# Local runtime noise
+*.log
+*.sock
+.DS_Store
+```
+
+If this city keeps rigs under `rigs/<name>` and each rig is tracked as its own
+repository, keep the parent city repository from accidentally absorbing those
+project files:
+
+```gitignore
+# Optional: rigs are tracked in their own repositories.
+rigs/*/
+!rigs/.gitkeep
+```
+
+Do not use that optional `rigs/*/` rule when the city repository intentionally
+owns files under `rigs/`.
+
+## Rig Repositories
+
+A rig repository is the project agents work on. It should normally commit the
+project source code and any project-owned Gas City configuration you expect other
+developers or agents to reuse.
+
+Commit intentional project files such as:
+
+- source code, tests, and project docs
+- project-local scripts used by `work_query`, `sling_query`, `session_setup`, or
+  `pre_start`
+- rig-specific pack references or overrides when they are meant to travel with
+  the project
+
+Ignore generated or machine-local files such as:
+
+- `.beads/`, including the rig bead database and generated `routes.jsonl`
+- `.gc/` if a workflow writes rig-local Gas City state there
+- `worktrees/` when the rig config or local scripts create disposable worktrees
+- provider transcripts, logs, sockets, and editor files that should stay local
+
+For a rig repository, start with:
+
+```gitignore
+# Gas City rig-local state
+.beads/
+.gc/
+
+# Disposable agent worktrees, when configured at the rig root
+worktrees/
+
+# Local runtime noise
+*.log
+*.sock
+.DS_Store
+```
+
+## Published Packs
+
+A published pack should contain reusable definitions, not the state from a
+running city. Commit pack files, templates, formulas, commands, examples, and
+docs. Exclude `.gc/`, `.beads/`, generated `routes.jsonl`, local worktrees,
+provider transcripts, and anything that encodes one developer's path or machine
+identity.
+
+As a quick review before committing, ask: would this file still be correct on a
+different machine with a different city name, rig path, bead prefix, and active
+sessions? If not, keep it out of the shared pack or city repo.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -7,6 +7,7 @@ These guides are task-oriented and current.
 
 - [Migrating to Pack/City v.next](/guides/migrating-to-pack-vnext)
 - [Shareable Packs](/guides/shareable-packs)
+- [Gitignore Guidance](/guides/gitignore)
 - [Using Gas City as a Multi-Agent Engineering Environment](/guides/multi-agent-engineering-environment)
 
 See also the [Troubleshooting runbooks](/troubleshooting/dolt-bloat-recovery)


### PR DESCRIPTION
## Summary

- Adds a Gitignore Guidance guide for city, rig, and published-pack repositories.
- Documents what should be committed versus ignored for `.gc/`, `.beads/`, generated `routes.jsonl`, worktrees, and reusable pack content.
- Adds pasteable city-root and rig-root `.gitignore` snippets.
- Links the guide from the docs guide index and Mintlify navigation.
- Closes #814.

## Testing

- [x] `make check-docs`
- [x] `make check` status addressed: local full check is blocked by unrelated macOS-local main-branch unit failures; focused branch validation above passed, and GitHub-required checks are awaiting maintainer approval for fork PRs rather than failing this diff
- [x] `make test-integration` not required; no runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed: closes #814.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
