### PR TITLE
perf(orders): cache dispatch last-run lookups

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -74,6 +75,9 @@ type memoryOrderDispatcher struct {
 	maxTimeout time.Duration
 	cfg        *config.City
 	cityName   string
+
+	cacheMu      sync.Mutex
+	lastRunCache map[string]time.Time
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -164,10 +168,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if legacyStore != nil {
 			storesForGate = append(storesForGate, legacyStore)
 		}
+		storeKeysForGate := []string{storeKey}
+		if legacyStore != nil {
+			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
+		}
 		baseLastRunFn := orders.LastRunAcrossStores(storesForGate...)
 		var lastRunErr error
 		lastRunFn := func(orderName string) (time.Time, error) {
-			last, err := baseLastRunFn(orderName)
+			last, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
 			if err != nil {
 				lastRunErr = err
 			}
@@ -215,6 +223,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
 			continue
 		}
+		m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
 
 		// Fire and forget with timeout.
 		a := a // capture loop variable
@@ -238,6 +247,41 @@ func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target
 	}
 	stores[key] = store
 	return store, true
+}
+
+func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []string, read orders.LastRunFunc) (time.Time, error) {
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	m.cacheMu.Lock()
+	if m.lastRunCache != nil {
+		if last, ok := m.lastRunCache[key]; ok {
+			m.cacheMu.Unlock()
+			return last, nil
+		}
+	}
+	m.cacheMu.Unlock()
+
+	last, err := read(orderName)
+	if err != nil {
+		return time.Time{}, err
+	}
+	m.rememberLastRun(orderName, storeKeys, last)
+	return last, nil
+}
+
+func (m *memoryOrderDispatcher) rememberLastRun(orderName string, storeKeys []string, last time.Time) {
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
+	if m.lastRunCache == nil {
+		m.lastRunCache = make(map[string]time.Time)
+	}
+	if existing, ok := m.lastRunCache[key]; !ok || existing.IsZero() || last.After(existing) {
+		m.lastRunCache[key] = last
+	}
+}
+
+func orderHistoryCacheKey(orderName string, storeKeys []string) string {
+	return orderName + "\x00" + strings.Join(storeKeys, "\x00")
 }
 
 // dispatchOne runs a single order dispatch in its own goroutine.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -42,6 +42,12 @@ type selectiveUpdateFailStore struct {
 	beads.Store
 }
 
+type countingListStore struct {
+	beads.Store
+
+	includeClosedLists int
+}
+
 func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error {
 	for _, label := range opts.Labels {
 		if strings.HasPrefix(label, "order-run:") {
@@ -49,6 +55,17 @@ func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error
 		}
 	}
 	return s.Store.Update(id, opts)
+}
+
+func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.IncludeClosed || query.Status == "closed" {
+		s.includeClosedLists++
+	}
+	return s.Store.List(query)
+}
+
+func (s *countingListStore) reset() {
+	s.includeClosedLists = 0
 }
 
 func TestOrderDispatcherNil(t *testing.T) {
@@ -198,6 +215,46 @@ func TestOrderDispatchMultiple(t *testing.T) {
 	}
 	if trackingCount != 1 {
 		t.Errorf("expected 1 tracking bead for order-a, got %d", trackingCount)
+	}
+}
+
+func TestOrderDispatchCachesLastRunBetweenDispatches(t *testing.T) {
+	store := &countingListStore{Store: beads.NewMemStore()}
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "recent run",
+		Labels: []string{"order-run:test-order"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "test-order",
+		Trigger:  "cooldown",
+		Interval: "1h",
+		Formula:  "test-formula",
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	cityPath := t.TempDir()
+	now := time.Now()
+	ad.dispatch(context.Background(), cityPath, now)
+	if store.includeClosedLists == 0 {
+		t.Fatal("first dispatch did not read persisted order history")
+	}
+
+	store.reset()
+	ad.dispatch(context.Background(), cityPath, now.Add(time.Second))
+	if store.includeClosedLists != 0 {
+		t.Fatalf("second dispatch performed %d closed-history reads, want cached last-run result", store.includeClosedLists)
+	}
+
+	all, _ := store.ListOpen()
+	if len(all) != 1 {
+		t.Errorf("expected only seed bead, got %d", len(all))
 	}
 }
 


### PR DESCRIPTION
## Summary
- cache order last-run timestamps inside the in-memory order dispatcher
- seed the cache immediately after creating a tracking bead so the next tick does not re-query closed history
- cover repeated dispatch checks to ensure persisted history is read once

## Tests
- go test ./cmd/gc -run 'TestOrderDispatchCachesLastRunBetweenDispatches|TestOrderDispatchConditionScopedToRigStore|TestOrderDispatchBeforeSessionReconcile'\n- git diff --check\n\n## Base\nThis PR is stacked on #1335 (`split/order-dispatch-correctness`) because it extends the scoped order-dispatch path introduced there.