### PR TITLE
perf(wait): use session snapshot for wait nudges

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1202,7 +1202,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cityName, sessionBeads)
 
-	readyWaitSet, err := prepareWaitWakeStateForCity(cr.cityPath, store, time.Now())
+	readyWaitSet, err := prepareWaitWakeStateForCityWithSnapshot(cr.cityPath, store, time.Now(), sessionBeads)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: preparing waits: %v\n", cr.logPrefix, err) //nolint:errcheck
 		readyWaitSet = nil
@@ -1315,7 +1315,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			})
 		}
 	}
-	if err := dispatchReadyWaitNudges(cr.cityPath, store, cr.sp, time.Now()); err != nil {
+	dispatchSessionBeads, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
+	} else if err := dispatchReadyWaitNudgesWithSnapshot(cr.cityPath, store, time.Now(), dispatchSessionBeads); err != nil {
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
 	}
 

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -564,6 +564,10 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 	if err != nil {
 		return nil, err
 	}
+	sessionBeads, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		return nil, err
+	}
 	readyWaitSet := make(map[string]bool)
 	for _, wait := range waits {
 		state := wait.Metadata["state"]
@@ -574,8 +578,8 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 		if isWaitTerminal(state) {
 			continue
 		}
-		sessionBead, err := store.Get(sessionID)
-		if err != nil {
+		sessionBead, ok := sessionBeads.FindByID(sessionID)
+		if !ok {
 			continue
 		}
 		if epoch := wait.Metadata["registered_epoch"]; epoch != "" && sessionBead.Metadata["continuation_epoch"] != "" && epoch != sessionBead.Metadata["continuation_epoch"] {
@@ -657,6 +661,10 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 	if err != nil {
 		return err
 	}
+	sessionBeads, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		return err
+	}
 	for _, wait := range waits {
 		if wait.Metadata["state"] != waitStateReady {
 			continue
@@ -665,12 +673,11 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 		if sessionID == "" {
 			continue
 		}
-		sessionBead, err := store.Get(sessionID)
-		if err != nil {
+		sessionBead, ok := sessionBeads.FindByID(sessionID)
+		if !ok {
 			continue
 		}
-		running, err := workerSessionTargetRunningWithConfig(cityPath, store, sp, nil, sessionID)
-		if err != nil || !running {
+		if !cachedSessionCanReceiveWaitNudge(sessionBead) {
 			continue
 		}
 		nudgeID := waitNudgeID(wait)
@@ -709,6 +716,18 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 		}
 	}
 	return nil
+}
+
+func cachedSessionCanReceiveWaitNudge(sessionBead beads.Bead) bool {
+	if sessionBead.Status == "closed" {
+		return false
+	}
+	switch sessionpkg.State(strings.TrimSpace(sessionBead.Metadata["state"])) {
+	case "", sessionpkg.StateActive, sessionpkg.StateAwake:
+		return true
+	default:
+		return false
+	}
 }
 
 func finalizeReadyWaitFromNudge(store beads.Store, wait beads.Bead, now time.Time) (bool, error) {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -560,13 +560,20 @@ func prepareWaitWakeState(store beads.Store, now time.Time) (map[string]bool, er
 }
 
 func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Time) (map[string]bool, error) {
+	return prepareWaitWakeStateForCityWithSnapshot(cityPath, store, now, nil)
+}
+
+func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store, now time.Time, sessionBeads *sessionBeadSnapshot) (map[string]bool, error) {
 	waits, err := loadWaitBeads(store)
 	if err != nil {
 		return nil, err
 	}
-	sessionBeads, err := loadSessionBeadSnapshot(store)
-	if err != nil {
-		return nil, err
+	if sessionBeads == nil {
+		var err error
+		sessionBeads, err = loadSessionBeadSnapshot(store)
+		if err != nil {
+			return nil, err
+		}
 	}
 	readyWaitSet := make(map[string]bool)
 	for _, wait := range waits {
@@ -580,7 +587,11 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 		}
 		sessionBead, ok := sessionBeads.FindByID(sessionID)
 		if !ok {
-			continue
+			if anySessionBead, found := sessionBeads.findByIDIncludingClosed(sessionID); found {
+				sessionBead = anySessionBead
+			} else {
+				continue
+			}
 		}
 		if epoch := wait.Metadata["registered_epoch"]; epoch != "" && sessionBead.Metadata["continuation_epoch"] != "" && epoch != sessionBead.Metadata["continuation_epoch"] {
 			if err := setWaitTerminalState(store, wait.ID, map[string]string{
@@ -593,6 +604,9 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 			if err := clearSessionWaitHoldIfIdle(store, sessionID); err != nil {
 				return nil, err
 			}
+			continue
+		}
+		if !ok {
 			continue
 		}
 		if expiresAt := wait.Metadata["expires_at"]; expiresAt != "" {
@@ -656,14 +670,21 @@ func prepareWaitWakeStateForCity(cityPath string, store beads.Store, now time.Ti
 	return readyWaitSet, nil
 }
 
-func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Provider, now time.Time) error {
+func dispatchReadyWaitNudges(cityPath string, store beads.Store, _ runtime.Provider, now time.Time) error {
+	return dispatchReadyWaitNudgesWithSnapshot(cityPath, store, now, nil)
+}
+
+func dispatchReadyWaitNudgesWithSnapshot(cityPath string, store beads.Store, now time.Time, sessionBeads *sessionBeadSnapshot) error {
 	waits, err := loadWaitBeads(store)
 	if err != nil {
 		return err
 	}
-	sessionBeads, err := loadSessionBeadSnapshot(store)
-	if err != nil {
-		return err
+	if sessionBeads == nil {
+		var err error
+		sessionBeads, err = loadSessionBeadSnapshot(store)
+		if err != nil {
+			return err
+		}
 	}
 	for _, wait := range waits {
 		if wait.Metadata["state"] != waitStateReady {
@@ -719,9 +740,6 @@ func dispatchReadyWaitNudges(cityPath string, store beads.Store, sp runtime.Prov
 }
 
 func cachedSessionCanReceiveWaitNudge(sessionBead beads.Bead) bool {
-	if sessionBead.Status == "closed" {
-		return false
-	}
 	switch sessionpkg.State(strings.TrimSpace(sessionBead.Metadata["state"])) {
 	case "", sessionpkg.StateActive, sessionpkg.StateAwake:
 		return true

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -29,11 +29,21 @@ type waitNudgeMetadataFailStore struct {
 	*beads.MemStore
 }
 
+type waitGetSpyStore struct {
+	beads.Store
+	getIDs []string
+}
+
 func (s waitNudgeMetadataFailStore) SetMetadata(id, key, value string) error {
 	if key == "nudge_id" {
 		return errors.New("set nudge id failed")
 	}
 	return s.MemStore.SetMetadata(id, key, value)
+}
+
+func (s *waitGetSpyStore) Get(id string) (beads.Bead, error) {
+	s.getIDs = append(s.getIDs, id)
+	return s.Store.Get(id)
 }
 
 var (
@@ -432,6 +442,53 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 	}
 }
 
+func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "1",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"registered_epoch": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if len(readyWaitSet) != 0 {
+		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
+	}
+	for _, id := range store.getIDs {
+		if id == sessionBead.ID {
+			t.Fatalf("prepare used Get for non-open session %s; getIDs=%v", sessionBead.ID, store.getIDs)
+		}
+	}
+}
+
 func TestDepsWaitReady_IgnoresEmptyDependencyEntries(t *testing.T) {
 	store := beads.NewMemStore()
 	dep, err := store.Create(beads.Bead{Title: "dep"})
@@ -735,6 +792,111 @@ func TestDispatchReadyWaitNudges_EnqueuesDeterministicNudge(t *testing.T) {
 	}
 	if _, err := refreshedStore.Get(pending[0].BeadID); err != nil {
 		t.Fatalf("refreshedStore.Get(%s): %v", pending[0].BeadID, err)
+	}
+}
+
+func TestDispatchReadyWaitNudges_UsesOpenSessionSnapshotInsteadOfWorkerRunningCheck(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"template":           "worker",
+			"continuation_epoch": "1",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:        waitBeadType,
+		Labels:      []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Description: "Continue after review closes.",
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"dep_ids":          "gc-1",
+			"dep_mode":         "all",
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	sp := runtime.NewFake()
+
+	if err := dispatchReadyWaitNudges(dir, store, sp, time.Now().UTC()); err != nil {
+		t.Fatalf("dispatchReadyWaitNudges: %v", err)
+	}
+	for _, id := range store.getIDs {
+		if id == sessionBead.ID {
+			t.Fatalf("dispatch used Get for session %s instead of the open-session snapshot; getIDs=%v", sessionBead.ID, store.getIDs)
+		}
+	}
+	for _, call := range sp.Calls {
+		switch call.Method {
+		case "IsRunning", "ProcessAlive", "IsAttached", "GetLastActivity", "GetMeta":
+			t.Fatalf("dispatch should trust cached session state, saw provider call %#v", call)
+		}
+	}
+}
+
+func TestDispatchReadyWaitNudges_SkipsClosedSessionWithoutBackingGet(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"template":           "worker",
+			"continuation_epoch": "1",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"registered_epoch": "1",
+			"delivery_attempt": "1",
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+	sp := runtime.NewFake()
+
+	if err := dispatchReadyWaitNudges(dir, store, sp, time.Now().UTC()); err != nil {
+		t.Fatalf("dispatchReadyWaitNudges: %v", err)
+	}
+	for _, id := range store.getIDs {
+		if id == sessionBead.ID {
+			t.Fatalf("dispatch used Get for closed session %s; getIDs=%v", sessionBead.ID, store.getIDs)
+		}
+	}
+	if len(sp.Calls) != 0 {
+		t.Fatalf("dispatch should not query provider for a session absent from the open-session snapshot, calls=%#v", sp.Calls)
 	}
 }
 

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -489,6 +489,62 @@ func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testin
 	}
 }
 
+func TestPrepareWaitWakeState_CancelsStaleEpochWaitForClosedSession(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"agent_name":         "worker",
+			"continuation_epoch": "2",
+			"state":              string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	waitBead, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":       sessionBead.ID,
+			"session_name":     "worker",
+			"kind":             "deps",
+			"state":            waitStateReady,
+			"registered_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if len(readyWaitSet) != 0 {
+		t.Fatalf("readyWaitSet = %#v, want empty after stale wait cancellation", readyWaitSet)
+	}
+	updated, err := store.Get(waitBead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(wait): %v", err)
+	}
+	if got := updated.Metadata["state"]; got != waitStateCanceled {
+		t.Fatalf("wait state = %q, want %q", got, waitStateCanceled)
+	}
+	if got := updated.Metadata["last_error"]; got != "continuation-stale" {
+		t.Fatalf("last_error = %q, want continuation-stale", got)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("wait status = %q, want closed", updated.Status)
+	}
+}
+
 func TestDepsWaitReady_IgnoresEmptyDependencyEntries(t *testing.T) {
 	store := beads.NewMemStore()
 	dep, err := store.Create(beads.Bead{Title: "dep"})

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -116,6 +116,30 @@ func (s *sessionBeadSnapshot) FindSessionNameByTemplate(template string) string 
 	return s.sessionNameByTemplateHint[template]
 }
 
+func (s *sessionBeadSnapshot) FindByID(id string) (beads.Bead, bool) {
+	if s == nil || strings.TrimSpace(id) == "" {
+		return beads.Bead{}, false
+	}
+	for _, bead := range s.open {
+		if bead.ID == id {
+			return bead, true
+		}
+	}
+	return beads.Bead{}, false
+}
+
+func (s *sessionBeadSnapshot) FindBySessionName(name string) (beads.Bead, bool) {
+	if s == nil || strings.TrimSpace(name) == "" {
+		return beads.Bead{}, false
+	}
+	for _, bead := range s.open {
+		if strings.TrimSpace(bead.Metadata["session_name"]) == name {
+			return bead, true
+		}
+	}
+	return beads.Bead{}, false
+}
+
 func (s *sessionBeadSnapshot) FindSessionNameByNamedIdentity(identity string) string {
 	if s == nil || strings.TrimSpace(identity) == "" {
 		return ""

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -1,33 +1,53 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
-// sessionBeadSnapshot caches open session-bead state for a single reconcile
-// cycle so build/sync/reconcile can reuse one store scan.
+// sessionBeadSnapshot caches session-bead state for a single reconcile cycle.
+// Open-session lookups stay open-only; closed records are retained by ID for
+// lifecycle guards such as stale wait epoch cancellation.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
+	recordByID                map[string]beads.Bead
 	sessionNameByAgentName    map[string]string
 	sessionNameByTemplateHint map[string]string
 }
 
 func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
-	open, err := loadSessionBeads(store)
-	if err != nil {
-		return nil, err
+	if store == nil {
+		return newSessionBeadSnapshot(nil), nil
 	}
-	return newSessionBeadSnapshot(open), nil
+	all, err := store.List(beads.ListQuery{
+		Label:         sessionBeadLabel,
+		IncludeClosed: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing session beads: %w", err)
+	}
+	sessions := make([]beads.Bead, 0, len(all))
+	for _, bead := range all {
+		if sessionpkg.IsSessionBeadOrRepairable(bead) {
+			sessions = append(sessions, bead)
+		}
+	}
+	return newSessionBeadSnapshot(sessions), nil
 }
 
-func newSessionBeadSnapshot(open []beads.Bead) *sessionBeadSnapshot {
-	filtered := make([]beads.Bead, 0, len(open))
+func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
+	filtered := make([]beads.Bead, 0, len(beadsIn))
+	byID := make(map[string]beads.Bead)
 	sessionNameByAgentName := make(map[string]string)
 	sessionNameByTemplateHint := make(map[string]string)
 
-	for _, b := range open {
+	for _, b := range beadsIn {
+		if b.ID != "" {
+			byID[b.ID] = b
+		}
 		if b.Status == "closed" {
 			continue
 		}
@@ -69,6 +89,7 @@ func newSessionBeadSnapshot(open []beads.Bead) *sessionBeadSnapshot {
 
 	return &sessionBeadSnapshot{
 		open:                      filtered,
+		recordByID:                byID,
 		sessionNameByAgentName:    sessionNameByAgentName,
 		sessionNameByTemplateHint: sessionNameByTemplateHint,
 	}
@@ -81,6 +102,7 @@ func (s *sessionBeadSnapshot) replaceOpen(open []beads.Bead) {
 	rebuilt := newSessionBeadSnapshot(open)
 	if rebuilt == nil {
 		s.open = nil
+		s.recordByID = nil
 		s.sessionNameByAgentName = nil
 		s.sessionNameByTemplateHint = nil
 		return
@@ -128,16 +150,15 @@ func (s *sessionBeadSnapshot) FindByID(id string) (beads.Bead, bool) {
 	return beads.Bead{}, false
 }
 
-func (s *sessionBeadSnapshot) FindBySessionName(name string) (beads.Bead, bool) {
-	if s == nil || strings.TrimSpace(name) == "" {
+func (s *sessionBeadSnapshot) findByIDIncludingClosed(id string) (beads.Bead, bool) {
+	if s == nil || strings.TrimSpace(id) == "" {
 		return beads.Bead{}, false
 	}
-	for _, bead := range s.open {
-		if strings.TrimSpace(bead.Metadata["session_name"]) == name {
-			return bead, true
-		}
+	bead, ok := s.recordByID[id]
+	if !ok {
+		return beads.Bead{}, false
 	}
-	return beads.Bead{}, false
+	return bead, true
 }
 
 func (s *sessionBeadSnapshot) FindSessionNameByNamedIdentity(identity string) string {


### PR DESCRIPTION
Supersedes https://github.com/gastownhall/gascity/pull/1342.

Original PR title: perf(wait): use session snapshot for wait nudges
Original PR state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

Review synthesis:
- The original PR correctly replaces per-wait session `Get` calls and live provider running checks with an open-session snapshot for wait preparation and ready-nudge dispatch.
- Review found a major stale-epoch regression for waits whose session bead closed before the next controller tick. The follow-up includes a fix that falls back to the closed session bead only for stale-epoch cancellation.
- The follow-up also threads the already-loaded city runtime session snapshot through wait preparation and ready-nudge dispatch, and removes unused/dead snapshot API surface.

Validation:
- `git diff --check origin/main..HEAD`
- `go test ./cmd/gc -run 'TestPrepareWaitWakeState_(SkipsMissingOpenSessionWithoutBackingGet|CancelsStaleEpochWaitForClosedSession)|TestDispatchReadyWaitNudges_(UsesOpenSessionSnapshotInsteadOfWorkerRunningCheck|SkipsClosedSessionWithoutBackingGet)'`

Known baseline note:
- The broader author-listed `go test ./cmd/gc -run 'TestPrepareWaitWakeState|TestDispatchReadyWaitNudges|TestDepsWaitReady'` still fails in `TestDispatchReadyWaitNudges_EnqueuesDeterministicNudge` and `TestDispatchReadyWaitNudges_StartsCodexPoller`; those failures were already reproduced by the review on the recorded upstream base and are not attributed to this change.