### PR TITLE
fix(status): use cached session state with liveness overlay (follow-up)

### DIFF
--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -3,10 +3,13 @@ package api
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
-	"github.com/gastownhall/gascity/internal/worker"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 // statusResponse is the JSON body for GET /v0/status.
@@ -50,28 +53,34 @@ func (s *Server) humaHandleStatus(ctx context.Context, input *StatusInput) (*Ind
 func (s *Server) buildStatusBody() StatusBody {
 	cfg := s.state.Config()
 	sp := s.state.SessionProvider()
-	store := s.state.CityBeadStore()
 	cityName := s.state.CityName()
 	sessTmpl := cfg.Workspace.SessionTemplate
+	sessionSnapshot := s.statusSessionSnapshot()
 
 	// Count agents by state.
 	var ac agentCounts
 	var rawRunning int
+	rigAgentCounts := make(map[string]int)
+	rigSuspendedCounts := make(map[string]int)
 	for _, a := range cfg.Agents {
-		for _, ea := range expandAgent(a, cityName, sessTmpl, sp) {
+		rigName := workdirutil.ConfiguredRigName(s.state.CityPath(), a, cfg.Rigs)
+		for _, slot := range statusAgentSlots(a, cityName, sessTmpl, sessionSnapshot) {
 			ac.Total++
-			sessName := agentSessionName(cityName, ea.qualifiedName, sessTmpl)
-			handle, _ := s.workerHandleForSessionTarget(store, sessName)
-			obs, _ := worker.ObserveHandle(context.Background(), handle)
-			running := obs.Running
+			if rigName != "" {
+				rigAgentCounts[rigName]++
+			}
+			running := statusProviderRunning(sp, slot.sessionName)
 			if running {
 				rawRunning++
 			}
-			suspended := ea.suspended || obs.Suspended
+			suspended := a.Suspended || slot.suspended
+			if suspended && rigName != "" {
+				rigSuspendedCounts[rigName]++
+			}
 			switch {
 			case suspended:
 				ac.Suspended++
-			case s.state.IsQuarantined(sessName):
+			case s.state.IsQuarantined(slot.sessionName):
 				ac.Quarantined++
 			case running:
 				ac.Running++
@@ -82,7 +91,11 @@ func (s *Server) buildStatusBody() StatusBody {
 	// Count rigs by state.
 	rc := rigCounts{Total: len(cfg.Rigs)}
 	for _, rig := range cfg.Rigs {
-		if s.rigSuspended(cfg, rig, sp, cityName, s.state.CityPath()) {
+		if rig.Suspended {
+			rc.Suspended++
+			continue
+		}
+		if total := rigAgentCounts[rig.Name]; total > 0 && total == rigSuspendedCounts[rig.Name] {
 			rc.Suspended++
 		}
 	}
@@ -149,6 +162,118 @@ func (s *Server) buildStatusBody() StatusBody {
 		Work:       wc,
 		Mail:       mc,
 	}
+}
+
+type statusSessionSnapshot struct {
+	bySessionName map[string]statusSessionInfo
+	byTemplate    map[string][]statusSessionInfo
+}
+
+type statusSessionInfo struct {
+	sessionName string
+	template    string
+	state       session.State
+}
+
+type statusAgentSlot struct {
+	sessionName string
+	suspended   bool
+}
+
+func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
+	snapshot := statusSessionSnapshot{
+		bySessionName: make(map[string]statusSessionInfo),
+		byTemplate:    make(map[string][]statusSessionInfo),
+	}
+	store := s.state.CityBeadStore()
+	if store == nil {
+		return snapshot
+	}
+
+	rows, err := listSessionBeadsForReadModel(store)
+	if err != nil {
+		return snapshot
+	}
+
+	for _, b := range rows {
+		if b.Status == "closed" {
+			continue
+		}
+		info := statusSessionInfo{
+			sessionName: strings.TrimSpace(b.Metadata["session_name"]),
+			template:    strings.TrimSpace(b.Metadata["template"]),
+			state:       statusSessionState(b),
+		}
+		if info.sessionName == "" {
+			continue
+		}
+		snapshot.bySessionName[info.sessionName] = info
+		if info.template != "" {
+			snapshot.byTemplate[info.template] = append(snapshot.byTemplate[info.template], info)
+		}
+	}
+	return snapshot
+}
+
+func statusSessionState(b beads.Bead) session.State {
+	state := session.State(strings.TrimSpace(b.Metadata["state"]))
+	switch state {
+	case "awake":
+		return session.StateActive
+	case "drained":
+		return session.StateAsleep
+	default:
+		return state
+	}
+}
+
+func statusAgentSlots(a config.Agent, cityName, sessTmpl string, snapshot statusSessionSnapshot) []statusAgentSlot {
+	maxSess := a.EffectiveMaxActiveSessions()
+	isMultiSession := maxSess == nil || *maxSess != 1
+	if isMultiSession && (maxSess == nil || *maxSess < 0) {
+		sessions := snapshot.byTemplate[a.QualifiedName()]
+		slots := make([]statusAgentSlot, 0, len(sessions))
+		for _, info := range sessions {
+			slots = append(slots, statusAgentSlot{
+				sessionName: info.sessionName,
+				suspended:   info.state == session.StateSuspended,
+			})
+		}
+		return slots
+	}
+
+	if !isMultiSession {
+		sessionName := agentSessionName(cityName, a.QualifiedName(), sessTmpl)
+		info, ok := snapshot.bySessionName[sessionName]
+		return []statusAgentSlot{{
+			sessionName: sessionName,
+			suspended:   ok && info.state == session.StateSuspended,
+		}}
+	}
+
+	poolMax := 1
+	if maxSess != nil && *maxSess > 1 {
+		poolMax = *maxSess
+	}
+	slots := make([]statusAgentSlot, 0, poolMax)
+	for i := 1; i <= poolMax; i++ {
+		memberName := poolInstanceNameForAPI(a.Name, i, a)
+		sessionName := agentSessionName(cityName, a.QualifiedInstanceName(memberName), sessTmpl)
+		info, ok := snapshot.bySessionName[sessionName]
+		slots = append(slots, statusAgentSlot{
+			sessionName: sessionName,
+			suspended:   ok && info.state == session.StateSuspended,
+		})
+	}
+	return slots
+}
+
+func statusProviderRunning(sp interface{ IsRunning(string) bool }, sessionName string) bool {
+	sessionName = strings.TrimSpace(sessionName)
+	if sp == nil || sessionName == "" {
+		return false
+	}
+	return sp.IsRunning(sessionName)
 }
 
 // HealthInput is the Huma input for GET /v0/city/{cityName}/health.

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -195,6 +195,7 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 		return snapshot
 	}
 
+	seenSessionName := make(map[string]bool, len(rows))
 	for _, b := range rows {
 		if b.Status == "closed" {
 			continue
@@ -207,6 +208,13 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 		if info.sessionName == "" {
 			continue
 		}
+		if info.state == session.StateArchived {
+			continue
+		}
+		if seenSessionName[info.sessionName] {
+			continue
+		}
+		seenSessionName[info.sessionName] = true
 		snapshot.bySessionName[info.sessionName] = info
 		if info.template != "" {
 			snapshot.byTemplate[info.template] = append(snapshot.byTemplate[info.template], info)

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestHandleStatus(t *testing.T) {
@@ -131,5 +133,77 @@ func TestHandleStatus_Suspended(t *testing.T) {
 	}
 	if !resp.Suspended {
 		t.Error("expected suspended=true in status response")
+	}
+}
+
+func TestHandleStatusUsesCachedSessionStateForSuspendedAgents(t *testing.T) {
+	state := newFakeState(t)
+	store := beads.NewMemStore()
+	state.cityBeadStore = store
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateSuspended),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker",
+		},
+	}); err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	state.sp.Calls = nil
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Suspended != 1 {
+		t.Fatalf("Agents.Suspended = %d, want 1", resp.Agents.Suspended)
+	}
+	if resp.Agents.Running != 0 {
+		t.Fatalf("Agents.Running = %d, want 0 for suspended session", resp.Agents.Running)
+	}
+	if resp.Running != 1 {
+		t.Fatalf("Running = %d, want raw liveness count 1", resp.Running)
+	}
+}
+
+func TestHandleStatusOnlyUsesProviderLiveness(t *testing.T) {
+	state := newFakeState(t)
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := state.sp.SetMeta("myrig--worker", "suspended", "true"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	state.sp.SetAttached("myrig--worker", true)
+	state.sp.SetActivity("myrig--worker", state.startedAt)
+	state.sp.Calls = nil
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	for _, call := range state.sp.Calls {
+		switch call.Method {
+		case "ProcessAlive", "IsAttached", "GetLastActivity", "GetMeta", "ListRunning":
+			t.Fatalf("/status called provider %s for %q; calls=%#v", call.Method, call.Name, state.sp.Calls)
+		}
 	}
 }

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -180,6 +180,170 @@ func TestHandleStatusUsesCachedSessionStateForSuspendedAgents(t *testing.T) {
 	}
 }
 
+func TestHandleStatusUsesNewestSessionBeadForDuplicateSessionName(t *testing.T) {
+	state := newFakeState(t)
+	store := beads.NewMemStore()
+	state.cityBeadStore = store
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateSuspended),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker",
+		},
+	}); err != nil {
+		t.Fatalf("Create old session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateActive),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker",
+		},
+	}); err != nil {
+		t.Fatalf("Create new session bead: %v", err)
+	}
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Suspended != 0 {
+		t.Fatalf("Agents.Suspended = %d, want 0 from newest active bead", resp.Agents.Suspended)
+	}
+	if resp.Agents.Running != 1 {
+		t.Fatalf("Agents.Running = %d, want 1", resp.Agents.Running)
+	}
+}
+
+func TestHandleStatusUnlimitedPoolUsesOpenNonArchivedSessionBeads(t *testing.T) {
+	state := newFakeState(t)
+	state.cfg.Agents[0].MaxActiveSessions = intPtr(-1)
+	store := beads.NewMemStore()
+	state.cityBeadStore = store
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateActive),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker-1",
+		},
+	}); err != nil {
+		t.Fatalf("Create active session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateSuspended),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker-2",
+		},
+	}); err != nil {
+		t.Fatalf("Create suspended session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateArchived),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker-3",
+		},
+	}); err != nil {
+		t.Fatalf("Create archived session bead: %v", err)
+	}
+	if err := state.sp.Start(context.Background(), "myrig--worker-1", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Total != 2 {
+		t.Fatalf("Agents.Total = %d, want 2 non-archived unlimited-pool slots", resp.Agents.Total)
+	}
+	if resp.Agents.Running != 1 {
+		t.Fatalf("Agents.Running = %d, want 1", resp.Agents.Running)
+	}
+	if resp.Agents.Suspended != 1 {
+		t.Fatalf("Agents.Suspended = %d, want 1", resp.Agents.Suspended)
+	}
+}
+
+func TestHandleStatusBoundedPoolUsesCachedSessionState(t *testing.T) {
+	state := newFakeState(t)
+	state.cfg.Agents[0].MaxActiveSessions = intPtr(2)
+	store := beads.NewMemStore()
+	state.cityBeadStore = store
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateSuspended),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker-2",
+		},
+	}); err != nil {
+		t.Fatalf("Create suspended pool session bead: %v", err)
+	}
+	if err := state.sp.Start(context.Background(), "myrig--worker-1", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Total != 2 {
+		t.Fatalf("Agents.Total = %d, want 2 bounded pool slots", resp.Agents.Total)
+	}
+	if resp.Agents.Running != 1 {
+		t.Fatalf("Agents.Running = %d, want 1", resp.Agents.Running)
+	}
+	if resp.Agents.Suspended != 1 {
+		t.Fatalf("Agents.Suspended = %d, want 1", resp.Agents.Suspended)
+	}
+}
+
 func TestHandleStatusOnlyUsesProviderLiveness(t *testing.T) {
 	state := newFakeState(t)
 	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
@@ -205,5 +369,15 @@ func TestHandleStatusOnlyUsesProviderLiveness(t *testing.T) {
 		case "ProcessAlive", "IsAttached", "GetLastActivity", "GetMeta", "ListRunning":
 			t.Fatalf("/status called provider %s for %q; calls=%#v", call.Method, call.Name, state.sp.Calls)
 		}
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Running != 1 {
+		t.Fatalf("Agents.Running = %d, want 1", resp.Agents.Running)
+	}
+	if resp.Running != 1 {
+		t.Fatalf("Running = %d, want 1", resp.Running)
 	}
 }


