### PR TITLE
fix(scale): treat scale_check as new demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Existing managed cities may see a `dolt-config` doctor warning until
   `gc dolt restart` or the next managed server start regenerates
   `dolt-config.yaml`.
+- In bead-backed pool reconciliation, `scale_check` output is now documented
+  and enforced as additive new-session demand. Assigned work is resumed
+  separately; custom checks that previously returned total desired sessions
+  should return only new unassigned demand.
 
 ## [1.0.0] - 2026-04-21
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -49,10 +49,11 @@ type DesiredStateResult struct {
 }
 
 type poolEvalWork struct {
-	agentIdx int
-	sp       scaleParams
-	poolDir  string
-	env      map[string]string
+	agentIdx  int
+	sp        scaleParams
+	poolDir   string
+	env       map[string]string
+	newDemand bool
 }
 
 func evaluatePendingPools(
@@ -80,12 +81,19 @@ func evaluatePendingPools(
 		template := cfg.Agents[pw.agentIdx].QualifiedName()
 		agentName := cfg.Agents[pw.agentIdx].Name
 		agentIndex := pw.agentIdx
-		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string) {
+		newDemand := pw.newDemand
+		go func(idx int, template, agentName string, agentIndex int, sp scaleParams, dir string, newDemand bool) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			started := time.Now()
-			d, err := evaluatePool(agentName, sp, dir, probeEnv, shellScaleCheck)
+			var d int
+			var err error
+			if newDemand {
+				d, err = evaluatePoolNewDemand(agentName, sp, dir, probeEnv, shellScaleCheck)
+			} else {
+				d, err = evaluatePool(agentName, sp, dir, probeEnv, shellScaleCheck)
+			}
 			evalResults[idx] = poolEvalResult{desired: d, err: err}
 			if trace != nil {
 				outcome := "success"
@@ -102,7 +110,7 @@ func evaluatePendingPools(
 					"agent_index":    agentIndex,
 				}, "")
 			}
-		}(j, template, agentName, agentIndex, sp, pw.poolDir)
+		}(j, template, agentName, agentIndex, sp, pw.poolDir, newDemand)
 	}
 	wg.Wait()
 
@@ -110,7 +118,11 @@ func evaluatePendingPools(
 	for j, pw := range pendingPools {
 		pr := evalResults[j]
 		if pr.err != nil {
-			fmt.Fprintf(stderr, "buildDesiredState: %v (using min=%d)\n", pr.err, pw.sp.Min) //nolint:errcheck
+			if pw.newDemand {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", pr.err) //nolint:errcheck
+			} else {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using min=%d)\n", pr.err, pw.sp.Min) //nolint:errcheck
+			}
 		}
 		counts[j] = pr.desired
 	}
@@ -219,7 +231,7 @@ func buildDesiredStateWithSessionBeads(
 			// but generic scale_check/min demand for the backing template still
 			// creates ephemeral capacity through the pool pipeline.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
-			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir})
+			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
 			continue
 		}
 
@@ -231,7 +243,7 @@ func buildDesiredStateWithSessionBeads(
 		// them directly; bead-backed mode falls back to them when work-bead
 		// listing fails so transient store errors do not collapse demand to 0.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
-		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i])})
+		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i]), newDemand: store != nil})
 	}
 
 	// scale_check runs in parallel for all pool agents — the authoritative

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -129,9 +129,10 @@ func evaluatePendingPools(
 	return counts
 }
 
-// evaluatePendingPoolsMap is like evaluatePendingPools but returns a map
-// from agent qualified name → desired count. Used to feed scale_check
-// results into ComputePoolDesiredStates.
+// evaluatePendingPoolsMap is like evaluatePendingPools but returns a map from
+// agent qualified name to scale_check count. In bead-backed reconciliation the
+// count is additive new demand; legacy no-store callers still use desired
+// counts.
 func evaluatePendingPoolsMap(
 	cfg *config.City,
 	pendingPools []poolEvalWork,
@@ -239,9 +240,9 @@ func buildDesiredStateWithSessionBeads(
 		if rigName != "" && suspendedRigPaths[filepath.Clean(rigRootForName(rigName, cfg.Rigs))] {
 			continue
 		}
-		// Pool agent: collect scale-check inputs. Legacy no-store mode uses
-		// them directly; bead-backed mode falls back to them when work-bead
-		// listing fails so transient store errors do not collapse demand to 0.
+		// Pool agent: collect scale_check inputs. Legacy no-store mode uses
+		// them as desired counts; bead-backed mode uses them as authoritative
+		// new unassigned demand while assigned work drives resume requests.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i]), newDemand: store != nil})
 	}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -20,7 +20,7 @@ type AwakeInput struct {
 	NamedSessions    []AwakeNamedSession
 	SessionBeads     []AwakeSessionBead
 	WorkBeads        []AwakeWorkBead
-	ScaleCheckCounts map[string]int  // agent template → desired count
+	ScaleCheckCounts map[string]int  // agent template → scale_check count
 	WorkSet          map[string]bool // agent template → work_query found pending work
 	RunningSessions  map[string]bool // session name → tmux exists
 	AttachedSessions map[string]bool // session name → user attached

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -127,17 +127,10 @@ func evaluatePool(agentName string, sp scaleParams, dir string, env map[string]s
 		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, err)
 		return sp.Min, fmt.Errorf("agent %q: %w", agentName, err)
 	}
-	trimmed := strings.TrimSpace(out)
-	if trimmed == "" {
-		checkErr := fmt.Errorf("agent %q: check %q produced empty output", agentName, sp.Check)
-		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, checkErr)
-		return sp.Min, checkErr
-	}
-	n, err := strconv.Atoi(trimmed)
+	n, err := parseScaleCheckCount(agentName, sp.Check, out)
 	if err != nil {
-		parseErr := fmt.Errorf("agent %q: check output %q is not an integer", agentName, trimmed)
-		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, parseErr)
-		return sp.Min, parseErr
+		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, sp.Min, err)
+		return sp.Min, err
 	}
 	desired := n
 	if desired < sp.Min {
@@ -148,6 +141,38 @@ func evaluatePool(agentName string, sp scaleParams, dir string, env map[string]s
 	}
 	telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, desired, nil)
 	return desired, nil
