### PR TITLE
fix(dolt/health): probe a user db so __gc_probe stops hosting stats

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -322,7 +322,8 @@ func defaultScopeDoltDatabase(cityPath, dir, prefix string) string {
 }
 
 func isReservedManagedDoltDatabase(name string) bool {
-	return strings.EqualFold(strings.TrimSpace(name), managedDoltProbeDatabase)
+	_, ok := managedDoltSystemDatabases[strings.ToLower(strings.TrimSpace(name))]
+	return ok
 }
 
 func canonicalScopeDoltDatabase(cityPath, dir, prefix string) string {
@@ -952,6 +953,10 @@ func validateManagedDoltDatabaseName(path, doltDatabase string) (string, error) 
 	return doltDatabase, nil
 }
 
+func isLegacyManagedDoltProbeDatabase(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), managedDoltProbeDatabase)
+}
+
 func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, preserveExisting bool) error {
 	path := filepath.Join(scopeRoot, ".beads", "metadata.json")
 	preserveReservedExisting := false
@@ -962,9 +967,10 @@ func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, pr
 			doltDatabase = strings.TrimSpace(existing)
 			if isReservedManagedDoltDatabase(doltDatabase) {
 				// New init paths reject this reserved name, but existing metadata
-				// may predate the reservation. Preserve it during startup
-				// normalization so operators can migrate the scope deliberately.
-				preserveReservedExisting = true
+				// may use the legacy probe database as its real bead store.
+				// Preserve only that one migration case; Dolt system databases
+				// are unsafe bead-store targets even when already pinned.
+				preserveReservedExisting = isLegacyManagedDoltProbeDatabase(doltDatabase)
 			}
 		}
 	}

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -166,7 +166,7 @@ func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	}
 }
 
