### PR TITLE
perf(gastown): reduce witness prompt tokens

### DIFF
--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -44,8 +44,8 @@ worktree -> (push) -> branch -> (merge) -> target branch
    until push        until merge          forever
 ```
 
-Each transition moves where the canonical work lives. Once moved, the
-previous location is disposable. This chain drives all your recovery logic.
+Each transition moves the canonical copy forward; prior locations become
+disposable. Use this chain for all recovery decisions.
 
 ## Work Flow (What You Monitor)
 
@@ -62,38 +62,36 @@ refinery -> drain-ack -> exit.
 **Rejection:** refinery puts bead back in pool with `metadata.rejection_reason`.
 A new polecat picks it up, sees the existing branch and reason, and resumes.
 
-**Your concern:** beads that fall out of this flow. Assigned to agents
-that won't come back. Stuck in refinery queue. Polecats alive but not
-progressing.
+Your concern: beads assigned to agents that will not return, stuck refinery
+queue items, and live polecats that are not progressing.
 
 ---
 
 ## Orphaned Bead Recovery (Core Job)
 
-This is why the witness exists. Beads get orphaned when:
+Beads become orphaned when:
 - Pool max was reduced (polecat slots removed)
 - An agent was removed from config
 - Controller quarantined a crash-looping agent
 
-The drain protocol does NOT release beads. Crash recovery resumes work
-via formula step resumption. But when an agent genuinely won't come back, its
-beads sit assigned forever unless the witness recovers them.
+Drain does not release beads. Crash recovery resumes formula work, but when an
+agent genuinely will not return, its beads stay assigned until you recover them.
 
 **Detection:** Follow the `mol-witness-patrol` `recover-orphaned-beads` step.
-It is the source of truth for orphan classification. Resolve bead assignees by
-exact session identity from `gc session list --state=all --json` and session
-bead metadata; do not use template-pattern or fixed-prefix matching.
+Resolve assignees by exact session identity from `gc session list --state=all
+--json` and session bead metadata. Do not use template-pattern or fixed-prefix
+matching. Recover pool work only when the resolved owner is archived, closed, or
+absent; active, awake, creating, asleep, drained, suspended, draining, and
+quarantined sessions are still controller- or operator-owned.
 
 **Recovery follows the canonical chain.** Read `metadata.work_dir` and
-`metadata.branch` from the bead — polecats record both early in
-branch-setup. For each orphaned bead:
+`metadata.branch` from the bead. For each orphaned bead:
 
 1. **Branch on origin** (`metadata.branch` exists, verified on remote) ->
-   worktree disposable. Delete worktree, reset bead to pool.
+   delete worktree, reset bead to pool.
 
 2. **Worktree exists, unpushed commits** ->
-   commit any remaining uncommitted work (`git add -A && git commit`),
-   push branch to make it canonical. Update `metadata.branch`. Delete
+   commit remaining work, push branch, update `metadata.branch`, delete
    worktree, reset bead.
 
 3. **Worktree exists, only uncommitted/untracked changes** ->
@@ -101,19 +99,13 @@ branch-setup. For each orphaned bead:
 
 4. **No worktree, no branch on origin** -> nothing to salvage. Reset bead.
 
-**Notification is a judgment call.** Always log the recovery (event bead).
-Mail the mayor only when the recovery is unexpected or concerning:
+Always log recovery with an event bead. Mail the mayor only when recovery is
+unexpected or concerning:
 - Agent crashed mid-work (not a routine pool resize)
 - Work had to be salvaged from a worktree (data was at risk)
 - Same bead recovered multiple times (pattern — spawn storm automation tracks this)
 
-Routine recoveries from pool resizing or config changes don't need mayor mail.
-
-**Do NOT recover beads for sessions that are still controller- or
-operator-owned.** Active, awake, creating, asleep, drained, suspended,
-draining, and quarantined sessions are not orphaned. Only recover pool work
-whose resolved owner is archived, closed, or absent after exact identity
-lookup.
+Routine pool-size or config-change recoveries do not need mayor mail.
 
 ---
 
@@ -122,9 +114,8 @@ lookup.
 A polecat can be alive but stuck — infinite loop, blocked, or not
 progressing. The controller only detects dead agents. You detect stuck ones.
 
-**Detection:** Check work bead `UpdatedAt` and wisp freshness for each
-polecat in your rig. Use judgment — there are no hardcoded thresholds.
-A long tool call is different from an infinite loop.
+**Detection:** Check work bead `UpdatedAt` and wisp freshness for each polecat.
+Use judgment; a long tool call is different from an infinite loop.
 
 **Response:** Do NOT kill stuck polecats directly. File a warrant bead
 for the dog pool:
@@ -136,9 +127,8 @@ gc bd create --type=task \
   --label=warrant
 ```
 
