### PR TITLE
perf: trust session bead snapshot during sync

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -55,6 +55,28 @@ func snapshotOrLoadSessionBeads(store beads.Store, sessionBeads *sessionBeadSnap
 	return loadSessionBeads(store)
 }
 
+func syncSessionCachedState(sessionName string, existing beads.Bead, exists bool, sp runtime.Provider) string {
+	if exists {
+		switch session.State(strings.TrimSpace(existing.Metadata["state"])) {
+		case "", session.StateActive, session.StateAwake:
+			return string(session.StateActive)
+		case session.StateCreating:
+			return string(session.StateCreating)
+		case session.StateAsleep, session.StateSuspended, session.StateDraining, session.StateArchived, session.StateQuarantined:
+			return strings.TrimSpace(existing.Metadata["state"])
+		default:
+			if state := strings.TrimSpace(existing.Metadata["state"]); state != "" {
+				return state
+			}
+			return string(session.StateActive)
+		}
+	}
+	if sp != nil && strings.TrimSpace(sessionName) != "" && sp.IsRunning(sessionName) {
+		return string(session.StateActive)
+	}
+	return "stopped"
+}
+
 func stampResolvedProviderSessionMetadata(meta map[string]string, resolved *config.ResolvedProvider) {
 	if meta == nil || resolved == nil {
 		return
@@ -612,13 +634,6 @@ func syncSessionBeadsWithSnapshot(
 		isConfiguredNamed := strings.TrimSpace(tp.ConfiguredNamedIdentity) != ""
 		origin := templateParamsSessionOrigin(tp)
 
-		// Use provider for liveness check (includes zombie detection).
-		state := "stopped"
-		alive, _ := workerSessionTargetAliveWithConfig(store, sp, cfg, sn, tp.Hints.ProcessNames)
-		if alive {
-			state = "active"
-		}
-
 		agentName := tp.TemplateName
 		// For pool instances, use the qualified instance name as the agent_name.
 		if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
@@ -629,10 +644,12 @@ func syncSessionBeadsWithSnapshot(
 		isManagedPool := origin == "ephemeral"
 
 		b, exists := bySessionName[sn]
+		state := syncSessionCachedState(sn, b, exists, sp)
 		if !exists && isConfiguredNamed {
 			if reopened, ok := reopenClosedConfiguredNamedSessionBead(cityPath, store, cfg, cityName, tp.ConfiguredNamedIdentity, sn, state, now, nil, stderr); ok {
 				b = reopened
 				exists = true
+				state = syncSessionCachedState(sn, b, exists, sp)
 				bySessionName[sn] = reopened
 				openBeads = append(openBeads, reopened)
 				indexBySessionName[sn] = len(openBeads) - 1

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -27,6 +27,11 @@ type countingMetadataStore struct {
 	batchCalls  int
 }
 
+type sessionGetSpyStore struct {
+	beads.Store
+	getIDs []string
+}
+
 type failingCloseStore struct {
 	*beads.MemStore
 }
@@ -47,6 +52,11 @@ func (s *countingMetadataStore) SetMetadata(id, key, value string) error {
 func (s *countingMetadataStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	s.batchCalls++
 	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+func (s *sessionGetSpyStore) Get(id string) (beads.Bead, error) {
+	s.getIDs = append(s.getIDs, id)
+	return s.Store.Get(id)
 }
 
 // allConfiguredDS builds configuredNames from a desiredState map.
@@ -107,6 +117,52 @@ func TestSyncSessionBeads_CreatesNewBeads(t *testing.T) {
 	}
 	if b.Metadata["instance_token"] == "" {
 		t.Error("instance_token is empty")
+	}
+}
+
+func TestSyncSessionBeads_ExistingDesiredUsesSnapshotStateWithoutWorkerLookup(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &sessionGetSpyStore{Store: base}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 22, 0, 0, 0, time.UTC)}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "control-dispatcher",
+			"agent_name":         "control-dispatcher",
+			"template":           "control-dispatcher",
+			"command":            "claude",
+			"state":              string(session.StateActive),
+			"generation":         "1",
+			"continuation_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	ds := map[string]TemplateParams{
+		"control-dispatcher": {TemplateName: "control-dispatcher", Command: "claude"},
+	}
+	sp := runtime.NewFake()
+
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshot(
+		"", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false,
+		newSessionBeadSnapshot([]beads.Bead{sessionBead}),
+	)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	for _, id := range store.getIDs {
+		if id == "control-dispatcher" {
+			t.Fatalf("sync looked up configured session name as bead id; getIDs=%v", store.getIDs)
+		}
+	}
+	for _, call := range sp.Calls {
+		switch call.Method {
+		case "IsRunning", "ProcessAlive", "IsAttached", "GetLastActivity", "GetMeta":
+			t.Fatalf("sync should trust the session snapshot for existing desired sessions, saw provider call %#v", call)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- use the current session bead snapshot state for existing desired sessions during sync
- avoid per-session worker/provider liveness lookups in the hot sync path
- keep provider lookup only for newly missing session beads where no snapshot state exists

## Tests
- go test ./cmd/gc -run 'TestSyncSessionBeads_ExistingDesiredUsesSnapshotStateWithoutWorkerLookup|TestSyncSessionBeads_CreatesNewBeads'\n- git diff --check