### PR TITLE
fix(status): use cached session state with liveness overlay

### DIFF
--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/worker"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 // statusResponse is the JSON body for GET /v0/status.
@@ -50,28 +53,34 @@ func (s *Server) humaHandleStatus(ctx context.Context, input *StatusInput) (*Ind
 func (s *Server) buildStatusBody() StatusBody {
 	cfg := s.state.Config()
 	sp := s.state.SessionProvider()
-	store := s.state.CityBeadStore()
 	cityName := s.state.CityName()
 	sessTmpl := cfg.Workspace.SessionTemplate
+	sessionSnapshot := s.statusSessionSnapshot()
 
 	// Count agents by state.
 	var ac agentCounts
 	var rawRunning int
+	rigAgentCounts := make(map[string]int)
+	rigSuspendedCounts := make(map[string]int)
 	for _, a := range cfg.Agents {
-		for _, ea := range expandAgent(a, cityName, sessTmpl, sp) {
+		rigName := workdirutil.ConfiguredRigName(s.state.CityPath(), a, cfg.Rigs)
+		for _, slot := range statusAgentSlots(a, cityName, sessTmpl, sessionSnapshot) {
 			ac.Total++
-			sessName := agentSessionName(cityName, ea.qualifiedName, sessTmpl)
-			handle, _ := s.workerHandleForSessionTarget(store, sessName)
-			obs, _ := worker.ObserveHandle(context.Background(), handle)
-			running := obs.Running
+			if rigName != "" {
+				rigAgentCounts[rigName]++
+			}
+			running := statusProviderRunning(sp, slot.sessionName)
 			if running {
 				rawRunning++
 			}
-			suspended := ea.suspended || obs.Suspended
+			suspended := a.Suspended || slot.suspended
+			if suspended && rigName != "" {
+				rigSuspendedCounts[rigName]++
+			}
 			switch {
 			case suspended:
 				ac.Suspended++
-			case s.state.IsQuarantined(sessName):
+			case s.state.IsQuarantined(slot.sessionName):
 				ac.Quarantined++
 			case running:
 				ac.Running++
@@ -82,7 +91,11 @@ func (s *Server) buildStatusBody() StatusBody {
 	// Count rigs by state.
 	rc := rigCounts{Total: len(cfg.Rigs)}
 	for _, rig := range cfg.Rigs {
-		if s.rigSuspended(cfg, rig, store, sp, cityName, s.state.CityPath()) {
+		if rig.Suspended {
+			rc.Suspended++
+			continue
+		}
+		if total := rigAgentCounts[rig.Name]; total > 0 && total == rigSuspendedCounts[rig.Name] {
 			rc.Suspended++
 		}
 	}
@@ -149,6 +162,132 @@ func (s *Server) buildStatusBody() StatusBody {
 		Work:       wc,
 		Mail:       mc,
 	}
+}
+
+type statusSessionSnapshot struct {
+	bySessionName map[string]statusSessionInfo
+	byTemplate    map[string][]statusSessionInfo
+}
+
+type statusSessionInfo struct {
+	sessionName string
+	template    string
+	state       session.State
+}
+
+type statusAgentSlot struct {
+	sessionName string
+	suspended   bool
+}
+
+type cachedStatusListStore interface {
+	CachedList(beads.ListQuery) ([]beads.Bead, bool)
+}
+
+func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
+	snapshot := statusSessionSnapshot{
+		bySessionName: make(map[string]statusSessionInfo),
+		byTemplate:    make(map[string][]statusSessionInfo),
+	}
+	store := s.state.CityBeadStore()
+	if store == nil {
+		return snapshot
+	}
+
+	query := beads.ListQuery{Label: session.LabelSession, Sort: beads.SortCreatedDesc}
+	var rows []beads.Bead
+	if cached, ok := store.(cachedStatusListStore); ok {
+		if cachedRows, cacheOK := cached.CachedList(query); cacheOK {
+			rows = cachedRows
+		}
+	}
+	if rows == nil {
+		var err error
+		rows, err = store.List(query)
+		if err != nil {
+			return snapshot
+		}
+	}
+
+	for _, b := range rows {
+		if b.Status == "closed" {
+			continue
+		}
+		info := statusSessionInfo{
+			sessionName: strings.TrimSpace(b.Metadata["session_name"]),
+			template:    strings.TrimSpace(b.Metadata["template"]),
+			state:       statusSessionState(b),
+		}
+		if info.sessionName == "" {
+			continue
+		}
+		snapshot.bySessionName[info.sessionName] = info
+		if info.template != "" {
+			snapshot.byTemplate[info.template] = append(snapshot.byTemplate[info.template], info)
+		}
+	}
+	return snapshot
+}
+
+func statusSessionState(b beads.Bead) session.State {
+	state := session.State(strings.TrimSpace(b.Metadata["state"]))
+	switch state {
+	case "awake":
+		return session.StateActive
+	case "drained":
+		return session.StateAsleep
+	default:
+		return state
+	}
+}
+
+func statusAgentSlots(a config.Agent, cityName, sessTmpl string, snapshot statusSessionSnapshot) []statusAgentSlot {
+	maxSess := a.EffectiveMaxActiveSessions()
+	isMultiSession := maxSess == nil || *maxSess != 1
+	if isMultiSession && (maxSess == nil || *maxSess < 0) {
+		sessions := snapshot.byTemplate[a.QualifiedName()]
+		slots := make([]statusAgentSlot, 0, len(sessions))
+		for _, info := range sessions {
+			slots = append(slots, statusAgentSlot{
+				sessionName: info.sessionName,
+				suspended:   info.state == session.StateSuspended,
+			})
+		}
+		return slots
+	}
+
+	if !isMultiSession {
+		sessionName := agentSessionName(cityName, a.QualifiedName(), sessTmpl)
+		info, ok := snapshot.bySessionName[sessionName]
+		return []statusAgentSlot{{
+			sessionName: sessionName,
+			suspended:   ok && info.state == session.StateSuspended,
+		}}
+	}
+
+	poolMax := 1
+	if maxSess != nil && *maxSess > 1 {
+		poolMax = *maxSess
+	}
+	slots := make([]statusAgentSlot, 0, poolMax)
+	for i := 1; i <= poolMax; i++ {
+		memberName := poolInstanceNameForAPI(a.Name, i, a)
+		sessionName := agentSessionName(cityName, a.QualifiedInstanceName(memberName), sessTmpl)
+		info, ok := snapshot.bySessionName[sessionName]
+		slots = append(slots, statusAgentSlot{
+			sessionName: sessionName,
+			suspended:   ok && info.state == session.StateSuspended,
+		})
+	}
+	return slots
+}
+
+func statusProviderRunning(sp interface{ IsRunning(string) bool }, sessionName string) bool {
+	sessionName = strings.TrimSpace(sessionName)
+	if sp == nil || sessionName == "" {
+		return false
+	}
+	return sp.IsRunning(sessionName)
 }
 
 // HealthInput is the Huma input for GET /v0/city/{cityName}/health.

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestHandleStatus(t *testing.T) {
@@ -131,5 +133,77 @@ func TestHandleStatus_Suspended(t *testing.T) {
 	}
 	if !resp.Suspended {
 		t.Error("expected suspended=true in status response")
+	}
+}
+
+func TestHandleStatusUsesCachedSessionStateForSuspendedAgents(t *testing.T) {
+	state := newFakeState(t)
+	store := beads.NewMemStore()
+	state.cityBeadStore = store
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateSuspended),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker",
+		},
+	}); err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	state.sp.Calls = nil
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Suspended != 1 {
+		t.Fatalf("Agents.Suspended = %d, want 1", resp.Agents.Suspended)
+	}
+	if resp.Agents.Running != 0 {
+		t.Fatalf("Agents.Running = %d, want 0 for suspended session", resp.Agents.Running)
+	}
+	if resp.Running != 1 {
+		t.Fatalf("Running = %d, want raw liveness count 1", resp.Running)
+	}
+}
+
+func TestHandleStatusOnlyUsesProviderLiveness(t *testing.T) {
+	state := newFakeState(t)
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := state.sp.SetMeta("myrig--worker", "suspended", "true"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	state.sp.SetAttached("myrig--worker", true)
+	state.sp.SetActivity("myrig--worker", state.startedAt)
+	state.sp.Calls = nil
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	for _, call := range state.sp.Calls {
+		switch call.Method {
+		case "ProcessAlive", "IsAttached", "GetLastActivity", "GetMeta", "ListRunning":
+			t.Fatalf("/status called provider %s for %q; calls=%#v", call.Method, call.Name, state.sp.Calls)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- build /status agent and rig counts from cached session bead state
- overlay only provider IsRunning liveness instead of full per-session observation
- avoid provider metadata/activity/process probes in the status hot path

## Validation
- go test ./internal/api -run 'TestHandleStatus|TestHandleRig|TestRig|TestHandleAgent|TestHumaHandleAgent|TestHandleSessionListActiveBeadUsesCachedListWhenAvailable|TestHandleStatusEnriched'
- git diff --check origin/main..HEAD