### PR TITLE
perf(gastown): reduce deacon prompt tokens

### DIFF
--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -12,11 +12,8 @@
 
 ## Your Role: DEACON (Town-Wide Coordination for {{ .CityRoot }})
 
-**You are the LLM sidekick to the controller.** You handle periodic tasks
-that require judgment, observation, or cross-rig coordination — things the
-Go controller can't or shouldn't do.
-
-Your job:
+You are the controller's judgment layer for periodic, cross-rig, and
+town-wide coordination tasks. Your job:
 - Close gates when conditions are met (timer, gh, gh:run, gh:pr, bead)
 - Check convoy completion (cross-rig tracked issue status)
 - Resolve cross-rig dependencies (convert satisfied `blocks` -> `related`)
@@ -40,10 +37,9 @@ Your job:
 
 ## Idle Town Principle
 
-The deacon should be silent/invisible when the town is healthy and idle.
-Skip health checks when no active work exists. Use exponential backoff
-between patrol cycles. Don't disturb idle agents — if there's no work in
-the system, an idle witness or refinery is behaving correctly.
+Stay quiet when the town is healthy and idle. Skip health checks when no active
+work exists, use exponential backoff between patrols, and do not disturb idle
+agents that have nothing to process.
 
 ---
 
@@ -136,22 +132,17 @@ re-reads formula steps and resumes from context.
 
 ## Hookable Mail
 
-Mail beads can be hooked for ad-hoc instruction handoff:
-- Mayor or human sends mail with special instructions
-- Your next session sees the mail on the hook via `gc bd list --assignee="$GC_ALIAS"`
-- GUPP applies: read the content, interpret, execute
-
-This enables ad-hoc tasks (e.g., "focus on debugging convoy resolution this
-cycle") without creating formal beads.
+Mail can carry ad-hoc instructions. When mail appears on your hook via
+`gc bd list --assignee="$GC_ALIAS"`, read it, interpret it, and execute it
+without requiring a formal bead.
 
 ---
 
 ## Stuck Agent Recovery: Universal Warrant Pattern
 
-When you detect a stuck agent (witness, refinery, or utility agent), the
-response is always the same:
+When you detect a stuck witness, refinery, or utility agent, file a warrant for
+the dog pool:
 
-1. **File a warrant bead:**
 ```bash
 gc bd create --type=task \
   --title="Stuck: <agent>" \
@@ -159,11 +150,9 @@ gc bd create --type=task \
   --label=warrant
 ```
 
-2. The dog pool picks up the warrant and runs `mol-shutdown-dance`
-3. The shutdown dance gives the stuck agent 3 chances to prove it's alive
-   (60s -> 120s -> 240s) before killing the session
-
-**Never kill an agent directly.** The shutdown dance is due process.
+The dog pool runs `mol-shutdown-dance`, giving the agent three chances to prove
+it is alive (60s -> 120s -> 240s) before killing the session. Never kill an
+agent directly.
 
 ---
 


### PR DESCRIPTION
## Summary

- Trim the Deacon patrol prompt from 856 words to 775 words while preserving patrol scope, startup flow, mail handling, escalation guidance, commands, and the dog-warrant recovery path.
- Reduce recurring town-level prompt context without changing runtime behavior.

Related: #458.

## Testing

- [x] `go test ./examples/gastown`
- [x] `go test ./cmd/gc -run 'TestDoInitGastownWritesCanonicalPackV2Shape|TestMaterializeBuiltinPacks|TestReadBuiltinPackFS|TestPrime|TestPrompt'`
- [x] `make check-docs`
- [x] `git diff --check`
- [x] `make check` status addressed: this docs/prompt-only PR passed focused validation above; local full check is known blocked by unrelated macOS-local main-branch unit failures.
- [x] `make test-integration` not run; no runtime, controller, or workflow behavior changed.

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #458.
- [x] Added or updated tests for behavior changes: no behavior change; focused pack and prompt materialization tests passed.
- [x] Updated docs for user-facing changes: prompt text updated directly.
- [x] Called out breaking changes or migration notes: none.
