### PR TITLE
fix(session): close pool assignment cleanup gap and slot collision

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -936,7 +936,20 @@ func realizePoolDesiredSessions(
 ) {
 	qualifiedName := cfgAgent.QualifiedName()
 	used := make(map[string]bool)
-	usedSlots := make(map[int]bool)
+	// Seed the slot allocator with every pool_slot already bound by an
+	// open (non-closed) session bead of this template. Without this, a
+	// new-tier spawn whose `selectOrCreatePoolSessionBead` returns a
+	// freshly created bead with no slot metadata will get slot 1 from
+	// claimPoolSlot's "next free" search — even when slot 1 is still
+	// held by, e.g., a drained or asleep bead in the store. The
+	// alias-bind step at session creation would then fail with "alias
+	// unavailable: already belongs to <holder>", silently leaving the
+	// pool under-spawned and re-attempting the same collision on every
+	// reconcile tick. Beads that this realize call will explicitly
+	// reuse via the request loop are exempt: their slots are still
+	// available to be claimed by their own session bead through
+	// `existingPoolSlot`.
+	usedSlots := preBoundPoolSlots(cfgAgent, bp.sessionBeads, poolState.Requests, &config.City{Agents: bp.agents})
 	for _, request := range poolState.Requests {
 		var prefer *beads.Bead
 		if request.SessionBeadID != "" {
@@ -1110,6 +1123,40 @@ func sessionBeadConfigAgent(cfgAgent *config.Agent, qualifiedName string) *confi
 	}
 	instanceAgent := deepCopyAgent(cfgAgent, localName, cfgAgent.Dir)
 	return &instanceAgent
+}
+
+// preBoundPoolSlots returns a `used` set of pool_slot values already
+// held by open session beads matching cfgAgent. Slots held by beads
+// that the upcoming request loop will explicitly reuse (resume tier
+// with SessionBeadID) are excluded so claimPoolSlot's existing-slot
+// reclaim path can return them naturally.
+func preBoundPoolSlots(cfgAgent *config.Agent, sessionBeads *sessionBeadSnapshot, requests []SessionRequest, cfg *config.City) map[int]bool {
+	used := make(map[int]bool)
+	if sessionBeads == nil || cfgAgent == nil {
+		return used
+	}
+	resumeIDs := make(map[string]struct{}, len(requests))
+	for _, r := range requests {
+		if r.SessionBeadID != "" {
+			resumeIDs[r.SessionBeadID] = struct{}{}
+		}
+	}
+	template := cfgAgent.QualifiedName()
+	for _, b := range sessionBeads.Open() {
+		if b.Status == "closed" {
+			continue
+		}
+		if _, ok := resumeIDs[b.ID]; ok {
+			continue
+		}
+		if normalizedSessionTemplate(b, cfg) != template {
+			continue
+		}
+		if slot := existingPoolSlot(cfgAgent, b); slot > 0 {
+			used[slot] = true
+		}
+	}
+	return used
 }
 
 func claimPoolSlot(cfgAgent *config.Agent, sessionBead beads.Bead, used map[int]bool) int {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2506,6 +2506,82 @@ func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 	}
 }
 
