### PR TITLE
fix: recover unassigned in-progress pool work

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -28,7 +28,7 @@ type DesiredStateResult struct {
 	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
 	PoolDesiredCounts map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
 	WorkSet           map[string]bool
-	AssignedWorkBeads []beads.Bead // actionable assigned work: in_progress or ready+assigned
+	AssignedWorkBeads []beads.Bead // actionable assigned work, plus stranded pool work that needs release
 	// AssignedWorkStores is aligned by index with AssignedWorkBeads, so later
 	// mutation paths update rig-owned work in the right store even when
 	// independent stores produce overlapping bead IDs.
@@ -501,9 +501,8 @@ func refreshDesiredStateWithSessionBeads(
 // collectAssignedWorkBeads queries each store (city + rigs) for actionable
 // assigned work. It includes in-progress assigned work plus open assigned
 // work that is actually ready. Routed-but-unassigned pool queue work is
-// intentionally excluded here; new session demand comes from scale_check
-// (and work_query as a defense-in-depth wake signal), while this helper is
-// only for preserving sessions that already own actionable work.
+// intentionally excluded here, except stranded in-progress pool work with no
+// assignee is included so reconciliation can reopen it for normal claiming.
 func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
@@ -535,9 +534,10 @@ func collectAssignedWorkBeadsWithStores(
 	var partial bool
 	for _, s := range stores {
 		seen := make(map[string]struct{})
-		// In-progress beads with an assignee (active work).
+		// In-progress beads with an assignee (active work), plus stranded
+		// unassigned pool work that needs to be reopened.
 		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
-			appendAssignedUnique(&result, &resultStores, inProgress, seen, s)
+			appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
 		} else {
 			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
 			partial = true
@@ -580,27 +580,40 @@ func mergeNamedSessionDemand(poolDesired map[string]int, namedDemand map[string]
 	}
 }
 
+func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
+	for _, b := range beadList {
+		if strings.TrimSpace(b.Assignee) == "" && !isRecoverableUnassignedInProgressPoolWork(cfg, b) {
+			continue
+		}
+		appendWorkUnique(dst, stores, b, seen, store)
+	}
+}
+
 func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
 		}
-		// Session beads are not actionable work — filter them at the source
-		// so all consumers see only real tasks. Message beads are NOT filtered
-		// here because they represent mail that should wake/materialize sessions;
-		// idle nudge filters messages locally since mail nudging is handled
-		// separately by the mail system.
-		if b.Type == sessionBeadType {
-			continue
-		}
-		if _, ok := seen[b.ID]; ok {
-			continue
-		}
-		seen[b.ID] = struct{}{}
-		*dst = append(*dst, b)
-		if stores != nil {
-			*stores = append(*stores, store)
-		}
+		appendWorkUnique(dst, stores, b, seen, store)
+	}
+}
+
+func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, b beads.Bead, seen map[string]struct{}, store beads.Store) {
+	// Session beads are not actionable work — filter them at the source
+	// so all consumers see only real tasks. Message beads are NOT filtered
+	// here because they represent mail that should wake/materialize sessions;
+	// idle nudge filters messages locally since mail nudging is handled
+	// separately by the mail system.
+	if b.Type == sessionBeadType {
+		return
+	}
+	if _, ok := seen[b.ID]; ok {
+		return
+	}
+	seen[b.ID] = struct{}{}
+	*dst = append(*dst, b)
+	if stores != nil {
+		*stores = append(*stores, store)
 	}
 }
 

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -46,8 +46,9 @@ func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, se
 }
 
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
-// assignee no longer maps to any open session bead. This recovers attempts
-// that were left in_progress after a pooled worker exited or was swept.
+// assignee no longer maps to any open session bead. This also recovers
+// pool-routed work left in_progress with no assignee, which cannot be claimed
+// again until it is moved back to open.
 func releaseOrphanedPoolAssignments(
 	store beads.Store,
 	cfg *config.City,
@@ -86,12 +87,6 @@ func releaseOrphanedPoolAssignments(
 			continue
 		}
 		assignee := strings.TrimSpace(wb.Assignee)
-		if assignee == "" {
-			continue
-		}
-		if _, ok := openIdentifiers[assignee]; ok {
-			continue
-		}
 		template := strings.TrimSpace(wb.Metadata["gc.routed_to"])
 		if template == "" {
 			continue
@@ -100,8 +95,17 @@ func releaseOrphanedPoolAssignments(
 		if agentCfg == nil || !agentCfg.SupportsGenericEphemeralSessions() {
 			continue
 		}
-		if assigneePreservesNamedSessionRoute(cfg, template, assignee) {
-			continue
+		if assignee == "" {
+			if wb.Status != "in_progress" {
+				continue
+			}
+		} else {
+			if _, ok := openIdentifiers[assignee]; ok {
+				continue
+			}
+			if assigneePreservesNamedSessionRoute(cfg, template, assignee) {
+				continue
+			}
 		}
 
 		var ownerStore beads.Store
@@ -145,6 +149,18 @@ func storeForPoolAssignment(cfg *config.City, cityStore beads.Store, rigStores m
 		}
 	}
 	return cityStore
+}
+
+func isRecoverableUnassignedInProgressPoolWork(cfg *config.City, wb beads.Bead) bool {
+	if wb.Status != "in_progress" || strings.TrimSpace(wb.Assignee) != "" {
+		return false
+	}
+	template := strings.TrimSpace(wb.Metadata["gc.routed_to"])
+	if template == "" {
+		return false
+	}
+	agentCfg := findAgentByTemplate(cfg, template)
+	return agentCfg != nil && agentCfg.SupportsGenericEphemeralSessions()
 }
 
 func beadIDPrefix(id string) string {

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -183,6 +183,80 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 	}
 }
 
+func TestReleaseOrphanedPoolAssignments_ReopensUnassignedInProgressPoolWork(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "stranded pool work",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+	if work.Assignee != "" {
+		t.Fatalf("test setup assignee = %q, want empty", work.Assignee)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		nil,
+		[]beads.Bead{work},
+		nil,
+		nil,
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Fatalf("assignee = %q, want empty", got.Assignee)
+	}
+}
+
+func TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "stranded pool work",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+
+	found, stores, partial := collectAssignedWorkBeadsWithStores(
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		store,
+		nil,
+		nil,
+	)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(found) != 1 || found[0].ID != work.ID {
+		t.Fatalf("found = %#v, want stranded work %s", found, work.ID)
+	}
+	if len(stores) != 1 || stores[0] != store {
+		t.Fatalf("stores = %#v, want owner store", stores)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_UpdatesRigStoreFallback(t *testing.T) {
 	cityStore := beads.NewMemStore()
 	rigStore := beads.NewMemStore()


### PR DESCRIPTION
## Summary
- reopen pool-routed in-progress work that has lost its assignee
- include that stranded work shape in the assigned-work snapshot so reconciliation can recover it
- add regression coverage for direct release and collector paths

## Tests
- go test ./cmd/gc -run 'TestReleaseOrphanedPoolAssignments|TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery|TestCollectAssignedWorkBeads_ExcludesRoutedToMetadataWithoutAssignee' -count=1