### PR DESCRIPTION
## Summary
- carry forward the contributor's cached session-state `/status` implementation from the original PR
- apply the reviewed fixup that deduplicates duplicate session beads, skips archived session beads, and expands status regression coverage
- open this as a distinct follow-up because the original PR is conflicting and maintainer edits are disabled

## Original PR
- URL: https://github.com/gastownhall/gascity/pull/1333
- Title: fix(status): use cached session state with liveness overlay
- State at follow-up creation: OPEN
- Configured base: main
- Original GitHub base: main
- Base mismatch: none
- Original head: split/status-cache-liveness @ b010591e949fe172574c7091ab6fb7f9a7fc3bb2

## Tests
- `git diff --check refs/adopt-pr/ga-w4rtp/upstream-base..HEAD`
- `go test ./internal/api -run 'TestHandleStatus|TestHandleSessionListActiveBeadUsesCachedListWhenAvailable'`

## Review synthesis
# Review: gastownhall/gascity#1333 fix(status): use cached session state with liveness overlay

## Decision: block

## Fix Validations
- **Avoid expensive per-agent observe calls:** correct - reviewers agree `/status` now builds a session bead snapshot and overlays only provider liveness through `IsRunning`.
- **Suspended state from config plus session metadata:** correct - config suspension is preserved and bead state can classify live sessions as suspended.
- **Provider-call regression:** correct - tests guard against reintroducing metadata/activity/list-running provider calls in the `/status` hot path.
- **State normalization:** correct - legacy state aliases such as `awake` and `drained` are mapped into the status state model.

## Top Risks
1. Duplicate open session beads can make stale state win and corrupt `/status` counts - blocker / high / claude+codex
2. Unlimited-pool status now counts open beads rather than running sessions - major / high / claude, noted by gemini
3. Bounded and unlimited pool status branches lack direct regression coverage - major / high / claude
4. Status provider-call test does not assert response counts - minor / high / claude
5. `cachedStatusListStore` optimization branch is unreachable - minor / high / claude

## Applied follow-up fixes
- Deduplicate session snapshot rows by `session_name` newest-first before populating `bySessionName` and `byTemplate`.
- Skip archived session beads in `/status` session snapshots.
- Reuse the existing `listSessionBeadsForReadModel` cached-list helper on current `main`.
- Add duplicate-session, unlimited-pool, bounded-pool, and provider-liveness response-count regressions.
