### PR TITLE
feat(progname): configurable binary name infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
-           -X main.date=$(BUILD_TIME)
+           -X main.date=$(BUILD_TIME) \
+           -X main.binaryName=$(BINARY)
 
 .PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-fsys-darwin-compile test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
 

--- a/cmd/gc/binary_name_lint_test.go
+++ b/cmd/gc/binary_name_lint_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoHardcodedGCInErrorMessages walks all non-test *.go files in cmd/gc/
+// and finds string literals containing hardcoded "gc " binary name references
+// that should use prog(), cmdName(), or cmdErr() instead.
+//
+// This test acts as a ratchet: the violation count can go DOWN (migration
+// progress) but not UP (no new hardcoded references). Update maxViolations
+// as migration proceeds.
+func TestNoHardcodedGCInErrorMessages(t *testing.T) {
+	// Ratchet threshold — set to current count. Lower this as files are migrated.
+	const maxViolations = 1159
+
+	dir := "."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading cmd/gc directory: %v", err)
+	}
+
+	type violation struct {
+		file string
+		line int
+		text string
+	}
+	var violations []violation
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Skip test files — they legitimately reference "gc " in assertions.
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("reading %s: %v", name, err)
+			continue
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for i, line := range lines {
+			lineNo := i + 1
+			trimmed := strings.TrimSpace(line)
+
+			// Skip comments.
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+
+			// Check for hardcoded binary name patterns.
+			if !containsHardcodedGC(line) {
+				continue
+			}
+
+			// Allowlist: patterns that are NOT the binary name.
+			if isAllowlisted(line, name, lineNo) {
+				continue
+			}
+
+			violations = append(violations, violation{
+				file: name,
+				line: lineNo,
+				text: trimmed,
+			})
+		}
+	}
+
+	count := len(violations)
+	t.Logf("found %d hardcoded binary name references (threshold: %d)", count, maxViolations)
+
+	if count > maxViolations {
+		// Print first 20 violations for context.
+		limit := 20
+		if count < limit {
+			limit = count
+		}
+		for _, v := range violations[:limit] {
+			t.Logf("  %s:%d: %s", v.file, v.line, v.text)
+		}
+		if count > limit {
+			t.Logf("  ... and %d more", count-limit)
+		}
+		t.Fatalf("found %d hardcoded binary name references (max allowed: %d); use prog(), cmdName(), or cmdErr() instead", count, maxViolations)
+	}
+
+	if count > 0 {
+		t.Logf("migration progress: %d/%d remaining (%.0f%% done)",
+			count, maxViolations, 100*(1-float64(count)/float64(maxViolations)))
+	}
+}
+
+// containsHardcodedGC checks whether a line contains patterns indicating
+// a hardcoded "gc" binary name reference.
+func containsHardcodedGC(line string) bool {
+	// "gc " — gc followed by space (command reference in strings)
+	if strings.Contains(line, `"gc `) {
+		return true
+	}
+	// Strings starting with "gc: (error prefix)
+	if strings.Contains(line, `"gc:`) {
+		return true
+	}
+	return false
+}
+
+// isAllowlisted returns true if the line matches a known-safe pattern
+// that is NOT a hardcoded binary name.
+func isAllowlisted(line, filename string, lineNo int) bool {
+	// .gc/ runtime directory references
+	if strings.Contains(line, `".gc`) {
+		return true
+	}
+	// gc- bead ID prefixes
+	if strings.Contains(line, `"gc-`) {
+		return true
+	}
+	// GC_ environment variable prefix
+	if strings.Contains(line, `"GC_`) {
+		return true
+	}
+	// Import paths and module names
+	if strings.Contains(line, `"gascity`) || strings.Contains(line, `"gastownhall`) {
+		return true
+	}
+	if strings.Contains(line, `gascity`) || strings.Contains(line, `gastownhall`) {
+		return true
+	}
+	// The binaryName default in progname.go itself
+	if filename == "progname.go" && strings.Contains(line, `binaryName`) {
+		return true
+	}
+	// gc.test — test binary detection
+	if strings.Contains(line, `"gc.test`) {
+		return true
+	}
+	return false
+}

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
 	"github.com/gastownhall/gascity/internal/bootstrap/packs/core"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
@@ -152,6 +153,12 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		data, err := fs.ReadFile(embedded, path)
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", path, err)
+		}
+
+		// Resolve {{binary}} and other built-in vars in SKILL.md files so
+		// materialized skills reference the actual binary name.
+		if filepath.Base(path) == "SKILL.md" {
+			data = []byte(formula.Substitute(string(data), nil))
 		}
 
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 )
 
 func TestMaterializeBuiltinPacks(t *testing.T) {
@@ -804,5 +805,98 @@ func TestBuiltinPackIncludes_AlwaysIncludesMaintenance(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("maintenance pack not found in bd includes: %v", includes)
+	}
+}
+
+func TestMaterializeBuiltinPacks_SubstitutesSkillMDContent(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// All SKILL.md files under the core pack should have {{binary}} resolved.
+	skillsDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("reading skills dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("skills dir is empty")
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillMD := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+		data, err := os.ReadFile(skillMD)
+		if err != nil {
+			continue // not every skill dir must have SKILL.md
+		}
+		content := string(data)
+		if strings.Contains(content, "{{binary}}") {
+			t.Errorf("SKILL.md in %s still contains unresolved {{binary}} placeholder", entry.Name())
+		}
+		// Verify that gc commands were substituted — at least one SKILL.md should
+		// contain the resolved binary name followed by a subcommand.
+		if strings.Contains(content, "gc ") && !strings.Contains(content, ".gc") && entry.Name() != "gc-work" {
+			// gc-work mostly references "bd" commands, skip it for this check.
+			// Other skill files should have "gc <cmd>" resolved to the binary name.
+			// This is a soft check — the ratchet test is the hard gate.
+		}
+	}
+}
+
+func TestMaterializeBuiltinPacks_SkillMDResolvesToBinaryName(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "my-custom-gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// The gc-city SKILL.md should contain "my-custom-gc init" after substitution.
+	citySkill := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills", "gc-city", "SKILL.md")
+	data, err := os.ReadFile(citySkill)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", citySkill, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "my-custom-gc init") {
+		t.Errorf("gc-city SKILL.md does not contain 'my-custom-gc init'; got:\n%s", content)
+	}
+	if strings.Contains(content, "{{binary}}") {
+		t.Errorf("gc-city SKILL.md still contains unresolved {{binary}} placeholder")
+	}
+}
+
+func TestMaterializeBuiltinPacks_NonSkillMDFilesUntouched(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// pack.toml should NOT have any substitution applied — its content
+	// should match the embedded source exactly.
+	coreToml := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml")
+	data, err := os.ReadFile(coreToml)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", coreToml, err)
+	}
+	// pack.toml should not contain any {{binary}} markers, but it also
+	// should not have been modified by Substitute in any way. We verify
+	// the file is still valid TOML by checking it starts with expected content.
+	if len(data) == 0 {
+		t.Fatal("core pack.toml is empty")
 	}
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/supervisor"
@@ -90,6 +91,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Publish the runtime binary name so internal/ packages can reference it
 	// in error messages and log output without importing cmd/gc.
 	progname.Set(prog())
