### PR TITLE
fix(mail): nudge reply recipients from human

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -723,6 +723,8 @@ Use --all to broadcast to all live sessions (excluding sender and "human").`,
 		},
 	}
 	cmd.Flags().BoolVar(&notify, "notify", false, "nudge the recipient after sending")
+	cmd.Flags().BoolVar(&notify, "nudge", false, "alias for --notify")
+	_ = cmd.Flags().MarkHidden("nudge")
 	cmd.Flags().BoolVar(&all, "all", false, "broadcast to all live sessions (excludes sender and human)")
 	cmd.Flags().StringVar(&from, "from", "", "sender identity (default: $GC_SESSION_ID, $GC_ALIAS, $GC_AGENT, or \"human\")")
 	cmd.Flags().StringVar(&to, "to", "", "recipient address (alternative to positional argument)")
@@ -796,6 +798,7 @@ func newMailReplyCmd(stdout, stderr io.Writer) *cobra.Command {
 		Long: `Reply to a message. The reply is addressed to the original sender.
 
 Inherits the thread ID from the original message for conversation tracking.
+Use --notify to nudge the recipient after replying.
 Use -s/--subject for the reply subject and -m/--message for the reply body.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -1208,25 +1211,46 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	rec := openCityRecorder(stderr)
 
 	sender := defaultMailIdentity()
+	providerName := mailProviderName()
 	var store beads.Store
