### PR TITLE
Fix queued nudge poller wakeups

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -84,6 +84,13 @@ func (t nudgeTarget) agentKey() string {
 	return t.sessionName
 }
 
+func (t nudgeTarget) pollerKey() string {
+	if t.sessionID != "" {
+		return t.sessionID
+	}
+	return t.agentKey()
+}
+
 func (t nudgeTarget) queueKeys() []string {
 	var keys []string
 	seen := map[string]bool{}
@@ -781,10 +788,25 @@ func tryDeliverQueuedNudgesByPoller(target nudgeTarget, store beads.Store, sp ru
 
 func pollerSessionIdleEnough(target nudgeTarget, store beads.Store, sp runtime.Provider, quiescence time.Duration) bool {
 	obs, err := workerObserveNudgeTarget(target, store, sp)
-	if err != nil || obs.LastActivity == nil || obs.LastActivity.IsZero() {
+	if err != nil {
 		return false
 	}
-	return time.Since(*obs.LastActivity) >= quiescence
+	if quiescence <= 0 {
+		return true
+	}
+	if obs.LastActivity != nil && !obs.LastActivity.IsZero() {
+		return time.Since(*obs.LastActivity) >= quiescence
+	}
+	if target.sessionName == "" {
+		return false
+	}
+	waiter, ok := sp.(runtime.IdleWaitProvider)
+	if !ok {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), quiescence)
+	defer cancel()
+	return waiter.WaitForIdle(ctx, target.sessionName, quiescence) == nil
 }
 
 func maybeStartNudgePoller(target nudgeTarget) {
@@ -794,7 +816,7 @@ func maybeStartNudgePoller(target nudgeTarget) {
 	if target.sessionTransport() == "acp" {
 		return
 	}
-	if err := startNudgePoller(target.cityPath, target.agentKey(), target.sessionName); err != nil {
+	if err := startNudgePoller(target.cityPath, target.pollerKey(), target.sessionName); err != nil {
 		return
 	}
 }

--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -804,6 +804,8 @@ func pollerSessionIdleEnough(target nudgeTarget, store beads.Store, sp runtime.P
 	if !ok {
 		return false
 	}
+	// The poller may take up to the quiescence window to exit while this
+	// runtime idle check is in progress.
 	ctx, cancel := context.WithTimeout(context.Background(), quiescence)
 	defer cancel()
 	return waiter.WaitForIdle(ctx, target.sessionName, quiescence) == nil

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -498,6 +498,30 @@ func TestPollerSessionIdleEnoughUsesLastActivityWithoutCapabilityFlag(t *testing
 	}
 }
 
+func TestPollerSessionIdleEnoughFallsBackToIdleWaitWhenActivityUnavailable(t *testing.T) {
+	fake := runtime.NewFake()
+	if err := fake.Start(context.Background(), "sess-worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	fake.WaitForIdleErrors["sess-worker"] = nil
+	target := nudgeTarget{sessionName: "sess-worker"}
+
+	if !pollerSessionIdleEnough(target, nil, fake, 3*time.Second) {
+		t.Fatal("pollerSessionIdleEnough = false, want idle wait fallback to allow delivery")
+	}
+
+	var sawWait bool
+	for _, call := range fake.Calls {
+		if call.Method == "WaitForIdle" && call.Name == "sess-worker" {
+			sawWait = true
+			break
+		}
+	}
+	if !sawWait {
+		t.Fatalf("calls = %#v, want WaitForIdle fallback", fake.Calls)
+	}
+}
+
 func TestShouldKeepNudgePollerAliveDuringStartupGrace(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
@@ -754,6 +778,56 @@ func TestSendMailNotifyWithProviderStartsClaudePollerWhenQueueingRunningSession(
 	}
 	if !called {
 		t.Fatal("startNudgePoller was not called")
+	}
+}
+
+func TestSendMailNotifyWithWorkerStartsPollerBySessionIDForAliasedTarget(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	dir := t.TempDir()
+	store := openNudgeBeadStore(dir)
+	fake := runtime.NewFake()
+	mgr := newSessionManagerWithConfig(dir, store, fake, nil)
+	info, err := mgr.Create(context.Background(), "mayor", "Mayor", "codex", dir, "codex", nil, session.ProviderResume{}, runtime.Config{WorkDir: dir})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Start(context.Background(), info.ID, "", runtime.Config{WorkDir: dir}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := store.SetMetadata(info.ID, "alias", "mayor"); err != nil {
+		t.Fatalf("SetMetadata(alias): %v", err)
+	}
+	target := nudgeTarget{
+		cityPath:    dir,
+		alias:       "mayor",
+		agent:       config.Agent{Name: "mayor", MaxActiveSessions: intPtrNudge(1)},
+		sessionID:   info.ID,
+		resolved:    &config.ResolvedProvider{Name: "codex"},
+		sessionName: info.SessionName,
+	}
+
+	prev := startNudgePoller
+	startNudgePoller = func(cityPath, agentName, sessionName string) error {
+		if cityPath != dir || agentName != info.ID || sessionName != info.SessionName {
+			t.Fatalf("unexpected poller args city=%q agent=%q session=%q", cityPath, agentName, sessionName)
+		}
+		return nil
+	}
+	t.Cleanup(func() { startNudgePoller = prev })
+
+	if err := sendMailNotifyWithWorker(target, store, fake, "human"); err != nil {
+		t.Fatalf("sendMailNotifyWithWorker: %v", err)
+	}
+
+	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())
+	if err != nil {
+		t.Fatalf("listQueuedNudgesForTarget: %v", err)
+	}
+	if len(pending) != 1 || len(inFlight) != 0 || len(dead) != 0 {
+		t.Fatalf("pending/inFlight/dead = %d/%d/%d, want 1/0/0", len(pending), len(inFlight), len(dead))
+	}
+	if pending[0].Agent != "mayor" || pending[0].SessionID != info.ID {
+		t.Fatalf("queued nudge agent/session = %q/%q, want mayor/%s", pending[0].Agent, pending[0].SessionID, info.ID)
 	}
 }
 

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -520,6 +520,11 @@ func TestPollerSessionIdleEnoughFallsBackToIdleWaitWhenActivityUnavailable(t *te
 	if !sawWait {
 		t.Fatalf("calls = %#v, want WaitForIdle fallback", fake.Calls)
 	}
+
+	fake.WaitForIdleErrors["sess-worker"] = errors.New("timed out waiting for idle")
+	if pollerSessionIdleEnough(target, nil, fake, 3*time.Second) {
+		t.Fatal("pollerSessionIdleEnough = true, want idle wait error to suppress delivery")
+	}
 }
 
 func TestShouldKeepNudgePollerAliveDuringStartupGrace(t *testing.T) {
@@ -806,8 +811,10 @@ func TestSendMailNotifyWithWorkerStartsPollerBySessionIDForAliasedTarget(t *test
 		sessionName: info.SessionName,
 	}
 
+	called := false
 	prev := startNudgePoller
 	startNudgePoller = func(cityPath, agentName, sessionName string) error {
+		called = true
 		if cityPath != dir || agentName != info.ID || sessionName != info.SessionName {
 			t.Fatalf("unexpected poller args city=%q agent=%q session=%q", cityPath, agentName, sessionName)
 		}
@@ -817,6 +824,9 @@ func TestSendMailNotifyWithWorkerStartsPollerBySessionIDForAliasedTarget(t *test
 
 	if err := sendMailNotifyWithWorker(target, store, fake, "human"); err != nil {
 		t.Fatalf("sendMailNotifyWithWorker: %v", err)
+	}
+	if !called {
+		t.Fatal("startNudgePoller was not called")
 	}
 
 	pending, inFlight, dead, err := listQueuedNudgesForTarget(dir, target, time.Now())


### PR DESCRIPTION
This follow-up supersedes https://github.com/gastownhall/gascity/pull/1392 because maintainer edits are disabled on the original PR branch and the adopted branch includes reviewed fixups.

Original PR: https://github.com/gastownhall/gascity/pull/1392
Original title: Fix queued nudge poller wakeups
Original state at adoption: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

The branch preserves the contributor commit and adds the reviewed test hardening commit on top of the recorded upstream base.