### PR TITLE
fix(config): normalize provider option flag aliases

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -160,14 +160,71 @@ func ReplaceSchemaFlags(command string, schema []ProviderOption, overrideArgs []
 // independent flag group can be matched separately during stripping.
 func CollectAllSchemaFlags(schema []ProviderOption) [][]string {
 	var flags [][]string
+	seen := make(map[string]bool)
 	for _, opt := range schema {
 		for _, choice := range opt.Choices {
 			if len(choice.FlagArgs) > 0 {
-				flags = append(flags, splitFlagArgs(choice.FlagArgs)...)
+				for _, seq := range splitFlagArgs(choice.FlagArgs) {
+					for _, expanded := range expandEquivalentFlagSequences(seq) {
+						key := strings.Join(expanded, "\x00")
+						if seen[key] {
+							continue
+						}
+						seen[key] = true
+						flags = append(flags, expanded)
+					}
+				}
 			}
 		}
 	}
 	return flags
+}
+
+func expandEquivalentFlagSequences(seq []string) [][]string {
+	if len(seq) == 0 {
+		return nil
+	}
+	var out [][]string
+	add := func(candidate []string) {
+		copied := make([]string, len(candidate))
+		copy(copied, candidate)
+		out = append(out, copied)
+	}
+	add(seq)
+	if len(seq) == 2 && seq[0] == "--model" {
+		add([]string{"-m", seq[1]})
+	}
+	if len(seq) == 2 && seq[0] == "-m" {
+		add([]string{"--model", seq[1]})
+	}
+	if len(seq) == 2 && seq[0] == "-c" {
+		if quoted, ok := quoteAssignmentValue(seq[1]); ok {
+			add([]string{seq[0], quoted})
+		}
+		if unquoted, ok := unquoteAssignmentValue(seq[1]); ok {
+			add([]string{seq[0], unquoted})
+		}
+	}
+	return out
+}
+
+func quoteAssignmentValue(value string) (string, bool) {
+	key, val, ok := strings.Cut(value, "=")
+	if !ok || key == "" || val == "" || strings.HasPrefix(val, "\"") {
+		return "", false
+	}
+	return key + "=\"" + val + "\"", true
+}
+
+func unquoteAssignmentValue(value string) (string, bool) {
+	key, val, ok := strings.Cut(value, "=")
+	if !ok || key == "" || len(val) < 2 {
+		return "", false
+	}
+	if !strings.HasPrefix(val, "\"") || !strings.HasSuffix(val, "\"") {
+		return "", false
+	}
+	return key + "=" + strings.Trim(val, "\""), true
 }
 
 // splitFlagArgs splits a FlagArgs slice into independent flag groups at
@@ -290,12 +347,37 @@ func inferChoiceFromFlags(schema []ProviderOption, flagSeq []string, defaults ma
 			continue
 		}
 		for _, choice := range opt.Choices {
-			if flagsEqual(choice.FlagArgs, flagSeq) {
+			if flagsEquivalent(choice.FlagArgs, flagSeq) {
 				defaults[opt.Key] = choice.Value
 				return
 			}
 		}
 	}
+}
+
+func flagsEquivalent(a, b []string) bool {
+	if flagsEqual(a, b) {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if normalizeFlagToken(a[i]) != normalizeFlagToken(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeFlagToken(token string) string {
+	if token == "-m" {
+		return "--model"
+	}
+	if normalized, ok := unquoteAssignmentValue(token); ok {
+		return normalized
+	}
+	return token
 }
 
 func flagsEqual(a, b []string) bool {

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -118,6 +118,34 @@ func TestResolveOptions_EffectiveDefaultsOverrideSchemaDefaults(t *testing.T) {
 	}
 }
 
+func TestReplaceSchemaFlagsStripsCodexAliases(t *testing.T) {
+	codex := BuiltinProviders()["codex"]
+	defaultArgs := []string{
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--model", "gpt-5.5",
+		"-c", "model_reasoning_effort=xhigh",
+	}
+
+	got := ReplaceSchemaFlags(
+		`aimux run codex -- -m gpt-5.5 -c 'model_reasoning_effort="xhigh"'`,
+		codex.OptionsSchema,
+		defaultArgs,
+	)
+
+	if strings.Count(got, "gpt-5.5") != 1 {
+		t.Fatalf("ReplaceSchemaFlags() = %q, want one model flag", got)
+	}
+	if strings.Count(got, "model_reasoning_effort") != 1 {
+		t.Fatalf("ReplaceSchemaFlags() = %q, want one effort flag", got)
+	}
+	if !strings.Contains(got, "--model gpt-5.5") {
+		t.Fatalf("ReplaceSchemaFlags() = %q, want canonical model flag", got)
+	}
+	if strings.Contains(got, "-m gpt-5.5") || strings.Contains(got, `model_reasoning_effort=\"xhigh\"`) {
+		t.Fatalf("ReplaceSchemaFlags() = %q, retained non-canonical schema flag", got)
+	}
+}
+
 func TestResolveOptions_UserOptionOverridesEffectiveDefault(t *testing.T) {
 	schema := []ProviderOption{
 		{

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -627,6 +628,48 @@ func TestResolveProviderBaseChainEmitsDangerousBypass(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("ResolveDefaultArgs() = %v, missing %q — session would hang on first sandboxed command", args, want)
+	}
+}
+
+func TestResolveProviderBaseChainStripsCodexAliases(t *testing.T) {
+	b := "builtin:codex"
+	city := map[string]ProviderSpec{
+		"codex-max": {
+			Base:    &b,
+			Command: "aimux",
+			Args: []string{
+				"run", "codex", "--",
+				"--dangerously-bypass-approvals-and-sandbox",
+				"-m", "gpt-5.5",
+				"-c", "model_reasoning_effort=\"xhigh\"",
+			},
+			ResumeCommand: "aimux run codex -- --dangerously-bypass-approvals-and-sandbox -m gpt-5.5 resume {{.SessionKey}}",
+		},
+	}
+	agent := &Agent{Name: "codex-max", Provider: "codex-max"}
+	resolved, err := ResolveProvider(agent, nil, city, lookPathAll)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	wantArgs := []string{"run", "codex", "--"}
+	if !reflect.DeepEqual(resolved.Args, wantArgs) {
+		t.Fatalf("Args = %v, want %v", resolved.Args, wantArgs)
+	}
+	if got := resolved.EffectiveDefaults["model"]; got != "gpt-5.5" {
+		t.Fatalf("EffectiveDefaults[model] = %q, want gpt-5.5", got)
+	}
+	if got := resolved.EffectiveDefaults["effort"]; got != "xhigh" {
+		t.Fatalf("EffectiveDefaults[effort] = %q, want xhigh", got)
+	}
+	command := resolved.CommandString()
+	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
+		command = command + " " + strings.Join(defaultArgs, " ")
+	}
+	if strings.Count(command, "gpt-5.5") != 1 {
+		t.Fatalf("resolved launch command = %q, want one model flag", command)
+	}
+	if strings.Count(command, "model_reasoning_effort") != 1 {
+		t.Fatalf("resolved launch command = %q, want one effort flag", command)
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat Codex `-m` and `--model` as equivalent schema flags
- normalize quoted/unquoted assignment values for `-c model_reasoning_effort=...`
- prevent provider chains from keeping duplicate non-canonical model/effort flags

## Tests
- `go test ./internal/config -run 'TestReplaceSchemaFlagsStripsCodexAliases|TestResolveProviderBaseChainStripsCodexAliases|TestResolveProviderBaseChainEmitsDangerousBypass|TestResolveOptions'`\n- `git diff --check HEAD~1..HEAD`