### PR TITLE
perf(orders): cache order check read model

### DIFF
--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -405,6 +406,36 @@ func TestHandleOrderCheckTreatsWispFailedAsFailed(t *testing.T) {
 	}
 }
 
+func TestHandleOrderCheckDoesNotRunConditionByDefault(t *testing.T) {
+	fs := newFakeState(t)
+	marker := t.TempDir() + "/condition-ran"
+	fs.autos = []orders.Order{
+		{Name: "router", Formula: "review-pr", Trigger: "condition", Check: "touch " + marker},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("condition marker stat err = %v, want not exist", err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check?fresh=true"), nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fresh status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("condition marker after fresh check: %v", err)
+	}
+}
+
 func TestLastRunOutcomeFromLabelsPrioritizesTerminalLabels(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -728,6 +759,73 @@ func TestHandleOrderCheckUsesRigStoreLastRunState(t *testing.T) {
 	}
 	if check.LastRunOutcome == nil || *check.LastRunOutcome != "success" {
 		t.Fatalf("last_run_outcome = %v, want success", check.LastRunOutcome)
+	}
+}
+
+type cachedOnlyOrderHistoryStore struct {
+	beads.Store
+	cached                 []beads.Bead
+	includeClosedListCalls int
+}
+
+func (s *cachedOnlyOrderHistoryStore) CachedList(query beads.ListQuery) ([]beads.Bead, bool) {
+	return beads.ApplyListQuery(s.cached, query), true
+}
+
+func (s *cachedOnlyOrderHistoryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.IncludeClosed {
+		s.includeClosedListCalls++
+	}
+	return s.Store.List(query)
+}
+
+func TestHandleOrderCheckUsesCachedHistoryWhenAvailable(t *testing.T) {
+	fs := newFakeState(t)
+	run := beads.Bead{
+		ID:        "run-1",
+		Title:     "nightly-review wisp",
+		Status:    "closed",
+		CreatedAt: time.Now().UTC(),
+		Labels:    []string{"order-run:nightly-review", "wisp"},
+	}
+	cachedStore := &cachedOnlyOrderHistoryStore{
+		Store:  beads.NewMemStore(),
+		cached: []beads.Bead{run},
+	}
+	fs.cityBeadStore = cachedStore
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Trigger: "cooldown", Interval: "24h"},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Checks []struct {
+			Due            bool    `json:"due"`
+			LastRunOutcome *string `json:"last_run_outcome"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(resp.Checks))
+	}
+	if resp.Checks[0].Due {
+		t.Fatal("due = true, want false from cached recent run")
+	}
+	if resp.Checks[0].LastRunOutcome == nil || *resp.Checks[0].LastRunOutcome != "success" {
+		t.Fatalf("last_run_outcome = %v, want success", resp.Checks[0].LastRunOutcome)
+	}
+	if cachedStore.includeClosedListCalls != 0 {
+		t.Fatalf("IncludeClosed List calls = %d, want 0 when cached history is available", cachedStore.includeClosedListCalls)
 	}
 }
 

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -64,10 +65,18 @@ type OrderCheckListOutput struct {
 }
 
 // humaHandleOrderCheck is the Huma-typed handler for GET /v0/orders/check.
-func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*OrderCheckListOutput, error) {
+func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput) (*OrderCheckListOutput, error) {
 	aa := s.state.Orders()
 
 	ep := s.state.EventProvider()
+
+	index := s.latestIndex()
+	cacheKey := cacheKeyFor("orders-check", input)
+	if !input.Fresh {
+		if body, ok := cachedResponseAs[OrderCheckListBody](s, cacheKey, index); ok {
+			return &OrderCheckListOutput{Body: body}, nil
+		}
+	}
 
 	now := time.Now()
 	checks := make([]orderCheckResponse, 0, len(aa))
@@ -76,8 +85,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 		if err != nil {
 			storeInfos = nil
 		}
-		stores := storesFromWorkflowInfos(storeInfos)
-		result := orders.CheckTrigger(a, now, orders.LastRunAcrossStores(stores...), ep, orders.CursorAcrossStores(stores...))
+		history, _ := orderHistoryBeadsAcrossStoreInfosForCheck(storeInfos, a.ScopedName(), 1, time.Time{}, input.Fresh)
+		result := checkOrderTriggerForAPI(a, now, history, storeInfos, ep, input.Fresh)
 		cr := orderCheckResponse{
 			Name:       a.Name,
 			ScopedName: a.ScopedName(),
@@ -89,8 +98,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 			ts := result.LastRun.Format(time.RFC3339)
 			cr.LastRun = &ts
 		}
-		if results, err := orderHistoryBeadsAcrossStoreInfos(storeInfos, a.ScopedName(), 1, time.Time{}); err == nil && len(results) > 0 {
-			outcome := lastRunOutcomeFromLabels(results[0].bead.Labels)
+		if len(history) > 0 {
+			outcome := lastRunOutcomeFromLabels(history[0].bead.Labels)
 			if outcome != "" {
 				cr.LastRunOutcome = &outcome
 			}
@@ -104,7 +113,36 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 
 	out := &OrderCheckListOutput{}
 	out.Body.Checks = checks
+	if !input.Fresh {
+		s.storeResponse(cacheKey, index, out.Body)
+	}
 	return out, nil
+}
+
+func checkOrderTriggerForAPI(a orders.Order, now time.Time, history []orderHistoryStoreBead, infos []workflowStoreInfo, ep events.Provider, fresh bool) orders.TriggerResult {
+	lastRunFn := func(string) (time.Time, error) {
+		if len(history) == 0 {
+			return time.Time{}, nil
+		}
+		return history[0].bead.CreatedAt, nil
+	}
+	if a.Trigger == "condition" && !fresh {
+		return orders.TriggerResult{Due: false, Reason: "condition: not evaluated in cached API check"}
+	}
+	var cursorFn orders.CursorFunc
+	if a.Trigger == "event" {
+		if fresh {
+			cursorFn = orders.CursorAcrossStores(storesFromWorkflowInfos(infos)...)
+		} else {
+			labelSets := make([][]string, 0, len(history))
+			for _, row := range history {
+				labelSets = append(labelSets, row.bead.Labels)
+			}
+			cursor := orders.MaxSeqFromLabels(labelSets)
+			cursorFn = func(string) uint64 { return cursor }
+		}
+	}
+	return orders.CheckTrigger(a, now, lastRunFn, ep, cursorFn)
 }
 
 // orderCheckResponse is the response item for GET /v0/orders/check.
@@ -306,6 +344,10 @@ type orderHistoryStoreBead struct {
 	bead     beads.Bead
 }
 
+type cachedListStore interface {
+	CachedList(beads.ListQuery) ([]beads.Bead, bool)
+}
+
 func orderStoreInfosForState(state State, a orders.Order) ([]workflowStoreInfo, error) {
 	cityName := workflowCityScopeRef(state.CityName())
 	infos := make([]workflowStoreInfo, 0, 2)
@@ -343,6 +385,74 @@ func storesFromWorkflowInfos(infos []workflowStoreInfo) []beads.Store {
 		}
 	}
 	return stores
+}
+
+func orderHistoryBeadsAcrossStoreInfosForCheck(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time, fresh bool) ([]orderHistoryStoreBead, error) {
+	if fresh {
+		return orderHistoryBeadsAcrossStoreInfos(infos, scopedName, limit, beforeTime)
+	}
+	return orderHistoryBeadsAcrossStoreInfosCachedFirst(infos, scopedName, limit, beforeTime)
+}
+
+func orderHistoryBeadsAcrossStoreInfosCachedFirst(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time) ([]orderHistoryStoreBead, error) {
+	if len(infos) == 0 {
+		return nil, errNoOrderStores
+	}
+
+	label := "order-run:" + scopedName
+	seen := make(map[string]bool)
+	results := make([]orderHistoryStoreBead, 0)
+	for i, info := range infos {
+		if info.store == nil {
+			continue
+		}
+		query := beads.ListQuery{
+			Label:         label,
+			CreatedBefore: beforeTime,
+			Limit:         limit,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+		}
+		var (
+			rows []beads.Bead
+			err  error
+		)
+		if cached, ok := info.store.(cachedListStore); ok {
+			var cacheOK bool
+			rows, cacheOK = cached.CachedList(query)
+			if !cacheOK {
+				continue
+			}
+		} else {
+			rows, err = info.store.List(query)
+			if err != nil {
+				if i == 0 {
+					return nil, err
+				}
+				log.Printf("api: order history list failed for %s: %v", info.ref, err)
+				continue
+			}
+		}
+		for _, row := range rows {
+			if !beforeTime.IsZero() && !row.CreatedAt.Before(beforeTime) {
+				continue
+			}
+			key := info.ref + "\x00" + row.ID
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			results = append(results, orderHistoryStoreBead{storeRef: info.ref, bead: row})
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].bead.CreatedAt.After(results[j].bead.CreatedAt)
+	})
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
 }
 
 func orderHistoryBeadsAcrossStoreInfos(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time) ([]orderHistoryStoreBead, error) {

--- a/internal/api/huma_types_orders.go
+++ b/internal/api/huma_types_orders.go
@@ -28,6 +28,7 @@ type OrderGetInput struct {
 // OrderCheckInput is the Huma input for GET /v0/city/{cityName}/orders/check.
 type OrderCheckInput struct {
 	CityScope
+	Fresh bool `query:"fresh" required:"false" doc:"Force fresh trigger evaluation, including condition scripts and backing-store order history."`
 }
 
 // OrderHistoryInput is the Huma input for GET /v0/city/{cityName}/orders/history.


### PR DESCRIPTION
## Summary
- add fresh=true to /orders/check for force-evaluating condition scripts and backing-store history
- serve default order checks from cached history when available
- avoid running condition trigger commands during cached dashboard/API checks

## Validation
- go test ./internal/api -run 'TestHandleOrderCheck(DoesNotRunConditionByDefault|UsesCachedHistoryWhenAvailable|TreatsWispFailedAsFailed|UsesRigStoreLastRunState|SkipsUnavailableRigStore)|TestLastRunOutcomeFromLabels'\n- go test ./internal/api -run 'TestHandleOrder(Check|History|List|Get)|TestHumaHandleOrder|TestLastRunOutcomeFromLabels'\n- git diff --check