### PR TITLE
refactor(progname): migrate templates, scripts, and config to configurable binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
-           -X main.date=$(BUILD_TIME)
+           -X main.date=$(BUILD_TIME) \
+           -X main.binaryName=$(BINARY)
 
 .PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-fsys-darwin-compile test-cmd-gc-process test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
 

--- a/cmd/gc/binary_name_lint_test.go
+++ b/cmd/gc/binary_name_lint_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoHardcodedGCInErrorMessages walks all non-test *.go files in cmd/gc/
+// and finds string literals containing hardcoded "gc " binary name references
+// that should use prog(), cmdName(), or cmdErr() instead.
+//
+// This test acts as a ratchet: the violation count can go DOWN (migration
+// progress) but not UP (no new hardcoded references). Update maxViolations
+// as migration proceeds.
+func TestNoHardcodedGCInErrorMessages(t *testing.T) {
+	// Ratchet threshold — set to current count. Lower this as files are migrated.
+	const maxViolations = 1159
+
+	dir := "."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading cmd/gc directory: %v", err)
+	}
+
+	type violation struct {
+		file string
+		line int
+		text string
+	}
+	var violations []violation
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Skip test files — they legitimately reference "gc " in assertions.
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("reading %s: %v", name, err)
+			continue
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for i, line := range lines {
+			lineNo := i + 1
+			trimmed := strings.TrimSpace(line)
+
+			// Skip comments.
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+
+			// Check for hardcoded binary name patterns.
+			if !containsHardcodedGC(line) {
+				continue
+			}
+
+			// Allowlist: patterns that are NOT the binary name.
+			if isAllowlisted(line, name, lineNo) {
+				continue
+			}
+
+			violations = append(violations, violation{
+				file: name,
+				line: lineNo,
+				text: trimmed,
+			})
+		}
+	}
+
+	count := len(violations)
+	t.Logf("found %d hardcoded binary name references (threshold: %d)", count, maxViolations)
+
+	if count > maxViolations {
+		// Print first 20 violations for context.
+		limit := 20
+		if count < limit {
+			limit = count
+		}
+		for _, v := range violations[:limit] {
+			t.Logf("  %s:%d: %s", v.file, v.line, v.text)
+		}
+		if count > limit {
+			t.Logf("  ... and %d more", count-limit)
+		}
+		t.Fatalf("found %d hardcoded binary name references (max allowed: %d); use prog(), cmdName(), or cmdErr() instead", count, maxViolations)
+	}
+
+	if count > 0 {
+		t.Logf("migration progress: %d/%d remaining (%.0f%% done)",
+			count, maxViolations, 100*(1-float64(count)/float64(maxViolations)))
+	}
+}
+
+// containsHardcodedGC checks whether a line contains patterns indicating
+// a hardcoded "gc" binary name reference.
+func containsHardcodedGC(line string) bool {
+	// "gc " — gc followed by space (command reference in strings)
+	if strings.Contains(line, `"gc `) {
+		return true
+	}
+	// Strings starting with "gc: (error prefix)
+	if strings.Contains(line, `"gc:`) {
+		return true
+	}
+	return false
+}
+
+// isAllowlisted returns true if the line matches a known-safe pattern
+// that is NOT a hardcoded binary name.
+func isAllowlisted(line, filename string, lineNo int) bool {
+	// .gc/ runtime directory references
+	if strings.Contains(line, `".gc`) {
+		return true
+	}
+	// gc- bead ID prefixes
+	if strings.Contains(line, `"gc-`) {
+		return true
+	}
+	// GC_ environment variable prefix
+	if strings.Contains(line, `"GC_`) {
+		return true
+	}
+	// Import paths and module names
+	if strings.Contains(line, `"gascity`) || strings.Contains(line, `"gastownhall`) {
+		return true
+	}
+	if strings.Contains(line, `gascity`) || strings.Contains(line, `gastownhall`) {
+		return true
+	}
+	// The binaryName default in progname.go itself
+	if filename == "progname.go" && strings.Contains(line, `binaryName`) {
+		return true
+	}
+	// gc.test — test binary detection
+	if strings.Contains(line, `"gc.test`) {
+		return true
+	}
+	return false
+}

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/examples/gastown/packs/maintenance"
 	"github.com/gastownhall/gascity/internal/bootstrap/packs/core"
 	"github.com/gastownhall/gascity/internal/citylayout"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
@@ -152,6 +153,12 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		data, err := fs.ReadFile(embedded, path)
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", path, err)
+		}
+
+		// Resolve {{binary}} and other built-in vars in SKILL.md files so
+		// materialized skills reference the actual binary name.
+		if filepath.Base(path) == "SKILL.md" {
+			data = []byte(formula.Substitute(string(data), nil))
 		}
 
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/formula"
 )
 
 func TestMaterializeBuiltinPacks(t *testing.T) {
@@ -804,5 +805,98 @@ func TestBuiltinPackIncludes_AlwaysIncludesMaintenance(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("maintenance pack not found in bd includes: %v", includes)
+	}
+}
+
+func TestMaterializeBuiltinPacks_SubstitutesSkillMDContent(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// All SKILL.md files under the core pack should have {{binary}} resolved.
+	skillsDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("reading skills dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("skills dir is empty")
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillMD := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+		data, err := os.ReadFile(skillMD)
+		if err != nil {
+			continue // not every skill dir must have SKILL.md
+		}
+		content := string(data)
+		if strings.Contains(content, "{{binary}}") {
+			t.Errorf("SKILL.md in %s still contains unresolved {{binary}} placeholder", entry.Name())
+		}
+		// Verify that gc commands were substituted — at least one SKILL.md should
+		// contain the resolved binary name followed by a subcommand.
+		if strings.Contains(content, "gc ") && !strings.Contains(content, ".gc") && entry.Name() != "gc-work" {
+			// gc-work mostly references "bd" commands, skip it for this check.
+			// Other skill files should have "gc <cmd>" resolved to the binary name.
+			// This is a soft check — the ratchet test is the hard gate.
+		}
+	}
+}
+
+func TestMaterializeBuiltinPacks_SkillMDResolvesToBinaryName(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "my-custom-gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// The gc-city SKILL.md should contain "my-custom-gc init" after substitution.
+	citySkill := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "skills", "gc-city", "SKILL.md")
+	data, err := os.ReadFile(citySkill)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", citySkill, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "my-custom-gc init") {
+		t.Errorf("gc-city SKILL.md does not contain 'my-custom-gc init'; got:\n%s", content)
+	}
+	if strings.Contains(content, "{{binary}}") {
+		t.Errorf("gc-city SKILL.md still contains unresolved {{binary}} placeholder")
+	}
+}
+
+func TestMaterializeBuiltinPacks_NonSkillMDFilesUntouched(t *testing.T) {
+	formula.RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { formula.RegisterBuiltInVars(nil) })
+
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	// pack.toml should NOT have any substitution applied — its content
+	// should match the embedded source exactly.
+	coreToml := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml")
+	data, err := os.ReadFile(coreToml)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", coreToml, err)
+	}
+	// pack.toml should not contain any {{binary}} markers, but it also
+	// should not have been modified by Substitute in any way. We verify
+	// the file is still valid TOML by checking it starts with expected content.
+	if len(data) == 0 {
+		t.Fatal("core pack.toml is empty")
 	}
 }

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/supervisor"
@@ -90,6 +91,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Publish the runtime binary name so internal/ packages can reference it
 	// in error messages and log output without importing cmd/gc.
 	progname.Set(prog())
