### PR TITLE
perf(sessions): enqueue reconciler starts asynchronously

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1329,6 +1329,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
 		cr.cfg.Daemon.DriftDrainTimeoutDuration(),
 		cr.stdout, cr.stderr, trace,
+		withAsyncStartExecution(),
 	)
 	cr.requestDeferredDrainFollowUpTick()
 	if trace != nil {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -68,8 +68,10 @@ type CityRuntime struct {
 	standaloneRigStores map[string]beads.Store
 
 	// Bead-driven reconciler state (Phase 2f).
-	sessionDrains  *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
-	demandSnapshot *runtimeDemandSnapshot
+	sessionDrains     *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	asyncStartLimiter chan struct{}
+	asyncStarts       asyncStartTracker
+	demandSnapshot    *runtimeDemandSnapshot
 
 	convHandler         *convergence.Handler     // nil until bead store available
 	convStoreAdapter    *convergenceStoreAdapter // typed reference; avoids type assertions in tick/reconcile
@@ -204,6 +206,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		poolSessions:            p.PoolSessions,
 		poolDeathHandlers:       p.PoolDeathHandlers,
 		suspendedNames:          suspendedNames,
+		asyncStartLimiter:       make(chan struct{}, defaultMaxParallelStartsPerWave),
 		convergenceReqCh:        p.ConvergenceReqCh,
 		reloadReqCh: func() chan reloadRequest {
 			if p.ReloadReqCh != nil {
@@ -1330,6 +1333,9 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		cr.cfg.Daemon.DriftDrainTimeoutDuration(),
 		cr.stdout, cr.stderr, trace,
 		withAsyncStartExecution(),
+		withAsyncStartFollowUp(cr.requestAsyncStartFollowUpTick),
+		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
+		withAsyncStartTracker(&cr.asyncStarts),
 	)
 	cr.requestDeferredDrainFollowUpTick()
 	if trace != nil {
@@ -1391,6 +1397,41 @@ func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {
 	select {
 	case cr.pokeCh <- struct{}{}:
 	default:
+	}
+}
+
+func (cr *CityRuntime) ensureAsyncStartLimiter() chan struct{} {
+	if cr.asyncStartLimiter == nil {
+		cr.asyncStartLimiter = make(chan struct{}, defaultMaxParallelStartsPerWave)
+	}
+	return cr.asyncStartLimiter
+}
+
+func (cr *CityRuntime) requestAsyncStartFollowUpTick() {
+	if cr == nil {
+		return
+	}
+	// Async completion can commit, rollback, or reject stale work; each case
+	// should prompt one cheap reconciliation pass to observe the new reality.
+	select {
+	case cr.pokeCh <- struct{}{}:
+	default:
+	}
+}
+
+func (cr *CityRuntime) waitForAsyncStarts() {
+	if cr == nil {
+		return
+	}
+	timeout := time.Duration(0)
+	if cr.cfg != nil {
+		timeout = cr.cfg.Daemon.ShutdownTimeoutDuration()
+	}
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	if !cr.asyncStarts.wait(timeout) && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: async session starts still running after %s; continuing shutdown\n", cr.logPrefix, timeout) //nolint:errcheck // best-effort stderr
 	}
 }
 
@@ -1826,6 +1867,7 @@ func (cr *CityRuntime) beginTraceCycle(trigger, detail string, sessionBeads *ses
 // normal shutdown) — only the first call takes effect.
 func (cr *CityRuntime) shutdown() {
 	cr.shutdownOnce.Do(func() {
+		cr.waitForAsyncStarts()
 		if cr.trace != nil {
 			_ = cr.trace.Close()
 		}

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -67,6 +67,18 @@ type startResult struct {
 	rollbackPending bool
 }
 
+type startExecutionOptions struct {
+	async bool
+}
+
+type startExecutionOption func(*startExecutionOptions)
+
+func withAsyncStartExecution() startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.async = true
+	}
+}
+
 type stopTarget struct {
 	sessionID   string
 	name        string
@@ -521,109 +533,183 @@ func executePreparedStartWaveForCity(
 		i, item := i, item
 		sem <- struct{}{}
 		go func() {
-			started := time.Now()
 			defer func() {
-				if recovered := recover(); recovered != nil {
-					stack := debug.Stack()
-					results[i] = startResult{
-						prepared: item,
-						err:      fmt.Errorf("panic during start: %v\n%s", recovered, stack),
-						outcome:  "panic_recovered",
-						started:  started,
-						finished: time.Now(),
-					}
-				}
 				<-sem
 				done <- i
 			}()
-			startCtx := ctx
-			cancel := func() {}
-			if startupTimeout > 0 {
-				startCtx, cancel = context.WithTimeout(ctx, startupTimeout)
-			}
-			defer cancel()
-			_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
-			if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
-				running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
-				if runningErr == nil && running {
-					err = nil
-				}
-			}
-			// Stale session key detection: if the session was started
-			// with a resume flag but dies immediately, the session key
-			// likely references a conversation that no longer exists
-			// (e.g., "No conversation found"). Report as a failure so
-			// recordWakeFailure clears the key for the next attempt.
-			if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
-				time.Sleep(staleKeyDetectDelay)
-				running := false
-				alive := false
-				if store == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
-					running = sp != nil && sp.IsRunning(item.candidate.name())
-					alive = running && (sp == nil || sp.ProcessAlive(item.candidate.name(), item.cfg.ProcessNames))
-				} else {
-					var obs worker.LiveObservation
-					obs, err = workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
-					running = obs.Running
-					alive = obs.Alive
-				}
-				if err != nil || !running || !alive {
-					err = fmt.Errorf("session %q died during startup", item.candidate.name())
-				}
-			}
-			finished := time.Now()
-			rollbackPending := err != nil && shouldRollbackPendingCreate(item.candidate.session)
-			if err != nil && rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
-				results[i] = startResult{
-					prepared:        item,
-					err:             nil,
-					outcome:         "start_error_converged",
-					started:         started,
-					finished:        finished,
-					rollbackPending: false,
-				}
-				return
-			}
-			var outcome string
-			switch {
-			case err == nil:
-				outcome = "success"
-			case startCtx.Err() == context.DeadlineExceeded:
-				outcome = "deadline_exceeded"
-			case startCtx.Err() == context.Canceled:
-				outcome = "canceled"
-			case errors.Is(err, runtime.ErrSessionInitializing):
-				outcome = "session_initializing"
-				err = nil
-			case errors.Is(err, runtime.ErrSessionExists):
-				running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
-				switch {
-				case runningErr != nil || !running:
-					outcome = "provider_error"
-				case rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
-					outcome = "session_exists_converged"
-					err = nil
-					rollbackPending = false
-				default:
-					outcome = "session_exists"
-				}
-			default:
-				outcome = "provider_error"
-			}
-			results[i] = startResult{
-				prepared:        item,
-				err:             err,
-				outcome:         outcome,
-				started:         started,
-				finished:        finished,
-				rollbackPending: rollbackPending,
-			}
+			results[i] = runPreparedStartCandidate(ctx, item, cityPath, sp, store, cfg, startupTimeout)
 		}()
 	}
 	for range prepared {
 		<-done
 	}
 	return results
+}
+
+func runPreparedStartCandidate(
+	ctx context.Context,
+	item preparedStart,
+	cityPath string,
+	sp runtime.Provider,
+	store beads.Store,
+	cfg *config.City,
+	startupTimeout time.Duration,
+) (result startResult) {
+	started := time.Now()
+	result = startResult{
+		prepared: item,
+		started:  started,
+		finished: started,
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			stack := debug.Stack()
+			result = startResult{
+				prepared: item,
+				err:      fmt.Errorf("panic during start: %v\n%s", recovered, stack),
+				outcome:  "panic_recovered",
+				started:  started,
+				finished: time.Now(),
+			}
+		}
+	}()
+
+	startCtx := ctx
+	cancel := func() {}
+	if startupTimeout > 0 {
+		startCtx, cancel = context.WithTimeout(ctx, startupTimeout)
+	}
+	defer cancel()
+	_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
+	if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
+		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		if runningErr == nil && running {
+			err = nil
+		}
+	}
+	// Stale session key detection: if the session was started
+	// with a resume flag but dies immediately, the session key
+	// likely references a conversation that no longer exists
+	// (e.g., "No conversation found"). Report as a failure so
+	// recordWakeFailure clears the key for the next attempt.
+	if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
+		time.Sleep(staleKeyDetectDelay)
+		running := false
+		alive := false
+		if store == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
+			running = sp != nil && sp.IsRunning(item.candidate.name())
+			alive = running && (sp == nil || sp.ProcessAlive(item.candidate.name(), item.cfg.ProcessNames))
+		} else {
+			var obs worker.LiveObservation
+			obs, err = workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, item.candidate.name(), item.cfg.ProcessNames)
+			running = obs.Running
+			alive = obs.Alive
+		}
+		if err != nil || !running || !alive {
+			err = fmt.Errorf("session %q died during startup", item.candidate.name())
+		}
+	}
+	finished := time.Now()
+	rollbackPending := err != nil && shouldRollbackPendingCreate(item.candidate.session)
+	if err != nil && rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
+		return startResult{
+			prepared:        item,
+			err:             nil,
+			outcome:         "start_error_converged",
+			started:         started,
+			finished:        finished,
+			rollbackPending: false,
+		}
+	}
+	var outcome string
+	switch {
+	case err == nil:
+		outcome = "success"
+	case startCtx.Err() == context.DeadlineExceeded:
+		outcome = "deadline_exceeded"
+	case startCtx.Err() == context.Canceled:
+		outcome = "canceled"
+	case errors.Is(err, runtime.ErrSessionInitializing):
+		outcome = "session_initializing"
+		err = nil
+	case errors.Is(err, runtime.ErrSessionExists):
+		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		switch {
+		case runningErr != nil || !running:
+			outcome = "provider_error"
+		case rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
+			outcome = "session_exists_converged"
+			err = nil
+			rollbackPending = false
+		default:
+			outcome = "session_exists"
+		}
+	default:
+		outcome = "provider_error"
+	}
+	return startResult{
+		prepared:        item,
+		err:             err,
+		outcome:         outcome,
+		started:         started,
+		finished:        finished,
+		rollbackPending: rollbackPending,
+	}
+}
+
+func enqueuePreparedStartWaveForCity(
+	ctx context.Context,
+	prepared []preparedStart,
+	cityPath string,
+	sp runtime.Provider,
+	store beads.Store,
+	cfg *config.City,
+	clk clock.Clock,
+	rec events.Recorder,
+	startupTimeout time.Duration,
+	wave int,
+	stdout, stderr io.Writer,
+) []startResult {
+	if len(prepared) == 0 {
+		return nil
+	}
+	results := make([]startResult, len(prepared))
+	for i, item := range prepared {
+		item = clonePreparedStartForAsync(item)
+		now := time.Now()
+		results[i] = startResult{
+			prepared: item,
+			outcome:  "start_enqueued",
+			started:  now,
+			finished: now,
+		}
+		go func(item preparedStart) {
+			result := runPreparedStartCandidate(ctx, item, cityPath, sp, store, cfg, startupTimeout)
+			if result.err == nil && result.outcome != "session_initializing" {
+				clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())
+			}
+			commitStartResultTraced(result, store, clk, rec, wave, stdout, stderr, nil)
+		}(item)
+	}
+	return results
+}
+
+func clonePreparedStartForAsync(item preparedStart) preparedStart {
+	if item.candidate.session == nil {
+		return item
+	}
+	sessionCopy := *item.candidate.session
+	if item.candidate.session.Labels != nil {
+		sessionCopy.Labels = append([]string(nil), item.candidate.session.Labels...)
+	}
+	if item.candidate.session.Metadata != nil {
+		sessionCopy.Metadata = make(map[string]string, len(item.candidate.session.Metadata))
+		for key, value := range item.candidate.session.Metadata {
+			sessionCopy.Metadata[key] = value
+		}
+	}
+	item.candidate.session = &sessionCopy
+	return item
 }
 
 func startPreparedStartCandidate(
@@ -950,9 +1036,16 @@ func executePlannedStartsTraced(
 	startupTimeout time.Duration,
 	stdout, stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
+	options ...startExecutionOption,
 ) int {
 	if len(candidates) == 0 {
 		return 0
+	}
+	startOpts := startExecutionOptions{}
+	for _, apply := range options {
+		if apply != nil {
+			apply(&startOpts)
+		}
 	}
 	maxWakes := cfg.Daemon.MaxWakesPerTickOrDefault()
 	waveByCandidate, ok := candidateWaveOrder(candidates, cfg, desiredState, sp, cityName, store)
@@ -1015,13 +1108,23 @@ func executePlannedStartsTraced(
 				prepared = append(prepared, *item)
 			}
 			offset = end
-			results := executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
+			var results []startResult
+			if startOpts.async {
+				results = enqueuePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr)
+			} else {
+				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
+			}
 			for _, result := range results {
 				if trace != nil {
 					trace.recordOperation("reconciler.start.execute", result.prepared.candidate.tp.TemplateName, result.prepared.candidate.name(), "", "start", result.outcome, traceRecordPayload{
 						"rollback_pending": result.rollbackPending,
 						"duration_ms":      result.finished.Sub(result.started).Milliseconds(),
 					}, "")
+				}
+				if result.outcome == "start_enqueued" {
+					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), result.outcome, result.started, result.finished, nil)
+					wakeCount++
+					continue
 				}
 				if result.err == nil && result.outcome != "session_initializing" {
 					clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -68,7 +69,10 @@ type startResult struct {
 }
 
 type startExecutionOptions struct {
-	async bool
+	async         bool
+	asyncFollowUp func()
+	asyncLimiter  chan struct{}
+	asyncTracker  *asyncStartTracker
 }
 
 type startExecutionOption func(*startExecutionOptions)
@@ -77,6 +81,81 @@ func withAsyncStartExecution() startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.async = true
 	}
