### PR TITLE
fix(codex): emit hook context as Codex JSON (follow-up)

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -248,7 +248,7 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	if inject {
 		if hasWork {
 			content := formatHookInjectReminder(normalized)
-			_ = writeProviderHookContext(stdout, hookFormat, content)
+			_ = writeProviderHookContextForEvent(stdout, hookFormat, "Stop", content)
 		}
 		return 0 // --inject always exits 0
 	}

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -29,11 +29,7 @@ With --inject: wraps output in <system-reminder> for hook injection, always exit
 		The agent is determined from $GC_AGENT or a positional argument.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			code := cmdHook(args, inject, stdout, stderr)
-			if hookFormat != "" {
-				code = cmdHookWithFormat(args, inject, hookFormat, stdout, stderr)
-			}
-			if code != 0 {
+			if cmdHookWithFormat(args, inject, hookFormat, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -47,8 +43,8 @@ With --inject: wraps output in <system-reminder> for hook injection, always exit
 // cmdHook is the CLI entry point for gc hook. Resolves the agent from
 // $GC_AGENT or a positional argument, loads the city config, and runs
 // the agent's work query.
-func cmdHook(args []string, inject bool, stdout, stderr io.Writer) int {
-	return cmdHookWithFormat(args, inject, "", stdout, stderr)
+func cmdHook(args []string, stdout, stderr io.Writer) int {
+	return cmdHookWithFormat(args, false, "", stdout, stderr)
 }
 
 func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -116,6 +117,46 @@ func TestHookInjectFormatsOutput(t *testing.T) {
 	}
 }
 
+func TestHookCommandCodexInjectEmitsSingleStopPayload(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newHookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"worker", "--inject", "--hook-format", "codex"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc hook command failed: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not a single JSON payload: %v\n%s", err, stdout.String())
+	}
+	if got, want := payload.Decision, "block"; got != want {
+		t.Fatalf("decision = %q, want %q", got, want)
+	}
+	if !strings.Contains(payload.Reason, "hw-1") {
+		t.Fatalf("reason = %q, want pending work", payload.Reason)
+	}
+}
+
 func TestHookInjectAlwaysExitsZero(t *testing.T) {
 	// Even on command failure, inject mode exits 0.
 	runner := func(string, string) (string, error) { return "", fmt.Errorf("command failed") }
@@ -213,7 +254,7 @@ max = 5
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook(nil, false, &stdout, &stderr)
+	code := cmdHook(nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -292,7 +333,7 @@ dir = "myrig"
 	t.Setenv("BEADS_DIR", cityBeads)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -359,7 +400,7 @@ dir = "myrig"
 	t.Setenv("GC_DIR", rigAbs)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -416,7 +457,7 @@ work_query = "bd {{.CityName}} {{.Rig}} {{.AgentBase}}"
 	t.Setenv("GC_DIR", rigDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -464,7 +505,7 @@ dir = "workdir"
 	t.Setenv("GC_CITY", cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -538,7 +579,7 @@ max = 5
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook(nil, false, &stdout, &stderr)
+	code := cmdHook(nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -602,7 +643,7 @@ name = "worker"
 	t.Setenv("GC_CITY", cityDir)
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -662,7 +703,7 @@ dir = "myrig"
 	wantSession := cliSessionName(cityDir, "test-city", wantAgent, "")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook([]string{"worker"}, false, &stdout, &stderr)
+	code := cmdHook([]string{"worker"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -213,7 +213,7 @@ func doMailCheckTargetWithFormat(mp mail.Provider, target resolvedMailTarget, in
 
 	if inject {
 		if len(messages) > 0 {
-			_ = writeProviderHookContext(stdout, hookFormat, formatInjectOutput(messages))
+			_ = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", formatInjectOutput(messages))
 		}
 		return 0 // --inject always exits 0
 	}

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -357,7 +357,7 @@ func cmdNudgeDrainWithFormat(args []string, inject bool, hookFormat string, stdo
 	}
 	var writeErr error
 	if inject {
-		writeErr = writeProviderHookContext(stdout, hookFormat, out)
+		writeErr = writeProviderHookContextForEvent(stdout, hookFormat, "UserPromptSubmit", out)
 	} else {
 		_, writeErr = io.WriteString(stdout, out)
 	}

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -175,7 +175,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: no city config found: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
+		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 		return 0
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
@@ -184,7 +184,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 			fmt.Fprintf(stderr, "gc prime: loading city config: %v\n", err) //nolint:errcheck
 			return 1
 		}
-		fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
+		writePrimePromptWithFormat(stdout, "", "", defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 		return 0
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
@@ -317,7 +317,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// when the agent has no prompt_template and doesn't match a builtin
 	// worker prompt — a supported config shape, so the default prompt is
 	// the correct output even under --strict.
-	fmt.Fprint(stdout, defaultPrimePrompt) //nolint:errcheck // best-effort stdout
+	writePrimePromptWithFormat(stdout, "", agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 	return 0
 }
 
@@ -396,7 +396,7 @@ func writePrimePromptWithFormat(stdout io.Writer, cityName, agentName, prompt st
 		prompt = prependHookBeacon(cityName, agentName, prompt)
 	}
 	if hookMode && hookFormat != "" {
-		_ = writeProviderHookContext(stdout, hookFormat, prompt)
+		_ = writeProviderHookContextForEvent(stdout, hookFormat, "SessionStart", prompt)
 		return
 	}
 	fmt.Fprint(stdout, prompt) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -428,6 +428,34 @@ prompt_template = "prompts/worker.md"
 	}
 }
 
+func TestDoPrimeWithHookFormat_FormatsDefaultFallback(t *testing.T) {
+	t.Setenv("GC_CITY", filepath.Join(t.TempDir(), "missing-city"))
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not hook JSON: %v\n%s", err, stdout.String())
+	}
+	if got, want := payload.HookSpecificOutput.HookEventName, "SessionStart"; got != want {
+		t.Fatalf("hookEventName = %q, want %q", got, want)
+	}
+	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, "# Gas City Agent") {
+		t.Fatalf("additionalContext = %q, want default prime prompt", payload.HookSpecificOutput.AdditionalContext)
+	}
+}
+
 func withPrimeHookStdin(t *testing.T, payload map[string]string) {
 	t.Helper()
 

--- a/cmd/gc/hook_output.go
+++ b/cmd/gc/hook_output.go
@@ -6,17 +6,39 @@ import (
 	"strings"
 )
 
-const hookOutputFormatGemini = "gemini"
+const (
+	hookOutputFormatCodex  = "codex"
+	hookOutputFormatGemini = "gemini"
+)
 
 func writeProviderHookContext(stdout io.Writer, format, content string) error {
+	return writeProviderHookContextForEvent(stdout, format, "", content)
+}
+
+func writeProviderHookContextForEvent(stdout io.Writer, format, eventName, content string) error {
 	if content == "" {
 		return nil
 	}
-	if strings.EqualFold(strings.TrimSpace(format), hookOutputFormatGemini) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case hookOutputFormatCodex:
+		return json.NewEncoder(stdout).Encode(codexHookAdditionalContext(eventName, content))
+	case hookOutputFormatGemini:
 		return json.NewEncoder(stdout).Encode(geminiHookAdditionalContext(content))
 	}
 	_, err := io.WriteString(stdout, content)
 	return err
+}
+
+func codexHookAdditionalContext(eventName, content string) map[string]any {
+	if eventName == "" {
+		eventName = "SessionStart"
+	}
+	return map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":     eventName,
+			"additionalContext": strings.TrimRight(content, "\n"),
+		},
+	}
 }
 
 func geminiHookAdditionalContext(content string) map[string]any {

--- a/cmd/gc/hook_output.go
+++ b/cmd/gc/hook_output.go
@@ -21,12 +21,22 @@ func writeProviderHookContextForEvent(stdout io.Writer, format, eventName, conte
 	}
 	switch strings.ToLower(strings.TrimSpace(format)) {
 	case hookOutputFormatCodex:
-		return json.NewEncoder(stdout).Encode(codexHookAdditionalContext(eventName, content))
+		return json.NewEncoder(stdout).Encode(codexHookOutput(eventName, content))
 	case hookOutputFormatGemini:
 		return json.NewEncoder(stdout).Encode(geminiHookAdditionalContext(content))
 	}
 	_, err := io.WriteString(stdout, content)
 	return err
+}
+
+func codexHookOutput(eventName, content string) map[string]any {
+	if strings.EqualFold(strings.TrimSpace(eventName), "Stop") {
+		return map[string]any{
+			"decision": "block",
+			"reason":   strings.TrimRight(content, "\n"),
+		}
+	}
+	return codexHookAdditionalContext(eventName, content)
 }
 
 func codexHookAdditionalContext(eventName, content string) map[string]any {

--- a/cmd/gc/hook_output_test.go
+++ b/cmd/gc/hook_output_test.go
@@ -26,6 +26,30 @@ func TestWriteProviderHookContextGemini(t *testing.T) {
 	}
 }
 
+func TestWriteProviderHookContextCodex(t *testing.T) {
+	var out bytes.Buffer
+	err := writeProviderHookContextForEvent(&out, "codex", "Stop", "<system-reminder>\nhello\n</system-reminder>\n")
+	if err != nil {
+		t.Fatalf("writeProviderHookContextForEvent: %v", err)
+	}
+
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out.String())
+	}
+	if got, want := payload.HookSpecificOutput.HookEventName, "Stop"; got != want {
+		t.Fatalf("hookEventName = %q, want %q", got, want)
+	}
+	if got, want := payload.HookSpecificOutput.AdditionalContext, "<system-reminder>\nhello\n</system-reminder>"; got != want {
+		t.Fatalf("additionalContext = %q, want %q", got, want)
+	}
+}
+
 func TestWriteProviderHookContextPlain(t *testing.T) {
 	var out bytes.Buffer
 	err := writeProviderHookContext(&out, "", "<system-reminder>\nhello\n</system-reminder>\n")

--- a/cmd/gc/hook_output_test.go
+++ b/cmd/gc/hook_output_test.go
@@ -34,6 +34,28 @@ func TestWriteProviderHookContextCodex(t *testing.T) {
 	}
 
 	var payload struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out.String())
+	}
+	if got, want := payload.Decision, "block"; got != want {
+		t.Fatalf("decision = %q, want %q", got, want)
+	}
+	if got, want := payload.Reason, "<system-reminder>\nhello\n</system-reminder>"; got != want {
+		t.Fatalf("reason = %q, want %q", got, want)
+	}
+}
+
+func TestWriteProviderHookContextCodexAdditionalContext(t *testing.T) {
+	var out bytes.Buffer
+	err := writeProviderHookContextForEvent(&out, "codex", "UserPromptSubmit", "<system-reminder>\nhello\n</system-reminder>\n")
+	if err != nil {
+		t.Fatalf("writeProviderHookContextForEvent: %v", err)
+	}
+
+	var payload struct {
 		HookSpecificOutput struct {
 			HookEventName     string `json:"hookEventName"`
 			AdditionalContext string `json:"additionalContext"`
@@ -42,7 +64,7 @@ func TestWriteProviderHookContextCodex(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal output: %v\n%s", err, out.String())
 	}
-	if got, want := payload.HookSpecificOutput.HookEventName, "Stop"; got != want {
+	if got, want := payload.HookSpecificOutput.HookEventName, "UserPromptSubmit"; got != want {
 		t.Fatalf("hookEventName = %q, want %q", got, want)
 	}
 	if got, want := payload.HookSpecificOutput.AdditionalContext, "<system-reminder>\nhello\n</system-reminder>"; got != want {

--- a/cmd/gc/session_model_phase0_hook_spec_test.go
+++ b/cmd/gc/session_model_phase0_hook_spec_test.go
@@ -49,7 +49,7 @@ work_query = "printf 'pwd=%s|agent=%s|template=%s|session=%s|origin=%s' \"$PWD\"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook(nil, false, &stdout, &stderr)
+	code := cmdHook(nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -107,7 +107,7 @@ work_query = "printf 'agent=%s|template=%s|session=%s|origin=%s' \"$GC_AGENT\" \
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook(nil, false, &stdout, &stderr)
+	code := cmdHook(nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -169,7 +169,7 @@ start_command = "true"
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHook(nil, false, &stdout, &stderr)
+	code := cmdHook(nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("cmdHook() = %d, want 0; stderr=%s", code, stderr.String())
 	}

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
           }
         ]
       }
@@ -17,11 +17,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc nudge drain --inject --hook-format codex"
           },
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject --hook-format codex"
           }
         ]
       }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject --hook-format codex"
           }
         ]
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -158,6 +158,9 @@ func overlayManagedNeedsUpgrade(provider, rel string) func([]byte) bool {
 	if provider == "pi" && rel == path.Join(".pi", "extensions", "gc-hooks.js") {
 		return piHookNeedsUpgrade
 	}
+	if provider == "codex" && rel == path.Join(".codex", "hooks.json") {
+		return codexFileNeedsUpgrade
+	}
 	return nil
 }
 
