### PR TITLE
fix(scale): treat scale_check as new demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -49,10 +49,11 @@ type DesiredStateResult struct {
 }
 
 type poolEvalWork struct {
-	agentIdx int
-	sp       scaleParams
-	poolDir  string
-	env      map[string]string
+	agentIdx  int
+	sp        scaleParams
+	poolDir   string
+	env       map[string]string
+	newDemand bool
 }
 
 func evaluatePendingPools(
@@ -80,12 +81,19 @@ func evaluatePendingPools(
 		template := cfg.Agents[pw.agentIdx].QualifiedName()
 		agentName := cfg.Agents[pw.agentIdx].Name
 		agentIndex := pw.agentIdx
-		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string) {
+		newDemand := pw.newDemand
+		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string, newDemand bool) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			started := time.Now()
-			d, err := evaluatePool(agentName, sp, dir, probeEnv, shellScaleCheck)
+			var d int
+			var err error
+			if newDemand {
+				d, err = evaluatePoolNewDemand(agentName, sp, dir, probeEnv, shellScaleCheck)
+			} else {
+				d, err = evaluatePool(agentName, sp, dir, probeEnv, shellScaleCheck)
+			}
 			evalResults[idx] = poolEvalResult{desired: d, err: err}
 			if trace != nil {
 				outcome := "success"
@@ -102,7 +110,7 @@ func evaluatePendingPools(
 					"agent_index":    agentIndex,
 				}, "")
 			}
-		}(j, template, agentName, agentIndex, sp, pw.poolDir)
+		}(j, template, agentName, agentIndex, sp, pw.poolDir, newDemand)
 	}
 	wg.Wait()
 
@@ -110,7 +118,11 @@ func evaluatePendingPools(
 	for j, pw := range pendingPools {
 		pr := evalResults[j]
 		if pr.err != nil {
-			fmt.Fprintf(stderr, "buildDesiredState: %v (using min=%d)\n", pr.err, pw.sp.Min) //nolint:errcheck
+			if pw.newDemand {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", pr.err) //nolint:errcheck
+			} else {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using min=%d)\n", pr.err, pw.sp.Min) //nolint:errcheck
+			}
 		}
 		counts[j] = pr.desired
 	}
@@ -219,7 +231,7 @@ func buildDesiredStateWithSessionBeads(
 			// but generic scale_check/min demand for the backing template still
 			// creates ephemeral capacity through the pool pipeline.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
-			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir})
+			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
 			continue
 		}
 
@@ -231,7 +243,7 @@ func buildDesiredStateWithSessionBeads(
 		// them directly; bead-backed mode falls back to them when work-bead
 		// listing fails so transient store errors do not collapse demand to 0.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
-		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i])})
+		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i]), newDemand: store != nil})
 	}
 
 	// scale_check runs in parallel for all pool agents — the authoritative

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -127,17 +127,10 @@ func evaluatePool(agentName string, sp scaleParams, dir string, env map[string]s
 		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, err)
 		return sp.Min, fmt.Errorf("agent %q: %w", agentName, err)
 	}
-	trimmed := strings.TrimSpace(out)
-	if trimmed == "" {
-		checkErr := fmt.Errorf("agent %q: check %q produced empty output", agentName, sp.Check)
-		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, checkErr)
-		return sp.Min, checkErr
-	}
-	n, err := strconv.Atoi(trimmed)
+	n, err := parseScaleCheckCount(agentName, sp.Check, out)
 	if err != nil {
-		parseErr := fmt.Errorf("agent %q: check output %q is not an integer", agentName, trimmed)
-		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, parseErr)
-		return sp.Min, parseErr
+		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, err)
+		return sp.Min, err
 	}
 	desired := n
 	if desired < sp.Min {
@@ -148,6 +141,38 @@ func evaluatePool(agentName string, sp scaleParams, dir string, env map[string]s
 	}
 	telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, desired, nil)
 	return desired, nil
