### PR TITLE
Follow-up: perf(orders): cache dispatch last-run lookups

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -374,6 +374,11 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
+	// Dispatch due orders before startup session reconciliation. A cold-start
+	// reconcile can take minutes when it has stale or config-drifted sessions;
+	// due event/condition formulas should not wait behind that maintenance work.
+	cr.dispatchOrders(ctx, cityRoot)
+
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).
@@ -668,6 +673,10 @@ func (cr *CityRuntime) tick(
 		}
 	}
 
+	// Order dispatch is intentionally before the expensive session reconcile
+	// phases so due formulas are not starved by slow startup/config drift work.
+	cr.dispatchOrders(ctx, cityRoot)
+
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
 	// corrects bead state, and the pre-reconcile sync is sufficient for
@@ -728,11 +737,6 @@ func (cr *CityRuntime) tick(
 		}
 	}
 
-	// Order dispatch.
-	if cr.od != nil {
-		cr.od.dispatch(ctx, cityRoot, time.Now())
-	}
-
 	if cr.svc != nil {
 		cr.svc.Tick(ctx, time.Now())
 	}
@@ -755,6 +759,12 @@ func (cr *CityRuntime) tick(
 	}
 	completion = TraceCompletionCompleted
 	tickCompleted = true
+}
+
+func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
+	if cr.od != nil {
+		cr.od.dispatch(ctx, cityRoot, time.Now())
+	}
 }
 
 func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -374,11 +374,6 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
-	// Dispatch due orders before startup session reconciliation. A cold-start
-	// reconcile can take minutes when it has stale or config-drifted sessions;
-	// due event/condition formulas should not wait behind that maintenance work.
-	cr.dispatchOrders(ctx, cityRoot)
-
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -195,6 +195,44 @@ func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	}
 }
 
+type recordingOrderDispatcher struct {
+	called atomic.Bool
+}
+
+func (r *recordingOrderDispatcher) dispatch(context.Context, string, time.Time) {
+	r.called.Store(true)
+}
+
+func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	od := &recordingOrderDispatcher{}
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cityPath:            t.TempDir(),
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		od:                  od,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		if !od.called.Load() {
+			t.Fatal("order dispatch should happen before demand snapshot build")
+		}
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	var dirty atomic.Bool
+	var lastProviderName string
+	var prevPoolRunning map[string]bool
+	cr.tick(context.Background(), &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "patrol")
+
+	if !od.called.Load() {
+		t.Fatal("order dispatcher was not called")
+	}
+}
+
 func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2486,6 +2486,7 @@ func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T)
 	sp := runtime.NewFake()
 	var stdout bytes.Buffer
 	var started bool
+	od := &recordingOrderDispatcher{}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cr := newCityRuntime(CityRuntimeParams{
@@ -2504,6 +2505,7 @@ func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T)
 		Stdout:    &stdout,
 		Stderr:    io.Discard,
 	})
+	cr.od = od
 
 	cs := newControllerState(context.Background(), cfg, sp, events.NewFake(), "test-city", cityPath)
 	cs.cityBeadStore = beads.NewMemStore()
@@ -2513,6 +2515,9 @@ func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T)
 
 	if started {
 		t.Fatal("OnStarted called after cancellation")
+	}
+	if od.called.Load() {
+		t.Fatal("order dispatcher called before startup completed")
 	}
 	if strings.Contains(stdout.String(), "City started.") {
 		t.Fatalf("stdout = %q, want no started banner after cancellation", stdout.String())

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -574,7 +574,7 @@ func cmdOrderCheck(stdout, stderr io.Writer) int {
 		return epCode
 	}
 	defer ep.Close() //nolint:errcheck // best-effort
-	return doOrderCheckWithStoresResolver(aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), stdout, stderr)
+	return doOrderCheckWithStoresResolverScoped(cityPath, cfg, aa, time.Now(), ep, cachedOrderStoresResolver(cityPath, cfg), stdout, stderr)
 }
 
 // orderLastRunFn returns a LastRunFunc that queries BdStore for the most
@@ -638,6 +638,10 @@ func doOrderCheck(aa []orders.Order, now time.Time, lastRunFn orders.LastRunFunc
 }
 
 func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