@@ -342,6 +345,18 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 		return candidateMissing, nil, nil
 	}
 	return candidateUnreadable, nil, err
+}
+
+func codexFileNeedsUpgrade(existing []byte) bool {
+	content := string(existing)
+	return codexContainsManagedHook(content) && !strings.Contains(content, `--hook-format codex`)
+}
+
+func codexContainsManagedHook(content string) bool {
+	return strings.Contains(content, `gc prime --hook`) ||
+		strings.Contains(content, `gc nudge drain --inject`) ||
+		strings.Contains(content, `gc mail check --inject`) ||
+		strings.Contains(content, `gc hook --inject`)
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -7,6 +7,7 @@ package hooks
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	iofs "io/fs"
@@ -150,6 +151,9 @@ func installOverlayManaged(fs fsys.FS, workDir, provider string) error {
 			return fmt.Errorf("reading %s: %w", name, err)
 		}
 		dst := filepath.Join(workDir, filepath.FromSlash(rel))
+		if provider == "codex" && rel == path.Join(".codex", "hooks.json") {
+			return writeCodexHooksManaged(fs, dst, data)
+		}
 		return writeEmbeddedManaged(fs, dst, data, overlayManagedNeedsUpgrade(provider, rel))
 	})
 }
@@ -157,9 +161,6 @@ func installOverlayManaged(fs fsys.FS, workDir, provider string) error {
 func overlayManagedNeedsUpgrade(provider, rel string) func([]byte) bool {
 	if provider == "pi" && rel == path.Join(".pi", "extensions", "gc-hooks.js") {
 		return piHookNeedsUpgrade
-	}
-	if provider == "codex" && rel == path.Join(".codex", "hooks.json") {
-		return codexFileNeedsUpgrade
 	}
 	return nil
 }
@@ -347,16 +348,92 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 	return candidateUnreadable, nil, err
 }
 