+}
+
+func evaluatePoolNewDemand(agentName string, sp scaleParams, dir string, env map[string]string, runner ScaleCheckRunner) (int, error) {
+	start := time.Now()
+	out, err := runner(sp.Check, dir, env)
+	durationMs := float64(time.Since(start).Milliseconds())
+	if err != nil {
+		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, 0, err)
+		return 0, fmt.Errorf("agent %q: %w", agentName, err)
+	}
+	n, err := parseScaleCheckCount(agentName, sp.Check, out)
+	if err != nil {
+		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, 0, err)
+		return 0, err
+	}
+	telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, n, nil)
+	return n, nil
+}
+
+func parseScaleCheckCount(agentName, check, out string) (int, error) {
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return 0, fmt.Errorf("agent %q: check %q produced empty output", agentName, check)
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("agent %q: check output %q is not an integer", agentName, trimmed)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("agent %q: check output %q is negative", agentName, trimmed)
+	}
+	return n, nil
 }
 
 // SessionSetupContext holds template variables for session_setup command expansion.

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -54,7 +54,7 @@ func PoolDesiredCounts(states []PoolDesiredState) map[string]int {
 // from scale_check, while this function only preserves sessions that already
 // own actionable work.
 // Each bead's gc.routed_to determines which agent template it belongs to.
-// scaleCheckCounts maps agent template → desired count from scale_check.
+// scaleCheckCounts maps agent template → new session demand from scale_check.
 // Pass nil for either when unavailable.
 func ComputePoolDesiredStates(
 	cfg *config.City,
@@ -151,16 +151,11 @@ func computePoolDesiredStates(
 		}
 	}
 
-	// Merge scale_check demand: for each agent, if scale_check wants more
-	// sessions than bead-driven requests already cover, add the difference
-	// as "new" tier requests. This ensures the scale_check command (which
-	// runs in the correct rig directory) is always the authoritative demand
-	// signal, while bead-driven resume requests preserve running sessions.
+	// Merge scale_check demand. In bead-backed reconciliation, scale_check is
+	// the authoritative signal for new unassigned demand only; resume requests
+	// are calculated independently from assigned work and must not be deducted
+	// from that count.
 	if len(scaleCheckCounts) > 0 {
-		beadDriven := make(map[string]int, len(allRequests))
-		for _, r := range allRequests {
-			beadDriven[r.Template]++
-		}
 		for _, agent := range cfg.Agents {
 			if agent.Suspended {
 				continue
@@ -170,8 +165,7 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			deficit := scaleCount - beadDriven[template]
-			for j := 0; j < deficit; j++ {
+			for j := 0; j < scaleCount; j++ {
 				allRequests = append(allRequests, SessionRequest{
 					Template: template,
 					Tier:     "new",

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -41,12 +41,13 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},
 	}
-	// 1 assigned (resume) + 2 unassigned. scale_check reports 3 total demand.
+	// 1 assigned (resume) + 2 new demand. scale_check reports only the new
+	// demand, and the max cap admits one of those two new requests.
 	work := []beads.Bead{
 		workBead("w1", "rig/claude", "sess-1", "in_progress", 5),
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
-	scaleCheck := map[string]int{"rig/claude": 3}
+	scaleCheck := map[string]int{"rig/claude": 2}
 
 	result := ComputePoolDesiredStates(cfg, work, sessions, scaleCheck)
 
@@ -54,7 +55,7 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 	reqs := result[0].Requests
-	// Max=2: resume (w1) + 1 new from scale_check deficit (3-1=2, capped at max=2).
+	// Max=2: resume (w1) + 1 new from scale_check, capped at max=2.
 	if len(reqs) != 2 {
 		t.Fatalf("len(requests) = %d, want 2 (max=2)", len(reqs))
 	}
@@ -487,7 +488,7 @@ func TestComputePoolDesiredStates_NoDemandNoAssignment(t *testing.T) {
 	}
 }
 
-// Regression: scale_check=3 with 1 assigned → poolDesired=3 (1 resume + 2 new).
+// Regression: scale_check reports new demand, not total desired sessions.
 func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
@@ -496,7 +497,7 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 		workBead("w1", "claude", "sess-1", "in_progress", 5),
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
-	scaleCheck := map[string]int{"claude": 3}
+	scaleCheck := map[string]int{"claude": 2}
 
 	result := ComputePoolDesiredStates(cfg, work, sessions, scaleCheck)
 
@@ -504,7 +505,7 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 	if len(result[0].Requests) != 3 {
-		t.Fatalf("len(requests) = %d, want 3 (1 resume + 2 new from scale_check deficit)", len(result[0].Requests))
+		t.Fatalf("len(requests) = %d, want 3 (1 resume + 2 new from scale_check)", len(result[0].Requests))
 	}
 	resumeCount := 0
 	newCount := 0

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -144,7 +144,7 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
 	}
 }
 
-func TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork(t *testing.T) {
+func TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork(t *testing.T) {
 	skipSlowCmdGCTest(t, "uses real bd and jq for default scale_check coverage; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
 	if err != nil {
@@ -187,8 +187,34 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork(t *testin
 	if err != nil {
 		t.Fatalf("evaluatePool with routed in-progress work: %v", err)
 	}
-	if got != 1 {
-		t.Fatalf("evaluatePool with routed in-progress work = %d, want 1", got)
+	if got != 0 {
+		t.Fatalf("evaluatePool with routed in-progress work = %d, want 0", got)
+	}
+}
+
+func TestEvaluatePoolNewDemandDoesNotApplyMinOrMax(t *testing.T) {
+	sp := scaleParams{Min: 2, Max: 3, Check: "ignored"}
+	runner := func(_, _ string, _ map[string]string) (string, error) { return "5\n", nil }
+
+	got, err := evaluatePoolNewDemand("worker", sp, "", nil, runner)
+	if err != nil {
+		t.Fatalf("evaluatePoolNewDemand: %v", err)
+	}
+	if got != 5 {
+		t.Fatalf("evaluatePoolNewDemand = %d, want raw new demand 5", got)
+	}
+}
+
+func TestEvaluatePoolNewDemandErrorFallsBackToZero(t *testing.T) {
+	sp := scaleParams{Min: 2, Max: 3, Check: "ignored"}
+	runner := func(_, _ string, _ map[string]string) (string, error) { return "not-a-number\n", nil }
+
+	got, err := evaluatePoolNewDemand("worker", sp, "", nil, runner)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if got != 0 {
+		t.Fatalf("evaluatePoolNewDemand error fallback = %d, want 0", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1909,10 +1909,10 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 
 // EffectiveScaleCheck returns the scale check command for this agent.
 // If ScaleCheck is set, returns it. Otherwise returns a default that
-// counts actionable work routed to this agent's template, including
+// counts new unassigned work routed to this agent's template, including
 // standalone formula-dispatched molecule beads (which bd ready excludes).
-// Attached formulas contribute demand through the routed source bead in the
-// ready/in_progress tiers instead of through the molecule count.
+// Assigned in-progress work is resumed from session beads, so it must not
+// create additional generic pool demand here.
 func (a *Agent) EffectiveScaleCheck() string {
 	if a.ScaleCheck != "" {
 		return a.ScaleCheck
@@ -1920,11 +1920,9 @@ func (a *Agent) EffectiveScaleCheck() string {
 	template := a.QualifiedName()
 	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
 		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`active=$(bd list --metadata-field gc.routed_to=` + template +
-		` --status=in_progress --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
 		`molecules=$(bd list --metadata-field gc.routed_to=` + template +
 		` --status=open --type=molecule --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`echo "$(( ${ready:-0} + ${active:-0} + ${molecules:-0} ))" || echo 0`
+		`echo "$(( ${ready:-0} + ${molecules:-0} ))" || echo 0`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1489,11 +1489,11 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("EffectiveScaleCheck() = %q, want bd ready for blocker-aware counting", check)
 	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("EffectiveScaleCheck() = %q, want --status=in_progress for active work", check)
-	}
 	if !strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck() = %q, want --type=molecule for formula-dispatched work", check)
+	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck() = %q, should not count in-progress work as new demand", check)
 	}
 }
 
@@ -1587,21 +1587,21 @@ func TestEffectiveScaleCheckDefaults(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(1),
 	}
 	check := a.EffectiveScaleCheck()
-	// Default check uses bd ready (blocker-aware) + in_progress count + molecule count via gc.routed_to.
+	// Default check uses bd ready (blocker-aware) + molecule count via gc.routed_to.
 	if !strings.Contains(check, "gc.routed_to=refinery") {
 		t.Errorf("EffectiveScaleCheck = %q, want gc.routed_to=refinery", check)
 	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("EffectiveScaleCheck = %q, want --status=in_progress for active work", check)
-	}
 	if !strings.Contains(check, "--no-assignee") {
-		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for active unassigned work", check)
+		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for new unassigned demand", check)
 	}
 	if !strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck = %q, want --type=molecule for formula-dispatched work", check)
 	}
 	if !strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("EffectiveScaleCheck = %q, want ${molecules:-0} in arithmetic sum", check)
+	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 }
 
@@ -1616,14 +1616,14 @@ func TestEffectiveScaleCheckDefaultsQualified(t *testing.T) {
 	if !strings.Contains(check, "gc.routed_to=myproject/polecat") {
 		t.Errorf("EffectiveScaleCheck = %q, want gc.routed_to=myproject/polecat", check)
 	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("EffectiveScaleCheck = %q, want --status=in_progress for active work", check)
-	}
 	if !strings.Contains(check, "--no-assignee") {
-		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for active unassigned work", check)
+		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for new unassigned demand", check)
 	}
 	if !strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck = %q, want --type=molecule for formula-dispatched work", check)
+	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 }
 
@@ -1637,23 +1637,20 @@ func TestEffectiveScaleCheckMoleculeQuery(t *testing.T) {
 	}
 	check := a.EffectiveScaleCheck()
 
-	// Must contain three separate queries summed together.
+	// Must contain blocker-aware ready demand and standalone molecule demand.
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("missing bd ready query for blocker-aware task counting")
-	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("missing in_progress query for active work")
 	}
 	if !strings.Contains(check, "--status=open --type=molecule") {
 		t.Errorf("missing molecule query for formula-dispatched work (GH #505)")
 	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
+	}
 
-	// All three variables must appear in the arithmetic sum.
+	// Both variables must appear in the arithmetic sum.
 	if !strings.Contains(check, "${ready:-0}") {
 		t.Errorf("missing ${ready:-0} in arithmetic sum")
-	}
-	if !strings.Contains(check, "${active:-0}") {
-		t.Errorf("missing ${active:-0} in arithmetic sum")
 	}
 	if !strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("missing ${molecules:-0} in arithmetic sum")


### PR DESCRIPTION
## Summary
- make the default shell scale_check count only new unassigned routed work plus standalone molecules
- have bead-backed pool reconciliation add scale_check new-demand requests on top of assigned-work resume requests
- keep legacy no-store evaluatePool clamping behavior separate from store-backed new-demand evaluation

## Validation
- go test ./internal/config -run 'TestDefaultPoolCheckUsesBdReady|TestEffectiveScaleCheckDefaults|TestEffectiveScaleCheckDefaultsQualified|TestEffectiveScaleCheckMoleculeQuery'\n- go test ./cmd/gc -run 'TestComputePoolDesiredStates_(ResumeBeatsNew|ScaleCheckMerge|ScaleCheckRespectsCaps|ResumeOverridesZeroScaleCheck|NoDemandNoAssignment|ScaleCheckAndResumeAddUp)|TestEvaluatePool(NewDemandDoesNotApplyMinOrMax|NewDemandErrorFallsBackToZero|DefaultScaleCheckIgnoresRoutedActiveUnassignedWork)|TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession'\n- go test ./cmd/gc -run 'TestComputePoolDesiredStates|TestBuildDesiredState_.*ScaleCheck|TestBuildDesiredState_.*Pool|TestEvaluatePool'\n- git diff --check origin/main..HEAD