### PR TITLE
perf(api): serve read models from cached session state

### DIFF
--- a/internal/api/cache_read_model.go
+++ b/internal/api/cache_read_model.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+type cachedListStore interface {
+	CachedList(beads.ListQuery) ([]beads.Bead, bool)
+}
+
+func listSessionBeadsForReadModel(store beads.Store) ([]beads.Bead, error) {
+	query := beads.ListQuery{
+		Label: session.LabelSession,
+		Sort:  beads.SortCreatedDesc,
+	}
+	if cached, ok := store.(cachedListStore); ok {
+		if rows, cacheOK := cached.CachedList(query); cacheOK {
+			return rows, nil
+		}
+	}
+	return store.List(query)
+}

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -243,13 +243,25 @@ func (s *Server) findActiveBeadForAssigneesWithFreshness(rig string, live bool, 
 	}
 	for _, assignee := range unique {
 		for _, rn := range rigNames {
-			matches, err := stores[rn].List(beads.ListQuery{
+			query := beads.ListQuery{
 				Assignee: assignee,
 				Status:   "in_progress",
 				Live:     live,
 				Limit:    1,
 				Sort:     beads.SortCreatedDesc,
-			})
+			}
+			if !live {
+				if cached, ok := stores[rn].(cachedListStore); ok {
+					matches, cacheOK := cached.CachedList(query)
+					if cacheOK {
+						if len(matches) > 0 {
+							return matches[0].ID
+						}
+						continue
+					}
+				}
+			}
+			matches, err := stores[rn].List(query)
 			if err != nil {
 				continue
 			}

--- a/internal/api/handler_rigs.go
+++ b/internal/api/handler_rigs.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
-	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	gitpkg "github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/runtime"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
-	"github.com/gastownhall/gascity/internal/worker"
 )
 
 type rigResponse struct {
@@ -33,7 +32,7 @@ type gitStatus struct {
 }
 
 // buildRigResponse creates a rigResponse with agent counts and last activity.
-func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, store beads.Store, sp sessionLister, cityName, cityPath string) rigResponse {
+func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, sp runtime.Provider, cityName, cityPath string) rigResponse {
 	tmpl := cfg.Workspace.SessionTemplate
 	var agentCount, runningCount int
 	var maxActivity time.Time
@@ -46,8 +45,7 @@ func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, store beads.
 		for _, ea := range expanded {
 			agentCount++
 			sessionName := agent.SessionNameFor(cityName, ea.qualifiedName, tmpl)
-			handle, _ := s.workerHandleForSessionTarget(store, sessionName)
-			obs, _ := worker.ObserveHandle(context.Background(), handle)
+			obs := observeProviderSession(sp, sessionName, nil)
 			if obs.Running {
 				runningCount++
 			}
@@ -60,7 +58,7 @@ func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, store beads.
 	resp := rigResponse{
 		Name:         rig.Name,
 		Path:         rig.Path,
-		Suspended:    s.rigSuspended(cfg, rig, store, sp, cityName, cityPath),
+		Suspended:    s.rigSuspended(cfg, rig, sp, cityName, cityPath),
 		Prefix:       rig.Prefix,
 		AgentCount:   agentCount,
 		RunningCount: runningCount,
@@ -74,7 +72,7 @@ func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, store beads.
 // rigSuspended computes effective suspended state for a rig by merging config
 // and runtime session metadata. A rig is suspended if the config says so, or
 // if all its agents are runtime-suspended via session metadata.
-func (s *Server) rigSuspended(cfg *config.City, rig config.Rig, store beads.Store, sp sessionLister, cityName, cityPath string) bool {
+func (s *Server) rigSuspended(cfg *config.City, rig config.Rig, sp runtime.Provider, cityName, cityPath string) bool {
 	if rig.Suspended {
 		return true
 	}
@@ -88,8 +86,7 @@ func (s *Server) rigSuspended(cfg *config.City, rig config.Rig, store beads.Stor
 		for _, ea := range expanded {
 			agentCount++
 			sessionName := agent.SessionNameFor(cityName, ea.qualifiedName, tmpl)
-			handle, _ := s.workerHandleForSessionTarget(store, sessionName)
-			obs, _ := worker.ObserveHandle(context.Background(), handle)
+			obs := observeProviderSession(sp, sessionName, nil)
 			if obs.Suspended {
 				suspendedCount++
 			}

--- a/internal/api/handler_session_create.go
+++ b/internal/api/handler_session_create.go
@@ -241,7 +241,7 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if handle, handleErr := s.workerHandleForSession(store, info.ID); handleErr == nil {
-		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false, true)
+		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false, true, true)
 	}
 	statusCode := http.StatusAccepted // always async for agent sessions
 	s.idem.storeResponse(idemKey, bodyHash, statusCode, resp)
@@ -428,7 +428,7 @@ func (s *Server) createProviderSession(w http.ResponseWriter, r *http.Request, s
 		}
 	}
 	if handle, handleErr := s.workerHandleForSession(store, info.ID); handleErr == nil {
-		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false, true)
+		s.enrichSessionResponse(&resp, info, s.state.Config(), handle, false, true, true)
 	}
 	statusCode := http.StatusCreated
 	s.idem.storeResponse(idemKey, bodyHash, statusCode, resp)

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -71,6 +71,13 @@ type sessionResponseHandle interface {
 	worker.PeekHandle
 }
 
+func (s *Server) runtimeSessionResponseHandle(info session.Info) sessionResponseHandle {
+	if info.State != session.StateActive {
+		return nil
+	}
+	return newProviderSessionResponseHandle(s.state.SessionProvider(), info.SessionName, info.Provider)
+}
+
 func sessionToResponse(info session.Info, cfg *config.City) sessionResponse {
 	provider, displayName := info.Provider, ""
 	if cfg != nil {
@@ -201,28 +208,25 @@ func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
 	templateFilter := q.Get("template")
 	wantPeek := q.Get("peek") == "true"
 
-	sessions, err := catalog.List(stateFilter, templateFilter)
+	all, err := listSessionBeadsForReadModel(store)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
+	listResult := catalog.ListFullFromBeads(all, stateFilter, templateFilter)
+	sessions := listResult.Sessions
 
 	// Build bead index for reason enrichment.
 	beadIndex := make(map[string]*beads.Bead)
-	if all, err := store.List(beads.ListQuery{Label: session.LabelSession}); err == nil {
-		for i := range all {
-			beadIndex[all[i].ID] = &all[i]
-		}
+	for i := range listResult.Beads {
+		beadIndex[listResult.Beads[i].ID] = &listResult.Beads[i]
 	}
 
 	items := make([]sessionResponse, len(sessions))
 	hasDeferredQueue := strings.TrimSpace(s.state.CityPath()) != ""
 	for i, sess := range sessions {
 		items[i] = sessionResponseWithReason(sess, beadIndex[sess.ID], cfg, hasDeferredQueue)
-		handle, err := s.workerHandleForSession(store, sess.ID)
-		if err == nil {
-			s.enrichSessionResponse(&items[i], sess, cfg, handle, wantPeek, false)
-		}
+		s.enrichSessionResponse(&items[i], sess, cfg, s.runtimeSessionResponseHandle(sess), wantPeek, false, false)
 	}
 
 	pp := parsePagination(r, maxPaginationLimit)
@@ -268,7 +272,7 @@ func (s *Server) handleSessionGet(w http.ResponseWriter, r *http.Request) {
 	resp := sessionResponseWithReason(info, &b, cfg, strings.TrimSpace(s.state.CityPath()) != "")
 	handle, err := s.workerHandleForSession(store, id)
 	if err == nil {
-		s.enrichSessionResponse(&resp, info, cfg, handle, wantPeek, true)
+		s.enrichSessionResponse(&resp, info, cfg, handle, wantPeek, true, true)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -449,7 +453,7 @@ func (s *Server) handleSessionRename(w http.ResponseWriter, r *http.Request) {
 
 // enrichSessionResponse populates runtime fields on a session response:
 // running state, active bead, peek output, and model/context metadata.
-func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info, _ *config.City, runtimeHandle any, wantPeek, liveActiveBead bool) {
+func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info, cfg *config.City, runtimeHandle any, wantPeek, liveActiveBead, allowWorkdirTranscriptDiscovery bool) {
 	if info.State != session.StateActive {
 		return
 	}
@@ -523,7 +527,14 @@ func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info,
 		}
 		// Prefer session-key lookup to avoid cross-reading another session's transcript.
 		// Cache the resolved file path — session files don't move once created.
-		sessionFile := factory.DiscoverTranscript(info.Provider, workDir, info.SessionKey)
+		provider := info.Provider
+		if strings.TrimSpace(provider) == "" && cfg != nil {
+			provider, _ = resolveProviderInfo(provider, cfg)
+		}
+		if !allowWorkdirTranscriptDiscovery && !canUseCheapTranscriptLookup(provider, info.SessionKey) {
+			return
+		}
+		sessionFile := factory.DiscoverTranscript(provider, workDir, info.SessionKey)
 		if sessionFile != "" {
 			if meta, err := factory.TailMeta(sessionFile); err == nil && meta != nil {
 				resp.Model = meta.Model
@@ -535,6 +546,17 @@ func (s *Server) enrichSessionResponse(resp *sessionResponse, info session.Info,
 			}
 		}
 	}
+}
+
+func canUseCheapTranscriptLookup(provider, sessionKey string) bool {
+	if strings.TrimSpace(sessionKey) == "" {
+		return false
+	}
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if strings.Contains(p, "codex") || strings.Contains(p, "gemini") {
+		return false
+	}
+	return true
 }
 
 // handleSessionPatch handles PATCH /v0/session/{id}. Title and alias are mutable.

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -42,6 +42,28 @@ func createTestSession(t *testing.T, store beads.Store, sp *runtime.Fake, title 
 	return info
 }
 
+type cachedOnlyListStoreForSessionTest struct {
+	*beads.MemStore
+	blockList bool
+	listCalls int
+}
+
+func (s *cachedOnlyListStoreForSessionTest) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if s.blockList {
+		s.listCalls++
+		return nil, errors.New("backing List should not be used")
+	}
+	return s.MemStore.List(query)
+}
+
+func (s *cachedOnlyListStoreForSessionTest) CachedList(query beads.ListQuery) ([]beads.Bead, bool) {
+	rows, err := s.MemStore.List(query)
+	if err != nil {
+		return nil, false
+	}
+	return rows, true
+}
+
 func writeGeminiHistoryFixtureForAPI(t *testing.T, path, sessionID string, messages ...string) {
 	t.Helper()
 
@@ -404,13 +426,180 @@ func TestHandleSessionListActiveBeadUsesCachedLookup(t *testing.T) {
 	resp := sessionResponse{}
 	srv.enrichSessionResponse(&resp, info, fs.Config(), sessionResponseCapabilityHandle{
 		state: worker.State{Phase: worker.PhaseReady},
-	}, false, false)
+	}, false, false, false)
 
 	if !resp.Running {
 		t.Fatal("Running = false, want true")
 	}
 	if got := resp.ActiveBead; got != work.ID {
 		t.Fatalf("active_bead = %q, want cached %q", got, work.ID)
+	}
+}
+
+func TestHandleSessionListUsesCachedSessionBeadsWhenAvailable(t *testing.T) {
+	fs := newSessionFakeState(t)
+	store := &cachedOnlyListStoreForSessionTest{MemStore: beads.NewMemStore()}
+	fs.cityBeadStore = store
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "My Session")
+	store.blockList = true
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/sessions"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []sessionResponse `json:"items"`
+		Total int               `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Items) != 1 || resp.Items[0].ID != info.ID {
+		t.Fatalf("response = %#v, want one session %s", resp, info.ID)
+	}
+	if store.listCalls != 0 {
+		t.Fatalf("backing List calls = %d, want 0", store.listCalls)
+	}
+}
+
+func TestHandleSessionListSkipsWorkdirOnlyCodexTranscriptDiscovery(t *testing.T) {
+	fs := newSessionFakeState(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755); err != nil {
+		t.Fatalf("MkdirAll default codex sessions: %v", err)
+	}
+	searchBase := t.TempDir()
+	srv := New(fs)
+	srv.sessionLogSearchPaths = []string{searchBase}
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	workDir := t.TempDir()
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	info, err := mgr.Create(context.Background(), "myrig/worker", "Codex Chat", "codex", workDir, "codex-max", nil, session.ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if info.SessionKey != "" {
+		t.Fatalf("SessionKey = %q, want empty for codex provider without SessionIDFlag", info.SessionKey)
+	}
+
+	codexDir := filepath.Join(searchBase, "2026", "04", "18")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	codexPayload := strings.Join([]string{
+		fmt.Sprintf(`{"type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		`{"type":"assistant","message":{"model":"gpt-5.5","usage":{"input_tokens":1000}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "session.jsonl"), []byte(codexPayload), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/sessions?template=myrig%2Fworker"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []sessionResponse `json:"items"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].ID != info.ID {
+		t.Fatalf("items = %#v, want session %s", resp.Items, info.ID)
+	}
+	if resp.Items[0].Model != "" || resp.Items[0].ContextPct != nil {
+		t.Fatalf("session list used workdir-only Codex transcript discovery: model=%q context=%v", resp.Items[0].Model, resp.Items[0].ContextPct)
+	}
+}
+
+func TestHandleSessionGetAllowsWorkdirOnlyCodexTranscriptDiscovery(t *testing.T) {
+	fs := newSessionFakeState(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755); err != nil {
+		t.Fatalf("MkdirAll default codex sessions: %v", err)
+	}
+	searchBase := t.TempDir()
+	srv := New(fs)
+	srv.sessionLogSearchPaths = []string{searchBase}
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	workDir := t.TempDir()
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	info, err := mgr.Create(context.Background(), "myrig/worker", "Codex Chat", "codex", workDir, "codex-max", nil, session.ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	codexDir := filepath.Join(searchBase, "2026", "04", "18")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	codexPayload := strings.Join([]string{
+		fmt.Sprintf(`{"type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		`{"type":"assistant","message":{"model":"gpt-5.5","usage":{"input_tokens":1000}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "session.jsonl"), []byte(codexPayload), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp sessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != info.ID {
+		t.Fatalf("ID = %q, want %q", resp.ID, info.ID)
+	}
+	if resp.Model != "gpt-5.5" {
+		t.Fatalf("model = %q, want gpt-5.5", resp.Model)
+	}
+}
+
+func TestHandleSessionListActiveBeadUsesCachedListWhenAvailable(t *testing.T) {
+	fs := newSessionFakeState(t)
+	store := &cachedOnlyListStoreForSessionTest{MemStore: beads.NewMemStore(), blockList: true}
+	fs.stores["myrig"] = store
+	srv := New(fs)
+
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "My Session")
+	work, err := store.Create(beads.Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	status := "in_progress"
+	assignee := info.ID
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(work): %v", err)
+	}
+
+	resp := sessionResponse{}
+	srv.enrichSessionResponse(&resp, info, fs.Config(), sessionResponseCapabilityHandle{
+		state: worker.State{Phase: worker.PhaseReady},
+	}, false, false, false)
+
+	if got := resp.ActiveBead; got != work.ID {
+		t.Fatalf("active_bead = %q, want cached %q", got, work.ID)
+	}
+	if store.listCalls != 0 {
+		t.Fatalf("backing List calls = %d, want 0", store.listCalls)
 	}
 }
 
@@ -442,7 +631,7 @@ func TestHandleSessionGetActiveBeadUsesLiveLookup(t *testing.T) {
 	resp := sessionResponse{}
 	srv.enrichSessionResponse(&resp, info, fs.Config(), sessionResponseCapabilityHandle{
 		state: worker.State{Phase: worker.PhaseReady},
-	}, false, true)
+	}, false, true, true)
 
 	if !resp.Running {
 		t.Fatal("Running = false, want true")

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -82,7 +82,7 @@ func (s *Server) buildStatusBody() StatusBody {
 	// Count rigs by state.
 	rc := rigCounts{Total: len(cfg.Rigs)}
 	for _, rig := range cfg.Rigs {
-		if s.rigSuspended(cfg, rig, store, sp, cityName, s.state.CityPath()) {
+		if s.rigSuspended(cfg, rig, sp, cityName, s.state.CityPath()) {
 			rc.Suspended++
 		}
 	}

--- a/internal/api/huma_handlers_rigs.go
+++ b/internal/api/huma_handlers_rigs.go
@@ -19,12 +19,11 @@ func (s *Server) humaHandleRigList(ctx context.Context, input *RigListInput) (*L
 	cfg := s.state.Config()
 	sp := s.state.SessionProvider()
 	cityName := s.state.CityName()
-	store := s.state.CityBeadStore()
 	wantGit := input.Git
 
 	rigs := make([]rigResponse, 0, len(cfg.Rigs))
 	for _, rig := range cfg.Rigs {
-		resp := s.buildRigResponse(cfg, rig, store, sp, cityName, s.state.CityPath())
+		resp := s.buildRigResponse(cfg, rig, sp, cityName, s.state.CityPath())
 		if wantGit {
 			resp.Git = fetchGitStatus(rig.Path)
 		}
@@ -41,12 +40,11 @@ func (s *Server) humaHandleRigGet(_ context.Context, input *RigGetInput) (*Index
 	name := input.Name
 	cfg := s.state.Config()
 	sp := s.state.SessionProvider()
-	store := s.state.CityBeadStore()
 	wantGit := input.Git
 
 	for _, rig := range cfg.Rigs {
 		if rig.Name == name {
-			resp := s.buildRigResponse(cfg, rig, store, sp, s.state.CityName(), s.state.CityPath())
+			resp := s.buildRigResponse(cfg, rig, sp, s.state.CityName(), s.state.CityPath())
 			if wantGit {
 				resp.Git = fetchGitStatus(rig.Path)
 			}

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -177,7 +177,7 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 	if caps, capErr := s.sessionManager(store).SubmissionCapabilities(info.ID); capErr == nil {
 		resp.SubmissionCapabilities = caps
 	}
-	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false, true)
+	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false, true, true)
 
 	out := &SessionCreateOutput{Status: http.StatusAccepted}
 	out.Body = resp
@@ -327,7 +327,7 @@ func (s *Server) humaCreateProviderSession(ctx context.Context, store beads.Stor
 	if caps, capErr := s.sessionManager(store).SubmissionCapabilities(info.ID); capErr == nil {
 		resp.SubmissionCapabilities = caps
 	}
-	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false, true)
+	s.enrichSessionResponse(&resp, info, s.state.Config(), s.state.SessionProvider(), false, true, true)
 
 	out := &SessionCreateOutput{Status: http.StatusCreated}
 	out.Body = resp

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -24,19 +24,18 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	}
 	mgr := s.sessionManager(store)
 	cfg := s.state.Config()
-	sp := s.state.SessionProvider()
 
-	sessions, err := mgr.List(input.State, input.Template)
+	all, err := listSessionBeadsForReadModel(store)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
+	listResult := mgr.ListFullFromBeads(all, input.State, input.Template)
+	sessions := listResult.Sessions
 
 	// Build bead index for reason enrichment.
 	beadIndex := make(map[string]*beads.Bead)
-	if all, listErr := store.List(beads.ListQuery{Label: session.LabelSession}); listErr == nil {
-		for i := range all {
-			beadIndex[all[i].ID] = &all[i]
-		}
+	for i := range listResult.Beads {
+		beadIndex[listResult.Beads[i].ID] = &listResult.Beads[i]
 	}
 
 	wantPeek := input.Peek
@@ -44,7 +43,7 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	items := make([]sessionResponse, len(sessions))
 	for i, sess := range sessions {
 		items[i] = sessionResponseWithReason(sess, beadIndex[sess.ID], cfg, hasDeferredQueue)
-		s.enrichSessionResponse(&items[i], sess, cfg, sp, wantPeek, false)
+		s.enrichSessionResponse(&items[i], sess, cfg, s.runtimeSessionResponseHandle(sess), wantPeek, false, false)
 	}
 
 	// Pagination support.
@@ -109,7 +108,7 @@ func (s *Server) humaHandleSessionGet(_ context.Context, input *SessionGetInput)
 	b, _ := store.Get(id)
 	wantPeek := input.Peek
 	resp := sessionResponseWithReason(info, &b, cfg, strings.TrimSpace(s.state.CityPath()) != "")
-	s.enrichSessionResponse(&resp, info, cfg, sp, wantPeek, true)
+	s.enrichSessionResponse(&resp, info, cfg, sp, wantPeek, true, true)
 	return &IndexOutput[sessionResponse]{
 		Index: s.latestIndex(),
 		Body:  resp,

--- a/internal/api/read_model_no_get_test.go
+++ b/internal/api/read_model_no_get_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+type getCountingStore struct {
+	beads.Store
+	gets atomic.Int64
+}
+
+func (s *getCountingStore) Get(id string) (beads.Bead, error) {
+	s.gets.Add(1)
+	return s.Store.Get(id)
+}
+
+func TestSessionListUsesLoadedSessionBeadsWithoutPerSessionGet(t *testing.T) {
+	fs := newSessionFakeState(t)
+	createTestSession(t, fs.cityBeadStore, fs.sp, "Session A")
+	createTestSession(t, fs.cityBeadStore, fs.sp, "Session B")
+	counting := &getCountingStore{Store: fs.cityBeadStore}
+	fs.cityBeadStore = counting
+
+	h := newTestCityHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := counting.gets.Load(); got != 0 {
+		t.Fatalf("store.Get calls = %d, want 0 for session list read model", got)
+	}
+}
+
+func TestSessionListDoesNotProbePendingInteractions(t *testing.T) {
+	fs := newSessionFakeState(t)
+	createTestSession(t, fs.cityBeadStore, fs.sp, "Session A")
+	createTestSession(t, fs.cityBeadStore, fs.sp, "Session B")
+	fs.sp.Calls = nil
+
+	h := newTestCityHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	for _, call := range fs.sp.Calls {
+		if call.Method == "Pending" {
+			t.Fatalf("session list called Pending for %s; calls=%#v", call.Name, fs.sp.Calls)
+		}
+	}
+}
+
+func TestRigListUsesProviderStateWithoutSessionStoreGet(t *testing.T) {
+	state := newFakeState(t)
+	counting := &getCountingStore{Store: beads.NewMemStore()}
+	state.cityBeadStore = counting
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("start provider session: %v", err)
+	}
+
+	h := newTestCityHandler(t, state)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, cityURL(state, "/rigs"), nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp struct {
+		Items []rigResponse `json:"items"`
+		Total int           `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Items) != 1 {
+		t.Fatalf("rig response total/items = %d/%d, want 1/1", resp.Total, len(resp.Items))
+	}
+	if resp.Items[0].RunningCount != 1 {
+		t.Fatalf("RunningCount = %d, want 1", resp.Items[0].RunningCount)
+	}
+	if got := counting.gets.Load(); got != 0 {
+		t.Fatalf("store.Get calls = %d, want 0 for rig list read model", got)
+	}
+}

--- a/internal/api/runtime_observation.go
+++ b/internal/api/runtime_observation.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/worker"
+)
+
+func observeProviderSession(sp runtime.Provider, sessionName string, processNames []string) worker.LiveObservation {
+	sessionName = strings.TrimSpace(sessionName)
+	obs := worker.LiveObservation{SessionName: sessionName}
+	if sp == nil || sessionName == "" {
+		return obs
+	}
+	obs.Running = sp.IsRunning(sessionName)
+	if suspended, err := sp.GetMeta(sessionName, "suspended"); err == nil && strings.TrimSpace(suspended) == "true" {
+		obs.Suspended = true
+	}
+	if sessionID, err := sp.GetMeta(sessionName, "GC_SESSION_ID"); err == nil {
+		obs.RuntimeSessionID = strings.TrimSpace(sessionID)
+	}
+	if !obs.Running {
+		return obs
+	}
+	obs.Alive = sp.ProcessAlive(sessionName, processNames)
+	obs.Attached = sp.IsAttached(sessionName)
+	if lastActive, err := sp.GetLastActivity(sessionName); err == nil && !lastActive.IsZero() {
+		last := lastActive
+		obs.LastActivity = &last
+	}
+	return obs
+}
+
+type providerSessionResponseHandle struct {
+	provider     runtime.Provider
+	sessionName  string
+	providerName string
+}
+
+func newProviderSessionResponseHandle(sp runtime.Provider, sessionName, providerName string) sessionResponseHandle {
+	sessionName = strings.TrimSpace(sessionName)
+	if sp == nil || sessionName == "" {
+		return nil
+	}
+	return providerSessionResponseHandle{
+		provider:     sp,
+		sessionName:  sessionName,
+		providerName: strings.TrimSpace(providerName),
+	}
+}
+
+func (h providerSessionResponseHandle) State(context.Context) (worker.State, error) {
+	state := worker.State{
+		SessionName: h.sessionName,
+		Provider:    h.providerName,
+	}
+	if h.provider == nil || !h.provider.IsRunning(h.sessionName) {
+		state.Phase = worker.PhaseStopped
+		return state, nil
+	}
+	state.Phase = worker.PhaseReady
+	return state, nil
+}
+
+func (h providerSessionResponseHandle) Peek(_ context.Context, lines int) (string, error) {
+	if h.provider == nil || !h.provider.IsRunning(h.sessionName) {
+		return "", fmt.Errorf("%w: %s", session.ErrSessionInactive, h.sessionName)
+	}
+	return h.provider.Peek(h.sessionName, lines)
+}

--- a/internal/api/worker_capability_guardrail_test.go
+++ b/internal/api/worker_capability_guardrail_test.go
@@ -53,7 +53,7 @@ func TestEnrichSessionResponseAcceptsStateAndPeekCapability(t *testing.T) {
 	}, nil, sessionResponseCapabilityHandle{
 		state:  worker.State{Phase: worker.PhaseReady},
 		output: "peek output",
-	}, true, false)
+	}, true, false, false)
 
 	if !resp.Running {
 		t.Fatal("Running = false, want true")

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -598,6 +598,37 @@ func TestCachingStoreCloseAllMarksRefreshFailuresDirty(t *testing.T) {
 	}
 }
 
+func TestCachingStoreCachedListReturnsSnapshotWithDirtyEntries(t *testing.T) {
+	t.Parallel()
+
+	backing := &refreshFailingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "active work"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	title := "updated while refresh fails"
+	backing.failNextGet = true
+	if err := cache.Update(bead.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	rows, ok := cache.CachedList(ListQuery{Status: "open"})
+	if !ok {
+		t.Fatal("CachedList returned ok=false for dirty cache, want snapshot")
+	}
+	if len(rows) != 1 || rows[0].ID != bead.ID {
+		t.Fatalf("CachedList = %#v, want dirty snapshot row %s", rows, bead.ID)
+	}
+	if rows[0].Title == title {
+		t.Fatalf("CachedList returned refreshed title %q; test setup did not create a dirty stale snapshot", rows[0].Title)
+	}
+}
+
 type refreshFailingStore struct {
 	Store
 	failNextGet bool

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -83,6 +83,31 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	return c.backing.List(query)
 }
 
+// CachedList returns query results from the in-memory cache only. The boolean
+// reports whether the cache was initialized enough to answer without touching
+// the backing store. Dirty entries are returned from the last observed
+// snapshot; callers must treat this as a read model that may lag writes or
+// reconciliation by one tick.
+func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return nil, false
+	}
+	cached := make([]Bead, 0, len(c.beads))
+	for _, b := range c.beads {
+		if !query.Matches(b) {
+			continue
+		}
+		cached = append(cached, cloneBead(b))
+	}
+	sortBeadsForQuery(cached, query.Sort)
+	if query.Limit > 0 && len(cached) > query.Limit {
+		cached = cached[:query.Limit]
+	}
+	return cached, true
+}
+
 func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, items []Bead) []Bead {
 	refreshedParents := make(map[string]Bead)
 	removedParents := make(map[string]struct{})
@@ -250,7 +275,6 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 		statusByID := make(map[string]string, len(c.beads))
 		depsByID := make(map[string][]Dep, len(c.deps))
 		openBeads := make([]Bead, 0, len(c.beads))
-		missingDepIDs := make(map[string]struct{})
 		for _, b := range c.beads {
 			statusByID[b.ID] = b.Status
 			if b.Status == "open" && !IsReadyExcludedType(b.Type) {
@@ -260,29 +284,8 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 		for _, b := range openBeads {
 			deps := cloneDeps(c.deps[b.ID])
 			depsByID[b.ID] = deps
-			for _, dep := range deps {
-				switch dep.Type {
-				case "blocks", "waits-for", "conditional-blocks":
-				default:
-					continue
-				}
-				if _, ok := statusByID[dep.DependsOnID]; !ok {
-					missingDepIDs[dep.DependsOnID] = struct{}{}
-				}
-			}
 		}
 		c.mu.RUnlock()
-
-		for depID := range missingDepIDs {
-			dep, err := c.backing.Get(depID)
-			if err != nil {
-				if errors.Is(err, ErrNotFound) {
-					continue
-				}
-				return nil, err
-			}
-			statusByID[depID] = dep.Status
-		}
 
 		var result []Bead
 		for _, b := range openBeads {
@@ -293,7 +296,7 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 				default:
 					continue
 				}
-				if statusByID[dep.DependsOnID] != "closed" {
+				if status, ok := statusByID[dep.DependsOnID]; ok && status != "closed" {
 					blocked = true
 					break
 				}

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -681,7 +681,32 @@ func TestCachingStoreGetFallsBackForClosedBeadsAfterPrime(t *testing.T) {
 	}
 }
 
-func TestCachingStoreReadyFallsBackForClosedBlockingDepsAfterPrime(t *testing.T) {
+type countingGetStore struct {
+	beads.Store
+	mu   sync.Mutex
+	gets int
+}
+
+func (s *countingGetStore) Get(id string) (beads.Bead, error) {
+	s.mu.Lock()
+	s.gets++
+	s.mu.Unlock()
+	return s.Store.Get(id)
+}
+
+func (s *countingGetStore) resetGets() {
+	s.mu.Lock()
+	s.gets = 0
+	s.mu.Unlock()
+}
+
+func (s *countingGetStore) getCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gets
+}
+
+func TestCachingStoreReadyTreatsMissingDepTargetAsClosedWithoutBackingGet(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
 	blocker, err := mem.Create(beads.Bead{Title: "Closed blocker"})
@@ -699,10 +724,12 @@ func TestCachingStoreReadyFallsBackForClosedBlockingDepsAfterPrime(t *testing.T)
 		t.Fatalf("DepAdd: %v", err)
 	}
 
-	cs := beads.NewCachingStoreForTest(mem, nil)
+	backing := &countingGetStore{Store: mem}
+	cs := beads.NewCachingStoreForTest(backing, nil)
 	if err := cs.Prime(context.Background()); err != nil {
 		t.Fatalf("Prime: %v", err)
 	}
+	backing.resetGets()
 
 	got, err := cs.Ready()
 	if err != nil {
@@ -710,6 +737,9 @@ func TestCachingStoreReadyFallsBackForClosedBlockingDepsAfterPrime(t *testing.T)
 	}
 	if len(got) != 1 || got[0].ID != ready.ID {
 		t.Fatalf("Ready() = %v, want only %s", got, ready.ID)
+	}
+	if gets := backing.getCount(); gets != 0 {
+		t.Fatalf("Ready() performed %d backing Get calls, want 0", gets)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a cache-only list read model for CachingStore
- use cached session bead lists for session list responses and avoid per-session worker handle resolution
- use provider state for rig list/status liveness instead of session store Get calls
- avoid expensive transcript discovery in list responses when no cheap session-key lookup is available

## Validation
- go test ./internal/beads -run 'TestCachingStore(ReadyTreatsMissingDepTargetAsClosedWithoutBackingGet|CachedListReturnsSnapshotWithDirtyEntries|ListByLabelSeesCreatedBeadAfterMetadataWrite)'\n- go test ./internal/beads\n- go test ./internal/api -run 'Test(SessionListUsesLoadedSessionBeadsWithoutPerSessionGet|SessionListDoesNotProbePendingInteractions|RigListUsesProviderStateWithoutSessionStoreGet|HandleSessionListUsesCachedSessionBeadsWhenAvailable|HandleSessionListActiveBeadUsesCachedListWhenAvailable|HandleSessionListSkipsWorkdirOnlyCodexTranscriptDiscovery|HandleSessionGetAllowsWorkdirOnlyCodexTranscriptDiscovery|HandleSessionListActiveBeadUsesCachedLookup|HandleSessionGetActiveBeadUsesLiveLookup|EnrichSessionResponseAcceptsStateAndPeekCapability|HandleRig|Rig|HandleStatus)'\n- git diff --check\n\nNote: a full go test ./internal/api run was stopped after it hung in existing TestHandleSessionSubmitFollowUpQueuesMessage nudge-poll child processes; the targeted API coverage above passed.