### PR TITLE
fix(dispatch): close cross-store source beads on successful workflow finalize

### DIFF
--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -1803,6 +1803,36 @@ func TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure(t *testi
 		t.Fatalf("workflow result = %+v, want processed workflow-fail", result)
 	}
 
+	rigRootAfter, err := rigStore.Get(workflow.ID)
+	if err != nil {
+		t.Fatalf("get workflow root: %v", err)
+	}
+	if rigRootAfter.Status != "closed" {
+		t.Fatalf("workflow root status = %q, want closed", rigRootAfter.Status)
+	}
+	if got := rigRootAfter.Metadata["gc.outcome"]; got != "fail" {
+		t.Errorf("workflow root gc.outcome = %q, want %q", got, "fail")
+	}
+
+	finalizerAfter, err := rigStore.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("get workflow finalizer: %v", err)
+	}
+	if finalizerAfter.Status != "closed" {
+		t.Fatalf("workflow finalizer status = %q, want closed", finalizerAfter.Status)
+	}
+	if got := finalizerAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Errorf("workflow finalizer gc.outcome = %q, want %q", got, "pass")
+	}
+
+	rigLaunchAfter, err := rigStore.Get(rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("get rig launch bead: %v", err)
+	}
+	if rigLaunchAfter.Status == "closed" {
+		t.Fatalf("rig launch bead status = closed; want still open on failed workflow")
+	}
+
 	citySourceAfter, err := cityStore.Get(citySource.ID)
 	if err != nil {
 		t.Fatalf("get city source bead: %v", err)
@@ -1810,6 +1840,200 @@ func TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure(t *testi
 	if citySourceAfter.Status == "closed" {
 		t.Fatalf("city source bead status = closed; want still open on failed workflow so the human can act on the failure")
 	}
+}
+
+func TestProcessWorkflowFinalizeKeepsFinalizerOpenWhenSourceResolverFails(t *testing.T) {
+	t.Parallel()
+
+	rigStore := beads.NewMemStore()
+
+	rigLaunch := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Adopt PR workflow: gastownhall/example#3",
+		Type:  "task",
+	})
+
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   rigLaunch.ID,
+			"gc.source_store_ref": "rig:test",
+		},
+	})
+
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	_, err := ProcessControl(rigStore, finalizer, ProcessOptions{
+		ResolveStoreRef: func(ref string) (beads.Store, error) {
+			return nil, fmt.Errorf("resolver offline for %s", ref)
+		},
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) error = nil, want resolver failure")
+	}
+	if !strings.Contains(err.Error(), "resolver offline for rig:test") {
+		t.Fatalf("ProcessControl(workflow-finalize) error = %v, want resolver failure context", err)
+	}
+
+	finalizerAfter, err := rigStore.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("get workflow finalizer: %v", err)
+	}
+	if finalizerAfter.Status != "open" {
+		t.Fatalf("workflow finalizer status = %q, want open so source-chain closure can retry", finalizerAfter.Status)
+	}
+
+	rigLaunchAfter, err := rigStore.Get(rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("get rig launch bead: %v", err)
+	}
+	if rigLaunchAfter.Status != "open" {
+		t.Fatalf("rig launch bead status = %q, want open after resolver failure", rigLaunchAfter.Status)
+	}
+}
+
+func TestProcessWorkflowFinalizeKeepsFinalizerOpenWhenSourceStoreReadFails(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#4",
+		Type:  "task",
+	})
+
+	rigLaunch := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Adopt PR workflow: gastownhall/example#4",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   rigLaunch.ID,
+			"gc.source_store_ref": "rig:test",
+		},
+	})
+
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return getFailStore{
+				Store:  cityStore,
+				failID: citySource.ID,
+				err:    fmt.Errorf("city store read failed"),
+			}, nil
+		case "rig:test":
+			return rigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+
+	_, err := ProcessControl(rigStore, finalizer, ProcessOptions{
+		ResolveStoreRef: resolver,
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) error = nil, want source-store read failure")
+	}
+	if !strings.Contains(err.Error(), "city store read failed") {
+		t.Fatalf("ProcessControl(workflow-finalize) error = %v, want source-store read failure context", err)
+	}
+
+	finalizerAfter, err := rigStore.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("get workflow finalizer: %v", err)
+	}
+	if finalizerAfter.Status != "open" {
+		t.Fatalf("workflow finalizer status = %q, want open so source-chain closure can retry", finalizerAfter.Status)
+	}
+
+	workflowAfter, err := rigStore.Get(workflow.ID)
+	if err != nil {
+		t.Fatalf("get workflow root: %v", err)
+	}
+	if workflowAfter.Status != "open" {
+		t.Fatalf("workflow root status = %q, want open because source-chain preflight failed", workflowAfter.Status)
+	}
+
+	rigLaunchAfter, err := rigStore.Get(rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("get rig launch bead: %v", err)
+	}
+	if rigLaunchAfter.Status != "open" {
+		t.Fatalf("rig launch bead status = %q, want open because source-chain preflight failed", rigLaunchAfter.Status)
+	}
+
+	citySourceAfter, err := cityStore.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source bead: %v", err)
+	}
+	if citySourceAfter.Status != "open" {
+		t.Fatalf("city source bead status = %q, want open after source-store read failure", citySourceAfter.Status)
+	}
+}
+
+type getFailStore struct {
+	beads.Store
+	failID string
+	err    error
+}
+
+func (s getFailStore) Get(id string) (beads.Bead, error) {
+	if id == s.failID {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
 }
 
 func TestProcessRalphCheckRetriesThenPasses(t *testing.T) {


### PR DESCRIPTION
## Summary

When a graph workflow finalizes with `outcome=pass`, walk the `gc.source_bead_id` chain (across stores via `gc.source_store_ref`) and close every parent source bead in its native store. Without this, the city-scope source bead that spawned a rig-scope graph workflow stays open forever even after the workflow root is fully closed.

## The bug

PR-review (`mol-adopt-pr-v2`) is the canonical case: the city store holds the human-visible "Adopt PR" source bead, the rig store holds the launch bead and workflow root. Today the operator agent closes the rig launch bead and the workflow finalizer closes the rig workflow root, but **nothing reaches back across the city/rig boundary to close the city source bead**. They accumulate as orphans even on successful merge.

Recent live evidence on the maintainer-city: five PRs (#1344, #1346, #1347, #1348, #1350) had to be `gc bd close`'d by hand after their workflows finished (3 merged, 2 closed). All five rig launch beads + workflow roots were ✓ closed; only the city source beads were stuck open with `pr_review.workflow_status=completed`. Same pattern, different symptom from the worker-churn bug fixed in #1389.

## Mechanism

- `dispatch.ProcessOptions` gains `ResolveStoreRef func(ref string) (beads.Store, error)` — nil-safe; single-store callers and tests without resolvers continue to work.
- `processWorkflowFinalize` (`internal/dispatch/runtime.go`) walks `gc.source_bead_id` from the workflow root upward, resolving each `gc.source_store_ref` to a store via the callback. Each parent source bead is closed with `gc.outcome=pass`. Already-closed beads are no-ops, so a partial-crash retry converges to the same state.
- The control-dispatcher (`cmd/gc/cmd_convoy_dispatch.go`) supplies a resolver that maps `"city:<name>"` to the city store and `"rig:<name>"` to the matching rig store from the city config.

## Asymmetric failure semantics — by design

A workflow that ends with `outcome=fail` deliberately leaves parent sources open so a human can act on the failure from the human-visible queue. The bead IS the audit handle. Pinned by `TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure`.

## What this needs from upstream

For PR-review specifically, the workflows-pack router (`packs/workflows/scripts/pr_review.py:create_rig_launch_bead`) currently stamps `pr_review.city_source_bead_id` and `pr_review.city_source_city` on the rig launch bead. To wire up the cross-store closure, the router should additionally stamp generic `gc.source_bead_id=<city-source-id>` and `gc.source_store_ref=city:<city-name>` on the launch bead. That's a separate (small) change in the workflows pack repo and is not included in this PR.

## Test plan

- [x] New: `TestProcessWorkflowFinalizeClosesCrossStoreSourceBead` — happy path with two MemStore instances.
- [x] New: `TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure` — failure-side contract.
- [x] Existing: `TestProcessWorkflowFinalizeClosesWorkflow` still passes (no regression on the single-store path).
- [x] `go test ./internal/dispatch/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)