### PR TITLE
fix(dispatch): route graph control beads by concrete assignee

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -36,10 +36,13 @@ func bdStoreForCity(dir, cityPath string) *beads.BdStore {
 // when available, falling back to city-level config. Use this when the rig
 // may have its own Dolt server (e.g., shared from another city).
 func bdStoreForRig(rigDir, cityPath string, cfg *config.City) *beads.BdStore {
-	return beads.NewBdStore(rigDir, bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
-		env := bdRuntimeEnvForRig(cityPath, cfg, rigDir)
-		return env
-	}))
+	return beads.NewBdStore(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir))
+}
+
+func bdCommandRunnerForRig(cityPath string, cfg *config.City, rigDir string) beads.CommandRunner {
+	return bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
+		return bdRuntimeEnvForRig(cityPath, cfg, rigDir)
+	})
 }
 
 func canonicalScopeDoltTarget(cityPath, scopeRoot string) (contract.DoltConnectionTarget, bool, error) {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -459,14 +459,14 @@ func newConvoyDeleteCmd(stdout, stderr io.Writer) *cobra.Command {
 	var deleteBeads bool
 	cmd := &cobra.Command{
 		Use:   "delete <convoy-id>",
-		Short: "Close and optionally delete a convoy and all its beads",
-		Long: `Close all open beads in a convoy, then optionally delete them.
+		Short: "Close or delete a convoy and all its beads",
+		Long: `Close all open beads in a convoy, or delete them.
 
 Searches all stores (city + rigs) for the convoy root and all beads
 with matching gc.root_bead_id. Without --force, shows a preview.
 
 By default, beads are closed with gc.outcome=skipped. Use --delete to
-also remove them from the store after closing.`,
+remove them from the store via bd delete --cascade --force.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdWorkflowDelete(args[0], force, deleteBeads, stdout, stderr) != 0 {
@@ -476,7 +476,7 @@ also remove them from the store after closing.`,
 		},
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Actually close/delete (without this, shows preview)")
-	cmd.Flags().BoolVar(&deleteBeads, "delete", false, "Also delete beads from the store after closing")
+	cmd.Flags().BoolVar(&deleteBeads, "delete", false, "Delete beads from the store instead of closing")
 	return cmd
 }
 
@@ -533,6 +533,14 @@ func newConvoyReopenSourceCmd(stdout, stderr io.Writer) *cobra.Command {
 	return cmd
 }
 
+type workflowStoreMatch struct {
+	store  beads.Store
+	beads  []beads.Bead
+	label  string
+	path   string
+	runner beads.CommandRunner
+}
+
 func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCity()
 	if err != nil {
@@ -544,16 +552,12 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	resolveRigPaths(cityPath, cfg.Rigs)
 
-	type storeMatch struct {
-		store beads.Store
-		beads []beads.Bead
-		label string
-	}
-	var matches []storeMatch
+	var matches []workflowStoreMatch
 
 	stores, err := openConvoyStores(cfg, cityPath, workflowID, func(dir string) (beads.Store, error) {
-		return openStoreAtForCity(dir, cityPath)
+		return openControlStoreAtForCity(dir, cityPath, cfg)
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc workflow delete: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -564,10 +568,12 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		if len(found) == 0 {
 			continue
 		}
-		matches = append(matches, storeMatch{
-			store: info.store,
-			beads: found,
-			label: workflowDeleteStoreLabel(cfg, cityPath, info.path),
+		matches = append(matches, workflowStoreMatch{
+			store:  info.store,
+			beads:  found,
+			label:  workflowDeleteStoreLabel(cfg, cityPath, info.path),
+			path:   info.path,
+			runner: workflowDeleteRunnerForPath(cfg, cityPath, info.path),
 		})
 	}
 
@@ -600,34 +606,53 @@ func cmdWorkflowDelete(workflowID string, force, deleteBeads bool, stdout, stder
 		return 0
 	}
 
-	// Phase 1: Batch close all open beads with gc.outcome=skipped.
+	if deleteBeads {
+		deleted, err := deleteWorkflowMatches(matches)
+		if err != nil {
+			fmt.Fprintf(stderr, "  batch delete: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		fmt.Fprintf(stdout, "Deleted %d beads\n", deleted) //nolint:errcheck // best-effort stdout
+		return 0
+	}
+
+	closed := closeWorkflowMatches(matches)
+	fmt.Fprintf(stdout, "Closed %d open beads\n", closed) //nolint:errcheck // best-effort stdout
+	return 0
+}
+
+func closeWorkflowMatches(matches []workflowStoreMatch) int {
 	closed := 0
 	for _, m := range matches {
 		ids := workflowBeadIDs(m.beads)
 		n, _ := m.store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
 		closed += n
 	}
-	fmt.Fprintf(stdout, "Closed %d open beads\n", closed) //nolint:errcheck // best-effort stdout
+	return closed
+}
 
-	if !deleteBeads {
-		return 0
+func workflowDeleteRunnerForPath(cfg *config.City, cityPath, scopePath string) beads.CommandRunner {
+	if samePath(scopePath, cityPath) {
+		return bdCommandRunnerForCity(cityPath)
 	}
+	return bdCommandRunnerForRig(cityPath, cfg, scopePath)
+}
 
+func deleteWorkflowMatches(matches []workflowStoreMatch) (int, error) {
 	deleted := 0
-	deleteFailed := false
 	for _, m := range matches {
-		count, errs := deleteWorkflowBeads(m.store, workflowBeadIDs(m.beads))
-		deleted += count
-		for _, err := range errs {
-			deleteFailed = true
-			fmt.Fprintf(stderr, "  delete %s: %v\n", m.label, err) //nolint:errcheck // best-effort stderr
+		if m.runner == nil {
+			return deleted, fmt.Errorf("%s: delete runner missing", m.label)
 		}
+		ids := workflowBeadIDs(m.beads)
+		args := append([]string{"delete"}, ids...)
+		args = append(args, "--cascade", "--force")
+		if _, err := m.runner(m.path, "bd", args...); err != nil {
+			return deleted, fmt.Errorf("%s: %w", m.label, err)
+		}
+		deleted += len(ids)
 	}
-	fmt.Fprintf(stdout, "Deleted %d beads\n", deleted) //nolint:errcheck // best-effort stdout
-	if deleteFailed {
-		return 1
-	}
-	return 0
+	return deleted, nil
 }
 
 type sourceWorkflowStoreMatch struct {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -117,13 +118,47 @@ func runControlDispatcher(beadID string, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	// Try all stores (city + rigs) to find the bead.
-	store, bead, err := findBeadAcrossStores(cityPath, beadID, stderr)
+	// Manual control dispatch keeps the operator convenience of resolving a
+	// bead ID across city and rig stores.
+	store, bead, storePath, err := findBeadAcrossStores(cityPath, beadID, stderr)
 	if err != nil {
 		return fmt.Errorf("loading bead %s: %w", beadID, err)
 	}
 
-	opts := dispatch.ProcessOptions{CityPath: cityPath}
+	return runControlDispatcherWithStore(cityPath, storePath, store, bead, beadID, stdout, stderr)
+}
+
+func runControlDispatcherInStore(cityPath, storePath, beadID string, stdout, stderr io.Writer) error {
+	if cityPath == "" {
+		var err error
+		cityPath, err = resolveCity()
+		if err != nil {
+			return err
+		}
+	}
+	if storePath == "" {
+		storePath = cityPath
+	}
+
+	cfg, err := loadCityConfig(cityPath, stderr)
+	if err != nil {
+		return err
+	}
+	resolveRigPaths(cityPath, cfg.Rigs)
+	store, err := openControlStoreAtForCity(storePath, cityPath, cfg)
+	if err != nil {
+		return fmt.Errorf("opening scoped control store %q: %w", storePath, err)
+	}
+	bead, err := store.Get(beadID)
+	if err != nil {
+		return fmt.Errorf("loading bead %s from scoped control store %q: %w", beadID, storePath, err)
+	}
+
+	return runControlDispatcherWithStore(cityPath, storePath, store, bead, beadID, stdout, stderr)
+}
+
+func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store, bead beads.Bead, beadID string, stdout, stderr io.Writer) error {
+	opts := dispatch.ProcessOptions{CityPath: cityPath, StorePath: storePath}
 	opts.Tracef = workflowTracef
 	loadCfg := false
 	switch bead.Metadata["gc.kind"] {
@@ -179,43 +214,59 @@ func runControlDispatcher(beadID string, stdout, stderr io.Writer) error {
 	return nil
 }
 
+func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (beads.Store, error) {
+	if cfg != nil {
+		for _, rig := range cfg.Rigs {
+			rigPath := rig.Path
+			if !filepath.IsAbs(rigPath) {
+				rigPath = filepath.Join(cityPath, rigPath)
+			}
+			if samePath(rigPath, storePath) {
+				if !scopeUsesManagedBdStoreContract(cityPath, storePath) {
+					return openStoreAtForCity(storePath, cityPath)
+				}
+				return bdStoreForRig(storePath, cityPath, cfg), nil
+			}
+		}
+	}
+	return openStoreAtForCity(storePath, cityPath)
+}
+
 // findBeadAcrossStores tries the city store first, then all rig stores,
 // returning the store and bead on first match.
-func findBeadAcrossStores(cityPath, beadID string, warningWriter io.Writer) (beads.Store, beads.Bead, error) {
+func findBeadAcrossStores(cityPath, beadID string, warningWriter io.Writer) (beads.Store, beads.Bead, string, error) {
 	// Try city store first.
 	cityStore, err := openStoreAtForCity(cityPath, cityPath)
 	if err != nil {
-		return nil, beads.Bead{}, fmt.Errorf("opening city store: %w", err)
+		return nil, beads.Bead{}, "", fmt.Errorf("opening city store: %w", err)
 	}
-	if bead, err := cityStore.Get(beadID); err == nil {
-		return cityStore, bead, nil
+	if b, err := cityStore.Get(beadID); err == nil {
+		return cityStore, b, cityPath, nil
 	} else if !errors.Is(err, beads.ErrNotFound) {
-		return nil, beads.Bead{}, fmt.Errorf("getting bead %q from %s: %w", beadID, cityPath, err)
+		return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q from %s: %w", beadID, cityPath, err)
 	}
 
 	// Try rig stores.
 	cfg, err := loadCityConfig(cityPath, warningWriter)
 	if err != nil {
-		return nil, beads.Bead{}, err
+		return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q: not in city store, and config unavailable: %w", beadID, err)
 	}
-	for _, dir := range convoyStoreCandidates(cfg, cityPath, beadID) {
-		if dir == cityPath {
-			continue
-		}
-		store, err := openStoreAtForCity(dir, cityPath)
+	resolveRigPaths(cityPath, cfg.Rigs)
+	for _, rig := range cfg.Rigs {
+		store, err := openControlStoreAtForCity(rig.Path, cityPath, cfg)
 		if err != nil {
-			return nil, beads.Bead{}, fmt.Errorf("opening store %s: %w", dir, err)
+			return nil, beads.Bead{}, "", fmt.Errorf("opening rig store %q: %w", rig.Name, err)
 		}
 		bead, err := store.Get(beadID)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
 				continue
 			}
-			return nil, beads.Bead{}, fmt.Errorf("getting bead %q from %s: %w", beadID, dir, err)
+			return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q from %s: %w", beadID, rig.Path, err)
 		}
-		return store, bead, nil
+		return store, bead, rig.Path, nil
 	}
-	return nil, beads.Bead{}, fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
+	return nil, beads.Bead{}, "", fmt.Errorf("getting bead %q: %w", beadID, beads.ErrNotFound)
 }
 
 func findUniqueBeadAcrossStoresView(cityPath, beadID string) (convoyStoreView, beads.Bead, error) {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1427,6 +1427,65 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 	}
 }
 
+func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	var attempted []string
+	var processed []string
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		switch calls {
+		case 1:
+			return []hookBead{
+				{ID: "gc-legacy", Metadata: map[string]string{"gc.kind": "ralph"}},
+				{ID: "gc-ready", Metadata: map[string]string{"gc.kind": "scope-check"}},
+			}, nil
+		default:
+			return nil, nil
+		}
+	}
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
+		attempted = append(attempted, beadID)
+		if beadID == "gc-legacy" {
+			return fmt.Errorf("gc-legacy: recording attempt log: setting metadata on %q: failed to record event: old_value is too large", beadID)
+		}
+		processed = append(processed, beadID)
+		return nil
+	}
+
+	if err := runWorkflowServe("", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+
+	if !slices.Equal(attempted, []string{"gc-legacy", "gc-ready"}) {
+		t.Fatalf("attempted beads = %#v, want legacy oversized control skipped before ready bead is processed", attempted)
+	}
+	if !slices.Equal(processed, []string{"gc-ready"}) {
+		t.Fatalf("processed beads = %#v, want only later ready bead to be processed", processed)
+	}
+}
+
 func TestRunWorkflowServeReturnsQueryError(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -313,6 +313,104 @@ func TestFindWorkflowBeadsResolvesLogicalWorkflowID(t *testing.T) {
 	}
 }
 
+func TestDeleteWorkflowMatchesUsesCascadeWithoutPreClose(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title: "Workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title: "Child",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+
+	var gotDir, gotName string
+	var gotArgs []string
+	deleted, err := deleteWorkflowMatches([]workflowStoreMatch{{
+		store: store,
+		beads: []beads.Bead{root, child},
+		label: "city",
+		path:  "/city",
+		runner: func(dir, name string, args ...string) ([]byte, error) {
+			gotDir = dir
+			gotName = name
+			gotArgs = append([]string(nil), args...)
+			return nil, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("deleteWorkflowMatches: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+	if gotDir != "/city" || gotName != "bd" {
+		t.Fatalf("runner target = (%q, %q), want (/city, bd)", gotDir, gotName)
+	}
+	wantArgs := []string{"delete", root.ID, child.ID, "--cascade", "--force"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("delete args = %#v, want %#v", gotArgs, wantArgs)
+	}
+	for _, id := range []string{root.ID, child.ID} {
+		after, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if after.Status != "open" || after.Metadata["gc.outcome"] == "skipped" {
+			t.Fatalf("bead %s mutated before delete: status=%q metadata=%#v", id, after.Status, after.Metadata)
+		}
+	}
+}
+
+func TestDeleteWorkflowMatchesFailureDoesNotCloseBeads(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title: "Workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+
+	deleted, err := deleteWorkflowMatches([]workflowStoreMatch{{
+		store: store,
+		beads: []beads.Bead{root},
+		label: "city",
+		path:  "/city",
+		runner: func(string, string, ...string) ([]byte, error) {
+			return nil, fmt.Errorf("delete failed")
+		},
+	}})
+	if err == nil {
+		t.Fatal("deleteWorkflowMatches returned nil error, want delete failure")
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0 after failed delete", deleted)
+	}
+	after, err := store.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if after.Status != "open" || after.Metadata["gc.outcome"] == "skipped" {
+		t.Fatalf("root mutated after failed delete: status=%q metadata=%#v", after.Status, after.Metadata)
+	}
+}
+
 func TestCmdWorkflowDeleteSourceClosesMatchedRootsAndClearsWorkflowID(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -968,7 +968,7 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 		sequence = sequence[1:]
 		return next, nil
 	}
-	controlDispatcherServe = func(beadID string, _ io.Writer, _ io.Writer) error {
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
 		controlled = append(controlled, beadID)
 		return nil
 	}
@@ -1000,6 +1000,156 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 		if env["GC_STORE_SCOPE"] != "city" {
 			t.Fatalf("workflowServeList env[%d] GC_STORE_SCOPE = %q, want city", i, env["GC_STORE_SCOPE"])
 		}
+	}
+}
+
+// TestRunWorkflowServeOverridesInheritedCityBeadsDir is a regression test for
+// #514: the serve path must pass rig-scoped env to work query subprocesses,
+// not inherit a city-scoped BEADS_DIR from the parent.
+func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig-repo")
+
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"myrig\"\npath = %q\n\n[[agent]]\nname = \"worker\"\ndir = \"myrig\"\n", rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_CITY", cityDir)
+	// Pollute parent env with a city-scoped BEADS_DIR. Without the fix,
+	// this value leaks into work query subprocesses.
+	cityBeads := filepath.Join(cityDir, ".beads")
+	t.Setenv("BEADS_DIR", cityBeads)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	var capturedEnv map[string]string
+	workflowServeList = func(_, _ string, env map[string]string) ([]hookBead, error) {
+		capturedEnv = maps.Clone(env)
+		return nil, nil // no work: exits immediately
+	}
+	controlDispatcherServe = func(_, _, _ string, _ io.Writer, _ io.Writer) error {
+		return nil
+	}
+
+	if err := runWorkflowServe("worker", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+
+	if capturedEnv == nil {
+		t.Fatal("workflowServeList received nil env, want rig-scoped env")
+	}
+	wantBeads := filepath.Join(rigDir, ".beads")
+	if got := capturedEnv["BEADS_DIR"]; got != wantBeads {
+		t.Fatalf("BEADS_DIR = %q, want rig store %q", got, wantBeads)
+	}
+	if capturedEnv["BEADS_DIR"] == cityBeads {
+		t.Fatalf("BEADS_DIR inherited city store %q", cityBeads)
+	}
+	if got := capturedEnv["GC_STORE_ROOT"]; got != rigDir {
+		t.Fatalf("GC_STORE_ROOT = %q, want rig root %q", got, rigDir)
+	}
+	if got := capturedEnv["GC_STORE_SCOPE"]; got != "rig" {
+		t.Fatalf("GC_STORE_SCOPE = %q, want rig", got)
+	}
+}
+
+func TestRunWorkflowServeProcessesControlBeadsInAgentStoreScope(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig-repo")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[rigs]]
+name = "myrig"
+path = %q
+`, rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	calls := 0
+	var queryDir string
+	workflowServeList = func(_, dir string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		queryDir = dir
+		if calls == 1 {
+			return []hookBead{{ID: "gc-rig-control", Metadata: map[string]string{"gc.kind": "scope-check"}}}, nil
+		}
+		return nil, nil
+	}
+
+	var gotCityPath, gotStorePath, gotBeadID string
+	controlDispatcherServe = func(cityPath, storePath, beadID string, _ io.Writer, _ io.Writer) error {
+		gotCityPath = cityPath
+		gotStorePath = storePath
+		gotBeadID = beadID
+		return nil
+	}
+
+	if err := runWorkflowServe("myrig/control-dispatcher", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+	if canonicalTestPath(queryDir) != canonicalTestPath(rigDir) {
+		t.Fatalf("query dir = %q, want rig root %q", queryDir, rigDir)
+	}
+	if canonicalTestPath(gotCityPath) != canonicalTestPath(cityDir) {
+		t.Fatalf("control cityPath = %q, want %q", gotCityPath, cityDir)
+	}
+	if canonicalTestPath(gotStorePath) != canonicalTestPath(rigDir) {
+		t.Fatalf("control storePath = %q, want rig root %q", gotStorePath, rigDir)
+	}
+	if gotBeadID != "gc-rig-control" {
+		t.Fatalf("control beadID = %q, want gc-rig-control", gotBeadID)
 	}
 }
 
@@ -1062,7 +1212,7 @@ max = 5
 		gotDir = dir
 		return nil, nil
 	}
-	controlDispatcherServe = func(_ string, _ io.Writer, _ io.Writer) error {
+	controlDispatcherServe = func(_, _, _ string, _ io.Writer, _ io.Writer) error {
 		t.Fatal("controlDispatcherServe should not run when no control work is returned")
 		return nil
 	}
@@ -1116,7 +1266,7 @@ func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.
 			return nil, nil
 		}
 	}
-	controlDispatcherServe = func(beadID string, _ io.Writer, _ io.Writer) error {
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
 		controlled = append(controlled, beadID)
 		return nil
 	}
@@ -1168,7 +1318,7 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 			return nil, nil
 		}
 	}
-	controlDispatcherServe = func(beadID string, _ io.Writer, _ io.Writer) error {
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
 		attempted = append(attempted, beadID)
 		if beadID == "gc-pending" {
 			return dispatch.ErrControlPending
@@ -1209,7 +1359,7 @@ func TestRunWorkflowServeReturnsQueryError(t *testing.T) {
 	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
 		return nil, os.ErrDeadlineExceeded
 	}
-	controlDispatcherServe = func(string, io.Writer, io.Writer) error {
+	controlDispatcherServe = func(_, _, _ string, _ io.Writer, _ io.Writer) error {
 		t.Fatal("controlDispatcherServe should not be called on query failure")
 		return nil
 	}
@@ -1296,7 +1446,7 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 			return nil, nil
 		}
 	}
-	controlDispatcherServe = func(beadID string, _ io.Writer, _ io.Writer) error {
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
 		processed = append(processed, beadID)
 		return os.ErrDeadlineExceeded
 	}
@@ -1304,8 +1454,9 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 	wfcAgent := config.Agent{Name: "control-dispatcher", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(1)}
 	err := runWorkflowServeFollow(
 		wfcAgent,
-		wfcAgent.EffectiveWorkQuery(),
 		t.TempDir(),
+		t.TempDir(),
+		wfcAgent.EffectiveWorkQuery(),
 		nil,
 		io.Discard,
 	)
@@ -1378,7 +1529,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 			return nil, nil
 		}
 	}
-	controlDispatcherServe = func(beadID string, _ io.Writer, _ io.Writer) error {
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
 		if beadID == "gc-pending" {
 			return dispatch.ErrControlPending
 		}
@@ -1386,7 +1537,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	}
 
 	agent := config.Agent{Name: "control-dispatcher"}
-	err := runWorkflowServeFollow(agent, agent.EffectiveWorkQuery(), t.TempDir(), nil, io.Discard)
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
 	if !errors.Is(err, stopErr) {
 		t.Fatalf("runWorkflowServeFollow error = %v, want %v", err, stopErr)
 	}
@@ -1796,7 +1947,7 @@ name = "test-city"
 	}
 	t.Setenv("GC_BEADS", "exec:/definitely/missing/provider")
 
-	_, _, err := findBeadAcrossStores(cityPath, "gc-missing", io.Discard)
+	_, _, _, err := findBeadAcrossStores(cityPath, "gc-missing", io.Discard)
 	if err == nil {
 		t.Fatal("findBeadAcrossStores() error = nil, want provider failure")
 	}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -944,10 +944,8 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 		workflowServeIdlePollAttempts = prevAttempts
 	})
 
-	// The tiered query has sh -c wrapper; workflowServeQuery replaces the
-	// first --limit=1 with --limit=20 for scan width.
 	cdAgent := config.Agent{Name: config.ControlDispatcherAgentName}
-	wantQuery := workflowServeQuery(cdAgent.EffectiveWorkQuery())
+	wantQuery := workflowServeWorkQuery(cdAgent)
 	var gotQueries []string
 	var gotDirs []string
 	var gotEnv []map[string]string
@@ -1001,6 +999,96 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 			t.Fatalf("workflowServeList env[%d] GC_STORE_SCOPE = %q, want city", i, env["GC_STORE_SCOPE"])
 		}
 	}
+}
+
+func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
+	if strings.Contains(query, "GC_SESSION_ORIGIN") {
+		t.Fatalf("workflowServeControlReadyQuery should not gate legacy routes on session origin: %q", query)
+	}
+	for _, want := range []string{
+		`bd list --status in_progress --assignee="$cand"`,
+		`bd ready --assignee="$cand"`,
+		`bd ready --metadata-field gc.routed_to=control-dispatcher --unassigned`,
+		`bd ready --metadata-field gc.routed_to=workflow-control --unassigned`,
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
+		}
+	}
+	if !strings.Contains(query, `--limit=20`) {
+		t.Fatalf("workflowServeControlReadyQuery missing scan limit: %q", query)
+	}
+}
+
+func TestWorkflowServeControlReadyQueryPrefersInProgressAssigned(t *testing.T) {
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
+	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
+		"GC_SESSION_NAME":   "gascity--control-dispatcher",
+		"GC_ALIAS":          "gascity/control-dispatcher",
+		"GC_SESSION_ORIGIN": "named",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=20")
+    printf '[{"id":"ga-in-progress"}]'
+    ;;
+  "ready --assignee=gascity--control-dispatcher --json --limit=20")
+    printf '[{"id":"ga-ready"}]'
+    ;;
+  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=20")
+    printf '[{"id":"ga-routed"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-in-progress"}]`; got != want {
+		t.Fatalf("control query output = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowServeControlReadyQueryUsesLegacyRouteForNamedSessions(t *testing.T) {
+	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
+	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
+		"GC_SESSION_NAME":   "gascity--control-dispatcher",
+		"GC_ALIAS":          "gascity/control-dispatcher",
+		"GC_SESSION_ORIGIN": "named",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=20")
+    printf '[{"id":"ga-legacy-route"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-legacy-route"}]`; got != want {
+		t.Fatalf("control query output = %q, want %q", got, want)
+	}
+}
+
+func runWorkflowServeShellQueryForTest(t *testing.T, query string, env map[string]string, bdScript string) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	queryEnv := []string{"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH")}
+	for key, value := range env {
+		queryEnv = append(queryEnv, key+"="+value)
+	}
+	out, err := shellWorkQueryWithEnv(query, t.TempDir(), queryEnv)
+	if err != nil {
+		t.Fatalf("run workflow serve query: %v", err)
+	}
+	return out
 }
 
 // TestRunWorkflowServeOverridesInheritedCityBeadsDir is a regression test for

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -185,8 +185,8 @@ func TestDecorateDynamicFragmentRecipeSupportsExplicitPerStepAgents(t *testing.T
 	if control.Assignee != config.ControlDispatcherAgentName {
 		t.Fatalf("review scope-check assignee = %q, want %q", control.Assignee, config.ControlDispatcherAgentName)
 	}
-	if control.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-		t.Fatalf("review scope-check gc.routed_to = %q, want %q", control.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+	if got := control.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("review scope-check gc.routed_to = %q, want empty direct dispatcher assignee", got)
 	}
 	if control.Metadata[graphExecutionRouteMetaKey] != "reviewer" {
 		t.Fatalf("review scope-check execution route = %q, want reviewer", control.Metadata[graphExecutionRouteMetaKey])
@@ -802,8 +802,11 @@ func TestDecorateDynamicFragmentRecipePreservesPoolFallbackAndScopeMetadata(t *t
 	if control.Metadata["gc.scope_role"] != "control" {
 		t.Fatalf("control gc.scope_role = %q, want control", control.Metadata["gc.scope_role"])
 	}
-	if control.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-		t.Fatalf("control gc.routed_to = %q, want %q", control.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+	if control.Assignee != config.ControlDispatcherAgentName {
+		t.Fatalf("control assignee = %q, want %q", control.Assignee, config.ControlDispatcherAgentName)
+	}
+	if got := control.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("control gc.routed_to = %q, want empty direct dispatcher assignee", got)
 	}
 	if control.Metadata[graphExecutionRouteMetaKey] != "frontend/reviewer" {
 		t.Fatalf("control execution route = %q, want frontend/reviewer", control.Metadata[graphExecutionRouteMetaKey])
@@ -1481,8 +1484,11 @@ func TestDecorateDynamicFragmentRecipeSynthesizesInheritedScopeChecks(t *testing
 	if control.Metadata["gc.scope_ref"] != "body" {
 		t.Fatalf("review scope-check gc.scope_ref = %q, want body", control.Metadata["gc.scope_ref"])
 	}
-	if control.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-		t.Fatalf("review scope-check gc.routed_to = %q, want %q", control.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+	if control.Assignee != config.ControlDispatcherAgentName {
+		t.Fatalf("review scope-check assignee = %q, want %q", control.Assignee, config.ControlDispatcherAgentName)
+	}
+	if got := control.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("review scope-check gc.routed_to = %q, want empty direct dispatcher assignee", got)
 	}
 	if control.Metadata[graphExecutionRouteMetaKey] != "reviewer" {
 		t.Fatalf("review scope-check execution route = %q, want reviewer", control.Metadata[graphExecutionRouteMetaKey])

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -831,8 +831,8 @@ title = "Do work"
 			if bead.Assignee != config.ControlDispatcherAgentName {
 				t.Fatalf("finalizer assignee = %q, want %q", bead.Assignee, config.ControlDispatcherAgentName)
 			}
-			if bead.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-				t.Fatalf("finalizer gc.routed_to = %q, want %q", bead.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+			if bead.Metadata["gc.routed_to"] != "" {
+				t.Fatalf("finalizer gc.routed_to = %q, want empty for concrete control dispatcher assignee", bead.Metadata["gc.routed_to"])
 			}
 			if bead.Metadata[graphExecutionRouteMetaKey] != "quinn" {
 				t.Fatalf("finalizer execution route = %q, want quinn", bead.Metadata[graphExecutionRouteMetaKey])

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2548,8 +2548,8 @@ title = "Do work"
 			if bead.Assignee != config.ControlDispatcherAgentName {
 				t.Fatalf("workflow-finalize assignee = %q, want %q", bead.Assignee, config.ControlDispatcherAgentName)
 			}
-			if bead.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-				t.Fatalf("workflow-finalize gc.routed_to = %q, want %q", bead.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+			if got := bead.Metadata["gc.routed_to"]; got != "" {
+				t.Fatalf("workflow-finalize gc.routed_to = %q, want empty direct dispatcher assignee", got)
 			}
 			if bead.Metadata[graphExecutionRouteMetaKey] != "mayor" {
 				t.Fatalf("workflow-finalize execution route = %q, want mayor", bead.Metadata[graphExecutionRouteMetaKey])

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -231,6 +231,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 		idlePolls = 0
 		processedThisCycle := false
 		pendingCount := 0
+		legacyOversizedCount := 0
 		for _, candidate := range queue {
 			beadID := candidate.ID
 			kind := strings.TrimSpace(candidate.Metadata["gc.kind"])
@@ -256,6 +257,10 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 					continue
 				}
 				workflowTracef("serve process-error bead=%s kind=%s err=%v", beadID, kind, err)
+				if isLegacyOversizedControlEventError(err) {
+					legacyOversizedCount++
+					continue
+				}
 				return result, fmt.Errorf("processing control bead %s: %w", beadID, err)
 			}
 			workflowTracef("serve processed bead=%s kind=%s", beadID, kind)
@@ -270,7 +275,21 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 			workflowTracef("serve pending-queue agent=%s count=%d", agentCfg.QualifiedName(), pendingCount)
 			return result, nil
 		}
+		if legacyOversizedCount > 0 {
+			workflowTracef("serve legacy-oversized-queue agent=%s count=%d", agentCfg.QualifiedName(), legacyOversizedCount)
+			return result, nil
+		}
 	}
+}
+
+func isLegacyOversizedControlEventError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "recording attempt log") &&
+		strings.Contains(msg, "old_value") &&
+		strings.Contains(msg, "too large")
 }
 
 func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) error {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -213,7 +213,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 	result := workflowServeDrainResult{}
 	idlePolls := 0
 	for {
-		queue, err := workflowServeList(workflowServeQuery(workQuery), storePath, workEnv)
+		queue, err := workflowServeList(workflowServeWorkQuery(agentCfg, workQuery), storePath, workEnv)
 		if err != nil {
 			workflowTracef("serve query-error agent=%s err=%v", agentCfg.QualifiedName(), err)
 			return result, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
@@ -399,6 +399,72 @@ func workflowServeQuery(workQuery string) string {
 		return strings.Replace(workQuery, single, scan, 1)
 	}
 	return workQuery
+}
+
+func workflowServeWorkQuery(agentCfg config.Agent, expandedWorkQuery ...string) string {
+	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
+		return workflowServeControlReadyQuery(agentCfg)
+	}
+	workQuery := agentCfg.EffectiveWorkQuery()
+	if len(expandedWorkQuery) > 0 {
+		workQuery = expandedWorkQuery[0]
+	}
+	return workflowServeQuery(workQuery)
+}
+
+func isWorkflowServeControlDispatcherAgent(agentCfg config.Agent) bool {
+	qualified := strings.TrimSpace(agentCfg.QualifiedName())
+	return qualified == config.ControlDispatcherAgentName ||
+		strings.HasSuffix(qualified, "/"+config.ControlDispatcherAgentName)
+}
+
+func workflowServeControlReadyQuery(agentCfg config.Agent) string {
+	target := strings.TrimSpace(agentCfg.QualifiedName())
+	if target == "" {
+		target = config.ControlDispatcherAgentName
+	}
+	limit := fmt.Sprintf("%d", workflowServeScanLimit)
+	query := `sh -c '` +
+		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS" "` + target + `"; do ` +
+		`[ -z "$id" ] && continue; ` +
+		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
+		`for cand in "$id" "$legacy"; do ` +
+		`[ -z "$cand" ] && continue; ` +
+		`r=$(bd list --status in_progress --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`done; ` +
+		`done; ` +
+		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS" "` + target + `"; do ` +
+		`[ -z "$id" ] && continue; ` +
+		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
+		`for cand in "$id" "$legacy"; do ` +
+		`[ -z "$cand" ] && continue; ` +
+		`r=$(bd ready --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+		`done; ` +
+		`done; ` +
+		`r=$(bd ready --metadata-field gc.routed_to=` + target +
+		` --unassigned --json --limit=` + limit + ` 2>/dev/null); ` +
+		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `
+	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
+		query += `bd ready --metadata-field gc.routed_to=` + legacy +
+			` --unassigned --json --limit=` + limit + ` 2>/dev/null'`
+	} else {
+		query += `printf "[]"` + `'`
+	}
+	return query
+}
+
+func workflowServeLegacyControlRoute(target string) string {
+	target = strings.TrimSpace(target)
+	if target == config.ControlDispatcherAgentName {
+		return "workflow-control"
+	}
+	const suffix = "/" + config.ControlDispatcherAgentName
+	if strings.HasSuffix(target, suffix) {
+		return strings.TrimSuffix(target, suffix) + "/workflow-control"
+	}
+	return ""
 }
 
 func nextWorkflowServeBeads(workQuery, dir string, env map[string]string) ([]hookBead, error) {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -65,7 +65,7 @@ func applyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string,
 
 var (
 	workflowServeList               = nextWorkflowServeBeads
-	controlDispatcherServe          = runControlDispatcher
+	controlDispatcherServe          = runControlDispatcherInStore
 	workflowServeOpenEventsProvider = func(stderr io.Writer) (events.Provider, error) {
 		ep, code := openCityEventsProvider(stderr, "gc convoy control --serve")
 		if ep == nil {
@@ -194,10 +194,10 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	workQuery := expandAgentCommandTemplate(cityPath, loadedCityName(cfg, cityPath), &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
-		_, err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
+		_, err := drainWorkflowServeWork(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
 		return err
 	}
-	return runWorkflowServeFollow(agentCfg, workQuery, workDir, workEnv, stderr)
+	return runWorkflowServeFollow(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
 }
 
 type workflowServeDrainResult struct {
@@ -209,11 +209,11 @@ type workflowServeDrainResult struct {
 // for a single invocation. Returns whether it advanced a control bead and
 // whether the queue still contains only pending work so the --follow caller
 // can distinguish blocked work from genuine idle.
-func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir string, workEnv map[string]string, stderr io.Writer) (workflowServeDrainResult, error) {
+func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) (workflowServeDrainResult, error) {
 	result := workflowServeDrainResult{}
 	idlePolls := 0
 	for {
-		queue, err := workflowServeList(workflowServeQuery(workQuery), workDir, workEnv)
+		queue, err := workflowServeList(workflowServeQuery(workQuery), storePath, workEnv)
 		if err != nil {
 			workflowTracef("serve query-error agent=%s err=%v", agentCfg.QualifiedName(), err)
 			return result, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
@@ -238,7 +238,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 				workflowTracef("serve unexpected-kind bead=%s kind=%s", beadID, kind)
 				return result, fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
 			}
-			workflowTracef("serve process bead=%s kind=%s", beadID, kind)
+			workflowTracef("serve process bead=%s kind=%s store=%s", beadID, kind, storePath)
 			// controlDispatcherServe currently returns nil both when it
 			// successfully advanced a control bead AND when ProcessControl
 			// chose to no-op (e.g., status != "open"). The caller cannot
@@ -248,7 +248,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 			// control ga-fw2fm. The silent no-op now emits a separate
 			// `process-control ... skip reason=bead_not_open` line inside
 			// ProcessControl itself; see runtime.go.
-			if err := controlDispatcherServe(beadID, io.Discard, stderr); err != nil {
+			if err := controlDispatcherServe(cityPath, storePath, beadID, io.Discard, stderr); err != nil {
 				if errors.Is(err, dispatch.ErrControlPending) {
 					pendingCount++
 					result.pendingAny = true
@@ -273,7 +273,7 @@ func drainWorkflowServeWork(agentCfg config.Agent, workQuery string, workDir str
 	}
 }
 
-func runWorkflowServeFollow(agentCfg config.Agent, workQuery string, workDir string, workEnv map[string]string, stderr io.Writer) error {
+func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) error {
 	ep, err := workflowServeOpenEventsProvider(stderr)
 	if err != nil {
 		return err
@@ -297,7 +297,7 @@ func runWorkflowServeFollow(agentCfg config.Agent, workQuery string, workDir str
 
 	idleSweeps := 0
 	for {
-		drainResult, err := drainWorkflowServeWork(agentCfg, workQuery, workDir, workEnv, stderr)
+		drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, storePath, workQuery, workEnv, stderr)
 		if err != nil {
 			return err
 		}

--- a/cmd/gc/graph_dispatch_mem_test.go
+++ b/cmd/gc/graph_dispatch_mem_test.go
@@ -433,8 +433,8 @@ func TestGraphWorkflowInMemoryRouteUsesControlDispatcherForControlBeads(t *testi
 		if bead.Assignee != config.ControlDispatcherAgentName {
 			t.Fatalf("control bead %s assignee = %q, want %q", bead.ID, bead.Assignee, config.ControlDispatcherAgentName)
 		}
-		if bead.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-			t.Fatalf("control bead %s gc.routed_to = %q, want %q", bead.ID, bead.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+		if got := bead.Metadata["gc.routed_to"]; got != "" {
+			t.Fatalf("control bead %s gc.routed_to = %q, want empty direct dispatcher assignee", bead.ID, got)
 		}
 	}
 	if !foundControl {

--- a/cmd/gc/session_model_phase0_workflow_spec_test.go
+++ b/cmd/gc/session_model_phase0_workflow_spec_test.go
@@ -231,8 +231,11 @@ func TestPhase0WorkflowRouting_ControlStepPreservesExecutionConfigLane(t *testin
 	if check == nil {
 		t.Fatal("scope-check step missing after decorate")
 	}
-	if got := check.Metadata["gc.routed_to"]; got != "frontend/control-dispatcher" {
-		t.Fatalf("scope-check gc.routed_to = %q, want frontend/control-dispatcher", got)
+	if got := check.Assignee; got != "frontend--control-dispatcher" {
+		t.Fatalf("scope-check assignee = %q, want frontend--control-dispatcher", got)
+	}
+	if got := check.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("scope-check gc.routed_to = %q, want empty direct dispatcher assignee", got)
 	}
 	if got := check.Metadata[graphExecutionRouteMetaKey]; got != "frontend/codex" {
 		t.Fatalf("scope-check execution route = %q, want frontend/codex", got)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -643,7 +643,7 @@ gc convoy
 | [gc convoy close](#gc-convoy-close) | Close a convoy |
 | [gc convoy control](#gc-convoy-control) | Execute control beads or run the control-dispatcher loop |
 | [gc convoy create](#gc-convoy-create) | Create a convoy and optionally track issues |
-| [gc convoy delete](#gc-convoy-delete) | Close and optionally delete a convoy and all its beads |
+| [gc convoy delete](#gc-convoy-delete) | Close or delete a convoy and all its beads |
 | [gc convoy delete-source](#gc-convoy-delete-source) | Close workflows sourced from a bead |
 | [gc convoy land](#gc-convoy-land) | Land an owned convoy (terminate + cleanup) |
 | [gc convoy list](#gc-convoy-list) | List open convoys with progress |
@@ -730,13 +730,13 @@ gc convoy create sprint-42
 
 ## gc convoy delete
 
-Close all open beads in a convoy, then optionally delete them.
+Close all open beads in a convoy, or delete them.
 
 Searches all stores (city + rigs) for the convoy root and all beads
 with matching gc.root_bead_id. Without --force, shows a preview.
 
 By default, beads are closed with gc.outcome=skipped. Use --delete to
-also remove them from the store after closing.
+remove them from the store via bd delete --cascade --force.
 
 ```
 gc convoy delete <convoy-id> [flags]
@@ -744,7 +744,7 @@ gc convoy delete <convoy-id> [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--delete` | bool |  | Also delete beads from the store after closing |
+| `--delete` | bool |  | Delete beads from the store instead of closing |
 | `-f`, `--force` | bool |  | Actually close/delete (without this, shows preview) |
 
 ## gc convoy delete-source

--- a/internal/convergence/condition.go
+++ b/internal/convergence/condition.go
@@ -52,6 +52,7 @@ type ConditionEnv struct {
 	BeadID               string
 	Iteration            int
 	CityPath             string
+	StorePath            string
 	WorkDir              string
 	WispID               string
 	DocPath              string // from var.doc_path, may be empty
@@ -66,7 +67,8 @@ type ConditionEnv struct {
 
 // Environ returns the environment variable slice for exec.Cmd.
 // Only whitelisted variables: PATH (safe default), HOME, TMPDIR, convergence
-// vars, and GC_INTEGRATION_REAL_BD when present for integration-test bd shims.
+// vars, Dolt/Beads connection env, and GC_INTEGRATION_REAL_BD when present for
+// integration-test bd shims.
 func (ce ConditionEnv) Environ() []string {
 	// Use CityPath as HOME to sandbox gate scripts from the
 	// controller's home directory (which may contain .ssh, .gnupg, etc).
@@ -74,11 +76,15 @@ func (ce ConditionEnv) Environ() []string {
 	if home == "" {
 		home = os.TempDir()
 	}
+	storePath := ce.StorePath
+	if storePath == "" {
+		storePath = ce.CityPath
+	}
 	env := []string{
 		"PATH=" + conditionPATH(),
 		"HOME=" + home,
 		"TMPDIR=" + os.TempDir(),
-		"BEADS_DIR=" + filepath.Join(ce.CityPath, ".beads"),
+		"BEADS_DIR=" + filepath.Join(storePath, ".beads"),
 		"GC_BEAD_ID=" + ce.BeadID,
 		"GC_ITERATION=" + strconv.Itoa(ce.Iteration),
 		"GC_WISP_ID=" + ce.WispID,
@@ -105,8 +111,27 @@ func (ce ConditionEnv) Environ() []string {
 	if ce.WorkDir != "" {
 		env = append(env, "GC_WORK_DIR="+ce.WorkDir)
 	}
+	if ce.StorePath != "" {
+		env = append(env, "GC_STORE_PATH="+ce.StorePath)
+	}
 	if realBD := os.Getenv("GC_INTEGRATION_REAL_BD"); realBD != "" {
 		env = append(env, "GC_INTEGRATION_REAL_BD="+realBD)
+	}
+	for _, key := range []string{
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_PASSWORD",
+		"GC_DOLT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+	} {
+		if value := os.Getenv(key); value != "" {
+			env = append(env, key+"="+value)
+		}
 	}
 
 	return env
@@ -197,6 +222,9 @@ func runOnce(ctx context.Context, scriptPath string, env ConditionEnv, timeout t
 
 	cmd := exec.CommandContext(execCtx, scriptPath)
 	cmd.Dir = env.CityPath
+	if env.StorePath != "" {
+		cmd.Dir = env.StorePath
+	}
 	if env.WorkDir != "" {
 		cmd.Dir = env.WorkDir
 	}

--- a/internal/convergence/condition_test.go
+++ b/internal/convergence/condition_test.go
@@ -136,6 +136,65 @@ func TestConditionEnvEnvironPreservesIntegrationRealBD(t *testing.T) {
 	}
 }
 
+func TestConditionEnvEnvironUsesStorePathForBeadsDir(t *testing.T) {
+	env := ConditionEnv{
+		BeadID:    "bead-store",
+		Iteration: 1,
+		CityPath:  "/city",
+		StorePath: "/rig",
+	}
+
+	vars := env.Environ()
+	lookup := make(map[string]string)
+	for _, v := range vars {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) == 2 {
+			lookup[parts[0]] = parts[1]
+		}
+	}
+
+	if got := lookup["BEADS_DIR"]; got != filepath.Join("/rig", ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want rig beads dir", got)
+	}
+	if got := lookup["GC_STORE_PATH"]; got != "/rig" {
+		t.Fatalf("GC_STORE_PATH = %q, want /rig", got)
+	}
+	if got := lookup["GC_CITY"]; got != "/city" {
+		t.Fatalf("GC_CITY = %q, want /city", got)
+	}
+}
+
+func TestConditionEnvEnvironPreservesDoltConnection(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "33061")
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PASSWORD", "secret")
+
+	env := ConditionEnv{
+		BeadID:    "bead-dolt",
+		Iteration: 1,
+		CityPath:  "/city",
+	}
+
+	vars := env.Environ()
+	lookup := make(map[string]string)
+	for _, v := range vars {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) == 2 {
+			lookup[parts[0]] = parts[1]
+		}
+	}
+
+	for key, want := range map[string]string{
+		"BEADS_DOLT_SERVER_PORT": "33061",
+		"GC_DOLT_HOST":           "127.0.0.1",
+		"GC_DOLT_PASSWORD":       "secret",
+	} {
+		if got := lookup[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestResolveConditionPath(t *testing.T) {
 	t.Run("absolute path", func(t *testing.T) {
 		dir := t.TempDir()
@@ -307,6 +366,40 @@ func TestRunConditionUsesWorkDir(t *testing.T) {
 		t.Errorf("Stdout = %q, want to contain workdir %q", result.Stdout, workDir)
 	}
 	wantBeadsDir := filepath.Join(cityDir, ".beads")
+	if !strings.Contains(result.Stdout, wantBeadsDir) {
+		t.Errorf("Stdout = %q, want to contain BEADS_DIR %q", result.Stdout, wantBeadsDir)
+	}
+	if !strings.Contains(result.Stdout, "ok") {
+		t.Errorf("Stdout = %q, want to contain file contents", result.Stdout)
+	}
+}
+
+func TestRunConditionUsesStorePathAsDefaultWorkDir(t *testing.T) {
+	cityDir := t.TempDir()
+	storeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(storeDir, "target.txt"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := filepath.Join(cityDir, "check-store.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\npwd\nprintf '%s\\n' \"$BEADS_DIR\"\ncat target.txt\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env := ConditionEnv{
+		BeadID:    "b-store",
+		CityPath:  cityDir,
+		StorePath: storeDir,
+	}
+
+	result := RunCondition(context.Background(), script, env, 5*time.Second, 0)
+	if result.Outcome != GatePass {
+		t.Fatalf("Outcome = %q, want %q (stderr=%q)", result.Outcome, GatePass, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, storeDir) {
+		t.Errorf("Stdout = %q, want to contain store dir %q", result.Stdout, storeDir)
+	}
+	wantBeadsDir := filepath.Join(storeDir, ".beads")
 	if !strings.Contains(result.Stdout, wantBeadsDir) {
 		t.Errorf("Stdout = %q, want to contain BEADS_DIR %q", result.Stdout, wantBeadsDir)
 	}

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -43,23 +43,22 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 
 	attemptNum, _ := strconv.Atoi(attempt.Metadata["gc.attempt"])
 	result := classifyRetryAttempt(attempt)
-
-	// Record decision in attempt log.
-	if err := appendAttemptLog(store, bead.ID, attemptNum, result.Outcome, result.Reason); err != nil {
+	attemptLog, err := appendAttemptLogValue(bead.Metadata["gc.attempt_log"], attemptNum, result.Outcome, result.Reason)
+	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
 	}
 
 	switch result.Outcome {
 	case "pass":
+		closeMetadata := map[string]string{
+			"gc.attempt_log": attemptLog,
+			"gc.outcome":     "pass",
+		}
 		if outputJSON := attempt.Metadata["gc.output_json"]; outputJSON != "" {
-			if err := store.SetMetadata(bead.ID, "gc.output_json", outputJSON); err != nil {
-				return ControlResult{}, fmt.Errorf("%s: propagating output: %w", bead.ID, err)
-			}
+			closeMetadata["gc.output_json"] = outputJSON
 		}
-		if err := propagateRetrySubjectMetadata(store, bead.ID, attempt); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: propagating metadata: %w", bead.ID, err)
-		}
-		if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
+		copyNonGCMetadata(closeMetadata, attempt.Metadata)
+		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
 		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
@@ -69,15 +68,14 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		return ControlResult{Processed: true, Action: "pass", Skipped: scopeResult.Skipped}, nil
 
 	case "hard":
-		if err := store.SetMetadataBatch(bead.ID, map[string]string{
+		if err := updateMetadataAndClose(store, bead.ID, map[string]string{
+			"gc.attempt_log":       attemptLog,
+			"gc.outcome":           "fail",
 			"gc.failed_attempt":    strconv.Itoa(attemptNum),
 			"gc.failure_class":     "hard",
 			"gc.failure_reason":    result.Reason,
 			"gc.final_disposition": "hard_fail",
 		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: marking hard fail: %w", bead.ID, err)
-		}
-		if err := setOutcomeAndClose(store, bead.ID, "fail"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing hard-failed: %w", bead.ID, err)
 		}
 		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
@@ -88,7 +86,7 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 
 	case "transient":
 		if attemptNum >= maxAttempts {
-			exhaustedResult, err := handleRetryExhaustion(store, bead.ID, attemptNum, result.Reason, onExhausted)
+			exhaustedResult, err := handleRetryExhaustion(store, bead.ID, attemptNum, result.Reason, onExhausted, attemptLog)
 			if err != nil {
 				return ControlResult{}, err
 			}
@@ -101,6 +99,9 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		}
 
 		// Spawn next attempt.
+		if err := store.SetMetadata(bead.ID, "gc.attempt_log", attemptLog); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
+		}
 		nextAttempt := attemptNum + 1
 		if err := spawnNextAttempt(context.Background(), store, bead, nextAttempt, opts); err != nil {
 			// Controller-internal failure → close with hard error.
@@ -163,17 +164,20 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		return ControlResult{}, fmt.Errorf("%s: running check: %w", bead.ID, err)
 	}
 
-	if err := appendAttemptLog(store, bead.ID, iterationNum, checkResult.Outcome, checkResult.Stderr); err != nil {
+	attemptLog, err := appendAttemptLogValue(bead.Metadata["gc.attempt_log"], iterationNum, checkResult.Outcome, checkResult.Stderr)
+	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
 	}
 
 	if checkResult.Outcome == convergence.GatePass {
-		if outputJSON := iteration.Metadata["gc.output_json"]; outputJSON != "" {
-			if err := store.SetMetadata(bead.ID, "gc.output_json", outputJSON); err != nil {
-				return ControlResult{}, fmt.Errorf("%s: propagating output: %w", bead.ID, err)
-			}
+		closeMetadata := map[string]string{
+			"gc.attempt_log": attemptLog,
+			"gc.outcome":     "pass",
 		}
-		if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
+		if outputJSON := iteration.Metadata["gc.output_json"]; outputJSON != "" {
+			closeMetadata["gc.output_json"] = outputJSON
+		}
+		if err := updateMetadataAndClose(store, bead.ID, closeMetadata); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing passed: %w", bead.ID, err)
 		}
 		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
@@ -184,13 +188,11 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	}
 
 	if iterationNum >= maxAttempts {
-		if err := store.SetMetadataBatch(bead.ID, map[string]string{
+		if err := updateMetadataAndClose(store, bead.ID, map[string]string{
+			"gc.attempt_log":    attemptLog,
 			"gc.outcome":        "fail",
 			"gc.failed_attempt": strconv.Itoa(iterationNum),
 		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: marking exhausted: %w", bead.ID, err)
-		}
-		if err := setOutcomeAndClose(store, bead.ID, "fail"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", bead.ID, err)
 		}
 		scopeResult, err := reconcileClosedScopeMember(store, bead.ID)
@@ -201,6 +203,9 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	}
 
 	// Spawn next iteration.
+	if err := store.SetMetadata(bead.ID, "gc.attempt_log", attemptLog); err != nil {
+		return ControlResult{}, fmt.Errorf("%s: recording attempt log: %w", bead.ID, err)
+	}
 	nextIteration := iterationNum + 1
 	if err := spawnNextAttempt(context.Background(), store, bead, nextIteration, opts); err != nil {
 		_ = store.SetMetadataBatch(bead.ID, map[string]string{
@@ -217,31 +222,29 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 	return ControlResult{Processed: true, Action: "retry", Created: 1}, nil
 }
 
-func handleRetryExhaustion(store beads.Store, beadID string, attemptNum int, reason, onExhausted string) (ControlResult, error) {
+func handleRetryExhaustion(store beads.Store, beadID string, attemptNum int, reason, onExhausted, attemptLog string) (ControlResult, error) {
 	if onExhausted == "soft_fail" {
-		if err := store.SetMetadataBatch(beadID, map[string]string{
+		if err := updateMetadataAndClose(store, beadID, map[string]string{
+			"gc.attempt_log":       attemptLog,
+			"gc.outcome":           "pass",
 			"gc.failed_attempt":    strconv.Itoa(attemptNum),
 			"gc.failure_class":     "transient",
 			"gc.failure_reason":    reason,
 			"gc.final_disposition": "soft_fail",
 		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: marking soft-fail: %w", beadID, err)
-		}
-		if err := setOutcomeAndClose(store, beadID, "pass"); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: closing soft-failed: %w", beadID, err)
 		}
 		return ControlResult{Processed: true, Action: "soft-fail"}, nil
 	}
 
-	if err := store.SetMetadataBatch(beadID, map[string]string{
+	if err := updateMetadataAndClose(store, beadID, map[string]string{
+		"gc.attempt_log":       attemptLog,
+		"gc.outcome":           "fail",
 		"gc.failed_attempt":    strconv.Itoa(attemptNum),
 		"gc.failure_class":     "transient",
 		"gc.failure_reason":    reason,
 		"gc.final_disposition": "hard_fail",
 	}); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: marking exhausted: %w", beadID, err)
-	}
-	if err := setOutcomeAndClose(store, beadID, "fail"); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: closing exhausted: %w", beadID, err)
 	}
 	return ControlResult{Processed: true, Action: "fail"}, nil
@@ -977,10 +980,17 @@ func appendAttemptLog(store beads.Store, controlID string, attempt int, outcome,
 	if err != nil {
 		return err
 	}
+	logJSON, err := appendAttemptLogValue(control.Metadata["gc.attempt_log"], attempt, outcome, reason)
+	if err != nil {
+		return err
+	}
+	return store.SetMetadata(controlID, "gc.attempt_log", logJSON)
+}
 
+func appendAttemptLogValue(existing string, attempt int, outcome, reason string) (string, error) {
 	var log []map[string]string
-	if raw := control.Metadata["gc.attempt_log"]; raw != "" {
-		_ = json.Unmarshal([]byte(raw), &log)
+	if existing != "" {
+		_ = json.Unmarshal([]byte(existing), &log)
 	}
 
 	entry := map[string]string{
@@ -1007,10 +1017,27 @@ func appendAttemptLog(store beads.Store, controlID string, attempt int, outcome,
 	log = append(log, entry)
 	logJSON, err := json.Marshal(log)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return store.SetMetadata(controlID, "gc.attempt_log", string(logJSON))
+	return string(logJSON), nil
+}
+
+func copyNonGCMetadata(dst, src map[string]string) {
+	for key, value := range src {
+		if key == "" || strings.HasPrefix(key, "gc.") {
+			continue
+		}
+		dst[key] = value
+	}
+}
+
+func updateMetadataAndClose(store beads.Store, beadID string, metadata map[string]string) error {
+	status := "closed"
+	return store.Update(beadID, beads.UpdateOpts{
+		Status:   &status,
+		Metadata: metadata,
+	})
 }
 
 // Note: listByWorkflowRoot, setOutcomeAndClose, propagateRetrySubjectMetadata,

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -605,16 +605,14 @@ func applyAttemptControlStepRoute(step *formula.RecipeStep, executionTarget stri
 		step.Metadata = make(map[string]string)
 	}
 	if binding, ok := resolveAttemptRouteBinding(executionTarget, cfg, store); ok {
-		if binding.directSessionID != "" {
-			delete(step.Metadata, "gc.routed_to")
-			delete(step.Metadata, "gc.execution_routed_to")
-			step.Labels = removeAttemptPoolLabels(step.Labels)
-			step.Assignee = binding.directSessionID
-			return
-		}
-		if binding.qualifiedName != "" {
+		switch {
+		case binding.qualifiedName != "":
 			step.Metadata["gc.execution_routed_to"] = binding.qualifiedName
-		} else {
+		case executionTarget != "":
+			// Direct session delivery still executes via the named/session target,
+			// but control beads themselves must remain on control-dispatcher.
+			step.Metadata["gc.execution_routed_to"] = executionTarget
+		default:
 			delete(step.Metadata, "gc.execution_routed_to")
 		}
 	} else if executionTarget != "" {
@@ -631,7 +629,7 @@ func applyAttemptControlStepRoute(step *formula.RecipeStep, executionTarget stri
 		return
 	}
 
-	delete(step.Metadata, "gc.routed_to")
+	step.Metadata["gc.routed_to"] = controlTarget
 	step.Assignee = ""
 }
 
@@ -667,9 +665,6 @@ func resolveAttemptControlAssignee(target string, cfg *config.City, store beads.
 				return sessionName, true
 			}
 		}
-	}
-	if sessionName := config.NamedSessionRuntimeName("", config.Workspace{}, target); sessionName != "" {
-		return sessionName, true
 	}
 	return "", false
 }

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -574,8 +574,13 @@ func applyAttemptStepRoute(step *formula.RecipeStep, target string, cfg *config.
 			step.Assignee = binding.directSessionID
 			return
 		}
-		step.Metadata["gc.routed_to"] = binding.qualifiedName
-		step.Metadata["gc.execution_routed_to"] = binding.qualifiedName
+		if binding.qualifiedName != "" {
+			step.Metadata["gc.routed_to"] = binding.qualifiedName
+			step.Metadata["gc.execution_routed_to"] = binding.qualifiedName
+		} else {
+			delete(step.Metadata, "gc.routed_to")
+			delete(step.Metadata, "gc.execution_routed_to")
+		}
 		step.Labels = removeAttemptPoolLabels(step.Labels)
 		if binding.metadataOnly {
 			step.Assignee = ""
@@ -598,14 +603,16 @@ func applyAttemptControlStepRoute(step *formula.RecipeStep, executionTarget stri
 		step.Metadata = make(map[string]string)
 	}
 	if binding, ok := resolveAttemptRouteBinding(executionTarget, cfg, store); ok {
-		switch {
-		case binding.qualifiedName != "":
+		if binding.directSessionID != "" {
+			delete(step.Metadata, "gc.routed_to")
+			delete(step.Metadata, "gc.execution_routed_to")
+			step.Labels = removeAttemptPoolLabels(step.Labels)
+			step.Assignee = binding.directSessionID
+			return
+		}
+		if binding.qualifiedName != "" {
 			step.Metadata["gc.execution_routed_to"] = binding.qualifiedName
-		case executionTarget != "":
-			// Direct session delivery still executes via the named/session target,
-			// but control beads themselves must remain on control-dispatcher.
-			step.Metadata["gc.execution_routed_to"] = executionTarget
-		default:
+		} else {
 			delete(step.Metadata, "gc.execution_routed_to")
 		}
 	} else if executionTarget != "" {
@@ -616,27 +623,13 @@ func applyAttemptControlStepRoute(step *formula.RecipeStep, executionTarget stri
 	step.Labels = removeAttemptPoolLabels(step.Labels)
 
 	controlTarget := controlDispatcherTargetForExecutionTarget(executionTarget)
-	if binding, ok := resolveAttemptRouteBinding(controlTarget, cfg, store); ok {
-		if binding.directSessionID != "" {
-			delete(step.Metadata, "gc.routed_to")
-			step.Assignee = binding.directSessionID
-			return
-		}
-		if binding.sessionName != "" {
-			delete(step.Metadata, "gc.routed_to")
-			step.Assignee = binding.sessionName
-			return
-		}
-		if binding.qualifiedName != "" {
-			step.Metadata["gc.routed_to"] = binding.qualifiedName
-		} else {
-			delete(step.Metadata, "gc.routed_to")
-		}
-		step.Assignee = ""
+	if assignee, ok := resolveAttemptControlAssignee(controlTarget, cfg, store); ok {
+		delete(step.Metadata, "gc.routed_to")
+		step.Assignee = assignee
 		return
 	}
 
-	step.Metadata["gc.routed_to"] = controlTarget
+	delete(step.Metadata, "gc.routed_to")
 	step.Assignee = ""
 }
 
@@ -646,6 +639,37 @@ func controlDispatcherTargetForExecutionTarget(executionTarget string) string {
 		return executionTarget[:slash] + "/" + config.ControlDispatcherAgentName
 	}
 	return config.ControlDispatcherAgentName
+}
+
+func resolveAttemptControlAssignee(target string, cfg *config.City, store beads.Store) (string, bool) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", false
+	}
+	if binding, ok := resolveAttemptRouteBinding(target, cfg, store); ok {
+		if binding.directSessionID != "" {
+			return binding.directSessionID, true
+		}
+		if binding.sessionName != "" {
+			return binding.sessionName, true
+		}
+	}
+	if cfg != nil {
+		if named := config.FindNamedSession(cfg, target); named != nil {
+			if spec, ok := session.FindNamedSessionSpec(cfg, cfg.EffectiveCityName(), named.QualifiedName()); ok && spec.SessionName != "" {
+				return spec.SessionName, true
+			}
+		}
+		if agentCfg := config.FindAgent(cfg, target); agentCfg != nil {
+			if sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, agentCfg.QualifiedName()); sessionName != "" {
+				return sessionName, true
+			}
+		}
+	}
+	if sessionName := config.NamedSessionRuntimeName("", config.Workspace{}, target); sessionName != "" {
+		return sessionName, true
+	}
+	return "", false
 }
 
 func isAttemptControlKind(kind string) bool {
@@ -670,13 +694,16 @@ func resolveAttemptRouteBinding(target string, cfg *config.City, store beads.Sto
 	}
 	if cfg != nil {
 		if named := config.FindNamedSession(cfg, target); named != nil {
-			if store != nil {
-				if spec, ok := session.FindNamedSessionSpec(cfg, cfg.EffectiveCityName(), named.QualifiedName()); ok {
+			if spec, ok := session.FindNamedSessionSpec(cfg, cfg.EffectiveCityName(), named.QualifiedName()); ok {
+				if store != nil {
 					if candidates, err := store.List(beads.ListQuery{Label: session.LabelSession}); err == nil {
 						if bead, found := session.FindCanonicalNamedSessionBead(candidates, spec); found {
 							return attemptRouteBinding{directSessionID: bead.ID}, true
 						}
 					}
+				}
+				if spec.SessionName != "" {
+					return attemptRouteBinding{sessionName: spec.SessionName}, true
 				}
 			}
 			return attemptRouteBinding{

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -615,23 +615,37 @@ func applyAttemptControlStepRoute(step *formula.RecipeStep, executionTarget stri
 	}
 	step.Labels = removeAttemptPoolLabels(step.Labels)
 
-	controlTarget := config.ControlDispatcherAgentName
+	controlTarget := controlDispatcherTargetForExecutionTarget(executionTarget)
 	if binding, ok := resolveAttemptRouteBinding(controlTarget, cfg, store); ok {
-		step.Metadata["gc.routed_to"] = controlTarget
 		if binding.directSessionID != "" {
+			delete(step.Metadata, "gc.routed_to")
 			step.Assignee = binding.directSessionID
 			return
 		}
-		if binding.metadataOnly {
-			step.Assignee = ""
+		if binding.sessionName != "" {
+			delete(step.Metadata, "gc.routed_to")
+			step.Assignee = binding.sessionName
 			return
 		}
-		step.Assignee = binding.sessionName
+		if binding.qualifiedName != "" {
+			step.Metadata["gc.routed_to"] = binding.qualifiedName
+		} else {
+			delete(step.Metadata, "gc.routed_to")
+		}
+		step.Assignee = ""
 		return
 	}
 
 	step.Metadata["gc.routed_to"] = controlTarget
 	step.Assignee = ""
+}
+
+func controlDispatcherTargetForExecutionTarget(executionTarget string) string {
+	executionTarget = strings.TrimSpace(executionTarget)
+	if slash := strings.IndexByte(executionTarget, '/'); slash > 0 {
+		return executionTarget[:slash] + "/" + config.ControlDispatcherAgentName
+	}
+	return config.ControlDispatcherAgentName
 }
 
 func isAttemptControlKind(kind string) bool {

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -38,8 +38,7 @@ func processRetryControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		return ControlResult{}, fmt.Errorf("%s: no attempt found", bead.ID)
 	}
 	if attempt.Status != "closed" {
-		// Invariant violation: control bead should not be ready if attempt is open.
-		return ControlResult{}, fmt.Errorf("%s: latest attempt %s is %s, not closed (invariant violation)", bead.ID, attempt.ID, attempt.Status)
+		return ControlResult{}, ErrControlPending
 	}
 
 	attemptNum, _ := strconv.Atoi(attempt.Metadata["gc.attempt"])
@@ -139,7 +138,7 @@ func processRalphControl(store beads.Store, bead beads.Bead, opts ProcessOptions
 		return ControlResult{}, fmt.Errorf("%s: no iteration found", bead.ID)
 	}
 	if iteration.Status != "closed" {
-		return ControlResult{}, fmt.Errorf("%s: latest iteration %s is %s, not closed (invariant violation)", bead.ID, iteration.ID, iteration.Status)
+		return ControlResult{}, ErrControlPending
 	}
 
 	iterationNum, _ := strconv.Atoi(iteration.Metadata["gc.attempt"])

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -2,6 +2,7 @@ package dispatch
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1163,14 +1164,14 @@ func TestRetryIdempotencyKeyPreventsDoubleSpawn(t *testing.T) {
 	allAfterFirst, _ := store.ListOpen()
 	countAfterFirst := len(allAfterFirst)
 
-	// Process again with same state — epoch conflict should prevent double spawn.
+	// Process again with same state -- epoch conflict should prevent double spawn.
 	// The epoch was already incremented by the first Attach, so a second
 	// processRetryControl with the same attempt (attempt 1 still closed, attempt 2
 	// still open) will find attempt 2 as the latest and see it's not closed.
-	// This verifies the invariant violation guard.
+	// This verifies the pending guard.
 	_, err = processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
-	if err == nil {
-		t.Fatal("expected error on second process (attempt 2 is open)")
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("second process error = %v, want %v", err, ErrControlPending)
 	}
 
 	// No new beads should have been created.

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -1075,8 +1075,8 @@ func TestApplyAttemptControlStepRoute_KeepsControlBeadsOnDispatcherForNamedExecu
 	if got := step.Metadata["gc.execution_routed_to"]; got != "worker" {
 		t.Fatalf("gc.execution_routed_to = %q, want worker", got)
 	}
-	if got := step.Metadata["gc.routed_to"]; got != config.ControlDispatcherAgentName {
-		t.Fatalf("gc.routed_to = %q, want %q", got, config.ControlDispatcherAgentName)
+	if got := step.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("gc.routed_to = %q, want empty for concrete control-dispatcher assignee", got)
 	}
 	if step.Assignee != dispatcher.ID {
 		t.Fatalf("assignee = %q, want canonical control-dispatcher bead %q", step.Assignee, dispatcher.ID)

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -593,6 +593,11 @@ dir = "gascity"
 [agent.pool]
 min = 0
 max = -1
+
+[[agent]]
+name = "control-dispatcher"
+dir = "gascity"
+max_active_sessions = 1
 `), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
 	}
@@ -671,8 +676,8 @@ max = -1
 	if claude.ID == "" {
 		t.Fatal("review-claude child not created")
 	}
-	if claude.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-		t.Fatalf("review-claude gc.routed_to = %q, want %q", claude.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+	if got := claude.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("review-claude gc.routed_to = %q, want empty direct dispatcher assignee", got)
 	}
 	if claude.Metadata["gc.execution_routed_to"] != "gascity/claude" {
 		t.Fatalf("review-claude gc.execution_routed_to = %q, want gascity/claude", claude.Metadata["gc.execution_routed_to"])
@@ -680,16 +685,16 @@ max = -1
 	if containsString(claude.Labels, "pool:gascity/claude") {
 		t.Fatalf("review-claude labels = %v, should not contain legacy pool label", claude.Labels)
 	}
-	if claude.Assignee != "" {
-		t.Fatalf("review-claude assignee = %q, want empty metadata-only control route", claude.Assignee)
+	if claude.Assignee != "gascity--control-dispatcher" {
+		t.Fatalf("review-claude assignee = %q, want gascity--control-dispatcher", claude.Assignee)
 	}
 
 	codex := findAttemptByRef(t, store, root.ID, "mol-adopt-pr-v2.review-loop.iteration.2.review-codex")
 	if codex.ID == "" {
 		t.Fatal("review-codex child not created")
 	}
-	if codex.Metadata["gc.routed_to"] != config.ControlDispatcherAgentName {
-		t.Fatalf("review-codex gc.routed_to = %q, want %q", codex.Metadata["gc.routed_to"], config.ControlDispatcherAgentName)
+	if got := codex.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("review-codex gc.routed_to = %q, want empty direct dispatcher assignee", got)
 	}
 	if codex.Metadata["gc.execution_routed_to"] != "gascity/codex" {
 		t.Fatalf("review-codex gc.execution_routed_to = %q, want gascity/codex", codex.Metadata["gc.execution_routed_to"])
@@ -700,8 +705,8 @@ max = -1
 	if containsString(codex.Labels, "pool:gascity/claude") {
 		t.Fatalf("review-codex labels = %v, should not contain pool:gascity/claude", codex.Labels)
 	}
-	if codex.Assignee != "" {
-		t.Fatalf("review-codex assignee = %q, want empty metadata-only control route", codex.Assignee)
+	if codex.Assignee != "gascity--control-dispatcher" {
+		t.Fatalf("review-codex assignee = %q, want gascity--control-dispatcher", codex.Assignee)
 	}
 
 	synthesize := findAttemptByRef(t, store, root.ID, "mol-adopt-pr-v2.review-loop.iteration.2.synthesize")

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -913,7 +913,7 @@ func TestResolveAttemptRouteBinding_NamedSessionTargetUsesCanonicalBeadID(t *tes
 	}
 }
 
-func TestResolveAttemptRouteBinding_NamedSessionTargetWithoutCanonicalBeadUsesMetadataOnly(t *testing.T) {
+func TestResolveAttemptRouteBinding_NamedSessionTargetWithoutCanonicalBeadUsesSessionName(t *testing.T) {
 	t.Parallel()
 
 	store := beads.NewMemStore()
@@ -934,11 +934,81 @@ func TestResolveAttemptRouteBinding_NamedSessionTargetWithoutCanonicalBeadUsesMe
 	if !ok {
 		t.Fatal("resolveAttemptRouteBinding did not resolve named target")
 	}
-	if binding.directSessionID != "" || binding.sessionName != "" {
-		t.Fatalf("binding = %+v, want no direct or legacy session-name target without a canonical bead", binding)
+	if binding.directSessionID != "" {
+		t.Fatalf("directSessionID = %q, want empty without canonical bead", binding.directSessionID)
 	}
-	if binding.qualifiedName != "worker" || !binding.metadataOnly {
-		t.Fatalf("binding = %+v, want metadata-only worker route", binding)
+	if binding.sessionName != "worker" {
+		t.Fatalf("sessionName = %q, want worker", binding.sessionName)
+	}
+	if binding.qualifiedName != "" || binding.metadataOnly {
+		t.Fatalf("binding = %+v, want concrete session-name route", binding)
+	}
+}
+
+func TestApplyAttemptControlStepRoute_ImplicitControlDispatcherUsesConcreteAssignee(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "maintainer-city"},
+		Daemon:    config.DaemonConfig{FormulaV2: true},
+		Rigs: []config.Rig{{
+			Name: "gascity",
+			Path: t.TempDir(),
+		}},
+		Agents: []config.Agent{{
+			Name: "claude",
+			Dir:  "gascity",
+		}},
+	}
+	config.InjectImplicitAgents(cfg)
+
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{
+			"gc.routed_to": "stale-route",
+		},
+	}
+	applyAttemptControlStepRoute(step, "gascity/claude", cfg, beads.NewMemStore())
+
+	if step.Assignee != "gascity--control-dispatcher" {
+		t.Fatalf("assignee = %q, want gascity--control-dispatcher", step.Assignee)
+	}
+	if got := step.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("gc.routed_to = %q, want empty for concrete control dispatcher assignee", got)
+	}
+	if got := step.Metadata["gc.execution_routed_to"]; got != "gascity/claude" {
+		t.Fatalf("gc.execution_routed_to = %q, want gascity/claude", got)
+	}
+}
+
+func TestApplyAttemptControlStepRoute_ConfiguredControlDispatcherNeverUsesMetadataRoute(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "maintainer-city"},
+		Agents: []config.Agent{
+			{
+				Name: "claude",
+				Dir:  "gascity",
+			},
+			{
+				Name: "control-dispatcher",
+				Dir:  "gascity",
+			},
+		},
+	}
+
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{
+			"gc.routed_to": "stale-route",
+		},
+	}
+	applyAttemptControlStepRoute(step, "gascity/claude", cfg, beads.NewMemStore())
+
+	if step.Assignee != "gascity--control-dispatcher" {
+		t.Fatalf("assignee = %q, want gascity--control-dispatcher", step.Assignee)
+	}
+	if got := step.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("gc.routed_to = %q, want empty for concrete control dispatcher assignee", got)
 	}
 }
 

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -72,6 +72,69 @@ func TestProcessRetryControlPass(t *testing.T) {
 	}
 }
 
+func TestProcessRetryControlPassClosesWithSingleFinalMetadataUpdate(t *testing.T) {
+	t.Parallel()
+	base := beads.NewMemStore()
+
+	root := mustCreate(t, base, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, base, beads.Bead{
+		Title: "review",
+		Metadata: map[string]string{
+			"gc.kind":             "retry",
+			"gc.root_bead_id":     root.ID,
+			"gc.step_ref":         "mol-test.review",
+			"gc.step_id":          "review",
+			"gc.max_attempts":     "3",
+			"gc.on_exhausted":     "hard_fail",
+			"gc.source_step_spec": `{"id":"review","title":"Review","type":"task","retry":{"max_attempts":3}}`,
+			"gc.control_epoch":    "1",
+		},
+	})
+	attempt1 := mustCreate(t, base, beads.Bead{
+		Title: "review attempt 1",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review.attempt.1",
+			"gc.attempt":      "1",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"ok":true}`,
+			"review.verdict":  "approved",
+		},
+	})
+	mustClose(t, base, attempt1.ID)
+	mustDep(t, base, control.ID, attempt1.ID, "blocks")
+
+	store := &controlCloseTrackingStore{Store: base, targetID: control.ID}
+	result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("processRetryControl: %v", err)
+	}
+	if !result.Processed || result.Action != "pass" {
+		t.Fatalf("result = %+v, want processed pass", result)
+	}
+	if store.setMetadataCalls != 0 || store.setMetadataBatchCalls != 0 {
+		t.Fatalf("metadata calls before close = SetMetadata:%d SetMetadataBatch:%d, want none", store.setMetadataCalls, store.setMetadataBatchCalls)
+	}
+	if store.closeUpdateCalls != 1 {
+		t.Fatalf("close update calls = %d, want 1", store.closeUpdateCalls)
+	}
+	for key, want := range map[string]string{
+		"gc.outcome":     "pass",
+		"gc.output_json": `{"ok":true}`,
+		"review.verdict": "approved",
+	} {
+		if got := store.closeUpdateMetadata[key]; got != want {
+			t.Fatalf("close metadata %s = %q, want %q", key, got, want)
+		}
+	}
+	if store.closeUpdateMetadata["gc.attempt_log"] == "" {
+		t.Fatal("close metadata missing gc.attempt_log")
+	}
+}
+
 func TestProcessRetryControlHardFail(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()
@@ -1235,6 +1298,40 @@ func mustDep(t *testing.T, store beads.Store, from, to, depType string) { //noli
 	if err := store.DepAdd(from, to, depType); err != nil {
 		t.Fatalf("dep %s -> %s: %v", from, to, err)
 	}
+}
+
+type controlCloseTrackingStore struct {
+	beads.Store
+	targetID              string
+	setMetadataCalls      int
+	setMetadataBatchCalls int
+	closeUpdateCalls      int
+	closeUpdateMetadata   map[string]string
+}
+
+func (s *controlCloseTrackingStore) SetMetadata(id, key, value string) error {
+	if id == s.targetID {
+		s.setMetadataCalls++
+	}
+	return s.Store.SetMetadata(id, key, value)
+}
+
+func (s *controlCloseTrackingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.targetID {
+		s.setMetadataBatchCalls++
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
+}
+
+func (s *controlCloseTrackingStore) Update(id string, opts beads.UpdateOpts) error {
+	if id == s.targetID && opts.Status != nil && *opts.Status == "closed" {
+		s.closeUpdateCalls++
+		s.closeUpdateMetadata = make(map[string]string, len(opts.Metadata))
+		for key, value := range opts.Metadata {
+			s.closeUpdateMetadata[key] = value
+		}
+	}
+	return s.Store.Update(id, opts)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -2,8 +2,8 @@ package dispatch
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -439,11 +439,8 @@ func TestProcessRetryControlInvariantViolation(t *testing.T) {
 	mustDep(t, store, control.ID, attempt1.ID, "blocks")
 
 	_, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
-	if err == nil {
-		t.Fatal("expected invariant violation error")
-	}
-	if !strings.Contains(err.Error(), "invariant violation") {
-		t.Fatalf("error = %v, want invariant violation", err)
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("error = %v, want %v", err, ErrControlPending)
 	}
 }
 
@@ -844,6 +841,42 @@ func TestProcessRalphControlClosesEnclosingScopeOnIterationFailure(t *testing.T)
 	scopeAfter := mustGet(t, store, scopeBody.ID)
 	if scopeAfter.Status != "closed" || scopeAfter.Metadata["gc.outcome"] != "fail" {
 		t.Fatalf("scope body = status %q outcome %q, want closed/fail", scopeAfter.Status, scopeAfter.Metadata["gc.outcome"])
+	}
+}
+
+func TestProcessRalphControlReturnsPendingForOpenIteration(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop",
+			"gc.step_id":      "review-loop",
+			"gc.max_attempts": "2",
+		},
+	})
+	iteration := mustCreate(t, store, beads.Bead{
+		Title: "review loop iteration 1",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.1",
+			"gc.scope_role":   "body",
+			"gc.attempt":      "1",
+		},
+	})
+	mustDep(t, store, control.ID, iteration.ID, "blocks")
+
+	_, err := processRalphControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("error = %v, want %v", err, ErrControlPending)
 	}
 }
 

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -146,6 +146,10 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 	if cityPath == "" {
 		return convergence.GateResult{}, fmt.Errorf("%s: missing city path for exec check", bead.ID)
 	}
+	storePath := opts.StorePath
+	if storePath == "" {
+		storePath = cityPath
+	}
 
 	workDir := resolveInheritedMetadata(store, bead, "work_dir", "gc.work_dir")
 	resolvedWorkDir := ""
@@ -153,10 +157,10 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		if filepath.IsAbs(workDir) {
 			resolvedWorkDir = workDir
 		} else {
-			resolvedWorkDir = filepath.Join(cityPath, workDir)
+			resolvedWorkDir = filepath.Join(storePath, workDir)
 		}
 	}
-	scriptBase := cityPath
+	scriptBase := storePath
 	if resolvedWorkDir != "" {
 		scriptBase = resolvedWorkDir
 	}
@@ -184,10 +188,15 @@ func runRalphCheck(store beads.Store, bead, subject beads.Bead, attempt int, opt
 		timeout = parsed
 	}
 
+	conditionBeadID := subject.ID
+	if conditionBeadID == "" {
+		conditionBeadID = bead.ID
+	}
 	result := convergence.RunCondition(context.Background(), scriptPath, convergence.ConditionEnv{
-		BeadID:    bead.ID,
+		BeadID:    conditionBeadID,
 		Iteration: attempt,
 		CityPath:  cityPath,
+		StorePath: storePath,
 		WorkDir:   resolvedWorkDir,
 	}, timeout, 0)
 	return result, nil

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -22,6 +22,7 @@ type ControlResult struct {
 // ProcessOptions provides control-dispatcher execution context.
 type ProcessOptions struct {
 	CityPath           string
+	StorePath          string
 	FormulaSearchPaths []string
 	PrepareFragment    func(*formula.FragmentRecipe, beads.Bead) error
 	RecycleSession     func(beads.Bead) error

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3036,6 +3036,61 @@ func TestRunRalphCheckTimeoutMetadataPrecedence(t *testing.T) {
 	}
 }
 
+func TestRunRalphCheckUsesStorePathForRelativeCheckAndSubjectEnv(t *testing.T) {
+	cityPath := t.TempDir()
+	storePath := t.TempDir()
+	workDir := filepath.Join(storePath, "frontend")
+	checkDir := filepath.Join(workDir, "checks")
+	if err := os.MkdirAll(checkDir, 0o755); err != nil {
+		t.Fatalf("mkdir check dir: %v", err)
+	}
+
+	checkPath := filepath.Join(checkDir, "env.sh")
+	script := "#!/bin/sh\n" +
+		"pwd\n" +
+		"printf 'BEAD=%s\\n' \"$GC_BEAD_ID\"\n" +
+		"printf 'CITY=%s\\n' \"$GC_CITY\"\n" +
+		"printf 'STORE=%s\\n' \"$GC_STORE_PATH\"\n" +
+		"printf 'BEADS=%s\\n' \"$BEADS_DIR\"\n"
+	if err := os.WriteFile(checkPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write check script: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	check := beads.Bead{
+		ID:   "check-1",
+		Type: "task",
+		Metadata: map[string]string{
+			"gc.check_path":    "checks/env.sh",
+			"gc.check_timeout": "30s",
+			"gc.work_dir":      "frontend",
+		},
+	}
+	subject := beads.Bead{ID: "run-1", Type: "task"}
+
+	result, err := runRalphCheck(store, check, subject, 2, ProcessOptions{
+		CityPath:  cityPath,
+		StorePath: storePath,
+	})
+	if err != nil {
+		t.Fatalf("runRalphCheck: %v", err)
+	}
+	if result.Outcome != "pass" {
+		t.Fatalf("result.Outcome = %q, want pass (stderr=%q)", result.Outcome, result.Stderr)
+	}
+	for _, want := range []string{
+		workDir,
+		"BEAD=run-1",
+		"CITY=" + cityPath,
+		"STORE=" + storePath,
+		"BEADS=" + filepath.Join(storePath, ".beads"),
+	} {
+		if !strings.Contains(result.Stdout, want) {
+			t.Fatalf("stdout = %q, want to contain %q", result.Stdout, want)
+		}
+	}
+}
+
 func writeCheckScript(t *testing.T, cityPath, name, contents string) string {
 	t.Helper()
 	scriptDir := filepath.Join(cityPath, ".gc", "scripts")

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -148,6 +148,29 @@ func ApplyGraphRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding)
 	step.Assignee = binding.SessionName
 }
 
+// ApplyGraphControlRouteBinding routes control steps directly to the
+// control-dispatcher session when possible. gc.routed_to intentionally means
+// "work for this config queue"; using it for a named dispatcher would create
+// config-routed work instead of delivering to the known dispatcher session.
+func ApplyGraphControlRouteBinding(step *formula.RecipeStep, binding GraphRouteBinding) {
+	if binding.DirectSessionID != "" {
+		delete(step.Metadata, "gc.routed_to")
+		step.Assignee = binding.DirectSessionID
+		return
+	}
+	if binding.SessionName != "" {
+		delete(step.Metadata, "gc.routed_to")
+		step.Assignee = binding.SessionName
+		return
+	}
+	if binding.QualifiedName != "" {
+		step.Metadata["gc.routed_to"] = binding.QualifiedName
+	} else {
+		delete(step.Metadata, "gc.routed_to")
+	}
+	step.Assignee = ""
+}
+
 // AssignGraphStepRoute applies routing to a step, optionally diverting
 // control steps to the control dispatcher.
 func AssignGraphStepRoute(step *formula.RecipeStep, executionBinding GraphRouteBinding, controlBinding *GraphRouteBinding) {
@@ -157,7 +180,7 @@ func AssignGraphStepRoute(step *formula.RecipeStep, executionBinding GraphRouteB
 		} else {
 			delete(step.Metadata, GraphExecutionRouteMetaKey)
 		}
-		ApplyGraphRouteBinding(step, *controlBinding)
+		ApplyGraphControlRouteBinding(step, *controlBinding)
 		return
 	}
 	delete(step.Metadata, GraphExecutionRouteMetaKey)

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -163,11 +163,7 @@ func ApplyGraphControlRouteBinding(step *formula.RecipeStep, binding GraphRouteB
 		step.Assignee = binding.SessionName
 		return
 	}
-	if binding.QualifiedName != "" {
-		step.Metadata["gc.routed_to"] = binding.QualifiedName
-	} else {
-		delete(step.Metadata, "gc.routed_to")
-	}
+	delete(step.Metadata, "gc.routed_to")
 	step.Assignee = ""
 }
 
@@ -217,9 +213,6 @@ func ControlDispatcherBinding(store beads.Store, cityName string, cfg *config.Ci
 		return GraphRouteBinding{}, fmt.Errorf("control-dispatcher agent %q not found", config.ControlDispatcherAgentName)
 	}
 	binding := GraphRouteBinding{QualifiedName: agentCfg.QualifiedName()}
-	if agentutil.IsMultiSessionAgent(&agentCfg) {
-		return binding, nil
-	}
 	sn := agentutil.LookupSessionName(store, cityName, agentCfg.QualifiedName(), cfg.Workspace.SessionTemplate)
 	if sn == "" {
 		return GraphRouteBinding{}, fmt.Errorf("could not resolve session name for %q", agentCfg.QualifiedName())

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -367,6 +367,27 @@ func TestControlDispatcherBinding_NilResolver(t *testing.T) {
 	}
 }
 
+func TestControlDispatcherBinding_ConfiguredDispatcherUsesConcreteSessionName(t *testing.T) {
+	cfg := &config.City{Agents: []config.Agent{{
+		Name: "control-dispatcher",
+		Dir:  "gascity",
+	}}}
+
+	binding, err := ControlDispatcherBinding(nil, "test-city", cfg, "gascity", Deps{Resolver: testAgentResolver{}})
+	if err != nil {
+		t.Fatalf("ControlDispatcherBinding: %v", err)
+	}
+	if binding.QualifiedName != "gascity/control-dispatcher" {
+		t.Fatalf("QualifiedName = %q, want gascity/control-dispatcher", binding.QualifiedName)
+	}
+	if binding.SessionName != "gascity--control-dispatcher" {
+		t.Fatalf("SessionName = %q, want gascity--control-dispatcher", binding.SessionName)
+	}
+	if binding.MetadataOnly {
+		t.Fatalf("MetadataOnly = true, want false")
+	}
+}
+
 func TestAssignGraphStepRoute_ControlBindingUsesDirectAssigneeWithoutRoutedTo(t *testing.T) {
 	step := &formula.RecipeStep{
 		Metadata: map[string]string{

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -367,6 +367,34 @@ func TestControlDispatcherBinding_NilResolver(t *testing.T) {
 	}
 }
 
+func TestAssignGraphStepRoute_ControlBindingUsesDirectAssigneeWithoutRoutedTo(t *testing.T) {
+	step := &formula.RecipeStep{
+		Metadata: map[string]string{
+			"gc.routed_to": "stale-control-route",
+		},
+	}
+	execution := GraphRouteBinding{
+		QualifiedName: "gascity/claude",
+		MetadataOnly:  true,
+	}
+	control := GraphRouteBinding{
+		QualifiedName: "gascity/control-dispatcher",
+		SessionName:   "gascity--control-dispatcher",
+	}
+
+	AssignGraphStepRoute(step, execution, &control)
+
+	if step.Assignee != "gascity--control-dispatcher" {
+		t.Fatalf("control assignee = %q, want gascity--control-dispatcher", step.Assignee)
+	}
+	if got := step.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("control gc.routed_to = %q, want empty direct assignee", got)
+	}
+	if got := step.Metadata[GraphExecutionRouteMetaKey]; got != "gascity/claude" {
+		t.Fatalf("control execution route = %q, want gascity/claude", got)
+	}
+}
+
 func TestWorkflowExecutionRoute(t *testing.T) {
 	b := beads.Bead{Metadata: map[string]string{"gc.routed_to": "myrig/worker"}}
 	if got := WorkflowExecutionRoute(b); got != "myrig/worker" {


### PR DESCRIPTION
## Summary
- route graph control beads through concrete assignees instead of broad template labels
- treat open retry controls as pending and close control beads with final metadata
- process scoped control stores and use the control-specific serve query

## Validation
- go test ./internal/dispatch ./internal/graphroute ./internal/convergence
- go test ./cmd/gc -run 'Test.*(Convoy|Graph|Control|Serve|Workflow)'
- git diff --check origin/main..HEAD