### PR TITLE
fix(mail): use session bead id for senders

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -155,14 +155,21 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	if len(args) > 1 {
 		message = args[1]
 	}
+	metadata, err := mailSenderRouteMetadata(store, sessionAddress)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc handoff: resolving sender route: %v\n", err) //nolint:errcheck // best-effort stderr
+		return handoffOutcome{code: 1}
+	}
+	senderDisplay := mailSenderDisplayFromMetadata(sessionAddress, metadata)
 
 	b, err := store.Create(beads.Bead{
 		Title:       subject,
 		Description: message,
 		Type:        "message",
 		Assignee:    sessionAddress,
-		From:        sessionAddress,
+		From:        senderDisplay,
 		Labels:      []string{"thread:" + handoffThreadID()},
+		Metadata:    metadata,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -170,7 +177,7 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	}
 	rec.Record(events.Event{
 		Type:    events.MailSent,
-		Actor:   sessionAddress,
+		Actor:   senderDisplay,
 		Subject: b.ID,
 		Message: sessionAddress,
 		Payload: mailEventPayload(nil),
@@ -277,6 +284,12 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 	if len(args) > 1 {
 		message = args[1]
 	}
+	metadata, err := mailSenderRouteMetadata(store, sender)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc handoff: resolving sender route: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	senderDisplay := mailSenderDisplayFromMetadata(sender, metadata)
 
 	// Send mail to target.
 	b, err := store.Create(beads.Bead{
@@ -284,8 +297,9 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 		Description: message,
 		Type:        "message",
 		Assignee:    targetAddress,
-		From:        sender,
+		From:        senderDisplay,
 		Labels:      []string{"thread:" + handoffThreadID()},
+		Metadata:    metadata,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -293,7 +307,7 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 	}
 	rec.Record(events.Event{
 		Type:    events.MailSent,
-		Actor:   sender,
+		Actor:   senderDisplay,
 		Subject: b.ID,
 		Message: targetAddress,
 		Payload: mailEventPayload(nil),

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -601,8 +601,14 @@ func TestCmdHandoffRemoteDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *
 	if !found {
 		t.Fatalf("message bead not found; beads=%#v", all)
 	}
-	if msg.From != senderBead.ID {
-		t.Fatalf("message From = %q, want session bead ID %q", msg.From, senderBead.ID)
+	if msg.From != "sender" {
+		t.Fatalf("message From = %q, want sender", msg.From)
+	}
+	if msg.Metadata["mail.from_session_id"] != senderBead.ID {
+		t.Fatalf("mail.from_session_id = %q, want %q", msg.Metadata["mail.from_session_id"], senderBead.ID)
+	}
+	if msg.Metadata["mail.from_display"] != "sender" {
+		t.Fatalf("mail.from_display = %q, want sender", msg.Metadata["mail.from_display"])
 	}
 	if msg.Assignee != "recipient" {
 		t.Fatalf("message Assignee = %q, want recipient", msg.Assignee)

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -549,14 +549,15 @@ func TestCmdHandoffRemoteDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	if _, err := store.Create(beads.Bead{
+	senderBead, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
 			"alias":        "sender",
 			"session_name": "sender-gc-42",
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create sender: %v", err)
 	}
 	if _, err := store.Create(beads.Bead{
@@ -600,8 +601,8 @@ func TestCmdHandoffRemoteDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *
 	if !found {
 		t.Fatalf("message bead not found; beads=%#v", all)
 	}
-	if msg.From != "sender" {
-		t.Fatalf("message From = %q, want sender", msg.From)
+	if msg.From != senderBead.ID {
+		t.Fatalf("message From = %q, want session bead ID %q", msg.From, senderBead.ID)
 	}
 	if msg.Assignee != "recipient" {
 		t.Fatalf("message Assignee = %q, want recipient", msg.Assignee)

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -291,13 +291,6 @@ func sessionMailboxAddress(b beads.Bead) string {
 	return strings.TrimSpace(b.Metadata["session_name"])
 }
 
-func sessionMailboxSenderAddress(b beads.Bead) string {
-	if b.ID != "" {
-		return b.ID
-	}
-	return sessionMailboxAddress(b)
-}
-
 func sessionMailboxAddresses(b beads.Bead) []string {
 	seen := map[string]bool{}
 	var addresses []string
@@ -381,67 +374,6 @@ func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, store bead
 	return resolveMailIdentity(store, identifier)
 }
 
-func resolveMailSenderIdentity(store beads.Store, identifier string) (string, error) {
-	if identifier == "" || identifier == "human" {
-		return "human", nil
-	}
-	sessionID, err := resolveSessionID(store, identifier)
-	if err != nil {
-		if errors.Is(err, session.ErrSessionNotFound) {
-			if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
-				return "", targetErr
-			} else if matched {
-				return target.senderAddress(), nil
-			}
-			if address, ok := configuredMailboxAddress(identifier); ok {
-				return address, nil
-			}
-		}
-		return "", err
-	}
-	b, err := store.Get(sessionID)
-	if err != nil {
-		return "", err
-	}
-	address := sessionMailboxSenderAddress(b)
-	if address == "" {
-		return "", fmt.Errorf("session %q has no mailbox identity", identifier)
-	}
-	return address, nil
-}
-
-func resolveMailSenderIdentityWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
-	if identifier == "" || identifier == "human" {
-		return "human", nil
-	}
-	if store != nil && cfg != nil {
-		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, identifier)
-		if err == nil {
-			b, err := store.Get(sessionID)
-			if err != nil {
-				return "", err
-			}
-			address := sessionMailboxSenderAddress(b)
-			if address == "" {
-				return "", fmt.Errorf("session %q has no mailbox identity", identifier)
-			}
-			return address, nil
-		}
-		if !errors.Is(err, session.ErrSessionNotFound) {
-			return "", err
-		}
-	}
-	if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
-		return "", targetErr
-	} else if matched {
-		return target.senderAddress(), nil
-	}
-	if address, ok := configuredMailboxAddressWithConfig(cityPath, cfg, identifier); ok {
-		return address, nil
-	}
-	return resolveMailSenderIdentity(store, identifier)
-}
-
 func resolveMailRecipientIdentity(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
 	if identifier == "" || identifier == "human" {
 		return "human", nil
@@ -508,14 +440,55 @@ func listLiveSessionMailboxes(store beads.Store) (map[string]bool, error) {
 type resolvedMailTarget struct {
 	display    string
 	recipients []string
-	sessionID  string
 }
 
-func (t resolvedMailTarget) senderAddress() string {
-	if strings.TrimSpace(t.sessionID) != "" {
-		return strings.TrimSpace(t.sessionID)
+func mailSenderRouteMetadata(store beads.Store, sender string) (map[string]string, error) {
+	sender = strings.TrimSpace(sender)
+	if store == nil || sender == "" || sender == "human" {
+		return nil, nil
 	}
-	return strings.TrimSpace(t.display)
+	sessionID, err := resolveSessionID(store, sender)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) || errors.Is(err, session.ErrAmbiguous) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("resolving sender route %q: %w", sender, err)
+	}
+	b, err := store.Get(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("loading sender session %q: %w", sessionID, err)
+	}
+	display := mailSenderDisplayAddress(b, sender)
+	return map[string]string{
+		mail.FromSessionIDMetadataKey: sessionID,
+		mail.FromDisplayMetadataKey:   display,
+	}, nil
+}
+
+func mailSenderDisplayAddress(b beads.Bead, fallback string) string {
+	if alias := strings.TrimSpace(b.Metadata["alias"]); alias != "" {
+		return alias
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" && fallback != b.ID {
+		return fallback
+	}
+	if name := strings.TrimSpace(b.Metadata["session_name"]); name != "" {
+		return name
+	}
+	if b.ID != "" {
+		return b.ID
+	}
+	return fallback
+}
+
+func mailSenderDisplayFromMetadata(fallback string, metadata map[string]string) string {
+	if metadata != nil {
+		if display := strings.TrimSpace(metadata[mail.FromDisplayMetadataKey]); display != "" {
+			return display
+		}
+	}
+	return strings.TrimSpace(fallback)
 }
 
 func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) (resolvedMailTarget, bool, error) {
@@ -554,7 +527,6 @@ func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) 
 		matches[display] = resolvedMailTarget{
 			display:    display,
 			recipients: addresses,
-			sessionID:  b.ID,
 		}
 		order = append(order, display)
 	}
@@ -653,7 +625,7 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 func resolveDefaultMailSenderForCommand(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string) (string, bool) {
 	candidates := defaultMailIdentityCandidates()
 	for _, c := range candidates {
-		sender, err := resolveMailSenderIdentityWithConfig(cityPath, cfg, store, c)
+		sender, err := resolveMailIdentityWithConfig(cityPath, cfg, store, c)
 		if err == nil {
 			return sender, true
 		}
@@ -764,6 +736,10 @@ func collectMailCounts(count func(string) (int, int, error), recipients []string
 		unread += recipientUnread
 	}
 	return total, unread, nil
+}
+
+type multiRecipientMailCounter interface {
+	CountRecipients([]string) (int, int, error)
 }
 
 func newMailSendCmd(stdout, stderr io.Writer) *cobra.Command {
@@ -1010,7 +986,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 			sender = defaultMailIdentity()
 		}
 	} else if sender != "human" && store != nil {
-		sender, err = resolveMailSenderIdentityWithConfig(cityPath, cfg, store, sender)
+		sender, err = resolveMailIdentityWithConfig(cityPath, cfg, store, sender)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1093,7 +1069,7 @@ func doMailSend(mp mail.Provider, rec events.Recorder, validRecipients map[strin
 	}
 	rec.Record(events.Event{
 		Type:    events.MailSent,
-		Actor:   sender,
+		Actor:   m.From,
 		Subject: m.ID,
 		Message: to,
 		Payload: mailEventPayload(&m),
@@ -1148,7 +1124,7 @@ func doMailSendAll(mp mail.Provider, rec events.Recorder, validRecipients map[st
 		}
 		rec.Record(events.Event{
 			Type:    events.MailSent,
-			Actor:   sender,
+			Actor:   m.From,
 			Subject: m.ID,
 			Message: to,
 			Payload: mailEventPayload(&m),
@@ -1329,7 +1305,7 @@ func doMailReply(mp mail.Provider, rec events.Recorder, id, sender, subject, bod
 	}
 	rec.Record(events.Event{
 		Type:    events.MailReplied,
-		Actor:   sender,
+		Actor:   reply.From,
 		Subject: reply.ID,
 		Message: reply.To,
 		Payload: mailEventPayload(&reply),
@@ -1510,7 +1486,13 @@ func doMailCount(mp mail.Provider, recipient string, stdout, stderr io.Writer) i
 }
 
 func doMailCountTarget(mp mail.Provider, target resolvedMailTarget, stdout, stderr io.Writer) int {
-	total, unread, err := collectMailCounts(mp.Count, target.recipients)
+	var total, unread int
+	var err error
+	if counter, ok := mp.(multiRecipientMailCounter); ok {
+		total, unread, err = counter.CountRecipients(target.recipients)
+	} else {
+		total, unread, err = collectMailCounts(mp.Count, target.recipients)
+	}
 	if err != nil {
 		fmt.Fprintf(stderr, "gc mail count: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -291,6 +291,13 @@ func sessionMailboxAddress(b beads.Bead) string {
 	return strings.TrimSpace(b.Metadata["session_name"])
 }
 
+func sessionMailboxSenderAddress(b beads.Bead) string {
+	if b.ID != "" {
+		return b.ID
+	}
+	return sessionMailboxAddress(b)
+}
+
 func sessionMailboxAddresses(b beads.Bead) []string {
 	seen := map[string]bool{}
 	var addresses []string
@@ -374,6 +381,67 @@ func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, store bead
 	return resolveMailIdentity(store, identifier)
 }
 
+func resolveMailSenderIdentity(store beads.Store, identifier string) (string, error) {
+	if identifier == "" || identifier == "human" {
+		return "human", nil
+	}
+	sessionID, err := resolveSessionID(store, identifier)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
+				return "", targetErr
+			} else if matched {
+				return target.senderAddress(), nil
+			}
+			if address, ok := configuredMailboxAddress(identifier); ok {
+				return address, nil
+			}
+		}
+		return "", err
+	}
+	b, err := store.Get(sessionID)
+	if err != nil {
+		return "", err
+	}
+	address := sessionMailboxSenderAddress(b)
+	if address == "" {
+		return "", fmt.Errorf("session %q has no mailbox identity", identifier)
+	}
+	return address, nil
+}
+
+func resolveMailSenderIdentityWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
+	if identifier == "" || identifier == "human" {
+		return "human", nil
+	}
+	if store != nil && cfg != nil {
+		sessionID, err := resolveSessionIDWithConfig(cityPath, cfg, store, identifier)
+		if err == nil {
+			b, err := store.Get(sessionID)
+			if err != nil {
+				return "", err
+			}
+			address := sessionMailboxSenderAddress(b)
+			if address == "" {
+				return "", fmt.Errorf("session %q has no mailbox identity", identifier)
+			}
+			return address, nil
+		}
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			return "", err
+		}
+	}
+	if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
+		return "", targetErr
+	} else if matched {
+		return target.senderAddress(), nil
+	}
+	if address, ok := configuredMailboxAddressWithConfig(cityPath, cfg, identifier); ok {
+		return address, nil
+	}
+	return resolveMailSenderIdentity(store, identifier)
+}
+
 func resolveMailRecipientIdentity(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
 	if identifier == "" || identifier == "human" {
 		return "human", nil
@@ -440,6 +508,14 @@ func listLiveSessionMailboxes(store beads.Store) (map[string]bool, error) {
 type resolvedMailTarget struct {
 	display    string
 	recipients []string
+	sessionID  string
+}
+
+func (t resolvedMailTarget) senderAddress() string {
+	if strings.TrimSpace(t.sessionID) != "" {
+		return strings.TrimSpace(t.sessionID)
+	}
+	return strings.TrimSpace(t.display)
 }
 
 func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) (resolvedMailTarget, bool, error) {
@@ -478,6 +554,7 @@ func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) 
 		matches[display] = resolvedMailTarget{
 			display:    display,
 			recipients: addresses,
+			sessionID:  b.ID,
 		}
 		order = append(order, display)
 	}
@@ -576,7 +653,7 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 func resolveDefaultMailSenderForCommand(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string) (string, bool) {
 	candidates := defaultMailIdentityCandidates()
 	for _, c := range candidates {
-		sender, err := resolveMailIdentityWithConfig(cityPath, cfg, store, c)
+		sender, err := resolveMailSenderIdentityWithConfig(cityPath, cfg, store, c)
 		if err == nil {
 			return sender, true
 		}
@@ -933,7 +1010,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 			sender = defaultMailIdentity()
 		}
 	} else if sender != "human" && store != nil {
-		sender, err = resolveMailIdentityWithConfig(cityPath, cfg, store, sender)
+		sender, err = resolveMailSenderIdentityWithConfig(cityPath, cfg, store, sender)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
 			return 1

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -353,7 +353,7 @@ func TestResolveDefaultMailTargetsForCommand_FallsBackToGCAliasWhenSessionIDMiss
 	}
 }
 
-func TestResolveDefaultMailSenderForCommand_UsesSessionBeadIDBeforeAlias(t *testing.T) {
+func TestResolveDefaultMailSenderForCommand_UsesDisplayAliasBeforeSessionName(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_MAIL", "")
 
@@ -389,12 +389,12 @@ func TestResolveDefaultMailSenderForCommand_UsesSessionBeadIDBeforeAlias(t *test
 	if !ok {
 		t.Fatalf("resolveDefaultMailSenderForCommand() = not ok; stderr=%q", stderr.String())
 	}
-	if sender != b.ID {
-		t.Fatalf("sender = %q, want session bead ID %q", sender, b.ID)
+	if sender != "gascity/workflows.codex-min-1" {
+		t.Fatalf("sender = %q, want display alias", sender)
 	}
 }
 
-func TestResolveMailSenderIdentityWithConfig_ExplicitAliasUsesSessionBeadID(t *testing.T) {
+func TestResolveMailIdentityWithConfig_ExplicitAliasUsesDisplayAlias(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_MAIL", "")
 
@@ -408,27 +408,26 @@ func TestResolveMailSenderIdentityWithConfig_ExplicitAliasUsesSessionBeadID(t *t
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	b, err := store.Create(beads.Bead{
+	if _, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
 			"alias":        "gascity/workflows.codex-min-16",
 			"session_name": "workflows__codex-min-mc-explicit",
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	cfg, _ := loadCityConfig(cityPath)
 
 	for _, from := range []string{"gascity/workflows.codex-min-16", "workflows.codex-min-16"} {
 		t.Run(from, func(t *testing.T) {
-			sender, err := resolveMailSenderIdentityWithConfig(cityPath, cfg, store, from)
+			sender, err := resolveMailIdentityWithConfig(cityPath, cfg, store, from)
 			if err != nil {
-				t.Fatalf("resolveMailSenderIdentityWithConfig(%q): %v", from, err)
+				t.Fatalf("resolveMailIdentityWithConfig(%q): %v", from, err)
 			}
-			if sender != b.ID {
-				t.Fatalf("sender = %q, want session bead ID %q", sender, b.ID)
+			if sender != "gascity/workflows.codex-min-16" {
+				t.Fatalf("sender = %q, want display alias", sender)
 			}
 		})
 	}
@@ -448,15 +447,14 @@ func TestResolveDefaultMailSenderForCommand_FallsBackToGCAliasWhenSessionIDMissi
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	b, err := store.Create(beads.Bead{
+	if _, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
 			"alias":        "sky",
 			"session_name": "sky-gc-42",
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	cfg, _ := loadCityConfig(cityPath)
@@ -470,8 +468,8 @@ func TestResolveDefaultMailSenderForCommand_FallsBackToGCAliasWhenSessionIDMissi
 	if !ok {
 		t.Fatalf("resolveDefaultMailSenderForCommand() = not ok; stderr=%q", stderr.String())
 	}
-	if sender != b.ID {
-		t.Fatalf("sender = %q, want session bead ID %q", sender, b.ID)
+	if sender != "sky" {
+		t.Fatalf("sender = %q, want sky", sender)
 	}
 }
 
@@ -540,8 +538,14 @@ func TestCmdMailSendDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *testi
 	if !found {
 		t.Fatalf("message bead not found; beads=%#v", all)
 	}
-	if msg.From != senderBead.ID {
-		t.Fatalf("message From = %q, want session bead ID %q", msg.From, senderBead.ID)
+	if msg.From != "sender" {
+		t.Fatalf("message From = %q, want sender", msg.From)
+	}
+	if msg.Metadata["mail.from_session_id"] != senderBead.ID {
+		t.Fatalf("mail.from_session_id = %q, want %q", msg.Metadata["mail.from_session_id"], senderBead.ID)
+	}
+	if msg.Metadata["mail.from_display"] != "sender" {
+		t.Fatalf("mail.from_display = %q, want sender", msg.Metadata["mail.from_display"])
 	}
 	if msg.Assignee != "recipient" {
 		t.Fatalf("message Assignee = %q, want recipient", msg.Assignee)

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -353,6 +353,87 @@ func TestResolveDefaultMailTargetsForCommand_FallsBackToGCAliasWhenSessionIDMiss
 	}
 }
 
+func TestResolveDefaultMailSenderForCommand_UsesSessionBeadIDBeforeAlias(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "gascity/workflows.codex-min-1",
+			"session_name": "workflows__codex-min-mc-abc123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cfg, _ := loadCityConfig(cityPath)
+
+	t.Setenv("GC_SESSION_ID", b.ID)
+	t.Setenv("GC_ALIAS", "gascity/workflows.codex-min-1")
+	t.Setenv("GC_AGENT", "gascity/workflows.codex-min-1")
+
+	var stderr bytes.Buffer
+	sender, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, &stderr, "gc mail send")
+	if !ok {
+		t.Fatalf("resolveDefaultMailSenderForCommand() = not ok; stderr=%q", stderr.String())
+	}
+	if sender != b.ID {
+		t.Fatalf("sender = %q, want session bead ID %q", sender, b.ID)
+	}
+}
+
+func TestResolveMailSenderIdentityWithConfig_ExplicitAliasUsesSessionBeadID(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "gascity/workflows.codex-min-16",
+			"session_name": "workflows__codex-min-mc-explicit",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cfg, _ := loadCityConfig(cityPath)
+
+	for _, from := range []string{"gascity/workflows.codex-min-16", "workflows.codex-min-16"} {
+		t.Run(from, func(t *testing.T) {
+			sender, err := resolveMailSenderIdentityWithConfig(cityPath, cfg, store, from)
+			if err != nil {
+				t.Fatalf("resolveMailSenderIdentityWithConfig(%q): %v", from, err)
+			}
+			if sender != b.ID {
+				t.Fatalf("sender = %q, want session bead ID %q", sender, b.ID)
+			}
+		})
+	}
+}
+
 func TestResolveDefaultMailSenderForCommand_FallsBackToGCAliasWhenSessionIDMissing(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_MAIL", "")
@@ -367,14 +448,15 @@ func TestResolveDefaultMailSenderForCommand_FallsBackToGCAliasWhenSessionIDMissi
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	if _, err := store.Create(beads.Bead{
+	b, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
 			"alias":        "sky",
 			"session_name": "sky-gc-42",
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	cfg, _ := loadCityConfig(cityPath)
@@ -388,8 +470,8 @@ func TestResolveDefaultMailSenderForCommand_FallsBackToGCAliasWhenSessionIDMissi
 	if !ok {
 		t.Fatalf("resolveDefaultMailSenderForCommand() = not ok; stderr=%q", stderr.String())
 	}
-	if sender != "sky" {
-		t.Fatalf("sender = %q, want sky", sender)
+	if sender != b.ID {
+		t.Fatalf("sender = %q, want session bead ID %q", sender, b.ID)
 	}
 }
 
@@ -407,14 +489,15 @@ func TestCmdMailSendDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *testi
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
-	if _, err := store.Create(beads.Bead{
+	senderBead, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
 			"alias":        "sender",
 			"session_name": "sender-gc-42",
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create sender: %v", err)
 	}
 	if _, err := store.Create(beads.Bead{
@@ -457,8 +540,8 @@ func TestCmdMailSendDefaultSenderFallsBackToGCAliasWhenSessionIDMissing(t *testi
 	if !found {
 		t.Fatalf("message bead not found; beads=%#v", all)
 	}
-	if msg.From != "sender" {
-		t.Fatalf("message From = %q, want sender", msg.From)
+	if msg.From != senderBead.ID {
+		t.Fatalf("message From = %q, want session bead ID %q", msg.From, senderBead.ID)
 	}
 	if msg.Assignee != "recipient" {
 		t.Fatalf("message Assignee = %q, want recipient", msg.Assignee)

--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -299,6 +299,11 @@ func mailMessagesForRecipients(fetch func(string) ([]mail.Message, error), recip
 
 func mailCountForRecipients(mp mail.Provider, recipients []string) (int, int, error) {
 	recipients = uniqueMailRecipients(recipients)
+	if counter, ok := mp.(interface {
+		CountRecipients([]string) (int, int, error)
+	}); ok {
+		return counter.CountRecipients(recipients)
+	}
 	var totalAll, unreadAll int
 	for _, recipient := range recipients {
 		total, unread, err := mp.Count(recipient)

--- a/internal/api/huma_handlers_mail.go
+++ b/internal/api/huma_handlers_mail.go
@@ -263,7 +263,7 @@ func (s *Server) humaHandleMailSend(ctx context.Context, input *MailSendInput) (
 	}
 	msg.Rig = input.Body.Rig
 	s.idem.storeResponse(idemKey, bodyHash, msg)
-	s.recordMailEvent(events.MailSent, input.Body.From, msg.ID, input.Body.Rig, &msg)
+	s.recordMailEvent(events.MailSent, msg.From, msg.ID, input.Body.Rig, &msg)
 
 	return &IndexOutput[mail.Message]{
 		Index: s.latestIndex(),
@@ -449,7 +449,7 @@ func (s *Server) humaHandleMailReply(_ context.Context, input *MailReplyInput) (
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
 	msg.Rig = resolvedRig
-	s.recordMailEvent(events.MailReplied, input.Body.From, msg.ID, resolvedRig, &msg)
+	s.recordMailEvent(events.MailReplied, msg.From, msg.ID, resolvedRig, &msg)
 
 	return &IndexOutput[mail.Message]{
 		Index: s.latestIndex(),

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -5,7 +5,9 @@ package beadmail
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,8 +18,10 @@ import (
 )
 
 const (
-	fromSessionIDMetadataKey = "mail.from_session_id"
-	fromDisplayMetadataKey   = "mail.from_display"
+	fromSessionIDMetadataKey = mail.FromSessionIDMetadataKey
+	fromDisplayMetadataKey   = mail.FromDisplayMetadataKey
+	toSessionIDMetadataKey   = mail.ToSessionIDMetadataKey
+	toDisplayMetadataKey     = mail.ToDisplayMetadataKey
 )
 
 // Provider implements [mail.Provider] using [beads.Store] as the backend.
@@ -37,7 +41,10 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 	if to == "" {
 		return mail.Message{}, fmt.Errorf("beadmail send: recipient is required")
 	}
-	from, metadata := p.resolveSenderRoute(from)
+	from, metadata, err := p.resolveSenderRoute(from)
+	if err != nil {
+		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)
+	}
 	threadID := generateThreadID()
 	labels := []string{"thread:" + threadID}
 
@@ -64,20 +71,45 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 	return beadToMessage(b), nil
 }
 
-func (p *Provider) resolveSenderRoute(from string) (string, map[string]string) {
+func (p *Provider) resolveSenderRoute(from string) (string, map[string]string, error) {
 	from = strings.TrimSpace(from)
 	if from == "" || from == "human" || p.store == nil {
-		return from, nil
+		return from, nil, nil
 	}
 	sessionID, err := session.ResolveSessionID(p.store, from)
 	if err != nil {
-		return from, nil
+		if errors.Is(err, session.ErrSessionNotFound) || errors.Is(err, session.ErrAmbiguous) {
+			return from, nil, nil
+		}
+		return "", nil, fmt.Errorf("resolving sender %q: %w", from, err)
 	}
+	b, err := p.store.Get(sessionID)
+	if err != nil {
+		return "", nil, fmt.Errorf("loading sender session %q: %w", sessionID, err)
+	}
+	display := senderDisplayAddress(b, from)
 	metadata := map[string]string{fromSessionIDMetadataKey: sessionID}
-	if sessionID != from {
-		metadata[fromDisplayMetadataKey] = from
+	if display != "" {
+		metadata[fromDisplayMetadataKey] = display
 	}
-	return sessionID, metadata
+	return display, metadata, nil
+}
+
+func senderDisplayAddress(b beads.Bead, fallback string) string {
+	if alias := strings.TrimSpace(b.Metadata["alias"]); alias != "" {
+		return alias
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" && fallback != b.ID {
+		return fallback
+	}
+	if name := strings.TrimSpace(b.Metadata["session_name"]); name != "" {
+		return name
+	}
+	if b.ID != "" {
+		return b.ID
+	}
+	return fallback
 }
 
 // Inbox returns all unread messages for the recipient.
@@ -172,12 +204,30 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
 	}
-	to := strings.TrimSpace(original.Metadata[fromSessionIDMetadataKey])
+	toSessionID := strings.TrimSpace(original.Metadata[fromSessionIDMetadataKey])
+	to := toSessionID
 	if to == "" {
 		to = strings.TrimSpace(original.From)
 	}
 	if to == "" {
 		return mail.Message{}, fmt.Errorf("beadmail reply: original message %s has no sender to reply to", id)
+	}
+	toDisplay := strings.TrimSpace(original.Metadata[fromDisplayMetadataKey])
+	if toDisplay == "" {
+		toDisplay = strings.TrimSpace(original.From)
+	}
+	from, metadata, err := p.resolveSenderRoute(from)
+	if err != nil {
+		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
+	}
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+	if toSessionID != "" {
+		metadata[toSessionIDMetadataKey] = toSessionID
+	}
+	if toDisplay != "" {
+		metadata[toDisplayMetadataKey] = toDisplay
 	}
 
 	threadID := extractLabel(original.Labels, "thread:")
@@ -194,6 +244,7 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 		Assignee:    to, // reply goes back to sender
 		From:        from,
 		Labels:      labels,
+		Metadata:    metadata,
 	})
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
@@ -250,16 +301,30 @@ func (p *Provider) Thread(threadID string) ([]mail.Message, error) {
 
 // Count returns (total, unread) message counts for a recipient.
 func (p *Provider) Count(recipient string) (int, int, error) {
-	candidates, err := p.messageCandidates(recipient)
+	total, unread, err := p.CountRecipients([]string{recipient})
 	if err != nil {
 		return 0, 0, fmt.Errorf("beadmail count: %w", err)
+	}
+	return total, unread, nil
+}
+
+// CountRecipients returns deduplicated total and unread counts for all recipient
+// routes represented by recipients.
+func (p *Provider) CountRecipients(recipients []string) (int, int, error) {
+	if len(recipients) == 0 {
+		return 0, 0, nil
+	}
+	routes := p.recipientRoutesForAll(recipients)
+	candidates, err := p.messageCandidatesForRoutes(routes)
+	if err != nil {
+		return 0, 0, fmt.Errorf("listing messages: %w", err)
 	}
 	var total, unread int
 	for _, b := range candidates {
 		if b.Status != "open" {
 			continue
 		}
-		if recipient != "" && b.Assignee != recipient {
+		if len(routes) > 0 && !matchesRecipientRoute(routes, b.Assignee) {
 			continue
 		}
 		total++
@@ -273,7 +338,8 @@ func (p *Provider) Count(recipient string) (int, int, error) {
 // filterMessages returns open message beads assigned to the recipient.
 // When includeRead is false, messages with the "read" label are excluded.
 func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Message, error) {
-	candidates, err := p.messageCandidates(recipient)
+	routes := p.recipientRoutes(recipient)
+	candidates, err := p.messageCandidatesForRoutes(routes)
 	if err != nil {
 		return nil, fmt.Errorf("beadmail: listing beads: %w", err)
 	}
@@ -282,7 +348,7 @@ func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Me
 		if b.Status != "open" {
 			continue
 		}
-		if recipient != "" && b.Assignee != recipient {
+		if len(routes) > 0 && !matchesRecipientRoute(routes, b.Assignee) {
 			continue
 		}
 		if !includeRead && hasLabel(b.Labels, "read") {
@@ -303,7 +369,102 @@ func (p *Provider) filterMessages(recipient string, includeRead bool) ([]mail.Me
 //
 // Type="message" is the authoritative discriminator; the legacy gc:message
 // label supplement was removed in #862 along with writes to that label.
-func (p *Provider) messageCandidates(recipient string) ([]beads.Bead, error) {
+func (p *Provider) recipientRoutes(recipient string) []string {
+	recipient = strings.TrimSpace(recipient)
+	if recipient == "" {
+		return nil
+	}
+	routes := make([]string, 0, 4)
+	routes = appendRecipientRoute(routes, recipient)
+	if recipient == "human" || p.store == nil {
+		return routes
+	}
+	sessions, err := p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	if err != nil {
+		log.Printf("beadmail: listing sessions for recipient route %q: %v", recipient, err)
+		return routes
+	}
+	var liveMatches []beads.Bead
+	var closedMatches []beads.Bead
+	for _, b := range sessions {
+		if !session.IsSessionBeadOrRepairable(b) {
+			continue
+		}
+		addresses := sessionAddressesForRecipientRouting(b)
+		if !containsRecipientRoute(addresses, recipient) {
+			continue
+		}
+		if b.Status == "closed" {
+			closedMatches = append(closedMatches, b)
+			continue
+		}
+		liveMatches = append(liveMatches, b)
+	}
+	matches := liveMatches
+	if len(matches) == 0 {
+		matches = closedMatches
+	}
+	if len(matches) > 1 {
+		return []string{recipient}
+	}
+	for _, b := range matches {
+		for _, address := range sessionAddressesForRecipientRouting(b) {
+			routes = appendRecipientRoute(routes, address)
+		}
+	}
+	return routes
+}
+
+func (p *Provider) recipientRoutesForAll(recipients []string) []string {
+	var routes []string
+	for _, recipient := range recipients {
+		recipientRoutes := p.recipientRoutes(recipient)
+		for _, route := range recipientRoutes {
+			routes = appendRecipientRoute(routes, route)
+		}
+	}
+	return routes
+}
+
+func sessionAddressesForRecipientRouting(b beads.Bead) []string {
+	var routes []string
+	routes = appendRecipientRoute(routes, b.ID)
+	routes = appendRecipientRoute(routes, b.Metadata["alias"])
+	routes = appendRecipientRoute(routes, b.Metadata["session_name"])
+	for _, alias := range session.AliasHistory(b.Metadata) {
+		routes = appendRecipientRoute(routes, alias)
+	}
+	return routes
+}
+
+func appendRecipientRoute(routes []string, route string) []string {
+	route = strings.TrimSpace(route)
+	if route == "" || containsRecipientRoute(routes, route) {
+		return routes
+	}
+	return append(routes, route)
+}
+
+func containsRecipientRoute(routes []string, route string) bool {
+	route = strings.TrimSpace(route)
+	for _, candidate := range routes {
+		if candidate == route {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesRecipientRoute(routes []string, assignee string) bool {
+	for _, route := range routes {
+		if assignee == route {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Provider) messageCandidatesForRoutes(routes []string) ([]beads.Bead, error) {
 	seen := make(map[string]beads.Bead)
 	order := make([]string, 0)
 	add := func(bs []beads.Bead) {
@@ -319,16 +480,18 @@ func (p *Provider) messageCandidates(recipient string) ([]beads.Bead, error) {
 	}
 
 	// Primary: targeted query scoped to recipient.
-	if recipient != "" {
-		assigned, err := p.store.List(beads.ListQuery{
-			Assignee: recipient,
-			Type:     "message",
-			Status:   "open",
-		})
-		if err != nil {
-			return nil, fmt.Errorf("listing by assignee: %w", err)
+	if len(routes) > 0 {
+		for _, route := range routes {
+			assigned, err := p.store.List(beads.ListQuery{
+				Assignee: route,
+				Type:     "message",
+				Status:   "open",
+			})
+			if err != nil {
+				return nil, fmt.Errorf("listing by assignee %q: %w", route, err)
+			}
+			add(assigned)
 		}
-		add(assigned)
 	} else {
 		// No recipient filter — use type-based query for global discovery.
 		all, err := p.store.List(beads.ListQuery{Type: "message"})
@@ -353,10 +516,18 @@ func isMessage(b beads.Bead) bool {
 
 // beadToMessage converts a bead to a mail.Message.
 func beadToMessage(b beads.Bead) mail.Message {
+	from := b.From
+	if display := strings.TrimSpace(b.Metadata[fromDisplayMetadataKey]); display != "" {
+		from = display
+	}
+	to := b.Assignee
+	if display := strings.TrimSpace(b.Metadata[toDisplayMetadataKey]); display != "" {
+		to = display
+	}
 	return mail.Message{
 		ID:        b.ID,
-		From:      b.From,
-		To:        b.Assignee,
+		From:      from,
+		To:        to,
 		Subject:   b.Title,
 		Body:      b.Description,
 		CreatedAt: b.CreatedAt,

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -12,6 +12,12 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+const (
+	fromSessionIDMetadataKey = "mail.from_session_id"
+	fromDisplayMetadataKey   = "mail.from_display"
 )
 
 // Provider implements [mail.Provider] using [beads.Store] as the backend.
@@ -31,6 +37,7 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 	if to == "" {
 		return mail.Message{}, fmt.Errorf("beadmail send: recipient is required")
 	}
+	from, metadata := p.resolveSenderRoute(from)
 	threadID := generateThreadID()
 	labels := []string{"thread:" + threadID}
 
@@ -49,11 +56,28 @@ func (p *Provider) Send(from, to, subject, body string) (mail.Message, error) {
 		Assignee:    to,
 		From:        from,
 		Labels:      labels,
+		Metadata:    metadata,
 	})
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail send: %w", err)
 	}
 	return beadToMessage(b), nil
+}
+
+func (p *Provider) resolveSenderRoute(from string) (string, map[string]string) {
+	from = strings.TrimSpace(from)
+	if from == "" || from == "human" || p.store == nil {
+		return from, nil
+	}
+	sessionID, err := session.ResolveSessionID(p.store, from)
+	if err != nil {
+		return from, nil
+	}
+	metadata := map[string]string{fromSessionIDMetadataKey: sessionID}
+	if sessionID != from {
+		metadata[fromDisplayMetadataKey] = from
+	}
+	return sessionID, metadata
 }
 
 // Inbox returns all unread messages for the recipient.
@@ -148,7 +172,11 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 	if err != nil {
 		return mail.Message{}, fmt.Errorf("beadmail reply: %w", err)
 	}
-	if original.From == "" {
+	to := strings.TrimSpace(original.Metadata[fromSessionIDMetadataKey])
+	if to == "" {
+		to = strings.TrimSpace(original.From)
+	}
+	if to == "" {
 		return mail.Message{}, fmt.Errorf("beadmail reply: original message %s has no sender to reply to", id)
 	}
 
@@ -163,7 +191,7 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 		Title:       deriveReplyTitle(subject, original.Title, body),
 		Description: body,
 		Type:        "message",
-		Assignee:    original.From, // reply goes back to sender
+		Assignee:    to, // reply goes back to sender
 		From:        from,
 		Labels:      labels,
 	})

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -186,7 +186,7 @@ func TestSend(t *testing.T) {
 	}
 }
 
-func TestSendCanonicalizesSessionSender(t *testing.T) {
+func TestSendStoresStableSessionRouteWithoutChangingDisplaySender(t *testing.T) {
 	store := beads.NewMemStore()
 	p := New(store)
 
@@ -207,18 +207,148 @@ func TestSendCanonicalizesSessionSender(t *testing.T) {
 		t.Fatalf("Send: %v", err)
 	}
 
-	if msg.From != sender.ID {
-		t.Fatalf("message From = %q, want sender session ID %q", msg.From, sender.ID)
+	if msg.From != "gascity/workflows.codex-min-9" {
+		t.Fatalf("message From = %q, want display alias", msg.From)
 	}
 	b, err := store.Get(msg.ID)
 	if err != nil {
 		t.Fatalf("Get message: %v", err)
+	}
+	if b.From != "gascity/workflows.codex-min-9" {
+		t.Fatalf("bead From = %q, want display alias", b.From)
 	}
 	if b.Metadata[fromSessionIDMetadataKey] != sender.ID {
 		t.Fatalf("%s = %q, want %q", fromSessionIDMetadataKey, b.Metadata[fromSessionIDMetadataKey], sender.ID)
 	}
 	if b.Metadata[fromDisplayMetadataKey] != "gascity/workflows.codex-min-9" {
 		t.Fatalf("%s = %q, want original display alias", fromDisplayMetadataKey, b.Metadata[fromDisplayMetadataKey])
+	}
+}
+
+func TestReplyUsesStoredSenderSessionIDAfterAliasRename(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sender, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "old-sender",
+			"session_name": "sender-gc-42",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	original, err := p.Send("old-sender", "human", "Approval", "please approve")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := store.SetMetadataBatch(sender.ID, session.UpdatedAliasMetadata(sender.Metadata, "new-sender")); err != nil {
+		t.Fatalf("SetMetadataBatch(alias rename): %v", err)
+	}
+
+	reply, err := p.Reply(original.ID, "human", "approved", "approved")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if reply.To != "old-sender" {
+		t.Fatalf("reply To = %q, want original display sender", reply.To)
+	}
+	b, err := store.Get(reply.ID)
+	if err != nil {
+		t.Fatalf("Get reply: %v", err)
+	}
+	if b.Assignee != sender.ID {
+		t.Fatalf("reply bead Assignee = %q, want stable sender session ID %q", b.Assignee, sender.ID)
+	}
+	if b.Metadata[toSessionIDMetadataKey] != sender.ID {
+		t.Fatalf("reply %s = %q, want %q", toSessionIDMetadataKey, b.Metadata[toSessionIDMetadataKey], sender.ID)
+	}
+	if b.Metadata[toDisplayMetadataKey] != "old-sender" {
+		t.Fatalf("reply %s = %q, want original display sender", toDisplayMetadataKey, b.Metadata[toDisplayMetadataKey])
+	}
+	inbox, err := p.Inbox("new-sender")
+	if err != nil {
+		t.Fatalf("Inbox(new-sender): %v", err)
+	}
+	if len(inbox) != 1 || inbox[0].ID != reply.ID {
+		t.Fatalf("Inbox(new-sender) = %#v, want reply %s", inbox, reply.ID)
+	}
+	oldInbox, err := p.Inbox("old-sender")
+	if err != nil {
+		t.Fatalf("Inbox(old-sender): %v", err)
+	}
+	if len(oldInbox) != 1 || oldInbox[0].ID != reply.ID {
+		t.Fatalf("Inbox(old-sender) = %#v, want reply %s", oldInbox, reply.ID)
+	}
+	total, unread, err := p.Count("new-sender")
+	if err != nil {
+		t.Fatalf("Count(new-sender): %v", err)
+	}
+	if total != 1 || unread != 1 {
+		t.Fatalf("Count(new-sender) = (%d, %d), want (1, 1)", total, unread)
+	}
+}
+
+func TestSendFallsBackToLiteralSenderWhenSessionIdentifierIsAmbiguous(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	for i := 0; i < 2; i++ {
+		if _, err := store.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"alias": "duplicate",
+			},
+		}); err != nil {
+			t.Fatalf("Create session %d: %v", i, err)
+		}
+	}
+
+	msg, err := p.Send("duplicate", "human", "subject", "body")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if msg.From != "duplicate" {
+		t.Fatalf("message From = %q, want literal ambiguous sender", msg.From)
+	}
+	b, err := store.Get(msg.ID)
+	if err != nil {
+		t.Fatalf("Get message: %v", err)
+	}
+	if b.Metadata[fromSessionIDMetadataKey] != "" {
+		t.Fatalf("ambiguous sender stored %s = %q, want empty", fromSessionIDMetadataKey, b.Metadata[fromSessionIDMetadataKey])
+	}
+}
+
+func TestInboxFallsBackToLiteralRecipientWhenSessionIdentifierIsAmbiguous(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	for i := 0; i < 2; i++ {
+		if _, err := store.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"alias": "duplicate",
+			},
+		}); err != nil {
+			t.Fatalf("Create session %d: %v", i, err)
+		}
+	}
+	msg, err := p.Send("human", "duplicate", "subject", "body")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	inbox, err := p.Inbox("duplicate")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(inbox) != 1 || inbox[0].ID != msg.ID {
+		t.Fatalf("Inbox = %#v, want literal recipient message %s", inbox, msg.ID)
 	}
 }
 
@@ -751,6 +881,17 @@ func TestReplyPrefersStoredSenderSessionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create session: %v", err)
 	}
+	responder, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "gascity/workflows.codex-min-10",
+			"session_name": "workflows__codex-min-mc-responder",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create responder session: %v", err)
+	}
 	original, err := store.Create(beads.Bead{
 		Title:       "Approval needed",
 		Description: "please approve",
@@ -767,13 +908,175 @@ func TestReplyPrefersStoredSenderSessionID(t *testing.T) {
 		t.Fatalf("Create original message: %v", err)
 	}
 
-	reply, err := p.Reply(original.ID, "human", "approved", "approved")
+	reply, err := p.Reply(original.ID, "gascity/workflows.codex-min-10", "approved", "approved")
 	if err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
-	if reply.To != sender.ID {
-		t.Fatalf("reply To = %q, want stable sender session ID %q", reply.To, sender.ID)
+	if reply.To != "gascity/workflows.codex-min-9" {
+		t.Fatalf("reply To = %q, want sender display alias", reply.To)
+	}
+	if reply.From != "gascity/workflows.codex-min-10" {
+		t.Fatalf("reply From = %q, want display alias", reply.From)
+	}
+	b, err := store.Get(reply.ID)
+	if err != nil {
+		t.Fatalf("Get reply: %v", err)
+	}
+	if b.Metadata[fromSessionIDMetadataKey] != responder.ID {
+		t.Fatalf("reply %s = %q, want %q", fromSessionIDMetadataKey, b.Metadata[fromSessionIDMetadataKey], responder.ID)
+	}
+	if b.Metadata[fromDisplayMetadataKey] != "gascity/workflows.codex-min-10" {
+		t.Fatalf("reply %s = %q, want responder display alias", fromDisplayMetadataKey, b.Metadata[fromDisplayMetadataKey])
+	}
+	if b.Assignee != sender.ID {
+		t.Fatalf("reply bead Assignee = %q, want stable sender session ID %q", b.Assignee, sender.ID)
+	}
+	if b.Metadata[toSessionIDMetadataKey] != sender.ID {
+		t.Fatalf("reply %s = %q, want %q", toSessionIDMetadataKey, b.Metadata[toSessionIDMetadataKey], sender.ID)
+	}
+	if b.Metadata[toDisplayMetadataKey] != "gascity/workflows.codex-min-9" {
+		t.Fatalf("reply %s = %q, want sender display alias", toDisplayMetadataKey, b.Metadata[toDisplayMetadataKey])
+	}
+}
+
+func TestReplyToClosedSenderSessionIsDiscoverableByHistoricalAlias(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sender, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "gascity/workflows.codex-min-9",
+			"alias_history": "gascity/workflows.codex-min-8",
+			"session_name":  "workflows__codex-min-mc-sender",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create sender session: %v", err)
+	}
+	responder, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "gascity/workflows.codex-min-10",
+			"session_name": "workflows__codex-min-mc-responder",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create responder session: %v", err)
+	}
+	original, err := store.Create(beads.Bead{
+		Title:       "Approval needed",
+		Description: "please approve",
+		Type:        "message",
+		Assignee:    "human",
+		From:        "gascity/workflows.codex-min-8",
+		Labels:      []string{"thread:closed-sender-route"},
+		Metadata: map[string]string{
+			fromSessionIDMetadataKey: sender.ID,
+			fromDisplayMetadataKey:   "gascity/workflows.codex-min-8",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create original message: %v", err)
+	}
+	if err := store.Close(sender.ID); err != nil {
+		t.Fatalf("Close sender session: %v", err)
+	}
+
+	reply, err := p.Reply(original.ID, "gascity/workflows.codex-min-10", "approved", "approved")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if reply.To != "gascity/workflows.codex-min-8" {
+		t.Fatalf("reply To = %q, want historical sender display alias", reply.To)
+	}
+	if reply.From != "gascity/workflows.codex-min-10" {
+		t.Fatalf("reply From = %q, want responder display alias", reply.From)
+	}
+	b, err := store.Get(reply.ID)
+	if err != nil {
+		t.Fatalf("Get reply: %v", err)
+	}
+	if b.Assignee != sender.ID {
+		t.Fatalf("reply bead Assignee = %q, want closed sender session ID %q", b.Assignee, sender.ID)
+	}
+	if b.Metadata[fromSessionIDMetadataKey] != responder.ID {
+		t.Fatalf("reply %s = %q, want %q", fromSessionIDMetadataKey, b.Metadata[fromSessionIDMetadataKey], responder.ID)
+	}
+
+	msgs, err := p.Inbox("gascity/workflows.codex-min-8")
+	if err != nil {
+		t.Fatalf("Inbox by historical alias: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox by historical alias returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != reply.ID {
+		t.Fatalf("Inbox by historical alias returned %s, want reply %s", msgs[0].ID, reply.ID)
+	}
+}
+
+func TestRecipientRoutesPreferLiveSessionOverClosedHistory(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	closed, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "old-worker",
+			"alias_history": "worker",
+			"session_name":  "workflows__codex-min-mc-old",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create closed session: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close session: %v", err)
+	}
+	live, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "workflows__codex-min-mc-live",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live session: %v", err)
+	}
+	closedReply, err := store.Create(beads.Bead{
+		Title:    "old reply",
+		Type:     "message",
+		Assignee: closed.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create closed reply: %v", err)
+	}
+	liveMail, err := store.Create(beads.Bead{
+		Title:    "live mail",
+		Type:     "message",
+		Assignee: live.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create live mail: %v", err)
+	}
+
+	msgs, err := p.Inbox("worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != liveMail.ID {
+		t.Fatalf("Inbox returned %s, want live message %s; closed reply was %s", msgs[0].ID, liveMail.ID, closedReply.ID)
 	}
 }
 
@@ -852,6 +1155,22 @@ func TestCount(t *testing.T) {
 	}
 	if unread != 1 {
 		t.Errorf("unread = %d, want 1", unread)
+	}
+}
+
+func TestCountRecipientsEmptyDoesNotCountAllMessages(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+	if _, err := p.Send("human", "mayor", "", "msg"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	total, unread, err := p.CountRecipients(nil)
+	if err != nil {
+		t.Fatalf("CountRecipients(nil): %v", err)
+	}
+	if total != 0 || unread != 0 {
+		t.Fatalf("CountRecipients(nil) = (%d,%d), want (0,0)", total, unread)
 	}
 }
 

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // noListScanStore errors when List is called without a filter, proving that
@@ -182,6 +183,42 @@ func TestSend(t *testing.T) {
 	}
 	if hasLabel(b.Labels, "gc:message") {
 		t.Error("bead should no longer carry the legacy gc:message label")
+	}
+}
+
+func TestSendCanonicalizesSessionSender(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sender, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "gascity/workflows.codex-min-9",
+			"session_name": "workflows__codex-min-mc-sender",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+
+	msg, err := p.Send("gascity/workflows.codex-min-9", "human", "Approval", "please approve")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if msg.From != sender.ID {
+		t.Fatalf("message From = %q, want sender session ID %q", msg.From, sender.ID)
+	}
+	b, err := store.Get(msg.ID)
+	if err != nil {
+		t.Fatalf("Get message: %v", err)
+	}
+	if b.Metadata[fromSessionIDMetadataKey] != sender.ID {
+		t.Fatalf("%s = %q, want %q", fromSessionIDMetadataKey, b.Metadata[fromSessionIDMetadataKey], sender.ID)
+	}
+	if b.Metadata[fromDisplayMetadataKey] != "gascity/workflows.codex-min-9" {
+		t.Fatalf("%s = %q, want original display alias", fromDisplayMetadataKey, b.Metadata[fromDisplayMetadataKey])
 	}
 }
 
@@ -696,6 +733,47 @@ func TestReplyAgainstBdStoreValidatesTitle(t *testing.T) {
 	}
 	if reply.Subject != "Re: Hello" {
 		t.Errorf("Reply Subject = %q, want %q", reply.Subject, "Re: Hello")
+	}
+}
+
+func TestReplyPrefersStoredSenderSessionID(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sender, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "gascity/workflows.codex-min-9",
+			"session_name": "workflows__codex-min-mc-sender",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	original, err := store.Create(beads.Bead{
+		Title:       "Approval needed",
+		Description: "please approve",
+		Type:        "message",
+		Assignee:    "human",
+		From:        "gascity/workflows.codex-min-9",
+		Labels:      []string{"thread:stable-route"},
+		Metadata: map[string]string{
+			fromSessionIDMetadataKey: sender.ID,
+			fromDisplayMetadataKey:   "gascity/workflows.codex-min-9",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create original message: %v", err)
+	}
+
+	reply, err := p.Reply(original.ID, "human", "approved", "approved")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	if reply.To != sender.ID {
+		t.Fatalf("reply To = %q, want stable sender session ID %q", reply.To, sender.ID)
 	}
 }
 

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -16,6 +16,21 @@ var ErrAlreadyArchived = errors.New("already archived")
 // ErrNotFound is returned when a message ID does not exist.
 var ErrNotFound = errors.New("message not found")
 
+const (
+	// FromSessionIDMetadataKey stores the stable session bead ID used for
+	// reply routing when a message's display sender may later be renamed.
+	FromSessionIDMetadataKey = "mail.from_session_id"
+	// FromDisplayMetadataKey stores the human-readable sender captured when
+	// the message was created.
+	FromDisplayMetadataKey = "mail.from_display"
+	// ToSessionIDMetadataKey stores the stable recipient session bead ID used
+	// for routing replies while keeping the public To field human-readable.
+	ToSessionIDMetadataKey = "mail.to_session_id"
+	// ToDisplayMetadataKey stores the human-readable recipient captured when
+	// the message was created.
+	ToDisplayMetadataKey = "mail.to_display"
+)
+
 // Message represents a mail message between agents or humans.
 type Message struct {
 	ID        string    `json:"id"`


### PR DESCRIPTION
## Summary
- resolve mail sender identities to the live session bead ID when available
- keep recipient resolution alias-friendly so gc mail inbox targets remain human-readable
- update mail and handoff tests for stable sender IDs

## Tests
- git diff --check HEAD~1..HEAD
- go test ./cmd/gc -run 'Mail|HandoffRemote' -count=1