### PR TITLE
fix(session): preserve in_progress claims across worker churn

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1554,9 +1554,10 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 	)
 	desiredState := wfcResult.State
 	cfgNames := configuredSessionNamesWithSnapshot(filteredCfg, cr.cityName, sessionBeads)
-	_, updated := syncSessionBeadsWithSnapshot(
+	_, updated := syncSessionBeadsWithSnapshotAndRigStores(
 		cr.cityPath,
 		store,
+		cr.rigBeadStores(),
 		desiredState,
 		cr.sp,
 		cfgNames,
@@ -1606,8 +1607,8 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 func (cr *CityRuntime) syncBeadsAndUpdateIndex(desiredState map[string]TemplateParams, sessionBeads *sessionBeadSnapshot) *sessionBeadSnapshot {
 	store := cr.cityBeadStore()
 	cfgNames := configuredSessionNamesWithSnapshot(cr.cfg, cr.cityName, sessionBeads)
-	_, updated := syncSessionBeadsWithSnapshot(
-		cr.cityPath, store, desiredState, cr.sp, cfgNames, cr.cfg, clock.Real{}, cr.stderr, cr.sessionDrains != nil, sessionBeads,
+	_, updated := syncSessionBeadsWithSnapshotAndRigStores(
+		cr.cityPath, store, cr.rigBeadStores(), desiredState, cr.sp, cfgNames, cr.cfg, clock.Real{}, cr.stderr, cr.sessionDrains != nil, sessionBeads,
 	)
 	return updated
 }

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -579,6 +579,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		// Beads won't be persisted, but the reconciler still manages lifecycle.
 		oneShotStore = beads.NewMemStore()
 	}
+	rigStores := buildStandaloneRigStores(cfg, cityPath, stderr)
 
 	// One-shot bead reconciliation: same code path as the daemon.
 	sessionBeads, err := loadSessionBeadSnapshot(oneShotStore)
@@ -586,24 +587,40 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc start: loading session beads: %v\n", err) //nolint:errcheck
 		sessionBeads = nil
 	}
-	dsResult := buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, nil, sessionBeads, nil, stderr)
+	dsResult := buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, rigStores, sessionBeads, nil, stderr)
 	ds := dsResult.State
 	cfgNames := configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
-	_, sessionBeads = syncSessionBeadsWithSnapshot(
-		cityPath, oneShotStore, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
+	_, sessionBeads = syncSessionBeadsWithSnapshotAndRigStores(
+		cityPath, oneShotStore, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
 	)
 
 	open := sessionBeads.Open()
+	if released := releaseOrphanedPoolAssignments(oneShotStore, cfg, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStores, rigStores); len(released) > 0 {
+		for _, r := range released {
+			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
+		}
+		// Standalone start has no follow-up patrol tick, so after reopening
+		// orphaned pool work we must immediately rebuild demand and sync once
+		// more so replacement session beads can be materialized in this run.
+		dsResult = buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, rigStores, sessionBeads, nil, stderr)
+		ds = dsResult.State
+		cfgNames = configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
+		_, sessionBeads = syncSessionBeadsWithSnapshotAndRigStores(
+			cityPath, oneShotStore, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, true, sessionBeads,
+		)
+		open = sessionBeads.Open()
+	}
+
 	dt := newDrainTracker()
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
-		cfg, nil, sessionBeads.Open(), dsResult.ScaleCheckCounts))
+		cfg, dsResult.AssignedWorkBeads, open, dsResult.ScaleCheckCounts))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
 	reconcileSessionBeadsAtPath(
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
-		nil, nil, nil, nil, dt, poolDesired,
+		nil, dsResult.AssignedWorkBeads, rigStores, nil, dt, poolDesired,
 		dsResult.StoreQueryPartial,
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
@@ -616,10 +633,12 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc start: loading session beads: %v\n", err) //nolint:errcheck
 		sessionBeads = nil
 	}
-	dsResult = buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, nil, sessionBeads, nil, stderr)
+	dsResult = buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, rigStores, sessionBeads, nil, stderr)
 	ds = dsResult.State
 	cfgNames = configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
-	syncSessionBeadsWithSnapshot(cityPath, oneShotStore, ds, sp, cfgNames, cfg, clock.Real{}, stderr, false, sessionBeads)
+	syncSessionBeadsWithSnapshotAndRigStores(
+		cityPath, oneShotStore, rigStores, ds, sp, cfgNames, cfg, clock.Real{}, stderr, false, sessionBeads,
+	)
 
 	fmt.Fprintln(stdout, "City started.") //nolint:errcheck // best-effort stdout
 	return 0

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -111,7 +111,13 @@ func TestUnclaimWorkAssignedToRetiredSessionBead_UsesLiveOpenOwnership(t *testin
 		t.Fatalf("Update(%s, reassigned): %v", work.ID, err)
 	}
 
-	unclaimWorkAssignedToRetiredSessionBead(cache, "retired-session", "worker", io.Discard)
+	unclaimWorkAssignedToRetiredSessionBead(
+		cache,
+		nil,
+		beads.Bead{ID: "retired-session"},
+		"worker",
+		io.Discard,
+	)
 
 	got, err := backing.Get(work.ID)
 	if err != nil {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -396,6 +396,7 @@ func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallb
 		stderr = io.Discard
 	}
 	empty := ""
+	open := "open"
 	for _, status := range []string{"open", "in_progress"} {
 		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: true})
 		if err != nil {
@@ -407,6 +408,13 @@ func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallb
 				continue
 			}
 			update := beads.UpdateOpts{Assignee: &empty}
+			// Clearing assignee on an in_progress bead leaves it invisible to
+			// the work_query: Tier 1 needs an assignee match, Tiers 2/3 only
+			// match "ready" status. Reset to "open" so a fresh worker can
+			// re-claim via the routed queue (gc.routed_to + --unassigned).
+			if item.Status == "in_progress" {
+				update.Status = &open
+			}
 			if fallbackRoute != "" && strings.TrimSpace(item.Metadata["gc.routed_to"]) == "" {
 				update.Metadata = map[string]string{"gc.routed_to": fallbackRoute}
 			}
@@ -1222,13 +1230,20 @@ func setMetaBatch(store beads.Store, id string, batch map[string]string, stderr 
 	return nil
 }
 
-// reapStaleSessionBeads cross-references open session beads against live
-// tmux sessions. If a bead claims a session_name but no matching tmux
-// session exists, and the bead has been in that state past the startup
-// grace period, the bead is closed.
+// reapStaleSessionBeads closes session beads that are stuck in the creating
+// state past the startup grace period — sessions whose tmux process never
+// completed startup, so they are guaranteed not to hold work claims (claim
+// is the first thing a worker does after startup).
 //
