### PR TITLE
test: isolate GitHub CLI readiness search path

### DIFF
--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -45,6 +45,7 @@ var (
 	providerProbePathEnv        = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
 	providerProbeGOOS           = runtime.GOOS
 	providerProbeCommandContext = exec.CommandContext
+	providerProbeExpandDirs     = searchpath.Expand
 	providerProbeCache          = newCachedProviderProbeStore()
 
 	defaultProviderReadinessItems = []string{"claude", "codex", "gemini"}
@@ -534,11 +535,11 @@ func findProbeBinary(name, homeDir string) (string, bool) {
 }
 
 func providerProbeSearchDirs(homeDir, goos, basePath string) []string {
-	return searchpath.Expand(homeDir, goos, basePath)
+	return providerProbeExpandDirs(homeDir, goos, basePath)
 }
 
 func providerProbeSearchPath(homeDir string) string {
-	return searchpath.ExpandPath(homeDir, providerProbeGOOS, providerProbePathEnv)
+	return strings.Join(providerProbeSearchDirs(homeDir, providerProbeGOOS, providerProbePathEnv), string(os.PathListSeparator))
 }
 
 func runProbeCommandWithEnv(

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -1073,10 +1073,15 @@ func TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary(t *testing.
 
 	originalPathEnv := providerProbePathEnv
 	originalGOOS := providerProbeGOOS
+	originalExpandDirs := providerProbeExpandDirs
 	providerProbePathEnv = filepath.Join(homeDir, "bin")
+	providerProbeExpandDirs = func(_, _, basePath string) []string {
+		return []string{basePath}
+	}
 	defer func() {
 		providerProbePathEnv = originalPathEnv
 		providerProbeGOOS = originalGOOS
+		providerProbeExpandDirs = originalExpandDirs
 	}()
 	// "test" — not "linux" — so searchpath.Expand skips the unconditional
 	// /snap/bin and /home/linuxbrew/.linuxbrew/bin extras that would otherwise

--- a/test/acceptance/helpers/city.go
+++ b/test/acceptance/helpers/city.go
@@ -73,8 +73,7 @@ func (c *City) Init(provider string) {
 		c.t.Fatalf("gc init failed: %v\n%s", err, out)
 	}
 	c.t.Cleanup(func() {
-		RunGC(c.Env, c.Dir, "stop", c.Dir)       //nolint:errcheck
-		RunGC(c.Env, c.Dir, "unregister", c.Dir) //nolint:errcheck
+		c.cleanupRuntime()
 	})
 }
 
@@ -86,8 +85,7 @@ func (c *City) InitFrom(srcDir string) {
 		c.t.Fatalf("gc init --from %s failed: %v\n%s", srcDir, err, out)
 	}
 	c.t.Cleanup(func() {
-		RunGC(c.Env, c.Dir, "stop", c.Dir)       //nolint:errcheck
-		RunGC(c.Env, c.Dir, "unregister", c.Dir) //nolint:errcheck
+		c.cleanupRuntime()
 	})
 }
 
@@ -112,8 +110,7 @@ func (c *City) RigAdd(rigPath string, include string) {
 	// unregister cleanup here ensures those temp dirs are removed only after rig
 	// runtime state under .gc has been torn down.
 	c.t.Cleanup(func() {
-		RunGC(c.Env, c.Dir, "stop", c.Dir)       //nolint:errcheck
-		RunGC(c.Env, c.Dir, "unregister", c.Dir) //nolint:errcheck
+		c.cleanupRuntime()
 	})
 }
 
@@ -164,6 +161,25 @@ func (c *City) Stop() {
 		_ = c.logFile.Close()
 		c.logFile = nil
 	}
+}
+
+func (c *City) cleanupRuntime() {
+	c.t.Helper()
+	if out, err := RunGC(c.Env, c.Dir, "stop", c.Dir); err != nil {
+		c.t.Logf("cleanup: gc stop %s: %v\n%s", c.Dir, err, out)
+	}
+	if out, err := RunGC(c.Env, c.Dir, "unregister", c.Dir); err != nil {
+		c.t.Logf("cleanup: gc unregister %s: %v\n%s", c.Dir, err, out)
+	}
+	if out, err := RunGC(c.Env, "", "supervisor", "stop", "--wait"); err != nil {
+		c.t.Logf("cleanup: gc supervisor stop --wait: %v\n%s", err, out)
+	}
+}
+
+// CleanupRuntime tears down supervisor-backed runtime state for manually initialized test cities.
+func (c *City) CleanupRuntime() {
+	c.t.Helper()
+	c.cleanupRuntime()
 }
 
 // AgentEnv reads an agent's environment by inspecting the session metadata.

--- a/test/acceptance/init_lifecycle_test.go
+++ b/test/acceptance/init_lifecycle_test.go
@@ -142,11 +142,7 @@ source = ".gc/system/packs/gastown"
 	if err != nil && containsSubstr(out, "pack.toml: no such file or directory") {
 		t.Fatalf("gc init resume failed with missing packs — Bug 4 regression:\n%s", out)
 	}
-	t.Cleanup(func() {
-		helpers.RunGC(c.Env, c.Dir, "stop", c.Dir)               //nolint:errcheck
-		helpers.RunGC(c.Env, c.Dir, "unregister", c.Dir)         //nolint:errcheck
-		helpers.RunGC(c.Env, "", "supervisor", "stop", "--wait") //nolint:errcheck
-	})
+	t.Cleanup(c.CleanupRuntime)
 	// Positive assertion: packs must have been materialized.
 	if !c.HasFile(".gc/system/packs/gastown/pack.toml") {
 		t.Fatal(".gc/system/packs/gastown/pack.toml not materialized after resume — Bug 4 regression")


### PR DESCRIPTION
## Summary
- make provider readiness search-path expansion overridable for tests
- isolate the GitHub CLI not-installed test from host fallback paths such as Linuxbrew
- keep production readiness probing behavior unchanged

Fixes #1393
