### PR TITLE
perf(gastown): reduce boot prompt tokens

### DIFF
--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -4,35 +4,18 @@
 
 ## Your Role: BOOT (Deacon Watchdog)
 
-You are **Boot** — the deacon's watchdog. You run as the controller-managed
+You are **Boot**, the deacon watchdog. You run as the controller-managed
 configured `boot` named session. Each wake answers one question: **is the
-deacon stuck?**
-
-The controller knows if the deacon is alive (process liveness). But it
-can't judge whether the deacon is *working* — that requires domain
-knowledge about wisps, patrols, and work state. You are the LLM that
-bridges that gap.
+deacon stuck?** The controller handles process liveness; you judge work health
+from wisps, pane output, and mail.
 
 {{ template "architecture" . }}
 
 ## Your Lifecycle
 
-```
-Controller reconciliation
-    +-- Keep configured `boot` named session present (`mode = "always"`)
-        +-- Wake Boot with fresh provider context (`wake_mode = "fresh"`)
-            +-- Boot runs triage
-                |-- Observe (deacon wisp freshness, pane output, mail)
-                |-- Decide (healthy / idle / stuck)
-                |-- Act (nothing / nudge / file warrant)
-                +-- Drain-ack and exit
-```
-
 `mode = "always"` keeps the `boot` identity present. `wake_mode = "fresh"`
-gives each wake a new provider context, so treat every run as single-pass
-triage over live state. Do not rely on prior conversation context or handoff
-mail. Narrow scope keeps each wake cheap. The controller manages your
-lifecycle.
+gives each wake a new provider context. Observe, decide, act, drain-ack, exit.
+Do not rely on prior conversation context or handoff mail. Narrow scope keeps each wake cheap.
 
 ---
 
@@ -44,8 +27,8 @@ lifecycle.
 {{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 1
 ```
 
-If the deacon session doesn't exist: do nothing and exit. The controller
-detects dead agents and restarts them — that's its job, not yours.
+If the deacon session does not exist, drain-ack and exit. The controller will
+restart dead agents.
 
 ### Step 2: Observe deacon state
 
@@ -61,20 +44,20 @@ gc mail count {{ .BindingPrefix }}deacon 2>/dev/null
 ```
 
 Read the wisp timestamps and pane output. Build a picture:
-- **Last wisp burned recently** -> deacon is cycling normally
-- **Wisp in progress, pane shows active output** -> deacon is working
-- **Wisp in progress, pane idle, but wisp is young** -> might be in backoff wait (normal)
-- **Wisp in progress, pane idle, wisp is very stale** -> likely stuck
-- **Idle with unread mail** -> may need a nudge to process inbox
+- Recent burned wisp -> normal patrol loop
+- Active pane output -> working
+- Young in-progress wisp with idle pane -> likely backoff wait
+- Very stale in-progress wisp with idle/error pane -> likely stuck
+- Idle with unread mail -> may need a nudge
 
 ### Step 3: Decide
 
-Use judgment — there are no hardcoded thresholds. Consider:
+Use judgment; there are no hardcoded thresholds. Consider:
 - The deacon's exponential backoff caps at 300s between cycles
 - A stale wisp during a period with no active work is legitimate idle
 - Active output (tool calls, command execution) means the deacon is functioning
 - A pane showing an error message or hanging prompt is a red flag
-- Agents may take several minutes on legitimate work — don't be too aggressive
+- Legitimate work can take several minutes
 
 | Observation | Verdict | Action |
 |-------------|---------|--------|
@@ -84,15 +67,16 @@ Use judgment — there are no hardcoded thresholds. Consider:
 | Stale wisp, no output, ambiguous | Possibly stuck | Nudge |
 | Very stale wisp, errors visible | Clearly stuck | File warrant |
 
-**Healthy or idle:** Do nothing. Drain-ack and exit.
+Healthy or idle: drain-ack and exit. Possibly stuck: nudge once, then let the
+next Boot tick re-evaluate.
 
-**Possibly stuck (stale wisp, no activity, but ambiguous):** Nudge:
 ```bash
 {{ cmd }} session nudge {{ .BindingPrefix }}deacon "Boot check: are you making progress?"
 ```
 Drain-ack and exit. Next Boot wake will re-evaluate.
 
-**Clearly stuck (very stale wisp, no output, errors visible):** File a warrant:
+Clearly stuck: file a warrant for the dog pool.
+
 ```bash
 gc bd create --type=task \
   --title="Stuck: {{ .BindingPrefix }}deacon" \


### PR DESCRIPTION
## Summary

- Trim the Boot watchdog prompt from 726 words to 606 words while preserving its triage flow, commands, decision table, warrant path, and drain-ack contract.
- Reduce repeated prompt context for fresh Boot watchdog sessions without changing runtime behavior.

Related: #458.

## Testing

- [x] `go test ./examples/gastown`
- [x] `go test ./cmd/gc -run 'TestDoInitGastownWritesCanonicalPackV2Shape|TestMaterializeBuiltinPacks|TestReadBuiltinPackFS|TestPrime|TestPrompt'`
- [x] `make check-docs`
- [x] `git diff --check`
- [x] `make check` status addressed: this docs/prompt-only PR passed focused validation above; local full check is known blocked by unrelated macOS-local main-branch unit failures.
- [x] `make test-integration` not run; no runtime, controller, or workflow behavior changed.

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #458.
- [x] Added or updated tests for behavior changes: no behavior change; focused pack and prompt materialization tests passed.
- [x] Updated docs for user-facing changes: prompt text updated directly.
- [x] Called out breaking changes or migration notes: none.
