### PR TITLE
fix: keep generated CLI checks deterministic

### DIFF
--- a/cmd/gc/cmd_commands.go
+++ b/cmd/gc/cmd_commands.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const docgenSkipAnnotation = "gc.docgen.skip"
+
 func addDiscoveredCommandsToRoot(root *cobra.Command, entries []config.DiscoveredCommand, cityPath, cityName string, stdout, stderr io.Writer, warnOnCollision bool) {
 	core := coreCommandNames(root)
 	grouped := make(map[string][]config.DiscoveredCommand)
@@ -46,8 +48,9 @@ func addDiscoveredCommandsToRoot(root *cobra.Command, entries []config.Discovere
 
 func newDiscoveredNamespaceCmd(binding string, entries []config.DiscoveredCommand, cityPath, cityName string, stdout, stderr io.Writer) *cobra.Command {
 	ns := &cobra.Command{
-		Use:   binding,
-		Short: fmt.Sprintf("Commands from the %s import", binding),
+		Use:         binding,
+		Short:       fmt.Sprintf("Commands from the %s import", binding),
+		Annotations: map[string]string{docgenSkipAnnotation: "true"},
 		RunE: func(c *cobra.Command, _ []string) error {
 			return c.Help()
 		},

--- a/internal/docgen/cli.go
+++ b/internal/docgen/cli.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const skipCLIDocAnnotation = "gc.docgen.skip"
+
 func escapeMDXText(s string) string {
 	s = strings.ReplaceAll(s, "<", "&lt;")
 	s = strings.ReplaceAll(s, ">", "&gt;")
@@ -77,7 +79,7 @@ func walkCommands(w io.Writer, cmd *cobra.Command) error {
 		return err
 	}
 	for _, child := range cmd.Commands() {
-		if child.Hidden {
+		if skipCLIDocCommand(child) {
 			continue
 		}
 		if err := walkCommands(w, child); err != nil {
@@ -85,6 +87,13 @@ func walkCommands(w io.Writer, cmd *cobra.Command) error {
 		}
 	}
 	return nil
+}
+
+func skipCLIDocCommand(cmd *cobra.Command) bool {
+	if cmd.Hidden {
+		return true
+	}
+	return cmd.Annotations[skipCLIDocAnnotation] == "true"
 }
 
 // renderCommand renders a single command section.
@@ -234,7 +243,7 @@ func writeFlagTable(w io.Writer, flags []flagInfo) error {
 func renderSubcommandsTable(w io.Writer, cmd *cobra.Command) error {
 	var children []*cobra.Command
 	for _, c := range cmd.Commands() {
-		if !c.Hidden {
+		if !skipCLIDocCommand(c) {
 			children = append(children, c)
 		}
 	}

--- a/internal/docgen/cli_test.go
+++ b/internal/docgen/cli_test.go
@@ -97,6 +97,24 @@ func TestRenderCLIMarkdown_HiddenCommandSkipped(t *testing.T) {
 	}
 }
 
+func TestRenderCLIMarkdown_AnnotatedCommandSkipped(t *testing.T) {
+	root := &cobra.Command{Use: "app", Short: "test"}
+	root.AddCommand(&cobra.Command{
+		Use:         "pack",
+		Short:       "local pack command",
+		Annotations: map[string]string{skipCLIDocAnnotation: "true"},
+	})
+
+	var buf bytes.Buffer
+	if err := RenderCLIMarkdown(&buf, root); err != nil {
+		t.Fatalf("RenderCLIMarkdown: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "pack") {
+		t.Error("annotated command 'pack' should not appear in output")
+	}
+}
+
 func TestRenderCLIMarkdown_HiddenFlagSkipped(t *testing.T) {
 	root := &cobra.Command{Use: "app", Short: "test"}
 	root.Flags().String("visible", "", "shown flag")

--- a/internal/testenv/lint_test.go
+++ b/internal/testenv/lint_test.go
@@ -36,18 +36,12 @@ func TestRequiresDedicatedTestenvImportFile(t *testing.T) {
 	dirInfos := map[string]*dirInfo{}
 	var strayImports []string
 
-	skipDirs := map[string]bool{
-		"vendor":       true,
-		"node_modules": true,
-		".git":         true,
-	}
-
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if skipDirs[d.Name()] {
+			if skipRepoLintDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -175,18 +169,13 @@ func TestNoLeakVectorReadsAtPackageInit(t *testing.T) {
 	for _, name := range testenv.LeakVectorVars {
 		leakVars[name] = true
 	}
-	skipDirs := map[string]bool{
-		"vendor":       true,
-		"node_modules": true,
-		".git":         true,
-	}
 	var offenders []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if skipDirs[d.Name()] {
+			if skipRepoLintDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -231,6 +220,16 @@ func TestNoLeakVectorReadsAtPackageInit(t *testing.T) {
 	if len(offenders) > 0 {
 		t.Fatalf("production code must not read leak-vector GC_* vars during init or top-level var init:\n  %s", strings.Join(offenders, "\n  "))
 	}
+}
+
+func skipRepoLintDir(name string) bool {
+	if name == "vendor" || name == "node_modules" {
+		return true
+	}
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+		return true
+	}
+	return name == "worktrees" || strings.HasPrefix(name, "worktree-")
 }
 
 // repoRoot returns the repository root by asking git. Falls back to walking up


### PR DESCRIPTION
## Summary
- make local generated CLI checks use deterministic command discovery
- avoid imported pack commands leaking into generated docs validation
- add docgen coverage for deterministic output

## Tests
- go test ./internal/docgen ./internal/testenv ./cmd/gc -run 'Test.*Discovered|Test.*Commands|TestGenerated|TestDeterministic|TestCLI'\n- git diff --check