### PR TITLE
perf(sessions): enqueue reconciler starts asynchronously

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1329,6 +1329,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
 		cr.cfg.Daemon.DriftDrainTimeoutDuration(),
 		cr.stdout, cr.stderr, trace,
+		withAsyncStartExecution(),
 	)
 	cr.requestDeferredDrainFollowUpTick()
 	if trace != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -67,6 +67,18 @@ type startResult struct {
 	rollbackPending bool
 }
 
+type startExecutionOptions struct {
+	async bool
+}
+
+type startExecutionOption func(*startExecutionOptions)
+
+func withAsyncStartExecution() startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.async = true
+	}
+}
+
 type stopTarget struct {
 	sessionID   string
 	name        string
@@ -521,109 +533,183 @@ func executePreparedStartWaveForCity(
 		i, item := i, item
 		sem <- struct{}{}
 		go func() {
-			started := time.Now()
 			defer func() {
-				if recovered := recover(); recovered != nil {
-					stack := debug.Stack()
-					results[i] = startResult{
-						prepared: item,
-						err:      fmt.Errorf("panic during start: %v\n%s", recovered, stack),
-						outcome:  "panic_recovered",
-						started:  started,
-						finished: time.Now(),
-					}
-				}
 				<-sem
 				done <- i
 			}()
-			startCtx := ctx
-			cancel := func() {}
-			if startupTimeout > 0 {
-				startCtx, cancel = context.WithTimeout(ctx, startupTimeout)
-			}
-			defer cancel()
-			_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
-			if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
-				running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
-				if runningErr == nil && running {
-					err = nil
-				}
-			}
-			// Stale session key detection: if the session was started
-			// with a resume flag but dies immediately, the session key
-			// likely references a conversation that no longer exists
-			// (e.g., "No conversation found"). Report as a failure so
-			// recordWakeFailure clears the key for the next attempt.
-			if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
-				time.Sleep(staleKeyDetectDelay)
-				running := false
-				alive := false
-				if store == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
-					running = sp != nil && sp.IsRunning(item.candidate.name())
-					alive = running && (sp == nil || sp.ProcessAlive(item.candidate.name(), item.cfg.ProcessNames))
-				} else {
-					var obs worker.LiveObservation
-					obs, err = workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
-					running = obs.Running
-					alive = obs.Alive
-				}
-				if err != nil || !running || !alive {
-					err = fmt.Errorf("session %q died during startup", item.candidate.name())
-				}
-			}
-			finished := time.Now()
-			rollbackPending := err != nil && shouldRollbackPendingCreate(item.candidate.session)
-			if err != nil && rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
-				results[i] = startResult{
-					prepared:        item,
-					err:             nil,
-					outcome:         "start_error_converged",
-					started:         started,
-					finished:        finished,
-					rollbackPending: false,
-				}
-				return
-			}
-			var outcome string
-			switch {
-			case err == nil:
-				outcome = "success"
-			case startCtx.Err() == context.DeadlineExceeded:
-				outcome = "deadline_exceeded"
-			case startCtx.Err() == context.Canceled:
-				outcome = "canceled"
-			case errors.Is(err, runtime.ErrSessionInitializing):
-				outcome = "session_initializing"
-				err = nil
-			case errors.Is(err, runtime.ErrSessionExists):
-				running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
-				switch {
-				case runningErr != nil || !running:
-					outcome = "provider_error"
-				case rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
-					outcome = "session_exists_converged"
-					err = nil
-					rollbackPending = false
-				default:
-					outcome = "session_exists"
-				}
-			default:
-				outcome = "provider_error"
-			}
-			results[i] = startResult{
-				prepared:        item,
-				err:             err,
-				outcome:         outcome,
-				started:         started,
-				finished:        finished,
-				rollbackPending: rollbackPending,
-			}
+			results[i] = runPreparedStartCandidate(ctx, item, cityPath, sp, store, cfg, startupTimeout)
 		}()
 	}
 	for range prepared {
 		<-done
 	}
 	return results
