### PR TITLE
fix(sessions): harden lifecycle reconciliation correctness (follow-up to #1336)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -51,6 +51,12 @@ type controllerState struct {
 	services      workspacesvc.Registry
 	extmsgSvc     *extmsg.Services
 	adapterReg    *extmsg.AdapterRegistry
+	updateMu      sync.Mutex // serializes rebuild+swap so stale reloads cannot overtake newer mutations
+
+	// True after an API config mutation refreshes controller state ahead of the
+	// runtime reload loop. Runtime reloads that would drop newly bound rigs are
+	// ignored until the loop observes and applies the same or a newer config.
+	configMutationPending atomic.Bool
 }
 
 type configMutationSnapshot struct {
@@ -272,6 +278,9 @@ func (cs *controllerState) applyBeadEventToStores(evt events.Event) {
 // update replaces the config, session provider, and reopens stores.
 // Stores are built outside the lock to avoid blocking readers during I/O.
 func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
+	cs.updateMu.Lock()
+	defer cs.updateMu.Unlock()
+
 	// Build new stores outside the lock (may do file I/O / subprocess spawns).
 	stores := cs.buildStores(cfg)
 	// Reopen city-level store for session beads and mail.
@@ -302,6 +311,40 @@ func (cs *controllerState) update(cfg *config.City, sp runtime.Provider) {
 	}
 	// Keep prior non-nil store/provider if reopen fails.
 	cs.mu.Unlock()
+}
+
+func (cs *controllerState) updateFromRuntime(cfg *config.City, sp runtime.Provider) {
+	if cs.configMutationPending.Load() && cs.runtimeUpdateDropsPendingRigs(cfg) {
+		return
+	}
+	cs.update(cfg, sp)
+	cs.configMutationPending.Store(false)
+}
+
+func (cs *controllerState) runtimeUpdateDropsPendingRigs(next *config.City) bool {
+	cs.mu.RLock()
+	current := cs.cfg
+	cs.mu.RUnlock()
+	return configDropsBoundRigs(current, next)
+}
+
+func configDropsBoundRigs(current, next *config.City) bool {
+	if current == nil || next == nil {
+		return false
+	}
+	nextRigPaths := make(map[string]string, len(next.Rigs))
+	for _, rig := range next.Rigs {
+		nextRigPaths[rig.Name] = strings.TrimSpace(rig.Path)
+	}
+	for _, rig := range current.Rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		if nextRigPaths[rig.Name] == "" {
+			return true
+		}
+	}
+	return false
 }
 
 // --- api.State implementation ---
@@ -748,6 +791,7 @@ func (cs *controllerState) mutateAndPoke(mutate func() error) error {
 		}
 		return fmt.Errorf("refreshing updated city config: %w", err)
 	}
+	cs.configMutationPending.Store(true)
 	if cs.configDirty != nil {
 		cs.configDirty.Store(true)
 	}

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -185,7 +185,7 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 		if sharedLegacyFileStore != nil && scopeProvider == "file" && !scopeUsesFileStoreContract(scopeRoot) {
 			store = sharedLegacyFileStore
 		} else {
-			store = cs.openRigStore(scopeProvider, rig.Name, scopeRoot, rig.EffectivePrefix())
+			store = cs.openRigStore(scopeProvider, rig.Name, scopeRoot, rig.EffectivePrefix(), cfg)
 		}
 		stores[rig.Name] = wrapWithCachingStore(cs.cacheCtx, store, cs.eventProv)
 	}
@@ -193,7 +193,7 @@ func (cs *controllerState) buildStores(cfg *config.City) map[string]beads.Store 
 }
 
 // openRigStore creates a bead store for a rig path using the given provider.
-func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix string) beads.Store {
+func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix string, cfg *config.City) beads.Store {
 	scopeRoot := resolveStoreScopeRoot(cs.cityPath, rigPath)
 	if strings.HasPrefix(provider, "exec:") {
 		s := beadsexec.NewStore(strings.TrimPrefix(provider, "exec:"))
@@ -213,7 +213,7 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 		}
 		return store
 	default: // "bd" or unrecognized
-		return bdStoreForRig(scopeRoot, cs.cityPath, cs.cfg)
+		return bdStoreForRig(scopeRoot, cs.cityPath, cfg)
 	}
 }
 

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -317,8 +317,47 @@ func (cs *controllerState) updateFromRuntime(cfg *config.City, sp runtime.Provid
 	if cs.configMutationPending.Load() && cs.runtimeUpdateDropsPendingRigs(cfg) {
 		return
 	}
+	if cs.configMutationPending.Load() && cs.runtimeUpdateCanReuseCurrentStores(cfg) {
+		cs.updateConfigAndProviderOnly(cfg, sp)
+		cs.configMutationPending.Store(false)
+		return
+	}
 	cs.update(cfg, sp)
 	cs.configMutationPending.Store(false)
+}
+
+func (cs *controllerState) updateConfigAndProviderOnly(cfg *config.City, sp runtime.Provider) {
+	cs.updateMu.Lock()
+	defer cs.updateMu.Unlock()
+
+	cs.mu.Lock()
+	cs.cfg = cfg
+	cs.sp = sp
+	cs.mu.Unlock()
+}
+
+func (cs *controllerState) runtimeUpdateCanReuseCurrentStores(next *config.City) bool {
+	cs.mu.RLock()
+	current := cs.cfg
+	cityStore := cs.cityBeadStore
+	stores := make(map[string]beads.Store, len(cs.beadStores))
+	for name, store := range cs.beadStores {
+		stores[name] = store
+	}
+	cs.mu.RUnlock()
+
+	if cityStore == nil || !sameStoreTopology(cs.cityPath, current, next) {
+		return false
+	}
+	for _, rig := range next.Rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		if stores[rig.Name] == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (cs *controllerState) runtimeUpdateDropsPendingRigs(next *config.City) bool {
@@ -326,6 +365,46 @@ func (cs *controllerState) runtimeUpdateDropsPendingRigs(next *config.City) bool
 	current := cs.cfg
 	cs.mu.RUnlock()
 	return configDropsBoundRigs(current, next)
+}
+
+type storeTopologyRig struct {
+	path   string
+	prefix string
+}
+
+func sameStoreTopology(cityPath string, current, next *config.City) bool {
+	if current == nil || next == nil {
+		return false
+	}
+	if config.EffectiveHQPrefix(current) != config.EffectiveHQPrefix(next) {
+		return false
+	}
+	currentRigs := storeTopologyRigs(cityPath, current.Rigs)
+	nextRigs := storeTopologyRigs(cityPath, next.Rigs)
+	if len(currentRigs) != len(nextRigs) {
+		return false
+	}
+	for name, currentRig := range currentRigs {
+		if nextRig, ok := nextRigs[name]; !ok || nextRig != currentRig {
+			return false
+		}
+	}
+	return true
+}
+
+func storeTopologyRigs(cityPath string, rigs []config.Rig) map[string]storeTopologyRig {
+	result := make(map[string]storeTopologyRig, len(rigs))
+	for _, rig := range rigs {
+		path := strings.TrimSpace(rig.Path)
+		if path != "" {
+			path = resolveStoreScopeRoot(cityPath, path)
+		}
+		result[rig.Name] = storeTopologyRig{
+			path:   path,
+			prefix: rig.EffectivePrefix(),
+		}
+	}
+	return result
 }
 
 func configDropsBoundRigs(current, next *config.City) bool {
@@ -593,9 +672,37 @@ func (cs *controllerState) DeleteAgent(name string) error {
 
 // CreateRig adds a new rig to city.toml.
 func (cs *controllerState) CreateRig(r config.Rig) error {
+	if err := cs.initializeRigStoreForCreate(r); err != nil {
+		return err
+	}
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.CreateRig(r)
 	})
+}
+
+func (cs *controllerState) initializeRigStoreForCreate(r config.Rig) error {
+	cityPath := strings.TrimSpace(cs.cityPath)
+	rigPath := strings.TrimSpace(r.Path)
+	if cityPath == "" || rigPath == "" {
+		return nil
+	}
+
+	cs.mu.RLock()
+	cfg := cs.cfg
+	cs.mu.RUnlock()
+	if cfg != nil {
+		for _, existing := range cfg.Rigs {
+			if existing.Name == r.Name {
+				return fmt.Errorf("%w: rig %q", configedit.ErrAlreadyExists, r.Name)
+			}
+		}
+	}
+
+	scopeRoot := resolveStoreScopeRoot(cityPath, rigPath)
+	if _, err := initDirIfReady(cityPath, scopeRoot, r.EffectivePrefix()); err != nil {
+		return fmt.Errorf("initializing rig %q beads: %w", r.Name, err)
+	}
+	return nil
 }
 
 // UpdateRig partially updates a rig in city.toml.

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -136,6 +136,40 @@ func TestControllerStateUpdate(t *testing.T) {
 	}
 }
 
