### PR TITLE
docs(core): clarify rig-local worker queries

### DIFF
--- a/internal/bootstrap/packs/core/skills/gc-rigs/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-rigs/SKILL.md
@@ -22,6 +22,39 @@ bd list --dir /path/to/rig             # List rig's beads
 Running `bd` from the city root hits the city-level `.beads/`, not
 the rig's. Use `gc rig list` to find rig paths.
 
+## Rig-Local Custom Workers
+
+Custom workers that combine `start_command`, `work_query`, and `work_dir`
+must query the same bead store where routed work is created. A common failure
+looks like "No routed work found" even though a bead has
+`gc.routed_to=<worker>`: the worker is running `bd` from the city root, so it is
+looking in the city `.beads/` database instead of the rig `.beads/` database.
+
+Prefer one of these patterns for rig-scoped workers:
+
+```
+# Run the worker from the rig root so plain `bd ...` discovers the rig DB.
+dir = "frontend"
+work_dir = "{{.RigRoot}}"
+start_command = "scripts/custom-worker.sh"
+work_query = "bd ready --metadata-field gc.routed_to={{.Rig}}/{{.AgentBase}} --unassigned --json --limit=1"
+```
+
+```
+# Or keep another working directory but force bd to the rig path.
+dir = "frontend"
+work_dir = ".gc/worktrees/{{.Rig}}/{{.AgentBase}}"
+start_command = "scripts/custom-worker.sh"
+work_query = "bd ready --dir {{.RigRoot}} --metadata-field gc.routed_to={{.Rig}}/{{.AgentBase}} --unassigned --json --limit=1"
+```
+
+When debugging a custom worker lane:
+
+- run `gc rig list` to confirm the rig path and prefix
+- create or inspect rig work with `gc bd --rig <rig> ...` or `bd --dir <rig-path> ...`
+- make `work_query` use `{{.RigRoot}}` when it shells out from a city or worktree path
+- keep `sling_query` and `work_query` pointed at the same rig database
+
 ## Convention
 
 The canonical location for rigs is `<city-root>/rigs/<rig-name>`. Always


### PR DESCRIPTION
## Summary

- Adds a rig-local custom worker section to the built-in `gc-rigs` skill.
- Shows `start_command`, `work_dir`, and `work_query` examples that keep `bd` pointed at the rig bead store.
- Calls out the “No routed work found” symptom when a worker accidentally queries the city `.beads/` database.
- Lists quick debugging checks for rig path, prefix, and matching `sling_query` / `work_query` scope.
- Closes #490.

## Testing

- [x] `TMPDIR=/tmp go test ./internal/materialize ./cmd/gc -run 'Test(ReadSkillDescription|InternalMaterializeSkillsMaterializesClaude|SkillListCityCatalog)'`
- [x] `make check` status addressed: local full check is blocked by unrelated macOS-local main-branch unit failures; focused branch validation above passed, and GitHub-required checks are awaiting maintainer approval for fork PRs rather than failing this diff
- [x] `make check-docs` not required; no docs navigation or link changes
- [x] `make test-integration` not required; no runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed: closes #490.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes
