### PR TITLE
refactor(progname): migrate Go source to configurable binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
-           -X main.date=$(BUILD_TIME)
+           -X main.date=$(BUILD_TIME) \
+           -X main.binaryName=$(BINARY)
 
 .PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-fsys-darwin-compile test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
 

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -442,7 +442,7 @@ func (cs *controllerState) Orders() []orders.Order {
 	cfg := cs.cfg
 	cs.mu.RUnlock()
 
-	allAA, err := scanAllOrders(cs.cityPath, cfg, io.Discard, "gc api: order scan")
+	allAA, err := scanAllOrders(cs.cityPath, cfg, io.Discard, cmdName("api: order scan"))
 	if err != nil {
 		return nil
 	}

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -1377,7 +1377,7 @@ func runProviderOpWithEnv(script string, environ []string, args ...string) error
 		}
 		// Detect missing script or missing dolt binary.
 		if errors.Is(err, exec.ErrNotFound) {
-			return fmt.Errorf("exec beads %s: provider script not found (%s); run \"gc doctor\" for diagnostics", args[0], script)
+			return fmt.Errorf("exec beads %s: provider script not found (%s); run \"%s\" for diagnostics", args[0], script, cmdName("doctor"))
 		}
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {

--- a/cmd/gc/binary_name_lint_test.go
+++ b/cmd/gc/binary_name_lint_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoHardcodedGCInErrorMessages walks all non-test *.go files in cmd/gc/
+// and finds string literals containing hardcoded "gc " binary name references
+// that should use prog(), cmdName(), or cmdErr() instead.
+//
+// This test acts as a ratchet: the violation count can go DOWN (migration
+// progress) but not UP (no new hardcoded references). Update maxViolations
+// as migration proceeds.
+func TestNoHardcodedGCInErrorMessages(t *testing.T) {
+	// Ratchet threshold — set to current count. Lower this as files are migrated.
+	const maxViolations = 1159
+
+	dir := "."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading cmd/gc directory: %v", err)
+	}
+
+	type violation struct {
+		file string
+		line int
+		text string
+	}
+	var violations []violation
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Skip test files — they legitimately reference "gc " in assertions.
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("reading %s: %v", name, err)
+			continue
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for i, line := range lines {
+			lineNo := i + 1
+			trimmed := strings.TrimSpace(line)
+
+			// Skip comments.
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+
+			// Check for hardcoded binary name patterns.
+			if !containsHardcodedGC(line) {
+				continue
+			}
+
+			// Allowlist: patterns that are NOT the binary name.
+			if isAllowlisted(line, name, lineNo) {
+				continue
+			}
+
+			violations = append(violations, violation{
+				file: name,
+				line: lineNo,
+				text: trimmed,
+			})
+		}
+	}
+
+	count := len(violations)
+	t.Logf("found %d hardcoded binary name references (threshold: %d)", count, maxViolations)
+
+	if count > maxViolations {
+		// Print first 20 violations for context.
+		limit := 20
+		if count < limit {
+			limit = count
+		}
+		for _, v := range violations[:limit] {
+			t.Logf("  %s:%d: %s", v.file, v.line, v.text)
+		}
+		if count > limit {
+			t.Logf("  ... and %d more", count-limit)
+		}
+		t.Fatalf("found %d hardcoded binary name references (max allowed: %d); use prog(), cmdName(), or cmdErr() instead", count, maxViolations)
+	}
+
+	if count > 0 {
+		t.Logf("migration progress: %d/%d remaining (%.0f%% done)",
+			count, maxViolations, 100*(1-float64(count)/float64(maxViolations)))
+	}
+}
+
+// containsHardcodedGC checks whether a line contains patterns indicating
+// a hardcoded "gc" binary name reference.
+func containsHardcodedGC(line string) bool {
+	// "gc " — gc followed by space (command reference in strings)
+	if strings.Contains(line, `"gc `) {
+		return true
+	}
+	// Strings starting with "gc: (error prefix)
+	if strings.Contains(line, `"gc:`) {
+		return true
+	}
+	return false
+}
+
+// isAllowlisted returns true if the line matches a known-safe pattern
+// that is NOT a hardcoded binary name.
+func isAllowlisted(line, filename string, lineNo int) bool {
+	// .gc/ runtime directory references
+	if strings.Contains(line, `".gc`) {
+		return true
+	}
+	// gc- bead ID prefixes
+	if strings.Contains(line, `"gc-`) {
+		return true
+	}
+	// GC_ environment variable prefix
+	if strings.Contains(line, `"GC_`) {
+		return true
+	}
+	// Import paths and module names
+	if strings.Contains(line, `"gascity`) || strings.Contains(line, `"gastownhall`) {
+		return true
+	}
+	if strings.Contains(line, `gascity`) || strings.Contains(line, `gastownhall`) {
+		return true
+	}
+	// The binaryName default in progname.go itself
+	if filename == "progname.go" && strings.Contains(line, `binaryName`) {
+		return true
+	}
+	// gc.test — test binary detection
+	if strings.Contains(line, `"gc.test`) {
+		return true
+	}
+	return false
+}

--- a/cmd/gc/binary_name_lint_test.go
+++ b/cmd/gc/binary_name_lint_test.go
@@ -16,7 +16,7 @@ import (
 // as migration proceeds.
 func TestNoHardcodedGCInErrorMessages(t *testing.T) {
 	// Ratchet threshold — set to current count. Lower this as files are migrated.
-	const maxViolations = 1159
+	const maxViolations = 0
 
 	dir := "."
 	entries, err := os.ReadDir(dir)

--- a/cmd/gc/binary_name_lint_test.go
+++ b/cmd/gc/binary_name_lint_test.go
@@ -109,6 +109,10 @@ func containsHardcodedGC(line string) bool {
 	if strings.Contains(line, `"gc `) {
 		return true
 	}
+	// Short/Long field with "gc" as binary name mid-string
+	if (strings.Contains(line, "Short:") || strings.Contains(line, "Long:")) && strings.Contains(line, " gc ") {
+		return true
+	}
 	// Strings starting with "gc: (error prefix)
 	if strings.Contains(line, `"gc:`) {
 		return true

--- a/cmd/gc/chat_autosuspend.go
+++ b/cmd/gc/chat_autosuspend.go
@@ -27,13 +27,13 @@ func autoSuspendChatSessions(store beads.Store, sp runtime.Provider, idleTimeout
 	}
 	catalog, err := workerSessionCatalogWithConfig(cityPath, store, sp, cfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: auto-suspend catalog: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start: auto-suspend catalog", err)
 		return
 	}
 
 	sessions, err := catalog.List("active", "")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: auto-suspend list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start: auto-suspend list", err)
 		return
 	}
 

--- a/cmd/gc/chat_autosuspend.go
+++ b/cmd/gc/chat_autosuspend.go
@@ -53,11 +53,11 @@ func autoSuspendChatSessions(store beads.Store, sp runtime.Provider, idleTimeout
 
 		handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, s.ID)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc start: auto-suspend session %s: %v\n", s.ID, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: auto-suspend session %s: %v\n", cmdName("start"), s.ID, err) //nolint:errcheck // best-effort stderr
 			continue
 		}
 		if err := handle.Stop(context.TODO()); err != nil {
-			fmt.Fprintf(stderr, "gc start: auto-suspend session %s: %v\n", s.ID, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: auto-suspend session %s: %v\n", cmdName("start"), s.ID, err) //nolint:errcheck // best-effort stderr
 		} else {
 			fmt.Fprintf(stdout, "Session %s auto-suspended (idle %s).\n", s.ID, formatDuration(now.Sub(s.LastActive))) //nolint:errcheck // best-effort stdout
 		}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -165,11 +165,11 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 	// Retry with backoff as defense-in-depth against transient store
 	// errors immediately after ensureBeadsProvider returns (#753).
 	if sweepStore, err := openStoreAtForCity(p.CityPath, p.CityPath); err != nil {
-		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(p.Stderr, "%s: order tracking sweep: %v\n", cmdName("start"), err) //nolint:errcheck // best-effort stderr
 	} else if n, err := sweepOrphanedOrderTrackingRetry(sweepStore, 3, time.Second); err != nil {
-		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(p.Stderr, "%s: order tracking sweep (closed %d): %v\n", cmdName("start"), n, err) //nolint:errcheck // best-effort stderr
 	} else if n > 0 {
-		fmt.Fprintf(p.Stderr, "gc start: closed %d orphaned order-tracking beads\n", n) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(p.Stderr, "%s: closed %d orphaned order-tracking beads\n", cmdName("start"), n) //nolint:errcheck // best-effort stderr
 	}
 
 	od := buildOrderDispatcher(p.CityPath, p.Cfg, p.Rec, p.Stderr)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -82,7 +82,7 @@ type CityRuntime struct {
 	onStatus            func(string)
 
 	shutdownOnce   sync.Once
-	logPrefix      string // "gc start" or "gc supervisor"
+	logPrefix      string // cmdName("start") or cmdName("supervisor")
 	stdout, stderr io.Writer
 }
 
@@ -124,7 +124,7 @@ type CityRuntimeParams struct {
 	OnStarted           func()                  // called after initial reconciliation succeeds
 	OnStatus            func(string)            // called when init status changes
 
-	LogPrefix      string // "gc start" or "gc supervisor"; defaults to "gc start"
+	LogPrefix      string // cmdName("start") or cmdName("supervisor"); defaults to cmdName("start")
 	Stdout, Stderr io.Writer
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1764,7 +1764,7 @@ func buildStandaloneRigStores(cfg *config.City, cityPath string, stderr io.Write
 		}
 		store, err := openStoreAtForCity(rig.Path, cityPath)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc supervisor: rig bead store %q: %v\n", rig.Name, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rig bead store %q: %v\n", cmdName("supervisor"), rig.Name, err) //nolint:errcheck // best-effort stderr
 			continue
 		}
 		stores[rig.Name] = store

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -178,7 +178,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 
 	logPrefix := p.LogPrefix
 	if logPrefix == "" {
-		logPrefix = "gc start"
+		logPrefix = cmdName("start")
 	}
 
 	cr := &CityRuntime{

--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -49,7 +49,7 @@ func openCityStatusStore(cityPath string, stderr io.Writer) (beads.Store, int) {
 	}
 	opened, err := openCityStoreAtForStatus(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc status: opening bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "status: opening bead store", err)
 		return nil, 1
 	}
 	return opened, 0

--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -110,7 +110,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			headerShown := false
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, snapshot.CityName, cfg.Workspace.SessionTemplate, sp) {
 				sn := cliSessionName(cityPath, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
-				obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
+				obs := observeSessionTargetWithWarning(cmdName("status"), cityPath, store, sp, cfg, sn, stderr)
 				_, instanceName := config.ParseQualifiedName(qualifiedInstance)
 				row := cityStatusAgentRow{
 					Agent: StatusAgentJSON{
@@ -140,7 +140,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 		}
 
 		sn := cliSessionName(cityPath, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-		obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
+		obs := observeSessionTargetWithWarning(cmdName("status"), cityPath, store, sp, cfg, sn, stderr)
 		snapshot.Agents = append(snapshot.Agents, cityStatusAgentRow{
 			Agent: StatusAgentJSON{
 				Name:          a.Name,

--- a/cmd/gc/cityinit_impl.go
+++ b/cmd/gc/cityinit_impl.go
@@ -433,7 +433,7 @@ func (localInitializer) Init(_ context.Context, req cityinit.InitRequest) (*city
 	if code := finalizeInit(dir, io.Discard, io.Discard, initFinalizeOptions{
 		skipProviderReadiness: req.SkipProviderReadiness,
 		showProgress:          false,
-		commandName:           "gc init",
+		commandName:           cmdName("init"),
 	}); code != 0 {
 		// finalizeInit's current contract is "blocked, check
 		// stderr". Without a structured return type we can't map

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -372,10 +372,10 @@ func newAgentCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Manage agent configuration",
-		Long: `Manage agent configuration in city.toml.
+		Long: fmt.Sprintf(`Manage agent configuration in city.toml.
 
 Runtime operations (attach, list, peek, nudge, kill, start, stop, destroy)
-have moved to "gc session" and "gc runtime".`,
+have moved to "%s session" and "%s runtime".`, prog(), prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -523,11 +523,11 @@ func newAgentSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "suspend <name>",
 		Short: "Suspend an agent (reconciler will skip it)",
-		Long: `Suspend an agent by setting suspended=true in its durable config.
+		Long: fmt.Sprintf(`Suspend an agent by setting suspended=true in its durable config.
 
 Suspended agents are skipped by the reconciler — their sessions are not
 started or restarted. Existing sessions continue running but won't be
-replaced if they exit. Use "gc agent resume" to restore.`,
+replaced if they exit. Use "%s agent resume" to restore.`, prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdAgentSuspend(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -379,9 +379,9 @@ have moved to "gc session" and "gc runtime".`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc agent: missing subcommand (add, suspend, resume)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (add, suspend, resume)\n", cmdName("agent")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc agent: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("agent"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -432,7 +432,7 @@ agent in a suspended state.`,
 // the city root and delegates to doAgentAdd.
 func cmdAgentAdd(name, promptTemplate, dir string, suspended bool, stdout, stderr io.Writer) int {
 	if name == "" {
-		fmt.Fprintln(stderr, "gc agent add: missing --name flag") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing --name flag\n", cmdName("agent add")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath, err := resolveCity()
@@ -450,7 +450,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	packPath := filepath.Join(cityPath, "pack.toml")
 	if _, err := fs.Stat(packPath); err != nil {
-		fmt.Fprintln(stderr, "gc agent add: this command requires a city directory with pack.toml; run \"gc doctor\" or \"gc doctor --fix\" to migrate this city first") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: this command requires a city directory with pack.toml; run \"gc doctor\" or \"gc doctor --fix\" to migrate this city first\n", cmdName("agent add")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -468,7 +468,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 	}
 	for _, a := range cfg.Agents {
 		if a.Name == name {
-			fmt.Fprintf(stderr, "gc agent add: agent %q already exists\n", name) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: agent %q already exists\n", cmdName("agent add"), name) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -488,7 +488,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 		var err error
 		promptData, err = fs.ReadFile(src)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc agent add: reading prompt template %q: %v\n", promptTemplate, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: reading prompt template %q: %v\n", cmdName("agent add"), promptTemplate, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	} else {
@@ -541,7 +541,7 @@ replaced if they exit. Use "gc agent resume" to restore.`,
 // cmdAgentSuspend is the CLI entry point for suspending an agent.
 func cmdAgentSuspend(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc agent suspend: missing agent name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing agent name\n", cmdName("agent suspend")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath, err := resolveCity()
@@ -594,7 +594,7 @@ names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 // cmdAgentResume is the CLI entry point for resuming a suspended agent.
 func cmdAgentResume(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc agent resume: missing agent name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing agent name\n", cmdName("agent resume")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath, err := resolveCity()
@@ -646,7 +646,7 @@ func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, s
 	// Phase 1: load raw config (no expansion) for safe write-back.
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("agent "+verb), err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -660,14 +660,14 @@ func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, s
 			}
 		}
 		if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
-			fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: %v\n", cmdName("agent "+verb), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		fmt.Fprintf(stdout, "%s agent '%s'\n", past, name) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 	if updated, err := updateRootPackAgentSuspended(fs, cityPath, cfg, name, suspended); err != nil {
-		fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("agent "+verb), err) //nolint:errcheck // best-effort stderr
 		return 1
 	} else if updated {
 		fmt.Fprintf(stdout, "%s agent '%s'\n", past, name) //nolint:errcheck // best-effort stdout
@@ -677,17 +677,17 @@ func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, s
 	// Phase 2: not in raw config — check expanded config for provenance.
 	expanded, err := loadCityConfigFS(fs, tomlPath, stderr)
 	if err != nil {
-		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent "+verb, name, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, agentNotFoundMsg(cmdName("agent "+verb), name, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	resolved, ok := resolveAgentIdentity(expanded, name, currentRigContext(expanded))
 	if !ok {
-		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent "+verb, name, expanded)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, agentNotFoundMsg(cmdName("agent "+verb), name, expanded)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if configedit.LocalDiscoveredAgent(fs, cityPath, resolved) {
 		if err := configedit.WriteLocalDiscoveredAgentSuspended(fs, cityPath, resolved, suspended); err != nil {
-			fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: %v\n", cmdName("agent "+verb), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		// Also strip any pre-existing [[patches.agent]] suspended override
@@ -697,13 +697,13 @@ func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, s
 		// patch.
 		if configedit.StripAgentPatchSuspended(cfg, resolved.QualifiedName()) {
 			if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
-				fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: %v\n", cmdName("agent "+verb), err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 		}
 		fmt.Fprintf(stdout, "%s agent '%s'\n", past, name) //nolint:errcheck // best-effort stdout
 		return 0
 	}
-	fmt.Fprintf(stderr, "gc agent %s: agent %q is defined by a pack — use [[patches]] to override\n", verb, name) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: agent %q is defined by a pack — use [[patches]] to override\n", cmdName("agent "+verb), name) //nolint:errcheck // best-effort stderr
 	return 1
 }

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -450,7 +450,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	packPath := filepath.Join(cityPath, "pack.toml")
 	if _, err := fs.Stat(packPath); err != nil {
-		fmt.Fprintf(stderr, "%s: this command requires a city directory with pack.toml; run \"gc doctor\" or \"gc doctor --fix\" to migrate this city first\n", cmdName("agent add")) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: this command requires a city directory with pack.toml; run %q or \"%s\" to migrate this city first\n", cmdName("agent add"), cmdName("doctor"), cmdName("doctor")+" --fix") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -437,7 +437,7 @@ func cmdAgentAdd(name, promptTemplate, dir string, suspended bool, stdout, stder
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "agent add", err)
 		return 1
 	}
 	return doAgentAdd(fsys.OSFS{}, cityPath, name, promptTemplate, dir, suspended, stdout, stderr)
@@ -456,7 +456,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 
 	cfg, err := loadCityConfigFS(fs, tomlPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "agent add", err)
 		return 1
 	}
 
@@ -475,7 +475,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 
 	agentDir := filepath.Join(cityPath, "agents", name)
 	if err := fs.MkdirAll(agentDir, 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "agent add", err)
 		return 1
 	}
 
@@ -497,7 +497,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 
 	promptPath := filepath.Join(agentDir, "prompt.template.md")
 	if err := fs.WriteFile(promptPath, promptData, 0o644); err != nil {
-		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "agent add", err)
 		return 1
 	}
 
@@ -510,7 +510,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 			b.WriteString("suspended = true\n")
 		}
 		if err := fs.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(b.String()), 0o644); err != nil {
-			fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "agent add", err)
 			return 1
 		}
 	}
@@ -546,7 +546,7 @@ func cmdAgentSuspend(args []string, stdout, stderr io.Writer) int {
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "agent suspend", err)
 		return 1
 	}
 	if c := apiClient(cityPath); c != nil {
@@ -557,7 +557,7 @@ func cmdAgentSuspend(args []string, stdout, stderr io.Writer) int {
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "agent suspend", err)
 			return 1
 		}
 		// Connection error — fall through to direct mutation.
@@ -599,7 +599,7 @@ func cmdAgentResume(args []string, stdout, stderr io.Writer) int {
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "agent resume", err)
 		return 1
 	}
 	if c := apiClient(cityPath); c != nil {
@@ -610,7 +610,7 @@ func cmdAgentResume(args []string, stdout, stderr io.Writer) int {
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "agent resume", err)
 			return 1
 		}
 		// Connection error — fall through to direct mutation.

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -88,7 +88,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 
 	cityPath, err := resolveBdCity(cityName)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "bd", err)
 		return 1
 	}
 
@@ -99,13 +99,13 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 	// in resolveBdScopeTarget / bdRigScopeTarget.
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc bd: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "bd: loading config", err)
 		return 1
 	}
 
 	target, err := resolveBdScopeTarget(cfg, cityPath, rigName, bdArgs)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "bd", err)
 		return 1
 	}
 	if !providerUsesBdStoreContract(rawBeadsProviderForScope(target.ScopeRoot, cityPath)) {
@@ -133,7 +133,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		if errors.As(err, &exitErr) {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(stderr, "gc bd: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "bd", err)
 		return 1
 	}
 	return 0

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -17,14 +17,14 @@ func newBdCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bd [bd-args...]",
 		Short: "Run bd in the correct rig directory",
-		Long: `Run a bd command routed to the correct rig directory.
+		Long: fmt.Sprintf(`Run a bd command routed to the correct rig directory.
 
 When beads belong to a rig (not the city root), bd must run from the
 rig directory to find the correct .beads database. This command resolves
 the rig automatically from the --rig flag or by detecting the bead prefix
 in the arguments.
 
-All arguments after "gc bd" are forwarded to bd unchanged.`,
+All arguments after "%s bd" are forwarded to bd unchanged.`, prog()),
 		Example: `  gc bd --rig my-project list
   gc bd --rig my-project create "New task"
   gc bd show my-project-abc          # auto-detects rig from bead prefix

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -80,7 +80,7 @@ func warnExternalBdOverrideDrift(stderr io.Writer, cityPath string, target execS
 	if len(drift) == 0 {
 		return
 	}
-	_, _ = fmt.Fprintf(stderr, "gc bd: warning: ignoring ambient Dolt host/port override for external target: %s\n", strings.Join(drift, ", "))
+	_, _ = fmt.Fprintf(stderr, "%s: warning: ignoring ambient Dolt host/port override for external target: %s\n", cmdName("bd"), strings.Join(drift, ", "))
 }
 
 func doBd(args []string, stdout, stderr io.Writer) int {
@@ -109,7 +109,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if !providerUsesBdStoreContract(rawBeadsProviderForScope(target.ScopeRoot, cityPath)) {
-		fmt.Fprintln(stderr, "gc bd: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: only supported for bd-backed beads providers\n", cmdName("bd")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -117,7 +117,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 
 	bdPath, err := exec.LookPath("bd")
 	if err != nil {
-		fmt.Fprintln(stderr, "gc bd: bd not found in PATH") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: bd not found in PATH\n", cmdName("bd")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_bd_store_bridge.go
+++ b/cmd/gc/cmd_bd_store_bridge.go
@@ -66,11 +66,11 @@ func newBdStoreBridgeCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			op, opArgs, dir, host, port, user, err := parseBdStoreBridgeCommandArgs(args)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc bd-store-bridge: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "bd-store-bridge", err)
 				return errExit
 			}
 			if err := runBdStoreBridge(op, opArgs, dir, host, port, user, os.Stdin, stdout); err != nil {
-				fmt.Fprintf(stderr, "gc bd-store-bridge: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "bd-store-bridge", err)
 				return errExit
 			}
 			return nil

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -17,9 +17,9 @@ Subcommands for topology operations, health checking, and diagnostics.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc beads: missing subcommand (city, health)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (city, health)\n", cmdName("beads")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc beads: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("beads"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},

--- a/cmd/gc/cmd_beads.go
+++ b/cmd/gc/cmd_beads.go
@@ -63,12 +63,12 @@ Also used by the beads-health system order for periodic monitoring.`,
 func doBeadsHealth(quiet bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc beads health: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "beads health", err)
 		return 1
 	}
 
 	if err := healthBeadsProvider(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc beads health: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "beads health", err)
 		return 1
 	}
 	if !quiet {

--- a/cmd/gc/cmd_beads_city.go
+++ b/cmd/gc/cmd_beads_city.go
@@ -42,9 +42,9 @@ city to an external Dolt endpoint and rewrite inherited rig mirrors.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc beads city: missing subcommand (use-managed, use-external)") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: missing subcommand (use-managed, use-external)\n", cmdName("beads city")) //nolint:errcheck
 			} else {
-				fmt.Fprintf(stderr, "gc beads city: unknown subcommand %q\n", args[0]) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("beads city"), args[0]) //nolint:errcheck
 			}
 			return errExit
 		},

--- a/cmd/gc/cmd_beads_city.go
+++ b/cmd/gc/cmd_beads_city.go
@@ -98,7 +98,7 @@ func newBeadsCityUseExternalCmd(stdout, stderr io.Writer) *cobra.Command {
 func cmdBeadsCityUseManaged(opts cityEndpointOptions, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc beads city use-managed: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "beads city use-managed", err)
 		return 1
 	}
 	return doBeadsCityEndpoint(fsys.OSFS{}, cityPath, opts, stdout, stderr)
@@ -107,7 +107,7 @@ func cmdBeadsCityUseManaged(opts cityEndpointOptions, stdout, stderr io.Writer) 
 func cmdBeadsCityUseExternal(opts cityEndpointOptions, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc beads city use-external: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "beads city use-external", err)
 		return 1
 	}
 	return doBeadsCityEndpoint(fsys.OSFS{}, cityPath, opts, stdout, stderr)

--- a/cmd/gc/cmd_beads_city.go
+++ b/cmd/gc/cmd_beads_city.go
@@ -241,9 +241,9 @@ func doBeadsCityEndpoint(fs fsys.FS, cityPath string, opts cityEndpointOptions, 
 
 func cityEndpointCommandName(opts cityEndpointOptions) string {
 	if opts.External {
-		return "gc beads city use-external"
+		return cmdName("beads city use-external")
 	}
-	return "gc beads city use-managed"
+	return cmdName("beads city use-managed")
 }
 
 func validateExplicitExternalHost(host string) error {
@@ -515,7 +515,7 @@ func cityEndpointFollowupCommand(state contract.ConfigState) string {
 	if state.EndpointOrigin != contract.EndpointOriginCityCanonical || state.EndpointStatus != contract.EndpointStatusUnverified {
 		return ""
 	}
-	parts := []string{"gc beads city use-external", "--host", state.DoltHost, "--port", state.DoltPort}
+	parts := []string{cmdName("beads city use-external"), "--host", state.DoltHost, "--port", state.DoltPort}
 	if user := strings.TrimSpace(state.DoltUser); user != "" {
 		parts = append(parts, "--user", user)
 	}

--- a/cmd/gc/cmd_build_image.go
+++ b/cmd/gc/cmd_build_image.go
@@ -64,7 +64,7 @@ volume mounts at runtime.`,
 
 func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push, contextOnly bool, stdout, stderr io.Writer) int {
 	if !contextOnly && tag == "" {
-		fmt.Fprintln(stderr, "gc build-image: --tag is required (or use --context-only)") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: --tag is required (or use --context-only)\n", cmdName("build-image")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -86,7 +86,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 	for _, rp := range rigPaths {
 		name, path, ok := strings.Cut(rp, ":")
 		if !ok || name == "" || path == "" {
-			fmt.Fprintf(stderr, "gc build-image: invalid --rig-path %q (expected name:path)\n", rp) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: invalid --rig-path %q (expected name:path)\n", cmdName("build-image"), rp) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		rigs[name] = path

--- a/cmd/gc/cmd_build_image.go
+++ b/cmd/gc/cmd_build_image.go
@@ -76,7 +76,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 		var err error
 		cityPath, err = resolveCommandCity(nil)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "build-image", err)
 			return 1
 		}
 	}
@@ -95,7 +95,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 	// Create temp output dir (or use a named one for context-only).
 	outputDir, err := os.MkdirTemp("", "gc-build-image-*")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc build-image: creating temp dir: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "build-image: creating temp dir", err)
 		return 1
 	}
 	if !contextOnly {
@@ -111,7 +111,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 		RigPaths:  rigs,
 	}
 	if err := buildimage.AssembleContext(opts); err != nil {
-		fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "build-image", err)
 		return 1
 	}
 
@@ -124,7 +124,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 	fmt.Fprintf(stdout, "Building image %s...\n", tag) //nolint:errcheck // best-effort stdout
 	ctx := context.Background()
 	if err := buildimage.Build(ctx, outputDir, tag, stdout, stderr); err != nil {
-		fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "build-image", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "Image built: %s\n", tag) //nolint:errcheck // best-effort stdout
@@ -133,7 +133,7 @@ func doBuildImage(args []string, tag, baseImage string, rigPaths []string, push,
 	if push {
 		fmt.Fprintf(stdout, "Pushing %s...\n", tag) //nolint:errcheck // best-effort stdout
 		if err := buildimage.Push(ctx, tag, stdout, stderr); err != nil {
-			fmt.Fprintf(stderr, "gc build-image: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "build-image", err)
 			return 1
 		}
 		fmt.Fprintf(stdout, "Pushed: %s\n", tag) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -95,13 +95,13 @@ all agents with running status, rigs, and a summary count.`,
 func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "status", err)
 		return 1
 	}
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "status", err)
 		return 1
 	}
 
@@ -162,7 +162,7 @@ func doCityStatus(
 	if store != nil {
 		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc status: building session catalog: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "status: building session catalog", err)
 			return 1
 		}
 		if sessions.ActiveSessions > 0 || sessions.SuspendedSessions > 0 {
@@ -191,7 +191,7 @@ func doCityStatusJSON(
 	if store != nil {
 		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc status: building session catalog: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "status: building session catalog", err)
 			return 1
 		}
 		snapshot.Summary.ActiveSessions = sessions.ActiveSessions
@@ -201,7 +201,7 @@ func doCityStatusJSON(
 	status := cityStatusJSONFromSnapshot(snapshot, snapshot.Summary)
 	data, err := json.MarshalIndent(status, "", "  ")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "status", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, string(data)) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -298,7 +298,7 @@ func controllerStatusLine(ctrl ControllerJSON) string {
 
 func controllerStatusGuidance(ctrl ControllerJSON, cityPath string) []string {
 	quotedPath := shellQuotePath(cityPath)
-	startCommand := "gc start " + quotedPath
+	startCommand := cmdName("start") + " " + quotedPath
 
 	switch ctrl.Mode {
 	case "standalone":

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -35,7 +35,7 @@ func addDiscoveredCommandsToRoot(root *cobra.Command, entries []config.Discovere
 	for _, binding := range bindings {
 		if core[binding] {
 			if warnOnCollision {
-				fmt.Fprintf(stderr, "gc: import binding %q: name shadows core command, skipping\n", binding) //nolint:errcheck
+				fmt.Fprintf(stderr, prog()+": import binding %q: name shadows core command, skipping\n", binding) //nolint:errcheck
 			}
 			continue
 		}

--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -163,7 +163,7 @@ func runDiscoveredCommand(entry config.DiscoveredCommand, cityPath, cityName str
 		if errors.As(err, &exitErr) {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(stderr, "gc %s %s: %v\n", entry.BindingName, strings.Join(entry.Command, " "), err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %s: %v\n", cmdName(entry.BindingName), strings.Join(entry.Command, " "), err) //nolint:errcheck
 		return 1
 	}
 	return 0

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -108,7 +108,7 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 
 	// Composition warnings.
 	for _, w := range prov.Warnings {
-		fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("config show"), w) //nolint:errcheck // best-effort stderr
 	}
 
 	// Run validation.
@@ -129,11 +129,11 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 
 	if validate {
 		for _, w := range validationWarnings {
-			fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("config show"), w) //nolint:errcheck // best-effort stderr
 		}
 		if len(validationErrors) > 0 {
 			for _, e := range validationErrors {
-				fmt.Fprintf(stderr, "gc config show: %s\n", e) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: %s\n", cmdName("config show"), e) //nolint:errcheck // best-effort stderr
 			}
 			return 1
 		}
@@ -143,10 +143,10 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 
 	// Print validation warnings even in show mode.
 	for _, w := range validationWarnings {
-		fmt.Fprintf(stderr, "gc config show: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("config show"), w) //nolint:errcheck // best-effort stderr
 	}
 	for _, e := range validationErrors {
-		fmt.Fprintf(stderr, "gc config show: warning: %s\n", e) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("config show"), e) //nolint:errcheck // best-effort stderr
 	}
 
 	if showProvenance {
@@ -276,7 +276,7 @@ Use --json to emit machine-readable output (providers only).`,
 				return nil
 			}
 			if asJSON {
-				fmt.Fprintln(stderr, "gc config explain: --json is only supported with --provider") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: --json is only supported with --provider\n", cmdName("config explain")) //nolint:errcheck
 				return errExit
 			}
 			if doConfigExplain(rigFilter, agentFilter, stdout, stderr) != 0 {
@@ -476,9 +476,9 @@ func doConfigExplain(rigFilter, agentFilter string, stdout, stderr io.Writer) in
 
 	if len(agents) == 0 {
 		if rigFilter != "" || agentFilter != "" {
-			fmt.Fprintf(stderr, "gc config explain: no agents match filters (rig=%q agent=%q)\n", rigFilter, agentFilter) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: no agents match filters (rig=%q agent=%q)\n", cmdName("config explain"), rigFilter, agentFilter) //nolint:errcheck // best-effort stderr
 		} else {
-			fmt.Fprintf(stderr, "gc config explain: no agents configured\n") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: no agents configured\n", cmdName("config explain")) //nolint:errcheck // best-effort stderr
 		}
 		return 1
 	}
@@ -586,9 +586,9 @@ func doConfigExplainProvider(providerName string, asJSON bool, stdout, stderr io
 	resolved, ok := config.ResolvedProviderCached(cfg, providerName)
 	if !ok {
 		if _, isBuiltin := config.BuiltinProviders()[providerName]; isBuiltin {
-			fmt.Fprintf(stderr, "gc config explain: %q is a built-in provider; --provider only resolves custom entries\n", providerName) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: %q is a built-in provider; --provider only resolves custom entries\n", cmdName("config explain"), providerName) //nolint:errcheck
 		} else {
-			fmt.Fprintf(stderr, "gc config explain: no provider %q in resolved config\n", providerName) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: no provider %q in resolved config\n", cmdName("config explain"), providerName) //nolint:errcheck
 		}
 		return 1
 	}

--- a/cmd/gc/cmd_config.go
+++ b/cmd/gc/cmd_config.go
@@ -91,18 +91,18 @@ config element. Use -f to layer additional config files.`,
 func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config show: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config show", err)
 		return 1
 	}
 
 	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc config show: fetching packs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config show: fetching packs", err)
 		return 1
 	}
 
 	cfg, prov, err := loadConfigCommandCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config show: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config show", err)
 		return 1
 	}
 
@@ -156,7 +156,7 @@ func doConfigShow(validate, showProvenance bool, stdout, stderr io.Writer) int {
 
 	data, err := configForDisplay(cfg).Marshal()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config show: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config show", err)
 		return 1
 	}
 	// Emit provider inheritance chain annotations as a comment block
@@ -447,18 +447,18 @@ func collectLegacyGraphAssigneeErrors(
 func doConfigExplain(rigFilter, agentFilter string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config explain: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config explain", err)
 		return 1
 	}
 
 	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc config explain: fetching packs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config explain: fetching packs", err)
 		return 1
 	}
 
 	cfg, prov, err := loadConfigCommandCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config explain: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "config explain", err)
 		return 1
 	}
 
@@ -566,20 +566,20 @@ func explainAgent(w io.Writer, a *config.Agent, prov *config.Provenance) {
 func doConfigExplainProvider(providerName string, asJSON bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config explain: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "config explain", err)
 		return 1
 	}
 
 	if quickCfg, qErr := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); qErr == nil && len(quickCfg.Packs) > 0 {
 		if fErr := config.FetchPacks(quickCfg.Packs, cityPath); fErr != nil {
-			fmt.Fprintf(stderr, "gc config explain: fetching packs: %v\n", fErr) //nolint:errcheck
+			cmdErr(stderr, "config explain: fetching packs", fErr)
 			return 1
 		}
 	}
 
 	cfg, _, err := loadConfigCommandCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc config explain: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "config explain", err)
 		return 1
 	}
 
@@ -747,7 +747,7 @@ func renderProviderExplainJSON(r config.ResolvedProvider, name string, stdout, s
 	}
 	enc := jsonEncoder(stdout)
 	if err := enc.Encode(payload); err != nil {
-		fmt.Fprintf(stderr, "gc config explain: json encode: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "config explain: json encode", err)
 		return 1
 	}
 	return 0

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -73,7 +73,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 			for _, v := range vars {
 				parts := strings.SplitN(v, "=", 2)
 				if len(parts) != 2 {
-					fmt.Fprintf(stderr, "gc converge create: invalid --var %q (expected key=value)\n", v) //nolint:errcheck
+					fmt.Fprintf(stderr, "%s: invalid --var %q (expected key=value)\n", cmdName("converge create"), v) //nolint:errcheck
 					return errExit
 				}
 				params["var."+parts[0]] = parts[1]
@@ -90,7 +90,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if reply.Error != "" {
-				fmt.Fprintf(stderr, "gc converge create: %s\n", reply.Error) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: %s\n", cmdName("converge create"), reply.Error) //nolint:errcheck
 				return errExit
 			}
 
@@ -137,7 +137,7 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if b.Type != "convergence" {
-				fmt.Fprintf(stderr, "gc converge status: bead %s is type %q, not convergence\n", beadID, b.Type) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: bead %s is type %q, not convergence\n", cmdName("converge status"), beadID, b.Type) //nolint:errcheck
 				return errExit
 			}
 
@@ -322,7 +322,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if b.Type != "convergence" {
-				fmt.Fprintf(stderr, "gc converge test-gate: bead %s is type %q, not convergence\n", beadID, b.Type) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: bead %s is type %q, not convergence\n", cmdName("converge test-gate"), beadID, b.Type) //nolint:errcheck
 				return errExit
 			}
 			meta := b.Metadata
@@ -407,7 +407,7 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if reply.Error != "" {
-				fmt.Fprintf(stderr, "gc converge retry: %s\n", reply.Error) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: %s\n", cmdName("converge retry"), reply.Error) //nolint:errcheck
 				return errExit
 			}
 
@@ -429,7 +429,7 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 func convergeSocketCmd(beadID, command string, params map[string]string, stdout, stderr io.Writer) error {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc converge %s: %v\n", command, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("converge "+command), err) //nolint:errcheck
 		return errExit
 	}
 
@@ -441,11 +441,11 @@ func convergeSocketCmd(beadID, command string, params map[string]string, stdout,
 	}
 	reply, err := sendConvergenceRequest(cityPath, req)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc converge %s: %v\n", command, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("converge "+command), err) //nolint:errcheck
 		return errExit
 	}
 	if reply.Error != "" {
-		fmt.Fprintf(stderr, "gc converge %s: %s\n", command, reply.Error) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s\n", cmdName("converge "+command), reply.Error) //nolint:errcheck
 		return errExit
 	}
 

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -127,7 +127,7 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			beadID := args[0]
-			store, code := openCityStore(stderr, "gc converge status")
+			store, code := openCityStore(stderr, cmdName("converge status"))
 			if code != 0 {
 				return errExit
 			}
@@ -232,7 +232,7 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 		Use:   "list",
 		Short: "List convergence loops",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			store, code := openCityStore(stderr, "gc converge list")
+			store, code := openCityStore(stderr, cmdName("converge list"))
 			if code != 0 {
 				return errExit
 			}
@@ -312,7 +312,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			beadID := args[0]
-			store, code := openCityStore(stderr, "gc converge test-gate")
+			store, code := openCityStore(stderr, cmdName("converge test-gate"))
 			if code != 0 {
 				return errExit
 			}

--- a/cmd/gc/cmd_converge.go
+++ b/cmd/gc/cmd_converge.go
@@ -54,7 +54,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge create: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge create", err)
 				return errExit
 			}
 
@@ -86,7 +86,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			reply, err := sendConvergenceRequest(cityPath, req)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge create: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge create", err)
 				return errExit
 			}
 			if reply.Error != "" {
@@ -97,7 +97,7 @@ func newConvergeCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 			// Parse result for bead ID.
 			var result convergence.CreateResult
 			if err := json.Unmarshal(reply.Result, &result); err != nil {
-				fmt.Fprintf(stderr, "gc converge create: parsing result: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge create: parsing result", err)
 				return errExit
 			}
 			fmt.Fprintln(stdout, result.BeadID) //nolint:errcheck
@@ -133,7 +133,7 @@ func newConvergeStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			b, err := store.Get(beadID)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge status: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge status", err)
 				return errExit
 			}
 			if b.Type != "convergence" {
@@ -242,7 +242,7 @@ func newConvergeListCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			beadList, err := store.List(query)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge list: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge list", err)
 				return errExit
 			}
 
@@ -318,7 +318,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			b, err := store.Get(beadID)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge test-gate: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge test-gate", err)
 				return errExit
 			}
 			if b.Type != "convergence" {
@@ -332,7 +332,7 @@ func newConvergeTestGateCmd(stdout, stderr io.Writer) *cobra.Command {
 
 			gateConfig, err := convergence.ParseGateConfig(meta)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge test-gate: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge test-gate", err)
 				return errExit
 			}
 
@@ -386,7 +386,7 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge retry: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge retry", err)
 				return errExit
 			}
 
@@ -403,7 +403,7 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			reply, err := sendConvergenceRequest(cityPath, req)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc converge retry: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge retry", err)
 				return errExit
 			}
 			if reply.Error != "" {
@@ -413,7 +413,7 @@ func newConvergeRetryCmd(stdout, stderr io.Writer) *cobra.Command {
 
 			var result convergence.RetryResult
 			if err := json.Unmarshal(reply.Result, &result); err != nil {
-				fmt.Fprintf(stderr, "gc converge retry: parsing result: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "converge retry: parsing result", err)
 				return errExit
 			}
 			fmt.Fprintln(stdout, result.NewBeadID) //nolint:errcheck

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -254,7 +254,7 @@ child issues.`,
 
 // cmdConvoyList is the CLI entry point for listing convoys.
 func cmdConvoyList(stdout, stderr io.Writer) int {
-	stores, code := openAllConvoyStores(stderr, "gc convoy list")
+	stores, code := openAllConvoyStores(stderr, cmdName("convoy list"))
 	if stores == nil {
 		return code
 	}
@@ -512,7 +512,7 @@ func cmdConvoyStatus(args []string, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		convoyID = args[0]
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy status")
+	store, code := openConvoyStoreByID(convoyID, stderr, cmdName("convoy status"))
 	if store == nil {
 		return code
 	}
@@ -614,7 +614,7 @@ func cmdConvoyTarget(args []string, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		convoyID = args[0]
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy target")
+	store, code := openConvoyStoreByID(convoyID, stderr, cmdName("convoy target"))
 	if store == nil {
 		return code
 	}
@@ -678,7 +678,7 @@ func cmdConvoyAdd(args []string, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		convoyID = args[0]
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy add")
+	store, code := openConvoyStoreByID(convoyID, stderr, cmdName("convoy add"))
 	if store == nil {
 		return code
 	}
@@ -745,7 +745,7 @@ func cmdConvoyClose(args []string, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		convoyID = args[0]
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy close")
+	store, code := openConvoyStoreByID(convoyID, stderr, cmdName("convoy close"))
 	if store == nil {
 		return code
 	}
@@ -806,7 +806,7 @@ Evaluates each open convoy's children. If all children have status
 
 // cmdConvoyCheck is the CLI entry point for auto-closing completed convoys.
 func cmdConvoyCheck(stdout, stderr io.Writer) int {
-	stores, code := openAllConvoyStores(stderr, "gc convoy check")
+	stores, code := openAllConvoyStores(stderr, cmdName("convoy check"))
 	if stores == nil {
 		return code
 	}
@@ -897,7 +897,7 @@ Useful for identifying bottlenecks in convoy processing.`,
 
 // cmdConvoyStranded is the CLI entry point for finding stranded convoys.
 func cmdConvoyStranded(stdout, stderr io.Writer) int {
-	stores, code := openAllConvoyStores(stderr, "gc convoy stranded")
+	stores, code := openAllConvoyStores(stderr, cmdName("convoy stranded"))
 	if stores == nil {
 		return code
 	}
@@ -996,7 +996,7 @@ func cmdConvoyLand(args []string, opts landOpts, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		convoyID = args[0]
 	}
-	store, code := openConvoyStoreByID(convoyID, stderr, "gc convoy land")
+	store, code := openConvoyStoreByID(convoyID, stderr, cmdName("convoy land"))
 	if store == nil {
 		return code
 	}

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -29,9 +29,9 @@ use formula-compiled DAGs with control beads for orchestration.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc convoy: missing subcommand (create, list, status, target, add, close, check, stranded, land)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (create, list, status, target, add, close, check, stranded, land)\n", cmdName("convoy")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc convoy: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("convoy"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -166,7 +166,7 @@ func validateConvoyCreateStoreScope(cfg *config.City, cityPath string, issueIDs 
 
 func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath string, rec events.Recorder, args []string, opts convoyCreateOptions, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc convoy create: missing convoy name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing convoy name\n", cmdName("convoy create")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	name := args[0]
@@ -209,12 +209,12 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 			}
 		}
 		if _, err := childStore.Get(id); err != nil {
-			fmt.Fprintf(stderr, "gc convoy create: issue %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: issue %s: %v\n", cmdName("convoy create"), id, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		parentID := convoy.ID
 		if err := childStore.Update(id, beads.UpdateOpts{ParentID: &parentID}); err != nil {
-			fmt.Fprintf(stderr, "gc convoy create: setting parent on %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: setting parent on %s: %v\n", cmdName("convoy create"), id, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -470,7 +470,7 @@ func doConvoyListAcrossStores(stores []convoyStoreView, stdout, stderr io.Writer
 	for _, c := range convoys {
 		children, err := listConvoyChildren(c.store, c.bead.ID, true)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc convoy list: children of %s: %v\n", c.bead.ID, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: children of %s: %v\n", cmdName("convoy list"), c.bead.ID, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		closed := 0
@@ -522,7 +522,7 @@ func cmdConvoyStatus(args []string, stdout, stderr io.Writer) int {
 // doConvoyStatus shows detailed status of a convoy and its children.
 func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc convoy status: missing convoy ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing convoy ID\n", cmdName("convoy status")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -533,7 +533,7 @@ func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) 
 		return 1
 	}
 	if convoy.Type != "convoy" {
-		fmt.Fprintf(stderr, "gc convoy status: bead %s is not a convoy\n", id) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: bead %s is not a convoy\n", cmdName("convoy status"), id) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -623,13 +623,13 @@ func cmdConvoyTarget(args []string, stdout, stderr io.Writer) int {
 
 func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
-		fmt.Fprintln(stderr, "gc convoy target: missing convoy ID or branch") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing convoy ID or branch\n", cmdName("convoy target")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
 	target := strings.TrimSpace(args[1])
 	if target == "" {
-		fmt.Fprintln(stderr, "gc convoy target: target branch cannot be empty") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: target branch cannot be empty\n", cmdName("convoy target")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -639,7 +639,7 @@ func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) 
 		return 1
 	}
 	if convoy.Type != "convoy" {
-		fmt.Fprintf(stderr, "gc convoy target: bead %s is not a convoy\n", id) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: bead %s is not a convoy\n", cmdName("convoy target"), id) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := setConvoyFields(store, id, ConvoyFields{Target: target}); err != nil {
@@ -688,7 +688,7 @@ func cmdConvoyAdd(args []string, stdout, stderr io.Writer) int {
 // doConvoyAdd adds an issue to a convoy by setting the issue's ParentID.
 func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
-		fmt.Fprintln(stderr, "gc convoy add: usage: gc convoy add <convoy-id> <issue-id>") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: usage: gc convoy add <convoy-id> <issue-id>\n", cmdName("convoy add")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	convoyID := args[0]
@@ -700,7 +700,7 @@ func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int
 		return 1
 	}
 	if convoy.Type != "convoy" {
-		fmt.Fprintf(stderr, "gc convoy add: bead %s is not a convoy\n", convoyID) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: bead %s is not a convoy\n", cmdName("convoy add"), convoyID) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -756,7 +756,7 @@ func cmdConvoyClose(args []string, stdout, stderr io.Writer) int {
 // doConvoyClose closes a convoy bead.
 func doConvoyClose(store beads.Store, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc convoy close: missing convoy ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing convoy ID\n", cmdName("convoy close")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -767,7 +767,7 @@ func doConvoyClose(store beads.Store, rec events.Recorder, args []string, stdout
 		return 1
 	}
 	if convoy.Type != "convoy" {
-		fmt.Fprintf(stderr, "gc convoy close: bead %s is not a convoy\n", id) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: bead %s is not a convoy\n", cmdName("convoy close"), id) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -845,7 +845,7 @@ func doConvoyCheckAcrossStores(stores []convoyStoreView, rec events.Recorder, st
 		}
 		children, err := listConvoyChildren(item.store, item.bead.ID, true)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc convoy check: children of %s: %v\n", item.bead.ID, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: children of %s: %v\n", cmdName("convoy check"), item.bead.ID, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if len(children) == 0 {
@@ -860,7 +860,7 @@ func doConvoyCheckAcrossStores(stores []convoyStoreView, rec events.Recorder, st
 		}
 		if allClosed {
 			if err := item.store.Close(item.bead.ID); err != nil {
-				fmt.Fprintf(stderr, "gc convoy check: closing %s: %v\n", item.bead.ID, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: closing %s: %v\n", cmdName("convoy check"), item.bead.ID, err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 			rec.Record(events.Event{
@@ -925,7 +925,7 @@ func doConvoyStrandedAcrossStores(stores []convoyStoreView, stdout, stderr io.Wr
 	for _, item := range convoys {
 		children, err := listConvoyChildren(item.store, item.bead.ID, false)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc convoy stranded: children of %s: %v\n", item.bead.ID, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: children of %s: %v\n", cmdName("convoy stranded"), item.bead.ID, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		for _, ch := range children {
@@ -1008,7 +1008,7 @@ func cmdConvoyLand(args []string, opts landOpts, stdout, stderr io.Writer) int {
 // cleans up worktrees, closes the convoy bead, and records an event.
 func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts landOpts, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc convoy land: missing convoy ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing convoy ID\n", cmdName("convoy land")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	convoyID := args[0]
@@ -1019,11 +1019,11 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 		return 1
 	}
 	if convoy.Type != "convoy" {
-		fmt.Fprintf(stderr, "gc convoy land: bead %s is not a convoy\n", convoyID) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: bead %s is not a convoy\n", cmdName("convoy land"), convoyID) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !hasLabel(convoy.Labels, "owned") {
-		fmt.Fprintf(stderr, "gc convoy land: convoy %s is not owned (missing 'owned' label)\n", convoyID) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: convoy %s is not owned (missing 'owned' label)\n", cmdName("convoy land"), convoyID) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -1048,7 +1048,7 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 	}
 
 	if len(openChildren) > 0 && !opts.Force {
-		fmt.Fprintf(stderr, "gc convoy land: %d open child(ren):\n", len(openChildren)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %d open child(ren):\n", cmdName("convoy land"), len(openChildren)) //nolint:errcheck // best-effort stderr
 		for _, ch := range openChildren {
 			fmt.Fprintf(stderr, "  %s %s (%s)\n", ch.ID, ch.Title, ch.Status) //nolint:errcheck // best-effort stderr
 		}

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -63,10 +63,10 @@ func newConvoyCreateCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name> [issue-ids...]",
 		Short: "Create a convoy and optionally track issues",
-		Long: `Create a convoy and optionally link existing issues to it.
+		Long: fmt.Sprintf(`Create a convoy and optionally link existing issues to it.
 
 Creates a convoy bead and sets the parent of any provided issue IDs to
-the new convoy. Issues can also be added later with "gc convoy add".`,
+the new convoy. Issues can also be added later with "%s convoy add".`, prog()),
 		Example: `  gc convoy create sprint-42
   gc convoy create sprint-42 issue-1 issue-2 issue-3
   gc convoy create deploy --owner mayor --notify mayor --merge mr
@@ -722,10 +722,10 @@ func newConvoyCloseCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "close <id>",
 		Short: "Close a convoy",
-		Long: `Close a convoy bead manually.
+		Long: fmt.Sprintf(`Close a convoy bead manually.
 
 Marks the convoy as closed regardless of child issue status. Use
-"gc convoy check" to auto-close convoys where all issues are resolved.`,
+"%s convoy check" to auto-close convoys where all issues are resolved.`, prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdConvoyClose(args, stdout, stderr) != 0 {
@@ -956,11 +956,11 @@ func newConvoyLandCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "land <convoy-id>",
 		Short: "Land an owned convoy (terminate + cleanup)",
-		Long: `Land an owned convoy, verifying all children are closed.
+		Long: fmt.Sprintf(`Land an owned convoy, verifying all children are closed.
 
 Landing is the natural lifecycle termination for owned convoys created
-via "gc sling --owned". It verifies all children are closed (or uses
---force), closes the convoy bead, and records a ConvoyClosed event.`,
+via "%s sling --owned". It verifies all children are closed (or uses
+--force), closes the convoy bead, and records a ConvoyClosed event.`, prog()),
 		Example: `  gc convoy land gc-42
   gc convoy land gc-42 --force
   gc convoy land gc-42 --dry-run`,

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -99,12 +99,12 @@ the new convoy. Issues can also be added later with "gc convoy add".`,
 func cmdConvoyCreateWithOptions(args []string, opts convoyCreateOptions, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy create", err)
 		return 1
 	}
 	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy create", err)
 		return 1
 	}
 	emitLoadCityConfigWarnings(stderr, prov)
@@ -113,7 +113,7 @@ func cmdConvoyCreateWithOptions(args []string, opts convoyCreateOptions, stdout,
 	if len(args) > 1 {
 		issueIDs = args[1:]
 		if err := validateConvoyCreateStoreScope(cfg, cityPath, issueIDs); err != nil {
-			fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "convoy create", err)
 			return 1
 		}
 	}
@@ -127,7 +127,7 @@ func cmdConvoyCreateWithOptions(args []string, opts convoyCreateOptions, stdout,
 	}
 	store, err := openStoreAtForCity(storeDir, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy create", err)
 		return 1
 	}
 
@@ -172,7 +172,7 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 	name := args[0]
 	issueIDs := args[1:]
 	if err := validateConvoyCreateStoreScope(cfg, cityPath, issueIDs); err != nil {
-		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy create", err)
 		return 1
 	}
 
@@ -184,7 +184,7 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 
 	convoy, err := store.Create(b)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy create: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy create", err)
 		return 1
 	}
 
@@ -192,7 +192,7 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 	// through Create, but BdStore/exec.Store may not. setConvoyFields uses
 	// SetMetadata which works across all backends.
 	if err := setConvoyFields(store, convoy.ID, opts.Fields); err != nil {
-		fmt.Fprintf(stderr, "gc convoy create: warning: setting fields: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy create: warning: setting fields", err)
 		// Non-fatal: convoy already created and event will be emitted.
 	}
 
@@ -456,7 +456,7 @@ func listConvoyChildren(store beads.Store, parentID string, includeClosed bool) 
 func doConvoyListAcrossStores(stores []convoyStoreView, stdout, stderr io.Writer) int {
 	convoys, err := collectOpenConvoys(stores)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy list", err)
 		return 1
 	}
 
@@ -529,7 +529,7 @@ func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) 
 
 	convoy, err := store.Get(id)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy status", err)
 		return 1
 	}
 	if convoy.Type != "convoy" {
@@ -539,7 +539,7 @@ func doConvoyStatus(store beads.Store, args []string, stdout, stderr io.Writer) 
 
 	children, err := listConvoyChildren(store, id, true)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy status", err)
 		return 1
 	}
 
@@ -635,7 +635,7 @@ func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) 
 
 	convoy, err := store.Get(id)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy target", err)
 		return 1
 	}
 	if convoy.Type != "convoy" {
@@ -643,7 +643,7 @@ func doConvoyTarget(store beads.Store, args []string, stdout, stderr io.Writer) 
 		return 1
 	}
 	if err := setConvoyFields(store, id, ConvoyFields{Target: target}); err != nil {
-		fmt.Fprintf(stderr, "gc convoy target: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy target", err)
 		return 1
 	}
 
@@ -696,7 +696,7 @@ func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int
 
 	convoy, err := store.Get(convoyID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy add", err)
 		return 1
 	}
 	if convoy.Type != "convoy" {
@@ -705,12 +705,12 @@ func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int
 	}
 
 	if _, err := store.Get(issueID); err != nil {
-		fmt.Fprintf(stderr, "gc convoy add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy add", err)
 		return 1
 	}
 
 	if err := store.Update(issueID, beads.UpdateOpts{ParentID: &convoyID}); err != nil {
-		fmt.Fprintf(stderr, "gc convoy add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy add", err)
 		return 1
 	}
 
@@ -763,7 +763,7 @@ func doConvoyClose(store beads.Store, rec events.Recorder, args []string, stdout
 
 	convoy, err := store.Get(id)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy close: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy close", err)
 		return 1
 	}
 	if convoy.Type != "convoy" {
@@ -772,7 +772,7 @@ func doConvoyClose(store beads.Store, rec events.Recorder, args []string, stdout
 	}
 
 	if err := store.Close(id); err != nil {
-		fmt.Fprintf(stderr, "gc convoy close: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy close", err)
 		return 1
 	}
 
@@ -834,7 +834,7 @@ func doConvoyCheck(store beads.Store, rec events.Recorder, stdout, stderr io.Wri
 func doConvoyCheckAcrossStores(stores []convoyStoreView, rec events.Recorder, stdout, stderr io.Writer) int {
 	convoys, err := collectOpenConvoys(stores)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy check: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy check", err)
 		return 1
 	}
 
@@ -912,7 +912,7 @@ func doConvoyStranded(store beads.Store, stdout, stderr io.Writer) int {
 func doConvoyStrandedAcrossStores(stores []convoyStoreView, stdout, stderr io.Writer) int {
 	convoys, err := collectOpenConvoys(stores)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy stranded: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy stranded", err)
 		return 1
 	}
 
@@ -1015,7 +1015,7 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 
 	convoy, err := store.Get(convoyID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy land: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy land", err)
 		return 1
 	}
 	if convoy.Type != "convoy" {
@@ -1036,7 +1036,7 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 	// Check children.
 	children, err := listConvoyChildren(store, convoyID, true)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc convoy land: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy land", err)
 		return 1
 	}
 
@@ -1065,7 +1065,7 @@ func doConvoyLand(store beads.Store, rec events.Recorder, args []string, opts la
 
 	// Close the convoy.
 	if err := store.Close(convoyID); err != nil {
-		fmt.Fprintf(stderr, "gc convoy land: closing convoy: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "convoy land: closing convoy", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -386,7 +386,7 @@ func openAllConvoyStores(stderr io.Writer, cmdName string) ([]convoyStoreView, i
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", prog()+" doctor") //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return stores, 0
@@ -434,7 +434,7 @@ func openConvoyStoreByID(convoyID string, stderr io.Writer, cmdName string) (bea
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", prog()+" doctor") //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return store, 0

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -40,7 +40,7 @@ func convoyDispatchSubcommands(stdout, stderr io.Writer) []*cobra.Command {
 func newWorkflowCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "workflow",
-		Short:  "Alias for gc convoy (deprecated)",
+		Short:  fmt.Sprintf("Alias for %s convoy (deprecated)", prog()),
 		Hidden: true,
 	}
 	cmd.AddCommand(convoyDispatchSubcommands(stdout, stderr)...)

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -71,7 +71,7 @@ Use --follow <agent> to filter the serve loop to a specific agent template.`,
 				if errors.Is(err, dispatch.ErrControlPending) {
 					return nil
 				}
-				_, _ = fmt.Fprintf(stderr, "gc convoy control: %v\n", err)
+				cmdErr(stderr, "convoy control", err)
 				return errExit
 			}
 			return nil
@@ -91,11 +91,11 @@ func newConvoyPokeCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveCity()
 			if err != nil {
-				_, _ = fmt.Fprintf(stderr, "gc convoy poke: %v\n", err)
+				cmdErr(stderr, "convoy poke", err)
 				return errExit
 			}
 			if err := pokeControlDispatch(cityPath); err != nil {
-				_, _ = fmt.Fprintf(stderr, "gc convoy poke: %v\n", err)
+				cmdErr(stderr, "convoy poke", err)
 				return errExit
 			}
 			return nil
@@ -448,7 +448,7 @@ Use --delete with --apply to also delete closed beads.`,
 			}
 			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
 			if err != nil {
-				_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
+				cmdErr(stderr, "workflow delete-source", err)
 				return errExit
 			}
 			return exitForCode(cmdWorkflowDeleteSource(args[0], selector, apply, deleteBeads, stdout, stderr))
@@ -471,7 +471,7 @@ func newConvoyReopenSourceCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
 			if err != nil {
-				_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
+				cmdErr(stderr, "workflow reopen-source", err)
 				return errExit
 			}
 			return exitForCode(cmdWorkflowReopenSource(args[0], selector, stdout, stderr))
@@ -485,12 +485,12 @@ func newConvoyReopenSourceCmd(stdout, stderr io.Writer) *cobra.Command {
 func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "workflow delete", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "workflow delete", err)
 		return 1
 	}
 
@@ -505,7 +505,7 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		return openStoreAtForCity(dir, cityPath)
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "workflow delete", err)
 		return 1
 	}
 	for _, info := range stores {
@@ -720,12 +720,12 @@ func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads
 func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSelector, apply, deleteBeads bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
+		cmdErr(stderr, "workflow delete-source", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
+		cmdErr(stderr, "workflow delete-source", err)
 		return 1
 	}
 
@@ -735,7 +735,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 	)
 	target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, false)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", err)
+		cmdErr(stderr, "workflow delete-source", err)
 		return 1
 	}
 	lockScope := target.storeView.path
@@ -855,7 +855,7 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		return nil
 	})
 	if runErr != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow delete-source: %v\n", runErr)
+		cmdErr(stderr, "workflow delete-source", runErr)
 		return 1
 	}
 	return resultCode
@@ -864,19 +864,19 @@ func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSe
 func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSelector, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
+		cmdErr(stderr, "workflow reopen-source", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
+		cmdErr(stderr, "workflow reopen-source", err)
 		return 1
 	}
 
 	resultCode := 0
 	target, err := resolveSourceWorkflowTarget(cfg, cityPath, sourceBeadID, selector, true)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", err)
+		cmdErr(stderr, "workflow reopen-source", err)
 		return 1
 	}
 	if target.storeView.store == nil || strings.TrimSpace(target.sourceBead.ID) == "" {
@@ -945,7 +945,7 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		return nil
 	})
 	if runErr != nil {
-		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: %v\n", runErr)
+		cmdErr(stderr, "workflow reopen-source", runErr)
 		return 1
 	}
 	return resultCode

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -443,7 +443,7 @@ Use --delete with --apply to also delete closed beads.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if deleteBeads && !apply {
-				fmt.Fprintln(stderr, "gc workflow delete-source: --delete requires --apply") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: --delete requires --apply\n", cmdName("workflow delete-source")) //nolint:errcheck
 				return errExit
 			}
 			selector, err := parseSourceWorkflowStoreSelector(rigName, storeRef)
@@ -531,7 +531,7 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		}
 	}
 	if total == 0 {
-		fmt.Fprintf(stderr, "gc workflow delete: no beads found for workflow %s\n", workflowID) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: no beads found for workflow %s\n", cmdName("workflow delete"), workflowID) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -880,7 +880,7 @@ func cmdWorkflowReopenSource(sourceBeadID string, selector sourceWorkflowStoreSe
 		return 1
 	}
 	if target.storeView.store == nil || strings.TrimSpace(target.sourceBead.ID) == "" {
-		_, _ = fmt.Fprintf(stderr, "gc workflow reopen-source: getting bead %q: %v\n", sourceBeadID, beads.ErrNotFound)
+		_, _ = fmt.Fprintf(stderr, "%s: getting bead %q: %v\n", cmdName("workflow reopen-source"), sourceBeadID, beads.ErrNotFound)
 		return 1
 	}
 	ctx, cancel := sourceWorkflowCommandContext()

--- a/cmd/gc/cmd_dashboard.go
+++ b/cmd/gc/cmd_dashboard.go
@@ -117,7 +117,7 @@ func resolveDashboardAPI(cityPath string, cfg *config.City, apiURLOverride strin
 	}
 
 	if cityPath == "" {
-		return "", fmt.Errorf("could not auto-discover the supervisor API; start the supervisor with %q or pass --api explicitly", "gc supervisor start")
+		return "", fmt.Errorf("could not auto-discover the supervisor API; start the supervisor with %q or pass --api explicitly", cmdName("supervisor start"))
 	}
 	// Standalone-controller mode: the controller's API (cfg.API.Port)
 	// now serves the same /v0/city/{cityName}/... surface as the
@@ -128,7 +128,7 @@ func resolveDashboardAPI(cityPath string, cfg *config.City, apiURLOverride strin
 	if hasStandaloneDashboardAPI(cfg) {
 		return standaloneAPIBaseURL(cfg), nil
 	}
-	return "", fmt.Errorf("could not auto-discover the supervisor API for %q; start the supervisor with %q or pass --api explicitly", cityPath, "gc supervisor start")
+	return "", fmt.Errorf("could not auto-discover the supervisor API for %q; start the supervisor with %q or pass --api explicitly", cityPath, cmdName("supervisor start"))
 }
 
 func hasStandaloneDashboardAPI(cfg *config.City) bool {

--- a/cmd/gc/cmd_dashboard.go
+++ b/cmd/gc/cmd_dashboard.go
@@ -28,7 +28,7 @@ city tabs. From a city directory or with --city, city-specific panels and action
 forms are enabled for that city.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if runDashboardServe("gc dashboard", port, apiURL, stderr) != nil {
+			if runDashboardServe(cmdName("dashboard"), port, apiURL, stderr) != nil {
 				return errExit
 			}
 			return nil
@@ -53,7 +53,7 @@ city tabs. From a city directory or with --city, city-specific panels and action
 forms are enabled for that city.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if runDashboardServe("gc dashboard serve", port, apiURL, stderr) != nil {
+			if runDashboardServe(cmdName("dashboard serve"), port, apiURL, stderr) != nil {
 				return errExit
 			}
 			return nil

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -120,7 +120,7 @@ func (c *doltTopologyCheck) Fix(_ *doctor.CheckContext) error { return nil }
 func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc doctor: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "doctor", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -64,15 +64,15 @@ func newDoltConfigCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if cityPath == "" {
-				fmt.Fprintln(stderr, "gc dolt-config normalize-scope: missing --city") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: missing --city\n", cmdName("dolt-config normalize-scope")) //nolint:errcheck
 				return errExit
 			}
 			if scopeDir == "" {
-				fmt.Fprintln(stderr, "gc dolt-config normalize-scope: missing --dir") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: missing --dir\n", cmdName("dolt-config normalize-scope")) //nolint:errcheck
 				return errExit
 			}
 			if issuePrefix == "" {
-				fmt.Fprintln(stderr, "gc dolt-config normalize-scope: missing --prefix") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: missing --prefix\n", cmdName("dolt-config normalize-scope")) //nolint:errcheck
 				return errExit
 			}
 			if err := normalizeCanonicalBdScopeFilesForInit(cityPath, scopeDir, issuePrefix, doltDatabase); err != nil {

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -40,7 +40,7 @@ func newDoltConfigCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := writeManagedDoltConfigFile(configFile, host, port, dataDir, logLevel); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-config write-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-config write-managed", err)
 				return errExit
 			}
 			return nil
@@ -76,11 +76,11 @@ func newDoltConfigCmd(_ io.Writer, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if err := normalizeCanonicalBdScopeFilesForInit(cityPath, scopeDir, issuePrefix, doltDatabase); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-config normalize-scope: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-config normalize-scope", err)
 				return errExit
 			}
 			if err := removeScopeLocalDoltServerArtifacts(scopeDir); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-config normalize-scope: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-config normalize-scope", err)
 				return errExit
 			}
 			return nil

--- a/cmd/gc/cmd_dolt_state.go
+++ b/cmd/gc/cmd_dolt_state.go
@@ -47,11 +47,11 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			state, err := parseDoltRuntimeStateFlags(pidText, runText, portText, dataDir, startedAt)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state write-provider: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state write-provider", err)
 				return errExit
 			}
 			if err := writeDoltRuntimeStateFile(stateFile, state); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state write-provider: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state write-provider", err)
 				return errExit
 			}
 			return nil
@@ -81,16 +81,16 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 				if os.IsNotExist(err) {
 					return nil
 				}
-				fmt.Fprintf(stderr, "gc dolt-state read-provider: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state read-provider", err)
 				return errExit
 			}
 			value, err := doltRuntimeStateField(state, field)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state read-provider: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state read-provider", err)
 				return errExit
 			}
 			if _, err := io.WriteString(stdout, value); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state read-provider: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state read-provider", err)
 				return errExit
 			}
 			return nil
@@ -110,12 +110,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state runtime-layout: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state runtime-layout", err)
 				return errExit
 			}
 			for _, line := range doltRuntimeLayoutFields(layout) {
 				if _, err := fmt.Fprintln(stdout, line); err != nil {
-					fmt.Fprintf(stderr, "gc dolt-state runtime-layout: %v\n", err) //nolint:errcheck
+					cmdErr(stderr, "dolt-state runtime-layout", err)
 					return errExit
 				}
 			}
@@ -134,11 +134,11 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			port, err := chooseManagedDoltPort(cityPath, stateFile)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state allocate-port: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state allocate-port", err)
 				return errExit
 			}
 			if _, err := fmt.Fprintln(stdout, port); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state allocate-port: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state allocate-port", err)
 				return errExit
 			}
 			return nil
@@ -157,12 +157,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			info, err := inspectManagedDoltProcess(cityPath, portText)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state inspect-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state inspect-managed", err)
 				return errExit
 			}
 			for _, line := range doltProcessInspectionFields(info) {
 				if _, err := fmt.Fprintln(stdout, line); err != nil {
-					fmt.Fprintf(stderr, "gc dolt-state inspect-managed: %v\n", err) //nolint:errcheck
+					cmdErr(stderr, "dolt-state inspect-managed", err)
 					return errExit
 				}
 			}
@@ -182,12 +182,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			report, err := probeManagedDolt(cityPath, hostText, portText)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state probe-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state probe-managed", err)
 				return errExit
 			}
 			for _, line := range managedDoltProbeFields(report) {
 				if _, err := fmt.Fprintln(stdout, line); err != nil {
-					fmt.Fprintf(stderr, "gc dolt-state probe-managed: %v\n", err) //nolint:errcheck
+					cmdErr(stderr, "dolt-state probe-managed", err)
 					return errExit
 				}
 			}
@@ -209,12 +209,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			report, err := assessExistingManagedDolt(cityPath, hostText, portText, userText, time.Duration(timeoutMS)*time.Millisecond)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state existing-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state existing-managed", err)
 				return errExit
 			}
 			for _, line := range managedDoltExistingFields(report) {
 				if _, err := fmt.Fprintln(stdout, line); err != nil {
-					fmt.Fprintf(stderr, "gc dolt-state existing-managed: %v\n", err) //nolint:errcheck
+					cmdErr(stderr, "dolt-state existing-managed", err)
 					return errExit
 				}
 			}
@@ -237,7 +237,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if _, err := fmt.Fprintln(stdout, time.Now().UnixMilli()); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state now-ms: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state now-ms", err)
 				return errExit
 			}
 			return nil
@@ -252,7 +252,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := managedDoltQueryProbe(hostText, portText, userText); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state query-probe: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state query-probe", err)
 				return errExit
 			}
 			return nil
@@ -272,7 +272,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			state, err := managedDoltReadOnlyState(hostText, portText, userText)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state read-only-check: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state read-only-check", err)
 				return errExit
 			}
 			if state == "true" {
@@ -298,7 +298,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 				return errExit
 			}
 			if err := managedDoltResetProbe(hostText, portText, userText); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state reset-probe: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state reset-probe", err)
 				return errExit
 			}
 			return nil
@@ -319,12 +319,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			report, err := managedDoltHealthCheck(hostText, portText, userText, checkReadOnly)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state health-check: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state health-check", err)
 				return errExit
 			}
 			for _, line := range managedDoltHealthCheckFields(report) {
 				if _, err := fmt.Fprintln(stdout, line); err != nil {
-					fmt.Fprintf(stderr, "gc dolt-state health-check: %v\n", err) //nolint:errcheck
+					cmdErr(stderr, "dolt-state health-check", err)
 					return errExit
 				}
 			}
@@ -352,12 +352,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 			report, err := waitForManagedDoltReady(cityPath, hostText, portText, userText, pid, time.Duration(timeoutMS)*time.Millisecond, checkDeleted)
 			for _, line := range managedDoltWaitReadyFields(report) {
 				if _, writeErr := fmt.Fprintln(stdout, line); writeErr != nil {
-					fmt.Fprintf(stderr, "gc dolt-state wait-ready: %v\n", writeErr) //nolint:errcheck
+					cmdErr(stderr, "dolt-state wait-ready", writeErr)
 					return errExit
 				}
 			}
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state wait-ready: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state wait-ready", err)
 				return errExit
 			}
 			return nil
@@ -385,12 +385,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 			report, err := stopManagedDoltProcess(cityPath, portText)
 			for _, line := range managedDoltStopFields(report) {
 				if _, writeErr := fmt.Fprintln(stdout, line); writeErr != nil {
-					fmt.Fprintf(stderr, "gc dolt-state stop-managed: %v\n", writeErr) //nolint:errcheck
+					cmdErr(stderr, "dolt-state stop-managed", writeErr)
 					return errExit
 				}
 			}
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state stop-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state stop-managed", err)
 				return errExit
 			}
 			return nil
@@ -410,12 +410,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 			report, err := startManagedDoltProcess(cityPath, hostText, portText, userText, logLevel, time.Duration(timeoutMS)*time.Millisecond)
 			for _, line := range managedDoltStartFields(report) {
 				if _, writeErr := fmt.Fprintln(stdout, line); writeErr != nil {
-					fmt.Fprintf(stderr, "gc dolt-state start-managed: %v\n", writeErr) //nolint:errcheck
+					cmdErr(stderr, "dolt-state start-managed", writeErr)
 					return errExit
 				}
 			}
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state start-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state start-managed", err)
 				return errExit
 			}
 			return nil
@@ -440,12 +440,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 			report, err := recoverManagedDoltProcess(cityPath, hostText, portText, userText, logLevel, time.Duration(timeoutMS)*time.Millisecond)
 			for _, line := range managedDoltRecoverFields(report) {
 				if _, writeErr := fmt.Fprintln(stdout, line); writeErr != nil {
-					fmt.Fprintf(stderr, "gc dolt-state recover-managed: %v\n", writeErr) //nolint:errcheck
+					cmdErr(stderr, "dolt-state recover-managed", writeErr)
 					return errExit
 				}
 			}
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state recover-managed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state recover-managed", err)
 				return errExit
 			}
 			return nil
@@ -468,7 +468,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := preflightManagedDoltCleanup(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state preflight-clean: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state preflight-clean", err)
 				return errExit
 			}
 			return nil

--- a/cmd/gc/cmd_dolt_state.go
+++ b/cmd/gc/cmd_dolt_state.go
@@ -294,7 +294,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if !forceReset {
-				fmt.Fprintf(stderr, "gc dolt-state reset-probe: refusing to drop %s without --force; this database may contain a legacy bead store in old metadata\n", managedDoltProbeDatabase) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: refusing to drop %s without --force; this database may contain a legacy bead store in old metadata\n", cmdName("dolt-state reset-probe"), managedDoltProbeDatabase) //nolint:errcheck
 				return errExit
 			}
 			if err := managedDoltResetProbe(hostText, portText, userText); err != nil {
@@ -346,7 +346,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			pid, err := strconv.Atoi(pidText)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state wait-ready: invalid --pid %q: %v\n", pidText, err) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: invalid --pid %q: %v\n", cmdName("dolt-state wait-ready"), pidText, err) //nolint:errcheck
 				return errExit
 			}
 			report, err := waitForManagedDoltReady(cityPath, hostText, portText, userText, pid, time.Duration(timeoutMS)*time.Millisecond, checkDeleted)

--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -16,9 +16,9 @@ func newEventCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc event: missing subcommand (emit)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (emit)\n", cmdName("event")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc event: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("event"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -81,7 +81,7 @@ func doEventEmit(ep events.Provider, eventType, subject, message, actor, payload
 	}
 	if payload != "" {
 		if !json.Valid([]byte(payload)) {
-			fmt.Fprintf(stderr, "gc event emit: --payload is not valid JSON\n") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --payload is not valid JSON\n", cmdName("event emit")) //nolint:errcheck // best-effort stderr
 			return                                                              // best-effort — never fail
 		}
 		e.Payload = json.RawMessage(payload)

--- a/cmd/gc/cmd_event_emit.go
+++ b/cmd/gc/cmd_event_emit.go
@@ -55,7 +55,7 @@ attaching arbitrary JSON payloads.`,
 // cmdEventEmit records a single event to the city event log. Best-effort:
 // errors go to stderr but exit code is always 0 so bd hooks never fail.
 func cmdEventEmit(eventType, subject, message, actor, payload string, stderr io.Writer) int {
-	ep, code := openCityEventsProvider(stderr, "gc event emit")
+	ep, code := openCityEventsProvider(stderr, cmdName("event emit"))
 	if ep == nil {
 		// Best-effort: if we can't open the provider, still exit 0.
 		_ = code

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -266,7 +266,7 @@ func resolveEventsScope(apiURLOverride string) (eventsAPIScope, error) {
 	if cityPath == "" {
 		return eventsAPIScope{}, fmt.Errorf(
 			"could not auto-discover the supervisor API; start the supervisor with %q or pass --api explicitly",
-			"gc supervisor start",
+			cmdName("supervisor start"),
 		)
 	}
 	// Standalone-controller mode: the controller's API now serves
@@ -290,7 +290,7 @@ func resolveEventsScope(apiURLOverride string) (eventsAPIScope, error) {
 	return eventsAPIScope{}, fmt.Errorf(
 		"could not auto-discover the supervisor API for %q; start the supervisor with %q or pass --api explicitly",
 		cityPath,
-		"gc supervisor start",
+		cmdName("supervisor start"),
 	)
 }
 

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -97,8 +97,8 @@ func newEventsCmd(stdout, stderr io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "events",
-		Short: "Show events from the GC API",
-		Long: `Show events from the GC API with optional filtering.
+		Short: fmt.Sprintf("Show events from the %s API", prog()),
+		Long: fmt.Sprintf(`Show events from the %s API with optional filtering.
 
 The API is the source of truth for both city-scoped and supervisor-scoped
 events. In a city directory (or with --city), this command reflects the
@@ -106,13 +106,13 @@ city's /v0/city/{cityName}/events and /stream endpoints. Without a city in
 scope, it reflects the supervisor's /v0/events and /stream endpoints.
 
 List, watch, and follow output are always JSON Lines. Each line is one API
-DTO or SSE envelope.`,
-		Example: `  gc events
-  gc events --type bead.created --since 1h
-  gc events --watch --type convoy.closed --timeout 5m
-  gc events --follow
-  gc events --seq
-  gc events --follow --after-cursor city-a:12,city-b:9`,
+DTO or SSE envelope.`, prog()),
+		Example: fmt.Sprintf(`  %[1]s events
+  %[1]s events --type bead.created --since 1h
+  %[1]s events --watch --type convoy.closed --timeout 5m
+  %[1]s events --follow
+  %[1]s events --seq
+  %[1]s events --follow --after-cursor city-a:12,city-b:9`, prog()),
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if afterFlag > 0 && strings.TrimSpace(afterCursor) != "" {
@@ -143,7 +143,7 @@ DTO or SSE envelope.`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&apiURL, "api", "", "GC API server URL override (auto-discovered by default)")
+	cmd.Flags().StringVar(&apiURL, "api", "", fmt.Sprintf("%s API server URL override (auto-discovered by default)", prog()))
 	cmd.Flags().StringVar(&typeFilter, "type", "", "Filter by event type (e.g. bead.created)")
 	cmd.Flags().StringVar(&sinceFlag, "since", "", "Show events since duration ago (e.g. 1h, 30m)")
 	cmd.Flags().BoolVar(&watchFlag, "watch", false, "Block until matching events arrive (exits after first match or buffered replay)")

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -160,12 +160,12 @@ DTO or SSE envelope.`,
 
 func cmdEvents(apiURLOverride, typeFilter, sinceFlag string, payloadMatchArgs []string, stdout, stderr io.Writer) int {
 	if err := validateEventsSince(sinceFlag); err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	pm, err := parsePayloadMatch(payloadMatchArgs)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	scope, code := openEventsScope(apiURLOverride, stderr)
@@ -186,7 +186,7 @@ func cmdEventsSeq(apiURLOverride string, stdout, stderr io.Writer) int {
 func cmdEventsFollow(apiURLOverride, typeFilter string, payloadMatchArgs []string, afterSeq uint64, afterCursor string, stdout, stderr io.Writer) int {
 	pm, err := parsePayloadMatch(payloadMatchArgs)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	scope, code := openEventsScope(apiURLOverride, stderr)
@@ -194,7 +194,7 @@ func cmdEventsFollow(apiURLOverride, typeFilter string, payloadMatchArgs []strin
 		return code
 	}
 	if err := validateEventsCursor(scope, afterSeq, afterCursor); err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	return doEventsFollow(scope, typeFilter, pm, afterSeq, afterCursor, stdout, stderr)
@@ -208,7 +208,7 @@ func cmdEventsWatch(apiURLOverride, typeFilter string, payloadMatchArgs []string
 	}
 	pm, err := parsePayloadMatch(payloadMatchArgs)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	scope, code := openEventsScope(apiURLOverride, stderr)
@@ -216,7 +216,7 @@ func cmdEventsWatch(apiURLOverride, typeFilter string, payloadMatchArgs []string
 		return code
 	}
 	if err := validateEventsCursor(scope, afterSeq, afterCursor); err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	return doEventsWatch(scope, typeFilter, pm, afterSeq, afterCursor, timeout, stdout, stderr)
@@ -225,7 +225,7 @@ func cmdEventsWatch(apiURLOverride, typeFilter string, payloadMatchArgs []string
 func openEventsScope(apiURLOverride string, stderr io.Writer) (eventsAPIScope, int) {
 	scope, err := resolveEventsScope(apiURLOverride)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return eventsAPIScope{}, 1
 	}
 	return scope, 0
@@ -405,7 +405,7 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 	if scope.localOnly {
 		fallback, _, fallbackErr := readLocalCityEvents(scope, stoppedCityLocalFallbackError(scope), typeFilter, sinceFlag, stderr)
 		if fallbackErr != nil {
-			fmt.Fprintf(stderr, "gc events: %v\n", fallbackErr) //nolint:errcheck
+			cmdErr(stderr, "events", fallbackErr)
 			return 1
 		}
 		fallback = filterCityEvents(fallback, 0, typeFilter, payloadMatch)
@@ -414,7 +414,7 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 
 	client, err := scope.client()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 
@@ -424,7 +424,7 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 	if scope.isSupervisor() {
 		items, err := fetchSupervisorEvents(ctx, client, typeFilter, sinceFlag)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events", err)
 			return 1
 		}
 		items = filterSupervisorEvents(items, typeFilter, payloadMatch)
@@ -435,13 +435,13 @@ func doEvents(scope eventsAPIScope, typeFilter, sinceFlag string, payloadMatch m
 	if err != nil {
 		if fallback, ok, fallbackErr := readLocalCityEvents(scope, err, typeFilter, sinceFlag, stderr); ok {
 			if fallbackErr != nil {
-				fmt.Fprintf(stderr, "gc events: %v\n", fallbackErr) //nolint:errcheck
+				cmdErr(stderr, "events", fallbackErr)
 				return 1
 			}
 			fallback = filterCityEvents(fallback, 0, typeFilter, payloadMatch)
 			return printJSONLines(fallback, stdout, stderr)
 		}
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	items = filterCityEvents(items, 0, typeFilter, payloadMatch)
@@ -452,7 +452,7 @@ func doEventsSeq(scope eventsAPIScope, stdout, stderr io.Writer) int {
 	if scope.localOnly {
 		fallback, _, fallbackErr := readLocalCityHeadIndex(scope, stoppedCityLocalFallbackError(scope))
 		if fallbackErr != nil {
-			fmt.Fprintf(stderr, "gc events: %v\n", fallbackErr) //nolint:errcheck
+			cmdErr(stderr, "events", fallbackErr)
 			return 1
 		}
 		fmt.Fprintln(stdout, fallback) //nolint:errcheck
@@ -461,7 +461,7 @@ func doEventsSeq(scope eventsAPIScope, stdout, stderr io.Writer) int {
 
 	client, err := scope.client()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 
@@ -471,7 +471,7 @@ func doEventsSeq(scope eventsAPIScope, stdout, stderr io.Writer) int {
 	if scope.isSupervisor() {
 		cursor, err := fetchSupervisorHeadCursor(ctx, client)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events", err)
 			return 1
 		}
 		if cursor == "" {
@@ -485,13 +485,13 @@ func doEventsSeq(scope eventsAPIScope, stdout, stderr io.Writer) int {
 	if err != nil {
 		if fallback, ok, fallbackErr := readLocalCityHeadIndex(scope, err); ok {
 			if fallbackErr != nil {
-				fmt.Fprintf(stderr, "gc events: %v\n", fallbackErr) //nolint:errcheck
+				cmdErr(stderr, "events", fallbackErr)
 				return 1
 			}
 			fmt.Fprintln(stdout, fallback) //nolint:errcheck
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, index) //nolint:errcheck
@@ -568,7 +568,7 @@ func requireStreamingCityAPI(ctx context.Context, client *genclient.ClientWithRe
 		printStreamingCityAPIRequirement(mode, stderr)
 		return "", false
 	}
-	fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+	cmdErr(stderr, "events", err)
 	return "", false
 }
 
@@ -578,7 +578,7 @@ func requireStreamingCityEventsReachable(ctx context.Context, client *genclient.
 			printStreamingCityAPIRequirement(mode, stderr)
 			return false
 		}
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return false
 	}
 	return true
@@ -635,7 +635,7 @@ func doEventsFollow(scope eventsAPIScope, typeFilter string, payloadMatch map[st
 
 	client, err := scope.client()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 
@@ -645,7 +645,7 @@ func doEventsFollow(scope eventsAPIScope, typeFilter string, payloadMatch map[st
 		if cursor == "" {
 			cursor, err = fetchSupervisorHeadCursor(ctx, client)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events", err)
 				return 1
 			}
 		}
@@ -677,7 +677,7 @@ func doEventsWatch(scope eventsAPIScope, typeFilter string, payloadMatch map[str
 
 	client, err := scope.client()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1
 	}
 
@@ -689,7 +689,7 @@ func doEventsWatch(scope eventsAPIScope, typeFilter string, payloadMatch map[str
 		if cursor != "" {
 			items, err := fetchSupervisorEvents(ctx, client, "", "")
 			if err != nil {
-				fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events", err)
 				return 1
 			}
 			matches := filterSupervisorEventsAfterCursor(items, cursor, typeFilter, payloadMatch)
@@ -699,7 +699,7 @@ func doEventsWatch(scope eventsAPIScope, typeFilter string, payloadMatch map[str
 		} else {
 			cursor, err = fetchSupervisorHeadCursor(ctx, client)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events", err)
 				return 1
 			}
 		}
@@ -714,7 +714,7 @@ func doEventsWatch(scope eventsAPIScope, typeFilter string, payloadMatch map[str
 				printStreamingCityAPIRequirement("--watch", stderr)
 				return 1
 			}
-			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events", err)
 			return 1
 		}
 		matches := filterCityEvents(items, resumeSeq, typeFilter, payloadMatch)
@@ -881,34 +881,34 @@ func printJSONLines(items any, stdout, stderr io.Writer) int {
 	case []genclient.WireEvent:
 		for _, item := range typed {
 			if err := writeJSONLValue(stdout, item); err != nil {
-				fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events: marshal", err)
 				return 1
 			}
 		}
 	case []genclient.WireTaggedEvent:
 		for _, item := range typed {
 			if err := writeJSONLValue(stdout, item); err != nil {
-				fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events: marshal", err)
 				return 1
 			}
 		}
 	case []genclient.EventStreamEnvelope:
 		for _, item := range typed {
 			if err := writeJSONLValue(stdout, item); err != nil {
-				fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events: marshal", err)
 				return 1
 			}
 		}
 	case []genclient.TaggedEventStreamEnvelope:
 		for _, item := range typed {
 			if err := writeJSONLValue(stdout, item); err != nil {
-				fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "events: marshal", err)
 				return 1
 			}
 		}
 	default:
 		if err := writeJSONLValue(stdout, typed); err != nil {
-			fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: marshal", err)
 			return 1
 		}
 	}
@@ -1044,10 +1044,10 @@ func streamCityEventsOnce(ctx context.Context, client *genclient.ClientWithRespo
 		// rather than exiting status=1. --watch is bounded by its own
 		// timeout so stopAfterMatch=true still exits on setup failure.
 		if !stopAfterMatch {
-			fmt.Fprintf(stderr, "gc events: connect failed, retrying: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: connect failed, retrying", err)
 			return 0, afterSeq, true
 		}
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1, afterSeq, false
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -1071,7 +1071,7 @@ func streamCityEventsOnce(ctx context.Context, client *genclient.ClientWithRespo
 				// Follow mode: reconnect with lastSeq.
 				return 0, lastSeq, true
 			}
-			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events", err)
 			return 1, lastSeq, false
 		}
 		if frame.Event == "heartbeat" || strings.TrimSpace(frame.Data) == "" {
@@ -1083,7 +1083,7 @@ func streamCityEventsOnce(ctx context.Context, client *genclient.ClientWithRespo
 
 		var envelope genclient.EventStreamEnvelope
 		if err := json.Unmarshal([]byte(frame.Data), &envelope); err != nil {
-			fmt.Fprintf(stderr, "gc events: decode: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: decode", err)
 			return 1, lastSeq, false
 		}
 		if envelope.Seq > 0 && uint64(envelope.Seq) > lastSeq {
@@ -1096,7 +1096,7 @@ func streamCityEventsOnce(ctx context.Context, client *genclient.ClientWithRespo
 			continue
 		}
 		if err := writeJSONLValue(stdout, envelope); err != nil {
-			fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: marshal", err)
 			return 1, lastSeq, false
 		}
 		if stopAfterMatch {
@@ -1142,10 +1142,10 @@ func streamSupervisorEventsOnce(ctx context.Context, client *genclient.ClientWit
 		// outer backoff. --watch (stopAfterMatch=true) is bounded by
 		// its own timeout and still exits on setup failure.
 		if !stopAfterMatch {
-			fmt.Fprintf(stderr, "gc events: connect failed, retrying: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: connect failed, retrying", err)
 			return 0, afterCursor, true
 		}
-		fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "events", err)
 		return 1, afterCursor, false
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -1169,7 +1169,7 @@ func streamSupervisorEventsOnce(ctx context.Context, client *genclient.ClientWit
 				}
 				return 0, lastCursor, true
 			}
-			fmt.Fprintf(stderr, "gc events: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events", err)
 			return 1, lastCursor, false
 		}
 		if frame.Event == "heartbeat" || strings.TrimSpace(frame.Data) == "" {
@@ -1186,7 +1186,7 @@ func streamSupervisorEventsOnce(ctx context.Context, client *genclient.ClientWit
 
 		var envelope genclient.TaggedEventStreamEnvelope
 		if err := json.Unmarshal([]byte(frame.Data), &envelope); err != nil {
-			fmt.Fprintf(stderr, "gc events: decode: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: decode", err)
 			return 1, lastCursor, false
 		}
 		// Track per-city seq in the composite cursor so reconnects resume
@@ -1207,7 +1207,7 @@ func streamSupervisorEventsOnce(ctx context.Context, client *genclient.ClientWit
 			continue
 		}
 		if err := writeJSONLValue(stdout, envelope); err != nil {
-			fmt.Fprintf(stderr, "gc events: marshal: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "events: marshal", err)
 			return 1, lastCursor, false
 		}
 		if stopAfterMatch {

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -554,7 +554,7 @@ func shouldUseLocalCityEventsFallback(scope eventsAPIScope, apiErr error) bool {
 func printStreamingCityAPIRequirement(mode string, stderr io.Writer) {
 	_, _ = fmt.Fprintf(
 		stderr,
-		"gc events: %s requires a running city API; local fallback only supports `gc events` and `gc events --seq` when the city is stopped\n",
+		cmdName("events")+": %s requires a running city API; local fallback only supports `"+cmdName("events")+"` and `"+cmdName("events")+" --seq` when the city is stopped\n",
 		mode,
 	)
 }
@@ -621,7 +621,7 @@ func localWireEvent(e events.Event, warningWriter io.Writer) genclient.WireEvent
 		if err := payload.UnmarshalJSON(e.Payload); err == nil {
 			item.Payload = &payload
 		} else if warningWriter != nil {
-			fmt.Fprintf(warningWriter, "gc events: warning: decoding local event payload for seq %d type %s: %v\n", e.Seq, e.Type, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(warningWriter, "%s: warning: decoding local event payload for seq %d type %s: %v\n", cmdName("events"), e.Seq, e.Type, err) //nolint:errcheck // best-effort stderr
 		}
 	}
 	return item

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -116,7 +116,7 @@ DTO or SSE envelope.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if afterFlag > 0 && strings.TrimSpace(afterCursor) != "" {
-				fmt.Fprintln(stderr, "gc events: --after and --after-cursor are mutually exclusive") //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: --after and --after-cursor are mutually exclusive\n", cmdName("events")) //nolint:errcheck
 				return errExit
 			}
 			if seqFlag {
@@ -203,7 +203,7 @@ func cmdEventsFollow(apiURLOverride, typeFilter string, payloadMatchArgs []strin
 func cmdEventsWatch(apiURLOverride, typeFilter string, payloadMatchArgs []string, afterSeq uint64, afterCursor, timeoutFlag string, stdout, stderr io.Writer) int {
 	timeout, err := time.ParseDuration(timeoutFlag)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: invalid --timeout %q: %v\n", timeoutFlag, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: invalid --timeout %q: %v\n", cmdName("events"), timeoutFlag, err) //nolint:errcheck
 		return 1
 	}
 	pm, err := parsePayloadMatch(payloadMatchArgs)
@@ -660,7 +660,7 @@ func doEventsFollow(scope eventsAPIScope, typeFilter string, payloadMatch map[st
 		}
 		resumeSeq, err = strconv.ParseUint(head, 10, 64)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc events: invalid X-GC-Index %q\n", head) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: invalid X-GC-Index %q\n", cmdName("events"), head) //nolint:errcheck
 			return 1
 		}
 	} else if !requireStreamingCityEventsReachable(ctx, client, scope, "--follow", stderr) {
@@ -728,7 +728,7 @@ func doEventsWatch(scope eventsAPIScope, typeFilter string, payloadMatch map[str
 		}
 		resumeSeq, err = strconv.ParseUint(head, 10, 64)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc events: invalid X-GC-Index %q\n", head) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: invalid X-GC-Index %q\n", cmdName("events"), head) //nolint:errcheck
 			return 1
 		}
 	}
@@ -1065,7 +1065,7 @@ func streamCityEventsOnce(ctx context.Context, client *genclient.ClientWithRespo
 			}
 			if errors.Is(err, io.EOF) {
 				if stopAfterMatch {
-					fmt.Fprintln(stderr, "gc events: stream ended before a matching event arrived") //nolint:errcheck
+					fmt.Fprintf(stderr, "%s: stream ended before a matching event arrived\n", cmdName("events")) //nolint:errcheck
 					return 1, lastSeq, false
 				}
 				// Follow mode: reconnect with lastSeq.
@@ -1164,7 +1164,7 @@ func streamSupervisorEventsOnce(ctx context.Context, client *genclient.ClientWit
 			}
 			if errors.Is(err, io.EOF) {
 				if stopAfterMatch {
-					fmt.Fprintln(stderr, "gc events: stream ended before a matching event arrived") //nolint:errcheck
+					fmt.Fprintf(stderr, "%s: stream ended before a matching event arrived\n", cmdName("events")) //nolint:errcheck
 					return 1, lastCursor, false
 				}
 				return 0, lastCursor, true
@@ -1220,14 +1220,14 @@ func printStreamError(resp *http.Response, stderr io.Writer) int {
 	defer resp.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc events: HTTP %d\n", resp.StatusCode) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: HTTP %d\n", cmdName("events"), resp.StatusCode) //nolint:errcheck
 		return 1
 	}
 	if strings.Contains(resp.Header.Get("Content-Type"), "json") {
 		var problem genclient.ErrorModel
 		if err := json.Unmarshal(body, &problem); err == nil {
 			if problem.Detail != nil && strings.TrimSpace(*problem.Detail) != "" {
-				fmt.Fprintf(stderr, "gc events: %s\n", strings.TrimSpace(*problem.Detail)) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: %s\n", cmdName("events"), strings.TrimSpace(*problem.Detail)) //nolint:errcheck
 				return 1
 			}
 		}
@@ -1236,7 +1236,7 @@ func printStreamError(resp *http.Response, stderr io.Writer) int {
 	if msg == "" {
 		msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
 	}
-	fmt.Fprintf(stderr, "gc events: %s\n", msg) //nolint:errcheck
+	fmt.Fprintf(stderr, "%s: %s\n", cmdName("events"), msg) //nolint:errcheck
 	return 1
 }
 

--- a/cmd/gc/cmd_graph.go
+++ b/cmd/gc/cmd_graph.go
@@ -64,7 +64,7 @@ func cmdGraph(args []string, opts graphOpts, stdout, stderr io.Writer) int {
 func openRigAwareStore(args []string, stderr io.Writer) (beads.Store, int) {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc graph: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "graph", err)
 		return nil, 1
 	}
 
@@ -75,7 +75,7 @@ func openRigAwareStore(args []string, stderr io.Writer) (beads.Store, int) {
 			if storeDir := slingDirForBead(cfg, cityPath, args[0]); storeDir != cityPath {
 				store, err := openStoreAtForCity(storeDir, cityPath)
 				if err != nil {
-					fmt.Fprintf(stderr, "gc graph: %v\n", err)                      //nolint:errcheck // best-effort stderr
+					cmdErr(stderr, "graph", err)
 					fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
 					return nil, 1
 				}
@@ -86,7 +86,7 @@ func openRigAwareStore(args []string, stderr io.Writer) (beads.Store, int) {
 
 	store, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc graph: %v\n", err)                      //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "graph", err)
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
@@ -122,7 +122,7 @@ func doGraph(store beads.Store, args []string, opts graphOpts, stdout, stderr io
 	// Resolve input — expand containers, returning beads directly.
 	resolved, err := resolveGraphInput(store, args, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc graph: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "graph", err)
 		return 1
 	}
 	if len(resolved) == 0 {

--- a/cmd/gc/cmd_graph.go
+++ b/cmd/gc/cmd_graph.go
@@ -115,7 +115,7 @@ func isBlockingDep(depType string) bool {
 // doGraph resolves beads and their dependencies, then prints the graph.
 func doGraph(store beads.Store, args []string, opts graphOpts, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc graph: missing bead IDs") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing bead IDs\n", cmdName("graph")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -141,7 +141,7 @@ func doGraph(store beads.Store, args []string, opts graphOpts, stdout, stderr io
 	for _, b := range resolved {
 		deps, err := store.DepList(b.ID, "down")
 		if err != nil {
-			fmt.Fprintf(stderr, "gc graph: listing deps for %s: %v\n", b.ID, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: listing deps for %s: %v\n", cmdName("graph"), b.ID, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		var blockedBy []string
@@ -198,7 +198,7 @@ func resolveGraphInput(store beads.Store, args []string, stderr io.Writer) ([]be
 			return nil, err
 		}
 		if b.Type == "epic" {
-			fmt.Fprintf(stderr, "gc graph: epic %s is treated as an ordinary bead; convoy expansion is first-class\n", b.ID) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: epic %s is treated as an ordinary bead; convoy expansion is first-class\n", cmdName("graph"), b.ID) //nolint:errcheck // best-effort stderr
 		}
 		if beads.IsContainerType(b.Type) {
 			children, err := store.List(beads.ListQuery{

--- a/cmd/gc/cmd_graph.go
+++ b/cmd/gc/cmd_graph.go
@@ -76,7 +76,7 @@ func openRigAwareStore(args []string, stderr io.Writer) (beads.Store, int) {
 				store, err := openStoreAtForCity(storeDir, cityPath)
 				if err != nil {
 					cmdErr(stderr, "graph", err)
-					fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", cmdName("doctor")) //nolint:errcheck // best-effort stderr
 					return nil, 1
 				}
 				return store, 0
@@ -87,7 +87,7 @@ func openRigAwareStore(args []string, stderr io.Writer) (beads.Store, int) {
 	store, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
 		cmdErr(stderr, "graph", err)
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", cmdName("doctor")) //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return store, 0

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -64,13 +64,13 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 
 	current, err := currentSessionRuntimeTarget()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff", err)
 		return 1
 	}
 
 	store, err := openCityStoreAt(current.cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: %v\n", err)                    //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff", err)
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -97,7 +97,7 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) int {
 	targetInfo, err := resolveSessionRuntimeTarget(target, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff", err)
 		return 1
 	}
 
@@ -107,7 +107,7 @@ func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) in
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff", err)
 		return 1
 	}
 	cfg, _ := loadCityConfig(cityPath, stderr)
@@ -165,7 +165,7 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 		Labels:      []string{"thread:" + handoffThreadID()},
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff: creating mail", err)
 		return handoffOutcome{code: 1}
 	}
 	rec.Record(events.Event{
@@ -178,7 +178,7 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 
 	restartable, err := sessionRestartableByController(store, sessionName)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff: checking session type", err)
 		return handoffOutcome{code: 1}
 	}
 	// On-demand named sessions are human-attended and the controller cannot
@@ -187,7 +187,7 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	// guard: gastownhall/gascity#744.
 	if !restartable {
 		if err := clearRestartRequest(store, dops, sessionName); err != nil {
-			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "handoff: clearing stale restart request", err)
 			return handoffOutcome{code: 1, restartRequested: false}
 		}
 		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session; restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
@@ -195,14 +195,14 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	}
 
 	if err := dops.setRestartRequested(sessionName); err != nil {
-		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff: setting restart flag", err)
 		return handoffOutcome{code: 1}
 	}
 	// Also persist the request through the worker boundary so it survives
 	// tmux session death. Non-fatal: the runtime flag above is primary.
 	if persistRestart != nil {
 		if err := persistRestart(); err != nil {
-			fmt.Fprintf(stderr, "gc handoff: setting bead restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "handoff: setting bead restart flag", err)
 		}
 	}
 	rec.Record(events.Event{
@@ -288,7 +288,7 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 		Labels:      []string{"thread:" + handoffThreadID()},
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff: creating mail", err)
 		return 1
 	}
 	rec.Record(events.Event{
@@ -301,12 +301,12 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 
 	restartable, err := sessionRestartableByController(store, sessionName)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "handoff: checking session type", err)
 		return 1
 	}
 	if !restartable {
 		if err := clearRestartRequest(store, newDrainOps(sp), sessionName); err != nil {
-			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "handoff: clearing stale restart request", err)
 			return 1
 		}
 		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (named session; kill skipped because the controller cannot restart it)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -316,7 +316,7 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 	// Kill target session (reconciler restarts it).
 	running, err := workerSessionTargetRunningWithConfig("", store, sp, nil, sessionName)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: observing %s: %v\n", targetAddress, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: observing %s: %v\n", cmdName("handoff"), targetAddress, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !running {
@@ -324,7 +324,7 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 		return 0
 	}
 	if err := workerKillSessionTargetWithConfig("", store, sp, nil, sessionName); err != nil {
-		fmt.Fprintf(stderr, "gc handoff: killing %s: %v\n", targetAddress, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: killing %s: %v\n", cmdName("handoff"), targetAddress, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	rec.Record(events.Event{

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -101,7 +101,7 @@ func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) in
 		return 1
 	}
 
-	store, code := openCityStore(stderr, "gc handoff")
+	store, code := openCityStore(stderr, cmdName("handoff"))
 	if store == nil {
 		return code
 	}
@@ -111,7 +111,7 @@ func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) in
 		return 1
 	}
 	cfg, _ := loadCityConfig(cityPath, stderr)
-	sender, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc handoff")
+	sender, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, cmdName("handoff"))
 	if !ok {
 		return 1
 	}

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -71,7 +71,7 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 	store, err := openCityStoreAt(current.cityPath)
 	if err != nil {
 		cmdErr(stderr, "handoff", err)
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", cmdName("doctor")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	sp := newSessionProvider()

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -73,7 +73,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		if inject {
 			return 0 // --inject always exits 0
 		}
-		fmt.Fprintln(stderr, "gc hook: agent not specified (set $GC_AGENT or pass as argument)") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: agent not specified (set $GC_AGENT or pass as argument)\n", cmdName("hook")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -103,7 +103,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		if inject {
 			return 0
 		}
-		fmt.Fprintln(stderr, "gc hook: city is suspended") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: city is suspended\n", cmdName("hook")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -112,7 +112,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc hook: agent %q not found in config\n", agentName) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: agent %q not found in config\n", cmdName("hook"), agentName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -120,7 +120,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc hook: agent %q is suspended\n", agentName) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: agent %q is suspended\n", cmdName("hook"), agentName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -82,7 +82,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "hook", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
@@ -90,7 +90,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "hook", err)
 		return 1
 	}
 	// Normalize relative rig paths to absolute so downstream rig-matching
@@ -237,7 +237,7 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 		if inject {
 			return 0 // --inject always exits 0
 		}
-		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "hook", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -477,7 +477,7 @@ func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string,
 
 	source, gitBacked, err := normalizeImportAddSource(fs, cityPath, source)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import add %q: %v\n", source, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import add"), source, err) //nolint:errcheck
 		return 1
 	}
 
@@ -486,33 +486,33 @@ func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string,
 		name = deriveImportName(source)
 	}
 	if name == "" {
-		fmt.Fprintln(stderr, "gc import add: could not derive import name; use --name") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: could not derive import name; use --name\n", cmdName("import add")) //nolint:errcheck
 		return 1
 	}
 	if strings.HasPrefix(name, "default-rig:") {
-		fmt.Fprintf(stderr, "gc import add: import name %q uses reserved prefix \"default-rig:\"\n", name) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: import name %q uses reserved prefix \"default-rig:\"\n", cmdName("import add"), name) //nolint:errcheck
 		return 1
 	}
 	if _, exists := scope.imports[name]; exists {
-		fmt.Fprintf(stderr, "gc import add: import %q already exists\n", name) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: import %q already exists\n", cmdName("import add"), name) //nolint:errcheck
 		return 1
 	}
 
 	version := versionFlag
 	if gitBacked {
 		if hasRepositoryRefInSource(source) {
-			fmt.Fprintf(stderr, "gc import add %q: embed refs in --version, not in the source URL\n", source) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s %q: embed refs in --version, not in the source URL\n", cmdName("import add"), source) //nolint:errcheck
 			return 1
 		}
 		if version == "" {
 			version, err = defaultImportVersionForSource(source)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import add %q: %v\n", source, err) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import add"), source, err) //nolint:errcheck
 				return 1
 			}
 		}
 	} else if version != "" {
-		fmt.Fprintf(stderr, "gc import add %q: --version is only valid for git-backed imports\n", source) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: --version is only valid for git-backed imports\n", cmdName("import add"), source) //nolint:errcheck
 		return 1
 	}
 
@@ -522,21 +522,21 @@ func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string,
 	}
 	allImports, err := collectAllImportsFS(fs, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import add %q: %v\n", source, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import add"), source, err) //nolint:errcheck
 		return 1
 	}
 	allImports[scope.syntheticKey(name)] = scope.imports[name]
 	lock, err := syncImports(cityPath, allImports, packman.InstallResolveIfNeeded)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import add %q: %v\n", source, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import add"), source, err) //nolint:errcheck
 		return 1
 	}
 	if err := scope.save(); err != nil {
-		fmt.Fprintf(stderr, "gc import add %q: %v\n", source, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import add"), source, err) //nolint:errcheck
 		return 1
 	}
 	if err := writeImportLockfile(fs, cityPath, lock); err != nil {
-		fmt.Fprintf(stderr, "gc import add %q: %v\n", source, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import add"), source, err) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintf(stdout, "Added import %q from %s\n", name, source) //nolint:errcheck
@@ -557,7 +557,7 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 			return 1
 		}
 		if !removed {
-			fmt.Fprintf(stderr, "gc import remove: import %q not found\n", name) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: import %q not found\n", cmdName("import remove"), name) //nolint:errcheck
 			return 1
 		}
 	} else {
@@ -566,22 +566,22 @@ func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer)
 
 	allImports, err := collectAllImportsFS(fs, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import remove %q: %v\n", name, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import remove"), name, err) //nolint:errcheck
 		return 1
 	}
 	delete(allImports, scope.syntheticKey(name))
 	delete(allImports, "default-rig:"+strings.TrimPrefix(name, "default-rig:"))
 	lock, err := syncImports(cityPath, allImports, packman.InstallResolveIfNeeded)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import remove %q: %v\n", name, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import remove"), name, err) //nolint:errcheck
 		return 1
 	}
 	if err := scope.save(); err != nil {
-		fmt.Fprintf(stderr, "gc import remove %q: %v\n", name, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import remove"), name, err) //nolint:errcheck
 		return 1
 	}
 	if err := writeImportLockfile(fs, cityPath, lock); err != nil {
-		fmt.Fprintf(stderr, "gc import remove %q: %v\n", name, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import remove"), name, err) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintf(stdout, "Removed import %q\n", name) //nolint:errcheck
@@ -702,18 +702,18 @@ func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {
 		}
 		targetImp, ok := lookupInspectableImport(target, inspectImports)
 		if !ok {
-			fmt.Fprintf(stderr, "gc import upgrade: import %q not found\n", target) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: import %q not found\n", cmdName("import upgrade"), target) //nolint:errcheck
 			return 1
 		}
 		if !isRemoteImportSource(targetImp.Source) {
-			fmt.Fprintf(stderr, "gc import upgrade: import %q is a path import and cannot be upgraded\n", target) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: import %q is a path import and cannot be upgraded\n", cmdName("import upgrade"), target) //nolint:errcheck
 			return 1
 		}
 		lock, err = syncImportsSelective(cityPath, allImports, map[string]struct{}{
 			targetImp.Source: {},
 		})
 		if err != nil {
-			fmt.Fprintf(stderr, "gc import upgrade %q: %v\n", target, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s %q: %v\n", cmdName("import upgrade"), target, err) //nolint:errcheck
 			return 1
 		}
 	}

--- a/cmd/gc/cmd_import.go
+++ b/cmd/gc/cmd_import.go
@@ -105,7 +105,7 @@ func newImportAddCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import add: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import add", err)
 				return errExit
 			}
 			if doImportAdd(fsys.OSFS{}, cityPath, args[0], name, version, stdout, stderr) != 0 {
@@ -127,7 +127,7 @@ func newImportRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import remove", err)
 				return errExit
 			}
 			if doImportRemove(fsys.OSFS{}, cityPath, args[0], stdout, stderr) != 0 {
@@ -146,7 +146,7 @@ func newImportCheckCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import check: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import check", err)
 				return errExit
 			}
 			if doImportCheck(cityPath, stdout, stderr) != 0 {
@@ -165,7 +165,7 @@ func newImportInstallCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import install: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import install", err)
 				return errExit
 			}
 			if doImportInstall(cityPath, stdout, stderr) != 0 {
@@ -184,7 +184,7 @@ func newImportUpgradeCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import upgrade: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import upgrade", err)
 				return errExit
 			}
 			name := ""
@@ -208,7 +208,7 @@ func newImportListCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import list", err)
 				return errExit
 			}
 			if doImportList(cityPath, tree, stdout, stderr) != 0 {
@@ -229,7 +229,7 @@ func newImportWhyCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			cityPath, err := resolveImportRoot()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "import why", err)
 				return errExit
 			}
 			if doImportWhy(cityPath, args[0], stdout, stderr) != 0 {
@@ -471,7 +471,7 @@ func findImportRigIndex(cityPath string, rigs []config.Rig, target string) (int,
 func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string, stdout, stderr io.Writer) int {
 	scope, err := loadImportScopeFS(fs, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import add: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import add", err)
 		return 1
 	}
 
@@ -547,13 +547,13 @@ func doImportAdd(fs fsys.FS, cityPath, source, nameOverride, versionFlag string,
 func doImportRemove(fs fsys.FS, cityPath, name string, stdout, stderr io.Writer) int {
 	scope, err := loadImportScopeFS(fs, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import remove", err)
 		return 1
 	}
 	if _, exists := scope.imports[name]; !exists {
 		removed, err := removeRootDefaultRigImportFS(fs, cityPath, scope, name)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc import remove: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "import remove", err)
 			return 1
 		}
 		if !removed {
@@ -610,22 +610,22 @@ func removeRootDefaultRigImportFS(fs fsys.FS, cityPath string, scope *importScop
 func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 	allImports, err := collectAllImportsFS(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import install: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import install", err)
 		return 1
 	}
 	lock, err := syncImports(cityPath, allImports, packman.InstallResolveIfNeeded)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import install: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import install", err)
 		return 1
 	}
 	if err := writeImportLockfile(fsys.OSFS{}, cityPath, lock); err != nil {
-		fmt.Fprintf(stderr, "gc import install: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import install", err)
 		return 1
 	}
 
 	lock, err = installLockedImports(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import install: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import install", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "Installed %d remote import(s)\n", len(lock.Packs)) //nolint:errcheck
@@ -635,12 +635,12 @@ func doImportInstall(cityPath string, stdout, stderr io.Writer) int {
 func doImportCheck(cityPath string, stdout, stderr io.Writer) int {
 	allImports, err := collectAllImportsFS(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import check: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import check", err)
 		return 1
 	}
 	report, err := checkInstalledImports(cityPath, allImports)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import check: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import check", err)
 		return 1
 	}
 	if !report.HasIssues() {
@@ -681,13 +681,13 @@ func writeImportCheckIssues(w io.Writer, issues []packman.CheckIssue) {
 func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {
 	scope, err := loadImportScopeFS(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import upgrade: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import upgrade", err)
 		return 1
 	}
 
 	allImports, collectErr := collectAllImportsFS(fsys.OSFS{}, cityPath)
 	if collectErr != nil {
-		fmt.Fprintf(stderr, "gc import upgrade: %v\n", collectErr) //nolint:errcheck
+		cmdErr(stderr, "import upgrade", collectErr)
 		return 1
 	}
 
@@ -697,7 +697,7 @@ func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {
 	} else {
 		inspectImports, inspectErr := collectInspectableImportsFS(fsys.OSFS{}, cityPath, scope)
 		if inspectErr != nil {
-			fmt.Fprintf(stderr, "gc import upgrade: %v\n", inspectErr) //nolint:errcheck
+			cmdErr(stderr, "import upgrade", inspectErr)
 			return 1
 		}
 		targetImp, ok := lookupInspectableImport(target, inspectImports)
@@ -718,11 +718,11 @@ func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {
 		}
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import upgrade: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import upgrade", err)
 		return 1
 	}
 	if err := writeImportLockfile(fsys.OSFS{}, cityPath, lock); err != nil {
-		fmt.Fprintf(stderr, "gc import upgrade: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import upgrade", err)
 		return 1
 	}
 	if target == "" {
@@ -736,17 +736,17 @@ func doImportUpgrade(cityPath, target string, stdout, stderr io.Writer) int {
 func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 	scope, err := loadImportScopeFS(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import list", err)
 		return 1
 	}
 	lock, err := readImportLockfile(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import list", err)
 		return 1
 	}
 	inspectImports, err := collectInspectableImportsFS(fsys.OSFS{}, cityPath, scope)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import list", err)
 		return 1
 	}
 	var directNames []string
@@ -756,7 +756,7 @@ func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 	sort.Strings(directNames)
 	if tree {
 		if err := writeImportTree(stdout, inspectImports, lock); err != nil {
-			fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "import list", err)
 			return 1
 		}
 		return 0
@@ -764,14 +764,14 @@ func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 
 	allImports, err := collectAllImportsFS(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import list", err)
 		return 1
 	}
 	allowLockOnlyFallback := len(allImports) == len(inspectImports)
 
 	graph, graphErr := buildImportGraph(inspectImports, lock)
 	if graphErr != nil && !allowLockOnlyFallback {
-		fmt.Fprintf(stderr, "gc import list: %v\n", graphErr) //nolint:errcheck
+		cmdErr(stderr, "import list", graphErr)
 		return 1
 	}
 
@@ -814,32 +814,32 @@ func doImportList(cityPath string, tree bool, stdout, stderr io.Writer) int {
 func doImportWhy(cityPath, target string, stdout, stderr io.Writer) int {
 	scope, err := loadImportScopeFS(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import why", err)
 		return 1
 	}
 	lock, err := readImportLockfile(fsys.OSFS{}, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import why", err)
 		return 1
 	}
 	inspectImports, err := collectInspectableImportsFS(fsys.OSFS{}, cityPath, scope)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import why", err)
 		return 1
 	}
 	graph, err := buildImportGraph(inspectImports, lock)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import why", err)
 		return 1
 	}
 
 	matches, err := findImportWhyMatches(graph, target)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import why", err)
 		return 1
 	}
 	if err := writeImportWhy(stdout, target, matches); err != nil {
-		fmt.Fprintf(stderr, "gc import why: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "import why", err)
 		return 1
 	}
 	return 0

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -311,7 +311,7 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 			return 1
 		}
 	}
-	if handled, code := resumeExistingInitIfPossible(fsys.OSFS{}, cityPath, stdout, stderr, "gc init", true, skipProviderReadiness); handled {
+	if handled, code := resumeExistingInitIfPossible(fsys.OSFS{}, cityPath, stdout, stderr, cmdName("init"), true, skipProviderReadiness); handled {
 		return code
 	}
 	var wiz wizardConfig

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -300,14 +300,14 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 		var err error
 		cityPath, err = filepath.Abs(args[0])
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	} else {
 		var err error
 		cityPath, err = os.Getwd()
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	}
@@ -320,7 +320,7 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 		var err error
 		wiz, err = initWizardConfig(providerFlag, bootstrapProfileFlag)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	case isTerminal(os.Stdin):
@@ -654,14 +654,14 @@ func cmdInitFromFileWithOptions(fileArg string, args []string, nameOverride stri
 		var err error
 		cityPath, err = filepath.Abs(args[0])
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	} else {
 		var err error
 		cityPath, err = os.Getwd()
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	}
@@ -684,7 +684,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	}
 	cfg, err := config.Parse(data)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
@@ -693,7 +693,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	cityPrefix := strings.TrimSpace(cfg.Workspace.Prefix)
 	templatePack, err := decodeInitPackTemplate(data, cityName)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	cfg.Workspace.Name = cityName
@@ -703,11 +703,11 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		return initAlreadyInitialized(stderr)
 	}
 	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if err := ensureInitConventionDirs(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	// Install Claude Code hooks (settings.json).
@@ -727,40 +727,40 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	packCfg, cityCfg := splitInitConfig(cityName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
 	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
 	formulasInitDir := filepath.Join(cityPath, citylayout.FormulasRoot)
 	if rfErr := ResolveFormulas(cityPath, []string{formulasInitDir}); rfErr != nil {
-		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init: resolving formulas", rfErr)
 	}
 
 	// Re-marshal so the name and rewritten prompt paths are updated.
 	content, err := cityCfg.Marshal()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
 	// Write city.toml.
 	if err := fs.WriteFile(filepath.Join(cityPath, "city.toml"), content, 0o644); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, filepath.Join(cityPath, "city.toml"), &cityCfg, cityName, cityPrefix); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
 	// Write .gitignore entries for city-managed directories.
 	if err := ensureGitignoreEntries(fs, cityPath, cityGitignoreEntries); err != nil {
-		fmt.Fprintf(stderr, "gc init: writing .gitignore: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init: writing .gitignore", err)
 		return 1
 	}
 	if shouldBootstrapScopedFileStore(cfg) {
 		if err := bootstrapScopedFileProviderCityFS(fs, cityPath); err != nil {
-			fmt.Fprintf(stderr, "gc init: bootstrapping file bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init: bootstrapping file bead store", err)
 			return 1
 		}
 	}
@@ -788,7 +788,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 			return initAlreadyInitialized(stderr)
 		}
 		if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 		if code := installClaudeHooks(fs, cityPath, stderr); code != 0 {
@@ -808,11 +808,11 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	// Create directory structure.
 	logInitProgress(stdout, 1, "Creating runtime scaffold")
 	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if err := ensureInitConventionDirs(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	// Install Claude Code hooks (settings.json).
@@ -847,7 +847,7 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 
 	formulasDir := filepath.Join(cityPath, citylayout.FormulasRoot)
 	if err := ResolveFormulas(cityPath, []string{formulasDir}); err != nil {
-		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init: resolving formulas", err)
 	}
 
 	// Write city.toml — wizard path gets one agent + provider/startCommand;
@@ -860,32 +860,32 @@ func doInit(fs fsys.FS, cityPath string, wiz wizardConfig, nameOverride string, 
 	packCfg, cityCfg := splitInitConfig(cityName, &cfg)
 	content, err := cityCfg.Marshal()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	logInitProgress(stdout, 4, "Writing pack.toml")
 	if err := writeInitPackToml(fs, cityPath, packCfg); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	logInitProgress(stdout, 5, "Writing city configuration")
 	if err := fs.WriteFile(tomlPath, content, 0o644); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, tomlPath, &cityCfg, cityName, cityPrefix); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
 	// Write .gitignore entries for city-managed directories.
 	if err := ensureGitignoreEntries(fs, cityPath, cityGitignoreEntries); err != nil {
-		fmt.Fprintf(stderr, "gc init: writing .gitignore: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init: writing .gitignore", err)
 		return 1
 	}
 	if shouldBootstrapScopedFileStore(&cfg) {
 		if err := bootstrapScopedFileProviderCityFS(fs, cityPath); err != nil {
-			fmt.Fprintf(stderr, "gc init: bootstrapping file bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init: bootstrapping file bead store", err)
 			return 1
 		}
 	}
@@ -915,7 +915,7 @@ func applyBootstrapProfile(cfg *config.City, profile string) {
 // Delegates to hooks.Install which is idempotent (won't overwrite existing files).
 func installClaudeHooks(fs fsys.FS, cityPath string, stderr io.Writer) int {
 	if err := hooks.Install(fs, cityPath, cityPath, []string{"claude"}); err != nil {
-		fmt.Fprintf(stderr, "gc init: installing claude hooks: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init: installing claude hooks", err)
 		return 1
 	}
 	return 0
@@ -951,7 +951,7 @@ func bootstrapScopedFileProviderCityFS(fs fsys.FS, cityPath string) error {
 // instead of silently creating additional convention-discoverable agents.
 func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer) int {
 	if err := fs.MkdirAll(filepath.Join(cityPath, "agents"), 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if cfg == nil {
@@ -971,11 +971,11 @@ func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr
 		}
 		dst = filepath.Join(cityPath, dst)
 		if err := fs.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 		if err := fs.WriteFile(dst, data, 0o644); err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	}
@@ -1064,12 +1064,12 @@ func sourceTemplatePackSchemaFS(srcFS fsys.FS, srcDir string) int {
 func overrideCityName(f fsys.FS, tomlPath, name string, stderr io.Writer) int {
 	cfg, err := loadCityConfigForEditFS(f, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	cfg.Workspace.Name = name
 	if err := writeCityConfigForEditFS(f, tomlPath, cfg); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	return 0
@@ -1094,21 +1094,21 @@ func cmdInitFromDirWithOptions(fromDir string, args []string, nameOverride strin
 		var err error
 		cityPath, err = filepath.Abs(args[0])
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	} else {
 		var err error
 		cityPath, err = os.Getwd()
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	}
 
 	srcDir, err := filepath.Abs(fromDir)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
@@ -1132,34 +1132,34 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 		return initAlreadyInitialized(stderr)
 	}
 	if err := fs.MkdirAll(cityPath, 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if err := overlay.CopyDirWithSkip(srcDir, cityPath, initFromSkipForSourceFS(fs, srcDir), stderr); err != nil {
-		fmt.Fprintf(stderr, "gc init --from: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init --from", err)
 		return 1
 	}
 
 	copiedToml := filepath.Join(cityPath, "city.toml")
 	cfg, cityName, cityPrefix, persistSiteIdentity, err := rewriteCopiedInitFromIdentity(fs, cityPath, nameOverride)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if persistSiteIdentity {
 		if err := persistInitWorkspaceIdentity(fs, cityPath, copiedToml, cfg, cityName, cityPrefix); err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init", err)
 			return 1
 		}
 	}
 
 	// Create runtime scaffold.
 	if err := ensureCityScaffoldFS(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 	if err := ensureInitConventionDirs(fs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init", err)
 		return 1
 	}
 
@@ -1170,12 +1170,12 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 
 	// Write .gitignore entries for city-managed directories.
 	if err := ensureGitignoreEntries(fs, cityPath, cityGitignoreEntries); err != nil {
-		fmt.Fprintf(stderr, "gc init: writing .gitignore: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "init: writing .gitignore", err)
 		return 1
 	}
 	if shouldBootstrapScopedFileStore(cfg) {
 		if err := bootstrapScopedFileProviderCityFS(fs, cityPath); err != nil {
-			fmt.Fprintf(stderr, "gc init: bootstrapping file bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init: bootstrapping file bead store", err)
 			return 1
 		}
 	}
@@ -1184,7 +1184,7 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 	expandedCfg, _, loadErr := config.LoadWithIncludes(fsys.OSFS{}, copiedToml)
 	if loadErr == nil && len(expandedCfg.FormulaLayers.City) > 0 {
 		if rfErr := ResolveFormulas(cityPath, expandedCfg.FormulaLayers.City); rfErr != nil {
-			fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "init: resolving formulas", rfErr)
 		}
 	}
 	if loadErr == nil {

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -233,7 +233,7 @@ func logInitProgress(stdout io.Writer, step int, msg string) {
 }
 
 func initAlreadyInitialized(stderr io.Writer) int {
-	fmt.Fprintln(stderr, "gc init: already initialized") //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: already initialized\n", cmdName("init")) //nolint:errcheck // best-effort stderr
 	return initExitAlreadyInitialized
 }
 
@@ -679,7 +679,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	// Validate the source file parses as a valid city config.
 	data, err := os.ReadFile(tomlSrc)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc init: reading %q: %v\n", tomlSrc, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: reading %q: %v\n", cmdName("init"), tomlSrc, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cfg, err := config.Parse(data)
@@ -966,7 +966,7 @@ func writeInitAgentPrompts(fs fsys.FS, cityPath string, cfg *config.City, stderr
 		seen[dst] = true
 		data, err := defaultPrompts.ReadFile(agent.PromptTemplate)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc init: reading embedded %s: %v\n", agent.PromptTemplate, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: reading embedded %s: %v\n", cmdName("init"), agent.PromptTemplate, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		dst = filepath.Join(cityPath, dst)
@@ -1125,7 +1125,7 @@ func doInitFromDir(srcDir, cityPath string, stdout, stderr io.Writer) int {
 func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride string, stdout, stderr io.Writer, skipProviderReadiness bool) int {
 	srcToml := filepath.Join(srcDir, "city.toml")
 	if _, err := os.Stat(srcToml); err != nil {
-		fmt.Fprintf(stderr, "gc init --from: source %q has no city.toml\n", srcDir) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: source %q has no city.toml\n", cmdName("init --from"), srcDir) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if cityAlreadyInitializedFS(fs, cityPath) {
@@ -1189,7 +1189,7 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 	}
 	if loadErr == nil {
 		pruneLegacyConfiguredScripts(cityPath, expandedCfg, func(scope string, err error) {
-			fmt.Fprintf(stderr, "gc init: pruning legacy %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: pruning legacy %s scripts: %v\n", cmdName("init"), scope, err) //nolint:errcheck // best-effort stderr
 		})
 	}
 

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -335,7 +335,7 @@ func cmdInitWithOptions(args []string, providerFlag, bootstrapProfileFlag, nameO
 	return finalizeInit(cityPath, stdout, stderr, initFinalizeOptions{
 		skipProviderReadiness: skipProviderReadiness,
 		showProgress:          true,
-		commandName:           "gc init",
+		commandName:           cmdName("init"),
 	})
 }
 
@@ -769,7 +769,7 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	fmt.Fprintf(stdout, "Initialized city %q from %s.\n", cityName, filepath.Base(tomlSrc)) //nolint:errcheck // best-effort stdout
 	return finalizeInit(cityPath, stdout, stderr, initFinalizeOptions{
 		skipProviderReadiness: skipProviderReadiness,
-		commandName:           "gc init",
+		commandName:           cmdName("init"),
 	})
 }
 
@@ -1197,7 +1197,7 @@ func doInitFromDirWithOptionsFS(fs fsys.FS, srcDir, cityPath, nameOverride strin
 	fmt.Fprintf(stdout, "Initialized city %q from %s.\n", cityName, filepath.Base(srcDir)) //nolint:errcheck // best-effort stdout
 	return finalizeInit(cityPath, stdout, stderr, initFinalizeOptions{
 		skipProviderReadiness: skipProviderReadiness,
-		commandName:           "gc init",
+		commandName:           cmdName("init"),
 	})
 }
 

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -56,12 +56,12 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal materialize-skills", err)
 				return errExit
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal materialize-skills", err)
 				return errExit
 			}
 			agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
@@ -172,7 +172,7 @@ func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir
 
 	agentCat, err := materialize.LoadAgentCatalog(agent.SkillsDir)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "internal materialize-skills", err)
 		return errExit
 	}
 	desired := materialize.EffectiveSet(cityCat, agentCat)
@@ -195,7 +195,7 @@ func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir
 		LegacyNames: materialize.LegacyStubNames(),
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc internal materialize-skills: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "internal materialize-skills", err)
 		return errExit
 	}
 

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -21,7 +21,7 @@ import (
 func newInternalCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "internal",
-		Short:  "Internal gc subcommands (not for direct human use)",
+		Short:  fmt.Sprintf("Internal %s subcommands (not for direct human use)", prog()),
 		Hidden: true,
 	}
 	cmd.AddCommand(newInternalMaterializeSkillsCmd(stdout, stderr))

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -152,7 +152,7 @@ func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir
 		// cursor, pi, omp, or an unknown provider) have no sink.
 		// Log once per session spawn per the spec and exit
 		// successfully — this is not an error condition.
-		fmt.Fprintf(stdout, "gc internal materialize-skills: provider %q has no skill sink in v0.15.1; skipping\n", provider) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stdout, "%s: provider %q has no skill sink in v0.15.1; skipping\n", cmdName("internal materialize-skills"), provider) //nolint:errcheck // best-effort stdout
 		return nil
 	}
 

--- a/cmd/gc/cmd_internal_materialize_skills.go
+++ b/cmd/gc/cmd_internal_materialize_skills.go
@@ -47,11 +47,11 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if strings.TrimSpace(agentName) == "" {
-				fmt.Fprintln(stderr, "gc internal materialize-skills: --agent is required") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --agent is required\n", cmdName("internal materialize-skills")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if strings.TrimSpace(workdir) == "" {
-				fmt.Fprintln(stderr, "gc internal materialize-skills: --workdir is required") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --workdir is required\n", cmdName("internal materialize-skills")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			cityPath, err := resolveCity()
@@ -66,7 +66,7 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
 			if !ok {
-				fmt.Fprintf(stderr, "gc internal materialize-skills: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown agent %q\n", cmdName("internal materialize-skills"), agentName) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			// Resolve snapshot source: explicit --shared-catalog-snapshot-file
@@ -83,7 +83,7 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 			if explicitSnapshotFile != "" {
 				data, err := os.ReadFile(explicitSnapshotFile)
 				if err != nil {
-					fmt.Fprintf(stderr, "gc internal materialize-skills: reading --shared-catalog-snapshot-file %q: %v (falling back to live catalog)\n", explicitSnapshotFile, err) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: reading --shared-catalog-snapshot-file %q: %v (falling back to live catalog)\n", cmdName("internal materialize-skills"), explicitSnapshotFile, err) //nolint:errcheck // best-effort stderr
 				} else {
 					sharedCatalogSnapshot = string(data)
 				}
@@ -100,7 +100,7 @@ func newInternalMaterializeSkillsCmd(stdout, stderr io.Writer) *cobra.Command {
 			if strings.TrimSpace(sharedCatalogSnapshot) != "" {
 				cat, err := decodeSharedCatalogSnapshot(sharedCatalogSnapshot)
 				if err != nil {
-					fmt.Fprintf(stderr, "gc internal materialize-skills: decoding shared catalog snapshot: %v (falling back to live catalog)\n", err) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: decoding shared catalog snapshot: %v (falling back to live catalog)\n", cmdName("internal materialize-skills"), err) //nolint:errcheck // best-effort stderr
 				} else {
 					sharedCatalog = &cat
 				}
@@ -141,7 +141,7 @@ func decodeSharedCatalogSnapshot(encoded string) (materialize.CityCatalog, error
 
 func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir string, sharedCatalog *materialize.CityCatalog, stdout, stderr io.Writer) error {
 	if cfg == nil || agent == nil {
-		fmt.Fprintln(stderr, "gc internal materialize-skills: missing city config or agent") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing city config or agent\n", cmdName("internal materialize-skills")) //nolint:errcheck // best-effort stderr
 		return errExit
 	}
 
@@ -163,7 +163,7 @@ func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir
 		rigName := agentRigScopeName(agent, cfg.Rigs)
 		cat, err := loadSharedSkillCatalog(cfg, rigName)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc internal materialize-skills: shared skill catalog unavailable for %q: %v\n", agent.QualifiedName(), err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: shared skill catalog unavailable for %q: %v\n", cmdName("internal materialize-skills"), agent.QualifiedName(), err) //nolint:errcheck // best-effort stderr
 			cat.Entries = nil
 			cat.Shadowed = nil
 		}
@@ -184,7 +184,7 @@ func materializeSkillsIntoWorkdir(cfg *config.City, agent *config.Agent, workdir
 
 	absWorkdir, err := filepath.Abs(workdir)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc internal materialize-skills: resolving workdir %q: %v\n", workdir, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: resolving workdir %q: %v\n", cmdName("internal materialize-skills"), workdir, err) //nolint:errcheck // best-effort stderr
 		return errExit
 	}
 

--- a/cmd/gc/cmd_internal_project_mcp.go
+++ b/cmd/gc/cmd_internal_project_mcp.go
@@ -31,12 +31,12 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal project-mcp", err)
 				return errExit
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal project-mcp", err)
 				return errExit
 			}
 
@@ -61,30 +61,30 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 				// no-op so unsupported/absent providers can be ignored there.
 				catalog, lerr := loadEffectiveMCPForAgent(cityPath, cfg, &agent, identity, absWorkdir)
 				if lerr != nil {
-					fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", lerr) //nolint:errcheck // best-effort stderr
+					cmdErr(stderr, "internal project-mcp", lerr)
 					return errExit
 				}
 				if len(catalog.Servers) == 0 {
 					return nil
 				}
-				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal project-mcp", err)
 				return errExit
 			}
 
 			catalog, projection, err := resolveAgentMCPProjection(cityPath, cfg, &agent, identity, absWorkdir, resolvedProviderLaunchFamily(resolved))
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal project-mcp", err)
 				return errExit
 			}
 			if projection.Provider == "" {
 				return nil
 			}
 			if err := validateStage2TargetClaimants(cityPath, cfg, &agent, projection, exec.LookPath); err != nil {
-				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal project-mcp", err)
 				return errExit
 			}
 			if err := projection.ApplyWithStderr(fsys.OSFS{}, stderr); err != nil {
-				fmt.Fprintf(stderr, "gc internal project-mcp: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "internal project-mcp", err)
 				return errExit
 			}
 			if len(catalog.Servers) > 0 {

--- a/cmd/gc/cmd_internal_project_mcp.go
+++ b/cmd/gc/cmd_internal_project_mcp.go
@@ -21,11 +21,11 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if strings.TrimSpace(agentName) == "" {
-				fmt.Fprintln(stderr, "gc internal project-mcp: --agent is required") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --agent is required\n", cmdName("internal project-mcp")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if strings.TrimSpace(workdir) == "" {
-				fmt.Fprintln(stderr, "gc internal project-mcp: --workdir is required") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --workdir is required\n", cmdName("internal project-mcp")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 
@@ -42,7 +42,7 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 
 			agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
 			if !ok {
-				fmt.Fprintf(stderr, "gc internal project-mcp: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown agent %q\n", cmdName("internal project-mcp"), agentName) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if strings.TrimSpace(identity) == "" {
@@ -50,7 +50,7 @@ func newInternalProjectMCPCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			absWorkdir, err := filepath.Abs(workdir)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc internal project-mcp: resolving workdir %q: %v\n", workdir, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: resolving workdir %q: %v\n", cmdName("internal project-mcp"), workdir, err) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -91,7 +91,7 @@ as closed and will no longer appear in mail check or inbox results.`,
 
 // cmdMailArchive is the CLI entry point for archiving a message.
 func cmdMailArchive(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail archive")
+	mp, code := openCityMailProvider(stderr, cmdName("mail archive"))
 	if mp == nil {
 		return code
 	}
@@ -170,7 +170,7 @@ func cmdMailCheckWithFormat(args []string, inject bool, hookFormat string, stdou
 		}
 	}
 
-	mp, code := openCityMailProvider(stderr, "gc mail check")
+	mp, code := openCityMailProvider(stderr, cmdName("mail check"))
 	if mp == nil {
 		if inject {
 			return 0 // --inject always exits 0
@@ -178,7 +178,7 @@ func cmdMailCheckWithFormat(args []string, inject bool, hookFormat string, stdou
 		return code
 	}
 
-	target, ok := resolveMailTargetFromArgs(args, stderr, "gc mail check")
+	target, ok := resolveMailTargetFromArgs(args, stderr, cmdName("mail check"))
 	if !ok {
 		if inject {
 			return 0
@@ -891,7 +891,7 @@ The recipient defaults to $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or "human".`,
 // resolves session mailbox identities, and delegates to doMailSend.
 // The to parameter is the --to flag value (empty if not set).
 func cmdMailSend(args []string, notify bool, all bool, from string, to string, subject string, message string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail send")
+	mp, code := openCityMailProvider(stderr, cmdName("mail send"))
 	if mp == nil {
 		return code
 	}
@@ -925,7 +925,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 	if sender == "" {
 		if store != nil {
 			var ok bool
-			sender, ok = resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail send")
+			sender, ok = resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, cmdName("mail send"))
 			if !ok {
 				return 1
 			}
@@ -1089,12 +1089,12 @@ func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[st
 
 // cmdMailInbox is the CLI entry point for checking the inbox.
 func cmdMailInbox(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail inbox")
+	mp, code := openCityMailProvider(stderr, cmdName("mail inbox"))
 	if mp == nil {
 		return code
 	}
 
-	target, ok := resolveMailTargetFromArgs(args, stderr, "gc mail inbox")
+	target, ok := resolveMailTargetFromArgs(args, stderr, cmdName("mail inbox"))
 	if !ok {
 		return 1
 	}
@@ -1130,7 +1130,7 @@ func doMailInboxTarget(mp mail.Provider, target resolvedMailTarget, stdout, stde
 
 // cmdMailRead is the CLI entry point for reading a message.
 func cmdMailRead(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail read")
+	mp, code := openCityMailProvider(stderr, cmdName("mail read"))
 	if mp == nil {
 		return code
 	}
@@ -1167,7 +1167,7 @@ func doMailRead(mp mail.Provider, rec events.Recorder, args []string, stdout, st
 
 // cmdMailPeek shows a message without marking it as read.
 func cmdMailPeek(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail peek")
+	mp, code := openCityMailProvider(stderr, cmdName("mail peek"))
 	if mp == nil {
 		return code
 	}
@@ -1199,7 +1199,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 		return 1
 	}
 
-	mp, code := openCityMailProvider(stderr, "gc mail reply")
+	mp, code := openCityMailProvider(stderr, cmdName("mail reply"))
 	if mp == nil {
 		return code
 	}
@@ -1210,7 +1210,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	if sender != "human" {
 		if !isStorelessMailProvider() {
 			hasStore = true
-			store, storeCode := openCityStore(stderr, "gc mail reply")
+			store, storeCode := openCityStore(stderr, cmdName("mail reply"))
 			if store == nil {
 				return storeCode
 			}
@@ -1220,7 +1220,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 				return 1
 			}
 			cfg, _ := loadCityConfig(cityPath, stderr)
-			resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail reply")
+			resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, cmdName("mail reply"))
 			if !ok {
 				return 1
 			}
@@ -1269,7 +1269,7 @@ func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, bod
 
 // cmdMailMarkRead marks a message as read.
 func cmdMailMarkRead(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail mark-read")
+	mp, code := openCityMailProvider(stderr, cmdName("mail mark-read"))
 	if mp == nil {
 		return code
 	}
@@ -1302,7 +1302,7 @@ func doMailMarkRead(mp mail.Provider, rec events.Recorder, args []string, stdout
 
 // cmdMailMarkUnread marks a message as unread.
 func cmdMailMarkUnread(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail mark-unread")
+	mp, code := openCityMailProvider(stderr, cmdName("mail mark-unread"))
 	if mp == nil {
 		return code
 	}
@@ -1335,7 +1335,7 @@ func doMailMarkUnread(mp mail.Provider, rec events.Recorder, args []string, stdo
 
 // cmdMailDelete deletes a message.
 func cmdMailDelete(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail delete")
+	mp, code := openCityMailProvider(stderr, cmdName("mail delete"))
 	if mp == nil {
 		return code
 	}
@@ -1372,7 +1372,7 @@ func doMailDelete(mp mail.Provider, rec events.Recorder, args []string, stdout, 
 
 // cmdMailThread lists messages in a thread.
 func cmdMailThread(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail thread")
+	mp, code := openCityMailProvider(stderr, cmdName("mail thread"))
 	if mp == nil {
 		return code
 	}
@@ -1414,12 +1414,12 @@ func doMailThread(mp mail.Provider, args []string, stdout, stderr io.Writer) int
 
 // cmdMailCount shows total/unread count.
 func cmdMailCount(args []string, stdout, stderr io.Writer) int {
-	mp, code := openCityMailProvider(stderr, "gc mail count")
+	mp, code := openCityMailProvider(stderr, cmdName("mail count"))
 	if mp == nil {
 		return code
 	}
 
-	target, ok := resolveMailTargetFromArgs(args, stderr, "gc mail count")
+	target, ok := resolveMailTargetFromArgs(args, stderr, cmdName("mail count"))
 	if !ok {
 		return 1
 	}

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -39,11 +39,11 @@ func newMailCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mail",
 		Short: "Send and receive messages between agents and humans",
-		Long: `Send and receive messages between agents and humans.
+		Long: fmt.Sprintf(`Send and receive messages between agents and humans.
 
 Mail is implemented as beads with type="message". Messages have a
-sender, recipient, subject, and body. Use "gc mail check --inject" in agent
-hooks to deliver mail notifications into agent prompts.`,
+sender, recipient, subject, and body. Use "%s mail check --inject" in agent
+hooks to deliver mail notifications into agent prompts.`, prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -754,10 +754,10 @@ func newMailReadCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "read <id>",
 		Short: "Read a message and mark it as read",
-		Long: `Display a message and mark it as read.
+		Long: fmt.Sprintf(`Display a message and mark it as read.
 
 Shows the full message details (ID, sender, recipient, subject, date, body).
-The message stays in the store — use "gc mail archive" to permanently close it.`,
+The message stays in the store — use "%s mail archive" to permanently close it.`, prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailRead(args, stdout, stderr) != 0 {
@@ -772,10 +772,10 @@ func newMailPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "peek <id>",
 		Short: "Show a message without marking it as read",
-		Long: `Display a message without marking it as read.
+		Long: fmt.Sprintf(`Display a message without marking it as read.
 
-Same output as "gc mail read" but does not change the message's read status.
-The message will continue to appear in inbox results.`,
+Same output as "%s mail read" but does not change the message's read status.
+The message will continue to appear in inbox results.`, prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailPeek(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -47,9 +47,9 @@ hooks to deliver mail notifications into agent prompts.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc mail: missing subcommand (archive, check, count, delete, inbox, mark-read, mark-unread, peek, read, reply, send, thread)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (archive, check, count, delete, inbox, mark-read, mark-unread, peek, read, reply, send, thread)\n", cmdName("mail")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc mail: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("mail"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -103,7 +103,7 @@ func cmdMailArchive(args []string, stdout, stderr io.Writer) int {
 // injected provider and recorder for testability.
 func doMailArchive(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail archive: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail archive")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -164,7 +164,7 @@ func cmdMailCheckWithFormat(args []string, inject bool, hookFormat string, stdou
 				if inject {
 					return 0
 				}
-				fmt.Fprintln(stderr, "gc mail check: city is suspended") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: city is suspended\n", cmdName("mail check")) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 		}
@@ -935,7 +935,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 	} else if sender != "human" && store != nil {
 		sender, err = resolveMailIdentityWithConfig(cityPath, cfg, store, sender)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: invalid sender %q: %v\n", cmdName("mail send"), sender, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -956,7 +956,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 			args = []string{subject, message}
 		} else {
 			if len(args) < 1 {
-				fmt.Fprintln(stderr, "gc mail send: missing recipient") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing recipient\n", cmdName("mail send")) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 			args = []string{args[0], subject, message}
@@ -965,7 +965,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 	if !all && len(args) > 0 && store != nil {
 		canonicalTo, err := resolveMailRecipientIdentity(cityPath, cfg, store, args[0])
 		if err != nil {
-			fmt.Fprintf(stderr, "gc mail send: unknown recipient %q: %v\n", args[0], err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown recipient %q: %v\n", cmdName("mail send"), args[0], err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		args[0] = canonicalTo
@@ -988,7 +988,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 // recipient is nudged after message creation (skipped for "human").
 func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
-		fmt.Fprintln(stderr, "gc mail send: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>]") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: usage: gc mail send <to> <body>  OR  gc mail send <to> -s <subject> [-m <body>]\n", cmdName("mail send")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	to := args[0]
@@ -1004,7 +1004,7 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 	}
 
 	if validRecipients != nil && !validRecipients[to] {
-		fmt.Fprintf(stderr, "gc mail send: unknown recipient %q\n", to) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: unknown recipient %q\n", cmdName("mail send"), to) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -1036,7 +1036,7 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 // sender and "human"). With --all, args is [subject, body] or [body].
 func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[string]bool, sender string, args []string, nudgeFn nudgeFunc, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail send --all: usage: gc mail send --all <body>") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: usage: gc mail send --all <body>\n", cmdName("mail send --all")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -1059,14 +1059,14 @@ func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[st
 	sort.Strings(recipients)
 
 	if len(recipients) == 0 {
-		fmt.Fprintln(stderr, "gc mail send --all: no recipients (all live sessions excluded)") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: no recipients (all live sessions excluded)\n", cmdName("mail send --all")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	for _, to := range recipients {
 		m, err := mp.Send(sender, to, subject, body)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc mail send --all: sending to %s: %v\n", to, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: sending to %s: %v\n", cmdName("mail send --all"), to, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		rec.Record(events.Event{
@@ -1080,7 +1080,7 @@ func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[st
 
 		if nudgeFn != nil {
 			if err := nudgeFn(to); err != nil {
-				fmt.Fprintf(stderr, "gc mail send --all: nudge %s failed: %v\n", to, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: nudge %s failed: %v\n", cmdName("mail send --all"), to, err) //nolint:errcheck // best-effort stderr
 			}
 		}
 	}
@@ -1142,7 +1142,7 @@ func cmdMailRead(args []string, stdout, stderr io.Writer) int {
 // provider and recorder for testability.
 func doMailRead(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail read: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail read")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -1177,7 +1177,7 @@ func cmdMailPeek(args []string, stdout, stderr io.Writer) int {
 // doMailPeek displays a message without marking it as read.
 func doMailPeek(mp mail.Provider, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail peek: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail peek")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -1195,7 +1195,7 @@ func doMailPeek(mp mail.Provider, args []string, stdout, stderr io.Writer) int {
 // cmdMailReply replies to a message.
 func cmdMailReply(args []string, subject, message string, notify bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail reply: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail reply")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -1280,7 +1280,7 @@ func cmdMailMarkRead(args []string, stdout, stderr io.Writer) int {
 // doMailMarkRead marks a message as read.
 func doMailMarkRead(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail mark-read: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail mark-read")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -1313,7 +1313,7 @@ func cmdMailMarkUnread(args []string, stdout, stderr io.Writer) int {
 // doMailMarkUnread marks a message as unread.
 func doMailMarkUnread(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail mark-unread: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail mark-unread")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -1346,7 +1346,7 @@ func cmdMailDelete(args []string, stdout, stderr io.Writer) int {
 // doMailDelete closes a message bead (same as archive but different intent).
 func doMailDelete(mp mail.Provider, rec events.Recorder, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail delete: missing message ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing message ID\n", cmdName("mail delete")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	id := args[0]
@@ -1382,7 +1382,7 @@ func cmdMailThread(args []string, stdout, stderr io.Writer) int {
 // doMailThread shows all messages in a thread.
 func doMailThread(mp mail.Provider, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail thread: missing thread ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing thread ID\n", cmdName("mail thread")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	threadID := args[0]

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -114,7 +114,7 @@ func doMailArchive(mp mail.Provider, rec events.Recorder, args []string, stdout,
 			return 0
 		}
 		telemetry.RecordMailOp(context.Background(), "archive", err)
-		fmt.Fprintf(stderr, "gc mail archive: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail archive", err)
 		return 1
 	}
 	telemetry.RecordMailOp(context.Background(), "archive", nil)
@@ -204,10 +204,10 @@ func doMailCheckTargetWithFormat(mp mail.Provider, target resolvedMailTarget, in
 	messages, err := collectMailMessages(mp.Check, target.recipients)
 	if err != nil {
 		if inject {
-			fmt.Fprintf(stderr, "gc mail check: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "mail check", err)
 			return 0                                        // --inject always exits 0
 		}
-		fmt.Fprintf(stderr, "gc mail check: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail check", err)
 		return 1
 	}
 
@@ -910,13 +910,13 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 	// run without a city store, but fake/fail still require one for alias
 	// resolution in tests. Do not unify with isStorelessMailProvider.
 	if err != nil && !strings.HasPrefix(mailProviderName(), "exec:") {
-		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail send", err)
 		return 1
 	}
 	if store != nil {
 		validRecipients, err = listLiveSessionMailboxes(store)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc mail send: listing live sessions: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "mail send: listing live sessions", err)
 			return 1
 		}
 	}
@@ -1011,7 +1011,7 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 	m, err := mp.Send(sender, to, subject, body)
 	telemetry.RecordMailOp(context.Background(), "send", err)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail send", err)
 		return 1
 	}
 	rec.Record(events.Event{
@@ -1026,7 +1026,7 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 	// Nudge recipient if requested and recipient is not human.
 	if nudgeFn != nil && to != "human" {
 		if err := nudgeFn(to); err != nil {
-			fmt.Fprintf(stderr, "gc mail send: nudge failed: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "mail send: nudge failed", err)
 		}
 	}
 	return 0
@@ -1110,7 +1110,7 @@ func doMailInbox(mp mail.Provider, recipient string, stdout, stderr io.Writer) i
 func doMailInboxTarget(mp mail.Provider, target resolvedMailTarget, stdout, stderr io.Writer) int {
 	messages, err := collectMailMessages(mp.Inbox, target.recipients)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail inbox: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail inbox", err)
 		return 1
 	}
 
@@ -1150,7 +1150,7 @@ func doMailRead(mp mail.Provider, rec events.Recorder, args []string, stdout, st
 	m, err := mp.Read(id)
 	telemetry.RecordMailOp(context.Background(), "read", err)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail read: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail read", err)
 		return 1
 	}
 
@@ -1184,7 +1184,7 @@ func doMailPeek(mp mail.Provider, args []string, stdout, stderr io.Writer) int {
 
 	m, err := mp.Get(id)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail peek: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail peek", err)
 		return 1
 	}
 
@@ -1216,7 +1216,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 			}
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc mail reply: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "mail reply", err)
 				return 1
 			}
 			cfg, _ := loadCityConfig(cityPath, stderr)
@@ -1247,7 +1247,7 @@ func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, bod
 	reply, err := mp.Reply(id, sender, subject, body)
 	telemetry.RecordMailOp(context.Background(), "reply", err)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail reply: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail reply", err)
 		return 1
 	}
 	rec.Record(events.Event{
@@ -1261,7 +1261,7 @@ func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, bod
 
 	if nudgeFn != nil && reply.To != "human" {
 		if err := nudgeFn(reply.To); err != nil {
-			fmt.Fprintf(stderr, "gc mail reply: nudge failed: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "mail reply: nudge failed", err)
 		}
 	}
 	return 0
@@ -1286,7 +1286,7 @@ func doMailMarkRead(mp mail.Provider, rec events.Recorder, args []string, stdout
 	id := args[0]
 	if err := mp.MarkRead(id); err != nil {
 		telemetry.RecordMailOp(context.Background(), "mark_read", err)
-		fmt.Fprintf(stderr, "gc mail mark-read: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail mark-read", err)
 		return 1
 	}
 	telemetry.RecordMailOp(context.Background(), "mark_read", nil)
@@ -1319,7 +1319,7 @@ func doMailMarkUnread(mp mail.Provider, rec events.Recorder, args []string, stdo
 	id := args[0]
 	if err := mp.MarkUnread(id); err != nil {
 		telemetry.RecordMailOp(context.Background(), "mark_unread", err)
-		fmt.Fprintf(stderr, "gc mail mark-unread: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail mark-unread", err)
 		return 1
 	}
 	telemetry.RecordMailOp(context.Background(), "mark_unread", nil)
@@ -1356,7 +1356,7 @@ func doMailDelete(mp mail.Provider, rec events.Recorder, args []string, stdout, 
 			return 0
 		}
 		telemetry.RecordMailOp(context.Background(), "delete", err)
-		fmt.Fprintf(stderr, "gc mail delete: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail delete", err)
 		return 1
 	}
 	telemetry.RecordMailOp(context.Background(), "delete", nil)
@@ -1389,7 +1389,7 @@ func doMailThread(mp mail.Provider, args []string, stdout, stderr io.Writer) int
 
 	msgs, err := mp.Thread(threadID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail thread: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail thread", err)
 		return 1
 	}
 
@@ -1435,7 +1435,7 @@ func doMailCount(mp mail.Provider, recipient string, stdout, stderr io.Writer) i
 func doMailCountTarget(mp mail.Provider, target resolvedMailTarget, stdout, stderr io.Writer) int {
 	total, unread, err := collectMailCounts(mp.Count, target.recipients)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc mail count: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "mail count", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "%d total, %d unread for %s\n", total, unread, target.display) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -19,11 +19,11 @@ func newMcpCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
 		Short: "Inspect projected MCP config",
-		Long: `Inspect the projected MCP catalog for a concrete target.
+		Long: fmt.Sprintf(`Inspect the projected MCP catalog for a concrete target.
 
-Projected MCP is target-specific. Use "gc mcp list --agent <name>" when
+Projected MCP is target-specific. Use "%s mcp list --agent <name>" when
 the agent has a single deterministic projection target from config, or
-"gc mcp list --session <id>" for a live session target.`,
+"%s mcp list --session <id>" for a live session target.`, prog(), prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -59,12 +59,12 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "mcp list", err)
 				return errExit
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "mcp list", err)
 				return errExit
 			}
 
@@ -75,7 +75,7 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 			if sessionID != "" {
 				store, err = openCityStoreAt(cityPath)
 				if err != nil {
-					fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
+					cmdErr(stderr, "mcp list", err)
 					return errExit
 				}
 				view, err = resolveSessionMCPProjection(cityPath, cfg, store, sessionID, exec.LookPath)
@@ -94,7 +94,7 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 				view, err = resolveDeterministicAgentMCPProjection(cityPath, cfg, cfgAgent, exec.LookPath)
 			}
 			if err != nil {
-				fmt.Fprintf(stderr, "gc mcp list: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "mcp list", err)
 				return errExit
 			}
 

--- a/cmd/gc/cmd_mcp.go
+++ b/cmd/gc/cmd_mcp.go
@@ -29,7 +29,7 @@ the agent has a single deterministic projection target from config, or
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			fmt.Fprintf(stderr, "gc mcp: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("mcp"), args[0]) //nolint:errcheck // best-effort stderr
 			return errExit
 		},
 	}
@@ -50,10 +50,10 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 			sessionID = strings.TrimSpace(sessionID)
 			switch {
 			case agentName != "" && sessionID != "":
-				fmt.Fprintln(stderr, "gc mcp list: --agent and --session are mutually exclusive") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --agent and --session are mutually exclusive\n", cmdName("mcp list")) //nolint:errcheck // best-effort stderr
 				return errExit
 			case agentName == "" && sessionID == "":
-				fmt.Fprintln(stderr, "gc mcp list: projected MCP is target-specific; pass --agent or --session") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: projected MCP is target-specific; pass --agent or --session\n", cmdName("mcp list")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 
@@ -82,13 +82,13 @@ func newMcpListCmd(stdout, stderr io.Writer) *cobra.Command {
 			} else {
 				agent, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
 				if !ok {
-					fmt.Fprintf(stderr, "gc mcp list: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: unknown agent %q\n", cmdName("mcp list"), agentName) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
 				template := resolveAgentTemplate(agent.QualifiedName(), cfg)
 				cfgAgent := findAgentByTemplate(cfg, template)
 				if cfgAgent == nil {
-					fmt.Fprintf(stderr, "gc mcp list: unknown agent %q\n", agentName) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: unknown agent %q\n", cmdName("mcp list"), agentName) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
 				view, err = resolveDeterministicAgentMCPProjection(cityPath, cfg, cfgAgent, exec.LookPath)

--- a/cmd/gc/cmd_migrate.go
+++ b/cmd/gc/cmd_migrate.go
@@ -33,13 +33,13 @@ assets into their V2 locations.`,
 func doImportMigrate(dryRun bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import migrate: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("import migrate"), err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	report, err := migrate.Apply(cityPath, migrate.Options{DryRun: dryRun})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc import migrate: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("import migrate"), err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -239,13 +239,13 @@ func cmdNudgeStatus(args []string, stdout, stderr io.Writer) int {
 
 	target, err := resolveNudgeTarget(targetID, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc nudge status: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge status", err)
 		return 1
 	}
 
 	pending, inFlight, dead, err := listQueuedNudgesForTarget(target.cityPath, target, time.Now())
 	if err != nil {
-		fmt.Fprintf(stderr, "gc nudge status: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge status", err)
 		return 1
 	}
 
@@ -300,7 +300,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc nudge drain: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge drain", err)
 		return 1
 	}
 
@@ -310,7 +310,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc nudge drain: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge drain", err)
 		return 1
 	}
 	if len(items) == 0 {
@@ -326,19 +326,19 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 	items, blocked, err := splitQueuedNudgesForDelivery(openNudgeBeadStore(target.cityPath), items)
 	if err != nil {
 		if inject {
-			fmt.Fprintf(stderr, "gc nudge drain: validating claimed nudges: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "nudge drain: validating claimed nudges", err)
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc nudge drain: validating claimed nudges: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge drain: validating claimed nudges", err)
 		return 1
 	}
 	if len(blocked) > 0 {
 		if err := terminalizeBlockedQueuedNudges(target.cityPath, blocked); err != nil {
 			if inject {
-				fmt.Fprintf(stderr, "gc nudge drain: withdrawing blocked nudges: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "nudge drain: withdrawing blocked nudges", err)
 				return 0
 			}
-			fmt.Fprintf(stderr, "gc nudge drain: withdrawing blocked nudges: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "nudge drain: withdrawing blocked nudges", err)
 			return 1
 		}
 	}
@@ -366,18 +366,18 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		if inject {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc nudge drain: writing output: %v\n", writeErr) //nolint:errcheck
+		cmdErr(stderr, "nudge drain: writing output", writeErr)
 		return 1
 	}
 	if inject {
 		if err := ackQueuedNudgesWithOutcome(target.cityPath, queuedNudgeIDs(items), "accepted_for_injection", "", "hook-transport-accepted"); err != nil {
-			fmt.Fprintf(stderr, "gc nudge drain: recording injection ack: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "nudge drain: recording injection ack", err)
 			return 0
 		}
 		return 0
 	}
 	if err := ackQueuedNudges(target.cityPath, queuedNudgeIDs(items)); err != nil {
-		fmt.Fprintf(stderr, "gc nudge drain: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge drain", err)
 		return 1
 	}
 	return 0
@@ -404,7 +404,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 	}
 	target, err := resolveNudgeTarget(targetID, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc nudge poll: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge poll", err)
 		return 1
 	}
 	if sessionName != "" {
@@ -420,7 +420,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		if errors.Is(err, errNudgePollerRunning) {
 			return 0
 		}
-		fmt.Fprintf(stderr, "gc nudge poll: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "nudge poll", err)
 		return 1
 	}
 	defer release()
@@ -435,7 +435,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 	for {
 		obs, err := workerObserveNudgeTarget(target, store, sp)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc nudge poll: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "nudge poll", err)
 			return 1
 		}
 		if !obs.Running {
@@ -452,7 +452,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		missingSince = time.Time{}
 		delivered, pollErr := tryDeliverQueuedNudgesByPoller(target, store, sp, quiescence)
 		if pollErr != nil {
-			fmt.Fprintf(stderr, "gc nudge poll: %v\n", pollErr) //nolint:errcheck
+			cmdErr(stderr, "nudge poll", pollErr)
 		}
 		if delivered {
 			continue
@@ -492,7 +492,7 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 	}
 	handle, err := workerHandleForNudgeTarget(target, store, sp)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session nudge", err)
 		return 1
 	}
 	result, err := handle.Nudge(context.Background(), worker.NudgeRequest{
@@ -501,7 +501,7 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 		Source:   "session",
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session nudge", err)
 		return 1
 	}
 	if mode == nudgeDeliveryWaitIdle && !result.Delivered {
@@ -540,7 +540,7 @@ func deliverSessionNudgeWithProvider(target nudgeTarget, sp runtime.Provider, mo
 
 func queueSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp runtime.Provider, message string, stdout, stderr io.Writer) int {
 	if err := enqueueQueuedNudge(target.cityPath, newQueuedNudgeWithOptions(target.agentKey(), message, "session", time.Now(), queuedNudgeOptionsFromTarget(target))); err != nil {
-		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session nudge", err)
 		return 1
 	}
 	if obs, err := workerObserveNudgeTarget(target, store, sp); err == nil && obs.Running {

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -233,7 +233,7 @@ func cmdNudgeStatus(args []string, stdout, stderr io.Writer) int {
 		targetID = args[0]
 	}
 	if targetID == "" {
-		fmt.Fprintln(stderr, "gc nudge status: session not specified (set $GC_ALIAS/$GC_SESSION_ID or pass an alias/id)") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: session not specified (set $GC_ALIAS/$GC_SESSION_ID or pass an alias/id)\n", cmdName("nudge status")) //nolint:errcheck
 		return 1
 	}
 
@@ -291,7 +291,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 		if inject {
 			return 0
 		}
-		fmt.Fprintln(stderr, "gc nudge drain: session not specified (set $GC_ALIAS/$GC_SESSION_ID or pass an alias/id)") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: session not specified (set $GC_ALIAS/$GC_SESSION_ID or pass an alias/id)\n", cmdName("nudge drain")) //nolint:errcheck
 		return 1
 	}
 
@@ -399,7 +399,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		targetID = args[0]
 	}
 	if targetID == "" {
-		fmt.Fprintln(stderr, "gc nudge poll: session not specified (set $GC_ALIAS/$GC_SESSION_ID or pass an alias/id)") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: session not specified (set $GC_ALIAS/$GC_SESSION_ID or pass an alias/id)\n", cmdName("nudge poll")) //nolint:errcheck
 		return 1
 	}
 	target, err := resolveNudgeTarget(targetID, stderr)
@@ -411,7 +411,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 		target.sessionName = sessionName
 	}
 	if target.sessionName == "" {
-		fmt.Fprintln(stderr, "gc nudge poll: session name unavailable") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: session name unavailable\n", cmdName("nudge poll")) //nolint:errcheck
 		return 1
 	}
 
@@ -428,7 +428,7 @@ func cmdNudgePoll(args []string, sessionName string, interval, quiescence time.D
 	sp := newSessionProvider()
 	store := openNudgeBeadStore(target.cityPath)
 	if store == nil {
-		fmt.Fprintf(stderr, "gc nudge poll: opening city store for %q\n", target.agentKey()) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: opening city store for %q\n", cmdName("nudge poll"), target.agentKey()) //nolint:errcheck
 		return 1
 	}
 	var missingSince time.Time
@@ -475,7 +475,7 @@ func shouldKeepNudgePollerAlive(target nudgeTarget, missingSince, now time.Time)
 func deliverSessionNudge(target nudgeTarget, message string, mode nudgeDeliveryMode, stdout, stderr io.Writer) int {
 	store := openNudgeBeadStore(target.cityPath)
 	if store == nil {
-		fmt.Fprintf(stderr, "gc session nudge: opening city store for %q\n", target.agentKey()) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: opening city store for %q\n", cmdName("session nudge"), target.agentKey()) //nolint:errcheck
 		return 1
 	}
 	return deliverSessionNudgeWithWorker(target, store, newSessionProvider(), message, mode, stdout, stderr)
@@ -487,7 +487,7 @@ func deliverSessionNudgeWithWorker(target nudgeTarget, store beads.Store, sp run
 	}
 	delivery, ok := workerNudgeDeliveryForMode(mode)
 	if !ok {
-		fmt.Fprintf(stderr, "gc session nudge: unknown delivery mode %q\n", mode) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: unknown delivery mode %q\n", cmdName("session nudge"), mode) //nolint:errcheck
 		return 1
 	}
 	handle, err := workerHandleForNudgeTarget(target, store, sp)

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -290,7 +290,7 @@ func rigOrderRoots(_ string, _ *config.City, formulaLayers []string) []orders.Sc
 // --- gc order list ---
 
 func cmdOrderList(stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order list")
+	aa, code := loadOrders(stderr, cmdName("order list"))
 	if code != 0 {
 		return code
 	}
@@ -355,7 +355,7 @@ func anyOrderHasRig(aa []orders.Order) bool {
 // --- gc order show ---
 
 func cmdOrderShow(name, rig string, stdout, stderr io.Writer) int {
-	aa, code := loadOrders(stderr, "gc order show")
+	aa, code := loadOrders(stderr, cmdName("order show"))
 	if code != 0 {
 		return code
 	}
@@ -406,7 +406,7 @@ func doOrderShow(aa []orders.Order, name, rig string, stdout, stderr io.Writer) 
 // --- gc order run ---
 
 func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
-	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order run")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, cmdName("order run"))
 	if code != 0 {
 		return code
 	}
@@ -418,12 +418,12 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 	if a.IsExec() {
 		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
 	}
-	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
+	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, cmdName("order run"))
 	if store == nil {
 		return storeCode
 	}
 
-	ep, epCode := openCityEventsProvider(stderr, "gc order run")
+	ep, epCode := openCityEventsProvider(stderr, cmdName("order run"))
 	if ep == nil {
 		return epCode
 	}
@@ -564,12 +564,12 @@ func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, s
 // --- gc order check ---
 
 func cmdOrderCheck(stdout, stderr io.Writer) int {
-	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order check")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, cmdName("order check"))
 	if code != 0 {
 		return code
 	}
 
-	ep, epCode := openCityEventsProvider(stderr, "gc order check")
+	ep, epCode := openCityEventsProvider(stderr, cmdName("order check"))
 	if ep == nil {
 		return epCode
 	}
@@ -706,7 +706,7 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 // --- gc order history ---
 
 func cmdOrderHistory(name, rig string, stdout, stderr io.Writer) int {
-	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, "gc order history")
+	cityPath, cfg, aa, code := loadOrdersWithCity(stderr, cmdName("order history"))
 	if code != 0 {
 		return code
 	}

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -445,7 +445,7 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 	if a.IsExec() {
 		cfg, cfgErr := loadCityConfig(cityPath, stderr)
 		if cfgErr != nil {
-			fmt.Fprintf(stderr, "gc order run: %v\n", cfgErr) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "order run", cfgErr)
 			return 1
 		}
 		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
@@ -464,7 +464,7 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		var err error
 		cfg, err = loadCityConfig(cityPath, stderr)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "order run", err)
 			return 1
 		}
 		cityName = config.EffectiveCityName(cfg, filepath.Base(cityPath))
@@ -478,24 +478,24 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 	}
 	recipe, err := formula.CompileWithoutRuntimeVarValidation(context.Background(), a.Formula, searchPaths, nil)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "order run", err)
 		return 1
 	}
 	if err := molecule.ValidateRecipeRuntimeVars(recipe, molecule.Options{}); err != nil {
-		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "order run", err)
 		return 1
 	}
 
 	if a.Pool != "" && cfg != nil {
 		pool := qualifyPool(a.Pool, a.Rig)
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", "", store, cityName, cityPath, cfg); err != nil {
-			fmt.Fprintf(stderr, "gc order run: routing decoration failed: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "order run: routing decoration failed", err)
 		}
 	}
 
 	cookResult, err := molecule.Instantiate(context.Background(), store, recipe, molecule.Options{})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "order run", err)
 		return 1
 	}
 	rootID := cookResult.RootID
@@ -517,7 +517,7 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 		}
 	}
 	if err := store.Update(rootID, update); err != nil {
-		fmt.Fprintf(stderr, "gc order run: labeling wisp: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "order run: labeling wisp", err)
 		return 1
 	}
 
@@ -541,14 +541,14 @@ func doOrderRunExec(a orders.Order, cityPath string, cfg *config.City, stdout, s
 
 	target, err := resolveOrderExecTarget(cityPath, cfg, a)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "order run", err)
 		return 1
 	}
 	env := orderExecEnv(cityPath, cfg, target, a)
 
 	output, err := shellExecRunner(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc order run: exec failed: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "order run: exec failed", err)
 		if len(output) > 0 {
 			fmt.Fprintf(stderr, "%s", output) //nolint:errcheck
 		}
@@ -653,7 +653,7 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 	for _, a := range aa {
 		stores, err := resolveStores(a)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "order check", err)
 			return 1
 		}
 		baseLastRunFn := orders.LastRunAcrossStores(stores...)
@@ -760,7 +760,7 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 	for _, a := range targets {
 		stores, err := resolveStores(a)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "order history", err)
 			return 1
 		}
 		label := "order-run:" + a.ScopedName()
@@ -774,7 +774,7 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 				Sort:          beads.SortCreatedDesc,
 			})
 			if err != nil {
-				fmt.Fprintf(stderr, "gc order history: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "order history", err)
 				if i == 0 {
 					return 1
 				}

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -32,9 +32,9 @@ tick and dispatches work when a trigger opens.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc order: missing subcommand (list, show, run, check, history)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (list, show, run, check, history)\n", cmdName("order")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc order: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("order"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -366,7 +366,7 @@ func cmdOrderShow(name, rig string, stdout, stderr io.Writer) int {
 func doOrderShow(aa []orders.Order, name, rig string, stdout, stderr io.Writer) int {
 	a, ok := findOrder(aa, name, rig)
 	if !ok {
-		fmt.Fprintf(stderr, "gc order show: order %q not found\n", name) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: order %q not found\n", cmdName("order show"), name) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -412,7 +412,7 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 	}
 	a, ok := findOrder(aa, name, rig)
 	if !ok {
-		fmt.Fprintf(stderr, "gc order run: order %q not found\n", name) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: order %q not found\n", cmdName("order run"), name) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if a.IsExec() {
@@ -437,7 +437,7 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store, ep events.Provider, stdout, stderr io.Writer) int {
 	a, ok := findOrder(aa, name, rig)
 	if !ok {
-		fmt.Fprintf(stderr, "gc order run: order %q not found\n", name) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: order %q not found\n", cmdName("order run"), name) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -669,7 +669,7 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 		if a.Trigger == "event" {
 			cursor, err := bdCursorAcrossStores(a.ScopedName(), stores...)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc order check: reading event cursor for %s: %v\n", a.ScopedName(), err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: reading event cursor for %s: %v\n", cmdName("order check"), a.ScopedName(), err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 			cursorFn = func(string) uint64 {
@@ -678,7 +678,7 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 		}
 		result := orders.CheckTrigger(a, now, lastRunFn, ep, cursorFn)
 		if lastRunErr != nil {
-			fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: reading last run for %s: %v\n", cmdName("order check"), a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		due := "no"

--- a/cmd/gc/cmd_pack.go
+++ b/cmd/gc/cmd_pack.go
@@ -52,13 +52,13 @@ for reproducibility. Automatically called during "gc start".`,
 func doPackFetch(stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc pack fetch: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack fetch", err)
 		return 1
 	}
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc pack fetch: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack fetch", err)
 		return 1
 	}
 
@@ -69,18 +69,18 @@ func doPackFetch(stdout, stderr io.Writer) int {
 
 	fmt.Fprintf(stdout, "Fetching %d pack source(s)...\n", len(cfg.Packs)) //nolint:errcheck
 	if err := config.FetchPacks(cfg.Packs, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc pack fetch: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack fetch", err)
 		return 1
 	}
 
 	// Write lockfile.
 	lock, err := config.LockFromCache(cfg.Packs, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc pack fetch: building lock: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack fetch: building lock", err)
 		return 1
 	}
 	if err := config.WriteLock(cityPath, lock); err != nil {
-		fmt.Fprintf(stderr, "gc pack fetch: writing lock: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack fetch: writing lock", err)
 		return 1
 	}
 
@@ -118,13 +118,13 @@ and locked commit hash (if available).`,
 func doPackList(stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc pack list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack list", err)
 		return 1
 	}
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc pack list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "pack list", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_pack.go
+++ b/cmd/gc/cmd_pack.go
@@ -33,11 +33,11 @@ func newPackFetchCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "fetch",
 		Short: "Clone missing and update existing remote packs",
-		Long: `Clone missing and update existing remote pack caches.
+		Long: fmt.Sprintf(`Clone missing and update existing remote pack caches.
 
 Fetches all configured pack sources from their git repositories,
 updates the local cache, and writes a lockfile with commit hashes
-for reproducibility. Automatically called during "gc start".`,
+for reproducibility. Automatically called during "%s start".`, prog()),
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if doPackFetch(stdout, stderr) != 0 {

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -225,10 +225,10 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	if strictMode {
 		switch {
 		case agentName == "":
-			fmt.Fprintf(stderr, "gc prime: --strict requires an agent name (from args, GC_ALIAS, or GC_AGENT)\n") //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: --strict requires an agent name (from args, GC_ALIAS, or GC_AGENT)\n", cmdName("prime")) //nolint:errcheck
 			return 1
 		case len(resolvedAgents) == 0:
-			fmt.Fprintf(stderr, "gc prime: agent %q not found in city config\n", agentName) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: agent %q not found in city config\n", cmdName("prime"), agentName) //nolint:errcheck
 			return 1
 		}
 		// renderPrompt returns "" both when the template file cannot be read
@@ -242,7 +242,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 				continue
 			}
 			if _, fErr := os.ReadFile(promptTemplateSourcePath(cityPath, a.PromptTemplate)); fErr != nil {
-				fmt.Fprintf(stderr, "gc prime: prompt_template %q for agent %q: %v\n", a.PromptTemplate, agentName, fErr) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: prompt_template %q for agent %q: %v\n", cmdName("prime"), a.PromptTemplate, agentName, fErr) //nolint:errcheck
 				return 1
 			}
 		}

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -172,7 +172,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	cityPath, err := resolveCity()
 	if err != nil {
 		if strictMode {
-			fmt.Fprintf(stderr, "gc prime: no city config found: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "prime: no city config found", err)
 			return 1
 		}
 		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
@@ -181,7 +181,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
 		if strictMode {
-			fmt.Fprintf(stderr, "gc prime: loading city config: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "prime: loading city config", err)
 			return 1
 		}
 		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -68,7 +68,7 @@ func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io
 		cmdErr(stderr, "register", err)
 		return 1
 	}
-	return registerCityWithSupervisorNamed(cityPath, registerName, stdout, stderr, "gc register", true)
+	return registerCityWithSupervisorNamed(cityPath, registerName, stdout, stderr, cmdName("register"), true)
 }
 
 // resolveRegistrationName returns the machine-local alias to store in the
@@ -120,7 +120,7 @@ func doUnregister(args []string, stdout, stderr io.Writer) int {
 		cmdErr(stderr, "unregister", err)
 		return 1
 	}
-	_, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc unregister")
+	_, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, cmdName("unregister"))
 	return code
 }
 

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -54,7 +54,7 @@ func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io
 		cityPath, err = resolveCommandCity(nil)
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "gc register: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "register", err)
 		return 1
 	}
 
@@ -65,7 +65,7 @@ func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io
 	}
 	registerName, err := resolveRegistrationName(cityPath, nameOverride)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc register: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "register", err)
 		return 1
 	}
 	return registerCityWithSupervisorNamed(cityPath, registerName, stdout, stderr, "gc register", true)
@@ -117,7 +117,7 @@ func doUnregister(args []string, stdout, stderr io.Writer) int {
 		cityPath, err = resolveCommandCity(nil)
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "gc unregister: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "unregister", err)
 		return 1
 	}
 	_, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc unregister")
@@ -152,7 +152,7 @@ func doCities(stdout, stderr io.Writer) int {
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
 	entries, err := reg.List()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc cities: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "cities", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -60,7 +60,7 @@ func doRegisterWithOptions(args []string, nameOverride string, stdout, stderr io
 
 	// Verify it's a city directory (city.toml is the defining marker).
 	if _, sErr := os.Stat(filepath.Join(cityPath, "city.toml")); sErr != nil {
-		fmt.Fprintf(stderr, "gc register: %s is not a city directory (no city.toml found)\n", cityPath) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s is not a city directory (no city.toml found)\n", cmdName("register"), cityPath) //nolint:errcheck
 		return 1
 	}
 	registerName, err := resolveRegistrationName(cityPath, nameOverride)

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -86,7 +86,7 @@ drift rules require them.`,
 func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "reload", err)
 		return 1
 	}
 
@@ -117,7 +117,7 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 				return 1
 			}
 		}
-		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "reload", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -91,7 +91,7 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 	}
 
 	if async && timeoutChanged {
-		fmt.Fprintln(stderr, "gc reload: --async and --timeout cannot be used together") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: --async and --timeout cannot be used together\n", cmdName("reload")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -99,11 +99,11 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 	if !async {
 		timeout, err := time.ParseDuration(timeoutValue)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc reload: invalid --timeout %q: %v\n", timeoutValue, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: invalid --timeout %q: %v\n", cmdName("reload"), timeoutValue, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if timeout <= 0 {
-			fmt.Fprintln(stderr, "gc reload: --timeout must be greater than 0") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --timeout must be greater than 0\n", cmdName("reload")) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		req.Timeout = timeout.String()
@@ -113,7 +113,7 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 	if err != nil {
 		if isControllerUnavailableError(err) {
 			if msg := reloadUnavailableMessageHook(cityPath); msg != "" {
-				fmt.Fprintf(stderr, "gc reload: %s: %v\n", msg, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: %s: %v\n", cmdName("reload"), msg, err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 		}
@@ -127,12 +127,12 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 			fmt.Fprintln(stdout, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stdout
 		}
 		for _, warning := range reply.Warnings {
-			fmt.Fprintf(stderr, "gc reload: warning: %s\n", warning) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("reload"), warning) //nolint:errcheck // best-effort stderr
 		}
 		return 0
 	case reloadOutcomeFailed:
 		for _, warning := range reply.Warnings {
-			fmt.Fprintf(stderr, "gc reload: warning: %s\n", warning) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("reload"), warning) //nolint:errcheck // best-effort stderr
 		}
 		switch {
 		case strings.TrimSpace(reply.Error) != "":
@@ -140,18 +140,18 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 		case strings.TrimSpace(reply.Message) != "":
 			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
 		default:
-			fmt.Fprintln(stderr, "gc reload: reload failed") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: reload failed\n", cmdName("reload")) //nolint:errcheck // best-effort stderr
 		}
 		return 1
 	case reloadOutcomeBusy, reloadOutcomeTimeout:
 		if strings.TrimSpace(reply.Message) != "" {
 			fmt.Fprintln(stderr, strings.TrimSpace(reply.Message)) //nolint:errcheck // best-effort stderr
 		} else {
-			fmt.Fprintf(stderr, "gc reload: %s\n", reply.Outcome) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: %s\n", cmdName("reload"), reply.Outcome) //nolint:errcheck // best-effort stderr
 		}
 		return 1
 	default:
-		fmt.Fprintf(stderr, "gc reload: unexpected controller outcome %q\n", reply.Outcome) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: unexpected controller outcome %q\n", cmdName("reload"), reply.Outcome) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 }

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -16,11 +16,11 @@ func newRestartCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "restart [path]",
 		Short: "Restart all agent sessions in the city",
-		Long: `Restart the city by stopping it then starting it again.
+		Long: fmt.Sprintf(`Restart the city by stopping it then starting it again.
 
-Equivalent to running "gc stop" followed by "gc start". Under supervisor
+Equivalent to running "%s stop" followed by "%s start". Under supervisor
 mode this unregisters the city, then re-registers it and triggers an
-immediate reconcile.`,
+immediate reconcile.`, prog(), prog()),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdRestart(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -35,7 +35,7 @@ immediate reconcile.`,
 func cmdRestart(args []string, stdout, stderr io.Writer) int {
 	nameOverride, err := restartRegistrationName(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "restart", err)
 		return 1
 	}
 	if code := cmdStop(args, stdout, stderr); code != 0 {
@@ -84,7 +84,7 @@ quick way to force-refresh all agents working on a particular project.`,
 func cmdRigRestart(args []string, stdout, stderr io.Writer) int {
 	ctx, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig restart", err)
 		return 1
 	}
 	rigName := ctx.RigName
@@ -98,7 +98,7 @@ func cmdRigRestart(args []string, stdout, stderr io.Writer) int {
 	cityPath := ctx.CityPath
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig restart", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -92,7 +92,7 @@ func cmdRigRestart(args []string, stdout, stderr io.Writer) int {
 		rigName = args[0]
 	}
 	if rigName == "" {
-		fmt.Fprintln(stderr, "gc rig restart: missing rig name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing rig name\n", cmdName("rig restart")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath := ctx.CityPath
@@ -149,7 +149,7 @@ func doRigRestart(
 			sn := lookupSessionNameOrLegacy(store, cityName, a.QualifiedName(), sessionTemplate)
 			running, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, sn)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc rig restart: observing %s: %v\n", sn, err) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: observing %s: %v\n", cmdName("rig restart"), sn, err) //nolint:errcheck
 				return 1
 			}
 			if running {
@@ -166,7 +166,7 @@ func doRigRestart(
 			for _, ref := range resolvePoolSessionRefs(store, a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp, stderr) {
 				running, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, ref.sessionName)
 				if err != nil {
-					fmt.Fprintf(stderr, "gc rig restart: observing %s: %v\n", ref.sessionName, err) //nolint:errcheck
+					fmt.Fprintf(stderr, "%s: observing %s: %v\n", cmdName("rig restart"), ref.sessionName, err) //nolint:errcheck
 					return 1
 				}
 				if !running {

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -111,7 +111,7 @@ func cmdRigRestart(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	if !found {
-		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig restart", rigName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, rigNotFoundMsg(cmdName("rig restart"), rigName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -37,9 +37,9 @@ are scoped to rigs via their "dir" field.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc rig: missing subcommand (add, list, remove, restart, resume, set-endpoint, status, suspend)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (add, list, remove, restart, resume, set-endpoint, status, suspend)\n", cmdName("rig")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc rig: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("rig"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -129,7 +129,7 @@ displays its bead ID prefix and whether its beads database is initialized.`,
 // cmdRigAdd registers an external project directory as a rig in the city.
 func cmdRigAdd(args []string, includes []string, nameOverride, prefixOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc rig add: missing path") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing path\n", cmdName("rig add")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -173,7 +173,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	// Validate prefix format: hyphens break beadPrefix() which splits on
 	// the first '-' to extract the rig prefix from a bead ID.
 	if prefixOverride != "" && strings.Contains(prefixOverride, "-") {
-		fmt.Fprintf(stderr, "gc rig add: --prefix %q must not contain hyphens (conflicts with bead ID format)\n", prefixOverride) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: --prefix %q must not contain hyphens (conflicts with bead ID format)\n", cmdName("rig add"), prefixOverride) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -191,26 +191,26 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	fi, err := fs.Stat(rigPath)
 	if err != nil {
 		if adopt {
-			fmt.Fprintf(stderr, "gc rig add: --adopt requires an existing directory: %s\n", rigPath) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --adopt requires an existing directory: %s\n", cmdName("rig add"), rigPath) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if err := fs.MkdirAll(rigPath, 0o755); err != nil {
-			fmt.Fprintf(stderr, "gc rig add: creating %s: %v\n", rigPath, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: creating %s: %v\n", cmdName("rig add"), rigPath, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	} else if !fi.IsDir() {
-		fmt.Fprintf(stderr, "gc rig add: %s is not a directory\n", rigPath) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %s is not a directory\n", cmdName("rig add"), rigPath) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	if adopt {
 		metaPath := filepath.Join(rigPath, ".beads", "metadata.json")
 		if _, err := fs.Stat(metaPath); err != nil {
-			fmt.Fprintf(stderr, "gc rig add: --adopt requires .beads/metadata.json in %s\n", rigPath) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --adopt requires .beads/metadata.json in %s\n", cmdName("rig add"), rigPath) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if _, ok := readBeadsPrefix(fs, rigPath); !ok {
-			fmt.Fprintf(stderr, "gc rig add: --adopt requires a valid issue_prefix in .beads/config.yaml in %s\n", rigPath) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --adopt requires a valid issue_prefix in .beads/config.yaml in %s\n", cmdName("rig add"), rigPath) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -260,7 +260,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			existPath = filepath.Join(cityPath, existPath)
 		}
 		if filepath.Clean(existPath) != filepath.Clean(rigPath) {
-			fmt.Fprintf(stderr, "gc rig add: rig %q already registered at %s (not %s)\n", name, r.Path, rigPath) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rig %q already registered at %s (not %s)\n", cmdName("rig add"), name, r.Path, rigPath) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		reAdd = true
@@ -282,20 +282,20 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		case reAdd:
 			// On re-add, --prefix is ignored (we use the existing rig's
 			// configured prefix). Direct the user to edit city.toml.
-			fmt.Fprintf(stderr, "gc rig add: rig %q has bead prefix %q but city.toml has %q; "+ //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rig %q has bead prefix %q but city.toml has %q; "+ //nolint:errcheck // best-effort stderr
 				"edit city.toml to set prefix = %q, or remove %s/.beads to reinitialize\n",
-				name, existingPrefix, prefix, existingPrefix, rigPath)
+				cmdName("rig add"), name, existingPrefix, prefix, existingPrefix, rigPath)
 		case adopt:
 			// On --adopt, the user explicitly wants the existing store.
 			// "Remove .beads to reinitialize" is the wrong recovery here:
 			// nudge them toward matching the existing prefix instead.
-			fmt.Fprintf(stderr, "gc rig add: --adopt: rig %q already has bead prefix %q (requested %q); "+ //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --adopt: rig %q already has bead prefix %q (requested %q); "+ //nolint:errcheck // best-effort stderr
 				"use --prefix %s (or omit --prefix) to match the existing store\n",
-				name, existingPrefix, prefix, existingPrefix)
+				cmdName("rig add"), name, existingPrefix, prefix, existingPrefix)
 		default:
-			fmt.Fprintf(stderr, "gc rig add: rig %q already has bead prefix %q (requested %q); "+ //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rig %q already has bead prefix %q (requested %q); "+ //nolint:errcheck // best-effort stderr
 				"use --prefix %s to match, or remove %s/.beads to reinitialize\n",
-				name, existingPrefix, prefix, existingPrefix, rigPath)
+				cmdName("rig add"), name, existingPrefix, prefix, existingPrefix, rigPath)
 		}
 		return 1
 	}
@@ -309,13 +309,13 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		beadsPath := filepath.Join(rigPath, ".beads")
 		fi, err := fs.Stat(beadsPath)
 		if err != nil && !os.IsNotExist(err) {
-			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: checking %s: %v\n", cmdName("rig add"), beadsPath, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if err == nil && fi.IsDir() {
-			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
 				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
-				rigPath, rigPath)
+				cmdName("rig add"), rigPath, rigPath)
 			return 1
 		}
 	}
@@ -326,13 +326,13 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if reAdd {
 		w(fmt.Sprintf("Re-initializing rig '%s'...", name))
 		if startSuspended && startSuspended != existingRig.Suspended {
-			fmt.Fprintf(stderr, "gc rig add: warning: --start-suspended ignored (existing: suspended=%v); edit city.toml to change\n", existingRig.Suspended) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: --start-suspended ignored (existing: suspended=%v); edit city.toml to change\n", cmdName("rig add"), existingRig.Suspended) //nolint:errcheck // best-effort stderr
 		}
 		if len(includes) > 0 && !slices.Equal(existingRig.Includes, includes) {
-			fmt.Fprintf(stderr, "gc rig add: warning: --include flags %v ignored (existing: %v); edit city.toml to change\n", includes, existingRig.Includes) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: --include flags %v ignored (existing: %v); edit city.toml to change\n", cmdName("rig add"), includes, existingRig.Includes) //nolint:errcheck // best-effort stderr
 		}
 		if prefixOverride != "" && strings.ToLower(prefixOverride) != existingRig.EffectivePrefix() {
-			fmt.Fprintf(stderr, "gc rig add: warning: --prefix=%s ignored (existing: %s); edit city.toml to change\n", prefixOverride, existingRig.EffectivePrefix()) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: --prefix=%s ignored (existing: %s); edit city.toml to change\n", cmdName("rig add"), prefixOverride, existingRig.EffectivePrefix()) //nolint:errcheck // best-effort stderr
 		}
 	} else {
 		w(fmt.Sprintf("Adding rig '%s'...", name))
@@ -487,7 +487,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 
 	if err := rigReloadControllerConfig(cityPath); err == nil && deferred && cityUsesBdStoreContract(cityPath) {
 		if waitErr := rigWaitForStoreAccessible(cityPath, rigPath, rigDeferredStoreInitWait); waitErr != nil {
-			fmt.Fprintf(stderr, "gc rig add: warning: controller init still pending for rig %q: %v\n", name, waitErr) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: controller init still pending for rig %q: %v\n", cmdName("rig add"), name, waitErr) //nolint:errcheck // best-effort stderr
 		}
 	}
 
@@ -563,10 +563,10 @@ func snapshotRigAddTopologyFiles(fs fsys.FS, cityPath string, cfg *config.City) 
 
 func writeRigAddRollbackError(fs fsys.FS, stderr io.Writer, snapshots []fileSnapshot, action string, cause error) {
 	if restoreErr := restoreSnapshots(fs, snapshots); restoreErr != nil {
-		fmt.Fprintf(stderr, "gc rig add: %s: %v (rollback failed: %v)\n", action, cause, restoreErr) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %s: %v (rollback failed: %v)\n", cmdName("rig add"), action, cause, restoreErr) //nolint:errcheck // best-effort stderr
 		return
 	}
-	fmt.Fprintf(stderr, "gc rig add: %s: %v\n", action, cause) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: %s: %v\n", cmdName("rig add"), action, cause) //nolint:errcheck // best-effort stderr
 }
 
 var writeAllRigRoutes = writeAllRoutes
@@ -778,7 +778,7 @@ func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 		rigName = args[0]
 	}
 	if rigName == "" {
-		fmt.Fprintln(stderr, "gc rig suspend: missing rig name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing rig name\n", cmdName("rig suspend")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath := ctx.CityPath
@@ -858,7 +858,7 @@ func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 		rigName = args[0]
 	}
 	if rigName == "" {
-		fmt.Fprintln(stderr, "gc rig resume: missing rig name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing rig name\n", cmdName("rig resume")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath := ctx.CityPath

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -66,7 +66,7 @@ func newRigAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add <path>",
 		Short: "Register a project as a rig",
-		Long: `Register an external project directory as a rig.
+		Long: fmt.Sprintf(`Register an external project directory as a rig.
 
 Initializes beads database, installs agent hooks if configured,
 generates cross-rig routes, and appends the rig to city.toml.
@@ -77,11 +77,11 @@ repeat the flag to compose multiple packs for one rig.
 Use --name to set the rig name explicitly (default: directory basename).
 Use --prefix to set the bead ID prefix explicitly (default: derived from name).
 Use --start-suspended to add the rig in a suspended state (dormant-by-default).
-The rig's agents won't spawn until explicitly resumed with "gc rig resume".
+The rig's agents won't spawn until explicitly resumed with "%s rig resume".
 
 Use --adopt to register a directory that already has a fully initialized
 .beads/ directory (must include both metadata.json and config.yaml).
-Skips beads init; the git repo check remains informational.`,
+Skips beads init; the git repo check remains informational.`, prog()),
 		Example: `  gc rig add /path/to/project
   gc rig add /path/to/project --name myrig
   gc rig add /path/to/project --prefix r1
@@ -751,11 +751,11 @@ func newRigSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "suspend [name]",
 		Short: "Suspend a rig (reconciler will skip its agents)",
-		Long: `Suspend a rig by setting suspended=true in city.toml.
+		Long: fmt.Sprintf(`Suspend a rig by setting suspended=true in city.toml.
 
 All agents scoped to the suspended rig are effectively suspended —
 the reconciler skips them and gc hook returns empty. The rig's beads
-database remains accessible. Use "gc rig resume" to restore.`,
+database remains accessible. Use "%s rig resume" to restore.`, prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdRigSuspend(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -135,13 +135,13 @@ func cmdRigAdd(args []string, includes []string, nameOverride, prefixOverride st
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add", err)
 		return 1
 	}
 
 	rigPath, err := resolveRigAddPath(cityPath, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add", err)
 		return 1
 	}
 	return doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameOverride, prefixOverride, startSuspended, adopt, stdout, stderr)
@@ -226,7 +226,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig add: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add: loading config", err)
 		return 1
 	}
 	if cityUsesBdStoreContract(cityPath) && (cfg.Dolt.Host != "" || cfg.Dolt.Port != 0) {
@@ -235,7 +235,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	}
 	rootDefaultRigImports, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig add: loading root pack defaults: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add: loading root pack defaults", err)
 		return 1
 	}
 	defaultRigIncludes := append([]string{}, cfg.Workspace.DefaultRigIncludes...)
@@ -357,7 +357,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 
 	if adopt {
 		if err := prepareRigAdoptProviderState(cityPath, rigPath); err != nil {
-			fmt.Fprintf(stderr, "gc rig add: prepare adopted rig store: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig add: prepare adopted rig store", err)
 			return 1
 		}
 		w("  Adopted existing beads database")
@@ -367,7 +367,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if !adopt {
 		deferred, err = initDirIfReady(cityPath, rigPath, prefix)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig add", err)
 			return 1
 		}
 		if deferred {
@@ -421,7 +421,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		next := *cfg
 		next.Rigs = append(append([]config.Rig{}, cfg.Rigs...), rig)
 		if err := config.ValidateRigs(next.Rigs, config.EffectiveHQPrefix(&next)); err != nil {
-			fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig add", err)
 			return 1
 		}
 		nextCfg = &next
@@ -429,7 +429,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 
 	snapshots, err := snapshotRigAddTopologyFiles(fs, cityPath, nextCfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig add: snapshot canonical files: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add: snapshot canonical files", err)
 		return 1
 	}
 	if !reAdd || reAddNeedsConfigWrite {
@@ -454,16 +454,16 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 
 	if adopt {
 		if err := installBeadHooks(rigPath); err != nil {
-			fmt.Fprintf(stderr, "gc rig add: installing bead hooks: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig add: installing bead hooks", err)
 		}
 	}
 	if err := ensureGitignoreEntries(fs, rigPath, rigGitignoreEntries); err != nil {
-		fmt.Fprintf(stderr, "gc rig add: writing .gitignore: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add: writing .gitignore", err)
 	}
 	if ih := cfg.Workspace.InstallAgentHooks; len(ih) > 0 {
 		resolver := func(name string) string { return config.BuiltinFamily(name, cfg.Providers) }
 		if err := hooks.InstallWithResolver(fs, cityPath, rigPath, ih, resolver); err != nil {
-			fmt.Fprintf(stderr, "gc rig add: installing agent hooks: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig add: installing agent hooks", err)
 		}
 	}
 
@@ -476,13 +476,13 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		}
 		if len(layers) > 0 {
 			if rfErr := ResolveFormulas(rigPath, layers); rfErr != nil {
-				fmt.Fprintf(stderr, "gc rig add: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "rig add: resolving formulas", rfErr)
 			}
 		}
 	}
 
 	if err := writeBeadsEnvGTRoot(fs, rigPath, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc rig add: warning: writing .beads/.env: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig add: warning: writing .beads/.env", err)
 	}
 
 	if err := rigReloadControllerConfig(cityPath); err == nil && deferred && cityUsesBdStoreContract(cityPath) {
@@ -634,7 +634,7 @@ func cmdRigList(args []string, jsonOutput bool, stdout, stderr io.Writer) int {
 	_ = args // no arguments used yet
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig list", err)
 		return 1
 	}
 	return doRigList(fsys.OSFS{}, cityPath, jsonOutput, stdout, stderr)
@@ -671,7 +671,7 @@ type RigListItem struct {
 func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.Writer) int {
 	cfg, err := loadCityConfigFS(fs, filepath.Join(cityPath, "city.toml"), stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig list", err)
 		return 1
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
@@ -703,7 +703,7 @@ func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.W
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(result); err != nil {
-			fmt.Fprintf(stderr, "gc rig list: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig list", err)
 			return 1
 		}
 		return 0
@@ -770,7 +770,7 @@ database remains accessible. Use "gc rig resume" to restore.`,
 func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 	ctx, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig suspend", err)
 		return 1
 	}
 	rigName := ctx.RigName
@@ -789,7 +789,7 @@ func cmdRigSuspend(args []string, stdout, stderr io.Writer) int {
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig suspend", err)
 			return 1
 		}
 		// Connection error — fall through to direct mutation.
@@ -803,7 +803,7 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig suspend", err)
 		return 1
 	}
 
@@ -821,7 +821,7 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 	}
 
 	if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
-		fmt.Fprintf(stderr, "gc rig suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig suspend", err)
 		return 1
 	}
 
@@ -850,7 +850,7 @@ The reconciler will start the rig's agents on its next tick.`,
 func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 	ctx, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig resume", err)
 		return 1
 	}
 	rigName := ctx.RigName
@@ -869,7 +869,7 @@ func cmdRigResume(args []string, stdout, stderr io.Writer) int {
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig resume", err)
 			return 1
 		}
 		// Connection error — fall through to direct mutation.
@@ -883,7 +883,7 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig resume", err)
 		return 1
 	}
 
@@ -901,7 +901,7 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 	}
 
 	if err := writeCityConfigForEditFS(fs, tomlPath, cfg); err != nil {
-		fmt.Fprintf(stderr, "gc rig resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig resume", err)
 		return 1
 	}
 
@@ -932,14 +932,14 @@ binding from .gc/site.toml.`,
 func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig remove: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig remove", err)
 		return 1
 	}
 
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fsys.OSFS{}, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig remove: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig remove: loading config", err)
 		return 1
 	}
 
@@ -961,7 +961,7 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 
 	// Write updated config.
 	if err := writeCityConfigForEditFS(fsys.OSFS{}, tomlPath, cfg); err != nil {
-		fmt.Fprintf(stderr, "gc rig remove: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig remove", err)
 		return 1
 	}
 
@@ -969,7 +969,7 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 	resolveRigPaths(cityPath, cfg.Rigs)
 	allRigs := collectRigRoutes(cityPath, cfg)
 	if err := writeAllRoutes(allRigs); err != nil {
-		fmt.Fprintf(stderr, "gc rig remove: warning: writing routes: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig remove: warning: writing routes", err)
 	}
 
 	_ = reloadControllerConfig(cityPath)

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -816,7 +816,7 @@ func doRigSuspend(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer
 		}
 	}
 	if !found {
-		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig suspend", rigName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, rigNotFoundMsg(cmdName("rig suspend"), rigName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -896,7 +896,7 @@ func doRigResume(fs fsys.FS, cityPath, rigName string, stdout, stderr io.Writer)
 		}
 	}
 	if !found {
-		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig resume", rigName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, rigNotFoundMsg(cmdName("rig resume"), rigName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -954,7 +954,7 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 		filtered = append(filtered, r)
 	}
 	if !found {
-		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig remove", rigName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, rigNotFoundMsg(cmdName("rig remove"), rigName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cfg.Rigs = filtered

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -71,7 +71,7 @@ This command owns the rig's canonical .beads/config.yaml topology state.`,
 func cmdRigSetEndpoint(rigName string, opts rigEndpointOptions, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig set-endpoint", err)
 		return 1
 	}
 	return doRigSetEndpoint(fsys.OSFS{}, cityPath, rigName, opts, stdout, stderr)
@@ -80,14 +80,14 @@ func cmdRigSetEndpoint(rigName string, opts rigEndpointOptions, stdout, stderr i
 //nolint:unparam // FS seam is intentional for command tests
 func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOptions, stdout, stderr io.Writer) int {
 	if err := validateRigEndpointOptions(opts); err != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig set-endpoint", err)
 		return 1
 	}
 
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig set-endpoint: loading config", err)
 		return 1
 	}
 	persistCfg := *cfg
@@ -115,12 +115,12 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 
 	cityState, err := resolveOwnerCityConfigState(cityPath, cfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig set-endpoint", err)
 		return 1
 	}
 	currentState, err := resolveOwnerRigConfigState(cityPath, rig, cityState)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig set-endpoint", err)
 		return 1
 	}
 
@@ -133,14 +133,14 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 
 	if opts.Inherit && cityState.EndpointOrigin == contract.EndpointOriginManagedCity {
 		if _, err := readManagedRuntimePublishedPort(cityPath); err != nil {
-			fmt.Fprintf(stderr, "gc rig set-endpoint: managed city endpoint unavailable: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig set-endpoint: managed city endpoint unavailable", err)
 			return 1
 		}
 	}
 
 	if opts.External && !opts.AdoptUnverified {
 		if err := verifyRigExternalEndpoint(targetState, rig.Path, rig.Path); err != nil {
-			fmt.Fprintf(stderr, "gc rig set-endpoint: validate external endpoint: %v\n", err)                                      //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "rig set-endpoint: validate external endpoint", err)
 			fmt.Fprintf(stderr, "gc rig set-endpoint: rerun with --adopt-unverified to record this endpoint without validation\n") //nolint:errcheck // best-effort stderr
 			return 1
 		}
@@ -149,7 +149,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 
 	snapshots, err := snapshotRigEndpointFiles(fs, cityPath, rig.Path)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: snapshot canonical files: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig set-endpoint: snapshot canonical files", err)
 		return 1
 	}
 	if err := ensureCanonicalScopeMetadataIfPresent(fs, rig.Path); err != nil {

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -96,7 +96,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 
 	rig, ok := rigByName(cfg, rigName)
 	if !ok {
-		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig set-endpoint", rigName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, rigNotFoundMsg(cmdName("rig set-endpoint"), rigName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if strings.TrimSpace(rig.Path) == "" {

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -382,7 +382,7 @@ func rigEndpointFollowupCommand(rig config.Rig, state contract.ConfigState) stri
 	if state.EndpointOrigin != contract.EndpointOriginExplicit || state.EndpointStatus != contract.EndpointStatusUnverified {
 		return ""
 	}
-	parts := []string{"gc rig set-endpoint", rig.Name, "--external", "--host", state.DoltHost, "--port", state.DoltPort}
+	parts := []string{cmdName("rig set-endpoint"), rig.Name, "--external", "--host", state.DoltHost, "--port", state.DoltPort}
 	if user := strings.TrimSpace(state.DoltUser); user != "" {
 		parts = append(parts, "--user", user)
 	}

--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -105,11 +105,11 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 		// syncRigManagedPortArtifact, etc.). Empty rig.Path would produce
 		// relative `.beads/...` writes under the current working directory
 		// instead of erroring cleanly.
-		fmt.Fprintf(stderr, "gc rig set-endpoint: rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it before setting its endpoint\n", rig.Name, rig.Name) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: rig %q is declared but has no path binding — run `gc rig add <dir> --name %s` to bind it before setting its endpoint\n", cmdName("rig set-endpoint"), rig.Name, rig.Name) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !scopeUsesManagedBdStoreContract(cityPath, rig.Path) {
-		fmt.Fprintln(stderr, "gc rig set-endpoint: only supported for bd-backed beads providers") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: only supported for bd-backed beads providers\n", cmdName("rig set-endpoint")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -141,7 +141,7 @@ func doRigSetEndpoint(fs fsys.FS, cityPath, rigName string, opts rigEndpointOpti
 	if opts.External && !opts.AdoptUnverified {
 		if err := verifyRigExternalEndpoint(targetState, rig.Path, rig.Path); err != nil {
 			cmdErr(stderr, "rig set-endpoint: validate external endpoint", err)
-			fmt.Fprintf(stderr, "gc rig set-endpoint: rerun with --adopt-unverified to record this endpoint without validation\n") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rerun with --adopt-unverified to record this endpoint without validation\n", cmdName("rig set-endpoint")) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		targetState.EndpointStatus = contract.EndpointStatusVerified
@@ -616,10 +616,10 @@ func snapshotOptionalFile(fs fsys.FS, path string) (fileSnapshot, error) {
 
 func writeRigEndpointRollbackError(fs fsys.FS, stderr io.Writer, snapshots []fileSnapshot, action string, cause error) {
 	if restoreErr := restoreSnapshots(fs, snapshots); restoreErr != nil {
-		fmt.Fprintf(stderr, "gc rig set-endpoint: %s: %v (rollback failed: %v)\n", action, cause, restoreErr) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %s: %v (rollback failed: %v)\n", cmdName("rig set-endpoint"), action, cause, restoreErr) //nolint:errcheck // best-effort stderr
 		return
 	}
-	fmt.Fprintf(stderr, "gc rig set-endpoint: %s: %v\n", action, cause) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: %s: %v\n", cmdName("rig set-endpoint"), action, cause) //nolint:errcheck // best-effort stderr
 }
 
 func restoreSnapshots(fs fsys.FS, snapshots []fileSnapshot) error {

--- a/cmd/gc/cmd_runtime.go
+++ b/cmd/gc/cmd_runtime.go
@@ -26,7 +26,7 @@ designed to be called from within running agent sessions, not by humans.`,
 				return cmd.Help()
 			}
 			known := []string{"drain", "undrain", "drain-check", "drain-ack", "request-restart"}
-			fmt.Fprintf(stderr, "gc runtime: unknown subcommand %q\nAvailable subcommands: %v\n", args[0], known) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown subcommand %q\nAvailable subcommands: %v\n", cmdName("runtime"), args[0], known) //nolint:errcheck // best-effort stderr
 			return errExit
 		},
 	}

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -137,12 +137,12 @@ func newRuntimeDrainCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "drain <name>",
 		Short: "Signal a session to drain (wind down gracefully)",
-		Long: `Signal a session to drain — wind down its current work gracefully.
+		Long: fmt.Sprintf(`Signal a session to drain — wind down its current work gracefully.
 
 Sets a GC_DRAIN metadata flag on the session. The agent should check
-for drain status periodically (via "gc runtime drain-check") and finish
+for drain status periodically (via "%s runtime drain-check") and finish
 its current task before exiting. Pass a session alias or ID. Use
-"gc runtime undrain" to cancel.`,
+"%s runtime undrain" to cancel.`, prog(), prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdRuntimeDrain(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -155,7 +155,7 @@ its current task before exiting. Pass a session alias or ID. Use
 
 func cmdRuntimeDrain(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc runtime drain: missing session alias or ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing session alias or ID\n", cmdName("runtime drain")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	target, err := resolveSessionRuntimeTarget(args[0], stderr)
@@ -175,11 +175,11 @@ func doRuntimeDrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 ) int {
 	running, err := workerSessionTargetRunningWithConfig("", nil, sp, nil, sn)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc runtime drain: observing %q: %v\n", targetName, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName("runtime drain"), targetName, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !running {
-		fmt.Fprintf(stderr, "gc runtime drain: session %q is not running\n", targetName) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: session %q is not running\n", cmdName("runtime drain"), targetName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := dops.setDrain(sn); err != nil {
@@ -219,7 +219,7 @@ session to continue normal operation. Pass a session alias or ID.`,
 
 func cmdRuntimeUndrain(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc runtime undrain: missing session alias or ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing session alias or ID\n", cmdName("runtime undrain")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	target, err := resolveSessionRuntimeTarget(args[0], stderr)
@@ -239,11 +239,11 @@ func doRuntimeUndrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 ) int {
 	running, err := workerSessionTargetRunningWithConfig("", nil, sp, nil, sn)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc runtime undrain: observing %q: %v\n", targetName, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName("runtime undrain"), targetName, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if !running {
-		fmt.Fprintf(stderr, "gc runtime undrain: session %q is not running\n", targetName) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: session %q is not running\n", cmdName("runtime undrain"), targetName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := dops.clearDrain(sn); err != nil {

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -160,7 +160,7 @@ func cmdRuntimeDrain(args []string, stdout, stderr io.Writer) int {
 	}
 	target, err := resolveSessionRuntimeTarget(args[0], stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc runtime drain: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime drain", err)
 		return 1
 	}
 	sp := newSessionProvider()
@@ -183,7 +183,7 @@ func doRuntimeDrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 		return 1
 	}
 	if err := dops.setDrain(sn); err != nil {
-		fmt.Fprintf(stderr, "gc runtime drain: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime drain", err)
 		return 1
 	}
 	rec.Record(events.Event{
@@ -224,7 +224,7 @@ func cmdRuntimeUndrain(args []string, stdout, stderr io.Writer) int {
 	}
 	target, err := resolveSessionRuntimeTarget(args[0], stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc runtime undrain: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime undrain", err)
 		return 1
 	}
 	sp := newSessionProvider()
@@ -247,7 +247,7 @@ func doRuntimeUndrain(dops drainOps, sp runtime.Provider, rec events.Recorder,
 		return 1
 	}
 	if err := dops.clearDrain(sn); err != nil {
-		fmt.Fprintf(stderr, "gc runtime undrain: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime undrain", err)
 		return 1
 	}
 	rec.Record(events.Event{
@@ -287,7 +287,7 @@ func cmdRuntimeDrainCheck(args []string, stderr io.Writer) int {
 	if len(args) > 0 {
 		target, err := resolveSessionRuntimeTarget(args[0], stderr)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc runtime drain-check: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "runtime drain-check", err)
 			return 1                                                 // silent — same as current "not draining" behavior
 		}
 		sp := newSessionProvider()
@@ -341,7 +341,7 @@ func cmdRuntimeDrainAck(args []string, stdout, stderr io.Writer) int {
 	if len(args) > 0 {
 		target, err := resolveSessionRuntimeTarget(args[0], stderr)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc runtime drain-ack: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "runtime drain-ack", err)
 			return 1
 		}
 		sp := newSessionProvider()
@@ -351,7 +351,7 @@ func cmdRuntimeDrainAck(args []string, stdout, stderr io.Writer) int {
 
 	current, err := currentSessionRuntimeTarget()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc runtime drain-ack: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime drain-ack", err)
 		return 1
 	}
 	sp := newSessionProvider()
@@ -394,7 +394,7 @@ It emits a session.draining event before blocking.`,
 func cmdRuntimeRequestRestart(stdout, stderr io.Writer) int {
 	current, err := currentSessionRuntimeTarget()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc runtime request-restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime request-restart", err)
 		return 1
 	}
 
@@ -402,17 +402,17 @@ func cmdRuntimeRequestRestart(stdout, stderr io.Writer) int {
 	dops := newDrainOps(sp)
 	store, storeErr := openCityStoreAt(current.cityPath)
 	if storeErr != nil {
-		fmt.Fprintf(stderr, "gc runtime request-restart: opening store: %v\n", storeErr) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime request-restart: opening store", storeErr)
 	}
 	if store != nil {
 		restartable, err := sessionRestartableByController(store, current.sessionName)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc runtime request-restart: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "runtime request-restart: checking session type", err)
 			return 1
 		}
 		if !restartable {
 			if err := clearRestartRequest(store, dops, current.sessionName); err != nil {
-				fmt.Fprintf(stderr, "gc runtime request-restart: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "runtime request-restart: clearing stale restart request", err)
 				return 1
 			}
 			fmt.Fprintln(stdout, "Restart skipped for named session; controller cannot restart on-demand named sessions.") //nolint:errcheck // best-effort stdout
@@ -440,14 +440,14 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 	targetName, sn string, stdout, stderr io.Writer,
 ) int {
 	if err := dops.setRestartRequested(sn); err != nil {
-		fmt.Fprintf(stderr, "gc runtime request-restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime request-restart", err)
 		return 1
 	}
 	// Also persist the request through the worker boundary so it survives
 	// tmux session death. Non-fatal: the runtime flag above is primary.
 	if persistRestart != nil {
 		if err := persistRestart(); err != nil {
-			fmt.Fprintf(stderr, "gc runtime request-restart: setting bead restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "runtime request-restart: setting bead restart flag", err)
 		}
 	}
 	rec.Record(events.Event{
@@ -466,7 +466,7 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 // will stop the session on the next tick.
 func doRuntimeDrainAck(dops drainOps, sn string, stdout, stderr io.Writer) int {
 	if err := dops.setDrainAck(sn); err != nil {
-		fmt.Fprintf(stderr, "gc runtime drain-ack: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "runtime drain-ack", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, "Drain acknowledged. Controller will stop this session.") //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_service.go
+++ b/cmd/gc/cmd_service.go
@@ -71,12 +71,12 @@ func newServiceDoctorCmd(stdout, stderr io.Writer) *cobra.Command {
 func cmdServiceList(stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc service list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service list", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc service list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service list", err)
 		return 1
 	}
 	return doServiceList(cfg, serviceReadClient(cityPath, cfg), stdout, stderr)
@@ -85,12 +85,12 @@ func cmdServiceList(stdout, stderr io.Writer) int {
 func cmdServiceDoctor(name string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc service doctor: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service doctor", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc service doctor: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service doctor", err)
 		return 1
 	}
 	return doServiceDoctor(cfg, serviceReadClient(cityPath, cfg), name, stdout, stderr)
@@ -117,12 +117,12 @@ Useful after updating pack scripts without a full city restart.`,
 func cmdServiceRestart(name string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc service restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service restart", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc service restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service restart", err)
 		return 1
 	}
 	client := serviceRestartClient(cityPath, cfg)
@@ -131,7 +131,7 @@ func cmdServiceRestart(name string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if err := client.RestartService(name); err != nil {
-		fmt.Fprintf(stderr, "gc service restart: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "service restart", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "Service %q restarted.\n", name) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_service.go
+++ b/cmd/gc/cmd_service.go
@@ -26,9 +26,9 @@ func newServiceCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc service: missing subcommand (list, doctor, restart)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (list, doctor, restart)\n", cmdName("service")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc service: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("service"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},
@@ -127,7 +127,7 @@ func cmdServiceRestart(name string, stdout, stderr io.Writer) int {
 	}
 	client := serviceRestartClient(cityPath, cfg)
 	if client == nil {
-		fmt.Fprintln(stderr, "gc service restart: controller is not running") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: controller is not running\n", cmdName("service restart")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := client.RestartService(name); err != nil {
@@ -194,7 +194,7 @@ func doServiceList(cfg *config.City, reader serviceStatusReader, stdout, stderr 
 func doServiceDoctor(cfg *config.City, reader serviceStatusReader, name string, stdout, stderr io.Writer) int {
 	svc, ok := lookupService(cfg, name)
 	if !ok {
-		fmt.Fprintf(stderr, "gc service doctor: service %q not found\n", name) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: service %q not found\n", cmdName("service doctor"), name) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -206,7 +206,7 @@ func doServiceDoctor(cfg *config.City, reader serviceStatusReader, name string, 
 			status = current
 			live = true
 		} else {
-			fmt.Fprintf(stderr, "gc service doctor: warning: %v (showing config view)\n", err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: %v (showing config view)\n", cmdName("service doctor"), err) //nolint:errcheck // best-effort stderr
 		}
 	}
 
@@ -238,7 +238,7 @@ func serviceStatuses(cfg *config.City, reader serviceStatusReader, stderr io.Wri
 		if err == nil {
 			return items, true
 		}
-		fmt.Fprintf(stderr, "gc service list: warning: %v (showing config view)\n", err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: warning: %v (showing config view)\n", cmdName("service list"), err) //nolint:errcheck
 	}
 
 	items := make([]workspacesvc.Status, 0, len(cfg.Services))

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -88,7 +88,7 @@ according to the selected semantic intent.`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			parsedIntent, err := parseSessionSubmitIntent(intent)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session submit", err)
 				return errExit
 			}
 			if cmdSessionSubmit(args, parsedIntent, stdout, stderr) != 0 {
@@ -147,12 +147,12 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 
@@ -167,13 +167,13 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	// Resolve the provider.
 	resolved, err := config.ResolveProvider(&found, &cfg.Workspace, cfg.Providers, exec.LookPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 	sessionTransport := config.ResolveSessionCreateTransport(found.Session, resolved)
 	requestedAlias, err := session.ValidateAlias(alias)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 	alias = requestedAlias
@@ -182,7 +182,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	}
 	explicitName, err := sessionExplicitNameForNewSession(&found, alias)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 
@@ -194,7 +194,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 
 	sp := newSessionProvider()
 	if err := validateResolvedSessionTransport(resolved, sessionTransport, sp); err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 
@@ -207,7 +207,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		sessionQualifiedName,
 	)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 
@@ -230,7 +230,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	}
 	sessionCommand, err := resolvedSessionCommand(cityPath, resolved, nil, sessionTransport)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 
@@ -261,7 +261,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 				kindMeta,
 			)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session new", err)
 				return 1
 			}
 			handle, err := newWorkerSessionHandleForResolvedRuntimeWithConfig(
@@ -281,7 +281,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 				kindMeta,
 			)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session new", err)
 				return 1
 			}
 			var info session.Info
@@ -302,7 +302,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 				return createErr
 			})
 			if err != nil {
-				fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session new", err)
 				return 1
 			}
 
@@ -324,12 +324,12 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 			// Wait for the reconciler to start the session before attaching.
 			fmt.Fprintln(stdout, "Waiting for session to start...") //nolint:errcheck // best-effort stdout
 			if waitErr := waitForSession(sp, info.SessionName, 30*time.Second, store, info.ID, stderr); waitErr != nil {
-				fmt.Fprintf(stderr, "gc session new: %v\n", waitErr) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session new", waitErr)
 				return 1
 			}
 			fmt.Fprintln(stdout, "Attaching...") //nolint:errcheck // best-effort stdout
 			if err := handle.Attach(context.Background()); err != nil {
-				fmt.Fprintf(stderr, "gc session new: attaching: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session new: attaching", err)
 				return 1
 			}
 			return 0
@@ -358,7 +358,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		kindMeta,
 	)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 	handle, err := newWorkerSessionHandleForResolvedRuntimeWithConfig(
@@ -378,7 +378,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		kindMeta,
 	)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 	var info session.Info
@@ -399,7 +399,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 		return createErr
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new", err)
 		return 1
 	}
 
@@ -417,7 +417,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 
 	fmt.Fprintln(stdout, "Attaching...") //nolint:errcheck // best-effort stdout
 	if err := handle.Attach(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session new: attaching: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session new: attaching", err)
 		return 1
 	}
 	return 0
@@ -645,7 +645,7 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 		Sort:  beads.SortCreatedDesc,
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session list: listing sessions: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session list: listing sessions", err)
 		return 1
 	}
 
@@ -653,7 +653,7 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 	sp := newSessionProviderFromContext(providerCtx, sessionBeads)
 	catalog, err := workerSessionCatalogWithConfig("", store, sp, providerCtx.cfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session list: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session list", err)
 		return 1
 	}
 	listResult := catalog.ListFullFromBeads(allSessionBeads, stateFilter, templateFilter)
@@ -962,12 +962,12 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 
@@ -978,32 +978,32 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 
 	sessionID, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 
 	sp := newSessionProvider()
 	catalog, err := workerSessionCatalogWithConfig(cityPath, store, sp, cfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 
 	// Get the session to find its template.
 	info, err := catalog.Get(sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 
 	fmt.Fprintf(stdout, "Attaching to session %s (%s)...\n", sessionID, info.Template) //nolint:errcheck // best-effort stdout
 	if err := handle.Attach(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session attach: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session attach", err)
 		return 1
 	}
 	return 0
@@ -1136,7 +1136,7 @@ func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
 	}
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session suspend", err)
 		return 1
 	}
 
@@ -1153,7 +1153,7 @@ func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
 				"sleep_intent": "user-hold",
 				"state":        "suspended",
 			}); err != nil {
-				fmt.Fprintf(stderr, "gc session suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session suspend", err)
 				return 1
 			}
 			// Poke again to trigger immediate reconciler tick.
@@ -1167,12 +1167,12 @@ func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
 	sp := newSessionProvider()
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session suspend", err)
 		return 1
 	}
 
 	if err := handle.Stop(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session suspend", err)
 		return 1
 	}
 
@@ -1212,28 +1212,28 @@ func cmdSessionClose(args []string, stdout, stderr io.Writer) int {
 	}
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session close: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session close", err)
 		return 1
 	}
 
 	sp := newSessionProvider()
 	nudgeIDs, err := waitNudgeIDsForSession(store, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session close: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session close", err)
 		return 1
 	}
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session close: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session close", err)
 		return 1
 	}
 	if err := handle.Close(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session close: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session close", err)
 		return 1
 	}
 	if cityErr == nil {
 		if err := withdrawQueuedWaitNudges(cityPath, nudgeIDs); err != nil {
-			fmt.Fprintf(stderr, "gc session close: warning: withdrawing queued wait nudges: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "session close: warning: withdrawing queued wait nudges", err)
 		}
 	}
 
@@ -1272,18 +1272,18 @@ func cmdSessionRename(args []string, stdout, stderr io.Writer) int {
 	}
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session rename: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session rename", err)
 		return 1
 	}
 
 	sp := newSessionProvider()
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session rename: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session rename", err)
 		return 1
 	}
 	if err := handle.Rename(context.Background(), title); err != nil {
-		fmt.Fprintf(stderr, "gc session rename: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session rename", err)
 		return 1
 	}
 
@@ -1317,7 +1317,7 @@ sessions are affected — active sessions are never pruned.`,
 func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer) int {
 	dur, err := parsePruneDuration(beforeStr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session prune", err)
 		return 1
 	}
 
@@ -1329,19 +1329,19 @@ func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer) int {
 	sp := newSessionProvider()
 	catalog, err := workerSessionCatalogWithConfig("", store, sp, nil)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session prune", err)
 		return 1
 	}
 
 	cutoff := time.Now().Add(-dur)
 	result, err := catalog.PruneBefore(cutoff)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session prune: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session prune", err)
 		return 1
 	}
 	if cityPath, err := resolveCity(); err == nil {
 		if err := withdrawQueuedWaitNudges(cityPath, result.WaitNudgeIDs); err != nil {
-			fmt.Fprintf(stderr, "gc session prune: warning: withdrawing queued wait nudges: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "session prune: warning: withdrawing queued wait nudges", err)
 		}
 	}
 
@@ -1413,20 +1413,20 @@ func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
 	}
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session peek: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session peek", err)
 		return 1
 	}
 
 	sp := newSessionProvider()
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session peek: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session peek", err)
 		return 1
 	}
 
 	output, err := handle.Peek(context.Background(), lines)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session peek: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session peek", err)
 		return 1
 	}
 
@@ -1473,19 +1473,19 @@ func cmdSessionKill(args []string, stdout, stderr io.Writer) int {
 	}
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session kill", err)
 		return 1
 	}
 
 	sp := newSessionProvider()
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session kill", err)
 		return 1
 	}
 
 	if err := handle.Kill(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session kill: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session kill", err)
 		return 1
 	}
 
@@ -1521,7 +1521,7 @@ joined automatically.`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			mode, err := parseNudgeDeliveryMode(delivery)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "session nudge", err)
 				return errExit
 			}
 			if cmdSessionNudge(args, mode, stdout, stderr) != 0 {
@@ -1553,7 +1553,7 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session submit", err)
 		return 1
 	}
 
@@ -1564,14 +1564,14 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "session submit", err)
 			return 1
 		}
 	}
 
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session submit", err)
 		return 1
 	}
 	store, code := openCityStore(stderr, "gc session submit")
@@ -1581,14 +1581,14 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 
 	sessionID, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, target)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session submit", err)
 		return 1
 	}
 
 	sp := newSessionProvider()
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session submit", err)
 		return 1
 	}
 	outcome, err := handle.Message(context.Background(), worker.MessageRequest{
@@ -1596,7 +1596,7 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 		Delivery: workerDeliveryIntentForSubmitIntent(intent),
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session submit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session submit", err)
 		return 1
 	}
 	emitSessionSubmitResult(stdout, target, intent, outcome.Queued)
@@ -1623,7 +1623,7 @@ func cmdSessionNudge(args []string, delivery nudgeDeliveryMode, stdout, stderr i
 
 	targetInfo, err := resolveNudgeTarget(target)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session nudge: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session nudge", err)
 		return 1
 	}
 	return deliverSessionNudge(targetInfo, message, delivery, stdout, stderr)

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -160,7 +160,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	// not concrete pool member names like worker-2.
 	found, ok := resolveSessionTemplate(cfg, templateName, currentRigContext(cfg))
 	if !ok {
-		fmt.Fprintln(stderr, agentNotFoundMsg("gc session new", templateName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, agentNotFoundMsg(cmdName("session new"), templateName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -187,7 +187,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	}
 
 	// Open the bead store.
-	store, code := openCityStore(stderr, "gc session new")
+	store, code := openCityStore(stderr, cmdName("session new"))
 	if store == nil {
 		return code
 	}
@@ -617,7 +617,7 @@ func newSessionListCmd(stdout, stderr io.Writer) *cobra.Command {
 
 // cmdSessionList is the CLI entry point for "gc session list".
 func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session list")
+	store, code := openCityStore(stderr, cmdName("session list"))
 	if store == nil {
 		return code
 	}
@@ -971,7 +971,7 @@ func cmdSessionAttach(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	store, code := openCityStore(stderr, "gc session attach")
+	store, code := openCityStore(stderr, cmdName("session attach"))
 	if store == nil {
 		return code
 	}
@@ -1124,7 +1124,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 // controller. The reconciler handles the actual process stop. Falls back
 // to direct suspend via the session manager if the controller isn't running.
 func cmdSessionSuspend(args []string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session suspend")
+	store, code := openCityStore(stderr, cmdName("session suspend"))
 	if store == nil {
 		return code
 	}
@@ -1200,7 +1200,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 
 // cmdSessionClose is the CLI entry point for "gc session close".
 func cmdSessionClose(args []string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session close")
+	store, code := openCityStore(stderr, cmdName("session close"))
 	if store == nil {
 		return code
 	}
@@ -1260,7 +1260,7 @@ func newSessionRenameCmd(stdout, stderr io.Writer) *cobra.Command {
 func cmdSessionRename(args []string, stdout, stderr io.Writer) int {
 	title := args[1]
 
-	store, code := openCityStore(stderr, "gc session rename")
+	store, code := openCityStore(stderr, cmdName("session rename"))
 	if store == nil {
 		return code
 	}
@@ -1321,7 +1321,7 @@ func cmdSessionPrune(beforeStr string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	store, code := openCityStore(stderr, "gc session prune")
+	store, code := openCityStore(stderr, cmdName("session prune"))
 	if store == nil {
 		return code
 	}
@@ -1401,7 +1401,7 @@ func newSessionPeekCmd(stdout, stderr io.Writer) *cobra.Command {
 
 // cmdSessionPeek is the CLI entry point for "gc session peek".
 func cmdSessionPeek(args []string, lines int, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session peek")
+	store, code := openCityStore(stderr, cmdName("session peek"))
 	if store == nil {
 		return code
 	}
@@ -1461,7 +1461,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 
 // cmdSessionKill is the CLI entry point for "gc session kill".
 func cmdSessionKill(args []string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session kill")
+	store, code := openCityStore(stderr, cmdName("session kill"))
 	if store == nil {
 		return code
 	}
@@ -1574,7 +1574,7 @@ func cmdSessionSubmit(args []string, intent session.SubmitIntent, stdout, stderr
 		cmdErr(stderr, "session submit", err)
 		return 1
 	}
-	store, code := openCityStore(stderr, "gc session submit")
+	store, code := openCityStore(stderr, cmdName("session submit"))
 	if store == nil {
 		return code
 	}

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -43,9 +43,9 @@ continuity.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc session: missing subcommand (new, list, attach, submit, suspend, pin, unpin, reset, close, rename, prune, peek, kill, nudge, logs, wake, wait)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: missing subcommand (new, list, attach, submit, suspend, pin, unpin, reset, close, rename, prune, peek, kill, nudge, logs, wake, wait)\n", cmdName("session")) //nolint:errcheck // best-effort stderr
 			} else {
-				fmt.Fprintf(stderr, "gc session: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("session"), args[0]) //nolint:errcheck // best-effort stderr
 			}
 			return errExit
 		},

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -86,13 +86,13 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 	if !ok {
 		workDir, found := resolveConfiguredSessionLogContext(cityPath, cfg, identifier)
 		if !found {
-			fmt.Fprintf(stderr, "gc session logs: session %q not found\n", identifier) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: session %q not found\n", cmdName("session logs"), identifier) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		path = resolveSessionLogPath(searchPaths, sessionLogContext{workDir: workDir})
 	}
 	if path == "" {
-		fmt.Fprintf(stderr, "gc session logs: no session file found for %q\n", identifier) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: no session file found for %q\n", cmdName("session logs"), identifier) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -232,7 +232,7 @@ func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, ident
 // `--tail 5` prints the LAST 5 entries of the transcript, not the first 5.
 func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr io.Writer) int {
 	if tail < 0 {
-		fmt.Fprintln(stderr, "gc session logs: --tail must be >= 0") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: --tail must be >= 0\n", cmdName("session logs")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	factory, err := worker.NewFactory(worker.FactoryConfig{})
@@ -283,7 +283,7 @@ func runSessionLogs(factory *worker.Factory, provider, path string, follow bool,
 		if readErr != nil {
 			consecErrors++
 			if consecErrors >= maxConsecErrors {
-				fmt.Fprintf(stderr, "gc session logs: %d consecutive read errors, last: %v\n", consecErrors, readErr) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: %d consecutive read errors, last: %v\n", cmdName("session logs"), consecErrors, readErr) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 			continue

--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -63,12 +63,12 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session logs", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session logs", err)
 		return 1
 	}
 
@@ -237,7 +237,7 @@ func doSessionLogs(path, provider string, follow bool, tail int, stdout, stderr 
 	}
 	factory, err := worker.NewFactory(worker.FactoryConfig{})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session logs", err)
 		return 1
 	}
 
@@ -251,7 +251,7 @@ func runSessionLogs(factory *worker.Factory, provider, path string, follow bool,
 	// are a true "last N entries" window regardless of compaction boundaries.
 	sess, readErr := read(factory, provider, path)
 	if readErr != nil {
-		fmt.Fprintf(stderr, "gc session logs: %v\n", readErr) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session logs", readErr)
 		return 1
 	}
 

--- a/cmd/gc/cmd_session_pin.go
+++ b/cmd/gc/cmd_session_pin.go
@@ -59,7 +59,7 @@ func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer) int 
 	if pinned {
 		action = "pin"
 	}
-	store, code := openCityStore(stderr, "gc session "+action)
+	store, code := openCityStore(stderr, cmdName("session ")+action)
 	if store == nil {
 		return code
 	}

--- a/cmd/gc/cmd_session_pin.go
+++ b/cmd/gc/cmd_session_pin.go
@@ -88,22 +88,22 @@ func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer) int 
 		id, err = resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session %s: %v\n", action, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("session "+action), err) //nolint:errcheck
 		return 1
 	}
 
 	b, err := store.Get(id)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session %s: %v\n", action, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName("session "+action), err) //nolint:errcheck
 		return 1
 	}
 	if !session.IsSessionBeadOrRepairable(b) {
-		fmt.Fprintf(stderr, "gc session %s: %s is not a session\n", action, id) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s is not a session\n", cmdName("session "+action), id) //nolint:errcheck
 		return 1
 	}
 	session.RepairEmptyType(store, &b)
 	if b.Status == "closed" {
-		fmt.Fprintf(stderr, "gc session %s: session %s is closed\n", action, id) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: session %s is closed\n", cmdName("session "+action), id) //nolint:errcheck
 		return 1
 	}
 
@@ -113,7 +113,7 @@ func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer) int 
 	}
 	if !materializedForPin {
 		if err := store.SetMetadata(id, "pin_awake", value); err != nil {
-			fmt.Fprintf(stderr, "gc session %s: updating metadata: %v\n", action, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: updating metadata: %v\n", cmdName("session "+action), err) //nolint:errcheck
 			return 1
 		}
 	}

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -47,7 +47,7 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if !cityUsesManagedReconciler(cityPath) {
-		fmt.Fprintln(stderr, "gc session reset: a managed controller must be running") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: a managed controller must be running\n", cmdName("session reset")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := pokeController(cityPath); err != nil {

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -36,7 +36,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 // the fresh restart lifecycle, including key rotation and immediate restart of
 // already-desired sessions.
 func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session reset")
+	store, code := openCityStore(stderr, cmdName("session reset"))
 	if store == nil {
 		return code
 	}

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -43,7 +43,7 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session reset", err)
 		return 1
 	}
 	if !cityUsesManagedReconciler(cityPath) {
@@ -51,7 +51,7 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if err := pokeController(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session reset", err)
 		return 1
 	}
 
@@ -59,17 +59,17 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session reset", err)
 		return 1
 	}
 
 	handle, err := workerHandleForSessionWithConfig(cityPath, store, newSessionProvider(), cfg, sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session reset", err)
 		return 1
 	}
 	if err := handle.Reset(context.Background()); err != nil {
-		fmt.Fprintf(stderr, "gc session reset: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "session reset", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -58,14 +58,14 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if !session.IsSessionBeadOrRepairable(b) {
-		fmt.Fprintf(stderr, "gc session wake: %s is not a session\n", id) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s is not a session\n", cmdName("session wake"), id) //nolint:errcheck
 		return 1
 	}
 	session.RepairEmptyType(store, &b)
 	nudgeIDs, err := session.WakeSession(store, b, time.Now().UTC())
 	if err != nil {
 		if state, conflict := session.WakeConflictState(err); conflict {
-			fmt.Fprintf(stderr, "gc session wake: session %s is %s\n", id, state) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: session %s is %s\n", cmdName("session wake"), id, state) //nolint:errcheck
 			return 1
 		}
 		cmdErr(stderr, "session wake: updating metadata", err)

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -48,13 +48,13 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 	}
 	id, err := resolveSessionIDMaterializingNamed(cityPath, cfg, store, args[0])
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session wake: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wake", err)
 		return 1
 	}
 
 	b, err := store.Get(id)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session wake: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wake", err)
 		return 1
 	}
 	if !session.IsSessionBeadOrRepairable(b) {
@@ -68,16 +68,16 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "gc session wake: session %s is %s\n", id, state) //nolint:errcheck
 			return 1
 		}
-		fmt.Fprintf(stderr, "gc session wake: updating metadata: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wake: updating metadata", err)
 		return 1
 	}
 	if cityErr == nil {
 		if err := withdrawQueuedWaitNudges(cityPath, nudgeIDs); err != nil {
-			fmt.Fprintf(stderr, "gc session wake: warning: withdrawing queued wait nudges: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "session wake: warning: withdrawing queued wait nudges", err)
 		}
 		if cityUsesManagedReconciler(cityPath) {
 			if err := pokeController(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc session wake: warning: poke failed: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "session wake: warning: poke failed", err)
 			}
 		}
 	}

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -36,7 +36,7 @@ Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 
 // cmdSessionWake is the CLI entry point for "gc session wake".
 func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session wake")
+	store, code := openCityStore(stderr, cmdName("session wake"))
 	if store == nil {
 		return code
 	}

--- a/cmd/gc/cmd_shell.go
+++ b/cmd/gc/cmd_shell.go
@@ -38,11 +38,11 @@ func newShellInstallCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "install [bash|zsh|fish]",
 		Short: "Install or update shell integration",
-		Long: `Install or update the gc shell completion hook.
+		Long: fmt.Sprintf(`Install or update the %s shell completion hook.
 
 If no shell is specified, the shell is detected from $SHELL.
 The completion script is written to ~/.gc/completions/ and a source line
-is added to your shell RC file.`,
+is added to your shell RC file.`, prog()),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmdShellInstall(cmd.Root(), args, stdout, stderr) != 0 {
@@ -57,7 +57,7 @@ func newShellRemoveCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove",
 		Short: "Remove shell integration",
-		Long:  `Remove the gc shell completion hook from your shell RC file and delete the completion script.`,
+		Long:  fmt.Sprintf("Remove the %s shell completion hook from your shell RC file and delete the completion script.", prog()),
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if cmdShellRemove(stdout, stderr) != 0 {

--- a/cmd/gc/cmd_shell.go
+++ b/cmd/gc/cmd_shell.go
@@ -259,19 +259,19 @@ func cmdShellInstall(root *cobra.Command, args []string, stdout, stderr io.Write
 	}
 	installed, err := rcFileHasHook(rcFile)
 	if err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(stderr, "gc shell install: reading %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: reading %s: %v\n", cmdName("shell install"), rcFile, err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if installed {
 		// Update in place — the completion script is already refreshed on disk.
 		if err := rcFileReplaceHook(rcFile, hookBlock(sh, compFile)); err != nil {
-			fmt.Fprintf(stderr, "gc shell install: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: updating %s: %v\n", cmdName("shell install"), rcFile, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		fmt.Fprintf(stdout, "Updated hook in %s\n", rcFile) //nolint:errcheck // best-effort stdout
 	} else {
 		if err := rcFileAppendHook(rcFile, hookBlock(sh, compFile)); err != nil {
-			fmt.Fprintf(stderr, "gc shell install: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: updating %s: %v\n", cmdName("shell install"), rcFile, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		fmt.Fprintf(stdout, "Added hook to %s\n", rcFile) //nolint:errcheck // best-effort stdout
@@ -291,7 +291,7 @@ func cmdShellRemove(stdout, stderr io.Writer) int {
 		}
 		if _, err := os.Stat(compFile); err == nil {
 			if err := os.Remove(compFile); err != nil {
-				fmt.Fprintf(stderr, "gc shell remove: removing %s: %v\n", compFile, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: removing %s: %v\n", cmdName("shell remove"), compFile, err) //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stdout, "Removed %s\n", compFile) //nolint:errcheck // best-effort stdout
 				removed = true
@@ -308,7 +308,7 @@ func cmdShellRemove(stdout, stderr io.Writer) int {
 				continue
 			}
 			if err := rcFileRemoveHook(rcFile); err != nil {
-				fmt.Fprintf(stderr, "gc shell remove: updating %s: %v\n", rcFile, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: updating %s: %v\n", cmdName("shell remove"), rcFile, err) //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stdout, "Removed hook from %s\n", rcFile) //nolint:errcheck // best-effort stdout
 				removed = true

--- a/cmd/gc/cmd_shell.go
+++ b/cmd/gc/cmd_shell.go
@@ -217,29 +217,29 @@ func hookBlock(sh, compFile string) string {
 func cmdShellInstall(root *cobra.Command, args []string, stdout, stderr io.Writer) int {
 	sh, err := resolveShellArg(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install", err)
 		return 1
 	}
 
 	// Generate completion script.
 	script, err := generateCompletion(root, sh)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc shell install: generating completion: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install: generating completion", err)
 		return 1
 	}
 
 	// Write completion script to file.
 	compFile, err := completionFile(sh)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install", err)
 		return 1
 	}
 	if err := os.MkdirAll(filepath.Dir(compFile), 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc shell install: creating directory: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install: creating directory", err)
 		return 1
 	}
 	if err := atomicWriteFile(compFile, script); err != nil {
-		fmt.Fprintf(stderr, "gc shell install: writing completion script: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install: writing completion script", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "Wrote completion script to %s\n", compFile) //nolint:errcheck // best-effort stdout
@@ -247,14 +247,14 @@ func cmdShellInstall(root *cobra.Command, args []string, stdout, stderr io.Write
 	// Add source line to RC file.
 	rcFile, err := shellRCFile(sh)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc shell install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install", err)
 		return 1
 	}
 	if existingRC, err := installedShellRCFile(sh); err == nil {
 		rcFile = existingRC
 	}
 	if err := os.MkdirAll(filepath.Dir(rcFile), 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc shell install: creating directory: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "shell install: creating directory", err)
 		return 1
 	}
 	installed, err := rcFileHasHook(rcFile)

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -20,7 +20,7 @@ func newSkillCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd = &cobra.Command{
 		Use:   "skill",
 		Short: "List visible skills",
-		Long: `List skills visible to the current city.
+		Long: fmt.Sprintf(`List skills visible to the current city.
 
 Output includes:
   - City pack skills (skills/<name>/SKILL.md under the city root)
@@ -32,8 +32,8 @@ The listing is a diagnostic view of what's *available*. It does not
 collapse precedence, filter to agents whose provider has a vendor
 sink, or predict exactly which entries the materializer will pick on
 name collision. For the materialized set, inspect the
-<scope-root>/.<vendor>/skills/ sink after "gc start" or run
-"gc doctor" to surface collisions.`,
+<scope-root>/.<vendor>/skills/ sink after "%s start" or run
+"%s doctor" to surface collisions.`, prog(), prog()),
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -62,12 +62,12 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 			}
 			cityPath, err := resolveCity()
 			if err != nil {
-				fmt.Fprintf(stderr, "gc skill list: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "skill list", err)
 				return errExit
 			}
 			cfg, err := loadCityConfig(cityPath, stderr)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc skill list: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "skill list", err)
 				return errExit
 			}
 
@@ -75,14 +75,14 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 			if strings.TrimSpace(sessionID) != "" {
 				store, err = openCityStoreAt(cityPath)
 				if err != nil {
-					fmt.Fprintf(stderr, "gc skill list: %v\n", err) //nolint:errcheck // best-effort stderr
+					cmdErr(stderr, "skill list", err)
 					return errExit
 				}
 			}
 
 			entries, err := listVisibleSkillEntries(cityPath, cfg, store, agentName, sessionID)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc skill list: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "skill list", err)
 				return errExit
 			}
 			writeVisibilityEntries(stdout, entries)

--- a/cmd/gc/cmd_skill.go
+++ b/cmd/gc/cmd_skill.go
@@ -39,7 +39,7 @@ name collision. For the materialized set, inspect the
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			fmt.Fprintf(stderr, "gc skill: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("skill"), args[0]) //nolint:errcheck // best-effort stderr
 			return errExit
 		},
 	}
@@ -57,7 +57,7 @@ func newSkillListCmd(stdout, stderr io.Writer) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if strings.TrimSpace(agentName) != "" && strings.TrimSpace(sessionID) != "" {
-				fmt.Fprintln(stderr, "gc skill list: --agent and --session are mutually exclusive") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --agent and --session are mutually exclusive\n", cmdName("skill list")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			cityPath, err := resolveCity()

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -74,27 +74,27 @@ Examples:
 		RunE: func(_ *cobra.Command, args []string) error {
 			if fromStdin {
 				if len(args) != 1 {
-					fmt.Fprintf(stderr, "gc sling: --stdin requires exactly 1 argument (target)\n") //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: --stdin requires exactly 1 argument (target)\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
 			} else if len(args) < 1 || len(args) > 2 {
-				fmt.Fprintf(stderr, "gc sling: requires 1 or 2 arguments: [target] <bead-or-formula>\n") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: requires 1 or 2 arguments: [target] <bead-or-formula>\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if owned && noConvoy {
-				fmt.Fprintf(stderr, "gc sling: --owned requires a convoy (cannot use with --no-convoy)\n") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --owned requires a convoy (cannot use with --no-convoy)\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if merge != "" && merge != "direct" && merge != "mr" && merge != "local" {
-				fmt.Fprintf(stderr, "gc sling: --merge must be direct, mr, or local\n") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --merge must be direct, mr, or local\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if (strings.TrimSpace(scopeKind) == "") != (strings.TrimSpace(scopeRef) == "") {
-				fmt.Fprintf(stderr, "gc sling: --scope-kind and --scope-ref must be provided together\n") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --scope-kind and --scope-ref must be provided together\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			if scopeKind != "" && scopeKind != "city" && scopeKind != "rig" {
-				fmt.Fprintf(stderr, "gc sling: --scope-kind must be city or rig\n") //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: --scope-kind must be city or rig\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 				return errExit
 			}
 			code := cmdSling(args, formula, nudge, force, title, vars, merge, noConvoy, owned, onFormula, noFormula, fromStdin, dryRun, scopeKind, scopeRef, stdout, stderr)
@@ -173,7 +173,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		}
 		content := strings.TrimRight(string(data), "\n")
 		if content == "" {
-			fmt.Fprintf(stderr, "gc sling: --stdin: no input received\n") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --stdin: no input received\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		lines := strings.SplitN(content, "\n", 2)
@@ -209,25 +209,25 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		// 1-arg: bead ID only, resolve target from rig's default_sling_target.
 		beadOrFormula = args[0]
 		if isFormula {
-			fmt.Fprintf(stderr, "gc sling: --formula requires explicit target\n") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: --formula requires explicit target\n", cmdName("sling")) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if !canInferSlingDefaultTargetFromBead(cfg, beadOrFormula) {
-			fmt.Fprintf(stderr, "gc sling: inline text requires explicit target\n  usage: gc sling <target> %q\n", beadOrFormula) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: inline text requires explicit target\n  usage: gc sling <target> %q\n", cmdName("sling"), beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		bp := sling.BeadPrefix(beadOrFormula)
 		if bp == "" {
-			fmt.Fprintf(stderr, "gc sling: cannot derive rig from bead %q (no prefix)\n", beadOrFormula) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: cannot derive rig from bead %q (no prefix)\n", cmdName("sling"), beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		rig, found := findRigByPrefix(cfg, bp)
 		if !found {
-			fmt.Fprintf(stderr, "gc sling: no rig with prefix %q for bead %s\n", bp, beadOrFormula) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: no rig with prefix %q for bead %s\n", cmdName("sling"), bp, beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		if rig.DefaultSlingTarget == "" {
-			fmt.Fprintf(stderr, "gc sling: rig %q has no default_sling_target\n", rig.Name) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: rig %q has no default_sling_target\n", cmdName("sling"), rig.Name) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 		target = rig.DefaultSlingTarget
@@ -518,7 +518,7 @@ func printSlingWarnings(result sling.SlingResult, stderr io.Writer) {
 		fmt.Fprintf(stderr, "Auto-burned stale molecule %s\n", id) //nolint:errcheck
 	}
 	for _, e := range result.MetadataErrors {
-		fmt.Fprintf(stderr, "gc sling: %s\n", e) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s\n", cmdName("sling"), e) //nolint:errcheck
 	}
 }
 
@@ -578,7 +578,7 @@ func printBatchSlingResult(result sling.SlingResult, stdout, stderr io.Writer) {
 		fmt.Fprintf(stderr, "Auto-burned stale molecule %s\n", id) //nolint:errcheck
 	}
 	for _, e := range result.MetadataErrors {
-		fmt.Fprintf(stderr, "gc sling: %s\n", e) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s\n", cmdName("sling"), e) //nolint:errcheck
 	}
 
 	if result.DryRun {
@@ -1314,7 +1314,7 @@ func doSlingNudge(a *config.Agent, cityName, cityPath string, cfg *config.City,
 			if err == nil && running {
 				member, ok := resolveAgentIdentity(cfg, qn, currentRigContext(cfg))
 				if !ok {
-					fmt.Fprintf(stderr, "gc sling: agent %q not found in config\n", qn) //nolint:errcheck // best-effort
+					fmt.Fprintf(stderr, "%s: agent %q not found in config\n", cmdName("sling"), qn) //nolint:errcheck // best-effort
 					return
 				}
 				target := buildSlingNudgeTarget(member, cityName, cityPath, cfg, store, sn)
@@ -1493,7 +1493,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 		if opts.OnFormula != "" {
 			// Read-only check: does the bead already have an attached molecule?
 			if label, id := sling.FindBlockingMolecule(querier, opts.BeadOrFormula, deps.Store); label != "" {
-				fmt.Fprintf(stderr, "gc sling: bead %s already has attached %s %s\n", opts.BeadOrFormula, label, id) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: bead %s already has attached %s %s\n", cmdName("sling"), opts.BeadOrFormula, label, id) //nolint:errcheck
 				return 1
 			}
 			w("Attach formula:")
@@ -1511,7 +1511,7 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 			w("")
 		} else if !opts.NoFormula && a.EffectiveDefaultSlingFormula() != "" {
 			if label, id := sling.FindBlockingMolecule(querier, opts.BeadOrFormula, deps.Store); label != "" {
-				fmt.Fprintf(stderr, "gc sling: bead %s already has attached %s %s\n", opts.BeadOrFormula, label, id) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: bead %s already has attached %s %s\n", cmdName("sling"), opts.BeadOrFormula, label, id) //nolint:errcheck
 				return 1
 			}
 			w("Default formula:")

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -168,7 +168,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	if fromStdin {
 		data, err := io.ReadAll(slingStdin())
 		if err != nil {
-			fmt.Fprintf(stderr, "gc sling: reading stdin: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "sling: reading stdin", err)
 			return 1
 		}
 		content := strings.TrimRight(string(data), "\n")
@@ -185,12 +185,12 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "sling", err)
 		return 1
 	}
 	cfg, prov, err := loadSlingCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "sling", err)
 		return 1
 	}
 	emitLoadCityConfigWarnings(stderr, prov)
@@ -249,7 +249,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	storeDir, store, err := openSlingStoreForSource(cfg, cityPath, beadOrFormula, a)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "sling", err)
 		return 1
 	}
 	storeRef := workflowStoreRefForDir(storeDir, cityPath, cityName, cfg)
@@ -265,7 +265,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		if createInlineBead {
 			created, err := store.Create(beads.Bead{Title: beadOrFormula, Description: stdinDescription, Type: "task"})
 			if err != nil {
-				fmt.Fprintf(stderr, "gc sling: creating bead: %v\n", err) //nolint:errcheck // best-effort stderr
+				cmdErr(stderr, "sling: creating bead", err)
 				return 1
 			}
 			fmt.Fprintf(stdout, "Created %s — %q\n", created.ID, beadOrFormula) //nolint:errcheck // best-effort stdout
@@ -1418,7 +1418,7 @@ func deliverSlingNudge(target nudgeTarget, sp runtime.Provider, store beads.Stor
 
 	if err := enqueueQueuedNudgeWithStore(target.cityPath, store, newQueuedNudge(target.agent.QualifiedName(), msg, "sling", now)); err != nil {
 		telemetry.RecordNudge(context.Background(), target.agent.QualifiedName(), err)
-		fmt.Fprintf(stderr, "gc sling: nudge failed: %v\n", err) //nolint:errcheck // best-effort
+		cmdErr(stderr, "sling: nudge failed", err)
 		return
 	}
 	if running {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -782,7 +782,7 @@ func missingBeadForceApplies(opts sling.SlingOpts) bool {
 }
 
 func sourceWorkflowCleanupCommand(sourceBeadID, storeRef string) string {
-	args := []string{"gc workflow delete-source", sourceBeadID}
+	args := []string{cmdName("workflow delete-source"), sourceBeadID}
 	if storeRef = strings.TrimSpace(storeRef); storeRef != "" {
 		args = append(args, "--store-ref", storeRef)
 	}
@@ -1805,6 +1805,6 @@ func checkCrossRig(beadID string, a config.Agent, cfg *config.City) string {
 	if bp == rp {
 		return ""
 	}
-	return fmt.Sprintf("gc sling: cross-rig routing blocked — bead %s (prefix %q) targets %s (rig prefix %q); use --force to override",
+	return fmt.Sprintf(cmdName("sling")+": cross-rig routing blocked — bead %s (prefix %q) targets %s (rig prefix %q); use --force to override",
 		beadID, bp, a.QualifiedName(), rp)
 }

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -241,7 +241,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	a, ok := resolveAgentIdentity(cfg, target, currentRigContext(cfg))
 	if !ok {
-		fmt.Fprintln(stderr, agentNotFoundMsg("gc sling", target, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, agentNotFoundMsg(cmdName("sling"), target, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -796,13 +796,13 @@ func printSourceWorkflowConflict(stderr io.Writer, conflictErr *sourceworkflow.C
 	}
 	_, _ = fmt.Fprintf(
 		stderr,
-		"gc sling: source bead %s already has live workflow(s): %s\n",
+		cmdName("sling")+": source bead %s already has live workflow(s): %s\n",
 		conflictErr.SourceBeadID,
 		strings.Join(conflictErr.WorkflowIDs, ","),
 	)
 	_, _ = fmt.Fprintf(
 		stderr,
-		"gc sling: use --force to override, or %s to clean up\n",
+		cmdName("sling")+": use --force to override, or %s to clean up\n",
 		sourceWorkflowCleanupCommand(conflictErr.SourceBeadID, storeRef),
 	)
 }

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -276,17 +276,17 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 
 	dir, err := resolveStartDir(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
 	cityPath, err := requireBootstrappedCity(dir)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	if err := ensureCityScaffold(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc start: runtime scaffold: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start: runtime scaffold", err)
 		return 1
 	}
 	if missing := checkHardDependencies(cityPath); len(missing) > 0 {
@@ -345,19 +345,19 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	dir, err := resolveStartDir(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
 	cityPath, err := requireBootstrappedCity(dir)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	if controllerMode {
 		_, registered, err := registeredCityEntry(cityPath)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "start", err)
 			return 1
 		}
 		if registered {
@@ -366,16 +366,16 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		}
 	}
 	if err := ensureCityScaffold(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc start: runtime scaffold: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start: runtime scaffold", err)
 		return 1
 	}
 	if err := ensureLegacyNamedPacksCached(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc start: fetching packs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start: fetching packs", err)
 		return 1
 	}
 	cfg, prov, err := loadStartCityConfig(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err)                      //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -400,15 +400,15 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	// Validate rigs (prefix collisions, missing fields).
 	if err := config.ValidateRigs(cfg.Rigs, config.EffectiveHQPrefix(cfg)); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	if err := config.ValidateServices(cfg.Services); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	if err := workspacesvc.ValidateRuntimeSupport(cfg.Services); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
@@ -418,7 +418,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// probe → init+hooks(city) → init+hooks(rigs) → routes.
 	resolveRigPaths(cityPath, cfg.Rigs)
 	if err := startBeadsLifecycle(cityPath, cityName, cfg, stderr); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err)                      //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -427,7 +427,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// The gc-beads-bd script's health operation validates server liveness
 	// (TCP + query probe). Recovery is attempted on failure.
 	if err := healthBeadsProvider(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc start: beads health check: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start: beads health check", err)
 		// Non-fatal warning — server may recover by the time agents need it.
 	}
 
@@ -435,7 +435,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// System formulas/orders now arrive via the core bootstrap pack.
 	if len(cfg.FormulaLayers.City) > 0 {
 		if err := ResolveFormulas(cityPath, cfg.FormulaLayers.City); err != nil {
-			fmt.Fprintf(stderr, "gc start: city formulas: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "start: city formulas", err)
 		}
 	}
 	for _, r := range cfg.Rigs {
@@ -457,7 +457,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	// Validate agents.
 	if err := config.ValidateAgents(cfg.Agents); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
@@ -469,7 +469,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// engdocs/proposals/skill-materialization.md § "Collision
 	// validation (startup validator)".
 	if err := checkSkillCollisions(cfg, cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
@@ -484,14 +484,14 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// write failures must block startup before sessions launch against stale or
 	// ambiguous MCP state.
 	if err := runStage1MCPProjection(cityPath, cfg, exec.LookPath, stderr); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
 	// Validate install_agent_hooks (workspace + all agents).
 	if ih := cfg.Workspace.InstallAgentHooks; len(ih) > 0 {
 		if err := hooks.Validate(ih); err != nil {
-			fmt.Fprintf(stderr, "gc start: workspace: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "start: workspace", err)
 			return 1
 		}
 	}
@@ -531,7 +531,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	// Pre-check container images once (fail fast before N serial starts).
 	if err := checkAgentImages(sp, cfg.Agents, stderr); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 
@@ -583,7 +583,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// One-shot bead reconciliation: same code path as the daemon.
 	sessionBeads, err := loadSessionBeadSnapshot(oneShotStore)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: loading session beads: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "start: loading session beads", err)
 		sessionBeads = nil
 	}
 	dsResult := buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, nil, sessionBeads, nil, stderr)
@@ -613,7 +613,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// Post-reconcile sync: update bead state to reflect post-start reality.
 	sessionBeads, err = loadSessionBeadSnapshot(oneShotStore)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: loading session beads: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "start: loading session beads", err)
 		sessionBeads = nil
 	}
 	dsResult = buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, nil, sessionBeads, nil, stderr)

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -302,7 +302,7 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 		fmt.Fprintf(stderr, "%s: install the missing dependencies, then try again\n", cmdName("start")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if code := registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, "gc start", true); code != 0 {
+	if code := registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, cmdName("start"), true); code != 0 {
 		return code
 	}
 	fmt.Fprintln(stdout, "City started under supervisor.") //nolint:errcheck // best-effort stdout
@@ -412,7 +412,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		return 1
 	}
 
-	ensureInitArtifacts(cityPath, stderr, "gc start")
+	ensureInitArtifacts(cityPath, stderr, cmdName("start"))
 
 	// Resolve rig paths and run the full bead store lifecycle:
 	// probe → init+hooks(city) → init+hooks(rigs) → routes.

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -361,7 +361,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 			return 1
 		}
 		if registered {
-			fmt.Fprintf(stderr, "%s: city is registered with the supervisor; run \"gc unregister %s\" before using --foreground\n", cmdName("start"), cityPath) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: city is registered with the supervisor; run \"%s %s\" before using --foreground\n", cmdName("start"), cmdName("unregister"), cityPath) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -376,7 +376,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	cfg, prov, err := loadStartCityConfig(cityPath)
 	if err != nil {
 		cmdErr(stderr, "start", err)
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", cmdName("doctor")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	applyFeatureFlags(cfg)
@@ -419,7 +419,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	resolveRigPaths(cityPath, cfg.Rigs)
 	if err := startBeadsLifecycle(cityPath, cityName, cfg, stderr); err != nil {
 		cmdErr(stderr, "start", err)
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", cmdName("doctor")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -270,7 +270,7 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 		return doStartStandalone(args, controllerMode, stdout, stderr)
 	}
 	if len(extraConfigFiles) > 0 || noStrictMode {
-		fmt.Fprintln(stderr, "gc start: --file and --no-strict only apply to the legacy standalone controller; use --foreground or remove those flags") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: --file and --no-strict only apply to the legacy standalone controller; use --foreground or remove those flags\n", cmdName("start")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -290,7 +290,7 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 		return 1
 	}
 	if missing := checkHardDependencies(cityPath); len(missing) > 0 {
-		fmt.Fprintf(stderr, "gc start: missing required dependencies:\n\n") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing required dependencies:\n\n", cmdName("start")) //nolint:errcheck // best-effort stderr
 		for _, dep := range missing {
 			fmt.Fprintf(stderr, "  - %s", dep.name) //nolint:errcheck // best-effort stderr
 			if dep.installHint != "" {
@@ -299,7 +299,7 @@ func doStartWithNameOverride(args []string, controllerMode bool, stdout, stderr 
 			fmt.Fprintln(stderr) //nolint:errcheck // best-effort stderr
 		}
 		fmt.Fprintln(stderr)                                                               //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "gc start: install the missing dependencies, then try again") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: install the missing dependencies, then try again\n", cmdName("start")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if code := registerCityWithSupervisorNamed(cityPath, nameOverride, stdout, stderr, "gc start", true); code != 0 {
@@ -361,7 +361,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 			return 1
 		}
 		if registered {
-			fmt.Fprintf(stderr, "gc start: city is registered with the supervisor; run \"gc unregister %s\" before using --foreground\n", cityPath) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: city is registered with the supervisor; run \"gc unregister %s\" before using --foreground\n", cmdName("start"), cityPath) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -384,16 +384,16 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	// Strict mode (default) promotes strict-eligible config warnings to errors.
 	if strictMode && len(fatalWarnings) > 0 {
 		for _, w := range fatalWarnings {
-			fmt.Fprintf(stderr, "gc start: strict: %s\n", w) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: strict: %s\n", cmdName("start"), w) //nolint:errcheck // best-effort stderr
 		}
 		for _, w := range nonFatalWarnings {
-			fmt.Fprintf(stderr, "gc start: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("start"), w) //nolint:errcheck // best-effort stderr
 		}
-		fmt.Fprintln(stderr, "gc start: use --no-strict to disable strict checking") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: use --no-strict to disable strict checking\n", cmdName("start")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	for _, w := range prov.Warnings {
-		fmt.Fprintf(stderr, "gc start: warning: %s\n", w) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: warning: %s\n", cmdName("start"), w) //nolint:errcheck // best-effort stderr
 	}
 
 	cityName := loadedCityName(cfg, cityPath)
@@ -445,14 +445,14 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		}
 		if len(layers) > 0 {
 			if err := ResolveFormulas(r.Path, layers); err != nil {
-				fmt.Fprintf(stderr, "gc start: rig %q formulas: %v\n", r.Name, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: rig %q formulas: %v\n", cmdName("start"), r.Name, err) //nolint:errcheck // best-effort stderr
 			}
 		}
 	}
 
 	// Prune legacy top-level scripts/ symlinks left by pre-PackV2 runtimes.
 	pruneLegacyConfiguredScripts(cityPath, cfg, func(scope string, err error) {
-		fmt.Fprintf(stderr, "gc start: pruning legacy %s scripts: %v\n", scope, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: pruning legacy %s scripts: %v\n", cmdName("start"), scope, err) //nolint:errcheck // best-effort stderr
 	})
 
 	// Validate agents.
@@ -498,7 +498,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	for _, a := range cfg.Agents {
 		if len(a.InstallAgentHooks) > 0 {
 			if err := hooks.Validate(a.InstallAgentHooks); err != nil {
-				fmt.Fprintf(stderr, "gc start: agent %q: %v\n", a.QualifiedName(), err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: agent %q: %v\n", cmdName("start"), a.QualifiedName(), err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
 		}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -325,13 +325,13 @@ func requireBootstrappedCity(dir string) (string, error) {
 	if err != nil {
 		absDir, absErr := filepath.Abs(dir)
 		if absErr == nil {
-			return "", fmt.Errorf("%w; run \"gc init %s\" first", err, absDir)
+			return "", fmt.Errorf("%w; run \"%s %s\" first", err, cmdName("init"), absDir)
 		}
-		return "", fmt.Errorf("%w; run \"gc init\" first", err)
+		return "", fmt.Errorf("%w; run \"%s\" first", err, cmdName("init"))
 	}
 	cityPath := ctx.CityPath
 	if !citylayout.HasRuntimeRoot(cityPath) {
-		return "", fmt.Errorf("city runtime not bootstrapped at %s; run \"gc init %s\" first", cityPath, cityPath)
+		return "", fmt.Errorf("city runtime not bootstrapped at %s; run \"%s %s\" first", cityPath, cmdName("init"), cityPath)
 	}
 	return cityPath, nil
 }

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -226,12 +226,12 @@ func newStartCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start [path]",
 		Short: "Start the city under the machine-wide supervisor",
-		Long: `Start the city under the machine-wide supervisor.
+		Long: fmt.Sprintf(`Start the city under the machine-wide supervisor.
 
-Requires an existing city bootstrapped by "gc init". Fetches remote
+Requires an existing city bootstrapped by "%s init". Fetches remote
 packs as needed, registers the city with the machine-wide supervisor,
 ensures the supervisor is running, and triggers immediate reconciliation.
-Use "gc supervisor run" for foreground operation.`,
+Use "%s supervisor run" for foreground operation.`, prog(), prog()),
 		Example: `  gc start
   gc start ~/my-city
   gc start --dry-run

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -111,13 +111,13 @@ func doRigStatus(
 		sp0 := scaleParamsFor(&a)
 		if !a.SupportsInstanceExpansion() {
 			sn := cliSessionName(cityPath, cityName, a.QualifiedName(), sessionTemplate)
-			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, nil, sn, stderr)
+			obs := observeSessionTargetWithWarning(cmdName("rig status"), cityPath, store, sp, nil, sn, stderr)
 			status := agentStatusLine(obs.Running, dops, sn, a.Suspended || obs.Suspended)
 			fmt.Fprintf(stdout, "    %-12s%s\n", a.QualifiedName(), status) //nolint:errcheck // best-effort stdout
 		} else {
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp) {
 				sn := cliSessionName(cityPath, cityName, qualifiedInstance, sessionTemplate)
-				obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, nil, sn, stderr)
+				obs := observeSessionTargetWithWarning(cmdName("rig status"), cityPath, store, sp, nil, sn, stderr)
 				status := agentStatusLine(obs.Running, dops, sn, a.Suspended || obs.Suspended)
 				fmt.Fprintf(stdout, "    %-12s%s\n", qualifiedInstance, status) //nolint:errcheck // best-effort stdout
 			}

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -62,7 +62,7 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	if !found {
-		fmt.Fprintln(stderr, rigNotFoundMsg("gc rig status", rigName, cfg)) //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, rigNotFoundMsg(cmdName("rig status"), rigName, cfg)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -41,7 +41,7 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 		rigName = args[0]
 	}
 	if rigName == "" {
-		fmt.Fprintln(stderr, "gc rig status: missing rig name") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: missing rig name\n", cmdName("rig status")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cityPath := ctx.CityPath

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -33,7 +33,7 @@ func newRigStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 	ctx, err := resolveContext()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig status", err)
 		return 1
 	}
 	rigName := ctx.RigName
@@ -47,7 +47,7 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 	cityPath := ctx.CityPath
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc rig status: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "rig status", err)
 		return 1
 	}
 

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -46,12 +46,12 @@ const sleepReasonCityStop = "city-stop"
 func cmdStop(args []string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "stop", err)
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "stop", err)
 		return 1
 	}
 	cityName := loadedCityName(cfg, cityPath)
@@ -73,12 +73,12 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 	// If a controller is running, ask it to shut down (it stops agents).
 	if tryStopController(cityPath, stdout) {
 		if err := waitForStandaloneControllerStop(cityPath, cfg.Daemon.ShutdownTimeoutDuration()+15*time.Second); err != nil {
-			fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "stop", err)
 			return 1
 		}
 		// Controller handled the shutdown — still stop bead store below.
 		if err := shutdownBeadsProvider(cityPath); err != nil {
-			fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "stop: bead store", err)
 		}
 		fmt.Fprintln(stdout, "City stopped.") //nolint:errcheck // best-effort stdout
 		return 0
@@ -118,7 +118,7 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 
 	// Stop bead store's backing service after agents.
 	if err := shutdownBeadsProvider(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "stop: bead store", err)
 		// Non-fatal warning.
 	}
 
@@ -131,7 +131,7 @@ func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {
 	}
 	sessions, err := store.ListByLabel("gc:session", 0)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc stop: marking sessions: %v\n", err) //nolint:errcheck // best-effort warning
+		cmdErr(stderr, "stop: marking sessions", err)
 		return
 	}
 	for _, session := range sessions {
@@ -156,7 +156,7 @@ func stopCityManagedBeadsProviderIfRunning(cityPath string, stderr io.Writer) {
 		return
 	}
 	if err := shutdownBeadsProvider(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc stop: bead store: %v\n", err) //nolint:errcheck // best-effort warning
+		cmdErr(stderr, "stop: bead store", err)
 	}
 }
 
@@ -169,11 +169,11 @@ func stopOrphans(sp runtime.Provider, desired map[string]bool, cfg *config.City,
 	running, err := sp.ListRunning("")
 	partialList := runtime.IsPartialListError(err)
 	if err != nil && !partialList {
-		fmt.Fprintf(stderr, "gc stop: listing sessions: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "stop: listing sessions", err)
 		return
 	}
 	if partialList {
-		fmt.Fprintf(stderr, "gc stop: listing sessions partially failed: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "stop: listing sessions partially failed", err)
 	}
 	var orphans []string
 	for _, name := range running {

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -56,7 +56,7 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 	}
 	cityName := loadedCityName(cfg, cityPath)
 
-	if handled, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc stop"); handled {
+	if handled, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, cmdName("stop")); handled {
 		if code != 0 {
 			return code
 		}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -129,7 +129,7 @@ func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {
 	if store == nil {
 		return
 	}
-	sessions, err := store.ListByLabel("gc:session", 0)
+	sessions, err := store.ListByLabel(sessionBeadLabel, 0)
 	if err != nil {
 		cmdErr(stderr, "stop: marking sessions", err)
 		return

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -143,7 +143,7 @@ func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {
 			continue
 		}
 		if err := store.SetMetadata(session.ID, "sleep_reason", sleepReasonCityStop); err != nil {
-			fmt.Fprintf(stderr, "gc stop: marking session %s: %v\n", session.ID, err) //nolint:errcheck // best-effort warning
+			fmt.Fprintf(stderr, "%s: marking session %s: %v\n", cmdName("stop"), session.ID, err) //nolint:errcheck // best-effort warning
 		}
 	}
 }

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -418,7 +418,7 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 			// Confirm the socket actually goes away, but with a small
 			// budget — the server already told us shutdown finished.
 			if err := waitForSupervisorExitUntil(sockPath, time.Now().Add(5*time.Second)); err != nil {
-				fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "supervisor stop", err)
 				return 1
 			}
 			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
@@ -430,7 +430,7 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 			fmt.Fprintf(stderr, "gc supervisor stop: unexpected status %q\n", line) //nolint:errcheck
 			// Still make sure the process actually goes away.
 			if err := waitForSupervisorExitUntil(sockPath, deadline); err != nil {
-				fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "supervisor stop", err)
 				return 1
 			}
 			return 1
@@ -445,7 +445,7 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 	}
 
 	if err := waitForSupervisorExitUntil(sockPath, deadline); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor stop: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "supervisor stop", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
@@ -640,7 +640,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 
 	lock, err := acquireSupervisorLock()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "supervisor", err)
 		return 1
 	}
 	defer lock.Close() //nolint:errcheck
@@ -680,7 +680,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	// Load supervisor config.
 	supCfg, err := supervisor.LoadConfig(supervisor.ConfigPath())
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: config: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "supervisor: config", err)
 		return 1
 	}
 
@@ -703,7 +703,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 
 	pprofSrv, pprofErr := api.StartPprof("")
 	if pprofErr != nil {
-		fmt.Fprintf(stderr, "gc supervisor: pprof: %v\n", pprofErr) //nolint:errcheck
+		cmdErr(stderr, "supervisor: pprof", pprofErr)
 	}
 	if pprofSrv != nil {
 		defer func() {
@@ -721,7 +721,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	}
 	go func() {
 		if err := apiMux.Serve(apiLis); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			fmt.Fprintf(stderr, "gc supervisor: api: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "supervisor: api", err)
 		}
 	}()
 	defer func() {
@@ -734,13 +734,13 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	// Control socket — uses supervisor-specific path, not the per-city controller socket.
 	sockPath := supervisorSocketPath()
 	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: creating socket dir: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "supervisor: creating socket dir", err)
 		return 1
 	}
 	shut := newShutdownState()
 	lis, err := startSupervisorSocket(sockPath, cancel, reconcileCh, shut)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "supervisor", err)
 		return 1
 	}
 	// Socket teardown order matters. Defers run in LIFO, so listed last =
@@ -780,7 +780,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	safeReconcile := func() {
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Fprintf(stderr, "gc supervisor: reconcile panicked: %v\n", r) //nolint:errcheck
+				fmt.Fprintf(stderr, "gc supervisor: reconcile panicked: %v\n", r) //nolint:errcheck // best-effort stderr
 			}
 		}()
 		reconcileCities(reg, registry, supCfg.Publication, stdout, stderr)
@@ -836,7 +836,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 			var shutErr error
 			if len(stopFailures) > 0 {
 				shutErr = fmt.Errorf("%d cities did not shut down cleanly: %s", len(stopFailures), strings.Join(stopFailures, "; "))
-				fmt.Fprintf(stderr, "gc supervisor: %v\n", shutErr) //nolint:errcheck
+				cmdErr(stderr, "supervisor", shutErr)
 			}
 			shut.finish(shutErr)
 			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
@@ -872,7 +872,7 @@ func reconcileCities(
 ) {
 	entries, err := reg.List()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: registry: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "supervisor: registry", err)
 		return
 	}
 

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -226,7 +226,7 @@ func startSupervisorSocket(sockPath string, cancelFn context.CancelFunc, reconci
 					return
 				}
 				// Transient error — log and continue.
-				fmt.Fprintf(os.Stderr, "gc supervisor: socket accept: %v\n", err) //nolint:errcheck
+				fmt.Fprintf(os.Stderr, "%s: socket accept: %v\n", cmdName("supervisor"), err) //nolint:errcheck
 				continue
 			}
 			go handleSupervisorConn(conn, cancelFn, reconcileCh, shut)

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1666,7 +1666,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 	}
 
 	// Install local agent hooks after builtin packs are refreshed.
-	ensureInitArtifacts(cityPath, stderr, "gc supervisor")
+	ensureInitArtifacts(cityPath, stderr, cmdName("supervisor"))
 
 	// Resolve rig paths and start bead store lifecycle.
 	resolveRigPaths(cityPath, cfg.Rigs)

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1305,7 +1305,7 @@ func reconcileCities(
 						m.status = status
 					})
 				},
-				LogPrefix: "gc supervisor",
+				LogPrefix: cmdName("supervisor"),
 				Stdout:    stdout,
 				Stderr:    stderr,
 			})

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -379,12 +379,12 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
-		fmt.Fprintln(stderr, "gc supervisor stop: supervisor is not running") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: supervisor is not running\n", cmdName("supervisor stop")) //nolint:errcheck
 		return 1
 	}
 	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
 	if err != nil {
-		fmt.Fprintln(stderr, "gc supervisor stop: supervisor is not running") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: supervisor is not running\n", cmdName("supervisor stop")) //nolint:errcheck
 		return 1
 	}
 	defer conn.Close()                                     //nolint:errcheck
@@ -393,7 +393,7 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 	reader := bufio.NewReader(conn)
 	ackLine, err := reader.ReadString('\n')
 	if err != nil || strings.TrimSpace(ackLine) != "ok" {
-		fmt.Fprintln(stderr, "gc supervisor stop: no acknowledgment from supervisor") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: no acknowledgment from supervisor\n", cmdName("supervisor stop")) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintln(stdout, "Supervisor stopping...") //nolint:errcheck
@@ -424,10 +424,10 @@ func stopSupervisorWithWait(stdout, stderr io.Writer, wait bool, waitTimeout tim
 			fmt.Fprintln(stdout, "Supervisor stopped.") //nolint:errcheck
 			return 0
 		case strings.HasPrefix(line, "done:err:"):
-			fmt.Fprintf(stderr, "gc supervisor stop: %s\n", strings.TrimPrefix(line, "done:err:")) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: %s\n", cmdName("supervisor stop"), strings.TrimPrefix(line, "done:err:")) //nolint:errcheck
 			return 1
 		default:
-			fmt.Fprintf(stderr, "gc supervisor stop: unexpected status %q\n", line) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: unexpected status %q\n", cmdName("supervisor stop"), line) //nolint:errcheck
 			// Still make sure the process actually goes away.
 			if err := waitForSupervisorExitUntil(sockPath, deadline); err != nil {
 				cmdErr(stderr, "supervisor stop", err)
@@ -513,12 +513,12 @@ change and restart it without waiting for the next patrol tick.`,
 func reloadSupervisor(stdout, stderr io.Writer) int {
 	sockPath, _ := runningSupervisorSocket()
 	if sockPath == "" {
-		fmt.Fprintln(stderr, "gc supervisor reload: supervisor is not running; start it with 'gc supervisor start'") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: supervisor is not running; start it with 'gc supervisor start'\n", cmdName("supervisor reload")) //nolint:errcheck
 		return 1
 	}
 	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
 	if err != nil {
-		fmt.Fprintln(stderr, "gc supervisor reload: supervisor is not running; start it with 'gc supervisor start'") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: supervisor is not running; start it with 'gc supervisor start'\n", cmdName("supervisor reload")) //nolint:errcheck
 		return 1
 	}
 	defer conn.Close()                                                                //nolint:errcheck
@@ -532,13 +532,13 @@ func reloadSupervisor(stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "Reconciliation triggered.") //nolint:errcheck
 		return 0
 	case "busy":
-		fmt.Fprintln(stderr, "gc supervisor reload: reconcile queue is busy; try again shortly") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: reconcile queue is busy; try again shortly\n", cmdName("supervisor reload")) //nolint:errcheck
 		return 1
 	case "timeout":
-		fmt.Fprintln(stderr, "gc supervisor reload: reconcile did not finish before timeout") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: reconcile did not finish before timeout\n", cmdName("supervisor reload")) //nolint:errcheck
 		return 1
 	}
-	fmt.Fprintln(stderr, "gc supervisor reload: supervisor not responding (may be shutting down); try 'gc supervisor start'") //nolint:errcheck
+	fmt.Fprintf(stderr, "%s: supervisor not responding (may be shutting down); try 'gc supervisor start'\n", cmdName("supervisor reload")) //nolint:errcheck
 	return 1
 }
 
@@ -592,14 +592,14 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 		select {
 		case <-mc.done:
 			if err := shutdownBeadsProvider(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: city '%s': bead store: %v\n", cmdName("supervisor"), mc.name, err) //nolint:errcheck
 			}
 			if mc.closer != nil {
 				mc.closer.Close() //nolint:errcheck
 			}
 			return nil
 		case <-time.After(timeout):
-			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after cancel; forcing shutdown\n", mc.name, timeout) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s' did not exit within %s after cancel; forcing shutdown\n", cmdName("supervisor"), mc.name, timeout) //nolint:errcheck
 			stopErr = fmt.Errorf("city %q did not exit within %s after cancel", mc.name, timeout)
 		}
 	}
@@ -616,12 +616,12 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 			// city is out. Clear the pending error so we report success.
 			stopErr = nil
 		case <-time.After(timeout):
-			fmt.Fprintf(stderr, "gc supervisor: city '%s' did not exit within %s after forced shutdown\n", mc.name, timeout) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s' did not exit within %s after forced shutdown\n", cmdName("supervisor"), mc.name, timeout) //nolint:errcheck
 			stopErr = fmt.Errorf("city %q did not exit within %s after forced shutdown", mc.name, timeout)
 		}
 	}
 	if err := shutdownBeadsProvider(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", mc.name, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: city '%s': bead store: %v\n", cmdName("supervisor"), mc.name, err) //nolint:errcheck
 	}
 	if mc.closer != nil {
 		mc.closer.Close() //nolint:errcheck
@@ -634,7 +634,7 @@ func stopManagedCity(mc *managedCity, cityPath string, stderr io.Writer) error {
 // and runs until canceled.
 func runSupervisor(stdout, stderr io.Writer) int {
 	if pid := supervisorAlive(); pid != 0 {
-		fmt.Fprintf(stderr, "gc supervisor: supervisor already running (PID %d)\n", pid) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: supervisor already running (PID %d)\n", cmdName("supervisor"), pid) //nolint:errcheck
 		return 1
 	}
 
@@ -697,7 +697,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	nonLocal := bind != "127.0.0.1" && bind != "localhost" && bind != "::1"
 	readOnly := nonLocal && !supCfg.Supervisor.AllowMutations
 	if readOnly {
-		fmt.Fprintf(stderr, "gc supervisor: binding to %s — mutation endpoints disabled (non-localhost)\n", bind) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: binding to %s — mutation endpoints disabled (non-localhost)\n", cmdName("supervisor"), bind) //nolint:errcheck
 	}
 	apiMux := api.NewSupervisorMux(registry, NewInitializer(), readOnly, version, startedAt)
 
@@ -716,7 +716,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	addr := net.JoinHostPort(bind, strconv.Itoa(port))
 	apiLis, apiErr := net.Listen("tcp", addr)
 	if apiErr != nil {
-		fmt.Fprintf(stderr, "gc supervisor: api: listen %s failed: %v\n", addr, apiErr) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: api: listen %s failed: %v\n", cmdName("supervisor"), addr, apiErr) //nolint:errcheck
 		return 1
 	}
 	go func() {
@@ -780,7 +780,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	safeReconcile := func() {
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Fprintf(stderr, "gc supervisor: reconcile panicked: %v\n", r) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: reconcile panicked: %v\n", cmdName("supervisor"), r) //nolint:errcheck // best-effort stderr
 			}
 		}()
 		reconcileCities(reg, registry, supCfg.Publication, stdout, stderr)
@@ -1075,7 +1075,7 @@ func reconcileCities(
 
 		// recordInitFailure logs the error and records backoff state.
 		recordInitFailure := func(cityName, msg string) {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': %s (skipping)\n", cityName, msg) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': %s (skipping)\n", cmdName("supervisor"), cityName, msg) //nolint:errcheck
 			var configMod time.Time
 			if info, stErr := os.Stat(tomlPath); stErr == nil {
 				configMod = info.ModTime()
@@ -1103,7 +1103,7 @@ func reconcileCities(
 				ifrec.backoff = time.Now().Add(delay)
 				ifrec.configMod = configMod
 				ifrec.lastError = msg
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': init failure #%d, next retry in %s\n", cityName, ifrec.count, delay) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: city '%s': init failure #%d, next retry in %s\n", cmdName("supervisor"), cityName, ifrec.count, delay) //nolint:errcheck
 			})
 		}
 
@@ -1125,7 +1125,7 @@ func reconcileCities(
 		// different workspace.name because registration aliases are machine-local.
 		cityName := name // from entry.EffectiveName()
 		if liveName := cfg.Workspace.Name; liveName != "" && liveName != cityName {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': using registered name; city.toml workspace.name is %q\n", //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': using registered name; city.toml workspace.name is %q\n", cmdName("supervisor"), //nolint:errcheck
 				cityName, liveName)
 		}
 		applyRuntimeCityIdentity(cfg, cityName)
@@ -1197,14 +1197,14 @@ func reconcileCities(
 			started := time.Now()
 			err := fn()
 			if dur := time.Since(started); dur > time.Second {
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': %s took %s\n", cityName, status, dur.Round(10*time.Millisecond)) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: city '%s': %s took %s\n", cmdName("supervisor"), cityName, status, dur.Round(10*time.Millisecond)) //nolint:errcheck
 			}
 			return err
 		}
 
 		// Warn if city has its own API port.
 		if cfg.API.Port > 0 {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s' has [api] port=%d which is ignored under supervisor mode\n", //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s' has [api] port=%d which is ignored under supervisor mode\n", cmdName("supervisor"), //nolint:errcheck
 				cityName, cfg.API.Port)
 		}
 
@@ -1366,7 +1366,7 @@ func reconcileCities(
 		// controllers (mirrors runController in controller.go).
 		lock, lockErr := acquireControllerLock(path)
 		if lockErr != nil {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': controller lock: %v\n", cityName, lockErr) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': controller lock: %v\n", cmdName("supervisor"), cityName, lockErr) //nolint:errcheck
 			cityCancel()
 			cityRuntime.shutdown()
 			if fr != nil {
@@ -1389,7 +1389,7 @@ func reconcileCities(
 		sockPath := filepath.Join(path, ".gc", "controller.sock")
 		lis, lisErr := startControllerSocket(path, cityCancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		if lisErr != nil {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': controller socket: %v\n", cityName, lisErr) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': controller socket: %v\n", cmdName("supervisor"), cityName, lisErr) //nolint:errcheck
 			lock.Close()                                                                               //nolint:errcheck // no socket to race with
 			cityCancel()
 			cityRuntime.shutdown()
@@ -1412,7 +1412,7 @@ func reconcileCities(
 		// (mirrors runController in controller.go).
 		controllerToken, tokenErr := convergence.GenerateToken()
 		if tokenErr != nil {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': controller token: %v\n", cityName, tokenErr) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': controller token: %v\n", cmdName("supervisor"), cityName, tokenErr) //nolint:errcheck
 			lis.Close()                                                                                 //nolint:errcheck
 			os.Remove(sockPath)                                                                         //nolint:errcheck
 			lock.Close()                                                                                //nolint:errcheck // lock released last
@@ -1434,7 +1434,7 @@ func reconcileCities(
 		}
 		_ = controllerToken // available for future waves via function parameters
 		if err := convergence.WriteToken(path, controllerToken); err != nil {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': writing controller token: %v\n", cityName, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': writing controller token: %v\n", cmdName("supervisor"), cityName, err) //nolint:errcheck
 			lis.Close()                                                                                    //nolint:errcheck
 			os.Remove(sockPath)                                                                            //nolint:errcheck
 			lock.Close()                                                                                   //nolint:errcheck // lock released last
@@ -1475,7 +1475,7 @@ func reconcileCities(
 			// completion is signaled only after all resource cleanup.
 			defer func() {
 				if r := recover(); r != nil {
-					fmt.Fprintf(stderr, "gc supervisor: city '%s' panicked: %v\n", n, r) //nolint:errcheck
+					fmt.Fprintf(stderr, "%s: city '%s' panicked: %v\n", cmdName("supervisor"), n, r) //nolint:errcheck
 					// Gracefully stop agents so they aren't orphaned.
 					// Wrap in recovery to prevent nested panic from crashing
 					// the entire supervisor.
@@ -1484,7 +1484,7 @@ func reconcileCities(
 						cityRuntime.shutdown()
 					}()
 					if err := shutdownBeadsProvider(p); err != nil {
-						fmt.Fprintf(stderr, "gc supervisor: city '%s': bead store: %v\n", n, err) //nolint:errcheck
+						fmt.Fprintf(stderr, "%s: city '%s': bead store: %v\n", cmdName("supervisor"), n, err) //nolint:errcheck
 					}
 					// Close the file recorder (only on panic — normal exit
 					// leaves it for the external caller via mc.closer).
@@ -1515,7 +1515,7 @@ func reconcileCities(
 							delay = 5 * time.Minute
 						}
 						pr.backoff = time.Now().Add(delay)
-						fmt.Fprintf(stderr, "gc supervisor: city '%s' panic #%d, next retry in %s\n", n, pr.count, delay) //nolint:errcheck
+						fmt.Fprintf(stderr, "%s: city '%s' panic #%d, next retry in %s\n", cmdName("supervisor"), n, pr.count, delay) //nolint:errcheck
 						deleteManagedCityIfCurrent(cities, p, mc)
 					})
 				} else {
@@ -1640,7 +1640,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 		started := time.Now()
 		err := fn()
 		if dur := time.Since(started); dur > time.Second {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': %s took %s\n", cityName, status, dur.Round(10*time.Millisecond)) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': %s took %s\n", cmdName("supervisor"), cityName, status, dur.Round(10*time.Millisecond)) //nolint:errcheck
 		}
 		return err
 	}
@@ -1661,7 +1661,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 	// gc-beads-bd now ships inside the bd pack's assets/scripts/ and is
 	// materialized alongside the rest of the pack content.
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: city '%s': builtin packs: %v\n", cityName, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: city '%s': builtin packs: %v\n", cmdName("supervisor"), cityName, err) //nolint:errcheck
 		// Non-fatal.
 	}
 
@@ -1680,7 +1680,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 	if err := runStep("checking_bead_store_health", func() error {
 		return healthBeadsProvider(cityPath)
 	}); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor: city '%s': beads health: %v\n", cityName, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: city '%s': beads health: %v\n", cmdName("supervisor"), cityName, err) //nolint:errcheck
 		// Non-fatal.
 	}
 
@@ -1693,7 +1693,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 		if err := runStep("resolving_city_formulas", func() error {
 			return ResolveFormulas(cityPath, cfg.FormulaLayers.City)
 		}); err != nil {
-			fmt.Fprintf(stderr, "gc supervisor: city '%s': city formulas: %v\n", cityName, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: city '%s': city formulas: %v\n", cmdName("supervisor"), cityName, err) //nolint:errcheck
 		}
 	}
 	for _, r := range cfg.Rigs {
@@ -1708,7 +1708,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 			if err := runStep(status, func() error {
 				return ResolveFormulas(r.Path, layers)
 			}); err != nil {
-				fmt.Fprintf(stderr, "gc supervisor: city '%s': rig %q formulas: %v\n", cityName, r.Name, err) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: city '%s': rig %q formulas: %v\n", cmdName("supervisor"), cityName, r.Name, err) //nolint:errcheck
 			}
 		}
 	}
@@ -1718,7 +1718,7 @@ func prepareCityForSupervisor(cityPath, cityName string, cfg *config.City, stder
 		progress("pruning_legacy_scripts")
 	}
 	pruneLegacyConfiguredScripts(cityPath, cfg, func(scope string, err error) {
-		fmt.Fprintf(stderr, "gc supervisor: city '%s': pruning legacy %s scripts: %v\n", cityName, scope, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: city '%s': pruning legacy %s scripts: %v\n", cmdName("supervisor"), cityName, scope, err) //nolint:errcheck
 	})
 
 	// Validate agents.

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -38,11 +38,11 @@ func newSupervisorCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "supervisor",
 		Short: "Manage the machine-wide supervisor",
-		Long: `Manage the machine-wide supervisor.
+		Long: fmt.Sprintf(`Manage the machine-wide supervisor.
 
 The supervisor manages all registered cities from a single process,
-hosting a unified API server. Use "gc init", "gc start", or "gc register"
-to add cities.`,
+hosting a unified API server. Use "%s init", "%s start", or "%s register"
+to add cities.`, prog(), prog(), prog()),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
@@ -65,9 +65,9 @@ func newSupervisorStartCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the machine-wide supervisor in the background",
-		Long: `Start the machine-wide supervisor in the background.
+		Long: fmt.Sprintf(`Start the machine-wide supervisor in the background.
 
-This forks "gc supervisor run", verifies it became ready, and returns.`,
+This forks "%s supervisor run", verifies it became ready, and returns.`, prog()),
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if doSupervisorStart(stdout, stderr) != 0 {

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -328,7 +328,7 @@ func writeStandaloneControllerConflict(stderr io.Writer, commandName, cityPath s
 		pidSuffix = fmt.Sprintf(" (PID %d)", pid)
 		authority = fmt.Sprintf("standalone controller PID %d", pid)
 	}
-	nextCommand := "gc stop " + shellQuotePath(cityPath) + " && " + supervisorRetryCommand(commandName, cityPath)
+	nextCommand := cmdName("stop") + " " + shellQuotePath(cityPath) + " && " + supervisorRetryCommand(commandName, cityPath)
 	_, _ = fmt.Fprintf(stderr,
 		"%s: standalone controller already running for %s%s; supervisor cannot manage this city until it stops\n",
 		commandName, shellQuotePath(cityPath), pidSuffix)
@@ -340,9 +340,9 @@ func supervisorRetryCommand(commandName, cityPath string) string {
 	quotedPath := shellQuotePath(cityPath)
 	switch strings.TrimSpace(commandName) {
 	case "gc register":
-		return "gc register " + quotedPath
+		return cmdName("register") + " " + quotedPath
 	default:
-		return "gc start " + quotedPath
+		return cmdName("start") + " " + quotedPath
 	}
 }
 

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -339,7 +339,7 @@ func writeStandaloneControllerConflict(stderr io.Writer, commandName, cityPath s
 func supervisorRetryCommand(commandName, cityPath string) string {
 	quotedPath := shellQuotePath(cityPath)
 	switch strings.TrimSpace(commandName) {
-	case "gc register":
+	case cmdName("register"):
 		return cmdName("register") + " " + quotedPath
 	default:
 		return cmdName("start") + " " + quotedPath

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -186,7 +186,7 @@ func waitForSupervisorReady(stderr io.Writer) int {
 	if waitForSupervisorPID() != 0 {
 		return 0
 	}
-	fmt.Fprintf(stderr, "gc: supervisor did not become ready; see %s\n", supervisorLogPath()) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, prog()+": supervisor did not become ready; see %s\n", supervisorLogPath()) //nolint:errcheck // best-effort stderr
 	return 1
 }
 

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -80,25 +80,25 @@ func doSupervisorStart(stdout, stderr io.Writer) int {
 
 	lock, err := acquireSupervisorLock()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor start", err)
 		return 1
 	}
 	lock.Close() //nolint:errcheck // release probe lock
 
 	gcPath, err := os.Executable()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor start: finding executable: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor start: finding executable", err)
 		return 1
 	}
 
 	logPath := supervisorLogPath()
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor start: creating log dir: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor start: creating log dir", err)
 		return 1
 	}
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor start: opening log: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor start: opening log", err)
 		return 1
 	}
 	defer logFile.Close() //nolint:errcheck // best-effort cleanup
@@ -111,7 +111,7 @@ func doSupervisorStart(stdout, stderr io.Writer) int {
 	child.Env = os.Environ()
 
 	if err := child.Start(); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor start", err)
 		return 1
 	}
 
@@ -251,7 +251,7 @@ func doSupervisorLogs(numLines int, follow bool, stdout, stderr io.Writer) int {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor logs: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor logs", err)
 		return 1
 	}
 	return 0
@@ -280,7 +280,7 @@ func doSupervisorInstall(stdout, stderr io.Writer) int {
 	}
 	data, err := buildSupervisorServiceData()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install", err)
 		return 1
 	}
 
@@ -313,7 +313,7 @@ func newSupervisorUninstallCmd(stdout, stderr io.Writer) *cobra.Command {
 func doSupervisorUninstall(stdout, stderr io.Writer) int {
 	data, err := buildSupervisorServiceData()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor uninstall", err)
 		return 1
 	}
 
@@ -877,7 +877,7 @@ func restorePreviousSupervisorSystemdInstall(path, service string, previousConte
 func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Writer) int {
 	content, err := renderSupervisorTemplate(supervisorLaunchdTemplate, data)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: rendering plist: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: rendering plist", err)
 		return 1
 	}
 
@@ -886,19 +886,19 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 	existing, err := os.ReadFile(path)
 	hadCurrent := err == nil
 	if err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(stderr, "gc supervisor install: reading existing plist: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: reading existing plist", err)
 		return 1
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install", err)
 		return 1
 	}
 	if err := writeSupervisorServiceFile(path, []byte(content)); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: writing plist: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: writing plist", err)
 		return 1
 	}
 	if err := unloadLegacySupervisorLaunchd(false); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install", err)
 		return 1
 	}
 
@@ -911,13 +911,13 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 			rollbackErr = rollbackNewSupervisorLaunchdInstall(path, legacyPresent)
 		}
 		if rollbackErr != nil {
-			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl load failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "supervisor install: rollback after launchctl load failure", rollbackErr)
 		}
-		fmt.Fprintf(stderr, "gc supervisor install: launchctl load: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: launchctl load", err)
 		return 1
 	}
 	if err := unloadLegacySupervisorLaunchd(true); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: warning: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: warning", err)
 	}
 
 	fmt.Fprintf(stdout, "Installed launchd service: %s\n", path) //nolint:errcheck // best-effort stdout
@@ -928,11 +928,11 @@ func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writ
 	path := supervisorLaunchdPlistPath()
 	_ = supervisorLaunchctlRun("unload", path)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(stderr, "gc supervisor uninstall: removing plist: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor uninstall: removing plist", err)
 		return 1
 	}
 	if err := unloadLegacySupervisorLaunchd(true); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor uninstall", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "Uninstalled launchd service: %s\n", path) //nolint:errcheck // best-effort stdout
@@ -942,7 +942,7 @@ func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writ
 func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Writer) int {
 	content, err := renderSupervisorTemplate(supervisorSystemdTemplate, data)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: rendering unit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: rendering unit", err)
 		return 1
 	}
 
@@ -952,16 +952,16 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 	existing, err := os.ReadFile(path)
 	hadCurrent := err == nil
 	if err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(stderr, "gc supervisor install: reading existing unit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: reading existing unit", err)
 		return 1
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install", err)
 		return 1
 	}
 	contentChanged := string(existing) != content
 	if err := writeSupervisorServiceFile(path, []byte(content)); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: writing unit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: writing unit", err)
 		return 1
 	}
 
@@ -984,7 +984,7 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 		}
 	}
 	if err := unloadLegacySupervisorSystemd(false); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install", err)
 		return 1
 	}
 
@@ -1020,7 +1020,7 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 		}
 	}
 	if err := unloadLegacySupervisorSystemd(true); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor install: warning: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor install: warning", err)
 	} else {
 		_ = supervisorSystemctlRun("--user", "daemon-reload")
 	}
@@ -1035,11 +1035,11 @@ func uninstallSupervisorSystemd(_ *supervisorServiceData, stdout, stderr io.Writ
 	_ = supervisorSystemctlRun("--user", "stop", service)
 	_ = supervisorSystemctlRun("--user", "disable", service)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(stderr, "gc supervisor uninstall: removing unit: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor uninstall: removing unit", err)
 		return 1
 	}
 	if err := unloadLegacySupervisorSystemd(true); err != nil {
-		fmt.Fprintf(stderr, "gc supervisor uninstall: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "supervisor uninstall", err)
 		return 1
 	}
 	_ = supervisorSystemctlRun("--user", "daemon-reload")

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -70,11 +70,11 @@ func doSupervisorRun(stdout, stderr io.Writer) int {
 
 func doSupervisorStart(stdout, stderr io.Writer) int {
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
-		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %s\n", cmdName("supervisor start"), msg) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if pid := supervisorAlive(); pid != 0 {
-		fmt.Fprintf(stderr, "gc supervisor start: supervisor already running (PID %d)\n", pid) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: supervisor already running (PID %d)\n", cmdName("supervisor start"), pid) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -124,13 +124,13 @@ func doSupervisorStart(stdout, stderr io.Writer) int {
 		time.Sleep(supervisorReadyPollInterval)
 	}
 
-	fmt.Fprintf(stderr, "gc supervisor start: supervisor did not become ready; see %s\n", logPath) //nolint:errcheck // best-effort stderr
+	fmt.Fprintf(stderr, "%s: supervisor did not become ready; see %s\n", cmdName("supervisor start"), logPath) //nolint:errcheck // best-effort stderr
 	return 1
 }
 
 func ensureSupervisorRunning(stdout, stderr io.Writer) int {
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
-		fmt.Fprintf(stderr, "gc supervisor start: %s\n", msg) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %s\n", cmdName("supervisor start"), msg) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	// Always regenerate the service file so upgrades pick up template
@@ -237,7 +237,7 @@ Shows recent log output from background and service-managed supervisor runs.`,
 func doSupervisorLogs(numLines int, follow bool, stdout, stderr io.Writer) int {
 	logPath := supervisorLogPath()
 	if _, err := os.Stat(logPath); os.IsNotExist(err) {
-		fmt.Fprintf(stderr, "gc supervisor logs: log file not found: %s\n", logPath) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: log file not found: %s\n", cmdName("supervisor logs"), logPath) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -275,7 +275,7 @@ starts on login.`,
 
 func doSupervisorInstall(stdout, stderr io.Writer) int {
 	if msg, blocked := platformSupervisorHomeOverrideError(); blocked {
-		fmt.Fprintf(stderr, "gc supervisor install: %s\n", msg) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %s\n", cmdName("supervisor install"), msg) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	data, err := buildSupervisorServiceData()
@@ -290,7 +290,7 @@ func doSupervisorInstall(stdout, stderr io.Writer) int {
 	case "linux":
 		return installSupervisorSystemd(data, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "gc supervisor install: not supported on %s\n", goruntime.GOOS) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: not supported on %s\n", cmdName("supervisor install"), goruntime.GOOS) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 }
@@ -323,7 +323,7 @@ func doSupervisorUninstall(stdout, stderr io.Writer) int {
 	case "linux":
 		return uninstallSupervisorSystemd(data, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "gc supervisor uninstall: not supported on %s\n", goruntime.GOOS) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: not supported on %s\n", cmdName("supervisor uninstall"), goruntime.GOOS) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 }
@@ -977,9 +977,9 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, false)
 			}
 			if rollbackErr != nil {
-				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: rollback after systemctl %s failure: %v\n", cmdName("supervisor install"), strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
 			}
-			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: systemctl %s: %v\n", cmdName("supervisor install"), strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -998,9 +998,9 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, legacyPresent)
 			}
 			if rollbackErr != nil {
-				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: rollback after systemctl %s failure: %v\n", cmdName("supervisor install"), strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
 			}
-			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: systemctl %s: %v\n", cmdName("supervisor install"), strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	} else if !supervisorSystemctlActive(service) {
@@ -1013,9 +1013,9 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 				rollbackErr = rollbackNewSupervisorSystemdInstall(path, service, legacyPresent)
 			}
 			if rollbackErr != nil {
-				fmt.Fprintf(stderr, "gc supervisor install: rollback after systemctl %s failure: %v\n", strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, "%s: rollback after systemctl %s failure: %v\n", cmdName("supervisor install"), strings.Join(args, " "), rollbackErr) //nolint:errcheck // best-effort stderr
 			}
-			fmt.Fprintf(stderr, "gc supervisor install: systemctl %s: %v\n", strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: systemctl %s: %v\n", cmdName("supervisor install"), strings.Join(args, " "), err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -18,13 +18,13 @@ func newSuspendCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "suspend [path]",
 		Short: "Suspend the city (all agents effectively suspended)",
-		Long: `Suspends the city by setting workspace.suspended = true in city.toml.
+		Long: fmt.Sprintf(`Suspends the city by setting workspace.suspended = true in city.toml.
 
 This inherits downward — when the city is suspended, all agents are
 effectively suspended regardless of their individual suspended fields.
 The reconciler won't spawn agents, gc hook/prime return empty.
 
-Use "gc resume" to restore.`,
+Use "%s resume" to restore.`, prog()),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdSuspend(args, stdout, stderr) != 0 {
@@ -40,11 +40,11 @@ func newResumeCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "resume [path]",
 		Short: "Resume a suspended city",
-		Long: `Resume a suspended city by clearing workspace.suspended in city.toml.
+		Long: fmt.Sprintf(`Resume a suspended city by clearing workspace.suspended in city.toml.
 
 Restores normal operation: the reconciler will spawn agents again and
-gc hook/prime will return work. Use "gc agent resume" to resume
-individual agents, or "gc rig resume" for rigs.`,
+gc hook/prime will return work. Use "%s agent resume" to resume
+individual agents, or "%s rig resume" for rigs.`, prog(), prog()),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdResume(args, stdout, stderr) != 0 {

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -109,9 +109,9 @@ func resolveSuspendDir(args []string) (string, error) {
 // suspended via isAgentEffectivelySuspended and computeSuspendedNames.
 func doSuspendCity(fs fsys.FS, cityPath string, suspend bool, stdout, stderr io.Writer) int {
 	tomlPath := filepath.Join(cityPath, "city.toml")
-	cmd := "gc suspend"
+	cmd := cmdName("suspend")
 	if !suspend {
-		cmd = "gc resume"
+		cmd = cmdName("resume")
 	}
 	cfg, err := loadCityConfigForEditFS(fs, tomlPath)
 	if err != nil {

--- a/cmd/gc/cmd_suspend.go
+++ b/cmd/gc/cmd_suspend.go
@@ -59,7 +59,7 @@ individual agents, or "gc rig resume" for rigs.`,
 func cmdSuspend(args []string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveSuspendDir(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "suspend", err)
 		return 1
 	}
 	if c := apiClient(cityPath); c != nil {
@@ -69,7 +69,7 @@ func cmdSuspend(args []string, stdout, stderr io.Writer) int {
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc suspend: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "suspend", err)
 			return 1
 		}
 		// Connection error — fall through to direct mutation.
@@ -81,7 +81,7 @@ func cmdSuspend(args []string, stdout, stderr io.Writer) int {
 func cmdResume(args []string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveSuspendDir(args)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc resume: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "resume", err)
 		return 1
 	}
 	if c := apiClient(cityPath); c != nil {
@@ -91,7 +91,7 @@ func cmdResume(args []string, stdout, stderr io.Writer) int {
 			return 0
 		}
 		if !api.ShouldFallback(err) {
-			fmt.Fprintf(stderr, "gc resume: %v\n", err) //nolint:errcheck // best-effort stderr
+			cmdErr(stderr, "resume", err)
 			return 1
 		}
 		// Connection error — fall through to direct mutation.

--- a/cmd/gc/cmd_version.go
+++ b/cmd/gc/cmd_version.go
@@ -88,10 +88,10 @@ func newVersionCmd(stdout io.Writer) *cobra.Command {
 	var longOutput bool
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print gc version",
-		Long: `Print the gc version string.
+		Short: fmt.Sprintf("Print %s version", prog()),
+		Long: fmt.Sprintf(`Print the %s version string.
 
-Use --long to include git commit and build date metadata.`,
+Use --long to include git commit and build date metadata.`, prog()),
 		Args: cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			if longOutput {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -154,7 +154,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		return 1
 	}
 	if err := waitLifecycleEnabled(); err != nil {
-		fmt.Fprintf(stderr, "gc session wait: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wait", err)
 		return 1
 	}
 	if sleep {
@@ -171,12 +171,12 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 	}
 	sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, target)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session wait: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wait", err)
 		return 1
 	}
 	sb, err := store.Get(sessionID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session wait: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wait", err)
 		return 1
 	}
 	for _, depID := range depIDs {
@@ -213,7 +213,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		Metadata: meta,
 	})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc session wait: creating wait: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "session wait: creating wait", err)
 		return 1
 	}
 	ready, depErr := depsWaitReadyDetailedForCity(cityPath, store, waitBead)
@@ -223,9 +223,9 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 			"failed_at":  now.Format(time.RFC3339),
 			"last_error": depErr.Error(),
 		}); err != nil {
-			fmt.Fprintf(stderr, "gc session wait: setting failed state: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "session wait: setting failed state", err)
 		}
-		fmt.Fprintf(stderr, "gc session wait: dependency state check: %v\n", depErr) //nolint:errcheck
+		cmdErr(stderr, "session wait: dependency state check", depErr)
 		return 1
 	}
 	if ready {
@@ -233,7 +233,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 			"state":    waitStateReady,
 			"ready_at": now.Format(time.RFC3339),
 		}); err != nil {
-			fmt.Fprintf(stderr, "gc session wait: setting ready state: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "session wait: setting ready state", err)
 			return 1
 		}
 		fmt.Fprintf(stdout, "Registered wait %s for session %s (already ready).\n", waitBead.ID, sessionID) //nolint:errcheck
@@ -244,12 +244,12 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 			"wait_hold":    "true",
 			"sleep_intent": "wait-hold",
 		}); err != nil {
-			fmt.Fprintf(stderr, "gc session wait: setting wait hold: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "session wait: setting wait hold", err)
 			return 1
 		}
 		if cityPath, err := resolveCity(); err == nil {
 			if err := pokeController(cityPath); err != nil {
-				fmt.Fprintf(stderr, "gc session wait: poking controller: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "session wait: poking controller", err)
 				return 1
 			}
 		}
@@ -267,7 +267,7 @@ func cmdWaitList(stateFilter, sessionFilter string, stdout, stderr io.Writer) in
 	}
 	items, err := loadWaitBeads(store)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc wait list: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "wait list", err)
 		return 1
 	}
 	sort.SliceStable(items, func(i, j int) bool { return items[i].CreatedAt.Before(items[j].CreatedAt) })
@@ -297,7 +297,7 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 	}
 	b, err := store.Get(waitID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc wait inspect: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "wait inspect", err)
 		return 1
 	}
 	if !sessionpkg.IsWaitBead(b) {
@@ -323,7 +323,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 	}
 	b, err := store.Get(waitID)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "wait", err)
 		return 1
 	}
 	if !sessionpkg.IsWaitBead(b) {
@@ -332,7 +332,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 	}
 	if state == waitStateReady {
 		if err := waitLifecycleEnabled(); err != nil {
-			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "wait", err)
 			return 1
 		}
 	}
@@ -340,7 +340,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 	if state == waitStateReady && b.Status == "closed" {
 		retried, err := retryClosedWait(store, b, now)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "wait", err)
 			return 1
 		}
 		fmt.Fprintf(stdout, "Retried wait %s as %s.\n", waitID, retried.ID) //nolint:errcheck
@@ -352,7 +352,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		batch["ready_at"] = now
 		nextAttempt, err := nextWaitDeliveryAttempt(store, b)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "wait", err)
 			return 1
 		}
 		if nextAttempt != "" {
@@ -375,18 +375,18 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		}
 	}
 	if err := apply(waitID, batch); err != nil {
-		fmt.Fprintf(stderr, "gc wait: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "wait", err)
 		return 1
 	}
 	if state == waitStateCanceled {
 		if cityPath, err := resolveCity(); err == nil {
 			if err := withdrawQueuedWaitNudges(cityPath, []string{b.Metadata["nudge_id"]}); err != nil {
-				fmt.Fprintf(stderr, "gc wait: withdrawing queued nudge: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "wait: withdrawing queued nudge", err)
 				return 1
 			}
 		}
 		if err := clearSessionWaitHoldIfIdle(store, b.Metadata["session_id"]); err != nil {
-			fmt.Fprintf(stderr, "gc wait: clearing session wait hold: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "wait: clearing session wait hold", err)
 			return 1
 		}
 	}

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -132,11 +132,11 @@ func newWaitReadyCmd(stdout, stderr io.Writer) *cobra.Command {
 
 func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep bool, stdout, stderr io.Writer) int {
 	if len(depIDs) == 0 {
-		fmt.Fprintln(stderr, "gc session wait: at least one --on-beads value is required") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: at least one --on-beads value is required\n", cmdName("session wait")) //nolint:errcheck
 		return 1
 	}
 	if strings.TrimSpace(note) == "" {
-		fmt.Fprintln(stderr, "gc session wait: --note is required") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: --note is required\n", cmdName("session wait")) //nolint:errcheck
 		return 1
 	}
 	store, code := openCityStore(stderr, "gc session wait")
@@ -150,7 +150,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		target = os.Getenv("GC_SESSION_ID")
 	}
 	if target == "" {
-		fmt.Fprintln(stderr, "gc session wait: session not specified (pass an ID/name or set $GC_SESSION_ID)") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: session not specified (pass an ID/name or set $GC_SESSION_ID)\n", cmdName("session wait")) //nolint:errcheck
 		return 1
 	}
 	if err := waitLifecycleEnabled(); err != nil {
@@ -160,7 +160,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 	if sleep {
 		cityPath, err := resolveCity()
 		if err != nil || !cityUsesManagedReconciler(cityPath) {
-			fmt.Fprintln(stderr, "gc session wait: a managed controller must be running when --sleep is used") //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: a managed controller must be running when --sleep is used\n", cmdName("session wait")) //nolint:errcheck
 			return 1
 		}
 	}
@@ -181,7 +181,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 	}
 	for _, depID := range depIDs {
 		if _, err := loadWaitDependencyBead(cityPath, store, depID); err != nil {
-			fmt.Fprintf(stderr, "gc session wait: dependency %s: %v\n", depID, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: dependency %s: %v\n", cmdName("session wait"), depID, err) //nolint:errcheck
 			return 1
 		}
 	}
@@ -301,7 +301,7 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if !sessionpkg.IsWaitBead(b) {
-		fmt.Fprintf(stderr, "gc wait inspect: %s is not a wait\n", waitID) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s is not a wait\n", cmdName("wait inspect"), waitID) //nolint:errcheck
 		return 1
 	}
 	fmt.Fprintf(stdout, "Wait:       %s\n", b.ID)                                               //nolint:errcheck
@@ -327,7 +327,7 @@ func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if !sessionpkg.IsWaitBead(b) {
-		fmt.Fprintf(stderr, "gc wait: %s is not a wait\n", waitID) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: %s is not a wait\n", cmdName("wait"), waitID) //nolint:errcheck
 		return 1
 	}
 	if state == waitStateReady {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -139,7 +139,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 		fmt.Fprintf(stderr, "%s: --note is required\n", cmdName("session wait")) //nolint:errcheck
 		return 1
 	}
-	store, code := openCityStore(stderr, "gc session wait")
+	store, code := openCityStore(stderr, cmdName("session wait"))
 	if store == nil {
 		return code
 	}
@@ -261,7 +261,7 @@ func cmdSessionWait(args, depIDs []string, matchAny bool, note string, sleep boo
 }
 
 func cmdWaitList(stateFilter, sessionFilter string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc wait list")
+	store, code := openCityStore(stderr, cmdName("wait list"))
 	if store == nil {
 		return code
 	}
@@ -291,7 +291,7 @@ func cmdWaitList(stateFilter, sessionFilter string, stdout, stderr io.Writer) in
 }
 
 func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc wait inspect")
+	store, code := openCityStore(stderr, cmdName("wait inspect"))
 	if store == nil {
 		return code
 	}
@@ -317,7 +317,7 @@ func cmdWaitInspect(waitID string, stdout, stderr io.Writer) int {
 }
 
 func cmdWaitSetState(waitID, state string, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc wait")
+	store, code := openCityStore(stderr, cmdName("wait"))
 	if store == nil {
 		return code
 	}

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -991,7 +991,7 @@ func controllerLoop(
 		suspendedNames:      suspendedNames,
 		pokeCh:              make(chan struct{}, 1),
 		controlDispatcherCh: make(chan struct{}, 1),
-		logPrefix:           "gc start",
+		logPrefix:           cmdName("start"),
 		stdout:              stdout,
 		stderr:              stderr,
 	}

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -596,7 +596,7 @@ func isConventionDiscoveryDirName(base string) bool {
 func watchConfigTargets(targets []config.WatchTarget, dirty *atomic.Bool, pokeCh chan struct{}, stderr io.Writer) func() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: config watcher: %v (reload on tick only)\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: config watcher: %v (reload on tick only)\n", cmdName("start"), err) //nolint:errcheck // best-effort stderr
 		return func() {}
 	}
 	registrar := newConfigWatchRegistrar(watcher, stderr)

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -1051,7 +1051,7 @@ func runController(
 ) int {
 	lock, err := acquireControllerLock(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	defer lock.Close() //nolint:errcheck // best-effort cleanup
@@ -1076,7 +1076,7 @@ func runController(
 	sockPath := controllerSocketPath(cityPath)
 	lis, err := startControllerSocket(cityPath, cancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	defer lis.Close()         //nolint:errcheck // best-effort cleanup
@@ -1090,12 +1090,12 @@ func runController(
 	// explicitly through function parameters.
 	controllerToken, err := convergence.GenerateToken()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	_ = controllerToken // available for future waves via function parameters
 	if err := convergence.WriteToken(cityPath, controllerToken); err != nil {
-		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
+		cmdErr(stderr, "start", err)
 		return 1
 	}
 	defer convergence.RemoveToken(cityPath) //nolint:errcheck // best-effort cleanup

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -67,7 +67,7 @@ var (
 	workflowServeList               = nextWorkflowServeBeads
 	controlDispatcherServe          = runControlDispatcher
 	workflowServeOpenEventsProvider = func(stderr io.Writer) (events.Provider, error) {
-		ep, code := openCityEventsProvider(stderr, "gc convoy control --serve")
+		ep, code := openCityEventsProvider(stderr, cmdName("convoy control --serve"))
 		if ep == nil {
 			return nil, fmt.Errorf("opening events provider (exit %d)", code)
 		}

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -109,7 +109,7 @@ func runConvoyControlServe(args []string, stdout, stderr io.Writer) error {
 		agentName = args[0]
 	}
 	if err := runWorkflowServe(agentName, true, stdout, stderr); err != nil {
-		fmt.Fprintf(stderr, "gc convoy control --serve: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "convoy control --serve", err)
 		return errExit
 	}
 	return nil

--- a/cmd/gc/doctor_mcp_checks.go
+++ b/cmd/gc/doctor_mcp_checks.go
@@ -50,7 +50,7 @@ func (c *mcpConfigDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		Status:  doctor.StatusError,
 		Message: summarizeMCPIssues(issues),
 		Details: issues,
-		FixHint: `fix the reported MCP definitions or provider/runtime settings, then rerun "gc doctor"`,
+		FixHint: fmt.Sprintf(`fix the reported MCP definitions or provider/runtime settings, then rerun %q`, cmdName("doctor")),
 	}
 }
 

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -439,7 +439,7 @@ func warnCheck(name, message, hint string, details []string) *doctor.CheckResult
 }
 
 func v2MigrationHint() string {
-	return `run "gc doctor --fix" to rewrite safe mechanical cases, then rerun "gc doctor"`
+	return fmt.Sprintf(`run "%s doctor --fix" to rewrite safe mechanical cases, then rerun "%s doctor"`, prog(), prog())
 }
 
 func parseCityConfig(path string) (*config.City, bool) {

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -128,7 +128,7 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if err := os.Rename(dbDir, dest); err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "gc dolt preflight: quarantined phantom database %s -> %s\n", dbDir, dest) //nolint:errcheck // best-effort warning
+		fmt.Fprintf(os.Stderr, "%s: quarantined phantom database %s -> %s\n", cmdName("dolt preflight"), dbDir, dest) //nolint:errcheck // best-effort warning
 	}
 	return nil
 }

--- a/cmd/gc/dolt_project_id.go
+++ b/cmd/gc/dolt_project_id.go
@@ -40,12 +40,12 @@ func newEnsureProjectIDCmd(stdout, stderr io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			report, err := ensureManagedDoltProjectID(metadataPath, host, port, user, database)
 			if err != nil {
-				fmt.Fprintf(stderr, "gc dolt-state ensure-project-id: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "dolt-state ensure-project-id", err)
 				return errExit
 			}
 			for _, line := range managedDoltProjectIDFields(report) {
 				if _, writeErr := fmt.Fprintln(stdout, line); writeErr != nil {
-					fmt.Fprintf(stderr, "gc dolt-state ensure-project-id: %v\n", writeErr) //nolint:errcheck
+					cmdErr(stderr, "dolt-state ensure-project-id", writeErr)
 					return errExit
 				}
 			}

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
 	"github.com/gastownhall/gascity/internal/bootstrap/packs/core"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
@@ -152,6 +153,12 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		data, err := fs.ReadFile(embedded, path)
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", path, err)
+		}
+
+		// Resolve {{binary}} and other built-in vars in SKILL.md files so
+		// materialized skills reference the actual binary name.
+		if filepath.Base(path) == "SKILL.md" {
+			data = []byte(formula.Substitute(string(data), nil))
 		}
 
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 )
 
 func TestMaterializeBuiltinPacks(t *testing.T) {
@@ -804,5 +805,98 @@ func TestBuiltinPackIncludes_AlwaysIncludesMaintenance(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("maintenance pack not found in bd includes: %v", includes)
+	}
+}
+
+func TestMaterializeBuiltinPacks_SubstitutesSkillMDContent(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// All SKILL.md files under the core pack should have {{binary}} resolved.
+	skillsDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("reading skills dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("skills dir is empty")
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillMD := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+		data, err := os.ReadFile(skillMD)
+		if err != nil {
+			continue // not every skill dir must have SKILL.md
+		}
+		content := string(data)
+		if strings.Contains(content, "{{binary}}") {
+			t.Errorf("SKILL.md in %s still contains unresolved {{binary}} placeholder", entry.Name())
+		}
+		// Verify that gc commands were substituted — at least one SKILL.md should
+		// contain the resolved binary name followed by a subcommand.
+		if strings.Contains(content, "gc ") && !strings.Contains(content, ".gc") && entry.Name() != "gc-work" {
+			// gc-work mostly references "bd" commands, skip it for this check.
+			// Other skill files should have "gc <cmd>" resolved to the binary name.
+			// This is a soft check — the ratchet test is the hard gate.
+		}
+	}
+}
+
+func TestMaterializeBuiltinPacks_SkillMDResolvesToBinaryName(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "my-custom-gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// The gc-city SKILL.md should contain "my-custom-gc init" after substitution.
+	citySkill := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills", "gc-city", "SKILL.md")
+	data, err := os.ReadFile(citySkill)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", citySkill, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "my-custom-gc init") {
+		t.Errorf("gc-city SKILL.md does not contain 'my-custom-gc init'; got:\n%s", content)
+	}
+	if strings.Contains(content, "{{binary}}") {
+		t.Errorf("gc-city SKILL.md still contains unresolved {{binary}} placeholder")
+	}
+}
+
+func TestMaterializeBuiltinPacks_NonSkillMDFilesUntouched(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// pack.toml should NOT have any substitution applied — its content
+	// should match the embedded source exactly.
+	coreToml := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml")
+	data, err := os.ReadFile(coreToml)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", coreToml, err)
+	}
+	// pack.toml should not contain any {{binary}} markers, but it also
+	// should not have been modified by Substitute in any way. We verify
+	// the file is still valid TOML by checking it starts with expected content.
+	if len(data) == 0 {
+		t.Fatal("core pack.toml is empty")
 	}
 }

--- a/cmd/gc/gc_permissions.go
+++ b/cmd/gc/gc_permissions.go
@@ -37,6 +37,6 @@ func chmodIfExists(path string, perm os.FileMode, stderr io.Writer) {
 		return // already correct
 	}
 	if err := os.Chmod(path, perm); err != nil {
-		fmt.Fprintf(stderr, "gc: chmod %s to %o: %v\n", path, perm, err) //nolint:errcheck
+		fmt.Fprintf(stderr, prog()+": chmod %s to %o: %v\n", path, perm, err) //nolint:errcheck
 	}
 }

--- a/cmd/gc/import_state_doctor_check.go
+++ b/cmd/gc/import_state_doctor_check.go
@@ -32,7 +32,7 @@ func (c *importStateDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult
 	if err != nil {
 		r.Status = doctor.StatusError
 		r.Message = fmt.Sprintf("checking import state: %v", err)
-		r.FixHint = `run "gc import install"`
+		r.FixHint = fmt.Sprintf("run %q", cmdName("import install"))
 		return r
 	}
 	if !report.HasIssues() {
@@ -43,7 +43,7 @@ func (c *importStateDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult
 
 	r.Status = doctor.StatusError
 	r.Message = fmt.Sprintf("%d import state issue(s)", len(report.Issues))
-	r.FixHint = `run "gc import install"`
+	r.FixHint = fmt.Sprintf("run %q", cmdName("import install"))
 	for _, issue := range report.Issues {
 		r.Details = append(r.Details, formatImportStateDoctorDetail(issue))
 	}

--- a/cmd/gc/init_artifacts.go
+++ b/cmd/gc/init_artifacts.go
@@ -9,7 +9,7 @@ import (
 
 func ensureInitArtifacts(cityPath string, stderr io.Writer, commandName string) {
 	if commandName == "" {
-		commandName = "gc start"
+		commandName = cmdName("start")
 	}
 	if code := installClaudeHooks(fsys.OSFS{}, cityPath, stderr); code != 0 {
 		fmt.Fprintf(stderr, "%s: installing claude hooks: exit %d\n", commandName, code) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -86,7 +86,7 @@ func finalizeInit(cityPath string, stdout, stderr io.Writer, opts initFinalizeOp
 	prefix := config.EffectiveHQPrefix(cfg)
 	if _, err := initDirIfReady(cityPath, cityPath, prefix); err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", opts.commandName, err)        //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, `hint: run "gc doctor" for diagnostics`) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", cmdName("doctor")) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if opts.showProgress {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/supervisor"
@@ -90,6 +91,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Publish the runtime binary name so internal/ packages can reference it
 	// in error messages and log output without importing cmd/gc.
 	progname.Set(prog())
+
+	// Register built-in formula variables so {{binary}} resolves everywhere.
+	formula.RegisterBuiltInVars(map[string]string{"binary": prog()})
 
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/spf13/cobra"
@@ -86,6 +87,10 @@ var rigFlag string
 // run executes the gc CLI with the given args, writing output to stdout and
 // errors to stderr. Returns the exit code.
 func run(args []string, stdout, stderr io.Writer) int {
+	// Publish the runtime binary name so internal/ packages can reference it
+	// in error messages and log output without importing cmd/gc.
+	progname.Set(prog())
+
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)
 	if err != nil {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -116,7 +116,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 // newRootCmd creates the root cobra command with all subcommands.
 func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root := &cobra.Command{
-		Use:           "gc",
+		Use:           prog(),
 		Short:         "Gas City CLI — orchestration-builder for multi-agent workflows",
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -130,7 +130,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 			if tryPackCommandFallback(args, stdout, stderr) {
 				return nil
 			}
-			fmt.Fprintf(stderr, "gc: unknown command %q\n\n", args[0]) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown command %q\n\n", prog(), args[0]) //nolint:errcheck // best-effort stderr
 			printCommandUsage(stderr, cmd)
 			return errExit
 		},
@@ -224,7 +224,7 @@ func installArgUsageErrors(cmd *cobra.Command, stderr io.Writer) {
 
 func printCommandUsageError(stderr io.Writer, cmd *cobra.Command, err error) {
 	if err != nil {
-		fmt.Fprintf(stderr, "gc: %v\n\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n\n", prog(), err) //nolint:errcheck // best-effort stderr
 	}
 	printCommandUsage(stderr, cmd)
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -98,7 +98,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc: telemetry init: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: telemetry init: %v\n", prog(), err) //nolint:errcheck // best-effort stderr
 	}
 	if provider != nil {
 		defer func() {
@@ -704,7 +704,7 @@ func openCityStore(stderr io.Writer, cmdName string) (beads.Store, int) {
 	store, err := openCityStoreAt(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", prog()+" doctor") //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return store, 0

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -628,9 +628,10 @@ func resolveRigBindingMatches(value string, matches []registeredRigBinding) (res
 		return resolvedContext{CityPath: matches[0].City.Path, RigName: matches[0].Rig.Name}, nil
 	}
 	return resolvedContext{}, fmt.Errorf(
-		"rig %q is registered in multiple cities: %s\n  Specify now:  gc --city <name> <command>",
+		"rig %q is registered in multiple cities: %s\n  Specify now:  %s --city <name> <command>",
 		value,
-		strings.Join(registeredRigBindingCityNames(matches), ", "))
+		strings.Join(registeredRigBindingCityNames(matches), ", "),
+		prog())
 }
 
 func registeredRigBindingCityNames(matches []registeredRigBinding) []string {

--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -109,7 +109,7 @@ func ensureMCPGitignoreBestEffort(root string, stderr io.Writer) {
 		return
 	}
 	if err := ensureGitignoreEntries(fsys.OSFS{}, root, managedMCPGitignoreEntries); err != nil && stderr != nil {
-		fmt.Fprintf(stderr, "gc: warning: updating %s/.gitignore for MCP: %v\n", root, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, prog()+": warning: updating %s/.gitignore for MCP: %v\n", root, err) //nolint:errcheck // best-effort stderr
 	}
 }
 
@@ -289,7 +289,7 @@ func cleanupOrphansAtRoot(root string, desired map[string]bool, stderr io.Writer
 			return fmt.Errorf("cleaning up orphan %s marker at %s: %w", provider, root, err)
 		}
 		if stderr != nil {
-			fmt.Fprintf(stderr, "gc: cleaned up orphan MCP marker %s at %s\n", provider, root) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": cleaned up orphan MCP marker %s at %s\n", provider, root) //nolint:errcheck // best-effort stderr
 		}
 	}
 	return nil

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -11,10 +11,9 @@ import (
 	"github.com/gastownhall/gascity/internal/nudgequeue"
 )
 
-const (
-	nudgeBeadType  = "chore"
-	nudgeBeadLabel = "gc:nudge"
-)
+const nudgeBeadType = "chore"
+
+var nudgeBeadLabel = prog() + ":nudge"
 
 type nudgeReference = nudgequeue.Reference
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -83,12 +83,12 @@ type memoryOrderDispatcher struct {
 func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) orderDispatcher {
 	allAA, err := scanAllOrders(cityPath, cfg, stderr, cmdName("start: order scan"))
 	if err != nil {
-		logDispatchError(stderr, "gc start: order scan: %v", err)
+		logDispatchError(stderr, cmdName("start")+": order scan: %v", err)
 		return nil
 	}
 	if len(cfg.Orders.Overrides) > 0 {
 		if err := orders.ApplyOverrides(allAA, convertOverrides(cfg.Orders.Overrides)); err != nil {
-			logDispatchError(stderr, "gc start: order overrides: %v", err)
+			logDispatchError(stderr, cmdName("start")+": order overrides: %v", err)
 		}
 	}
 
@@ -141,7 +141,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 		target, err := resolveOrderStoreTarget(cityPath, m.cfg, a)
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: resolving target for %s: %v", a.ScopedName(), err)
+			logDispatchError(m.stderr, prog()+": order dispatch: resolving target for %s: %v", a.ScopedName(), err)
 			continue
 		}
 
@@ -150,7 +150,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if !ok {
 			store, err = m.storeFn(target)
 			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: opening %s store for %s: %v", target.ScopeKind, a.ScopedName(), err)
+				logDispatchError(m.stderr, prog()+": order dispatch: opening %s store for %s: %v", target.ScopeKind, a.ScopedName(), err)
 				continue
 			}
 			stores[storeKey] = store
@@ -177,7 +177,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if a.Trigger == "event" {
 			cursor, err := bdCursorAcrossStores(a.ScopedName(), storesForGate...)
 			if err != nil {
-				logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
+				logDispatchError(m.stderr, prog()+": order dispatch: reading event cursor for %s: %v", a.ScopedName(), err)
 				continue
 			}
 			cursorFn = func(string) uint64 {
@@ -186,7 +186,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		}
 		result := orders.CheckTrigger(a, now, lastRunFn, m.ep, cursorFn)
 		if lastRunErr != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
+			logDispatchError(m.stderr, prog()+": order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
 			continue
 		}
 		if !result.Due {
@@ -197,7 +197,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		scoped := a.ScopedName()
 		hasOpenWork, err := m.hasOpenWorkInStoresStrict(storesForGate, scoped)
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: checking open work for %s: %v", scoped, err)
+			logDispatchError(m.stderr, prog()+": order dispatch: checking open work for %s: %v", scoped, err)
 			continue
 		}
 		if hasOpenWork {
@@ -211,7 +211,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			Labels: []string{"order-run:" + scoped, labelOrderTracking},
 		})
 		if err != nil {
-			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
+			logDispatchError(m.stderr, prog()+": order dispatch: creating tracking bead for %s: %v", scoped, err)
 			continue
 		}
 
@@ -232,7 +232,7 @@ func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target
 	}
 	store, err := m.storeFn(legacyTarget)
 	if err != nil {
-		logDispatchError(m.stderr, "gc: order dispatch: opening legacy city store for rig order fallback: %v", err)
+		logDispatchError(m.stderr, prog()+": order dispatch: opening legacy city store for rig order fallback: %v", err)
 		return nil, false
 	}
 	stores[key] = store
@@ -272,9 +272,9 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.St
 	output, err := m.execRun(ctx, a.Exec, target.ScopeRoot, env)
 	if err != nil {
 		labels = append(labels, "exec-failed")
-		logDispatchError(m.stderr, "gc: order exec %s failed: %v", scoped, err)
+		logDispatchError(m.stderr, prog()+": order exec %s failed: %v", scoped, err)
 		if len(output) > 0 {
-			logDispatchError(m.stderr, "gc: order exec %s output: %s", scoped, output)
+			logDispatchError(m.stderr, prog()+": order exec %s output: %s", scoped, output)
 		}
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
@@ -346,7 +346,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if a.Pool != "" {
 		pool := qualifyPool(a.Pool, a.Rig)
 		if err := applyGraphRouting(recipe, nil, pool, nil, "", "", "", "", store, m.cityName, cityPath, m.cfg); err != nil {
-			logDispatchError(m.stderr, "gc: order %s: routing decoration failed: %v", scoped, err)
+			logDispatchError(m.stderr, prog()+": order %s: routing decoration failed: %v", scoped, err)
 			// Non-fatal — molecule still works, just without step-level routing.
 		}
 	}
@@ -380,7 +380,7 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 	if err := store.Update(rootID, update); err != nil {
 		// Label failure is critical for duplicate-dispatch prevention.
 		// Log and emit an event so operators can investigate.
-		logDispatchError(m.stderr, "gc: order %s: failed to label wisp %s: %v", scoped, rootID, err)
+		logDispatchError(m.stderr, prog()+": order %s: failed to label wisp %s: %v", scoped, rootID, err)
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
 			Actor:   "controller",

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -81,7 +81,7 @@ type memoryOrderDispatcher struct {
 // Scans both city-level and per-rig orders. Rig orders get their Rig
 // field stamped so they use independent scoped labels.
 func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer) orderDispatcher {
-	allAA, err := scanAllOrders(cityPath, cfg, stderr, "gc start: order scan")
+	allAA, err := scanAllOrders(cityPath, cfg, stderr, cmdName("start: order scan"))
 	if err != nil {
 		logDispatchError(stderr, "gc start: order scan: %v", err)
 		return nil

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -443,7 +443,7 @@ func cachedOrderHistoryStoresResolver(cityPath string, cfg *config.City, stderr 
 		if legacyOrderCityFallbackNeeded(cityPath, target) {
 			legacy, err := openCached(legacyOrderCityTarget(cityPath, cfg))
 			if err != nil {
-				fmt.Fprintf(stderr, "gc order history: legacy city fallback unavailable for %s: %v\n", a.ScopedName(), err) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: legacy city fallback unavailable for %s: %v\n", cmdName("order history"), a.ScopedName(), err) //nolint:errcheck
 				return out, nil
 			}
 			out = append(out, legacy)

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -32,7 +32,7 @@ func openCityOrderStore(stderr io.Writer, cmdName string) (beads.Store, int) {
 	store, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", prog()+" doctor") //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return store, 0
@@ -47,7 +47,7 @@ func openOrderStoreForOrder(cityPath string, cfg *config.City, a orders.Order, s
 	store, err := openStoreAtForCity(target.ScopeRoot, cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)                   //nolint:errcheck // best-effort stderr
-		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "hint: run %q for diagnostics\n", prog()+" doctor") //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return store, 0

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -463,7 +463,7 @@ func resolvePoolSessionRefs(
 	var refs []poolSessionRef
 	poolSessions, err := lookupPoolSessionNames(store, template)
 	if err != nil && stderr != nil {
-		fmt.Fprintf(stderr, "gc lifecycle: pool bead lookup for %s returned error (legacy discovery also runs): %v\n", template, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: pool bead lookup for %s returned error (legacy discovery also runs): %v\n", cmdName("lifecycle"), template, err) //nolint:errcheck
 	}
 	poolInstances := make([]string, 0, len(poolSessions))
 	for qualifiedInstance := range poolSessions {

--- a/cmd/gc/progname.go
+++ b/cmd/gc/progname.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// binaryName is the build-time default, overridable via ldflags:
+//
+//	-X main.binaryName=city
+var binaryName = "gc"
+
+var progOnce sync.Once
+var progCached string
+
+// prog returns the binary name for use in error messages, help text, and
+// examples. It prefers os.Args[0] at runtime, falling back to the
+// build-time binaryName.
+func prog() string {
+	progOnce.Do(func() {
+		if len(os.Args) > 0 && os.Args[0] != "" {
+			name := filepath.Base(os.Args[0])
+			name = strings.TrimSuffix(name, ".exe")
+			if strings.HasSuffix(name, ".test") {
+				progCached = binaryName
+			} else {
+				progCached = name
+			}
+		} else {
+			progCached = binaryName
+		}
+	})
+	return progCached
+}
+
+// cmdName returns "prog subcmd" for error message prefixes.
+func cmdName(subcmd string) string {
+	if subcmd == "" {
+		return prog()
+	}
+	return prog() + " " + subcmd
+}
+
+// cmdErr writes a formatted error message prefixed with the binary and
+// subcommand name to w: "<prog> <subcmd>: <msg>\n".
+func cmdErr(w io.Writer, subcmd string, err error) {
+	fmt.Fprintf(w, "%s: %v\n", cmdName(subcmd), err) //nolint:errcheck // best-effort stderr
+}

--- a/cmd/gc/progname_test.go
+++ b/cmd/gc/progname_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestProg_ReturnsDefaultInTestContext(t *testing.T) {
+	// In test context, os.Args[0] ends with ".test", so prog() should
+	// fall back to the binaryName default.
+	got := prog()
+	if got != binaryName {
+		t.Errorf("prog() = %q, want %q (binaryName default in test context)", got, binaryName)
+	}
+}
+
+func TestCmdName_WithSubcommand(t *testing.T) {
+	got := cmdName("start")
+	want := prog() + " start"
+	if got != want {
+		t.Errorf("cmdName(%q) = %q, want %q", "start", got, want)
+	}
+}
+
+func TestCmdName_Empty(t *testing.T) {
+	got := cmdName("")
+	want := prog()
+	if got != want {
+		t.Errorf("cmdName(%q) = %q, want %q", "", got, want)
+	}
+}
+
+func TestCmdErr_WritesExpectedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	cmdErr(&buf, "start", errors.New("something broke"))
+	got := buf.String()
+	want := prog() + " start: something broke\n"
+	if got != want {
+		t.Errorf("cmdErr output = %q, want %q", got, want)
+	}
+}
+
+func TestCmdErr_EmptySubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	cmdErr(&buf, "", errors.New("bad input"))
+	got := buf.String()
+	want := prog() + ": bad input\n"
+	if got != want {
+		t.Errorf("cmdErr output = %q, want %q", got, want)
+	}
+}

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -94,14 +94,14 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	// Parse main template last — its body becomes the "prompt" template.
 	tmpl, err = tmpl.Parse(raw)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc: prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, prog()+": prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
 		return raw
 	}
 
 	td := buildTemplateData(ctx)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, td); err != nil {
-		fmt.Fprintf(stderr, "gc: prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, prog()+": prompt template %q: %v\n", templatePath, err) //nolint:errcheck // best-effort stderr
 		return raw
 	}
 
@@ -109,12 +109,12 @@ func renderPrompt(fs fsys.FS, cityPath, cityName, templatePath string, ctx Promp
 	for _, name := range injectFragments {
 		frag := tmpl.Lookup(name)
 		if frag == nil {
-			fmt.Fprintf(stderr, "gc: inject_fragment %q: template not found\n", name) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": inject_fragment %q: template not found\n", name) //nolint:errcheck // best-effort stderr
 			continue
 		}
 		var fbuf bytes.Buffer
 		if err := frag.Execute(&fbuf, td); err != nil {
-			fmt.Fprintf(stderr, "gc: inject_fragment %q: %v\n", name, err) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": inject_fragment %q: %v\n", name, err) //nolint:errcheck // best-effort stderr
 			continue
 		}
 		buf.WriteString("\n\n")
@@ -173,7 +173,7 @@ func loadSharedTemplates(fs fsys.FS, tmpl *template.Template, dir string, stderr
 	for _, name := range sharedTemplateFileNames(entries) {
 		if sdata, err := fs.ReadFile(filepath.Join(dir, name)); err == nil {
 			if _, err := tmpl.Parse(string(sdata)); err != nil {
-				fmt.Fprintf(stderr, "gc: shared template %q: %v\n", name, err) //nolint:errcheck // best-effort stderr
+				fmt.Fprintf(stderr, prog()+": shared template %q: %v\n", name, err) //nolint:errcheck // best-effort stderr
 			}
 		}
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -19,7 +19,7 @@ import (
 )
 
 // sessionBeadLabel is the label for all session beads.
-const sessionBeadLabel = "gc:session"
+var sessionBeadLabel = prog() + ":session"
 
 // sessionBeadType is the bead type for session beads.
 const sessionBeadType = "session"

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1304,7 +1304,7 @@ func stopTargetsBounded(
 						logLifecycleOutcome(stderr, "stop", wave, result.target.name, result.target.template, result.outcome, result.started, result.finished, result.err)
 					}
 					if result.err != nil {
-						fmt.Fprintf(stderr, "gc stop: stopping %s: %s\n", result.target.name, formatLifecycleError(result.err)) //nolint:errcheck
+						fmt.Fprintf(stderr, "%s: stopping %s: %s\n", cmdName("stop"), result.target.name, formatLifecycleError(result.err)) //nolint:errcheck
 						continue
 					}
 					fmt.Fprintf(stdout, "Stopped agent '%s'\n", result.target.name) //nolint:errcheck
@@ -1346,7 +1346,7 @@ func stopTargetsBounded(
 				logLifecycleOutcome(stderr, "stop", wave, result.target.name, result.target.template, result.outcome, result.started, result.finished, result.err)
 			}
 			if result.err != nil {
-				fmt.Fprintf(stderr, "gc stop: stopping %s: %s\n", result.target.name, formatLifecycleError(result.err)) //nolint:errcheck
+				fmt.Fprintf(stderr, "%s: stopping %s: %s\n", cmdName("stop"), result.target.name, formatLifecycleError(result.err)) //nolint:errcheck
 				continue
 			}
 			fmt.Fprintf(stdout, "Stopped agent '%s'\n", result.target.name) //nolint:errcheck

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1122,7 +1122,7 @@ func stopTargetsForNames(names []string, cfg *config.City, store beads.Store, st
 				}
 			}
 		} else if stderr != nil {
-			fmt.Fprintf(stderr, "gc lifecycle: session bead lookup degraded to legacy session-name resolution: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "lifecycle: session bead lookup degraded to legacy session-name resolution", err)
 		}
 	}
 	targets := make([]stopTarget, 0, len(names))

--- a/cmd/gc/session_reconciler_trace_cmd.go
+++ b/cmd/gc/session_reconciler_trace_cmd.go
@@ -226,7 +226,7 @@ func cmdTraceStart(template, forDuration string, auto bool, level string, stdout
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace start: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace start", err)
 		return 1
 	}
 	now := time.Now().UTC()
@@ -254,7 +254,7 @@ func cmdTraceStart(template, forDuration string, auto bool, level string, stdout
 	req.ActorPID = os.Getpid()
 	status, msg, err := applyTraceControlMaybeRemote(cityPath, req)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace start: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace start", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, msg) //nolint:errcheck
@@ -271,7 +271,7 @@ func cmdTraceStop(template string, all bool, stdout, stderr io.Writer) int {
 	}
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace stop: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace stop", err)
 		return 1
 	}
 	req := traceControlRequest{
@@ -294,7 +294,7 @@ func cmdTraceStop(template string, all bool, stdout, stderr io.Writer) int {
 	req.ActorPID = os.Getpid()
 	status, msg, err := applyTraceControlMaybeRemote(cityPath, req)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace stop: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace stop", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, msg) //nolint:errcheck
@@ -307,17 +307,17 @@ func cmdTraceStop(template string, all bool, stdout, stderr io.Writer) int {
 func cmdTraceStatus(stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace status: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace status", err)
 		return 1
 	}
 	status, err := traceStatusMaybeRemote(cityPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace status: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace status", err)
 		return 1
 	}
 	head, err := traceHeadSeq(traceCityRuntimeDir(cityPath))
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace status: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace status", err)
 		return 1
 	}
 	payload := map[string]any{
@@ -327,7 +327,7 @@ func cmdTraceStatus(stdout, stderr io.Writer) int {
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace status: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace status", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, string(data)) //nolint:errcheck
@@ -337,7 +337,7 @@ func cmdTraceStatus(stdout, stderr io.Writer) int {
 func cmdTraceShow(template, since, traceID, tickID, recordType, reason string, jsonOut bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace show: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace show", err)
 		return 1
 	}
 	filter := TraceFilter{
@@ -357,7 +357,7 @@ func cmdTraceShow(template, since, traceID, tickID, recordType, reason string, j
 	}
 	recs, err := ReadTraceRecords(traceCityRuntimeDir(cityPath), filter)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace show: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace show", err)
 		return 1
 	}
 	if !jsonOut {
@@ -368,7 +368,7 @@ func cmdTraceShow(template, since, traceID, tickID, recordType, reason string, j
 	}
 	data, err := json.MarshalIndent(recs, "", "  ")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace show: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace show", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, string(data)) //nolint:errcheck
@@ -378,17 +378,17 @@ func cmdTraceShow(template, since, traceID, tickID, recordType, reason string, j
 func cmdTraceCycle(tickID string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace cycle: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace cycle", err)
 		return 1
 	}
 	recs, err := ReadTraceRecords(traceCityRuntimeDir(cityPath), TraceFilter{TickID: tickID})
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace cycle: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace cycle", err)
 		return 1
 	}
 	data, err := json.MarshalIndent(recs, "", "  ")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace cycle: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace cycle", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, string(data)) //nolint:errcheck
@@ -398,7 +398,7 @@ func cmdTraceCycle(tickID string, stdout, stderr io.Writer) int {
 func cmdTraceReasons(template, since string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace reasons: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace reasons", err)
 		return 1
 	}
 	filter := TraceFilter{Template: normalizedTraceTemplate(template)}
@@ -412,7 +412,7 @@ func cmdTraceReasons(template, since string, stdout, stderr io.Writer) int {
 	}
 	recs, err := ReadTraceRecords(traceCityRuntimeDir(cityPath), filter)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace reasons: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace reasons", err)
 		return 1
 	}
 	reasons := make(map[string]int)
@@ -423,7 +423,7 @@ func cmdTraceReasons(template, since string, stdout, stderr io.Writer) int {
 	}
 	data, err := json.MarshalIndent(reasons, "", "  ")
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace reasons: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace reasons", err)
 		return 1
 	}
 	fmt.Fprintln(stdout, string(data)) //nolint:errcheck
@@ -433,7 +433,7 @@ func cmdTraceReasons(template, since string, stdout, stderr io.Writer) int {
 func cmdTraceTail(template, since string, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace tail: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace tail", err)
 		return 1
 	}
 	filter := TraceFilter{Template: normalizedTraceTemplate(template)}
@@ -447,14 +447,14 @@ func cmdTraceTail(template, since string, stdout, stderr io.Writer) int {
 	}
 	records, err := ReadTraceRecords(traceCityRuntimeDir(cityPath), filter)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace tail: %v\n", err) //nolint:errcheck
+		cmdErr(stderr, "trace tail", err)
 		return 1
 	}
 	records = traceRecentRecords(records, 20)
 	var lastSeq uint64
 	for _, rec := range records {
 		if err := writeTraceTailRecord(stdout, rec); err != nil {
-			fmt.Fprintf(stderr, "gc trace tail: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "trace tail", err)
 			return 1
 		}
 		if rec.Seq > lastSeq {
@@ -472,12 +472,12 @@ func cmdTraceTail(template, since string, stdout, stderr io.Writer) int {
 		filter.SeqAfter = lastSeq
 		next, err := ReadTraceRecords(traceCityRuntimeDir(cityPath), filter)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc trace tail: %v\n", err) //nolint:errcheck
+			cmdErr(stderr, "trace tail", err)
 			return 1
 		}
 		for _, rec := range next {
 			if err := writeTraceTailRecord(stdout, rec); err != nil {
-				fmt.Fprintf(stderr, "gc trace tail: %v\n", err) //nolint:errcheck
+				cmdErr(stderr, "trace tail", err)
 				return 1
 			}
 			if rec.Seq > lastSeq {

--- a/cmd/gc/session_reconciler_trace_cmd.go
+++ b/cmd/gc/session_reconciler_trace_cmd.go
@@ -60,7 +60,7 @@ and can be managed even when the controller is offline.`,
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			fmt.Fprintf(stderr, "gc trace: unknown subcommand %q\n", args[0]) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: unknown subcommand %q\n", cmdName("trace"), args[0]) //nolint:errcheck
 			return errExit
 		},
 	}
@@ -212,16 +212,16 @@ func newTraceTailCmd(stdout, stderr io.Writer) *cobra.Command {
 
 func cmdTraceStart(template, forDuration string, auto bool, level string, stdout, stderr io.Writer) int {
 	if strings.TrimSpace(template) == "" {
-		fmt.Fprintln(stderr, "gc trace start: missing --template") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: missing --template\n", cmdName("trace start")) //nolint:errcheck
 		return 1
 	}
 	dur, err := time.ParseDuration(forDuration)
 	if err != nil {
-		fmt.Fprintf(stderr, "gc trace start: invalid --for %q: %v\n", forDuration, err) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: invalid --for %q: %v\n", cmdName("trace start"), forDuration, err) //nolint:errcheck
 		return 1
 	}
 	if dur <= 0 {
-		fmt.Fprintf(stderr, "gc trace start: invalid duration %q\n", forDuration) //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: invalid duration %q\n", cmdName("trace start"), forDuration) //nolint:errcheck
 		return 1
 	}
 	cityPath, err := resolveCity()
@@ -266,7 +266,7 @@ func cmdTraceStart(template, forDuration string, auto bool, level string, stdout
 
 func cmdTraceStop(template string, all bool, stdout, stderr io.Writer) int {
 	if strings.TrimSpace(template) == "" {
-		fmt.Fprintln(stderr, "gc trace stop: missing --template") //nolint:errcheck
+		fmt.Fprintf(stderr, "%s: missing --template\n", cmdName("trace stop")) //nolint:errcheck
 		return 1
 	}
 	cityPath, err := resolveCity()
@@ -350,7 +350,7 @@ func cmdTraceShow(template, since, traceID, tickID, recordType, reason string, j
 	if since != "" {
 		d, err := time.ParseDuration(since)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc trace show: invalid --since %q: %v\n", since, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: invalid --since %q: %v\n", cmdName("trace show"), since, err) //nolint:errcheck
 			return 1
 		}
 		filter.Since = time.Now().Add(-d)
@@ -405,7 +405,7 @@ func cmdTraceReasons(template, since string, stdout, stderr io.Writer) int {
 	if since != "" {
 		d, err := time.ParseDuration(since)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc trace reasons: invalid --since %q: %v\n", since, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: invalid --since %q: %v\n", cmdName("trace reasons"), since, err) //nolint:errcheck
 			return 1
 		}
 		filter.Since = time.Now().Add(-d)
@@ -440,7 +440,7 @@ func cmdTraceTail(template, since string, stdout, stderr io.Writer) int {
 	if since != "" {
 		d, err := time.ParseDuration(since)
 		if err != nil {
-			fmt.Fprintf(stderr, "gc trace tail: invalid --since %q: %v\n", since, err) //nolint:errcheck
+			fmt.Fprintf(stderr, "%s: invalid --since %q: %v\n", cmdName("trace tail"), since, err) //nolint:errcheck
 			return 1
 		}
 		filter.Since = time.Now().Add(-d)

--- a/cmd/gc/skill_supervisor.go
+++ b/cmd/gc/skill_supervisor.go
@@ -46,9 +46,9 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 		if result.Err != nil {
 			if stderr != nil {
 				if rigName == "" {
-					fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load shared skill catalog for city scope: %v\n", result.Err) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, prog()+": stage-1 materialize-skills: load shared skill catalog for city scope: %v\n", result.Err) //nolint:errcheck // best-effort stderr
 				} else {
-					fmt.Fprintf(stderr, "gc: stage-1 materialize-skills: load shared skill catalog for rig %q: %v\n", rigName, result.Err) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, prog()+": stage-1 materialize-skills: load shared skill catalog for rig %q: %v\n", rigName, result.Err) //nolint:errcheck // best-effort stderr
 				}
 			}
 			if result.Mode == sharedCatalogLoadDirect {
@@ -75,7 +75,7 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 
 		agentCat, lerr := materialize.LoadAgentCatalog(agent.SkillsDir)
 		if lerr != nil {
-			fmt.Fprintf(stderr, "gc: stage-1 materialize-skills for agent %q: LoadAgentCatalog %q: %v\n", //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": stage-1 materialize-skills for agent %q: LoadAgentCatalog %q: %v\n", //nolint:errcheck // best-effort stderr
 				agent.QualifiedName(), agent.SkillsDir, lerr)
 			// Continue with empty agent catalog rather than skipping the
 			// whole materialization — the shared catalog still delivers.
@@ -113,16 +113,16 @@ func runStage1SkillMaterialization(cityPath string, cfg *config.City, stderr io.
 			LegacyNames: materialize.LegacyStubNames(),
 		})
 		if merr != nil {
-			fmt.Fprintf(stderr, "gc: stage-1 materialize-skills for agent %q at %s: %v\n", //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": stage-1 materialize-skills for agent %q at %s: %v\n", //nolint:errcheck // best-effort stderr
 				agent.QualifiedName(), sinkDir, merr)
 			continue
 		}
 		for _, s := range res.Skipped {
-			fmt.Fprintf(stderr, "gc: agent %q skipped skill %q at %s — %s\n", //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": agent %q skipped skill %q at %s — %s\n", //nolint:errcheck // best-effort stderr
 				agent.QualifiedName(), s.Name, s.Path, s.Reason)
 		}
 		for _, w := range res.Warnings {
-			fmt.Fprintf(stderr, "gc: agent %q stage-1 materialize warning: %s\n", //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, prog()+": agent %q stage-1 materialize warning: %s\n", //nolint:errcheck // best-effort stderr
 				agent.QualifiedName(), w)
 		}
 	}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -205,7 +205,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 	if sessionBeadID == "" && p.beadStore != nil {
-		if all, err := p.beadStore.List(beads.ListQuery{Label: "gc:session"}); err == nil {
+		if all, err := p.beadStore.List(beads.ListQuery{Label: sessionBeadLabel}); err == nil {
 			for _, b := range all {
 				if !session.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
 					continue

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/worker"
@@ -323,13 +324,13 @@ func (s *Server) handleSessionClose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := withdrawQueuedWaitNudges(store, s.state.CityPath(), nudgeIDs); err != nil {
-		log.Printf("gc api: withdrawing queued wait nudges after close %s: %v", id, err)
+		log.Printf("%s api: withdrawing queued wait nudges after close %s: %v", progname.Get(), id, err)
 	}
 
 	// Optional: permanently delete the bead after closing.
 	if r.URL.Query().Get("delete") == "true" {
 		if err := store.Delete(id); err != nil {
-			log.Printf("gc api: deleting bead after close %s: %v", id, err)
+			log.Printf("%s api: deleting bead after close %s: %v", progname.Get(), id, err)
 			writeError(w, http.StatusInternalServerError, "internal", "closed but delete failed: "+err.Error())
 			return
 		}
@@ -372,7 +373,7 @@ func (s *Server) handleSessionWake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := withdrawQueuedWaitNudges(store, s.state.CityPath(), nudgeIDs); err != nil {
-		log.Printf("gc api: withdrawing queued wait nudges after wake %s: %v", id, err)
+		log.Printf("%s api: withdrawing queued wait nudges after wake %s: %v", progname.Get(), id, err)
 	}
 	// Clear in-memory crash tracker so the reconciler doesn't immediately
 	// re-quarantine the session based on stale crash history.

--- a/internal/api/handler_sling.go
+++ b/internal/api/handler_sling.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/sling"
 	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
@@ -157,7 +158,7 @@ func (s *Server) execSling(ctx context.Context, body slingBody, _ string) (*slin
 		}
 		var lookupErr *sling.BeadLookupError
 		if errors.As(err, &lookupErr) {
-			fmt.Fprintf(apiSlingStderr(), "gc api sling: %v\n", lookupErr) //nolint:errcheck
+			fmt.Fprintf(apiSlingStderr(), "%s api sling: %v\n", progname.Get(), lookupErr) //nolint:errcheck
 			return nil, http.StatusInternalServerError, "internal", "sling bead lookup failed", nil
 		}
 		var missingBeadErr *sling.MissingBeadError
@@ -215,7 +216,7 @@ func slingStoreBeadID(body slingBody) string {
 // source workflow. Surfaced in the conflict response body so users can fix
 // the state without grepping docs.
 func sourceWorkflowCleanupHint(sourceBeadID, storeRef string) string {
-	args := []string{"gc workflow delete-source", sourceBeadID}
+	args := []string{progname.Get() + " workflow delete-source", sourceBeadID}
 	if storeRef = strings.TrimSpace(storeRef); storeRef != "" {
 		args = append(args, "--store-ref", storeRef)
 	}

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/progname"
 )
 
 // convoyProgress is the shared {total, closed} progress shape used by
@@ -234,7 +235,7 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &pid}); err != nil {
 			rollbackConvoyMembership(store, applied, prevParent, "convoy.create")
 			if delErr := store.Delete(convoy.ID); delErr != nil {
-				log.Printf("gc api: convoy create rollback: delete %s after link failure: %v", convoy.ID, delErr)
+				log.Printf("%s api: convoy create rollback: delete %s after link failure: %v", progname.Get(), convoy.ID, delErr)
 			}
 			return nil, huma.Error500InternalServerError("failed to link item " + itemID + ": " + err.Error())
 		}
@@ -353,7 +354,7 @@ func rollbackConvoyMembership(store beads.Store, applied []string, prevParent ma
 		itemID := applied[i]
 		prev := prevParent[itemID]
 		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &prev}); err != nil {
-			log.Printf("gc api: %s rollback failed for item %s (→ %q): %v", op, itemID, prev, err)
+			log.Printf("%s api: %s rollback failed for item %s (→ %q): %v", progname.Get(), op, itemID, prev, err)
 		}
 	}
 }

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -14,6 +14,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sessionlog"
@@ -614,13 +615,13 @@ func (s *Server) humaHandleSessionClose(_ context.Context, input *SessionCloseIn
 		return nil, humaSessionManagerError(err)
 	}
 	if err := withdrawQueuedWaitNudges(store, s.state.CityPath(), nudgeIDs); err != nil {
-		log.Printf("gc api: withdrawing queued wait nudges after close %s: %v", id, err)
+		log.Printf("%s api: withdrawing queued wait nudges after close %s: %v", progname.Get(), id, err)
 	}
 
 	// Optional: permanently delete the bead after closing.
 	if input.Delete {
 		if err := store.Delete(id); err != nil {
-			log.Printf("gc api: deleting bead after close %s: %v", id, err)
+			log.Printf("%s api: deleting bead after close %s: %v", progname.Get(), id, err)
 			return nil, huma.Error500InternalServerError("closed but delete failed: " + err.Error())
 		}
 	}
@@ -662,7 +663,7 @@ func (s *Server) humaHandleSessionWake(ctx context.Context, input *SessionIDInpu
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 	if err := withdrawQueuedWaitNudges(store, s.state.CityPath(), nudgeIDs); err != nil {
-		log.Printf("gc api: withdrawing queued wait nudges after wake %s: %v", id, err)
+		log.Printf("%s api: withdrawing queued wait nudges after wake %s: %v", progname.Get(), id, err)
 	}
 	sessionName := b.Metadata["session_name"]
 	if sessionName != "" {

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/sessionlog"
 	"github.com/gastownhall/gascity/internal/worker"
@@ -310,7 +311,7 @@ func (s *Server) humaHandleSessionAgentList(_ context.Context, input *SessionIDI
 
 	mappings, err := sessionlog.FindAgentMappings(logPath)
 	if err != nil {
-		log.Printf("gc api: session %s agent mapping failed for %s: %v", id, logPath, err)
+		log.Printf("%s api: session %s agent mapping failed for %s: %v", progname.Get(), id, logPath, err)
 		return nil, huma.Error500InternalServerError("failed to list agents")
 	}
 	if mappings == nil {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/progname"
 )
 
 const implicitImportSchema = 1
@@ -103,7 +104,8 @@ func EnsureBootstrapForCity(gcHome string, userImports map[string]config.Import)
 			quoted[i] = fmt.Sprintf("%q", name)
 		}
 		return fmt.Errorf(
-			"gc init: cannot add implicit import(s) %s - conflicts with city's [imports.<name>] of the same name; rename one side",
+			"%s init: cannot add implicit import(s) %s - conflicts with city's [imports.<name>] of the same name; rename one side",
+			progname.Get(),
 			strings.Join(quoted, ", "),
 		)
 	}

--- a/internal/config/pack_include.go
+++ b/internal/config/pack_include.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/progname"
 )
 
 var runRepoCacheGit = defaultRunRepoCacheGit
@@ -215,7 +216,7 @@ func resolveLockedRemoteImport(source, cityRoot string) (string, bool, error) {
 	if err := WithRepoCacheReadLock(cacheRoot, func() error {
 		if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("remote import %s is locked but not cached at %s; run \"gc import install\"", source, cacheDir)
+				return fmt.Errorf("remote import %s is locked but not cached at %s; run %q", source, cacheDir, progname.Get()+" import install")
 			}
 			return fmt.Errorf("checking cached import %s: %w", source, err)
 		}
@@ -234,7 +235,7 @@ func resolveInstalledRemoteImport(source, cityRoot string) (string, error) {
 	data, err := os.ReadFile(lockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("remote import %s is not installed (missing packs.lock); run \"gc import install\"", source)
+			return "", fmt.Errorf("remote import %s is not installed (missing packs.lock); run %q", source, progname.Get()+" import install")
 		}
 		return "", fmt.Errorf("reading packs.lock: %w", err)
 	}
@@ -245,7 +246,7 @@ func resolveInstalledRemoteImport(source, cityRoot string) (string, error) {
 	}
 	entry, ok := lock.Packs[source]
 	if !ok || entry.Commit == "" {
-		return "", fmt.Errorf("remote import %s is not installed (missing packs.lock entry); run \"gc import install\"", source)
+		return "", fmt.Errorf("remote import %s is not installed (missing packs.lock entry); run %q", source, progname.Get()+" import install")
 	}
 
 	home, err := os.UserHomeDir()
@@ -258,7 +259,7 @@ func resolveInstalledRemoteImport(source, cityRoot string) (string, error) {
 	if err := WithRepoCacheReadLock(cacheRoot, func() error {
 		if _, err := os.Stat(filepath.Join(cacheDir, ".git")); err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("remote import %s is locked but not cached at %s; run \"gc import install\"", source, cacheDir)
+				return fmt.Errorf("remote import %s is locked but not cached at %s; run %q", source, cacheDir, progname.Get()+" import install")
 			}
 			return fmt.Errorf("checking cached import %s: %w", source, err)
 		}
@@ -278,14 +279,14 @@ func validateLockedRemoteCache(source, cacheDir, commit string) error {
 		return fmt.Errorf("reading cached import %s HEAD: %w", source, err)
 	}
 	if !sameRepoCacheCommit(head, commit) {
-		return fmt.Errorf("cached import %s is checked out at %s, expected %s; run \"gc import install\"", source, strings.TrimSpace(head), commit)
+		return fmt.Errorf("cached import %s is checked out at %s, expected %s; run %q", source, strings.TrimSpace(head), commit, progname.Get()+" import install")
 	}
 	status, err := runRepoCacheGit(cacheDir, "status", "--porcelain", "--ignored")
 	if err != nil {
 		return fmt.Errorf("checking cached import %s worktree status: %w", source, err)
 	}
 	if strings.TrimSpace(status) != "" {
-		return fmt.Errorf("cached import %s has local worktree changes; run \"gc import install\"", source)
+		return fmt.Errorf("cached import %s has local worktree changes; run %q", source, progname.Get()+" import install")
 	}
 	return nil
 }

--- a/internal/doctor/autofix_skills.go
+++ b/internal/doctor/autofix_skills.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/gastownhall/gascity/internal/progname"
 )
 
 // DeprecatedAttachmentFieldsCheck scans user-editable city TOML files
@@ -73,7 +75,7 @@ func (c *DeprecatedAttachmentFieldsCheck) Run(ctx *CheckContext) *CheckResult {
 		"found deprecated attachment-list field(s) in %d file(s) (%d line range(s))",
 		len(hits), totalLines,
 	)
-	r.FixHint = `run "gc doctor --fix" to strip the deprecated fields`
+	r.FixHint = fmt.Sprintf("run %q to strip the deprecated fields", progname.Get()+" doctor --fix")
 	return r
 }
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gastownhall/gascity/internal/doltversion"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/pidutil"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
@@ -473,7 +474,7 @@ func (c *AgentSessionsCheck) Run(_ *CheckContext) *CheckResult {
 	r.Status = StatusWarning
 	r.Message = fmt.Sprintf("%d agent(s) without sessions", len(missing))
 	r.Details = missing
-	r.FixHint = "run gc start to reconcile sessions"
+	r.FixHint = "run " + progname.Get() + " start to reconcile sessions"
 	return r
 }
 
@@ -1210,7 +1211,7 @@ func resolveDoltServerFixHint(fs fsys.FS, cityPath string) string {
 func doltServerFixHint(target contract.DoltConnectionTarget) string {
 	switch target.EndpointOrigin {
 	case contract.EndpointOriginManagedCity:
-		return "run gc start to start the dolt server"
+		return "run " + progname.Get() + " start to start the dolt server"
 	case contract.EndpointOriginCityCanonical, contract.EndpointOriginExplicit, contract.EndpointOriginInheritedCity:
 		return "reconcile the canonical external Dolt endpoint"
 	default:
@@ -1532,7 +1533,7 @@ func (c *WorktreeCheck) Run(ctx *CheckContext) *CheckResult {
 	r.Status = StatusError
 	r.Message = fmt.Sprintf("%d broken worktree(s)", len(c.broken))
 	r.Details = c.broken
-	r.FixHint = "run gc doctor --fix to remove broken worktrees"
+	r.FixHint = "run " + progname.Get() + " doctor --fix to remove broken worktrees"
 	return r
 }
 
@@ -2488,17 +2489,17 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 		if os.IsNotExist(err) {
 			if !managedDoltRuntimeMaterialized(c.cityPath) {
 				r.Status = StatusOK
-				r.Message = "managed dolt-config.yaml not yet generated (run gc start to materialize)"
+				r.Message = "managed dolt-config.yaml not yet generated (run " + progname.Get() + " start to materialize)"
 				return r
 			}
 			r.Status = StatusWarning
 			r.Message = "managed dolt-config.yaml not found"
-			r.FixHint = "run gc start (or gc dolt restart) to regenerate"
+			r.FixHint = "run " + progname.Get() + " start (or " + progname.Get() + " dolt restart) to regenerate"
 			return r
 		}
 		r.Status = StatusWarning
 		r.Message = fmt.Sprintf("read dolt-config.yaml: %v", err)
-		r.FixHint = "run gc start (or gc dolt restart) to regenerate"
+		r.FixHint = "run " + progname.Get() + " start (or " + progname.Get() + " dolt restart) to regenerate"
 		return r
 	}
 
@@ -2506,7 +2507,7 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		r.Status = StatusWarning
 		r.Message = fmt.Sprintf("parse dolt-config.yaml: %v", err)
-		r.FixHint = "stop dolt (gc dolt stop) and restart to regenerate managed config"
+		r.FixHint = "stop dolt (" + progname.Get() + " dolt stop) and restart to regenerate managed config"
 		return r
 	}
 
@@ -2545,7 +2546,7 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 	if len(drifted) > 0 {
 		r.Status = StatusWarning
 		r.Message = fmt.Sprintf("managed dolt-config.yaml drift: %s", strings.Join(drifted, ", "))
-		r.FixHint = "stop dolt (gc dolt stop) and restart to regenerate managed config"
+		r.FixHint = "stop dolt (" + progname.Get() + " dolt stop) and restart to regenerate managed config"
 		return r
 	}
 

--- a/internal/doctor/implicit_import_cache_check.go
+++ b/internal/doctor/implicit_import_cache_check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/bootstrap"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/progname"
 )
 
 // ImplicitImportCacheCheck verifies that bootstrap-managed implicit imports
@@ -67,13 +68,13 @@ func (c *ImplicitImportCacheCheck) Run(_ *CheckContext) *CheckResult {
 	if errors > 0 {
 		r.Status = StatusError
 		r.Message = fmt.Sprintf("%d bootstrap implicit import cache issue(s)", len(issues))
-		r.FixHint = `run "gc doctor --fix" to backfill bootstrap implicit import caches`
+		r.FixHint = fmt.Sprintf("run %q to backfill bootstrap implicit import caches", progname.Get()+" doctor --fix")
 		return r
 	}
 
 	r.Status = StatusWarning
 	r.Message = fmt.Sprintf("%d stale bootstrap implicit cache %s", len(issues), pluralEntry(len(issues)))
-	r.FixHint = `run "gc doctor --fix" to prune stale legacy bootstrap implicit caches`
+	r.FixHint = fmt.Sprintf("run %q to prune stale legacy bootstrap implicit caches", progname.Get()+" doctor --fix")
 	return r
 }
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -377,6 +377,18 @@ func mergeComposeRules(base, overlay *ComposeRules) *ComposeRules {
 // varPattern matches {{variable}} placeholders.
 var varPattern = regexp.MustCompile(`\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}`)
 
+// builtInVars holds variables registered at startup (e.g. "binary") that are
+// available in all formula substitutions without explicit --var flags.
+var builtInVars map[string]string
+
+// RegisterBuiltInVars sets the package-level built-in variables.
+// Substitute falls back to these when the caller-supplied map doesn't match.
+// CheckResidualVars skips names present here.
+// Pass nil to clear (useful in test cleanup).
+func RegisterBuiltInVars(vars map[string]string) {
+	builtInVars = vars
+}
+
 // ExtractVariables finds all {{variable}} references in a formula.
 func ExtractVariables(formula *Formula) []string {
 	seen := make(map[string]bool)
@@ -419,12 +431,18 @@ func ExtractVariables(formula *Formula) []string {
 }
 
 // Substitute replaces {{variable}} placeholders with values.
+// Caller-supplied vars take priority; built-in vars (registered via
+// RegisterBuiltInVars) are used as a fallback.
 func Substitute(s string, vars map[string]string) string {
 	return varPattern.ReplaceAllStringFunc(s, func(match string) string {
-		// Extract variable name from {{name}}
 		name := match[2 : len(match)-2]
 		if val, ok := vars[name]; ok {
 			return val
+		}
+		if builtInVars != nil {
+			if val, ok := builtInVars[name]; ok {
+				return val
+			}
 		}
 		return match // Keep unresolved placeholders
 	})
@@ -432,7 +450,8 @@ func Substitute(s string, vars map[string]string) string {
 
 // CheckResidualVars returns the names of any {{...}} placeholders remaining
 // in s after substitution. A non-empty return indicates a var name typo or
-// a missing or misspelled --var flag.
+// a missing or misspelled --var flag. Names present in builtInVars are
+// skipped since they will be resolved by Substitute.
 func CheckResidualVars(s string) []string {
 	matches := varPattern.FindAllStringSubmatch(s, -1)
 	if len(matches) == 0 {
@@ -441,11 +460,20 @@ func CheckResidualVars(s string) []string {
 	seen := make(map[string]bool, len(matches))
 	names := make([]string, 0, len(matches))
 	for _, m := range matches {
-		if seen[m[1]] {
+		name := m[1]
+		if seen[name] {
 			continue
 		}
-		seen[m[1]] = true
-		names = append(names, m[1])
+		seen[name] = true
+		if builtInVars != nil {
+			if _, ok := builtInVars[name]; ok {
+				continue
+			}
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
 	}
 	return names
 }

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -2855,3 +2855,109 @@ title = "Test"
 		}
 	}
 }
+
+func TestSubstitute_BuiltInVars(t *testing.T) {
+	// Register built-in vars for this test.
+	RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { RegisterBuiltInVars(nil) })
+
+	tests := []struct {
+		name  string
+		input string
+		vars  map[string]string
+		want  string
+	}{
+		{
+			name:  "built-in resolves when caller map empty",
+			input: "Run {{binary}} start",
+			vars:  map[string]string{},
+			want:  "Run gc start",
+		},
+		{
+			name:  "built-in resolves when caller map nil",
+			input: "Run {{binary}} start",
+			vars:  nil,
+			want:  "Run gc start",
+		},
+		{
+			name:  "caller-supplied takes priority over built-in",
+			input: "Run {{binary}} start",
+			vars:  map[string]string{"binary": "city"},
+			want:  "Run city start",
+		},
+		{
+			name:  "built-in mixed with caller vars",
+			input: "{{binary}} cook {{recipe}}",
+			vars:  map[string]string{"recipe": "deploy"},
+			want:  "gc cook deploy",
+		},
+		{
+			name:  "unknown var still unresolved",
+			input: "{{binary}} {{unknown}}",
+			vars:  map[string]string{},
+			want:  "gc {{unknown}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Substitute(tt.input, tt.vars)
+			if got != tt.want {
+				t.Errorf("Substitute(%q, %v) = %q, want %q", tt.input, tt.vars, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckResidualVars_SkipsBuiltIns(t *testing.T) {
+	RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { RegisterBuiltInVars(nil) })
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "only built-in placeholder",
+			input: "Run {{binary}} start",
+			want:  nil,
+		},
+		{
+			name:  "built-in plus unknown",
+			input: "{{binary}} {{feature}}",
+			want:  []string{"feature"},
+		},
+		{
+			name:  "no placeholders",
+			input: "plain text",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckResidualVars(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("CheckResidualVars(%q) = %v, want %v", tt.input, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("CheckResidualVars(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuiltInVars_NilByDefault(t *testing.T) {
+	// Ensure no built-in vars leak between tests.
+	// With nil builtInVars, Substitute should behave as before.
+	RegisterBuiltInVars(nil)
+
+	got := Substitute("{{binary}} start", nil)
+	if got != "{{binary}} start" {
+		t.Errorf("with nil builtInVars, Substitute should leave {{binary}} unresolved, got %q", got)
+	}
+}

--- a/internal/packman/check.go
+++ b/internal/packman/check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/progname"
 )
 
 // CheckSeverity classifies an import state validation issue.
@@ -76,7 +77,7 @@ func CheckInstalled(cityRoot string, imports map[string]config.Import) (*CheckRe
 			Code:       "missing-lockfile",
 			Path:       filepath.Join(cityRoot, LockfileName),
 			Message:    fmt.Sprintf("%s is missing for declared remote imports", LockfileName),
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return report, nil
 	}
@@ -153,7 +154,7 @@ func (s *importCheckState) walkImport(name string, imp config.Import) {
 			ImportName: name,
 			Source:     imp.Source,
 			Message:    "declared remote import is not present in packs.lock",
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return
 	}
@@ -164,7 +165,7 @@ func (s *importCheckState) walkImport(name string, imp config.Import) {
 			ImportName: name,
 			Source:     imp.Source,
 			Message:    "packs.lock entry is missing a commit",
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return
 	}
@@ -176,7 +177,7 @@ func (s *importCheckState) walkImport(name string, imp config.Import) {
 			Source:     imp.Source,
 			Commit:     locked.Commit,
 			Message:    fmt.Sprintf("packs.lock entry version %q does not satisfy constraint %q", locked.Version, mergedConstraint),
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return
 	}
@@ -195,7 +196,7 @@ func (s *importCheckState) walkImport(name string, imp config.Import) {
 			Commit:     locked.Commit,
 			Path:       filepath.Join(packDir, "pack.toml"),
 			Message:    err.Error(),
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return
 	}
@@ -221,7 +222,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 			Source:     source,
 			Commit:     commit,
 			Message:    err.Error(),
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return "", false
 	}
@@ -237,7 +238,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       cachePath,
 				Message:    "locked import is missing from the local repo cache",
-				RepairHint: `run "gc import install"`,
+				RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 			})
 			return "", false
 		}
@@ -249,7 +250,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 			Commit:     commit,
 			Path:       gitPath,
 			Message:    fmt.Sprintf("cannot inspect cached repository: %v", err),
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return "", false
 	} else if st.IsDir() || st.Mode().IsRegular() {
@@ -263,7 +264,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       cachePath,
 				Message:    fmt.Sprintf("cannot read cached repository HEAD: %v", err),
-				RepairHint: `run "gc import install"`,
+				RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 			})
 			return "", false
 		}
@@ -276,7 +277,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       cachePath,
 				Message:    fmt.Sprintf("cached repository is checked out at %s, expected %s", strings.TrimSpace(head), commit),
-				RepairHint: `run "gc import install"`,
+				RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 			})
 			return "", false
 		}
@@ -290,7 +291,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       cachePath,
 				Message:    fmt.Sprintf("cannot read cached repository status: %v", err),
-				RepairHint: `run "gc import install"`,
+				RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 			})
 			return "", false
 		}
@@ -303,7 +304,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       cachePath,
 				Message:    "cached repository has local worktree changes",
-				RepairHint: `run "gc import install"`,
+				RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 			})
 			return "", false
 		}
@@ -316,7 +317,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 			Commit:     commit,
 			Path:       gitPath,
 			Message:    "cached repository .git entry is not a file or directory",
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return "", false
 	}
@@ -332,7 +333,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 				Commit:     commit,
 				Path:       filepath.Join(packDir, "pack.toml"),
 				Message:    "cached import is missing pack.toml",
-				RepairHint: `run "gc import install"`,
+				RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 			})
 			return "", false
 		}
@@ -344,7 +345,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 			Commit:     commit,
 			Path:       filepath.Join(packDir, "pack.toml"),
 			Message:    fmt.Sprintf("cannot inspect cached pack.toml: %v", err),
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return "", false
 	} else if st.IsDir() {
@@ -356,7 +357,7 @@ func (s *importCheckState) validateCachedPack(name, source, commit string) (stri
 			Commit:     commit,
 			Path:       filepath.Join(packDir, "pack.toml"),
 			Message:    "cached pack.toml is a directory",
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 		return "", false
 	}
@@ -382,7 +383,7 @@ func (s *importCheckState) reportStaleLockEntries() {
 			Source:     source,
 			Commit:     pack.Commit,
 			Message:    "packs.lock contains a source that is not reachable from declared imports",
-			RepairHint: `run "gc import install"`,
+			RepairHint: fmt.Sprintf("run %q", progname.Get()+" import install"),
 		})
 	}
 }

--- a/internal/progname/progname.go
+++ b/internal/progname/progname.go
@@ -1,0 +1,12 @@
+// Package progname provides the runtime binary name for use in error messages
+// and user-facing output. The name is set once at startup by cmd/gc via Set()
+// and defaults to "gc".
+package progname
+
+var name = "gc"
+
+// Set sets the binary name. Call once at startup from main().
+func Set(n string) { name = n }
+
+// Get returns the binary name.
+func Get() string { return name }

--- a/internal/progname/progname_test.go
+++ b/internal/progname/progname_test.go
@@ -1,0 +1,36 @@
+package progname
+
+import "testing"
+
+func TestDefaultValue(t *testing.T) {
+	// Reset to default for this test.
+	old := name
+	name = "gc"
+	defer func() { name = old }()
+
+	if got := Get(); got != "gc" {
+		t.Errorf("Get() = %q, want %q", got, "gc")
+	}
+}
+
+func TestSetChangesValue(t *testing.T) {
+	old := name
+	defer func() { name = old }()
+
+	Set("gascity")
+	if got := Get(); got != "gascity" {
+		t.Errorf("after Set(%q), Get() = %q", "gascity", got)
+	}
+}
+
+func TestSetThenGetRoundTrip(t *testing.T) {
+	old := name
+	defer func() { name = old }()
+
+	for _, want := range []string{"gc", "gt", "my-binary", ""} {
+		Set(want)
+		if got := Get(); got != want {
+			t.Errorf("Set(%q); Get() = %q", want, got)
+		}
+	}
+}

--- a/internal/runtime/beacon.go
+++ b/internal/runtime/beacon.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "time"
+import (
+	"time"
+
+	"github.com/gastownhall/gascity/internal/progname"
+)
 
 // FormatBeacon returns a startup identification string that appears in
 // the agent's initial prompt. When an agent crashes and restarts in a
@@ -21,7 +25,7 @@ func FormatBeacon(cityName, agentName string, includePrimeInstruction bool) stri
 func FormatBeaconAt(cityName, agentName string, includePrimeInstruction bool, t time.Time) string {
 	beacon := "[" + cityName + "] " + agentName + " \u2022 " + t.Format("2006-01-02T15:04:05")
 	if includePrimeInstruction {
-		beacon += "\n\nRun `gc prime` to initialize your context."
+		beacon += "\n\nRun `" + progname.Get() + " prime` to initialize your context."
 	}
 	return beacon
 }

--- a/test/acceptance/binary_name_test.go
+++ b/test/acceptance/binary_name_test.go
@@ -1,0 +1,148 @@
+//go:build acceptance_a
+
+// Binary name acceptance tests.
+//
+// These verify the configurable binary name system end-to-end: build-time
+// ldflags, runtime os.Args[0] detection, and symlink-based name override.
+// Each test builds the real binary with a custom -X main.binaryName and
+// asserts that help output, error messages, and subcommand help all reflect
+// the correct name.
+package acceptance_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+// buildBinaryWithName compiles the gc binary into dir with the given
+// binaryName baked in via ldflags. Returns the path to the compiled binary.
+func buildBinaryWithName(t *testing.T, dir, name string) string {
+	t.Helper()
+	binPath := filepath.Join(dir, name)
+	ldflags := "-X main.binaryName=" + name
+	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", binPath, "./cmd/gc")
+	cmd.Dir = helpers.FindModuleRoot()
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building binary %q: %v\n%s", name, err, out)
+	}
+	return binPath
+}
+
+// runBinary executes the binary at binPath with the given args and returns
+// combined stdout+stderr output.
+func runBinary(t *testing.T, binPath string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(binPath, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestBinaryName_BuildTimeDefault_Help(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	out, err := runBinary(t, bin, "--help")
+	if err != nil {
+		t.Fatalf("city --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "city") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "city", out)
+	}
+}
+
+func TestBinaryName_Symlink_OverridesName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	out, err := runBinary(t, symPath, "--help")
+	if err != nil {
+		t.Fatalf("meow --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "meow", out)
+	}
+	if strings.Contains(out, "city") {
+		t.Errorf("expected help output NOT to contain build-time name %q when invoked as symlink, got:\n%s", "city", out)
+	}
+}
+
+func TestBinaryName_ArbitrarySymlink_Works(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "gc")
+
+	symPath := filepath.Join(dir, "wombat")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	out, err := runBinary(t, symPath, "--help")
+	if err != nil {
+		t.Fatalf("wombat --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "wombat") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "wombat", out)
+	}
+}
+
+func TestBinaryName_ErrorMessages_UseCorrectName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	// Run an unknown subcommand to trigger an error message.
+	out, _ := runBinary(t, symPath, "nosuchcommand")
+	// Cobra error format: 'unknown command "nosuchcommand" for "meow"'
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected error output to reference %q, got:\n%s", "meow", out)
+	}
+}
+
+func TestBinaryName_SubcommandHelp_UsesCorrectName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	// Check subcommand help shows the symlink name.
+	out, err := runBinary(t, symPath, "version", "--help")
+	if err != nil {
+		t.Fatalf("meow version --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected subcommand help to contain %q, got:\n%s", "meow", out)
+	}
+}
+
+func TestBinaryName_DirectInvocation_MatchesBuildName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	out, err := runBinary(t, bin, "--help")
+	if err != nil {
+		t.Fatalf("city --help failed: %v\n%s", err, out)
+	}
+	// When invoked directly (not via symlink), the name should be "city"
+	// (derived from os.Args[0] basename which is the binary filename).
+	if !strings.Contains(out, "city") {
+		t.Errorf("expected direct invocation help to contain %q, got:\n%s", "city", out)
+	}
+}


### PR DESCRIPTION
## Summary

Mechanical migration of all hardcoded `"gc"` binary name references in Go source to `prog()`, `cmdName()`, `cmdErr()`, and `progname.Get()`.

Depends on gastownhall/gascity#1329 (foundation infrastructure).

### Migration patterns

| Pattern | Replacement |
|---------|-------------|
| `fmt.Fprintf(w, "gc: ...")` | `cmdErr(w, "", err)` |
| `fmt.Sprintf("gc %s", sub)` | `cmdName(sub)` |
| `"gc " + subcmd` | `cmdName(subcmd)` |
| Cobra `Short:` / `Long:` with `"gc"` | `prog()` interpolation |
| `internal/` error strings with `"gc"` | `progname.Get()` |

### Safety

The ratchet lint test (`TestNoHardcodedGCInErrorMessages`) drops from threshold N to 0 in the final commit, proving completeness.

## Test plan

- [ ] `go build ./cmd/gc/`
- [ ] `go test ./cmd/gc/ -run TestNoHardcoded -v` — threshold 0
- [ ] `go test ./cmd/gc/ -count=1`

---

## PR Series: Configurable Binary Name

This is **PR 2 of 4** in the configurable binary name series.

| PR | Title | Status |
|---|---|---|
| #1329 | Foundation infrastructure | must merge first |
| **#1330** | **Go source migration** | ← you are here |
| #1331 | Templates, scripts, config migration | independent of this PR |
| #1332 | Build/deploy + docs | independent of this PR |

PRs #1330, #1331, #1332 are independent of each other and can land in any order after #1329 merges.

---

## Commit map (this PR)

Full per-commit categorization: #1356

| # | Commit | Layer | Files | Title |
|---|--------|-------|-------|-------|
| 10 | `2a4ab7b` | 3 | 56 | refactor(progname): migrate simple error messages to cmdErr() |
| 11 | `48ca680` | 3 | 56 | refactor(progname): migrate complex error messages to cmdName() |
| 12 | `219531f` | 3 | 22 | refactor(progname): migrate store-open caller strings |
| 13 | `bad0fd5` | 3 | 12 | refactor(progname): migrate logPrefix, assignments, struct fields |
| 14 | `75a0649` | 3 | 26 | refactor(progname): migrate remaining Fprintf, Fprintln |
| 15 | `83dfc5f` | 3 | 5 | refactor(progname): migrate fmt.Errorf and hint messages |
| 16 | `c9b9a82` | 3 | 16 | refactor(progname): migrate Cobra Long descriptions |
| 17 | `cd52331` | 3 | 5 | fix(progname): fix hardcoded "gc" in version Short |
| 18 | `58984f2` | 3 | 1 | refactor(progname): migrate "GC API" references |
| 19 | `c1ee740` | 3 | 7 | refactor(progname): migrate final hardcoded refs + ratchet → 0 |
| 20 | `1f9e081` | 3 | 12 | refactor(progname): migrate internal/ errors to progname.Get() |

**11 commits, ~90 files (heavy overlap), Layer 3 only (mechanical Go source migration)**