+func TestControllerStateRuntimeUpdateDoesNotDropPendingMutationRigs(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n\n[beads]\nprovider = \"file\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	current := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Rigs:      []config.Rig{{Name: "alpha", Path: t.TempDir()}},
+	}
+	stale := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}
+
+	cs := newControllerState(context.Background(), current, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	cs.configMutationPending.Store(true)
+
+	cs.updateFromRuntime(stale, runtime.NewFake())
+
+	if got := cs.Config(); got != current {
+		t.Fatalf("Config() = %+v, want pending mutation config with rig alpha", got)
+	}
+	if !cs.configMutationPending.Load() {
+		t.Fatal("pending mutation marker cleared by stale runtime update")
+	}
+
+	cs.updateFromRuntime(current, runtime.NewFake())
+
+	if cs.configMutationPending.Load() {
+		t.Fatal("pending mutation marker not cleared after matching runtime update")
+	}
+}
+
 func TestControllerStateCreateRigPokesReconciler(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -616,7 +616,7 @@ func TestControllerStateOpenRigStoreFileOpenErrorDoesNotFallbackToBd(t *testing.
 	}
 
 	cs := &controllerState{cityPath: cityDir}
-	store := cs.openRigStore("file", "rig1", rigDir, "rg")
+	store := cs.openRigStore("file", "rig1", rigDir, "rg", nil)
 	if _, ok := store.(*beads.BdStore); ok {
 		t.Fatalf("openRigStore returned %T, want file-open failure instead of bd fallback", store)
 	}
@@ -1351,6 +1351,62 @@ func TestBuildStores_ExecProviderSetsPerRigEnv(t *testing.T) {
 		t.Errorf("regression: alpha and bravo exec stores received the same "+
 			"GC_BEADS_PREFIX=%q — store identity is not being propagated per rig",
 			alphaPrefix)
+	}
+}
+
+func TestBuildStoresBdProviderUsesPassedConfigForRigEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	capturePath := filepath.Join(t.TempDir(), "bd.env")
+	binDir := t.TempDir()
+	fakeBD := filepath.Join(binDir, "bd")
+	script := "#!/bin/sh\n" +
+		"printf 'GC_RIG=%s\\nGC_RIG_ROOT=%s\\nBEADS_DIR=%s\\n' \"${GC_RIG:-}\" \"${GC_RIG_ROOT:-}\" \"${BEADS_DIR:-}\" > \"$BD_ENV_CAPTURE\"\n" +
+		"printf '[]\\n'\n"
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_ENV_CAPTURE", capturePath)
+	t.Setenv("GC_BEADS", "bd")
+
+	staleCfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	nextCfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name:   "alpha",
+			Path:   rigDir,
+			Prefix: "al",
+		}},
+	}
+	cs := &controllerState{
+		cfg:      staleCfg,
+		cityName: "test-city",
+		cityPath: cityDir,
+	}
+
+	stores := cs.buildStores(nextCfg)
+	if stores["alpha"] == nil {
+		t.Fatal("buildStores did not create alpha store")
+	}
+
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read captured bd env: %v", err)
+	}
+	env := string(data)
+	if !strings.Contains(env, "GC_RIG=alpha\n") {
+		t.Fatalf("captured env missing GC_RIG=alpha; got:\n%s", env)
+	}
+	if !strings.Contains(env, "GC_RIG_ROOT="+rigDir+"\n") {
+		t.Fatalf("captured env missing rig root %q; got:\n%s", rigDir, env)
+	}
+	if !strings.Contains(env, "BEADS_DIR="+filepath.Join(rigDir, ".beads")+"\n") {
+		t.Fatalf("captured env missing rig BEADS_DIR; got:\n%s", env)
 	}
 }
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -170,6 +170,53 @@ func TestControllerStateRuntimeUpdateDoesNotDropPendingMutationRigs(t *testing.T
 	}
 }
 
