### PR TITLE
fix(config): make provider option aliases schema-driven

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -350,6 +350,7 @@ OptionChoice is one allowed value for a "select" option.
 | `value` | string | **yes** |  |  |
 | `label` | string | **yes** |  |  |
 | `flag_args` | []string | **yes** |  | FlagArgs are the CLI arguments injected when this choice is selected. json:"-" is intentional: FlagArgs must never appear in the public API DTO (security boundary — prevents clients from seeing internal CLI flags). |
+| `flag_aliases` | []array |  |  | FlagAliases are equivalent CLI argument sequences stripped from legacy provider args. Like FlagArgs, they stay server-side only. |
 
 ## OrderOverride
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1266,6 +1266,16 @@
           },
           "type": "array",
           "description": "FlagArgs are the CLI arguments injected when this choice is selected.\njson:\"-\" is intentional: FlagArgs must never appear in the public API DTO\n(security boundary — prevents clients from seeing internal CLI flags)."
+        },
+        "flag_aliases": {
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array",
+          "description": "FlagAliases are equivalent CLI argument sequences stripped from legacy\nprovider args. Like FlagArgs, they stay server-side only."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1266,6 +1266,16 @@
           },
           "type": "array",
           "description": "FlagArgs are the CLI arguments injected when this choice is selected.\njson:\"-\" is intentional: FlagArgs must never appear in the public API DTO\n(security boundary — prevents clients from seeing internal CLI flags)."