+}
+
+func runPreparedStartCandidate(
+	ctx context.Context,
+	item preparedStart,
+	cityPath string,
+	sp runtime.Provider,
+	store beads.Store,
+	cfg *config.City,
+	startupTimeout time.Duration,
+) (result startResult) {
+	started := time.Now()
+	result = startResult{
+		prepared: item,
+		started:  started,
+		finished: started,
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			stack := debug.Stack()
+			result = startResult{
+				prepared: item,
+				err:      fmt.Errorf("panic during start: %v\n%s", recovered, stack),
+				outcome:  "panic_recovered",
+				started:  started,
+				finished: time.Now(),
+			}
+		}
+	}()
+
+	startCtx := ctx
+	cancel := func() {}
+	if startupTimeout > 0 {
+		startCtx, cancel = context.WithTimeout(ctx, startupTimeout)
+	}
+	defer cancel()
+	_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
+	if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
+		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		if runningErr == nil && running {
+			err = nil
+		}
+	}
+	// Stale session key detection: if the session was started
+	// with a resume flag but dies immediately, the session key
+	// likely references a conversation that no longer exists
+	// (e.g., "No conversation found"). Report as a failure so
+	// recordWakeFailure clears the key for the next attempt.
+	if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
+		time.Sleep(staleKeyDetectDelay)
+		running := false
+		alive := false
+		if store == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
+			running = sp != nil && sp.IsRunning(item.candidate.name())
+			alive = running && (sp == nil || sp.ProcessAlive(item.candidate.name(), item.cfg.ProcessNames))
+		} else {
+			var obs worker.LiveObservation
+			obs, err = workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
+			running = obs.Running
+			alive = obs.Alive
+		}
+		if err != nil || !running || !alive {
+			err = fmt.Errorf("session %q died during startup", item.candidate.name())
+		}
+	}
+	finished := time.Now()
+	rollbackPending := err != nil && shouldRollbackPendingCreate(item.candidate.session)
+	if err != nil && rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
+		return startResult{
+			prepared:        item,
+			err:             nil,
+			outcome:         "start_error_converged",
+			started:         started,
+			finished:        finished,
+			rollbackPending: false,
+		}
+	}
+	var outcome string
+	switch {
+	case err == nil:
+		outcome = "success"
+	case startCtx.Err() == context.DeadlineExceeded:
+		outcome = "deadline_exceeded"
+	case startCtx.Err() == context.Canceled:
+		outcome = "canceled"
+	case errors.Is(err, runtime.ErrSessionInitializing):
+		outcome = "session_initializing"
+		err = nil
+	case errors.Is(err, runtime.ErrSessionExists):
+		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		switch {
+		case runningErr != nil || !running:
+			outcome = "provider_error"
+		case rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
+			outcome = "session_exists_converged"
+			err = nil
+			rollbackPending = false
+		default:
+			outcome = "session_exists"
+		}
+	default:
+		outcome = "provider_error"
+	}
+	return startResult{
+		prepared:        item,
+		err:             err,
+		outcome:         outcome,
+		started:         started,
+		finished:        finished,
+		rollbackPending: rollbackPending,
+	}
+}
+
+func enqueuePreparedStartWaveForCity(
+	ctx context.Context,
+	prepared []preparedStart,
+	cityPath string,
+	sp runtime.Provider,
+	store beads.Store,
+	cfg *config.City,
+	clk clock.Clock,
+	rec events.Recorder,
+	startupTimeout time.Duration,
+	wave int,
+	stdout, stderr io.Writer,
+) []startResult {
+	if len(prepared) == 0 {
+		return nil
+	}
+	results := make([]startResult, len(prepared))
+	for i, item := range prepared {
+		item = clonePreparedStartForAsync(item)
+		now := time.Now()
+		results[i] = startResult{
+			prepared: item,
+			outcome:  "start_enqueued",
+			started:  now,
+			finished: now,
+		}
+		go func(item preparedStart) {
+			result := runPreparedStartCandidate(ctx, item, cityPath, sp, store, cfg, startupTimeout)
+			if result.err == nil && result.outcome != "session_initializing" {
+				clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())
+			}
+			commitStartResultTraced(result, store, clk, rec, wave, stdout, stderr, nil)
+		}(item)
+	}
+	return results
+}
+
+func clonePreparedStartForAsync(item preparedStart) preparedStart {
+	if item.candidate.session == nil {
+		return item
+	}
+	sessionCopy := *item.candidate.session
+	if item.candidate.session.Labels != nil {
+		sessionCopy.Labels = append([]string(nil), item.candidate.session.Labels...)
+	}
+	if item.candidate.session.Metadata != nil {
+		sessionCopy.Metadata = make(map[string]string, len(item.candidate.session.Metadata))
+		for key, value := range item.candidate.session.Metadata {
+			sessionCopy.Metadata[key] = value
+		}
+	}
+	item.candidate.session = &sessionCopy
+	return item
 }
 
 func startPreparedStartCandidate(
@@ -950,9 +1036,16 @@ func executePlannedStartsTraced(
 	startupTimeout time.Duration,
 	stdout, stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
+	options ...startExecutionOption,
 ) int {
 	if len(candidates) == 0 {
 		return 0
+	}
+	startOpts := startExecutionOptions{}
+	for _, apply := range options {
+		if apply != nil {
+			apply(&startOpts)
+		}
 	}
 	maxWakes := cfg.Daemon.MaxWakesPerTickOrDefault()
 	waveByCandidate, ok := candidateWaveOrder(candidates, cfg, desiredState, sp, cityName, store)
@@ -1015,13 +1108,23 @@ func executePlannedStartsTraced(
 				prepared = append(prepared, *item)
 			}
 			offset = end
-			results := executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
+			var results []startResult
+			if startOpts.async {
+				results = enqueuePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr)
+			} else {
+				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
+			}
 			for _, result := range results {
 				if trace != nil {
 					trace.recordOperation("reconciler.start.execute", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), "", "start", result.outcome, traceRecordPayload{
 						"rollback_pending": result.rollbackPending,
 						"duration_ms":      result.finished.Sub(result.started).Milliseconds(),
 					}, "")
+				}
+				if result.outcome == "start_enqueued" {
+					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), result.outcome, result.started, result.finished, nil)
+					wakeCount++
+					continue
 				}
 				if result.err == nil && result.outcome != "session_initializing" {
 					clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -934,6 +934,158 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 	}
 }
 
