### PR TITLE
fix(codex): emit hook context as Codex JSON

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -248,7 +248,7 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	if inject {
 		if hasWork {
 			content := formatHookInjectReminder(normalized)
-			_ = writeProviderHookContext(stdout, hookFormat, content)
+			_ = writeProviderHookContextForEvent(stdout, hookFormat, "Stop", content)
 		}
 		return 0 // --inject always exits 0
 	}

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -213,7 +213,7 @@ func doMailCheckTargetWithFormat(mp mail.Provider, target resolvedMailTarget, in
 
 	if inject {
 		if len(messages) > 0 {
-			_ = writeProviderHookContext(stdout, hookFormat, formatInjectOutput(messages))
+			_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatInjectOutput(messages))
 		}
 		return 0 // --inject always exits 0
 	}

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -357,7 +357,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 	}
 	var writeErr error
 	if inject {
-		writeErr = writeProviderHookContext(stdout, hookFormat, out)
+		writeErr = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", out)
 	} else {
 		_, writeErr = io.WriteString(stdout, out)
 	}

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -175,7 +175,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: no city config found: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
+		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 		return 0
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
@@ -184,7 +184,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: loading city config: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
+		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 		return 0
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
@@ -317,7 +317,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// when the agent has no prompt_template and doesn't match a builtin
 	// worker prompt — a supported config shape, so the default prompt is
 	// the correct output even under --strict.
-	fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
+	writePrimePromptWithFormat(stdout, "", agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 	return 0
 }
 
@@ -396,7 +396,7 @@ func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt st
 		prompt = prependHookBeacon(cityName, agentName, prompt)
 	}
 	if hookMode && hookFormat != "" {
-		_ = writeProviderHookContext(stdout, hookFormat, prompt)
+		_ = writeProviderHookContextForEvent(stdout, hookFormat, "SessionStart", prompt)
 		return
 	}
 	fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -428,6 +428,34 @@ prompt_template = "prompts/worker.md"
 	}
 }
 
+func TestDoPrimeWithHookFormat_FormatsDefaultFallback(t *testing.T) {
+	t.Setenv("GC_CITY", filepath.Join(t.TempDir(), "missing-city"))
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not hook JSON: %v\n%s", err, stdout.String())
+	}
+	if got, want := payload.HookSpecificOutput.HookEventName, "SessionStart"; got != want {
+		t.Fatalf("hookEventName = %q, want %q", got, want)
+	}
+	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, "# Gas City Agent") {
+		t.Fatalf("additionalContext = %q, want default prime prompt", payload.HookSpecificOutput.AdditionalContext)
+	}
+}
+
 func withPrimeHookStdin(t *testing.T, payload map[string]string) {
 	t.Helper()
 

--- a/cmd/gc/hook_output.go
+++ b/cmd/gc/hook_output.go
@@ -6,17 +6,39 @@ import (
 	"strings"
 )
 
-const hookOutputFormatGemini = "gemini"
+const (
+	hookOutputFormatCodex  = "codex"
+	hookOutputFormatGemini = "gemini"
+)
 
 func writeProviderHookContext(stdout io.Writer, format, content string) error {
+	return writeProviderHookContextForEvent(stdout, format, "", content)
+}
+
+func writeProviderHookContextForEvent(stdout io.Writer, format, eventName, content string) error {
 	if content == "" {
 		return nil
 	}
-	if strings.EqualFold(strings.TrimSpace(format), hookOutputFormatGemini) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case hookOutputFormatCodex:
+		return json.NewEncoder(stdout).Encode(codexHookAdditionalContext(eventName, content))
+	case hookOutputFormatGemini:
 		return json.NewEncoder(stdout).Encode(geminiHookAdditionalContext(content))
 	}
 	_, err := io.WriteString(stdout, content)
 	return err
+}
+
+func codexHookAdditionalContext(eventName, content string) map[string]any {
+	if eventName == "" {
+		eventName = "SessionStart"
+	}
+	return map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":     eventName,
+			"additionalContext": strings.TrimRight(content, "\n"),
+		},
+	}
 }
 
 func geminiHookAdditionalContext(content string) map[string]any {

--- a/cmd/gc/hook_output_test.go
+++ b/cmd/gc/hook_output_test.go
@@ -26,6 +26,30 @@ func TestWriteProviderHookContextGemini(t *testing.T) {
 	}
 }
 