+func TestControllerStateRuntimeUpdateAfterMutationPreservesCurrentStores(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "alpha")
+	current := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Rigs: []config.Rig{{
+			Name:   "alpha",
+			Path:   rigDir,
+			Prefix: "al",
+		}},
+	}
+	rigStore := beads.NewMemStore()
+	cityStore := beads.NewMemStore()
+	cs := &controllerState{
+		cfg:           current,
+		sp:            runtime.NewFake(),
+		beadStores:    map[string]beads.Store{"alpha": rigStore},
+		cityBeadStore: cityStore,
+		cityName:      "city1",
+		cityPath:      cityDir,
+	}
+	cs.configMutationPending.Store(true)
+
+	next := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Rigs: []config.Rig{{
+			Name:   "alpha",
+			Path:   rigDir,
+			Prefix: "al",
+		}},
+	}
+	cs.updateFromRuntime(next, runtime.NewFake())
+
+	if got := cs.BeadStore("alpha"); got != rigStore {
+		t.Fatalf("BeadStore(alpha) = %T %p, want original store %T %p", got, got, rigStore, rigStore)
+	}
+	if got := cs.CityBeadStore(); got != cityStore {
+		t.Fatalf("CityBeadStore() = %T %p, want original store %T %p", got, got, cityStore, cityStore)
+	}
+	if cs.Config() != next {
+		t.Fatal("Config() was not advanced to runtime snapshot")
+	}
+	if cs.configMutationPending.Load() {
+		t.Fatal("pending mutation marker not cleared after matching runtime update")
+	}
+}
+
 func TestControllerStateCreateRigPokesReconciler(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
@@ -198,6 +245,46 @@ func TestControllerStateCreateRigPokesReconciler(t *testing.T) {
 	}
 	if got := cs.Config(); got == nil || len(got.Rigs) != 1 || got.Rigs[0].Name != "rig1" {
 		t.Fatalf("Config() rigs = %+v, want in-memory rig snapshot to include rig1", got.Rigs)
+	}
+}
+
+func TestControllerStateCreateRigInitializesStoreBeforePublishing(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("enable scoped file store layout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("init city store: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	rigDir := filepath.Join(cityDir, "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	if err := cs.CreateRig(config.Rig{Name: "alpha", Path: rigDir, Prefix: "al"}); err != nil {
+		t.Fatalf("CreateRig: %v", err)
+	}
+
+	store := cs.BeadStore("alpha")
+	if store == nil {
+		t.Fatal("BeadStore(alpha) = nil")
+	}
+	created, err := store.Create(beads.Bead{Title: "first rig bead", Type: "task"})
+	if err != nil {
+		t.Fatalf("newly published rig store Create: %v", err)
+	}
+	if _, err := store.Get(created.ID); err != nil {
+		t.Fatalf("newly published rig store Get(%q): %v", created.ID, err)
 	}
 }
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -690,10 +690,11 @@ func discoverSessionBeadsWithRoots(
 		if isEphemeralSessionBeadForAgent(b, cfgAgent) {
 			manualSession := isManualSessionBeadForAgent(b, cfgAgent)
 			creating := b.Metadata["state"] == "creating"
-			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating {
+			pendingCreate := isPendingPoolCreate(b)
+			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating && !pendingCreate {
 				continue
 			}
-			if !manualSession && !desiredHasTemplate(desired, template) {
+			if !manualSession && !desiredHasTemplate(desired, template) && !pendingCreate {
 				continue
 			}
 		}
@@ -754,6 +755,16 @@ func discoverSessionBeadsWithRoots(
 		desired[sn] = tp
 	}
 	return roots
+}
+
+func isPendingPoolCreate(b beads.Bead) bool {
+	if !isPoolManagedSessionBead(b) || strings.TrimSpace(b.Metadata["pending_create_claim"]) != boolMetadata(true) {
+		return false
+	}
+	if strings.TrimSpace(b.Metadata["state"]) != "creating" {
+		return false
+	}
+	return true
 }
 
 func realizeDependencyFloors(

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1936,6 +1936,57 @@ func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *t
 	}
 }
 
+func TestBuildDesiredState_PendingCreatePoolSessionStaysDesiredWithoutScaleDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	sessionName := "workflows__codex-max-mc-new"
+	if _, err := store.Create(beads.Bead{
+		Title:  "codex-max",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:gascity/workflows.codex-max-1"},
+		Metadata: map[string]string{
+			"template":             "gascity/workflows.codex-max",
+			"session_name":         sessionName,
+			"agent_name":           "gascity/workflows.codex-max-1",
+			"session_origin":       "ephemeral",
+			"pool_managed":         boolMetadata(true),
+			"pool_slot":            "1",
+			"pending_create_claim": boolMetadata(true),
+			"state":                "creating",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "gascity", Path: filepath.Join(cityPath, "repos", "gascity")}},
+		Agents: []config.Agent{{
+			Name:              "workflows.codex-max",
+			Dir:               "gascity",
+			Provider:          "test-agent",
+			StartCommand:      "true",
+			WorkDir:           ".",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+			ScaleCheck:        "printf 0",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if got := dsResult.ScaleCheckCounts["gascity/workflows.codex-max"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[gascity/workflows.codex-max] = %d, want 0", got)
+	}
+	got, ok := dsResult.State[sessionName]
+	if !ok {
+		t.Fatalf("desired state missing pending-create pool session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.TemplateName != "gascity/workflows.codex-max" {
+		t.Fatalf("TemplateName = %q, want gascity/workflows.codex-max", got.TemplateName)
+	}
+	if got.InstanceName != sessionName {
+		t.Fatalf("InstanceName = %q, want existing session name %q", got.InstanceName, sessionName)
+	}
+}
+
 func TestBuildDesiredState_LegacyAliaslessEphemeralPoolSessionFallsBackToSessionNameIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1153,7 +1153,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
-	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores, rigStores); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -374,6 +374,11 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
+	cr.applyStartupConfigReload(ctx, dirty, &lastProviderName, cityRoot)
+	if ctx.Err() != nil {
+		return
+	}
+
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).
@@ -815,6 +820,24 @@ func (cr *CityRuntime) reloadConfig(
 	cityRoot string,
 ) {
 	cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, nil, reloadSourceWatch)
+}
+
+func (cr *CityRuntime) applyStartupConfigReload(
+	ctx context.Context,
+	dirty *atomic.Bool,
+	lastProviderName *string,
+	cityRoot string,
+) {
+	if cr.tomlPath == "" || cityRoot == "" || cr.configRev == "" || lastProviderName == nil || ctx.Err() != nil {
+		return
+	}
+	if dirty != nil {
+		dirty.Swap(false)
+	}
+	reply := cr.reloadConfigTraced(ctx, lastProviderName, cityRoot, nil, reloadSourceWatch)
+	if reply.Outcome == reloadOutcomeFailed && dirty != nil {
+		dirty.Store(true)
+	}
 }
 
 func (cr *CityRuntime) reloadConfigTraced(

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1810,6 +1810,8 @@ func (cr *CityRuntime) shutdown() {
 				fmt.Fprintf(cr.stderr, "%s: shutdown session listing failed: %v\n", cr.logPrefix, listErr) //nolint:errcheck // best-effort stderr
 			}
 		}
-		gracefulStopAll(running, cr.sp, timeout, cr.rec, cr.cfg, cr.cityBeadStore(), cr.stdout, cr.stderr)
+		store := cr.cityBeadStore()
+		markCityStopSessionSleepReason(store, cr.stderr)
+		gracefulStopAll(running, cr.sp, timeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr)
 	})
 }

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1058,7 +1058,7 @@ func (cr *CityRuntime) reloadConfigTraced(
 	cr.serviceStateMu.Unlock()
 
 	if cr.cs != nil {
-		cr.cs.update(nextCfg, nextSp)
+		cr.cs.updateFromRuntime(nextCfg, nextSp)
 	}
 	if cr.svc != nil {
 		if err := cr.svc.Reload(); err != nil {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -132,6 +132,45 @@ func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeShutdownMarksCityStopSleepReason(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "control-dispatcher",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "control-dispatcher",
+			"template":     "control-dispatcher",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cr := &CityRuntime{
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+		},
+		sp:                  runtime.NewFake(),
+		rec:                 events.Discard,
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	cr.shutdown()
+
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["sleep_reason"] != sleepReasonCityStop {
+		t.Fatalf("sleep_reason = %q, want %q", got.Metadata["sleep_reason"], sleepReasonCityStop)
+	}
+}
+
 func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	buildCalls := 0
 	cr := &CityRuntime{

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2137,6 +2137,68 @@ func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeRunReloadsConfigBeforeStartupReconcile(t *testing.T) {
+	cityPath := t.TempDir()
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	writeCityRuntimeConfig(t, tomlPath, "fake")
+
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	configRev := config.Revision(fsys.OSFS{}, prov, cfg, cityPath)
+
+	if err := os.WriteFile(tomlPath, []byte(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "fake"
+
+[[agent]]
+name = "fresh-agent"
+`), 0o644); err != nil {
+		t.Fatalf("write updated config: %v", err)
+	}
+
+	sp := runtime.NewFake()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var startupAgentCount atomic.Int32
+	cr := newCityRuntime(CityRuntimeParams{
+		CityPath:  cityPath,
+		CityName:  "test-city",
+		TomlPath:  tomlPath,
+		ConfigRev: configRev,
+		Cfg:       cfg,
+		SP:        sp,
+		BuildFn: func(cfg *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+			startupAgentCount.Store(int32(len(cfg.Agents)))
+			cancel()
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
+	cs.cityBeadStore = beads.NewMemStore()
+	cr.setControllerState(cs)
+
+	cr.run(ctx)
+
+	if got := startupAgentCount.Load(); got != 1 {
+		t.Fatalf("startup saw %d agent(s), want reloaded config with 1 agent", got)
+	}
+	if got := cr.cfg.Agents[0].Name; got != "fresh-agent" {
+		t.Fatalf("reloaded agent = %q, want fresh-agent", got)
+	}
+}
+
 func TestNewCityRuntimeUsesRegisteredAliasForEffectiveIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -898,6 +898,9 @@ func gracefulStopAll(
 			if target, ok := targetByName[name]; ok && target.subject != "" {
 				subject = target.subject
 			}
+			if target, ok := targetByName[name]; ok && cityStopSessionMarked(store, target.sessionID) {
+				markCityStopSessionAsAsleep(store, target.sessionID, stderr)
+			}
 			rec.Record(events.Event{
 				Type: events.SessionStopped, Actor: "gc", Subject: subject,
 			})

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -54,6 +54,7 @@ func releaseOrphanedPoolAssignments(
 	openSessionBeads []beads.Bead,
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStores []beads.Store,
+	rigStores map[string]beads.Store,
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
 		return nil
@@ -103,13 +104,18 @@ func releaseOrphanedPoolAssignments(
 			continue
 		}
 
-		ownerStore := store
+		var ownerStore beads.Store
 		if storeAware {
 			if i >= len(assignedWorkStores) || assignedWorkStores[i] == nil {
 				log.Printf("releaseOrphanedPoolAssignments: missing owner store for assigned work %q at index %d", wb.ID, i)
 				continue
 			}
 			ownerStore = assignedWorkStores[i]
+		} else {
+			ownerStore = storeForPoolAssignment(cfg, store, rigStores, wb)
+			if ownerStore == nil {
+				continue
+			}
 		}
 		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID) {
 			continue
@@ -117,6 +123,36 @@ func releaseOrphanedPoolAssignments(
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	return released
+}
+
+func storeForPoolAssignment(cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, wb beads.Bead) beads.Store {
+	if cfg == nil || len(rigStores) == 0 {
+		return cityStore
+	}
+	if routed := strings.TrimSpace(wb.Metadata["gc.routed_to"]); routed != "" {
+		if slash := strings.IndexByte(routed, '/'); slash > 0 {
+			if store := rigStores[routed[:slash]]; store != nil {
+				return store
+			}
+		}
+	}
+	idPrefix := beadIDPrefix(wb.ID)
+	for _, rig := range cfg.Rigs {
+		if idPrefix == rig.EffectivePrefix() {
+			if store := rigStores[rig.Name]; store != nil {
+				return store
+			}
+		}
+	}
+	return cityStore
+}
+
+func beadIDPrefix(id string) string {
+	trimmed := strings.TrimSpace(id)
+	if dash := strings.IndexByte(trimmed, '-'); dash > 0 {
+		return trimmed[:dash]
+	}
+	return ""
 }
 
 func releaseOrphanedPoolAssignment(store beads.Store, id string) bool {

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -165,6 +165,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 		nil,
 		[]beads.Bead{work},
 		nil,
+		nil,
 	)
 	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
@@ -179,6 +180,55 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 	}
 	if got.Assignee != "" {
 		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_UpdatesRigStoreFallback(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "orphaned rig pool work",
+		Assignee: "worker-dead",
+		Metadata: map[string]string{"gc.routed_to": "rig/worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		&config.City{
+			Rigs:   []config.Rig{{Name: "rig", Prefix: "ga"}},
+			Agents: []config.Agent{{Name: "worker", Dir: "rig", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		},
+		nil,
+		[]beads.Bead{work},
+		nil,
+		map[string]beads.Store{"rig": rigStore},
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("rig status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("rig assignee = %q, want empty", got.Assignee)
+	}
+	if _, err := cityStore.Get(work.ID); err == nil {
+		t.Fatalf("city store unexpectedly contains rig work bead %s", work.ID)
 	}
 }
 
@@ -227,6 +277,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensRigStoreMissingPoolAssignee(t *te
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{rigStore},
+		nil,
 	)
 	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
@@ -305,6 +356,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensCrossStoreIDCollisions(t *testing
 		nil,
 		[]beads.Bead{cityWork, rigWork},
 		[]beads.Store{cityStore, rigStore},
+		nil,
 	)
 	if len(released) != 2 || released[0].ID != cityWork.ID || released[1].ID != rigWork.ID {
 		t.Fatalf("released = %v, want [%s %s]", released, cityWork.ID, rigWork.ID)
@@ -350,6 +402,7 @@ func TestReleaseOrphanedPoolAssignments_SkipsStoreAwareEntryWithoutOwnerStore(t 
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{nil},
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released = %v, want none without owner store", released)
@@ -401,6 +454,7 @@ func TestReleaseOrphanedPoolAssignments_KeepsOpenSessionOwnership(t *testing.T) 
 		[]beads.Bead{session},
 		[]beads.Bead{work},
 		nil,
+		nil,
 	)
 	if len(released) != 0 {
 		t.Fatalf("released = %v, want none", released)
@@ -446,7 +500,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensStaleDirectAssigneeForNamedBacked
 		ResolvedWorkspaceName: "test-city",
 	}
 
-	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil)
+	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil, nil)
 	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
 	}
@@ -491,7 +545,7 @@ func TestReleaseOrphanedPoolAssignments_PreservesCanonicalNamedIdentity(t *testi
 		ResolvedWorkspaceName: "test-city",
 	}
 
-	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil)
+	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil, nil)
 	if len(released) != 0 {
 		t.Fatalf("released = %v, want none", released)
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1263,6 +1263,13 @@ func reapStaleSessionBeads(
 		if dt != nil && dt.get(b.ID) != nil {
 			continue
 		}
+		// Configured named-session beads are controller-owned identities.
+		// They may legitimately be stopped between supervisor restarts; the
+		// named-session reconciler is responsible for preserving, waking, or
+		// retiring them after desired state is rebuilt from config.
+		if isNamedSessionBead(b) {
+			continue
+		}
 		// Session is alive — nothing to reap.
 		if sp.IsRunning(sn) {
 			continue

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -3021,6 +3021,26 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   1,
 		},
 		{
+			name: "configured_named_session_skipped",
+			beads: []beads.Bead{{
+				Title:  "gascity/control-dispatcher",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":              "gascity--control-dispatcher",
+					"template":                  "gascity/control-dispatcher",
+					"state":                     "active",
+					"configured_named_session":  "true",
+					"configured_named_identity": "gascity/control-dispatcher",
+					"configured_named_mode":     "always",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
 			name: "multiple_stale_reaped",
 			beads: []beads.Bead{
 				{

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/shellquote"
+	"github.com/gastownhall/gascity/internal/worker"
 )
 
 const (
@@ -498,12 +499,17 @@ func executePreparedStartWave(
 			if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
 				time.Sleep(staleKeyDetectDelay)
 				running := false
+				alive := false
 				if store == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
 					running = sp != nil && sp.IsRunning(item.candidate.name())
+					alive = running && (sp == nil || sp.ProcessAlive(item.candidate.name(), item.cfg.ProcessNames))
 				} else {
-					running, err = workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+					var obs worker.LiveObservation
+					obs, err = workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
+					running = obs.Running
+					alive = obs.Alive
 				}
-				if err != nil || !running {
+				if err != nil || !running || !alive {
 					err = fmt.Errorf("session %q died during startup", item.candidate.name())
 				}
 			}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -270,11 +270,59 @@ func prepareStartCandidate(
 	store beads.Store,
 	clk clock.Clock,
 ) (*preparedStart, error) {
+	return prepareStartCandidateForCity(candidate, "", "", cfg, nil, store, clk, io.Discard)
+}
+
+func prepareStartCandidateForCity(
+	candidate startCandidate,
+	cityPath string,
+	cityName string,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	clk clock.Clock,
+	stderr io.Writer,
+) (*preparedStart, error) {
 	session := candidate.session
 	if _, _, err := preWakeCommit(session, store, clk); err != nil {
 		return nil, err
 	}
+	candidate = refreshConfiguredNamedStartCandidate(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
 	return buildPreparedStart(candidate, cfg, store)
+}
+
+func refreshConfiguredNamedStartCandidate(
+	candidate startCandidate,
+	cityPath string,
+	cityName string,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	clk clock.Clock,
+	stderr io.Writer,
+) startCandidate {
+	if candidate.session == nil || cfg == nil || store == nil || !isNamedSessionBead(*candidate.session) {
+		return candidate
+	}
+	if cityName == "" {
+		cityName = config.EffectiveCityName(cfg, "")
+	}
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session reconciler: refreshing named session start %s: listing sessions: %v\n", candidate.name(), err) //nolint:errcheck
+		}
+		return candidate
+	}
+	refreshed, err := resolvePreservedConfiguredNamedSessionTemplate(cityPath, cityName, cfg, sp, store, snapshot.Open(), *candidate.session, clk, stderr)
+	if err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session reconciler: refreshing named session start %s: %v\n", candidate.name(), err) //nolint:errcheck
+		}
+		return candidate
+	}
+	candidate.tp = refreshed
+	return candidate
 }
 
 func buildPreparedStart(
@@ -445,6 +493,17 @@ func executePreparedStartWave(
 	prepared []preparedStart,
 	sp runtime.Provider,
 	store beads.Store,
+	startupTimeout time.Duration,
+) []startResult {
+	return executePreparedStartWaveForCity(ctx, prepared, "", sp, store, nil, startupTimeout, 1)
+}
+
+func executePreparedStartWaveForCity(
+	ctx context.Context,
+	prepared []preparedStart,
+	cityPath string,
+	sp runtime.Provider,
+	store beads.Store,
 	cfg *config.City,
 	startupTimeout time.Duration,
 	maxParallel int,
@@ -452,7 +511,6 @@ func executePreparedStartWave(
 	if len(prepared) == 0 {
 		return nil
 	}
-	cityPath := ""
 	if maxParallel <= 0 {
 		maxParallel = 1
 	}
@@ -875,7 +933,7 @@ func executePlannedStarts(
 	startupTimeout time.Duration,
 	stdout, stderr io.Writer,
 ) int {
-	return executePlannedStartsTraced(ctx, candidates, cfg, desiredState, sp, store, cityName, clk, rec, startupTimeout, stdout, stderr, nil)
+	return executePlannedStartsTraced(ctx, candidates, cfg, desiredState, sp, store, cityName, "", clk, rec, startupTimeout, stdout, stderr, nil)
 }
 
 func executePlannedStartsTraced(
@@ -886,6 +944,7 @@ func executePlannedStartsTraced(
 	sp runtime.Provider,
 	store beads.Store,
 	cityName string,
+	cityPath string,
 	clk clock.Clock,
 	rec events.Recorder,
 	startupTimeout time.Duration,
@@ -947,7 +1006,7 @@ func executePlannedStartsTraced(
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
 					continue
 				}
-				item, err := prepareStartCandidate(candidate, cfg, store, clk)
+				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
 				if err != nil {
 					fmt.Fprintf(stderr, "session reconciler: pre-wake %s: %s\n", candidate.name(), formatLifecycleError(err)) //nolint:errcheck
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "failed", time.Time{}, time.Time{}, err)
@@ -956,7 +1015,7 @@ func executePlannedStartsTraced(
 				prepared = append(prepared, *item)
 			}
 			offset = end
-			results := executePreparedStartWave(ctx, prepared, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
+			results := executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
 			for _, result := range results {
 				if trace != nil {
 					trace.recordOperation("reconciler.start.execute", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), "", "start", result.outcome, traceRecordPayload{

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1237,7 +1237,35 @@ func stopTargetThroughWorkerBoundary(target stopTarget, store beads.Store, sp ru
 	if targetID == "" {
 		targetID = strings.TrimSpace(target.name)
 	}
+	if cityStopSessionMarked(store, target.sessionID) {
+		if err := workerKillSessionTargetWithConfig("", store, sp, cfg, targetID); err != nil {
+			return err
+		}
+		markCityStopSessionAsAsleep(store, target.sessionID, nil)
+		return nil
+	}
 	return workerStopSessionTargetWithConfig("", store, sp, cfg, targetID)
+}
+
+func cityStopSessionMarked(store beads.Store, sessionID string) bool {
+	if store == nil || strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	b, err := store.Get(sessionID)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(b.Metadata["sleep_reason"]) == sleepReasonCityStop
+}
+
+func markCityStopSessionAsAsleep(store beads.Store, sessionID string, stderr io.Writer) {
+	if store == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	batch := sessionpkg.SleepPatch(time.Now().UTC(), sleepReasonCityStop)
+	if err := store.SetMetadataBatch(sessionID, batch); err != nil && stderr != nil {
+		fmt.Fprintf(stderr, "gc stop: marking session %s asleep: %v\n", sessionID, err) //nolint:errcheck
+	}
 }
 
 func interruptTargetsBounded(targets []stopTarget, cfg *config.City, store beads.Store, sp runtime.Provider, stderr io.Writer) int {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -993,6 +994,97 @@ func TestCommitStartResult_AtomicBatchFailureLeavesClaimIntact(t *testing.T) {
 	}
 }
 
+func TestRefreshConfiguredNamedStartCandidateAddsCurrentSkillFingerprint(t *testing.T) {
+	resetSkillCatalogCache()
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"),
+		[]byte("[pack]\nname = \"named-refresh-test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillDir := filepath.Join(cityPath, "skills", "plan")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: plan\ndescription: test skill\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city", Provider: "claude"},
+		Session:       config.SessionConfig{Provider: "tmux"},
+		PackSkillsDir: filepath.Join(cityPath, "skills"),
+		Providers: map[string]config.ProviderSpec{
+			"claude": {Command: "true", PromptMode: "none", SupportsACP: boolPtr(true)},
+		},
+		Agents: []config.Agent{{
+			Name:     "mayor",
+			Scope:    "city",
+			Provider: "claude",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Mode:     "always",
+		}},
+	}
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "mayor",
+			"session_name_explicit":      boolMetadata(true),
+			"template":                   "mayor",
+			"agent_name":                 "mayor",
+			"state":                      string(sessionpkg.StateCreating),
+			"pending_create_claim":       "true",
+			namedSessionMetadataKey:      boolMetadata(true),
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "always",
+			"continuation_epoch":         "1",
+			"generation":                 "1",
+			"instance_token":             sessionpkg.NewInstanceToken(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := TemplateParams{
+		TemplateName: "mayor",
+		SessionName:  "mayor",
+		InstanceName: "mayor",
+		Command:      "true",
+		WorkDir:      cityPath,
+	}
+	candidate := startCandidate{session: &bead, tp: stale}
+	refreshed := refreshConfiguredNamedStartCandidate(
+		candidate,
+		cityPath,
+		cfg.Workspace.Name,
+		cfg,
+		runtime.NewFake(),
+		store,
+		&clock.Fake{Time: time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)},
+		ioDiscard{},
+	)
+
+	if _, ok := stale.FPExtra["skills:plan"]; ok {
+		t.Fatal("test setup invalid: stale candidate already had skills fingerprint")
+	}
+	if got := refreshed.tp.FPExtra["skills:plan"]; got == "" {
+		t.Fatalf("refreshed FPExtra missing skills:plan: %#v", refreshed.tp.FPExtra)
+	}
+	if refreshed.tp.ConfiguredNamedIdentity != "mayor" {
+		t.Fatalf("ConfiguredNamedIdentity = %q, want mayor", refreshed.tp.ConfiguredNamedIdentity)
+	}
+	if runtime.CoreFingerprint(templateParamsToConfig(refreshed.tp)) == runtime.CoreFingerprint(templateParamsToConfig(stale)) {
+		t.Fatal("refreshed candidate core fingerprint did not change after skill FPExtra refresh")
+	}
+}
+
 func TestExecutePlannedStartsClearsLegacyDrainAckAfterProviderStartBeforeMetadataRetry(t *testing.T) {
 	store := &failNthMetadataBatchStore{MemStore: beads.NewMemStore(), failOn: 2}
 	sp := runtime.NewFake()
@@ -1911,9 +2003,7 @@ func TestExecutePreparedStartWave_PanicIncludesStackTrace(t *testing.T) {
 		}},
 		&panicStartProvider{Fake: runtime.NewFake()},
 		nil,
-		nil,
 		time.Second,
-		1,
 	)
 	if len(results) != 1 {
 		t.Fatalf("len(results) = %d, want 1", len(results))
@@ -2176,9 +2266,7 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 		[]preparedStart{item},
 		sp,
 		nil,
-		nil,
 		10*time.Second,
-		1,
 	)
 
 	if len(results) != 1 {
@@ -2222,9 +2310,7 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *tes
 		[]preparedStart{item},
 		sp,
 		nil,
-		nil,
 		10*time.Second,
-		1,
 	)
 
 	if len(results) != 1 {
@@ -2266,9 +2352,7 @@ func TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey(t *testing.T) {
 		[]preparedStart{item},
 		sp,
 		nil,
-		nil,
 		10*time.Second,
-		1,
 	)
 
 	if len(results) != 1 {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -2134,6 +2134,21 @@ func (p *dieAfterStartProvider) IsRunning(name string) bool {
 	return p.Fake.IsRunning(name)
 }
 
+// zombieAfterStartProvider leaves the runtime container/pane present but marks
+// the actual agent process dead. This matches wrappers that keep tmux alive
+// after the CLI exits with a stale resume-session error.
+type zombieAfterStartProvider struct {
+	*runtime.Fake
+}
+
+func (p *zombieAfterStartProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	if err := p.Fake.Start(ctx, name, cfg); err != nil {
+		return err
+	}
+	p.Zombies[name] = true
+	return nil
+}
+
 func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
@@ -2172,6 +2187,52 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 	r := results[0]
 	if r.err == nil {
 		t.Fatal("expected error for session that died during startup with stale key")
+	}
+	if !strings.Contains(r.err.Error(), "died during startup") {
+		t.Fatalf("unexpected error: %v", r.err)
+	}
+}
+
+func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *testing.T) {
+	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-99",
+				Metadata: map[string]string{
+					"session_name": "test-agent",
+					"session_key":  "stale-key-abc",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume stale-key-abc",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume stale-key-abc",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		nil,
+		10*time.Second,
+		1,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.err == nil {
+		t.Fatal("expected error for dead agent process left behind in a live pane")
 	}
 	if !strings.Contains(r.err.Error(), "died during startup") {
 		t.Fatalf("unexpected error: %v", r.err)

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -2711,3 +2711,48 @@ func TestCommitStartResult_PersistsMCPIdentityForACPStart(t *testing.T) {
 		t.Fatal("mcp_servers_snapshot = empty, want persisted snapshot")
 	}
 }
+
+func TestStopTargetThroughWorkerBoundary_CityStopLeavesSessionAsleep(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	session, err := store.Create(beads.Bead{
+		Title:  "control-dispatcher",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "control-dispatcher",
+			"template":     "control-dispatcher",
+			"state":        "active",
+			"sleep_reason": sleepReasonCityStop,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := sp.Start(context.Background(), "control-dispatcher", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	err = stopTargetThroughWorkerBoundary(stopTarget{
+		sessionID: session.ID,
+		name:      "control-dispatcher",
+		resolved:  true,
+	}, store, sp, &config.City{})
+	if err != nil {
+		t.Fatalf("stopTargetThroughWorkerBoundary: %v", err)
+	}
+
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["state"] != string(sessionpkg.StateAsleep) {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], sessionpkg.StateAsleep)
+	}
+	if got.Metadata["sleep_reason"] != sleepReasonCityStop {
+		t.Fatalf("sleep_reason = %q, want %q", got.Metadata["sleep_reason"], sleepReasonCityStop)
+	}
+	if got.Metadata["suspended_at"] != "" {
+		t.Fatalf("suspended_at = %q, want empty", got.Metadata["suspended_at"])
+	}
+}

--- a/cmd/gc/session_lifecycle_start_boundary_test.go
+++ b/cmd/gc/session_lifecycle_start_boundary_test.go
@@ -37,9 +37,7 @@ func TestExecutePreparedStartWaveUsesWorkerBoundaryForKnownSession(t *testing.T)
 		}},
 		sp,
 		store,
-		nil,
 		10*time.Second,
-		1,
 	)
 	if len(results) != 1 {
 		t.Fatalf("len(results) = %d, want 1", len(results))

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1043,6 +1043,7 @@ func reconcileSessionBeadsTraced(
 
 	plannedWakes := executePlannedStartsTraced(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
+		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
 	)
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -358,6 +358,38 @@ func reconcileSessionBeadsTraced(
 				}
 				continue
 			default:
+				if dops != nil {
+					if acked, _ := dops.isDrainAcked(name); acked {
+						stopped := !providerAlive
+						if providerAlive {
+							if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
+								fmt.Fprintf(stderr, "session reconciler: stopping drain-acked %s: %v\n", name, err) //nolint:errcheck
+							} else {
+								stopped = true
+								fmt.Fprintf(stdout, "Stopped drain-acked session '%s'\n", name) //nolint:errcheck
+							}
+						}
+						if stopped {
+							_ = dops.clearDrain(name)
+							if dt != nil {
+								dt.clearIdleProbe(session.ID)
+								dt.remove(session.ID)
+							}
+							template := normalizedSessionTemplate(*session, cfg)
+							if template == "" {
+								template = session.Metadata["template"]
+							}
+							rec.Record(events.Event{
+								Type:    events.SessionStopped,
+								Actor:   "gc",
+								Subject: template,
+								Message: "drain acknowledged by agent",
+							})
+							closeSessionBeadIfUnassigned(store, rigStores, *session, "drained", clk.Now().UTC(), stderr)
+						}
+						continue
+					}
+				}
 				if providerAlive {
 					// When a store query failed (partial results),
 					// skip drain — the session may have work that we

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -370,11 +370,6 @@ func reconcileSessionBeadsTraced(
 							}
 						}
 						if stopped {
-							_ = dops.clearDrain(name)
-							if dt != nil {
-								dt.clearIdleProbe(session.ID)
-								dt.remove(session.ID)
-							}
 							template := normalizedSessionTemplate(*session, cfg)
 							if template == "" {
 								template = session.Metadata["template"]
@@ -385,6 +380,32 @@ func reconcileSessionBeadsTraced(
 								Subject: template,
 								Message: "drain acknowledged by agent",
 							})
+							hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
+							if assignedErr != nil {
+								fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
+								hasAssignedWork = true
+							}
+							if hasAssignedWork {
+								batch := sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", session.Metadata["wake_mode"] == "fresh")
+								_ = store.SetMetadataBatch(session.ID, batch)
+								if session.Metadata == nil {
+									session.Metadata = make(map[string]string, len(batch))
+								}
+								for key, value := range batch {
+									session.Metadata[key] = value
+								}
+								_ = dops.clearDrain(name)
+								if dt != nil {
+									dt.clearIdleProbe(session.ID)
+									dt.remove(session.ID)
+								}
+								continue
+							}
+							_ = dops.clearDrain(name)
+							if dt != nil {
+								dt.clearIdleProbe(session.ID)
+								dt.remove(session.ID)
+							}
 							closeSessionBeadIfUnassigned(store, rigStores, *session, "drained", clk.Now().UTC(), stderr)
 						}
 						continue

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -365,6 +365,62 @@ func TestReconcileSessionBeads_DrainAckWithAssignedOpenWorkSleepsInsteadOfDraini
 	}
 }
 
+func TestReconcileSessionBeads_UndesiredDrainAckStopsAndCloses(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if env.sp.IsRunning("worker") {
+		t.Fatal("worker should be stopped after drain-ack even after leaving desired state")
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed; metadata=%v", got.Status, got.Metadata)
+	}
+	if got.Metadata["close_reason"] != "drained" {
+		t.Fatalf("close_reason = %q, want drained", got.Metadata["close_reason"])
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckUsesLiveStoreQuery is the regression
 // guard for the stuck-pool-worker bug on ga-ttn5z. Pool workers close
 // their own work bead with `bd close` BEFORE calling `gc runtime

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -421,6 +421,76 @@ func TestReconcileSessionBeads_UndesiredDrainAckStopsAndCloses(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_UndesiredDrainAckWithAssignedOpenWorkSleepsInsteadOfClosing(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	if _, err := env.store.Create(beads.Bead{
+		Title:    "future work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create(future work): %v", err)
+	}
+
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		env.desiredState,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if env.sp.IsRunning("worker") {
+		t.Fatal("worker should be stopped after drain-ack even after leaving desired state")
+	}
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
+	}
+	if got.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", got.Metadata["state"])
+	}
+	if got.Metadata["sleep_reason"] != "idle" {
+		t.Fatalf("sleep_reason = %q, want idle", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared after drain-ack", got.Metadata["pending_create_claim"])
+	}
+}
+
 // TestReconcileSessionBeads_DrainAckUsesLiveStoreQuery is the regression
 // guard for the stuck-pool-worker bug on ga-ttn5z. Pool workers close
 // their own work bead with `bd close` BEFORE calling `gc runtime

--- a/cmd/gc/session_reconciler_trace_integration_test.go
+++ b/cmd/gc/session_reconciler_trace_integration_test.go
@@ -345,6 +345,7 @@ func TestSessionReconcilerTraceStartAndDrainSubOps(t *testing.T) {
 		sp,
 		store,
 		"trace-town",
+		"",
 		clock.Real{},
 		events.NewFake(),
 		5*time.Second,

--- a/cmd/gc/store_target_exec_test.go
+++ b/cmd/gc/store_target_exec_test.go
@@ -503,7 +503,7 @@ func TestControllerStateOpenRigStoreExecProjectsRigTarget(t *testing.T) {
 	t.Setenv("GC_DOLT_HOST", "ambient-dolt")
 
 	cs := &controllerState{cityPath: cityDir}
-	store := cs.openRigStore(provider, "frontend", rigDir, "fe")
+	store := cs.openRigStore(provider, "frontend", rigDir, "fe", nil)
 	if _, err := store.Create(beads.Bead{Title: "rig"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/internal/api/handler_beads.go
+++ b/internal/api/handler_beads.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -109,7 +110,11 @@ func (s *Server) findStore(rig string) beads.Store {
 // prefix/routes mapping when possible. If there is no routed match, it falls
 // back to the legacy store scan order.
 func (s *Server) beadStoresForID(id string) []beads.Store {
-	if prefix := beadPrefix(strings.TrimSpace(id)); prefix != "" {
+	id = strings.TrimSpace(id)
+	if store := s.resolveStoreByConfiguredIDPrefix(id); store != nil {
+		return []beads.Store{store}
+	}
+	if prefix := beadPrefix(id); prefix != "" {
 		if store := s.resolveStoreByPrefix(prefix); store != nil {
 			return []beads.Store{store}
 		}
@@ -125,6 +130,45 @@ func (s *Server) beadStoresForID(id string) []beads.Store {
 		candidates = append(candidates, stores[rigName])
 	}
 	return candidates
+}
+
+func (s *Server) resolveStoreByConfiguredIDPrefix(id string) beads.Store {
+	if id == "" {
+		return nil
+	}
+	cfg := s.state.Config()
+	if cfg == nil {
+		return nil
+	}
+
+	var bestStore beads.Store
+	bestLen := -1
+	if prefix := strings.TrimSpace(config.EffectiveHQPrefix(cfg)); beadIDHasConfiguredPrefix(id, prefix) {
+		if cityStore := s.state.CityBeadStore(); cityStore != nil {
+			bestStore = cityStore
+			bestLen = len(prefix)
+		}
+	}
+	for _, rig := range cfg.Rigs {
+		prefix := strings.TrimSpace(rig.EffectivePrefix())
+		if !beadIDHasConfiguredPrefix(id, prefix) || len(prefix) <= bestLen {
+			continue
+		}
+		store := s.state.BeadStore(rig.Name)
+		if store == nil {
+			continue
+		}
+		bestStore = store
+		bestLen = len(prefix)
+	}
+	return bestStore
+}
+
+func beadIDHasConfiguredPrefix(id, prefix string) bool {
+	if prefix == "" {
+		return false
+	}
+	return id == prefix || strings.HasPrefix(id, prefix+"-")
 }
 
 // resolveStoreByPrefix finds the store that owns a bead prefix by checking

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -727,6 +727,26 @@ func TestBeadUpdateUsesRoutePrefixStore(t *testing.T) {
 	}
 }
 
+func TestBeadStoresForIDUsesLongestConfiguredHyphenatedPrefix(t *testing.T) {
+	state := newFakeState(t)
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	state.cityBeadStore = cityStore
+	state.cfg.Workspace.Prefix = "mc"
+	state.cfg.Rigs = []config.Rig{{
+		Name:   "alpha",
+		Path:   "/tmp/alpha",
+		Prefix: "mc-alpha",
+	}}
+	state.stores = map[string]beads.Store{"alpha": rigStore}
+
+	server := &Server{state: state}
+	stores := server.beadStoresForID("mc-alpha-123")
+	if len(stores) != 1 || stores[0] != rigStore {
+		t.Fatalf("beadStoresForID returned %#v, want only authoritative rig store", stores)
+	}
+}
+
 func TestBeadUpdateSetsAndClearsParent(t *testing.T) {
 	state := newFakeState(t)
 	store := state.stores["myrig"]


### PR DESCRIPTION
Follow-up PR for https://github.com/gastownhall/gascity/pull/1336.

Original PR metadata:
- Original URL: https://github.com/gastownhall/gascity/pull/1336
- Original title: fix(sessions): harden lifecycle reconciliation correctness
- Original state at follow-up creation: OPEN
- Configured base: main
- Original GitHub base: main
- Follow-up base: main
- Base mismatch: none
- Original head: split/session-lifecycle-correctness @ a8d8ba130c2f951cccdeab3499a71d6f1a78ae6a

Reason for follow-up:
The adopt-pr review found a major issue in the undesired-session drain-ack path. The original PR has maintainer edits disabled, so the reviewed maintainer fixup is carried here on a distinct branch instead of mutating the original branch.

Contents:
- The eight contributor commits from #1336, preserving authorship.
- One maintainer fixup commit: `fix: preserve assigned work on undesired drain ack`.

Validation:
- `env -i PATH="$PATH" HOME="$HOME" USER="$USER" TMPDIR="${TMPDIR:-/tmp}" go test ./cmd/gc -run '^(TestCityRuntimeRunReloadsConfigBeforeStartupReconcile|TestBuildDesiredState_PendingCreatePoolSessionStaysDesiredWithoutScaleDemand|TestCityRuntimeShutdownMarksCityStopSleepReason|TestReleaseOrphanedPoolAssignments_UpdatesRigStoreFallback|TestRefreshConfiguredNamedStartCandidateAddsCurrentSkillFingerprint|TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives|TestStopTargetThroughWorkerBoundary_CityStopLeavesSessionAsleep|TestReconcileSessionBeads_UndesiredDrainAckStopsAndCloses)$' -count=1 -v`
- `env -i PATH="$PATH" HOME="$HOME" USER="$USER" TMPDIR="${TMPDIR:-/tmp}" go test ./cmd/gc -run '^TestReconcileSessionBeads_UndesiredDrainAckWithAssignedOpenWorkSleepsInsteadOfClosing$' -count=1 -v`

Review status:
- Blocker/major review finding addressed by maintainer fixup.
- Remaining findings are minor follow-up risks and not merge-blocking.
