### PR TITLE
fix(profiles): copilot uses PromptMode "none" for 1.0.x CLI compatibility

### DIFF
--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -276,10 +276,18 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 		InstructionsFile:  "AGENTS.md",
 	},
 	"copilot": {
-		DisplayName:       "GitHub Copilot",
-		Command:           "copilot",
-		Args:              []string{"--yolo"},
-		PromptMode:        "arg",
+		DisplayName: "GitHub Copilot",
+		Command:     "copilot",
+		Args:        []string{"--yolo"},
+		// PromptMode "none" delivers the prompt via tmux send-keys after the
+		// ready prefix is detected (Step 6 in doStartSession), instead of
+		// appending to argv. Required for copilot CLI 1.0.x which rejects
+		// positional prompt arguments ("error: too many arguments"). The old
+		// 0.0.x line accepted argv prompts; the rewrite in 1.0 made -p the
+		// only non-interactive entry, but -p exits after completion and
+		// breaks the long-running session contract gascity needs. Using
+		// "none" + send-keys preserves the interactive REPL.
+		PromptMode:        "none",
 		ReadyPromptPrefix: "\u276f ",
 		ReadyDelayMs:      5000,
 		ProcessNames:      []string{"copilot"},


### PR DESCRIPTION
## Summary

The built-in `copilot` provider profile uses `PromptMode: "arg"`, which appends the prompt to argv as a positional argument. This worked for copilot CLI 0.0.x but breaks on 1.0.x:

```
error: too many arguments. Expected 0 arguments but got 1
```

The launched pane exits immediately with status 1, and the supervisor retries session creation in a loop. With PR #1064 in place this is rate-limited by the spawn-storm backoff, but the underlying session never reaches `active` — the user just sees the rig fail to come up.

## Fix

One-line change in `internal/worker/builtin/profiles.go`: switch `PromptMode` from `"arg"` to `"none"`. With `"none"`, `template_resolve.go:565-571` routes the prompt into `runtime.Config.Nudge`, and `doStartSession` Step 6 (`adapter.go:742-744`) sends it via `Tmux.NudgeSession` after the ready prefix is detected. This is the same path opencode uses (and that profile already specifies `PromptMode: "none"`).

Why not `-p` / a flag mode? Copilot 1.0 does have `-p` for non-interactive prompts, but it exits after the response completes. That breaks the long-running REPL contract gascity sessions depend on (subsequent nudges, drain-ack, etc). `"none"` + send-keys keeps the interactive REPL alive.

## Verification

Verified against copilot CLI 1.0.36 on macOS:
- `copilot --yolo` (no positional arg) launches REPL in ~8s
- `❯ ` ready prefix unchanged (matches existing `ReadyPromptPrefix`)
- `Tmux.SendKeysDebounced` delivers the prompt and copilot processes it
- Long-running session contract preserved — REPL stays alive after each response
- End-to-end: spawn → claim wisp → read bead → TDD cycle → format → commit → drain, no fork-bomb, no orphans

Tests:
- `go test ./internal/worker/builtin/... ./internal/config/...` — pass (the resolve test compares against the built-in dynamically, so it stays green automatically)
- `make fmt-check`, `make vet`, `make lint` — clean

## Notes

- No code change beyond the profile constant + a comment explaining why `"none"` is correct.
- 0.0.x users are unaffected: the profile previously sent argv, but `"none"` + send-keys works on 0.0.x too (copilot 0.0.x accepts argv but doesn't require it).
- Independent of #1064 (the spawn-storm backoff). Both are needed in practice — #1064 prevents the visible fork-bomb symptom, this PR fixes the root cause that triggered it.