+	return doOrderCheckWithStoresResolverScoped("", nil, aa, now, ep, resolveStores, stdout, stderr)
+}
+
+func doOrderCheckWithStoresResolverScoped(cityPath string, cfg *config.City, aa []orders.Order, now time.Time, ep events.Provider, resolveStores orderStoresResolver, stdout, stderr io.Writer) int {
 	if len(aa) == 0 {
 		fmt.Fprintln(stdout, "No orders found.") //nolint:errcheck // best-effort stdout
 		return 1
@@ -676,7 +680,12 @@ func doOrderCheckWithStoresResolver(aa []orders.Order, now time.Time, ep events.
 				return cursor
 			}
 		}
-		result := orders.CheckTrigger(a, now, lastRunFn, ep, cursorFn)
+		triggerOpts, err := orderTriggerOptions(cityPath, cfg, a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order check: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, triggerOpts)
 		if lastRunErr != nil {
 			fmt.Fprintf(stderr, "gc order check: reading last run for %s: %v\n", a.ScopedName(), lastRunErr) //nolint:errcheck // best-effort stderr
 			return 1

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -599,6 +599,37 @@ func TestOrderCheckWithStoresResolverUsesLegacyCityStore(t *testing.T) {
 	}
 }
 
+func TestOrderCheckConditionUsesCityScope(t *testing.T) {
+	cityDir := t.TempDir()
+	orderDir := filepath.Join(cityDir, "packs", "workflows", "orders")
+	check := fmt.Sprintf(
+		`test "$GC_CITY_PATH" = '%s' && test "$GC_STORE_ROOT" = '%s' && test "$GC_STORE_SCOPE" = city && test "$ORDER_DIR" = '%s'`,
+		cityDir,
+		cityDir,
+		orderDir,
+	)
+	aa := []orders.Order{{
+		Name:    "pr-review-router",
+		Trigger: "condition",
+		Check:   check,
+		Formula: "mol-pr-review-router",
+		Pool:    "workflows.pr-review-router",
+		Source:  filepath.Join(orderDir, "pr-review-router.toml"),
+	}}
+	resolver := func(orders.Order) ([]beads.Store, error) {
+		return []beads.Store{beads.NewMemStore()}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderCheckWithStoresResolverScoped(cityDir, &config.City{}, aa, time.Now(), nil, resolver, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderCheckWithStoresResolverScoped = %d, want 0; stderr: %s; stdout: %s", code, stderr.String(), stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "yes") {
+		t.Fatalf("stdout missing due row:\n%s", stdout.String())
+	}
+}
+
 func TestOrderCheckWithStoresResolverFailsWhenLegacyEventCursorReadFails(t *testing.T) {
 	rigStore := beads.NewMemStore()
 	legacyStore := labelFailListStore{

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -426,9 +426,9 @@ func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
 	return false
 }
 
-// hasOpenWorkStrict reports whether any non-closed work bead exists for this
-// order. Tracking beads (title "order:<name>") are excluded, so only actual
-// work (wisps, exec results) counts.
+// hasOpenWorkStrict reports whether any non-closed work or tracking bead
+// exists for this order. Open tracking beads represent in-flight dispatch and
+// must block condition/event orders that do not consult LastRun.
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
 		Label: "order-run:" + scopedName,
@@ -437,9 +437,8 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 	if err != nil {
 		return false, fmt.Errorf("listing order work beads: %w", err)
 	}
-	trackingTitle := "order:" + scopedName
 	for _, b := range results {
-		if b.Status != "closed" && b.Title != trackingTitle {
+		if b.Status != "closed" {
 			return true, nil
 		}
 	}

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -184,7 +184,8 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 				return cursor
 			}
 		}
-		result := orders.CheckTrigger(a, now, lastRunFn, m.ep, cursorFn)
+		triggerOpts := orderTriggerOptionsForTarget(cityPath, m.cfg, target, a)
+		result := orders.CheckTriggerWithOptions(a, now, lastRunFn, m.ep, cursorFn, triggerOpts)
 		if lastRunErr != nil {
 			logDispatchError(m.stderr, "gc: order dispatch: reading last run for %s: %v", a.ScopedName(), lastRunErr)
 			continue

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -74,6 +75,9 @@ type memoryOrderDispatcher struct {
 	maxTimeout time.Duration
 	cfg        *config.City
 	cityName   string
+
+	cacheMu      sync.Mutex
+	lastRunCache map[string]time.Time
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -164,10 +168,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		if legacyStore != nil {
 			storesForGate = append(storesForGate, legacyStore)
 		}
+		storeKeysForGate := []string{storeKey}
+		if legacyStore != nil {
+			storeKeysForGate = append(storeKeysForGate, orderStoreTargetKey(legacyOrderCityTarget(cityPath, m.cfg)))
+		}
 		baseLastRunFn := orders.LastRunAcrossStores(storesForGate...)
 		var lastRunErr error
 		lastRunFn := func(orderName string) (time.Time, error) {
-			last, err := baseLastRunFn(orderName)
+			last, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
 			if err != nil {
 				lastRunErr = err
 			}
@@ -215,6 +223,7 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 			logDispatchError(m.stderr, "gc: order dispatch: creating tracking bead for %s: %v", scoped, err)
 			continue
 		}
+		m.rememberLastRun(scoped, storeKeysForGate, trackingBead.CreatedAt)
 
 		// Fire and forget with timeout.
 		a := a // capture loop variable
@@ -238,6 +247,41 @@ func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target
 	}
 	stores[key] = store
 	return store, true
+}
+
+func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []string, read orders.LastRunFunc) (time.Time, error) {
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	m.cacheMu.Lock()
+	if m.lastRunCache != nil {
+		if last, ok := m.lastRunCache[key]; ok {
+			m.cacheMu.Unlock()
+			return last, nil
+		}
+	}
+	m.cacheMu.Unlock()
+
+	last, err := read(orderName)
+	if err != nil {
+		return time.Time{}, err
+	}
+	m.rememberLastRun(orderName, storeKeys, last)
+	return last, nil
+}
+
+func (m *memoryOrderDispatcher) rememberLastRun(orderName string, storeKeys []string, last time.Time) {
+	key := orderHistoryCacheKey(orderName, storeKeys)
+	m.cacheMu.Lock()
+	defer m.cacheMu.Unlock()
+	if m.lastRunCache == nil {
+		m.lastRunCache = make(map[string]time.Time)
+	}
+	if existing, ok := m.lastRunCache[key]; !ok || existing.IsZero() || last.After(existing) {
+		m.lastRunCache[key] = last
+	}
+}
+
+func orderHistoryCacheKey(orderName string, storeKeys []string) string {
+	return orderName + "\x00" + strings.Join(storeKeys, "\x00")
 }
 
 // dispatchOne runs a single order dispatch in its own goroutine.

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -174,10 +174,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		}
 		baseLastRunFn := orders.LastRunAcrossStores(storesForGate...)
 		var lastRunErr error