-func codexFileNeedsUpgrade(existing []byte) bool {
-	content := string(existing)
-	return codexContainsManagedHook(content) && !strings.Contains(content, `--hook-format codex`)
+func writeCodexHooksManaged(fs fsys.FS, dst string, data []byte) error {
+	if existing, err := fs.ReadFile(dst); err == nil {
+		upgraded, changed, upgradeErr := upgradeCodexHookCommands(existing)
+		if upgradeErr != nil || !changed {
+			return nil
+		}
+		return writeManagedData(fs, dst, upgraded)
+	} else if _, statErr := fs.Stat(dst); statErr == nil {
+		return nil
+	}
+	return writeManagedData(fs, dst, data)
 }
 
-func codexContainsManagedHook(content string) bool {
-	return strings.Contains(content, `gc prime --hook`) ||
-		strings.Contains(content, `gc nudge drain --inject`) ||
-		strings.Contains(content, `gc mail check --inject`) ||
-		strings.Contains(content, `gc hook --inject`)
+func writeManagedData(fs fsys.FS, dst string, data []byte) error {
+	dir := filepath.Dir(dst)
+	if err := fs.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	if err := fs.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", dst, err)
+	}
+	return nil
+}
+
+func upgradeCodexHookCommands(existing []byte) ([]byte, bool, error) {
+	var root any
+	if err := json.Unmarshal(existing, &root); err != nil {
+		return nil, false, err
+	}
+	if !upgradeCodexHookValue(root) {
+		return nil, false, nil
+	}
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, false, err
+	}
+	return append(data, '\n'), true, nil
+}
+
+func upgradeCodexHookValue(v any) bool {
+	switch node := v.(type) {
+	case map[string]any:
+		changed := false
+		for key, val := range node {
+			if key == "command" {
+				if command, ok := val.(string); ok {
+					if upgraded, didUpgrade := upgradeCodexHookCommand(command); didUpgrade {
+						node[key] = upgraded
+						changed = true
+					}
+				}
+				continue
+			}
+			if upgradeCodexHookValue(val) {
+				changed = true
+			}
+		}
+		return changed
+	case []any:
+		changed := false
+		for _, elem := range node {
+			if upgradeCodexHookValue(elem) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
+}
+
+func upgradeCodexHookCommand(command string) (string, bool) {
+	if strings.Contains(command, `--hook-format codex`) {
+		return "", false
+	}
+	for _, needle := range []string{
+		`gc prime --hook`,
+		`gc nudge drain --inject`,
+		`gc mail check --inject`,
+		`gc hook --inject`,
+	} {
+		if strings.Contains(command, needle) {
+			return strings.Replace(command, needle, needle+` --hook-format codex`, 1), true
+		}
+	}
+	return "", false
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -231,6 +231,29 @@ func TestInstallClaudeUpgradesGeneratedFileSessionStartMatcher(t *testing.T) {
 	}
 }
 
+func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, "--hook-format codex") {
+		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
+	}
+}
+
 func TestInstallClaudeUpgradesGeneratedFileWithCombinedKnownDrift(t *testing.T) {
 	fs := fsys.NewFake()
 	current, err := readEmbedded("config/claude.json")
@@ -683,6 +706,10 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 		if _, ok := fs.Files[rel]; !ok {
 			t.Errorf("expected overlay-managed provider file %s to be written", rel)
 		}
+	}
+	codexHooks := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(codexHooks, "--hook-format codex") {
+		t.Error("codex hooks should request Codex hook output format")
 	}
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -254,6 +254,38 @@ func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
 	}
 }
 