+func TestExecutePlannedStartsTraced_AsyncReturnsBeforeProviderStartCompletes(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	tp := TemplateParams{
+		Command:      "worker",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	desired := map[string]TemplateParams{"worker": tp}
+
+	done := make(chan int, 1)
+	go func() {
+		done <- executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{{session: &session, tp: tp}},
+			cfg,
+			desired,
+			sp,
+			store,
+			"test-city",
+			"",
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			ioDiscard{},
+			nil,
+			withAsyncStartExecution(),
+		)
+	}()
+
+	select {
+	case woken := <-done:
+		if woken != 1 {
+			t.Fatalf("woken = %d, want 1", woken)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("async planned start blocked waiting for provider Start to finish")
+	}
+	sp.waitForStarts(t, 1)
+
+	inFlight, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inFlight.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want true until async start commits", inFlight.Metadata["pending_create_claim"])
+	}
+	if inFlight.Metadata["last_woke_at"] == "" {
+		t.Fatal("last_woke_at was not stamped before async start")
+	}
+
+	sp.release("worker")
+	deadline := time.After(2 * time.Second)
+	for {
+		updated, err := store.Get(session.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if updated.Metadata["state"] == "active" && updated.Metadata["pending_create_claim"] == "" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("async start did not commit active state; metadata=%v", updated.Metadata)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 0, 30, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	tp := TemplateParams{
+		Command:      "worker",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		map[string]TemplateParams{"worker": tp},
+		configuredSessionNames(cfg, "", store),
+		cfg,
+		sp,
+		store,
+		nil,
+		nil,
+		nil,
+		newDrainTracker(),
+		map[string]int{"worker": 1},
+		false,
+		map[string]bool{"worker": true},
+		"test-city",
+		nil,
+		clk,
+		events.Discard,
+		time.Minute,
+		0,
+		ioDiscard{},
+		ioDiscard{},
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 while start is already in flight", woken)
+	}
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+}
+
 // When the atomic start batch fails, NO state change lands: state stays
 // "creating", pending_create_claim stays "true", and the post-create marker
 // is absent. The reconciler's next tick retries via recoverRunningPendingCreate.

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -137,6 +137,28 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 	return agent != nil && !agent.Suspended
 }
 
+func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+		return false
+	}
+	lastWoke := strings.TrimSpace(session.Metadata["last_woke_at"])
+	if lastWoke == "" {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, lastWoke)
+	if err != nil {
+		return false
+	}
+	if startupTimeout <= 0 {
+		startupTimeout = time.Minute
+	}
+	now := time.Now()
+	if clk != nil {
+		now = clk.Now()
+	}
+	return now.Before(started.Add(startupTimeout + staleKeyDetectDelay + 5*time.Second))
+}
+
 // reconcileSessionBeads performs bead-driven reconciliation using wake/sleep
 // semantics. For each session bead, it determines if the session should be
 // awake (has a matching entry in the desired state) and manages lifecycle