+		var lastRunFromCache bool
 		lastRunFn := func(orderName string) (time.Time, error) {
-			last, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
+			last, fromCache, err := m.cachedLastRun(orderName, storeKeysForGate, baseLastRunFn)
 			if err != nil {
 				lastRunErr = err
+			}
+			if fromCache {
+				lastRunFromCache = true
 			}
 			return last, err
 		}
@@ -200,6 +204,23 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 		}
 		if !result.Due {
 			continue
+		}
+		if lastRunFromCache && orderTriggerUsesLastRun(a) {
+			refreshedLastRun, err := baseLastRunFn(a.ScopedName())
+			if err != nil {
+				logDispatchError(m.stderr, "gc: order dispatch: refreshing last run for %s: %v", a.ScopedName(), err)
+				continue
+			}
+			if refreshedLastRun.After(result.LastRun) {
+				m.rememberLastRun(a.ScopedName(), storeKeysForGate, refreshedLastRun)
+				refreshedLastRunFn := func(string) (time.Time, error) {
+					return refreshedLastRun, nil
+				}
+				result = orders.CheckTriggerWithOptions(a, now, refreshedLastRunFn, m.ep, cursorFn, triggerOpts)
+				if !result.Due {
+					continue
+				}
+			}
 		}
 
 		// Skip dispatch if previous work hasn't been processed yet.
@@ -249,23 +270,23 @@ func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target
 	return store, true
 }
 