+func TestInstallCodexUpgradePreservesCustomHooks(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook"
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "hooks": [{
+        "type": "command",
+        "command": "printf custom-codex-hook"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, "--hook-format codex") {
+		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
+	}
+	if !strings.Contains(got, "printf custom-codex-hook") {
+		t.Errorf("custom codex hook was not preserved:\n%s", got)
+	}
+}
+
 func TestInstallClaudeUpgradesGeneratedFileWithCombinedKnownDrift(t *testing.T) {
 	fs := fsys.NewFake()
 	current, err := readEmbedded("config/claude.json")


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1344.

Original PR metadata:
- Original PR: https://github.com/gastownhall/gascity/pull/1344
- Original title: fix(codex): emit hook context as Codex JSON
- Original state at finalization: OPEN
- Configured base: main
- Original GitHub base: main
- Base mismatch: none

Why this follow-up exists:
- The adopted review branch contains one contributor commit plus one maintainer fixup commit.
- GitHub reports `maintainerCanModify=false` for the original PR, so the adopt-pr finalize path requires a separate maintainer branch instead of mutating the original branch.

Review/fix summary:
- Review found that Codex Stop hook continuation output still used the wrong JSON shape / double-output path.
- Review also found that managed Codex hook upgrades could replace user-authored hook entries.
- The maintainer fixup routes Codex hook injection through a single formatted output path, emits Codex Stop continuation JSON, preserves custom Codex hook entries during managed upgrades, and adds focused regression coverage.

Validation recorded before finalization:
- `git diff --check refs/adopt-pr/ga-gm1a6/upstream-base..HEAD` passed.
- Focused regressions passed for the Codex hook output path and managed hook upgrade preservation.
- Wider `go test ./cmd/gc ./internal/hooks` was attempted in the routed environment; `internal/hooks` passed, while `cmd/gc` had unrelated active rig/city and Dolt setup failures recorded in the approval summary.