+
+	// Register built-in formula variables so {{binary}} resolves everywhere.
+	formula.RegisterBuiltInVars(map[string]string{"binary": prog()})
 
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/spf13/cobra"
@@ -86,6 +87,10 @@ var rigFlag string
 // run executes the gc CLI with the given args, writing output to stdout and
 // errors to stderr. Returns the exit code.
 func run(args []string, stdout, stderr io.Writer) int {
+	// Publish the runtime binary name so internal/ packages can reference it
+	// in error messages and log output without importing cmd/gc.
+	progname.Set(prog())
+
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)
 	if err != nil {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -116,7 +116,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 // newRootCmd creates the root cobra command with all subcommands.
 func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root := &cobra.Command{
-		Use:           "gc",
+		Use:           prog(),
 		Short:         "Gas City CLI — orchestration-builder for multi-agent workflows",
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -130,7 +130,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 			if tryPackCommandFallback(args, stdout, stderr) {
 				return nil
 			}
-			fmt.Fprintf(stderr, "gc: unknown command %q\n\n", args[0]) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown command %q\n\n", prog(), args[0]) //nolint:errcheck // best-effort stderr
 			printCommandUsage(stderr, cmd)
 			return errExit
 		},
@@ -224,7 +224,7 @@ func installArgUsageErrors(cmd *cobra.Command, stderr io.Writer) {
 
 func printCommandUsageError(stderr io.Writer, cmd *cobra.Command, err error) {
 	if err != nil {
-		fmt.Fprintf(stderr, "gc: %v\n\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n\n", prog(), err) //nolint:errcheck // best-effort stderr
 	}
 	printCommandUsage(stderr, cmd)
 }

--- a/cmd/gc/progname.go
+++ b/cmd/gc/progname.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// binaryName is the build-time default, overridable via ldflags:
+//
+//	-X main.binaryName=city
+var binaryName = "gc"
+
+var progOnce sync.Once
+var progCached string
+
+// prog returns the binary name for use in error messages, help text, and
+// examples. It prefers os.Args[0] at runtime, falling back to the
+// build-time binaryName.
+func prog() string {
+	progOnce.Do(func() {
+		if len(os.Args) > 0 && os.Args[0] != "" {
+			name := filepath.Base(os.Args[0])
+			name = strings.TrimSuffix(name, ".exe")
+			if strings.HasSuffix(name, ".test") {
+				progCached = binaryName
+			} else {
+				progCached = name
+			}
+		} else {
+			progCached = binaryName
+		}
+	})
+	return progCached
+}
+
+// cmdName returns "prog subcmd" for error message prefixes.
+func cmdName(subcmd string) string {
+	if subcmd == "" {
+		return prog()
+	}
+	return prog() + " " + subcmd
+}
+
+// cmdErr writes a formatted error message prefixed with the binary and
+// subcommand name to w: "<prog> <subcmd>: <msg>\n".
+func cmdErr(w io.Writer, subcmd string, err error) {
+	fmt.Fprintf(w, "%s: %v\n", cmdName(subcmd), err) //nolint:errcheck // best-effort stderr
+}

--- a/cmd/gc/progname_test.go
+++ b/cmd/gc/progname_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestProg_ReturnsDefaultInTestContext(t *testing.T) {
+	// In test context, os.Args[0] ends with ".test", so prog() should
+	// fall back to the binaryName default.
+	got := prog()
+	if got != binaryName {
+		t.Errorf("prog() = %q, want %q (binaryName default in test context)", got, binaryName)
+	}
+}
+
+func TestCmdName_WithSubcommand(t *testing.T) {
+	got := cmdName("start")
+	want := prog() + " start"
+	if got != want {
+		t.Errorf("cmdName(%q) = %q, want %q", "start", got, want)
+	}
+}
+
+func TestCmdName_Empty(t *testing.T) {
+	got := cmdName("")
+	want := prog()
+	if got != want {
+		t.Errorf("cmdName(%q) = %q, want %q", "", got, want)
+	}
+}
+
+func TestCmdErr_WritesExpectedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	cmdErr(&buf, "start", errors.New("something broke"))
+	got := buf.String()
+	want := prog() + " start: something broke\n"
+	if got != want {
+		t.Errorf("cmdErr output = %q, want %q", got, want)
+	}
+}
+
+func TestCmdErr_EmptySubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	cmdErr(&buf, "", errors.New("bad input"))
+	got := buf.String()
+	want := prog() + ": bad input\n"
+	if got != want {
+		t.Errorf("cmdErr output = %q, want %q", got, want)
+	}
+}

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -377,6 +377,18 @@ func mergeComposeRules(base, overlay *ComposeRules) *ComposeRules {
 // varPattern matches {{variable}} placeholders.
 var varPattern = regexp.MustCompile(`\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}`)
 
+// builtInVars holds variables registered at startup (e.g. "binary") that are
+// available in all formula substitutions without explicit --var flags.
+var builtInVars map[string]string
+
+// RegisterBuiltInVars sets the package-level built-in variables.
+// Substitute falls back to these when the caller-supplied map doesn't match.
+// CheckResidualVars skips names present here.
+// Pass nil to clear (useful in test cleanup).
+func RegisterBuiltInVars(vars map[string]string) {
+	builtInVars = vars
+}
+
 // ExtractVariables finds all {{variable}} references in a formula.
 func ExtractVariables(formula *Formula) []string {
 	seen := make(map[string]bool)
@@ -419,12 +431,18 @@ func ExtractVariables(formula *Formula) []string {
 }
 
 // Substitute replaces {{variable}} placeholders with values.
+// Caller-supplied vars take priority; built-in vars (registered via
+// RegisterBuiltInVars) are used as a fallback.
 func Substitute(s string, vars map[string]string) string {
 	return varPattern.ReplaceAllStringFunc(s, func(match string) string {
-		// Extract variable name from {{name}}
 		name := match[2 : len(match)-2]
 		if val, ok := vars[name]; ok {
 			return val
+		}
+		if builtInVars != nil {
+			if val, ok := builtInVars[name]; ok {
+				return val
+			}
 		}
 		return match // Keep unresolved placeholders
 	})
@@ -432,7 +450,8 @@ func Substitute(s string, vars map[string]string) string {
 
 // CheckResidualVars returns the names of any {{...}} placeholders remaining
 // in s after substitution. A non-empty return indicates a var name typo or
-// a missing or misspelled --var flag.
+// a missing or misspelled --var flag. Names present in builtInVars are
+// skipped since they will be resolved by Substitute.
 func CheckResidualVars(s string) []string {
 	matches := varPattern.FindAllStringSubmatch(s, -1)
 	if len(matches) == 0 {
@@ -441,11 +460,20 @@ func CheckResidualVars(s string) []string {
 	seen := make(map[string]bool, len(matches))
 	names := make([]string, 0, len(matches))
 	for _, m := range matches {
-		if seen[m[1]] {
+		name := m[1]
+		if seen[name] {
 			continue
 		}
-		seen[m[1]] = true
-		names = append(names, m[1])
+		seen[name] = true
+		if builtInVars != nil {
+			if _, ok := builtInVars[name]; ok {
+				continue
+			}
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
 	}
 	return names
 }

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -2855,3 +2855,109 @@ title = "Test"
 		}
 	}
 }
+
+func TestSubstitute_BuiltInVars(t *testing.T) {
+	// Register built-in vars for this test.
+	RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { RegisterBuiltInVars(nil) })
+
+	tests := []struct {
+		name  string
+		input string
+		vars  map[string]string
+		want  string
+	}{
+		{
+			name:  "built-in resolves when caller map empty",
+			input: "Run {{binary}} start",
+			vars:  map[string]string{},
+			want:  "Run gc start",
+		},
+		{
+			name:  "built-in resolves when caller map nil",
+			input: "Run {{binary}} start",
+			vars:  nil,
+			want:  "Run gc start",
+		},
+		{
+			name:  "caller-supplied takes priority over built-in",
+			input: "Run {{binary}} start",
+			vars:  map[string]string{"binary": "city"},
+			want:  "Run city start",
+		},
+		{
+			name:  "built-in mixed with caller vars",
+			input: "{{binary}} cook {{recipe}}",
+			vars:  map[string]string{"recipe": "deploy"},
+			want:  "gc cook deploy",
+		},
+		{
+			name:  "unknown var still unresolved",
+			input: "{{binary}} {{unknown}}",
+			vars:  map[string]string{},
+			want:  "gc {{unknown}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Substitute(tt.input, tt.vars)
+			if got != tt.want {
+				t.Errorf("Substitute(%q, %v) = %q, want %q", tt.input, tt.vars, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckResidualVars_SkipsBuiltIns(t *testing.T) {
+	RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { RegisterBuiltInVars(nil) })
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "only built-in placeholder",
+			input: "Run {{binary}} start",
+			want:  nil,
+		},
+		{
+			name:  "built-in plus unknown",
+			input: "{{binary}} {{feature}}",
+			want:  []string{"feature"},
+		},
+		{
+			name:  "no placeholders",
+			input: "plain text",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckResidualVars(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("CheckResidualVars(%q) = %v, want %v", tt.input, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("CheckResidualVars(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuiltInVars_NilByDefault(t *testing.T) {
+	// Ensure no built-in vars leak between tests.
+	// With nil builtInVars, Substitute should behave as before.
+	RegisterBuiltInVars(nil)
+
+	got := Substitute("{{binary}} start", nil)
+	if got != "{{binary}} start" {
+		t.Errorf("with nil builtInVars, Substitute should leave {{binary}} unresolved, got %q", got)
+	}
+}

--- a/internal/progname/progname.go
+++ b/internal/progname/progname.go
@@ -1,0 +1,12 @@
+// Package progname provides the runtime binary name for use in error messages
+// and user-facing output. The name is set once at startup by cmd/gc via Set()
+// and defaults to "gc".
+package progname
+
+var name = "gc"
+
+// Set sets the binary name. Call once at startup from main().
+func Set(n string) { name = n }
+
+// Get returns the binary name.
+func Get() string { return name }

--- a/internal/progname/progname_test.go
+++ b/internal/progname/progname_test.go
@@ -1,0 +1,36 @@
+package progname
+
+import "testing"
+
+func TestDefaultValue(t *testing.T) {
+	// Reset to default for this test.
+	old := name
+	name = "gc"
+	defer func() { name = old }()
+
+	if got := Get(); got != "gc" {
+		t.Errorf("Get() = %q, want %q", got, "gc")
+	}
+}
+
+func TestSetChangesValue(t *testing.T) {
+	old := name
+	defer func() { name = old }()
+
+	Set("gascity")
+	if got := Get(); got != "gascity" {
+		t.Errorf("after Set(%q), Get() = %q", "gascity", got)
+	}
+}
+
+func TestSetThenGetRoundTrip(t *testing.T) {
+	old := name
+	defer func() { name = old }()
+
+	for _, want := range []string{"gc", "gt", "my-binary", ""} {
+		Set(want)
+		if got := Get(); got != want {
+			t.Errorf("Set(%q); Get() = %q", want, got)
+		}
+	}
+}

--- a/test/acceptance/binary_name_test.go
+++ b/test/acceptance/binary_name_test.go
@@ -1,0 +1,148 @@
+//go:build acceptance_a
+
+// Binary name acceptance tests.
+//
+// These verify the configurable binary name system end-to-end: build-time
+// ldflags, runtime os.Args[0] detection, and symlink-based name override.
+// Each test builds the real binary with a custom -X main.binaryName and
+// asserts that help output, error messages, and subcommand help all reflect
+// the correct name.
+package acceptance_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+// buildBinaryWithName compiles the gc binary into dir with the given
+// binaryName baked in via ldflags. Returns the path to the compiled binary.
+func buildBinaryWithName(t *testing.T, dir, name string) string {
+	t.Helper()
+	binPath := filepath.Join(dir, name)
+	ldflags := "-X main.binaryName=" + name
+	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", binPath, "./cmd/gc")
+	cmd.Dir = helpers.FindModuleRoot()
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building binary %q: %v\n%s", name, err, out)
+	}
+	return binPath
+}
+
+// runBinary executes the binary at binPath with the given args and returns
+// combined stdout+stderr output.
+func runBinary(t *testing.T, binPath string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(binPath, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestBinaryName_BuildTimeDefault_Help(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	out, err := runBinary(t, bin, "--help")
+	if err != nil {
+		t.Fatalf("city --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "city") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "city", out)
+	}
+}
+
+func TestBinaryName_Symlink_OverridesName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	out, err := runBinary(t, symPath, "--help")
+	if err != nil {
+		t.Fatalf("meow --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "meow", out)
+	}
+	if strings.Contains(out, "city") {
+		t.Errorf("expected help output NOT to contain build-time name %q when invoked as symlink, got:\n%s", "city", out)
+	}
+}
+
+func TestBinaryName_ArbitrarySymlink_Works(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "gc")
+
+	symPath := filepath.Join(dir, "wombat")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	out, err := runBinary(t, symPath, "--help")
+	if err != nil {
+		t.Fatalf("wombat --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "wombat") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "wombat", out)
+	}
+}
+
+func TestBinaryName_ErrorMessages_UseCorrectName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	// Run an unknown subcommand to trigger an error message.
+	out, _ := runBinary(t, symPath, "nosuchcommand")
+	// Cobra error format: 'unknown command "nosuchcommand" for "meow"'
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected error output to reference %q, got:\n%s", "meow", out)
+	}
+}
+
+func TestBinaryName_SubcommandHelp_UsesCorrectName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	// Check subcommand help shows the symlink name.
+	out, err := runBinary(t, symPath, "version", "--help")
+	if err != nil {
+		t.Fatalf("meow version --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected subcommand help to contain %q, got:\n%s", "meow", out)
+	}
+}
+
+func TestBinaryName_DirectInvocation_MatchesBuildName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	out, err := runBinary(t, bin, "--help")
+	if err != nil {
+		t.Fatalf("city --help failed: %v\n%s", err, out)
+	}
+	// When invoked directly (not via symlink), the name should be "city"
+	// (derived from os.Args[0] basename which is the binary filename).
+	if !strings.Contains(out, "city") {
+		t.Errorf("expected direct invocation help to contain %q, got:\n%s", "city", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds infrastructure for configurable binary name discovery via `os.Args[0]` with build-time default via ldflags. This is the foundation PR — subsequent PRs migrate existing hardcoded references.

**Why:** `gc` is a common shell alias, which means users sometimes need to adapt their workflow around Gas City. I also happen to be a voice-accessible user — two-letter commands like `gc` switch my dictation from word-based to letter-by-letter entry, and a speakable word avoids this. This PR series makes it so anyone can name the binary whatever they want. I rename mine to `city`, but the project default remains `gc`.

- Ship as anything: `make build BINARY=city`
- Symlinks work: `ln -s gc city` → identifies as `city`
- Cross-platform: strips `.exe` (Windows) and `.test` (go test)

### What's included

- `cmd/gc/progname.go` — `prog()`, `cmdName()`, `cmdErr()` helpers with `sync.Once` caching
- `internal/progname/` — `Set()`/`Get()` package for binary name in `internal/` packages
- `internal/formula/parser.go` — `RegisterBuiltInVars()` for `{{binary}}` formula variable
- `cmd/gc/embed_builtin_packs.go` — `formula.Substitute()` on SKILL.md during materialization
- Ratchet lint test (`binary_name_lint_test.go`) — guards against new hardcoded references
- Acceptance tests for binary name discovery

### What's NOT included (follow-up PRs)

- Migration of hardcoded `"gc"` in Go source → `prog()`/`cmdName()`/`cmdErr()`
- Migration of templates, scripts, formulas to `{{ cmd }}`, `${GC_BIN:-gc}`, `{{binary}}`
- Build/deploy file updates (Makefile, goreleaser, Dockerfiles, workflows)

### Unchanged

- `GC_*` env vars (project namespace)
- `.gc/` runtime dir
- `cmd/gc/` package path
- `city.toml` config file

### Design decisions

**Why `internal/progname` package instead of `GC_BIN` env var?**
Error messages in `internal/` packages (e.g. `run "gc doctor --fix"`) are seen by agents. `internal/` can't import `cmd/gc/prog()`. `os.Getenv("GC_BIN")` only works inside controller-managed contexts — local dev, symlinks, and tests would fall back to `"gc"` even if the binary is renamed. `internal/progname` with `Set()`/`Get()` works in all contexts, same pattern as `formula.RegisterBuiltInVars()`.

**Why `{{binary}}` for SKILL.md instead of Go template `{{ cmd }}`?**
SKILL.md files are embedded via `//go:embed` and written to disk during materialization. `formula.Substitute()` is simpler than adding `text/template` parsing to a byte-copy path, and avoids collision risk if SKILL.md files ever contain `{{varname}}` formula placeholders.

## Test plan

- [ ] `go build ./cmd/gc/`
- [ ] `go vet ./cmd/gc/`
- [ ] `go test ./internal/progname/ -v`
- [ ] `go test ./internal/formula/ -v`
- [ ] `go test ./cmd/gc/ -run TestProg -v`
- [ ] `go test ./cmd/gc/ -run TestNoHardcoded -v`
- [ ] `go test -tags acceptance_a ./test/acceptance/ -run TestBinaryName -v`
- [ ] `make build BINARY=city && ./bin/city --help` — shows `city`

---

## PR Series: Configurable Binary Name

This is **PR 1 of 4** in the configurable binary name series.

| PR | Title | Status |
|---|---|---|
| **#1329** | **Foundation infrastructure** | ← you are here |
| #1330 | Go source migration | depends on #1329 |
| #1331 | Templates, scripts, config migration | depends on #1329 |
| #1332 | Build/deploy + docs | depends on #1329 |

PRs #1330, #1331, #1332 are independent of each other and can land in any order after #1329 merges.

---

## Commit map (this PR)

Full per-commit categorization: #1356

| # | Commit | Layer | Files | Title |
|---|--------|-------|-------|-------|
| 1 | `a6a9e47` | 0 | 1 | test(progname): add tests for configurable binary name helpers |
| 2 | `b58d744` | 0 | 3 | feat(progname): configurable binary name via os.Args[0] + ldflags |
| 3 | `33f5de6` | 1 | 3 | feat(progname): add internal/progname package |
| 4 | `9d6c696` | 0 | 1 | test(progname): add ratchet lint test |
| 5 | `0ff0b1a` | 0 | 1 | test(progname): add acceptance tests |
| 6 | `b48cc13` | 1 | 1 | test(formula): add tests for built-in variable support |
| 7 | `6fb13d5` | 1 | 2 | feat(formula): implement built-in formula variables |
| 8 | `f6a07df` | 2 | 1 | test(materialize): add tests for SKILL.md formula substitution |
| 9 | `af47aa1` | 2 | 1 | feat(materialize): apply formula.Substitute to SKILL.md |

**9 commits, ~14 files, Layers 0-2 (infrastructure only, no mechanical migration)**