### PR TITLE
fix(beads): skip bead.closed re-emission for already-closed cache entries

### DIFF
--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -733,3 +733,50 @@ func (s *closeAllRefreshFailingStore) List(query ListQuery) ([]Bead, error) {
 	s.listCalls++
 	return s.Store.List(query)
 }
+
+// Reconciliation must not re-emit bead.closed for a cache entry whose status
+// is already "closed". When ApplyEvent ingests an external bead.closed event
+// (from the bus), it stores the closed bead in c.beads. List({AllowScan:true})
+// filters out closed beads, so the next reconcile sees the entry as missing
+// from the fresh DB read and would re-emit a duplicate close notification.
+// Routed back through the event bus, that notification re-applies into every
+// caching store and reconciles into another spurious close — the storm.
+func TestCachingStoreRunReconciliationDoesNotEmitBeadClosedForAlreadyClosedCacheEntry(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "task"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	// External writer closes the bead in the backing store, then the close
+	// event is delivered through the bus and applied to this cache.
+	if err := backing.Close(bead.ID); err != nil {
+		t.Fatalf("backing Close: %v", err)
+	}
+	closed := bead
+	closed.Status = "closed"
+	payload, err := json.Marshal(closed)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	cache.ApplyEvent("bead.closed", payload)
+	events = nil // ignore notifications from prime/apply; only assert on reconcile output
+
+	cache.runReconciliation()
+
+	for _, e := range events {
+		if e == "bead.closed:"+bead.ID {
+			t.Fatalf("reconciler emitted duplicate bead.closed for an already-closed cache entry; events=%v", events)
+		}
+	}
+}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -139,12 +139,14 @@ func (c *CachingStore) runReconciliation() {
 				continue
 			}
 			removes++
-			closed := cloneBead(old)
-			closed.Status = "closed"
-			notifications = append(notifications, cacheNotification{
-				eventType: "bead.closed",
-				bead:      closed,
-			})
+			if old.Status != "closed" {
+				closed := cloneBead(old)
+				closed.Status = "closed"
+				notifications = append(notifications, cacheNotification{
+					eventType: "bead.closed",
+					bead:      closed,
+				})
+			}
 			delete(c.beads, id)
 			delete(c.deps, id)
 			delete(c.dirty, id)
@@ -207,6 +209,9 @@ func (c *CachingStore) runReconciliation() {
 	for id, old := range c.beads {
 		if _, exists := freshByID[id]; !exists {
 			removes++
+			if old.Status == "closed" {
+				continue
+			}
 			closed := cloneBead(old)
 			closed.Status = "closed"
 			notifications = append(notifications, cacheNotification{

--- a/internal/beads/caching_store_reconcile_internal_test.go
+++ b/internal/beads/caching_store_reconcile_internal_test.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -129,6 +130,123 @@ func TestCachingStoreReconciliationPreservesConcurrentEvent(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].Title != eventBead.Title {
 		t.Fatalf("ListOpen = %#v, want event title %q", items, eventBead.Title)
+	}
+}
+
+func TestCachingStoreReconciliationSkipsReemitForAlreadyClosedBead(t *testing.T) {
+	mem := NewMemStore()
+	bead, err := mem.Create(Bead{Title: "to be closed"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var events []string
+	cs := NewCachingStoreForTest(mem, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := cs.Close(bead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	wantClose := "bead.closed:" + bead.ID
+	closeSeen := false
+	for _, e := range events {
+		if e == wantClose {
+			closeSeen = true
+			break
+		}
+	}
+	if !closeSeen {
+		t.Fatalf("events after Close = %v, want to include %q", events, wantClose)
+	}
+	events = nil
+
+	cs.runReconciliation()
+
+	for _, e := range events {
+		if strings.HasPrefix(e, "bead.closed:") {
+			t.Fatalf("reconciliation re-emitted close event: %v", events)
+		}
+	}
+
+	cs.mu.RLock()
+	_, stillCached := cs.beads[bead.ID]
+	cs.mu.RUnlock()
+	if stillCached {
+		t.Fatalf("closed bead %s should be evicted from cache after reconcile", bead.ID)
+	}
+}
+
+func TestCachingStoreReconciliationSkipsReemitForAlreadyClosedBeadWithConcurrentMutation(t *testing.T) {
+	mem := NewMemStore()
+	closedBead, err := mem.Create(Bead{Title: "closed before reconcile"})
+	if err != nil {
+		t.Fatalf("Create(closed): %v", err)
+	}
+	other, err := mem.Create(Bead{Title: "concurrent target"})
+	if err != nil {
+		t.Fatalf("Create(other): %v", err)
+	}
+
+	backing := &reconcileRaceStore{
+		Store:   mem,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		stale:   []Bead{other},
+	}
+
+	var events []string
+	var eventsMu sync.Mutex
+	cs := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := cs.Close(closedBead.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	eventsMu.Lock()
+	events = nil
+	eventsMu.Unlock()
+
+	backing.mu.Lock()
+	backing.block = true
+	backing.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		cs.runReconciliation()
+		close(done)
+	}()
+
+	<-backing.started
+	title := "after concurrent update"
+	if err := cs.Update(other.ID, UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update(other): %v", err)
+	}
+	close(backing.release)
+	<-done
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	for _, e := range events {
+		if strings.HasPrefix(e, "bead.closed:") {
+			t.Fatalf("reconciliation re-emitted close event in race path: %v", events)
+		}
+	}
+
+	cs.mu.RLock()
+	_, stillCached := cs.beads[closedBead.ID]
+	cs.mu.RUnlock()
+	if stillCached {
+		t.Fatalf("closed bead %s should be evicted from cache after reconcile", closedBead.ID)
 	}
 }
 


### PR DESCRIPTION
The cache-reconciler was emitting `bead.closed` events for cache entries already in `closed` status — every reconciliation tick. The bus watcher applied each event back to all stores, which fired another close, which the next reconciliation re-emitted. A self-sustaining loop.

Observed in city_hy on 2026-04-27: ~9,700 close events/hr against an otherwise quiet city, sustained ~300% dolt CPU on top of the heartbeat baseline.

Add an early-return guard (matching the same pattern as #1231 / `clearChurn`) so reconciliation only emits `bead.closed` when the cached row's status is actually transitioning into closed, not when it's already there.

## Summary

- `internal/beads/caching_store_reconcile.go`: skip the `bead.closed` emission when the cached entry's `Status` is already `"closed"`.
- `internal/beads/caching_store_internal_test.go`: red/green test `TestCachingStoreRunReconciliationDoesNotEmitBeadClosedForAlreadyClosedCacheEntry`.

## Testing

- [x] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

Locally hot-swapped the patched `gc` into city_hy ~3 hr before this PR; close-event rate returned to expected baseline and load avg dropped from ~20 to ~7 (the rest of the load was on-demand-mode flips on crew sessions, separate change).

## Checklist

- [x] Linked an issue, or explained why one is not needed — sibling fix #1231 cited; no separate issue filed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)