-func TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase(t *testing.T) {
+func TestGcBeadsBdReadOnlyFallbackDoesNotTargetLegacyProbeDatabase(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {
 		t.Fatalf("MaterializeBuiltinPacks: %v", err)
@@ -177,14 +177,25 @@ func TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase(t *testing.T) {
 	}
 	script := string(scriptData)
 	assertNoManagedDoltProbeDrop(t, "gc-beads-bd read-only fallback", script)
-	if !strings.Contains(script, "CREATE TABLE IF NOT EXISTS __gc_probe.__probe") {
-		t.Fatalf("gc-beads-bd read-only fallback missing qualified persistent probe table")
+	assertNoManagedDoltProbeLegacyTarget(t, "gc-beads-bd read-only fallback", script)
+	for _, want := range []string{"SHOW DATABASES", managedDoltProbeTable, "performance_schema", "sys"} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("gc-beads-bd read-only fallback missing %q", want)
+		}
 	}
-	assertManagedDoltProbeWrites(t, "gc-beads-bd read-only fallback", script)
 }
 
 func TestGcBeadsBdInitRejectsManagedProbeDatabaseName(t *testing.T) {
-	for _, dbName := range []string{managedDoltProbeDatabase, strings.ToUpper(managedDoltProbeDatabase), " " + managedDoltProbeDatabase + " "} {
+	for _, dbName := range []string{
+		managedDoltProbeDatabase,
+		strings.ToUpper(managedDoltProbeDatabase),
+		" " + managedDoltProbeDatabase + " ",
+		"information_schema",
+		"mysql",
+		"dolt_cluster",
+		"performance_schema",
+		"sys",
+	} {
 		t.Run(dbName, func(t *testing.T) {
 			cityPath := t.TempDir()
 			scopePath := filepath.Join(cityPath, "rigs", "frontend")
@@ -210,14 +221,25 @@ func TestGcBeadsBdInitRejectsManagedProbeDatabaseName(t *testing.T) {
 	}
 }
 
-func TestEnsureCanonicalScopeMetadataRejectsManagedProbeDatabase(t *testing.T) {
-	scopePath := t.TempDir()
-	err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, scopePath, managedDoltProbeDatabase)
-	if err == nil {
-		t.Fatalf("ensureCanonicalScopeMetadataForInit unexpectedly accepted %s", managedDoltProbeDatabase)
-	}
-	if !strings.Contains(err.Error(), "reserved pinned dolt_database") || !strings.Contains(err.Error(), "choose a different dolt_database") {
-		t.Fatalf("ensureCanonicalScopeMetadataForInit error = %v, want reserved database remediation", err)
+func TestEnsureCanonicalScopeMetadataRejectsManagedSystemDatabases(t *testing.T) {
+	for _, dbName := range []string{
+		managedDoltProbeDatabase,
+		"information_schema",
+		"mysql",
+		"dolt_cluster",
+		"performance_schema",
+		"sys",
+	} {
+		t.Run(dbName, func(t *testing.T) {
+			scopePath := t.TempDir()
+			err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, scopePath, dbName)
+			if err == nil {
+				t.Fatalf("ensureCanonicalScopeMetadataForInit unexpectedly accepted %s", dbName)
+			}
+			if !strings.Contains(err.Error(), "reserved pinned dolt_database") || !strings.Contains(err.Error(), "choose a different dolt_database") {
+				t.Fatalf("ensureCanonicalScopeMetadataForInit error = %v, want reserved database remediation", err)
+			}
+		})
 	}
 }
 
@@ -252,6 +274,34 @@ func TestNormalizeCanonicalBdScopeFilesPreservesExistingManagedProbeDatabase(t *
 	}
 }
 
+func TestNormalizeCanonicalBdScopeFilesRejectsExistingManagedSystemDatabase(t *testing.T) {
+	cityPath := t.TempDir()
+	metadataPath := filepath.Join(cityPath, ".beads", "metadata.json")
+	if err := os.MkdirAll(filepath.Dir(metadataPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, metadataPath, contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "mysql",
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte("issue_prefix: hq\nissue-prefix: hq\ndolt.auto-start: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "dogfood-city"}}
+	err := normalizeCanonicalBdScopeFiles(cityPath, cfg)
+	if err == nil {
+		t.Fatal("normalizeCanonicalBdScopeFiles() error = nil, want reserved metadata rejection")
+	}
+	if !strings.Contains(err.Error(), "reserved pinned dolt_database") || !strings.Contains(err.Error(), "mysql") {
+		t.Fatalf("normalizeCanonicalBdScopeFiles() error = %v, want mysql reserved metadata rejection", err)
+	}
+}
+
 func TestNormalizeCanonicalBdScopeFilesForInitPreservesExistingManagedProbeDatabase(t *testing.T) {
 	cityPath := t.TempDir()
 	metadataPath := filepath.Join(cityPath, ".beads", "metadata.json")
@@ -280,6 +330,224 @@ func TestNormalizeCanonicalBdScopeFilesForInitPreservesExistingManagedProbeDatab
 	}
 	if !ok || got != strings.ToUpper(managedDoltProbeDatabase) {
 		t.Fatalf("dolt_database = %q, ok=%v; want existing reserved name preserved", got, ok)
+	}
+}
+
+func TestGcBeadsBdReadOnlyFallbackNoUserDatabaseIsDiagnostic(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	prelude, _, ok := strings.Cut(string(scriptData), "# --- Main ---")
+	if !ok {
+		t.Fatal("gc-beads-bd script missing main marker")
+	}
+
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	if err := os.WriteFile(filepath.Join(binDir, "dolt"), []byte(`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("WriteFile(dolt): %v", err)
+	}
+
+	harness := filepath.Join(t.TempDir(), "read-only-fallback.sh")
+	body := prelude + `
+GC_BIN=""
+GC_DOLT_HOST=""
+DOLT_PORT=3311
+DOLT_USER=root
+set +e
+check_read_only
+status=$?
+set -e
+printf 'status=%s\n' "$status"
+`
+	if err := os.WriteFile(harness, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", harness)
+	cmd.Env = append(sanitizedBaseEnv(
+		"INVOCATION_FILE="+invocationFile,
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	), "GC_BIN=")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check_read_only harness failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "status=2") {
+		t.Fatalf("check_read_only output = %s, want diagnostic status 2", out)
+	}
+	if !strings.Contains(string(out), "no user database") {
+		t.Fatalf("check_read_only output = %s, want no-user-database diagnostic", out)
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("check_read_only ran write probe without user database:\n%s", invocation)
+	}
+}
+
+func TestGcBeadsBdHealthNoUserDatabaseWarnsAndContinues(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	prelude, _, ok := strings.Cut(string(scriptData), "# --- Main ---")
+	if !ok {
+		t.Fatal("gc-beads-bd script missing main marker")
+	}
+
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	if err := os.WriteFile(filepath.Join(binDir, "dolt"), []byte(`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("WriteFile(dolt): %v", err)
+	}
+
+	harness := filepath.Join(t.TempDir(), "health-fallback.sh")
+	body := prelude + `
+GC_BIN=""
+GC_DOLT_HOST=""
+DOLT_PORT=3311
+DOLT_USER=root
+tcp_check() { return 0; }
+do_query_probe() { return 0; }
+get_connection_count() { return 1; }
+set +e
+op_health
+status=$?
+set -e
+printf 'status=%s\n' "$status"
+`
+	if err := os.WriteFile(harness, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", harness)
+	cmd.Env = append(sanitizedBaseEnv(
+		"INVOCATION_FILE="+invocationFile,
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	), "GC_BIN=")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("op_health harness failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "status=0") {
+		t.Fatalf("op_health output = %s, want success status", out)
+	}
+	if !strings.Contains(string(out), "warning: dolt read-only probe inconclusive") {
+		t.Fatalf("op_health output = %s, want warning", out)
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("op_health ran write probe without user database:\n%s", invocation)
+	}
+}
+
+func TestGcBeadsBdReadOnlyHelperErrorIsDiagnostic(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	prelude, _, ok := strings.Cut(string(scriptData), "# --- Main ---")
+	if !ok {
+		t.Fatal("gc-beads-bd script missing main marker")
+	}
+
+	gcBin := filepath.Join(t.TempDir(), "gc")
+	if err := os.WriteFile(gcBin, []byte(`#!/bin/sh
+set -eu
+case "$1 $2" in
+  "dolt-state read-only-check")
+    echo "gc dolt-state read-only-check: no user database available for managed Dolt read-only probe" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected gc command: $*" >&2
+    exit 66
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("WriteFile(gc): %v", err)
+	}
+
+	harness := filepath.Join(t.TempDir(), "read-only-helper.sh")
+	body := prelude + fmt.Sprintf(`
+GC_BIN=%q
+GC_DOLT_HOST=""
+DOLT_PORT=3311
+DOLT_USER=root
+set +e
+check_read_only
+status=$?
+set -e
+printf 'status=%%s\n' "$status"
+`, gcBin)
+	if err := os.WriteFile(harness, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", harness)
+	cmd.Env = sanitizedBaseEnv("PATH=" + os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("check_read_only harness failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "status=2") {
+		t.Fatalf("check_read_only output = %s, want diagnostic status 2", out)
+	}
+	if !strings.Contains(string(out), "no user database") {
+		t.Fatalf("check_read_only output = %s, want helper diagnostic", out)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_state.go
+++ b/cmd/gc/cmd_dolt_state.go
@@ -289,12 +289,12 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 
 	resetProbe := &cobra.Command{
 		Use:    "reset-probe",
-		Short:  "Drop the managed Dolt health probe database",
+		Short:  "Reset managed Dolt health probe artifacts",
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if !forceReset {
-				fmt.Fprintf(stderr, "gc dolt-state reset-probe: refusing to drop %s without --force; this database may contain a legacy bead store in old metadata\n", managedDoltProbeDatabase) //nolint:errcheck
+				fmt.Fprintf(stderr, "gc dolt-state reset-probe: refusing to reset health probe artifacts without --force; %s may contain a legacy bead store in old metadata\n", managedDoltProbeDatabase) //nolint:errcheck
 				return errExit
 			}
 			if err := managedDoltResetProbe(hostText, portText, userText); err != nil {
@@ -307,7 +307,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 	resetProbe.Flags().StringVar(&hostText, "host", "", "Dolt host")
 	resetProbe.Flags().StringVar(&portText, "port", "", "Dolt port")
 	resetProbe.Flags().StringVar(&userText, "user", "", "Dolt user")
-	resetProbe.Flags().BoolVar(&forceReset, "force", false, "acknowledge dropping the managed probe database")
+	resetProbe.Flags().BoolVar(&forceReset, "force", false, "acknowledge dropping the legacy probe database and GC-owned probe table")
 	_ = resetProbe.MarkFlagRequired("port")
 	cmd.AddCommand(resetProbe)
 

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1783,7 +1783,7 @@ case "$*" in
     printf 'Database\ngascity\ninformation_schema\nmysql\ndolt_cluster\n__gc_probe\n'
     exit 0
     ;;
-  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
     echo 'database is read only' >&2
     exit 1
     ;;
@@ -1809,7 +1809,7 @@ esac
 	bt := "`"
 	assertNoManagedDoltProbeDrop(t, "read-only-check invocation", text)
 	assertNoManagedDoltProbeLegacyTarget(t, "read-only-check invocation", text)
-	wantWrite := "REPLACE INTO " + bt + "gascity" + bt + "." + bt + "__probe" + bt + " VALUES (1)"
+	wantWrite := "REPLACE INTO " + bt + "gascity" + bt + "." + bt + managedDoltProbeTable + bt + " VALUES (1)"
 	if !strings.Contains(text, wantWrite) {
 		t.Fatalf("read-only-check invocation = %s, want %q", text, wantWrite)
 	}
@@ -1846,13 +1846,69 @@ esac
 	assertNoManagedDoltProbeLegacyTarget(t, "read-only-check writable invocation", string(invocation))
 }
 
+func TestDoltStateReadOnlyCheckCmdNoUserDatabaseReturnsDiagnostic(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "read-only-check", "--host", "127.0.0.1", "--port", "3311", "--user", "root"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run() = %d, want 1; stdout = %s stderr = %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no user database") {
+		t.Fatalf("stderr = %q, want no-user-database diagnostic", stderr.String())
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("read-only-check ran write probe without user database:\n%s", invocation)
+	}
+}
+
 func TestDoltStateResetProbeCmdDropsManagedProbeDatabase(t *testing.T) {
 	binDir := t.TempDir()
 	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
 	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
-exit 0
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\ninformation_schema\nbeads\n__gc_probe\n'
+    exit 0
+    ;;
+  *"DROP DATABASE IF EXISTS __gc_probe"*)
+    exit 0
+    ;;
+  *"DROP TABLE IF EXISTS"*"__gc_read_only_probe"*)
+    exit 0
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
 `)
 	t.Setenv("INVOCATION_FILE", invocationFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -1870,6 +1926,11 @@ exit 0
 	if !strings.Contains(text, "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase) {
 		t.Fatalf("reset-probe invocation = %s, want managed probe drop", text)
 	}
+	for _, want := range []string{"DROP TABLE IF EXISTS `gascity`.`" + managedDoltProbeTable + "`", "DROP TABLE IF EXISTS `beads`.`" + managedDoltProbeTable + "`"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("reset-probe invocation = %s, want %q", text, want)
+		}
+	}
 }
 
 func TestDoltStateResetProbeCmdRequiresForce(t *testing.T) {
@@ -1878,7 +1939,8 @@ func TestDoltStateResetProbeCmdRequiresForce(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("run() = %d, want 1; stderr = %s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "refusing to drop "+managedDoltProbeDatabase+" without --force") ||
+	if !strings.Contains(stderr.String(), "refusing to reset health probe artifacts without --force") ||
+		!strings.Contains(stderr.String(), managedDoltProbeDatabase) ||
 		!strings.Contains(stderr.String(), "legacy bead store") {
 		t.Fatalf("stderr = %q, want force warning with legacy bead store context", stderr.String())
 	}
@@ -1936,7 +1998,7 @@ case "$*" in
     printf 'Database\ngascity\ninformation_schema\nmysql\ndolt_cluster\n__gc_probe\n'
     exit 0
     ;;
-  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
     echo 'database is read only' >&2
     exit 1
     ;;
@@ -1976,7 +2038,7 @@ esac
 	assertNoManagedDoltProbeDrop(t, "health-check read-only probe", text)
 	assertNoManagedDoltProbeLegacyTarget(t, "health-check read-only probe", text)
 	bt := "`"
-	wantWrite := "REPLACE INTO " + bt + "gascity" + bt + "." + bt + "__probe" + bt + " VALUES (1)"
+	wantWrite := "REPLACE INTO " + bt + "gascity" + bt + "." + bt + managedDoltProbeTable + bt + " VALUES (1)"
 	if !strings.Contains(text, wantWrite) {
 		t.Fatalf("health-check probe = %s, want %q", text, wantWrite)
 	}
@@ -1984,6 +2046,61 @@ esac
 		if strings.Contains(text, want) == false {
 			t.Fatalf("dolt invocation missing %q: %s", want, text)
 		}
+	}
+}
+
+func TestDoltStateHealthCheckCmdNoUserDatabaseReportsUnknown(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -q SELECT active_branch()"*)
+    exit 0
+    ;;
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"sql -r csv -q SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST"*)
+    printf 'cnt\n0\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "health-check", "--host", "0.0.0.0", "--port", "3311", "--user", "root", "--check-read-only"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stdout = %s stderr = %s", code, stdout.String(), stderr.String())
+	}
+	got := parseDoltStateOutput(t, stdout.String())
+	if got["query_ready"] != "true" {
+		t.Fatalf("query_ready = %q, want true", got["query_ready"])
+	}
+	if got["read_only"] != "unknown" {
+		t.Fatalf("read_only = %q, want unknown", got["read_only"])
+	}
+	if got["connection_count"] != "0" {
+		t.Fatalf("connection_count = %q, want 0", got["connection_count"])
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("health-check ran write probe without user database:\n%s", invocation)
 	}
 }
 
@@ -2026,7 +2143,7 @@ esac
 		t.Fatalf("ReadFile(invocation): %v", err)
 	}
 	text := string(invocation)
-	if strings.Contains(text, "CREATE TABLE IF NOT EXISTS") && strings.Contains(text, "__probe") {
+	if strings.Contains(text, "CREATE TABLE IF NOT EXISTS") && strings.Contains(text, managedDoltProbeTable) {
 		t.Fatalf("health-check unexpectedly ran read-only probe: %s", text)
 	}
 	if strings.Contains(text, "SHOW DATABASES") {
@@ -2073,7 +2190,7 @@ case "$*" in
     printf 'Database\ngascity\n'
     exit 0
     ;;
-  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
     echo 'probe exploded' >&2
     exit 1
     ;;
@@ -2470,7 +2587,7 @@ INNERPY
     printf 'Database\ngascity\n'
     exit 0
     ;;
-  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
     if [ -f "$READ_ONLY_ONCE" ]; then
       rm -f "$READ_ONLY_ONCE"
       echo "read only" >&2
@@ -2536,6 +2653,127 @@ esac
 	}
 	if managedStopPIDAlive(original.Process.Pid) {
 		t.Fatalf("original pid %d still alive after recovery", original.Process.Pid)
+	}
+}
+
+func TestDoltStateRecoverManagedCmdNoUserDatabaseHealthSucceeds(t *testing.T) {
+	skipSlowCmdGCTest(t, "spawns managed dolt recovery processes; run make test-cmd-gc-process for full coverage")
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(layout.PIDFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll(runtime dir): %v", err)
+	}
+	if err := os.MkdirAll(layout.DataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(data dir): %v", err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	original := startTCPListenerProcessInDir(t, port, layout.DataDir)
+	defer func() {
+		_ = original.Process.Kill()
+		_ = original.Wait()
+	}()
+	if err := os.WriteFile(layout.PIDFile, []byte(strconv.Itoa(original.Process.Pid)+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(pid): %v", err)
+	}
+	if err := writeDoltRuntimeStateFile(layout.StateFile, doltRuntimeState{
+		Running:   true,
+		PID:       original.Process.Pid,
+		Port:      port,
+		DataDir:   layout.DataDir,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile: %v", err)
+	}
+
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  "sql-server --config "*)
+    config_file=$3
+    port=$(awk '/port:/ {print $2; exit}' "$config_file")
+    data_dir=$(awk '/data_dir:/ {print $2; exit}' "$config_file" | tr -d '"')
+    exec python3 - "$port" "$data_dir" <<'INNERPY'
+import os
+import signal
+import socket
+import sys
+import time
+
+port = int(sys.argv[1])
+data_dir = sys.argv[2]
+if data_dir:
+    os.chdir(data_dir)
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", port))
+sock.listen(5)
+def _stop(*_args):
+    raise SystemExit(0)
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+while True:
+    time.sleep(1)
+INNERPY
+    ;;
+  *"SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST"*)
+    printf 'cnt\n0\n'
+    ;;
+  *"SELECT active_branch()"*)
+    exit 0
+    ;;
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(func() {
+		if state, err := readDoltRuntimeStateFile(layout.StateFile); err == nil && state.PID > 0 {
+			_ = terminateManagedDoltPID(state.PID)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "recover-managed", "--city", cityPath, "--host", "127.0.0.1", "--port", strconv.Itoa(port), "--user", "root", "--timeout-ms", "5000"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stdout = %s stderr = %s", code, stdout.String(), stderr.String())
+	}
+	got := parseDoltStateOutput(t, stdout.String())
+	if got["diagnosed_read_only"] != "false" {
+		t.Fatalf("diagnosed_read_only = %q, want false", got["diagnosed_read_only"])
+	}
+	if got["had_pid"] != "true" {
+		t.Fatalf("had_pid = %q, want true", got["had_pid"])
+	}
+	if got["ready"] != "true" {
+		t.Fatalf("ready = %q, want true", got["ready"])
+	}
+	if got["healthy"] != "true" {
+		t.Fatalf("healthy = %q, want true", got["healthy"])
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("recover-managed ran write probe without user database:\n%s", invocation)
 	}
 }
 
@@ -2913,7 +3151,7 @@ INNERPY
     printf 'Database\ngascity\n'
     exit 0
     ;;
-  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
     exit 0
     ;;
   *)

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1778,8 +1778,20 @@ func TestDoltStateReadOnlyCheckCmdDetectsReadOnly(t *testing.T) {
 	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
-echo 'database is read only' >&2
-exit 1
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\ninformation_schema\nmysql\ndolt_cluster\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
+    echo 'database is read only' >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
 `)
 	t.Setenv("INVOCATION_FILE", invocationFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -1793,8 +1805,14 @@ exit 1
 	if err != nil {
 		t.Fatalf("ReadFile(invocation): %v", err)
 	}
-	assertNoManagedDoltProbeDrop(t, "read-only-check invocation", string(invocation))
-	assertManagedDoltProbeWrites(t, "read-only-check invocation", string(invocation))
+	text := string(invocation)
+	bt := "`"
+	assertNoManagedDoltProbeDrop(t, "read-only-check invocation", text)
+	assertNoManagedDoltProbeLegacyTarget(t, "read-only-check invocation", text)
+	wantWrite := "REPLACE INTO " + bt + "gascity" + bt + "." + bt + "__probe" + bt + " VALUES (1)"
+	if !strings.Contains(text, wantWrite) {
+		t.Fatalf("read-only-check invocation = %s, want %q", text, wantWrite)
+	}
 }
 
 func TestDoltStateReadOnlyCheckCmdReturnsErrExitWhenWritable(t *testing.T) {
@@ -1803,7 +1821,15 @@ func TestDoltStateReadOnlyCheckCmdReturnsErrExitWhenWritable(t *testing.T) {
 	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$INVOCATION_FILE"
-exit 0
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
 `)
 	t.Setenv("INVOCATION_FILE", invocationFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -1813,6 +1839,11 @@ exit 0
 	if code != 1 {
 		t.Fatalf("run() = %d, want 1; stderr = %s", code, stderr.String())
 	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	assertNoManagedDoltProbeLegacyTarget(t, "read-only-check writable invocation", string(invocation))
 }
 
 func TestDoltStateResetProbeCmdDropsManagedProbeDatabase(t *testing.T) {
@@ -1901,7 +1932,11 @@ case "$*" in
   *"sql -q SELECT active_branch()"*)
     exit 0
     ;;
-  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);"*)
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\ninformation_schema\nmysql\ndolt_cluster\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
     echo 'database is read only' >&2
     exit 1
     ;;
@@ -1939,8 +1974,13 @@ esac
 	}
 	text := string(invocation)
 	assertNoManagedDoltProbeDrop(t, "health-check read-only probe", text)
-	assertManagedDoltProbeWrites(t, "health-check read-only probe", text)
-	for _, want := range []string{"--host 127.0.0.1", "--port 3311", "--user root", "SELECT active_branch()", "information_schema.PROCESSLIST"} {
+	assertNoManagedDoltProbeLegacyTarget(t, "health-check read-only probe", text)
+	bt := "`"
+	wantWrite := "REPLACE INTO " + bt + "gascity" + bt + "." + bt + "__probe" + bt + " VALUES (1)"
+	if !strings.Contains(text, wantWrite) {
+		t.Fatalf("health-check probe = %s, want %q", text, wantWrite)
+	}
+	for _, want := range []string{"--host 127.0.0.1", "--port 3311", "--user root", "SELECT active_branch()", "information_schema.PROCESSLIST", "SHOW DATABASES"} {
 		if strings.Contains(text, want) == false {
 			t.Fatalf("dolt invocation missing %q: %s", want, text)
 		}
@@ -1986,9 +2026,13 @@ esac
 		t.Fatalf("ReadFile(invocation): %v", err)
 	}
 	text := string(invocation)
-	if strings.Contains(text, "CREATE DATABASE IF NOT EXISTS __gc_probe") {
+	if strings.Contains(text, "CREATE TABLE IF NOT EXISTS") && strings.Contains(text, "__probe") {
 		t.Fatalf("health-check unexpectedly ran read-only probe: %s", text)
 	}
+	if strings.Contains(text, "SHOW DATABASES") {
+		t.Fatalf("health-check unexpectedly enumerated databases without --check-read-only: %s", text)
+	}
+	assertNoManagedDoltProbeLegacyTarget(t, "health-check skip-read-only probe", text)
 	for _, want := range []string{"SELECT active_branch()", "information_schema.PROCESSLIST"} {
 		if strings.Contains(text, want) == false {
 			t.Fatalf("dolt invocation missing %q: %s", want, text)
@@ -2025,7 +2069,11 @@ case "$*" in
   *"sql -q SELECT active_branch()"*)
     exit 0
     ;;
-  *"sql -q CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);"*)
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
     echo 'probe exploded' >&2
     exit 1
     ;;
@@ -2418,7 +2466,11 @@ INNERPY
   *"SELECT active_branch()"*)
     exit 0
     ;;
-  *"CREATE DATABASE IF NOT EXISTS __gc_probe;"*)
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
     if [ -f "$READ_ONLY_ONCE" ]; then
       rm -f "$READ_ONLY_ONCE"
       echo "read only" >&2
@@ -2857,7 +2909,11 @@ INNERPY
     echo "final health probe failed" >&2
     exit 1
     ;;
-  *"CREATE DATABASE IF NOT EXISTS __gc_probe;"*)
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__probe"*)
     exit 0
     ;;
   *)

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -19,26 +19,73 @@ type managedDoltSQLHealthReport struct {
 	ConnectionCount string
 }
 
+// managedDoltProbeDatabase is the legacy dedicated probe database name. The
+// read-only probe no longer creates or writes to it: Dolt's autostats subsystem
+// (statspro) randomly elects one server-wide database to host the on-disk
+// stats backing store, and a tiny dedicated DB lost the lottery in production
+// — accumulating ~600k buckets / 2GB of stats noms it was never meant to
+// hold. The probe now writes into a discovered user database instead so it
+// shares a backing store with real workload traffic. This constant remains so
+// `gc dolt-state reset-probe` can still drop the legacy DB on demand and so
+// `gc dolt-state init` can keep rejecting it as a user-supplied database name.
 const managedDoltProbeDatabase = "__gc_probe"
 
+const managedDoltProbeTable = "__probe"
+
 var (
-	managedDoltQueryProbeDirectFn      = managedDoltQueryProbeDirect
-	managedDoltReadOnlyStateDirectFn   = managedDoltReadOnlyStateDirect
-	managedDoltConnectionCountDirectFn = managedDoltConnectionCountDirect
-	managedDoltResetProbeDirectFn      = managedDoltResetProbeDirect
-	managedDoltSQLCommandTimeout       = 5 * time.Second
+	managedDoltQueryProbeDirectFn         = managedDoltQueryProbeDirect
+	managedDoltReadOnlyStateDirectFn      = managedDoltReadOnlyStateDirect
+	managedDoltConnectionCountDirectFn    = managedDoltConnectionCountDirect
+	managedDoltResetProbeDirectFn         = managedDoltResetProbeDirect
+	managedDoltSelectUserDatabaseDirectFn = managedDoltSelectUserDatabaseDirect
+	managedDoltSQLCommandTimeout          = 5 * time.Second
 )
 
-// The probe database is intentionally persistent. Dropping Dolt databases leaves
-// .dolt_dropped_databases backups, so the health check keeps a stable table and
-// rewrites a single row to test writability.
-var managedDoltReadOnlyProbeStatements = [...]string{
-	"CREATE DATABASE IF NOT EXISTS " + managedDoltProbeDatabase,
-	"CREATE TABLE IF NOT EXISTS " + managedDoltProbeDatabase + ".__probe (k INT PRIMARY KEY)",
-	"REPLACE INTO " + managedDoltProbeDatabase + ".__probe VALUES (1)",
+// managedDoltSystemDatabases lists databases that the read-only probe must not
+// pick as its write target. `__gc_probe` is included so existing legacy data
+// is left in place while we migrate off of it.
+var managedDoltSystemDatabases = map[string]struct{}{
+	"information_schema": {},
+	"mysql":              {},
+	"dolt_cluster":       {},
+	managedDoltProbeDatabase: {},
 }
 
-var managedDoltReadOnlyProbeSQL = strings.Join(managedDoltReadOnlyProbeStatements[:], "; ") + ";"
+// managedDoltReadOnlyProbeStatementsFor returns the read-only probe statements
+// for db. Each invocation creates the persistent `__probe` table inside db
+// (idempotent) and rewrites a single row to test writability. db must be a
+// real user database; the empty string returns nil so the caller can skip the
+// probe entirely. The database identifier is backtick-quoted because Dolt
+// derives DB names from repository directory names, which can start with a
+// digit or contain other characters that need quoting.
+func managedDoltReadOnlyProbeStatementsFor(db string) []string {
+	db = strings.TrimSpace(db)
+	if db == "" {
+		return nil
+	}
+	target := managedDoltQuoteIdent(db) + "." + managedDoltQuoteIdent(managedDoltProbeTable)
+	return []string{
+		"CREATE TABLE IF NOT EXISTS " + target + " (k INT PRIMARY KEY)",
+		"REPLACE INTO " + target + " VALUES (1)",
+	}
+}
+
+// managedDoltQuoteIdent backtick-quotes a SQL identifier and escapes any
+// embedded backticks by doubling them (MySQL convention).
+func managedDoltQuoteIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// managedDoltReadOnlyProbeSQLFor joins managedDoltReadOnlyProbeStatementsFor
+// into a single semicolon-terminated SQL string suitable for passing to
+// `dolt sql -q`.
+func managedDoltReadOnlyProbeSQLFor(db string) string {
+	stmts := managedDoltReadOnlyProbeStatementsFor(db)
+	if len(stmts) == 0 {
+		return ""
+	}
+	return strings.Join(stmts, "; ") + ";"
+}
 
 func managedDoltQueryProbe(host, port, user string) error {
 	if managedDoltPassword() != "" {
@@ -58,7 +105,14 @@ func managedDoltReadOnlyState(host, port, user string) (string, error) {
 	if managedDoltPassword() != "" {
 		return managedDoltReadOnlyStateDirectFn(host, port, user)
 	}
-	_, err := runManagedDoltSQL(host, port, user, "-q", managedDoltReadOnlyProbeSQL)
+	db, err := managedDoltSelectUserDatabase(host, port, user)
+	if err != nil {
+		return "unknown", err
+	}
+	if db == "" {
+		return "false", nil
+	}
+	_, err = runManagedDoltSQL(host, port, user, "-q", managedDoltReadOnlyProbeSQLFor(db))
 	if err == nil {
 		return "false", nil
 	}
@@ -67,6 +121,40 @@ func managedDoltReadOnlyState(host, port, user string) (string, error) {
 		return "true", nil
 	}
 	return "unknown", err
+}
+
+// managedDoltSelectUserDatabase returns the alphabetically-first database that
+// is not a system database. Returns "" when the server has no user database
+// (callers should skip the write probe in that case).
+func managedDoltSelectUserDatabase(host, port, user string) (string, error) {
+	if managedDoltPassword() != "" {
+		return managedDoltSelectUserDatabaseDirectFn(host, port, user)
+	}
+	out, err := runManagedDoltSQL(host, port, user, "-r", "csv", "-q", "SHOW DATABASES")
+	if err != nil {
+		return "", err
+	}
+	return managedDoltFirstUserDatabase(strings.Split(out, "\n")), nil
+}
+
+// managedDoltFirstUserDatabase scans csv-format `SHOW DATABASES` output (one
+// row per line, header `Database` first) and returns the first non-system
+// database, or "" when none exist.
+func managedDoltFirstUserDatabase(lines []string) string {
+	for _, line := range lines {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		if strings.EqualFold(name, "Database") {
+			continue
+		}
+		if _, system := managedDoltSystemDatabases[strings.ToLower(name)]; system {
+			continue
+		}
+		return name
+	}
+	return ""
 }
 
 func managedDoltConnectionCount(host, port, user string) (string, error) {
@@ -187,7 +275,14 @@ func managedDoltReadOnlyStateDirect(host, port, user string) (string, error) {
 	}
 	defer conn.Close() //nolint:errcheck
 
-	for _, query := range managedDoltReadOnlyProbeStatements {
+	userDB, err := managedDoltSelectUserDatabaseFromConn(ctx, conn)
+	if err != nil {
+		return "unknown", err
+	}
+	if userDB == "" {
+		return "false", nil
+	}
+	for _, query := range managedDoltReadOnlyProbeStatementsFor(userDB) {
 		if _, err := conn.ExecContext(ctx, query); err != nil {
 			msg := strings.ToLower(err.Error())
 			if strings.Contains(msg, "read only") || strings.Contains(msg, "read-only") {
@@ -197,6 +292,43 @@ func managedDoltReadOnlyStateDirect(host, port, user string) (string, error) {
 		}
 	}
 	return "false", nil
+}
+
+func managedDoltSelectUserDatabaseDirect(host, port, user string) (string, error) {
+	db, err := managedDoltOpenDB(host, port, user)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close() //nolint:errcheck
+	return managedDoltSelectUserDatabaseFromConn(ctx, conn)
+}
+
+func managedDoltSelectUserDatabaseFromConn(ctx context.Context, conn *sql.Conn) (string, error) {
+	rows, err := conn.QueryContext(ctx, "SHOW DATABASES")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close() //nolint:errcheck
+	names := []string{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return "", err
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return managedDoltFirstUserDatabase(names), nil
 }
 
 func managedDoltConnectionCountDirect(host, port, user string) (string, error) {

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/csv"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -23,22 +26,23 @@ type managedDoltSQLHealthReport struct {
 // read-only probe no longer creates or writes to it: Dolt's autostats subsystem
 // (statspro) randomly elects one server-wide database to host the on-disk
 // stats backing store, and a tiny dedicated DB lost the lottery in production
-// — accumulating ~600k buckets / 2GB of stats noms it was never meant to
-// hold. The probe now writes into a discovered user database instead so it
-// shares a backing store with real workload traffic. This constant remains so
+// by accumulating stats noms it was never meant to hold. The probe now writes
+// into a GC-owned table inside a discovered user database instead so it shares
+// a backing store with real workload traffic. This constant remains so
 // `gc dolt-state reset-probe` can still drop the legacy DB on demand and so
 // `gc dolt-state init` can keep rejecting it as a user-supplied database name.
 const managedDoltProbeDatabase = "__gc_probe"
 
-const managedDoltProbeTable = "__probe"
+const managedDoltProbeTable = "__gc_read_only_probe"
+
+var errManagedDoltNoUserDatabase = errors.New("no user database available for managed Dolt read-only probe")
 
 var (
-	managedDoltQueryProbeDirectFn         = managedDoltQueryProbeDirect
-	managedDoltReadOnlyStateDirectFn      = managedDoltReadOnlyStateDirect
-	managedDoltConnectionCountDirectFn    = managedDoltConnectionCountDirect
-	managedDoltResetProbeDirectFn         = managedDoltResetProbeDirect
-	managedDoltSelectUserDatabaseDirectFn = managedDoltSelectUserDatabaseDirect
-	managedDoltSQLCommandTimeout          = 5 * time.Second
+	managedDoltQueryProbeDirectFn      = managedDoltQueryProbeDirect
+	managedDoltReadOnlyStateDirectFn   = managedDoltReadOnlyStateDirect
+	managedDoltConnectionCountDirectFn = managedDoltConnectionCountDirect
+	managedDoltResetProbeDirectFn      = managedDoltResetProbeDirect
+	managedDoltSQLCommandTimeout       = 5 * time.Second
 )
 
 // managedDoltSystemDatabases lists databases that the read-only probe must not
@@ -48,16 +52,18 @@ var managedDoltSystemDatabases = map[string]struct{}{
 	"information_schema":     {},
 	"mysql":                  {},
 	"dolt_cluster":           {},
+	"performance_schema":     {},
+	"sys":                    {},
 	managedDoltProbeDatabase: {},
 }
 
 // managedDoltReadOnlyProbeStatementsFor returns the read-only probe statements
-// for db. Each invocation creates the persistent `__probe` table inside db
-// (idempotent) and rewrites a single row to test writability. db must be a
-// real user database; the empty string returns nil so the caller can skip the
-// probe entirely. The database identifier is backtick-quoted because Dolt
-// derives DB names from repository directory names, which can start with a
-// digit or contain other characters that need quoting.
+// for db. Each invocation creates the persistent GC-owned probe table inside db
+// (idempotent) and rewrites a single row to test writability. db must be a real
+// user database; the empty string returns nil so the caller can skip the probe
+// entirely. The database identifier is backtick-quoted because Dolt derives DB
+// names from repository directory names, which can start with a digit or contain
+// other characters that need quoting.
 func managedDoltReadOnlyProbeStatementsFor(db string) []string {
 	db = strings.TrimSpace(db)
 	if db == "" {
@@ -110,7 +116,7 @@ func managedDoltReadOnlyState(host, port, user string) (string, error) {
 		return "unknown", err
 	}
 	if db == "" {
-		return "false", nil
+		return "unknown", errManagedDoltNoUserDatabase
 	}
 	_, err = runManagedDoltSQL(host, port, user, "-q", managedDoltReadOnlyProbeSQLFor(db))
 	if err == nil {
@@ -123,24 +129,62 @@ func managedDoltReadOnlyState(host, port, user string) (string, error) {
 	return "unknown", err
 }
 
-// managedDoltSelectUserDatabase returns the alphabetically-first database that
-// is not a system database. Returns "" when the server has no user database
-// (callers should skip the write probe in that case).
+// managedDoltSelectUserDatabase returns the first database from SHOW DATABASES
+// that is not a system database. It returns "" when the server has no user database.
 func managedDoltSelectUserDatabase(host, port, user string) (string, error) {
-	if managedDoltPassword() != "" {
-		return managedDoltSelectUserDatabaseDirectFn(host, port, user)
-	}
-	out, err := runManagedDoltSQL(host, port, user, "-r", "csv", "-q", "SHOW DATABASES")
-	if err != nil {
+	dbs, err := managedDoltSelectUserDatabases(host, port, user)
+	if err != nil || len(dbs) == 0 {
 		return "", err
 	}
-	return managedDoltFirstUserDatabase(strings.Split(out, "\n")), nil
+	return dbs[0], nil
 }
 
-// managedDoltFirstUserDatabase scans csv-format `SHOW DATABASES` output (one
-// row per line, header `Database` first) and returns the first non-system
+func managedDoltSelectUserDatabases(host, port, user string) ([]string, error) {
+	out, err := runManagedDoltSQL(host, port, user, "-r", "csv", "-q", "SHOW DATABASES")
+	if err != nil {
+		return nil, err
+	}
+	return managedDoltUserDatabasesFromCSV(out)
+}
+
+// managedDoltFirstUserDatabaseFromCSV parses csv-format `SHOW DATABASES`
+// output and returns the first non-system database, or "" when none exist.
+func managedDoltFirstUserDatabaseFromCSV(out string) (string, error) {
+	dbs, err := managedDoltUserDatabasesFromCSV(out)
+	if err != nil || len(dbs) == 0 {
+		return "", err
+	}
+	return dbs[0], nil
+}
+
+func managedDoltUserDatabasesFromCSV(out string) ([]string, error) {
+	reader := csv.NewReader(strings.NewReader(out))
+	reader.FieldsPerRecord = 1
+	dbs := []string{}
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			return dbs, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse SHOW DATABASES csv: %w", err)
+		}
+		dbs = append(dbs, managedDoltUserDatabases(record)...)
+	}
+}
+
+// managedDoltFirstUserDatabase scans database names and returns the first non-system
 // database, or "" when none exist.
 func managedDoltFirstUserDatabase(lines []string) string {
+	dbs := managedDoltUserDatabases(lines)
+	if len(dbs) == 0 {
+		return ""
+	}
+	return dbs[0]
+}
+
+func managedDoltUserDatabases(lines []string) []string {
+	dbs := []string{}
 	for _, line := range lines {
 		name := strings.TrimSpace(line)
 		if name == "" {
@@ -152,9 +196,9 @@ func managedDoltFirstUserDatabase(lines []string) string {
 		if _, system := managedDoltSystemDatabases[strings.ToLower(name)]; system {
 			continue
 		}
-		return name
+		dbs = append(dbs, name)
 	}
-	return ""
+	return dbs
 }
 
 func managedDoltConnectionCount(host, port, user string) (string, error) {
@@ -191,7 +235,9 @@ func managedDoltHealthCheck(host, port, user string, checkReadOnly bool) (manage
 	if checkReadOnly {
 		state, err := managedDoltReadOnlyState(host, port, user)
 		if err != nil {
-			return managedDoltSQLHealthReport{}, err
+			if !errors.Is(err, errManagedDoltNoUserDatabase) {
+				return managedDoltSQLHealthReport{}, err
+			}
 		}
 		report.ReadOnly = state
 	}
@@ -280,7 +326,7 @@ func managedDoltReadOnlyStateDirect(host, port, user string) (string, error) {
 		return "unknown", err
 	}
 	if userDB == "" {
-		return "false", nil
+		return "unknown", errManagedDoltNoUserDatabase
 	}
 	for _, query := range managedDoltReadOnlyProbeStatementsFor(userDB) {
 		if _, err := conn.ExecContext(ctx, query); err != nil {
@@ -294,41 +340,32 @@ func managedDoltReadOnlyStateDirect(host, port, user string) (string, error) {
 	return "false", nil
 }
 
-func managedDoltSelectUserDatabaseDirect(host, port, user string) (string, error) {
-	db, err := managedDoltOpenDB(host, port, user)
-	if err != nil {
+func managedDoltSelectUserDatabaseFromConn(ctx context.Context, conn *sql.Conn) (string, error) {
+	dbs, err := managedDoltSelectUserDatabasesFromConn(ctx, conn)
+	if err != nil || len(dbs) == 0 {
 		return "", err
 	}
-	defer db.Close() //nolint:errcheck
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close() //nolint:errcheck
-	return managedDoltSelectUserDatabaseFromConn(ctx, conn)
+	return dbs[0], nil
 }
 
-func managedDoltSelectUserDatabaseFromConn(ctx context.Context, conn *sql.Conn) (string, error) {
+func managedDoltSelectUserDatabasesFromConn(ctx context.Context, conn *sql.Conn) ([]string, error) {
 	rows, err := conn.QueryContext(ctx, "SHOW DATABASES")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer rows.Close() //nolint:errcheck
 	names := []string{}
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			return "", err
+			return nil, err
 		}
 		names = append(names, name)
 	}
 	if err := rows.Err(); err != nil {
-		return "", err
+		return nil, err
 	}
-	return managedDoltFirstUserDatabase(names), nil
+	return managedDoltUserDatabases(names), nil
 }
 
 func managedDoltConnectionCountDirect(host, port, user string) (string, error) {
@@ -354,8 +391,19 @@ func managedDoltResetProbe(host, port, user string) error {
 	if managedDoltPassword() != "" {
 		return managedDoltResetProbeDirectFn(host, port, user)
 	}
-	_, err := runManagedDoltSQL(host, port, user, "-q", "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase)
-	return err
+	if _, err := runManagedDoltSQL(host, port, user, "-q", "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase); err != nil {
+		return err
+	}
+	dbs, err := managedDoltSelectUserDatabases(host, port, user)
+	if err != nil {
+		return err
+	}
+	for _, db := range dbs {
+		if _, err := runManagedDoltSQL(host, port, user, "-q", managedDoltDropProbeTableSQLFor(db)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func managedDoltResetProbeDirect(host, port, user string) error {
@@ -370,8 +418,28 @@ func managedDoltResetProbeDirect(host, port, user string) error {
 	if err := db.PingContext(ctx); err != nil {
 		return err
 	}
-	_, err = db.ExecContext(ctx, "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase)
-	return err
+	if _, err := db.ExecContext(ctx, "DROP DATABASE IF EXISTS "+managedDoltProbeDatabase); err != nil {
+		return err
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close() //nolint:errcheck
+	dbs, err := managedDoltSelectUserDatabasesFromConn(ctx, conn)
+	if err != nil {
+		return err
+	}
+	for _, userDB := range dbs {
+		if _, err := conn.ExecContext(ctx, managedDoltDropProbeTableSQLFor(userDB)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func managedDoltDropProbeTableSQLFor(db string) string {
+	return "DROP TABLE IF EXISTS " + managedDoltQuoteIdent(db) + "." + managedDoltQuoteIdent(managedDoltProbeTable)
 }
 
 func runManagedDoltSQL(host, port, user string, args ...string) (string, error) {

--- a/cmd/gc/dolt_sql_health.go
+++ b/cmd/gc/dolt_sql_health.go
@@ -45,9 +45,9 @@ var (
 // pick as its write target. `__gc_probe` is included so existing legacy data
 // is left in place while we migrate off of it.
 var managedDoltSystemDatabases = map[string]struct{}{
-	"information_schema": {},
-	"mysql":              {},
-	"dolt_cluster":       {},
+	"information_schema":     {},
+	"mysql":                  {},
+	"dolt_cluster":           {},
 	managedDoltProbeDatabase: {},
 }
 

--- a/cmd/gc/dolt_sql_health_test.go
+++ b/cmd/gc/dolt_sql_health_test.go
@@ -10,19 +10,77 @@ import (
 	"time"
 )
 
-func TestManagedDoltReadOnlyProbeDoesNotDropProbeDatabase(t *testing.T) {
-	for _, query := range append(append([]string{}, managedDoltReadOnlyProbeStatements[:]...), managedDoltReadOnlyProbeSQL) {
-		assertNoManagedDoltProbeDrop(t, "read-only probe", query)
-	}
-	assertManagedDoltProbeWrites(t, "joined read-only probe", managedDoltReadOnlyProbeSQL)
-	foundWriteStatement := false
-	for _, query := range managedDoltReadOnlyProbeStatements {
-		if strings.Contains(query, "REPLACE INTO __gc_probe.__probe VALUES (1)") {
-			foundWriteStatement = true
+func TestManagedDoltReadOnlyProbeStatementsForReturnsNothingForEmptyDB(t *testing.T) {
+	for _, db := range []string{"", " ", "\t"} {
+		if got := managedDoltReadOnlyProbeStatementsFor(db); got != nil {
+			t.Fatalf("managedDoltReadOnlyProbeStatementsFor(%q) = %v, want nil", db, got)
+		}
+		if got := managedDoltReadOnlyProbeSQLFor(db); got != "" {
+			t.Fatalf("managedDoltReadOnlyProbeSQLFor(%q) = %q, want \"\"", db, got)
 		}
 	}
-	if !foundWriteStatement {
-		t.Fatal("read-only probe statements must include a write to __gc_probe.__probe")
+}
+
+func TestManagedDoltReadOnlyProbeNeverTargetsLegacyDatabase(t *testing.T) {
+	for _, db := range []string{"gascity", "gm", "be", "user_db", "003", "name-with-hyphen"} {
+		stmts := managedDoltReadOnlyProbeStatementsFor(db)
+		joined := managedDoltReadOnlyProbeSQLFor(db)
+		for _, q := range append(append([]string{}, stmts...), joined) {
+			assertNoManagedDoltProbeLegacyTarget(t, "probe stmts for "+db, q)
+			assertNoManagedDoltProbeDrop(t, "probe stmts for "+db, q)
+		}
+		wantTable := "`" + db + "`.`__probe`"
+		for _, q := range stmts {
+			if !strings.Contains(q, wantTable) {
+				t.Fatalf("probe stmt for %s missing %q: %s", db, wantTable, q)
+			}
+		}
+		if !strings.Contains(joined, "REPLACE INTO "+wantTable+" VALUES (1)") {
+			t.Fatalf("probe SQL for %s must write to %s: %s", db, wantTable, joined)
+		}
+	}
+}
+
+func TestManagedDoltQuoteIdentEscapesBackticks(t *testing.T) {
+	cases := map[string]string{
+		"gascity":            "`gascity`",
+		"003":                "`003`",
+		"with`backtick":      "`with``backtick`",
+		"name with spaces":   "`name with spaces`",
+		"":                   "``",
+	}
+	for in, want := range cases {
+		if got := managedDoltQuoteIdent(in); got != want {
+			t.Fatalf("managedDoltQuoteIdent(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestManagedDoltFirstUserDatabaseSkipsSystemDatabases(t *testing.T) {
+	cases := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{"all system", []string{"Database", "information_schema", "mysql", "dolt_cluster", "__gc_probe"}, ""},
+		{"first user wins", []string{"Database", "__gc_probe", "dolt_cluster", "gascity", "be"}, "gascity"},
+		{"case-insensitive system match", []string{"Database", "Information_Schema", "MySQL", "DOLT_CLUSTER", "__GC_PROBE", "gm"}, "gm"},
+		{"empty", []string{}, ""},
+		{"only header", []string{"Database"}, ""},
+		{"whitespace + blanks ignored", []string{"Database", "", "  ", "gascity"}, "gascity"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := managedDoltFirstUserDatabase(tc.lines); got != tc.want {
+				t.Fatalf("managedDoltFirstUserDatabase(%v) = %q, want %q", tc.lines, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestManagedDoltSystemDatabasesIncludesLegacyProbe(t *testing.T) {
+	if _, ok := managedDoltSystemDatabases[managedDoltProbeDatabase]; !ok {
+		t.Fatalf("managedDoltSystemDatabases missing %q — probe could re-elect legacy database", managedDoltProbeDatabase)
 	}
 }
 
@@ -38,6 +96,24 @@ func assertNoManagedDoltProbeDrop(t *testing.T, label, text string) {
 	}
 }
 
+// assertNoManagedDoltProbeLegacyTarget enforces that gc CLI probe SQL never
+// CREATEs or writes to the legacy `__gc_probe` database — that's what made
+// it dolt's stats backing store and accumulated 596k buckets in production.
+func assertNoManagedDoltProbeLegacyTarget(t *testing.T, label, text string) {
+	t.Helper()
+	createLegacy := regexp.MustCompile("(?i)\\bCREATE\\s+(DATABASE|TABLE)\\s+(IF\\s+NOT\\s+EXISTS\\s+)?`?__gc_probe`?")
+	writeLegacy := regexp.MustCompile("(?i)\\b(REPLACE|INSERT)\\s+INTO\\s+`?__gc_probe`?")
+	if createLegacy.MatchString(text) {
+		t.Fatalf("%s must not create __gc_probe: %s", label, text)
+	}
+	if writeLegacy.MatchString(text) {
+		t.Fatalf("%s must not write to __gc_probe: %s", label, text)
+	}
+}
+
+// assertManagedDoltProbeWrites is retained for the gc-beads-bd.sh fallback
+// test (the bash branch still hits the legacy probe target until its own
+// follow-up bead lands).
 func assertManagedDoltProbeWrites(t *testing.T, label, text string) {
 	t.Helper()
 	if !strings.Contains(text, "REPLACE INTO __gc_probe.__probe VALUES (1)") {

--- a/cmd/gc/dolt_sql_health_test.go
+++ b/cmd/gc/dolt_sql_health_test.go
@@ -43,11 +43,11 @@ func TestManagedDoltReadOnlyProbeNeverTargetsLegacyDatabase(t *testing.T) {
 
 func TestManagedDoltQuoteIdentEscapesBackticks(t *testing.T) {
 	cases := map[string]string{
-		"gascity":            "`gascity`",
-		"003":                "`003`",
-		"with`backtick":      "`with``backtick`",
-		"name with spaces":   "`name with spaces`",
-		"":                   "``",
+		"gascity":          "`gascity`",
+		"003":              "`003`",
+		"with`backtick":    "`with``backtick`",
+		"name with spaces": "`name with spaces`",
+		"":                 "``",
 	}
 	for in, want := range cases {
 		if got := managedDoltQuoteIdent(in); got != want {

--- a/cmd/gc/dolt_sql_health_test.go
+++ b/cmd/gc/dolt_sql_health_test.go
@@ -29,10 +29,13 @@ func TestManagedDoltReadOnlyProbeNeverTargetsLegacyDatabase(t *testing.T) {
 			assertNoManagedDoltProbeLegacyTarget(t, "probe stmts for "+db, q)
 			assertNoManagedDoltProbeDrop(t, "probe stmts for "+db, q)
 		}
-		wantTable := "`" + db + "`.`__probe`"
+		wantTable := "`" + db + "`.`" + managedDoltProbeTable + "`"
 		for _, q := range stmts {
 			if !strings.Contains(q, wantTable) {
 				t.Fatalf("probe stmt for %s missing %q: %s", db, wantTable, q)
+			}
+			if strings.Contains(q, "`.`__probe`") {
+				t.Fatalf("probe stmt for %s uses generic probe table: %s", db, q)
 			}
 		}
 		if !strings.Contains(joined, "REPLACE INTO "+wantTable+" VALUES (1)") {
@@ -62,9 +65,9 @@ func TestManagedDoltFirstUserDatabaseSkipsSystemDatabases(t *testing.T) {
 		lines []string
 		want  string
 	}{
-		{"all system", []string{"Database", "information_schema", "mysql", "dolt_cluster", "__gc_probe"}, ""},
-		{"first user wins", []string{"Database", "__gc_probe", "dolt_cluster", "gascity", "be"}, "gascity"},
-		{"case-insensitive system match", []string{"Database", "Information_Schema", "MySQL", "DOLT_CLUSTER", "__GC_PROBE", "gm"}, "gm"},
+		{"all system", []string{"Database", "information_schema", "mysql", "dolt_cluster", "performance_schema", "sys", "__gc_probe"}, ""},
+		{"first user wins", []string{"Database", "__gc_probe", "dolt_cluster", "performance_schema", "sys", "gascity", "be"}, "gascity"},
+		{"case-insensitive system match", []string{"Database", "Information_Schema", "MySQL", "DOLT_CLUSTER", "PERFORMANCE_SCHEMA", "SYS", "__GC_PROBE", "gm"}, "gm"},
 		{"empty", []string{}, ""},
 		{"only header", []string{"Database"}, ""},
 		{"whitespace + blanks ignored", []string{"Database", "", "  ", "gascity"}, "gascity"},
@@ -78,21 +81,190 @@ func TestManagedDoltFirstUserDatabaseSkipsSystemDatabases(t *testing.T) {
 	}
 }
 
-func TestManagedDoltSystemDatabasesIncludesLegacyProbe(t *testing.T) {
-	if _, ok := managedDoltSystemDatabases[managedDoltProbeDatabase]; !ok {
-		t.Fatalf("managedDoltSystemDatabases missing %q — probe could re-elect legacy database", managedDoltProbeDatabase)
+func TestManagedDoltFirstUserDatabaseFromCSVHandlesEscapedNames(t *testing.T) {
+	got, err := managedDoltFirstUserDatabaseFromCSV("Database\ninformation_schema\n\"tenant,one\"\n")
+	if err != nil {
+		t.Fatalf("managedDoltFirstUserDatabaseFromCSV() error = %v", err)
+	}
+	if got != "tenant,one" {
+		t.Fatalf("managedDoltFirstUserDatabaseFromCSV() = %q, want tenant,one", got)
+	}
+
+	got, err = managedDoltFirstUserDatabaseFromCSV("Database\n\"tenant\"\"two\"\n")
+	if err != nil {
+		t.Fatalf("managedDoltFirstUserDatabaseFromCSV() quote error = %v", err)
+	}
+	if got != "tenant\"two" {
+		t.Fatalf("managedDoltFirstUserDatabaseFromCSV() = %q, want tenant\"two", got)
+	}
+}
+
+func TestManagedDoltReadOnlyStateNoUserDatabaseIsUnknown(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*"__gc_read_only_probe"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	state, err := managedDoltReadOnlyState("127.0.0.1", "3311", "root")
+	if err == nil {
+		t.Fatal("managedDoltReadOnlyState() error = nil, want no-user-database diagnostic")
+	}
+	if state != "unknown" {
+		t.Fatalf("managedDoltReadOnlyState() state = %q, want unknown", state)
+	}
+	if !strings.Contains(err.Error(), "no user database") {
+		t.Fatalf("managedDoltReadOnlyState() error = %v, want no user database", err)
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("managedDoltReadOnlyState() ran write probe without user database:\n%s", invocation)
+	}
+}
+
+func TestManagedDoltHealthCheckNoUserDatabaseIsUnknown(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -q SELECT active_branch()"*)
+    exit 0
+    ;;
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ninformation_schema\nmysql\ndolt_cluster\nperformance_schema\nsys\n__gc_probe\n'
+    exit 0
+    ;;
+  *"sql -r csv -q SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST"*)
+    printf 'cnt\n0\n'
+    exit 0
+    ;;
+  *"CREATE TABLE IF NOT EXISTS"*)
+    echo "unexpected write probe without a user database" >&2
+    exit 2
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	report, err := managedDoltHealthCheck("127.0.0.1", "3311", "root", true)
+	if err != nil {
+		t.Fatalf("managedDoltHealthCheck() error = %v", err)
+	}
+	if !report.QueryReady || report.ReadOnly != "unknown" || report.ConnectionCount != "0" {
+		t.Fatalf("managedDoltHealthCheck() = %+v, want query-ready unknown with connection count", report)
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	if strings.Contains(string(invocation), "CREATE TABLE IF NOT EXISTS") {
+		t.Fatalf("managedDoltHealthCheck() ran write probe without user database:\n%s", invocation)
+	}
+}
+
+func TestManagedDoltResetProbeDropsUserProbeTables(t *testing.T) {
+	binDir := t.TempDir()
+	invocationFile := filepath.Join(t.TempDir(), "dolt-invocation.txt")
+	writeFakeDoltSQLBinary(t, binDir, invocationFile, `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$INVOCATION_FILE"
+case "$*" in
+  *"sql -r csv -q SHOW DATABASES"*)
+    printf 'Database\ngascity\ninformation_schema\nwith-hyphen\n__gc_probe\n'
+    exit 0
+    ;;
+  *"DROP DATABASE IF EXISTS __gc_probe"*)
+    exit 0
+    ;;
+  *"DROP TABLE IF EXISTS"*"__gc_read_only_probe"*)
+    exit 0
+    ;;
+  *)
+    echo "unexpected command: $*" >&2
+    exit 2
+    ;;
+esac
+`)
+	t.Setenv("INVOCATION_FILE", invocationFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := managedDoltResetProbe("127.0.0.1", "3311", "root"); err != nil {
+		t.Fatalf("managedDoltResetProbe() error = %v", err)
+	}
+	invocation, err := os.ReadFile(invocationFile)
+	if err != nil {
+		t.Fatalf("ReadFile(invocation): %v", err)
+	}
+	text := string(invocation)
+	for _, want := range []string{
+		"DROP DATABASE IF EXISTS __gc_probe",
+		"DROP TABLE IF EXISTS `gascity`.`" + managedDoltProbeTable + "`",
+		"DROP TABLE IF EXISTS `with-hyphen`.`" + managedDoltProbeTable + "`",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("managedDoltResetProbe() invocation = %s, want %q", text, want)
+		}
+	}
+	if strings.Contains(text, "information_schema`.`"+managedDoltProbeTable) || strings.Contains(text, "__gc_probe`.`"+managedDoltProbeTable) {
+		t.Fatalf("managedDoltResetProbe() dropped probe table in system database:\n%s", text)
+	}
+}
+
+func TestManagedDoltSystemDatabasesIncludesManagedAndDoltSystemDatabases(t *testing.T) {
+	for _, name := range []string{
+		"information_schema",
+		"mysql",
+		"dolt_cluster",
+		"performance_schema",
+		"sys",
+		managedDoltProbeDatabase,
+	} {
+		if _, ok := managedDoltSystemDatabases[name]; !ok {
+			t.Fatalf("managedDoltSystemDatabases missing %q", name)
+		}
 	}
 }
 
 func assertNoManagedDoltProbeDrop(t *testing.T, label, text string) {
 	t.Helper()
 	dropProbeDatabase := regexp.MustCompile("(?i)\\bDROP\\s+DATABASE\\s+(IF\\s+EXISTS\\s+)?`?__gc_probe`?")
-	dropProbeTable := regexp.MustCompile("(?i)\\bDROP\\s+TABLE\\s+(IF\\s+EXISTS\\s+)?(`?__gc_probe`?\\.)?`?__probe`?")
+	dropGenericProbeTable := regexp.MustCompile("(?i)\\bDROP\\s+TABLE\\s+(IF\\s+EXISTS\\s+)?(`?__gc_probe`?\\.)?`?__probe`?")
+	dropManagedProbeTable := regexp.MustCompile("(?i)\\bDROP\\s+TABLE\\s+(IF\\s+EXISTS\\s+)?(`?__gc_probe`?\\.)?`?" + regexp.QuoteMeta(managedDoltProbeTable) + "`?")
 	if dropProbeDatabase.MatchString(text) {
 		t.Fatalf("%s must not drop __gc_probe: %s", label, text)
 	}
-	if dropProbeTable.MatchString(text) {
-		t.Fatalf("%s must keep __gc_probe.__probe stable: %s", label, text)
+	if dropGenericProbeTable.MatchString(text) {
+		t.Fatalf("%s must not drop generic __probe tables: %s", label, text)
+	}
+	if dropManagedProbeTable.MatchString(text) {
+		t.Fatalf("%s must not drop %s from normal probe paths: %s", label, managedDoltProbeTable, text)
 	}
 }
 
@@ -108,16 +280,6 @@ func assertNoManagedDoltProbeLegacyTarget(t *testing.T, label, text string) {
 	}
 	if writeLegacy.MatchString(text) {
 		t.Fatalf("%s must not write to __gc_probe: %s", label, text)
-	}
-}
-
-// assertManagedDoltProbeWrites is retained for the gc-beads-bd.sh fallback
-// test (the bash branch still hits the legacy probe target until its own
-// follow-up bead lands).
-func assertManagedDoltProbeWrites(t *testing.T, label, text string) {
-	t.Helper()
-	if !strings.Contains(text, "REPLACE INTO __gc_probe.__probe VALUES (1)") {
-		t.Fatalf("%s must write to __gc_probe.__probe: %s", label, text)
 	}
 }
 

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -111,18 +111,20 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
 	}
 
+	doltSystemNeedle := "information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe"
+	maintenanceSystemNeedle := "^information_schema$\\|^mysql$\\|^dolt_cluster$\\|^performance_schema$\\|^sys$\\|^__gc_probe$"
 	for _, tt := range []struct {
 		pack     string
 		rel      string
 		needle   string
 		minCount int
 	}{
-		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), "^dolt_cluster$\\|^__gc_probe$", 1},
-		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), "^dolt_cluster$\\|^__gc_probe$", 1},
-		{"dolt", filepath.Join("commands", "list", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 1},
-		{"dolt", filepath.Join("commands", "cleanup", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 1},
-		{"dolt", filepath.Join("commands", "health", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 2},
-		{"dolt", filepath.Join("commands", "sync", "run.sh"), "information_schema|mysql|dolt_cluster|__gc_probe", 2},
+		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), maintenanceSystemNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), maintenanceSystemNeedle, 1},
+		{"dolt", filepath.Join("commands", "list", "run.sh"), doltSystemNeedle, 1},
+		{"dolt", filepath.Join("commands", "cleanup", "run.sh"), doltSystemNeedle, 1},
+		{"dolt", filepath.Join("commands", "health", "run.sh"), doltSystemNeedle, 2},
+		{"dolt", filepath.Join("commands", "sync", "run.sh"), doltSystemNeedle, 2},
 		{"dolt", filepath.Join("formulas", "mol-dog-stale-db.toml"), "__gc_probe", 1},
 		{"dolt", filepath.Join("formulas", "mol-dog-doctor.toml"), "__gc_probe", 1},
 	} {
@@ -138,7 +140,16 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 }
 
 func TestDoltSyncRejectsManagedProbeDatabaseFilter(t *testing.T) {
-	for _, dbName := range []string{managedDoltProbeDatabase, strings.ToUpper(managedDoltProbeDatabase), " " + managedDoltProbeDatabase + " "} {
+	for _, dbName := range []string{
+		managedDoltProbeDatabase,
+		strings.ToUpper(managedDoltProbeDatabase),
+		" " + managedDoltProbeDatabase + " ",
+		"information_schema",
+		"mysql",
+		"dolt_cluster",
+		"performance_schema",
+		"sys",
+	} {
 		t.Run(dbName, func(t *testing.T) {
 			dir := t.TempDir()
 			if err := MaterializeBuiltinPacks(dir); err != nil {
@@ -152,7 +163,7 @@ func TestDoltSyncRejectsManagedProbeDatabaseFilter(t *testing.T) {
 			if err == nil {
 				t.Fatalf("gc dolt sync unexpectedly accepted %s:\n%s", dbName, out)
 			}
-			if !strings.Contains(string(out), "reserved Dolt database name: "+managedDoltProbeDatabase) {
+			if !strings.Contains(string(out), "reserved Dolt database name: "+strings.TrimSpace(dbName)) {
 				t.Fatalf("gc dolt sync output = %s, want reserved database error", out)
 			}
 		})

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -79,6 +79,68 @@ connect_host() {
     fi
 }
 
+trim_space() {
+    printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+lower_dolt_database_name() {
+    trim_space "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_system_dolt_database_name() {
+    case "$(lower_dolt_database_name "$1")" in
+        information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_legacy_managed_probe_database_name() {
+    [ "$(lower_dolt_database_name "$1")" = "__gc_probe" ]
+}
+
+csv_unquote_single_field() {
+    local value
+    value="$1"
+    case "$value" in
+        \"*\")
+            case "$value" in
+                *\") ;;
+                *) return 1 ;;
+            esac
+            value=${value#\"}
+            value=${value%\"}
+            printf '%s\n' "$value" | sed 's/""/"/g'
+            ;;
+        *)
+            printf '%s\n' "$value"
+            ;;
+    esac
+}
+
+first_user_database_from_show_databases_csv() {
+    local line name
+    while IFS= read -r line || [ -n "$line" ]; do
+        name=$(csv_unquote_single_field "$line") || return 1
+        name=$(trim_space "$name")
+        [ -n "$name" ] || continue
+        [ "$(lower_dolt_database_name "$name")" = "database" ] && continue
+        if is_system_dolt_database_name "$name"; then
+            continue
+        fi
+        printf '%s\n' "$name"
+        return 0
+    done <<GC_SHOW_DATABASES_CSV
+$1
+GC_SHOW_DATABASES_CSV
+    return 0
+}
+
+quote_dolt_identifier() {
+    local escaped
+    escaped=$(printf '%s' "$1" | sed 's/`/``/g')
+    printf '`%s`' "$escaped"
+}
+
 # tcp_check_port returns 0 if the given port is reachable.
 tcp_check_port() {
     local port="$1"
@@ -1012,28 +1074,62 @@ get_connection_count() {
 }
 
 # check_read_only tests if the dolt server is in read-only mode.
-# Returns 0 if read-only, 1 if writable.
+# Returns 0 if read-only, 1 if writable, 2 if the write probe is inconclusive.
 check_read_only() {
-    local host gc_bin
+    local host gc_bin db quoted_db probe_table sql output err_file err_text status
     host=$(connect_host)
     gc_bin=$(resolve_gc_helper_bin)
     if [ -n "$gc_bin" ]; then
-        "$gc_bin" dolt-state read-only-check --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" >/dev/null 2>&1
-        case $? in
-            0) return 0 ;;
-            *) return 1 ;;
-        esac
+        err_file=$(mktemp "${TMPDIR:-/tmp}/gc-dolt-read-only-check.XXXXXX") || return 2
+        if "$gc_bin" dolt-state read-only-check --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" >/dev/null 2>"$err_file"; then
+            rm -f "$err_file"
+            return 0
+        fi
+        err_text=$(cat "$err_file" 2>/dev/null || true)
+        rm -f "$err_file"
+        if [ -n "$err_text" ]; then
+            echo "$err_text" >&2
+            return 2
+        fi
+        return 1
     fi
-    local output
-    # Keep __gc_probe stable. Dropping Dolt databases leaves
-    # .dolt_dropped_databases backups behind.
-    output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls         sql -q "CREATE DATABASE IF NOT EXISTS __gc_probe; CREATE TABLE IF NOT EXISTS __gc_probe.__probe (k INT PRIMARY KEY); REPLACE INTO __gc_probe.__probe VALUES (1);" 2>&1) || true
+    err_file=$(mktemp "${TMPDIR:-/tmp}/gc-dolt-show-databases.XXXXXX") || return 2
+    if output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls \
+        sql -r csv -q "SHOW DATABASES" 2>"$err_file"); then
+        status=0
+    else
+        status=$?
+    fi
+    err_text=$(cat "$err_file" 2>/dev/null || true)
+    rm -f "$err_file"
+    if [ "$status" -ne 0 ]; then
+        case "$err_text" in
+            *"read only"*|*"READ ONLY"*|*"Read-only"*)
+                return 0
+                ;;
+        esac
+        [ -n "$err_text" ] && echo "dolt SHOW DATABASES failed: $err_text" >&2
+        return 2
+    fi
+    db=$(first_user_database_from_show_databases_csv "$output") || return 2
+    if [ -z "$db" ]; then
+        echo "dolt read-only probe inconclusive: no user database available" >&2
+        return 2
+    fi
+    quoted_db=$(quote_dolt_identifier "$db")
+    probe_table='`__gc_read_only_probe`'
+    sql="CREATE TABLE IF NOT EXISTS ${quoted_db}.${probe_table} (k INT PRIMARY KEY); REPLACE INTO ${quoted_db}.${probe_table} VALUES (1);"
+    if output=$(dolt --host "$host" --port "$DOLT_PORT" --user "$DOLT_USER" --password "${DOLT_PASSWORD:-}" --no-tls \
+        sql -q "$sql" 2>&1); then
+        return 1
+    fi
     case "$output" in
         *"read only"*|*"READ ONLY"*|*"Read-only"*)
             return 0  # Is read-only.
             ;;
     esac
-    return 1  # Writable.
+    [ -n "$output" ] && echo "dolt write probe failed: $output" >&2
+    return 2
 }
 
 load_health_check_from_gc() {
@@ -1479,10 +1575,7 @@ valid_sql_name() {
 }
 
 is_reserved_dolt_database_name() {
-    case "$(printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" in
-        __gc_probe) return 0 ;;
-        *) return 1 ;;
-    esac
+    is_system_dolt_database_name "$1"
 }
 
 # clean_stale_sockets removes stale Unix domain sockets left by a crashed
@@ -1929,7 +2022,7 @@ op_init() {
 
     if [ -f "$metadata_path" ]; then
         existing_db=$(read_existing_dolt_database "$metadata_path")
-        if [ -n "$existing_db" ] && is_reserved_dolt_database_name "$existing_db"; then
+        if [ -n "$existing_db" ] && is_legacy_managed_probe_database_name "$existing_db"; then
             allow_reserved_existing=true
         fi
     fi
@@ -2104,7 +2197,7 @@ op_store_bridge() {
     return $?
 }
 op_health() {
-    local conn_count=""
+    local conn_count="" read_only_status
 
     # TCP check.
     if ! tcp_check; then
@@ -2117,6 +2210,9 @@ op_health() {
         fi
         if ! is_remote && [ "$GC_HEALTH_READ_ONLY" = "true" ]; then
             die "dolt server is in read-only mode"
+        fi
+        if ! is_remote && [ "$GC_HEALTH_READ_ONLY" = "unknown" ]; then
+            echo "warning: dolt read-only probe inconclusive" >&2
         fi
         conn_count="$GC_HEALTH_CONNECTION_COUNT"
     else
@@ -2132,9 +2228,15 @@ op_health() {
 
         # Read-only detection (local only).
         if ! is_remote; then
-            if check_read_only; then
-                die "dolt server is in read-only mode"
-            fi
+            set +e
+            check_read_only
+            read_only_status=$?
+            set -e
+            case "$read_only_status" in
+                0) die "dolt server is in read-only mode" ;;
+                1) ;;
+                *) echo "warning: dolt read-only probe inconclusive" >&2 ;;
+            esac
         fi
 
         # Connection capacity warning (non-fatal, single query).
@@ -2192,6 +2294,8 @@ op_probe() {
 
 # op_recover stops the dolt server, restarts it, and verifies health.
 op_recover() {
+    local read_only_status
+
     if is_remote; then
         die "recovery not supported for remote dolt servers"
     fi
@@ -2216,8 +2320,15 @@ op_recover() {
             if [ "$GC_HEALTH_READ_ONLY" = "true" ]; then
                 echo "detected read-only dolt server — restarting" >&2
             fi
-        elif check_read_only; then
-            echo "detected read-only dolt server — restarting" >&2
+        else
+            set +e
+            check_read_only
+            read_only_status=$?
+            set -e
+            case "$read_only_status" in
+                0) echo "detected read-only dolt server — restarting" >&2 ;;
+                2) echo "dolt read-only probe inconclusive before recovery" >&2 ;;
+            esac
         fi
     fi
 

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -97,7 +97,7 @@ orphan_count=0
 for d in "$data_dir"/*/; do
   [ ! -d "$d/.dolt" ] && continue
   name="$(basename "$d")"
-  case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
+  case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
   case "$referenced" in
     *" $name "*) continue ;; # referenced, not orphan
   esac

--- a/examples/dolt/commands/gc-nudge/run.sh
+++ b/examples/dolt/commands/gc-nudge/run.sh
@@ -209,7 +209,7 @@ valid_database_name() {
 is_system_database() {
   name=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   case "$name" in
-    information_schema|mysql|dolt_cluster|__gc_probe) return 0 ;;
+    information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -133,7 +133,7 @@ if [ -d "$data_dir" ] && [ "$server_reachable" = true ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     # Reject names with anything outside [A-Za-z0-9_-] before interpolating
     # into the SQL identifier. The first byte must still be alnum/underscore
     # so the command-side contract matches gc-nudge and avoids option-shaped
@@ -213,7 +213,7 @@ if [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     case "$referenced" in *" $name "*) continue ;; esac
     size_bytes=$(du -sb "$d" 2>/dev/null | cut -f1 || echo 0)
     if [ "$size_bytes" -ge 1048576 ]; then

--- a/examples/dolt/commands/list/run.sh
+++ b/examples/dolt/commands/list/run.sh
@@ -21,7 +21,7 @@ for d in "$data_dir"/*/; do
   name="$(basename "$d")"
   # Skip system databases.
   case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in
-    information_schema|mysql|dolt_cluster|__gc_probe) continue ;;
+    information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;;
   esac
   printf "%s\t%s\n" "$name" "$d"
   found=$((found + 1))

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -41,10 +41,12 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" = "__gc_probe" ]; then
-  echo "gc dolt sync: reserved Dolt database name: __gc_probe (used internally by gc)" >&2
+case "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" in
+  information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe)
+  echo "gc dolt sync: reserved Dolt database name: $(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//') (used internally by Dolt or gc)" >&2
   exit 1
-fi
+  ;;
+esac
 
 # Check if server is running.
 is_running() {
@@ -82,7 +84,7 @@ if [ "$do_gc" = true ] && [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
     beads_dir=""
     # Find the .beads directory for this database.
@@ -120,7 +122,7 @@ if [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
     name="$(basename "$d")"
-    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
 
     # Check for remote.

--- a/examples/dolt/formulas/mol-dog-doctor.toml
+++ b/examples/dolt/formulas/mol-dog-doctor.toml
@@ -100,7 +100,8 @@ Check data directory size. Warn if exceeding configured threshold.
 SHOW DATABASES;
 ```
 Count databases matching orphan patterns: testdb_*, beads_t*, beads_pt*, doctest_*.
-Ignore Dolt internals: information_schema, mysql, dolt_cluster, __gc_probe.
+Ignore Dolt internals: information_schema, mysql, dolt_cluster,
+performance_schema, sys, __gc_probe.
 If orphan count > threshold, recommend cleanup:
 ```bash
 gc dolt cleanup

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -60,7 +60,7 @@ Query the Dolt server and identify orphaned databases.
 SHOW DATABASES;
 ```
 Filter out Dolt internals (information_schema, mysql, dolt_cluster,
-__gc_probe).
+performance_schema, sys, __gc_probe).
 
 **2. Classify each database:**
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -34,7 +34,7 @@ mkdir -p "$(dirname "$STATE_FILE")"
 
 # Discover databases. Exclude Dolt/MySQL system schemas and Gas City's internal
 # health-probe database; the remaining databases are expected to be bead stores.
-DATABASES=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -vi '^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$' || true)
+DATABASES=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -vi '^information_schema$\|^mysql$\|^dolt_cluster$\|^performance_schema$\|^sys$\|^__gc_probe$' || true)
 if [ -z "$DATABASES" ]; then
     exit 0
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -34,7 +34,7 @@ MAIL_AGE_H=$(duration_to_hours "$MAIL_DELETE_AGE")
 
 # Discover databases from Dolt server. Exclude Dolt/MySQL system schemas and
 # Gas City's internal health-probe database; remaining DBs are bead stores.
-DATABASES=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -vi '^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$' || true)
+DATABASES=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | grep -vi '^information_schema$\|^mysql$\|^dolt_cluster$\|^performance_schema$\|^sys$\|^__gc_probe$' || true)
 if [ -z "$DATABASES" ]; then
     # No databases accessible — nothing to do.
     exit 0

--- a/release-gates/ga-hivi-probe-user-db-gate.md
+++ b/release-gates/ga-hivi-probe-user-db-gate.md
@@ -1,56 +1,96 @@
 # Release gate — probe a user DB so `__gc_probe` stops hosting stats (ga-42gi / ga-hivi)
 
-**Verdict:** PASS
+**Verdict:** PASS with maintainer fixups
 
-Branch: `release/ga-hivi-probe-user-db` (cut fresh off `origin/main` @ `a4d32733`)
-Commits on the branch:
+Branch: `release/ga-hivi-probe-user-db` rebased for review on `origin/main` @ `936dea150`.
 
-- `81f5bcb6` — fix(dolt/health): probe a user db so __gc_probe stops hosting stats (ga-42gi). Cherry-pick of source SHA `db6831b0` from `fork/gc-builder-1-01561d4fb9ea`. Clean (no conflicts).
-- `8047de53` — chore(fmt): align map literals after ga-42gi cherry-pick. Pure formatting — `golangci-lint fmt` normalizer flagged the new map literal alignment that the original commit missed. No behavior change.
+Commits under review:
 
-Diff vs `origin/main`: 3 files changed, +302/-38 lines (cherry-pick) plus +8/-8 (formatting):
+- `390278080` — fix(dolt/health): probe a user db so __gc_probe stops hosting stats (ga-42gi). Rebased cherry-pick of source SHA `db6831b0` from `fork/gc-builder-1-01561d4fb9ea`.
+- `842002634` — chore(fmt): align map literals after ga-42gi cherry-pick. Pure formatting for `golangci-lint fmt`.
+- `3d319fad` — chore: release gate PASS for ga-hivi (ga-42gi). Original gate artifact from the contributor branch.
+- Current maintainer fixup commit — `fix(dolt): harden user-db health probe`,
+  resolving the PR-review loop findings for CSV database parsing, Dolt system
+  database exclusions, reserved existing metadata, no-user-database diagnostics,
+  and stale user-database `__gc_read_only_probe` cleanup.
 
+Diff vs `origin/main` now covers these files:
+
+- `cmd/gc/beads_provider_lifecycle.go`
+- `cmd/gc/beads_provider_lifecycle_test.go`
+- `cmd/gc/cmd_dolt_state.go`
+- `cmd/gc/cmd_dolt_state_test.go`
 - `cmd/gc/dolt_sql_health.go`
 - `cmd/gc/dolt_sql_health_test.go`
-- `cmd/gc/cmd_dolt_state_test.go`
+- `cmd/gc/embed_builtin_packs_test.go`
+- `examples/bd/assets/scripts/gc-beads-bd.sh`
+- `examples/dolt/commands/cleanup/run.sh`
+- `examples/dolt/commands/gc-nudge/run.sh`
+- `examples/dolt/commands/health/run.sh`
+- `examples/dolt/commands/list/run.sh`
+- `examples/dolt/commands/sync/run.sh`
+- `examples/dolt/formulas/mol-dog-doctor.toml`
+- `examples/dolt/formulas/mol-dog-stale-db.toml`
+- `release-gates/ga-hivi-probe-user-db-gate.md`
 
 ## Review
 
-| Review bead | Reviews | Verdict | Reviewer           |
-|-------------|---------|---------|--------------------|
-| ga-hivi     | ga-42gi | PASS    | gascity/reviewer-1 |
-
-Reviewer message (`gm-wisp-mbo`): *"Reviewed db6831b0. Tests + vet + build clean. Indirect-enforcement verified. Ready for release gate."*
-
-Reviewer notes recorded one INFO/style observation that the variable-width key alignment "gofmt accepts" — the deployer-side `golangci-lint fmt --diff ./...` (CI's `make fmt-check`) actually flags it on Go 1.26.2, so the formatter was applied as a follow-up commit. Non-functional.
-
-Gemini second-pass: disabled per current rig configuration.
+| Review source | Verdict | Notes |
+|---------------|---------|-------|
+| Original ga-hivi review | PASS | Reviewed source commit `db6831b0`; formatter follow-up addressed the style note. |
+| PR-review synthesis `ga-5sq14q2` attempt 1 | request_changes | Major findings are resolved by the local maintainer fixup and require another review iteration before merge. |
 
 ## Criteria
 
-| # | Criterion                             | Verdict | Evidence |
-|---|---------------------------------------|---------|----------|
-| 1 | Review PASS present                   | PASS    | reviewer-1 PASS on ga-hivi via mail `gm-wisp-mbo`; verdict recorded in bead notes. |
-| 2 | Acceptance criteria met               | PASS    | New probe path doesn't create or write to `__gc_probe` — enforced by `assertNoManagedDoltProbeLegacyTarget` (`cmd/gc/dolt_sql_health_test.go`) AND by `managedDoltSystemDatabases` skiplist (`cmd/gc/dolt_sql_health.go:47-52`) AND case-insensitive lookup at line 152. Existing health-check tests pass. Comment block updated. |
-| 3 | Tests pass                            | PASS    | `go vet ./...` clean; `go build ./...` clean; targeted `go test -short -run "TestManagedDolt\|TestDoltStateReadOnlyCheckCmd\|TestDoltStateHealthCheckCmd\|TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase\|TestGcBeadsBdInitRejectsManagedProbeDatabaseName" ./cmd/gc/...` → ok 2.7s. Pre-existing env-leak failures reproduce identically on `origin/main` (see below). |
-| 4 | No high-severity review findings open | PASS    | Reviewer reported no blocking findings. INFO note on alignment resolved by `8047de53`. |
-| 5 | Final branch is clean                 | PASS    | `git status` clean (only this gate file untracked at write time, plus a stray `.gitkeep` from worktree init). |
-| 6 | Branch diverges cleanly from main     | PASS    | Cherry-pick of `db6831b0` onto fresh branch off `origin/main` applied with zero conflicts. |
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Probe no longer writes `__gc_probe` | PASS | Go probe SQL targets a selected user DB; bash fallback now runs `SHOW DATABASES` and writes `<user_db>.__gc_read_only_probe`; tests reject legacy create/write targets. |
+| 2 | System databases are not probe targets | PASS | Go and shell skip `information_schema`, `mysql`, `dolt_cluster`, `performance_schema`, `sys`, and `__gc_probe`. |
+| 3 | CSV database names parse correctly | PASS | CLI `SHOW DATABASES -r csv` output is parsed with `encoding/csv`; tests cover comma and quote escaped names. |
+| 4 | Existing reserved metadata is rejected except legacy `__gc_probe` | PASS | Canonical metadata normalization now preserves only the legacy `__gc_probe` migration case; existing `mysql` metadata is rejected by regression coverage. |
+| 5 | No-user-database probes are diagnostic, not writable | PASS | Go and shell fallback probes now return an unknown/diagnostic state without issuing a write probe when `SHOW DATABASES` contains no user database. |
+| 6 | Probe-table cleanup covers rotated user DBs | PASS | `gc dolt-state reset-probe` still drops legacy `__gc_probe` and now drops `__gc_read_only_probe` tables from each discovered user database. It deliberately does not drop generic `__probe` tables because those can be user-owned. |
+| 7 | Review-loop major findings closed locally | PASS | Reserved metadata, no-user-database behavior, and stale probe-table cleanup findings are fixed; the workflow must run a fresh review/scorecard before final approval. |
+| 8 | Branch evidence is current | PASS | This artifact records the rebased base SHA, current commit chain, and full changed-file set. |
 
-## Build / vet / fmt
+## Upgrade remediation
 
-- `go vet ./...` → clean
-- `go build ./...` → clean
-- `golangci-lint fmt --diff ./cmd/gc/...` → clean after `8047de53`
-- Cherry-pick clean (no conflicts)
+Managed Dolt servers upgraded from a build that wrote `__gc_probe` must run this
+once per server after the new binary is available:
 
-## Pre-existing failures (not introduced)
+```bash
+gc dolt-state reset-probe --host <host> --port <port> --user <user> --force
+```
 
-Running `go test -short ./cmd/gc/...` surfaces 4 failures (`TestRigAnywhere_ResolveContext` subtests, `TestOpenStoreAtForCityExecProjectsConfiguredTargets`, `TestOpenStoreAtForCityExecBeadsBdProjectsScopedExternalDoltEnv`, `TestOpenStoreAtForCityExecUsesUniversalStoreTargetEnv`, `TestControllerQueryRuntimeEnvReturnsNilForNonBD`).
+That command removes the legacy `__gc_probe` database and the GC-owned
+`__gc_read_only_probe` table from discovered user databases. It is idempotent.
+Do not manually drop generic `__probe` tables; they are outside the GC reserved
+contract and may belong to user data.
 
-All four reproduce identically on `origin/main` with the same Go 1.26.2 toolchain and the same shell environment (deployer rig has `GC_RIG=gascity` exported, which leaks into tests that don't scrub it). Not regressions; the broader env-scrubbing fix is being tracked in the builder-rig backlog (ga-d02c, ga-y64o landed on the builder branch but are not yet on `origin/main`).
+## Validation
+
+- `git diff --check` → pass.
+- `sh -n examples/bd/assets/scripts/gc-beads-bd.sh` → pass.
+- `sh -n examples/dolt/commands/health/run.sh` → pass.
+- `sh -n examples/dolt/commands/{cleanup,gc-nudge,list,sync}/run.sh` → pass.
+- `bash -n examples/gastown/packs/maintenance/assets/scripts/{jsonl-export,reaper}.sh` → pass.
+- `go test ./cmd/gc -run 'TestManagedDolt|TestDoltStateReadOnlyCheckCmd|TestDoltStateHealthCheckCmd|TestGcBeadsBdReadOnlyFallback|TestGcBeadsBdHealthNoUserDatabaseWarnsAndContinues|TestGcBeadsBdReadOnlyHelperErrorIsDiagnostic|TestGcBeadsBdInitRejectsManagedProbeDatabaseName|TestEnsureCanonicalScopeMetadataRejectsManagedSystemDatabases|TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase|TestDoltSyncRejectsManagedProbeDatabaseFilter|TestNormalizeCanonicalBdScopeFilesRejectsExistingManagedSystemDatabase' -count=1` with workflow `GC_*` / `BEADS_*` environment stripped → pass.
+- `GC_FAST_UNIT=0 go test ./cmd/gc -run 'TestDoltStateRecoverManagedCmdNoUserDatabaseHealthSucceeds' -count=1` with workflow `GC_*` / `BEADS_*` environment stripped → pass.
+- `go test ./cmd/gc -run 'TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase|TestDoltSyncRejectsManagedProbeDatabaseFilter'` → pass.
+- `go test ./test/docsync -count=1` → pass.
+- `go test ./examples/dolt ./examples/gastown -count=1` → pass.
+
+## Known Environment Noise
+
+`go test ./...` fails in this rig outside the changed surface. With the workflow
+`GC_*` / `BEADS_*` environment stripped, it narrows to
+`TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag`,
+which fails because a `mayor` session is already active in the local runtime.
+Without stripping the workflow environment, many unrelated command tests also
+fail from `GC_RIG=gascity`, the rig-local `bd` behavior, and local managed-Dolt
+startup state. The focused checks above cover the changed files and the review
+findings.
 
 ## Push target
 
-`fork` (quad341/gascity) — `origin` (gastownhall/gascity) is read-only from this rig (`git push --dry-run origin HEAD` → 403).
-PR cross-repo: `--head quad341:release/ga-hivi-probe-user-db --base main`.
+`fork` (quad341/gascity) — `origin` (gastownhall/gascity) is read-only from this rig. PR cross-repo target remains `--head quad341:release/ga-hivi-probe-user-db --base main`.

--- a/release-gates/ga-hivi-probe-user-db-gate.md
+++ b/release-gates/ga-hivi-probe-user-db-gate.md
@@ -1,0 +1,56 @@
+# Release gate — probe a user DB so `__gc_probe` stops hosting stats (ga-42gi / ga-hivi)
+
+**Verdict:** PASS
+
+Branch: `release/ga-hivi-probe-user-db` (cut fresh off `origin/main` @ `a4d32733`)
+Commits on the branch:
+
+- `81f5bcb6` — fix(dolt/health): probe a user db so __gc_probe stops hosting stats (ga-42gi). Cherry-pick of source SHA `db6831b0` from `fork/gc-builder-1-01561d4fb9ea`. Clean (no conflicts).
+- `8047de53` — chore(fmt): align map literals after ga-42gi cherry-pick. Pure formatting — `golangci-lint fmt` normalizer flagged the new map literal alignment that the original commit missed. No behavior change.
+
+Diff vs `origin/main`: 3 files changed, +302/-38 lines (cherry-pick) plus +8/-8 (formatting):
+
+- `cmd/gc/dolt_sql_health.go`
+- `cmd/gc/dolt_sql_health_test.go`
+- `cmd/gc/cmd_dolt_state_test.go`
+
+## Review
+
+| Review bead | Reviews | Verdict | Reviewer           |
+|-------------|---------|---------|--------------------|
+| ga-hivi     | ga-42gi | PASS    | gascity/reviewer-1 |
+
+Reviewer message (`gm-wisp-mbo`): *"Reviewed db6831b0. Tests + vet + build clean. Indirect-enforcement verified. Ready for release gate."*
+
+Reviewer notes recorded one INFO/style observation that the variable-width key alignment "gofmt accepts" — the deployer-side `golangci-lint fmt --diff ./...` (CI's `make fmt-check`) actually flags it on Go 1.26.2, so the formatter was applied as a follow-up commit. Non-functional.
+
+Gemini second-pass: disabled per current rig configuration.
+
+## Criteria
+
+| # | Criterion                             | Verdict | Evidence |
+|---|---------------------------------------|---------|----------|
+| 1 | Review PASS present                   | PASS    | reviewer-1 PASS on ga-hivi via mail `gm-wisp-mbo`; verdict recorded in bead notes. |
+| 2 | Acceptance criteria met               | PASS    | New probe path doesn't create or write to `__gc_probe` — enforced by `assertNoManagedDoltProbeLegacyTarget` (`cmd/gc/dolt_sql_health_test.go`) AND by `managedDoltSystemDatabases` skiplist (`cmd/gc/dolt_sql_health.go:47-52`) AND case-insensitive lookup at line 152. Existing health-check tests pass. Comment block updated. |
+| 3 | Tests pass                            | PASS    | `go vet ./...` clean; `go build ./...` clean; targeted `go test -short -run "TestManagedDolt\|TestDoltStateReadOnlyCheckCmd\|TestDoltStateHealthCheckCmd\|TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase\|TestGcBeadsBdInitRejectsManagedProbeDatabaseName" ./cmd/gc/...` → ok 2.7s. Pre-existing env-leak failures reproduce identically on `origin/main` (see below). |
+| 4 | No high-severity review findings open | PASS    | Reviewer reported no blocking findings. INFO note on alignment resolved by `8047de53`. |
+| 5 | Final branch is clean                 | PASS    | `git status` clean (only this gate file untracked at write time, plus a stray `.gitkeep` from worktree init). |
+| 6 | Branch diverges cleanly from main     | PASS    | Cherry-pick of `db6831b0` onto fresh branch off `origin/main` applied with zero conflicts. |
+
+## Build / vet / fmt
+
+- `go vet ./...` → clean
+- `go build ./...` → clean
+- `golangci-lint fmt --diff ./cmd/gc/...` → clean after `8047de53`
+- Cherry-pick clean (no conflicts)
+
+## Pre-existing failures (not introduced)
+
+Running `go test -short ./cmd/gc/...` surfaces 4 failures (`TestRigAnywhere_ResolveContext` subtests, `TestOpenStoreAtForCityExecProjectsConfiguredTargets`, `TestOpenStoreAtForCityExecBeadsBdProjectsScopedExternalDoltEnv`, `TestOpenStoreAtForCityExecUsesUniversalStoreTargetEnv`, `TestControllerQueryRuntimeEnvReturnsNilForNonBD`).
+
+All four reproduce identically on `origin/main` with the same Go 1.26.2 toolchain and the same shell environment (deployer rig has `GC_RIG=gascity` exported, which leaks into tests that don't scrub it). Not regressions; the broader env-scrubbing fix is being tracked in the builder-rig backlog (ga-d02c, ga-y64o landed on the builder branch but are not yet on `origin/main`).
+
+## Push target
+
+`fork` (quad341/gascity) — `origin` (gastownhall/gascity) is read-only from this rig (`git push --dry-run origin HEAD` → 403).
+PR cross-repo: `--head quad341:release/ga-hivi-probe-user-db --base main`.


### PR DESCRIPTION
## What this changes

`gc dolt-state health-check --check-read-only` now writes its probe row inside an existing user database instead of inside a dedicated `__gc_probe` database. The probe table is still named `__probe` so it stays grep-friendly; the host database is the alphabetically first non-system DB returned by Dolt's `SHOW DATABASES` (legacy `__gc_probe` is in the system skiplist so existing data on it is left alone).

The motivation: Dolt's autostats subsystem picks one database, server-wide, to back the on-disk stats prolly map. In production today, `__gc_probe` won that lottery and accumulated 596k buckets / ~2GB of stats noms it was never meant to hold. Co-tenancy between health probes (constant `REPLACE INTO`) and autostats (constant background flushes) is invisible contention; dropping the probe DB to "reset" it would also wipe the entire server's stats state. After this change, the probe writes into a real user DB that's already a stats participant, so there's no separate database to elect.

DB names returned by `SHOW DATABASES` are backtick-quoted before being interpolated into SQL because Dolt derives DB names from on-disk repo directory names — those can begin with a digit (`003`) or contain hyphens, both of which require quoting. Quoting uses MySQL's standard backtick-doubling for embedded backticks, and the ident set is server-supplied (not user input), so there is no injection surface.

## Review notes

- Skiplist (`managedDoltSystemDatabases` in `cmd/gc/dolt_sql_health.go`) keeps `information_schema`, `mysql`, `dolt_cluster`, `performance_schema`, `sys`, and `__gc_probe` out of the candidate set. The legacy `__gc_probe` entry is intentional — its presence on disk is operationally fine (a planned restart will migrate stats off it later); the goal here is to stop *electing* it for new probes.
- Empty-DB short-circuit: a server with zero user DBs reports writable after `SELECT @@read_only` returns off, without attempting any temporary-table probe. That's the only state where `dolt_stats_info().backing != "__gc_probe"` is not directly verifiable; the assertion is enforced indirectly via the skiplist + the SQL-path test (`assertNoManagedDoltProbeLegacyTarget`).
- Bash fallback: `gc-beads-bd.sh` delegates to the Go helper when available. Its POSIX fallback now uses the same flow: check `SELECT @@read_only`, enumerate `SHOW DATABASES`, filter managed/system databases including `__gc_probe`, quote the selected user database, and run a temporary `__probe` table there. Cleanup of the legacy 2GB `__gc_probe` data on disk is a separate operational task.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `golangci-lint fmt --diff ./...` clean (formatter applied as a follow-up commit; the cherry-pick alone introduced a map-literal alignment regression that the original review missed)
- [x] Targeted: `go test -short -run "TestManagedDolt|TestDoltStateReadOnlyCheckCmd|TestDoltStateHealthCheckCmd|TestGcBeadsBdReadOnlyFallbackDoesNotDropProbeDatabase|TestGcBeadsBdInitRejectsManagedProbeDatabaseName" ./cmd/gc/...` -> ok
- [x] Release gate: [`release-gates/ga-hivi-probe-user-db-gate.md`](release-gates/ga-hivi-probe-user-db-gate.md)