+        },
+        "flag_aliases": {
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "array",
+          "description": "FlagAliases are equivalent CLI argument sequences stripped from legacy\nprovider args. Like FlagArgs, they stay server-side only."
         }
       },
       "additionalProperties": false,

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -160,14 +160,71 @@ func ReplaceSchemaFlags(command string, schema []ProviderOption, overrideArgs []
 // independent flag group can be matched separately during stripping.
 func CollectAllSchemaFlags(schema []ProviderOption) [][]string {
 	var flags [][]string
+	seen := make(map[string]bool)
 	for _, opt := range schema {
 		for _, choice := range opt.Choices {
 			if len(choice.FlagArgs) > 0 {
-				flags = append(flags, splitFlagArgs(choice.FlagArgs)...)
+				for _, seq := range splitFlagArgs(choice.FlagArgs) {
+					for _, expanded := range expandEquivalentFlagSequences(seq) {
+						key := strings.Join(expanded, "\x00")
+						if seen[key] {
+							continue
+						}
+						seen[key] = true
+						flags = append(flags, expanded)
+					}
+				}
 			}
 		}
 	}
 	return flags
+}
+
+func expandEquivalentFlagSequences(seq []string) [][]string {
+	if len(seq) == 0 {
+		return nil
+	}
+	var out [][]string
+	add := func(candidate []string) {
+		copied := make([]string, len(candidate))
+		copy(copied, candidate)
+		out = append(out, copied)
+	}
+	add(seq)
+	if len(seq) == 2 && seq[0] == "--model" {
+		add([]string{"-m", seq[1]})
+	}
+	if len(seq) == 2 && seq[0] == "-m" {
+		add([]string{"--model", seq[1]})
+	}
+	if len(seq) == 2 && seq[0] == "-c" {
+		if quoted, ok := quoteAssignmentValue(seq[1]); ok {
+			add([]string{seq[0], quoted})
+		}
+		if unquoted, ok := unquoteAssignmentValue(seq[1]); ok {
+			add([]string{seq[0], unquoted})
+		}
+	}
+	return out
+}
+
+func quoteAssignmentValue(value string) (string, bool) {
+	key, val, ok := strings.Cut(value, "=")
+	if !ok || key == "" || val == "" || strings.HasPrefix(val, "\"") {
+		return "", false
+	}
+	return key + "=\"" + val + "\"", true
+}
+
+func unquoteAssignmentValue(value string) (string, bool) {
+	key, val, ok := strings.Cut(value, "=")
+	if !ok || key == "" || len(val) < 2 {
+		return "", false
+	}
+	if !strings.HasPrefix(val, "\"") || !strings.HasSuffix(val, "\"") {
+		return "", false
+	}
+	return key + "=" + strings.Trim(val, "\""), true
 }
 
 // splitFlagArgs splits a FlagArgs slice into independent flag groups at
@@ -290,12 +347,37 @@ func inferChoiceFromFlags(schema []ProviderOption, flagSeq []string, defaults ma
 			continue
 		}
 		for _, choice := range opt.Choices {
-			if flagsEqual(choice.FlagArgs, flagSeq) {
+			if flagsEquivalent(choice.FlagArgs, flagSeq) {
 				defaults[opt.Key] = choice.Value
 				return
 			}
 		}
 	}
+}
+
+func flagsEquivalent(a, b []string) bool {
+	if flagsEqual(a, b) {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if normalizeFlagToken(a[i]) != normalizeFlagToken(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeFlagToken(token string) string {
+	if token == "-m" {
+		return "--model"
+	}
+	if normalized, ok := unquoteAssignmentValue(token); ok {
+		return normalized
+	}
+	return token
 }
 
 func flagsEqual(a, b []string) bool {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -155,76 +155,34 @@ func ReplaceSchemaFlags(command string, schema []ProviderOption, overrideArgs []
 	return stripped
 }
 
-// CollectAllSchemaFlags gathers all FlagArgs from all choices across all options.
-// Multi-flag FlagArgs sequences are split at "--" boundaries so that each
-// independent flag group can be matched separately during stripping.
+// CollectAllSchemaFlags gathers all FlagArgs and FlagAliases from all choices
+// across all options. Multi-flag sequences are split at "--" boundaries so that
+// each independent flag group can be matched separately during stripping.
 func CollectAllSchemaFlags(schema []ProviderOption) [][]string {
 	var flags [][]string
 	seen := make(map[string]bool)
 	for _, opt := range schema {
 		for _, choice := range opt.Choices {
-			if len(choice.FlagArgs) > 0 {
-				for _, seq := range splitFlagArgs(choice.FlagArgs) {
-					for _, expanded := range expandEquivalentFlagSequences(seq) {
-						key := strings.Join(expanded, "\x00")
-						if seen[key] {
-							continue
-						}
-						seen[key] = true
-						flags = append(flags, expanded)
-					}
+			for _, seq := range choiceFlagSequences(choice) {
+				key := strings.Join(seq, "\x00")
+				if seen[key] {
+					continue
 				}
+				seen[key] = true
+				flags = append(flags, cloneStrings(seq))
 			}
 		}
 	}
 	return flags
 }
 
-func expandEquivalentFlagSequences(seq []string) [][]string {
-	if len(seq) == 0 {
-		return nil
+func choiceFlagSequences(choice OptionChoice) [][]string {
+	var sequences [][]string
+	sequences = append(sequences, splitFlagArgs(choice.FlagArgs)...)
+	for _, alias := range choice.FlagAliases {
+		sequences = append(sequences, splitFlagArgs(alias)...)
 	}
-	var out [][]string
-	add := func(candidate []string) {
-		copied := make([]string, len(candidate))
-		copy(copied, candidate)
-		out = append(out, copied)
-	}
-	add(seq)
-	if len(seq) == 2 && seq[0] == "--model" {
-		add([]string{"-m", seq[1]})
-	}
-	if len(seq) == 2 && seq[0] == "-m" {
-		add([]string{"--model", seq[1]})
-	}
-	if len(seq) == 2 && seq[0] == "-c" {
-		if quoted, ok := quoteAssignmentValue(seq[1]); ok {
-			add([]string{seq[0], quoted})
-		}
-		if unquoted, ok := unquoteAssignmentValue(seq[1]); ok {
-			add([]string{seq[0], unquoted})
-		}
-	}
-	return out
-}
-
-func quoteAssignmentValue(value string) (string, bool) {
-	key, val, ok := strings.Cut(value, "=")
-	if !ok || key == "" || val == "" || strings.HasPrefix(val, "\"") {
-		return "", false
-	}
-	return key + "=\"" + val + "\"", true
-}
-
-func unquoteAssignmentValue(value string) (string, bool) {
-	key, val, ok := strings.Cut(value, "=")
-	if !ok || key == "" || len(val) < 2 {
-		return "", false
-	}
-	if !strings.HasPrefix(val, "\"") || !strings.HasSuffix(val, "\"") {
-		return "", false
-	}
-	return key + "=" + strings.Trim(val, "\""), true
+	return sequences
 }
 
 // splitFlagArgs splits a FlagArgs slice into independent flag groups at
@@ -337,9 +295,9 @@ func stripArgsSlice(args []string, flags [][]string, schema []ProviderOption, in
 	return result
 }
 
-// inferChoiceFromFlags finds which schema option+choice produced the given
-// flag sequence and, if the key is not already present in defaults, sets
-// the inferred value. Only infers from exact full-FlagArgs matches to
+// inferChoiceFromFlags finds which schema option+choice produced the given flag
+// sequence and, if the key is not already present in defaults, sets the
+// inferred value. Only infers from exact full FlagArgs or FlagAliases matches to
 // avoid ambiguity with partial multi-flag matches.
 func inferChoiceFromFlags(schema []ProviderOption, flagSeq []string, defaults map[string]string) {
 	for _, opt := range schema {
@@ -347,7 +305,7 @@ func inferChoiceFromFlags(schema []ProviderOption, flagSeq []string, defaults ma
 			continue
 		}
 		for _, choice := range opt.Choices {
-			if flagsEquivalent(choice.FlagArgs, flagSeq) {
+			if choiceHasFlagSequence(choice, flagSeq) {
 				defaults[opt.Key] = choice.Value
 				return
 			}
@@ -355,29 +313,26 @@ func inferChoiceFromFlags(schema []ProviderOption, flagSeq []string, defaults ma
 	}
 }
 
-func flagsEquivalent(a, b []string) bool {
-	if flagsEqual(a, b) {
-		return true
-	}
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if normalizeFlagToken(a[i]) != normalizeFlagToken(b[i]) {
-			return false
+func choiceHasFlagSequence(choice OptionChoice, flagSeq []string) bool {
+	for _, seq := range choiceFullFlagSequences(choice) {
+		if flagsEqual(seq, flagSeq) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-func normalizeFlagToken(token string) string {
-	if token == "-m" {
-		return "--model"
+func choiceFullFlagSequences(choice OptionChoice) [][]string {
+	var sequences [][]string
+	if len(choice.FlagArgs) > 0 {
+		sequences = append(sequences, choice.FlagArgs)
 	}
-	if normalized, ok := unquoteAssignmentValue(token); ok {
-		return normalized
+	for _, alias := range choice.FlagAliases {
+		if len(alias) > 0 {
+			sequences = append(sequences, alias)
+		}
 	}
-	return token
+	return sequences
 }
 
 func flagsEqual(a, b []string) bool {

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -118,6 +118,34 @@ func TestResolveOptions_EffectiveDefaultsOverrideSchemaDefaults(t *testing.T) {
 	}
 }
 
+func TestReplaceSchemaFlagsStripsCodexAliases(t *testing.T) {
+	codex := BuiltinProviders()["codex"]
+	defaultArgs := []string{
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--model", "gpt-5.5",
+		"-c", "model_reasoning_effort=xhigh",
+	}
+
+	got := ReplaceSchemaFlags(
+		`aimux run codex -- -m gpt-5.5 -c 'model_reasoning_effort="xhigh"'`,
+		codex.OptionsSchema,
+		defaultArgs,
+	)
+
+	if strings.Count(got, "gpt-5.5") != 1 {
+		t.Fatalf("ReplaceSchemaFlags() = %q, want one model flag", got)
+	}
+	if strings.Count(got, "model_reasoning_effort") != 1 {
+		t.Fatalf("ReplaceSchemaFlags() = %q, want one effort flag", got)
+	}
+	if !strings.Contains(got, "--model gpt-5.5") {
+		t.Fatalf("ReplaceSchemaFlags() = %q, want canonical model flag", got)
+	}
+	if strings.Contains(got, "-m gpt-5.5") || strings.Contains(got, `model_reasoning_effort=\"xhigh\"`) {
+		t.Fatalf("ReplaceSchemaFlags() = %q, retained non-canonical schema flag", got)
+	}
+}
+
 func TestResolveOptions_UserOptionOverridesEffectiveDefault(t *testing.T) {
 	schema := []ProviderOption{
 		{

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -143,6 +144,73 @@ func TestReplaceSchemaFlagsStripsCodexAliases(t *testing.T) {
 	}
 	if strings.Contains(got, "-m gpt-5.5") || strings.Contains(got, `model_reasoning_effort=\"xhigh\"`) {
 		t.Fatalf("ReplaceSchemaFlags() = %q, retained non-canonical schema flag", got)
+	}
+}
+
+func TestCollectAllSchemaFlagsUsesDeclaredFlagAliases(t *testing.T) {
+	schema := []ProviderOption{
+		{
+			Key: "model",
+			Choices: []OptionChoice{
+				{
+					Value:       "opus",
+					FlagArgs:    []string{"--model", "opus"},
+					FlagAliases: [][]string{{"-m", "opus"}},
+				},
+			},
+		},
+	}
+
+	flags := CollectAllSchemaFlags(schema)
+	got := StripFlags("agent -m opus --other", flags)
+
+	if got != "agent --other" {
+		t.Fatalf("StripFlags() = %q, want alias stripped", got)
+	}
+}
+
+func TestCollectAllSchemaFlagsDoesNotInferUndeclaredProviderAliases(t *testing.T) {
+	schema := []ProviderOption{
+		{
+			Key: "model",
+			Choices: []OptionChoice{
+				{Value: "opus", FlagArgs: []string{"--model", "opus"}},
+			},
+		},
+	}
+
+	flags := CollectAllSchemaFlags(schema)
+	got := StripFlags("agent -m opus --other", flags)
+
+	if got != "agent -m opus --other" {
+		t.Fatalf("StripFlags() = %q, want undeclared alias preserved", got)
+	}
+}
+
+func TestStripArgsSliceInfersChoiceFromDeclaredAlias(t *testing.T) {
+	schema := []ProviderOption{
+		{
+			Key: "model",
+			Choices: []OptionChoice{
+				{
+					Value:       "opus",
+					FlagArgs:    []string{"--model", "opus"},
+					FlagAliases: [][]string{{"-m", "opus"}},
+				},
+			},
+		},
+	}
+	flags := CollectAllSchemaFlags(schema)
+	inferred := make(map[string]string)
+
+	got := stripArgsSlice([]string{"run", "-m", "opus", "--other"}, flags, schema, inferred)
+
+	want := []string{"run", "--other"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stripArgsSlice() = %v, want %v", got, want)
+	}
+	if inferred["model"] != "opus" {
+		t.Fatalf("inferred model = %q, want opus", inferred["model"])
 	}
 }
 

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1584,6 +1584,7 @@ func deepCopyOptionChoices(in []OptionChoice) []OptionChoice {
 	for i := range in {
 		out[i] = in[i]
 		out[i].FlagArgs = append([]string(nil), in[i].FlagArgs...)
+		out[i].FlagAliases = cloneStringSlices(in[i].FlagAliases)
 	}
 	return out
 }

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -29,6 +29,9 @@ type OptionChoice struct {
 	// json:"-" is intentional: FlagArgs must never appear in the public API DTO
 	// (security boundary — prevents clients from seeing internal CLI flags).
 	FlagArgs []string `toml:"flag_args" json:"-"`
+	// FlagAliases are equivalent CLI argument sequences stripped from legacy
+	// provider args. Like FlagArgs, they stay server-side only.
+	FlagAliases [][]string `toml:"flag_aliases,omitempty" json:"-"`
 }
 
 // ProviderSpec defines a named provider's startup parameters.
@@ -411,9 +414,10 @@ func providerChoicesFromWorker(choices []workerbuiltin.BuiltinOptionChoice) []Op
 	out := make([]OptionChoice, len(choices))
 	for i, choice := range choices {
 		out[i] = OptionChoice{
-			Value:    choice.Value,
-			Label:    choice.Label,
-			FlagArgs: cloneStrings(choice.FlagArgs),
+			Value:       choice.Value,
+			Label:       choice.Label,
+			FlagArgs:    cloneStrings(choice.FlagArgs),
+			FlagAliases: cloneStringSlices(choice.FlagAliases),
 		}
 	}
 	return out
@@ -436,5 +440,16 @@ func cloneStrings(values []string) []string {
 	}
 	out := make([]string, len(values))
 	copy(out, values)
+	return out
+}
+
+func cloneStringSlices(values [][]string) [][]string {
+	if values == nil {
+		return nil
+	}
+	out := make([][]string, len(values))
+	for i := range values {
+		out[i] = cloneStrings(values[i])
+	}
 	return out
 }

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -507,6 +507,9 @@ func specToResolved(name string, spec *ProviderSpec) *ResolvedProvider {
 						rp.OptionsSchema[i].Choices[j].FlagArgs = make([]string, len(c.FlagArgs))
 						copy(rp.OptionsSchema[i].Choices[j].FlagArgs, c.FlagArgs)
 					}
+					if len(c.FlagAliases) > 0 {
+						rp.OptionsSchema[i].Choices[j].FlagAliases = cloneStringSlices(c.FlagAliases)
+					}
 				}
 			}
 		}
@@ -734,7 +737,7 @@ func resolvedChainToSpec(r ResolvedProvider, leaf ProviderSpec) ProviderSpec {
 		}
 	}
 	if r.OptionsSchema != nil {
-		out.OptionsSchema = append([]ProviderOption(nil), r.OptionsSchema...)
+		out.OptionsSchema = deepCopyProviderOptions(r.OptionsSchema)
 	}
 	// EffectiveDefaults on ResolvedProvider is the merged defaults; fold
 	// into OptionDefaults on the spec so downstream specToResolved picks

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -627,6 +628,48 @@ func TestResolveProviderBaseChainEmitsDangerousBypass(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("ResolveDefaultArgs() = %v, missing %q — session would hang on first sandboxed command", args, want)
+	}
+}
+
+func TestResolveProviderBaseChainStripsCodexAliases(t *testing.T) {
+	b := "builtin:codex"
+	city := map[string]ProviderSpec{
+		"codex-max": {
+			Base:    &b,
+			Command: "aimux",
+			Args: []string{
+				"run", "codex", "--",
+				"--dangerously-bypass-approvals-and-sandbox",
+				"-m", "gpt-5.5",
+				"-c", "model_reasoning_effort=\"xhigh\"",
+			},
+			ResumeCommand: "aimux run codex -- --dangerously-bypass-approvals-and-sandbox -m gpt-5.5 resume {{.SessionKey}}",
+		},
+	}
+	agent := &Agent{Name: "codex-max", Provider: "codex-max"}
+	resolved, err := ResolveProvider(agent, nil, city, lookPathAll)
+	if err != nil {
+		t.Fatalf("ResolveProvider: %v", err)
+	}
+	wantArgs := []string{"run", "codex", "--"}
+	if !reflect.DeepEqual(resolved.Args, wantArgs) {
+		t.Fatalf("Args = %v, want %v", resolved.Args, wantArgs)
+	}
+	if got := resolved.EffectiveDefaults["model"]; got != "gpt-5.5" {
+		t.Fatalf("EffectiveDefaults[model] = %q, want gpt-5.5", got)
+	}
+	if got := resolved.EffectiveDefaults["effort"]; got != "xhigh" {
+		t.Fatalf("EffectiveDefaults[effort] = %q, want xhigh", got)
+	}
+	command := resolved.CommandString()
+	if defaultArgs := resolved.ResolveDefaultArgs(); len(defaultArgs) > 0 {
+		command = command + " " + strings.Join(defaultArgs, " ")
+	}
+	if strings.Count(command, "gpt-5.5") != 1 {
+		t.Fatalf("resolved launch command = %q, want one model flag", command)
+	}
+	if strings.Count(command, "model_reasoning_effort") != 1 {
+		t.Fatalf("resolved launch command = %q, want one effort flag", command)
 	}
 }
 

--- a/internal/config/resolved_cache.go
+++ b/internal/config/resolved_cache.go
@@ -183,6 +183,9 @@ func deepCopyResolvedProvider(r ResolvedProvider) ResolvedProvider {
 					if c.FlagArgs != nil {
 						nc.FlagArgs = append([]string(nil), c.FlagArgs...)
 					}
+					if c.FlagAliases != nil {
+						nc.FlagAliases = cloneStringSlices(c.FlagAliases)
+					}
 					nopt.Choices[j] = nc
 				}
 			}

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -22,9 +22,10 @@ type BuiltinProviderOption struct {
 //
 //nolint:revive // Mirrors the config boundary naming intentionally.
 type BuiltinOptionChoice struct {
-	Value    string
-	Label    string
-	FlagArgs []string
+	Value       string
+	Label       string
+	FlagArgs    []string
+	FlagAliases [][]string
 }
 
 // BuiltinProviderSpec is the canonical builtin worker materialization source.
@@ -139,9 +140,9 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
-					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-6"}},
-					{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}},
-					{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "claude-haiku-4-5-20251001"}},
+					{Value: "opus", Label: "Opus", FlagArgs: []string{"--model", "claude-opus-4-6"}, FlagAliases: [][]string{{"-m", "claude-opus-4-6"}}},
+					{Value: "sonnet", Label: "Sonnet", FlagArgs: []string{"--model", "claude-sonnet-4-6"}, FlagAliases: [][]string{{"-m", "claude-sonnet-4-6"}}},
+					{Value: "haiku", Label: "Haiku", FlagArgs: []string{"--model", "claude-haiku-4-5-20251001"}, FlagAliases: [][]string{{"-m", "claude-haiku-4-5-20251001"}}},
 				},
 			},
 		},
@@ -187,9 +188,9 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
-					{Value: "gpt-5.5", Label: "GPT-5.5", FlagArgs: []string{"--model", "gpt-5.5"}},
-					{Value: "o3", Label: "o3", FlagArgs: []string{"--model", "o3"}},
-					{Value: "o4-mini", Label: "o4-mini", FlagArgs: []string{"--model", "o4-mini"}},
+					{Value: "gpt-5.5", Label: "GPT-5.5", FlagArgs: []string{"--model", "gpt-5.5"}, FlagAliases: [][]string{{"-m", "gpt-5.5"}}},
+					{Value: "o3", Label: "o3", FlagArgs: []string{"--model", "o3"}, FlagAliases: [][]string{{"-m", "o3"}}},
+					{Value: "o4-mini", Label: "o4-mini", FlagArgs: []string{"--model", "o4-mini"}, FlagAliases: [][]string{{"-m", "o4-mini"}}},
 				},
 			},
 			{
@@ -208,10 +209,10 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
-					{Value: "low", Label: "Low", FlagArgs: []string{"-c", "model_reasoning_effort=low"}},
-					{Value: "medium", Label: "Medium", FlagArgs: []string{"-c", "model_reasoning_effort=medium"}},
-					{Value: "high", Label: "High", FlagArgs: []string{"-c", "model_reasoning_effort=high"}},
-					{Value: "xhigh", Label: "Extra High", FlagArgs: []string{"-c", "model_reasoning_effort=xhigh"}},
+					{Value: "low", Label: "Low", FlagArgs: []string{"-c", "model_reasoning_effort=low"}, FlagAliases: [][]string{{"-c", "model_reasoning_effort=\"low\""}}},
+					{Value: "medium", Label: "Medium", FlagArgs: []string{"-c", "model_reasoning_effort=medium"}, FlagAliases: [][]string{{"-c", "model_reasoning_effort=\"medium\""}}},
+					{Value: "high", Label: "High", FlagArgs: []string{"-c", "model_reasoning_effort=high"}, FlagAliases: [][]string{{"-c", "model_reasoning_effort=\"high\""}}},
+					{Value: "xhigh", Label: "Extra High", FlagArgs: []string{"-c", "model_reasoning_effort=xhigh"}, FlagAliases: [][]string{{"-c", "model_reasoning_effort=\"xhigh\""}}},
 				},
 			},
 		},
@@ -257,8 +258,8 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Type:  "select",
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
-					{Value: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", FlagArgs: []string{"--model", "gemini-2.5-pro"}},
-					{Value: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", FlagArgs: []string{"--model", "gemini-2.5-flash"}},
+					{Value: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", FlagArgs: []string{"--model", "gemini-2.5-pro"}, FlagAliases: [][]string{{"-m", "gemini-2.5-pro"}}},
+					{Value: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", FlagArgs: []string{"--model", "gemini-2.5-flash"}, FlagAliases: [][]string{{"-m", "gemini-2.5-flash"}}},
 				},
 			},
 		},
@@ -420,9 +421,10 @@ func cloneBuiltinChoices(choices []BuiltinOptionChoice) []BuiltinOptionChoice {
 	out := make([]BuiltinOptionChoice, len(choices))
 	for i, choice := range choices {
 		out[i] = BuiltinOptionChoice{
-			Value:    choice.Value,
-			Label:    choice.Label,
-			FlagArgs: cloneStrings(choice.FlagArgs),
+			Value:       choice.Value,
+			Label:       choice.Label,
+			FlagArgs:    cloneStrings(choice.FlagArgs),
+			FlagAliases: cloneStringSlices(choice.FlagAliases),
 		}
 	}
 	return out
@@ -445,5 +447,16 @@ func cloneStrings(values []string) []string {
 	}
 	out := make([]string, len(values))
 	copy(out, values)
+	return out
+}
+
+func cloneStringSlices(values [][]string) [][]string {
+	if values == nil {
+		return nil
+	}
+	out := make([][]string, len(values))
+	for i := range values {
+		out[i] = cloneStrings(values[i])
+	}
 	return out
 }


### PR DESCRIPTION
## Summary
- carries forward the contributor fix from #1343 for provider option alias normalization
- moves equivalent provider flag forms into schema/profile data instead of hardcoded generic config branches
- adds regression coverage for declared aliases, undeclared alias preservation, and inherited provider args inference

## Original PR Context
- Original PR: https://github.com/gastownhall/gascity/pull/1343
- Original title: fix(config): normalize provider option flag aliases
- Original state at adoption finalize: OPEN
- Configured base branch: main
- Original GitHub base branch: main
- Base mismatch: none
- Original head SHA recorded: 0ae70ca21f6eec25d6b8ff36754760fc0673a869
- Adopted upstream base: ee69f95e6f226d85a7e9ae37153cfa2d27b68836
- Final adopted head: 0b2692b70d088f97e1bb707236d85cc05b62720d

## Review Synthesis
The multi-review pass found one architectural issue in the original PR: provider-specific alias behavior had landed in generic config option stripping. The follow-up commit makes aliases schema-driven through declared `FlagAliases` and removes the hardcoded `-m` / quoted `-c` normalization branches from the generic config path.

Final Codex re-review found no new issues. Claude's remaining note about exact quote trimming was addressed by removing the generic quote-normalization helper entirely in favor of declared aliases.

## Tests
- `go test ./internal/config -run 'TestReplaceSchemaFlagsStripsCodexAliases|TestResolveProviderBaseChainStripsCodexAliases|TestResolveProviderBaseChainEmitsDangerousBypass|TestResolveOptions'`
- `go test ./internal/config`
- `git diff --check refs/adopt-pr/ga-8ingw/upstream-base...HEAD`

Full `go test ./...` was attempted during review but failed on unrelated local rig/store/runtime environment issues; touched-package tests passed.