+// TestRealizePoolDesiredSessions_NewSpawnSkipsSlotHeldByOpenSessionBead
+// reproduces the production bug where the slot allocator picks slot N
+// for a new pool spawn while another open (non-closed) session bead in
+// the store still holds slot N. The alias-bind step then fails with
+//
+//	session beads: alias "<template>-N" unavailable: already belongs to <other>
+//
+// silently leaving the pool under-spawned. Each subsequent reconcile
+// tick repeats the same collision until the holder bead closes, which
+// can be blocked indefinitely if its assigned work has a stale
+// assignee. The fix: claimPoolSlot must seed its `used` set with every
+// pool_slot already bound by an open session bead of the same template,
+// so a new spawn advances to the next free slot.
+func TestRealizePoolDesiredSessions_NewSpawnSkipsSlotHeldByOpenSessionBead(t *testing.T) {
+	store := beads.NewMemStore()
+	cityDir := t.TempDir()
+	cfgAgent := config.Agent{Name: "codex-max", Dir: cityDir, MinActiveSessions: intPtr(0), StartCommand: "/bin/true"}
+	template := cfgAgent.QualifiedName()
+	// Pool session bead currently in "drained" state still holds
+	// pool_slot=1 in the store. selectOrCreatePoolSessionBead skips
+	// drained beads for new-tier requests, so a new bead would be
+	// created — but claimPoolSlot, which has only the per-tick `used`
+	// map, has no idea slot 1 is taken by the drained bead and assigns
+	// slot 1 to the new spawn.
+	blocking, err := store.Create(beads.Bead{
+		Title:  "codex-max",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     template,
+			"agent_name":   template,
+			"session_name": "codex-max-1-prior",
+			"pool_slot":    "1",
+			"state":        "drained",
+			"pool_managed": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{blocking})
+	cfg := &config.City{Agents: []config.Agent{cfgAgent}}
+	bp := &agentBuildParams{
+		city:         cfg,
+		cityPath:     cityDir,
+		workspace:    &cfg.Workspace,
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+		providers:    cfg.Providers,
+		lookPath:     func(string) (string, error) { return "/bin/true", nil },
+		fs:           fsys.OSFS{},
+	}
+
+	poolState := PoolDesiredState{
+		Template: "codex-max",
+		Requests: []SessionRequest{
+			{Template: "codex-max", Tier: "new"},
+		},
+	}
+
+	desired := make(map[string]TemplateParams)
+	var stderr strings.Builder
+	realizePoolDesiredSessions(bp, &cfgAgent, poolState, desired, &stderr)
+
+	if len(desired) == 0 {
+		t.Fatalf("realize produced no desired entries; stderr=%s", stderr.String())
+	}
+	for sn, tp := range desired {
+		if tp.PoolSlot == 1 {
+			t.Errorf("desired entry %q got pool_slot=1, which is already bound by open session bead %q (alias=%q) — alias-bind would fail",
+				sn, blocking.ID, tp.Alias)
+		}
+	}
+}
+
 func TestSelectOrCreatePoolSessionBead_SkipsAsleepBeads(t *testing.T) {
 	// An asleep pool session should NOT be reused for new demand.
 	// The reconciler should create a fresh session instead.

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -111,7 +111,7 @@ func TestUnclaimWorkAssignedToRetiredSessionBead_UsesLiveOpenOwnership(t *testin
 		t.Fatalf("Update(%s, reassigned): %v", work.ID, err)
 	}
 
-	unclaimWorkAssignedToRetiredSessionBead(cache, "retired-session", "worker", io.Discard)
+	unclaimWorkAssignedToRetiredSessionBead(cache, beads.Bead{ID: "retired-session"}, "worker", io.Discard)
 
 	got, err := backing.Get(work.ID)
 	if err != nil {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -376,7 +376,7 @@ func retireRemovedConfiguredNamedSessionBead(
 		fmt.Fprintf(stderr, "session beads: archiving removed named session %s: %v\n", b.ID, err) //nolint:errcheck
 		return false
 	}
-	unclaimWorkAssignedToRetiredSessionBead(store, b.ID, retiredSessionFallbackRoute(b), stderr)
+	unclaimWorkAssignedToRetiredSessionBead(store, b, retiredSessionFallbackRoute(b), stderr)
 	cancelStateAssignedToRetiredSessionBead(store, b.ID, now, stderr)
 	return true
 }
@@ -388,41 +388,91 @@ func retiredSessionFallbackRoute(b beads.Bead) string {
 	return strings.TrimSpace(b.Metadata["agent_name"])
 }
 
-func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallbackRoute string, stderr io.Writer) {
-	if store == nil || strings.TrimSpace(sessionID) == "" {
+// unclaimWorkAssignedToRetiredSessionBead clears assignees on every
+// work bead that points at the retired session, then resets in_progress
+// beads to "open" so the work_query can re-route them via Tier 3
+// (gc.routed_to + --unassigned).
+//
+// Workers may stamp `assignee` with any of the session's identifiers —
+// the bead ID, the runtime session_name (e.g.
+// "workflows__codex-max-mc-XYZ", what $GC_SESSION_NAME / $GC_AGENT
+// expand to for pool sessions), or, for configured named sessions, the
+// configured named identity. We must query each form. Using only the
+// bead ID misses every pool session, since pool workers always stamp
+// the session_name form. Worse, sessionHasOpenAssignedWorkInStore (the
+// session-bead-close gate) DOES match all three identifiers, so the
+// gate sees the work and refuses to close the retiring session bead —
+// which keeps the bead "open" and makes releaseOrphanedPoolAssignments
+// skip the work bead too. The result is a deadlock: the work sits with
+// a stale assignee forever, invisible to the demand counter and
+// blocking new spawns at the same slot. Mirroring the identifier set
+// here is what breaks that cycle.
+func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionBead beads.Bead, fallbackRoute string, stderr io.Writer) {
+	if store == nil {
 		return
 	}
 	if stderr == nil {
 		stderr = io.Discard
 	}
+	identifiers := dedupeNonEmpty(
+		strings.TrimSpace(sessionBead.ID),
+		strings.TrimSpace(sessionBead.Metadata["session_name"]),
+		strings.TrimSpace(sessionBead.Metadata[namedSessionIdentityMetadata]),
+	)
+	if len(identifiers) == 0 {
+		return
+	}
 	empty := ""
 	open := "open"
+	seen := make(map[string]struct{})
 	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: true})
-		if err != nil {
-			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", sessionID, err) //nolint:errcheck
-			continue
-		}
-		for _, item := range work {
-			if session.IsSessionBeadOrRepairable(item) {
+		for _, assignee := range identifiers {
+			work, err := store.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
+			if err != nil {
+				fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", assignee, err) //nolint:errcheck
 				continue
 			}
-			update := beads.UpdateOpts{Assignee: &empty}
-			// Clearing assignee on an in_progress bead leaves it invisible to
-			// the work_query: Tier 1 needs an assignee match, Tiers 2/3 only
-			// match "ready" status. Reset to "open" so a fresh worker can
-			// re-claim via the routed queue (gc.routed_to + --unassigned).
-			if item.Status == "in_progress" {
-				update.Status = &open
-			}
-			if fallbackRoute != "" && strings.TrimSpace(item.Metadata["gc.routed_to"]) == "" {
-				update.Metadata = map[string]string{"gc.routed_to": fallbackRoute}
-			}
-			if err := store.Update(item.ID, update); err != nil {
-				fmt.Fprintf(stderr, "session beads: unclaiming work %s assigned to retired session %s: %v\n", item.ID, sessionID, err) //nolint:errcheck
+			for _, item := range work {
+				if session.IsSessionBeadOrRepairable(item) {
+					continue
+				}
+				if _, dup := seen[item.ID]; dup {
+					continue
+				}
+				seen[item.ID] = struct{}{}
+				update := beads.UpdateOpts{Assignee: &empty}
+				// Clearing assignee on an in_progress bead leaves it invisible to
+				// the work_query: Tier 1 needs an assignee match, Tiers 2/3 only
+				// match "ready" status. Reset to "open" so a fresh worker can
+				// re-claim via the routed queue (gc.routed_to + --unassigned).
+				if item.Status == "in_progress" {
+					update.Status = &open
+				}
+				if fallbackRoute != "" && strings.TrimSpace(item.Metadata["gc.routed_to"]) == "" {
+					update.Metadata = map[string]string{"gc.routed_to": fallbackRoute}
+				}
+				if err := store.Update(item.ID, update); err != nil {
+					fmt.Fprintf(stderr, "session beads: unclaiming work %s assigned to retired session %s: %v\n", item.ID, assignee, err) //nolint:errcheck
+				}
 			}
 		}
 	}
+}
+
+func dedupeNonEmpty(values ...string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }
 
 func reassignWorkAssignedToRetiredSessionBead(store beads.Store, oldSessionID, newSessionID string, stderr io.Writer) {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -3265,7 +3265,7 @@ func TestUnclaimResetsInProgressStatus(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	unclaimWorkAssignedToRetiredSessionBead(store, sessionBead.ID, "myrig/codex-max", &stderr)
+	unclaimWorkAssignedToRetiredSessionBead(store, sessionBead, "myrig/codex-max", &stderr)
 
 	gotInProgress, err := store.Get(work.ID)
 	if err != nil {
@@ -3287,6 +3287,94 @@ func TestUnclaimResetsInProgressStatus(t *testing.T) {
 	}
 	if gotOpen.Status != "open" {
 		t.Errorf("open status = %q, want %q (already open, must stay open)", gotOpen.Status, "open")
+	}
+}
+
+// TestUnclaimMatchesSessionNameAssignee verifies that unclaim looks up
+// assigned work by every identifier the worker might have stamped: the
+// session bead ID, the session_name (sanitized tmux form, the form
+// $GC_SESSION_NAME / $GC_AGENT take), and any configured named identity.
+//
+// Real bug observed in production: an open work bead routed to a pool
+// template had assignee="<session_name>" (e.g.
+// "workflows__codex-max-mc-5w0w6j"), pointing at a session whose tmux
+// process was already gone. The unclaim hook ran with sessionID set to
+// the session bead ID ("mc-5w0w6j") and queried only Assignee=sessionID,
+// so the SQL filter never matched the work bead. The work bead kept its
+// stale assignee. Worse, sessionHasOpenAssignedWorkInStore (used by the
+// session-bead-close gate) DOES match all three identifiers, so it sees
+// the bead and refuses to close the session bead. The result is a
+// circular gate: the session bead can't close because of a stale
+// assignment, and the assignment can't clear because the session bead
+// is still open (which makes releaseOrphanedPoolAssignments skip it
+// too). The only way out is for unclaim's identifier set to match the
+// close-gate's identifier set.
+func TestUnclaimMatchesSessionNameAssignee(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Session bead with a session_name that differs from its bead ID —
+	// the typical pool layout where the runtime/tmux name is
+	// "<sanitized template>-<bead ID>".
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "workflows__codex-max-mc-5w0w6j",
+			"template":     "workflows/codex-max",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// Open work whose assignee is the session_name form (what
+	// $GC_SESSION_NAME / $GC_AGENT would stamp), not the bead ID.
+	openWork, err := store.Create(beads.Bead{
+		Title:    "apply-fix",
+		Status:   "open",
+		Assignee: "workflows__codex-max-mc-5w0w6j",
+		Metadata: map[string]string{"gc.routed_to": "workflows/codex-max"},
+	})
+	if err != nil {
+		t.Fatalf("create open work: %v", err)
+	}
+
+	// In-progress work also assigned by session_name.
+	inProgressWork, err := store.Create(beads.Bead{
+		Title:    "review-fix",
+		Status:   "in_progress",
+		Assignee: "workflows__codex-max-mc-5w0w6j",
+		Metadata: map[string]string{"gc.routed_to": "workflows/codex-max"},
+	})
+	if err != nil {
+		t.Fatalf("create in_progress work: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	unclaimWorkAssignedToRetiredSessionBead(store, sessionBead, "workflows/codex-max", &stderr)
+
+	got, err := store.Get(openWork.ID)
+	if err != nil {
+		t.Fatalf("get open work: %v", err)
+	}
+	if got.Assignee != "" {
+		t.Errorf("open work assignee = %q, want empty (session_name-form assignee should be cleared)", got.Assignee)
+	}
+	if got.Status != "open" {
+		t.Errorf("open work status = %q, want open", got.Status)
+	}
+
+	gotInProgress, err := store.Get(inProgressWork.ID)
+	if err != nil {
+		t.Fatalf("get in_progress work: %v", err)
+	}
+	if gotInProgress.Assignee != "" {
+		t.Errorf("in_progress work assignee = %q, want empty", gotInProgress.Assignee)
+	}
+	if gotInProgress.Status != "open" {
+		t.Errorf("in_progress work status = %q, want open (must reset so work_query Tier 3 can route it)", gotInProgress.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked on top of #1389. Fixes two related lifecycle bugs that together cause stale pool assignments to deadlock the supervisor for the duration of a workflow.

### 1. unclaim queries only one assignee form, deadlocking the close gate

`unclaimWorkAssignedToRetiredSessionBead` queried the bead store only by session-bead ID:

\`\`\`go
store.List(beads.ListQuery{Assignee: sessionID, Status: status, ...})
\`\`\`

But pool workers stamp their work bead's \`Assignee\` with \`\$GC_SESSION_NAME\` — the runtime/tmux form (e.g. \`workflows__codex-max-mc-XYZ\`), not the bead ID. The SQL filter never matches, so unclaim does nothing, the work bead keeps its stale assignee.

\`sessionHasOpenAssignedWorkInStore\` (the close-gate that decides whether the session bead can close) DOES match all three identifiers \`{ID, session_name, configured_named_identity}\`, so it sees the orphaned work and refuses to close the retiring session bead. The session bead stays open, \`releaseOrphanedPoolAssignments\` builds \`openIdentifiers\` from the same three forms and skips the work bead because its assignee is in the open set, and the work sits invisible to the demand counter forever — for the entire duration of the workflow that owns the bead.

Take the full session bead instead of an ID, build the same \`{ID, session_name, configured_named_identity}\` identifier list as \`sessionHasOpenAssignedWorkInStore\`, and run the unclaim query for each identifier with per-bead deduplication.

### 2. slot allocator can pick a slot still bound by an open session bead

\`realizePoolDesiredSessions\` starts each tick with an empty \`usedSlots\` map. For new-tier requests that end up creating a fresh session bead, \`claimPoolSlot\` returns the next free slot from \`used\` — but \`used\` doesn't know about \`pool_slot\` values still held by open (non-closed) session beads in the store: drained or asleep beads that \`selectOrCreate\` skips for reuse but that haven't yet closed. The new spawn gets slot N, its alias becomes \`<template>-N\`, and the alias-bind step at session creation fails with

\`\`\`
session beads: alias \"<template>-N\" unavailable: already belongs to <holder>
\`\`\`

silently leaving the pool under-spawned and re-attempting the same collision on every reconcile tick until the holder bead closes. With bug 1 above blocking closes indefinitely, the collision is permanent.

Pre-seed \`usedSlots\` from every open session bead matching the template, excluding beads the request loop will explicitly reuse via \`SessionBeadID\` (so \`claimPoolSlot\`'s existing-slot reclaim path can return their slot naturally). New-tier spawns now skip occupied slots and advance to the next truly free index.

## Test plan

- [x] New \`TestUnclaimMatchesSessionNameAssignee\` reproduces bug 1 (fails on a single-identifier unclaim, passes after the fix).
- [x] New \`TestRealizePoolDesiredSessions_NewSpawnSkipsSlotHeldByOpenSessionBead\` reproduces bug 2 (fails when \`usedSlots\` is unseeded, passes after the seed).
- [x] Existing \`TestUnclaimResetsInProgressStatus\` and \`TestUnclaimWorkAssignedToRetiredSessionBead_UsesLiveOpenOwnership\` updated for the new signature, still pass.
- [x] \`go test ./cmd/gc -run \"TestUnclaim|TestRealizePoolDesiredSessions_NewSpawn|TestSelectOrCreatePoolSessionBead|TestReleaseOrphanedPoolAssignments|TestReconcileSessionBeads_Orphan\"\` green.