### PR TITLE
fix(orders): run conditions in scoped env before reconcile

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -374,6 +374,11 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
+	// Dispatch due orders before startup session reconciliation. A cold-start
+	// reconcile can take minutes when it has stale or config-drifted sessions;
+	// due event/condition formulas should not wait behind that maintenance work.
+	cr.dispatchOrders(ctx, cityRoot)
+
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).
@@ -668,6 +673,10 @@ func (cr *CityRuntime) tick(
 		}
 	}
 
+	// Order dispatch is intentionally before the expensive session reconcile
+	// phases so due formulas are not starved by slow startup/config drift work.
+	cr.dispatchOrders(ctx, cityRoot)
+
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
 	// corrects bead state, and the pre-reconcile sync is sufficient for
@@ -728,11 +737,6 @@ func (cr *CityRuntime) tick(
 		}
 	}
 
-	// Order dispatch.
-	if cr.od != nil {
-		cr.od.dispatch(ctx, cityRoot, time.Now())
-	}
-
 	if cr.svc != nil {
 		cr.svc.Tick(ctx, time.Now())
 	}
@@ -755,6 +759,12 @@ func (cr *CityRuntime) tick(
 	}
 	completion = TraceCompletionCompleted
 	tickCompleted = true
+}
+
+func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
+	if cr.od != nil {
+		cr.od.dispatch(ctx, cityRoot, time.Now())
+	}
 }
 
 func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -195,6 +195,44 @@ func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	}
 }
 
+type recordingOrderDispatcher struct {
+	called atomic.Bool
+}
+
+func (r *recordingOrderDispatcher) dispatch(context.Context, string, time.Time) {
+	r.called.Store(true)
+}
+
+func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	od := &recordingOrderDispatcher{}
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cityPath:            t.TempDir(),
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		od:                  od,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		if !od.called.Load() {
+			t.Fatal("order dispatch should happen before demand snapshot build")
+		}
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	var dirty atomic.Bool
+	var lastProviderName string
+	var prevPoolRunning map[string]bool
+	cr.tick(context.Background(), &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "patrol")
+
+	if !od.called.Load() {
+		t.Fatal("order dispatcher was not called")
+	}
+}
+
 func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -574,7 +574,7 @@ func cmdOrderCheck(stdout, stderr io.Writer) int {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderCheckWithStoresResolver(aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), stdout, stderr)
+	return doOrderCheckWithStoresResolverScoped(cityPath, cfg, aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), stdout, stderr)
 }
 
 // orderLastRunFn returns a LastRunFunc that queries BdStore for the most
@@ -638,6 +638,10 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 }
 
 func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
+	return doOrderCheckWithStoresResolverScoped("", nil, aa, now, ep, resolveStores, stdout, stderr)
+}
+
+func doOrderCheckWithStoresResolverScoped(cityPath string, cfg *config.City, aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
 	if len(aa) == 0 {
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
 		return 1
@@ -676,7 +680,12 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 				return cursor
 			}
 		}
-		result := orders.CheckTrigger(a, now, lastRunFn, ep, cursorFn)
+		triggerOpts, err := orderTriggerOptions(cityPath, cfg, a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, triggerOpts)
 		if lastRunErr != nil {
 			fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
 			return 1

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -599,6 +599,37 @@ func TestOrderCheckWithStoresResolverUsesLegacyCityStore(t *testing.T) {
 	}
 }
 
