### PR TITLE
fix: make graph workers claim routed beads

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4768,6 +4768,53 @@ max = -1
 	}
 }
 
+func TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork(t *testing.T) {
+	dir := t.TempDir()
+	if err := materializeBuiltinPrompts(dir); err != nil {
+		t.Fatalf("materializeBuiltinPrompts: %v", err)
+	}
+	tomlContent := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+dir = "myrig"
+start_command = "echo"
+
+[agent.pool]
+min = 0
+max = -1
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrime([]string{"worker"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "gc hook") {
+		t.Fatalf("graph-worker prompt missing gc hook routed-queue lookup:\n%s", out)
+	}
+	if !strings.Contains(out, "bd update <id> --claim") {
+		t.Fatalf("graph-worker prompt missing atomic claim instruction:\n%s", out)
+	}
+	if !strings.Contains(out, "Do not start work with `bd update --status in_progress`") {
+		t.Fatalf("graph-worker prompt missing guard against unassigned in_progress work:\n%s", out)
+	}
+}
+
 func materializeBuiltinPrompts(cityPath string) error {
 	return MaterializeBuiltinPacks(cityPath)
 }

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -22,6 +22,9 @@ bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
 
 # Step 3: If still nothing, check the routed queue (multi-session configs only)
 gc hook
+
+# Step 4: If gc hook returned an unassigned routed bead, claim it atomically
+bd update <id> --claim
 ```
 
 If you have no work after all three checks, run:
@@ -33,14 +36,17 @@ gc runtime drain-ack
 ## How To Work
 
 1. Find your assigned bead (see Startup above).
-2. Read it with `bd show <id>`.
-3. **Claim continuation group** (see below).
-4. Execute exactly that bead's description.
-5. On success, close it:
+2. If the bead came from `gc hook`, claim it with `bd update <id> --claim`
+   before doing any work. Do not start work with `bd update --status in_progress`;
+   only `--claim` sets both assignee and in-progress state atomically.
+3. Read it with `bd show <id>`.
+4. **Claim continuation group** (see below).
+5. Execute exactly that bead's description.
+6. On success, close it:
    ```bash
    bd update <id> --set-metadata gc.outcome=pass --status closed
    ```
-6. On transient failure, mark it transient and close it:
+7. On transient failure, mark it transient and close it:
    ```bash
    bd update <id> \
      --set-metadata gc.outcome=fail \
@@ -48,7 +54,7 @@ gc runtime drain-ack
      --set-metadata gc.failure_reason=<short_reason> \
      --status closed
    ```
-7. On unrecoverable failure, mark it hard-failed and close it:
+8. On unrecoverable failure, mark it hard-failed and close it:
    ```bash
    bd update <id> \
      --set-metadata gc.outcome=fail \
@@ -56,11 +62,11 @@ gc runtime drain-ack
      --set-metadata gc.failure_reason=<short_reason> \
      --status closed
    ```
-8. After closing, check for more assigned work:
+9. After closing, check for more assigned work:
    ```bash
    bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
    ```
-9. If more work exists, go to step 2. If not, poll briefly (see below).
+10. If more work exists, go to step 2. If not, poll briefly (see below).
 
 ## Continuation Group — Session Affinity
 


### PR DESCRIPTION
## Summary
- teach graph workers to claim beads returned by gc hook before acting
- document that bd update --status in_progress is not sufficient for routed unassigned work
- add prime prompt coverage so the claim instruction remains present

## Tests
- go test ./cmd/gc -run TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork
- git diff --check