### PR TITLE
fix: detect rate-limit screen before crash recovery

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -153,6 +153,7 @@ type startResult struct {
 	started         time.Time
 	finished        time.Time
 	rollbackPending bool
+	rateLimitScreen bool
 }
 
 type startExecutionOptions struct {
@@ -824,7 +825,8 @@ func runPreparedStartCandidate(
 	}
 	finished := time.Now()
 	rollbackPending := err != nil && shouldRollbackPendingCreate(item.candidate.session)
-	if err != nil && rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
+	rateLimitScreen := err != nil && startupRateLimitScreenDetected(item, cityPath, sp, store, cfg)
+	if err != nil && rollbackPending && !rateLimitScreen && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp) {
 		return startResult{
 			prepared:        item,
 			err:             nil,
@@ -856,7 +858,7 @@ func runPreparedStartCandidate(
 		switch {
 		case runningErr != nil || !running:
 			outcome = "provider_error"
-		case rollbackPending && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
+		case rollbackPending && !rateLimitScreen && runningSessionMatchesPendingCreate(item.candidate.session, item.candidate.name(), sp):
 			outcome = "session_exists_converged"
 			err = nil
 			rollbackPending = false
@@ -866,6 +868,9 @@ func runPreparedStartCandidate(
 	default:
 		outcome = "provider_error"
 	}
+	if err == nil {
+		rateLimitScreen = false
+	}
 	return startResult{
 		prepared:        item,
 		err:             err,
@@ -873,7 +878,40 @@ func runPreparedStartCandidate(
 		started:         started,
 		finished:        finished,
 		rollbackPending: rollbackPending,
+		rateLimitScreen: rateLimitScreen,
 	}
+}
+
+func startupRateLimitScreenDetected(
+	item preparedStart,
+	cityPath string,
+	sp runtime.Provider,
+	store beads.Store,
+	cfg *config.City,
+) bool {
+	if item.candidate.session == nil {
+		return false
+	}
+	if cfg != nil && cfg.Session.Provider == "subprocess" {
+		return false
+	}
+	lastWoke := item.candidate.session.Metadata["last_woke_at"]
+	if lastWoke == "" {
+		return false
+	}
+	if _, err := time.Parse(time.RFC3339, lastWoke); err != nil {
+		return false
+	}
+	content, err := workerSessionTargetPeekWithConfig(
+		cityPath,
+		store,
+		sp,
+		cfg,
+		item.candidate.name(),
+		rateLimitPeekLines,
+		item.cfg.ProcessNames,
+	)
+	return err == nil && runtime.ContainsProviderRateLimitScreen(content)
 }
 
 func enqueuePreparedStartWaveForCity(
@@ -1211,8 +1249,28 @@ func commitStartResultTraced(
 		return false
 	}
 	if result.err != nil {
+		fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck
+		if result.rateLimitScreen {
+			if err := recordRateLimitQuarantine(session, store, clk); err != nil {
+				fmt.Fprintf(stderr, "session reconciler: recording startup rate-limit hold for %s: %v\n", name, err) //nolint:errcheck
+				if trace != nil {
+					trace.recordOperation("reconciler.start.rate_limit_hold", tp.TemplateName, name, "", "start", "hold_deferred", traceRecordPayload{
+						"error": formatLifecycleError(result.err),
+						"cause": err.Error(),
+					}, "")
+				}
+				logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
+				return false
+			}
+			if trace != nil {
+				trace.recordOperation("reconciler.start.rate_limit_hold", tp.TemplateName, name, "", "start", "held", traceRecordPayload{
+					"error": formatLifecycleError(result.err),
+				}, "")
+			}
+			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
+			return false
+		}
 		if result.rollbackPending {
-			fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck
 			if trace != nil {
 				trace.recordOperation("reconciler.start.rollback_pending", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{
 					"error": formatLifecycleError(result.err),
@@ -1222,7 +1280,6 @@ func commitStartResultTraced(
 			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
 			return false
 		}
-		fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck
 		if err := store.SetMetadata(session.ID, "last_woke_at", ""); err != nil {
 			fmt.Fprintf(stderr, "session reconciler: clearing last_woke_at for %s: %v\n", name, err) //nolint:errcheck
 		} else {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -4626,6 +4626,193 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *tes
 	}
 }
 
+func TestExecutePreparedStartWave_RateLimitStartupDeathQuarantinesWithoutWakeFailure(t *testing.T) {
+	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-99",
+		Title:  "test-agent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "test-agent",
+			"session_key":          "stale-key-abc",
+			"template":             "worker",
+			"state":                "active",
+			"last_woke_at":         clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+			"wake_attempts":        "2",
+			"started_config_hash":  "keep-hash",
+			"continuation_command": "resume",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	sp.SetPeekOutput("test-agent", "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &session,
+			tp: TemplateParams{
+				Command:      "claude --resume stale-key-abc",
+				SessionName:  "test-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume stale-key-abc",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWaveForCity(
+		context.Background(),
+		[]preparedStart{item},
+		"",
+		sp,
+		nil,
+		&config.City{},
+		10*time.Second,
+		1,
+	)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].err == nil {
+		t.Fatal("expected startup-death error")
+	}
+
+	if commitStartResult(results[0], store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}) {
+		t.Fatal("startup rate-limit hold should not count as a committed wake")
+	}
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["wake_attempts"] != "2" {
+		t.Fatalf("wake_attempts = %q, want 2", got.Metadata["wake_attempts"])
+	}
+	if got.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", got.Metadata["state"])
+	}
+	if got.Metadata["session_key"] != "stale-key-abc" {
+		t.Fatalf("session_key = %q, want preserved", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "keep-hash" {
+		t.Fatalf("started_config_hash = %q, want preserved", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "" {
+		t.Fatalf("continuation_reset_pending = %q, want empty", got.Metadata["continuation_reset_pending"])
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared after rate-limit hold", got.Metadata["last_woke_at"])
+	}
+	qUntil, err := time.Parse(time.RFC3339, got.Metadata["quarantined_until"])
+	if err != nil {
+		t.Fatalf("quarantined_until parse: %v", err)
+	}
+	if want := clk.Now().Add(defaultRateLimitQuarantineDuration); !qUntil.Equal(want) {
+		t.Fatalf("quarantined_until = %s, want %s", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+func TestExecutePreparedStartWave_RateLimitPendingCreateDeathClearsClaim(t *testing.T) {
+	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 30, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-creating",
+		Title:  "creating-agent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "creating-agent",
+			"session_key":          "resume-key",
+			"template":             "worker",
+			"last_woke_at":         clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+			"wake_attempts":        "2",
+			"started_config_hash":  "keep-hash",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	sp.SetPeekOutput("creating-agent", "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &session,
+			tp: TemplateParams{
+				Command:      "claude --resume resume-key",
+				SessionName:  "creating-agent",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{
+			Command:      "claude --resume resume-key",
+			ProcessNames: []string{"claude"},
+		},
+	}
+
+	results := executePreparedStartWaveForCity(
+		context.Background(),
+		[]preparedStart{item},
+		"",
+		sp,
+		nil,
+		&config.City{},
+		10*time.Second,
+		1,
+	)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].err == nil {
+		t.Fatal("expected startup-death error")
+	}
+	if !results[0].rateLimitScreen {
+		t.Fatal("pending-create startup death should still classify provider rate-limit screen")
+	}
+
+	if commitStartResult(results[0], store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}) {
+		t.Fatal("startup rate-limit hold should not count as a committed wake")
+	}
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Metadata["close_reason"] != "" {
+		t.Fatalf("close_reason = %q, want empty", got.Metadata["close_reason"])
+	}
+	if got.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", got.Metadata["state"])
+	}
+	if got.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["wake_attempts"] != "2" {
+		t.Fatalf("wake_attempts = %q, want 2", got.Metadata["wake_attempts"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared by rate-limit hold", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["session_key"] != "resume-key" {
+		t.Fatalf("session_key = %q, want preserved", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "keep-hash" {
+		t.Fatalf("started_config_hash = %q, want preserved", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared after rate-limit hold", got.Metadata["last_woke_at"])
+	}
+}
+
 func TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey(t *testing.T) {
 	// Session without a session_key should not trigger stale detection,
 	// even if the session dies after start.

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -482,15 +482,20 @@ func healExpiredTimers(session *beads.Bead, store beads.Store, clk clock.Clock) 
 	}
 }
 
-// checkStability detects rapid exits. If a session was woken within
-// stabilityThreshold and is already dead, counts it as either a provider
-// rate-limit hold or a crash.
+// checkStability detects dead sessions that still have last_woke_at. Provider
+// rate-limit screens are retried until the hold metadata persists; ordinary
+// crash wake failures are counted only inside stabilityThreshold.
+//
+// Production callers must run checkRateLimitStability before healState and
+// pass nil here after healing. That ordering preserves continuation metadata
+// for provider rate-limit screens while still letting crash recovery clear
+// stale continuation identity after advisory state has been healed.
 // Returns true if a stability event was recorded.
 // Edge-triggered: clears last_woke_at after recording so the same crash
 // is counted exactly once.
 // Drain-aware: draining sessions died by request, not by crash.
 func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock, peek func(lines int) (string, error)) bool {
-	if checkRateLimitStability(session, cfg, alive, dt, store, clk, peek) {
+	if handled, err := checkRateLimitStability(session, cfg, alive, dt, store, clk, peek); handled || err != nil {
 		return true
 	}
 	if !rapidExitWithinStabilityThreshold(session, cfg, alive, dt, clk) {
@@ -501,19 +506,50 @@ func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drain
 	return true
 }
 
-func checkRateLimitStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock, peek func(lines int) (string, error)) bool {
-	if !rapidExitWithinStabilityThreshold(session, cfg, alive, dt, clk) {
-		return false
+func checkRateLimitStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock, peek func(lines int) (string, error)) (bool, error) {
+	if !rateLimitStabilityCandidate(session, cfg, alive, dt, clk) {
+		return false, nil
 	}
 	if peek == nil {
-		return false
+		return false, nil
 	}
 	content, err := peek(rateLimitPeekLines)
-	if err != nil || !runtime.ContainsRateLimitDialog(content) {
+	if err != nil {
+		return false, nil
+	}
+	if !runtime.ContainsProviderRateLimitScreen(content) {
+		return false, nil
+	}
+	if err := recordRateLimitQuarantine(session, store, clk); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func rateLimitStabilityCandidate(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, clk clock.Clock) bool {
+	if session == nil || alive {
 		return false
 	}
-	recordRateLimitQuarantine(session, store, clk)
-	clearLastWokeAt(session, store)
+	if cfg != nil && cfg.Session.Provider == "subprocess" {
+		return false
+	}
+	if dt != nil && dt.get(session.ID) != nil {
+		return false
+	}
+	lastWoke := session.Metadata["last_woke_at"]
+	if lastWoke == "" {
+		return false
+	}
+	var startupTimeout time.Duration
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
+	if pendingCreateStartInFlight(*session, clk, startupTimeout) {
+		return false
+	}
+	if _, err := time.Parse(time.RFC3339, lastWoke); err != nil {
+		return false
+	}
 	return true
 }
 
@@ -557,21 +593,26 @@ func clearLastWokeAt(session *beads.Bead, store beads.Store) {
 // recordRateLimitQuarantine backs off a session that exited into a provider
 // rate-limit screen without treating the exit as a crash or resetting its
 // conversation metadata.
-func recordRateLimitQuarantine(session *beads.Bead, store beads.Store, clk clock.Clock) {
+func recordRateLimitQuarantine(session *beads.Bead, store beads.Store, clk clock.Clock) error {
 	if session.Metadata == nil {
 		session.Metadata = make(map[string]string)
 	}
 	qUntil := clk.Now().Add(defaultRateLimitQuarantineDuration).UTC().Format(time.RFC3339)
 	batch := map[string]string{
-		"state":             string(sessionpkg.StateAsleep),
-		"quarantined_until": qUntil,
-		"sleep_reason":      "rate_limit",
+		"state":                string(sessionpkg.StateAsleep),
+		"quarantined_until":    qUntil,
+		"sleep_reason":         "rate_limit",
+		"last_woke_at":         "",
+		"pending_create_claim": "",
 	}
-	if err := store.SetMetadataBatch(session.ID, batch); err == nil {
-		for k, v := range batch {
-			session.Metadata[k] = v
-		}
+	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+		fmt.Fprintf(os.Stderr, "recordRateLimitQuarantine: SetMetadataBatch %s: %v\n", session.ID, err) //nolint:errcheck
+		return err
 	}
+	for k, v := range batch {
+		session.Metadata[k] = v
+	}
+	return nil
 }
 
 // recordWakeFailure increments wake_attempts and quarantines if threshold exceeded.

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -483,12 +483,41 @@ func healExpiredTimers(session *beads.Bead, store beads.Store, clk clock.Clock) 
 }
 
 // checkStability detects rapid exits. If a session was woken within
-// stabilityThreshold and is already dead, counts as a crash.
-// Returns true if a failure was recorded (caller should skip recordWakeFailure).
+// stabilityThreshold and is already dead, counts it as either a provider
+// rate-limit hold or a crash.
+// Returns true if a stability event was recorded.
 // Edge-triggered: clears last_woke_at after recording so the same crash
 // is counted exactly once.
 // Drain-aware: draining sessions died by request, not by crash.
-func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock) bool {
+func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock, peek func(lines int) (string, error)) bool {
+	if checkRateLimitStability(session, cfg, alive, dt, store, clk, peek) {
+		return true
+	}
+	if !rapidExitWithinStabilityThreshold(session, cfg, alive, dt, clk) {
+		return false
+	}
+	recordWakeFailure(session, store, clk)
+	clearLastWokeAt(session, store)
+	return true
+}
+
+func checkRateLimitStability(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, store beads.Store, clk clock.Clock, peek func(lines int) (string, error)) bool {
+	if !rapidExitWithinStabilityThreshold(session, cfg, alive, dt, clk) {
+		return false
+	}
+	if peek == nil {
+		return false
+	}
+	content, err := peek(rateLimitPeekLines)
+	if err != nil || !runtime.ContainsRateLimitDialog(content) {
+		return false
+	}
+	recordRateLimitQuarantine(session, store, clk)
+	clearLastWokeAt(session, store)
+	return true
+}
+
+func rapidExitWithinStabilityThreshold(session *beads.Bead, cfg *config.City, alive bool, dt *drainTracker, clk clock.Clock) bool {
 	if alive {
 		return false
 	}
@@ -517,14 +546,32 @@ func checkStability(session *beads.Bead, cfg *config.City, alive bool, dt *drain
 	if err != nil {
 		return false
 	}
-	if clk.Now().Sub(t) < stabilityThreshold {
-		recordWakeFailure(session, store, clk)
-		// Clear last_woke_at so this crash is not re-counted next tick.
-		_ = store.SetMetadata(session.ID, "last_woke_at", "")
-		session.Metadata["last_woke_at"] = ""
-		return true
+	return clk.Now().Sub(t) < stabilityThreshold
+}
+
+func clearLastWokeAt(session *beads.Bead, store beads.Store) {
+	_ = store.SetMetadata(session.ID, "last_woke_at", "")
+	session.Metadata["last_woke_at"] = ""
+}
+
+// recordRateLimitQuarantine backs off a session that exited into a provider
+// rate-limit screen without treating the exit as a crash or resetting its
+// conversation metadata.
+func recordRateLimitQuarantine(session *beads.Bead, store beads.Store, clk clock.Clock) {
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string)
 	}
-	return false
+	qUntil := clk.Now().Add(defaultRateLimitQuarantineDuration).UTC().Format(time.RFC3339)
+	batch := map[string]string{
+		"state":             string(sessionpkg.StateAsleep),
+		"quarantined_until": qUntil,
+		"sleep_reason":      "rate_limit",
+	}
+	if err := store.SetMetadataBatch(session.ID, batch); err == nil {
+		for k, v := range batch {
+			session.Metadata[k] = v
+		}
+	}
 }
 
 // recordWakeFailure increments wake_attempts and quarantines if threshold exceeded.
@@ -651,7 +698,7 @@ func checkChurn(session *beads.Bead, cfg *config.City, alive bool, dt *drainTrac
 func isDeliberateSleepReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
 	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained",
-		sleepReasonCityStop, "user-hold", "wait-hold":
+		sleepReasonCityStop, "user-hold", "wait-hold", "rate_limit":
 		return true
 	default:
 		return false

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -22,8 +23,8 @@ import (
 //
 // Fix: extend checkStability to accept a peek callback (matching the shape
 // already used by AcceptStartupDialogs* in internal/runtime/dialog.go). When
-// peek returns content matching runtime.ContainsRateLimitDialog, the function
-// records a rate-limit quarantine (longer back-off, distinct
+// peek returns high-confidence provider rate-limit screen content, the
+// function records a rate-limit quarantine (longer back-off, distinct
 // sleep_reason="rate_limit") instead of a crash, and does NOT increment
 // wake_attempts.
 func TestCheckStability_RateLimitScreen_DoesNotCountAsCrash(t *testing.T) {
@@ -104,7 +105,11 @@ func TestCheckRateLimitStability_BeforeHealPreservesResumeMetadata(t *testing.T)
 		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
 	}
 
-	if !checkRateLimitStability(&session, nil, false, dt, store, clk, peek) {
+	handled, err := checkRateLimitStability(&session, nil, false, dt, store, clk, peek)
+	if err != nil {
+		t.Fatalf("recording rate-limit rapid exit: %v", err)
+	}
+	if !handled {
 		t.Fatal("rate-limit rapid exit should be recorded before advisory state healing")
 	}
 
@@ -121,6 +126,122 @@ func TestCheckRateLimitStability_BeforeHealPreservesResumeMetadata(t *testing.T)
 	}
 	if got := session.Metadata["state"]; got != "asleep" {
 		t.Errorf("state = %q, want asleep", got)
+	}
+	if got := session.Metadata["sleep_reason"]; got != "rate_limit" {
+		t.Errorf("sleep_reason = %q, want rate_limit", got)
+	}
+}
+
+func TestCheckRateLimitStability_BatchFailureDoesNotClearLastWokeAt(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	store.metadataBatchErr = errors.New("batch failed")
+	dt := newDrainTracker()
+	lastWoke := now.Add(-10 * time.Second).Format(time.RFC3339)
+
+	session := makeBead("b1", map[string]string{
+		"state":               "active",
+		"last_woke_at":        lastWoke,
+		"session_key":         "keep-session",
+		"started_config_hash": "keep-hash",
+	})
+	peek := func(_ int) (string, error) {
+		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
+	}
+
+	handled, err := checkRateLimitStability(&session, nil, false, dt, store, clk, peek)
+	if err == nil {
+		t.Fatal("rate-limit batch failure should be returned")
+	}
+	if handled {
+		t.Fatal("rate-limit rapid exit should not be handled when persistence fails")
+	}
+	if got := session.Metadata["last_woke_at"]; got != lastWoke {
+		t.Fatalf("last_woke_at = %q, want preserved after failed batch", got)
+	}
+	if got := session.Metadata["sleep_reason"]; got != "" {
+		t.Fatalf("sleep_reason = %q, want unchanged after failed batch", got)
+	}
+	if got, ok := store.metadata["b1"]["last_woke_at"]; ok {
+		t.Fatalf("separate last_woke_at write = %q, want no standalone clear", got)
+	}
+	if len(store.metadataBatchPatches) != 1 {
+		t.Fatalf("metadata batch calls = %d, want 1", len(store.metadataBatchPatches))
+	}
+	if got, ok := store.metadataBatchPatches[0]["last_woke_at"]; !ok || got != "" {
+		t.Fatalf("rate-limit batch last_woke_at = %q, present=%v; want empty value in batch", got, ok)
+	}
+
+	store.metadataBatchErr = nil
+	handled, err = checkRateLimitStability(&session, nil, false, dt, store, clk, peek)
+	if err != nil {
+		t.Fatalf("retrying rate-limit detection: %v", err)
+	}
+	if !handled {
+		t.Fatal("rate-limit detection should retry on the next tick after a failed batch")
+	}
+	healState(&session, false, store, clk)
+
+	if got := session.Metadata["session_key"]; got != "keep-session" {
+		t.Errorf("session_key = %q, want preserved", got)
+	}
+	if got := session.Metadata["started_config_hash"]; got != "keep-hash" {
+		t.Errorf("started_config_hash = %q, want preserved", got)
+	}
+	if got := session.Metadata["continuation_reset_pending"]; got != "" {
+		t.Errorf("continuation_reset_pending = %q, want empty", got)
+	}
+	if got := session.Metadata["last_woke_at"]; got != "" {
+		t.Errorf("last_woke_at = %q, want cleared by successful quarantine batch", got)
+	}
+}
+
+func TestCheckRateLimitStability_BatchFailureRetriesAfterStabilityThreshold(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	store.metadataBatchErr = errors.New("batch failed")
+	dt := newDrainTracker()
+	lastWoke := now.Add(-10 * time.Second).Format(time.RFC3339)
+
+	session := makeBead("b1", map[string]string{
+		"state":               "active",
+		"last_woke_at":        lastWoke,
+		"session_key":         "keep-session",
+		"started_config_hash": "keep-hash",
+	})
+	peek := func(_ int) (string, error) {
+		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
+	}
+
+	handled, err := checkRateLimitStability(&session, nil, false, dt, store, clk, peek)
+	if err == nil {
+		t.Fatal("initial failed batch should be returned")
+	}
+	if handled {
+		t.Fatal("initial failed batch should not be reported as handled")
+	}
+
+	clk.Time = now.Add(stabilityThreshold + time.Second)
+	store.metadataBatchErr = nil
+	handled, err = checkRateLimitStability(&session, nil, false, dt, store, clk, peek)
+	if err != nil {
+		t.Fatalf("retrying after stability threshold: %v", err)
+	}
+	if !handled {
+		t.Fatal("rate-limit detection should retry after the crash stability threshold")
+	}
+	healState(&session, false, store, clk)
+
+	if got := session.Metadata["session_key"]; got != "keep-session" {
+		t.Errorf("session_key = %q, want preserved", got)
+	}
+	if got := session.Metadata["started_config_hash"]; got != "keep-hash" {
+		t.Errorf("started_config_hash = %q, want preserved", got)
+	}
+	if got := session.Metadata["continuation_reset_pending"]; got != "" {
+		t.Errorf("continuation_reset_pending = %q, want empty", got)
 	}
 	if got := session.Metadata["sleep_reason"]; got != "rate_limit" {
 		t.Errorf("sleep_reason = %q, want rate_limit", got)
@@ -169,6 +290,29 @@ func TestCheckStability_RateLimitScreen_NilPeekFallsBackToCrash(t *testing.T) {
 
 	if !checkStability(&session, nil, false, dt, store, clk, nil) {
 		t.Error("rapid exit with nil peek should fall back to crash-counting behavior")
+	}
+	if got := session.Metadata["wake_attempts"]; got != "1" {
+		t.Errorf("wake_attempts = %q, want 1", got)
+	}
+}
+
+func TestCheckStability_RateLimitScreen_PeekErrorFallsBackToCrash(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":  now.Add(-10 * time.Second).Format(time.RFC3339),
+		"wake_attempts": "0",
+	})
+
+	peek := func(_ int) (string, error) {
+		return "", errors.New("peek failed")
+	}
+
+	if !checkStability(&session, nil, false, dt, store, clk, peek) {
+		t.Error("rapid exit with peek error should fall back to crash-counting behavior")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "1" {
 		t.Errorf("wake_attempts = %q, want 1", got)

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -1,0 +1,176 @@
+// This file pins the desired post-fix behavior for rate-limit-blind respawns.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/clock"
+)
+
+// TestCheckStability_RateLimitScreen_DoesNotCountAsCrash pins the desired
+// post-fix behavior of checkStability when the agent's pane shows a
+// Claude/Gemini rate-limit screen.
+//
+// When an agent CLI exits at the rate-limit screen, the session reconciler
+// sees process_alive==false, calls checkStability, which sees last_woke_at
+// within stabilityThreshold and counts it as a crash via recordWakeFailure.
+// Five consecutive rate-limit exits within 30s trigger a 5-minute quarantine,
+// so the system burns 5 wake/prime/--resume cycles before backing off, even
+// though every wake will hit the same rate limit and produce zero useful work.
+//
+// Fix: extend checkStability to accept a peek callback (matching the shape
+// already used by AcceptStartupDialogs* in internal/runtime/dialog.go). When
+// peek returns content matching runtime.ContainsRateLimitDialog, the function
+// records a rate-limit quarantine (longer back-off, distinct
+// sleep_reason="rate_limit") instead of a crash, and does NOT increment
+// wake_attempts.
+func TestCheckStability_RateLimitScreen_DoesNotCountAsCrash(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":        now.Add(-10 * time.Second).Format(time.RFC3339),
+		"session_key":         "keep-session",
+		"started_config_hash": "keep-hash",
+		"wake_attempts":       "3", // a real crash would push us to 4
+	})
+
+	paneContent := "You've hit your limit, Pro plan\n\n/rate-limit-options"
+	var gotLines int
+	peek := func(lines int) (string, error) {
+		gotLines = lines
+		return paneContent, nil
+	}
+
+	if !checkStability(&session, nil, false, dt, store, clk, peek) {
+		t.Fatal("checkStability should return true when it records a rate-limit hold")
+	}
+
+	if got := session.Metadata["wake_attempts"]; got != "3" {
+		t.Errorf("wake_attempts = %q, want 3; rate-limit exit must not count as a crash", got)
+	}
+
+	if got := session.Metadata["sleep_reason"]; got != "rate_limit" {
+		t.Errorf("sleep_reason = %q, want %q", got, "rate_limit")
+	}
+	if got := session.Metadata["state"]; got != "asleep" {
+		t.Errorf("state = %q, want asleep", got)
+	}
+
+	qUntil, err := time.Parse(time.RFC3339, session.Metadata["quarantined_until"])
+	if err != nil {
+		t.Fatalf("quarantined_until parse: %v", err)
+	}
+	if want := now.Add(defaultRateLimitQuarantineDuration); !qUntil.Equal(want) {
+		t.Errorf("quarantined_until = %s, want %s", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+
+	if gotLines != rateLimitPeekLines {
+		t.Errorf("peek lines = %d, want %d", gotLines, rateLimitPeekLines)
+	}
+
+	if got := session.Metadata["session_key"]; got != "keep-session" {
+		t.Errorf("session_key = %q, want preserved", got)
+	}
+	if got := session.Metadata["started_config_hash"]; got != "keep-hash" {
+		t.Errorf("started_config_hash = %q, want preserved", got)
+	}
+
+	// last_woke_at should be cleared (edge-triggered, mirroring the existing
+	// crash path) so the rate-limit detection isn't re-triggered next tick.
+	if session.Metadata["last_woke_at"] != "" {
+		t.Error("last_woke_at should be cleared after rate-limit detection")
+	}
+}
+
+func TestCheckRateLimitStability_BeforeHealPreservesResumeMetadata(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"state":               "active",
+		"last_woke_at":        now.Add(-10 * time.Second).Format(time.RFC3339),
+		"session_key":         "keep-session",
+		"started_config_hash": "keep-hash",
+	})
+
+	peek := func(_ int) (string, error) {
+		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
+	}
+
+	if !checkRateLimitStability(&session, nil, false, dt, store, clk, peek) {
+		t.Fatal("rate-limit rapid exit should be recorded before advisory state healing")
+	}
+
+	healState(&session, false, store, clk)
+
+	if got := session.Metadata["session_key"]; got != "keep-session" {
+		t.Errorf("session_key = %q, want preserved", got)
+	}
+	if got := session.Metadata["started_config_hash"]; got != "keep-hash" {
+		t.Errorf("started_config_hash = %q, want preserved", got)
+	}
+	if got := session.Metadata["continuation_reset_pending"]; got != "" {
+		t.Errorf("continuation_reset_pending = %q, want empty", got)
+	}
+	if got := session.Metadata["state"]; got != "asleep" {
+		t.Errorf("state = %q, want asleep", got)
+	}
+	if got := session.Metadata["sleep_reason"]; got != "rate_limit" {
+		t.Errorf("sleep_reason = %q, want rate_limit", got)
+	}
+}
+
+// TestCheckStability_RateLimitScreen_EmptyPaneStillCountsAsCrash ensures the
+// rate-limit detection requires positive evidence in the pane. If peek
+// returns nothing matching the rate-limit signature, behavior matches the
+// existing crash path: count as a crash, increment wake_attempts.
+func TestCheckStability_RateLimitScreen_EmptyPaneStillCountsAsCrash(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":  now.Add(-10 * time.Second).Format(time.RFC3339),
+		"wake_attempts": "0",
+	})
+
+	peek := func(_ int) (string, error) { return "", nil }
+
+	if !checkStability(&session, nil, false, dt, store, clk, peek) {
+		t.Error("rapid exit with no rate-limit signature should report stability failure")
+	}
+	if got := session.Metadata["wake_attempts"]; got != "1" {
+		t.Errorf("wake_attempts = %q, want 1", got)
+	}
+}
+
+// TestCheckStability_RateLimitScreen_NilPeekFallsBackToCrash ensures
+// backward compatibility for call sites that don't supply a peek (subprocess
+// providers, test paths). When peek is nil, behavior matches the legacy
+// crash-only path.
+func TestCheckStability_RateLimitScreen_NilPeekFallsBackToCrash(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":  now.Add(-10 * time.Second).Format(time.RFC3339),
+		"wake_attempts": "0",
+	})
+
+	if !checkStability(&session, nil, false, dt, store, clk, nil) {
+		t.Error("rapid exit with nil peek should fall back to crash-counting behavior")
+	}
+	if got := session.Metadata["wake_attempts"]; got != "1" {
+		t.Errorf("wake_attempts = %q, want 1", got)
+	}
+}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -24,6 +24,7 @@ type testStore struct {
 	metadata             map[string]map[string]string // id -> key -> value
 	metadataBatchCalls   int
 	metadataBatchPatches []map[string]string
+	metadataBatchErr     error
 }
 
 func newTestStore() *testStore {
@@ -45,6 +46,9 @@ func (s *testStore) SetMetadataBatch(id string, kvs map[string]string) error {
 		patch[k] = v
 	}
 	s.metadataBatchPatches = append(s.metadataBatchPatches, patch)
+	if s.metadataBatchErr != nil {
+		return s.metadataBatchErr
+	}
 	for k, v := range kvs {
 		if err := s.SetMetadata(id, k, v); err != nil {
 			return err
@@ -936,7 +940,7 @@ func TestCheckStability_PendingCreateInFlightNotCounted(t *testing.T) {
 		"wake_attempts":        "0",
 	})
 
-	if checkStability(&session, nil, false, dt, store, clk) {
+	if checkStability(&session, nil, false, dt, store, clk, nil) {
 		t.Fatal("in-flight pending create should not be counted as a rapid exit")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "0" {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -894,7 +894,7 @@ func TestCheckStability_AliveReturnsFalse(t *testing.T) {
 		"last_woke_at": clk.Now().Add(-10 * time.Second).Format(time.RFC3339),
 	})
 
-	if checkStability(&session, nil, true, dt, store, clk) {
+	if checkStability(&session, nil, true, dt, store, clk, nil) {
 		t.Error("alive session should not report stability failure")
 	}
 }
@@ -910,7 +910,7 @@ func TestCheckStability_RapidExit(t *testing.T) {
 		"wake_attempts": "0",
 	})
 
-	if !checkStability(&session, nil, false, dt, store, clk) {
+	if !checkStability(&session, nil, false, dt, store, clk, nil) {
 		t.Error("rapid exit should report stability failure")
 	}
 
@@ -958,7 +958,7 @@ func TestCheckStability_DrainingNotCounted(t *testing.T) {
 		"last_woke_at": now.Add(-10 * time.Second).Format(time.RFC3339),
 	})
 
-	if checkStability(&session, nil, false, dt, store, clk) {
+	if checkStability(&session, nil, false, dt, store, clk, nil) {
 		t.Error("draining session death should not count as stability failure")
 	}
 }
@@ -974,7 +974,7 @@ func TestCheckStability_StableSession(t *testing.T) {
 		"last_woke_at": now.Add(-2 * time.Minute).Format(time.RFC3339),
 	})
 
-	if checkStability(&session, nil, false, dt, store, clk) {
+	if checkStability(&session, nil, false, dt, store, clk, nil) {
 		t.Error("session that lived past threshold should not be stability failure")
 	}
 }
@@ -993,7 +993,7 @@ func TestCheckStability_SubprocessProviderSkipsCrashCounting(t *testing.T) {
 		"wake_attempts": "0",
 	})
 
-	if checkStability(&session, cfg, false, dt, store, clk) {
+	if checkStability(&session, cfg, false, dt, store, clk, nil) {
 		t.Fatal("subprocess rapid exit should not be counted as a crash")
 	}
 	if got := session.Metadata["wake_attempts"]; got != "0" {
@@ -1709,7 +1709,7 @@ func TestCheckStability_RapidExitAfterHealStateKeepsStartedConfigHashCleared(t *
 	if session.Metadata["started_config_hash"] != "" {
 		t.Fatalf("healState started_config_hash = %q, want empty", session.Metadata["started_config_hash"])
 	}
-	if !checkStability(&session, nil, false, nil, store, clk) {
+	if !checkStability(&session, nil, false, nil, store, clk, nil) {
 		t.Fatal("checkStability should record the rapid exit")
 	}
 	if session.Metadata["started_config_hash"] != "" {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -730,6 +730,14 @@ func reconcileSessionBeadsTraced(
 
 		policy := resolveSessionSleepPolicy(*session, cfg, sp)
 
+		peek := func(lines int) (string, error) {
+			return workerSessionTargetPeekWithConfig(cityPath, store, sp, cfg, session.ID, lines, tp.Hints.ProcessNames)
+		}
+
+		if checkRateLimitStability(session, cfg, alive, dt, store, clk, peek) {
+			continue // rate-limit hold recorded before state healing resets continuity metadata
+		}
+
 		// Heal advisory state metadata.
 		stateBeforeHeal := sessionpkg.State(strings.TrimSpace(session.Metadata["state"]))
 		healState(session, alive, store, clk)
@@ -738,9 +746,9 @@ func reconcileSessionBeadsTraced(
 		}
 		reconcileDetachedAt(session, store, policy, alive, sp, clk)
 
-		// Stability check: detect rapid exit (crash).
-		if checkStability(session, cfg, alive, dt, store, clk) {
-			continue // crash recorded, skip further processing
+		// Stability check: detect rapid exit (rate-limit screen or crash).
+		if checkStability(session, cfg, alive, dt, store, clk, nil) {
+			continue // rapid exit recorded, skip further processing
 		}
 
 		// Churn check: detect context exhaustion death spiral.

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -413,18 +413,49 @@ func reconcileSessionBeadsTraced(
 			if err != nil {
 				providerAlive = false
 			}
+			preserveNamed := preserveConfiguredNamedSessionBead(*session, cfg, cityName)
+			var (
+				preservedTP  TemplateParams
+				preserveErr  error
+				rateLimitHit bool
+				rateLimitErr error
+			)
+			if preserveNamed {
+				preservedTP, preserveErr = resolvePreservedConfiguredNamedSessionTemplate(cityPath, cityName, cfg, sp, store, ordered, *session, clk, stderr)
+				if preserveErr == nil {
+					obs, obsErr := workerObserveSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, session.ID, preservedTP.Hints.ProcessNames)
+					rateLimitAlive := rateLimitAliveFromObservation(obs.Alive, obsErr)
+					peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, preservedTP.Hints.ProcessNames)
+					rateLimitHit, rateLimitErr = checkRateLimitStability(session, cfg, rateLimitAlive, dt, store, clk, peek)
+				}
+			}
+			if rateLimitHit || rateLimitErr != nil {
+				if trace != nil {
+					template := normalizedSessionTemplate(*session, cfg)
+					if template == "" {
+						template = session.Metadata["template"]
+					}
+					result := "held"
+					if rateLimitErr != nil {
+						result = "hold_deferred"
+					}
+					trace.recordDecision("reconciler.session.preserve_configured_named", template, name, "rate_limit", result, traceRecordPayload{
+						"provider_alive": providerAlive,
+					}, nil, "")
+				}
+				continue
+			}
 			// Heal state using provider liveness, not agent membership.
 			healState(session, providerAlive, store, clk)
 			switch {
-			case preserveConfiguredNamedSessionBead(*session, cfg, cityName):
+			case preserveNamed:
 				template := normalizedSessionTemplate(*session, cfg)
 				if template == "" {
 					template = session.Metadata["template"]
 				}
-				preservedTP, err := resolvePreservedConfiguredNamedSessionTemplate(cityPath, cityName, cfg, sp, store, ordered, *session, clk, stderr)
 				switch {
-				case err != nil:
-					fmt.Fprintf(stderr, "session reconciler: resolve preserved named session %s: %v\n", name, err) //nolint:errcheck
+				case preserveErr != nil:
+					fmt.Fprintf(stderr, "session reconciler: resolve preserved named session %s: %v\n", name, preserveErr) //nolint:errcheck
 				default:
 					tp = preservedTP
 					desired = true
@@ -435,7 +466,7 @@ func reconcileSessionBeadsTraced(
 						false: "resolution_failed",
 					}[desired], traceRecordPayload{
 						"provider_alive": providerAlive,
-						"degraded":       err != nil,
+						"degraded":       preserveErr != nil,
 					}, nil, "")
 				}
 			case pendingCreateSessionStillLeased(*session, cfg, clk):
@@ -566,17 +597,20 @@ func reconcileSessionBeadsTraced(
 		}
 		running := obs.Running
 		alive := obs.Alive
+		peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, tp.Hints.ProcessNames)
 
 		// Zombie capture: session exists but process dead — grab scrollback for forensics.
 		if running && !alive {
-			if output, err := workerSessionTargetPeekWithConfig(cityPath, store, sp, cfg, session.ID, 50, tp.Hints.ProcessNames); err == nil && output != "" {
-				rec.Record(events.Event{
-					Type:    events.SessionCrashed,
-					Actor:   "gc",
-					Subject: tp.DisplayName(),
-					Message: output,
-				})
-				telemetry.RecordAgentCrash(context.Background(), tp.DisplayName(), output)
+			if output, err := peek(rateLimitPeekLines); err == nil && output != "" {
+				if !runtime.ContainsProviderRateLimitScreen(output) {
+					rec.Record(events.Event{
+						Type:    events.SessionCrashed,
+						Actor:   "gc",
+						Subject: tp.DisplayName(),
+						Message: output,
+					})
+					telemetry.RecordAgentCrash(context.Background(), tp.DisplayName(), output)
+				}
 			}
 		}
 		if alive && shouldRollbackPendingCreate(session) && !runningSessionMatchesPendingCreate(session, name, sp) {
@@ -600,6 +634,10 @@ func reconcileSessionBeadsTraced(
 				startupTimeout = cfg.Session.StartupTimeoutDuration()
 			}
 			if !pendingCreateStartInFlight(*session, clk, startupTimeout) && staleCreatingState(*session, clk) {
+				rateLimitHit, rateLimitErr := checkRateLimitStability(session, cfg, alive, dt, store, clk, peek)
+				if rateLimitHit || rateLimitErr != nil {
+					continue
+				}
 				fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: lease expired and no live runtime\n", name) //nolint:errcheck
 				if trace != nil {
 					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_lease_expired", "rollback", nil, nil, "")
@@ -730,11 +768,8 @@ func reconcileSessionBeadsTraced(
 
 		policy := resolveSessionSleepPolicy(*session, cfg, sp)
 
-		peek := func(lines int) (string, error) {
-			return workerSessionTargetPeekWithConfig(cityPath, store, sp, cfg, session.ID, lines, tp.Hints.ProcessNames)
-		}
-
-		if checkRateLimitStability(session, cfg, alive, dt, store, clk, peek) {
+		rateLimitHit, rateLimitErr := checkRateLimitStability(session, cfg, alive, dt, store, clk, peek)
+		if rateLimitHit || rateLimitErr != nil {
 			continue // rate-limit hold recorded before state healing resets continuity metadata
 		}
 
@@ -746,7 +781,8 @@ func reconcileSessionBeadsTraced(
 		}
 		reconcileDetachedAt(session, store, policy, alive, sp, clk)
 
-		// Stability check: detect rapid exit (rate-limit screen or crash).
+		// Stability check: detect rapid crash after state healing. Rate-limit
+		// detection intentionally ran above before healState.
 		if checkStability(session, cfg, alive, dt, store, clk, nil) {
 			continue // rapid exit recorded, skip further processing
 		}
@@ -1284,6 +1320,36 @@ func reconcileSessionBeadsTraced(
 	clearMissingIdleProbes(dt, beadByID)
 
 	return plannedWakes
+}
+
+func cachedSessionPeek(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, target string, processNames []string) func(lines int) (string, error) {
+	var (
+		cached      bool
+		cachedLines int
+		content     string
+	)
+	return func(lines int) (string, error) {
+		if cached && cachedLines >= lines {
+			return content, nil
+		}
+		nextContent, nextErr := workerSessionTargetPeekWithConfig(cityPath, store, sp, cfg, target, lines, processNames)
+		if nextErr != nil {
+			return nextContent, nextErr
+		}
+		// Cache only successful peeks; transient capture errors must not
+		// suppress a later rate-limit classifier in the same reconcile tick.
+		content = nextContent
+		cachedLines = lines
+		cached = true
+		return content, nil
+	}
+}
+
+func rateLimitAliveFromObservation(alive bool, err error) bool {
+	if err != nil {
+		return false
+	}
+	return alive
 }
 
 func resolvePreservedConfiguredNamedSessionTemplate(

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -34,11 +35,58 @@ func (f *fakeIdleTracker) checkIdle(sessionName string, _ runtime.Provider, _ ti
 
 func (f *fakeIdleTracker) setTimeout(_ string, _ time.Duration) {}
 
+type lineLimitedPeekProvider struct {
+	*runtime.Fake
+	peekLines []int
+}
+
+func (p *lineLimitedPeekProvider) Peek(name string, lines int) (string, error) {
+	p.peekLines = append(p.peekLines, lines)
+	output, err := p.Fake.Peek(name, lines)
+	if err != nil || lines <= 0 {
+		return output, err
+	}
+	parts := strings.Split(output, "\n")
+	if len(parts) <= lines {
+		return output, nil
+	}
+	return strings.Join(parts[len(parts)-lines:], "\n"), nil
+}
+
+type transientPeekErrorProvider struct {
+	*runtime.Fake
+	calls int
+}
+
+func (p *transientPeekErrorProvider) Peek(name string, lines int) (string, error) {
+	p.calls++
+	if p.calls == 1 {
+		return "", errors.New("peek failed")
+	}
+	return p.Fake.Peek(name, lines)
+}
+
 type delayedSessionExistsProvider struct {
 	*runtime.Fake
 	pendingConflict map[string]bool
 	hiddenRunning   map[string]bool
 	hiddenMeta      map[string]map[string]string
+}
+
+type failRateLimitHoldStore struct {
+	*beads.MemStore
+	failRateLimitHold  bool
+	rateLimitHoldCalls int
+}
+
+func (s *failRateLimitHoldStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if kvs["sleep_reason"] == "rate_limit" {
+		s.rateLimitHoldCalls++
+		if s.failRateLimitHold {
+			return errors.New("rate-limit hold batch failed")
+		}
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
 func newDelayedSessionExistsProvider() *delayedSessionExistsProvider {
@@ -1853,6 +1901,322 @@ func TestReconcileSessionBeads_SkipsAliveSession(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_RateLimitScreenQuarantinesBeforeHeal(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+	}
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd", ProcessNames: []string{"agent-cli"}}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	env.sp.Zombies["worker"] = true
+	env.sp.SetPeekOutput("worker", "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":               "active",
+		"last_woke_at":        env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		"session_key":         "keep-session",
+		"started_config_hash": "keep-hash",
+		"wake_attempts":       "2",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["wake_attempts"] != "2" {
+		t.Fatalf("wake_attempts = %q, want 2", got.Metadata["wake_attempts"])
+	}
+	if got.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", got.Metadata["state"])
+	}
+	qUntil, err := time.Parse(time.RFC3339, got.Metadata["quarantined_until"])
+	if err != nil {
+		t.Fatalf("quarantined_until parse: %v", err)
+	}
+	if want := env.clk.Now().Add(defaultRateLimitQuarantineDuration); !qUntil.Equal(want) {
+		t.Fatalf("quarantined_until = %s, want %s", qUntil.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	if got.Metadata["session_key"] != "keep-session" {
+		t.Fatalf("session_key = %q, want preserved", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "keep-hash" {
+		t.Fatalf("started_config_hash = %q, want preserved", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "" {
+		t.Fatalf("continuation_reset_pending = %q, want empty", got.Metadata["continuation_reset_pending"])
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared", got.Metadata["last_woke_at"])
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionCrashed {
+			t.Fatalf("recorded %s for rate-limit screen; want crash telemetry suppressed", e.Type)
+		}
+	}
+}
+
+func TestReconcileSessionBeads_RateLimitScreenBeyondCrashCaptureSuppressesTelemetry(t *testing.T) {
+	env := newReconcilerTestEnv()
+	sp := &lineLimitedPeekProvider{Fake: runtime.NewFake()}
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+	}
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd", ProcessNames: []string{"agent-cli"}}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	sp.Zombies["worker"] = true
+	var paneLines []string
+	paneLines = append(paneLines, "You've hit your limit, Pro plan", "", "/rate-limit-options")
+	for i := 0; i < 60; i++ {
+		paneLines = append(paneLines, fmt.Sprintf("trailing line %02d", i))
+	}
+	sp.SetPeekOutput("worker", strings.Join(paneLines, "\n"))
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":               "active",
+		"last_woke_at":        env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		"session_key":         "keep-session",
+		"started_config_hash": "keep-hash",
+		"wake_attempts":       "2",
+	})
+
+	cfgNames := configuredSessionNames(env.cfg, "", env.store)
+	woken := reconcileSessionBeads(
+		context.Background(), []beads.Bead{session}, env.desiredState, cfgNames,
+		env.cfg, sp, env.store, nil, nil, nil, env.dt, map[string]int{"worker": 1}, false, nil, "",
+		nil, env.clk, rec, 0, 0, &env.stdout, &env.stderr,
+	)
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	if len(sp.peekLines) != 1 || sp.peekLines[0] != rateLimitPeekLines {
+		t.Fatalf("peek lines = %v, want single %d-line read", sp.peekLines, rateLimitPeekLines)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["wake_attempts"] != "2" {
+		t.Fatalf("wake_attempts = %q, want 2", got.Metadata["wake_attempts"])
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionCrashed {
+			t.Fatalf("recorded %s for rate-limit marker outside old 50-line capture", e.Type)
+		}
+	}
+}
+
+func TestCachedSessionPeekRetriesAfterError(t *testing.T) {
+	sp := &transientPeekErrorProvider{Fake: runtime.NewFake()}
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd"}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	sp.SetPeekOutput("worker", "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	peek := cachedSessionPeek("", nil, sp, &config.City{}, "worker", nil)
+
+	if output, err := peek(rateLimitPeekLines); err == nil {
+		t.Fatalf("first peek err = nil, output = %q; want transient error", output)
+	}
+	output, err := peek(rateLimitPeekLines)
+	if err != nil {
+		t.Fatalf("second peek should retry after transient error: %v", err)
+	}
+	if !runtime.ContainsProviderRateLimitScreen(output) {
+		t.Fatalf("second peek output = %q, want provider rate-limit screen", output)
+	}
+	if sp.calls != 2 {
+		t.Fatalf("peek calls = %d, want 2", sp.calls)
+	}
+}
+
+func TestRateLimitAliveFromObservationDoesNotTreatObservationErrorAsAlive(t *testing.T) {
+	if rateLimitAliveFromObservation(true, errors.New("observe failed")) {
+		t.Fatal("observation errors must not reuse runtime-running state as process-alive")
+	}
+	if !rateLimitAliveFromObservation(true, nil) {
+		t.Fatal("successful live observation should report alive")
+	}
+	if rateLimitAliveFromObservation(false, nil) {
+		t.Fatal("successful dead observation should report dead")
+	}
+}
+
+func TestReconcileSessionBeads_RateLimitScreenReholdsAfterQuarantineExpiry(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Providers:     map[string]config.ProviderSpec{"test-provider": {Command: "test-cmd", ProcessNames: []string{"agent-cli"}}},
+		Agents:        []config.Agent{{Name: "worker", Provider: "test-provider", StartCommand: "test-cmd"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "test-cmd",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+		Hints:                   agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+	}
+	env.sp.SetPeekOutput(sessionName, "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	session := env.createSessionBead(sessionName, "worker")
+	startedHash := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd", ProcessNames: []string{"agent-cli"}})
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"last_woke_at":               env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		"session_key":                "keep-session",
+		"started_config_hash":        startedHash,
+		"wake_attempts":              "2",
+	})
+
+	env.reconcile([]beads.Bead{session})
+	held, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get held session: %v", err)
+	}
+	if held.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("initial sleep_reason = %q, want rate_limit", held.Metadata["sleep_reason"])
+	}
+	qUntil, err := time.Parse(time.RFC3339, held.Metadata["quarantined_until"])
+	if err != nil {
+		t.Fatalf("quarantined_until parse: %v", err)
+	}
+
+	env.clk.Time = qUntil.Add(time.Second)
+	woken := env.reconcile([]beads.Bead{held})
+	if woken != 1 {
+		t.Fatalf("woken after quarantine expiry = %d, want 1", woken)
+	}
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatal("worker should be restarted after rate-limit quarantine expiry")
+	}
+	afterWake, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get after wake: %v", err)
+	}
+	if got := afterWake.Metadata["session_key"]; got != "keep-session" {
+		t.Fatalf("session_key after wake = %q, want preserved", got)
+	}
+	afterWakeHash := afterWake.Metadata["started_config_hash"]
+	if afterWakeHash == "" {
+		t.Fatal("started_config_hash should be set after wake")
+	}
+
+	if err := env.sp.Stop(sessionName); err != nil {
+		t.Fatalf("Stop(%s) after wake: %v", sessionName, err)
+	}
+	env.reconcile([]beads.Bead{afterWake})
+	reheld, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get reheld session: %v", err)
+	}
+	if got := reheld.Metadata["sleep_reason"]; got != "rate_limit" {
+		t.Fatalf("sleep_reason after re-detection = %q, want rate_limit", got)
+	}
+	if got := reheld.Metadata["session_key"]; got != "keep-session" {
+		t.Fatalf("session_key after re-detection = %q, want preserved", got)
+	}
+	if got := reheld.Metadata["started_config_hash"]; got != afterWakeHash {
+		t.Fatalf("started_config_hash after re-detection = %q, want %q", got, afterWakeHash)
+	}
+	if got := reheld.Metadata["continuation_reset_pending"]; got != "" {
+		t.Fatalf("continuation_reset_pending after re-detection = %q, want empty", got)
+	}
+	for _, e := range rec.Events {
+		if e.Type == events.SessionCrashed {
+			t.Fatalf("recorded %s during rate-limit expiry/re-hold cycle", e.Type)
+		}
+	}
+}
+
+func TestReconcileSessionBeads_GenericRateLimitCrashRecordsTelemetry(t *testing.T) {
+	env := newReconcilerTestEnv()
+	rec := events.NewFake()
+	env.rec = rec
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+	}
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd", ProcessNames: []string{"agent-cli"}}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	env.sp.Zombies["worker"] = true
+	env.sp.SetPeekOutput("worker", "worker failed while parsing rate limit config")
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":               "active",
+		"last_woke_at":        env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		"session_key":         "reset-session",
+		"started_config_hash": "reset-hash",
+		"wake_attempts":       "2",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["sleep_reason"] == "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want normal crash path", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["wake_attempts"] != "3" {
+		t.Fatalf("wake_attempts = %q, want 3", got.Metadata["wake_attempts"])
+	}
+	if got.Metadata["session_key"] != "" {
+		t.Fatalf("session_key = %q, want cleared after normal crash", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Fatalf("started_config_hash = %q, want cleared after normal crash", got.Metadata["started_config_hash"])
+	}
+	crashRecorded := false
+	for _, e := range rec.Events {
+		if e.Type == events.SessionCrashed && e.Message == "worker failed while parsing rate limit config" {
+			crashRecorded = true
+			break
+		}
+	}
+	if !crashRecorded {
+		t.Fatal("expected SessionCrashed event for generic crash output that mentions rate limit")
+	}
+}
+
 func TestReconcileSessionBeads_SkipsQuarantinedSession(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
@@ -2275,6 +2639,55 @@ func TestReconcileSessionBeads_PreservesConfiguredNamedSessionOutsideDesiredStat
 	}
 	if ds := env.dt.get(session.ID); ds != nil {
 		t.Fatalf("unexpected drain for configured named session: %+v", ds)
+	}
+}
+
+func TestReconcileSessionBeads_PreservedConfiguredNamedRateLimitRunsBeforeHeal(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: intPtr(2)}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"state":                      "active",
+		"last_woke_at":               env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		"session_key":                "keep-session",
+		"started_config_hash":        "keep-hash",
+	})
+	env.sp.SetPeekOutput(sessionName, "You've hit your limit, Pro plan\n\n/rate-limit-options")
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", got.Metadata["state"])
+	}
+	if got.Metadata["session_key"] != "keep-session" {
+		t.Fatalf("session_key = %q, want preserved", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "keep-hash" {
+		t.Fatalf("started_config_hash = %q, want preserved", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "" {
+		t.Fatalf("continuation_reset_pending = %q, want empty", got.Metadata["continuation_reset_pending"])
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("unexpected drain for rate-limited configured named session: %+v", ds)
 	}
 }
 
@@ -2937,6 +3350,88 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntim
 	}
 	if got.Metadata["close_reason"] != "failed-create" {
 		t.Fatalf("close_reason = %q, want failed-create", got.Metadata["close_reason"])
+	}
+}
+
+func TestReconcileSessionBeads_RateLimitPendingCreateBatchFailureRetriesBeforeRollback(t *testing.T) {
+	env := newReconcilerTestEnv()
+	store := &failRateLimitHoldStore{
+		MemStore:          beads.NewMemStore(),
+		failRateLimitHold: true,
+	}
+	env.store = store
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.desiredState["worker"] = TemplateParams{
+		Command:      "test-cmd",
+		SessionName:  "worker",
+		TemplateName: "worker",
+		Hints:        agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+	}
+	if err := env.sp.Start(context.Background(), "worker", runtime.Config{Command: "test-cmd", ProcessNames: []string{"agent-cli"}}); err != nil {
+		t.Fatalf("Start(worker): %v", err)
+	}
+	env.sp.Zombies["worker"] = true
+	env.sp.SetPeekOutput("worker", "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	lastWoke := env.clk.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	session := env.createSessionBead("worker", "worker")
+	session.CreatedAt = env.clk.Now().Add(-5 * time.Minute)
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                 "creating",
+		"pending_create_claim":  "true",
+		"last_woke_at":          lastWoke,
+		"session_key":           "keep-session",
+		"started_config_hash":   "keep-hash",
+		"wake_attempts":         "2",
+		"continuation_epoch":    "1",
+		"session_name_explicit": "true",
+	})
+
+	if woken := env.reconcile([]beads.Bead{session}); woken != 0 {
+		t.Fatalf("woken after failed hold write = %d, want 0", woken)
+	}
+	if store.rateLimitHoldCalls != 1 {
+		t.Fatalf("rate-limit hold attempts = %d, want 1", store.rateLimitHoldCalls)
+	}
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get after failed hold write: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed with close_reason=%q, want retryable pending-create hold", got.Metadata["close_reason"])
+	}
+	if got.Metadata["pending_create_claim"] != "true" {
+		t.Fatalf("pending_create_claim = %q, want preserved after failed hold write", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["last_woke_at"] != lastWoke {
+		t.Fatalf("last_woke_at = %q, want preserved after failed hold write", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["state"] != "creating" {
+		t.Fatalf("state = %q, want unchanged creating after failed hold write", got.Metadata["state"])
+	}
+
+	store.failRateLimitHold = false
+	got.CreatedAt = session.CreatedAt
+	if woken := env.reconcile([]beads.Bead{got}); woken != 0 {
+		t.Fatalf("woken after retry = %d, want 0", woken)
+	}
+	retried, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get after retry: %v", err)
+	}
+	if retried.Status == "closed" {
+		t.Fatalf("status = closed after successful retry, want rate-limit hold")
+	}
+	if retried.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit after retry", retried.Metadata["sleep_reason"])
+	}
+	if retried.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep after retry", retried.Metadata["state"])
+	}
+	if retried.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared after durable hold", retried.Metadata["pending_create_claim"])
+	}
+	if retried.Metadata["last_woke_at"] != "" {
+		t.Fatalf("last_woke_at = %q, want cleared after durable hold", retried.Metadata["last_woke_at"])
 	}
 }
 

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -210,9 +210,18 @@ const (
 	// after exceeding max wake failures.
 	defaultQuarantineDuration = 5 * time.Minute
 
+	// defaultRateLimitQuarantineDuration is how long to hold a session when
+	// the pane shows a provider rate-limit screen. This is intentionally
+	// longer than crash-loop quarantine because immediate retries cannot help.
+	defaultRateLimitQuarantineDuration = 30 * time.Minute
+
 	// defaultMaxWakeAttempts is how many consecutive wake failures before
 	// quarantine.
 	defaultMaxWakeAttempts = 5
+
+	// rateLimitPeekLines is the amount of pane scrollback inspected before a
+	// rapid dead process is classified as a crash.
+	rateLimitPeekLines = 120
 
 	// churnProductivityThreshold is how long a session must run to be
 	// considered productive. Sessions that survive past stabilityThreshold

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -212,7 +212,9 @@ const (
 
 	// defaultRateLimitQuarantineDuration is how long to hold a session when
 	// the pane shows a provider rate-limit screen. This is intentionally
-	// longer than crash-loop quarantine because immediate retries cannot help.
+	// longer than crash-loop quarantine because immediate retries cannot help;
+	// 30m limits noisy respawn cycles for common minute-scale provider limits
+	// while still re-detecting and re-quarantining during longer windows.
 	defaultRateLimitQuarantineDuration = 30 * time.Minute
 
 	// defaultMaxWakeAttempts is how many consecutive wake failures before
@@ -220,7 +222,9 @@ const (
 	defaultMaxWakeAttempts = 5
 
 	// rateLimitPeekLines is the amount of pane scrollback inspected before a
-	// rapid dead process is classified as a crash.
+	// rapid dead process is classified as a crash. Known provider rate-limit
+	// screens are short, so 120 lines favors robust detection over shaving a
+	// cheap pane read.
 	rateLimitPeekLines = 120
 
 	// churnProductivityThreshold is how long a session must run to be

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -209,7 +209,7 @@ func acceptCodexUpdateDialog(
 			containsWorkspaceTrustDialog(content) ||
 			strings.Contains(content, "Bypass Permissions mode") ||
 			containsCustomAPIKeyDialog(content) ||
-			containsRateLimitDialog(content) {
+			ContainsRateLimitDialog(content) {
 			return nil
 		}
 
@@ -243,7 +243,7 @@ func containsPostUpdateStartupDialog(content string) bool {
 	return containsWorkspaceTrustDialog(content) ||
 		strings.Contains(content, "Bypass Permissions mode") ||
 		containsCustomAPIKeyDialog(content) ||
-		containsRateLimitDialog(content)
+		ContainsRateLimitDialog(content)
 }
 
 // acceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
@@ -314,7 +314,7 @@ func containsWorkspaceTrustDialog(content string) bool {
 func containsPostTrustStartupDialog(content string) bool {
 	return strings.Contains(content, "Bypass Permissions mode") ||
 		containsCustomAPIKeyDialog(content) ||
-		containsRateLimitDialog(content)
+		ContainsRateLimitDialog(content)
 }
 
 // acceptBypassPermissionsWarning dismisses the Claude Code bypass permissions
@@ -370,7 +370,7 @@ func acceptBypassPermissionsWarningFromStream(
 }
 
 func containsPostBypassStartupDialog(content string) bool {
-	return containsCustomAPIKeyDialog(content) || containsRateLimitDialog(content)
+	return containsCustomAPIKeyDialog(content) || ContainsRateLimitDialog(content)
 }
 
 // acceptCustomAPIKeyDialog dismisses Claude's API-key confirmation prompt.
@@ -402,7 +402,7 @@ func acceptCustomAPIKeyDialog(
 			return sendKeys("Enter")
 		}
 
-		if containsPromptIndicator(content) || containsRateLimitDialog(content) {
+		if containsPromptIndicator(content) || ContainsRateLimitDialog(content) {
 			return nil
 		}
 
@@ -422,7 +422,7 @@ func acceptCustomAPIKeyDialogFromStream(
 		matchKeys:   []string{"Up", "Enter"},
 		matchDelay:  bypassDialogConfirmDelay,
 		ready:       containsPromptIndicator,
-		readyOrNext: containsRateLimitDialog,
+		readyOrNext: ContainsRateLimitDialog,
 	})
 }
 
@@ -452,7 +452,7 @@ func dismissRateLimitDialog(
 			return err
 		}
 
-		if containsRateLimitDialog(content) {
+		if ContainsRateLimitDialog(content) {
 			// Select "Stop" (option 2). The menu has "Keep trying" selected
 			// by default, so press Down then Enter.
 			if err := sendKeys("Down"); err != nil {
@@ -478,7 +478,7 @@ func dismissRateLimitDialogFromStream(
 	sendKeys func(keys ...string) error,
 ) (bool, error) {
 	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
-		match:      containsRateLimitDialog,
+		match:      ContainsRateLimitDialog,
 		matchKeys:  []string{"Down", "Enter"},
 		matchDelay: bypassDialogConfirmDelay,
 		ready:      containsPromptIndicator,
@@ -718,8 +718,12 @@ func sendDialogKeys(
 	return nil
 }
 
-func containsRateLimitDialog(content string) bool {
+// ContainsRateLimitDialog reports whether pane content shows a provider
+// rate-limit or usage-limit screen.
+func ContainsRateLimitDialog(content string) bool {
 	return strings.Contains(content, "Usage limit reached") ||
+		strings.Contains(content, "You've hit your limit") ||
+		strings.Contains(content, "/rate-limit-options") ||
 		strings.Contains(content, "rate limit") ||
 		strings.Contains(content, "Rate limit")
 }

--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -433,8 +433,9 @@ func containsCustomAPIKeyDialog(content string) bool {
 
 // dismissRateLimitDialog detects rate limit / usage limit dialogs (e.g.,
 // Gemini's "Usage limit reached") and selects "Stop" to let the session
-// exit cleanly. The reconciler treats the exit as a startup failure and
-// retries later when the rate limit resets.
+// exit cleanly. The reconciler then peeks the pane and quarantines provider
+// rate-limit exits with sleep_reason=rate_limit instead of counting them as
+// wake failures.
 func dismissRateLimitDialog(
 	ctx context.Context,
 	timeout time.Duration,
@@ -719,13 +720,28 @@ func sendDialogKeys(
 }
 
 // ContainsRateLimitDialog reports whether pane content shows a provider
-// rate-limit or usage-limit screen.
+// rate-limit or usage-limit startup dialog. It is intentionally permissive for
+// startup compatibility; use ContainsProviderRateLimitScreen when classifying
+// arbitrary post-crash scrollback.
 func ContainsRateLimitDialog(content string) bool {
 	return strings.Contains(content, "Usage limit reached") ||
 		strings.Contains(content, "You've hit your limit") ||
 		strings.Contains(content, "/rate-limit-options") ||
 		strings.Contains(content, "rate limit") ||
 		strings.Contains(content, "Rate limit")
+}
+
+// ContainsProviderRateLimitScreen reports whether pane content has
+// high-confidence provider rate-limit screen evidence.
+func ContainsProviderRateLimitScreen(content string) bool {
+	if strings.Contains(content, "Usage limit reached") ||
+		strings.Contains(content, "You've hit your limit") ||
+		strings.Contains(content, "/rate-limit-options") {
+		return true
+	}
+	return strings.Contains(strings.ToLower(content), "rate limit") &&
+		strings.Contains(content, "Keep trying") &&
+		strings.Contains(content, "Stop")
 }
 
 // containsPromptIndicator checks whether any line in the content looks like a

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -732,6 +732,8 @@ func TestContainsRateLimitDialog(t *testing.T) {
 		want    bool
 	}{
 		{name: "gemini usage limit", content: "Usage limit reached for gemini-3-flash-preview.", want: true},
+		{name: "claude hit limit", content: "You've hit your limit, Pro plan", want: true},
+		{name: "claude rate limit options", content: "/rate-limit-options", want: true},
 		{name: "generic rate limit", content: "rate limit exceeded", want: true},
 		{name: "Rate limit caps", content: "Rate limit: try again later", want: true},
 		{name: "normal output", content: "Hello world", want: false},
@@ -739,8 +741,8 @@ func TestContainsRateLimitDialog(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := containsRateLimitDialog(tt.content); got != tt.want {
-				t.Errorf("containsRateLimitDialog(%q) = %v, want %v", tt.content, got, tt.want)
+			if got := ContainsRateLimitDialog(tt.content); got != tt.want {
+				t.Errorf("ContainsRateLimitDialog(%q) = %v, want %v", tt.content, got, tt.want)
 			}
 		})
 	}

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -748,6 +748,30 @@ func TestContainsRateLimitDialog(t *testing.T) {
 	}
 }
 
+func TestContainsProviderRateLimitScreen(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "gemini usage limit", content: "Usage limit reached for gemini-3-flash-preview.", want: true},
+		{name: "claude hit limit", content: "You've hit your limit, Pro plan", want: true},
+		{name: "claude rate limit options", content: "/rate-limit-options", want: true},
+		{name: "provider menu shape", content: "Rate limit reached\n1. Keep trying\n2. Stop", want: true},
+		{name: "generic crash output", content: "worker failed while parsing rate limit config", want: false},
+		{name: "generic lower-case mention", content: "rate limit exceeded", want: false},
+		{name: "normal output", content: "Hello world", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsProviderRateLimitScreen(tt.content); got != tt.want {
+				t.Errorf("ContainsProviderRateLimitScreen(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestContainsCustomAPIKeyDialog(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -225,7 +225,7 @@ func LifecycleDisplayReason(status string, metadata map[string]string, now time.
 		return ""
 	}
 	if reason := strings.TrimSpace(metadata["sleep_reason"]); reason != "" {
-		staleTimedQuarantine := (reason == "quarantine" || reason == "context-churn") &&
+		staleTimedQuarantine := (reason == "quarantine" || reason == "context-churn" || reason == "rate_limit") &&
 			strings.TrimSpace(metadata["quarantined_until"]) != "" &&
 			!view.HasBlocker(BlockerQuarantined)
 		staleTimedHold := reason == "user-hold" &&
@@ -521,7 +521,7 @@ func shouldResetContinuation(base BaseState, meta map[string]string, sleepReason
 		return false
 	}
 	switch strings.TrimSpace(sleepReason) {
-	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained", "city-stop", "user-hold", "wait-hold":
+	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained", "city-stop", "user-hold", "wait-hold", "rate_limit":
 		return false
 	}
 	return base == BaseStateActive || base == BaseStateCreating

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -346,6 +346,23 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 			wantReset:           true,
 		},
 		{
+			name: "dead active runtime with rate-limit reason preserves resume identity",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":               "active",
+					"session_name":        "s-worker",
+					"session_key":         "provider-conversation",
+					"started_config_hash": "config",
+					"sleep_reason":        "rate_limit",
+				},
+				Runtime: RuntimeFacts{Observed: true, Alive: false},
+				Now:     now,
+			},
+			wantRuntime:         RuntimeProjectionMissing,
+			wantReconciledState: StateAsleep,
+		},
+		{
 			name: "fresh creating state stays creating after restart",
 			input: LifecycleInput{
 				Status: "open",
@@ -508,6 +525,14 @@ func TestLifecycleDisplayReasonUsesOnlyActiveLifecycleReasons(t *testing.T) {
 			name: "expired production context churn reason is not visible",
 			meta: map[string]string{
 				"sleep_reason":      "context-churn",
+				"quarantined_until": past,
+			},
+			want: "",
+		},
+		{
+			name: "expired rate-limit reason is not visible",
+			meta: map[string]string{
+				"sleep_reason":      "rate_limit",
 				"quarantined_until": past,
 			},
 			want: "",

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -113,7 +113,7 @@ func ClearWakeBlockersPatch(state State, sleepReason string) MetadataPatch {
 		patch["state"] = string(StateAsleep)
 	}
 	switch sleepReason {
-	case "user-hold", "wait-hold", "quarantine", "context-churn", string(StateDrained):
+	case "user-hold", "wait-hold", "quarantine", "context-churn", "rate_limit", string(StateDrained):
 		patch["sleep_reason"] = ""
 	}
 	return patch
@@ -131,8 +131,8 @@ func ClearExpiredHoldPatch(sleepReason string) MetadataPatch {
 	return patch
 }
 
-// ClearExpiredQuarantinePatch clears an expired quarantine or context churn
-// timer and resets retry counters associated with that blocker.
+// ClearExpiredQuarantinePatch clears an expired quarantine-like timer and
+// resets retry counters associated with that blocker.
 func ClearExpiredQuarantinePatch(sleepReason string) MetadataPatch {
 	patch := MetadataPatch{
 		"quarantined_until": "",
@@ -140,7 +140,7 @@ func ClearExpiredQuarantinePatch(sleepReason string) MetadataPatch {
 		"churn_count":       "0",
 	}
 	switch sleepReason {
-	case "quarantine", "context-churn":
+	case "quarantine", "context-churn", "rate_limit":
 		patch["sleep_reason"] = ""
 	}
 	return patch

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -347,6 +347,16 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			},
 		},
 		{
+			name:  "clear expired rate limit",
+			patch: ClearExpiredQuarantinePatch("rate_limit"),
+			want: MetadataPatch{
+				"quarantined_until": "",
+				"wake_attempts":     "0",
+				"churn_count":       "0",
+				"sleep_reason":      "",
+			},
+		},
+		{
 			name:  "clear expired non-quarantine timer",
 			patch: ClearExpiredQuarantinePatch("idle"),
 			want: MetadataPatch{
@@ -517,6 +527,20 @@ func TestClearWakeBlockersPatchClearsOnlyWakeBlockerMetadata(t *testing.T) {
 				"sleep_intent":      "",
 				"wake_attempts":     "0",
 				"churn_count":       "0",
+			},
+		},
+		{
+			name:        "rate limit reason is cleared",
+			state:       StateAsleep,
+			sleepReason: "rate_limit",
+			want: MetadataPatch{
+				"held_until":        "",
+				"quarantined_until": "",
+				"wait_hold":         "",
+				"sleep_intent":      "",
+				"wake_attempts":     "0",
+				"churn_count":       "0",
+				"sleep_reason":      "",
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #1400

## Summary

- Detect provider rate-limit screens during rapid-exit reconciliation before advisory state healing clears continuation metadata.
- Quarantine rate-limited sessions with `sleep_reason=rate_limit` without incrementing `wake_attempts` or resetting `session_key` / `started_config_hash`.
- Reuse the runtime dialog detector via exported `runtime.ContainsRateLimitDialog`, and cover the Claude/Gemini rate-limit strings.

## Tests

- `env GOCACHE=/tmp/gascity-go-cache go test ./cmd/gc ./internal/session ./internal/runtime`
- `env PATH=... GOCACHE=/tmp/gascity-go-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache golangci-lint run ./cmd/gc ./internal/runtime ./internal/session`
- `git diff --check`
- `.githooks/pre-commit` was attempted with writable caches and got through formatting, full lint, and vet. Its full `make test` step is not green on this checkout for unrelated local/mainline issues:
  - `cmd/gc` `TestPackV2ImportsScript/pack-v2-imports` can fail at `maintenance:check-binaries` when `gh` is absent; this is covered by #1270.
  - Unsandboxed `internal/api` fails at `TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary` because this host has a real `gh` visible and reports `needs_auth` instead of `not_installed`; this is covered by #1394.
  - Sandboxed full-suite runs cannot bind TCP/Unix listeners (`socket: operation not permitted`), e.g. `httptest` in `internal/api`; rerunning outside the sandbox changes the failure to the #1394 case above.
