### PR TITLE
fix: make graph workers claim routed beads (follow-up)

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4768,6 +4768,53 @@ max = -1
 	}
 }
 
+func TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork(t *testing.T) {
+	dir := t.TempDir()
+	if err := materializeBuiltinPrompts(dir); err != nil {
+		t.Fatalf("materializeBuiltinPrompts: %v", err)
+	}
+	tomlContent := `[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[agent]]
+name = "worker"
+dir = "myrig"
+start_command = "echo"
+
+[agent.pool]
+min = 0
+max = -1
+`
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doPrime([]string{"worker"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doPrime = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "gc hook") {
+		t.Fatalf("graph-worker prompt missing gc hook routed-queue lookup:\n%s", out)
+	}
+	if !strings.Contains(out, "bd update <id> --claim") {
+		t.Fatalf("graph-worker prompt missing atomic claim instruction:\n%s", out)
+	}
+	if !strings.Contains(out, "Do not start work with `bd update --status in_progress`") {
+		t.Fatalf("graph-worker prompt missing guard against unassigned in_progress work:\n%s", out)
+	}
+}
+
 func materializeBuiltinPrompts(cityPath string) error {
 	return MaterializeBuiltinPacks(cityPath)
 }

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -4773,6 +4773,12 @@ func TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork(t *testing.T) {
 	if err := materializeBuiltinPrompts(dir); err != nil {
 		t.Fatalf("materializeBuiltinPrompts: %v", err)
 	}
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_DIR", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
 	tomlContent := `[workspace]
 name = "test-city"
 

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -22,6 +22,9 @@ bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
 
 # Step 3: If still nothing, check the routed queue (multi-session configs only)
 gc hook
+
+# Step 4: If gc hook returned an unassigned routed bead, claim it atomically
+bd update <id> --claim
 ```
 
 If you have no work after all three checks, run:
@@ -33,14 +36,17 @@ gc runtime drain-ack
 ## How To Work
 
 1. Find your assigned bead (see Startup above).
-2. Read it with `bd show <id>`.
-3. **Claim continuation group** (see below).
-4. Execute exactly that bead's description.
-5. On success, close it:
+2. If the bead came from `gc hook`, claim it with `bd update <id> --claim`
+   before doing any work. Do not start work with `bd update --status in_progress`;
+   only `--claim` sets both assignee and in-progress state atomically.
+3. Read it with `bd show <id>`.
+4. **Claim continuation group** (see below).
+5. Execute exactly that bead's description.
+6. On success, close it:
    ```bash
    bd update <id> --set-metadata gc.outcome=pass --status closed
    ```
-6. On transient failure, mark it transient and close it:
+7. On transient failure, mark it transient and close it:
    ```bash
    bd update <id> \
      --set-metadata gc.outcome=fail \
@@ -48,7 +54,7 @@ gc runtime drain-ack
      --set-metadata gc.failure_reason=<short_reason> \
      --status closed
    ```
-7. On unrecoverable failure, mark it hard-failed and close it:
+8. On unrecoverable failure, mark it hard-failed and close it:
    ```bash
    bd update <id> \
      --set-metadata gc.outcome=fail \
@@ -56,11 +62,11 @@ gc runtime drain-ack
      --set-metadata gc.failure_reason=<short_reason> \
      --status closed
    ```
-8. After closing, check for more assigned work:
+9. After closing, check for more assigned work:
    ```bash
    bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
    ```
-9. If more work exists, go to step 2. If not, poll briefly (see below).
+10. If more work exists, go to step 2. If not, poll briefly (see below).
 
 ## Continuation Group — Session Affinity
 


### PR DESCRIPTION
## Summary
- carry forward the contributor's graph-worker claim protocol fix from the original PR
- apply the reviewed maintainer fixup that isolates the new prime regression from ambient GC_* environment
- open this as a distinct follow-up because the original PR cannot be edited by maintainers

## Original PR
- URL: https://github.com/gastownhall/gascity/pull/1347
- Title: fix: make graph workers claim routed beads
- State at follow-up creation: OPEN
- Configured base: main
- Original GitHub base: main
- Base mismatch: none
- Original head: split/graph-worker-claim-routed @ 839c733699f0282ac39534e8291ee21d72ac1980

## Tests
- go test ./cmd/gc -run TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork -count=1

## Review synthesis
# Review: gastownhall/gascity#1347

## Decision: block

## Fix Validations
- **Graph worker source prompt adds atomic routed-bead claiming:** correct - `graph-worker.md` now tells workers to run `gc hook` and claim returned beads with `bd update <id> --claim` before doing work.
- **Graph worker instructions are delivered by `gc prime worker` in a formula_v2 city:** wrong - the branch's new regression still receives the generic `# Gas City Agent` prompt instead of `graph-worker.md`.
- **Regression coverage proves the shipped behavior:** incomplete - the new test targets the right path, but it currently fails on this branch.

## Top Risks
1. Formula_v2 workers can still receive the generic prime prompt without routed-queue claim instructions - blocker / high / source: codex

## New Findings
### Behavioral Correctness
- **Severity:** blocker
- **Confidence:** high
- **Source:** codex
- **Evidence:** `cmd/gc/main_test.go:4802`, `cmd/gc/main_test.go:4807`, `cmd/gc/cmd_prime.go:302`
- **Why it matters:** The PR claims to make graph workers claim routed beads, but the tested `gc prime worker` path still emits the generic fallback prompt, so newly started graph workers may not receive the new claim protocol.
- **Required fix:** Fix the formula_v2 prime prompt selection or test setup so the configured worker resolves to `.gc/system/packs/core/assets/prompts/graph-worker.md`, then rerun `go test ./cmd/gc -run TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork -count=1`.

## Category Coverage
1. Behavioral Correctness: Finding 1.
2. Contract & Interface Fidelity: No finding.
3. Change Impact / Blast Radius: No finding.
4. Concurrency, Ordering & State Safety: No finding beyond Finding 1; the source prompt's `--claim` semantics are correct when delivered.
5. Error Handling & Resilience: No required finding; Claude noted claim-failure recovery remains unspecified as a follow-up.
6. Security Surface: No finding.
7. Resource Lifecycle & Cleanup: No finding.
8. Release Safety: Finding 1 blocks merge because the new targeted test fails.
9. Test Evidence Quality: Finding 1; the intended regression exists but is red.
10. Architectural Consistency: No finding.
11. Debuggability & Operability: No finding.

## Pre-Merge Checklist
- [ ] Make `gc prime worker` in a formula_v2 city output the graph-worker prompt instead of `defaultPrimePrompt`.
- [ ] Confirm the rendered prompt contains `gc hook`, `bd update <id> --claim`, and the guard against `bd update --status in_progress`.
- [ ] Rerun `go test ./cmd/gc -run TestDoPrimeFormulaV2GraphWorkerPromptClaimsRoutedWork -count=1`.

## Decision Policy
- Unresolved blocker in categories 1-4 -> block
- Unresolved blocker in categories 5-8 -> request_changes
- Major issues in 1-8 without mitigation -> request_changes
- Purely minor/nit -> approve
- No new findings -> approve