-	if !isStorelessMailProvider() && (sender != "human" || notify) {
-		var storeCode int
-		store, storeCode = openCityStore(stderr, "gc mail reply")
-		if store == nil {
-			return storeCode
-		}
-		cityPath, err := resolveCity()
-		if err != nil {
-			fmt.Fprintf(stderr, "gc mail reply: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		cfg, _ := loadCityConfig(cityPath, stderr)
-		if sender != "human" {
-			resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail reply")
-			if !ok {
+	var cityPath string
+	var cfg *config.City
+	var notifySetupErr error
+	if sender != "human" || notify {
+		switch {
+		case strings.HasPrefix(providerName, "exec:"):
+			var err error
+			cityPath, err = resolveCity()
+			if err == nil {
+				cfg, _ = loadCityConfig(cityPath, stderr)
+				store, err = openCityStoreAt(cityPath)
+			}
+			if err != nil {
+				notifySetupErr = err
+				store = nil
+			}
+		case !isStorelessMailProvider():
+			var storeCode int
+			store, storeCode = openCityStore(stderr, "gc mail reply")
+			if store == nil {
+				return storeCode
+			}
+			var err error
+			cityPath, err = resolveCity()
+			if err != nil {
+				fmt.Fprintf(stderr, "gc mail reply: %v\n", err) //nolint:errcheck // best-effort stderr
 				return 1
 			}
-			sender = resolved
+			cfg, _ = loadCityConfig(cityPath, stderr)
+		}
+		if sender != "human" {
+			if store != nil {
+				resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail reply")
+				if !ok {
+					return 1
+				}
+				sender = resolved
+			}
 		}
 	}
 
@@ -1239,6 +1263,8 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	var nf nudgeFunc
 	if notify && store != nil {
 		nf = newMailNudgeFunc(sender)
+	} else if notify && strings.HasPrefix(providerName, "exec:") && notifySetupErr != nil {
+		fmt.Fprintf(stderr, "gc mail reply: --notify requested but no city store available; nudge skipped: %v\n", notifySetupErr) //nolint:errcheck // best-effort stderr
 	}
 
 	return doMailReply(mp, rec, args[0], sender, subject, body, nf, stdout, stderr)

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -808,6 +808,8 @@ Use -s/--subject for the reply subject and -m/--message for the reply body.`,
 	cmd.Flags().StringVarP(&subject, "subject", "s", "", "reply subject line")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "reply body text")
 	cmd.Flags().BoolVar(&notify, "notify", false, "nudge the recipient after replying")
+	cmd.Flags().BoolVar(&notify, "nudge", false, "alias for --notify")
+	_ = cmd.Flags().MarkHidden("nudge")
 	return cmd
 }
 
@@ -1206,20 +1208,20 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	rec := openCityRecorder(stderr)
 
 	sender := defaultMailIdentity()
-	var hasStore bool
-	if sender != "human" {
-		if !isStorelessMailProvider() {
-			hasStore = true
-			store, storeCode := openCityStore(stderr, "gc mail reply")
-			if store == nil {
-				return storeCode
-			}
-			cityPath, err := resolveCity()
-			if err != nil {
-				fmt.Fprintf(stderr, "gc mail reply: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
-			}
-			cfg, _ := loadCityConfig(cityPath, stderr)
+	var store beads.Store
+	if !isStorelessMailProvider() && (sender != "human" || notify) {
+		var storeCode int
+		store, storeCode = openCityStore(stderr, "gc mail reply")
+		if store == nil {
+			return storeCode
+		}
+		cityPath, err := resolveCity()
+		if err != nil {
+			fmt.Fprintf(stderr, "gc mail reply: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		cfg, _ := loadCityConfig(cityPath, stderr)
+		if sender != "human" {
 			resolved, ok := resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail reply")
 			if !ok {
 				return 1
@@ -1235,7 +1237,7 @@ func cmdMailReply(args []string, subject, message string, notify bool, stdout, s
 	}
 
 	var nf nudgeFunc
-	if notify && hasStore {
+	if notify && store != nil {
 		nf = newMailNudgeFunc(sender)
 	}
 

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1474,13 +1473,175 @@ func TestCmdMailReplyHumanNotifyQueuesNudge(t *testing.T) {
 	}
 }
 
-func TestMailReplyAcceptsNudgeAlias(t *testing.T) {
-	cmd := newMailReplyCmd(io.Discard, io.Discard)
+func TestCmdMailReplyExecProviderNotifyQueuesNudge(t *testing.T) {
+	cityPath, sessionID, script := setupExecMailReplyNudgeTest(t)
+	t.Setenv("GC_MAIL", "exec:"+script)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{"gc-1", "reply body"}, "", "", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailReply() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	assertQueuedMailNudge(t, cityPath, sessionID, stderr.String())
+}
+
+func TestMailReplyNudgeAliasQueuesNudge(t *testing.T) {
+	cityPath, sessionID, script := setupExecMailReplyNudgeTest(t)
+	t.Setenv("GC_MAIL", "exec:"+script)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newMailReplyCmd(&stdout, &stderr)
 	if cmd.Flags().Lookup("nudge") == nil {
 		t.Fatal("reply command missing --nudge alias")
 	}
-	if err := cmd.Flags().Set("nudge", "true"); err != nil {
-		t.Fatalf("set --nudge: %v", err)
+	cmd.SetArgs([]string{"gc-1", "--nudge", "reply body"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("reply --nudge: %v; stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	assertQueuedMailNudge(t, cityPath, sessionID, stderr.String())
+}
+
+func TestCmdMailReplyExecProviderNotifyWithoutCityWarnsAndSendsReply(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "exec:"+writeExecReplyScript(t))
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("GC_AGENT", "")
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{"gc-1", "reply body"}, "", "", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailReply() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Replied to gc-1") {
+		t.Fatalf("stdout = %q, want reply confirmation", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--notify requested but no city store available") {
+		t.Fatalf("stderr = %q, want notify warning", stderr.String())
+	}
+}
+
+func TestCmdMailReplyExecProviderNotifyResolvesNonHumanSender(t *testing.T) {
+	cityPath, sessionID, script := setupExecMailReplyNudgeTest(t)
+	t.Setenv("GC_MAIL", "exec:"+script)
+	t.Setenv("GC_SESSION_ID", "bob-session")
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "bob",
+			"session_name": "bob-session",
+			"provider":     "fake",
+		},
+	}); err != nil {
+		t.Fatalf("Create(sender session): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{"gc-1", "reply body"}, "", "", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailReply() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	assertQueuedMailNudgeMessage(t, cityPath, sessionID, "You have mail from bob", stderr.String())
+}
+
+func setupExecMailReplyNudgeTest(t *testing.T) (string, string, string) {
+	t.Helper()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("GC_AGENT", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+	t.Setenv("GC_CITY_PATH", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "alice",
+			"session_name": "alice-session",
+			"provider":     "fake",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	return cityPath, sessionBead.ID, writeExecReplyScript(t)
+}
+
+func writeExecReplyScript(t *testing.T) string {
+	t.Helper()
+	script := filepath.Join(t.TempDir(), "mail-exec")
+	data := `#!/bin/sh
+case "$1" in
+  ensure-running)
+    exit 0
+    ;;
+  reply)
+    cat >/dev/null
+    printf '{"id":"exec-reply-1","from":"human","to":"alice","subject":"RE: Hello","body":"reply body","created_at":"2026-04-28T00:00:00Z","read":false,"thread_id":"thread-1","reply_to":"%s"}\n' "$2"
+    exit 0
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(script, []byte(data), 0o755); err != nil {
+		t.Fatalf("WriteFile(exec script): %v", err)
+	}
+	return script
+}
+
+func assertQueuedMailNudge(t *testing.T, cityPath, sessionID, stderr string) {
+	t.Helper()
+	assertQueuedMailNudgeMessage(t, cityPath, sessionID, "You have mail from human", stderr)
+}
+
+func assertQueuedMailNudgeMessage(t *testing.T, cityPath, sessionID, message, stderr string) {
+	t.Helper()
+	state, err := nudgequeue.LoadState(cityPath)
+	if err != nil {
+		t.Fatalf("LoadState(): %v", err)
+	}
+	if len(state.Pending) != 1 {
+		t.Fatalf("pending nudges = %d, want 1; state=%+v stderr=%s", len(state.Pending), state, stderr)
+	}
+	nudge := state.Pending[0]
+	if nudge.Agent != "alice" {
+		t.Fatalf("nudge.Agent = %q, want alice", nudge.Agent)
+	}
+	if nudge.SessionID != sessionID {
+		t.Fatalf("nudge.SessionID = %q, want %q", nudge.SessionID, sessionID)
+	}
+	if nudge.Source != "mail" {
+		t.Fatalf("nudge.Source = %q, want mail", nudge.Source)
+	}
+	if nudge.Message != message {
+		t.Fatalf("nudge.Message = %q", nudge.Message)
 	}
 }
 
@@ -1915,6 +2076,17 @@ func TestMailSendToFlag(t *testing.T) {
 	}
 	if b.Assignee != "mayor" {
 		t.Errorf("bead Assignee = %q, want %q", b.Assignee, "mayor")
+	}
+}
+
+func TestMailSendAcceptsNudgeAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := newMailSendCmd(&stdout, &stderr)
+	if cmd.Flags().Lookup("nudge") == nil {
+		t.Fatal("send command missing --nudge alias")
+	}
+	if err := cmd.Flags().Set("nudge", "true"); err != nil {
+		t.Fatalf("set --nudge: %v", err)
 	}
 }
 

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/mail/beadmail"
+	"github.com/gastownhall/gascity/internal/nudgequeue"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -1401,6 +1403,84 @@ func TestCmdMailReply_FallsBackToGCSessionIDWhenAliasMissing(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "to alice") {
 		t.Fatalf("stdout = %q, want reply addressed to alice", stdout.String())
+	}
+}
+
+func TestCmdMailReplyHumanNotifyQueuesNudge(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_MAIL", "")
+	t.Setenv("GC_SESSION", "fake")
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("GC_AGENT", "")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Setenv("GC_CITY", cityPath)
+
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "alice",
+			"session_name": "alice-session",
+			"provider":     "fake",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	mp := beadmail.New(store)
+	original, err := mp.Send("alice", "human", "Hello", "first")
+	if err != nil {
+		t.Fatalf("mp.Send(): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdMailReply([]string{original.ID, "reply body"}, "", "", true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdMailReply() = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "to alice") {
+		t.Fatalf("stdout = %q, want reply addressed to alice", stdout.String())
+	}
+
+	state, err := nudgequeue.LoadState(cityPath)
+	if err != nil {
+		t.Fatalf("LoadState(): %v", err)
+	}
+	if len(state.Pending) != 1 {
+		t.Fatalf("pending nudges = %d, want 1; state=%+v stderr=%s", len(state.Pending), state, stderr.String())
+	}
+	nudge := state.Pending[0]
+	if nudge.Agent != "alice" {
+		t.Fatalf("nudge.Agent = %q, want alice", nudge.Agent)
+	}
+	if nudge.SessionID != sessionBead.ID {
+		t.Fatalf("nudge.SessionID = %q, want %q", nudge.SessionID, sessionBead.ID)
+	}
+	if nudge.Source != "mail" {
+		t.Fatalf("nudge.Source = %q, want mail", nudge.Source)
+	}
+	if nudge.Message != "You have mail from human" {
+		t.Fatalf("nudge.Message = %q", nudge.Message)
+	}
+}
+
+func TestMailReplyAcceptsNudgeAlias(t *testing.T) {
+	cmd := newMailReplyCmd(io.Discard, io.Discard)
+	if cmd.Flags().Lookup("nudge") == nil {
+		t.Fatal("reply command missing --nudge alias")
+	}
+	if err := cmd.Flags().Set("nudge", "true"); err != nil {
+		t.Fatalf("set --nudge: %v", err)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1410,6 +1410,7 @@ gc mail read <id>
 Reply to a message. The reply is addressed to the original sender.
 
 Inherits the thread ID from the original message for conversation tracking.
+Use --notify to nudge the recipient after replying.
 Use -s/--subject for the reply subject and -m/--message for the reply body.
 
 ```


### PR DESCRIPTION
## Summary
Supersedes #1370 by @julianknutsen, which correctly identified that human `gc mail reply --notify` replies were not queueing recipient nudges because the reply path skipped city-store setup.

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

- Preserve the original reply notification fix and hidden `mail reply --nudge` alias.
- Queue reply nudges for `exec:` mail providers when a city store is available.
- Keep `exec:` replies best-effort when no city store exists: send the reply, warn once, and skip only the nudge.
- Add regression coverage for human replies, exec-provider replies, no-city degradation, non-human sender resolution, and the hidden `mail send --nudge` alias.

## Adoption Review
Initial review found that `exec:` reply providers still dropped recipient nudges and that alias coverage had drifted. Maintainer fixups addressed those issues.

Final review status: approved. Remaining findings were minor follow-up quality gaps, not merge blockers.

Review iterations: 3 review passes performed.

## Tests
- `go test ./cmd/gc -run 'TestCmdMailReplyHumanNotifyQueuesNudge|TestCmdMailReplyExecProviderNotifyQueuesNudge|TestCmdMailReplyExecProviderNotifyWithoutCityWarnsAndSendsReply|TestCmdMailReplyExecProviderNotifyResolvesNonHumanSender|TestMailReplyNudgeAliasQueuesNudge|TestMailSendAcceptsNudgeAlias|TestMailReplyNotify(Success|NudgeError)|TestCmdMailReply_FallsBackToGCSessionIDWhenAliasMissing' -count=1`\n- `go vet ./...`\n- `go test ./...`\n\n---\n_Adopted via `/adopt-pr` workflow (Path C-style superseding PR). Original: #1370. Contributor commits preserved._