### PR TITLE
fix(codex): skip startup update dialog

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2178,6 +2178,7 @@ func TestInitBeadsForDirExecWithoutCityPathPreservesAmbientEnv(t *testing.T) {
 }
 
 func TestInitBeadsForDirExecPreventsStrayGitInit(t *testing.T) {
+	skipSlowCmdGCTest(t, "uses real bd init process behavior; run make test-cmd-gc-process for full coverage")
 	configureTestDoltIdentityEnv(t)
 
 	findRealBD := func() string {

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -30,9 +30,10 @@ func StartupDialogTimeout() time.Duration {
 
 // AcceptStartupDialogs dismisses startup dialogs that can block automated
 // sessions. Handles (in order):
-//  1. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
-//  2. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
-//  3. Claude custom API key confirmation — requires Up+Enter to select "Yes"
+//  1. Codex update dialog ("Update available") — requires Down+Enter to skip
+//  2. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
+//  3. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
+//  4. Claude custom API key confirmation — requires Up+Enter to select "Yes"
 //
 // The peek function should return the last N lines of the session's terminal output.
 // The sendKeys function should send bare tmux-style keystrokes (e.g., "Enter", "Down").
@@ -136,6 +137,12 @@ func AcceptStartupDialogsWithTimeout(
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
+	if err := acceptCodexUpdateDialog(ctx, timeout, peek, sendKeys); err != nil {
+		return fmt.Errorf("codex update dialog: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := acceptWorkspaceTrustDialog(ctx, timeout, peek, sendKeys); err != nil {
 		return fmt.Errorf("workspace trust dialog: %w", err)
 	}
@@ -158,6 +165,52 @@ func AcceptStartupDialogsWithTimeout(
 		return fmt.Errorf("rate limit dialog: %w", err)
 	}
 	return nil
+}
+
+// acceptCodexUpdateDialog skips Codex's interactive update prompt. The default
+// selection is "Update now", so automated sessions must move down to "Skip".
+func acceptCodexUpdateDialog(
+	ctx context.Context,
+	timeout time.Duration,
+	peek func(lines int) (string, error),
+	sendKeys func(keys ...string) error,
+) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		content, err := peek(startupDialogPeekLines)
+		if err != nil {
+			return err
+		}
+
+		if containsCodexUpdateDialog(content) {
+			if err := sendKeys("Down"); err != nil {
+				return err
+			}
+			sleep(ctx, bypassDialogConfirmDelay)
+			return sendKeys("Enter")
+		}
+
+		if containsPromptIndicator(content) ||
+			containsWorkspaceTrustDialog(content) ||
+			strings.Contains(content, "Bypass Permissions mode") ||
+			containsCustomAPIKeyDialog(content) ||
+			containsRateLimitDialog(content) {
+			return nil
+		}
+
+		sleep(ctx, dialogPollInterval)
+	}
+	return nil
+}
+
+func containsCodexUpdateDialog(content string) bool {
+	return strings.Contains(content, "Update available!") &&
+		strings.Contains(content, "Skip until next version") &&
+		strings.Contains(content, "Press enter to continue")
 }
 
 // acceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
@@ -638,9 +691,10 @@ func containsRateLimitDialog(content string) bool {
 		strings.Contains(content, "Rate limit")
 }
 
-// containsPromptIndicator checks whether any line in the content ends with
-// a common shell or REPL prompt suffix, indicating the session is ready
-// and no dialog is present.
+// containsPromptIndicator checks whether any line in the content looks like a
+// common shell or agent prompt, indicating the session is ready and no dialog is
+// present. Full-screen agent UIs often render placeholder input after the prompt
+// glyph, so Claude/Codex prompts are accepted as prefixes too.
 func containsPromptIndicator(content string) bool {
 	for _, line := range strings.Split(content, "\n") {
 		trimmed := strings.ReplaceAll(line, "\u00a0", " ")
@@ -648,7 +702,12 @@ func containsPromptIndicator(content string) bool {
 		if trimmed == "" {
 			continue
 		}
-		for _, suffix := range []string{">", "$", "%", "#", "\u276f"} {
+		for _, prefix := range []string{"\u276f", "\u203a"} {
+			if trimmed == prefix || strings.HasPrefix(trimmed, prefix+" ") {
+				return true
+			}
+		}
+		for _, suffix := range []string{">", "$", "%", "#", "\u276f", "\u203a"} {
 			if strings.HasSuffix(trimmed, suffix) {
 				return true
 			}

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -76,7 +76,18 @@ func AcceptStartupDialogsFromStreamWithStatus(
 		return sendKeys(keys...)
 	}
 
-	phaseObserved, err := acceptWorkspaceTrustDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	phaseObserved, err := acceptCodexUpdateDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	if err != nil {
+		return observed, fmt.Errorf("codex update dialog: %w", err)
+	}
+	observed = observed || phaseObserved
+	if !phaseObserved && !observed {
+		return false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return observed, err
+	}
+	phaseObserved, err = acceptWorkspaceTrustDialogFromStream(ctx, timeout, stream, trackingSendKeys)
 	if err != nil {
 		return observed, fmt.Errorf("workspace trust dialog: %w", err)
 	}
@@ -211,6 +222,28 @@ func containsCodexUpdateDialog(content string) bool {
 	return strings.Contains(content, "Update available!") &&
 		strings.Contains(content, "Skip until next version") &&
 		strings.Contains(content, "Press enter to continue")
+}
+
+func acceptCodexUpdateDialogFromStream(
+	ctx context.Context,
+	timeout time.Duration,
+	snapshots *replayableSnapshotCursor,
+	sendKeys func(keys ...string) error,
+) (bool, error) {
+	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
+		match:       containsCodexUpdateDialog,
+		matchKeys:   []string{"Down", "Enter"},
+		matchDelay:  bypassDialogConfirmDelay,
+		ready:       containsPromptIndicator,
+		readyOrNext: containsPostUpdateStartupDialog,
+	})
+}
+
+func containsPostUpdateStartupDialog(content string) bool {
+	return containsWorkspaceTrustDialog(content) ||
+		strings.Contains(content, "Bypass Permissions mode") ||
+		containsCustomAPIKeyDialog(content) ||
+		containsRateLimitDialog(content)
 }
 
 // acceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
@@ -703,7 +736,8 @@ func containsPromptIndicator(content string) bool {
 			continue
 		}
 		for _, prefix := range []string{"\u276f", "\u203a"} {
-			if trimmed == prefix || strings.HasPrefix(trimmed, prefix+" ") {
+			rest, ok := strings.CutPrefix(trimmed, prefix+" ")
+			if trimmed == prefix || (ok && !isNumberedMenuRow(rest)) {
 				return true
 			}
 		}
@@ -714,6 +748,14 @@ func containsPromptIndicator(content string) bool {
 		}
 	}
 	return false
+}
+
+func isNumberedMenuRow(content string) bool {
+	digits := 0
+	for digits < len(content) && content[digits] >= '0' && content[digits] <= '9' {
+		digits++
+	}
+	return digits > 0 && digits < len(content) && content[digits] == '.'
 }
 
 // sleep waits for the given duration or until ctx is canceled.

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -79,12 +79,10 @@ func TestAcceptStartupDialogsAcceptsCodexTrustDialog(t *testing.T) {
 	dialogPollTimeout = time.Second
 
 	var sent []string
-	peekCall := 0
 	err := AcceptStartupDialogs(
 		context.Background(),
 		func(_ int) (string, error) {
-			peekCall++
-			if peekCall == 1 {
+			if len(sent) == 0 {
 				return "Do you trust the contents of this directory?", nil
 			}
 			return "user@host $", nil
@@ -107,12 +105,10 @@ func TestAcceptStartupDialogsAcceptsGeminiTrustDialog(t *testing.T) {
 	dialogPollTimeout = time.Second
 
 	var sent []string
-	peekCall := 0
 	err := AcceptStartupDialogs(
 		context.Background(),
 		func(_ int) (string, error) {
-			peekCall++
-			if peekCall == 1 {
+			if len(sent) == 0 {
 				return "Do you trust the files in this folder?\n● 1. Trust folder (city)\n  2. Trust parent folder\n  3. Don't trust", nil
 			}
 			return "Type your message or @path/to/file", nil
@@ -153,6 +149,36 @@ func TestAcceptStartupDialogsPeeksDeepEnoughForLateTrustDialog(t *testing.T) {
 	}
 	if !reflect.DeepEqual(sent, []string{"Enter"}) {
 		t.Fatalf("sent keys = %v, want [Enter]", sent)
+	}
+}
+
+func TestAcceptStartupDialogsSkipsCodexUpdateDialog(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(lines int) (string, error) {
+			if lines < 100 {
+				return "loading...", nil
+			}
+			return "✨ Update available! 0.124.0 -> 0.125.0\n" +
+				"› 1. Update now (runs `bun install -g @openai/codex`)\n" +
+				"  2. Skip\n" +
+				"  3. Skip until next version\n" +
+				"Press enter to continue", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Down,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
 	}
 }
 
@@ -485,6 +511,10 @@ func TestContainsPromptIndicator(t *testing.T) {
 		{name: "angle prompt", content: "claude >", want: true},
 		{name: "powerline prompt", content: "dir \u276f", want: true},
 		{name: "claude nbsp prompt", content: "❯\u00a0", want: true},
+		{name: "codex prompt", content: "›", want: true},
+		{name: "codex prompt with nbsp", content: "›\u00a0", want: true},
+		{name: "codex prompt with placeholder", content: "› Improve documentation in @filename", want: true},
+		{name: "claude prompt with text", content: "❯ run tests", want: true},
 		{name: "empty content", content: "", want: false},
 		{name: "no prompt", content: "loading...", want: false},
 		{name: "blank lines only", content: "\n\n", want: false},

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -182,6 +182,67 @@ func TestAcceptStartupDialogsSkipsCodexUpdateDialog(t *testing.T) {
 	}
 }
 
+func TestAcceptStartupDialogsSkipsUpdateThenHandlesTrustDialog(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	staleUpdateReturned := false
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(lines int) (string, error) {
+			if lines < 100 {
+				return "loading...", nil
+			}
+			switch {
+			case len(sent) < 2:
+				return codexUpdateDialogFixture(), nil
+			case !staleUpdateReturned:
+				staleUpdateReturned = true
+				return codexUpdateDialogFixture(), nil
+			case len(sent) == 2:
+				return "Do you trust the contents of this directory?", nil
+			default:
+				return "› Implement {feature}", nil
+			}
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs returned error: %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Down,Enter,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
+func TestAcceptStartupDialogsFromStreamSkipsCodexUpdateDialog(t *testing.T) {
+	var sent []string
+	snapshots := make(chan string, 2)
+	snapshots <- codexUpdateDialogFixture()
+	snapshots <- "› Implement {feature}"
+	close(snapshots)
+
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		time.Second,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if got, want := strings.Join(sent, ","), "Down,Enter"; got != want {
+		t.Fatalf("sent keys = %q, want %q", got, want)
+	}
+}
+
 func TestAcceptStartupDialogsAcceptsBypassPermissionsWarning(t *testing.T) {
 	withZeroDialogTimings(t)
 	dialogPollTimeout = time.Second
@@ -515,6 +576,7 @@ func TestContainsPromptIndicator(t *testing.T) {
 		{name: "codex prompt with nbsp", content: "›\u00a0", want: true},
 		{name: "codex prompt with placeholder", content: "› Improve documentation in @filename", want: true},
 		{name: "claude prompt with text", content: "❯ run tests", want: true},
+		{name: "codex numbered menu row", content: "› 1. Update now (runs `bun install -g @openai/codex`)", want: false},
 		{name: "empty content", content: "", want: false},
 		{name: "no prompt", content: "loading...", want: false},
 		{name: "blank lines only", content: "\n\n", want: false},
@@ -529,6 +591,14 @@ func TestContainsPromptIndicator(t *testing.T) {
 			}
 		})
 	}
+}
+
+func codexUpdateDialogFixture() string {
+	return "✨ Update available! 0.124.0 -> 0.125.0\n" +
+		"› 1. Update now (runs `bun install -g @openai/codex`)\n" +
+		"  2. Skip\n" +
+		"  3. Skip until next version\n" +
+		"Press enter to continue"
 }
 
 func TestExitsEarlyOnPrompt(t *testing.T) {


### PR DESCRIPTION
Adopts and supersedes https://github.com/gastownhall/gascity/pull/1345 because maintainer edits are disabled on the original PR.

Original PR: https://github.com/gastownhall/gascity/pull/1345
Original title: fix(codex): skip startup update dialog
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

Summary:
- Preserves Julian Knutsen's contributor change to skip the Codex startup update dialog.
- Adds a maintainer fix for the stream startup path so the Codex update menu is handled before workspace-trust readiness.
- Prevents Codex update or numbered menu rows from satisfying prompt readiness, and waits for stale update-dialog text to clear before later dialog phases.
- Skips the slow real-`bd init` process test under fast cmd/gc unit mode; full process coverage remains under the dedicated command.

Review synthesis:
- The original review blocked because exec-provider stream startup could report ready while still sitting on the Codex update menu.
- The review also called out a `› 1. Update now` false-positive prompt and stale update-dialog content after dismissal.
- Those blocker/major findings are addressed in the maintainer fixup commit.

Validation:
- `go test ./internal/runtime -count=1`
- `go test ./cmd/gc -run TestInitBeadsForDirExecPreventsStrayGitInit -count=1 -timeout=3m`

After this follow-up merges, the original PR should be closed as superseded.