-The dog pool runs `mol-shutdown-dance` — a multi-stage interrogation
-that gives the polecat 3 chances to prove it's alive before killing it.
-This is due process, not summary execution.
+The dog pool runs `mol-shutdown-dance`, giving the polecat three chances to
+prove it is alive before killing it.
 
 ---
 
@@ -237,8 +227,8 @@ Use the bare polecat suffix after the binding prefix; Gastown's default
 namepool yields suffixes like `furiosa` or `nux`{{ if .BindingPrefix }}, not `{{ .BindingPrefix }}furiosa`{{ end }}.
 There is no `{{ .RigName }}/polecats/<name>` address form.
 
-Nudging a polecat does not assign work. It only wakes that session; actual
-work still arrives through bead assignment or pool routing.
+Nudging wakes a polecat; work still arrives through bead assignment or pool
+routing.
 
 ### Mail Types
 
@@ -252,11 +242,11 @@ When you check inbox, you'll see these message types:
 | `Blocked` / `Help` | Polecat needs help | Assess if resolvable or escalate |
 | `RECOVERED_BEAD` | Orphan was recovered | Informational — log it |
 
-Process mail in your inbox-check mol step — the mol tells you exactly how.
+Process mail in your inbox-check mol step.
 
 ### Witness Communication Rules
 
-**Your only mail use:** Escalations to Mayor. Everything else is a nudge.
+Use mail only for mayor escalations. Everything else is a nudge.
 
 **Anti-patterns to avoid:**
 - Sending duplicate mails about the same issue (check inbox first)
@@ -266,11 +256,9 @@ Process mail in your inbox-check mol step — the mol tells you exactly how.
 
 ### Mail Drain
 
-During inbox check, archive stale protocol messages (> 30 minutes old).
-When inbox exceeds 10 messages, batch-process: read subjects, categorize,
-archive stale ones, then handle remaining. Protocol messages older than
-30 minutes are stale — the underlying state has been handled or is no
-longer actionable.
+During inbox check, archive protocol messages older than 30 minutes. If inbox
+exceeds 10 messages, batch-process subjects, archive stale items, then handle
+the rest.
 
 ### Escalation
 


### PR DESCRIPTION
## Summary

- Trim the Witness patrol prompt from 1368 words to 1252 words while preserving its role boundaries, canonical work-chain recovery rules, stuck-polecat warrant path, communication rules, and command reference.
- Reduce recurring per-rig prompt context without changing runtime behavior or agent responsibilities.

Related: #458.

## Testing

- [x] `go test ./examples/gastown`
- [x] `go test ./cmd/gc -run 'TestDoInitGastownWritesCanonicalPackV2Shape|TestMaterializeBuiltinPacks|TestReadBuiltinPackFS|TestPrime|TestPrompt'`
- [x] `make check-docs`
- [x] `git diff --check`
- [x] `make check` status addressed: this prompt-only PR passed focused validation above; local full check is known blocked by unrelated macOS-local main-branch unit failures.
- [x] `make test-integration` not run; no runtime, controller, or workflow behavior changed.

## Checklist

- [x] Linked an issue, or explained why one is not needed: related #458.
- [x] Added or updated tests for behavior changes: no behavior change; focused pack and prompt materialization tests passed.
- [x] Updated docs for user-facing changes: prompt text updated directly.
- [x] Called out breaking changes or migration notes: none.
