### PR TITLE
perf(wait): use session snapshot for wait nudges

### DIFF
--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -564,6 +564,10 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 	if err != nil {
 		return nil, err
 	}
+	sessionBeads, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		return nil, err
+	}
 	readyWaitSet := make(map[string]bool)
 	for _, wait := range waits {
 		state := wait.Metadata["state"]
@@ -574,8 +578,8 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 		if isWaitTerminal(state) {
 			continue
 		}
-		sessionBead, err := store.Get(sessionID)
-		if err != nil {
+		sessionBead, ok := sessionBeads.FindByID(sessionID)
+		if !ok {
 			continue
 		}
 		if epoch := wait.Metadata["registered_epoch"]; epoch != "" && sessionBead.Metadata["continuation_epoch"] != "" && epoch != sessionBead.Metadata["continuation_epoch"] {
@@ -657,6 +661,10 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 	if err != nil {
 		return err
 	}
+	sessionBeads, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		return err
+	}
 	for _, wait := range waits {
 		if wait.Metadata["state"] != waitStateReady {
 			continue
@@ -665,12 +673,11 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 		if sessionID == "" {
 			continue
 		}
-		sessionBead, err := store.Get(sessionID)
-		if err != nil {
+		sessionBead, ok := sessionBeads.FindByID(sessionID)
+		if !ok {
 			continue
 		}
-		running, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, nil, sessionID)
-		if err != nil || !running {
+		if !cachedSessionCanReceiveWaitNudge(sessionBead) {
 			continue
 		}
 		nudgeID := waitNudgeID(wait)
@@ -709,6 +716,18 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 		}
 	}
 	return nil
+}
+
+func cachedSessionCanReceiveWaitNudge(sessionBead beads.Bead) bool {
+	if sessionBead.Status == "closed" {
+		return false
+	}
+	switch sessionpkg.State(strings.TrimSpace(sessionBead.Metadata["state"])) {
+	case "", sessionpkg.StateActive, sessionpkg.StateAwake:
+		return true
+	default:
+		return false
+	}
 }
 
 func finalizeReadyWaitFromNudge(store beads.Store, wait beads.Bead, now time.Time) (bool, error) {

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -29,11 +29,21 @@ type waitNudgeMetadataFailStore struct {
 	*beads.MemStore
 }
 
+type waitGetSpyStore struct {
+	beads.Store
+	getIDs []string
+}
+
 func (s waitNudgeMetadataFailStore) SetMetadata(id, key, value string) error {
 	if key == "nudge_id" {
 		return errors.New("set nudge id failed")
 	}
 	return s.MemStore.SetMetadata(id, key, value)
+}
+
+func (s *waitGetSpyStore) Get(id string) (beads.Bead, error) {
+	s.getIDs = append(s.getIDs, id)
+	return s.Store.Get(id)
 }
 
 var (
@@ -432,6 +442,53 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 	}
 }
 
+func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "1",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"registered_epoch": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if len(readyWaitSet) != 0 {
+		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
+	}
+	for _, id := range store.getIDs {
+		if id == sessionBead.ID {
+			t.Fatalf("prepare used Get for non-open session %s; getIDs=%v", sessionBead.ID, store.getIDs)
+		}
+	}
+}
+
 func TestDepsWaitReady_IgnoresEmptyDependencyEntries(t *testing.T) {
 	store := beads.NewMemStore()
 	dep, err := store.Create(beads.Bead{Title: "dep"})
@@ -735,6 +792,111 @@ func TestDispatchReadyWaitNudges_EnqueuesDeterministicNudge(t *testing.T) {
 	}
 	if _, err := refreshedStore.Get(pending[0].BeadID); err != nil {
 		t.Fatalf("refreshedStore.Get(%s): %v", pending[0].BeadID, err)
+	}
+}
+
+func TestDispatchReadyWaitNudges_UsesOpenSessionSnapshotInsteadOfWorkerRunningCheck(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"template":           "worker",
+			"continuation_epoch": "1",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:        waitBeadType,
+		Labels:      []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Description: "Continue after review closes.",
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"dep_ids":          "gc-1",
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	sp := runtime.NewFake()
+
+	if err := dispatchReadyWaitNudges(dir, store, sp, time.Now().UTC()); err != nil {
+		t.Fatalf("dispatchReadyWaitNudges: %v", err)
+	}
+	for _, id := range store.getIDs {
+		if id == sessionBead.ID {
+			t.Fatalf("dispatch used Get for session %s instead of the open-session snapshot; getIDs=%v", sessionBead.ID, store.getIDs)
+		}
+	}
+	for _, call := range sp.Calls {
+		switch call.Method {
+		case "IsRunning", "ProcessAlive", "IsAttached", "GetLastActivity", "GetMeta":
+			t.Fatalf("dispatch should trust cached session state, saw provider call %#v", call)
+		}
+	}
+}
+
+func TestDispatchReadyWaitNudges_SkipsClosedSessionWithoutBackingGet(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"template":           "worker",
+			"continuation_epoch": "1",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	sp := runtime.NewFake()
+
+	if err := dispatchReadyWaitNudges(dir, store, sp, time.Now().UTC()); err != nil {
+		t.Fatalf("dispatchReadyWaitNudges: %v", err)
+	}
+	for _, id := range store.getIDs {
+		if id == sessionBead.ID {
+			t.Fatalf("dispatch used Get for closed session %s; getIDs=%v", sessionBead.ID, store.getIDs)
+		}
+	}
+	if len(sp.Calls) != 0 {
+		t.Fatalf("dispatch should not query provider for a session absent from the open-session snapshot, calls=%#v", sp.Calls)
 	}
 }
 

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -116,6 +116,30 @@ func (s *sessionBeadSnapshot) FindSessionNameByTemplate(template string) string 
 	return s.sessionNameByTemplateHint[template]
 }
 
+func (s *sessionBeadSnapshot) FindByID(id string) (beads.Bead, bool) {
+	if s == nil || strings.TrimSpace(id) == "" {
+		return beads.Bead{}, false
+	}
+	for _, bead := range s.open {
+		if bead.ID == id {
+			return bead, true
+		}
+	}
+	return beads.Bead{}, false
+}
+
+func (s *sessionBeadSnapshot) FindBySessionName(name string) (beads.Bead, bool) {
+	if s == nil || strings.TrimSpace(name) == "" {
+		return beads.Bead{}, false
+	}
+	for _, bead := range s.open {
+		if strings.TrimSpace(bead.Metadata["session_name"]) == name {
+			return bead, true
+		}
+	}
+	return beads.Bead{}, false
+}
+
 func (s *sessionBeadSnapshot) FindSessionNameByNamedIdentity(identity string) string {
 	if s == nil || strings.TrimSpace(identity) == "" {
 		return ""


### PR DESCRIPTION
## Summary
- load the open session-bead snapshot once during wait preparation and ready-nudge dispatch
- avoid per-wait session `Get` calls and live provider running checks when deciding whether to enqueue ready wait nudges
- add snapshot lookup helpers and regression coverage for closed/missing session beads

## Tests
- `go test ./cmd/gc -run 'TestPrepareWaitWakeState|TestDispatchReadyWaitNudges|TestDepsWaitReady'`\n- `go test ./cmd/gc -run 'Test.*Wait|Test.*Nudge'`\n- `go test ./cmd/gc -run 'TestPrepareWaitWakeState|TestDispatchReadyWaitNudges|TestDepsWaitReady|Test.*Wait|Test.*Nudge'`\n- `git diff --check HEAD~1..HEAD`