@@ -249,6 +271,7 @@ func reconcileSessionBeadsTraced(
 	driftDrainTimeout time.Duration,
 	stdout, stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
+	startOptions ...startExecutionOption,
 ) int {
 	deps := buildDepsMap(cfg)
 	if cityName == "" {
@@ -991,6 +1014,15 @@ func reconcileSessionBeadsTraced(
 			if sessionIsQuarantined(*target.session, clk) {
 				continue // crash-loop protection
 			}
+			if pendingCreateStartInFlight(*target.session, clk, startupTimeout) {
+				if trace != nil {
+					trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_in_flight", traceRecordPayload{
+						"pending_create_claim": strings.TrimSpace(target.session.Metadata["pending_create_claim"]),
+						"last_woke_at":         target.session.Metadata["last_woke_at"],
+					}, nil, "")
+				}
+				continue
+			}
 			if trace != nil {
 				trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_candidate", traceRecordPayload{
 					"should_wake": shouldWake,
@@ -1098,6 +1130,7 @@ func reconcileSessionBeadsTraced(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
+		startOptions...,
 	)
 
 	// Phase 2: Advance all in-flight drains.


### PR DESCRIPTION
## Summary
- refactor planned session start execution so provider Start can run in a background goroutine
- opt the main bead reconcile tick into async start execution while leaving direct/helper callers synchronous
- skip duplicate wake attempts while a pending-create start is still inside its startup window

## Dependency
This PR intentionally targets `split/session-lifecycle-correctness` / PR #1336. The async path relies on that PR's pending-create claim invariants and atomic start commit behavior, so keeping it dependent makes the risky change smaller and easier to review.

## Tests
- `go test ./cmd/gc -run 'TestExecutePlannedStartsTraced_AsyncReturnsBeforeProviderStartCompletes|TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight'`\n- `go test ./cmd/gc -run 'Test.*(AsyncReturnsBeforeProviderStartCompletes|SkipsPendingCreateStartAlreadyInFlight|PendingCreate|CommitStartResult|RecoverRunningPendingCreate|Stale|Zombie|CityStop|NamedSession|DrainAck|PendingPool|SessionLifecycle|RevalidatesDependenciesBetweenWaveBatches)'`\n- `go test ./cmd/gc -run 'TestExecutePlannedStartsTraced_AsyncReturnsBeforeProviderStartCompletes|TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight|Test.*(SessionReconcile|ReconcileSessionBeads|ExecutePlannedStarts|CommitStartResult|RecoverRunningPendingCreate|CityRuntime|BeadReconcile)'`\n- `git diff --check HEAD~1..HEAD`