+}
+
+func withAsyncStartFollowUp(fn func()) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.asyncFollowUp = fn
+	}
+}
+
+func withAsyncStartLimiter(limiter chan struct{}) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.asyncLimiter = limiter
+	}
+}
+
+func withAsyncStartTracker(tracker *asyncStartTracker) startExecutionOption {
+	return func(opts *startExecutionOptions) {
+		opts.asyncTracker = tracker
+	}
+}
+
+type asyncStartTracker struct {
+	mu       sync.Mutex
+	wg       sync.WaitGroup
+	stopping bool
+}
+
+func (t *asyncStartTracker) start() (func(), bool) {
+	if t == nil {
+		return func() {}, true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopping {
+		return nil, false
+	}
+	t.wg.Add(1)
+	return t.wg.Done, true
+}
+
+func (t *asyncStartTracker) wait(timeout time.Duration) bool {
+	if t == nil {
+		return true
+	}
+	t.mu.Lock()
+	t.stopping = true
+	t.mu.Unlock()
+	if timeout < 0 {
+		t.wg.Wait()
+		return true
+	}
+	done := make(chan struct{})
+	go func() {
+		t.wg.Wait()
+		close(done)
+	}()
+	if timeout == 0 {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+type asyncPreparedStart struct {
+	item    preparedStart
+	release func()
+	done    func()
 }
 
 type stopTarget struct {
@@ -198,6 +277,7 @@ func dependencyTemplateAlive(
 	sp runtime.Provider,
 	cityName string,
 	store beads.Store,
+	clk clock.Clock,
 ) bool {
 	if cfg == nil || template == "" {
 		return false
@@ -211,15 +291,60 @@ func dependencyTemplateAlive(
 			if tp.TemplateName != template {
 				continue
 			}
+			if dependencySessionStartInFlight(store, name, cfg, clk) {
+				continue
+			}
 			if alive, err := workerSessionTargetAliveWithConfig(store, sp, cfg, name, tp.Hints.ProcessNames); err == nil && alive {
 				return true
 			}
 		}
 	}
 	sessionName := lookupSessionNameOrLegacy(store, cityName, template, cfg.Workspace.SessionTemplate)
+	if dependencySessionStartInFlight(store, sessionName, cfg, clk) {
+		return false
+	}
 	depTP := desiredState[sessionName]
 	alive, err := workerSessionTargetAliveWithConfig(store, sp, cfg, sessionName, depTP.Hints.ProcessNames)
 	return err == nil && alive
+}
+
+func dependencySessionStartInFlight(store beads.Store, sessionName string, cfg *config.City, clk clock.Clock) bool {
+	sessionName = strings.TrimSpace(sessionName)
+	if store == nil || sessionName == "" {
+		return false
+	}
+	matches, err := store.ListByMetadata(map[string]string{"session_name": sessionName}, 0)
+	if err != nil {
+		return true
+	}
+	for _, session := range matches {
+		if session.Status == "closed" {
+			continue
+		}
+		if !isSessionBead(session) {
+			continue
+		}
+		var startupTimeout time.Duration
+		if cfg != nil {
+			startupTimeout = cfg.Session.StartupTimeoutDuration()
+		}
+		if pendingCreateStartInFlight(session, clk, startupTimeout) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSessionBead(session beads.Bead) bool {
+	if session.Type == sessionBeadType {
+		return true
+	}
+	for _, label := range session.Labels {
+		if label == sessionBeadLabel {
+			return true
+		}
+	}
+	return false
 }
 
 func candidateWaveOrder(
@@ -229,6 +354,7 @@ func candidateWaveOrder(
 	sp runtime.Provider,
 	cityName string,
 	store beads.Store,
+	clk clock.Clock,
 ) (map[int]int, bool) {
 	if len(candidates) == 0 {
 		return map[int]int{}, true
@@ -253,7 +379,7 @@ func candidateWaveOrder(
 			continue
 		}
 		for _, dep := range cfgAgent.DependsOn {
-			if dependencyTemplateAlive(dep, cfg, desiredState, sp, cityName, store) {
+			if dependencyTemplateAlive(dep, cfg, desiredState, sp, cityName, store, clk) {
 				continue
 			}
 			if candidateTemplates[dep] {
@@ -659,7 +785,7 @@ func runPreparedStartCandidate(
 
 func enqueuePreparedStartWaveForCity(
 	ctx context.Context,
-	prepared []preparedStart,
+	prepared []asyncPreparedStart,
 	cityPath string,
 	sp runtime.Provider,
 	store beads.Store,
@@ -669,13 +795,16 @@ func enqueuePreparedStartWaveForCity(
 	startupTimeout time.Duration,
 	wave int,
 	stdout, stderr io.Writer,
+	trace *sessionReconcilerTraceCycle,
+	asyncFollowUp func(),
 ) []startResult {
 	if len(prepared) == 0 {
 		return nil
 	}
 	results := make([]startResult, len(prepared))
-	for i, item := range prepared {
-		item = clonePreparedStartForAsync(item)
+	for i, reserved := range prepared {
+		item := clonePreparedStartForAsync(reserved.item)
+		release := reserved.release
 		now := time.Now()
 		results[i] = startResult{
 			prepared: item,
@@ -683,15 +812,199 @@ func enqueuePreparedStartWaveForCity(
 			started:  now,
 			finished: now,
 		}
-		go func(item preparedStart) {
-			result := runPreparedStartCandidate(ctx, item, cityPath, sp, store, cfg, startupTimeout)
-			if result.err == nil && result.outcome != "session_initializing" {
-				clearReconcilerDrainAckMetadata(sp, result.prepared.candidate.name())
+		done := reserved.done
+		go func(item preparedStart, release func(), done func()) {
+			if done != nil {
+				defer done()
 			}
-			commitStartResultTraced(result, store, clk, rec, wave, stdout, stderr, nil)
-		}(item)
+			if release != nil {
+				defer release()
+			}
+			result := runPreparedStartCandidate(ctx, item, cityPath, sp, store, cfg, startupTimeout)
+			commitAsyncStartResultWithContext(ctx, result, sp, store, clk, rec, wave, stdout, stderr, trace)
+			if asyncFollowUp != nil {
+				asyncFollowUp()
+			}
+		}(item, release, done)
 	}
 	return results
+}
+
+func reserveAsyncStartSlot(ctx context.Context, limiter chan struct{}) (func(), bool, string) {
+	if limiter == nil {
+		return func() {}, true, ""
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, false, "context_canceled"
+		default:
+		}
+	}
+	select {
+	case limiter <- struct{}{}:
+		return func() { <-limiter }, true, ""
+	default:
+		return nil, false, "deferred_by_async_start_limit"
+	}
+}
+
+func commitAsyncStartResultWithContext(
+	ctx context.Context,
+	result startResult,
+	sp runtime.Provider,
+	store beads.Store,
+	clk clock.Clock,
+	rec events.Recorder,
+	wave int,
+	stdout, stderr io.Writer,
+	trace *sessionReconcilerTraceCycle,
+) (committed bool) {
+	name := result.prepared.candidate.name()
+	template := result.prepared.candidate.tp.TemplateName
+	defer func() {
+		if trace != nil {
+			_ = trace.flushCurrentBatch(TraceDurabilityDurable)
+		}
+	}()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err := fmt.Errorf("panic during async start commit: %v\n%s", recovered, debug.Stack())
+			clearPendingStartInFlightLease(result.prepared.candidate.session, store, stderr)
+			fmt.Fprintf(stderr, "session reconciler: committing async start %s: %s\n", name, formatLifecycleError(err)) //nolint:errcheck
+			logLifecycleOutcome(stderr, "start", wave, name, template, "panic_recovered", result.started, time.Now(), err)
+			committed = false
+		}
+	}()
+
+	refreshed, ok, cleanupRuntime, releaseInFlight := refreshAsyncStartResult(result, store, stderr)
+	if !ok {
+		if cleanupRuntime {
+			stopStaleAsyncStartRuntime(result, sp, stderr)
+		}
+		outcome := "stale_async_start"
+		if releaseInFlight {
+			clearPendingStartInFlightLease(result.prepared.candidate.session, store, stderr)
+			outcome = "async_start_refresh_failed"
+		}
+		logLifecycleOutcome(stderr, "start", wave, name, template, outcome, result.started, time.Now(), nil)
+		return false
+	}
+	if refreshed.err != nil && refreshed.rollbackPending && runningSessionMatchesPendingCreate(refreshed.prepared.candidate.session, refreshed.prepared.candidate.name(), sp) {
+		refreshed.err = nil
+		refreshed.outcome = "session_exists_converged"
+		refreshed.rollbackPending = false
+	}
+	if ctx != nil && ctx.Err() != nil {
+		if refreshed.err != nil && refreshed.rollbackPending {
+			return commitStartResultTraced(refreshed, store, clk, rec, wave, stdout, stderr, trace)
+		}
+		if refreshed.err == nil && shouldRollbackPendingCreate(refreshed.prepared.candidate.session) {
+			stopStaleAsyncStartRuntime(refreshed, sp, stderr)
+			clearPendingStartInFlightLease(refreshed.prepared.candidate.session, store, stderr)
+		}
+		logLifecycleOutcome(stderr, "start", wave, name, template, "context_canceled", refreshed.started, time.Now(), ctx.Err())
+		return false
+	}
+	if sp != nil && refreshed.err == nil && refreshed.outcome != "session_initializing" {
+		clearReconcilerDrainAckMetadata(sp, refreshed.prepared.candidate.name())
+	}
+	return commitStartResultTraced(refreshed, store, clk, rec, wave, stdout, stderr, trace)
+}
+
+func refreshAsyncStartResult(result startResult, store beads.Store, stderr io.Writer) (startResult, bool, bool, bool) {
+	session := result.prepared.candidate.session
+	if store == nil || session == nil || strings.TrimSpace(session.ID) == "" {
+		return result, true, false, false
+	}
+	current, err := store.Get(session.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: refreshing async start %s: %v\n", result.prepared.candidate.name(), err) //nolint:errcheck
+		return result, false, false, true
+	}
+	if asyncStartPreparedCommandStale(result.prepared, current) {
+		fmt.Fprintf(stderr, "session reconciler: ignoring stale async start result for %s: desired command changed during startup\n", result.prepared.candidate.name()) //nolint:errcheck
+		return result, false, true, true
+	}
+	if !asyncStartSessionStillCurrent(*session, current) {
+		fmt.Fprintf(stderr, "session reconciler: ignoring stale async start result for %s\n", result.prepared.candidate.name()) //nolint:errcheck
+		return result, false, asyncStartStaleRuntimeCleanupAllowed(*session, current), false
+	}
+	result.prepared.candidate.session = &current
+	return result, true, false, false
+}
+
+func asyncStartPreparedCommandStale(prepared preparedStart, current beads.Bead) bool {
+	preparedCommand := strings.TrimSpace(prepared.candidate.tp.Command)
+	currentCommand := strings.TrimSpace(current.Metadata["command"])
+	return preparedCommand != "" && currentCommand != "" && preparedCommand != currentCommand
+}
+
+func clearPendingStartInFlightLease(session *beads.Bead, store beads.Store, stderr io.Writer) {
+	if session == nil || store == nil {
+		return
+	}
+	if setMeta(store, session.ID, "last_woke_at", "", stderr) == nil {
+		if session.Metadata == nil {
+			session.Metadata = make(map[string]string)
+		}
+		session.Metadata["last_woke_at"] = ""
+	}
+}
+
+func stopStaleAsyncStartRuntime(result startResult, sp runtime.Provider, stderr io.Writer) {
+	if sp == nil || result.prepared.candidate.session == nil {
+		return
+	}
+	name := result.prepared.candidate.name()
+	if !runningSessionMatchesPendingCreate(result.prepared.candidate.session, name, sp) {
+		return
+	}
+	if err := sp.Stop(name); err != nil && !runtime.IsSessionGone(err) {
+		fmt.Fprintf(stderr, "session reconciler: stopping stale async start runtime %s: %v\n", name, err) //nolint:errcheck
+	}
+}
+
+func asyncStartSessionStillCurrent(prepared, current beads.Bead) bool {
+	if strings.TrimSpace(current.Status) == "closed" {
+		return false
+	}
+	preparedGeneration := strings.TrimSpace(prepared.Metadata["generation"])
+	if preparedGeneration != "" && strings.TrimSpace(current.Metadata["generation"]) != preparedGeneration {
+		return false
+	}
+	preparedToken := strings.TrimSpace(prepared.Metadata["instance_token"])
+	if preparedToken != "" && strings.TrimSpace(current.Metadata["instance_token"]) != preparedToken {
+		return false
+	}
+	if shouldRollbackPendingCreate(&prepared) && !shouldRollbackPendingCreate(&current) {
+		return false
+	}
+	currentState := strings.TrimSpace(current.Metadata["state"])
+	return confirmPendingStart(currentState) ||
+		sessionpkg.State(currentState) == sessionpkg.StateAwake ||
+		sessionpkg.State(currentState) == sessionpkg.StateActive
+}
+
+func asyncStartStaleRuntimeCleanupAllowed(prepared, current beads.Bead) bool {
+	if strings.TrimSpace(current.Status) == "closed" {
+		return true
+	}
+	preparedGeneration := strings.TrimSpace(prepared.Metadata["generation"])
+	if preparedGeneration != "" && strings.TrimSpace(current.Metadata["generation"]) != preparedGeneration {
+		return true
+	}
+	preparedToken := strings.TrimSpace(prepared.Metadata["instance_token"])
+	if preparedToken != "" && strings.TrimSpace(current.Metadata["instance_token"]) != preparedToken {
+		return true
+	}
+	currentState := sessionpkg.State(strings.TrimSpace(current.Metadata["state"]))
+	if shouldRollbackPendingCreate(&prepared) && !shouldRollbackPendingCreate(&current) {
+		return currentState != sessionpkg.StateAwake && currentState != sessionpkg.StateActive
+	}
+	return !confirmPendingStart(string(currentState)) &&
+		currentState != sessionpkg.StateAwake &&
+		currentState != sessionpkg.StateActive
 }
 
 func clonePreparedStartForAsync(item preparedStart) preparedStart {
@@ -784,6 +1097,7 @@ func commitStartResultTraced(
 	// Session still starting up — back off silently without recording failure.
 	// The reconciler will retry on the next patrol tick.
 	if result.outcome == "session_initializing" {
+		clearPendingStartInFlightLease(session, store, stderr)
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
 		return false
 	}
@@ -842,6 +1156,7 @@ func commitStartResultTraced(
 	})
 	storedMCPSnapshot, err := sessionpkg.EncodeMCPServersSnapshot(result.prepared.cfg.MCPServers)
 	if err != nil {
+		clearPendingStartInFlightLease(session, store, stderr)
 		fmt.Fprintf(stderr, "session reconciler: encoding MCP snapshot for %s: %v\n", name, err) //nolint:errcheck
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "metadata_encode_failed", result.started, result.finished, err)
 		return false
@@ -850,6 +1165,7 @@ func commitStartResultTraced(
 		metadata[sessionpkg.MCPServersSnapshotMetadataKey] = storedMCPSnapshot
 	}
 	if err := sessionpkg.PersistRuntimeMCPServersSnapshot(result.prepared.cfg.Env["GC_CITY_PATH"], session.ID, result.prepared.cfg.MCPServers); err != nil {
+		clearPendingStartInFlightLease(session, store, stderr)
 		fmt.Fprintf(stderr, "session reconciler: storing runtime MCP snapshot for %s: %v\n", name, err) //nolint:errcheck
 		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "runtime_mcp_snapshot_failed", result.started, result.finished, err)
 		return false
@@ -867,6 +1183,7 @@ func commitStartResultTraced(
 		}
 	}
 	if err := store.SetMetadataBatch(session.ID, metadata); err != nil {
+		clearPendingStartInFlightLease(session, store, stderr)
 		fmt.Fprintf(stderr, "session reconciler: storing hashes for %s: %v\n", name, err) //nolint:errcheck
 		if trace != nil {
 			trace.recordMutation("bead_metadata", tp.TemplateName, name, "metadata_batch", session.ID, "started_config_hash", "", result.prepared.coreHash, "failed", traceRecordPayload{
@@ -974,27 +1291,43 @@ func runningSessionMatchesPendingCreate(session *beads.Bead, sessionName string,
 	if session == nil || sp == nil {
 		return false
 	}
-	if liveID, err := sp.GetMeta(sessionName, "GC_SESSION_ID"); err == nil {
-		liveID = strings.TrimSpace(liveID)
-		if liveID != "" {
-			return liveID == session.ID
+	liveID := ""
+	if value, err := sp.GetMeta(sessionName, "GC_SESSION_ID"); err == nil {
+		liveID = strings.TrimSpace(value)
+		if liveID != "" && liveID != session.ID {
+			return false
 		}
 	}
 	expectedToken := strings.TrimSpace(session.Metadata["instance_token"])
+	liveToken := ""
+	if value, err := sp.GetMeta(sessionName, "GC_INSTANCE_TOKEN"); err == nil {
+		liveToken = value
+		liveToken = strings.TrimSpace(liveToken)
+		if liveToken != "" && liveToken != expectedToken {
+			liveGeneration, _ := sp.GetMeta(sessionName, "GC_RUNTIME_EPOCH")
+			expectedGeneration := strings.TrimSpace(session.Metadata["generation"])
+			if strings.TrimSpace(liveGeneration) != "" && expectedGeneration != "" && strings.TrimSpace(liveGeneration) != expectedGeneration {
+				return false
+			}
+			if liveID == "" {
+				return false
+			}
+		}
+	}
+	if liveID != "" {
+		return liveID == session.ID
+	}
 	if expectedToken == "" {
 		return false
 	}
-	liveToken, err := sp.GetMeta(sessionName, "GC_INSTANCE_TOKEN")
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(liveToken) == expectedToken
+	return expectedToken != "" && liveToken == expectedToken
 }
 
 func rollbackPendingCreate(session *beads.Bead, store beads.Store, now time.Time, stderr io.Writer) {
 	if session == nil || store == nil {
 		return
 	}
+	clearPendingStartInFlightLease(session, store, stderr)
 	if strings.TrimSpace(session.Metadata["session_name_explicit"]) == "true" {
 		if setMeta(store, session.ID, "session_name", "", stderr) == nil {
 			if session.Metadata == nil {
@@ -1047,8 +1380,12 @@ func executePlannedStartsTraced(
 			apply(&startOpts)
 		}
 	}
+	asyncLimiter := startOpts.asyncLimiter
+	if startOpts.async && asyncLimiter == nil {
+		asyncLimiter = make(chan struct{}, defaultMaxParallelStartsPerWave)
+	}
 	maxWakes := cfg.Daemon.MaxWakesPerTickOrDefault()
-	waveByCandidate, ok := candidateWaveOrder(candidates, cfg, desiredState, sp, cityName, store)
+	waveByCandidate, ok := candidateWaveOrder(candidates, cfg, desiredState, sp, cityName, store, clk)
 	if !ok {
 		fmt.Fprintln(stderr, "session reconciler: dependency graph fallback to serial start order") //nolint:errcheck
 	}
@@ -1061,6 +1398,7 @@ func executePlannedStartsTraced(
 	wakeCount := 0
 	for wave := 0; wave <= maxWave; wave++ {
 		waveStarted := time.Now()
+		asyncBatchEnqueued := false
 		var waveCandidates []startCandidate
 		for idx, candidate := range candidates {
 			if waveByCandidate[idx] == wave {
@@ -1078,7 +1416,7 @@ func executePlannedStartsTraced(
 		}
 		var ready []startCandidate
 		for _, candidate := range waveCandidates {
-			if !allDependenciesAliveForTemplate(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store) {
+			if !allDependenciesAliveForTemplateWithClock(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store, clk) {
 				logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
 				continue
 			}
@@ -1094,23 +1432,53 @@ func executePlannedStartsTraced(
 			batchSize := min(defaultMaxParallelStartsPerWave, maxWakes-wakeCount)
 			end := min(offset+batchSize, len(ready))
 			var prepared []preparedStart
+			var asyncPrepared []asyncPreparedStart
 			for _, candidate := range ready[offset:end] {
-				if !allDependenciesAliveForTemplate(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store) {
+				if !allDependenciesAliveForTemplateWithClock(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store, clk) {
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
 					continue
 				}
+				var release func()
+				var done func()
+				if startOpts.async {
+					var tracking bool
+					done, tracking = startOpts.asyncTracker.start()
+					if !tracking {
+						logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "context_canceled", time.Time{}, time.Time{}, nil)
+						continue
+					}
+					var reserved bool
+					var outcome string
+					release, reserved, outcome = reserveAsyncStartSlot(ctx, asyncLimiter)
+					if !reserved {
+						done()
+						logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), outcome, time.Time{}, time.Time{}, nil)
+						continue
+					}
+				}
 				item, err := prepareStartCandidateForCity(candidate, cityPath, cityName, cfg, sp, store, clk, stderr)
 				if err != nil {
+					clearPendingStartInFlightLease(candidate.session, store, stderr)
+					if release != nil {
+						release()
+					}
+					if done != nil {
+						done()
+					}
 					fmt.Fprintf(stderr, "session reconciler: pre-wake %s: %s\n", candidate.name(), formatLifecycleError(err)) //nolint:errcheck
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "failed", time.Time{}, time.Time{}, err)
 					continue
 				}
-				prepared = append(prepared, *item)
+				if startOpts.async {
+					asyncPrepared = append(asyncPrepared, asyncPreparedStart{item: *item, release: release, done: done})
+				} else {
+					prepared = append(prepared, *item)
+				}
 			}
 			offset = end
 			var results []startResult
 			if startOpts.async {
-				results = enqueuePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr)
+				results = enqueuePreparedStartWaveForCity(ctx, asyncPrepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr, trace, startOpts.asyncFollowUp)
 			} else {
 				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
 			}
@@ -1124,6 +1492,7 @@ func executePlannedStartsTraced(
 				if result.outcome == "start_enqueued" {
 					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), result.outcome, result.started, result.finished, nil)
 					wakeCount++
+					asyncBatchEnqueued = true
 					continue
 				}
 				if result.err == nil && result.outcome != "session_initializing" {
@@ -1133,8 +1502,17 @@ func executePlannedStartsTraced(
 					wakeCount++
 				}
 			}
+			if startOpts.async && asyncBatchEnqueued {
+				break
+			}
 		}
 		logLifecycleWave(stderr, "start", wave, waveStarted, len(waveCandidates))
+		if startOpts.async && asyncBatchEnqueued {
+			// Async starts intentionally enqueue one bounded batch per tick.
+			// Completion pokes the controller so the next batch observes
+			// committed dependency and pending-create state first.
+			return wakeCount
+		}
 	}
 	return wakeCount
 }

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -934,6 +934,158 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 	}
 }
 
+func TestExecutePlannedStartsTraced_AsyncReturnsBeforeProviderStartCompletes(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	tp := TemplateParams{
+		Command:      "worker",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	desired := map[string]TemplateParams{"worker": tp}
+
+	done := make(chan int, 1)
+	go func() {
+		done <- executePlannedStartsTraced(
+			context.Background(),
+			[]startCandidate{{session: &session, tp: tp}},
+			cfg,
+			desired,
+			sp,
+			store,
+			"test-city",
+			"",
+			clk,
+			events.Discard,
+			time.Minute,
+			ioDiscard{},
+			ioDiscard{},
+			nil,
+			withAsyncStartExecution(),
+		)
+	}()
+
+	select {
+	case woken := <-done:
+		if woken != 1 {
+			t.Fatalf("woken = %d, want 1", woken)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("async planned start blocked waiting for provider Start to finish")
+	}
+	sp.waitForStarts(t, 1)
+
+	inFlight, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inFlight.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want true until async start commits", inFlight.Metadata["pending_create_claim"])
+	}
+	if inFlight.Metadata["last_woke_at"] == "" {
+		t.Fatal("last_woke_at was not stamped before async start")
+	}
+
+	sp.release("worker")
+	deadline := time.After(2 * time.Second)
+	for {
+		updated, err := store.Get(session.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if updated.Metadata["state"] == "active" && updated.Metadata["pending_create_claim"] == "" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("async start did not commit active state; metadata=%v", updated.Metadata)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 0, 30, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	tp := TemplateParams{
+		Command:      "worker",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		map[string]TemplateParams{"worker": tp},
+		configuredSessionNames(cfg, "", store),
+		cfg,
+		sp,
+		store,
+		nil,
+		nil,
+		nil,
+		newDrainTracker(),
+		map[string]int{"worker": 1},
+		false,
+		map[string]bool{"worker": true},
+		"test-city",
+		nil,
+		clk,
+		events.Discard,
+		time.Minute,
+		0,
+		ioDiscard{},
+		ioDiscard{},
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 while start is already in flight", woken)
+	}
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+}
+
 // When the atomic start batch fails, NO state change lands: state stays
 // "creating", pending_create_claim stays "true", and the post-create marker
 // is absent. The reconciler's next tick retries via recoverRunningPendingCreate.

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -51,6 +51,64 @@ func (s *failNthMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]s
 	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
+type failSetMetadataStore struct {
+	*beads.MemStore
+	failKey string
+}
+
+func (s *failSetMetadataStore) SetMetadata(id, key, value string) error {
+	if key == s.failKey {
+		return fmt.Errorf("set metadata %s failed", key)
+	}
+	return s.MemStore.SetMetadata(id, key, value)
+}
+
+type panicMetadataBatchStore struct {
+	*beads.MemStore
+}
+
+func (s *panicMetadataBatchStore) SetMetadataBatch(string, map[string]string) error {
+	panic("metadata batch panic")
+}
+
+type getErrorStore struct {
+	*beads.MemStore
+}
+
+func (s *getErrorStore) Get(string) (beads.Bead, error) {
+	return beads.Bead{}, fmt.Errorf("get failed")
+}
+
+type closedMetadataMatchStore struct {
+	*beads.MemStore
+	matches []beads.Bead
+}
+
+func (s *closedMetadataMatchStore) ListByMetadata(filters map[string]string, _ int, _ ...beads.QueryOpt) ([]beads.Bead, error) {
+	var out []beads.Bead
+	for _, match := range s.matches {
+		ok := true
+		for key, value := range filters {
+			if match.Metadata[key] != value {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			out = append(out, match)
+		}
+	}
+	return out, nil
+}
+
+type listMetadataErrorStore struct {
+	*beads.MemStore
+}
+
+func (s *listMetadataErrorStore) ListByMetadata(map[string]string, int, ...beads.QueryOpt) ([]beads.Bead, error) {
+	return nil, errors.New("list failed")
+}
+
 type gatedStartProvider struct {
 	*runtime.Fake
 	mu            sync.Mutex
@@ -136,6 +194,24 @@ func (p *gatedStartProvider) ensureNoFurtherStart(t *testing.T, wait time.Durati
 		t.Fatalf("unexpected extra start signal: %s", name)
 	case <-time.After(wait):
 	}
+}
+
+type shutdownWaitProvider struct {
+	*gatedStartProvider
+	listCalled chan struct{}
+	listOnce   sync.Once
+}
+
+func newShutdownWaitProvider() *shutdownWaitProvider {
+	return &shutdownWaitProvider{
+		gatedStartProvider: newGatedStartProvider(),
+		listCalled:         make(chan struct{}),
+	}
+}
+
+func (p *shutdownWaitProvider) ListRunning(prefix string) ([]string, error) {
+	p.listOnce.Do(func() { close(p.listCalled) })
+	return p.Fake.ListRunning(prefix)
 }
 
 func creatingMeta(meta map[string]string) map[string]string {
@@ -949,6 +1025,7 @@ func TestExecutePlannedStartsTraced_AsyncReturnsBeforeProviderStartCompletes(t *
 			"continuation_epoch":   "1",
 			"instance_token":       "tok-worker",
 			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
 		}),
 	})
 	if err != nil {
@@ -1026,6 +1103,700 @@ func TestExecutePlannedStartsTraced_AsyncReturnsBeforeProviderStartCompletes(t *
 	}
 }
 
+func TestExecutePlannedStartsTraced_AsyncLimitsEnqueuedStartsPerTick(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 0, 0, time.UTC)}
+	sp := newGatedStartProvider()
+	cfg := &config.City{}
+	desired := map[string]TemplateParams{}
+	var candidates []startCandidate
+	for _, name := range []string{"worker-1", "worker-2", "worker-3", "worker-4"} {
+		session, err := store.Create(beads.Bead{
+			ID:     "gc-" + name,
+			Title:  name,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: creatingMeta(map[string]string{
+				"session_name":         name,
+				"template":             name,
+				"generation":           "1",
+				"continuation_epoch":   "1",
+				"instance_token":       "tok-" + name,
+				"pending_create_claim": "true",
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { sp.release(name) })
+		cfg.Agents = append(cfg.Agents, config.Agent{Name: name})
+		tp := TemplateParams{Command: name, SessionName: name, TemplateName: name}
+		desired[name] = tp
+		candidates = append(candidates, startCandidate{session: &session, tp: tp})
+	}
+
+	woken := executePlannedStartsTraced(
+		context.Background(),
+		candidates,
+		cfg,
+		desired,
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+	)
+	if woken != defaultMaxParallelStartsPerWave {
+		t.Fatalf("woken = %d, want one bounded async batch of %d", woken, defaultMaxParallelStartsPerWave)
+	}
+	sp.waitForStarts(t, defaultMaxParallelStartsPerWave)
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+	if sp.maxInFlight > defaultMaxParallelStartsPerWave {
+		t.Fatalf("max in-flight starts = %d, want <= %d", sp.maxInFlight, defaultMaxParallelStartsPerWave)
+	}
+}
+
+func TestExecutePlannedStartsTraced_AsyncLimiterSharedAcrossTicks(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 15, 0, time.UTC)}
+	sp := newGatedStartProvider()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker-1"}, {Name: "worker-2"}},
+	}
+	desired := map[string]TemplateParams{}
+	makeCandidate := func(name string) startCandidate {
+		session, err := store.Create(beads.Bead{
+			ID:     "gc-" + name,
+			Title:  name,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: creatingMeta(map[string]string{
+				"session_name":         name,
+				"template":             name,
+				"generation":           "1",
+				"continuation_epoch":   "1",
+				"instance_token":       "tok-" + name,
+				"pending_create_claim": "true",
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { sp.release(name) })
+		tp := TemplateParams{Command: name, SessionName: name, TemplateName: name}
+		desired[name] = tp
+		return startCandidate{session: &session, tp: tp}
+	}
+	limiter := make(chan struct{}, 1)
+	first := makeCandidate("worker-1")
+	second := makeCandidate("worker-2")
+
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{first},
+		cfg,
+		desired,
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(limiter),
+	); got != 1 {
+		t.Fatalf("first woken = %d, want 1", got)
+	}
+	sp.waitForStarts(t, 1)
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{second},
+		cfg,
+		desired,
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(limiter),
+	); got != 0 {
+		t.Fatalf("second woken = %d, want 0 while shared limiter is full", got)
+	}
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+	deferred, err := store.Get(second.session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := deferred.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("deferred last_woke_at = %q, want empty until limiter slot is reserved", got)
+	}
+	sp.release("worker-1")
+	deadline := time.After(2 * time.Second)
+	for {
+		updated, err := store.Get(first.session.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if updated.Metadata["state"] == "active" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("first async start did not commit active state; metadata=%v", updated.Metadata)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{second},
+		cfg,
+		desired,
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(limiter),
+	); got != 1 {
+		t.Fatalf("second woken after release = %d, want 1", got)
+	}
+	started := sp.waitForStarts(t, 1)
+	if len(started) != 1 || started[0] != "worker-2" {
+		t.Fatalf("second start = %v, want [worker-2]", started)
+	}
+}
+
+func TestExecutePlannedStartsTraced_AsyncLimiterDeferredStartDoesNotRunAfterCancel(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 20, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	limiter := make(chan struct{}, 1)
+	limiter <- struct{}{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if got := executePlannedStartsTraced(
+		ctx,
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(limiter),
+	); got != 0 {
+		t.Fatalf("woken = %d, want 0 while async limiter is full", got)
+	}
+	cancel()
+	<-limiter
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want empty because no async start was queued", got)
+	}
+}
+
+func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 25, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newShutdownWaitProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{ShutdownTimeout: "500ms"},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	cr := &CityRuntime{
+		cfg:                 cfg,
+		sp:                  sp,
+		rec:                 events.Discard,
+		standaloneCityStore: store,
+		asyncStartLimiter:   make(chan struct{}, defaultMaxParallelStartsPerWave),
+		logPrefix:           "gc test",
+		stdout:              ioDiscard{},
+		stderr:              ioDiscard{},
+	}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
+		withAsyncStartTracker(&cr.asyncStarts),
+	); got != 1 {
+		t.Fatalf("woken = %d, want 1", got)
+	}
+	sp.waitForStarts(t, 1)
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		cr.shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-sp.listCalled:
+		t.Fatal("shutdown listed running sessions before the async start completed")
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before the async start completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	sp.release("worker")
+	select {
+	case <-shutdownDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown did not finish after the async start completed")
+	}
+	select {
+	case <-sp.listCalled:
+	default:
+		t.Fatal("shutdown did not list running sessions after waiting for async starts")
+	}
+	if sp.IsRunning("worker") {
+		t.Fatal("shutdown should stop the runtime that the async start created")
+	}
+}
+
+func TestExecutePlannedStartsTraced_AsyncPrepareFailureClearsPreWakeLease(t *testing.T) {
+	store := &failSetMetadataStore{MemStore: beads.NewMemStore(), failKey: "session_key"}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 27, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	tp := TemplateParams{
+		Command:          "worker",
+		SessionName:      "worker",
+		TemplateName:     "worker",
+		ResolvedProvider: &config.ResolvedProvider{SessionIDFlag: "--session-id"},
+	}
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+	); got != 0 {
+		t.Fatalf("woken = %d, want 0 when async preparation fails after preWake", got)
+	}
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared after async preparation failure", got)
+	}
+}
+
+func TestExecutePlannedStartsTraced_AsyncRequestsFollowUpAfterCommit(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 30, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newGatedStartProvider()
+	t.Cleanup(func() { sp.release("worker") })
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	followUp := make(chan struct{}, 1)
+
+	woken := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartFollowUp(func() {
+			select {
+			case followUp <- struct{}{}:
+			default:
+			}
+		}),
+	)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+	sp.waitForStarts(t, 1)
+	select {
+	case <-followUp:
+		t.Fatal("follow-up requested before async provider start finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	sp.release("worker")
+	select {
+	case <-followUp:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async completion follow-up")
+	}
+}
+
+func TestAllDependenciesAliveForTemplate_TreatsPendingCreateDependencyAsNotAlive(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Now().UTC()
+	dep, err := store.Create(beads.Bead{
+		ID:     "gc-db",
+		Title:  "db",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "db",
+			"template":             "db",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-db",
+			"pending_create_claim": "true",
+			"last_woke_at":         now.Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "db", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", DependsOn: []string{"db"}},
+			{Name: "db"},
+		},
+	}
+	desired := map[string]TemplateParams{
+		"worker": {Command: "worker", SessionName: "worker", TemplateName: "worker"},
+		"db":     {Command: "db", SessionName: "db", TemplateName: "db"},
+	}
+
+	if allDependenciesAliveForTemplate("worker", cfg, desired, sp, "test-city", store) {
+		t.Fatal("worker dependency should stay blocked while db start is still in flight")
+	}
+	if err := store.SetMetadataBatch(dep.ID, map[string]string{
+		"state":                string(sessionpkg.StateActive),
+		"pending_create_claim": "",
+		"creation_complete_at": now.Add(time.Second).Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !allDependenciesAliveForTemplate("worker", cfg, desired, sp, "test-city", store) {
+		t.Fatal("worker dependency should be alive after db start is committed")
+	}
+}
+
+func TestDependencySessionStartInFlightIgnoresClosedMetadataMatches(t *testing.T) {
+	now := time.Now().UTC()
+	store := &closedMetadataMatchStore{
+		MemStore: beads.NewMemStore(),
+		matches: []beads.Bead{{
+			ID:     "gc-db-old",
+			Title:  "db",
+			Status: "closed",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: creatingMeta(map[string]string{
+				"session_name":         "db",
+				"template":             "db",
+				"pending_create_claim": "true",
+				"last_woke_at":         now.Format(time.RFC3339),
+			}),
+		}},
+	}
+
+	if dependencySessionStartInFlight(store, "db", &config.City{}, clock.Real{}) {
+		t.Fatal("closed failed-create bead should not count as an in-flight dependency start")
+	}
+}
+
+func TestDependencySessionStartInFlightFailsClosedOnMetadataListError(t *testing.T) {
+	store := &listMetadataErrorStore{MemStore: beads.NewMemStore()}
+	if !dependencySessionStartInFlight(store, "db", &config.City{}, clock.Real{}) {
+		t.Fatal("metadata query errors should block dependent starts until the store recovers")
+	}
+}
+
+func TestPendingCreateStartInFlight_ZeroStartupTimeoutUsesRecoveryLease(t *testing.T) {
+	now := time.Date(2026, 4, 26, 12, 1, 40, 0, time.UTC)
+	recent := beads.Bead{
+		Metadata: map[string]string{
+			"pending_create_claim": "true",
+			"last_woke_at":         now.Add(-10 * time.Second).Format(time.RFC3339),
+		},
+	}
+	if !pendingCreateStartInFlight(recent, &clock.Fake{Time: now}, 0) {
+		t.Fatal("explicit zero startup timeout should still use a finite recovery lease while recent")
+	}
+	stale := beads.Bead{
+		Metadata: map[string]string{
+			"pending_create_claim": "true",
+			"last_woke_at":         now.Add(-24 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	if pendingCreateStartInFlight(stale, &clock.Fake{Time: now}, 0) {
+		t.Fatal("explicit zero startup timeout should not suppress recovery forever")
+	}
+}
+
+func TestAsyncStartTrackerWaitZeroDoesNotBlock(t *testing.T) {
+	var tracker asyncStartTracker
+	done, ok := tracker.start()
+	if !ok {
+		t.Fatal("tracker should accept work before shutdown")
+	}
+	if tracker.wait(0) {
+		t.Fatal("zero-timeout wait should not report completion while async work is still running")
+	}
+	done()
+	if !tracker.wait(time.Second) {
+		t.Fatal("tracker should report completion after async work finishes")
+	}
+}
+
+func TestReconcileSessionBeads_RollsBackPendingCreateWhenRuntimeTokenMismatches(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 45, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-new",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "tok-old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_RUNTIME_EPOCH", "1"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+
+	woken := reconcileSessionBeads(
+		context.Background(),
+		[]beads.Bead{session},
+		map[string]TemplateParams{"worker": tp},
+		configuredSessionNames(cfg, "test-city", store),
+		cfg,
+		sp,
+		store,
+		nil,
+		nil,
+		nil,
+		newDrainTracker(),
+		map[string]int{"worker": 1},
+		false,
+		map[string]bool{"worker": true},
+		"test-city",
+		nil,
+		clk,
+		events.Discard,
+		time.Minute,
+		0,
+		ioDiscard{},
+		ioDiscard{},
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed so stale runtime is not recovered", updated.Status)
+	}
+}
+
+func TestRunningSessionMatchesPendingCreateAcceptsTokenOnlyRuntime(t *testing.T) {
+	session := &beads.Bead{
+		ID: "gc-worker",
+		Metadata: map[string]string{
+			"session_name":   "worker",
+			"generation":     "2",
+			"instance_token": "tok-worker",
+		},
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "tok-worker"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !runningSessionMatchesPendingCreate(session, "worker", sp) {
+		t.Fatal("runtime with matching token and no session id should match pending create")
+	}
+}
+
+func TestRunningSessionMatchesPendingCreateAcceptsIDOnlyRuntime(t *testing.T) {
+	session := &beads.Bead{
+		ID: "gc-worker",
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"generation":   "2",
+		},
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if !runningSessionMatchesPendingCreate(session, "worker", sp) {
+		t.Fatal("runtime with matching session id and no token should match pending create")
+	}
+}
+
 func TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 0, 30, 0, time.UTC)}
@@ -1086,6 +1857,667 @@ func TestReconcileSessionBeads_SkipsPendingCreateStartAlreadyInFlight(t *testing
 	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
 }
 
+func TestCommitAsyncStartResult_IgnoresStaleSessionSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 2, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-old",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadataBatch(session.ID, map[string]string{
+		"generation":     "3",
+		"instance_token": "tok-new",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if commitAsyncStartResultWithContext(context.Background(), result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("stale async start result should not commit")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["state"]; got != "creating" {
+		t.Fatalf("state = %q, want creating", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+	if got := updated.Metadata["instance_token"]; got != "tok-new" {
+		t.Fatalf("instance_token = %q, want tok-new", got)
+	}
+}
+
+func TestCommitAsyncStartResult_IgnoresClosedSessionSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 2, 30, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(session.ID); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if commitAsyncStartResultWithContext(context.Background(), result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("closed async start result should not commit")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed", updated.Status)
+	}
+	if got := updated.Metadata["state"]; got != "creating" {
+		t.Fatalf("state = %q, want creating", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+}
+
+func TestCommitAsyncStartResult_StopsMatchingRuntimeForStaleSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 2, 45, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-old",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadataBatch(session.ID, map[string]string{
+		"generation":     "3",
+		"instance_token": "tok-new",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "tok-old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_RUNTIME_EPOCH", "2"); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if commitAsyncStartResultWithContext(context.Background(), result, sp, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("stale async start result should not commit")
+	}
+	if sp.IsRunning("worker") {
+		t.Fatal("stale runtime with matching old session metadata should be stopped")
+	}
+}
+
+func TestCommitAsyncStartResult_IgnoresCommandChangedDuringStartup(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 13, 6, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-drifter",
+		Title:  "drifter",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "drifter",
+			"template":             "drifter",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-drifter",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+			"command":              "CUSTOM_VERSION=v1 report",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(session.ID, "command", "CUSTOM_VERSION=v2 report"); err != nil {
+		t.Fatal(err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "drifter", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("drifter", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("drifter", "GC_INSTANCE_TOKEN", "tok-drifter"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("drifter", "GC_RUNTIME_EPOCH", "2"); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "CUSTOM_VERSION=v1 report",
+					SessionName:  "drifter",
+					TemplateName: "drifter",
+				},
+			},
+			coreHash: "core-v1",
+			liveHash: "live-v1",
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if commitAsyncStartResultWithContext(context.Background(), result, sp, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("async start with stale command should not commit")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sp.IsRunning("drifter") {
+		t.Fatal("stale runtime with old command should be stopped")
+	}
+	if got := updated.Metadata["started_config_hash"]; got != "" {
+		t.Fatalf("started_config_hash = %q, want empty until fresh command starts", got)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared so the new command can retry next tick", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true for pending-create retry", got)
+	}
+	if got := updated.Metadata["command"]; got != "CUSTOM_VERSION=v2 report" {
+		t.Fatalf("command = %q, want current config preserved", got)
+	}
+}
+
+func TestCommitAsyncStartResult_PreservesRuntimeWhenRefreshFails(t *testing.T) {
+	store := &getErrorStore{MemStore: beads.NewMemStore()}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 2, 50, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "tok-worker"); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if commitAsyncStartResultWithContext(context.Background(), result, sp, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("async result should not commit when refresh fails")
+	}
+	if !sp.IsRunning("worker") {
+		t.Fatal("refresh failure should not stop a runtime without proving staleness")
+	}
+	updated, err := store.MemStore.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared so the next tick can recover or retry", got)
+	}
+}
+
+func TestCommitAsyncStartResult_RecoversCommitPanic(t *testing.T) {
+	store := &panicMetadataBatchStore{MemStore: beads.NewMemStore()}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 3, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if commitAsyncStartResultWithContext(context.Background(), result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("async commit with panic should report not committed")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared after async commit panic", got)
+	}
+}
+
+func TestCommitAsyncStartResultWithContext_SkipsCanceledCommit(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 4, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if commitAsyncStartResultWithContext(ctx, result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("canceled async commit should report not committed")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["state"]; got != "creating" {
+		t.Fatalf("state = %q, want creating", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+}
+
+func TestCommitAsyncStartResultWithContext_StopsCanceledSuccessfulPendingCreateRuntime(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 4, 15, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_INSTANCE_TOKEN", "tok-worker"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.SetMeta("worker", "GC_RUNTIME_EPOCH", "2"); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if commitAsyncStartResultWithContext(ctx, result, sp, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("canceled async success should report not committed")
+	}
+	if sp.IsRunning("worker") {
+		t.Fatal("canceled async success should stop the runtime it started")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared so the next controller can retry", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true for next-tick retry", got)
+	}
+}
+
+func TestCommitAsyncStartResultWithContext_RollsBackCanceledPendingCreateError(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 4, 30, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		err:             context.Canceled,
+		outcome:         "canceled",
+		started:         clk.Now(),
+		finished:        clk.Now(),
+		rollbackPending: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if commitAsyncStartResultWithContext(ctx, result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("canceled async error commit should report not committed")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed so pending-create can be retried by replacement bead", updated.Status)
+	}
+}
+
+func TestCommitStartResult_SessionInitializingClearsInFlightLease(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 5, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+		},
+		outcome:         "session_initializing",
+		started:         clk.Now(),
+		finished:        clk.Now(),
+		rollbackPending: true,
+	}
+
+	if commitStartResult(result, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}) {
+		t.Fatal("session_initializing result should not count as committed")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "open" {
+		t.Fatalf("status = %q, want open", updated.Status)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared for next-tick retry", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+}
+
+func TestCommitStartResult_RollbackPendingErrorClearsInFlightLeaseWhenCloseFails(t *testing.T) {
+	store := &failingCloseStore{MemStore: beads.NewMemStore()}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-shortlived",
+		Title:  "shortlived",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "shortlived",
+			"template":             "shortlived",
+			"generation":           "2",
+			"instance_token":       "tok-shortlived",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "exit 0",
+					SessionName:  "shortlived",
+					TemplateName: "shortlived",
+				},
+			},
+		},
+		err:             errors.New("session died during startup"),
+		outcome:         "provider_error",
+		started:         clk.Now(),
+		finished:        clk.Now(),
+		rollbackPending: true,
+	}
+
+	if commitStartResult(result, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}) {
+		t.Fatal("rollback-pending error should not count as committed")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "open" {
+		t.Fatalf("status = %q, want open after injected close failure", updated.Status)
+	}
+	if got := updated.Metadata["last_woke_at"]; got != "" {
+		t.Fatalf("last_woke_at = %q, want cleared so the next reconciler tick can retry", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true for pending-create retry", got)
+	}
+	if pendingCreateStartInFlight(updated, clk, 0) {
+		t.Fatal("rollback-pending error left the pending-create bead leased")
+	}
+}
+
 // When the atomic start batch fails, NO state change lands: state stays
 // "creating", pending_create_claim stays "true", and the post-create marker
 // is absent. The reconciler's next tick retries via recoverRunningPendingCreate.
@@ -1104,6 +2536,7 @@ func TestCommitStartResult_AtomicBatchFailureLeavesClaimIntact(t *testing.T) {
 			"session_name_explicit": "true",
 			"pending_create_claim":  "true",
 			"state":                 "creating",
+			"last_woke_at":          "2026-03-18T12:00:00Z",
 		},
 	})
 	if err != nil {
@@ -1143,6 +2576,9 @@ func TestCommitStartResult_AtomicBatchFailureLeavesClaimIntact(t *testing.T) {
 	}
 	if got.Metadata["creation_complete_at"] != "" {
 		t.Fatalf("creation_complete_at = %q, want empty (atomic batch failed)", got.Metadata["creation_complete_at"])
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared so a failed metadata commit can retry", got.Metadata["last_woke_at"])
 	}
 }
 
@@ -2281,7 +3717,7 @@ func TestCandidateWaveOrder_FallsBackToSerialOnCycle(t *testing.T) {
 		},
 	}
 
-	waves, ok := candidateWaveOrder(candidates, cfg, map[string]TemplateParams{}, runtime.NewFake(), "city", nil)
+	waves, ok := candidateWaveOrder(candidates, cfg, map[string]TemplateParams{}, runtime.NewFake(), "city", nil, clock.Real{})
 	if ok {
 		t.Fatal("expected serial fallback for cycle")
 	}
@@ -2347,7 +3783,7 @@ func TestCandidateWaveOrder_UsesLegacyAgentLabelTemplate(t *testing.T) {
 		},
 	}
 
-	waves, ok := candidateWaveOrder(candidates, cfg, map[string]TemplateParams{}, runtime.NewFake(), "city", store)
+	waves, ok := candidateWaveOrder(candidates, cfg, map[string]TemplateParams{}, runtime.NewFake(), "city", store, clock.Real{})
 	if !ok {
 		t.Fatal("unexpected serial fallback")
 	}

--- a/cmd/gc/session_model_phase0_rare_state_spec_test.go
+++ b/cmd/gc/session_model_phase0_rare_state_spec_test.go
@@ -156,14 +156,14 @@ func TestPhase0ConfigDrift_IdleNamedSessionRestartsInPlaceWithoutCapVacancy(t *t
 	if all[0].Status != "open" {
 		t.Fatalf("status = %q, want open while live restart is in progress", all[0].Status)
 	}
-	if got := all[0].Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating for idle config-drift restart without cap vacancy", got)
+	if got := all[0].Metadata["state"]; got != "active" {
+		t.Fatalf("state = %q, want active after same-tick config-drift restart", got)
 	}
-	if got := all[0].Metadata["started_config_hash"]; got != "" {
-		t.Fatalf("started_config_hash = %q, want cleared so next start uses fresh config", got)
+	if got := all[0].Metadata["started_config_hash"]; got == "" || got == runtime.CoreFingerprint(oldRuntime) {
+		t.Fatalf("started_config_hash = %q, want non-empty fresh config hash", got)
 	}
-	if got := all[0].Metadata["continuation_reset_pending"]; got != "true" {
-		t.Fatalf("continuation_reset_pending = %q, want true for unified restart path", got)
+	if got := all[0].Metadata["continuation_reset_pending"]; got != "" {
+		t.Fatalf("continuation_reset_pending = %q, want cleared after same-tick wake", got)
 	}
 }
 
@@ -235,8 +235,8 @@ func TestPhase0ConfigDrift_NamedSessionBoundsRecentActivityDeferral(t *testing.T
 	if err != nil {
 		t.Fatalf("Get(%s) after deferral limit: %v", session.ID, err)
 	}
-	if got.Metadata["state"] != "creating" {
-		t.Fatalf("state = %q, want creating after bounded recent-activity deferral", got.Metadata["state"])
+	if got.Metadata["state"] != "active" {
+		t.Fatalf("state = %q, want active after bounded recent-activity restart", got.Metadata["state"])
 	}
 	if got.Metadata[namedSessionConfigDriftDeferredAtMetadata] != "" {
 		t.Fatalf("deferred timestamp = %q, want cleared after restart", got.Metadata[namedSessionConfigDriftDeferredAtMetadata])
@@ -293,8 +293,8 @@ func TestPhase0ConfigDrift_NamedSessionDrainsWhenStaleActivity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
-	if got.Metadata["state"] != "creating" {
-		t.Fatalf("state = %q, want creating for stale-activity config-drift restart", got.Metadata["state"])
+	if got.Metadata["state"] != "active" {
+		t.Fatalf("state = %q, want active after stale-activity config-drift restart", got.Metadata["state"])
 	}
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -506,6 +506,13 @@ func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drain
 	if lastWoke == "" {
 		return false
 	}
+	var startupTimeout time.Duration
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
+	if pendingCreateStartInFlight(*session, clk, startupTimeout) {
+		return false
+	}
 	t, err := time.Parse(time.RFC3339, lastWoke)
 	if err != nil {
 		return false

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -917,6 +917,28 @@ func TestCheckStability_RapidExit(t *testing.T) {
 	}
 }
 
+func TestCheckStability_PendingCreateInFlightNotCounted(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":         now.Add(-10 * time.Second).Format(time.RFC3339),
+		"pending_create_claim": "true",
+		"wake_attempts":        "0",
+	})
+
+	if checkStability(&session, nil, false, dt, store, clk) {
+		t.Fatal("in-flight pending create should not be counted as a rapid exit")
+	}
+	if got := session.Metadata["wake_attempts"]; got != "0" {
+		t.Fatalf("wake_attempts = %q, want 0", got)
+	}
+	if got := session.Metadata["last_woke_at"]; got == "" {
+		t.Fatal("last_woke_at should remain while pending create is still in flight")
+	}
+}
+
 func TestCheckStability_DrainingNotCounted(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -137,6 +137,28 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 	return agent != nil && !agent.Suspended
 }
 
+func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+		return false
+	}
+	lastWoke := strings.TrimSpace(session.Metadata["last_woke_at"])
+	if lastWoke == "" {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, lastWoke)
+	if err != nil {
+		return false
+	}
+	if startupTimeout <= 0 {
+		startupTimeout = time.Minute
+	}
+	now := time.Now()
+	if clk != nil {
+		now = clk.Now()
+	}
+	return now.Before(started.Add(startupTimeout + staleKeyDetectDelay + 5*time.Second))
+}
+
 // reconcileSessionBeads performs bead-driven reconciliation using wake/sleep
 // semantics. For each session bead, it determines if the session should be
 // awake (has a matching entry in the desired state) and manages lifecycle
@@ -249,6 +271,7 @@ func reconcileSessionBeadsTraced(
 	driftDrainTimeout time.Duration,
 	stdout, stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
+	startOptions ...startExecutionOption,
 ) int {
 	deps := buildDepsMap(cfg)
 	if cityName == "" {
@@ -991,6 +1014,15 @@ func reconcileSessionBeadsTraced(
 			if sessionIsQuarantined(*target.session, clk) {
 				continue // crash-loop protection
 			}
+			if pendingCreateStartInFlight(*target.session, clk, startupTimeout) {
+				if trace != nil {
+					trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_in_flight", traceRecordPayload{
+						"pending_create_claim": strings.TrimSpace(target.session.Metadata["pending_create_claim"]),
+						"last_woke_at":         target.session.Metadata["last_woke_at"],
+					}, nil, "")
+				}
+				continue
+			}
 			if trace != nil {
 				trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_candidate", traceRecordPayload{
 					"should_wake": shouldWake,
@@ -1098,6 +1130,7 @@ func reconcileSessionBeadsTraced(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
+		startOptions...,
 	)
 
 	// Phase 2: Advance all in-flight drains.

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -95,6 +95,18 @@ func allDependenciesAliveForTemplate(
 	cityName string,
 	store beads.Store,
 ) bool {
+	return allDependenciesAliveForTemplateWithClock(template, cfg, desiredState, sp, cityName, store, clock.Real{})
+}
+
+func allDependenciesAliveForTemplateWithClock(
+	template string,
+	cfg *config.City,
+	desiredState map[string]TemplateParams,
+	sp runtime.Provider,
+	cityName string,
+	store beads.Store,
+	clk clock.Clock,
+) bool {
 	cfgAgent := findAgentByTemplate(cfg, template)
 	if cfgAgent == nil || len(cfgAgent.DependsOn) == 0 {
 		return true
@@ -104,7 +116,7 @@ func allDependenciesAliveForTemplate(
 		if depCfg == nil {
 			continue // dependency not in config — skip
 		}
-		if !dependencyTemplateAlive(dep, cfg, desiredState, sp, cityName, store) {
+		if !dependencyTemplateAlive(dep, cfg, desiredState, sp, cityName, store, clk) {
 			return false
 		}
 	}
@@ -122,7 +134,7 @@ func allDependenciesAlive(
 	cityName string,
 	store beads.Store,
 ) bool {
-	return allDependenciesAliveForTemplate(normalizedSessionTemplate(session, cfg), cfg, desiredState, sp, cityName, store)
+	return allDependenciesAliveForTemplateWithClock(normalizedSessionTemplate(session, cfg), cfg, desiredState, sp, cityName, store, clock.Real{})
 }
 
 func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk clock.Clock) bool {
@@ -150,6 +162,9 @@ func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTime
 		return false
 	}
 	if startupTimeout <= 0 {
+		// Disabling the provider Start() deadline must not disable stuck-bead
+		// recovery forever. Use the default lease window for in-flight detection
+		// while leaving the actual Start() context unwrapped.
 		startupTimeout = time.Minute
 	}
 	now := time.Now()
@@ -177,7 +192,7 @@ func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTime
 // suspended agents). Used to distinguish "orphaned" (removed from config)
 // from "suspended" (still in config, not runnable) when closing beads.
 //
-// Returns the number of sessions woken this tick.
+// Returns the number of start attempts issued or enqueued this tick.
 //
 //nolint:unparam // compatibility wrapper retains the full production signature.
 func reconcileSessionBeads(
@@ -599,6 +614,7 @@ func reconcileSessionBeadsTraced(
 		policy := resolveSessionSleepPolicy(*session, cfg, sp)
 
 		// Heal advisory state metadata.
+		stateBeforeHeal := sessionpkg.State(strings.TrimSpace(session.Metadata["state"]))
 		healState(session, alive, store, clk)
 		if recoverPendingIdleSleep(session, store, running, clk) {
 			alive = false
@@ -627,6 +643,12 @@ func reconcileSessionBeadsTraced(
 			clearChurn(session, store)
 		}
 		if alive && shouldRollbackPendingCreate(session) {
+			if stateBeforeHeal == sessionpkg.StateCreating && pendingCreateStartInFlight(*session, clk, startupTimeout) {
+				if trace != nil {
+					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_recovery_in_flight", "deferred", nil, nil, "")
+				}
+				continue
+			}
 			if !recoverRunningPendingCreate(session, tp, cfg, store, clk, trace) {
 				fmt.Fprintf(stderr, "session reconciler: recovering pending create %s: metadata repair incomplete\n", name) //nolint:errcheck
 			}
@@ -732,6 +754,7 @@ func reconcileSessionBeadsTraced(
 							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
 						}
 						runtime.LogCoreFingerprintDrift(stderr, name, storedBreakdown, agentCfg)
+						restartedInPlace := false
 						if isNamedSessionBead(*session) {
 							// Defer config-drift restart for named sessions
 							// that are actively in use (pending interaction,
@@ -765,83 +788,70 @@ func reconcileSessionBeadsTraced(
 								Subject: tp.DisplayName(),
 								Message: "config drift detected",
 							})
+							alive = false
+							restartedInPlace = true
+						}
+						if !restartedInPlace {
+							// Defer ordinary-session config-drift drain while a
+							// user is attached. Named-session config drift is
+							// deferred when actively in use (see above).
+							if pendingInteractionKeepsAwake(*session, sp, name, clk) {
+								drainCancelled := false
+								if dt != nil {
+									drainCancelled = cancelSessionDrainForPending(*session, sp, dt)
+								}
+								if trace != nil {
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "pending", "deferred_pending", traceRecordPayload{
+										"stored_hash":    storedHash,
+										"current_hash":   currentHash,
+										"drain_canceled": drainCancelled,
+									}, nil, "")
+								}
+								continue
+							}
+							attached, err := workerSessionTargetAttachedWithConfig(cityPath, store, sp, cfg, session.ID)
+							if err == nil && attached {
+								if trace != nil {
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "deferred_attached", traceRecordPayload{
+										"stored_hash":  storedHash,
+										"current_hash": currentHash,
+									}, nil, "")
+								}
+								continue
+							}
+							// Defer ordinary-session config-drift drain while a
+							// user is attached. Named-session config drift is
+							// non-deferrable and is handled above.
+							if sp.IsAttached(name) {
+								if trace != nil {
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "deferred_attached", traceRecordPayload{
+										"stored_hash":  storedHash,
+										"current_hash": currentHash,
+									}, nil, "")
+								}
+								continue
+							}
+							ddt := driftDrainTimeout
+							if ddt <= 0 {
+								ddt = defaultDrainTimeout
+							}
+							if beginSessionDrain(*session, sp, dt, "config-drift", clk, ddt) {
+								fmt.Fprintf(stdout, "Draining session '%s': config-drift\n", name) //nolint:errcheck
+								if trace != nil {
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", traceRecordPayload{
+										"stored_hash":  storedHash,
+										"current_hash": currentHash,
+									}, nil, "")
+								}
+								rec.Record(events.Event{
+									Type:    events.SessionDraining,
+									Actor:   "gc",
+									Subject: tp.DisplayName(),
+									Message: "config drift detected",
+								})
+							}
 							continue
 						}
-						// Defer ordinary-session config-drift drain while a
-						// user is attached. Named-session config drift is
-						// deferred when actively in use (see above).
-						if pendingInteractionKeepsAwake(*session, sp, name, clk) {
-							drainCancelled := false
-							if dt != nil {
-								drainCancelled = cancelSessionDrainForPending(*session, sp, dt)
-							}
-							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "pending", "deferred_pending", traceRecordPayload{
-									"stored_hash":    storedHash,
-									"current_hash":   currentHash,
-									"drain_canceled": drainCancelled,
-								}, nil, "")
-							}
-							continue
-						}
-						attached, err := workerSessionTargetAttachedWithConfig(cityPath, store, sp, cfg, session.ID)
-						if err == nil && attached {
-							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "deferred_attached", traceRecordPayload{
-									"stored_hash":  storedHash,
-									"current_hash": currentHash,
-								}, nil, "")
-							}
-							continue
-						}
-						if isNamedSessionBead(*session) {
-							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, "creating", stderr)
-							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", traceRecordPayload{
-									"stored_hash":  storedHash,
-									"current_hash": currentHash,
-								}, nil, "")
-							}
-							rec.Record(events.Event{
-								Type:    events.SessionDraining,
-								Actor:   "gc",
-								Subject: tp.DisplayName(),
-								Message: "config drift detected",
-							})
-							continue
-						}
-						// Defer ordinary-session config-drift drain while a
-						// user is attached. Named-session config drift is
-						// non-deferrable and is handled above.
-						if sp.IsAttached(name) {
-							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "deferred_attached", traceRecordPayload{
-									"stored_hash":  storedHash,
-									"current_hash": currentHash,
-								}, nil, "")
-							}
-							continue
-						}
-						ddt := driftDrainTimeout
-						if ddt <= 0 {
-							ddt = defaultDrainTimeout
-						}
-						if beginSessionDrain(*session, sp, dt, "config-drift", clk, ddt) {
-							fmt.Fprintf(stdout, "Draining session '%s': config-drift\n", name) //nolint:errcheck
-							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", traceRecordPayload{
-									"stored_hash":  storedHash,
-									"current_hash": currentHash,
-								}, nil, "")
-							}
-							rec.Record(events.Event{
-								Type:    events.SessionDraining,
-								Actor:   "gc",
-								Subject: tp.DisplayName(),
-								Message: "config drift detected",
-							})
-						}
-						continue
 					}
 
 					if isNamedSessionBead(*session) {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1726,6 +1726,52 @@ func TestReconcileSessionBeads_NoDriftBeforeStartedHashWritten(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_DefersPendingCreateRecoveryWhileStartInFlight(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "new-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"command":              "old-cmd",
+		"state":                "creating",
+		"pending_create_claim": "true",
+		"last_woke_at":         env.clk.Now().UTC().Format(time.RFC3339),
+	})
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "old-cmd"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.sp.SetMeta("worker", "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.sp.SetMeta("worker", "GC_INSTANCE_TOKEN", session.Metadata["instance_token"]); err != nil {
+		t.Fatal(err)
+	}
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 while pending create start is still in flight", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want empty until async start commits", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want preserved while async start is in flight", got.Metadata["pending_create_claim"])
+	}
+	switch got.Metadata["state"] {
+	case "creating", "awake":
+	default:
+		t.Fatalf("state = %q, want creating or awake while async start is in flight", got.Metadata["state"])
+	}
+}
+
 func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}

--- a/cmd/gc/session_reconciler_trace_collector.go
+++ b/cmd/gc/session_reconciler_trace_collector.go
@@ -73,6 +73,7 @@ type SessionReconcilerTraceCycle struct {
 	recordCount        int
 	droppedRecords     int
 	droppedBatches     int
+	ended              bool
 	dropReasons        map[string]int
 	completionStatus   TraceCompletionStatus
 	traceMode          TraceMode
@@ -271,6 +272,13 @@ func (c *SessionReconcilerTraceCycle) addRecord(rec SessionReconcilerTraceRecord
 	if len(c.records) >= sessionReconcilerTraceMaxRecordsPerCycle {
 		c.droppedRecords++
 		c.dropReasons["record_budget_exceeded"]++
+		return
+	}
+	if c.ended {
+		rec.ensureFields()
+		rec.Fields["post_cycle_result"] = true
+		rec.Fields["rollup_excluded"] = true
+		c.records = append(c.records, rec)
 		return
 	}
 	c.accumulateRecordLocked(rec)
@@ -874,6 +882,8 @@ func (c *SessionReconcilerTraceCycle) End(completion TraceCompletionStatus, fiel
 	dur := now.Sub(c.start)
 	c.mu.Lock()
 	batch := append([]SessionReconcilerTraceRecord(nil), c.records...)
+	c.records = nil
+	c.ended = true
 	droppedRecords := c.droppedRecords
 	droppedBatches := c.droppedBatches
 	dropReasons := make(map[string]int, len(c.dropReasons))

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -458,6 +458,98 @@ func TestTraceCycleResultRollupIncludesFlushedRecords(t *testing.T) {
 	}
 }
 
+func TestTraceFlushAfterEndOnlyPersistsPostEndRecords(t *testing.T) {
+	cityDir := t.TempDir()
+	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)
+	if !tracer.Enabled() {
+		t.Fatal("tracer should be enabled")
+	}
+	now := time.Now().UTC()
+	if _, err := tracer.armStore.upsertArm(TraceArm{
+		ScopeType:      TraceArmScopeTemplate,
+		ScopeValue:     "worker",
+		Source:         TraceArmSourceManual,
+		Level:          TraceModeDetail,
+		ArmedAt:        now,
+		ExpiresAt:      now.Add(15 * time.Minute),
+		LastExtendedAt: now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsertArm: %v", err)
+	}
+	cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "", time.Now().UTC(), &config.City{})
+	if cycle == nil {
+		t.Fatal("BeginCycle returned nil")
+	}
+	cycle.RecordOperation(
+		TraceSiteLifecycleStartExecute,
+		TraceReasonWake,
+		TraceOutcomeApplied,
+		"provider_start",
+		"worker",
+		"worker",
+		10*time.Millisecond,
+		map[string]any{"step": "before-end"},
+	)
+	if err := cycle.End(TraceCompletionCompleted, map[string]any{}); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+	cycle.RecordOperation(
+		TraceSiteLifecycleStartExecute,
+		TraceReasonWake,
+		TraceOutcomeApplied,
+		"provider_start",
+		"worker",
+		"worker",
+		20*time.Millisecond,
+		map[string]any{"step": "after-end"},
+	)
+	if err := cycle.flushCurrentBatch(TraceDurabilityDurable); err != nil {
+		t.Fatalf("flushCurrentBatch: %v", err)
+	}
+	if err := tracer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	var beforeEnd, afterEnd int
+	var cycleResult *SessionReconcilerTraceRecord
+	for _, rec := range records {
+		if rec.RecordType == TraceRecordCycleResult {
+			recCopy := rec
+			cycleResult = &recCopy
+			continue
+		}
+		if rec.RecordType != TraceRecordOperation {
+			continue
+		}
+		switch rec.Fields["step"] {
+		case "before-end":
+			beforeEnd++
+		case "after-end":
+			if got := rec.Fields["post_cycle_result"]; got != true {
+				t.Fatalf("post_cycle_result = %#v, want true", got)
+			}
+			if got := rec.Fields["rollup_excluded"]; got != true {
+				t.Fatalf("rollup_excluded = %#v, want true", got)
+			}
+			afterEnd++
+		}
+	}
+	if cycleResult == nil {
+		t.Fatal("cycle_result missing")
+	}
+	if cycleResult.RecordCount >= len(records) {
+		t.Fatalf("cycle_result record_count = %d, want less than persisted records %d because post-End records are rollup-excluded", cycleResult.RecordCount, len(records))
+	}
+	if beforeEnd != 1 || afterEnd != 1 {
+		t.Fatalf("operation counts before-end=%d after-end=%d, want 1 each", beforeEnd, afterEnd)
+	}
+}
+
 func TestTraceFlushCurrentBatchQueueFullDegrades(t *testing.T) {
 	cityDir := t.TempDir()
 	store, err := newSessionReconcilerTraceStore(cityDir, io.Discard)


### PR DESCRIPTION
## Summary

- Supersedes #1341 by @julianknutsen.
- Enqueues daemon reconciler session starts asynchronously while leaving direct/helper callers synchronous.
- Adds maintainer review fixups for async commit freshness, limiter ordering, shutdown cleanup, stale runtime ownership, and pending-create retry safety.

Credit: Original async-start fix by @julianknutsen; the contributor commit is preserved in this branch.

## Testing

- [x] `go test ./cmd/gc`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `.githooks/pre-commit`
- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed: supersedes #1341; no separate issue is needed for the adoption fixups.
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes: not applicable; behavior is internal reconciler lifecycle safety.
- [x] Called out breaking changes or migration notes: none.
