### PR TITLE
fix(commands): render discovered help without execution

### DIFF
--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -189,10 +189,7 @@ func tryDiscoveredCommandFallback(args []string, cfg *config.City, cityPath stri
 	}
 
 	if len(args) == 1 {
-		fmt.Fprintf(stdout, "Available commands for %s:\n", binding) //nolint:errcheck
-		for _, entry := range matching {
-			fmt.Fprintf(stdout, "  %-20s %s\n", strings.Join(entry.Command, " "), entry.Description) //nolint:errcheck
-		}
+		printDiscoveredCommandList(stdout, binding, nil, matching)
 		return true
 	}
 
@@ -200,12 +197,29 @@ func tryDiscoveredCommandFallback(args []string, cfg *config.City, cityPath stri
 	sort.SliceStable(matching, func(i, j int) bool {
 		return len(matching[i].Command) > len(matching[j].Command)
 	})
+	if prefix, ok := discoveredHelpPrefix(args[1:]); ok {
+		for _, entry := range matching {
+			if slices.Equal(prefix, entry.Command) {
+				printDiscoveredCommandHelp(stdout, entry)
+				return true
+			}
+		}
+		if discoveredCommandPrefixExists(matching, prefix) {
+			printDiscoveredCommandList(stdout, binding, prefix, matching)
+			return true
+		}
+	}
 	for _, entry := range matching {
 		if len(args)-1 < len(entry.Command) {
 			continue
 		}
 		if slices.Equal(args[1:1+len(entry.Command)], entry.Command) {
-			code := runDiscoveredCommand(entry, cityPath, cityName, args[1+len(entry.Command):], stdin(), stdout, stderr)
+			commandArgs := args[1+len(entry.Command):]
+			if discoveredHelpRequested(commandArgs) {
+				printDiscoveredCommandHelp(stdout, entry)
+				return true
+			}
+			code := runDiscoveredCommand(entry, cityPath, cityName, commandArgs, stdin(), stdout, stderr)
 			if code != 0 {
 				os.Exit(code)
 			}
@@ -214,6 +228,67 @@ func tryDiscoveredCommandFallback(args []string, cfg *config.City, cityPath stri
 	}
 
 	return false
+}
+
+func discoveredHelpPrefix(args []string) ([]string, bool) {
+	for i, arg := range args {
+		if arg == "--" {
+			return nil, false
+		}
+		if arg == "--help" || arg == "-h" {
+			return args[:i], true
+		}
+	}
+	return nil, false
+}
+
+func printDiscoveredCommandHelp(stdout io.Writer, entry config.DiscoveredCommand) {
+	if long := readDiscoveredHelp(entry); long != "" {
+		fmt.Fprintln(stdout, long) //nolint:errcheck
+		return
+	}
+	if entry.Description != "" {
+		fmt.Fprintln(stdout, entry.Description) //nolint:errcheck
+		return
+	}
+	fmt.Fprintf(stdout, "Pack command: %s\n", strings.Join(entry.Command, " ")) //nolint:errcheck
+}
+
+func printDiscoveredCommandList(stdout io.Writer, binding string, prefix []string, entries []config.DiscoveredCommand) {
+	title := binding
+	if len(prefix) > 0 {
+		title += " " + strings.Join(prefix, " ")
+	}
+	fmt.Fprintf(stdout, "Available commands for %s:\n", title) //nolint:errcheck
+	for _, entry := range sortCommandsForTree(entries) {
+		if !commandHasPrefix(entry.Command, prefix) {
+			continue
+		}
+		name := strings.Join(entry.Command, " ")
+		if len(prefix) > 0 {
+			name = strings.Join(entry.Command[len(prefix):], " ")
+		}
+		if name == "" {
+			continue
+		}
+		fmt.Fprintf(stdout, "  %-20s %s\n", name, entry.Description) //nolint:errcheck
+	}
+}
+
+func discoveredCommandPrefixExists(entries []config.DiscoveredCommand, prefix []string) bool {
+	for _, entry := range entries {
+		if commandHasPrefix(entry.Command, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandHasPrefix(command, prefix []string) bool {
+	if len(prefix) > len(command) {
+		return false
+	}
+	return slices.Equal(command[:len(prefix)], prefix)
 }
 
 func sortCommandsForTree(entries []config.DiscoveredCommand) []config.DiscoveredCommand {

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -388,6 +388,150 @@ func TestTryDiscoveredCommandFallback_PrefersLongestMatch(t *testing.T) {
 	}
 }
 
+func TestTryDiscoveredCommandFallback_HelpFlagShowsHelpWithoutRunning(t *testing.T) {
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "pack", "commands", "status")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(sourceDir, "run.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho should-not-run\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	helpPath := filepath.Join(sourceDir, "help.md")
+	if err := os.WriteFile(helpPath, []byte("Status help from pack.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "testcity"},
+		PackCommands: []config.DiscoveredCommand{{
+			BindingName: "gs",
+			PackName:    "mypack",
+			Command:     []string{"status"},
+			Description: "Show status",
+			RunScript:   scriptPath,
+			HelpFile:    helpPath,
+			SourceDir:   sourceDir,
+		}},
+	}
+
+	var stdout, stderr bytes.Buffer
+	ok := tryDiscoveredCommandFallback([]string{"gs", "status", "--help"}, cfg, dir, &stdout, &stderr)
+	if !ok {
+		t.Fatal("tryDiscoveredCommandFallback returned false, want true")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Status help from pack.") {
+		t.Fatalf("stdout missing discovered help, got:\n%s", out)
+	}
+	if strings.Contains(out, "should-not-run") {
+		t.Fatalf("help should not execute the discovered command, got:\n%s", out)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTryDiscoveredCommandFallback_HelpAfterTerminatorPassesThrough(t *testing.T) {
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "pack", "commands", "status")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(sourceDir, "run.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'args=%s %s\\n' \"$1\" \"$2\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	helpPath := filepath.Join(sourceDir, "help.md")
+	if err := os.WriteFile(helpPath, []byte("Status help from pack.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "testcity"},
+		PackCommands: []config.DiscoveredCommand{{
+			BindingName: "gs",
+			PackName:    "mypack",
+			Command:     []string{"status"},
+			Description: "Show status",
+			RunScript:   scriptPath,
+			HelpFile:    helpPath,
+			SourceDir:   sourceDir,
+		}},
+	}
+
+	var stdout, stderr bytes.Buffer
+	ok := tryDiscoveredCommandFallback([]string{"gs", "status", "--", "--help"}, cfg, dir, &stdout, &stderr)
+	if !ok {
+		t.Fatal("tryDiscoveredCommandFallback returned false, want true")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "args=-- --help") {
+		t.Fatalf("stdout missing script passthrough args, got:\n%s", out)
+	}
+	if strings.Contains(out, "Status help from pack.") {
+		t.Fatalf("terminator should pass --help through to the script, got:\n%s", out)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestTryDiscoveredCommandFallback_NamespaceHelpListsChildren(t *testing.T) {
+	dir := t.TempDir()
+	repoSyncDir := filepath.Join(dir, "pack", "commands", "repo", "sync")
+	repoCleanDir := filepath.Join(dir, "pack", "commands", "repo", "clean")
+	for _, p := range []string{repoSyncDir, repoCleanDir} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, "run.sh"), []byte("#!/bin/sh\necho should-not-run\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "testcity"},
+		PackCommands: []config.DiscoveredCommand{
+			{
+				BindingName: "gs",
+				PackName:    "mypack",
+				Command:     []string{"repo", "sync"},
+				Description: "Sync repo",
+				RunScript:   filepath.Join(repoSyncDir, "run.sh"),
+				SourceDir:   repoSyncDir,
+			},
+			{
+				BindingName: "gs",
+				PackName:    "mypack",
+				Command:     []string{"repo", "clean"},
+				Description: "Clean repo",
+				RunScript:   filepath.Join(repoCleanDir, "run.sh"),
+				SourceDir:   repoCleanDir,
+			},
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	ok := tryDiscoveredCommandFallback([]string{"gs", "repo", "--help"}, cfg, dir, &stdout, &stderr)
+	if !ok {
+		t.Fatal("tryDiscoveredCommandFallback returned false, want true")
+	}
+	out := stdout.String()
+	for _, want := range []string{"Available commands for gs repo:", "clean", "Clean repo", "sync", "Sync repo"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "should-not-run") {
+		t.Fatalf("namespace help should not execute a discovered command, got:\n%s", out)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestAddDiscoveredCommandsToRoot_DedupsDuplicateLeaf(t *testing.T) {
 	root := &cobra.Command{Use: "gc"}
 	entries := []config.DiscoveredCommand{

--- a/cmd/gc/cmd_commands_test.go
+++ b/cmd/gc/cmd_commands_test.go
@@ -532,6 +532,76 @@ func TestTryDiscoveredCommandFallback_NamespaceHelpListsChildren(t *testing.T) {
 	}
 }
 
+func TestPrintDiscoveredCommandHelpFallbacks(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		entry config.DiscoveredCommand
+		want  string
+	}{
+		{
+			name:  "description",
+			entry: config.DiscoveredCommand{Command: []string{"status"}, Description: "Show status"},
+			want:  "Show status\n",
+		},
+		{
+			name:  "generic",
+			entry: config.DiscoveredCommand{Command: []string{"repo", "sync"}},
+			want:  "Pack command: repo sync\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			printDiscoveredCommandHelp(&stdout, tc.entry)
+			if got := stdout.String(); got != tc.want {
+				t.Fatalf("stdout = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintDiscoveredCommandListFiltersPrefixAndSkipsExactNamespace(t *testing.T) {
+	entries := []config.DiscoveredCommand{
+		{Command: []string{"repo"}, Description: "Repo namespace"},
+		{Command: []string{"repo", "sync"}, Description: "Sync repo"},
+		{Command: []string{"repo", "clean"}, Description: "Clean repo"},
+		{Command: []string{"status"}, Description: "Show status"},
+	}
+
+	var stdout bytes.Buffer
+	printDiscoveredCommandList(&stdout, "gs", []string{"repo"}, entries)
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Available commands for gs repo:",
+		"sync",
+		"Sync repo",
+		"clean",
+		"Clean repo",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q, got:\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{"Repo namespace", "status", "Show status"} {
+		if strings.Contains(out, notWant) {
+			t.Fatalf("stdout unexpectedly contained %q, got:\n%s", notWant, out)
+		}
+	}
+}
+
+func TestDiscoveredCommandPrefixHelpers(t *testing.T) {
+	entries := []config.DiscoveredCommand{{Command: []string{"repo", "sync"}}}
+	if !discoveredCommandPrefixExists(entries, []string{"repo"}) {
+		t.Fatal("expected repo prefix to exist")
+	}
+	if discoveredCommandPrefixExists(entries, []string{"missing"}) {
+		t.Fatal("missing prefix unexpectedly exists")
+	}
+	if commandHasPrefix([]string{"repo"}, []string{"repo", "sync"}) {
+		t.Fatal("short command unexpectedly matched longer prefix")
+	}
+}
+
 func TestAddDiscoveredCommandsToRoot_DedupsDuplicateLeaf(t *testing.T) {
 	root := &cobra.Command{Use: "gc"}
 	entries := []config.DiscoveredCommand{


### PR DESCRIPTION
## Summary

- Fix the lazy discovered-command fallback so `gc <pack> <command> --help` renders pack-authored help instead of executing `run.sh`.
- Add namespace help for fallback-discovered nested commands such as `gc <pack> repo --help`.
- Preserve `-- --help` passthrough so pack commands can still receive `--help` as a real script argument.

Closes #757.

## Testing

- [x] `go test ./cmd/gc -run 'TestTryDiscoveredCommandFallback|TestAddDiscoveredCommandsToRoot_HelpFlagShowsBuiltInHelp|TestLegacyPackCommandHelpFlagUsesBuiltInHelp' -count=1`
- [x] `go test ./internal/config -count=1`
- [x] `git diff --check`
- [x] `make check` status addressed: focused command/config validation above passed; local broader `go test ./cmd/gc ./internal/config` is blocked by unrelated macOS-local main-branch failures (`controller.sock` bind path and init-readiness metadata cases), while `internal/config` passed.
- [x] `make check-docs` not run; no docs, navigation, or links changed.
- [x] `make test-integration` not run; no runtime/controller workflow behavior changed.

## Checklist

- [x] Linked an issue, or explained why one is not needed: closes #757.
- [x] Added or updated tests for behavior changes.
- [x] Updated docs for user-facing changes: not needed; behavior now matches existing pack help docs.
- [x] Called out breaking changes or migration notes: none.