-// This prevents infinite retry loops where a dead tmux session's bead
-// blocks name availability for new sessions (see #742).
+// Sessions that completed startup (state=active, awake, etc.) are NEVER reaped
+// here even if their tmux session has died: they may hold in_progress claims,
+// and reaping would orphan that work without a way for the reconciler to
+// recover via the assignee-keyed wake path. The session lifecycle reconciler
+// is responsible for restarting completed-but-dead session beads so the
+// original assignee resumes its work.
+//
+// This prevents infinite retry loops for stuck-creating sessions while
+// preserving claim continuity across tmux death+restart for active ones.
 //
 // Returns the number of beads reaped.
 func reapStaleSessionBeads(
@@ -1253,8 +1268,13 @@ func reapStaleSessionBeads(
 		if sn == "" {
 			continue
 		}
-		// Don't reap beads whose tmux session hasn't been started yet.
-		if b.Metadata["state"] == "creating" || strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true" {
+		// Only reap beads stuck in the creating state. Sessions past creating
+		// may hold work claims; reaping them would orphan in_progress beads
+		// because the assignee link to a live session is the only signal the
+		// reconciler has for resume-after-restart.
+		state := strings.TrimSpace(b.Metadata["state"])
+		pendingCreate := strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true"
+		if state != "creating" && !pendingCreate {
 			continue
 		}
 		// Don't reap beads with an active drain — the drainTracker is
@@ -1280,7 +1300,7 @@ func reapStaleSessionBeads(
 			continue
 		}
 		if closeBead(store, b.ID, "stale-session", now.UTC(), stderr) {
-			fmt.Fprintf(stderr, "WARN: reconciler: reaped stale session bead %s — tmux session %q not found\n", b.ID, sn) //nolint:errcheck
+			fmt.Fprintf(stderr, "WARN: reconciler: reaped stuck-creating session bead %s — tmux session %q not found\n", b.ID, sn) //nolint:errcheck
 			reaped++
 		}
 	}
@@ -1294,7 +1314,19 @@ func reapStaleSessionBeads(
 // Follows the commit-signal pattern: metadata is written first, and Close
 // is only called if all writes succeed. If any write fails, the bead stays
 // open so the next tick retries the entire sequence.
+//
+// Belt-and-suspenders against the stale-session reaper: refuses to close a
+// session bead while non-session work is still assigned to it. Closing would
+// strand that work — the reconciler relies on the assignee link to wake the
+// session and resume claims. Callers that legitimately need to retire an
+// active session must either drain it or unclaim its work first (via
+// unclaimWorkAssignedToRetiredSessionBead, which also resets in_progress
+// status to open so the routed queue can re-dispatch the work).
 func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Writer) bool {
+	if hasNonSessionAssignedWork(store, id, stderr) {
+		fmt.Fprintf(stderr, "session beads: refusing to close %s (reason=%s): has assigned work; drain or unclaim first\n", id, reason) //nolint:errcheck
+		return false
+	}
 	if setMetaBatch(store, id, session.ClosePatch(now, reason), stderr) != nil {
 		return false
 	}
@@ -1303,6 +1335,32 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 		return false
 	}
 	return true
+}
+
+// hasNonSessionAssignedWork reports whether any non-session bead is currently
+// assigned (open or in_progress) to the given session bead ID. Session beads
+// (and other session-repairable beads) are excluded so that session-internal
+// bookkeeping does not block close.
+func hasNonSessionAssignedWork(store beads.Store, sessionID string, stderr io.Writer) bool {
+	if store == nil || strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	for _, status := range []string{"open", "in_progress"} {
+		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: true})
+		if err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "session beads: listing assigned work for %s: %v\n", sessionID, err) //nolint:errcheck
+			}
+			continue
+		}
+		for _, item := range work {
+			if session.IsSessionBeadOrRepairable(item) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
 }
 
 // resolveAgentTemplate returns the config agent template name for a given

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -238,6 +238,7 @@ func reopenClosedConfiguredNamedSessionBead(
 
 func retireDuplicateConfiguredNamedSessionBeads(
 	store beads.Store,
+	rigStores map[string]beads.Store,
 	sp runtime.Provider,
 	cfg *config.City,
 	cityName string,
@@ -300,7 +301,7 @@ func retireDuplicateConfiguredNamedSessionBeads(
 				fmt.Fprintf(stderr, "session beads: archiving duplicate named session %s: %v\n", b.ID, err) //nolint:errcheck
 				continue
 			}
-			reassignWorkAssignedToRetiredSessionBead(store, b.ID, openBeads[winner].ID, stderr)
+			reassignWorkAssignedToRetiredSessionBead(store, rigStores, b, openBeads[winner].ID, stderr)
 			reassignStateAssignedToRetiredSessionBead(store, b.ID, openBeads[winner].ID, now, stderr)
 			if b.Metadata == nil {
 				b.Metadata = make(map[string]string, len(batch))
@@ -349,6 +350,7 @@ func namedSessionBeadWinsCanonicalRepair(candidate, incumbent beads.Bead, canoni
 
 func retireRemovedConfiguredNamedSessionBead(
 	store beads.Store,
+	rigStores map[string]beads.Store,
 	sp runtime.Provider,
 	b beads.Bead,
 	now time.Time,
@@ -376,7 +378,7 @@ func retireRemovedConfiguredNamedSessionBead(
 		fmt.Fprintf(stderr, "session beads: archiving removed named session %s: %v\n", b.ID, err) //nolint:errcheck
 		return false
 	}
-	unclaimWorkAssignedToRetiredSessionBead(store, b.ID, retiredSessionFallbackRoute(b), stderr)
+	unclaimWorkAssignedToRetiredSessionBead(store, rigStores, b, retiredSessionFallbackRoute(b), stderr)
 	cancelStateAssignedToRetiredSessionBead(store, b.ID, now, stderr)
 	return true
 }
@@ -388,8 +390,57 @@ func retiredSessionFallbackRoute(b beads.Bead) string {
 	return strings.TrimSpace(b.Metadata["agent_name"])
 }
 
-func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallbackRoute string, stderr io.Writer) {
-	if store == nil || strings.TrimSpace(sessionID) == "" {
+func sessionAssignmentIdentifiers(sessionBead beads.Bead) []string {
+	raw := []string{
+		strings.TrimSpace(sessionBead.ID),
+		strings.TrimSpace(sessionBead.Metadata["session_name"]),
+		strings.TrimSpace(sessionBead.Metadata[namedSessionIdentityMetadata]),
+	}
+	seen := make(map[string]struct{}, len(raw))
+	identifiers := make([]string, 0, len(raw))
+	for _, id := range raw {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		identifiers = append(identifiers, id)
+	}
+	return identifiers
+}
+
+func workAssignmentStores(store beads.Store, rigStores map[string]beads.Store) []beads.Store {
+	if store == nil {
+		return nil
+	}
+	stores := []beads.Store{store}
+	if len(rigStores) == 0 {
+		return stores
+	}
+	names := make([]string, 0, len(rigStores))
+	for name, rs := range rigStores {
+		if rs == nil {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		stores = append(stores, rigStores[name])
+	}
+	return stores
+}
+
+func unclaimWorkAssignedToRetiredSessionBead(
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	sessionBead beads.Bead,
+	fallbackRoute string,
+	stderr io.Writer,
+) {
+	if store == nil || strings.TrimSpace(sessionBead.ID) == "" {
 		return
 	}
 	if stderr == nil {
@@ -397,53 +448,81 @@ func unclaimWorkAssignedToRetiredSessionBead(store beads.Store, sessionID, fallb
 	}
 	empty := ""
 	open := "open"
-	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: true})
-		if err != nil {
-			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", sessionID, err) //nolint:errcheck
-			continue
-		}
-		for _, item := range work {
-			if session.IsSessionBeadOrRepairable(item) {
-				continue
-			}
-			update := beads.UpdateOpts{Assignee: &empty}
-			// Clearing assignee on an in_progress bead leaves it invisible to
-			// the work_query: Tier 1 needs an assignee match, Tiers 2/3 only
-			// match "ready" status. Reset to "open" so a fresh worker can
-			// re-claim via the routed queue (gc.routed_to + --unassigned).
-			if item.Status == "in_progress" {
-				update.Status = &open
-			}
-			if fallbackRoute != "" && strings.TrimSpace(item.Metadata["gc.routed_to"]) == "" {
-				update.Metadata = map[string]string{"gc.routed_to": fallbackRoute}
-			}
-			if err := store.Update(item.ID, update); err != nil {
-				fmt.Fprintf(stderr, "session beads: unclaiming work %s assigned to retired session %s: %v\n", item.ID, sessionID, err) //nolint:errcheck
+	identifiers := sessionAssignmentIdentifiers(sessionBead)
+	seen := make(map[string]struct{})
+	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores) {
+		for _, status := range []string{"open", "in_progress"} {
+			for _, assignee := range identifiers {
+				work, err := ownerStore.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
+				if err != nil {
+					fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s via %q: %v\n", sessionBead.ID, assignee, err) //nolint:errcheck
+					continue
+				}
+				for _, item := range work {
+					if session.IsSessionBeadOrRepairable(item) {
+						continue
+					}
+					key := strconv.Itoa(storeIndex) + "\x00" + item.ID
+					if _, ok := seen[key]; ok {
+						continue
+					}
+					seen[key] = struct{}{}
+					update := beads.UpdateOpts{Assignee: &empty}
+					// Clearing assignee on an in_progress bead leaves it invisible to
+					// the work_query: Tier 1 needs an assignee match, Tiers 2/3 only
+					// match "ready" status. Reset to "open" so a fresh worker can
+					// re-claim via the routed queue (gc.routed_to + --unassigned).
+					if item.Status == "in_progress" {
+						update.Status = &open
+					}
+					if fallbackRoute != "" && strings.TrimSpace(item.Metadata["gc.routed_to"]) == "" {
+						update.Metadata = map[string]string{"gc.routed_to": fallbackRoute}
+					}
+					if err := ownerStore.Update(item.ID, update); err != nil {
+						fmt.Fprintf(stderr, "session beads: unclaiming work %s assigned to retired session %s: %v\n", item.ID, sessionBead.ID, err) //nolint:errcheck
+					}
+				}
 			}
 		}
 	}
 }
 
-func reassignWorkAssignedToRetiredSessionBead(store beads.Store, oldSessionID, newSessionID string, stderr io.Writer) {
-	if store == nil || strings.TrimSpace(oldSessionID) == "" || strings.TrimSpace(newSessionID) == "" {
+func reassignWorkAssignedToRetiredSessionBead(
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	retiredSession beads.Bead,
+	newSessionID string,
+	stderr io.Writer,
+) {
+	if store == nil || strings.TrimSpace(retiredSession.ID) == "" || strings.TrimSpace(newSessionID) == "" {
 		return
 	}
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: oldSessionID, Status: status, Live: true})
-		if err != nil {
-			fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s: %v\n", oldSessionID, err) //nolint:errcheck
-			continue
-		}
-		for _, item := range work {
-			if session.IsSessionBeadOrRepairable(item) {
-				continue
-			}
-			if err := store.Update(item.ID, beads.UpdateOpts{Assignee: &newSessionID}); err != nil {
-				fmt.Fprintf(stderr, "session beads: reassigning work %s from retired session %s to %s: %v\n", item.ID, oldSessionID, newSessionID, err) //nolint:errcheck
+	identifiers := sessionAssignmentIdentifiers(retiredSession)
+	seen := make(map[string]struct{})
+	for storeIndex, ownerStore := range workAssignmentStores(store, rigStores) {
+		for _, status := range []string{"open", "in_progress"} {
+			for _, assignee := range identifiers {
+				work, err := ownerStore.List(beads.ListQuery{Assignee: assignee, Status: status, Live: true})
+				if err != nil {
+					fmt.Fprintf(stderr, "session beads: listing work assigned to retired session %s via %q: %v\n", retiredSession.ID, assignee, err) //nolint:errcheck
+					continue
+				}
+				for _, item := range work {
+					if session.IsSessionBeadOrRepairable(item) {
+						continue
+					}
+					key := strconv.Itoa(storeIndex) + "\x00" + item.ID
+					if _, ok := seen[key]; ok {
+						continue
+					}
+					seen[key] = struct{}{}
+					if err := ownerStore.Update(item.ID, beads.UpdateOpts{Assignee: &newSessionID}); err != nil {
+						fmt.Fprintf(stderr, "session beads: reassigning work %s from retired session %s to %s: %v\n", item.ID, retiredSession.ID, newSessionID, err) //nolint:errcheck
+					}
+				}
 			}
 		}
 	}
@@ -507,8 +586,8 @@ func syncSessionBeads(
 	stderr io.Writer,
 	skipClose bool,
 ) map[string]string {
-	openIndex, _ := syncSessionBeadsWithSnapshot(
-		cityPath, store, desiredState, sp, configuredNames, cfg, clk, stderr, skipClose, nil,
+	openIndex, _ := syncSessionBeadsWithSnapshotAndRigStores(
+		cityPath, store, nil, desiredState, sp, configuredNames, cfg, clk, stderr, skipClose, nil,
 	)
 	return openIndex
 }
@@ -516,6 +595,24 @@ func syncSessionBeads(
 func syncSessionBeadsWithSnapshot(
 	cityPath string,
 	store beads.Store,
+	desiredState map[string]TemplateParams,
+	sp runtime.Provider,
+	configuredNames map[string]bool,
+	cfg *config.City,
+	clk clock.Clock,
+	stderr io.Writer,
+	skipClose bool,
+	sessionBeads *sessionBeadSnapshot,
+) (map[string]string, *sessionBeadSnapshot) {
+	return syncSessionBeadsWithSnapshotAndRigStores(
+		cityPath, store, nil, desiredState, sp, configuredNames, cfg, clk, stderr, skipClose, sessionBeads,
+	)
+}
+
+func syncSessionBeadsWithSnapshotAndRigStores(
+	cityPath string,
+	store beads.Store,
+	rigStores map[string]beads.Store,
 	desiredState map[string]TemplateParams,
 	sp runtime.Provider,
 	configuredNames map[string]bool,
@@ -592,7 +689,7 @@ func syncSessionBeadsWithSnapshot(
 		}
 		canonical, ok := bySessionName[sn]
 		if ok && canonical.ID != b.ID {
-			if closeBead(store, b.ID, "duplicate", clk.Now().UTC(), stderr) {
+			if closeSessionBeadIfUnassigned(store, rigStores, b, "duplicate", clk.Now().UTC(), stderr) {
 				openBeads[i].Status = "closed"
 			}
 		}
@@ -617,7 +714,7 @@ func syncSessionBeadsWithSnapshot(
 			if strings.TrimSpace(b.Metadata["session_name"]) == spec.SessionName {
 				continue
 			}
-			if closeBead(store, b.ID, "reconfigured", now, stderr) {
+			if closeSessionBeadIfUnassigned(store, rigStores, b, "reconfigured", now, stderr) {
 				if sn := strings.TrimSpace(b.Metadata["session_name"]); sn != "" {
 					running, _ := workerSessionTargetRunningWithConfig("", store, sp, cfg, sn)
 					if running {
@@ -631,7 +728,7 @@ func syncSessionBeadsWithSnapshot(
 			}
 		}
 		openBeads = retireDuplicateConfiguredNamedSessionBeads(
-			store, sp, cfg, cityName, openBeads, bySessionName, indexBySessionName, now, stderr,
+			store, rigStores, sp, cfg, cityName, openBeads, bySessionName, indexBySessionName, now, stderr,
 		)
 	}
 
@@ -1023,7 +1120,7 @@ func syncSessionBeadsWithSnapshot(
 			if isNamedSessionBead(b) {
 				identity := namedSessionIdentity(b)
 				if identity != "" && (cfg == nil || config.FindNamedSession(cfg, identity) == nil) {
-					if retireRemovedConfiguredNamedSessionBead(store, sp, b, now, stderr) {
+					if retireRemovedConfiguredNamedSessionBead(store, rigStores, sp, b, now, stderr) {
 						if idx, ok := indexBySessionName[sn]; ok {
 							openBeads[idx].Status = "open"
 							if openBeads[idx].Metadata == nil {
@@ -1047,7 +1144,7 @@ func syncSessionBeadsWithSnapshot(
 				continue
 			}
 			if configuredNames[sn] {
-				if closeBead(store, b.ID, "suspended", now, stderr) {
+				if closeSessionBeadIfUnassigned(store, rigStores, b, "suspended", now, stderr) {
 					if idx, ok := indexBySessionName[sn]; ok {
 						openBeads[idx].Status = "closed"
 					}
@@ -1061,7 +1158,7 @@ func syncSessionBeadsWithSnapshot(
 						}
 					}
 				}
-				if closeBead(store, b.ID, "orphaned", now, stderr) {
+				if closeSessionBeadIfUnassigned(store, rigStores, b, "orphaned", now, stderr) {
 					if idx, ok := indexBySessionName[sn]; ok {
 						openBeads[idx].Status = "closed"
 					}
@@ -1268,13 +1365,14 @@ func reapStaleSessionBeads(
 		if sn == "" {
 			continue
 		}
-		// Only reap beads stuck in the creating state. Sessions past creating
-		// may hold work claims; reaping them would orphan in_progress beads
-		// because the assignee link to a live session is the only signal the
-		// reconciler has for resume-after-restart.
+		// Only reap beads stuck in the creating state after their one-shot
+		// pending_create_claim has already been cleared. The pending create
+		// claim is authoritative across the lifecycle model: it keeps an
+		// in-flight or partially-healed start eligible for retry even when
+		// the bead's cached state has already moved past creating.
 		state := strings.TrimSpace(b.Metadata["state"])
 		pendingCreate := strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true"
-		if state != "creating" && !pendingCreate {
+		if state != "creating" || pendingCreate {
 			continue
 		}
 		// Don't reap beads with an active drain — the drainTracker is
@@ -1315,18 +1413,12 @@ func reapStaleSessionBeads(
 // is only called if all writes succeed. If any write fails, the bead stays
 // open so the next tick retries the entire sequence.
 //
-// Belt-and-suspenders against the stale-session reaper: refuses to close a
-// session bead while non-session work is still assigned to it. Closing would
-// strand that work — the reconciler relies on the assignee link to wake the
-// session and resume claims. Callers that legitimately need to retire an
-// active session must either drain it or unclaim its work first (via
-// unclaimWorkAssignedToRetiredSessionBead, which also resets in_progress
-// status to open so the routed queue can re-dispatch the work).
+// Ownership checks live in closeSessionBeadIfUnassigned, which can see the
+// full cross-store, multi-identifier assignment picture. closeBead remains
+// the low-level metadata+close helper used once a caller has already decided
+// the bead is safe to retire (or the close reason is unrelated to work
+// ownership, such as failed-create cleanup).
 func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Writer) bool {
-	if hasNonSessionAssignedWork(store, id, stderr) {
-		fmt.Fprintf(stderr, "session beads: refusing to close %s (reason=%s): has assigned work; drain or unclaim first\n", id, reason) //nolint:errcheck
-		return false
-	}
 	if setMetaBatch(store, id, session.ClosePatch(now, reason), stderr) != nil {
 		return false
 	}
@@ -1335,32 +1427,6 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 		return false
 	}
 	return true
-}
-
-// hasNonSessionAssignedWork reports whether any non-session bead is currently
-// assigned (open or in_progress) to the given session bead ID. Session beads
-// (and other session-repairable beads) are excluded so that session-internal
-// bookkeeping does not block close.
-func hasNonSessionAssignedWork(store beads.Store, sessionID string, stderr io.Writer) bool {
-	if store == nil || strings.TrimSpace(sessionID) == "" {
-		return false
-	}
-	for _, status := range []string{"open", "in_progress"} {
-		work, err := store.List(beads.ListQuery{Assignee: sessionID, Status: status, Live: true})
-		if err != nil {
-			if stderr != nil {
-				fmt.Fprintf(stderr, "session beads: listing assigned work for %s: %v\n", sessionID, err) //nolint:errcheck
-			}
-			continue
-		}
-		for _, item := range work {
-			if session.IsSessionBeadOrRepairable(item) {
-				continue
-			}
-			return true
-		}
-	}
-	return false
 }
 
 // resolveAgentTemplate returns the config agent template name for a given

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2908,39 +2908,7 @@ func TestReapStaleSessionBeads(t *testing.T) {
 		wantOpen   int // expected number of open beads after reap
 	}{
 		{
-			name: "dead_session_reaped",
-			beads: []beads.Bead{{
-				Title:  "worker",
-				Type:   sessionBeadType,
-				Labels: []string{sessionBeadLabel},
-				Metadata: map[string]string{
-					"session_name": "worker-1",
-					"state":        "active",
-				},
-			}},
-			running:    nil,
-			clock:      clockPastGrace,
-			wantReaped: 1,
-			wantOpen:   0,
-		},
-		{
-			name: "live_session_kept",
-			beads: []beads.Bead{{
-				Title:  "worker",
-				Type:   sessionBeadType,
-				Labels: []string{sessionBeadLabel},
-				Metadata: map[string]string{
-					"session_name": "worker-1",
-					"state":        "active",
-				},
-			}},
-			running:    []string{"worker-1"},
-			clock:      clockPastGrace,
-			wantReaped: 0,
-			wantOpen:   1,
-		},
-		{
-			name: "creating_state_skipped",
+			name: "stuck_creating_reaped",
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -2952,11 +2920,11 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			}},
 			running:    nil,
 			clock:      clockPastGrace,
-			wantReaped: 0,
-			wantOpen:   1,
+			wantReaped: 1,
+			wantOpen:   0,
 		},
 		{
-			name: "pending_create_skipped",
+			name: "pending_create_reaped",
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -2969,11 +2937,15 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			}},
 			running:    nil,
 			clock:      clockPastGrace,
-			wantReaped: 0,
-			wantOpen:   1,
+			wantReaped: 1,
+			wantOpen:   0,
 		},
 		{
-			name: "grace_period_honored",
+			name: "active_session_dead_tmux_kept",
+			// Bug 1 fix: a session past creating must NEVER be reaped here,
+			// even when its tmux is dead. It may hold in_progress claims; the
+			// session lifecycle reconciler is responsible for restarting the
+			// same bead so the original assignee resumes the work.
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -2981,6 +2953,54 @@ func TestReapStaleSessionBeads(t *testing.T) {
 				Metadata: map[string]string{
 					"session_name": "worker-1",
 					"state":        "active",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "awake_session_dead_tmux_kept",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "awake",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "live_session_kept",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "creating",
+				},
+			}},
+			running:    []string{"worker-1"},
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "creating_within_grace_kept",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name": "worker-1",
+					"state":        "creating",
 				},
 			}},
 			running:    nil,
@@ -2995,7 +3015,7 @@ func TestReapStaleSessionBeads(t *testing.T) {
 				Type:   sessionBeadType,
 				Labels: []string{sessionBeadLabel},
 				Metadata: map[string]string{
-					"state": "active",
+					"state": "creating",
 				},
 			}},
 			running:    nil,
@@ -3004,14 +3024,14 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   1,
 		},
 		{
-			name: "draining_session_skipped",
+			name: "draining_creating_session_skipped",
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
 				Labels: []string{sessionBeadLabel},
 				Metadata: map[string]string{
 					"session_name": "worker-1",
-					"state":        "active",
+					"state":        "creating",
 				},
 			}},
 			running:    nil,
@@ -3041,7 +3061,29 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   1,
 		},
 		{
-			name: "multiple_stale_reaped",
+			name: "configured_named_creating_session_skipped",
+			beads: []beads.Bead{{
+				Title:  "gascity/control-dispatcher",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":              "gascity--control-dispatcher",
+					"template":                  "gascity/control-dispatcher",
+					"state":                     "creating",
+					"configured_named_session":  "true",
+					"configured_named_identity": "gascity/control-dispatcher",
+					"configured_named_mode":     "always",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "only_creating_among_dead_reaped",
+			// Mixed pool: alpha is stuck creating, beta is past creating
+			// (active) with dead tmux, gamma is alive. Only alpha is reaped.
 			beads: []beads.Bead{
 				{
 					Title:  "session alpha",
@@ -3049,7 +3091,7 @@ func TestReapStaleSessionBeads(t *testing.T) {
 					Labels: []string{sessionBeadLabel},
 					Metadata: map[string]string{
 						"session_name": "session-alpha",
-						"state":        "active",
+						"state":        "creating",
 					},
 				},
 				{
@@ -3058,7 +3100,7 @@ func TestReapStaleSessionBeads(t *testing.T) {
 					Labels: []string{sessionBeadLabel},
 					Metadata: map[string]string{
 						"session_name": "session-beta",
-						"state":        "awake",
+						"state":        "active",
 					},
 				},
 				{
@@ -3067,14 +3109,14 @@ func TestReapStaleSessionBeads(t *testing.T) {
 					Labels: []string{sessionBeadLabel},
 					Metadata: map[string]string{
 						"session_name": "session-gamma",
-						"state":        "active",
+						"state":        "creating",
 					},
 				},
 			},
-			running:    []string{"session-gamma"}, // only gamma is alive
+			running:    []string{"session-gamma"}, // gamma's tmux is alive
 			clock:      clockPastGrace,
-			wantReaped: 2,
-			wantOpen:   1,
+			wantReaped: 1, // only alpha (creating + dead tmux) is reaped
+			wantOpen:   2, // beta (active dead tmux), gamma (creating live tmux)
 		},
 	}
 
@@ -3154,8 +3196,8 @@ func TestReapStaleSessionBeads(t *testing.T) {
 							b.ID, b.Metadata["close_reason"], "stale-session")
 					}
 				}
-				if !strings.Contains(stderr.String(), "WARN: reconciler: reaped stale session bead") {
-					t.Error("expected WARN log line for reaped bead")
+				if !strings.Contains(stderr.String(), "WARN: reconciler: reaped stuck-creating session bead") {
+					t.Errorf("expected WARN log line for reaped bead; stderr=%q", stderr.String())
 				}
 			}
 		})
@@ -3174,5 +3216,154 @@ func TestReapStaleSessionBeads_NilStoreAndProvider(t *testing.T) {
 	}
 	if got := reapStaleSessionBeads(nil, runtime.NewFake(), nil, clk, &stderr); got != 0 {
 		t.Errorf("nil store: got %d, want 0", got)
+	}
+}
+
+// TestUnclaimResetsInProgressStatus verifies the Bug 2 fix: unclaiming a
+// retired session's in_progress work must reset status to "open" so a fresh
+// worker can re-claim via the routed queue (Tier 3: gc.routed_to +
+// --unassigned). Leaving status=in_progress with no assignee makes the bead
+// invisible to every work_query tier.
+func TestUnclaimResetsInProgressStatus(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Session bead the work was assigned to (mimics a retired worker).
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	// In-progress work assigned to that session, with gc.routed_to set so
+	// Tier 3 of the work_query can re-route it after unclaim.
+	work, err := store.Create(beads.Bead{
+		Title:    "finalize",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{"gc.routed_to": "myrig/codex-max"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	// Open work also assigned: should also be cleared but stays "open".
+	openWork, err := store.Create(beads.Bead{
+		Title:    "queued",
+		Status:   "open",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{"gc.routed_to": "myrig/codex-max"},
+	})
+	if err != nil {
+		t.Fatalf("create open work: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	unclaimWorkAssignedToRetiredSessionBead(store, sessionBead.ID, "myrig/codex-max", &stderr)
+
+	gotInProgress, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get in_progress work: %v", err)
+	}
+	if gotInProgress.Assignee != "" {
+		t.Errorf("in_progress assignee = %q, want empty", gotInProgress.Assignee)
+	}
+	if gotInProgress.Status != "open" {
+		t.Errorf("in_progress status = %q, want %q (status must reset so the bead is visible to the work_query)", gotInProgress.Status, "open")
+	}
+
+	gotOpen, err := store.Get(openWork.ID)
+	if err != nil {
+		t.Fatalf("get open work: %v", err)
+	}
+	if gotOpen.Assignee != "" {
+		t.Errorf("open assignee = %q, want empty", gotOpen.Assignee)
+	}
+	if gotOpen.Status != "open" {
+		t.Errorf("open status = %q, want %q (already open, must stay open)", gotOpen.Status, "open")
+	}
+}
+
+// TestCloseBeadRefusesWhenWorkAssigned verifies the belt-and-suspenders guard:
+// even if some caller bypasses the reaper's creating-state filter, closeBead
+// itself must refuse to close a session bead while work is assigned to it.
+// This protects the assignee link the reconciler uses for resume-after-restart.
+func TestCloseBeadRefusesWhenWorkAssigned(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	if _, err := store.Create(beads.Bead{
+		Title:    "finalize",
+		Status:   "in_progress",
+		Assignee: sessionBead.ID,
+	}); err != nil {
+		t.Fatalf("create assigned work: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	if closeBead(store, sessionBead.ID, "stale-session", now, &stderr) {
+		t.Fatal("closeBead returned true; want false because non-session work is assigned")
+	}
+	got, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("session bead status = closed; want still open after refused close")
+	}
+	if !strings.Contains(stderr.String(), "refusing to close") {
+		t.Errorf("stderr = %q, want refusal message", stderr.String())
+	}
+}
+
+// TestCloseBeadAllowsWhenNoAssignedWork confirms the guard does not block
+// legitimate closes: a session bead with only session-internal beads (or no
+// beads) assigned should close normally.
+func TestCloseBeadAllowsWhenNoAssignedWork(t *testing.T) {
+	store := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "creating",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	if !closeBead(store, sessionBead.ID, "stale-session", now, &stderr) {
+		t.Fatalf("closeBead returned false; want true: stderr=%s", stderr.String())
+	}
+	got, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("session bead status = %q, want %q", got.Status, "closed")
 	}
 }

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1226,7 +1226,7 @@ func TestRetireDuplicateConfiguredNamedSessionBeads_DoesNotStopWinnerSharingSess
 	indexBySessionName := map[string]int{sessionName: 1}
 
 	retired := retireDuplicateConfiguredNamedSessionBeads(
-		store, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
+		store, nil, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
 	)
 
 	if !sp.IsRunning(sessionName) {
@@ -2924,21 +2924,38 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   0,
 		},
 		{
-			name: "pending_create_reaped",
+			name: "pending_create_creating_kept",
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
 				Labels: []string{sessionBeadLabel},
 				Metadata: map[string]string{
 					"session_name":         "worker-1",
-					"state":                "stopped",
+					"state":                "creating",
 					"pending_create_claim": "true",
 				},
 			}},
 			running:    nil,
 			clock:      clockPastGrace,
-			wantReaped: 1,
-			wantOpen:   0,
+			wantReaped: 0,
+			wantOpen:   1,
+		},
+		{
+			name: "pending_create_active_kept",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":         "worker-1",
+					"state":                "active",
+					"pending_create_claim": "true",
+				},
+			}},
+			running:    nil,
+			clock:      clockPastGrace,
+			wantReaped: 0,
+			wantOpen:   1,
 		},
 		{
 			name: "active_session_dead_tmux_kept",
@@ -3252,6 +3269,10 @@ func TestUnclaimResetsInProgressStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create work bead: %v", err)
 	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
 
 	// Open work also assigned: should also be cleared but stays "open".
 	openWork, err := store.Create(beads.Bead{
@@ -3265,7 +3286,7 @@ func TestUnclaimResetsInProgressStatus(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	unclaimWorkAssignedToRetiredSessionBead(store, sessionBead.ID, "myrig/codex-max", &stderr)
+	unclaimWorkAssignedToRetiredSessionBead(store, nil, sessionBead, "myrig/codex-max", &stderr)
 
 	gotInProgress, err := store.Get(work.ID)
 	if err != nil {
@@ -3290,11 +3311,11 @@ func TestUnclaimResetsInProgressStatus(t *testing.T) {
 	}
 }
 
-// TestCloseBeadRefusesWhenWorkAssigned verifies the belt-and-suspenders guard:
-// even if some caller bypasses the reaper's creating-state filter, closeBead
-// itself must refuse to close a session bead while work is assigned to it.
-// This protects the assignee link the reconciler uses for resume-after-restart.
-func TestCloseBeadRefusesWhenWorkAssigned(t *testing.T) {
+// closeBead is the low-level metadata+close helper. Ownership checks live in
+// closeSessionBeadIfUnassigned, which has the full multi-store, multi-identifier
+// view of assigned work. closeBead itself must stay dumb so it doesn't
+// introduce a narrower contract than the live-query helper.
+func TestCloseBeadDoesNotDuplicateOwnershipGuard(t *testing.T) {
 	store := beads.NewMemStore()
 
 	sessionBead, err := store.Create(beads.Bead{
@@ -3320,26 +3341,21 @@ func TestCloseBeadRefusesWhenWorkAssigned(t *testing.T) {
 
 	var stderr bytes.Buffer
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	if closeBead(store, sessionBead.ID, "stale-session", now, &stderr) {
-		t.Fatal("closeBead returned true; want false because non-session work is assigned")
+	if !closeBead(store, sessionBead.ID, "stale-session", now, &stderr) {
+		t.Fatalf("closeBead returned false; want true because ownership gating belongs to closeSessionBeadIfUnassigned: stderr=%s", stderr.String())
 	}
 	got, err := store.Get(sessionBead.ID)
 	if err != nil {
 		t.Fatalf("get session bead: %v", err)
 	}
-	if got.Status == "closed" {
-		t.Fatalf("session bead status = closed; want still open after refused close")
-	}
-	if !strings.Contains(stderr.String(), "refusing to close") {
-		t.Errorf("stderr = %q, want refusal message", stderr.String())
+	if got.Status != "closed" {
+		t.Fatalf("session bead status = %q, want closed", got.Status)
 	}
 }
 
-// TestCloseBeadAllowsWhenNoAssignedWork confirms the guard does not block
-// legitimate closes: a session bead with only session-internal beads (or no
-// beads) assigned should close normally.
-func TestCloseBeadAllowsWhenNoAssignedWork(t *testing.T) {
+func TestCloseSessionBeadIfUnassignedRefusesWhenRigStoreWorkAssignedBySessionName(t *testing.T) {
 	store := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
 
 	sessionBead, err := store.Create(beads.Bead{
 		Title:  "worker",
@@ -3347,23 +3363,229 @@ func TestCloseBeadAllowsWhenNoAssignedWork(t *testing.T) {
 		Labels: []string{sessionBeadLabel},
 		Metadata: map[string]string{
 			"session_name": "worker-1",
-			"state":        "creating",
+			"state":        "active",
 		},
 	})
 	if err != nil {
 		t.Fatalf("create session bead: %v", err)
 	}
 
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "rig work",
+		Status:   "open",
+		Assignee: "worker-1",
+	}); err != nil {
+		t.Fatalf("create rig work: %v", err)
+	}
+
 	var stderr bytes.Buffer
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	if !closeBead(store, sessionBead.ID, "stale-session", now, &stderr) {
-		t.Fatalf("closeBead returned false; want true: stderr=%s", stderr.String())
+	if closeSessionBeadIfUnassigned(store, map[string]beads.Store{"demo": rigStore}, sessionBead, "stale-session", now, &stderr) {
+		t.Fatal("closeSessionBeadIfUnassigned returned true; want false because rig-store work is still assigned by session_name")
 	}
 	got, err := store.Get(sessionBead.ID)
 	if err != nil {
 		t.Fatalf("get session bead: %v", err)
 	}
-	if got.Status != "closed" {
-		t.Fatalf("session bead status = %q, want %q", got.Status, "closed")
+	if got.Status == "closed" {
+		t.Fatalf("session bead status = closed; want still open after helper refused close")
+	}
+}
+
+func TestUnclaimWorkAssignedToRetiredSessionBeadClearsRigStoreSessionIdentifiers(t *testing.T) {
+	store := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "worker-1",
+			"state":                      "retired",
+			namedSessionIdentityMetadata: "frontend/worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+
+	bySessionName, err := rigStore.Create(beads.Bead{
+		Title:    "session-name work",
+		Status:   "open",
+		Assignee: "worker-1",
+	})
+	if err != nil {
+		t.Fatalf("create session-name work: %v", err)
+	}
+
+	byIdentity, err := rigStore.Create(beads.Bead{
+		Title:    "named-identity work",
+		Status:   "open",
+		Assignee: "frontend/worker",
+	})
+	if err != nil {
+		t.Fatalf("create named-identity work: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := rigStore.Update(byIdentity.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark named-identity work in_progress: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	unclaimWorkAssignedToRetiredSessionBead(
+		store,
+		map[string]beads.Store{"frontend": rigStore},
+		sessionBead,
+		"frontend/codex-max",
+		&stderr,
+	)
+
+	gotBySessionName, err := rigStore.Get(bySessionName.ID)
+	if err != nil {
+		t.Fatalf("get session-name work: %v", err)
+	}
+	if gotBySessionName.Assignee != "" {
+		t.Fatalf("session-name assignee = %q, want empty", gotBySessionName.Assignee)
+	}
+	if gotBySessionName.Status != "open" {
+		t.Fatalf("session-name status = %q, want open", gotBySessionName.Status)
+	}
+
+	gotByIdentity, err := rigStore.Get(byIdentity.ID)
+	if err != nil {
+		t.Fatalf("get named-identity work: %v", err)
+	}
+	if gotByIdentity.Assignee != "" {
+		t.Fatalf("named-identity assignee = %q, want empty", gotByIdentity.Assignee)
+	}
+	if gotByIdentity.Status != "open" {
+		t.Fatalf("named-identity status = %q, want open after unclaim", gotByIdentity.Status)
+	}
+	if gotByIdentity.Metadata["gc.routed_to"] != "frontend/codex-max" {
+		t.Fatalf("named-identity gc.routed_to = %q, want frontend/codex-max", gotByIdentity.Metadata["gc.routed_to"])
+	}
+}
+
+func TestReassignWorkAssignedToRetiredSessionBeadReassignsRigStoreSessionIdentifiers(t *testing.T) {
+	store := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	retired, err := store.Create(beads.Bead{
+		Title:  "old worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "worker-1",
+			"state":                      "retired",
+			namedSessionIdentityMetadata: "frontend/worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create retired session bead: %v", err)
+	}
+	successor, err := store.Create(beads.Bead{
+		Title:  "new worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-2",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create successor session bead: %v", err)
+	}
+
+	bySessionName, err := rigStore.Create(beads.Bead{
+		Title:    "session-name work",
+		Status:   "open",
+		Assignee: "worker-1",
+	})
+	if err != nil {
+		t.Fatalf("create session-name work: %v", err)
+	}
+	byIdentity, err := rigStore.Create(beads.Bead{
+		Title:    "named-identity work",
+		Status:   "open",
+		Assignee: "frontend/worker",
+	})
+	if err != nil {
+		t.Fatalf("create named-identity work: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	reassignWorkAssignedToRetiredSessionBead(
+		store,
+		map[string]beads.Store{"frontend": rigStore},
+		retired,
+		successor.ID,
+		&stderr,
+	)
+
+	gotBySessionName, err := rigStore.Get(bySessionName.ID)
+	if err != nil {
+		t.Fatalf("get session-name work: %v", err)
+	}
+	if gotBySessionName.Assignee != successor.ID {
+		t.Fatalf("session-name assignee = %q, want %q", gotBySessionName.Assignee, successor.ID)
+	}
+
+	gotByIdentity, err := rigStore.Get(byIdentity.ID)
+	if err != nil {
+		t.Fatalf("get named-identity work: %v", err)
+	}
+	if gotByIdentity.Assignee != successor.ID {
+		t.Fatalf("named-identity assignee = %q, want %q", gotByIdentity.Assignee, successor.ID)
+	}
+}
+
+func TestSyncSessionBeadsWithSnapshotAndRigStoresLeavesOrphanedSessionBeadOpenWhenRigStoreWorkAssigned(t *testing.T) {
+	store := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	sp := runtime.NewFake()
+	clk := &clock.Fake{}
+
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "rig work",
+		Status:   "open",
+		Assignee: "worker-1",
+	}); err != nil {
+		t.Fatalf("create rig work: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshotAndRigStores(
+		"",
+		store,
+		map[string]beads.Store{"frontend": rigStore},
+		nil,
+		sp,
+		map[string]bool{},
+		nil,
+		clk,
+		&stderr,
+		false,
+		nil,
+	)
+
+	got, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("get session bead: %v", err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("session bead status = %q, want open because rig-store work still owns it", got.Status)
 	}
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -272,7 +272,7 @@ func reconcileSessionBeadsTraced(
 			}
 		}
 		sessions = retireDuplicateConfiguredNamedSessionBeads(
-			store, sp, cfg, cityName, sessions, bySessionName, indexBySessionName, clk.Now().UTC(), stderr,
+			store, rigStores, sp, cfg, cityName, sessions, bySessionName, indexBySessionName, clk.Now().UTC(), stderr,
 		)
 	}
 
@@ -1181,11 +1181,7 @@ func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (b
 	if store == nil {
 		return false, nil
 	}
-	identifiers := []string{
-		strings.TrimSpace(session.ID),
-		strings.TrimSpace(session.Metadata["session_name"]),
-		strings.TrimSpace(session.Metadata[namedSessionIdentityMetadata]),
-	}
+	identifiers := sessionAssignmentIdentifiers(session)
 	seen := make(map[string]struct{}, len(identifiers))
 	for _, status := range []string{"open", "in_progress"} {
 		for _, assignee := range identifiers {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2024,10 +2024,14 @@ func (a *Agent) EffectiveOnDeath() string {
 	if a.OnDeath != "" {
 		return a.OnDeath
 	}
+	// Reset both assignee and status: clearing assignee alone leaves the bead
+	// invisible to every work_query tier (Tier 1 needs assignee match, Tiers
+	// 2/3 only match "ready" status). The next worker re-claims via Tier 3
+	// (gc.routed_to + --unassigned).
 	return `bd list --assignee=` + a.QualifiedName() +
 		` --status=in_progress --json 2>/dev/null | ` +
 		`jq -r '.[].id' 2>/dev/null | ` +
-		`xargs -rI{} bd update {} --assignee "" 2>/dev/null`
+		`xargs -rI{} bd update {} --assignee "" --status open 2>/dev/null`
 }
 
 // EffectiveOnBoot returns the on_boot command for this agent.
@@ -2041,10 +2045,11 @@ func (a *Agent) EffectiveOnBoot() string {
 	if a.PoolName != "" {
 		template = a.PoolName
 	}
+	// Reset both assignee and status; see EffectiveOnDeath for rationale.
 	return `bd list --metadata-field gc.routed_to=` + template +
 		` --status=in_progress --json 2>/dev/null | ` +
 		`jq -r '.[].id' 2>/dev/null | ` +
-		`xargs -rI{} bd update {} --assignee "" 2>/dev/null`
+		`xargs -rI{} bd update {} --assignee "" --status open 2>/dev/null`
 }
 
 // InjectImplicitAgents adds on-demand agents for each configured provider at

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2024,14 +2024,26 @@ func (a *Agent) EffectiveOnDeath() string {
 	if a.OnDeath != "" {
 		return a.OnDeath
 	}
+	route := a.QualifiedName()
+	if a.PoolName != "" {
+		route = a.PoolName
+	}
 	// Reset both assignee and status: clearing assignee alone leaves the bead
 	// invisible to every work_query tier (Tier 1 needs assignee match, Tiers
 	// 2/3 only match "ready" status). The next worker re-claims via Tier 3
-	// (gc.routed_to + --unassigned).
+	// (gc.routed_to + --unassigned). If routed metadata is missing entirely,
+	// backfill the fallback route so reopened direct-assigned work does not
+	// stay invisible.
 	return `bd list --assignee=` + a.QualifiedName() +
 		` --status=in_progress --json 2>/dev/null | ` +
-		`jq -r '.[].id' 2>/dev/null | ` +
-		`xargs -rI{} bd update {} --assignee "" --status open 2>/dev/null`
+		`jq -r '.[] | [.id, (.metadata["gc.routed_to"] // "")] | @tsv' 2>/dev/null | ` +
+		`while IFS="$(printf '\t')" read -r id current_route; do ` +
+		`[ -z "$id" ] && continue; ` +
+		`if [ -n "$current_route" ]; then ` +
+		`bd update "$id" --assignee "" --status open 2>/dev/null; ` +
+		`else bd update "$id" --assignee "" --status open --set-metadata gc.routed_to=` + route + ` 2>/dev/null; ` +
+		`fi; ` +
+		`done`
 }
 
 // EffectiveOnBoot returns the on_boot command for this agent.
@@ -2045,11 +2057,10 @@ func (a *Agent) EffectiveOnBoot() string {
 	if a.PoolName != "" {
 		template = a.PoolName
 	}
-	// Reset both assignee and status; see EffectiveOnDeath for rationale.
 	return `bd list --metadata-field gc.routed_to=` + template +
-		` --status=in_progress --json 2>/dev/null | ` +
+		` --status=in_progress --no-assignee --json 2>/dev/null | ` +
 		`jq -r '.[].id' 2>/dev/null | ` +
-		`xargs -rI{} bd update {} --assignee "" --status open 2>/dev/null`
+		`xargs -rI{} bd update {} --status open 2>/dev/null`
 }
 
 // InjectImplicitAgents adds on-demand agents for each configured provider at

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3553,7 +3553,7 @@ func TestEffectiveOnDeathDefault(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
 	}
 	got := a.EffectiveOnDeath()
-	for _, want := range []string{"bd list --assignee=myrig/dog", "--status=in_progress", "--assignee \"\""} {
+	for _, want := range []string{"bd list --assignee=myrig/dog", "--status=in_progress", `--assignee "" --status open`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnDeath() = %q, want %q", got, want)
 		}
@@ -3574,7 +3574,7 @@ func TestEffectiveOnDeathCustom(t *testing.T) {
 func TestEffectiveOnDeathFixedAgent(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveOnDeath()
-	for _, want := range []string{"bd list --assignee=mayor", "--status=in_progress", "--assignee \"\""} {
+	for _, want := range []string{"bd list --assignee=mayor", "--status=in_progress", `--assignee "" --status open`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnDeath() = %q, want %q", got, want)
 		}
@@ -3588,7 +3588,7 @@ func TestEffectiveOnBootDefault(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
 	}
 	got := a.EffectiveOnBoot()
-	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", "--assignee \"\""} {
+	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", `--assignee "" --status open`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnBoot() = %q, want %q", got, want)
 		}
@@ -3604,7 +3604,7 @@ func TestEffectiveOnBootDefaultPoolName(t *testing.T) {
 		PoolName: "myrig/dog",
 	}
 	got := a.EffectiveOnBoot()
-	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", "--assignee \"\""} {
+	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", `--assignee "" --status open`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnBoot() = %q, want %q", got, want)
 		}
@@ -3625,7 +3625,7 @@ func TestEffectiveOnBootCustom(t *testing.T) {
 func TestEffectiveOnBootNonPool(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveOnBoot()
-	for _, want := range []string{"bd list --metadata-field gc.routed_to=mayor", "--status=in_progress", "--assignee \"\""} {
+	for _, want := range []string{"bd list --metadata-field gc.routed_to=mayor", "--status=in_progress", `--assignee "" --status open`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnBoot() = %q, want %q", got, want)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3190,6 +3190,34 @@ func runEffectiveWorkQuery(t *testing.T, a Agent, env map[string]string, bdScrip
 	return string(out)
 }
 
+func runLifecycleHookCommand(t *testing.T, command string, env map[string]string, bdScript string) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	logPath := filepath.Join(tmp, "bd.log")
+
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Env = []string{
+		"PATH=" + tmp + ":" + os.Getenv("PATH"),
+		"BD_LOG=" + logPath,
+	}
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run lifecycle hook: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hook log: %v", err)
+	}
+	return string(data)
+}
+
 // TestEffectiveMethodsAgentRouting verifies that all agents use
 // gc.routed_to=<qualified-name> metadata routing.
 func TestEffectiveMethodsAgentRouting(t *testing.T) {
@@ -3553,7 +3581,7 @@ func TestEffectiveOnDeathDefault(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
 	}
 	got := a.EffectiveOnDeath()
-	for _, want := range []string{"bd list --assignee=myrig/dog", "--status=in_progress", `--assignee "" --status open`} {
+	for _, want := range []string{"bd list --assignee=myrig/dog", "--status=in_progress", `--assignee "" --status open`, "--set-metadata gc.routed_to=myrig/dog"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnDeath() = %q, want %q", got, want)
 		}
@@ -3574,10 +3602,70 @@ func TestEffectiveOnDeathCustom(t *testing.T) {
 func TestEffectiveOnDeathFixedAgent(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveOnDeath()
-	for _, want := range []string{"bd list --assignee=mayor", "--status=in_progress", `--assignee "" --status open`} {
+	for _, want := range []string{"bd list --assignee=mayor", "--status=in_progress", `--assignee "" --status open`, "--set-metadata gc.routed_to=mayor"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnDeath() = %q, want %q", got, want)
 		}
+	}
+}
+
+func TestEffectiveOnDeathBackfillsMissingRouteOnReopen(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+
+	log := runLifecycleHookCommand(t, a.EffectiveOnDeath(), nil, `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '[{"id":"ga-missing","metadata":{}}]'
+    ;;
+  update)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	if !strings.Contains(log, "--status open") {
+		t.Fatalf("hook log = %q, want reopened status", log)
+	}
+	if !strings.Contains(log, "--set-metadata gc.routed_to=hello-world/dog") {
+		t.Fatalf("hook log = %q, want fallback route for ownerless reopened work", log)
+	}
+}
+
+func TestEffectiveOnDeathPreservesExistingRouteOnReopen(t *testing.T) {
+	a := Agent{
+		Name:              "dog-1",
+		Dir:               "hello-world",
+		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
+		PoolName: "hello-world/dog",
+	}
+
+	log := runLifecycleHookCommand(t, a.EffectiveOnDeath(), nil, `#!/bin/sh
+set -eu
+case "$1" in
+  list)
+    printf '[{"id":"ga-routed","metadata":{"gc.routed_to":"already/routed"}}]'
+    ;;
+  update)
+    printf '%s\n' "$*" >> "$BD_LOG"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	if !strings.Contains(log, "--status open") {
+		t.Fatalf("hook log = %q, want reopened status", log)
+	}
+	if strings.Contains(log, "--set-metadata") {
+		t.Fatalf("hook log = %q, want existing route preserved without overwrite", log)
 	}
 }
 
@@ -3588,10 +3676,13 @@ func TestEffectiveOnBootDefault(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(5),
 	}
 	got := a.EffectiveOnBoot()
-	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", `--assignee "" --status open`} {
+	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", "--no-assignee", "--status open"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnBoot() = %q, want %q", got, want)
 		}
+	}
+	if strings.Contains(got, `--assignee ""`) {
+		t.Errorf("EffectiveOnBoot() = %q, want to target only ownerless work instead of bulk-unassigning routed work", got)
 	}
 }
 
@@ -3604,10 +3695,13 @@ func TestEffectiveOnBootDefaultPoolName(t *testing.T) {
 		PoolName: "myrig/dog",
 	}
 	got := a.EffectiveOnBoot()
-	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", `--assignee "" --status open`} {
+	for _, want := range []string{"bd list --metadata-field gc.routed_to=myrig/dog", "--status=in_progress", "--no-assignee", "--status open"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnBoot() = %q, want %q", got, want)
 		}
+	}
+	if strings.Contains(got, `--assignee ""`) {
+		t.Errorf("EffectiveOnBoot() = %q, want to target only ownerless work instead of bulk-unassigning routed work", got)
 	}
 }
 
@@ -3625,10 +3719,13 @@ func TestEffectiveOnBootCustom(t *testing.T) {
 func TestEffectiveOnBootNonPool(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveOnBoot()
-	for _, want := range []string{"bd list --metadata-field gc.routed_to=mayor", "--status=in_progress", `--assignee "" --status open`} {
+	for _, want := range []string{"bd list --metadata-field gc.routed_to=mayor", "--status=in_progress", "--no-assignee", "--status open"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("EffectiveOnBoot() = %q, want %q", got, want)
 		}
+	}
+	if strings.Contains(got, `--assignee ""`) {
+		t.Errorf("EffectiveOnBoot() = %q, want to target only ownerless work instead of bulk-unassigning routed work", got)
 	}
 }
 

--- a/internal/config/session_model_phase0_spec_test.go
+++ b/internal/config/session_model_phase0_spec_test.go
@@ -92,11 +92,15 @@ func TestPhase0ConfigDefaults_OnBootUnclaimsRoutedWorkByDefault(t *testing.T) {
 	for _, want := range []string{
 		"bd list --metadata-field gc.routed_to=myrig/worker",
 		"--status=in_progress",
-		"--assignee \"\"",
+		"--no-assignee",
+		"--status open",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("EffectiveOnBoot() = %q, want %q", got, want)
 		}
+	}
+	if strings.Contains(got, `--assignee ""`) {
+		t.Fatalf("EffectiveOnBoot() = %q, want to target only ownerless work instead of bulk-unassigning routed work", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Supersedes #1389.
- Preserves the contributor's session-claim recovery fix for pool-worker churn.
- Adds the maintainer follow-up needed to make standalone `gc start` release orphaned pool work, rebuild demand immediately, and keep standalone cleanup on the same rig-store-aware ownership path as the daemon.

Maintainer follow-ups in this PR:
- run `releaseOrphanedPoolAssignments(...)` during standalone `gc start` before computing `poolDesired`
- immediately rebuild desired state and resync session beads after any orphan release because standalone start has no follow-up patrol tick
- thread assigned work and rig stores through the standalone reconcile/post-sync path so ownership checks match the daemon path

Credit: Original fix by @julianknutsen.

## Testing

- [x] `make check`
- [x] `make check-docs` if docs, navigation, or links changed (not needed)
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed (`Supersedes #1389`)
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes (not needed)
- [x] Called out breaking changes or migration notes (none)