+func TestWriteProviderHookContextCodex(t *testing.T) {
+	var out bytes.Buffer
+	err := writeProviderHookContextForEvent(&out, "codex", "Stop", "<system-reminder>\nhello\n</system-reminder>\n")
+	if err != nil {
+		t.Fatalf("writeProviderHookContextForEvent: %v", err)
+	}
+
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out.String())
+	}
+	if got, want := payload.HookSpecificOutput.HookEventName, "Stop"; got != want {
+		t.Fatalf("hookEventName = %q, want %q", got, want)
+	}
+	if got, want := payload.HookSpecificOutput.AdditionalContext, "<system-reminder>\nhello\n</system-reminder>"; got != want {
+		t.Fatalf("additionalContext = %q, want %q", got, want)
+	}
+}
+
 func TestWriteProviderHookContextPlain(t *testing.T) {
 	var out bytes.Buffer
 	err := writeProviderHookContext(&out, "", "<system-reminder>\nhello\n</system-reminder>\n")

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
           }
         ]
       }
@@ -17,11 +17,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject --hook-format codex"
           },
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject --hook-format codex"
           }
         ]
       }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject --hook-format codex"
           }
         ]
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -158,6 +158,9 @@ func overlayManagedNeedsUpgrade(provider, rel string) func([]byte) bool {
 	if provider == "pi" && rel == path.Join(".pi", "extensions", "gc-hooks.js") {
 		return piHookNeedsUpgrade
 	}
+	if provider == "codex" && rel == path.Join(".codex", "hooks.json") {
+		return codexFileNeedsUpgrade
+	}
 	return nil
 }
 
@@ -342,6 +345,18 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 		return candidateMissing, nil, nil
 	}
 	return candidateUnreadable, nil, err
+}
+
+func codexFileNeedsUpgrade(existing []byte) bool {
+	content := string(existing)
+	return codexContainsManagedHook(content) && !strings.Contains(content, `--hook-format codex`)
+}
+
+func codexContainsManagedHook(content string) bool {
+	return strings.Contains(content, `gc prime --hook`) ||
+		strings.Contains(content, `gc nudge drain --inject`) ||
+		strings.Contains(content, `gc mail check --inject`) ||
+		strings.Contains(content, `gc hook --inject`)
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -231,6 +231,29 @@ func TestInstallClaudeUpgradesGeneratedFileSessionStartMatcher(t *testing.T) {
 	}
 }
 
+func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, "--hook-format codex") {
+		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
+	}
+}
+
 func TestInstallClaudeUpgradesGeneratedFileWithCombinedKnownDrift(t *testing.T) {
 	fs := fsys.NewFake()
 	current, err := readEmbedded("config/claude.json")
@@ -683,6 +706,10 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 		if _, ok := fs.Files[rel]; !ok {
 			t.Errorf("expected overlay-managed provider file %s to be written", rel)
 		}
+	}
+	codexHooks := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(codexHooks, "--hook-format codex") {
+		t.Error("codex hooks should request Codex hook output format")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add hook-format selection so Codex provider hooks emit structured JSON
- update generated Codex hooks to pass --hook-format codex for prime/hook/mail/nudge
- upgrade generated Codex hook files that predate the hook-format flag

## Tests
- go test ./cmd/gc -run 'TestWriteProviderHookContext|TestDoPrimeWithHookFormat_FormatsDefaultFallback|TestPrime|TestHook|TestNudge|TestMail'\n- go test ./internal/hooks -run 'TestInstallCodexUpgradesGeneratedFileMissingHookFormat|TestInstallOverlayManagedProviders|TestInstallPiHookUsesCurrentExtensionAPI'\n- git diff --check HEAD~1..HEAD