### PR TITLE
Add compact session history mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ The `bd` (beads) provider is the default. To use a file-based store instead
 (no dolt/bd/flock needed), set `GC_BEADS=file` or add `[beads] provider = "file"`
 to your `city.toml`.
 
+For managed session lifecycle churn, you can compact volatile session metadata
+history with:
+
+```toml
+[observability.session_history]
+mode = "compact"
+```
+
+That keeps current session state visible while suppressing durable history rows
+for selected lifecycle-only metadata updates. See the generated
+[Config Reference](docs/reference/config.md) for the full schema.
+
 Install from Homebrew:
 
 ```bash

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -62,7 +62,8 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	session.RepairEmptyType(store, &b)
-	nudgeIDs, err := session.WakeSession(store, b, time.Now().UTC())
+	compactHistory := cfg != nil && cfg.Observability.SessionHistory.Compact()
+	nudgeIDs, err := session.WakeSessionWithOptions(store, b, time.Now().UTC(), compactHistory)
 	if err != nil {
 		if state, conflict := session.WakeConflictState(err); conflict {
 			fmt.Fprintf(stderr, "gc session wake: session %s is %s\n", id, state) //nolint:errcheck

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -71,6 +71,7 @@ func workerFactoryWithConfig(cityPath string, store beads.Store, sp runtime.Prov
 		SearchPaths:           searchPaths,
 		ResolveTransport:      resolveTransport,
 		ResolveSessionRuntime: workerSessionRuntimeResolverWithConfig(cityPath, cfg),
+		CompactSessionHistory: cfg != nil && cfg.Observability.SessionHistory.Compact(),
 	})
 }
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,6 +23,7 @@ City is the top-level configuration for a Gas City instance.
 | `session` | SessionConfig |  |  | Session configures the session provider backend. |
 | `mail` | MailConfig |  |  | Mail configures the mail provider backend. |
 | `events` | EventsConfig |  |  | Events configures the events provider backend. |
+| `observability` | ObservabilityConfig |  |  | Observability configures optional runtime observability behavior. |
 | `dolt` | DoltConfig |  |  | Dolt configures optional dolt server connection overrides. |
 | `formulas` | FormulasConfig |  |  | Formulas configures formula directory settings. |
 | `daemon` | DaemonConfig |  |  | Daemon configures controller daemon settings. |
@@ -341,6 +342,21 @@ NamedSession defines a canonical persistent session backed by an agent template.
 | `dir` | string |  |  | Dir is the identity prefix for rig-scoped named sessions after pack expansion. Empty means city-scoped. |
 | `mode` | string |  |  | Mode controls controller behavior for this named session. "on_demand" (default): reserve identity and materialize when work or an explicit reference requires it. "always": keep the canonical session controller-managed. Enum: `on_demand`, `always` |
 
+## ObservabilityConfig
+
+ObservabilityConfig holds optional observability settings.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `session_history` | SessionHistoryConfig |  |  | Controls how managed session lifecycle metadata history is persisted. |
+
+Example:
+
+```toml
+[observability.session_history]
+mode = "compact"
+```
+
 ## OptionChoice
 
 OptionChoice is one allowed value for a "select" option.
@@ -572,6 +588,14 @@ SessionConfig holds session provider settings.
 | `startup_timeout` | string |  | `60s` | StartupTimeout is how long to wait for each agent's Start() call before treating it as failed. Duration string (e.g., "60s", "2m"). Defaults to "60s". |
 | `socket` | string |  |  | Socket specifies the tmux socket name for per-city isolation. When set, all tmux commands use "tmux -L &lt;socket&gt;" to connect to a dedicated server. When empty, defaults to the city name (workspace.name) — giving every city its own tmux server automatically. Set explicitly to override. |
 | `remote_match` | string |  |  | RemoteMatch is a substring pattern for the hybrid provider to route sessions to the remote (K8s) backend. Sessions whose names contain this pattern go to K8s; all others stay local (tmux). Overridden by the GC_HYBRID_REMOTE_MATCH env var if set. |
+
+## SessionHistoryConfig
+
+SessionHistoryConfig configures durable history behavior for managed session metadata.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `mode` | string |  |  | Mode controls how volatile managed-session metadata updates are persisted. Supported values: ""/"full" (default) and "compact". |
 
 ## SessionSleepConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -951,6 +951,10 @@
           "$ref": "#/$defs/EventsConfig",
           "description": "Events configures the events provider backend."
         },
+        "observability": {
+          "$ref": "#/$defs/ObservabilityConfig",
+          "description": "Observability configures optional runtime observability behavior."
+        },
         "dolt": {
           "$ref": "#/$defs/DoltConfig",
           "description": "Dolt configures optional dolt server connection overrides."
@@ -1251,6 +1255,16 @@
         "template"
       ],
       "description": "NamedSession defines a canonical persistent session backed by an agent template."
+    },
+    "ObservabilityConfig": {
+      "properties": {
+        "session_history": {
+          "$ref": "#/$defs/SessionHistoryConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ObservabilityConfig holds optional observability settings."
     },
     "OptionChoice": {
       "properties": {
@@ -1985,6 +1999,17 @@
       "additionalProperties": false,
       "type": "object",
       "description": "SessionConfig holds session provider settings."
+    },
+    "SessionHistoryConfig": {
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Mode controls how volatile managed-session metadata updates are persisted.\nSupported values: \"\"/\"full\" (default) and \"compact\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SessionHistoryConfig configures durable history behavior for managed session metadata."
     },
     "SessionSleepConfig": {
       "properties": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -951,6 +951,10 @@
           "$ref": "#/$defs/EventsConfig",
           "description": "Events configures the events provider backend."
         },
+        "observability": {
+          "$ref": "#/$defs/ObservabilityConfig",
+          "description": "Observability configures optional runtime observability behavior."
+        },
         "dolt": {
           "$ref": "#/$defs/DoltConfig",
           "description": "Dolt configures optional dolt server connection overrides."
@@ -1251,6 +1255,16 @@
         "template"
       ],
       "description": "NamedSession defines a canonical persistent session backed by an agent template."
+    },
+    "ObservabilityConfig": {
+      "properties": {
+        "session_history": {
+          "$ref": "#/$defs/SessionHistoryConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ObservabilityConfig holds optional observability settings."
     },
     "OptionChoice": {
       "properties": {
@@ -1985,6 +1999,17 @@
       "additionalProperties": false,
       "type": "object",
       "description": "SessionConfig holds session provider settings."
+    },
+    "SessionHistoryConfig": {
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Mode controls how volatile managed-session metadata updates are persisted.\nSupported values: \"\"/\"full\" (default) and \"compact\"."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SessionHistoryConfig configures durable history behavior for managed session metadata."
     },
     "SessionSleepConfig": {
       "properties": {

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -36,6 +36,11 @@ shutdown_timeout = "5s"
 # molecule_id attachment semantics even when their own revision is version >= 2.
 formula_v2 = true
 
+# Optional: compact volatile managed-session lifecycle metadata history while
+# preserving current session state.
+[observability.session_history]
+mode = "compact"
+
 # Register a rig to activate per-rig agents (witness, refinery, polecat):
 # [[rigs]]
 # name = "myproject"

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -362,7 +362,11 @@ func (s *Server) handleSessionWake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	session.RepairEmptyType(store, &b)
-	nudgeIDs, err := session.WakeSession(store, b, time.Now().UTC())
+	compactHistory := false
+	if cfg := s.state.Config(); cfg != nil {
+		compactHistory = cfg.Observability.SessionHistory.Compact()
+	}
+	nudgeIDs, err := session.WakeSessionWithOptions(store, b, time.Now().UTC(), compactHistory)
 	if err != nil {
 		if state, conflict := session.WakeConflictState(err); conflict {
 			writeError(w, http.StatusConflict, "conflict", "session "+id+" is "+state)

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -657,7 +657,11 @@ func (s *Server) humaHandleSessionWake(ctx context.Context, input *SessionIDInpu
 		return nil, huma.Error409Conflict("session " + id + " is closed")
 	}
 
-	nudgeIDs, err := session.WakeSession(store, b, time.Now().UTC())
+	compactHistory := false
+	if cfg := s.state.Config(); cfg != nil {
+		compactHistory = cfg.Observability.SessionHistory.Compact()
+	}
+	nudgeIDs, err := session.WakeSessionWithOptions(store, b, time.Now().UTC(), compactHistory)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}

--- a/internal/api/session_manager.go
+++ b/internal/api/session_manager.go
@@ -13,7 +13,7 @@ func (s *Server) sessionManager(store beads.Store) *session.Manager {
 	if cfg == nil {
 		return session.NewManagerWithCityPath(store, s.state.SessionProvider(), s.state.CityPath())
 	}
-	return session.NewManagerWithTransportPolicyResolverAndCityPath(
+	manager := session.NewManagerWithTransportPolicyResolverAndCityPath(
 		store,
 		s.state.SessionProvider(),
 		s.state.CityPath(),
@@ -21,6 +21,8 @@ func (s *Server) sessionManager(store beads.Store) *session.Manager {
 			return configuredSessionTransportResolution(cfg, template, provider)
 		},
 	)
+	manager.SetCompactSessionHistory(cfg.Observability.SessionHistory.Compact())
+	return manager
 }
 
 func configuredSessionTransport(cfg *config.City, template, provider string) string {

--- a/internal/api/worker_factory.go
+++ b/internal/api/worker_factory.go
@@ -21,6 +21,7 @@ func (s *Server) workerFactory(store beads.Store) (*worker.Factory, error) {
 		Recorder:              s.state.EventProvider(),
 		ResolveTransport:      resolveTransport,
 		ResolveSessionRuntime: s.resolveWorkerSessionRuntimeWithMetadata,
+		CompactSessionHistory: cfg != nil && cfg.Observability.SessionHistory.Compact(),
 	})
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -568,6 +568,9 @@ func (s *BdStore) Update(id string, opts UpdateOpts) error {
 			args = append(args, "--set-metadata", k+"="+opts.Metadata[k])
 		}
 	}
+	if opts.SuppressHistory {
+		args = append(args, "--suppress-history")
+	}
 	for _, l := range opts.Labels {
 		args = append(args, "--add-label", l)
 	}

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -404,6 +404,23 @@ func TestBdStoreUpdatePassesPriority(t *testing.T) {
 	}
 }
 
+func TestBdStoreUpdatePassesSuppressHistory(t *testing.T) {
+	var gotArgs []string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`{"id":"bd-42","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}`), nil
+	}
+	s := beads.NewBdStore("/city", runner)
+	desc := "compact"
+	if err := s.Update("bd-42", beads.UpdateOpts{Description: &desc, SuppressHistory: true}); err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(gotArgs, " ")
+	if !strings.Contains(args, "--suppress-history") {
+		t.Fatalf("args = %q, want suppress-history flag", args)
+	}
+}
+
 func TestBdStoreCloseCLIError(t *testing.T) {
 	// CLI error should NOT be wrapped as ErrNotFound.
 	runner := func(_, _ string, _ ...string) ([]byte, error) {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -32,16 +32,17 @@ type Bead struct {
 
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.
 type UpdateOpts struct {
-	Title        *string // set title (nil = no change)
-	Status       *string // set status (nil = no change)
-	Type         *string // set issue type (nil = no change)
-	Priority     *int    // set priority (nil = no change)
-	Description  *string
-	ParentID     *string
-	Assignee     *string  // set assignee (nil = no change)
-	Labels       []string // append these labels (nil = no change)
-	RemoveLabels []string // remove these labels (nil = no change)
-	Metadata     map[string]string
+	Title           *string // set title (nil = no change)
+	Status          *string // set status (nil = no change)
+	Type            *string // set issue type (nil = no change)
+	Priority        *int    // set priority (nil = no change)
+	Description     *string
+	ParentID        *string
+	Assignee        *string  // set assignee (nil = no change)
+	Labels          []string // append these labels (nil = no change)
+	RemoveLabels    []string // remove these labels (nil = no change)
+	Metadata        map[string]string
+	SuppressHistory bool
 }
 
 func cloneIntPtr(v *int) *int {

--- a/internal/beads/exec/json.go
+++ b/internal/beads/exec/json.go
@@ -30,15 +30,16 @@ type createRequest struct {
 // updateRequest is the JSON wire format sent on stdin for update operations.
 // Null/missing fields are not applied. Labels appends (does not replace).
 type updateRequest struct {
-	Title        *string           `json:"title,omitempty"`
-	Status       *string           `json:"status,omitempty"`
-	Priority     *int              `json:"priority,omitempty"`
-	Description  *string           `json:"description,omitempty"`
-	ParentID     *string           `json:"parent_id,omitempty"`
-	Assignee     *string           `json:"assignee,omitempty"`
-	Labels       []string          `json:"labels,omitempty"`
-	RemoveLabels []string          `json:"remove_labels,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
+	Title           *string           `json:"title,omitempty"`
+	Status          *string           `json:"status,omitempty"`
+	Priority        *int              `json:"priority,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	ParentID        *string           `json:"parent_id,omitempty"`
+	Assignee        *string           `json:"assignee,omitempty"`
+	Labels          []string          `json:"labels,omitempty"`
+	RemoveLabels    []string          `json:"remove_labels,omitempty"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	SuppressHistory bool              `json:"suppress_history,omitempty"`
 }
 
 // beadWire is the JSON wire format returned by the script for bead data.
@@ -85,15 +86,16 @@ func marshalCreate(b beads.Bead) ([]byte, error) {
 // marshalUpdate converts update options to JSON for the exec script.
 func marshalUpdate(opts beads.UpdateOpts) ([]byte, error) {
 	r := updateRequest{
-		Title:        opts.Title,
-		Status:       opts.Status,
-		Priority:     opts.Priority,
-		Description:  opts.Description,
-		ParentID:     opts.ParentID,
-		Assignee:     opts.Assignee,
-		Labels:       opts.Labels,
-		RemoveLabels: opts.RemoveLabels,
-		Metadata:     opts.Metadata,
+		Title:           opts.Title,
+		Status:          opts.Status,
+		Priority:        opts.Priority,
+		Description:     opts.Description,
+		ParentID:        opts.ParentID,
+		Assignee:        opts.Assignee,
+		Labels:          opts.Labels,
+		RemoveLabels:    opts.RemoveLabels,
+		Metadata:        opts.Metadata,
+		SuppressHistory: opts.SuppressHistory,
 	}
 	return json.Marshal(r)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,8 @@ type City struct {
 	Mail MailConfig `toml:"mail,omitempty"`
 	// Events configures the events provider backend.
 	Events EventsConfig `toml:"events,omitempty"`
+	// Observability configures optional runtime observability behavior.
+	Observability ObservabilityConfig `toml:"observability,omitempty"`
 	// Dolt configures optional dolt server connection overrides.
 	Dolt DoltConfig `toml:"dolt,omitempty"`
 	// Formulas configures formula directory settings.
@@ -1037,6 +1039,22 @@ type EventsConfig struct {
 	// Provider selects the events backend: "fake", "fail",
 	// "exec:<script>", or "" (default: file-backed JSONL).
 	Provider string `toml:"provider,omitempty"`
+}
+
+// ObservabilityConfig holds optional observability settings.
+type ObservabilityConfig struct {
+	SessionHistory SessionHistoryConfig `toml:"session_history,omitempty"`
+}
+
+// SessionHistoryConfig configures durable history behavior for managed session metadata.
+type SessionHistoryConfig struct {
+	// Mode controls how volatile managed-session metadata updates are persisted.
+	// Supported values: ""/"full" (default) and "compact".
+	Mode string `toml:"mode,omitempty"`
+}
+
+func (c SessionHistoryConfig) Compact() bool {
+	return strings.EqualFold(strings.TrimSpace(c.Mode), "compact")
 }
 
 // DoltConfig holds optional dolt server overrides.

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -43,14 +43,12 @@ func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
 }
 
 func (m *Manager) clearStaleResumeMetadata(id string, b *beads.Bead) error {
-	if err := m.store.SetMetadata(id, "session_key", ""); err != nil {
-		return fmt.Errorf("clearing stale resume metadata session_key: %w", err)
-	}
-	if err := m.store.SetMetadata(id, "started_config_hash", ""); err != nil {
-		return fmt.Errorf("clearing stale resume metadata started_config_hash: %w", err)
-	}
-	if err := m.store.SetMetadata(id, "continuation_reset_pending", "true"); err != nil {
-		return fmt.Errorf("clearing stale resume metadata continuation_reset_pending: %w", err)
+	if err := m.updateSessionMetadata(id, map[string]string{
+		"session_key":                "",
+		"started_config_hash":        "",
+		"continuation_reset_pending": "true",
+	}); err != nil {
+		return fmt.Errorf("clearing stale resume metadata: %w", err)
 	}
 	if b.Metadata == nil {
 		b.Metadata = make(map[string]string)
@@ -225,7 +223,7 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 	instanceToken := b.Metadata["instance_token"]
 	if instanceToken == "" {
 		instanceToken = NewInstanceToken()
-		if err := m.store.SetMetadata(id, "instance_token", instanceToken); err != nil {
+		if err := m.setSessionMetadata(id, "instance_token", instanceToken); err != nil {
 			return fmt.Errorf("storing instance token: %w", err)
 		}
 		if b.Metadata == nil {
@@ -333,7 +331,7 @@ func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b bea
 	instanceToken := b.Metadata["instance_token"]
 	if instanceToken == "" {
 		instanceToken = NewInstanceToken()
-		if err := m.store.SetMetadata(id, "instance_token", instanceToken); err != nil {
+		if err := m.setSessionMetadata(id, "instance_token", instanceToken); err != nil {
 			return fmt.Errorf("storing instance token: %w", err)
 		}
 		if b.Metadata == nil {
@@ -409,7 +407,7 @@ func (m *Manager) confirmLiveSessionState(id string, b *beads.Bead) error {
 	if len(batch) == 0 {
 		return nil
 	}
-	if err := m.store.SetMetadataBatch(id, batch); err != nil {
+	if err := m.updateSessionMetadata(id, batch); err != nil {
 		return fmt.Errorf("%w: updating session state: %w", ErrStateSync, err)
 	}
 	if b.Metadata == nil {
@@ -558,7 +556,7 @@ func (m *Manager) dismissKnownDialogsLocked(ctx context.Context, sessName string
 }
 
 func (m *Manager) markStartupDialogsVerifiedLocked(id string, b *beads.Bead) {
-	if err := m.store.SetMetadata(id, startupDialogVerifiedKey, "true"); err != nil {
+	if err := m.setSessionMetadata(id, startupDialogVerifiedKey, "true"); err != nil {
 		return
 	}
 	if b.Metadata == nil {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -118,10 +118,11 @@ type ProviderResume struct {
 // Manager orchestrates chat session lifecycle using beads for persistence
 // and runtime.Provider for runtime.
 type Manager struct {
-	store             beads.Store
-	sp                runtime.Provider
-	cityPath          string
-	transportResolver func(template, provider string) transportResolution
+	store                 beads.Store
+	sp                    runtime.Provider
+	cityPath              string
+	transportResolver     func(template, provider string) transportResolution
+	compactSessionHistory bool
 }
 
 // PruneResult reports which sessions were pruned and which queued wait nudges
@@ -214,6 +215,36 @@ func (m *Manager) routeACPIfNeeded(provider, transport, sessName string) func() 
 	}
 	router.RouteACP(sessName)
 	return func() { router.Unroute(sessName) }
+}
+
+func storeSessionMetadata(store beads.Store, id string, kvs map[string]string, suppressHistory bool) error {
+	if len(kvs) == 0 {
+		return nil
+	}
+	if suppressHistory {
+		return store.Update(id, beads.UpdateOpts{Metadata: kvs, SuppressHistory: true})
+	}
+	return store.SetMetadataBatch(id, kvs)
+}
+
+func storeSessionMetadataKey(store beads.Store, id, key, value string, suppressHistory bool) error {
+	if suppressHistory {
+		return store.Update(id, beads.UpdateOpts{Metadata: map[string]string{key: value}, SuppressHistory: true})
+	}
+	return store.SetMetadata(id, key, value)
+}
+
+func (m *Manager) updateSessionMetadata(id string, kvs map[string]string) error {
+	return storeSessionMetadata(m.store, id, kvs, m.compactSessionHistory)
+}
+
+func (m *Manager) setSessionMetadata(id, key, value string) error {
+	return storeSessionMetadataKey(m.store, id, key, value, m.compactSessionHistory)
+}
+
+func (m *Manager) SetCompactSessionHistory(enabled bool) *Manager {
+	m.compactSessionHistory = enabled
+	return m
 }
 
 // NewManager creates a Manager backed by the given bead store and session provider.
@@ -728,11 +759,11 @@ func (m *Manager) Suspend(id string) error {
 		}
 
 		// Update state and record suspension timestamp.
-		if err := m.store.SetMetadata(id, "state", string(StateSuspended)); err != nil {
+		if err := m.updateSessionMetadata(id, map[string]string{
+			"state":        string(StateSuspended),
+			"suspended_at": time.Now().UTC().Format(time.RFC3339),
+		}); err != nil {
 			return fmt.Errorf("updating session state: %w", err)
-		}
-		if err := m.store.SetMetadata(id, "suspended_at", time.Now().UTC().Format(time.RFC3339)); err != nil {
-			return fmt.Errorf("storing suspension timestamp: %w", err)
 		}
 
 		return nil
@@ -746,7 +777,7 @@ func (m *Manager) RequestFreshRestart(id string) error {
 		if _, _, err := m.sessionBead(id); err != nil {
 			return err
 		}
-		return m.store.SetMetadataBatch(id, map[string]string{
+		return m.updateSessionMetadata(id, map[string]string{
 			"restart_requested":          "true",
 			"continuation_reset_pending": "true",
 		})
@@ -805,7 +836,7 @@ func (m *Manager) clearWakeAndHoldOverrides(id string) error {
 		"held_until":   "",
 		"sleep_intent": "",
 	}
-	if err := m.store.SetMetadataBatch(id, update); err != nil {
+	if err := m.updateSessionMetadata(id, update); err != nil {
 		return fmt.Errorf("clearing wake and hold overrides: %w", err)
 	}
 	return nil
@@ -862,7 +893,7 @@ func (m *Manager) BeginDrain(id, reason string) error {
 		if !cmdLegal {
 			return nil // idempotent: already draining
 		}
-		return m.store.SetMetadataBatch(id, BeginDrainPatch(time.Now().UTC(), reason))
+		return m.updateSessionMetadata(id, BeginDrainPatch(time.Now().UTC(), reason))
 	})
 }
 
@@ -877,7 +908,7 @@ func (m *Manager) Archive(id, reason string) error {
 		if !cmdLegal {
 			return nil // idempotent: already archived
 		}
-		return m.store.SetMetadataBatch(id, ArchivePatch(time.Now().UTC(), reason, false))
+		return m.updateSessionMetadata(id, ArchivePatch(time.Now().UTC(), reason, false))
 	})
 }
 
@@ -892,7 +923,7 @@ func (m *Manager) Quarantine(id string, until time.Time, cycle int) error {
 		if !cmdLegal {
 			return nil // idempotent: already quarantined
 		}
-		return m.store.SetMetadataBatch(id, QuarantinePatch(until, cycle))
+		return m.updateSessionMetadata(id, QuarantinePatch(until, cycle))
 	})
 }
 
@@ -919,7 +950,7 @@ func (m *Manager) Reactivate(id string) error {
 		// Note: quarantine_cycle is intentionally preserved across reactivations.
 		// It tracks how many quarantine rounds the session has been through,
 		// enabling eviction after quarantine_max_attempts.
-		return m.store.SetMetadataBatch(id, ReactivatePatch(view.ContinuityEligible))
+		return m.updateSessionMetadata(id, ReactivatePatch(view.ContinuityEligible))
 	})
 }
 
@@ -935,7 +966,7 @@ func (m *Manager) ConfirmCreation(id string) error {
 		if !cmdLegal {
 			return nil // idempotent: already active
 		}
-		return m.store.SetMetadataBatch(id, ConfirmStartedPatch(time.Now()))
+		return m.updateSessionMetadata(id, ConfirmStartedPatch(time.Now()))
 	})
 }
 
@@ -1285,7 +1316,7 @@ func (m *Manager) PersistSessionKey(id, sessionKey string) error {
 		if strings.TrimSpace(b.Metadata["session_key"]) != "" {
 			return nil
 		}
-		if err := m.store.SetMetadata(id, "session_key", sessionKey); err != nil {
+		if err := m.setSessionMetadata(id, "session_key", sessionKey); err != nil {
 			return fmt.Errorf("storing session key: %w", err)
 		}
 		return nil

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -151,11 +151,30 @@ type failMetadataKeyStore struct {
 	key string
 }
 
+type captureUpdateStore struct {
+	*beads.MemStore
+	lastUpdate beads.UpdateOpts
+	updatedID  string
+}
+
+func (s *captureUpdateStore) Update(id string, opts beads.UpdateOpts) error {
+	s.updatedID = id
+	s.lastUpdate = opts
+	return s.MemStore.Update(id, opts)
+}
+
 func (s failMetadataKeyStore) SetMetadata(id, key, value string) error {
 	if key == s.key {
 		return errors.New("set metadata failed")
 	}
 	return s.MemStore.SetMetadata(id, key, value)
+}
+
+func (s failMetadataKeyStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if _, ok := kvs[s.key]; ok {
+		return errors.New("set metadata failed")
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
 func (s waitFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -3151,6 +3170,27 @@ func TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata(t *test
 	}
 }
 
+func TestManagerUpdateSessionMetadataUsesSuppressHistoryWhenEnabled(t *testing.T) {
+	store := &captureUpdateStore{MemStore: beads.NewMemStore()}
+	mgr := NewManager(store, runtime.NewFake()).SetCompactSessionHistory(true)
+	bead, err := store.Create(beads.Bead{Type: BeadType, Labels: []string{LabelSession}, Metadata: map[string]string{"state": string(StateAsleep)}})
+	if err != nil {
+		t.Fatalf("Create bead: %v", err)
+	}
+	if err := mgr.updateSessionMetadata(bead.ID, map[string]string{"state": string(StateActive)}); err != nil {
+		t.Fatalf("updateSessionMetadata: %v", err)
+	}
+	if store.updatedID != bead.ID {
+		t.Fatalf("updatedID = %q, want %q", store.updatedID, bead.ID)
+	}
+	if !store.lastUpdate.SuppressHistory {
+		t.Fatal("expected SuppressHistory=true")
+	}
+	if got := store.lastUpdate.Metadata["state"]; got != string(StateActive) {
+		t.Fatalf("metadata[state] = %q, want %q", got, StateActive)
+	}
+}
+
 func TestEnsureRunning_StartupDeathClearMetadataFailurePropagates(t *testing.T) {
 	store := failMetadataKeyStore{MemStore: beads.NewMemStore(), key: "session_key"}
 	base := runtime.NewFake()
@@ -3184,7 +3224,7 @@ func TestEnsureRunning_StartupDeathClearMetadataFailurePropagates(t *testing.T) 
 	if err == nil {
 		t.Fatal("Send should fail when stale resume metadata cannot be cleared")
 	}
-	if !strings.Contains(err.Error(), "clearing stale resume metadata session_key") {
+	if !strings.Contains(err.Error(), "clearing stale resume metadata") {
 		t.Fatalf("Send error = %v, want stale metadata clear failure", err)
 	}
 

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -219,6 +219,42 @@ func TestSubmitDefaultCodexSkipsDeferredDialogsAfterVerification(t *testing.T) {
 	}
 }
 
+func TestSubmitDefaultCodexVerificationUsesSuppressHistoryWhenCompactModeEnabled(t *testing.T) {
+	store := &captureUpdateStore{MemStore: beads.NewMemStore()}
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp).SetCompactSessionHistory(true)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "codex", t.TempDir(), "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	outcome, err := mgr.Submit(context.Background(), info.ID, "hello", BuildResumeCommand(info), runtime.Config{WorkDir: info.WorkDir}, SubmitIntentDefault)
+	if err != nil {
+		t.Fatalf("Submit(default): %v", err)
+	}
+	if outcome.Queued {
+		t.Fatal("Submit(default) unexpectedly queued")
+	}
+	if store.updatedID != info.ID {
+		t.Fatalf("updated ID = %q, want %q", store.updatedID, info.ID)
+	}
+	if !store.lastUpdate.SuppressHistory {
+		t.Fatal("expected SuppressHistory=true")
+	}
+	if got := store.lastUpdate.Metadata[startupDialogVerifiedKey]; got != "true" {
+		t.Fatalf("%s metadata = %q, want true", startupDialogVerifiedKey, got)
+	}
+
+	updated, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get updated bead: %v", err)
+	}
+	if got := updated.Metadata[startupDialogVerifiedKey]; got != "true" {
+		t.Fatalf("stored %s = %q, want true", startupDialogVerifiedKey, got)
+	}
+}
+
 func TestSubmitDefaultResumesSuspendedGeminiSessionAndNudgesImmediately(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/session/waits.go
+++ b/internal/session/waits.go
@@ -162,6 +162,10 @@ func ReassignWaits(store beads.Store, oldSessionID, newSessionID string) error {
 // WakeSession clears hold/quarantine state and cancels open waits, returning
 // any queued wait-nudge IDs that should be eagerly withdrawn.
 func WakeSession(store beads.Store, sessionBead beads.Bead, now time.Time) ([]string, error) {
+	return WakeSessionWithOptions(store, sessionBead, now, false)
+}
+
+func WakeSessionWithOptions(store beads.Store, sessionBead beads.Bead, now time.Time, suppressHistory bool) ([]string, error) {
 	if store == nil || sessionBead.ID == "" {
 		return nil, nil
 	}
@@ -187,7 +191,7 @@ func WakeSession(store beads.Store, sessionBead beads.Bead, now time.Time) ([]st
 		batch["archived_at"] = ""
 		batch["continuity_eligible"] = "true"
 	}
-	if err := store.SetMetadataBatch(sessionBead.ID, batch); err != nil {
+	if err := storeSessionMetadata(store, sessionBead.ID, batch, suppressHistory); err != nil {
 		return nil, err
 	}
 	return nudgeIDs, nil

--- a/internal/session/waits_test.go
+++ b/internal/session/waits_test.go
@@ -180,3 +180,30 @@ func TestWakeSessionRequestsStartForContinuityEligibleArchivedBead(t *testing.T)
 		t.Fatalf("wait status/state = %q/%q, want closed/canceled", updatedWait.Status, updatedWait.Metadata["state"])
 	}
 }
+
+func TestWakeSessionWithOptionsUsesSuppressHistory(t *testing.T) {
+	store := &captureUpdateStore{MemStore: beads.NewMemStore()}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"state":        string(StateAsleep),
+			"sleep_reason": "hold",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := WakeSessionWithOptions(store, sessionBead, time.Now().UTC(), true); err != nil {
+		t.Fatalf("WakeSessionWithOptions: %v", err)
+	}
+	if store.updatedID != sessionBead.ID {
+		t.Fatalf("updatedID = %q, want %q", store.updatedID, sessionBead.ID)
+	}
+	if !store.lastUpdate.SuppressHistory {
+		t.Fatal("expected SuppressHistory=true")
+	}
+	if got := store.lastUpdate.Metadata["wake_attempts"]; got != "0" {
+		t.Fatalf("wake_attempts metadata = %q, want 0", got)
+	}
+}

--- a/internal/worker/factory.go
+++ b/internal/worker/factory.go
@@ -25,6 +25,7 @@ type FactoryConfig struct {
 	Recorder              events.Recorder
 	ResolveTransport      func(template, provider string) string
 	ResolveSessionRuntime SessionRuntimeResolver
+	CompactSessionHistory bool
 }
 
 // Factory centralizes worker-boundary object construction for callers such as
@@ -55,6 +56,7 @@ func NewFactory(cfg FactoryConfig) (*Factory, error) {
 	default:
 		manager = sessionpkg.NewManager(cfg.Store, cfg.Provider)
 	}
+	manager.SetCompactSessionHistory(cfg.CompactSessionHistory)
 	return newFactory(manager, cfg.Store, cfg.Provider, cfg.SearchPaths, cfg.Recorder, cfg.ResolveSessionRuntime)
 }
 


### PR DESCRIPTION
## Problem
Managed session lifecycle metadata updates generate a large amount of durable history churn even when the writes only reflect volatile current-state transitions.

## Why this fix is needed
We need a way to preserve current session state visibility and lifecycle behavior without paying durable history costs for every managed-session metadata update.

In practice, managed sessions write a lot of metadata that is operationally useful in the moment but not very valuable as a durable per-update history trail. Things like wake bookkeeping, suspend/resume state, quarantine/reactivation state, startup recovery metadata, and similar lifecycle-only fields can change frequently. Without a compact mode, each of those writes keeps appending durable history.

## What `mode = "compact"` actually does
This PR adds an opt-in city-level setting:

```toml
[observability.session_history]
mode = "compact"
```

When compact mode is enabled:
- Gas City still persists the **latest session state** so the supervisor, API, CLI, dashboard, and reconciler can all see current values.
- Gas City still performs the **same lifecycle transitions and wake behavior** as before.
- Gas City still preserves **runtime-facing behavior** such as wake, restart, suspend, quarantine, archive, and startup recovery flows.
- Gas City **does not record durable per-update history rows** for selected volatile managed-session metadata writes.

That means compact mode changes **how much durable history is recorded**, not **what the current session state is** and not **how the session behaves**.

## What fix we implemented
- add opt-in config support for `[observability.session_history]` with `mode = "compact"`
- thread compact-session-history behavior through session metadata writes, wake paths, API/session manager setup, worker factory setup, and bd-backed updates
- keep current-state persistence intact while using suppress-history updates for volatile managed-session lifecycle metadata
- add focused regressions for compact wake/update flows and startup-dialog verification
- document the config in README, reference docs, schema output, and the example city config

## Related dependency
This PR relies on the Beads-side suppress-history primitive implemented here:
- gastownhall/beads#3548 — https://github.com/gastownhall/beads/pull/3548

That Beads PR adds the lower-level storage capability that lets Gas City persist current values while skipping durable update-history rows for selected writes.

## Test plan
- [x] `GOTMPDIR=/home/joenathan/.claude/tmp-go/gascity go test ./internal/session -run 'TestWakeSessionWithOptionsUsesSuppressHistory|TestSubmitDefaultCodexVerificationUsesSuppressHistoryWhenCompactModeEnabled' -count=1`
- [x] `GOTMPDIR=/home/joenathan/.claude/tmp-go/gascity go test ./internal/beads -run TestBdStoreUpdatePassesSuppressHistory -count=1`

## Notes
- This PR depends on the upstream Beads suppress-history primitive PR.