### PR TITLE
fix: default managed bd beads role

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3643,6 +3643,156 @@ esac
 	}
 }
 
+func TestGcBeadsBdInitDefaultsBeadsRoleOnFreshInit(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	argsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+case "${1:-}" in
+  init)
+    printf '%%s\n' "$*" > %q
+    last=""
+    for arg in "$@"; do
+      last="$arg"
+    done
+    mkdir -p "$last/.beads"
+    cat > "$last/.beads/metadata.json" <<'JSON'
+{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gascity","project_id":"fresh-project"}
+JSON
+    exit 0
+    ;;
+  config|migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, argsFile)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
+	cmd.Env = sanitizedBaseEnv(
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read bd init args: %v", err)
+	}
+	args := string(data)
+	if !strings.Contains(args, "--role maintainer") {
+		t.Fatalf("bd init args = %q, want --role maintainer", args)
+	}
+}
+
+func TestGcBeadsBdInitDefaultsBeadsRoleOnMetadataFastPath(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"gascity","project_id":"existing-project"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := `#!/bin/sh
+set -eu
+case "${1:-}" in
+  init)
+    exit 99
+    ;;
+  config|migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	roleFile := filepath.Join(t.TempDir(), "role-config")
+	fakeGit := filepath.Join(binDir, "git")
+	fakeGitScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+if [ "$1" = "config" ] && [ "$2" = "--local" ] && [ "$3" = "--get" ] && [ "$4" = "beads.role" ]; then
+  exit 1
+fi
+if [ "$1" = "config" ] && [ "$2" = "--local" ] && [ "$3" = "beads.role" ] && [ "$4" = "maintainer" ]; then
+  printf 'set-local-maintainer\n' > %q
+  exit 0
+fi
+exit 0
+`, roleFile)
+	if err := os.WriteFile(fakeGit, []byte(fakeGitScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
+	cmd.Env = sanitizedBaseEnv(
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(roleFile)
+	if err != nil {
+		t.Fatalf("read role config marker: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "set-local-maintainer" {
+		t.Fatalf("role config marker = %q, want set-local-maintainer", got)
+	}
+}
+
 func TestGcBeadsBdInitFailsWhenBeadsDirPermissionsCannotBeTightened(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1637,6 +1637,16 @@ run_bd_pinned() {
     )
 }
 
+ensure_beads_role() {
+    local dir="$1"
+    (
+        cd "$dir" || exit 0
+        command -v git >/dev/null 2>&1 || exit 0
+        git config --local --get beads.role >/dev/null 2>&1 && exit 0
+        git config --local beads.role maintainer >/dev/null 2>&1 || true
+    )
+}
+
 ensure_beads_dir_permissions() {
     local dir="$1"
     local beads_dir="$dir/.beads"
@@ -1746,6 +1756,7 @@ op_init() {
             # and bd-specific bootstrap only.
             ensure_beads_dir_permissions "$dir"
             normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
+            ensure_beads_role "$dir"
             run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null || true
             run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
             backfill_project_id_if_missing "$dir"
@@ -1775,7 +1786,7 @@ op_init() {
     fi
 
     # Run bd init in server mode.
-    (cd "$dir" && bd init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT"         "$dir") || die "bd init failed for $dir"
+    (cd "$dir" && bd init --quiet --role maintainer --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT"         "$dir") || die "bd init failed for $dir"
 
     # Drop orphan database created by bd init (upstream gt-sv1h).
     # bd init --prefix creates beads_<prefix> on the Dolt server, but we
@@ -1788,6 +1799,7 @@ op_init() {
     # GC owns canonical metadata/config normalization after this backend
     # bridge returns. Keep bd-specific config/migration here only.
     ensure_beads_dir_permissions "$dir"
+    ensure_beads_role "$dir"
 
     # Keep bd's runtime config in sync with GC's canonical prefix. This is
     # compatibility state for raw bd operations, not a second GC authority.


### PR DESCRIPTION
## Summary
- pass --role maintainer during managed bd init
- backfill repo-local beads.role for existing managed bd metadata paths
- cover fresh init and metadata fast-path behavior in lifecycle tests

## Tests
- go test ./cmd/gc -run 'TestGcBeadsBdInitDefaultsBeadsRole'
- go test ./cmd/gc -run 'TestGcBeadsBdInit(TightensBeadsDirPermissions|DefaultsBeadsRole|BackfillsRepoIDMigrationWhenMetadataExistsWithoutProjectID|UsesProjectIDHelperWhenRepoIDMigrationFails|RejectsManagedProbeDatabaseName)'
- go test ./cmd/gc
- go vet ./...
- pre-commit hook: lint and vet passed; full test run is blocked by main's GitHub CLI readiness test, isolated separately in #1394