### PR TITLE
fix: keep provider transcript fallbacks scoped

### DIFF
--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -427,8 +427,10 @@ func FindSessionFileForProvider(searchPaths []string, provider, workDir string) 
 		return FindCodexSessionFile(searchPaths, workDir)
 	case "gemini":
 		return FindGeminiSessionFile(searchPaths, workDir)
-	default:
+	case "", "auto":
 		return FindSessionFile(searchPaths, workDir)
+	default:
+		return findSlugSessionFile(searchPaths, workDir)
 	}
 }
 

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -130,6 +130,34 @@ func TestDiscoverPathCodexIgnoresGCSessionID(t *testing.T) {
 	}
 }
 
+func TestDiscoverPathClaudeDoesNotScanCodexFallback(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(t.TempDir(), "claude-project")
+
+	payload, err := json.Marshal(map[string]any{
+		"type": "session_meta",
+		"payload": map[string]string{
+			"cwd": workDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	codexRoot := filepath.Join(base, "sessions")
+	codexDir := filepath.Join(codexRoot, "2026", "04", "18")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "session.jsonl"), append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := DiscoverPath([]string{codexRoot}, "claude/tmux-cli", workDir, "")
+	if got != "" {
+		t.Fatalf("DiscoverPath() = %q, want no Codex fallback for explicit Claude provider", got)
+	}
+}
+
 func TestSupportsIDLookup(t *testing.T) {
 	tests := []struct {
 		provider string


### PR DESCRIPTION
## Summary
- restrict broad transcript fallback to auto provider detection
- keep explicit provider lookups on provider-specific slug fallback paths
- cover Claude discovery so it does not scan Codex transcript fallback logs

## Tests
- go test ./internal/sessionlog ./internal/worker/transcript -run 'TestFindSessionFileForProvider|TestDiscoverPathClaudeDoesNotScanCodexFallback|TestDiscoverPath'\n- git diff --check