### PR TITLE
perf(orders): cache order check read model

### DIFF
--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -9009,7 +9009,10 @@ export interface operations {
     };
     "get-v0-city-by-city-name-orders-check": {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Bypass cached order-check responses and cached order history. */
+                fresh?: boolean;
+            };
             header?: never;
             path: {
                 /** @description City name. */

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -7616,7 +7616,12 @@ export type GetV0CityByCityNameOrdersCheckData = {
          */
         cityName: string;
     };
-    query?: never;
+    query?: {
+        /**
+         * Bypass cached order-check responses and cached order history.
+         */
+        fresh?: boolean;
+    };
     url: '/v0/city/{cityName}/orders/check';
 };
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -17743,6 +17743,16 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Bypass cached order-check responses and cached order history.",
+            "explode": false,
+            "in": "query",
+            "name": "fresh",
+            "schema": {
+              "description": "Bypass cached order-check responses and cached order history.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -17743,6 +17743,16 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Bypass cached order-check responses and cached order history.",
+            "explode": false,
+            "in": "query",
+            "name": "fresh",
+            "schema": {
+              "description": "Bypass cached order-check responses and cached order history.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -4327,6 +4327,12 @@ type PostV0CityByCityNameOrderByNameEnableParams struct {
 	XGCRequest string `json:"X-GC-Request"`
 }
 
+// GetV0CityByCityNameOrdersCheckParams defines parameters for GetV0CityByCityNameOrdersCheck.
+type GetV0CityByCityNameOrdersCheckParams struct {
+	// Fresh Bypass cached order-check responses and cached order history.
+	Fresh *bool `form:"fresh,omitempty" json:"fresh,omitempty"`
+}
+
 // GetV0CityByCityNameOrdersFeedParams defines parameters for GetV0CityByCityNameOrdersFeed.
 type GetV0CityByCityNameOrdersFeedParams struct {
 	// ScopeKind Scope kind (city or rig).
@@ -8186,7 +8192,7 @@ type ClientInterface interface {
 	GetV0CityByCityNameOrders(ctx context.Context, cityName string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetV0CityByCityNameOrdersCheck request
-	GetV0CityByCityNameOrdersCheck(ctx context.Context, cityName string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetV0CityByCityNameOrdersCheck(ctx context.Context, cityName string, params *GetV0CityByCityNameOrdersCheckParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetV0CityByCityNameOrdersFeed request
 	GetV0CityByCityNameOrdersFeed(ctx context.Context, cityName string, params *GetV0CityByCityNameOrdersFeedParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -9684,8 +9690,8 @@ func (c *Client) GetV0CityByCityNameOrders(ctx context.Context, cityName string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetV0CityByCityNameOrdersCheck(ctx context.Context, cityName string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetV0CityByCityNameOrdersCheckRequest(c.Server, cityName)
+func (c *Client) GetV0CityByCityNameOrdersCheck(ctx context.Context, cityName string, params *GetV0CityByCityNameOrdersCheckParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetV0CityByCityNameOrdersCheckRequest(c.Server, cityName, params)
 	if err != nil {
 		return nil, err
 	}
@@ -15952,7 +15958,7 @@ func NewGetV0CityByCityNameOrdersRequest(server string, cityName string) (*http.
 }
 
 // NewGetV0CityByCityNameOrdersCheckRequest generates requests for GetV0CityByCityNameOrdersCheck
-func NewGetV0CityByCityNameOrdersCheckRequest(server string, cityName string) (*http.Request, error) {
+func NewGetV0CityByCityNameOrdersCheckRequest(server string, cityName string, params *GetV0CityByCityNameOrdersCheckParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -15975,6 +15981,28 @@ func NewGetV0CityByCityNameOrdersCheckRequest(server string, cityName string) (*
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Fresh != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "fresh", *params.Fresh, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -19977,7 +20005,7 @@ type ClientWithResponsesInterface interface {
 	GetV0CityByCityNameOrdersWithResponse(ctx context.Context, cityName string, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrdersResponse, error)
 
 	// GetV0CityByCityNameOrdersCheckWithResponse request
-	GetV0CityByCityNameOrdersCheckWithResponse(ctx context.Context, cityName string, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrdersCheckResponse, error)
+	GetV0CityByCityNameOrdersCheckWithResponse(ctx context.Context, cityName string, params *GetV0CityByCityNameOrdersCheckParams, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrdersCheckResponse, error)
 
 	// GetV0CityByCityNameOrdersFeedWithResponse request
 	GetV0CityByCityNameOrdersFeedWithResponse(ctx context.Context, cityName string, params *GetV0CityByCityNameOrdersFeedParams, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrdersFeedResponse, error)
@@ -24413,8 +24441,8 @@ func (c *ClientWithResponses) GetV0CityByCityNameOrdersWithResponse(ctx context.
 }
 
 // GetV0CityByCityNameOrdersCheckWithResponse request returning *GetV0CityByCityNameOrdersCheckResponse
-func (c *ClientWithResponses) GetV0CityByCityNameOrdersCheckWithResponse(ctx context.Context, cityName string, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrdersCheckResponse, error) {
-	rsp, err := c.GetV0CityByCityNameOrdersCheck(ctx, cityName, reqEditors...)
+func (c *ClientWithResponses) GetV0CityByCityNameOrdersCheckWithResponse(ctx context.Context, cityName string, params *GetV0CityByCityNameOrdersCheckParams, reqEditors ...RequestEditorFn) (*GetV0CityByCityNameOrdersCheckResponse, error) {
+	rsp, err := c.GetV0CityByCityNameOrdersCheck(ctx, cityName, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -405,6 +406,36 @@ func TestHandleOrderCheckTreatsWispFailedAsFailed(t *testing.T) {
 	}
 }
 
+func TestHandleOrderCheckDoesNotRunConditionByDefault(t *testing.T) {
+	fs := newFakeState(t)
+	marker := t.TempDir() + "/condition-ran"
+	fs.autos = []orders.Order{
+		{Name: "router", Formula: "review-pr", Trigger: "condition", Check: "touch " + marker},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("condition marker stat err = %v, want not exist", err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check?fresh=true"), nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("fresh status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("condition marker after fresh check: %v", err)
+	}
+}
+
 func TestLastRunOutcomeFromLabelsPrioritizesTerminalLabels(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -728,6 +759,73 @@ func TestHandleOrderCheckUsesRigStoreLastRunState(t *testing.T) {
 	}
 	if check.LastRunOutcome == nil || *check.LastRunOutcome != "success" {
 		t.Fatalf("last_run_outcome = %v, want success", check.LastRunOutcome)
+	}
+}
+
+type cachedOnlyOrderHistoryStore struct {
+	beads.Store
+	cached                 []beads.Bead
+	includeClosedListCalls int
+}
+
+func (s *cachedOnlyOrderHistoryStore) CachedList(query beads.ListQuery) ([]beads.Bead, bool) {
+	return beads.ApplyListQuery(s.cached, query), true
+}
+
+func (s *cachedOnlyOrderHistoryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.IncludeClosed {
+		s.includeClosedListCalls++
+	}
+	return s.Store.List(query)
+}
+
+func TestHandleOrderCheckUsesCachedHistoryWhenAvailable(t *testing.T) {
+	fs := newFakeState(t)
+	run := beads.Bead{
+		ID:        "run-1",
+		Title:     "nightly-review wisp",
+		Status:    "closed",
+		CreatedAt: time.Now().UTC(),
+		Labels:    []string{"order-run:nightly-review", "wisp"},
+	}
+	cachedStore := &cachedOnlyOrderHistoryStore{
+		Store:  beads.NewMemStore(),
+		cached: []beads.Bead{run},
+	}
+	fs.cityBeadStore = cachedStore
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Trigger: "cooldown", Interval: "24h"},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Checks []struct {
+			Due            bool    `json:"due"`
+			LastRunOutcome *string `json:"last_run_outcome"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(resp.Checks))
+	}
+	if resp.Checks[0].Due {
+		t.Fatal("due = true, want false from cached recent run")
+	}
+	if resp.Checks[0].LastRunOutcome == nil || *resp.Checks[0].LastRunOutcome != "success" {
+		t.Fatalf("last_run_outcome = %v, want success", resp.Checks[0].LastRunOutcome)
+	}
+	if cachedStore.includeClosedListCalls != 0 {
+		t.Fatalf("IncludeClosed List calls = %d, want 0 when cached history is available", cachedStore.includeClosedListCalls)
 	}
 }
 

--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -406,33 +407,30 @@ func TestHandleOrderCheckTreatsWispFailedAsFailed(t *testing.T) {
 	}
 }
 
-func TestHandleOrderCheckDoesNotRunConditionByDefault(t *testing.T) {
+func TestHandleOrderCheckRunsConditionByDefault(t *testing.T) {
 	fs := newFakeState(t)
 	marker := t.TempDir() + "/condition-ran"
 	fs.autos = []orders.Order{
-		{Name: "router", Formula: "review-pr", Trigger: "condition", Check: "touch " + marker},
+		{Name: "router", Formula: "review-pr", Trigger: "condition", Check: "printf x >> " + strconv.Quote(marker)},
 	}
 
 	h := newTestCityHandler(t, fs)
-	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	for _, path := range []string{"/orders/check", "/orders/check", "/orders/check?fresh=true"} {
+		req := httptest.NewRequest(http.MethodGet, cityURL(fs, path), nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
-	}
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("condition marker stat err = %v, want not exist", err)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status for %s = %d, want 200; body = %s", path, w.Code, w.Body.String())
+		}
 	}
 
-	req = httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check?fresh=true"), nil)
-	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("fresh status = %d, want 200; body = %s", w.Code, w.Body.String())
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read condition marker: %v", err)
 	}
-	if _, err := os.Stat(marker); err != nil {
-		t.Fatalf("condition marker after fresh check: %v", err)
+	if string(got) != "xxx" {
+		t.Fatalf("condition marker = %q, want one execution per request", got)
 	}
 }
 
@@ -765,11 +763,12 @@ func TestHandleOrderCheckUsesRigStoreLastRunState(t *testing.T) {
 type cachedOnlyOrderHistoryStore struct {
 	beads.Store
 	cached                 []beads.Bead
+	cacheOK                bool
 	includeClosedListCalls int
 }
 
 func (s *cachedOnlyOrderHistoryStore) CachedList(query beads.ListQuery) ([]beads.Bead, bool) {
-	return beads.ApplyListQuery(s.cached, query), true
+	return beads.ApplyListQuery(s.cached, query), s.cacheOK
 }
 
 func (s *cachedOnlyOrderHistoryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -789,8 +788,9 @@ func TestHandleOrderCheckUsesCachedHistoryWhenAvailable(t *testing.T) {
 		Labels:    []string{"order-run:nightly-review", "wisp"},
 	}
 	cachedStore := &cachedOnlyOrderHistoryStore{
-		Store:  beads.NewMemStore(),
-		cached: []beads.Bead{run},
+		Store:   beads.NewMemStore(),
+		cached:  []beads.Bead{run},
+		cacheOK: true,
 	}
 	fs.cityBeadStore = cachedStore
 	fs.autos = []orders.Order{
@@ -826,6 +826,57 @@ func TestHandleOrderCheckUsesCachedHistoryWhenAvailable(t *testing.T) {
 	}
 	if cachedStore.includeClosedListCalls != 0 {
 		t.Fatalf("IncludeClosed List calls = %d, want 0 when cached history is available", cachedStore.includeClosedListCalls)
+	}
+}
+
+func TestHandleOrderCheckFallsBackToLiveHistoryWhenCacheUnavailable(t *testing.T) {
+	fs := newFakeState(t)
+	cachedStore := &cachedOnlyOrderHistoryStore{
+		Store: beads.NewMemStore(),
+	}
+	_, err := cachedStore.Create(beads.Bead{
+		Title:     "nightly-review wisp",
+		Status:    "closed",
+		CreatedAt: time.Now().UTC(),
+		Labels:    []string{"order-run:nightly-review", "wisp"},
+	})
+	if err != nil {
+		t.Fatalf("create live history bead: %v", err)
+	}
+	fs.cityBeadStore = cachedStore
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2", Trigger: "cooldown", Interval: "24h"},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/check"), nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Checks []struct {
+			Due            bool    `json:"due"`
+			LastRunOutcome *string `json:"last_run_outcome"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(resp.Checks))
+	}
+	if resp.Checks[0].Due {
+		t.Fatal("due = true, want false from live recent run")
+	}
+	if resp.Checks[0].LastRunOutcome == nil || *resp.Checks[0].LastRunOutcome != "success" {
+		t.Fatalf("last_run_outcome = %v, want success", resp.Checks[0].LastRunOutcome)
+	}
+	if cachedStore.includeClosedListCalls == 0 {
+		t.Fatal("IncludeClosed List calls = 0, want live fallback when cache is unavailable")
 	}
 }
 

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
@@ -64,10 +65,18 @@ type OrderCheckListOutput struct {
 }
 
 // humaHandleOrderCheck is the Huma-typed handler for GET /v0/orders/check.
-func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*OrderCheckListOutput, error) {
+func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput) (*OrderCheckListOutput, error) {
 	aa := s.state.Orders()
 
 	ep := s.state.EventProvider()
+
+	index := s.latestIndex()
+	cacheKey := cacheKeyFor("orders-check", input)
+	if !input.Fresh {
+		if body, ok := cachedResponseAs[OrderCheckListBody](s, cacheKey, index); ok {
+			return &OrderCheckListOutput{Body: body}, nil
+		}
+	}
 
 	now := time.Now()
 	checks := make([]orderCheckResponse, 0, len(aa))
@@ -76,8 +85,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 		if err != nil {
 			storeInfos = nil
 		}
-		stores := storesFromWorkflowInfos(storeInfos)
-		result := orders.CheckTrigger(a, now, orders.LastRunAcrossStores(stores...), ep, orders.CursorAcrossStores(stores...))
+		history, _ := orderHistoryBeadsAcrossStoreInfosForCheck(storeInfos, a.ScopedName(), 1, time.Time{}, input.Fresh)
+		result := checkOrderTriggerForAPI(a, now, history, storeInfos, ep, input.Fresh)
 		cr := orderCheckResponse{
 			Name:       a.Name,
 			ScopedName: a.ScopedName(),
@@ -89,8 +98,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 			ts := result.LastRun.Format(time.RFC3339)
 			cr.LastRun = &ts
 		}
-		if results, err := orderHistoryBeadsAcrossStoreInfos(storeInfos, a.ScopedName(), 1, time.Time{}); err == nil && len(results) > 0 {
-			outcome := lastRunOutcomeFromLabels(results[0].bead.Labels)
+		if len(history) > 0 {
+			outcome := lastRunOutcomeFromLabels(history[0].bead.Labels)
 			if outcome != "" {
 				cr.LastRunOutcome = &outcome
 			}
@@ -104,7 +113,36 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, _ *OrderCheckInput) (*O
 
 	out := &OrderCheckListOutput{}
 	out.Body.Checks = checks
+	if !input.Fresh {
+		s.storeResponse(cacheKey, index, out.Body)
+	}
 	return out, nil
+}
+
+func checkOrderTriggerForAPI(a orders.Order, now time.Time, history []orderHistoryStoreBead, infos []workflowStoreInfo, ep events.Provider, fresh bool) orders.TriggerResult {
+	lastRunFn := func(string) (time.Time, error) {
+		if len(history) == 0 {
+			return time.Time{}, nil
+		}
+		return history[0].bead.CreatedAt, nil
+	}
+	if a.Trigger == "condition" && !fresh {
+		return orders.TriggerResult{Due: false, Reason: "condition: not evaluated in cached API check"}
+	}
+	var cursorFn orders.CursorFunc
+	if a.Trigger == "event" {
+		if fresh {
+			cursorFn = orders.CursorAcrossStores(storesFromWorkflowInfos(infos)...)
+		} else {
+			labelSets := make([][]string, 0, len(history))
+			for _, row := range history {
+				labelSets = append(labelSets, row.bead.Labels)
+			}
+			cursor := orders.MaxSeqFromLabels(labelSets)
+			cursorFn = func(string) uint64 { return cursor }
+		}
+	}
+	return orders.CheckTrigger(a, now, lastRunFn, ep, cursorFn)
 }
 
 // orderCheckResponse is the response item for GET /v0/orders/check.
@@ -306,6 +344,10 @@ type orderHistoryStoreBead struct {
 	bead     beads.Bead
 }
 
+type cachedListStore interface {
+	CachedList(beads.ListQuery) ([]beads.Bead, bool)
+}
+
 func orderStoreInfosForState(state State, a orders.Order) ([]workflowStoreInfo, error) {
 	cityName := workflowCityScopeRef(state.CityName())
 	infos := make([]workflowStoreInfo, 0, 2)
@@ -343,6 +385,74 @@ func storesFromWorkflowInfos(infos []workflowStoreInfo) []beads.Store {
 		}
 	}
 	return stores
+}
+
+func orderHistoryBeadsAcrossStoreInfosForCheck(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time, fresh bool) ([]orderHistoryStoreBead, error) {
+	if fresh {
+		return orderHistoryBeadsAcrossStoreInfos(infos, scopedName, limit, beforeTime)
+	}
+	return orderHistoryBeadsAcrossStoreInfosCachedFirst(infos, scopedName, limit, beforeTime)
+}
+
+func orderHistoryBeadsAcrossStoreInfosCachedFirst(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time) ([]orderHistoryStoreBead, error) {
+	if len(infos) == 0 {
+		return nil, errNoOrderStores
+	}
+
+	label := "order-run:" + scopedName
+	seen := make(map[string]bool)
+	results := make([]orderHistoryStoreBead, 0)
+	for i, info := range infos {
+		if info.store == nil {
+			continue
+		}
+		query := beads.ListQuery{
+			Label:         label,
+			CreatedBefore: beforeTime,
+			Limit:         limit,
+			IncludeClosed: true,
+			Sort:          beads.SortCreatedDesc,
+		}
+		var (
+			rows []beads.Bead
+			err  error
+		)
+		if cached, ok := info.store.(cachedListStore); ok {
+			var cacheOK bool
+			rows, cacheOK = cached.CachedList(query)
+			if !cacheOK {
+				continue
+			}
+		} else {
+			rows, err = info.store.List(query)
+			if err != nil {
+				if i == 0 {
+					return nil, err
+				}
+				log.Printf("api: order history list failed for %s: %v", info.ref, err)
+				continue
+			}
+		}
+		for _, row := range rows {
+			if !beforeTime.IsZero() && !row.CreatedAt.Before(beforeTime) {
+				continue
+			}
+			key := info.ref + "\x00" + row.ID
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			results = append(results, orderHistoryStoreBead{storeRef: info.ref, bead: row})
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].bead.CreatedAt.After(results[j].bead.CreatedAt)
+	})
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
 }
 
 func orderHistoryBeadsAcrossStoreInfos(infos []workflowStoreInfo, scopedName string, limit int, beforeTime time.Time) ([]orderHistoryStoreBead, error) {

--- a/internal/api/huma_handlers_orders.go
+++ b/internal/api/huma_handlers_orders.go
@@ -72,7 +72,8 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput)
 
 	index := s.latestIndex()
 	cacheKey := cacheKeyFor("orders-check", input)
-	if !input.Fresh {
+	useResponseCache := !input.Fresh && !hasConditionOrder(aa)
+	if useResponseCache {
 		if body, ok := cachedResponseAs[OrderCheckListBody](s, cacheKey, index); ok {
 			return &OrderCheckListOutput{Body: body}, nil
 		}
@@ -113,10 +114,19 @@ func (s *Server) humaHandleOrderCheck(_ context.Context, input *OrderCheckInput)
 
 	out := &OrderCheckListOutput{}
 	out.Body.Checks = checks
-	if !input.Fresh {
+	if useResponseCache {
 		s.storeResponse(cacheKey, index, out.Body)
 	}
 	return out, nil
+}
+
+func hasConditionOrder(aa []orders.Order) bool {
+	for _, a := range aa {
+		if a.Trigger == "condition" {
+			return true
+		}
+	}
+	return false
 }
 
 func checkOrderTriggerForAPI(a orders.Order, now time.Time, history []orderHistoryStoreBead, infos []workflowStoreInfo, ep events.Provider, fresh bool) orders.TriggerResult {
@@ -125,9 +135,6 @@ func checkOrderTriggerForAPI(a orders.Order, now time.Time, history []orderHisto
 			return time.Time{}, nil
 		}
 		return history[0].bead.CreatedAt, nil
-	}
-	if a.Trigger == "condition" && !fresh {
-		return orders.TriggerResult{Due: false, Reason: "condition: not evaluated in cached API check"}
 	}
 	var cursorFn orders.CursorFunc
 	if a.Trigger == "event" {
@@ -344,10 +351,6 @@ type orderHistoryStoreBead struct {
 	bead     beads.Bead
 }
 
-type cachedListStore interface {
-	CachedList(beads.ListQuery) ([]beads.Bead, bool)
-}
-
 func orderStoreInfosForState(state State, a orders.Order) ([]workflowStoreInfo, error) {
 	cityName := workflowCityScopeRef(state.CityName())
 	infos := make([]workflowStoreInfo, 0, 2)
@@ -421,17 +424,17 @@ func orderHistoryBeadsAcrossStoreInfosCachedFirst(infos []workflowStoreInfo, sco
 			var cacheOK bool
 			rows, cacheOK = cached.CachedList(query)
 			if !cacheOK {
-				continue
+				rows, err = info.store.List(query)
 			}
 		} else {
 			rows, err = info.store.List(query)
-			if err != nil {
-				if i == 0 {
-					return nil, err
-				}
-				log.Printf("api: order history list failed for %s: %v", info.ref, err)
-				continue
+		}
+		if err != nil {
+			if i == 0 {
+				return nil, err
 			}
+			log.Printf("api: order history list failed for %s: %v", info.ref, err)
+			continue
 		}
 		for _, row := range rows {
 			if !beforeTime.IsZero() && !row.CreatedAt.Before(beforeTime) {

--- a/internal/api/huma_types_orders.go
+++ b/internal/api/huma_types_orders.go
@@ -28,6 +28,7 @@ type OrderGetInput struct {
 // OrderCheckInput is the Huma input for GET /v0/city/{cityName}/orders/check.
 type OrderCheckInput struct {
 	CityScope
+	Fresh bool `query:"fresh" required:"false" doc:"Force fresh trigger evaluation, including condition scripts and backing-store order history."`
 }
 
 // OrderHistoryInput is the Huma input for GET /v0/city/{cityName}/orders/history.

--- a/internal/api/huma_types_orders.go
+++ b/internal/api/huma_types_orders.go
@@ -28,7 +28,7 @@ type OrderGetInput struct {
 // OrderCheckInput is the Huma input for GET /v0/city/{cityName}/orders/check.
 type OrderCheckInput struct {
 	CityScope
-	Fresh bool `query:"fresh" required:"false" doc:"Force fresh trigger evaluation, including condition scripts and backing-store order history."`
+	Fresh bool `query:"fresh" required:"false" doc:"Bypass cached order-check responses and cached order history."`
 }
 
 // OrderHistoryInput is the Huma input for GET /v0/city/{cityName}/orders/history.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -17743,6 +17743,16 @@
               "pattern": "\\S",
               "type": "string"
             }
+          },
+          {
+            "description": "Bypass cached order-check responses and cached order history.",
+            "explode": false,
+            "in": "query",
+            "name": "fresh",
+            "schema": {
+              "description": "Bypass cached order-check responses and cached order history.",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1340.

Original PR metadata:
- Original title: perf(orders): cache order check read model
- Original state: CLOSED, unmerged
- Configured base: main
- Original GitHub base: main
- Base mismatch: none; reviewed diff was based on recorded upstream snapshot ee69f95e6f226d85a7e9ae37153cfa2d27b68836, and `git merge-tree origin/main HEAD` checked clean against current origin/main 19e8dc71700285c3ac62066871f5969188fc6de5.

What this includes:
- Preserves Julian's original `perf(orders): cache order check read model` commit.
- Adds a maintainer-reviewed fix for cold order-check caches so cache misses fall back to the backing store instead of returning empty history.
- Updates the Huma/OpenAPI generated artifacts and dashboard generated types for the `fresh` query parameter.

Review synthesis:
- Reviewers found the original PR did not compile because `cachedListStore` was redeclared.
- Reviewers found a cold-cache behavior bug where `/orders/check` could treat missing cached history as empty history and report incorrect due results.
- Reviewers asked for coverage of cache-unavailable fallback behavior and clearer `fresh=true` semantics for condition evaluation.
- The follow-up branch addresses the blocker/major findings and the review loop closed with `review.verdict=done`.

Validation run before opening this PR:
- `git diff --check refs/adopt-pr/ga-3m3ad/upstream-base..HEAD`
- `go test ./internal/api`
- `make dashboard-check`

Merge plan:
- Wait for visible passing CI on this follow-up PR.
- Merge only after `gh pr checks` reports checks and they are passing.
- Preserve contributor authorship on squash merge with Julian's noreply author email.