+}
+
+func evaluatePoolNewDemand(agentName string, sp scaleParams, dir string, env map[string]string, runner ScaleCheckRunner) (int, error) {
+	start := time.Now()
+	out, err := runner(sp.Check, dir, env)
+	durationMs := float64(time.Since(start).Milliseconds())
+	if err != nil {
+		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, 0, err)
+		return 0, fmt.Errorf("agent %q: %w", agentName, err)
+	}
+	n, err := parseScaleCheckCount(agentName, sp.Check, out)
+	if err != nil {
+		telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, 0, err)
+		return 0, err
+	}
+	telemetry.RecordPoolCheck(context.Background(), agentName, durationMs, n, nil)
+	return n, nil
+}
+
+func parseScaleCheckCount(agentName, check, out string) (int, error) {
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return 0, fmt.Errorf("agent %q: check %q produced empty output", agentName, check)
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("agent %q: check output %q is not an integer", agentName, trimmed)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("agent %q: check output %q is negative", agentName, trimmed)
+	}
+	return n, nil
 }
 
 // SessionSetupContext holds template variables for session_setup command expansion.

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -54,7 +54,7 @@ func PoolDesiredCounts(states []PoolDesiredState) map[string]int {
 // from scale_check, while this function only preserves sessions that already
 // own actionable work.
 // Each bead's gc.routed_to determines which agent template it belongs to.
-// scaleCheckCounts maps agent template → desired count from scale_check.
+// scaleCheckCounts maps agent template → new session demand from scale_check.
 // Pass nil for either when unavailable.
 func ComputePoolDesiredStates(
 	cfg *config.City,
@@ -151,16 +151,11 @@ func computePoolDesiredStates(
 		}
 	}
 
-	// Merge scale_check demand: for each agent, if scale_check wants more
-	// sessions than bead-driven requests already cover, add the difference
-	// as "new" tier requests. This ensures the scale_check command (which
-	// runs in the correct rig directory) is always the authoritative demand
-	// signal, while bead-driven resume requests preserve running sessions.
+	// Merge scale_check demand. In bead-backed reconciliation, scale_check is
+	// the authoritative signal for new unassigned demand only; resume requests
+	// are calculated independently from assigned work and must not be deducted
+	// from that count.
 	if len(scaleCheckCounts) > 0 {
-		beadDriven := make(map[string]int, len(allRequests))
-		for _, r := range allRequests {
-			beadDriven[r.Template]++
-		}
 		for _, agent := range cfg.Agents {
 			if agent.Suspended {
 				continue
@@ -170,8 +165,7 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			deficit := scaleCount - beadDriven[template]
-			for j := 0; j < deficit; j++ {
+			for j := 0; j < scaleCount; j++ {
 				allRequests = append(allRequests, SessionRequest{
 					Template: template,
 					Tier:     "new",

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -103,8 +103,7 @@ func computePoolDesiredStates(
 		}
 	}
 
-	// Collect uncapped requests per agent template.
-	var allRequests []SessionRequest
+	var resumeRequests []SessionRequest
 
 	for i := range cfg.Agents {
 		agent := &cfg.Agents[i]
@@ -138,7 +137,7 @@ func computePoolDesiredStates(
 				continue
 			}
 			if sessionBeadID != "" {
-				allRequests = append(allRequests, SessionRequest{
+				resumeRequests = append(resumeRequests, SessionRequest{
 					Template:      template,
 					BeadPriority:  beadPriority(wb),
 					Tier:          "resume",
@@ -151,12 +150,17 @@ func computePoolDesiredStates(
 		}
 	}
 
+	limits := newNestedCapLimits(cfg)
+	usage := acceptedNestedCapUsage(limits, resumeRequests)
+	allRequests := append([]SessionRequest(nil), resumeRequests...)
+
 	// Merge scale_check demand. In bead-backed reconciliation, scale_check is
 	// the authoritative signal for new unassigned demand only; resume requests
 	// are calculated independently from assigned work and must not be deducted
 	// from that count.
 	if len(scaleCheckCounts) > 0 {
-		for _, agent := range cfg.Agents {
+		for i := range cfg.Agents {
+			agent := &cfg.Agents[i]
 			if agent.Suspended {
 				continue
 			}
@@ -165,11 +169,14 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			for j := 0; j < scaleCount; j++ {
-				allRequests = append(allRequests, SessionRequest{
+			newCount := capNewDemandCount(limits, usage, agent, scaleCount)
+			for j := 0; j < newCount; j++ {
+				req := SessionRequest{
 					Template: template,
 					Tier:     "new",
-				})
+				}
+				allRequests = append(allRequests, req)
+				usage.accept(req, limits)
 			}
 		}
 	}
@@ -192,92 +199,20 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 		return false
 	})
 
-	// Counters for nested caps.
-	agentCount := make(map[string]int) // template → count
-	rigCount := make(map[string]int)   // rig name → count
-	workspaceCount := 0
-
-	// Resolve caps.
-	workspaceMax := -1 // -1 = unlimited
-	if cfg.Workspace.MaxActiveSessions != nil {
-		workspaceMax = *cfg.Workspace.MaxActiveSessions
-	}
-	rigMaxMap := make(map[string]int) // rig name → max (-1 = unlimited)
-	for _, rig := range cfg.Rigs {
-		if rig.MaxActiveSessions != nil {
-			rigMaxMap[rig.Name] = *rig.MaxActiveSessions
-		} else {
-			rigMaxMap[rig.Name] = -1
-		}
-	}
-	agentMaxMap := make(map[string]int)    // template → max (-1 = unlimited)
-	agentRigMap := make(map[string]string) // template → rig name
-	for i := range cfg.Agents {
-		agent := &cfg.Agents[i]
-		template := agent.QualifiedName()
-		agentRigMap[template] = agent.Dir
-		resolved := agent.ResolvedMaxActiveSessions(cfg)
-		if resolved != nil {
-			agentMaxMap[template] = *resolved
-		} else {
-			agentMaxMap[template] = -1
-		}
-	}
+	limits := newNestedCapLimits(cfg)
+	usage := newNestedCapUsage()
 
 	// Walk sorted requests, accepting each if all caps have room.
 	accepted := make(map[string][]SessionRequest) // template → accepted requests
-	// Dedup: don't accept multiple requests for the same session bead.
-	seenSessionBeads := make(map[string]bool)
 
 	for _, req := range requests {
-		// Dedup resume requests for the same session bead.
-		if req.Tier == "resume" && req.SessionBeadID != "" {
-			if seenSessionBeads[req.SessionBeadID] {
-				continue
-			}
-		}
-
 		template := req.Template
-		rig := agentRigMap[template]
-
-		// Check agent cap.
-		agentMax := agentMaxMap[template]
-		if agentMax >= 0 && agentCount[template] >= agentMax {
-			if trace != nil {
-				trace.recordDecision("reconciler.pool.agent_cap", template, "", "agent_cap", "rejected", traceRecordPayload{
-					"agent_max": agentMax,
-					"current":   agentCount[template],
-					"tier":      req.Tier,
-				}, nil, "")
-			}
+		if usage.isDuplicateResume(req) {
 			continue
 		}
-		// Check rig cap.
-		if rig != "" {
-			rigMax, ok := rigMaxMap[rig]
-			if !ok {
-				rigMax = -1
-			}
-			if rigMax >= 0 && rigCount[rig] >= rigMax {
-				if trace != nil {
-					trace.recordDecision("reconciler.pool.rig_cap", template, "", "rig_cap", "rejected", traceRecordPayload{
-						"rig":     rig,
-						"rig_max": rigMax,
-						"current": rigCount[rig],
-						"tier":    req.Tier,
-					}, nil, "")
-				}
-				continue
-			}
-		}
-		// Check workspace cap.
-		if workspaceMax >= 0 && workspaceCount >= workspaceMax {
+		if site, reason, payload, rejected := usage.rejection(req, limits); rejected {
 			if trace != nil {
-				trace.recordDecision("reconciler.pool.workspace_cap", template, "", "workspace_cap", "rejected", traceRecordPayload{
-					"workspace_max": workspaceMax,
-					"current":       workspaceCount,
-					"tier":          req.Tier,
-				}, nil, "")
+				trace.recordDecision(site, template, "", reason, "rejected", payload, nil, "")
 			}
 			continue
 		}
@@ -289,14 +224,7 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 				"tier": req.Tier,
 			}, nil, "")
 		}
-		agentCount[template]++
-		if rig != "" {
-			rigCount[rig]++
-		}
-		workspaceCount++
-		if req.Tier == "resume" && req.SessionBeadID != "" {
-			seenSessionBeads[req.SessionBeadID] = true
-		}
+		usage.accept(req, limits)
 	}
 
 	// Fill agent mins (if caps allow).
@@ -307,41 +235,23 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 		}
 		template := agent.QualifiedName()
 		minSess := agent.EffectiveMinActiveSessions()
-		for agentCount[template] < minSess {
-			rig := agentRigMap[template]
-			// Check caps before adding idle session.
-			agentMax := agentMaxMap[template]
-			if agentMax >= 0 && agentCount[template] >= agentMax {
-				break
-			}
-			if rig != "" {
-				rigMax, ok := rigMaxMap[rig]
-				if !ok {
-					rigMax = -1
-				}
-				if rigMax >= 0 && rigCount[rig] >= rigMax {
-					break
-				}
-			}
-			if workspaceMax >= 0 && workspaceCount >= workspaceMax {
-				break
-			}
-			accepted[template] = append(accepted[template], SessionRequest{
+		for usage.agentCount[template] < minSess {
+			req := SessionRequest{
 				Template: template,
 				Tier:     "new",
-			})
+			}
+			if _, _, _, rejected := usage.rejection(req, limits); rejected {
+				break
+			}
+			accepted[template] = append(accepted[template], req)
 			if trace != nil {
 				trace.recordDecision("reconciler.pool.min_fill", template, "", "min_fill", "accepted", traceRecordPayload{
 					"min":     minSess,
-					"current": agentCount[template],
+					"current": usage.agentCount[template],
 					"tier":    "new",
 				}, nil, "")
 			}
-			agentCount[template]++
-			if rig != "" {
-				rigCount[rig]++
-			}
-			workspaceCount++
+			usage.accept(req, limits)
 		}
 	}
 
@@ -358,4 +268,168 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 		return result[i].Template < result[j].Template
 	})
 	return result
+}
+
+type nestedCapLimits struct {
+	workspaceMax int
+	rigMax       map[string]int
+	agentMax     map[string]int
+	agentRig     map[string]string
+}
+
+type nestedCapUsage struct {
+	agentCount      map[string]int
+	rigCount        map[string]int
+	workspaceCount  int
+	seenSessionBead map[string]bool
+}
+
+func newNestedCapLimits(cfg *config.City) nestedCapLimits {
+	limits := nestedCapLimits{
+		workspaceMax: -1,
+		rigMax:       make(map[string]int),
+		agentMax:     make(map[string]int),
+		agentRig:     make(map[string]string),
+	}
+	if cfg.Workspace.MaxActiveSessions != nil {
+		limits.workspaceMax = *cfg.Workspace.MaxActiveSessions
+	}
+	for _, rig := range cfg.Rigs {
+		if rig.MaxActiveSessions != nil {
+			limits.rigMax[rig.Name] = *rig.MaxActiveSessions
+		} else {
+			limits.rigMax[rig.Name] = -1
+		}
+	}
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		template := agent.QualifiedName()
+		limits.agentRig[template] = agent.Dir
+		resolved := agent.ResolvedMaxActiveSessions(cfg)
+		if resolved != nil {
+			limits.agentMax[template] = *resolved
+		} else {
+			limits.agentMax[template] = -1
+		}
+	}
+	return limits
+}
+
+func newNestedCapUsage() nestedCapUsage {
+	return nestedCapUsage{
+		agentCount:      make(map[string]int),
+		rigCount:        make(map[string]int),
+		seenSessionBead: make(map[string]bool),
+	}
+}
+
+func acceptedNestedCapUsage(limits nestedCapLimits, requests []SessionRequest) nestedCapUsage {
+	usage := newNestedCapUsage()
+	sorted := append([]SessionRequest(nil), requests...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].BeadPriority != sorted[j].BeadPriority {
+			return sorted[i].BeadPriority > sorted[j].BeadPriority
+		}
+		if sorted[i].Tier != sorted[j].Tier {
+			return sorted[i].Tier == "resume"
+		}
+		return false
+	})
+	for _, req := range sorted {
+		if usage.canAccept(req, limits) {
+			usage.accept(req, limits)
+		}
+	}
+	return usage
+}
+
+func capNewDemandCount(limits nestedCapLimits, usage nestedCapUsage, agent *config.Agent, demand int) int {
+	if demand <= 0 {
+		return 0
+	}
+	template := agent.QualifiedName()
+	remaining := demand
+	if agentMax := limits.agentMax[template]; agentMax >= 0 {
+		remaining = minInt(remaining, agentMax-usage.agentCount[template])
+	}
+	if rig := limits.agentRig[template]; rig != "" {
+		rigMax, ok := limits.rigMax[rig]
+		if !ok {
+			rigMax = -1
+		}
+		if rigMax >= 0 {
+			remaining = minInt(remaining, rigMax-usage.rigCount[rig])
+		}
+	}
+	if limits.workspaceMax >= 0 {
+		remaining = minInt(remaining, limits.workspaceMax-usage.workspaceCount)
+	}
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (u nestedCapUsage) canAccept(req SessionRequest, limits nestedCapLimits) bool {
+	if u.isDuplicateResume(req) {
+		return false
+	}
+	_, _, _, rejected := u.rejection(req, limits)
+	return !rejected
+}
+
+func (u nestedCapUsage) isDuplicateResume(req SessionRequest) bool {
+	return req.Tier == "resume" && req.SessionBeadID != "" && u.seenSessionBead[req.SessionBeadID]
+}
+
+func (u nestedCapUsage) rejection(req SessionRequest, limits nestedCapLimits) (string, string, traceRecordPayload, bool) {
+	template := req.Template
+	if agentMax := limits.agentMax[template]; agentMax >= 0 && u.agentCount[template] >= agentMax {
+		return "reconciler.pool.agent_cap", "agent_cap", traceRecordPayload{
+			"agent_max": agentMax,
+			"current":   u.agentCount[template],
+			"tier":      req.Tier,
+		}, true
+	}
+	rig := limits.agentRig[template]
+	if rig != "" {
+		rigMax, ok := limits.rigMax[rig]
+		if !ok {
+			rigMax = -1
+		}
+		if rigMax >= 0 && u.rigCount[rig] >= rigMax {
+			return "reconciler.pool.rig_cap", "rig_cap", traceRecordPayload{
+				"rig":     rig,
+				"rig_max": rigMax,
+				"current": u.rigCount[rig],
+				"tier":    req.Tier,
+			}, true
+		}
+	}
+	if limits.workspaceMax >= 0 && u.workspaceCount >= limits.workspaceMax {
+		return "reconciler.pool.workspace_cap", "workspace_cap", traceRecordPayload{
+			"workspace_max": limits.workspaceMax,
+			"current":       u.workspaceCount,
+			"tier":          req.Tier,
+		}, true
+	}
+	return "", "", nil, false
+}
+
+func (u *nestedCapUsage) accept(req SessionRequest, limits nestedCapLimits) {
+	u.agentCount[req.Template]++
+	if rig := limits.agentRig[req.Template]; rig != "" {
+		u.rigCount[rig]++
+	}
+	u.workspaceCount++
+	if req.Tier == "resume" && req.SessionBeadID != "" {
+		u.seenSessionBead[req.SessionBeadID] = true
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -41,12 +41,13 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},
 	}
-	// 1 assigned (resume) + 2 unassigned. scale_check reports 3 total demand.
+	// 1 assigned (resume) + 2 new demand. scale_check reports only the new
+	// demand, and the max cap admits one of those two new requests.
 	work := []beads.Bead{
 		workBead("w1", "rig/claude", "sess-1", "in_progress", 5),
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
-	scaleCheck := map[string]int{"rig/claude": 3}
+	scaleCheck := map[string]int{"rig/claude": 2}
 
 	result := ComputePoolDesiredStates(cfg, work, sessions, scaleCheck)
 
@@ -54,7 +55,7 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 	reqs := result[0].Requests
-	// Max=2: resume (w1) + 1 new from scale_check deficit (3-1=2, capped at max=2).
+	// Max=2: resume (w1) + 1 new from scale_check, capped at max=2.
 	if len(reqs) != 2 {
 		t.Fatalf("len(requests) = %d, want 2 (max=2)", len(reqs))
 	}
@@ -487,7 +488,7 @@ func TestComputePoolDesiredStates_NoDemandNoAssignment(t *testing.T) {
 	}
 }
 
-// Regression: scale_check=3 with 1 assigned → poolDesired=3 (1 resume + 2 new).
+// Regression: scale_check reports new demand, not total desired sessions.
 func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "", intPtr(5), 0)},
@@ -496,7 +497,7 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 		workBead("w1", "claude", "sess-1", "in_progress", 5),
 	}
 	sessions := []beads.Bead{sessionBead("sess-1", "open")}
-	scaleCheck := map[string]int{"claude": 3}
+	scaleCheck := map[string]int{"claude": 2}
 
 	result := ComputePoolDesiredStates(cfg, work, sessions, scaleCheck)
 
@@ -504,7 +505,7 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 	if len(result[0].Requests) != 3 {
-		t.Fatalf("len(requests) = %d, want 3 (1 resume + 2 new from scale_check deficit)", len(result[0].Requests))
+		t.Fatalf("len(requests) = %d, want 3 (1 resume + 2 new from scale_check)", len(result[0].Requests))
 	}
 	resumeCount := 0
 	newCount := 0

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -24,6 +24,26 @@ func sessionBead(id, status string) beads.Bead {
 	return beads.Bead{ID: id, Status: status, Type: "session"}
 }
 
+func newPoolDesiredStateTestTrace(templates ...string) *sessionReconcilerTraceCycle {
+	detail := make(map[string]TraceSource, len(templates))
+	for _, template := range templates {
+		detail[normalizedTraceTemplate(template)] = TraceSourceManual
+	}
+	return &sessionReconcilerTraceCycle{
+		tracer:            &SessionReconcilerTracer{detail: detail},
+		dropReasons:       make(map[string]int),
+		pendingDetail:     make(map[string][]SessionReconcilerTraceRecord),
+		pendingDropped:    make(map[string]int),
+		templatesTouched:  make(map[string]struct{}),
+		detailedTemplates: make(map[string]struct{}),
+		decisionCounts:    make(map[string]int),
+		operationCounts:   make(map[string]int),
+		mutationCounts:    make(map[string]int),
+		reasonCounts:      make(map[string]int),
+		outcomeCounts:     make(map[string]int),
+	}
+}
+
 func poolAgent(name, dir string, maxSess *int, minSess int) config.Agent {
 	var minPtr *int
 	if minSess > 0 {
@@ -421,6 +441,43 @@ func TestComputePoolDesiredStates_ScaleCheckRespectsCaps(t *testing.T) {
 	}
 	if len(result[0].Requests) != 3 {
 		t.Fatalf("len(requests) = %d, want 3 (capped at max)", len(result[0].Requests))
+	}
+}
+
+func TestComputePoolDesiredStates_CapsNewDemandBeforeMaterializingRequests(t *testing.T) {
+	workspaceMax := 2
+	cfg := &config.City{
+		Workspace: config.Workspace{MaxActiveSessions: &workspaceMax},
+		Agents:    []config.Agent{poolAgent("claude", "", nil, 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "claude", "sess-1", "in_progress", 5),
+	}
+	sessions := []beads.Bead{sessionBead("sess-1", "open")}
+	trace := newPoolDesiredStateTestTrace("claude")
+
+	result := computePoolDesiredStates(cfg, work, sessions, map[string]int{"claude": 10}, trace)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if len(result[0].Requests) != 2 {
+		t.Fatalf("len(requests) = %d, want 2 (one resume plus one new demand within workspace cap)", len(result[0].Requests))
+	}
+	newCount := 0
+	for _, req := range result[0].Requests {
+		if req.Tier == "new" {
+			newCount++
+		}
+	}
+	if newCount != 1 {
+		t.Fatalf("new requests = %d, want 1", newCount)
+	}
+	capRejections := trace.decisionCounts[string(TraceSitePoolAgentCap)] +
+		trace.decisionCounts[string(TraceSitePoolRigCap)] +
+		trace.decisionCounts[string(TraceSitePoolWorkspaceCap)]
+	if capRejections != 0 {
+		t.Fatalf("cap rejections = %d, want 0; new demand should be capped before request materialization", capRejections)
 	}
 }
 

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -144,7 +144,7 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedReadyWork(t *testing.T) {
 	}
 }
 
-func TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork(t *testing.T) {
+func TestEvaluatePoolDefaultScaleCheckIgnoresRoutedActiveUnassignedWork(t *testing.T) {
 	skipSlowCmdGCTest(t, "uses real bd and jq for default scale_check coverage; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
 	if err != nil {
@@ -187,8 +187,34 @@ func TestEvaluatePoolDefaultScaleCheckCountsRoutedActiveUnassignedWork(t *testin
 	if err != nil {
 		t.Fatalf("evaluatePool with routed in-progress work: %v", err)
 	}
-	if got != 1 {
-		t.Fatalf("evaluatePool with routed in-progress work = %d, want 1", got)
+	if got != 0 {
+		t.Fatalf("evaluatePool with routed in-progress work = %d, want 0", got)
+	}
+}
+
+func TestEvaluatePoolNewDemandDoesNotApplyMinOrMax(t *testing.T) {
+	sp := scaleParams{Min: 2, Max: 3, Check: "ignored"}
+	runner := func(_, _ string, _ map[string]string) (string, error) { return "5\n", nil }
+
+	got, err := evaluatePoolNewDemand("worker", sp, "", nil, runner)
+	if err != nil {
+		t.Fatalf("evaluatePoolNewDemand: %v", err)
+	}
+	if got != 5 {
+		t.Fatalf("evaluatePoolNewDemand = %d, want raw new demand 5", got)
+	}
+}
+
+func TestEvaluatePoolNewDemandErrorFallsBackToZero(t *testing.T) {
+	sp := scaleParams{Min: 2, Max: 3, Check: "ignored"}
+	runner := func(_, _ string, _ map[string]string) (string, error) { return "not-a-number\n", nil }
+
+	got, err := evaluatePoolNewDemand("worker", sp, "", nil, runner)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if got != 0 {
+		t.Fatalf("evaluatePoolNewDemand error fallback = %d, want 0", got)
 	}
 }
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -83,7 +83,7 @@ Agent defines a configured agent in the city.
 | `option_defaults` | map[string]string |  |  | OptionDefaults overrides the provider's effective schema defaults for this agent. Keys are option keys, values are choice values. Applied on top of the provider's OptionDefaults (agent keys win). Example: option_defaults = &#123; permission_mode = "plan", model = "sonnet" &#125; |
 | `max_active_sessions` | integer |  |  | MaxActiveSessions is the agent-level cap on concurrent sessions. Nil means inherit from rig, then workspace, then unlimited. Replaces pool.max. |
 | `min_active_sessions` | integer |  |  | MinActiveSessions is the minimum number of sessions to keep alive. Agent-level only. Counts against rig/workspace caps. Replaces pool.min. |
-| `scale_check` | string |  |  | ScaleCheck is a shell command template whose output determines desired session count. Optional override — when set, its output is the desired count (still clamped by all cap levels). If it contains Go template placeholders, gc expands them using the same PathContext fields as work_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName) before running the command. |
+| `scale_check` | string |  |  | ScaleCheck is a shell command template whose output reports new unassigned session demand. In bead-backed reconciliation this is additive: assigned work is resumed separately, and ScaleCheck reports only how many new generic sessions to start, still bounded by all cap levels. Legacy no-store evaluation continues to treat the output as the desired session count. If it contains Go template placeholders, gc expands them using the same PathContext fields as work_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName) before running the command. |
 | `drain_timeout` | string |  | `5m` | DrainTimeout is the maximum time to wait for a session to finish its current work before force-killing it during scale-down. Duration string (e.g., "5m", "30m", "1h"). Defaults to "5m". |
 | `on_boot` | string |  |  | OnBoot is a shell command template run once at controller startup for this agent. If it contains Go template placeholders, gc expands them using the same PathContext fields as work_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName) before running the command. |
 | `on_death` | string |  |  | OnDeath is a shell command template run when a session dies unexpectedly. If it contains Go template placeholders, gc expands them using the same PathContext fields as work_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName) before running the command. |
@@ -172,7 +172,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `inject_fragments_append` | []string |  |  | InjectFragmentsAppend appends to the agent's inject_fragments list. |
 | `max_active_sessions` | integer |  |  | MaxActiveSessions overrides the agent-level cap on concurrent sessions. |
 | `min_active_sessions` | integer |  |  | MinActiveSessions overrides the minimum number of sessions to keep alive. |
-| `scale_check` | string |  |  | ScaleCheck overrides the shell command whose output determines desired session count. |
+| `scale_check` | string |  |  | ScaleCheck overrides the shell command whose output reports new unassigned session demand for bead-backed reconciliation. |
 | `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (override keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
 
 ## AgentPatch
@@ -222,7 +222,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `inject_fragments_append` | []string |  |  | InjectFragmentsAppend appends to the agent's inject_fragments list. |
 | `max_active_sessions` | integer |  |  | MaxActiveSessions overrides the agent-level cap on concurrent sessions. |
 | `min_active_sessions` | integer |  |  | MinActiveSessions overrides the minimum number of sessions to keep alive. |
-| `scale_check` | string |  |  | ScaleCheck overrides the command template whose output determines desired session count. Supports the same Go template placeholders as Agent.scale_check. |
+| `scale_check` | string |  |  | ScaleCheck overrides the command template whose output reports new unassigned session demand for bead-backed reconciliation. Supports the same Go template placeholders as Agent.scale_check. |
 | `option_defaults` | map[string]string |  |  | OptionDefaults adds or overrides provider option defaults for this agent. Keys are option keys, values are choice values. Merges additively (patch keys win over existing agent keys). Example: option_defaults = &#123; model = "sonnet" &#125; |
 
 ## BeadsConfig

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -169,7 +169,7 @@
         },
         "scale_check": {
           "type": "string",
-          "description": "ScaleCheck is a shell command template whose output determines desired\nsession count. Optional override — when set, its output is the desired\ncount (still clamped by all cap levels). If it contains Go template\nplaceholders, gc expands them using the same PathContext fields as\nwork_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot,\nCityName) before running the command."
+          "description": "ScaleCheck is a shell command template whose output reports new\nunassigned session demand. In bead-backed reconciliation this is\nadditive: assigned work is resumed separately, and ScaleCheck reports\nonly how many new generic sessions to start, still bounded by all cap\nlevels. Legacy no-store evaluation continues to treat the output as\nthe desired session count. If it contains Go template placeholders, gc\nexpands them using the same PathContext fields as work_dir and\nsession_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName)\nbefore running the command."
         },
         "drain_timeout": {
           "type": "string",
@@ -592,7 +592,7 @@
         },
         "scale_check": {
           "type": "string",
-          "description": "ScaleCheck overrides the shell command whose output determines desired session count."
+          "description": "ScaleCheck overrides the shell command whose output reports new\nunassigned session demand for bead-backed reconciliation."
         },
         "option_defaults": {
           "additionalProperties": {
@@ -835,7 +835,7 @@
         },
         "scale_check": {
           "type": "string",
-          "description": "ScaleCheck overrides the command template whose output determines desired\nsession count. Supports the same Go template placeholders as\nAgent.scale_check."
+          "description": "ScaleCheck overrides the command template whose output reports new\nunassigned session demand for bead-backed reconciliation. Supports the\nsame Go template placeholders as Agent.scale_check."
         },
         "option_defaults": {
           "additionalProperties": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -169,7 +169,7 @@
         },
         "scale_check": {
           "type": "string",
-          "description": "ScaleCheck is a shell command template whose output determines desired\nsession count. Optional override — when set, its output is the desired\ncount (still clamped by all cap levels). If it contains Go template\nplaceholders, gc expands them using the same PathContext fields as\nwork_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot,\nCityName) before running the command."
+          "description": "ScaleCheck is a shell command template whose output reports new\nunassigned session demand. In bead-backed reconciliation this is\nadditive: assigned work is resumed separately, and ScaleCheck reports\nonly how many new generic sessions to start, still bounded by all cap\nlevels. Legacy no-store evaluation continues to treat the output as\nthe desired session count. If it contains Go template placeholders, gc\nexpands them using the same PathContext fields as work_dir and\nsession_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName)\nbefore running the command."
         },
         "drain_timeout": {
           "type": "string",
@@ -592,7 +592,7 @@
         },
         "scale_check": {
           "type": "string",
-          "description": "ScaleCheck overrides the shell command whose output determines desired session count."
+          "description": "ScaleCheck overrides the shell command whose output reports new\nunassigned session demand for bead-backed reconciliation."
         },
         "option_defaults": {
           "additionalProperties": {
@@ -835,7 +835,7 @@
         },
         "scale_check": {
           "type": "string",
-          "description": "ScaleCheck overrides the command template whose output determines desired\nsession count. Supports the same Go template placeholders as\nAgent.scale_check."
+          "description": "ScaleCheck overrides the command template whose output reports new\nunassigned session demand for bead-backed reconciliation. Supports the\nsame Go template placeholders as Agent.scale_check."
         },
         "option_defaults": {
           "additionalProperties": {

--- a/internal/api/handler_session_chat_test.go
+++ b/internal/api/handler_session_chat_test.go
@@ -135,6 +135,7 @@ func TestBuildSessionResumePreservesStoredResolvedCommand(t *testing.T) {
 func TestBuildSessionResumeRebuildsBareStoredCommandForPoolClaudeAgent(t *testing.T) {
 	fs := newSessionFakeState(t)
 	claude := config.BuiltinProviders()["claude"]
+	claude.PathCheck = "true" // use /usr/bin/true so LookPath succeeds in CI
 	maxActive := 3
 	gcDir := filepath.Join(fs.cityPath, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1909,10 +1909,10 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 
 // EffectiveScaleCheck returns the scale check command for this agent.
 // If ScaleCheck is set, returns it. Otherwise returns a default that
-// counts actionable work routed to this agent's template, including
+// counts new unassigned work routed to this agent's template, including
 // standalone formula-dispatched molecule beads (which bd ready excludes).
-// Attached formulas contribute demand through the routed source bead in the
-// ready/in_progress tiers instead of through the molecule count.
+// Assigned in-progress work is resumed from session beads, so it must not
+// create additional generic pool demand here.
 func (a *Agent) EffectiveScaleCheck() string {
 	if a.ScaleCheck != "" {
 		return a.ScaleCheck
@@ -1920,11 +1920,9 @@ func (a *Agent) EffectiveScaleCheck() string {
 	template := a.QualifiedName()
 	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
 		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`active=$(bd list --metadata-field gc.routed_to=` + template +
-		` --status=in_progress --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
 		`molecules=$(bd list --metadata-field gc.routed_to=` + template +
 		` --status=open --type=molecule --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`echo "$(( ${ready:-0} + ${active:-0} + ${molecules:-0} ))" || echo 0`
+		`echo "$(( ${ready:-0} + ${molecules:-0} ))" || echo 0`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -547,7 +547,8 @@ type AgentOverride struct {
 	MaxActiveSessions *int `toml:"max_active_sessions,omitempty"`
 	// MinActiveSessions overrides the minimum number of sessions to keep alive.
 	MinActiveSessions *int `toml:"min_active_sessions,omitempty"`
-	// ScaleCheck overrides the shell command whose output determines desired session count.
+	// ScaleCheck overrides the shell command whose output reports new
+	// unassigned session demand for bead-backed reconciliation.
 	ScaleCheck *string `toml:"scale_check,omitempty"`
 	// OptionDefaults adds or overrides provider option defaults for this agent.
 	// Keys are option keys, values are choice values. Merges additively
@@ -1539,12 +1540,15 @@ type Agent struct {
 	// MinActiveSessions is the minimum number of sessions to keep alive.
 	// Agent-level only. Counts against rig/workspace caps. Replaces pool.min.
 	MinActiveSessions *int `toml:"min_active_sessions,omitempty"`
-	// ScaleCheck is a shell command template whose output determines desired
-	// session count. Optional override — when set, its output is the desired
-	// count (still clamped by all cap levels). If it contains Go template
-	// placeholders, gc expands them using the same PathContext fields as
-	// work_dir and session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot,
-	// CityName) before running the command.
+	// ScaleCheck is a shell command template whose output reports new
+	// unassigned session demand. In bead-backed reconciliation this is
+	// additive: assigned work is resumed separately, and ScaleCheck reports
+	// only how many new generic sessions to start, still bounded by all cap
+	// levels. Legacy no-store evaluation continues to treat the output as
+	// the desired session count. If it contains Go template placeholders, gc
+	// expands them using the same PathContext fields as work_dir and
+	// session_setup (Agent, AgentBase, Rig, RigRoot, CityRoot, CityName)
+	// before running the command.
 	ScaleCheck string `toml:"scale_check,omitempty"`
 	// DrainTimeout is the maximum time to wait for a session to finish its
 	// current work before force-killing it during scale-down. Duration string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1489,11 +1489,11 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("EffectiveScaleCheck() = %q, want bd ready for blocker-aware counting", check)
 	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("EffectiveScaleCheck() = %q, want --status=in_progress for active work", check)
-	}
 	if !strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck() = %q, want --type=molecule for formula-dispatched work", check)
+	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck() = %q, should not count in-progress work as new demand", check)
 	}
 }
 
@@ -1587,21 +1587,21 @@ func TestEffectiveScaleCheckDefaults(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(1),
 	}
 	check := a.EffectiveScaleCheck()
-	// Default check uses bd ready (blocker-aware) + in_progress count + molecule count via gc.routed_to.
+	// Default check uses bd ready (blocker-aware) + molecule count via gc.routed_to.
 	if !strings.Contains(check, "gc.routed_to=refinery") {
 		t.Errorf("EffectiveScaleCheck = %q, want gc.routed_to=refinery", check)
 	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("EffectiveScaleCheck = %q, want --status=in_progress for active work", check)
-	}
 	if !strings.Contains(check, "--no-assignee") {
-		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for active unassigned work", check)
+		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for new unassigned demand", check)
 	}
 	if !strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck = %q, want --type=molecule for formula-dispatched work", check)
 	}
 	if !strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("EffectiveScaleCheck = %q, want ${molecules:-0} in arithmetic sum", check)
+	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 }
 
@@ -1616,14 +1616,14 @@ func TestEffectiveScaleCheckDefaultsQualified(t *testing.T) {
 	if !strings.Contains(check, "gc.routed_to=myproject/polecat") {
 		t.Errorf("EffectiveScaleCheck = %q, want gc.routed_to=myproject/polecat", check)
 	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("EffectiveScaleCheck = %q, want --status=in_progress for active work", check)
-	}
 	if !strings.Contains(check, "--no-assignee") {
-		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for active unassigned work", check)
+		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for new unassigned demand", check)
 	}
 	if !strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck = %q, want --type=molecule for formula-dispatched work", check)
+	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 }
 
@@ -1637,23 +1637,20 @@ func TestEffectiveScaleCheckMoleculeQuery(t *testing.T) {
 	}
 	check := a.EffectiveScaleCheck()
 
-	// Must contain three separate queries summed together.
+	// Must contain blocker-aware ready demand and standalone molecule demand.
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("missing bd ready query for blocker-aware task counting")
-	}
-	if !strings.Contains(check, "--status=in_progress") {
-		t.Errorf("missing in_progress query for active work")
 	}
 	if !strings.Contains(check, "--status=open --type=molecule") {
 		t.Errorf("missing molecule query for formula-dispatched work (GH #505)")
 	}
+	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
+	}
 
-	// All three variables must appear in the arithmetic sum.
+	// Both variables must appear in the arithmetic sum.
 	if !strings.Contains(check, "${ready:-0}") {
 		t.Errorf("missing ${ready:-0} in arithmetic sum")
-	}
-	if !strings.Contains(check, "${active:-0}") {
-		t.Errorf("missing ${active:-0} in arithmetic sum")
 	}
 	if !strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("missing ${molecules:-0} in arithmetic sum")

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -122,9 +122,9 @@ type AgentPatch struct {
 	MaxActiveSessions *int `toml:"max_active_sessions,omitempty"`
 	// MinActiveSessions overrides the minimum number of sessions to keep alive.
 	MinActiveSessions *int `toml:"min_active_sessions,omitempty"`
-	// ScaleCheck overrides the command template whose output determines desired
-	// session count. Supports the same Go template placeholders as
-	// Agent.scale_check.
+	// ScaleCheck overrides the command template whose output reports new
+	// unassigned session demand for bead-backed reconciliation. Supports the
+	// same Go template placeholders as Agent.scale_check.
 	ScaleCheck *string `toml:"scale_check,omitempty"`
 	// OptionDefaults adds or overrides provider option defaults for this agent.
 	// Keys are option keys, values are choice values. Merges additively


### PR DESCRIPTION
Maintainer follow-up for https://github.com/gastownhall/gascity/pull/1337 because maintainer edits are disabled on the original PR.

Original PR title: fix(scale): treat scale_check as new demand
Original PR state: OPEN
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

Summary:
- Treat the default scale_check as new unassigned demand so unassigned in-progress routed work no longer causes a double restart.
- Preserve assigned bead-backed resume requests separately from additive new pool demand.
- Keep the legacy no-store pool path on the existing total desired session behavior.

Maintainer review fixes applied:
- Updated the public scale_check contract in comments, generated docs, schema, and changelog to describe additive new demand.
- Capped scale_check-driven request materialization before expanding one request per count.
- Added regression coverage for large scale_check counts under small caps and bead-backed default new-demand behavior.

Review synthesis:
- Claude and Codex agreed the original default scale_check double-restart fix was directionally correct.
- Required changes were contract documentation/migration coverage and pre-materialization capacity protection.
- Those major findings are addressed in the maintainer fixup commit.

Validation recorded during review:
- git diff --check passed.
- Targeted internal/config and cmd/gc pool/desired-state tests passed.
- Full go test ./cmd/gc was attempted in the review step and hit ambient rig/bd/Dolt harness failures unrelated to these pool changes.

Authorship:
- Contributor commit authorship is preserved as Julian Knutsen <julianknutsen@users.noreply.github.com>.
- Maintainer fixup commit is also authored as Julian Knutsen to preserve contributor authorship for the adopted branch.