+func TestOrderCheckConditionUsesCityScope(t *testing.T) {
+	cityDir := t.TempDir()
+	orderDir := filepath.Join(cityDir, "packs", "workflows", "orders")
+	check := fmt.Sprintf(
+		`test "$GC_CITY_PATH" = '%s' && test "$GC_STORE_ROOT" = '%s' && test "$GC_STORE_SCOPE" = city && test "$ORDER_DIR" = '%s'`,
+		cityDir,
+		cityDir,
+		orderDir,
+	)
+	aa := []orders.Order{{
+		Name:    "pr-review-router",
+		Trigger: "condition",
+		Check:   check,
+		Formula: "mol-pr-review-router",
+		Pool:    "workflows.pr-review-router",
+		Source:  filepath.Join(orderDir, "pr-review-router.toml"),
+	}}
+	resolver := func(orders.Order) ([]beads.Store, error) {
+		return []beads.Store{beads.NewMemStore()}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolverScoped(cityDir, &config.City{}, aa, time.Now(), nil, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderCheckWithStoresResolverScoped = %d, want 0; stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "yes") {
+		t.Fatalf("stdout missing due row:\n%s", stdout.String())
+	}
+}
+
 func TestOrderCheckWithStoresResolverFailsWhenLegacyEventCursorReadFails(t *testing.T) {
 	rigStore := beads.NewMemStore()
 	legacyStore := labelFailListStore{

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -426,9 +426,9 @@ func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
 	return false
 }
 
-// hasOpenWorkStrict reports whether any non-closed work bead exists for this
-// order. Tracking beads (title "order:<name>") are excluded, so only actual
-// work (wisps, exec results) counts.
+// hasOpenWorkStrict reports whether any non-closed work or tracking bead
+// exists for this order. Open tracking beads represent in-flight dispatch and
+// must block condition/event orders that do not consult LastRun.
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
 		Label: "order-run:" + scopedName,
@@ -437,9 +437,8 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 	if err != nil {
 		return false, fmt.Errorf("listing order work beads: %w", err)
 	}
-	trackingTitle := "order:" + scopedName
 	for _, b := range results {
-		if b.Status != "closed" && b.Title != trackingTitle {
+		if b.Status != "closed" {
 			return true, nil
 		}
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -184,7 +184,8 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 				return cursor
 			}
 		}
-		result := orders.CheckTrigger(a, now, lastRunFn, m.ep, cursorFn)
+		triggerOpts := orderTriggerOptionsForTarget(cityPath, m.cfg, target, a)
+		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
 		if lastRunErr != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
 			continue

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2641,6 +2641,39 @@ func TestOrderDispatchSkipsOpenWork(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchSkipsOpenTrackingBeadForConditionOrder(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:  "order:my-auto",
+		Labels: []string{"order-run:my-auto", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ran := false
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran = true
+		return nil, nil
+	}
+
+	aa := []orders.Order{{
+		Name:    "my-auto",
+		Trigger: "condition",
+		Check:   "true",
+		Exec:    "scripts/run.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	if ran {
+		t.Error("exec should not have run while an order-tracking bead is open")
+	}
+}
+
 func TestOrderDispatchFiresAfterWorkClosed(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2173,6 +2173,11 @@ func TestOrderDispatchSkipsRigEventWhenLegacyCursorReadFails(t *testing.T) {
 }
 
 func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	rigStore := beads.NewMemStore()
 	legacyStore := labelFailListStore{
 		Store:     beads.NewMemStore(),
@@ -2202,12 +2207,12 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 		cfg: &config.City{
 			Rigs: []config.Rig{{
 				Name: "frontend",
-				Path: "frontend",
+				Path: rigDir,
 			}},
 		},
 	}
 
-	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.dispatch(context.Background(), cityDir, time.Now())
 	time.Sleep(50 * time.Millisecond)
 
 	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
@@ -2216,6 +2221,37 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 	}
 	if !strings.Contains(stderr.String(), "open work") {
 		t.Fatalf("stderr missing open-work error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderDispatchConditionUsesScopedEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	store := beads.NewMemStore()
+	check := fmt.Sprintf(
+		`test "$GC_CITY_PATH" = '%s' && test "$GC_STORE_ROOT" = '%s' && test "$GC_STORE_SCOPE" = city && test "$(pwd)" = '%s'`,
+		cityDir,
+		cityDir,
+		cityDir,
+	)
+	ran := make(chan struct{}, 1)
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran <- struct{}{}
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:    "scoped-check",
+		Trigger: "condition",
+		Check:   check,
+		Exec:    "true",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("condition order did not dispatch with scoped cwd/env")
 	}
 }
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -128,6 +128,27 @@ func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a o
 	return mergeRuntimeEnv(nil, env)
 }
 
+func orderTriggerOptions(cityPath string, cfg *config.City, a orders.Order) (orders.TriggerOptions, error) {
+	if a.Trigger != "condition" || strings.TrimSpace(cityPath) == "" {
+		return orders.TriggerOptions{}, nil
+	}
+	target, err := resolveOrderExecTarget(cityPath, cfg, a)
+	if err != nil {
+		return orders.TriggerOptions{}, err
+	}
+	return orderTriggerOptionsForTarget(cityPath, cfg, target, a), nil
+}
+
+func orderTriggerOptionsForTarget(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) orders.TriggerOptions {
+	if a.Trigger != "condition" || strings.TrimSpace(cityPath) == "" {
+		return orders.TriggerOptions{}
+	}
+	return orders.TriggerOptions{
+		ConditionDir: target.ScopeRoot,
+		ConditionEnv: orderExecEnv(cityPath, cfg, target, a),
+	}
+}
+
 func applyOrderExecCanonicalDoltEnv(cityPath, scopeRoot string, env map[string]string) {
 	if env == nil {
 		return

--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -3,6 +3,7 @@ package orders
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -29,19 +30,32 @@ type LastRunFunc func(name string) (time.Time, error)
 // Returns 0 if no cursor exists.
 type CursorFunc func(orderName string) uint64
 
+// TriggerOptions carries execution context for triggers that run subprocesses.
+type TriggerOptions struct {
+	ConditionDir     string
+	ConditionEnv     []string
+	ConditionTimeout time.Duration
+}
+
 // CheckTrigger evaluates an order's trigger condition and returns whether it's due.
 // ep is an events Provider used by event triggers to query events; may be nil for
 // non-event triggers.
 // cursorFn returns the last-processed event seq for event triggers; may be nil for
 // non-event triggers.
 func CheckTrigger(a Order, now time.Time, lastRunFn LastRunFunc, ep events.Provider, cursorFn CursorFunc) TriggerResult {
+	return CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, TriggerOptions{})
+}
+
+// CheckTriggerWithOptions evaluates an order trigger using explicit execution
+// context for condition checks.
+func CheckTriggerWithOptions(a Order, now time.Time, lastRunFn LastRunFunc, ep events.Provider, cursorFn CursorFunc, opts TriggerOptions) TriggerResult {
 	switch a.Trigger {
 	case "cooldown":
 		return checkCooldown(a, now, lastRunFn)
 	case "cron":
 		return checkCron(a, now, lastRunFn)
 	case "condition":
-		return checkCondition(a)
+		return checkCondition(a, opts)
 	case "event":
 		return checkEvent(a, ep, cursorFn)
 	case "manual":
@@ -131,12 +145,21 @@ func cronFieldMatches(field string, value int) bool {
 
 // checkCondition runs the check command and returns due if exit code is 0.
 // Uses a timeout to prevent hanging check scripts from blocking trigger evaluation.
-func checkCondition(a Order) TriggerResult {
+func checkCondition(a Order, opts TriggerOptions) TriggerResult {
 	const triggerCheckTimeout = 10 * time.Second
-	timeout := triggerCheckTimeout
+	timeout := opts.ConditionTimeout
+	if timeout <= 0 {
+		timeout = triggerCheckTimeout
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sh", "-c", a.Check)
+	if opts.ConditionDir != "" {
+		cmd.Dir = opts.ConditionDir
+	}
+	if len(opts.ConditionEnv) > 0 {
+		cmd.Env = mergeConditionEnv(os.Environ(), opts.ConditionEnv)
+	}
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return TriggerResult{Due: false, Reason: fmt.Sprintf("check command timed out after %s", timeout)}
@@ -144,6 +167,27 @@ func checkCondition(a Order) TriggerResult {
 		return TriggerResult{Due: false, Reason: fmt.Sprintf("check command failed: %v", err)}
 	}
 	return TriggerResult{Due: true, Reason: "condition: check passed (exit 0)"}
+}
+
+func mergeConditionEnv(environ, extra []string) []string {
+	out := make([]string, 0, len(environ)+len(extra))
+	replaced := make(map[string]struct{}, len(extra))
+	for _, entry := range extra {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			replaced[key] = struct{}{}
+		}
+	}
+	for _, entry := range environ {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, found := replaced[key]; found {
+				continue
+			}
+		}
+		out = append(out, entry)
+	}
+	return append(out, extra...)
 }
 
 // checkEvent checks if matching events exist after the last cursor position.

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -97,6 +97,26 @@ func TestCheckTriggerCondition(t *testing.T) {
 	}
 }
 
+func TestCheckTriggerConditionUsesOptions(t *testing.T) {
+	dir := t.TempDir()
+	a := Order{
+		Name:    "check",
+		Trigger: "condition",
+		Check:   `test "$GC_CITY_PATH" = "$EXPECT_CITY" && test "$(pwd)" = "$EXPECT_CITY"`,
+	}
+	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
+	result := CheckTriggerWithOptions(a, now, neverRan, nil, nil, TriggerOptions{
+		ConditionDir: dir,
+		ConditionEnv: []string{
+			"EXPECT_CITY=" + dir,
+			"GC_CITY_PATH=" + dir,
+		},
+	})
+	if !result.Due {
+		t.Errorf("Due = false, want true with condition cwd/env: %s", result.Reason)
+	}
+}
+
 func TestCheckTriggerConditionFails(t *testing.T) {
 	a := Order{Name: "check", Trigger: "condition", Check: "false"}
 	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- run order condition checks with the scoped order environment
- dispatch eligible orders before session reconciliation
- add focused coverage for scoped condition env and dispatch ordering

## Validation
- go test ./internal/orders ./cmd/gc -run 'Test.*Order|Test.*Dispatch|Test.*Condition|Test.*SessionReconcile'
- git diff --check origin/main..HEAD