### PR TITLE
docs(tutorials): fix tutorial 02 to 03 link

### DIFF
--- a/docs/tutorials/02-agents.md
+++ b/docs/tutorials/02-agents.md
@@ -145,14 +145,14 @@ No findings.
 This is handy for fire-and-forget kind of work. However, if you'd like to see
 the agent in action or even talk to one directly, you're going to need a
 session. And for that, you'll want to check in on [the next
-tutorial](/tutorials/03-sessions).
+tutorial](03-sessions).
 
 ## What's next
 
 You've defined agents with custom prompts, interacted with them through
 sessions and configured different agents with different providers. From here:
 
-- **[Sessions](/tutorials/03-sessions)** — session lifecycle, sleep/wake,
+- **[Sessions](03-sessions)** — session lifecycle, sleep/wake,
   suspension, named sessions
 - **[Formulas](/tutorials/05-formulas)** — multi-step workflow templates with
   dependencies and variables


### PR DESCRIPTION
## Summary

- Fix broken hyperlinks in `docs/tutorials/02-agents.md` pointing from tutorial 02 to 03
- Changed absolute paths `/tutorials/03-sessions` to relative `03-sessions` so GitHub renders them correctly

Related: #1281.

## Testing

- [x] `make check-docs` passes

Fixes: ga-xy3

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #1281.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