-func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []string, read orders.LastRunFunc) (time.Time, error) {
+func (m *memoryOrderDispatcher) cachedLastRun(orderName string, storeKeys []string, read orders.LastRunFunc) (time.Time, bool, error) {
 	key := orderHistoryCacheKey(orderName, storeKeys)
 	m.cacheMu.Lock()
 	if m.lastRunCache != nil {
 		if last, ok := m.lastRunCache[key]; ok {
 			m.cacheMu.Unlock()
-			return last, nil
+			return last, true, nil
 		}
 	}
 	m.cacheMu.Unlock()
 
 	last, err := read(orderName)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, false, err
 	}
 	m.rememberLastRun(orderName, storeKeys, last)
-	return last, nil
+	return last, false, nil
 }
 
 func (m *memoryOrderDispatcher) rememberLastRun(orderName string, storeKeys []string, last time.Time) {
@@ -282,6 +303,10 @@ func (m *memoryOrderDispatcher) rememberLastRun(orderName string, storeKeys []st
 
 func orderHistoryCacheKey(orderName string, storeKeys []string) string {
 	return orderName + "\x00" + strings.Join(storeKeys, "\x00")
+}
+
+func orderTriggerUsesLastRun(a orders.Order) bool {
+	return a.Trigger == "cooldown" || a.Trigger == "cron"
 }
 
 // dispatchOne runs a single order dispatch in its own goroutine.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2641,6 +2641,39 @@ func TestOrderDispatchSkipsOpenWork(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchSkipsOpenTrackingBeadForConditionOrder(t *testing.T) {
+	store := beads.NewMemStore()
+
+	_, err := store.Create(beads.Bead{
+		Title:  "order:my-auto",
+		Labels: []string{"order-run:my-auto", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ran := false
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran = true
+		return nil, nil
+	}
+
+	aa := []orders.Order{{
+		Name:    "my-auto",
+		Trigger: "condition",
+		Check:   "true",
+		Exec:    "scripts/run.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	time.Sleep(50 * time.Millisecond)
+
+	if ran {
+		t.Error("exec should not have run while an order-tracking bead is open")
+	}
+}
+
 func TestOrderDispatchFiresAfterWorkClosed(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2173,6 +2173,11 @@ func TestOrderDispatchSkipsRigEventWhenLegacyCursorReadFails(t *testing.T) {
 }
 
 func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	rigStore := beads.NewMemStore()
 	legacyStore := labelFailListStore{
 		Store:     beads.NewMemStore(),
@@ -2202,12 +2207,12 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 		cfg: &config.City{
 			Rigs: []config.Rig{{
 				Name: "frontend",
-				Path: "frontend",
+				Path: rigDir,
 			}},
 		},
 	}
 
-	m.dispatch(context.Background(), t.TempDir(), time.Now())
+	m.dispatch(context.Background(), cityDir, time.Now())
 	time.Sleep(50 * time.Millisecond)
 
 	rigRuns := trackingBeads(t, rigStore, "order-run:rig-digest:rig:frontend")
@@ -2216,6 +2221,37 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 	}
 	if !strings.Contains(stderr.String(), "open work") {
 		t.Fatalf("stderr missing open-work error:\n%s", stderr.String())
+	}
+}
+
+func TestOrderDispatchConditionUsesScopedEnv(t *testing.T) {
+	cityDir := t.TempDir()
+	store := beads.NewMemStore()
+	check := fmt.Sprintf(
+		`test "$GC_CITY_PATH" = '%s' && test "$GC_STORE_ROOT" = '%s' && test "$GC_STORE_SCOPE" = city && test "$(pwd)" = '%s'`,
+		cityDir,
+		cityDir,
+		cityDir,
+	)
+	ran := make(chan struct{}, 1)
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran <- struct{}{}
+		return nil, nil
+	}
+	aa := []orders.Order{{
+		Name:    "scoped-check",
+		Trigger: "condition",
+		Check:   check,
+		Exec:    "true",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	ad.dispatch(context.Background(), cityDir, time.Now())
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("condition order did not dispatch with scoped cwd/env")
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -42,6 +42,12 @@ type selectiveUpdateFailStore struct {
 	beads.Store
 }
 
+type countingListStore struct {
+	beads.Store
+
+	includeClosedLists int
+}
+
 func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error {
 	for _, label := range opts.Labels {
 		if strings.HasPrefix(label, "order-run:") {
@@ -49,6 +55,17 @@ func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error
 		}
 	}
 	return s.Store.Update(id, opts)
+}
+
+func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.IncludeClosed || query.Status == "closed" {
+		s.includeClosedLists++
+	}
+	return s.Store.List(query)
+}
+
+func (s *countingListStore) reset() {
+	s.includeClosedLists = 0
 }
 
 func TestOrderDispatcherNil(t *testing.T) {
@@ -198,6 +215,46 @@ func TestOrderDispatchMultiple(t *testing.T) {
 	}
 	if trackingCount != 1 {
 		t.Errorf("expected 1 tracking bead for order-a, got %d", trackingCount)
+	}
+}
+
+func TestOrderDispatchCachesLastRunBetweenDispatches(t *testing.T) {
+	store := &countingListStore{Store: beads.NewMemStore()}
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "recent run",
+		Labels: []string{"order-run:test-order"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "test-order",
+		Trigger:  "cooldown",
+		Interval: "1h",
+		Formula:  "test-formula",
+	}}
+	ad := buildOrderDispatcherFromList(aa, store, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	cityPath := t.TempDir()
+	now := time.Now()
+	ad.dispatch(context.Background(), cityPath, now)
+	if store.includeClosedLists == 0 {
+		t.Fatal("first dispatch did not read persisted order history")
+	}
+
+	store.reset()
+	ad.dispatch(context.Background(), cityPath, now.Add(time.Second))
+	if store.includeClosedLists != 0 {
+		t.Fatalf("second dispatch performed %d closed-history reads, want cached last-run result", store.includeClosedLists)
+	}
+
+	all, _ := store.ListOpen()
+	if len(all) != 1 {
+		t.Errorf("expected only seed bead, got %d", len(all))
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -48,6 +48,12 @@ type countingListStore struct {
 	includeClosedLists int
 }
 
+type createdAtOverrideStore struct {
+	beads.Store
+
+	createdAt map[string]time.Time
+}
+
 func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error {
 	for _, label := range opts.Labels {
 		if strings.HasPrefix(label, "order-run:") {
@@ -66,6 +72,34 @@ func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 
 func (s *countingListStore) reset() {
 	s.includeClosedLists = 0
+}
+
+func (s *createdAtOverrideStore) Create(b beads.Bead) (beads.Bead, error) {
+	created, err := s.Store.Create(b)
+	if err != nil {
+		return beads.Bead{}, err
+	}
+	if !b.CreatedAt.IsZero() {
+		if s.createdAt == nil {
+			s.createdAt = make(map[string]time.Time)
+		}
+		s.createdAt[created.ID] = b.CreatedAt
+		created.CreatedAt = b.CreatedAt
+	}
+	return created, nil
+}
+
+func (s *createdAtOverrideStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	results, err := s.Store.List(query)
+	if err != nil {
+		return nil, err
+	}
+	for i := range results {
+		if created, ok := s.createdAt[results[i].ID]; ok {
+			results[i].CreatedAt = created
+		}
+	}
+	return results, nil
 }
 
 func TestOrderDispatcherNil(t *testing.T) {
@@ -255,6 +289,89 @@ func TestOrderDispatchCachesLastRunBetweenDispatches(t *testing.T) {
 	all, _ := store.ListOpen()
 	if len(all) != 1 {
 		t.Errorf("expected only seed bead, got %d", len(all))
+	}
+}
+
+func TestOrderDispatchRefreshesCachedLastRunBeforeDueDispatch(t *testing.T) {
+	baseStore := &createdAtOverrideStore{Store: beads.NewMemStore()}
+	store := &countingListStore{Store: baseStore}
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+
+	if _, err := store.Create(beads.Bead{
+		Title:     "recent run",
+		Labels:    []string{"order-run:test-order"},
+		CreatedAt: now.Add(-30 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	aa := []orders.Order{{
+		Name:     "test-order",
+		Trigger:  "cooldown",
+		Interval: "1h",
+		Exec:     "true",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	cityPath := t.TempDir()
+	ad.dispatch(context.Background(), cityPath, now)
+	if store.includeClosedLists == 0 {
+		t.Fatal("first dispatch did not read persisted order history")
+	}
+
+	store.reset()
+	if _, err := store.Create(beads.Bead{
+		Title:     "manual run",
+		Labels:    []string{"order-run:test-order"},
+		CreatedAt: now.Add(20 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ad.dispatch(context.Background(), cityPath, now.Add(31*time.Minute))
+	if store.includeClosedLists == 0 {
+		t.Fatal("due cached dispatch did not refresh persisted order history")
+	}
+
+	all := trackingBeads(t, store, "order-run:test-order")
+	if len(all) != 2 {
+		t.Fatalf("order-run beads = %d, want only seed plus manual run", len(all))
+	}
+}
+
+func TestOrderDispatchCachesAutoTrackingBeadCreatedAt(t *testing.T) {
+	store := &countingListStore{Store: beads.NewMemStore()}
+	now := time.Now()
+
+	aa := []orders.Order{{
+		Name:     "test-order",
+		Trigger:  "cooldown",
+		Interval: "1h",
+		Exec:     "true",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, successfulExec, nil)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	cityPath := t.TempDir()
+	ad.dispatch(context.Background(), cityPath, now)
+	all := trackingBeads(t, store, "order-run:test-order")
+	if len(all) != 1 {
+		t.Fatalf("order-run beads after first dispatch = %d, want 1", len(all))
+	}
+
+	store.reset()
+	ad.dispatch(context.Background(), cityPath, now.Add(time.Second))
+	if store.includeClosedLists != 0 {
+		t.Fatalf("second dispatch performed %d closed-history reads, want cached tracking bead timestamp", store.includeClosedLists)
+	}
+	all = trackingBeads(t, store, "order-run:test-order")
+	if len(all) != 1 {
+		t.Fatalf("order-run beads after second dispatch = %d, want cached cooldown suppression", len(all))
 	}
 }
 

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -128,6 +128,27 @@ func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a o
 	return mergeRuntimeEnv(nil, env)
 }
 
+func orderTriggerOptions(cityPath string, cfg *config.City, a orders.Order) (orders.TriggerOptions, error) {
+	if a.Trigger != "condition" || strings.TrimSpace(cityPath) == "" {
+		return orders.TriggerOptions{}, nil
+	}
+	target, err := resolveOrderExecTarget(cityPath, cfg, a)
+	if err != nil {
+		return orders.TriggerOptions{}, err
+	}
+	return orderTriggerOptionsForTarget(cityPath, cfg, target, a), nil
+}
+
+func orderTriggerOptionsForTarget(cityPath string, cfg *config.City, target execStoreTarget, a orders.Order) orders.TriggerOptions {
+	if a.Trigger != "condition" || strings.TrimSpace(cityPath) == "" {
+		return orders.TriggerOptions{}
+	}
+	return orders.TriggerOptions{
+		ConditionDir: target.ScopeRoot,
+		ConditionEnv: orderExecEnv(cityPath, cfg, target, a),
+	}
+}
+
 func applyOrderExecCanonicalDoltEnv(cityPath, scopeRoot string, env map[string]string) {
 	if env == nil {
 		return

--- a/internal/orders/triggers.go
+++ b/internal/orders/triggers.go
@@ -3,6 +3,7 @@ package orders
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -29,19 +30,32 @@ type LastRunFunc func(name string) (time.Time, error)
 // Returns 0 if no cursor exists.
 type CursorFunc func(orderName string) uint64
 
+// TriggerOptions carries execution context for triggers that run subprocesses.
+type TriggerOptions struct {
+	ConditionDir     string
+	ConditionEnv     []string
+	ConditionTimeout time.Duration
+}
+
 // CheckTrigger evaluates an order's trigger condition and returns whether it's due.
 // ep is an events Provider used by event triggers to query events; may be nil for
 // non-event triggers.
 // cursorFn returns the last-processed event seq for event triggers; may be nil for
 // non-event triggers.
 func CheckTrigger(a Order, now time.Time, lastRunFn LastRunFunc, ep events.Provider, cursorFn CursorFunc) TriggerResult {
+	return CheckTriggerWithOptions(a, now, lastRunFn, ep, cursorFn, TriggerOptions{})
+}
+
+// CheckTriggerWithOptions evaluates an order trigger using explicit execution
+// context for condition checks.
+func CheckTriggerWithOptions(a Order, now time.Time, lastRunFn LastRunFunc, ep events.Provider, cursorFn CursorFunc, opts TriggerOptions) TriggerResult {
 	switch a.Trigger {
 	case "cooldown":
 		return checkCooldown(a, now, lastRunFn)
 	case "cron":
 		return checkCron(a, now, lastRunFn)
 	case "condition":
-		return checkCondition(a)
+		return checkCondition(a, opts)
 	case "event":
 		return checkEvent(a, ep, cursorFn)
 	case "manual":
@@ -131,12 +145,21 @@ func cronFieldMatches(field string, value int) bool {
 
 // checkCondition runs the check command and returns due if exit code is 0.
 // Uses a timeout to prevent hanging check scripts from blocking trigger evaluation.
-func checkCondition(a Order) TriggerResult {
+func checkCondition(a Order, opts TriggerOptions) TriggerResult {
 	const triggerCheckTimeout = 10 * time.Second
-	timeout := triggerCheckTimeout
+	timeout := opts.ConditionTimeout
+	if timeout <= 0 {
+		timeout = triggerCheckTimeout
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sh", "-c", a.Check)
+	if opts.ConditionDir != "" {
+		cmd.Dir = opts.ConditionDir
+	}
+	if len(opts.ConditionEnv) > 0 {
+		cmd.Env = mergeConditionEnv(os.Environ(), opts.ConditionEnv)
+	}
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return TriggerResult{Due: false, Reason: fmt.Sprintf("check command timed out after %s", timeout)}
@@ -144,6 +167,27 @@ func checkCondition(a Order) TriggerResult {
 		return TriggerResult{Due: false, Reason: fmt.Sprintf("check command failed: %v", err)}
 	}
 	return TriggerResult{Due: true, Reason: "condition: check passed (exit 0)"}
+}
+
+func mergeConditionEnv(environ, extra []string) []string {
+	out := make([]string, 0, len(environ)+len(extra))
+	replaced := make(map[string]struct{}, len(extra))
+	for _, entry := range extra {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			replaced[key] = struct{}{}
+		}
+	}
+	for _, entry := range environ {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, found := replaced[key]; found {
+				continue
+			}
+		}
+		out = append(out, entry)
+	}
+	return append(out, extra...)
 }
 
 // checkEvent checks if matching events exist after the last cursor position.

--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -97,6 +97,26 @@ func TestCheckTriggerCondition(t *testing.T) {
 	}
 }
 
+func TestCheckTriggerConditionUsesOptions(t *testing.T) {
+	dir := t.TempDir()
+	a := Order{
+		Name:    "check",
+		Trigger: "condition",
+		Check:   `test "$GC_CITY_PATH" = "$EXPECT_CITY" && test "$(pwd)" = "$EXPECT_CITY"`,
+	}
+	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)
+	result := CheckTriggerWithOptions(a, now, neverRan, nil, nil, TriggerOptions{
+		ConditionDir: dir,
+		ConditionEnv: []string{
+			"EXPECT_CITY=" + dir,
+			"GC_CITY_PATH=" + dir,
+		},
+	})
+	if !result.Due {
+		t.Errorf("Due = false, want true with condition cwd/env: %s", result.Reason)
+	}
+}
+
 func TestCheckTriggerConditionFails(t *testing.T) {
 	a := Order{Name: "check", Trigger: "condition", Check: "false"}
 	now := time.Date(2026, 2, 27, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1349.

Original PR metadata:
- Title: perf(orders): cache dispatch last-run lookups
- Original state at finalization: OPEN
- Configured base: main
- Original GitHub base: split/order-dispatch-correctness
- Original head: split/order-dispatch-last-run-cache
- Base mismatch: the source PR was stacked on split/order-dispatch-correctness while the PR-review request targets main.

This follow-up branch was created from current origin/main and cherry-picked the contributor's stacked commits plus the reviewed maintainer fix:
- fix: run order condition checks in scoped env
- fix: dispatch orders before session reconcile
- perf: cache order dispatch last-run lookups
- fix: revalidate cached order last-run before dispatch

The two-commit minimal cherry-pick was rejected because the cache patch depends on orders.CheckTriggerWithOptions from the stacked base. All commits preserve the contributor author identity.

Local validation before opening:
- git diff --check
- go test ./cmd/gc -run 'TestOrderDispatch(CachesLastRunBetweenDispatches|RefreshesCachedLastRunBeforeDueDispatch|CachesAutoTrackingBeadCreatedAt)|TestOrderDispatchCooldown|TestOrderDispatchExecCooldown|TestOrderDispatchManualFiltered|TestOrderDispatchMultiple'

A broader `go test ./internal/orders ./cmd/gc` run passed internal/orders, then remained active in cmd/gc without additional output and was stopped; GitHub CI is the required merge gate for this follow-up.