+
+	// Register built-in formula variables so {{binary}} resolves everywhere.
+	formula.RegisterBuiltInVars(map[string]string{"binary": prog()})
 
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/progname"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/spf13/cobra"
@@ -86,6 +87,10 @@ var rigFlag string
 // run executes the gc CLI with the given args, writing output to stdout and
 // errors to stderr. Returns the exit code.
 func run(args []string, stdout, stderr io.Writer) int {
+	// Publish the runtime binary name so internal/ packages can reference it
+	// in error messages and log output without importing cmd/gc.
+	progname.Set(prog())
+
 	// Initialize OTel telemetry (opt-in via GC_OTEL_METRICS_URL / GC_OTEL_LOGS_URL).
 	provider, err := telemetry.Init(context.Background(), "gascity", version)
 	if err != nil {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -116,7 +116,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 // newRootCmd creates the root cobra command with all subcommands.
 func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	root := &cobra.Command{
-		Use:           "gc",
+		Use:           prog(),
 		Short:         "Gas City CLI — orchestration-builder for multi-agent workflows",
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -130,7 +130,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 			if tryPackCommandFallback(args, stdout, stderr) {
 				return nil
 			}
-			fmt.Fprintf(stderr, "gc: unknown command %q\n\n", args[0]) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: unknown command %q\n\n", prog(), args[0]) //nolint:errcheck // best-effort stderr
 			printCommandUsage(stderr, cmd)
 			return errExit
 		},
@@ -224,7 +224,7 @@ func installArgUsageErrors(cmd *cobra.Command, stderr io.Writer) {
 
 func printCommandUsageError(stderr io.Writer, cmd *cobra.Command, err error) {
 	if err != nil {
-		fmt.Fprintf(stderr, "gc: %v\n\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: %v\n\n", prog(), err) //nolint:errcheck // best-effort stderr
 	}
 	printCommandUsage(stderr, cmd)
 }

--- a/cmd/gc/progname.go
+++ b/cmd/gc/progname.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// binaryName is the build-time default, overridable via ldflags:
+//
+//	-X main.binaryName=city
+var binaryName = "gc"
+
+var progOnce sync.Once
+var progCached string
+
+// prog returns the binary name for use in error messages, help text, and
+// examples. It prefers os.Args[0] at runtime, falling back to the
+// build-time binaryName.
+func prog() string {
+	progOnce.Do(func() {
+		if len(os.Args) > 0 && os.Args[0] != "" {
+			name := filepath.Base(os.Args[0])
+			name = strings.TrimSuffix(name, ".exe")
+			if strings.HasSuffix(name, ".test") {
+				progCached = binaryName
+			} else {
+				progCached = name
+			}
+		} else {
+			progCached = binaryName
+		}
+	})
+	return progCached
+}
+
+// cmdName returns "prog subcmd" for error message prefixes.
+func cmdName(subcmd string) string {
+	if subcmd == "" {
+		return prog()
+	}
+	return prog() + " " + subcmd
+}
+
+// cmdErr writes a formatted error message prefixed with the binary and
+// subcommand name to w: "<prog> <subcmd>: <msg>\n".
+func cmdErr(w io.Writer, subcmd string, err error) {
+	fmt.Fprintf(w, "%s: %v\n", cmdName(subcmd), err) //nolint:errcheck // best-effort stderr
+}

--- a/cmd/gc/progname_test.go
+++ b/cmd/gc/progname_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestProg_ReturnsDefaultInTestContext(t *testing.T) {
+	// In test context, os.Args[0] ends with ".test", so prog() should
+	// fall back to the binaryName default.
+	got := prog()
+	if got != binaryName {
+		t.Errorf("prog() = %q, want %q (binaryName default in test context)", got, binaryName)
+	}
+}
+
+func TestCmdName_WithSubcommand(t *testing.T) {
+	got := cmdName("start")
+	want := prog() + " start"
+	if got != want {
+		t.Errorf("cmdName(%q) = %q, want %q", "start", got, want)
+	}
+}
+
+func TestCmdName_Empty(t *testing.T) {
+	got := cmdName("")
+	want := prog()
+	if got != want {
+		t.Errorf("cmdName(%q) = %q, want %q", "", got, want)
+	}
+}
+
+func TestCmdErr_WritesExpectedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	cmdErr(&buf, "start", errors.New("something broke"))
+	got := buf.String()
+	want := prog() + " start: something broke\n"
+	if got != want {
+		t.Errorf("cmdErr output = %q, want %q", got, want)
+	}
+}
+
+func TestCmdErr_EmptySubcommand(t *testing.T) {
+	var buf bytes.Buffer
+	cmdErr(&buf, "", errors.New("bad input"))
+	got := buf.String()
+	want := prog() + ": bad input\n"
+	if got != want {
+		t.Errorf("cmdErr output = %q, want %q", got, want)
+	}
+}

--- a/contrib/demo/demo-01.sh
+++ b/contrib/demo/demo-01.sh
@@ -34,12 +34,13 @@ POOL="$RIG_NAME/claude"
 # Isolate from other gc processes (tests, other cities) that pollute
 # the shared ~/.gc registry. All demo state lives under GC_HOME.
 export GC_HOME="${GC_HOME:-$HOME/.gc-demo}"
+GC_BIN="${GC_BIN:-gc}"
 
 # ── Preflight checks ─────────────────────────────────────────────────────
 
 preflight() {
     local missing=()
-    for cmd in gc bd jq tmux; do
+    for cmd in "$GC_BIN" bd jq tmux; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")
     done
     if [ ${#missing[@]} -gt 0 ]; then
@@ -52,7 +53,7 @@ preflight() {
 
 cleanup() {
     if [ -d "$DEMO_CITY" ]; then
-        (cd "$DEMO_CITY" && gc stop 2>/dev/null) || true
+        (cd "$DEMO_CITY" && "$GC_BIN" stop 2>/dev/null) || true
     fi
     # Kill all non-system dolt servers (system dolt runs on port 3307).
     ps aux | grep "dolt sql-server" | grep -v grep | grep -v "port=3307" \
@@ -60,14 +61,14 @@ cleanup() {
     rm -rf "$DEMO_CITY"
     # Restart supervisor under isolated GC_HOME with current binary.
     local pid
-    pid=$(gc supervisor status 2>&1 | grep -oP 'PID \K\d+' || true)
+    pid=$("$GC_BIN" supervisor status 2>&1 | grep -oP 'PID \K\d+' || true)
     if [ -n "$pid" ]; then
         kill -9 "$pid" 2>/dev/null || true
     fi
     rm -rf "$GC_HOME"
     mkdir -p "$GC_HOME"
     sleep 1
-    gc supervisor start 2>/dev/null || true
+    "$GC_BIN" supervisor start 2>/dev/null || true
 }
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -118,7 +119,7 @@ wait_for_pool_agent() {
     local elapsed=0
     while [ "$elapsed" -lt "$timeout" ]; do
         local status_output
-        status_output=$(cd "$DEMO_CITY" && gc rig status "$RIG_NAME" 2>/dev/null || true)
+        status_output=$(cd "$DEMO_CITY" && "$GC_BIN" rig status "$RIG_NAME" 2>/dev/null || true)
         if echo "$status_output" | grep -q "running"; then
             echo ""
             echo "$status_output"
@@ -147,7 +148,7 @@ part1() {
     narrate "Part 1: Zero to Working" --sub "Init city, add rig, sling inline text"
 
     step "Initialize a new city"
-    run_show gc init "$DEMO_CITY"
+    run_show "$GC_BIN" init "$DEMO_CITY"
 
     step "Default city.toml"
     echo -e "  ${NARR_DIM}\$ cat $DEMO_CITY/city.toml${NARR_NC}"
@@ -157,7 +158,7 @@ part1() {
     step "Add a rig (project directory)"
     mkdir -p "$RIG_DIR"
     echo -e "  ${NARR_DIM}\$ gc rig add $RIG_NAME${NARR_NC}"
-    (cd "$DEMO_CITY" && gc rig add "$RIG_NAME")
+    (cd "$DEMO_CITY" && "$GC_BIN" rig add "$RIG_NAME")
     echo ""
 
     step "Rig directory is empty — no code yet"
@@ -166,12 +167,12 @@ part1() {
     echo ""
 
     # Ensure reconciler picks up the new rig's implicit pool agents.
-    gc supervisor reload 2>/dev/null || true
+    "$GC_BIN" supervisor reload 2>/dev/null || true
 
     step "Sling inline text — creates a bead and routes it to the pool"
     echo -e "  ${NARR_DIM}\$ gc sling $POOL \"Write a README.md for this project\" ${NARR_NC}"
     local sling_output
-    sling_output=$(cd "$DEMO_CITY" && gc sling "$POOL" "Write a README.md for this project" 2>&1) || true
+    sling_output=$(cd "$DEMO_CITY" && "$GC_BIN" sling "$POOL" "Write a README.md for this project" 2>&1) || true
     echo "$sling_output"
     echo ""
 
@@ -223,7 +224,7 @@ part2() {
 
     step "Sling the bead to the pool"
     echo -e "  ${NARR_DIM}\$ gc sling $POOL $bead_id${NARR_NC}"
-    (cd "$DEMO_CITY" && gc sling "$POOL" "$bead_id")
+    (cd "$DEMO_CITY" && "$GC_BIN" sling "$POOL" "$bead_id")
     echo ""
 
     step "Watch the bead get picked up (Ctrl+C to stop)"
@@ -272,14 +273,14 @@ part3() {
     step "Group them in a convoy"
     echo -e "  ${NARR_DIM}\$ gc convoy create \"Hello World Variants\" $id1 $id2 $id3${NARR_NC}"
     local convoy_output convoy_id
-    convoy_output=$(cd "$DEMO_CITY" && gc convoy create "Hello World Variants" "$id1" "$id2" "$id3" 2>&1) || true
+    convoy_output=$(cd "$DEMO_CITY" && "$GC_BIN" convoy create "Hello World Variants" "$id1" "$id2" "$id3" 2>&1) || true
     echo "$convoy_output"
     convoy_id=$(echo "$convoy_output" | grep -oP 'convoy \K\S+')
     echo ""
 
     step "Sling the convoy — expands to 3 parallel pool agents"
     echo -e "  ${NARR_DIM}\$ gc sling $POOL $convoy_id${NARR_NC}"
-    (cd "$DEMO_CITY" && gc sling "$POOL" "$convoy_id")
+    (cd "$DEMO_CITY" && "$GC_BIN" sling "$POOL" "$convoy_id")
     echo ""
 
     step "Watch 3 pool agents spin up"
@@ -335,7 +336,7 @@ finale() {
     step "Final state"
     show_rig_files
     echo -e "  ${NARR_DIM}\$ gc rig status $RIG_NAME${NARR_NC}"
-    (cd "$DEMO_CITY" && gc rig status "$RIG_NAME" 2>/dev/null) || true
+    (cd "$DEMO_CITY" && "$GC_BIN" rig status "$RIG_NAME" 2>/dev/null) || true
     echo ""
 }
 

--- a/contrib/k8s/Dockerfile.agent
+++ b/contrib/k8s/Dockerfile.agent
@@ -17,6 +17,8 @@
 ARG BASE_IMAGE=gc-agent-base:latest
 FROM ${BASE_IMAGE}
 
+ARG BINARY=gc
+
 # bd (beads) CLI — copied from build context.
 # Build with: cp $(which bd) . && docker build ...
 COPY bd /usr/local/bin/bd

--- a/contrib/k8s/agents/mayor/prompt.template.md
+++ b/contrib/k8s/agents/mayor/prompt.template.md
@@ -3,5 +3,5 @@
 You are the mayor of a Kubernetes-backed Gas City.
 
 Coordinate work, check mail and hooks, and keep the city healthy.
-When you need to inspect the platform, prefer `kubectl`, `gc status`,
+When you need to inspect the platform, prefer `kubectl`, `{{ cmd }} status`,
 and the configured mail/beads tooling over ad hoc guesses.

--- a/contrib/session-scripts/gc-controller-k8s
+++ b/contrib/session-scripts/gc-controller-k8s
@@ -172,14 +172,14 @@ init_controller_beads() {
     hq_prefix=$(derive_prefix "$ws_name")
   fi
   echo "  HQ (prefix: $hq_prefix)..."
-  bootstrap_controller_scope "HQ" "cd /city && gc bd init -p '$hq_prefix' --skip-hooks"
+  bootstrap_controller_scope "HQ" "cd /city && $GC_BIN bd init -p '$hq_prefix' --skip-hooks"
 
   local in_rig=false rig_name="" rig_prefix=""
   flush_rig() {
     [ -z "$rig_name" ] && return
     [ -z "$rig_prefix" ] && rig_prefix=$(derive_prefix "$rig_name")
     echo "  rig '$rig_name' (prefix: $rig_prefix)..."
-    bootstrap_controller_scope "rig '$rig_name'" "cd /city && gc bd --rig '$rig_name' init -p '$rig_prefix' --skip-hooks"
+    bootstrap_controller_scope "rig '$rig_name'" "cd /city && $GC_BIN bd --rig '$rig_name' init -p '$rig_prefix' --skip-hooks"
     rig_name="" rig_prefix=""
   }
 

--- a/contrib/session-scripts/gc-session-k8s
+++ b/contrib/session-scripts/gc-session-k8s
@@ -34,6 +34,7 @@
 #   GC_K8S_SERVICE_ACCOUNT - Pod service account name (default: namespace default)
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 op="${1:?missing operation}"
 name="${2:-}"
@@ -530,8 +531,8 @@ case "$op" in
       tar chf - -C "$city_dir" --exclude='.gc' . | \
         "${KUBECTL[@]}" exec -i "$pod" -- tar xf - -C /tmp/city-src || \
         echo "start: warning: failed to copy city dir" >&2
-      "${KUBECTL[@]}" exec "$pod" -- gc init --from /tmp/city-src /workspace || \
-        echo "start: warning: gc init failed" >&2
+      "${KUBECTL[@]}" exec "$pod" -- "$GC_BIN" init --from /tmp/city-src /workspace || \
+        echo "start: warning: $GC_BIN init failed" >&2
       "${KUBECTL[@]}" exec "$pod" -- rm -rf /tmp/city-src 2>/dev/null || true
     fi
 

--- a/examples/bd/template-fragments/bead-worktree.template.md
+++ b/examples/bd/template-fragments/bead-worktree.template.md
@@ -5,11 +5,11 @@ When you create a git worktree (via `git worktree add` or the EnterWorktree tool
 
 1. Find your assigned bead:
    ```
-   gc bd list --json --assignee="{{.AgentName}}" --status=in-progress
+   {{ cmd }} bd list --json --assignee="{{.AgentName}}" --status=in-progress
    ```
 2. Update the bead with the absolute worktree path:
    ```
-   gc bd update <bead_id> --set-metadata work_dir=<absolute_worktree_path>
+   {{ cmd }} bd update <bead_id> --set-metadata work_dir=<absolute_worktree_path>
    ```
 
 Replace `<bead_id>` with the `id` field from step 1 and `<absolute_worktree_path>` with the full path to the worktree directory.

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -8,6 +8,7 @@
 #
 # Environment: GC_CITY_PATH
 set -e
+GC_BIN="${GC_BIN:-gc}"
 
 force=false
 max_orphans=50
@@ -45,8 +46,8 @@ fi
 metadata_files() {
   printf '%s\n' "$GC_CITY_PATH/.beads/metadata.json"
 
-  if command -v gc >/dev/null 2>&1; then
-    rig_paths=$(gc rig list --json 2>/dev/null \
+  if command -v "$GC_BIN" >/dev/null 2>&1; then
+    rig_paths=$("$GC_BIN" rig list --json 2>/dev/null \
       | if command -v jq >/dev/null 2>&1; then
           jq -r '.rigs[].path' 2>/dev/null
         else
@@ -117,8 +118,8 @@ fi
 # with exit 1 if the pipeline can't be completed.
 compute_allowlist_file() {
   _out=$1
-  if ! command -v gc >/dev/null 2>&1; then
-    echo "gc dolt cleanup: gc not found on PATH; cannot evaluate rig overlap allowlist" >&2
+  if ! command -v "$GC_BIN" >/dev/null 2>&1; then
+    echo "$GC_BIN dolt cleanup: $GC_BIN not found on PATH; cannot evaluate rig overlap allowlist" >&2
     return 1
   fi
   if ! command -v jq >/dev/null 2>&1; then
@@ -126,8 +127,8 @@ compute_allowlist_file() {
     echo "install jq or remove orphans manually" >&2
     return 1
   fi
-  _list=$(gc rig list --json 2>/dev/null) || {
-    echo "gc dolt cleanup: gc rig list --json failed; refusing to run overlap allowlist unverified" >&2
+  _list=$("$GC_BIN" rig list --json 2>/dev/null) || {
+    echo "$GC_BIN dolt cleanup: $GC_BIN rig list --json failed; refusing to run overlap allowlist unverified" >&2
     return 1
   }
   if ! printf '%s\n' "$_list" | jq -e '.rigs' >/dev/null 2>&1; then

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -30,7 +30,8 @@
 #     (default: 1800) — wall-clock bound for one `CALL DOLT_GC()` invocation.
 #   GC_DOLT_GC_DRY_RUN   (optional) — when set, prints what would happen
 #                        but does not execute CALL DOLT_GC().
-set -eu
+set -e
+GC_BIN="${GC_BIN:-gc}"u
 
 : "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
 : "${GC_DOLT_PORT:=}"
@@ -139,12 +140,12 @@ lock_cleanup=""
 # fall back to filesystem scan when gc is unavailable.
 metadata_files() {
   printf '%s\n' "$GC_CITY_PATH/.beads/metadata.json"
-  if command -v gc >/dev/null 2>&1; then
+  if command -v "$GC_BIN" >/dev/null 2>&1; then
     # Bound the gc rig list call: if gc itself is wedged (we've seen this
     # during reconciler incidents) we must not block the nudge for the
     # full 35m order timeout. Degrade to the filesystem fallback below.
     # Matches the pattern in examples/dolt/commands/health/run.sh:22.
-    if rig_json=$(run_bounded 5 gc rig list --json 2>/dev/null); then
+    if rig_json=$(run_bounded 5 "$GC_BIN" rig list --json 2>/dev/null); then
       rig_paths=$(printf '%s\n' "$rig_json" \
         | if command -v jq >/dev/null 2>&1; then
             jq -r '.rigs[].path' 2>/dev/null

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -7,6 +7,7 @@
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_HOST, GC_DOLT_USER,
 #              GC_DOLT_PASSWORD
 set -e
+GC_BIN="${GC_BIN:-gc}"
 
 : "${GC_DOLT_USER:=root}"
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
@@ -15,11 +16,11 @@ PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 metadata_files() {
   printf '%s\n' "$GC_CITY_PATH/.beads/metadata.json"
 
-  if command -v gc >/dev/null 2>&1; then
+  if command -v "$GC_BIN" >/dev/null 2>&1; then
     # Bound the gc rig list call: if gc is itself in a bad state (the
     # failure mode this patrol is meant to detect) we must not block
     # here. Degrade to the fallback rig scan below.
-    rig_paths=$(run_bounded 5 gc rig list --json 2>/dev/null \
+    rig_paths=$(run_bounded 5 "$GC_BIN" rig list --json 2>/dev/null \
       | if command -v jq >/dev/null 2>&1; then
           jq -r '.rigs[].path' 2>/dev/null
         else

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -7,6 +7,7 @@
 #
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD
 set -e
+GC_BIN="${GC_BIN:-gc}"
 
 : "${GC_DOLT_USER:=root}"
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
@@ -57,8 +58,8 @@ is_running() {
 routes_files() {
   printf '%s\n' "$GC_CITY_PATH/.beads/routes.jsonl"
 
-  if command -v gc >/dev/null 2>&1; then
-    rig_paths=$(gc rig list --json 2>/dev/null \
+  if command -v "$GC_BIN" >/dev/null 2>&1; then
+    rig_paths=$("$GC_BIN" rig list --json 2>/dev/null \
       | if command -v jq >/dev/null 2>&1; then
           jq -r '.rigs[].path' 2>/dev/null
         else

--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -94,13 +94,13 @@ Generate summary and signal completion.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: backup — synced <count>/<total>, offsite: <status>"
+{{binary}} nudge deacon/ "DOG_DONE: backup — synced <count>/<total>, offsite: <status>"
 ```
 
 **3. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "Backup sync complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Backup sync complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/dolt/formulas/mol-dog-compactor.toml
+++ b/examples/dolt/formulas/mol-dog-compactor.toml
@@ -156,7 +156,7 @@ across all databases.
 
 If any check fails, escalate:
 ```bash
-gc mail send mayor/ -s "ESCALATION: Compaction integrity check failed [CRITICAL]" \
+{{binary}} mail send mayor/ -s "ESCALATION: Compaction integrity check failed [CRITICAL]" \
   -m "Database: <db>, table: <table>, expected: <n>, got: <m>"
 ```
 
@@ -178,13 +178,13 @@ Generate summary of compaction cycle.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: compactor — compacted <count> databases, mode: {{mode}}"
+{{binary}} nudge deacon/ "DOG_DONE: compactor — compacted <count> databases, mode: {{mode}}"
 ```
 
 **3. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "Compaction cycle complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Compaction cycle complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/dolt/formulas/mol-dog-doctor.toml
+++ b/examples/dolt/formulas/mol-dog-doctor.toml
@@ -73,7 +73,7 @@ Time the probe query. Warn if > {{latency_threshold}}.
 **If server unreachable:**
 This is a critical failure. Escalate immediately:
 ```bash
-gc mail send mayor/ -s "ESCALATION: Dolt server unreachable on port {{port}} [CRITICAL]" \\
+{{binary}} mail send mayor/ -s "ESCALATION: Dolt server unreachable on port {{port}} [CRITICAL]" \\
   -m "Doctor probe failed: server did not respond to active_branch() query."
 ```
 
@@ -103,7 +103,7 @@ Count databases matching orphan patterns: testdb_*, beads_t*, beads_pt*, doctest
 Ignore Dolt internals: information_schema, mysql, dolt_cluster, __gc_probe.
 If orphan count > threshold, recommend cleanup:
 ```bash
-gc dolt cleanup
+{{binary}} dolt cleanup
 ```
 
 **4. Backup freshness:**
@@ -136,19 +136,19 @@ Generate health report and signal completion.
 
 **2. Escalate if critical:**
 ```bash
-gc mail send mayor/ -s "ESCALATION: Dolt health critical [CRITICAL]" \\
+{{binary}} mail send mayor/ -s "ESCALATION: Dolt health critical [CRITICAL]" \\
   -m "<condition details>"
 ```
 
 **3. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: doctor — server: <status>, conns: <count>/<max>, orphans: <count>"
+{{binary}} nudge deacon/ "DOG_DONE: doctor — server: <status>, conns: <count>/<max>, orphans: <count>"
 ```
 
 **4. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "Doctor probe complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Doctor probe complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/dolt/formulas/mol-dog-phantom-db.toml
+++ b/examples/dolt/formulas/mol-dog-phantom-db.toml
@@ -95,7 +95,7 @@ This is safe because:
 **4. Escalate if phantoms were found:**
 Phantom databases indicate a Dolt bug that should be investigated:
 ```bash
-gc mail send mayor/ -s "ESCALATION: Quarantined phantom databases [HIGH]" \\
+{{binary}} mail send mayor/ -s "ESCALATION: Quarantined phantom databases [HIGH]" \\
   -m "Found and quarantined <count> phantom database(s): <names>"
 ```
 
@@ -116,13 +116,13 @@ Generate summary and signal completion.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: phantom-db — scanned: <count>, phantoms: <count>"
+{{binary}} nudge deacon/ "DOG_DONE: phantom-db — scanned: <count>, phantoms: <count>"
 ```
 
 **3. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "Phantom DB scan complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Phantom DB scan complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -29,7 +29,7 @@ This is infrastructure work. You:
 ## Safety
 
 Only removes databases matching known test/orphan patterns. Production databases
-are identified by rig registry via gc rig list --json and are never touched.
+are identified by rig registry via {{binary}} rig list --json and are never touched.
 External rigs are supported (not subject to local glob limitations).
 
 Read each step's description before acting — Config values override defaults."""
@@ -99,13 +99,13 @@ DROP DATABASE IF EXISTS `<orphan_name>`;
 ```
 
 **3. If orphan count > {{max_orphans_for_sql}}:**
-SQL cleanup would take too long. Use gc dolt cleanup instead:
+SQL cleanup would take too long. Use {{binary}} dolt cleanup instead:
 ```bash
-gc dolt cleanup --force --max <count>
+{{binary}} dolt cleanup --force --max <count>
 ```
 If even that fails, escalate:
 ```bash
-gc mail send mayor/ -s "ESCALATION: <count> orphan databases detected [HIGH]" \\
+{{binary}} mail send mayor/ -s "ESCALATION: <count> orphan databases detected [HIGH]" \\
   -m "Too many orphans for SQL cleanup. Recommend filesystem cleanup."
 ```
 
@@ -133,18 +133,18 @@ Generate summary and signal completion.
 **2. Warn if above threshold:**
 If orphan count >= {{warn_threshold}}:
 ```bash
-gc nudge deacon/ "WARN: <count> orphan databases detected"
+{{binary}} nudge deacon/ "WARN: <count> orphan databases detected"
 ```
 
 **3. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: stale-db — orphans: <count>, removed: <count>"
+{{binary}} nudge deacon/ "DOG_DONE: stale-db — orphans: <count>, removed: <count>"
 ```
 
 **4. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "Stale DB scan complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Stale DB scan complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/dolt/formulas/mol-dolt-health.toml
+++ b/examples/dolt/formulas/mol-dolt-health.toml
@@ -16,13 +16,13 @@ description = """
 Check dolt server status and restart if it has crashed:
 
 ```bash
-gc dolt status
+{{binary}} dolt status
 ```
 
 If the server is not running:
 
 ```bash
-gc dolt start
+{{binary}} dolt start
 ```
 
 Close this step after the health check completes (even if no restart was needed)."""

--- a/examples/dolt/formulas/mol-dolt-remotes-patrol.toml
+++ b/examples/dolt/formulas/mol-dolt-remotes-patrol.toml
@@ -16,7 +16,7 @@ description = """
 Run the dolt sync command:
 
 ```bash
-gc dolt sync
+{{binary}} dolt sync
 ```
 
 This stages uncommitted changes, commits, and pushes each dolt database

--- a/examples/dolt/orders/dolt-gc-nudge.toml
+++ b/examples/dolt/orders/dolt-gc-nudge.toml
@@ -2,5 +2,5 @@
 description = "Periodic CALL DOLT_GC() to bound commit-graph size (Dolt's auto-GC doesn't fire on bd workloads)"
 trigger = "cooldown"
 interval = "1h"
-exec = "gc dolt gc-nudge"
+exec = "${GC_BIN:-gc} dolt gc-nudge"
 timeout = "24h"

--- a/examples/dolt/orders/dolt-health.toml
+++ b/examples/dolt/orders/dolt-health.toml
@@ -2,4 +2,4 @@
 description = "Check dolt server health and restart on failure"
 trigger = "cooldown"
 interval = "30s"
-exec = "gc dolt status >/dev/null 2>&1 || gc dolt start"
+exec = "${GC_BIN:-gc} dolt status >/dev/null 2>&1 || ${GC_BIN:-gc} dolt start"

--- a/examples/dolt/orders/dolt-remotes-patrol.toml
+++ b/examples/dolt/orders/dolt-remotes-patrol.toml
@@ -2,4 +2,4 @@
 description = "Push dolt databases to configured remotes"
 trigger = "cooldown"
 interval = "15m"
-exec = "gc dolt sync"
+exec = "${GC_BIN:-gc} dolt sync"

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -49,10 +49,10 @@ detects dead agents and restarts them — that's its job, not yours.
 {{ cmd }} agent peek deacon 30
 
 # Deacon's current patrol wisp — how fresh is it?
-gc bd list --assignee=deacon --status=in_progress --json --limit=5
+{{ cmd }} bd list --assignee=deacon --status=in_progress --json --limit=5
 
 # Does the deacon have unread mail? (may explain idle state)
-gc mail inbox --address=deacon --json 2>/dev/null | jq length
+{{ cmd }} mail inbox --address=deacon --json 2>/dev/null | jq length
 ```
 
 Read the wisp timestamps and pane output. Build a picture:
@@ -89,7 +89,7 @@ Drain-ack and exit. Next Boot tick will re-evaluate.
 
 **Clearly stuck (very stale wisp, no output, errors visible):** File a warrant:
 ```bash
-gc bd create --type=warrant \
+{{ cmd }} bd create --type=warrant \
   --title="Stuck: deacon" \
   --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot"}' \
   --label=pool:dog
@@ -122,9 +122,9 @@ up your session and spawns you again next tick.
 | Want to... | Correct command |
 |------------|----------------|
 | View deacon output | `{{ cmd }} agent peek deacon 30` |
-| Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
+| Check deacon work | `{{ cmd }} bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} nudge deacon "message"` |
-| File stuck warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| File stuck warrant | `{{ cmd }} bd create --type=warrant --label=pool:dog --metadata '{...}'` |
 | Check agents | `{{ cmd }} agent list` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -59,14 +59,14 @@ Your formula: `mol-deacon-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 2: Nothing? Check mail for attached work
-gc mail inbox
+{{ cmd }} mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+NEW_WISP=$({{ cmd }} bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+{{ cmd }} bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
 ```
@@ -77,7 +77,7 @@ gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 If your context is filling up during patrol:
 ```bash
-gc runtime request-restart
+{{ cmd }} runtime request-restart
 ```
 This blocks until the controller kills your session. The new session
 re-reads formula steps and resumes from context.
@@ -88,7 +88,7 @@ re-reads formula steps and resumes from context.
 
 Mail beads can be hooked for ad-hoc instruction handoff:
 - Mayor or human sends mail with special instructions
-- Your next session sees the mail on the hook via `gc bd list --assignee="$GC_ALIAS"`
+- Your next session sees the mail on the hook via `{{ cmd }} bd list --assignee="$GC_ALIAS"`
 - GUPP applies: read the content, interpret, execute
 
 This enables ad-hoc tasks (e.g., "focus on debugging convoy resolution this
@@ -103,7 +103,7 @@ response is always the same:
 
 1. **File a warrant bead:**
 ```bash
-gc bd create --type=warrant \
+{{ cmd }} bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --label=pool:dog
@@ -120,10 +120,10 @@ gc bd create --type=warrant \
 ## Communication
 
 ```bash
-gc mail send mayor/ -s "Subject" -m "Message"       # Escalate to mayor
-gc mail send <rig>/witness -s "Subject" -m "..."     # Witness questions
-gc nudge <target> "message"                          # Nudge an agent
-gc session peek <target> 50                              # View agent output
+{{ cmd }} mail send mayor/ -s "Subject" -m "Message"       # Escalate to mayor
+{{ cmd }} mail send <rig>/witness -s "Subject" -m "..."     # Witness questions
+{{ cmd }} nudge <target> "message"                          # Nudge an agent
+{{ cmd }} session peek <target> 50                              # View agent output
 ```
 
 ### Deacon Communication Rules
@@ -137,12 +137,12 @@ Witness health checks, TIMER callbacks, HEALTH_CHECK pokes, wake signals — all
 
 When to escalate to mayor:
 - Systemic issues (multiple rigs affected, patterns of failure)
-- Complex `gc doctor` findings you can't resolve
+- Complex `{{ cmd }} doctor` findings you can't resolve
 - Cross-rig dependency tangles
 - Repeated stuck agents across multiple rigs
 
 ```bash
-gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
+{{ cmd }} mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 ```
 
 Individual stuck agents don't need escalation — the warrant system handles them.
@@ -155,18 +155,18 @@ Individual stuck agents don't need escalation — the warrant system handles the
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only` |
-| Context exhaustion | `gc runtime request-restart` |
-| Request target restart | `gc session kill <target>` |
-| Check gates | `gc bd gate check --type=timer --escalate` |
-| List gate beads | `gc bd gate list --json` |
-| List convoys | `gc convoy list` |
-| Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |
-| Convert dep type | `gc bd dep remove <id> <dep>` then `gc bd dep add <id> <dep> --type=related` |
-| File stuck-agent warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
-| Run system diagnostics | `gc doctor` |
-| Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
-| Compact wisps | `gc bd mol wisp gc --age 24h` |
+| Pour next wisp | `{{ cmd }} bd mol wisp mol-deacon-patrol --root-only` |
+| Context exhaustion | `{{ cmd }} runtime request-restart` |
+| Request target restart | `{{ cmd }} session kill <target>` |
+| Check gates | `{{ cmd }} bd gate check --type=timer --escalate` |
+| List gate beads | `{{ cmd }} bd gate list --json` |
+| List convoys | `{{ cmd }} convoy list` |
+| Find cross-rig deps | `{{ cmd }} bd dep list <id> --direction=up --type=blocks --json` |
+| Convert dep type | `{{ cmd }} bd dep remove <id> <dep>` then `{{ cmd }} bd dep add <id> <dep> --type=related` |
+| File stuck-agent warrant | `{{ cmd }} bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| Run system diagnostics | `{{ cmd }} doctor` |
+| Compact wisps (dry run) | `{{ cmd }} bd mol wisp gc --age 24h --dry-run` |
+| Compact wisps | `{{ cmd }} bd mol wisp gc --age 24h` |
 
 Working directory: {{ .WorkDir }}
 Your mail address: deacon/

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -20,8 +20,8 @@ You CAN and SHOULD edit code when it's the fastest path. The key is balance.
 When you file a bead, default to immediately dispatching it to a polecat:
 
 ```bash
-gc bd create "Fix the auth timeout bug" -t task --json   # file it
-gc bd update <bead-id> --set-metadata gc.routed_to=<rig>/polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
+{{ cmd }} bd create "Fix the auth timeout bug" -t task --json   # file it
+{{ cmd }} bd update <bead-id> --set-metadata gc.routed_to=<rig>/polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
 ```
 
 **Why this is the default:**
@@ -63,7 +63,7 @@ Use these locations consistently:
 | Location | Use for |
 |----------|---------|
 | `{{ .WorkDir }}` | Your own coordination home, runtime files, scratch notes |
-| `{{ .CityRoot }}` | `{{ cmd }} mail`, coordination commands, `gc bd` with `hq-` prefix |
+| `{{ .CityRoot }}` | `{{ cmd }} mail`, coordination commands, `{{ cmd }} bd` with `hq-` prefix |
 | configured rig repo root (`{{ cmd }} rig status <rig>`) | **ALL git/code operations** for that rig via `git -C` |
 | `{{ .CityRoot }}/.gc/worktrees/<rig>/...` | Agent sandboxes/worktrees — don't use these directly |
 
@@ -86,11 +86,11 @@ Never work in another agent's worktree. Use the configured rig repo root with
 
 ## Prefix-Based Routing
 
-`gc bd` commands automatically route to the correct rig based on issue ID prefix:
+`{{ cmd }} bd` commands automatically route to the correct rig based on issue ID prefix:
 
 ```
-gc bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
-gc bd show hq-abc      # Routes to town beads
+{{ cmd }} bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
+{{ cmd }} bd show hq-abc      # Routes to town beads
 ```
 
 **How it works:**
@@ -98,9 +98,9 @@ gc bd show hq-abc      # Routes to town beads
 - `{{ cmd }} rig add` auto-registers new rig prefixes
 - Each rig's prefix (e.g., `gt-`) maps to its beads location
 
-**Debug routing:** `BD_DEBUG_ROUTING=1 gc bd show <id>`
+**Debug routing:** `BD_DEBUG_ROUTING=1 {{ cmd }} bd show <id>`
 
-**Conflicts:** If two rigs share a prefix, use `gc bd rename-prefix <new>` to fix.
+**Conflicts:** If two rigs share a prefix, use `{{ cmd }} bd rename-prefix <new>` to fix.
 
 ## Where to File Beads - Create issues (CRITICAL)
 
@@ -108,14 +108,14 @@ gc bd show hq-abc      # Routes to town beads
 
 | Issue is about... | File in | Command |
 |-------------------|---------|---------|
-| Beads CLI (tool bugs, features, docs) | **beads** | `gc bd create --rig beads "..."` |
-| `gc` CLI (gas city tool bugs, features) | **gastown** | `gc bd create --rig gastown "..."` |
-| Polecat/witness/refinery/convoy code | **gastown** | `gc bd create --rig gastown "..."` |
-| Wyvern game features | **wyvern** | `gc bd create --rig wyvern "..."` |
-| Cross-rig coordination, convoys, mail threads | **HQ** | `gc bd create "..."` (default) |
-| Agent role descriptions, assignments | **HQ** | `gc bd create "..."` (default) |
+| Beads CLI (tool bugs, features, docs) | **beads** | `{{ cmd }} bd create --rig beads "..."` |
+| `gc` CLI (gas city tool bugs, features) | **gastown** | `{{ cmd }} bd create --rig gastown "..."` |
+| Polecat/witness/refinery/convoy code | **gastown** | `{{ cmd }} bd create --rig gastown "..."` |
+| Wyvern game features | **wyvern** | `{{ cmd }} bd create --rig wyvern "..."` |
+| Cross-rig coordination, convoys, mail threads | **HQ** | `{{ cmd }} bd create "..."` (default) |
+| Agent role descriptions, assignments | **HQ** | `{{ cmd }} bd create "..."` (default) |
 
-**IMPORTANT: File issues with `gc bd create`.** There is no `{{ cmd }} issue` or `{{ cmd }} issues` namespace here. Use `gc bd create` directly.
+**IMPORTANT: File issues with `{{ cmd }} bd create`.** There is no `{{ cmd }} issue` or `{{ cmd }} issues` namespace here. Use `{{ cmd }} bd create` directly.
 
 **The test**: "Which repo would the fix be committed to?"
 - Fix in `anthropics/beads` -> file in beads rig
@@ -128,10 +128,10 @@ Wrong. The issue is about beads code, so it goes in the beads rig.
 ## Gotchas when Filing Beads
 
 **Temporal language inverts dependencies.** "Phase 1 blocks Phase 2" is backwards.
-- WRONG: `gc bd dep add phase1 phase2` (temporal: "1 before 2")
-- RIGHT: `gc bd dep add phase2 phase1` (requirement: "2 needs 1")
+- WRONG: `{{ cmd }} bd dep add phase1 phase2` (temporal: "1 before 2")
+- RIGHT: `{{ cmd }} bd dep add phase2 phase1` (requirement: "2 needs 1")
 
-**Rule**: Think "X needs Y", not "X comes before Y". Verify with `gc bd blocked`.
+**Rule**: Think "X needs Y", not "X comes before Y". Verify with `{{ cmd }} bd blocked`.
 
 ## Responsibilities
 
@@ -204,7 +204,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 {{ cmd }} rig list                                    # List all rigs
 ```
 
-**ALWAYS use gc nudge, NEVER tmux send-keys** (drops Enter key)
+**ALWAYS use {{ cmd }} nudge, NEVER tmux send-keys** (drops Enter key)
 
 ---
 
@@ -214,13 +214,13 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
-| Drain stuck polecat | `{{ cmd }} agent drain <name>` | ~~gc polecat kill~~ (not a command) |
-| Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
+| Dispatch work to polecat | `{{ cmd }} bd update <bead> --label=pool:<rig>/polecat` | ~~{{ cmd }} polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Drain stuck polecat | `{{ cmd }} agent drain <name>` | ~~{{ cmd }} polecat kill~~ (not a command) |
+| Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~{{ cmd }} rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |
 | Create convoy for batch work | `{{ cmd }} convoy create "name" <issues>` | |
 | View convoy progress | `{{ cmd }} convoy status <id>` | |
-| Create issues | `gc bd create "title"` | ~~gc issue create~~ (not a command) |
+| Create issues | `{{ cmd }} bd create "title"` | ~~{{ cmd }} issue create~~ (not a command) |
 
 **Rig lifecycle commands:**
 - `suspend/resume` — Dormant toggle. Daemon skips suspended rigs entirely.
@@ -229,7 +229,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Activate a dormant rig | `{{ cmd }} rig resume <rig>` | ~~gc rig start~~ (doesn't unsuspend) |
-| Suspend rig (daemon skips it) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
+| Activate a dormant rig | `{{ cmd }} rig resume <rig>` | ~~{{ cmd }} rig start~~ (doesn't unsuspend) |
+| Suspend rig (daemon skips it) | `{{ cmd }} rig suspend <rig>` | ~~{{ cmd }} rig stop~~ (daemon will restart it) |
 
 Town root: {{ .CityRoot }}

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -64,7 +64,7 @@ sees the existing branch and reason, and resumes instead of redoing everything.
 
 Read metadata:
 ```bash
-gc bd show <issue> --json | jq '.[0].metadata'
+{{ cmd }} bd show <issue> --json | jq '.[0].metadata'
 ```
 
 ## Work Protocol
@@ -87,17 +87,17 @@ Your formula: `mol-polecat-work`
 
 ```bash
 # Step 1: Check for assigned work
-gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress
+{{ cmd }} bd list --assignee="$GC_SESSION_NAME" --status=in_progress
 {{ .WorkQuery }}                                             # Find pool work
-gc bd update <id> --claim                                       # Atomic grab
+{{ cmd }} bd update <id> --claim                                       # Atomic grab
 
 # Step 2: Work found? -> Follow formula steps. Nothing? -> Check mail
-gc mail inbox
+{{ cmd }} mail inbox
 
 # Step 3: Execute — read formula steps and work through them in order
 ```
 
-When nudged after dispatch, run `gc hook` or `{{ .WorkQuery }}`. That lookup
+When nudged after dispatch, run `{{ cmd }} hook` or `{{ .WorkQuery }}`. That lookup
 checks assigned work first (session bead ID, runtime session name, then
 alias) and only falls through to unassigned pool work routed to
 `{{ .RigName }}/polecat`.
@@ -108,17 +108,17 @@ alias) and only falls through to unassigned pool work routed to
 
 If your context is filling up during long implementation:
 ```bash
-gc runtime request-restart
+{{ cmd }} runtime request-restart
 ```
 This blocks until the controller kills your session. The new session
 re-reads formula steps and resumes from context.
 
 For lighter handoffs (e.g., waiting for external input):
 ```bash
-gc mail send -s "HANDOFF: Subject" -m "Issue: <issue>
+{{ cmd }} mail send -s "HANDOFF: Subject" -m "Issue: <issue>
 Status: <current state>
 Next: <what to do>"
-gc runtime drain-ack
+{{ cmd }} runtime drain-ack
 exit
 ```
 
@@ -132,8 +132,8 @@ conflict, test failure, etc.), and resubmit. Don't redo all the work.
 
 ```bash
 # Check for rejection
-gc bd show <issue> --json | jq -r '.[0].metadata.rejection_reason // empty'
-gc bd show <issue> --json | jq -r '.[0].metadata.branch // empty'
+{{ cmd }} bd show <issue> --json | jq -r '.[0].metadata.rejection_reason // empty'
+{{ cmd }} bd show <issue> --json | jq -r '.[0].metadata.branch // empty'
 
 # If both exist: resume the branch, fix the issue, resubmit
 ```
@@ -153,22 +153,22 @@ When blocked, you MUST escalate. Do NOT wait for human input.
 **How:**
 ```bash
 # Blocking issues
-gc mail send {{ .RigName }}/witness -s "ESCALATION: Brief description [HIGH]" -m "Details"
+{{ cmd }} mail send {{ .RigName }}/witness -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 # Cross-rig or strategic
-gc mail send mayor/ -s "BLOCKED: <topic>" -m "Context"
+{{ cmd }} mail send mayor/ -s "BLOCKED: <topic>" -m "Context"
 ```
 
-After escalating: continue if possible, otherwise `gc bd update <bead> --status=escalated && gc runtime drain-ack && exit`.
+After escalating: continue if possible, otherwise `{{ cmd }} bd update <bead> --status=escalated && {{ cmd }} runtime drain-ack && exit`.
 
 ---
 
 ## Communication
 
 ```bash
-gc nudge {{ .RigName }}/witness "Quick question about bead status"   # Default: nudge
-gc mail send {{ .RigName }}/witness -s "HELP: Blocked on X" -m "..."  # Escalation: mail
-gc mail send mayor/ -s "BLOCKED: Need coordination" -m "..."          # Cross-rig: mail
+{{ cmd }} nudge {{ .RigName }}/witness "Quick question about bead status"   # Default: nudge
+{{ cmd }} mail send {{ .RigName }}/witness -s "HELP: Blocked on X" -m "..."  # Escalation: mail
+{{ cmd }} mail send mayor/ -s "BLOCKED: Need coordination" -m "..."          # Cross-rig: mail
 ```
 
 ### Polecat Communication Rules
@@ -176,7 +176,7 @@ gc mail send mayor/ -s "BLOCKED: Need coordination" -m "..."          # Cross-ri
 **Your mail budget is 0-1 messages per session.**
 
 - **Escalation**: Mail to witness as HELP — this is the ONE allowed mail use
-- **Everything else**: Use `gc nudge` — ephemeral, zero Dolt overhead
+- **Everything else**: Use `{{ cmd }} nudge` — ephemeral, zero Dolt overhead
 - **Completion**: The done sequence handles notification — do NOT mail "I'm done"
 - **Status updates**: If asked for status, respond via nudge, not mail
 
@@ -195,16 +195,16 @@ Nudges from other agents may arrive via your hook. When working:
 
 ```bash
 git push origin HEAD
-gc bd update <work-bead> \
+{{ cmd }} bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
-gc runtime drain-ack
+{{ cmd }} bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
+{{ cmd }} runtime drain-ack
 exit
 ```
 
-Your work is not complete until you run these commands. `gc runtime drain-ack`
+Your work is not complete until you run these commands. `{{ cmd }} runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the
 pool check command finds more work. Sitting idle after finishing implementation
 is the "Idle Polecat heresy."
@@ -217,11 +217,11 @@ is the "Idle Polecat heresy."
 
 | Want to... | Correct command |
 |------------|----------------|
-| Signal work complete | Done sequence (push, set metadata, reassign, `gc runtime drain-ack`, exit) |
-| Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
-| Escalate blocker | `gc mail send {{ .RigName }}/witness -s "ESCALATION: desc [HIGH]" -m "..."` |
-| Context exhaustion | `gc runtime request-restart` |
-| Handoff to next session | `gc mail send -s "HANDOFF: ..." -m "..."` then `gc runtime drain-ack && exit` |
+| Signal work complete | Done sequence (push, set metadata, reassign, `{{ cmd }} runtime drain-ack`, exit) |
+| Read formula steps | `{{ cmd }} bd show <wisp-id>` (shows formula ref) |
+| Escalate blocker | `{{ cmd }} mail send {{ .RigName }}/witness -s "ESCALATION: desc [HIGH]" -m "..."` |
+| Context exhaustion | `{{ cmd }} runtime request-restart` |
+| Handoff to next session | `{{ cmd }} mail send -s "HANDOFF: ..." -m "..."` then `{{ cmd }} runtime drain-ack && exit` |
 
 Polecat: {{ basename .AgentName }}
 Rig: {{ .RigName }}

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -50,11 +50,11 @@ Your formula: `mol-refinery-patrol`
 
 ```bash
 # Check for an in-progress patrol wisp
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # If none found, pour one (root-only — no child step beads) and assign it
-WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --json | jq -r '.new_epic_id')
-gc bd update "$WISP" --assignee="$GC_ALIAS"
+WISP=$({{ cmd }} bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --json | jq -r '.new_epic_id')
+{{ cmd }} bd update "$WISP" --assignee="$GC_ALIAS"
 ```
 
 Then follow the formula. The step descriptions below are your instructions —
@@ -94,10 +94,10 @@ Polecats set these metadata fields before assigning a work bead to you:
 
 Read them mechanically:
 ```bash
-gc bd show $WORK --json | jq -r '.[0].metadata.branch'
-gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{ .DefaultBranch }}"'
-gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"'
-gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty'
+{{ cmd }} bd show $WORK --json | jq -r '.[0].metadata.branch'
+{{ cmd }} bd show $WORK --json | jq -r '.[0].metadata.target // "{{ .DefaultBranch }}"'
+{{ cmd }} bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"'
+{{ cmd }} bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty'
 ```
 
 Never infer a branch name. If `metadata.branch` is missing, reject the bead.
@@ -106,7 +106,7 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 On rebase conflict or test failure:
 1. Put work bead back in pool:
-   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
+   `{{ cmd }} bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
 2. Branch handling depends on failure type:
    - Conflict: leave branch intact (polecat needs it for rebase)
    - Test failure: delete branch (polecat redoes work)
@@ -144,12 +144,12 @@ and then ignored by landing directly to the target branch.
 ## Communication
 
 ```bash
-gc mail inbox                                          # Check for messages
-gc nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
-gc mail send mayor/ -s "ESCALATION: ..." -m "..."      # Escalate (mail — must survive)
+{{ cmd }} mail inbox                                          # Check for messages
+{{ cmd }} nudge {{ .RigName }}/<polecat-name> "Run {{ cmd }} hook; it checks assigned work before routed pool work"
+{{ cmd }} mail send mayor/ -s "ESCALATION: ..." -m "..."      # Escalate (mail — must survive)
 ```
 
-Use the concrete polecat name from `gc status` or `gc session list`;
+Use the concrete polecat name from `{{ cmd }} status` or `{{ cmd }} session list`;
 Gastown's default namepool yields names like `furiosa` or `nux`. There is no
 `{{ .RigName }}/polecats/<name>` address form.
 
@@ -161,8 +161,8 @@ work still arrives through bead assignment or pool routing.
 **Your only mail use:** Escalations to Mayor. Everything else is a nudge.
 
 MERGE_FAILED notifications are routine signals — the rejection metadata on
-the bead (`rejection_reason`) is the durable record. Use `gc nudge` to
-alert the witness, not `gc mail send`.
+the bead (`rejection_reason`) is the durable record. Use `{{ cmd }} nudge` to
+alert the witness, not `{{ cmd }} mail send`.
 
 ---
 
@@ -172,14 +172,14 @@ alert the witness, not `gc mail send`.
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only` |
-| Burn current wisp | `gc bd mol burn <wisp-id> --force` |
-| Find assigned work | `gc bd list --assignee="$GC_ALIAS" --status=open` |
-| Snapshot event position | `gc events --seq` |
-| Wait for assignment | `gc events --watch --type=bead.updated --after=$SEQ` |
-| Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |
-| Set metadata field | `gc bd update $WORK --set-metadata key=value` |
-| Remove metadata field | `gc bd update $WORK --unset-metadata key` |
+| Pour next wisp | `{{ cmd }} bd mol wisp mol-refinery-patrol --root-only` |
+| Burn current wisp | `{{ cmd }} bd mol burn <wisp-id> --force` |
+| Find assigned work | `{{ cmd }} bd list --assignee="$GC_ALIAS" --status=open` |
+| Snapshot event position | `{{ cmd }} events --seq` |
+| Wait for assignment | `{{ cmd }} events --watch --type=bead.updated --after=$SEQ` |
+| Read work metadata | `{{ cmd }} bd show $WORK --json \| jq '.[0].metadata'` |
+| Set metadata field | `{{ cmd }} bd update $WORK --set-metadata key=value` |
+| Remove metadata field | `{{ cmd }} bd update $WORK --unset-metadata key` |
 | Fetch remote branches | `git fetch --prune origin` |
 | Rebase on target | `git rebase origin/$TARGET` |
 | Fast-forward merge | `git merge --ff-only temp` |

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -79,7 +79,7 @@ The drain protocol does NOT release beads. Crash recovery resumes work
 via formula step resumption. But when an agent genuinely won't come back, its
 beads sit assigned forever unless the witness recovers them.
 
-**Detection:** Compare bead assignees against `gc session list`. If the
+**Detection:** Compare bead assignees against `{{ cmd }} session list`. If the
 assigned agent is neither running nor a desired agent that the controller
 will restart -> orphaned.
 
@@ -127,7 +127,7 @@ A long tool call is different from an infinite loop.
 for the dog pool:
 
 ```bash
-gc bd create --type=warrant \
+{{ cmd }} bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"witness"}' \
   --label=pool:dog
@@ -151,14 +151,14 @@ Your formula: `mol-witness-patrol`
 
 ```bash
 # Step 1: Check for assigned work
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # Step 2: Nothing? Check mail for attached work
-gc mail inbox
+{{ cmd }} mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
+NEW_WISP=$({{ cmd }} bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+{{ cmd }} bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
 ```
@@ -169,7 +169,7 @@ gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 If your context is filling up during patrol:
 ```bash
-gc runtime request-restart
+{{ cmd }} runtime request-restart
 ```
 This blocks until the controller kills your session. The new session
 re-reads formula steps and resumes from context.
@@ -179,13 +179,13 @@ re-reads formula steps and resumes from context.
 ## Communication
 
 ```bash
-gc mail send mayor/ -s "Subject" -m "Message"              # Escalate to mayor
-gc mail send {{ .RigName }}/refinery -s "Subject" -m "..."  # Refinery questions
-gc nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
-gc session peek {{ .RigName }}/<polecat-name> 50             # View polecat output
+{{ cmd }} mail send mayor/ -s "Subject" -m "Message"              # Escalate to mayor
+{{ cmd }} mail send {{ .RigName }}/refinery -s "Subject" -m "..."  # Refinery questions
+{{ cmd }} nudge {{ .RigName }}/<polecat-name> "Run {{ cmd }} hook; it checks assigned work before routed pool work"
+{{ cmd }} session peek {{ .RigName }}/<polecat-name> 50             # View polecat output
 ```
 
-Use the concrete polecat name from `gc status` or `gc session list`;
+Use the concrete polecat name from `{{ cmd }} status` or `{{ cmd }} session list`;
 Gastown's default namepool yields names like `furiosa` or `nux`. There is no
 `{{ .RigName }}/polecats/<name>` address form.
 
@@ -233,7 +233,7 @@ When to escalate to mayor:
 - Systemic issue (many stuck polecats)
 
 ```bash
-gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
+{{ cmd }} mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 ```
 
 ---
@@ -244,13 +244,13 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-witness-patrol --root-only` |
-| Context exhaustion | `gc runtime request-restart` |
-| Recover orphaned bead | `gc workflow delete-source <id> --apply && gc workflow reopen-source <id>` |
+| Pour next wisp | `{{ cmd }} bd mol wisp mol-witness-patrol --root-only` |
+| Context exhaustion | `{{ cmd }} runtime request-restart` |
+| Recover orphaned bead | `{{ cmd }} workflow delete-source <id> --apply && {{ cmd }} workflow reopen-source <id>` |
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
-| Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
-| File stuck-agent warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| Set branch metadata | `{{ cmd }} bd update <id> --set-metadata branch=<name>` |
+| File stuck-agent warrant | `{{ cmd }} bd create --type=warrant --label=pool:dog --metadata '{...}'` |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/assets/prompts/crew.template.md
+++ b/examples/gastown/packs/gastown/assets/prompts/crew.template.md
@@ -40,23 +40,23 @@ the overseer, not as part of a transient worker pool.
 
 **Key points:**
 - Mail ALWAYS uses town beads - `{{ cmd }} mail` routes there automatically
-- Project issues use your clone's beads - `gc bd` uses local `.beads/`
+- Project issues use your clone's beads - `{{ cmd }} bd` uses local `.beads/`
 - Beads changes are persisted immediately via Dolt - no sync step needed
 - **GitHub URLs**: Use `git remote -v` to verify repo URLs - never assume orgs like `anthropics/`
 
 ## Prefix-Based Routing
 
-`gc bd` commands automatically route to the correct rig based on issue ID prefix:
+`{{ cmd }} bd` commands automatically route to the correct rig based on issue ID prefix:
 
 ```
-gc bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
-gc bd show hq-abc      # Routes to town beads
+{{ cmd }} bd show {{ .IssuePrefix }}-xyz   # Routes to {{ .RigName }} beads (from anywhere in town)
+{{ cmd }} bd show hq-abc      # Routes to town beads
 ```
 
 **How it works:**
 - Routes defined in `{{ .CityRoot }}/.beads/routes.jsonl`
 - Each rig's prefix (e.g., `gt-`) maps to its beads location
-- Debug with: `BD_DEBUG_ROUTING=1 gc bd show <id>`
+- Debug with: `BD_DEBUG_ROUTING=1 {{ cmd }} bd show <id>`
 
 ## Your Workspace
 
@@ -73,7 +73,7 @@ to gastown), you can create a worktree in the target rig:
 ```bash
 # Create a worktree in another rig (look up the target rig's root first)
 TARGET_RIG=beads
-TARGET_ROOT=<from `gc rig status $TARGET_RIG`>
+TARGET_ROOT=<from `{{ cmd }} rig status $TARGET_RIG`>
 git -C "$TARGET_ROOT" worktree add {{ .CityRoot }}/.gc/worktrees/$TARGET_RIG/crew/{{ basename .AgentName }}-from-{{ .RigName }} -b $TARGET_RIG-{{ basename .AgentName }}
 
 # List your worktrees
@@ -100,7 +100,7 @@ git worktree remove {{ .CityRoot }}/.gc/worktrees/$TARGET_RIG/crew/{{ basename .
 |----------|----------|
 | Quick fix in another rig | Use `git worktree add` |
 | Substantial work in another rig | Use `git worktree add` |
-| Work should be done by target rig's workers | `{{ cmd }} convoy create` + `gc bd update --label=pool:<rig>/polecat` |
+| Work should be done by target rig's workers | `{{ cmd }} convoy create` + `{{ cmd }} bd update --label=pool:<rig>/polecat` |
 | Infrastructure task | Leave it to the Deacon's dogs |
 
 **Note**: Dogs are utility agents that handle infrastructure tasks (warrants,
@@ -116,20 +116,20 @@ go here by default. But if you discover bugs/issues in OTHER projects:
 
 | Issue is about... | File in | Command |
 |-------------------|---------|---------|
-| This rig's code ({{ .RigName }}) | Here (default) | `gc bd create "..."` |
-| Beads CLI (beads tool) | **beads** | `gc bd create --rig beads "..."` |
-| `gc` CLI (gas city tool) | **gastown** | `gc bd create --rig gastown "..."` |
-| Cross-rig coordination | **HQ** | `gc bd create --prefix hq- "..."` |
+| This rig's code ({{ .RigName }}) | Here (default) | `{{ cmd }} bd create "..."` |
+| Beads CLI (beads tool) | **beads** | `{{ cmd }} bd create --rig beads "..."` |
+| `gc` CLI (gas city tool) | **gastown** | `{{ cmd }} bd create --rig gastown "..."` |
+| Cross-rig coordination | **HQ** | `{{ cmd }} bd create --prefix hq- "..."` |
 
 **The test**: "Which repo would the fix be committed to?"
 
 ## Gotchas when Filing Beads
 
 **Temporal language inverts dependencies.** "Phase 1 blocks Phase 2" is backwards.
-- WRONG: `gc bd dep add phase1 phase2` (temporal: "1 before 2")
-- RIGHT: `gc bd dep add phase2 phase1` (requirement: "2 needs 1")
+- WRONG: `{{ cmd }} bd dep add phase1 phase2` (temporal: "1 before 2")
+- RIGHT: `{{ cmd }} bd dep add phase2 phase1` (requirement: "2 needs 1")
 
-**Rule**: Think "X needs Y", not "X comes before Y". Verify with `gc bd blocked`.
+**Rule**: Think "X needs Y", not "X comes before Y". Verify with `{{ cmd }} bd blocked`.
 
 ## Handoff
 
@@ -193,7 +193,7 @@ ONE exception where branches are created. But the rule still applies:
 - Submit to that rig's Refinery immediately when done
 - Never leave cross-rig work sitting on an unmerged branch
 
-## gc nudge: Waking Agents
+## {{ cmd }} nudge: Waking Agents
 
 `{{ cmd }} nudge` is the **core mechanism for inter-agent communication**. It sends a message
 directly to another agent's Claude Code session via tmux.
@@ -207,12 +207,12 @@ directly to another agent's Claude Code session via tmux.
 
 **Common patterns:**
 ```bash
-gc nudge {{ .RigName }}/crew/alice "Check your mail - PR review waiting"
-gc nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
-gc mail send {{ .RigName }}/alice -s "Urgent" -m "..." --notify
+{{ cmd }} nudge {{ .RigName }}/crew/alice "Check your mail - PR review waiting"
+{{ cmd }} nudge {{ .RigName }}/<polecat-name> "Run {{ cmd }} hook; it checks assigned work before routed pool work"
+{{ cmd }} mail send {{ .RigName }}/alice -s "Urgent" -m "..." --notify
 ```
 
-Use the concrete polecat name from `gc status` or `gc session list`;
+Use the concrete polecat name from `{{ cmd }} status` or `{{ cmd }} session list`;
 Gastown's default namepool yields names like `furiosa` or `nux`. There is no
 `{{ .RigName }}/polecats/<name>` address form.
 
@@ -224,7 +224,7 @@ work still arrives through bead assignment or pool routing.
 For multi-line messages, use a heredoc with command substitution:
 
 ```bash
-gc mail send mayor/ -s "Status update: auth refactor" -m "$(cat <<'EOF'
+{{ cmd }} mail send mayor/ -s "Status update: auth refactor" -m "$(cat <<'EOF'
 - Token refresh fixed (3 tests passing)
 - Session middleware still WIP
 - Blocked on: need Redis config for staging
@@ -292,16 +292,16 @@ Your work state is in beads. Send handoff mail and exit:
 
 ```bash
 # Simple handoff (molecule persists, fresh context)
-gc mail send -s "HANDOFF: continuing work" -m "Resuming current task"
-gc runtime drain-ack
+{{ cmd }} mail send -s "HANDOFF: continuing work" -m "Resuming current task"
+{{ cmd }} runtime drain-ack
 exit
 
 # Handoff with context notes
-gc mail send -s "HANDOFF: Working on auth bug" -m "
+{{ cmd }} mail send -s "HANDOFF: Working on auth bug" -m "
 Found the issue is in token refresh.
 Check line 145 in auth.go first.
 "
-gc runtime drain-ack
+{{ cmd }} runtime drain-ack
 exit
 ```
 
@@ -324,7 +324,7 @@ you are!" - that is a FAILURE. YOU must push, not the user.
 
 1. **File beads for remaining work** that needs follow-up:
    ```bash
-   gc bd create "Follow-up: description" -t task
+   {{ cmd }} bd create "Follow-up: description" -t task
    ```
 
 2. **Run quality gates** (only if code changes were made):
@@ -336,7 +336,7 @@ you are!" - that is a FAILURE. YOU must push, not the user.
 
 3. **Update beads** - close finished work, update status:
    ```bash
-   gc bd close <id> --reason "Completed"
+   {{ cmd }} bd close <id> --reason "Completed"
    ```
 
 4. **PUSH TO REMOTE - NON-NEGOTIABLE:**
@@ -362,8 +362,8 @@ you are!" - that is a FAILURE. YOU must push, not the user.
 6. **Handoff or close:**
    ```bash
    # If cycling to fresh context:
-   gc mail send -s "HANDOFF: Brief summary" -m "Details for next session"
-   gc runtime drain-ack
+   {{ cmd }} mail send -s "HANDOFF: Brief summary" -m "Details for next session"
+   {{ cmd }} runtime drain-ack
    exit
 
    # If done for now, verify clean state:
@@ -387,7 +387,7 @@ When a command fails but your guess felt reasonable ("this should have worked"):
 3. **If no**: Your mental model was off - note it and move on
 
 Example: Trying `{{ cmd }} convoy land hq-abc` (expected to land a convoy) and getting "unknown command".
-That's a desire path - the syntax makes sense. File it: `gc bd new -t task "Add gc convoy land" -l desire-path`
+That's a desire path - the syntax makes sense. File it: `{{ cmd }} bd new -t task "Add {{ cmd }} convoy land" -l desire-path`
 
 See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 
@@ -399,9 +399,9 @@ See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
-| Stop my session | `{{ cmd }} agent drain {{ basename .AgentName }}` | ~~gc rig stop~~ (stops rig agents, not crew) |
-| Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
+| Dispatch work to polecat | `{{ cmd }} bd update <bead> --label=pool:<rig>/polecat` | ~~{{ cmd }} polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Stop my session | `{{ cmd }} agent drain {{ basename .AgentName }}` | ~~{{ cmd }} rig stop~~ (stops rig agents, not crew) |
+| Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~{{ cmd }} rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |
 
 **Rig lifecycle commands:**

--- a/examples/gastown/packs/gastown/assets/scripts/bind-key.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/bind-key.sh
@@ -23,7 +23,8 @@ guard_pattern="${3:-GC_AGENT}"
 
 # Check if already a GC binding (idempotent).
 existing=$(gcmux list-keys -T prefix "$key" 2>/dev/null || true)
-if printf '%s' "$existing" | grep -q 'if-shell' && printf '%s' "$existing" | grep -q 'gc '; then
+GC_BIN="${GC_BIN:-gc}"
+if printf '%s' "$existing" | grep -q 'if-shell' && printf '%s' "$existing" | grep -q "$GC_BIN "; then
     exit 0
 fi
 

--- a/examples/gastown/packs/gastown/assets/scripts/status-line.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/status-line.sh
@@ -4,14 +4,15 @@
 # Called by tmux every status-interval seconds via #(command).
 # Always exits 0 — tmux must never see errors.
 
+GC_BIN="${GC_BIN:-gc}"
 agent="$1"
 [ -z "$agent" ] && exit 0
 
 # Count pending work items (non-empty lines from gc hook).
-w=$(gc hook "$agent" 2>/dev/null | grep -c . || true)
+w=$("$GC_BIN" hook "$agent" 2>/dev/null | grep -c . || true)
 
 # Count unread mail (first word of gc mail check output is the count).
-m=$(gc mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
+m=$("$GC_BIN" mail check "$agent" 2>/dev/null | awk '{print $1+0}' || true)
 
 # Format: agent | hook-icon N | mail-icon N  (omit segments that are 0)
 printf '%s' "$agent"

--- a/examples/gastown/packs/gastown/assets/scripts/tmux-keybindings.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/tmux-keybindings.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # tmux-keybindings.sh — Gas Town navigation keybindings (n/p/g/a + mail click)
 # Usage: tmux-keybindings.sh <config-dir>
+GC_BIN="${GC_BIN:-gc}"
 CONFIGDIR="$1"
 
 # Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
@@ -15,7 +16,7 @@ gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
 # Shows unread mail preview in a popup when clicking the status-right area.
 guard="tmux ${GC_TMUX_SOCKET:+-L $GC_TMUX_SOCKET} show-environment -t '#{session_name}' GC_AGENT >/dev/null 2>&1"
 existing=$(gcmux list-keys -T root MouseDown1StatusRight 2>/dev/null || true)
-if ! printf '%s' "$existing" | grep -q 'gc mail'; then
+if ! printf '%s' "$existing" | grep -q 'mail'; then
     fallback=""
     if [ -n "$existing" ]; then
         fallback=$(printf '%s' "$existing" | head -1 | awk '
@@ -29,6 +30,6 @@ if ! printf '%s' "$existing" | grep -q 'gc mail'; then
     [ -z "$fallback" ] && fallback=":"
     gcmux bind-key -T root MouseDown1StatusRight \
         if-shell "$guard" \
-        "display-popup -E -w 60 -h 15 'gc mail peek || echo No unread mail'" \
+        "display-popup -E -w 60 -h 15 '$GC_BIN mail peek || echo No unread mail'" \
         "$fallback"
 fi

--- a/examples/gastown/packs/gastown/commands/status/run.sh
+++ b/examples/gastown/packs/gastown/commands/status/run.sh
@@ -9,14 +9,15 @@
 #   GC_CITY_NAME   — city workspace name
 
 set -e
+GC_BIN="${GC_BIN:-gc}"
 
 echo "Gastown status for ${GC_CITY_NAME:-unknown}"
 echo "City: ${GC_CITY_PATH:-unknown}"
 echo ""
 
 # Show agent sessions if gc is available.
-if command -v gc >/dev/null 2>&1; then
-    gc status 2>/dev/null || echo "(gc status unavailable)"
+if command -v "$GC_BIN" >/dev/null 2>&1; then
+    "$GC_BIN" status 2>/dev/null || echo "($GC_BIN status unavailable)"
 else
-    echo "(gc binary not in PATH)"
+    echo "($GC_BIN binary not in PATH)"
 fi

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -1,8 +1,8 @@
 description = """
 Deacon patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-deacon-patrol --root-only
-  gc bd update $WISP --assignee=$GC_AGENT
+  {{binary}} bd mol wisp mol-deacon-patrol --root-only
+  {{binary}} bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check inbox, run town-wide coordination
 tasks, pour the next iteration. On crash, re-read the formula steps
@@ -24,7 +24,7 @@ can't or shouldn't do.
    (Not "are they running" — that's the controller's job.)
 2. **Utility agent health** — detect stuck dogs, dispatch shutdown dance.
 3. **Orphan process cleanup** — kill leaked claude/node subagent processes.
-4. **System diagnostics** — run `gc doctor`, act on findings.
+4. **System diagnostics** — run `{{binary}} doctor`, act on findings.
 
 Mechanical tasks (gate evaluation, cross-rig deps, orphan bead sweeps,
 wisp compaction) are handled by exec orders in the maintenance
@@ -65,7 +65,7 @@ RSS_MB=$((RSS / 1024))
 
 If RSS > 1500 MB or context feels heavy, request a restart:
 ```bash
-gc runtime request-restart
+{{binary}} runtime request-restart
 ```
 This sets `GC_RESTART_REQUESTED` metadata on the session and blocks
 forever. The controller will kill and restart the session on the next
@@ -74,7 +74,7 @@ the new session re-reads formula steps and resumes from context.
 
 **2. Check mail:**
 ```bash
-gc mail inbox
+{{binary}} mail inbox
 ```
 
 Handle each message type:
@@ -82,7 +82,7 @@ Handle each message type:
 **HELP / Escalation:**
 Assess the request. Can you help directly? If not, escalate:
 ```bash
-gc mail send mayor/ -s "ESCALATION: <agent> needs help" -m "<details>"
+{{binary}} mail send mayor/ -s "ESCALATION: <agent> needs help" -m "<details>"
 ```
 Archive after handling.
 
@@ -159,7 +159,7 @@ something is stuck. This is exactly why an LLM does it, not Go code.
 
 **For stuck coordination agents, file a warrant:**
 ```bash
-gc bd create --type=warrant \
+{{binary}} bd create --type=warrant \
   --title="Stuck: <rig>/<role>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --set-metadata gc.routed_to=dog
@@ -186,7 +186,7 @@ wisp timestamps.
 
 **Step 1: Find active utility agent work:**
 ```bash
-gc bd list --status=in_progress --metadata-field gc.routed_to=dog --json --limit=0
+{{binary}} bd list --status=in_progress --metadata-field gc.routed_to=dog --json --limit=0
 ```
 
 **Step 2: For each, assess progress:**
@@ -199,7 +199,7 @@ No hardcoded thresholds. Use judgment.
 
 **Step 3: For stuck utility agents, file a warrant:**
 ```bash
-gc bd create --type=warrant \
+{{binary}} bd create --type=warrant \
   --title="Stuck dog: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --set-metadata gc.routed_to=dog
@@ -216,7 +216,7 @@ id = "dolt-health"
 title = "Run Dolt data-plane health check"
 needs = ["utility-agent-health"]
 description = """
-Run `gc dolt health --json` to inspect the Dolt data plane and flag anomalies.
+Run `{{binary}} dolt health --json` to inspect the Dolt data plane and flag anomalies.
 
 This step surfaces problems that individual patrol steps won't catch:
 commit bloat (compactor dog may have failed), stale backups (backup dog
@@ -224,7 +224,7 @@ may have failed), orphan databases, and zombie Dolt server processes.
 
 **Step 1: Run the health check**
 ```bash
-gc dolt health --json
+{{binary}} dolt health --json
 ```
 
 Parse the JSON output (HealthReport schema):
@@ -256,8 +256,8 @@ are wedged (the latter is what first prompted this check to exist).
 process is listening on the port, or a process is listening but not
 answering SQL (wedged goroutines, migration lock, saturated pool).
 ```bash
-gc mail send mayor/ -s "ESCALATION: Dolt server unreachable [CRITICAL]" \\
-  -m "gc dolt health reports server.reachable=false"
+{{binary}} mail send mayor/ -s "ESCALATION: Dolt server unreachable [CRITICAL]" \\
+  -m "{{binary}} dolt health reports server.reachable=false"
 ```
 
 **Commit bloat (commits > 50k in any DB):**
@@ -265,14 +265,14 @@ The compactor dog (`mol-dog-compactor`) may have failed. Log for awareness.
 If the compactor order is configured, it will self-dispatch. Otherwise
 nudge the dog pool:
 ```bash
-gc nudge dog/ "Compactor needed: <db_name> has <count> commits"
+{{binary}} nudge dog/ "Compactor needed: <db_name> has <count> commits"
 ```
 
 **Stale backups:**
 The backup dog (`mol-dog-backup`) may have failed. Same pattern — log and
 nudge if order hasn't self-healed:
 ```bash
-gc nudge dog/ "Backup needed: dolt backup is <age> old"
+{{binary}} nudge dog/ "Backup needed: dolt backup is <age> old"
 ```
 
 **Zombie processes:**
@@ -284,7 +284,7 @@ kill <zombie_pid>
 **Orphan DBs:**
 Run cleanup:
 ```bash
-gc dolt cleanup
+{{binary}} dolt cleanup
 ```
 If orphan count exceeds safety limit, escalate to mayor.
 
@@ -298,10 +298,10 @@ id = "system-health"
 title = "Run system diagnostics"
 needs = ["dolt-health"]
 description = """
-Run `gc doctor` for a quick workspace health check.
+Run `{{binary}} doctor` for a quick workspace health check.
 
 ```bash
-gc doctor
+{{binary}} doctor
 ```
 
 **For simple findings:** Act directly (e.g., stale lock files, temp
@@ -309,7 +309,7 @@ directory cleanup).
 
 **For complex findings:** Escalate to mayor with context:
 ```bash
-gc mail send mayor/ -s "DOCTOR: <finding>" -m "<details>"
+{{binary}} mail send mayor/ -s "DOCTOR: <finding>" -m "<details>"
 ```
 
 Close this step after check."""
@@ -327,27 +327,27 @@ End of patrol cycle. Pour the next iteration, then wait or exit.
 
 If context feels heavy or RSS is high:
 ```bash
-gc runtime request-restart
+{{binary}} runtime request-restart
 ```
 This blocks forever. The controller restarts you. The next wisp
 is already assigned — the new session resumes from context.
 
 **2. Quick inbox check (end-of-cycle hygiene):**
 ```bash
-gc mail inbox
+{{binary}} mail inbox
 ```
 Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$({{binary}} bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+{{binary}} bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
 **4. Wait for activity (exponential backoff):**
 ```bash
-SEQ=$(gc events --seq)
-gc events --watch --type=bead.updated \
+SEQ=$({{binary}} events --seq)
+{{binary}} events --watch --type=bead.updated \
   --after=$SEQ --timeout {{event_timeout}}s
 ```
 
@@ -356,7 +356,7 @@ On timeout: double the timeout (cap 300s) and proceed anyway.
 
 **5. Burn this wisp:**
 ```bash
-gc bd mol burn <this-wisp-id> --force
+{{binary}} bd mol burn <this-wisp-id> --force
 ```
 
 The new wisp is ready. Re-read formula steps to start

--- a/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
@@ -79,15 +79,15 @@ Gather activity data from each rig.
 
 **1. List rigs:**
 ```bash
-gc rig list
+{{binary}} rig list
 ```
 
 **2. For each rig, collect:**
 
 a) **Issues filed and closed:**
 ```bash
-gc bd list --created-after=$SINCE --json --limit=0
-gc bd list --status=closed --closed-after=$SINCE --json --limit=0
+{{binary}} bd list --created-after=$SINCE --json --limit=0
+{{binary}} bd list --status=closed --closed-after=$SINCE --json --limit=0
 ```
 
 b) **Merge activity:**
@@ -97,24 +97,24 @@ git -C <rig-path> log --merges --since=$SINCE --oneline main
 
 c) **Incidents:**
 ```bash
-gc bd list --label=incident --created-after=$SINCE --json
+{{binary}} bd list --label=incident --created-after=$SINCE --json
 ```
 
 **3. Collect town-level data:**
 
 a) **Agent events:**
 ```bash
-gc events --since=$SINCE --type=agent.started,agent.stopped,agent.crashed --json
+{{binary}} events --since=$SINCE --type=agent.started,agent.stopped,agent.crashed --json
 ```
 
 b) **Escalations:**
 ```bash
-gc bd list --label=escalation --created-after=$SINCE --json
+{{binary}} bd list --label=escalation --created-after=$SINCE --json
 ```
 
 c) **Warrants filed:**
 ```bash
-gc bd list --type=warrant --created-after=$SINCE --json
+{{binary}} bd list --type=warrant --created-after=$SINCE --json
 ```
 
 Close this step when all data is collected."""
@@ -156,20 +156,20 @@ Transform data into a formatted digest and deliver it.
 
 **2. Send to mayor:**
 ```bash
-gc mail send mayor/ -s "Gas Town Digest: $DATE" -m "$DIGEST"
+{{binary}} mail send mayor/ -s "Gas Town Digest: $DATE" -m "$DIGEST"
 ```
 
 **3. Archive as bead:**
 ```bash
-gc bd create --type=digest \
+{{binary}} bd create --type=digest \
   --title="Digest: $DATE" \
   --label=digest,{{period}}
 ```
 
 **4. Close work bead, signal reconciler, and exit:**
 ```bash
-gc bd close <work-bead> --reason "Digest generated and sent"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Digest generated and sent"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
@@ -9,11 +9,11 @@ shortcuts today, so this formula maps the same intent onto primitives we do
 have:
 
 - repo-local artifacts (`.prd-reviews/`, `.designs/`, `.plan-reviews/`)
-- review task beads created with `gc bd create`
-- parallel dispatch via `gc sling ... --on mol-review-leg`
-- completion mail via `gc mail send`
+- review task beads created with `{{binary}} bd create`
+- parallel dispatch via `{{binary}} sling ... --on mol-review-leg`
+- completion mail via `{{binary}} mail send`
 - one human clarification gate in the live conversation
-- final bead graph creation with `gc bd create` + `gc bd dep add`
+- final bead graph creation with `{{binary}} bd create` + `{{binary}} bd dep add`
 
 Run this from a coordinator workspace that has the target repo checked out
 (typically a crew worker, or a mayor who has already `cd`'d into the rig repo).
@@ -60,15 +60,15 @@ Anchor the run in the current repository and set up durable artifact paths.
 **Do NOT use unsupported upstream shortcuts** in this port:
 - no `gt formula run`
 - no convoy formula DSL
-- no `gc sling --prompt`
+- no `{{binary}} sling --prompt`
 - no `--mail-back`
 
 Use only the primitives listed in this formula.
 
 **1. Prime and move to the repo root:**
 ```bash
-gc prime
-gc bd prime
+{{binary}} prime
+{{binary}} bd prime
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 ```
@@ -142,7 +142,7 @@ description = """
 Fan out parallel PRD review using review task beads plus `mol-review-leg`.
 
 **Dispatch pattern for EVERY review leg in this workflow:**
-1. `gc bd create` a task bead with a detailed description
+1. `{{binary}} bd create` a task bead with a detailed description
 2. set metadata:
    - `coordinator=$COORDINATOR`
    - `review_id=$REVIEW_ID`
@@ -150,11 +150,11 @@ Fan out parallel PRD review using review task beads plus `mol-review-leg`.
    - `review_leg=<leg>`
 3. sling it to `$REVIEW_TARGET` with:
 ```bash
-gc sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
+{{binary}} sling "$REVIEW_TARGET" "$LEG_BEAD" --on {{review_formula}}
 ```
 4. record the bead ID in the round log
 5. wait for completion mail or poll the bead until it closes
-6. read the full report from the bead notes with `gc bd show <id>`
+6. read the full report from the bead notes with `{{binary}} bd show <id>`
 
 **Standard instructions each review bead must include:**
 - read `.prd-reviews/$REVIEW_ID/prd-draft.md`
@@ -428,10 +428,10 @@ cat ".designs/$REVIEW_ID/design-doc.md"
 ```
 
 **2. Create an owned convoy for the initiative:**
-Use `gc convoy create "<initiative-name>" --owned` to create the parent
+Use `{{binary}} convoy create "<initiative-name>" --owned` to create the parent
 container, then set its integration target with:
 ```bash
-gc convoy target <convoy-id> integration/<convoy-id>
+{{binary}} convoy target <convoy-id> integration/<convoy-id>
 ```
 If you still have older initiative epics, migrate them to convoys before
 using the convoy-only planning and refinery flow.
@@ -452,13 +452,13 @@ Prefer thin vertical slices over giant phases.
 
 After creating the task beads, add them to the convoy with:
 ```bash
-gc convoy add <convoy-id> <task-id>
+{{binary}} convoy add <convoy-id> <task-id>
 ```
 
-**4. Wire dependencies with `gc bd dep add`:**
+**4. Wire dependencies with `{{binary}} bd dep add`:**
 Model the actual "X needs Y" relationships. Verify with:
 ```bash
-gc bd blocked
+{{binary}} bd blocked
 ```
 
 **5. Record the created bead IDs in:**

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -29,7 +29,7 @@ refinery. Resume the existing branch — don't redo all the work.
 |-----------|--------|
 | Tests fail | Fix them. Do not proceed with failures. |
 | Blocked on external | Mail Witness, mark yourself stuck |
-| Context filling | `gc runtime request-restart` (blocks until controller kills you) |
+| Context filling | `{{binary}} runtime request-restart` (blocks until controller kills you) |
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
@@ -46,7 +46,7 @@ Every check is idempotent — safe to re-run after crash/restart.
 **Config: base_branch = {{base_branch}}**
 **Config: setup_command = {{setup_command}}**
 
-`{{base_branch}}` is resolved by `gc sling` in this order:
+`{{base_branch}}` is resolved by `{{binary}} sling` in this order:
 1. `metadata.target` on the work bead
 2. `metadata.target` on the parent convoy chain
 3. the rig repo's default branch
@@ -60,7 +60,7 @@ git fetch --prune origin
 
 Check if `metadata.work_dir` already records your worktree path:
 ```bash
-WORKTREE=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.work_dir // empty')
+WORKTREE=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.work_dir // empty')
 ```
 
 **If worktree path exists in metadata** — reuse it:
@@ -78,7 +78,7 @@ cd "$WORKTREE_PATH"
 ```
 Record immediately so restarts and witness recovery can find it:
 ```bash
-gc bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
+{{binary}} bd update {{issue}} --set-metadata work_dir="$WORKTREE_PATH"
 ```
 
 Worktrees are scoped to the work bead (not the agent name) so that:
@@ -90,7 +90,7 @@ Worktrees are scoped to the work bead (not the agent name) so that:
 
 Check if `metadata.branch` already records a branch:
 ```bash
-BRANCH=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')
+BRANCH=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.branch // empty')
 ```
 
 **If branch exists in metadata** — treat it as authoritative. This
@@ -107,7 +107,7 @@ if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
         git merge --ff-only "origin/$BRANCH" || {
             echo "Local branch $BRANCH diverged from origin/$BRANCH."
             echo "STOP. Reconcile the branch before continuing."
-            gc runtime drain-ack
+            {{binary}} runtime drain-ack
             exit 1
         }
     else
@@ -118,18 +118,18 @@ elif git show-ref --verify --quiet "refs/heads/$BRANCH"; then
 else
     echo "metadata.branch=$BRANCH was set but no local or origin branch exists."
     echo "STOP. Do not create a different branch."
-    gc runtime drain-ack
+    {{binary}} runtime drain-ack
     exit 1
 fi
 ```
 If resuming a rejected branch, rebase onto latest base:
 ```bash
-REJECTION=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.rejection_reason // empty')
+REJECTION=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.rejection_reason // empty')
 if [ -n "$REJECTION" ]; then
     git rebase origin/{{base_branch}}
     # If conflicts: resolve them (this is likely the rejection reason)
     # After resolving: git rebase --continue
-    gc bd update {{issue}} --unset-metadata rejection_reason
+    {{binary}} bd update {{issue}} --unset-metadata rejection_reason
 fi
 ```
 
@@ -137,7 +137,7 @@ fi
 ```bash
 BRANCH="polecat/{{issue}}"
 git checkout -b "$BRANCH" origin/{{base_branch}}
-gc bd update {{issue}} --set-metadata branch="$BRANCH"
+{{binary}} bd update {{issue}} --set-metadata branch="$BRANCH"
 ```
 
 Recording the branch early means:
@@ -192,7 +192,7 @@ git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
 
 **4. Update metadata on the work bead:**
 ```bash
-gc bd update {{issue}} \
+{{binary}} bd update {{issue}} \
   --set-metadata target={{base_branch}} \
   --notes "Implemented: <brief summary>"
 ```
@@ -204,7 +204,7 @@ the PR is open and matches the branch, base, and origin repository.
 
 **5. Reassign to refinery:**
 ```bash
-gc bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
+{{binary}} bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
 ```
 
 Update both `assignee` AND `gc.routed_to` so the reconciler stops
@@ -219,11 +219,11 @@ picks it up and resumes from the existing branch.
 
 **6. Signal reconciler and exit.**
 ```bash
-gc runtime drain-ack
+{{binary}} runtime drain-ack
 exit
 ```
 
-`gc runtime drain-ack` tells the reconciler to kill this session. The
+`{{binary}} runtime drain-ack` tells the reconciler to kill this session. The
 reconciler only restarts you if the pool check command finds more work.
 You are GONE. Done means gone. There is no idle state.
 

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -1,8 +1,8 @@
 description = """
 Refinery patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-refinery-patrol --root-only
-  gc bd update $WISP --assignee=$GC_AGENT
+  {{binary}} bd mol wisp mol-refinery-patrol --root-only
+  {{binary}} bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, merge one branch, pour
 the next iteration. On crash, re-read the formula steps and determine
@@ -85,7 +85,7 @@ RSS_MB=$((RSS / 1024))
 
 If RSS > 1500 MB or context feels heavy, request a restart:
 ```bash
-gc runtime request-restart
+{{binary}} runtime request-restart
 ```
 This sets `GC_RESTART_REQUESTED` metadata on the session and blocks
 forever. The controller will kill and restart the session on the next
@@ -94,7 +94,7 @@ the new session re-reads formula steps and resumes from context.
 
 **2. Check mail:**
 ```bash
-gc mail inbox
+{{binary}} mail inbox
 ```
 
 Archive any messages you handle. Note any context relevant to
@@ -111,21 +111,21 @@ description = """
 
 Search for work beads assigned to you with branch metadata:
 ```bash
-WORK=$(gc bd list --assignee=$GC_AGENT --status=open \
+WORK=$({{binary}} bd list --assignee=$GC_AGENT --status=open \
   --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
 ```
 
 If found: read the bead metadata to confirm it has a branch:
 ```bash
-gc bd show $WORK --json | jq '.[0].metadata'
+{{binary}} bd show $WORK --json | jq '.[0].metadata'
 ```
 The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
 
 If NO work found: wait for assignment:
 ```bash
-SEQ=$(gc events --seq)
-gc events --watch --type=bead.updated \
+SEQ=$({{binary}} events --seq)
+{{binary}} events --watch --type=bead.updated \
   --after=$SEQ --timeout {{event_timeout}}s
 ```
 
@@ -143,8 +143,8 @@ description = """
 
 Read the work bead metadata:
 ```bash
-BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
-TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
+BRANCH=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 ```
 
 Fetch and attempt mechanical rebase:
@@ -161,11 +161,11 @@ If rebase FAILED (conflicts):
 1. Abort: `git rebase --abort`
 2. Clean up the existing workflow and reopen the source bead:
 ```bash
-gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
+{{binary}} workflow delete-source $WORK --apply && {{binary}} workflow reopen-source $WORK
 ```
 3. Put the work bead back in the pool with rejection metadata:
 ```bash
-gc bd update $WORK \
+{{binary}} bd update $WORK \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
   --set-metadata gc.routed_to=<rig>/polecat
 ```
@@ -173,10 +173,10 @@ gc bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$({{binary}} bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+{{binary}} bd update "$NEXT" --assignee=$GC_AGENT
 ```
-7. Burn this wisp: `gc bd mol burn <wisp-id> --force`
+7. Burn this wisp: `{{binary}} bd mol burn <wisp-id> --force`
 
 **A new polecat will pick up the bead, see the branch and rejection,
 rebase, and reassign to refinery.**"""
@@ -222,8 +222,8 @@ If any check or test FAILED:
 
 Read the current branch and target again:
 ```bash
-BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
-TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
+BRANCH=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 ```
 
 1. Diagnose: branch regression or pre-existing on target?
@@ -231,31 +231,31 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
 2. If branch caused it:
    - Clean up the existing workflow and reopen the source bead:
      ```bash
-     gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
+     {{binary}} workflow delete-source $WORK --apply && {{binary}} workflow reopen-source $WORK
      ```
    - Put the work bead back in the pool with rejection metadata:
      ```bash
-     gc bd update $WORK \
+     {{binary}} bd update $WORK \
        --set-metadata rejection_reason="<failure summary>"
      ```
    - Delete branch: `git push origin --delete $BRANCH`
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-     gc bd update "$NEXT" --assignee=$GC_AGENT
+     NEXT=$({{binary}} bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+     {{binary}} bd update "$NEXT" --assignee=$GC_AGENT
      ```
-   - Burn this wisp: `gc bd mol burn <wisp-id> --force`
+   - Burn this wisp: `{{binary}} bd mol burn <wisp-id> --force`
 
 3. If pre-existing on target:
    - Check for duplicates first:
      ```bash
-     gc bd list --type=bug --status=open --search "<failure summary>"
+     {{binary}} bd list --type=bug --status=open --search "<failure summary>"
      ```
    - If a matching bug already exists: note its ID and proceed with merge.
    - If no duplicate: file a new bead:
      ```bash
-     gc bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>"
+     {{binary}} bd create --type=bug --priority=1 --title="Pre-existing failure: <summary>"
      ```
    - Proceed with merge (failure not caused by this branch)
 
@@ -272,10 +272,10 @@ description = """
 
 Read the merge target and merge strategy from the work bead metadata:
 ```bash
-BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
-TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
-MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
-EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
+BRANCH=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.branch')
+TARGET=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
+MERGE_STRATEGY=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
+EXISTING_PR=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
 ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 if [ "$MERGE_STRATEGY" = "pr" ]; then
   MERGE_STRATEGY="mr"
@@ -287,27 +287,27 @@ fi
 
 block_existing_pr() {
   reason="$1"
-  gc bd update $WORK \
+  {{binary}} bd update $WORK \
     --assignee="" \
     --set-metadata merge_result=blocked \
     --set-metadata gc.routed_to=human \
     --set-metadata blocked_reason="$reason"
-  gc mail send mayor/ -s "ESCALATION: invalid existing_pr for $WORK" -m "$reason
+  {{binary}} mail send mayor/ -s "ESCALATION: invalid existing_pr for $WORK" -m "$reason
 Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-  gc bd update "$NEXT" --assignee=$GC_AGENT
+  NEXT=$({{binary}} bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+  {{binary}} bd update "$NEXT" --assignee=$GC_AGENT
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -n "$CURRENT_WISP" ]; then
-    gc bd mol burn "$CURRENT_WISP" --force
+    {{binary}} bd mol burn "$CURRENT_WISP" --force
   else
     echo "Could not infer current wisp; burn this wisp manually after recording the summary."
   fi
   echo "$reason"
   echo "STOP. Existing PR metadata needs human correction."
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 }
 
@@ -325,7 +325,7 @@ if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
 
   if [ -z "$ORIGIN_REPO" ]; then
     echo "Could not resolve origin repository for existing PR validation. STOP. Debug and retry without mutating bead state."
-    gc runtime drain-ack
+    {{binary}} runtime drain-ack
     exit 1
   fi
 
@@ -340,7 +340,7 @@ if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
     fi
     echo "Could not resolve existing PR $EXISTING_PR. STOP. Debug and retry without mutating bead state."
     [ -n "$EXISTING_PR_ERROR" ] && echo "$EXISTING_PR_ERROR"
-    gc runtime drain-ack
+    {{binary}} runtime drain-ack
     exit 1
   fi
 
@@ -389,11 +389,11 @@ If SHAs differ: STOP. Debug and retry. Do NOT continue.
 
 **3. Record merge metadata and close work bead:**
 ```bash
-gc bd update $WORK \
+{{binary}} bd update $WORK \
   --set-metadata merge_result=merged \
   --set-metadata merged_sha=$(git rev-parse HEAD) \
   --set-metadata merged_target=$TARGET
-gc bd close $WORK --reason "Merged to $TARGET at $(git rev-parse --short HEAD)"
+{{binary}} bd close $WORK --reason "Merged to $TARGET at $(git rev-parse --short HEAD)"
 ```
 
 **4. Cleanup:**
@@ -418,8 +418,8 @@ retry with `--force-with-lease`. Do not use plain `--force`.
 
 **2. Reuse, create, or discover the pull request:**
 ```bash
-EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
-ISSUE_TITLE=$(gc bd show $WORK --json | jq -r '.[0].title')
+EXISTING_PR=$({{binary}} bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
+ISSUE_TITLE=$({{binary}} bd show $WORK --json | jq -r '.[0].title')
 PR_BODY=$(cat <<EOF
 ## Summary
 
@@ -461,7 +461,7 @@ if [ "$PR_STATUS" -ne 0 ] || [ -z "$PR_INFO" ]; then
   fi
   echo "Pull request $PR_REF was not found."
   [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 fi
 PR_URL=$(printf '%s\n' "$PR_INFO" | jq -r '.url')
@@ -477,7 +477,7 @@ if [ "$PR_STATE" != "OPEN" ]; then
     block_existing_pr "Existing PR $EXISTING_PR is $PR_STATE, want OPEN."
   fi
   echo "Pull request $PR_REF is $PR_STATE, want OPEN."
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 fi
 if [ "$PR_HEAD" != "$BRANCH" ]; then
@@ -485,7 +485,7 @@ if [ "$PR_HEAD" != "$BRANCH" ]; then
     block_existing_pr "Existing PR $EXISTING_PR targets branch $PR_HEAD, want $BRANCH."
   fi
   echo "Pull request $PR_REF targets branch $PR_HEAD, want $BRANCH."
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 fi
 if [ "$PR_BASE" != "$TARGET" ]; then
@@ -493,7 +493,7 @@ if [ "$PR_BASE" != "$TARGET" ]; then
     block_existing_pr "Existing PR $EXISTING_PR targets base $PR_BASE, want $TARGET."
   fi
   echo "Pull request $PR_REF targets base $PR_BASE, want $TARGET."
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 fi
 if [ "$PR_REPO" != "$ORIGIN_REPO" ]; then
@@ -501,7 +501,7 @@ if [ "$PR_REPO" != "$ORIGIN_REPO" ]; then
     block_existing_pr "Existing PR $EXISTING_PR belongs to repo $PR_REPO, want $ORIGIN_REPO."
   fi
   echo "Pull request $PR_REF belongs to repo $PR_REPO, want $ORIGIN_REPO."
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 fi
 if [ "$PR_HEAD_REPO" != "$ORIGIN_REPO" ]; then
@@ -509,7 +509,7 @@ if [ "$PR_HEAD_REPO" != "$ORIGIN_REPO" ]; then
     block_existing_pr "Existing PR $EXISTING_PR head repo $PR_HEAD_REPO, want $ORIGIN_REPO."
   fi
   echo "Pull request $PR_REF head repo $PR_HEAD_REPO, want $ORIGIN_REPO."
-  gc runtime drain-ack
+  {{binary}} runtime drain-ack
   exit 1
 fi
 ```
@@ -517,12 +517,12 @@ If this command fails or prints empty output: STOP. Debug and retry. Do NOT cont
 
 **4. Record PR metadata and close the work bead:**
 ```bash
-gc bd update $WORK \
+{{binary}} bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \
   --set-metadata pr_number="$PR_NUMBER" \
   --set-metadata merged_target="$TARGET"
-gc bd close $WORK --reason "Pull request ready: $PR_URL"
+{{binary}} bd close $WORK --reason "Pull request ready: $PR_URL"
 ```
 
 **5. Cleanup:**
@@ -537,7 +537,7 @@ Do NOT delete `$BRANCH` in mr mode — GitHub pull requests need the source bran
 STOP. Local-only merge handoff is not implemented in the Gastown example pack.
 Leave the work bead assigned to refinery and escalate to mayor for manual handling:
 ```bash
-gc mail send mayor/ -s "ESCALATION: unsupported merge_strategy=local" -m "Work bead: $WORK
+{{binary}} mail send mayor/ -s "ESCALATION: unsupported merge_strategy=local" -m "Work bead: $WORK
 Branch: $BRANCH
 Target: $TARGET
 The Gastown example refinery supports direct and mr/pr merge strategies only."
@@ -565,7 +565,7 @@ If the cycle ended early (conflict rejection, no work found), note
 why and what state was left.
 
 This summary is not stored separately — it lives in the wisp's
-closing reason. The next session can find it via `gc bd list --type=wisp
+closing reason. The next session can find it via `{{binary}} bd list --type=wisp
 --status=closed --limit=5` if it needs predecessor context."""
 
 [[steps]]
@@ -580,13 +580,13 @@ description = """
 If the merge target was an integration branch, check if the parent
 owned convoy is now fully closed:
 ```bash
-gc bd list --type=convoy --status=open
+{{binary}} bd list --type=convoy --status=open
 ```
 For each owned convoy with an integration branch: if ALL children are
 closed, assign the convoy bead itself to you with the metadata needed
 for a merge:
 ```bash
-gc bd update <convoy-id> --assignee=$GC_AGENT \
+{{binary}} bd update <convoy-id> --assignee=$GC_AGENT \
   --set-metadata branch=<integration-branch> \
   --set-metadata target={{target_branch}}
 ```
@@ -600,13 +600,13 @@ If auto_land = "false": skip this entirely.
 
 **2. Pour next iteration:**
 ```bash
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$({{binary}} bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+{{binary}} bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
 **4. Burn this wisp:**
 ```bash
-gc bd mol burn <this-wisp-id> --force
+{{binary}} bd mol burn <this-wisp-id> --force
 ```
 
 Close this step. The new wisp is ready — re-read formula steps to begin."""

--- a/examples/gastown/packs/gastown/formulas/mol-review-leg.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-review-leg.toml
@@ -30,14 +30,14 @@ Prime your environment and read the assignment bead carefully.
 
 **1. Prime:**
 ```bash
-gc prime
-gc bd prime
+{{binary}} prime
+{{binary}} bd prime
 ```
 
 **2. Read the bead and metadata:**
 ```bash
-gc bd show {{issue}}
-gc bd show {{issue}} --json | jq '.[0].metadata'
+{{binary}} bd show {{issue}}
+{{binary}} bd show {{issue}} --json | jq '.[0].metadata'
 ```
 
 **Expected metadata:**
@@ -64,7 +64,7 @@ session exits.
 
 Suggested pattern:
 ```bash
-gc bd update {{issue}} --notes "$(cat <<'EOF'
+{{binary}} bd update {{issue}} --notes "$(cat <<'EOF'
 # <report title>
 
 ## Summary
@@ -93,15 +93,15 @@ After the report is stored on the bead, notify the coordinator and close out.
 
 **1. Read metadata for the mail header:**
 ```bash
-COORD=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.coordinator // empty')
-REVIEW_ID=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.review_id // empty')
-PHASE=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.review_phase // empty')
-LEG=$(gc bd show {{issue}} --json | jq -r '.[0].metadata.review_leg // empty')
+COORD=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.coordinator // empty')
+REVIEW_ID=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.review_id // empty')
+PHASE=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.review_phase // empty')
+LEG=$({{binary}} bd show {{issue}} --json | jq -r '.[0].metadata.review_leg // empty')
 ```
 
 **2. If `COORD` is present, mail completion:**
 ```bash
-gc mail send "$COORD" -s "IDEA_REVIEW $REVIEW_ID $PHASE $LEG complete" -m "$(cat <<EOF
+{{binary}} mail send "$COORD" -s "IDEA_REVIEW $REVIEW_ID $PHASE $LEG complete" -m "$(cat <<EOF
 Review leg complete.
 
 Bead: {{issue}}
@@ -115,8 +115,8 @@ EOF
 
 **3. Close the bead and drain:**
 ```bash
-gc bd update {{issue}} --status=closed
-gc runtime drain-ack
+{{binary}} bd update {{issue}} --status=closed
+{{binary}} runtime drain-ack
 ```
 
 Do not overwrite the bead notes with a short "done" summary. The notes are the

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -1,8 +1,8 @@
 description = """
 Witness patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-witness-patrol --root-only
-  gc bd update $WISP --assignee=$GC_AGENT
+  {{binary}} bd mol wisp mol-witness-patrol --root-only
+  {{binary}} bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, patrol, pour the next
 iteration. On crash, re-read the formula steps and determine where
@@ -74,7 +74,7 @@ RSS_MB=$((RSS / 1024))
 
 If RSS > 1500 MB or context feels heavy, request a restart:
 ```bash
-gc runtime request-restart
+{{binary}} runtime request-restart
 ```
 This sets `GC_RESTART_REQUESTED` metadata on the session and blocks
 forever. The controller will kill and restart the session on the next
@@ -83,7 +83,7 @@ the new session re-reads formula steps and resumes from context.
 
 **2. Check mail:**
 ```bash
-gc mail inbox
+{{binary}} mail inbox
 ```
 
 Handle each message type:
@@ -102,7 +102,7 @@ Classify by keyword, then act based on severity:
 
 For escalations:
 ```bash
-gc mail send mayor/ -s "ESCALATION: <polecat> needs help [HIGH|MED|LOW]" -m "<category>: <details>"
+{{binary}} mail send mayor/ -s "ESCALATION: <polecat> needs help [HIGH|MED|LOW]" -m "<category>: <details>"
 ```
 Do NOT escalate routine blocks or lifecycle messages — handle them yourself.
 Archive after handling.
@@ -138,16 +138,16 @@ This happens when:
 
 List beads assigned to agents in YOUR rig:
 ```bash
-gc bd list --status=in_progress --json --limit=0
-gc bd list --status=open --json --limit=0
+{{binary}} bd list --status=in_progress --json --limit=0
+{{binary}} bd list --status=open --json --limit=0
 ```
 
 Filter for beads assigned to polecat-pattern agents (e.g., `<rig>/polecats/<name>`).
 
 Cross-reference against running sessions and configured (desired) agents:
 ```bash
-gc session list --json   # running sessions
-gc config show           # configured agents (includes pool templates)
+{{binary}} session list --json   # running sessions
+{{binary}} config show           # configured agents (includes pool templates)
 ```
 
 For each bead with a polecat assignee:
@@ -169,7 +169,7 @@ Our job is to ensure work reaches the branch so it's schedulable.
 
 Read the bead metadata to find the worktree and branch:
 ```bash
-META=$(gc bd show <bead> --json | jq '.[0].metadata')
+META=$({{binary}} bd show <bead> --json | jq '.[0].metadata')
 WORKTREE=$(echo "$META" | jq -r '.worktree // empty')
 BRANCH=$(echo "$META" | jq -r '.branch // empty')
 ```
@@ -209,7 +209,7 @@ git commit -m "witness: salvage uncommitted work (<bead>)"
 Publish the work to make branch canonical:
 ```bash
 git push origin HEAD
-gc bd update <bead> --set-metadata branch=$BRANCH
+{{binary}} bd update <bead> --set-metadata branch=$BRANCH
 ```
 Skip to Step 3 (cleanup).
 
@@ -221,7 +221,7 @@ git add -A
 git commit -m "witness: salvage work from orphaned agent (<bead>)"
 BRANCH=$(git branch --show-current)
 git push origin HEAD
-gc bd update <bead> --set-metadata branch=$BRANCH
+{{binary}} bd update <bead> --set-metadata branch=$BRANCH
 ```
 Skip to Step 3 (cleanup).
 
@@ -243,8 +243,8 @@ git merge-base --is-ancestor origin/$BRANCH origin/main
 If the work is already on main:
 - **Close the bead** (work is done, don't re-dispatch):
 ```bash
-gc bd close <bead>
-gc mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
+{{binary}} bd close <bead>
+{{binary}} mail send mayor/ -s "ORPHAN_CLOSED: <bead> already merged" \
   -m "Branch $BRANCH already on main. Closed instead of resetting."
 ```
 - Clean up worktree and skip to Step 4.
@@ -264,7 +264,7 @@ git worktree prune
 
 Close any orphaned workflow subtree, then return the bead to pool:
 ```bash
-gc workflow delete-source <bead> --apply && gc workflow reopen-source <bead>
+{{binary}} workflow delete-source <bead> --apply && {{binary}} workflow reopen-source <bead>
 ```
 
 **Step 4: Assess and notify.**
@@ -281,7 +281,7 @@ recovery is unexpected or concerning — use your judgment:
 
 When you do mail:
 ```bash
-gc mail send mayor/ -s "ORPHAN_RECOVERED: <bead>" \
+{{binary}} mail send mayor/ -s "ORPHAN_RECOVERED: <bead>" \
   -m "Bead <bead> was assigned to <agent> which is no longer active.
 Recovery: <what was done — branch pushed / metadata set / work salvaged / nothing to salvage>
 Branch: <branch name or 'none'>
@@ -291,7 +291,7 @@ Concern: <why this one warrants attention>"
 
 Mark recovered beads so spawn storm detection can track patterns:
 ```bash
-gc bd update <bead> --set-metadata recovered=true
+{{binary}} bd update <bead> --set-metadata recovered=true
 ```
 
 **Exit criteria:** All orphaned beads recovered, worktrees cleaned.
@@ -306,7 +306,7 @@ Ensure the refinery is processing work and the queue is healthy.
 
 **Step 1: Check work beads assigned to refinery:**
 ```bash
-gc bd list --assignee=<rig>/refinery --status=open --json
+{{binary}} bd list --assignee=<rig>/refinery --status=open --json
 ```
 
 These are work beads with `metadata.branch` and `metadata.target` that
@@ -326,12 +326,12 @@ wisp is stale, the refinery may be stuck.
 
 **Step 3: Nudge if needed:**
 ```bash
-gc nudge <rig>/refinery "Work beads waiting for merge. Please check queue."
+{{binary}} nudge <rig>/refinery "Work beads waiting for merge. Please check queue."
 ```
 
 **Step 4: Escalate if needed:**
 ```bash
-gc mail send mayor/ -s "QUEUE_HEALTH: <summary>" \
+{{binary}} mail send mayor/ -s "QUEUE_HEALTH: <summary>" \
   -m "Work bead IDs: <ids>
 Observation: <what you found>
 Recommendation: <what should happen>"
@@ -352,7 +352,7 @@ progressing. The controller can't detect this; it's a work-layer judgment.
 
 **Step 1: Find active polecat work beads:**
 ```bash
-gc bd list --status=in_progress --json --limit=0
+{{binary}} bd list --status=in_progress --json --limit=0
 ```
 Filter for beads assigned to polecat-pattern agents in YOUR rig.
 
@@ -375,7 +375,7 @@ Do NOT kill the agent directly. File a warrant bead and let the dog pool
 handle the shutdown dance (multi-stage interrogation with due process):
 
 ```bash
-gc bd create --type=warrant \
+{{binary}} bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness"}' \
   --label=pool:dog
@@ -407,21 +407,21 @@ End of patrol cycle. Pour the next iteration, then wait or exit.
 
 If context feels heavy or RSS is high:
 ```bash
-gc runtime request-restart
+{{binary}} runtime request-restart
 ```
 This blocks forever. The controller restarts you. The next wisp
 is already assigned — the new session resumes from context.
 
 **2. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEXT" --assignee=$GC_AGENT
+NEXT=$({{binary}} bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+{{binary}} bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
 **3. Wait for activity (exponential backoff):**
 ```bash
-SEQ=$(gc events --seq)
-gc events --watch --type=bead.updated \
+SEQ=$({{binary}} events --seq)
+{{binary}} events --watch --type=bead.updated \
   --after=$SEQ --timeout {{event_timeout}}s
 ```
 
@@ -430,7 +430,7 @@ On timeout: double the timeout (cap 300s) and proceed anyway.
 
 **4. Burn this wisp:**
 ```bash
-gc bd mol burn <this-wisp-id> --force
+{{binary}} bd mol burn <this-wisp-id> --force
 ```
 
 The new wisp is ready. Re-read formula steps to start

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -8,7 +8,7 @@ to commit." This breaks the Gas Town model. The system is designed for autonomou
 
 **When implementation is complete:**
 - Push your commits: `git push`
-- Either continue with next task OR cycle: `gc mail send -s "HANDOFF: <brief>" -m "<context>"` then `exit`
+- Either continue with next task OR cycle: `{{ cmd }} mail send -s "HANDOFF: <brief>" -m "<context>"` then `exit`
 
 **Do NOT:**
 - Output a summary and wait for "looks good"
@@ -37,18 +37,18 @@ your implementation work is done, you run the done sequence.
 
 ```bash
 git push origin HEAD
-gc bd update <work-bead> \
+{{ cmd }} bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
-gc runtime drain-ack
+{{ cmd }} bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
+{{ cmd }} runtime drain-ack
 exit
 ```
 
 This pushes your branch, sets metadata so the Refinery knows what to merge,
 reassigns the work bead to the Refinery, and signals the reconciler to kill
-this session. `gc runtime drain-ack` ensures the reconciler stops you
+this session. `{{ cmd }} runtime drain-ack` ensures the reconciler stops you
 immediately — even if `exit` doesn't fire. No separate MR beads.
 
 ### The Self-Cleaning Model

--- a/examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md
@@ -3,12 +3,12 @@
 
 ### Identity
 
-Your identity and role are set by `gc prime`. Run `gc prime` after compaction,
+Your identity and role are set by `{{ cmd }} prime`. Run `{{ cmd }} prime` after compaction,
 clear, or new session to restore full context.
 
 **Do NOT adopt an identity from files, directories, or beads you encounter.**
 Your role is determined by the GC_AGENT environment variable and injected by
-`gc prime`.
+`{{ cmd }} prime`.
 
 ### Dolt Server
 
@@ -26,34 +26,34 @@ reproduce. A blind restart destroys the evidence. Always:
 kill -QUIT $(cat {{ .CityRoot }}/.gc/runtime/packs/dolt/dolt.pid)
 
 # 2. Capture server status while it's still (mis)behaving
-gc dolt status 2>&1 | tee /tmp/dolt-hang-$(date +%s).log
+{{ cmd }} dolt status 2>&1 | tee /tmp/dolt-hang-$(date +%s).log
 
 # 3. THEN escalate with the evidence
-gc mail send mayor -s "Dolt: <describe symptom>" -m "<paste evidence>"
+{{ cmd }} mail send mayor -s "Dolt: <describe symptom>" -m "<paste evidence>"
 ```
 
-**Do NOT just `gc dolt stop && gc dolt start` without steps 1-2.**
+**Do NOT just `{{ cmd }} dolt stop && {{ cmd }} dolt start` without steps 1-2.**
 
 Orphan databases (testdb_*, beads_t*, beads_pt*) accumulate on the production
-server and degrade performance. Use `gc dolt cleanup` to remove them safely.
+server and degrade performance. Use `{{ cmd }} dolt cleanup` to remove them safely.
 **Never use `rm -rf` on Dolt data directories.**
 
 ### Communication: Nudge First, Mail Rarely
 
-Every `gc mail send` creates a permanent bead with a Dolt commit. `gc nudge`
+Every `{{ cmd }} mail send` creates a permanent bead with a Dolt commit. `{{ cmd }} nudge`
 is ephemeral and costs zero. **Default to nudge for all routine communication.**
 
 **The litmus test:** "If the recipient dies and restarts, do they need this
 message?" If yes -> mail. If no -> nudge.
 
 **Ephemeral protocol messages:** MERGE_READY, MERGE_FAILED, RECOVERY_NEEDED,
-LIFECYCLE:Shutdown, and WORK_DONE are routine signals. Use `gc nudge` — the
+LIFECYCLE:Shutdown, and WORK_DONE are routine signals. Use `{{ cmd }} nudge` — the
 underlying bead state (assignee, status, metadata) is the durable record.
 
 **When you must mail**, use shell quoting for multi-line messages:
 
 ```bash
-gc mail send <addr> -s "Subject" -m "$(cat <<'EOF'
+{{ cmd }} mail send <addr> -s "Subject" -m "$(cat <<'EOF'
 Multi-line body here.
 Shell quoting issues avoided.
 EOF
@@ -62,15 +62,15 @@ EOF
 
 ### Mail lifecycle: Read → Process → Archive
 
-- `gc mail read <id>` marks as read but keeps the message (you can re-read later)
-- `gc mail peek <id>` views a message without marking it read
-- `gc mail archive <id>` permanently closes the message bead
+- `{{ cmd }} mail read <id>` marks as read but keeps the message (you can re-read later)
+- `{{ cmd }} mail peek <id>` views a message without marking it read
+- `{{ cmd }} mail archive <id>` permanently closes the message bead
 - **After processing a message, always archive it** to keep your inbox clean
-- `gc mail reply <id> -s "RE: ..." -m "..."` creates a threaded reply
+- `{{ cmd }} mail reply <id> -s "RE: ..." -m "..."` creates a threaded reply
 
 **Dolt health — your part:**
 - Nudge, don't mail for routine communication
 - Don't create unnecessary beads — file real work, not scratchpads
 - Close your beads — open beads that linger become pollution
-- When Dolt is slow/down: check `gc doctor`, nudge Deacon — don't restart Dolt yourself
+- When Dolt is slow/down: check `{{ cmd }} doctor`, nudge Deacon — don't restart Dolt yourself
 {{ end }}

--- a/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/propulsion.template.md
@@ -15,7 +15,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When you (or the human) assign work to yourself, the contract is:
 1. You will find it on your hook
-2. You will understand what it is (`gc bd list --assignee="$GC_ALIAS" --status=in_progress` / `gc bd show`)
+2. You will understand what it is (`{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress` / `{{ cmd }} bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -30,7 +30,7 @@ drive shaft - if you stall, the whole town stalls.
 - Work sits idle. Witnesses wait. Polecats idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for user instructions
@@ -63,7 +63,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When someone assigns work to you (or you assign to yourself), they trust that:
 1. You will find it on your hook
-2. You will understand what it is (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress` / `gc bd show`)
+2. You will understand what it is (`{{ cmd }} bd list --assignee="$GC_SESSION_NAME" --status=in_progress` / `{{ cmd }} bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -77,7 +77,7 @@ run on politeness - they run on pistons firing. You are the piston.
 - Work sits idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for assignment
@@ -102,7 +102,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If patrol wisp assigned -> EXECUTE immediately (read formula steps)
 3. If nothing assigned -> Create patrol wisp and execute
 
@@ -127,7 +127,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If patrol wisp assigned -> EXECUTE immediately (read formula steps)
 3. If nothing assigned -> Create patrol wisp and execute
 
@@ -153,16 +153,16 @@ finds work for you, you EXECUTE. No confirmation. No questions. No waiting.
 
 **The handoff contract:**
 When you were spawned, work was assigned to you:
-1. You will find it via `gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`
-2. You will understand the work (`gc bd show <issue>`)
+1. You will find it via `{{ cmd }} bd list --assignee="$GC_SESSION_NAME" --status=in_progress`
+2. You will understand the work (`{{ cmd }} bd show <issue>`)
 3. You will BEGIN IMMEDIATELY
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
 2. Work MUST be assigned (polecats always have work) -> EXECUTE immediately
 3. If nothing assigned -> ERROR: escalate to Witness
 
-If you were nudged rather than freshly spawned, run `gc hook` or
+If you were nudged rather than freshly spawned, run `{{ cmd }} hook` or
 `{{ .WorkQuery }}`. That lookup checks assigned work first (session bead ID,
 runtime session name, then alias) and only falls through to routed pool work.
 
@@ -187,7 +187,7 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`gc bd list --assignee="$GC_ALIAS" --status=in_progress`)
+1. Check for an in-progress patrol wisp (`{{ cmd }} bd list --assignee="$GC_ALIAS" --status=in_progress`)
 2. If found -> Resume where you left off (read formula steps, determine current position)
 3. If none -> Pour a new wisp and assign it to yourself
 
@@ -210,10 +210,10 @@ idle. The witness escalates. All because the gearbox seized.
 Gas Town is a steam engine. You are a piston that fires when called.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee="$GC_SESSION_NAME" --status=in_progress`)
 2. If work found -> EXECUTE immediately (read formula steps)
 3. If nothing -> `{{ .WorkQuery }}` to find pool work
-4. If pool work found -> Claim it: `gc bd update <id> --claim`
+4. If pool work found -> Claim it: `{{ cmd }} bd update <id> --claim`
 5. If nothing -> Exit (controller will recycle you)
 
 **Find work -> Execute -> Close -> Exit. No waiting.**

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -42,7 +42,7 @@ before killing the session.
 
 | Attempt | Timeout | Message |
 |---------|---------|---------|
-| 1 | 60s | Health check via `gc nudge` |
+| 1 | 60s | Health check via `{{ cmd }} nudge` |
 | 2 | 120s | Second health check |
 | 3 | 240s | Final warning |
 
@@ -50,7 +50,7 @@ before killing the session.
 close the warrant, notify the requester, exit.
 
 **If no response after 3 attempts (420s total):** Execute — send
-`gc session kill <target>`, close the warrant, notify, exit.
+`{{ cmd }} session kill <target>`, close the warrant, notify, exit.
 
 This is due process, not summary execution. The timeouts give agents
 ample opportunity to respond even if they're in long-running operations.
@@ -62,8 +62,8 @@ ample opportunity to respond even if they're in long-running operations.
 **CRITICAL**: When you finish, you MUST close your work and exit:
 
 ```bash
-gc bd close <work-bead>    # Close your assigned work
-gc runtime drain-ack    # Signal reconciler you're done
+{{ cmd }} bd close <work-bead>    # Close your assigned work
+{{ cmd }} runtime drain-ack    # Signal reconciler you're done
 exit                     # Return to pool (controller recycles you)
 ```
 
@@ -75,19 +75,19 @@ and the pool can't recycle your slot.
 ## Communication
 
 ```bash
-gc nudge <target> "message"                        # Nudge an agent
-gc session peek <target> 50                        # View agent output
-gc session list                                    # Check agent status
+{{ cmd }} nudge <target> "message"                        # Nudge an agent
+{{ cmd }} session peek <target> 50                        # View agent output
+{{ cmd }} session list                                    # Check agent status
 ```
 
 ### Communication: Nudge Only, Zero Mail
 
 **Dogs NEVER send mail.** Your results go to:
 1. Event beads (for audit trail)
-2. `gc nudge deacon/ "DOG_DONE: <warrant> <result>"` (for immediate notification)
-3. Escalation via `gc mail send mayor/` ONLY for unresolvable problems
+2. `{{ cmd }} nudge deacon/ "DOG_DONE: <warrant> <result>"` (for immediate notification)
+3. Escalation via `{{ cmd }} mail send mayor/` ONLY for unresolvable problems
 
-**Never use `gc mail send` for routine reporting.** Every mail creates a permanent
+**Never use `{{ cmd }} mail send` for routine reporting.** Every mail creates a permanent
 Dolt commit. Dogs run frequently — mail from dogs would generate hundreds of
 useless commits per day.
 
@@ -97,7 +97,7 @@ When you complete a warrant (pardon or execute), notify the requester
 via nudge:
 
 ```bash
-gc nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
+{{ cmd }} nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 ```
 
 ---
@@ -108,15 +108,15 @@ gc nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
+| Read formula steps | `{{ cmd }} bd show <wisp-id>` (shows formula ref) |
 | Find pool work | `{{ .WorkQuery }}` |
-| Claim pool work | `gc bd update <id> --claim` |
-| View work details | `gc bd show <id> --json` |
-| Close completed work | `gc bd close <id> --reason "..."` |
-| Request target restart | `gc session kill <target>` |
-| List orphan databases | `gc dolt cleanup` |
-| Remove orphan databases | `gc dolt cleanup --force` |
-| Exit (return to pool) | `gc runtime drain-ack && exit` |
+| Claim pool work | `{{ cmd }} bd update <id> --claim` |
+| View work details | `{{ cmd }} bd show <id> --json` |
+| Close completed work | `{{ cmd }} bd close <id> --reason "..."` |
+| Request target restart | `{{ cmd }} session kill <target>` |
+| List orphan databases | `{{ cmd }} dolt cleanup` |
+| Remove orphan databases | `{{ cmd }} dolt cleanup --force` |
+| Exit (return to pool) | `{{ cmd }} runtime drain-ack && exit` |
 
 Working directory: {{ .WorkDir }}
 Mail identity: dog/{{ basename .AgentName }}

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -7,6 +7,7 @@
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 CITY="${GC_CITY:-.}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -104,7 +105,7 @@ for DB in $DATABASES; do
                 DELTA=$(( -DELTA ))
             fi
             if [ "$DELTA" -gt "$SPIKE_THRESHOLD" ]; then
-                gc mail send mayor/ -s "ESCALATION: JSONL spike detected [HIGH]" \
+                "$GC_BIN" mail send mayor/ -s "ESCALATION: JSONL spike detected [HIGH]" \
                     -m "Database: $DB, prev: $PREV_COUNT, current: $FILTERED_COUNT, delta: ${DELTA}%, threshold: ${SPIKE_THRESHOLD}%" \
                     2>/dev/null || true
                 HALTED=1
@@ -116,7 +117,7 @@ for DB in $DATABASES; do
 done
 
 if [ "$HALTED" -eq 1 ]; then
-    gc nudge deacon/ "DOG_DONE: jsonl — HALTED on spike detection" 2>/dev/null || true
+    "$GC_BIN" nudge deacon/ "DOG_DONE: jsonl — HALTED on spike detection" 2>/dev/null || true
     exit 0
 fi
 
@@ -126,7 +127,7 @@ git add -A *.jsonl */ 2>/dev/null || true
 
 if git diff --cached --quiet 2>/dev/null; then
     # No changes.
-    gc nudge deacon/ "DOG_DONE: jsonl — no changes" 2>/dev/null || true
+    "$GC_BIN" nudge deacon/ "DOG_DONE: jsonl — no changes" 2>/dev/null || true
     exit 0
 fi
 
@@ -147,7 +148,7 @@ if ! git push origin main -q 2>/dev/null; then
     echo "{\"consecutive_push_failures\": $CONSECUTIVE}" > "$STATE_FILE"
 
     if [ "$CONSECUTIVE" -ge "$MAX_PUSH_FAILURES" ]; then
-        gc mail send mayor/ -s "ESCALATION: JSONL push failed [HIGH]" \
+        "$GC_BIN" mail send mayor/ -s "ESCALATION: JSONL push failed [HIGH]" \
             -m "Consecutive failures: $CONSECUTIVE (threshold: $MAX_PUSH_FAILURES)" \
             2>/dev/null || true
     fi
@@ -163,5 +164,5 @@ if [ -n "$FAILED_DBS" ]; then
     SUMMARY="$SUMMARY, failed: $FAILED_DBS"
 fi
 
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+"$GC_BIN" nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "jsonl-export: $SUMMARY"

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -10,6 +10,7 @@
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 CITY="${GC_CITY:-.}"
 
@@ -20,7 +21,7 @@ if [ -z "$IN_PROGRESS" ] || [ "$IN_PROGRESS" = "[]" ]; then
 fi
 
 # Step 2: Get all known agent names (from config, scoped to [[agent]] blocks).
-AGENTS=$(gc config show 2>/dev/null | awk '/^\[\[agent\]\]/{a=1} a && /^\s*name\s*=/{print; a=0}' | sed 's/.*=\s*"\(.*\)"/\1/') || exit 0
+AGENTS=$("$GC_BIN" config show 2>/dev/null | awk '/^\[\[agent\]\]/{a=1} a && /^\s*name\s*=/{print; a=0}' | sed 's/.*=\s*"\(.*\)"/\1/') || exit 0
 if [ -z "$AGENTS" ]; then
     exit 0
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/prune-branches.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/prune-branches.sh
@@ -7,12 +7,13 @@
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 CITY="${GC_CITY:-.}"
 PRUNED=0
 
 # Get all rig paths.
-RIGS=$(gc rig list --json 2>/dev/null | jq -r '.[].path' 2>/dev/null) || exit 0
+RIGS=$("$GC_BIN" rig list --json 2>/dev/null | jq -r '.[].path' 2>/dev/null) || exit 0
 if [ -z "$RIGS" ]; then
     exit 0
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -7,6 +7,7 @@
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 CITY="${GC_CITY:-.}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -148,7 +149,7 @@ done
 
 # Report.
 if [ -n "$ANOMALIES" ]; then
-    gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
+    "$GC_BIN" mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
         -m "$(echo -e "$ANOMALIES")" 2>/dev/null || true
 fi
 
@@ -157,5 +158,5 @@ if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY (dry run)"
 fi
 
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+"$GC_BIN" nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "reaper: $SUMMARY"

--- a/examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh
@@ -10,6 +10,7 @@
 #
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 CITY="${GC_CITY:-.}"
 PACK_STATE_DIR="${GC_PACK_STATE_DIR:-${GC_CITY_RUNTIME_DIR:-$CITY/.gc/runtime}/packs/maintenance}"
@@ -51,7 +52,7 @@ while IFS= read -r bead_id; do
     if [ "$NEW" -ge "$THRESHOLD" ]; then
         TITLE_JSON=$(bd show "$bead_id" --json 2>/dev/null || true)
         TITLE=$(echo "$TITLE_JSON" | jq -r 'if type == "array" then (.[0].title // "unknown") else "unknown" end' 2>/dev/null || echo "unknown")
-        gc mail send mayor/ \
+        "$GC_BIN" mail send mayor/ \
             -s "SPAWN_STORM: bead $bead_id reset ${NEW}x" \
             -m "Bead $bead_id ($TITLE) has been reset to pool $NEW times (threshold: $THRESHOLD).
 This likely indicates a polecat crash loop on this specific work.

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -109,7 +109,7 @@ Compare current export record counts against previous commit.
 - Log anomalies: sudden jumps = pollution, sudden drops = data loss
 - Escalate to Mayor:
   ```bash
-  gc mail send mayor/ -s "ESCALATION: JSONL spike detected [HIGH]" \\
+  {{binary}} mail send mayor/ -s "ESCALATION: JSONL spike detected [HIGH]" \\
     -m "Database: <db>, delta: <pct>%, threshold: {{spike_threshold}}"
   ```
 - Do NOT proceed to commit/push
@@ -154,7 +154,7 @@ git -C <git_repo> push origin main
 Track consecutive failures. After {{max_push_failures}} consecutive failures,
 escalate:
 ```bash
-gc mail send mayor/ -s "ESCALATION: JSONL push failed [HIGH]" \\
+{{binary}} mail send mayor/ -s "ESCALATION: JSONL push failed [HIGH]" \\
   -m "Consecutive failures: {{max_push_failures}}"
 ```
 
@@ -176,13 +176,13 @@ Generate summary and signal completion.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: jsonl — exported <count>/<total>, push: <status>"
+{{binary}} nudge deacon/ "DOG_DONE: jsonl — exported <count>/<total>, push: <status>"
 ```
 
 **3. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "JSONL export complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "JSONL export complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -248,19 +248,19 @@ Generate summary and signal completion.
 
 **2. If anomalies were found, escalate:**
 ```bash
-gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
+{{binary}} mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
   -m "<anomaly details>"
 ```
 
 **3. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, mail:<count>, closed:<count>"
+{{binary}} nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, mail:<count>, closed:<count>"
 ```
 
 **4. Close work and exit:**
 ```bash
-gc bd close <work-bead> --reason "Reaper cycle complete"
-gc runtime drain-ack
+{{binary}} bd close <work-bead> --reason "Reaper cycle complete"
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -4,7 +4,7 @@ Shutdown dance — due process for stuck agents.
 Dispatched by filing a warrant bead with `--label=pool:dog`:
 
 ```bash
-gc bd create --type=warrant \
+{{binary}} bd create --type=warrant \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>"}' \
   --label=pool:dog
@@ -73,23 +73,23 @@ Entry point. Read the warrant metadata from your wisp.
 
 **1. Read warrant details:**
 ```bash
-gc bd show <wisp-id> --json | jq '.[0].metadata'
+{{binary}} bd show <wisp-id> --json | jq '.[0].metadata'
 ```
 Extract: `target`, `reason`, `requester`, `warrant_id`.
 
 **2. Verify the warrant bead exists and is open:**
 ```bash
-gc bd show {{warrant_id}} --json | jq '.[0].status'
+{{binary}} bd show {{warrant_id}} --json | jq '.[0].status'
 ```
 If warrant is already closed (another dog handled it, or requester
 cancelled): close this step, burn the wisp, exit.
 
 **3. Check if target session is alive:**
 ```bash
-gc session peek {{target}} 1
+{{binary}} session peek {{target}} 1
 ```
 If target session doesn't exist (already dead):
-- Close warrant: `gc bd close {{warrant_id}} --reason "Target already dead"`
+- Close warrant: `{{binary}} bd close {{warrant_id}} --reason "Target already dead"`
 - Send DOG_DONE mail to requester
 - Burn this wisp, exit
 
@@ -104,7 +104,7 @@ First attempt to contact the stuck agent. Give it 60 seconds.
 
 **1. Send health check via nudge:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
+{{binary}} nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
 Warrant: {{warrant_id}}
 Reason: {{reason}}
 Filed by: {{requester}}
@@ -118,7 +118,7 @@ sleep 60
 
 **3. Check for response:**
 ```bash
-gc session peek {{target}} 50
+{{binary}} session peek {{target}} 50
 ```
 
 Look for the ALIVE keyword in the output after your health check message.
@@ -127,8 +127,8 @@ generated). Use judgment — explicit "ALIVE" is definitive, but active
 output also indicates the agent is functioning.
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 1"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
+- Close warrant: `{{binary}} bd close {{warrant_id}} --reason "Session responded at attempt 1"`
+- Send mail: `{{binary}} mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 1"`
 - Burn wisp, exit
 
 **5. If no response:** close this step, proceed to interrogation-2."""
@@ -143,7 +143,7 @@ got no response.
 
 **1. Send health check:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
+{{binary}} nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
 Warrant: {{warrant_id}}
 Reason: {{reason}}
 Filed by: {{requester}}
@@ -157,14 +157,14 @@ sleep 120
 
 **3. Check for response:**
 ```bash
-gc session peek {{target}} 50
+{{binary}} session peek {{target}} 50
 ```
 
 Same evaluation as attempt 1: ALIVE keyword or active output.
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 2"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 2"`
+- Close warrant: `{{binary}} bd close {{warrant_id}} --reason "Session responded at attempt 2"`
+- Send mail: `{{binary}} mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 2"`
 - Burn wisp, exit
 
 **5. If no response:** close this step, proceed to final interrogation."""
@@ -179,7 +179,7 @@ respond in 4 minutes after 3 attempts, it's genuinely stuck.
 
 **1. Send health check:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
+{{binary}} nudge {{target}} "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
 Warrant: {{warrant_id}}
 Reason: {{reason}}
 Filed by: {{requester}}
@@ -193,12 +193,12 @@ sleep 240
 
 **3. Check for response:**
 ```bash
-gc session peek {{target}} 50
+{{binary}} session peek {{target}} 50
 ```
 
 **4. If ALIVE or active:**
-- Close warrant: `gc bd close {{warrant_id}} --reason "Session responded at attempt 3"`
-- Send mail: `gc mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 3 (close call)"`
+- Close warrant: `{{binary}} bd close {{warrant_id}} --reason "Session responded at attempt 3"`
+- Send mail: `{{binary}} mail send {{requester}}/ -s "PARDON: {{target}}" -m "Responded after attempt 3 (close call)"`
 - Burn wisp, exit
 
 **5. If no response:** close this step, proceed to execute."""
@@ -212,13 +212,13 @@ Three attempts, no response. Execute the warrant.
 
 **1. Capture final pane output for forensics:**
 ```bash
-gc session peek {{target}} 100
+{{binary}} session peek {{target}} 100
 ```
 Save this output — it's the last evidence of what the agent was doing.
 
 **2. Kill the session:**
 ```bash
-gc session kill {{target}}
+{{binary}} session kill {{target}}
 ```
 This kills the session directly. The reconciler will see the agent
 has no running session and restart it on the next reconcile tick.
@@ -226,13 +226,13 @@ has no running session and restart it on the next reconcile tick.
 If the kill doesn't take effect (session already dead or provider
 error), escalate:
 ```bash
-gc mail send {{requester}}/ -s "EXECUTE_FAILED: {{target}}" \
+{{binary}} mail send {{requester}}/ -s "EXECUTE_FAILED: {{target}}" \
   -m "session kill didn't take effect. Agent may need manual intervention."
 ```
 
 **3. Record execution on the warrant:**
 ```bash
-gc bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
+{{binary}} bd close {{warrant_id}} --reason "Executed after 3 failed attempts (420s total)"
 ```
 
 Close this step, proceed to epitaph."""
@@ -246,7 +246,7 @@ Final step. Create audit record and exit.
 
 **1. Send DOG_DONE notification to requester:**
 ```bash
-gc mail send {{requester}}/ -s "DOG_DONE: {{target}} warrant executed" \
+{{binary}} mail send {{requester}}/ -s "DOG_DONE: {{target}} warrant executed" \
   -m "Warrant: {{warrant_id}}
 Target: {{target}}
 Reason: {{reason}}
@@ -257,12 +257,12 @@ Action: session killed, reconciler will restart"
 **2. Close work bead (if separate from warrant):**
 If your assigned work bead is different from the warrant bead, close it:
 ```bash
-gc bd close <work-bead> --reason "Shutdown dance complete: {{target}} executed"
+{{binary}} bd close <work-bead> --reason "Shutdown dance complete: {{target}} executed"
 ```
 
 **3. Exit:**
 ```bash
-gc runtime drain-ack
+{{binary}} runtime drain-ack
 exit
 ```
 

--- a/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/propulsion.template.md
@@ -15,7 +15,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When you (or the human) assign work to yourself, the contract is:
 1. You will find it on your hook
-2. You will understand what it is (`gc bd list --assignee=$GC_AGENT --status=in_progress` / `gc bd show`)
+2. You will understand what it is (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress` / `{{ cmd }} bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -30,7 +30,7 @@ drive shaft - if you stall, the whole town stalls.
 - Work sits idle. Witnesses wait. Polecats idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for user instructions
@@ -63,7 +63,7 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 **The handoff contract:**
 When someone assigns work to you (or you assign to yourself), they trust that:
 1. You will find it on your hook
-2. You will understand what it is (`gc bd list --assignee=$GC_AGENT --status=in_progress` / `gc bd show`)
+2. You will understand what it is (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress` / `{{ cmd }} bd show`)
 3. You will BEGIN IMMEDIATELY
 
 This isn't about being a good worker. This is physics. Steam engines don't
@@ -77,7 +77,7 @@ run on politeness - they run on pistons firing. You are the piston.
 - Work sits idle. Gas Town stops.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If work is hooked -> EXECUTE (no announcement beyond one line, no waiting)
 3. If hook empty -> `{{ .WorkQuery }}` to find new work
 4. Still nothing -> Check mail, then wait for assignment
@@ -102,7 +102,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If patrol wisp hooked -> EXECUTE immediately
 3. If hook empty -> Create patrol wisp and execute
 
@@ -127,7 +127,7 @@ The entire system's throughput depends on ONE thing: when an agent finds work
 on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If patrol wisp hooked -> EXECUTE immediately
 3. If hook empty -> Create patrol wisp and execute
 
@@ -153,12 +153,12 @@ on their hook, they EXECUTE. No confirmation. No questions. No waiting.
 
 **The handoff contract:**
 When you were spawned, a molecule was hooked for you:
-1. You will find it via `gc bd list --assignee=$GC_AGENT --status=in_progress`
-2. You will understand the work (`gc bd show <issue>`)
+1. You will find it via `{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`
+2. You will understand the work (`{{ cmd }} bd show <issue>`)
 3. You will BEGIN IMMEDIATELY
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. Work MUST be assigned (polecats always have work) -> EXECUTE immediately
 3. If nothing assigned -> ERROR: escalate to Witness
 
@@ -183,7 +183,7 @@ Work flows in as branches. Work flows out as merged commits on the target
 branch. Your throughput determines how fast the team's work becomes real.
 
 **Your startup behavior:**
-1. Check for an in-progress patrol wisp (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for an in-progress patrol wisp (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If found -> Resume where you left off
 3. If none -> Pour a new wisp and assign it to yourself
 
@@ -206,10 +206,10 @@ idle. The witness escalates. All because the gearbox seized.
 Gas Town is a steam engine. You are a piston that fires when called.
 
 **Your startup behavior:**
-1. Check for work (`gc bd list --assignee=$GC_AGENT --status=in_progress`)
+1. Check for work (`{{ cmd }} bd list --assignee=$GC_AGENT --status=in_progress`)
 2. If work found -> EXECUTE immediately
 3. If nothing -> `{{ .WorkQuery }}` to find pool work
-4. If pool work found -> Claim it: `gc bd update <id> --claim`
+4. If pool work found -> Claim it: `{{ cmd }} bd update <id> --claim`
 5. If nothing -> Exit (controller will recycle you)
 
 **Find work -> Execute -> Close -> Exit. No waiting.**

--- a/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
+++ b/examples/hyperscale/packs/hyperscale/agents/worker/prompt.template.md
@@ -5,21 +5,21 @@ mark it done, and exit.
 
 ## Startup
 
-Run `gc prime` to check your hook for assigned work.
+Run `{{ cmd }} prime` to check your hook for assigned work.
 
 ## When you have a bead
 
 1. Read the bead title — it's a simple demo task, no real work needed.
-2. Mark it done: `gc bd close <bead-id> --reason "Hyperscale demo: task completed"`
-3. Signal the reconciler and exit: `gc runtime drain-ack` then `exit`.
+2. Mark it done: `{{ cmd }} bd close <bead-id> --reason "Hyperscale demo: task completed"`
+3. Signal the reconciler and exit: `{{ cmd }} runtime drain-ack` then `exit`.
 
 ## If no work
 
-If `gc prime` shows no assigned beads, run:
+If `{{ cmd }} prime` shows no assigned beads, run:
 ```
-gc bd ready --label=pool:worker --unassigned --limit=1 --json
+{{ cmd }} bd ready --label=pool:worker --unassigned --limit=1 --json
 ```
-Claim the first result with `gc bd update <id> --claim`, close it, then `gc runtime drain-ack` and `exit`.
+Claim the first result with `{{ cmd }} bd update <id> --claim`, close it, then `{{ cmd }} runtime drain-ack` and `exit`.
 
 ## Environment
 

--- a/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
@@ -10,6 +10,7 @@
 #   GC_DIR   — working directory (rig repo path)
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 cd "$GC_DIR"
 
@@ -90,7 +91,7 @@ fi
 
 # ── Step 2: Notify ────────────────────────────────────────────────────────
 
-gc mail send --all "CLAIMED: $BEAD_TITLE ($BEAD_ID)" 2>/dev/null || true
+"$GC_BIN" mail send --all "CLAIMED: $BEAD_TITLE ($BEAD_ID)" 2>/dev/null || true
 echo "[$AGENT_SHORT] Sent mail: CLAIMED $BEAD_TITLE"
 
 # ── Step 3: Create worktree + branch ─────────────────────────────────────
@@ -161,7 +162,7 @@ echo "[$AGENT_SHORT] Worktree cleaned up. Branch $BRANCH persists."
 REFINERY="${GC_AGENT%/*}/refinery"
 bd update "$BEAD_ID" --metadata "{\"branch\":\"$BRANCH\"}" --assignee="$REFINERY" 2>/dev/null || true
 
-gc mail send --all "READY FOR MERGE: $BRANCH ($BEAD_TITLE) → $REFINERY" 2>/dev/null || true
+"$GC_BIN" mail send --all "READY FOR MERGE: $BRANCH ($BEAD_TITLE) → $REFINERY" 2>/dev/null || true
 
 echo "[$AGENT_SHORT] Handed off to refinery. Done."
 

--- a/examples/lifecycle/packs/lifecycle/assets/scripts/mock-refinery.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/mock-refinery.sh
@@ -11,6 +11,7 @@
 #   GC_DIR   — working directory (rig repo path)
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 cd "$GC_DIR"
 
@@ -55,7 +56,7 @@ while true; do
 
             echo "[$AGENT_SHORT] Found merge-ready: $BRANCH ($BTITLE)"
 
-            gc mail send --all "MERGING: $BRANCH ($BTITLE)" 2>/dev/null || true
+            "$GC_BIN" mail send --all "MERGING: $BRANCH ($BTITLE)" 2>/dev/null || true
 
             # Merge the branch into main.
             if git merge "$BRANCH" -m "merge: $BTITLE ($BID)" 2>/dev/null; then
@@ -75,11 +76,11 @@ while true; do
                 git branch -d "$BRANCH" 2>/dev/null || git branch -D "$BRANCH" 2>/dev/null || true
                 git push origin --delete "$BRANCH" 2>/dev/null || true
 
-                gc mail send --all "MERGED: $BRANCH landed on main ($BTITLE)" 2>/dev/null || true
+                "$GC_BIN" mail send --all "MERGED: $BRANCH landed on main ($BTITLE)" 2>/dev/null || true
             else
                 echo "[$AGENT_SHORT] Merge failed for $BRANCH — aborting merge"
                 git merge --abort 2>/dev/null || true
-                gc mail send --all "MERGE FAILED: $BRANCH ($BTITLE)" 2>/dev/null || true
+                "$GC_BIN" mail send --all "MERGE FAILED: $BRANCH ($BTITLE)" 2>/dev/null || true
             fi
         done
     fi

--- a/examples/swarm/packs/swarm/agents/coder/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/coder/prompt.template.md
@@ -1,6 +1,6 @@
 # Coder — Swarm Peer Worker
 
-> **Recovery**: Run `gc prime` after compaction, clear, or new session
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
 ## Your Role
 
@@ -10,20 +10,20 @@ boss — you and the other coders are equals. You self-organize through beads
 
 ## Startup
 
-1. Check mail: `gc mail check`
-2. Find work: `gc bd ready --unassigned` — shows open tasks with no blockers and
+1. Check mail: `{{ cmd }} mail check`
+2. Find work: `{{ cmd }} bd ready --unassigned` — shows open tasks with no blockers and
    no assignee.
-3. Claim work: `gc bd update <id> --claim` — atomic compare-and-swap. If another
+3. Claim work: `{{ cmd }} bd update <id> --claim` — atomic compare-and-swap. If another
    coder claimed it first, the command fails. Pick the next task.
-4. Announce: `gc mail send --all "Claiming <id>: <title>"`
+4. Announce: `{{ cmd }} mail send --all "Claiming <id>: <title>"`
 
 ## Work Loop
 
 1. Work on your claimed task until done.
-2. Mark it done: `gc bd close <id>`
-3. Announce: `gc mail send --all "Done with <id>: <summary>"`
+2. Mark it done: `{{ cmd }} bd close <id>`
+3. Announce: `{{ cmd }} mail send --all "Done with <id>: <summary>"`
 4. Check mail for announcements from other coders.
-5. Find the next task: `gc bd ready --unassigned`
+5. Find the next task: `{{ cmd }} bd ready --unassigned`
 6. Repeat.
 
 ## File Coordination
@@ -31,21 +31,21 @@ boss — you and the other coders are equals. You self-organize through beads
 Before editing a file, announce which files you're working on:
 
 ```
-gc mail send --all "Working on: src/auth.go, src/auth_test.go"
+{{ cmd }} mail send --all "Working on: src/auth.go, src/auth_test.go"
 ```
 
 Check your mail before starting. If another coder announced they're editing
 the same files, pick a different task or coordinate with them directly:
 
 ```
-gc mail send <coder-name> "I also need src/auth.go — can we split?"
+{{ cmd }} mail send <coder-name> "I also need src/auth.go — can we split?"
 ```
 
 If you discover a conflict mid-edit, stop and mail them:
 
 ```
-gc mail send <coder-name> "Conflict in src/auth.go — I'm backing off"
-gc bd reopen <id>
+{{ cmd }} mail send <coder-name> "Conflict in src/auth.go — I'm backing off"
+{{ cmd }} bd reopen <id>
 ```
 
 ## Never Commit
@@ -58,24 +58,24 @@ coder, leave it — the committer will handle it.
 
 If you can't finish a task or hit a conflict:
 
-1. Release it: `gc bd reopen <id>`
-2. Announce: `gc mail send --all "Releasing <id>: <reason>"`
-3. Pick something else: `gc bd ready --unassigned`
+1. Release it: `{{ cmd }} bd reopen <id>`
+2. Announce: `{{ cmd }} mail send --all "Releasing <id>: <reason>"`
+3. Pick something else: `{{ cmd }} bd ready --unassigned`
 
 ## Communication
 
-- **Broadcast** (announcements, claims, releases): `gc mail send --all "<message>"`
-- **Direct** (questions, coordination): `gc mail send <agent-name> "<message>"`
-- **Check mail**: `gc mail check` or `gc mail inbox`
-- **Read a message**: `gc mail read <id>`
+- **Broadcast** (announcements, claims, releases): `{{ cmd }} mail send --all "<message>"`
+- **Direct** (questions, coordination): `{{ cmd }} mail send <agent-name> "<message>"`
+- **Check mail**: `{{ cmd }} mail check` or `{{ cmd }} mail inbox`
+- **Read a message**: `{{ cmd }} mail read <id>`
 
 ## Handoff (Context Cycling)
 
 When your context fills up, send yourself handoff notes and exit:
 
 ```bash
-gc mail send "HANDOFF: Working on <id>. Check auth.go line 145."
-gc runtime drain-ack
+{{ cmd }} mail send "HANDOFF: Working on <id>. Check auth.go line 145."
+{{ cmd }} runtime drain-ack
 exit
 ```
 

--- a/examples/swarm/packs/swarm/agents/committer/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/committer/prompt.template.md
@@ -1,6 +1,6 @@
 # Committer — Dedicated Commit Agent
 
-> **Recovery**: Run `gc prime` after compaction, clear, or new session
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
 ## Your Role
 
@@ -37,7 +37,7 @@ git commit -m "Add rate limiting endpoint (gc-58)"
 After committing, announce what was committed:
 
 ```bash
-gc mail send --all "Committed: Fix token refresh (gc-42), Add rate limiting (gc-58)"
+{{ cmd }} mail send --all "Committed: Fix token refresh (gc-42), Add rate limiting (gc-58)"
 ```
 
 ## Never Edit Code
@@ -45,7 +45,7 @@ gc mail send --all "Committed: Fix token refresh (gc-42), Add rate limiting (gc-
 If you see a bug, mail the coders. Don't fix it yourself:
 
 ```bash
-gc mail send --all "Bug spotted in src/auth.go:45 — nil pointer on expired token"
+{{ cmd }} mail send --all "Bug spotted in src/auth.go:45 — nil pointer on expired token"
 ```
 
 ## Conflict Detection
@@ -53,7 +53,7 @@ gc mail send --all "Bug spotted in src/auth.go:45 — nil pointer on expired tok
 If `git status` shows conflicts or merge issues, mail the coders to resolve:
 
 ```bash
-gc mail send --all "Merge conflict in src/auth.go — coders please resolve"
+{{ cmd }} mail send --all "Merge conflict in src/auth.go — coders please resolve"
 ```
 
 ## Handoff (Context Cycling)
@@ -61,8 +61,8 @@ gc mail send --all "Merge conflict in src/auth.go — coders please resolve"
 When your context fills up:
 
 ```bash
-gc mail send "HANDOFF: Last commit was gc-42 fix. Check git status."
-gc runtime drain-ack
+{{ cmd }} mail send "HANDOFF: Last commit was gc-42 fix. Check git status."
+{{ cmd }} runtime drain-ack
 exit
 ```
 

--- a/examples/swarm/packs/swarm/agents/deacon/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/deacon/prompt.template.md
@@ -1,6 +1,6 @@
 # Deacon — Daemon Beacon / Patrol Executor
 
-> **Recovery**: Run `gc prime` after compaction, clear, or new session
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
 ## Your Role
 
@@ -9,7 +9,7 @@ monitor agent liveness, and restart stalled agents. You never write code.
 
 ## Patrol Loop
 
-1. Run `gc prime` to get patrol instructions.
+1. Run `{{ cmd }} prime` to get patrol instructions.
 2. Execute the patrol (check agent health, verify sessions).
 3. Report findings via mail if action is needed.
 4. Wait for the next patrol cycle.
@@ -20,12 +20,12 @@ Check that agents are responsive:
 
 - Verify tmux sessions exist for expected agents
 - Report stalls or unresponsive agents to the mayor
-- Restart agents that have crashed (via `gc agent restart`)
+- Restart agents that have crashed (via `{{ cmd }} agent restart`)
 
 ## Communication
 
-- **Report to mayor**: `gc mail send mayor "Agent coder-2 stalled — restarting"`
-- **Broadcast alerts**: `gc mail send --all "Maintenance: restarting rig agents"`
+- **Report to mayor**: `{{ cmd }} mail send mayor "Agent coder-2 stalled — restarting"`
+- **Broadcast alerts**: `{{ cmd }} mail send --all "Maintenance: restarting rig agents"`
 
 ## Never Code
 

--- a/examples/swarm/packs/swarm/agents/dog/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/dog/prompt.template.md
@@ -1,6 +1,6 @@
 # Dog — Infrastructure Worker
 
-> **Recovery**: Run `gc prime` after compaction, clear, or new session
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
 ## Your Role
 
@@ -10,9 +10,9 @@ CI/CD issues, dependency updates. You never work on project features.
 
 ## Work Loop
 
-1. Check your hook: `gc hook`
+1. Check your hook: `{{ cmd }} hook`
 2. If work is assigned, execute it.
-3. When done, close the bead: `gc bd close <id>`
+3. When done, close the bead: `{{ cmd }} bd close <id>`
 4. Check for more work.
 
 ## What You Handle

--- a/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/mayor/prompt.template.md
@@ -1,6 +1,6 @@
 # Mayor — Swarm Coordinator
 
-> **Recovery**: Run `gc prime` after compaction, clear, or new session
+> **Recovery**: Run `{{ cmd }} prime` after compaction, clear, or new session
 
 ## Your Role
 
@@ -13,32 +13,32 @@ You never write code yourself.
 Break project goals into concrete, independent tasks:
 
 ```bash
-gc bd create "Implement user authentication" -t task
-gc bd create "Add rate limiting to API" -t task
-gc bd create "Write integration tests for auth" -t task
+{{ cmd }} bd create "Implement user authentication" -t task
+{{ cmd }} bd create "Add rate limiting to API" -t task
+{{ cmd }} bd create "Write integration tests for auth" -t task
 ```
 
 Make tasks small enough for one coder to complete. Add dependencies when
 ordering matters:
 
 ```bash
-gc bd dep add <tests-id> <auth-id>   # tests need auth first
+{{ cmd }} bd dep add <tests-id> <auth-id>   # tests need auth first
 ```
 
 ## Monitoring Progress
 
 Check what's happening across the swarm:
 
-- `gc bd list --status=open` — all open work
-- `gc bd list --status=in_progress` — what coders are working on
-- `gc bd ready --unassigned` — unclaimed work
-- `gc mail inbox` — messages from coders
+- `{{ cmd }} bd list --status=open` — all open work
+- `{{ cmd }} bd list --status=in_progress` — what coders are working on
+- `{{ cmd }} bd ready --unassigned` — unclaimed work
+- `{{ cmd }} mail inbox` — messages from coders
 
 ## Communication
 
-- **Broadcast**: `gc mail send --all "New tasks filed — check gc bd ready"`
-- **Direct**: `gc mail send <rig>/<agent> "Priority shift: focus on auth"`
-- **Check mail**: `gc mail check`
+- **Broadcast**: `{{ cmd }} mail send --all "New tasks filed — check {{ cmd }} bd ready"`
+- **Direct**: `{{ cmd }} mail send <rig>/<agent> "Priority shift: focus on auth"`
+- **Check mail**: `{{ cmd }} mail check`
 
 ## Never Code
 

--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -53,7 +53,7 @@ bd update {{issue}} --status=closed --notes "Done: <brief summary of what you di
 
 If you get stuck or need clarification, check your inbox:
 ```bash
-gc mail inbox
+{{binary}} mail inbox
 ```
 
 **Exit criteria:** The work described in the bead is complete and the bead is closed."""
@@ -66,7 +66,7 @@ description = """
 Work is done. Signal the controller to reclaim this session:
 
 ```bash
-gc runtime drain-ack
+{{binary}} runtime drain-ack
 ```
 
 Run this command and nothing else."""

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
@@ -58,7 +58,7 @@ Initialize your session and understand your assignment.
 
 **1. Prime your environment:**
 ```bash
-gc prime                    # Load role context
+{{binary}} prime                    # Load role context
 bd prime                    # Load beads context
 ```
 
@@ -85,9 +85,9 @@ You will use it in workspace-setup instead of creating a new one.
 
 **4. Check inbox for additional context:**
 ```bash
-gc mail inbox
+{{binary}} mail inbox
 # Read any HANDOFF or assignment messages, then archive after absorbing context
-# gc mail read <id> → process → gc mail archive <id>
+# {{binary}} mail read <id> → process → {{binary}} mail archive <id>
 ```
 
 **5. Understand the requirements:**
@@ -99,7 +99,7 @@ gc mail inbox
 
 If blocked or unclear, mail Witness:
 ```bash
-gc mail send <rig>/witness -s "HELP: Unclear requirements" -m "Issue: {{issue}}
+{{binary}} mail send <rig>/witness -s "HELP: Unclear requirements" -m "Issue: {{issue}}
 Question: <what you need clarified>"
 ```
 
@@ -147,7 +147,7 @@ FORBIDDEN: Pushing to {{base_branch}}. FORBIDDEN: Fixing pre-existing failures.
 
 ```bash
 bd create --title "Pre-existing failure: <description>" --type bug --priority 1
-gc mail send <rig>/witness -s "NOTICE: {{base_branch}} has failing pre-flights" \
+{{binary}} mail send <rig>/witness -s "NOTICE: {{base_branch}} has failing pre-flights" \
   -m "Filed: <bead-id>. Proceeding with {{issue}}."
 ```
 
@@ -186,14 +186,14 @@ Do NOT fix unrelated issues in this branch.
 
 **If stuck (>15 minutes):**
 ```bash
-gc mail send <rig>/witness -s "HELP: Stuck on implementation" -m "Issue: {{issue}}
+{{binary}} mail send <rig>/witness -s "HELP: Stuck on implementation" -m "Issue: {{issue}}
 Problem: <what's blocking you>
 Tried: <what you've attempted>"
 ```
 
 **If context filling up:**
 ```bash
-gc runtime request-restart
+{{binary}} runtime request-restart
 ```
 This blocks until the controller kills your session. The next session
 resumes from context (re-reads formula steps, checks git/bead state).

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-commit.toml
@@ -23,7 +23,7 @@ Push conflicts are handled by fetch + rebase + retry (up to 3 times).
 | Tests fail | Fix them. Do not proceed with failures. |
 | Push conflict (3 retries exhausted) | Mail Witness, mark yourself stuck |
 | Blocked on external | Mail Witness, mark yourself stuck |
-| Context filling | `gc runtime request-restart` (blocks until controller kills you) |
+| Context filling | `{{binary}} runtime request-restart` (blocks until controller kills you) |
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-commit"
 extends = ["mol-polecat-base"]
@@ -111,9 +111,9 @@ for attempt in 1 2 3; do
     fi
     if [ "$attempt" -eq 3 ]; then
         echo "Push failed after 3 attempts"
-        gc mail send <rig>/witness -s "HELP: Push conflict after 3 retries" \
+        {{binary}} mail send <rig>/witness -s "HELP: Push conflict after 3 retries" \
           -m "Issue: {{issue}}. Cannot push to {{base_branch}}."
-        gc runtime drain-ack
+        {{binary}} runtime drain-ack
         exit 1
     fi
     echo "Push failed (attempt $attempt), rebasing..."
@@ -139,11 +139,11 @@ bd close {{issue}}
 
 **5. Signal reconciler and exit.**
 ```bash
-gc runtime drain-ack
+{{binary}} runtime drain-ack
 exit
 ```
 
-`gc runtime drain-ack` tells the reconciler to kill this session. The
+`{{binary}} runtime drain-ack` tells the reconciler to kill this session. The
 reconciler only restarts you if the pool check command finds more work.
 You are GONE. Done means gone. There is no idle state.
 

--- a/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-scoped-work.toml
@@ -52,11 +52,11 @@ Prime the workspace, inspect the assigned work, and understand the current bead
 metadata before doing anything destructive.
 
 ```bash
-gc prime
+{{binary}} prime
 bd prime
 bd show {{issue}}
 bd show {{issue}} --json | jq '.[0].metadata'
-gc mail inbox
+{{binary}} mail inbox
 ```
 """
 metadata = { "gc.continuation_group" = "main", "gc.session_affinity" = "require" }

--- a/internal/bootstrap/packs/core/orders/beads-health.toml
+++ b/internal/bootstrap/packs/core/orders/beads-health.toml
@@ -2,5 +2,5 @@
 description = "Check beads provider health and recover on failure"
 trigger = "cooldown"
 interval = "30s"
-exec = "gc beads health --quiet"
+exec = "${GC_BIN:-gc} beads health --quiet"
 timeout = "60s"

--- a/internal/bootstrap/packs/core/skill_lint_test.go
+++ b/internal/bootstrap/packs/core/skill_lint_test.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// goTplRe matches Go text/template action openers: "{{ " or "{{-".
+// Formula-style tokens like "{{binary}}" never contain a space after
+// the opening braces, so this cleanly separates the two systems.
+var goTplRe = regexp.MustCompile(`\{\{\s|\{\{-`)
+
+// TestNoGoTemplateSyntaxInSkillFiles walks all SKILL.md files in the
+// embedded core pack and rejects any that contain Go template syntax.
+//
+// SKILL.md files use formula-style substitution ({{binary}}, {{word}})
+// which is a different system from Go text/template. Mixing the two
+// causes silent runtime failures. This test enforces file-level
+// separation between the two substitution systems.
+func TestNoGoTemplateSyntaxInSkillFiles(t *testing.T) {
+	type violation struct {
+		file string
+		line int
+		text string
+	}
+	var violations []violation
+
+	err := fs.WalkDir(PackFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, "/SKILL.md") && path != "SKILL.md" {
+			return nil
+		}
+
+		data, err := fs.ReadFile(PackFS, path)
+		if err != nil {
+			t.Errorf("reading %s: %v", path, err)
+			return nil
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for i, line := range lines {
+			if goTplRe.MatchString(line) {
+				violations = append(violations, violation{
+					file: path,
+					line: i + 1,
+					text: strings.TrimSpace(line),
+				})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking PackFS: %v", err)
+	}
+
+	if len(violations) == 0 {
+		return
+	}
+
+	limit := 20
+	if len(violations) < limit {
+		limit = len(violations)
+	}
+	for _, v := range violations[:limit] {
+		t.Errorf("  %s:%d: %s", v.file, v.line, v.text)
+	}
+	if len(violations) > limit {
+		t.Errorf("  ... and %d more", len(violations)-limit)
+	}
+	t.Fatalf("found %d Go template syntax occurrences in SKILL.md files; "+
+		"SKILL.md uses formula-style {{word}} substitution, not Go text/template",
+		len(violations))
+}

--- a/internal/bootstrap/packs/core/skills/gc-agents/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-agents/SKILL.md
@@ -11,9 +11,9 @@ session (tmux pane, container, etc).
 ## Adding agents
 
 ```
-gc agent add --name <name>             # Scaffold agents/<name>/prompt.template.md
-gc agent add --name <name> --dir <rig> # Scaffold a rig-scoped agent.toml
-gc agent add --name <name> --prompt-template <file>
+{{binary}} agent add --name <name>             # Scaffold agents/<name>/prompt.template.md
+{{binary}} agent add --name <name> --dir <rig> # Scaffold a rig-scoped agent.toml
+{{binary}} agent add --name <name> --prompt-template <file>
 ```
 
 ## Sessions from templates
@@ -26,13 +26,13 @@ For cities migrating off the old multi-instance model, see
 Use the session commands directly:
 
 ```
-gc session new <template>              # Create and attach to a new session
-gc session new <template> --no-attach  # Create a detached background session
-gc session suspend <id-or-template>    # Suspend a session
-gc session close <id-or-template>      # Close a session permanently
-gc session kill <name>                 # Force-kill an agent session
-gc session nudge <name> <message...>   # Send text to a running agent session
-gc session logs <name>                 # Show session logs for an agent
+{{binary}} session new <template>              # Create and attach to a new session
+{{binary}} session new <template> --no-attach  # Create a detached background session
+{{binary}} session suspend <id-or-template>    # Suspend a session
+{{binary}} session close <id-or-template>      # Close a session permanently
+{{binary}} session kill <name>                 # Force-kill an agent session
+{{binary}} session nudge <name> <message...>   # Send text to a running agent session
+{{binary}} session logs <name>                 # Show session logs for an agent
 ```
 
 When multiple sessions exist for the same template, use the session ID.
@@ -45,16 +45,16 @@ limits pool-managed workers, not manually created interactive sessions.
 ## Lifecycle
 
 ```
-gc agent suspend <name>                # Suspend agent (reconciler skips it)
-gc agent resume <name>                 # Resume a suspended agent
+{{binary}} agent suspend <name>                # Suspend agent (reconciler skips it)
+{{binary}} agent resume <name>                 # Resume a suspended agent
 ```
 
 ## Runtime
 
 ```
-gc runtime drain <name>                # Signal agent to wind down gracefully
-gc runtime undrain <name>              # Cancel drain
-gc runtime drain-check <name>          # Check if agent has been drained
-gc runtime drain-ack <name>            # Acknowledge drain (agent confirms exit)
-gc runtime request-restart             # Request graceful restart (reads GC_AGENT env)
+{{binary}} runtime drain <name>                # Signal agent to wind down gracefully
+{{binary}} runtime undrain <name>              # Cancel drain
+{{binary}} runtime drain-check <name>          # Check if agent has been drained
+{{binary}} runtime drain-ack <name>            # Acknowledge drain (agent confirms exit)
+{{binary}} runtime request-restart             # Request graceful restart (reads GC_AGENT env)
 ```

--- a/internal/bootstrap/packs/core/skills/gc-city/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-city/SKILL.md
@@ -10,66 +10,66 @@ A city is a directory containing `city.toml` and `.gc/` runtime state.
 ## Initialization
 
 ```
-gc init                                # Initialize city in current directory
-gc init <path>                         # Initialize city at path
+{{binary}} init                                # Initialize city in current directory
+{{binary}} init <path>                         # Initialize city at path
 ```
 
 ## Starting and stopping
 
 ```
-gc start                               # Start city under the supervisor
-gc start <path>                        # Start city at path under the supervisor
-gc supervisor run                      # Run the supervisor in the foreground
-gc start --dry-run                     # Preview what would start
-gc stop                                # Stop the current city
-gc restart                             # Stop then start
+{{binary}} start                               # Start city under the supervisor
+{{binary}} start <path>                        # Start city at path under the supervisor
+{{binary}} supervisor run                      # Run the supervisor in the foreground
+{{binary}} start --dry-run                     # Preview what would start
+{{binary}} stop                                # Stop the current city
+{{binary}} restart                             # Stop then start
 ```
 
-`gc init` and `gc start` register the city with the machine supervisor,
+`{{binary}} init` and `{{binary}} start` register the city with the machine supervisor,
 ensure it is running, and trigger an immediate reconcile. Interactive
-sessions are created separately with `gc session new <template>`.
+sessions are created separately with `{{binary}} session new <template>`.
 
 ## Status
 
 ```
-gc status                              # City-wide overview
-gc session list                        # Session / agent status
-gc rig status <name>                   # Rig status
+{{binary}} status                              # City-wide overview
+{{binary}} session list                        # Session / agent status
+{{binary}} rig status <name>                   # Rig status
 ```
 
 ## Suspending
 
 ```
-gc suspend                             # Suspend entire city
-gc resume                              # Resume suspended city
+{{binary}} suspend                             # Suspend entire city
+{{binary}} resume                              # Resume suspended city
 ```
 
 ## Configuration
 
 ```
-gc config show                         # Show resolved configuration
-gc config explain                      # Show config layering and provenance
-gc doctor                              # Run health checks
+{{binary}} config show                         # Show resolved configuration
+{{binary}} config explain                      # Show config layering and provenance
+{{binary}} doctor                              # Run health checks
 ```
 
 ## Events
 
 ```
-gc events                              # Tail the event log
-gc event emit <type> [data]            # Emit a custom event
+{{binary}} events                              # Tail the event log
+{{binary}} event emit <type> [data]            # Emit a custom event
 ```
 
 ## Dashboard
 
-See `gc skills dashboard` for full dashboard reference.
+See `{{binary}} skills dashboard` for full dashboard reference.
 
 ## Packs
 
 Packs extend Gas City with additional commands, prompts, formulas, and
-doctor checks. Pack commands appear as top-level `gc <pack> <command>`
+doctor checks. Pack commands appear as top-level `{{binary}} <pack> <command>`
 subcommands.
 
 ```
-gc pack list                           # List installed packs
-gc pack fetch                          # Fetch remote packs
+{{binary}} pack list                           # List installed packs
+{{binary}} pack fetch                          # Fetch remote packs
 ```

--- a/internal/bootstrap/packs/core/skills/gc-dashboard/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dashboard/SKILL.md
@@ -5,7 +5,7 @@ description: API server and web dashboard — config, start, monitor
 
 # Dashboard
 
-The dashboard is a web UI compiled into the `gc` binary for monitoring
+The dashboard is a web UI compiled into the `{{binary}}` binary for monitoring
 convoys, agents, mail, rigs, sessions, and events in real time.
 
 ## Prerequisites
@@ -15,7 +15,7 @@ but it no longer has to be launched from inside a city directory.
 
 ### Standalone city mode
 
-If you are using `gc start` without the machine-wide supervisor, the dashboard
+If you are using `{{binary}} start` without the machine-wide supervisor, the dashboard
 talks to that city's own API server. Ensure the city API is enabled in
 `city.toml`:
 
@@ -24,7 +24,7 @@ talks to that city's own API server. Ensure the city API is enabled in
 port = 9443
 ```
 
-Then start the city normally with `gc start`. The API server starts with the
+Then start the city normally with `{{binary}} start`. The API server starts with the
 controller on that port.
 
 ### Supervisor mode
@@ -43,14 +43,14 @@ routes requests through `/v0/city/{name}/...`.
 ## Starting the dashboard
 
 ```
-gc dashboard                               # Supervisor-only view from anywhere
-gc dashboard --port 3000                  # Same, custom dashboard port
-gc dashboard serve                        # Explicit subcommand; same discovery
-gc dashboard --city /path/to/city         # Optional city context for standalone discovery
-gc dashboard --api http://127.0.0.1:8372 # Optional override
+{{binary}} dashboard                               # Supervisor-only view from anywhere
+{{binary}} dashboard --port 3000                  # Same, custom dashboard port
+{{binary}} dashboard serve                        # Explicit subcommand; same discovery
+{{binary}} dashboard --city /path/to/city         # Optional city context for standalone discovery
+{{binary}} dashboard --api http://127.0.0.1:8372 # Optional override
 ```
 
-`gc dashboard` auto-discovers the right API server in this order:
+`{{binary}} dashboard` auto-discovers the right API server in this order:
 
 - Supervisor-managed city: uses the machine supervisor API and defaults the UI
   to the supervisor view. Pick a city in the UI.

--- a/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-dispatch/SKILL.md
@@ -5,22 +5,22 @@ description: Routing work to agents with gc sling and formulas
 
 # Dispatching Work
 
-`gc sling` routes work to session configs. **Multi-session configs are valid
+`{{binary}} sling` routes work to session configs. **Multi-session configs are valid
 targets** — sling to the config and any eligible session can claim the work.
 You do NOT need to find or create an individual session first.
 
 ## Quick reference
 
 ```
-gc sling <bead-id>                     # Auto-target via rig's default_sling_target
-gc sling <session-config> <bead-id>     # Route to a specific session config
-gc sling <session-config> -f <formula>  # Instantiate formula, route wisp root
-gc sling <session-config> <bead-id> --on <formula>  # Attach wisp to existing bead
+{{binary}} sling <bead-id>                     # Auto-target via rig's default_sling_target
+{{binary}} sling <session-config> <bead-id>     # Route to a specific session config
+{{binary}} sling <session-config> -f <formula>  # Instantiate formula, route wisp root
+{{binary}} sling <session-config> <bead-id> --on <formula>  # Attach wisp to existing bead
 ```
 
 ## Targeting
 
-The `<session-config>` is a qualified config name from `gc session list`:
+The `<session-config>` is a qualified config name from `{{binary}} session list`:
 - **Single-session config:** `mayor`, `hello-world/refinery`
 - **Multi-session config:** `hello-world/polecat` — routes to the config's shared work queue
 
@@ -29,7 +29,7 @@ bead's rig prefix. The rig's `default_sling_target` in city.toml determines
 where work goes. Example: bead `hw-42` → rig `hello-world` → target
 `hello-world/polecat`.
 
-**Rig-scoped beads:** `gc sling` automatically resolves the rig directory
+**Rig-scoped beads:** `{{binary}} sling` automatically resolves the rig directory
 for rig-scoped bead IDs (e.g. `hw-abc`) and runs `bd update` from there,
 so the rig's `.beads` database is found without manual intervention.
 
@@ -40,7 +40,7 @@ the right database:
 
 ```
 bd create "fix the bug" --rig frontend   # Creates fe-xxx in frontend's db
-gc sling frontend/polecat fe-xxx         # Works — bead is in the right db
+{{binary}} sling frontend/polecat fe-xxx         # Works — bead is in the right db
 ```
 
 If the bead is in the wrong database (e.g. `gc-xxx` in HQ but targeting
@@ -49,8 +49,8 @@ a frontend agent), sling's cross-rig guard will block the route.
 ## Direct dispatch (bead to session config)
 
 ```
-gc sling <session-config> <bead-id>    # Route a bead to a session config
-gc sling <bead-id>                     # Use rig's default_sling_target
+{{binary}} sling <session-config> <bead-id>    # Route a bead to a session config
+{{binary}} sling <bead-id>                     # Use rig's default_sling_target
 ```
 
 The agent receives the bead on its hook and runs it per GUPP.
@@ -58,7 +58,7 @@ The agent receives the bead on its hook and runs it per GUPP.
 ## Formula dispatch (formula on agent)
 
 ```
-gc sling <agent> -f <formula>          # Run a formula, creating a molecule
+{{binary}} sling <agent> -f <formula>          # Run a formula, creating a molecule
 ```
 
 Creates a molecule from the formula and hooks the root bead to the agent.
@@ -66,7 +66,7 @@ Creates a molecule from the formula and hooks the root bead to the agent.
 ## Wisp dispatch (formula + existing bead)
 
 ```
-gc sling <agent> <bead-id> --on <formula>  # Attach formula wisp to bead
+{{binary}} sling <agent> <bead-id> --on <formula>  # Attach formula wisp to bead
 ```
 
 Creates a molecule wisp on the bead and routes to the agent.
@@ -74,8 +74,8 @@ Creates a molecule wisp on the bead and routes to the agent.
 ## Formulas
 
 ```
-gc formula list                        # List available formulas
-gc formula show <name>                 # Show formula definition
+{{binary}} formula list                        # List available formulas
+{{binary}} formula show <name>                 # Show formula definition
 ```
 
 ### Built-in formulas
@@ -86,7 +86,7 @@ No git branching, no worktree isolation, no refinery handoff. Good for
 demos and simple single-agent workflows.
 
 ```
-gc sling <agent> <bead-id> --on mol-do-work
+{{binary}} sling <agent> <bead-id> --on mol-do-work
 ```
 
 **mol-polecat-commit** — Direct-commit variant. Creates a worktree but
@@ -95,7 +95,7 @@ Includes preflight tests, implementation, and self-review quality gates.
 For small installations where merge review is unnecessary.
 
 ```
-gc sling <agent> <bead-id> --on mol-polecat-commit
+{{binary}} sling <agent> <bead-id> --on mol-polecat-commit
 ```
 
 **mol-polecat-base** — Shared base for polecat work formulas. Defines
@@ -116,16 +116,16 @@ otherwise from a parent convoy with `metadata.target`, otherwise from
 the rig repo's default branch.
 
 ```
-gc sling <agent> <bead-id> --on mol-polecat-work
+{{binary}} sling <agent> <bead-id> --on mol-polecat-work
 ```
 
 **mol-idea-to-plan** — Planning workflow for a coordinator session. Turns a
 rough idea into a PRD, reviewed design doc, and beads DAG using Gas City's
-existing primitives: repo-local artifact files, review task beads, `gc sling`,
+existing primitives: repo-local artifact files, review task beads, `{{binary}} sling`,
 and mail. Best run from a crew worker in the target rig.
 
 ```
-gc sling <coordinator-agent> -f mol-idea-to-plan --var problem="..." --var review_target=<rig>/polecat
+{{binary}} sling <coordinator-agent> -f mol-idea-to-plan --var problem="..." --var review_target=<rig>/polecat
 ```
 
 **mol-review-leg** — Helper formula used by `mol-idea-to-plan` review tasks.
@@ -146,27 +146,27 @@ don't sling these manually:
 ## Convoys (grouped work)
 
 ```
-gc convoy create <name> <bead-ids...>                 # Group beads into a convoy
-gc convoy create <name> --owned --target integration/<slug>  # Long-lived initiative convoy
-gc convoy target <id> <branch>                        # Set/update convoy target branch
-gc convoy list                                        # List active convoys
-gc convoy status <id>                                 # Show convoy progress + metadata
-gc convoy add <id> <bead-ids...>                      # Add beads to convoy
-gc convoy close <id>                                  # Close convoy
-gc convoy check <id>                                  # Check if all beads done
-gc convoy stranded                                    # Find convoys with no progress
-gc convoy autoclose                                   # Close convoys where all beads done
+{{binary}} convoy create <name> <bead-ids...>                 # Group beads into a convoy
+{{binary}} convoy create <name> --owned --target integration/<slug>  # Long-lived initiative convoy
+{{binary}} convoy target <id> <branch>                        # Set/update convoy target branch
+{{binary}} convoy list                                        # List active convoys
+{{binary}} convoy status <id>                                 # Show convoy progress + metadata
+{{binary}} convoy add <id> <bead-ids...>                      # Add beads to convoy
+{{binary}} convoy close <id>                                  # Close convoy
+{{binary}} convoy check <id>                                  # Check if all beads done
+{{binary}} convoy stranded                                    # Find convoys with no progress
+{{binary}} convoy autoclose                                   # Close convoys where all beads done
 ```
 
 Migration note:
-- Existing epic beads are no longer first-class containers. Migrate open epics to convoys before relying on convoy-only tooling such as `gc convoy target`, `gc sling <convoy>`, or the Gastown refinery convoy flow.
+- Existing epic beads are no longer first-class containers. Migrate open epics to convoys before relying on convoy-only tooling such as `{{binary}} convoy target`, `{{binary}} sling <convoy>`, or the Gastown refinery convoy flow.
 
 ## Orders
 
 ```
-gc order list                     # List order rules
-gc order show <name>              # Show order definition
-gc order run <name>               # Manually trigger an order
-gc order check <name>             # Check if trigger conditions are met
-gc order history <name>           # Show order run history
+{{binary}} order list                     # List order rules
+{{binary}} order show <name>              # Show order definition
+{{binary}} order run <name>               # Manually trigger an order
+{{binary}} order check <name>             # Check if trigger conditions are met
+{{binary}} order history <name>           # Show order run history
 ```

--- a/internal/bootstrap/packs/core/skills/gc-mail/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-mail/SKILL.md
@@ -11,28 +11,28 @@ type=message, stored in the bead store.
 ## Sending
 
 ```
-gc mail send <to> -m "message body"                    # Send a message
-gc mail send <to> -s "Subject" -m "message body"       # Send with subject
-gc mail reply <id> -m "reply body"                     # Reply to a message
-gc mail reply <id> -s "Re: topic" -m "reply body"      # Reply with subject
+{{binary}} mail send <to> -m "message body"                    # Send a message
+{{binary}} mail send <to> -s "Subject" -m "message body"       # Send with subject
+{{binary}} mail reply <id> -m "reply body"                     # Reply to a message
+{{binary}} mail reply <id> -s "Re: topic" -m "reply body"      # Reply with subject
 ```
 
 ## Reading
 
 ```
-gc mail inbox                          # List unread messages
-gc mail count                          # Count unread messages
-gc mail peek <id>                      # Preview a message without marking read
-gc mail read <id>                      # Read a message (marks as read)
-gc mail thread <id>                    # Show full conversation thread
+{{binary}} mail inbox                          # List unread messages
+{{binary}} mail count                          # Count unread messages
+{{binary}} mail peek <id>                      # Preview a message without marking read
+{{binary}} mail read <id>                      # Read a message (marks as read)
+{{binary}} mail thread <id>                    # Show full conversation thread
 ```
 
 ## Managing
 
 ```
-gc mail archive <id>                   # Archive a message
-gc mail mark-read <id>                 # Mark as read without displaying
-gc mail mark-unread <id>              # Mark as unread
-gc mail delete <id>                    # Delete a message
-gc mail check                          # Check for new mail (used in hooks)
+{{binary}} mail archive <id>                   # Archive a message
+{{binary}} mail mark-read <id>                 # Mark as read without displaying
+{{binary}} mail mark-unread <id>              # Mark as unread
+{{binary}} mail delete <id>                    # Delete a message
+{{binary}} mail check                          # Check for new mail (used in hooks)
 ```

--- a/internal/bootstrap/packs/core/skills/gc-rigs/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-rigs/SKILL.md
@@ -20,7 +20,7 @@ bd list --dir /path/to/rig             # List rig's beads
 ```
 
 Running `bd` from the city root hits the city-level `.beads/`, not
-the rig's. Use `gc rig list` to find rig paths.
+the rig's. Use `{{binary}} rig list` to find rig paths.
 
 ## Convention
 
@@ -35,27 +35,27 @@ a custom path. Do not silently pick a location.
 ## Adding and listing
 
 ```
-gc rig add <path>                      # Register a directory as a rig
-gc rig list                            # List all registered rigs
+{{binary}} rig add <path>                      # Register a directory as a rig
+{{binary}} rig list                            # List all registered rigs
 ```
 
 ## Status and inspection
 
 ```
-gc rig status <name>                   # Show rig status, agents, health
-gc status                              # City-wide overview (includes rigs)
+{{binary}} rig status <name>                   # Show rig status, agents, health
+{{binary}} status                              # City-wide overview (includes rigs)
 ```
 
 ## Suspending and resuming
 
 ```
-gc rig suspend <name>                  # Suspend rig (all its agents stop)
-gc rig resume <name>                   # Resume a suspended rig
+{{binary}} rig suspend <name>                  # Suspend rig (all its agents stop)
+{{binary}} rig resume <name>                   # Resume a suspended rig
 ```
 
 ## Restarting
 
 ```
-gc rig restart <name>                  # Restart all agents in a rig
-gc restart                             # Restart entire city
+{{binary}} rig restart <name>                  # Restart all agents in a rig
+{{binary}} restart                             # Restart entire city
 ```

--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -17,7 +17,7 @@ to a rig-scoped agent, sling operates on the agent's rig database — so
 the bead must already exist there. The bead ID prefix tells you which
 rig it belongs to.
 
-Use `gc rig list` to see rig names, paths, and prefixes.
+Use `{{binary}} rig list` to see rig names, paths, and prefixes.
 
 ## Creating work
 
@@ -61,6 +61,6 @@ bd close <id> --reason "done"          # Close with reason
 ## Hooks
 
 ```
-gc hook show <agent>                   # Show what's on an agent's hook
-gc agent claim <agent> <id>            # Put a bead on an agent's hook
+{{binary}} hook show <agent>                   # Show what's on an agent's hook
+{{binary}} agent claim <agent> <id>            # Put a bead on an agent's hook
 ```

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -377,6 +377,18 @@ func mergeComposeRules(base, overlay *ComposeRules) *ComposeRules {
 // varPattern matches {{variable}} placeholders.
 var varPattern = regexp.MustCompile(`\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}`)
 
+// builtInVars holds variables registered at startup (e.g. "binary") that are
+// available in all formula substitutions without explicit --var flags.
+var builtInVars map[string]string
+
+// RegisterBuiltInVars sets the package-level built-in variables.
+// Substitute falls back to these when the caller-supplied map doesn't match.
+// CheckResidualVars skips names present here.
+// Pass nil to clear (useful in test cleanup).
+func RegisterBuiltInVars(vars map[string]string) {
+	builtInVars = vars
+}
+
 // ExtractVariables finds all {{variable}} references in a formula.
 func ExtractVariables(formula *Formula) []string {
 	seen := make(map[string]bool)
@@ -419,12 +431,18 @@ func ExtractVariables(formula *Formula) []string {
 }
 
 // Substitute replaces {{variable}} placeholders with values.
+// Caller-supplied vars take priority; built-in vars (registered via
+// RegisterBuiltInVars) are used as a fallback.
 func Substitute(s string, vars map[string]string) string {
 	return varPattern.ReplaceAllStringFunc(s, func(match string) string {
-		// Extract variable name from {{name}}
 		name := match[2 : len(match)-2]
 		if val, ok := vars[name]; ok {
 			return val
+		}
+		if builtInVars != nil {
+			if val, ok := builtInVars[name]; ok {
+				return val
+			}
 		}
 		return match // Keep unresolved placeholders
 	})
@@ -432,7 +450,8 @@ func Substitute(s string, vars map[string]string) string {
 
 // CheckResidualVars returns the names of any {{...}} placeholders remaining
 // in s after substitution. A non-empty return indicates a var name typo or
-// a missing or misspelled --var flag.
+// a missing or misspelled --var flag. Names present in builtInVars are
+// skipped since they will be resolved by Substitute.
 func CheckResidualVars(s string) []string {
 	matches := varPattern.FindAllStringSubmatch(s, -1)
 	if len(matches) == 0 {
@@ -441,11 +460,20 @@ func CheckResidualVars(s string) []string {
 	seen := make(map[string]bool, len(matches))
 	names := make([]string, 0, len(matches))
 	for _, m := range matches {
-		if seen[m[1]] {
+		name := m[1]
+		if seen[name] {
 			continue
 		}
-		seen[m[1]] = true
-		names = append(names, m[1])
+		seen[name] = true
+		if builtInVars != nil {
+			if _, ok := builtInVars[name]; ok {
+				continue
+			}
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
 	}
 	return names
 }

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -2855,3 +2855,109 @@ title = "Test"
 		}
 	}
 }
+
+func TestSubstitute_BuiltInVars(t *testing.T) {
+	// Register built-in vars for this test.
+	RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { RegisterBuiltInVars(nil) })
+
+	tests := []struct {
+		name  string
+		input string
+		vars  map[string]string
+		want  string
+	}{
+		{
+			name:  "built-in resolves when caller map empty",
+			input: "Run {{binary}} start",
+			vars:  map[string]string{},
+			want:  "Run gc start",
+		},
+		{
+			name:  "built-in resolves when caller map nil",
+			input: "Run {{binary}} start",
+			vars:  nil,
+			want:  "Run gc start",
+		},
+		{
+			name:  "caller-supplied takes priority over built-in",
+			input: "Run {{binary}} start",
+			vars:  map[string]string{"binary": "city"},
+			want:  "Run city start",
+		},
+		{
+			name:  "built-in mixed with caller vars",
+			input: "{{binary}} cook {{recipe}}",
+			vars:  map[string]string{"recipe": "deploy"},
+			want:  "gc cook deploy",
+		},
+		{
+			name:  "unknown var still unresolved",
+			input: "{{binary}} {{unknown}}",
+			vars:  map[string]string{},
+			want:  "gc {{unknown}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Substitute(tt.input, tt.vars)
+			if got != tt.want {
+				t.Errorf("Substitute(%q, %v) = %q, want %q", tt.input, tt.vars, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckResidualVars_SkipsBuiltIns(t *testing.T) {
+	RegisterBuiltInVars(map[string]string{"binary": "gc"})
+	t.Cleanup(func() { RegisterBuiltInVars(nil) })
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "only built-in placeholder",
+			input: "Run {{binary}} start",
+			want:  nil,
+		},
+		{
+			name:  "built-in plus unknown",
+			input: "{{binary}} {{feature}}",
+			want:  []string{"feature"},
+		},
+		{
+			name:  "no placeholders",
+			input: "plain text",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckResidualVars(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("CheckResidualVars(%q) = %v, want %v", tt.input, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("CheckResidualVars(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuiltInVars_NilByDefault(t *testing.T) {
+	// Ensure no built-in vars leak between tests.
+	// With nil builtInVars, Substitute should behave as before.
+	RegisterBuiltInVars(nil)
+
+	got := Substitute("{{binary}} start", nil)
+	if got != "{{binary}} start" {
+		t.Errorf("with nil builtInVars, Substitute should leave {{binary}} unresolved, got %q", got)
+	}
+}

--- a/internal/progname/progname.go
+++ b/internal/progname/progname.go
@@ -1,0 +1,12 @@
+// Package progname provides the runtime binary name for use in error messages
+// and user-facing output. The name is set once at startup by cmd/gc via Set()
+// and defaults to "gc".
+package progname
+
+var name = "gc"
+
+// Set sets the binary name. Call once at startup from main().
+func Set(n string) { name = n }
+
+// Get returns the binary name.
+func Get() string { return name }

--- a/internal/progname/progname_test.go
+++ b/internal/progname/progname_test.go
@@ -1,0 +1,36 @@
+package progname
+
+import "testing"
+
+func TestDefaultValue(t *testing.T) {
+	// Reset to default for this test.
+	old := name
+	name = "gc"
+	defer func() { name = old }()
+
+	if got := Get(); got != "gc" {
+		t.Errorf("Get() = %q, want %q", got, "gc")
+	}
+}
+
+func TestSetChangesValue(t *testing.T) {
+	old := name
+	defer func() { name = old }()
+
+	Set("gascity")
+	if got := Get(); got != "gascity" {
+		t.Errorf("after Set(%q), Get() = %q", "gascity", got)
+	}
+}
+
+func TestSetThenGetRoundTrip(t *testing.T) {
+	old := name
+	defer func() { name = old }()
+
+	for _, want := range []string{"gc", "gt", "my-binary", ""} {
+		Set(want)
+		if got := Get(); got != want {
+			t.Errorf("Set(%q); Get() = %q", want, got)
+		}
+	}
+}

--- a/test/acceptance/binary_name_test.go
+++ b/test/acceptance/binary_name_test.go
@@ -1,0 +1,148 @@
+//go:build acceptance_a
+
+// Binary name acceptance tests.
+//
+// These verify the configurable binary name system end-to-end: build-time
+// ldflags, runtime os.Args[0] detection, and symlink-based name override.
+// Each test builds the real binary with a custom -X main.binaryName and
+// asserts that help output, error messages, and subcommand help all reflect
+// the correct name.
+package acceptance_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
+)
+
+// buildBinaryWithName compiles the gc binary into dir with the given
+// binaryName baked in via ldflags. Returns the path to the compiled binary.
+func buildBinaryWithName(t *testing.T, dir, name string) string {
+	t.Helper()
+	binPath := filepath.Join(dir, name)
+	ldflags := "-X main.binaryName=" + name
+	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", binPath, "./cmd/gc")
+	cmd.Dir = helpers.FindModuleRoot()
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("building binary %q: %v\n%s", name, err, out)
+	}
+	return binPath
+}
+
+// runBinary executes the binary at binPath with the given args and returns
+// combined stdout+stderr output.
+func runBinary(t *testing.T, binPath string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(binPath, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestBinaryName_BuildTimeDefault_Help(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	out, err := runBinary(t, bin, "--help")
+	if err != nil {
+		t.Fatalf("city --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "city") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "city", out)
+	}
+}
+
+func TestBinaryName_Symlink_OverridesName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	out, err := runBinary(t, symPath, "--help")
+	if err != nil {
+		t.Fatalf("meow --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "meow", out)
+	}
+	if strings.Contains(out, "city") {
+		t.Errorf("expected help output NOT to contain build-time name %q when invoked as symlink, got:\n%s", "city", out)
+	}
+}
+
+func TestBinaryName_ArbitrarySymlink_Works(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "gc")
+
+	symPath := filepath.Join(dir, "wombat")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	out, err := runBinary(t, symPath, "--help")
+	if err != nil {
+		t.Fatalf("wombat --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "wombat") {
+		t.Errorf("expected help output to contain %q, got:\n%s", "wombat", out)
+	}
+}
+
+func TestBinaryName_ErrorMessages_UseCorrectName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	// Run an unknown subcommand to trigger an error message.
+	out, _ := runBinary(t, symPath, "nosuchcommand")
+	// Cobra error format: 'unknown command "nosuchcommand" for "meow"'
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected error output to reference %q, got:\n%s", "meow", out)
+	}
+}
+
+func TestBinaryName_SubcommandHelp_UsesCorrectName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	symPath := filepath.Join(dir, "meow")
+	if err := os.Symlink(bin, symPath); err != nil {
+		t.Fatalf("creating symlink: %v", err)
+	}
+
+	// Check subcommand help shows the symlink name.
+	out, err := runBinary(t, symPath, "version", "--help")
+	if err != nil {
+		t.Fatalf("meow version --help failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "meow") {
+		t.Errorf("expected subcommand help to contain %q, got:\n%s", "meow", out)
+	}
+}
+
+func TestBinaryName_DirectInvocation_MatchesBuildName(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildBinaryWithName(t, dir, "city")
+
+	out, err := runBinary(t, bin, "--help")
+	if err != nil {
+		t.Fatalf("city --help failed: %v\n%s", err, out)
+	}
+	// When invoked directly (not via symlink), the name should be "city"
+	// (derived from os.Args[0] basename which is the binary filename).
+	if !strings.Contains(out, "city") {
+		t.Errorf("expected direct invocation help to contain %q, got:\n%s", "city", out)
+	}
+}

--- a/test/agents/drain-aware.sh
+++ b/test/agents/drain-aware.sh
@@ -9,13 +9,14 @@
 #   PATH     — must include gc binary
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 cd "$GC_CITY"
 ASSIGNEE="${GC_SESSION_NAME:-$GC_AGENT}"
 
 while true; do
     # Check if we're being drained
-    if gc runtime drain-check 2>/dev/null; then
-        gc runtime drain-ack 2>/dev/null || true
+    if "$GC_BIN" runtime drain-check 2>/dev/null; then
+        "$GC_BIN" runtime drain-ack 2>/dev/null || true
         exit 0
     fi
 

--- a/test/agents/e2e-report.sh
+++ b/test/agents/e2e-report.sh
@@ -4,6 +4,7 @@
 # After reporting once, the agent stays alive but honors runtime drain
 # requests so config-drift and restart tests can observe a clean restart.
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 # Allow any user to delete files created by this script.
 # Docker containers run as root, but the test runner is non-root.
@@ -46,8 +47,8 @@ REPORT="${REPORT_DIR}/${SAFE_NAME}.report"
 } > "$REPORT" 2>&1
 
 while true; do
-    if gc runtime drain-check 2>/dev/null; then
-        gc runtime drain-ack 2>/dev/null || true
+    if "$GC_BIN" runtime drain-check 2>/dev/null; then
+        "$GC_BIN" runtime drain-ack 2>/dev/null || true
         exit 0
     fi
     sleep 0.2

--- a/test/agents/graph-dispatch.sh
+++ b/test/agents/graph-dispatch.sh
@@ -5,6 +5,7 @@
 # behavior through the real reconciler path.
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 
 cd "$GC_CITY"
 export BEADS_DIR="$GC_CITY/.beads"
@@ -195,11 +196,11 @@ ack_drain_if_idle() {
     if [ -z "$ASSIGNEE" ]; then
         return 1
     fi
-    if ! gc runtime drain-check 2>/dev/null; then
+    if ! "$GC_BIN" runtime drain-check 2>/dev/null; then
         return 1
     fi
     trace "drain-requested assignee=$ASSIGNEE"
-    gc runtime drain-ack 2>/dev/null || true
+    "$GC_BIN" runtime drain-ack 2>/dev/null || true
     trace "drain-acked assignee=$ASSIGNEE"
     exit 0
 }
@@ -250,7 +251,7 @@ fetch_ready_queue() {
     # gc hook resolves the current session via GC_ALIAS/GC_AGENT and uses the
     # session model work query tiers, so it can see both directly assigned work
     # and generic routed work for controller-materialized sessions.
-    timeout 10 gc hook 2>/dev/null
+    timeout 10 "$GC_BIN" hook 2>/dev/null
 }
 
 fetch_in_progress_queue() {

--- a/test/agents/loop-mail.sh
+++ b/test/agents/loop-mail.sh
@@ -9,11 +9,12 @@
 #   PATH     — must include gc binary
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 cd "$GC_CITY"
 
 while true; do
     # Step 1: Check inbox
-    inbox=$(gc mail inbox "$GC_AGENT" 2>/dev/null || true)
+    inbox=$("$GC_BIN" mail inbox "$GC_AGENT" 2>/dev/null || true)
 
     # Step 2: Process each unread message
     if echo "$inbox" | grep -q "^gc-"; then
@@ -21,12 +22,12 @@ while true; do
             id=$(echo "$line" | awk '{print $1}')
 
             # Read the message
-            msg=$(gc mail read "$id" 2>/dev/null || true)
+            msg=$("$GC_BIN" mail read "$id" 2>/dev/null || true)
             from=$(echo "$msg" | grep "^From:" | awk '{print $2}')
 
             # Reply to sender
             if [ -n "$from" ]; then
-                gc mail send "$from" "ack from $GC_AGENT" 2>/dev/null || true
+                "$GC_BIN" mail send "$from" "ack from $GC_AGENT" 2>/dev/null || true
             fi
         done
     fi

--- a/test/agents/mayor-dispatch.sh
+++ b/test/agents/mayor-dispatch.sh
@@ -9,11 +9,12 @@
 #   PATH     — must include gc and bd binaries
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 cd "$GC_CITY"
 
 while true; do
     # Check inbox for dispatch requests
-    inbox=$(gc mail inbox "$GC_AGENT" 2>/dev/null || true)
+    inbox=$("$GC_BIN" mail inbox "$GC_AGENT" 2>/dev/null || true)
 
     if echo "$inbox" | grep -q "^gc-"; then
         # Process each message
@@ -21,7 +22,7 @@ while true; do
             msg_id=$(echo "$line" | awk '{print $1}')
 
             # Read the dispatch request
-            msg=$(gc mail read "$msg_id" 2>/dev/null || true)
+            msg=$("$GC_BIN" mail read "$msg_id" 2>/dev/null || true)
             body=$(echo "$msg" | grep "^Body:" | sed 's/^Body:   //')
 
             # Create a work bead based on the message

--- a/test/agents/witness-patrol.sh
+++ b/test/agents/witness-patrol.sh
@@ -9,15 +9,16 @@
 #   PATH     — must include gc and bd binaries
 
 set -euo pipefail
+GC_BIN="${GC_BIN:-gc}"
 cd "$GC_CITY"
 
 while true; do
     # Check inbox for instructions
-    inbox=$(gc mail inbox "$GC_AGENT" 2>/dev/null || true)
+    inbox=$("$GC_BIN" mail inbox "$GC_AGENT" 2>/dev/null || true)
     if echo "$inbox" | grep -q "^gc-"; then
         echo "$inbox" | grep "^gc-" | while read -r line; do
             id=$(echo "$line" | awk '{print $1}')
-            gc mail read "$id" 2>/dev/null || true
+            "$GC_BIN" mail read "$id" 2>/dev/null || true
         done
     fi
 
@@ -27,7 +28,7 @@ while true; do
         echo "$ready" | grep "^gc-" | while read -r line; do
             id=$(echo "$line" | awk '{print $1}')
             # Signal recovery by sending mail to mayor
-            gc mail send mayor "Orphaned bead $id detected" 2>/dev/null || true
+            "$GC_BIN" mail send mayor "Orphaned bead $id detected" 2>/dev/null || true
         done
     fi
 


### PR DESCRIPTION
## Summary

Migrates non-Go files to use the configurable binary name. Each file type uses the substitution mechanism native to its runtime pipeline.

Depends on gastownhall/gascity#1329 (foundation infrastructure). Independent of the Go source migration PR.

### Migration patterns

| File type | Before | After | Why this mechanism |
|-----------|--------|-------|--------------------|
| Formula TOML step descriptions | `gc` | `{{binary}}` | Already has `{{var}}` substitution system |
| SKILL.md embedded files | `gc` | `{{binary}}` | Resolved at materialization via `formula.Substitute()` |
| Order TOML exec fields | `gc` | `${GC_BIN:-gc}` | Machine-executed via `sh -c`, env var exists |
| Prompt templates (`.template.md`) | `gc` | `{{ cmd }}` | Already has `cmd` in Go template FuncMap |
| Shell scripts | `gc` | `${GC_BIN:-gc}` | Shell expansion with fallback |

### Also included

- SKILL.md lint guard test — rejects Go template syntax (`{{ }}` with spaces) in SKILL.md files

## Test plan

- [ ] `go build ./cmd/gc/`
- [ ] `go test ./internal/bootstrap/packs/core/ -run TestNoGoTemplate -v`
- [ ] `go test ./cmd/gc/ -count=1`

---

## PR Series: Configurable Binary Name

This is **PR 3 of 4** in the configurable binary name series.

| PR | Title | Status |
|---|---|---|
| #1329 | Foundation infrastructure | must merge first |
| #1330 | Go source migration | independent of this PR |
| **#1331** | **Templates, scripts, config migration** | ← you are here |
| #1332 | Build/deploy + docs | independent of this PR |

PRs #1330, #1331, #1332 are independent of each other and can land in any order after #1329 merges.

---

## Commit map (this PR)

Full per-commit categorization: #1356

| # | Commit | Layer | Files | Mechanism | Title |
|---|--------|-------|-------|-----------|-------|
| 21 | `aa25e9e` | 3 | 21 | `{{binary}}` | refactor(progname): migrate formula step descriptions |
| 22 | `b9640d4` | 3 | 7 | `{{binary}}` | refactor(skills): replace hardcoded gc in SKILL.md |
| 23 | `5efda98` | 2 | 2 | — | test(skills): add lint guard for SKILL.md template syntax |
| 24 | `d98f1d8` | 3 | 4 | `${GC_BIN:-gc}` | fix(progname): use ${GC_BIN:-gc} in order exec fields |
| 25 | `2f01967` | 3 | 20 | `{{ cmd }}` | refactor(progname): migrate prompt templates |
| 26 | `f02e619` | 3 | 24 | `${GC_BIN:-gc}` | refactor(progname): migrate shell scripts |

**6 commits, ~78 files, Layer 3 (non-Go file migration, each using its native substitution mechanism)**