### PR TITLE
fix(beads): verify with backing.Get before synthesizing bead.closed

### DIFF
--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -61,19 +61,21 @@ const (
 
 // CacheStats exposes cache freshness, reconciliation, and problem state.
 type CacheStats struct {
-	TotalBeads      int
-	TotalDeps       int
-	LastFreshAt     time.Time
-	LastReconcileAt time.Time
-	LastReconcileMs float64
-	Adds            int64
-	Removes         int64
-	Updates         int64
-	SyncFailures    int
-	ProblemCount    int64
-	LastProblemAt   time.Time
-	LastProblem     string
-	State           string
+	TotalBeads              int
+	TotalDeps               int
+	LastFreshAt             time.Time
+	LastReconcileAt         time.Time
+	LastReconcileMs         float64
+	Adds                    int64
+	Removes                 int64
+	Updates                 int64
+	ReconcileRecoveries     int64
+	ReconcileCloseDeferrals int64
+	SyncFailures            int
+	ProblemCount            int64
+	LastProblemAt           time.Time
+	LastProblem             string
+	State                   string
 }
 
 const (

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -2,6 +2,8 @@ package beads
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 )
 
@@ -84,6 +86,8 @@ func (c *CachingStore) runReconciliation() {
 	for _, b := range fresh {
 		freshByID[b.ID] = cloneBead(b)
 	}
+
+	c.recoverMissingFromList(freshByID)
 
 	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
 	if depErr != nil {
@@ -279,4 +283,49 @@ func (c *CachingStore) runReconciliation() {
 	c.updateStatsLocked()
 	c.mu.Unlock()
 	c.notifyChanges(notifications)
+}
+
+// recoverMissingFromList re-fetches any cached active bead that didn't appear
+// in freshByID and merges verified-alive ones back. This guards against
+// partial or silently-truncated List results — a List that drops an active
+// bead must not synthesize a spurious bead.closed event for it.
+//
+// On ErrNotFound the bead is left absent so the diff path can emit
+// bead.closed as before. On any other error the cached entry is merged
+// back conservatively, deferring the close to a later scan when the
+// backing store's state is unambiguous.
+func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
+	c.mu.RLock()
+	candidates := make(map[string]Bead, len(c.beads))
+	for id, b := range c.beads {
+		if _, ok := freshByID[id]; ok {
+			continue
+		}
+		if b.Status == "closed" {
+			continue
+		}
+		candidates[id] = cloneBead(b)
+	}
+	c.mu.RUnlock()
+	if len(candidates) == 0 {
+		return
+	}
+	for id, cached := range candidates {
+		bead, err := c.backing.Get(id)
+		switch {
+		case err == nil:
+			if bead.Status == "closed" {
+				continue
+			}
+			freshByID[id] = cloneBead(bead)
+		case errors.Is(err, ErrNotFound):
+			// Confirmed gone; let the diff path emit bead.closed.
+		default:
+			c.recordProblem(
+				"verify missing bead before close",
+				fmt.Errorf("%s: %w", id, err),
+			)
+			freshByID[id] = cached
+		}
+	}
 }

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -287,16 +287,17 @@ func (c *CachingStore) runReconciliation() {
 
 // recoverMissingFromList re-fetches any cached active bead that didn't appear
 // in freshByID and merges verified-alive ones back. This guards against
-// partial or silently-truncated List results — a List that drops an active
-// bead must not synthesize a spurious bead.closed event for it.
+// cleanly incomplete List results: a List that drops an active bead must not
+// synthesize a spurious bead.closed event for it.
 //
 // On ErrNotFound the bead is left absent so the diff path can emit
 // bead.closed as before. On any other error the cached entry is merged
 // back conservatively, deferring the close to a later scan when the
-// backing store's state is unambiguous.
+// backing store's state is unambiguous. Callers must own freshByID and not
+// access it concurrently while recovery is running.
 func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
 	c.mu.RLock()
-	candidates := make(map[string]Bead, len(c.beads))
+	candidates := make(map[string]Bead)
 	for id, b := range c.beads {
 		if _, ok := freshByID[id]; ok {
 			continue
@@ -310,14 +311,26 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
 	if len(candidates) == 0 {
 		return
 	}
+	var recoveredAlive int64
+	var deferredClose int64
 	for id, cached := range candidates {
 		bead, err := c.backing.Get(id)
 		switch {
 		case err == nil:
+			if bead.ID != id {
+				c.recordProblem(
+					"verify missing bead before close",
+					fmt.Errorf("%s: backing returned bead %q", id, bead.ID),
+				)
+				freshByID[id] = cached
+				deferredClose++
+				continue
+			}
 			if bead.Status == "closed" {
 				continue
 			}
 			freshByID[id] = cloneBead(bead)
+			recoveredAlive++
 		case errors.Is(err, ErrNotFound):
 			// Confirmed gone; let the diff path emit bead.closed.
 		default:
@@ -326,6 +339,13 @@ func (c *CachingStore) recoverMissingFromList(freshByID map[string]Bead) {
 				fmt.Errorf("%s: %w", id, err),
 			)
 			freshByID[id] = cached
+			deferredClose++
 		}
+	}
+	if recoveredAlive != 0 || deferredClose != 0 {
+		c.mu.Lock()
+		c.stats.ReconcileRecoveries += recoveredAlive
+		c.stats.ReconcileCloseDeferrals += deferredClose
+		c.mu.Unlock()
 	}
 }

--- a/internal/beads/caching_store_reconcile_recovery_internal_test.go
+++ b/internal/beads/caching_store_reconcile_recovery_internal_test.go
@@ -1,0 +1,164 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// droppingListStore wraps a Store and silently omits selected bead IDs from
+// List results — simulating a tolerant parser that drops malformed entries
+// or a partial List under backend stress.
+type droppingListStore struct {
+	Store
+	dropFromList map[string]struct{}
+	getErr       map[string]error
+}
+
+func (s *droppingListStore) List(query ListQuery) ([]Bead, error) {
+	all, err := s.Store.List(query)
+	if err != nil || len(s.dropFromList) == 0 {
+		return all, err
+	}
+	filtered := make([]Bead, 0, len(all))
+	for _, b := range all {
+		if _, drop := s.dropFromList[b.ID]; drop {
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered, nil
+}
+
+func (s *droppingListStore) Get(id string) (Bead, error) {
+	if err, ok := s.getErr[id]; ok {
+		return Bead{}, err
+	}
+	return s.Store.Get(id)
+}
+
+// TestReconcileSkipsCloseWhenListDropsAliveBead reproduces the cache-thrash
+// scenario where bd's tolerant JSON parser silently drops an alive bead from
+// a List result. Before the fix, the reconciler would synthesize bead.closed
+// every cycle and re-introduction via other paths would re-trigger it.
+func TestReconcileSkipsCloseWhenListDropsAliveBead(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	survivor, err := mem.Create(Bead{Title: "Survivor"})
+	if err != nil {
+		t.Fatalf("Create survivor: %v", err)
+	}
+	dropped, err := mem.Create(Bead{Title: "Dropped by tolerant parser"})
+	if err != nil {
+		t.Fatalf("Create dropped: %v", err)
+	}
+
+	backing := &droppingListStore{Store: mem}
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.dropFromList = map[string]struct{}{dropped.ID: {}}
+	events = events[:0]
+
+	cache.runReconciliation()
+
+	for _, e := range events {
+		if e == "bead.closed:"+dropped.ID {
+			t.Fatalf("emitted bead.closed for an alive bead dropped by List; events = %v", events)
+		}
+	}
+
+	got, err := cache.Get(dropped.ID)
+	if err != nil {
+		t.Fatalf("Get(dropped) after reconcile: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("Get(dropped) returned status=closed; cache should still see it as alive")
+	}
+	if _, err := cache.Get(survivor.ID); err != nil {
+		t.Fatalf("Get(survivor) after reconcile: %v", err)
+	}
+}
+
+// TestReconcileEmitsCloseWhenBackingConfirmsNotFound verifies that a genuine
+// closure (List omits the bead AND backing.Get reports ErrNotFound) still
+// produces a bead.closed event.
+func TestReconcileEmitsCloseWhenBackingConfirmsNotFound(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	gone, err := mem.Create(Bead{Title: "Truly gone"})
+	if err != nil {
+		t.Fatalf("Create gone: %v", err)
+	}
+
+	backing := &droppingListStore{Store: mem}
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.dropFromList = map[string]struct{}{gone.ID: {}}
+	backing.getErr = map[string]error{
+		gone.ID: fmt.Errorf("getting bead %q: %w", gone.ID, ErrNotFound),
+	}
+	events = events[:0]
+
+	cache.runReconciliation()
+
+	want := "bead.closed:" + gone.ID
+	for _, e := range events {
+		if e == want {
+			return
+		}
+	}
+	t.Fatalf("events = %v, want %s when backing confirmed not-found", events, want)
+}
+
+// TestReconcileDefersCloseOnBackingError verifies that a transient backing
+// failure (List omits the bead, Get returns a non-NotFound error) does NOT
+// produce a bead.closed event — the close is deferred until a later scan.
+func TestReconcileDefersCloseOnBackingError(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	uncertain, err := mem.Create(Bead{Title: "Uncertain"})
+	if err != nil {
+		t.Fatalf("Create uncertain: %v", err)
+	}
+
+	backing := &droppingListStore{Store: mem}
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.dropFromList = map[string]struct{}{uncertain.ID: {}}
+	backing.getErr = map[string]error{uncertain.ID: errors.New("dolt: connection reset")}
+	events = events[:0]
+
+	cache.runReconciliation()
+
+	for _, e := range events {
+		if e == "bead.closed:"+uncertain.ID {
+			t.Fatalf("emitted bead.closed despite backing.Get error; events = %v", events)
+		}
+	}
+	if _, err := cache.Get(uncertain.ID); err != nil {
+		t.Fatalf("Get(uncertain) after reconcile: %v", err)
+	}
+}

--- a/internal/beads/caching_store_reconcile_recovery_internal_test.go
+++ b/internal/beads/caching_store_reconcile_recovery_internal_test.go
@@ -9,11 +9,12 @@ import (
 )
 
 // droppingListStore wraps a Store and silently omits selected bead IDs from
-// List results — simulating a tolerant parser that drops malformed entries
-// or a partial List under backend stress.
+// List results, simulating a cleanly parsed but incomplete List under backend
+// stress.
 type droppingListStore struct {
 	Store
 	dropFromList map[string]struct{}
+	getOverride  map[string]Bead
 	getErr       map[string]error
 }
 
@@ -36,13 +37,26 @@ func (s *droppingListStore) Get(id string) (Bead, error) {
 	if err, ok := s.getErr[id]; ok {
 		return Bead{}, err
 	}
+	if b, ok := s.getOverride[id]; ok {
+		return cloneBead(b), nil
+	}
 	return s.Store.Get(id)
 }
 
+func assertNotCached(t *testing.T, cache *CachingStore, id string) {
+	t.Helper()
+	cache.mu.RLock()
+	_, ok := cache.beads[id]
+	cache.mu.RUnlock()
+	if ok {
+		t.Fatalf("cache still has bead %q after confirmed close", id)
+	}
+}
+
 // TestReconcileSkipsCloseWhenListDropsAliveBead reproduces the cache-thrash
-// scenario where bd's tolerant JSON parser silently drops an alive bead from
-// a List result. Before the fix, the reconciler would synthesize bead.closed
-// every cycle and re-introduction via other paths would re-trigger it.
+// scenario where a cleanly incomplete List omits an alive bead. Before the
+// fix, the reconciler would synthesize bead.closed every cycle and
+// re-introduction via other paths would re-trigger it.
 func TestReconcileSkipsCloseWhenListDropsAliveBead(t *testing.T) {
 	t.Parallel()
 
@@ -86,6 +100,13 @@ func TestReconcileSkipsCloseWhenListDropsAliveBead(t *testing.T) {
 	if _, err := cache.Get(survivor.ID); err != nil {
 		t.Fatalf("Get(survivor) after reconcile: %v", err)
 	}
+	stats := cache.Stats()
+	if stats.ReconcileRecoveries != 1 {
+		t.Fatalf("ReconcileRecoveries = %d, want 1", stats.ReconcileRecoveries)
+	}
+	if stats.ReconcileCloseDeferrals != 0 {
+		t.Fatalf("ReconcileCloseDeferrals = %d, want 0", stats.ReconcileCloseDeferrals)
+	}
 }
 
 // TestReconcileEmitsCloseWhenBackingConfirmsNotFound verifies that a genuine
@@ -118,12 +139,61 @@ func TestReconcileEmitsCloseWhenBackingConfirmsNotFound(t *testing.T) {
 	cache.runReconciliation()
 
 	want := "bead.closed:" + gone.ID
+	found := false
 	for _, e := range events {
 		if e == want {
-			return
+			found = true
+			break
 		}
 	}
-	t.Fatalf("events = %v, want %s when backing confirmed not-found", events, want)
+	if !found {
+		t.Fatalf("events = %v, want %s when backing confirmed not-found", events, want)
+	}
+	if _, err := cache.Get(gone.ID); err == nil {
+		t.Fatalf("Get(gone) succeeded after confirmed close; cache should evict it")
+	}
+	assertNotCached(t, cache, gone.ID)
+}
+
+// TestReconcileEmitsCloseWhenGetReturnsClosed verifies that a real open-to-
+// closed transition still emits bead.closed when the closed bead is absent
+// from normal List results.
+func TestReconcileEmitsCloseWhenGetReturnsClosed(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	closing, err := mem.Create(Bead{Title: "Closing"})
+	if err != nil {
+		t.Fatalf("Create closing: %v", err)
+	}
+
+	backing := &droppingListStore{Store: mem}
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if err := mem.Close(closing.ID); err != nil {
+		t.Fatalf("Close backing bead: %v", err)
+	}
+	events = events[:0]
+
+	cache.runReconciliation()
+
+	want := "bead.closed:" + closing.ID
+	found := false
+	for _, e := range events {
+		if e == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("events = %v, want %s when backing returned closed bead", events, want)
+	}
+	assertNotCached(t, cache, closing.ID)
 }
 
 // TestReconcileDefersCloseOnBackingError verifies that a transient backing
@@ -160,5 +230,61 @@ func TestReconcileDefersCloseOnBackingError(t *testing.T) {
 	}
 	if _, err := cache.Get(uncertain.ID); err != nil {
 		t.Fatalf("Get(uncertain) after reconcile: %v", err)
+	}
+	stats := cache.Stats()
+	if stats.ReconcileRecoveries != 0 {
+		t.Fatalf("ReconcileRecoveries = %d, want 0", stats.ReconcileRecoveries)
+	}
+	if stats.ReconcileCloseDeferrals != 1 {
+		t.Fatalf("ReconcileCloseDeferrals = %d, want 1", stats.ReconcileCloseDeferrals)
+	}
+}
+
+// TestReconcileDefersCloseWhenGetReturnsWrongID verifies recovery does not
+// merge a successful but invalid Get result under the requested ID.
+func TestReconcileDefersCloseWhenGetReturnsWrongID(t *testing.T) {
+	t.Parallel()
+
+	mem := NewMemStore()
+	uncertain, err := mem.Create(Bead{Title: "Uncertain"})
+	if err != nil {
+		t.Fatalf("Create uncertain: %v", err)
+	}
+
+	backing := &droppingListStore{Store: mem}
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.dropFromList = map[string]struct{}{uncertain.ID: {}}
+	backing.getOverride = map[string]Bead{
+		uncertain.ID: {ID: "wrong-id", Title: "Wrong bead", Status: "open"},
+	}
+	events = events[:0]
+
+	cache.runReconciliation()
+
+	for _, e := range events {
+		if e == "bead.closed:"+uncertain.ID {
+			t.Fatalf("emitted bead.closed despite wrong backing.Get ID; events = %v", events)
+		}
+	}
+	got, err := cache.Get(uncertain.ID)
+	if err != nil {
+		t.Fatalf("Get(uncertain) after reconcile: %v", err)
+	}
+	if got.ID != uncertain.ID || got.Title != uncertain.Title {
+		t.Fatalf("Get(uncertain) = %#v, want cached bead %#v", got, uncertain)
+	}
+	stats := cache.Stats()
+	if stats.ReconcileRecoveries != 0 {
+		t.Fatalf("ReconcileRecoveries = %d, want 0", stats.ReconcileRecoveries)
+	}
+	if stats.ReconcileCloseDeferrals != 1 {
+		t.Fatalf("ReconcileCloseDeferrals = %d, want 1", stats.ReconcileCloseDeferrals)
 	}
 }


### PR DESCRIPTION
## Summary

The cache reconciler diffs `c.beads` against a fresh `backing.List(AllowScan: true)` result and emits `bead.closed` for any cache entry missing from the fresh list. Under dolt load this turns into a self-amplifying loop because:

- `BdStore.List` calls `parseIssuesTolerant`, which silently drops malformed entries; the caller swallows the resulting parse error whenever at least one bead survives.
- Under stress, `bd list` responses can also be truncated outright.

A dropped-but-alive bead is "closed" every reconcile cycle; other paths (`Get`, `Create`, `ApplyEvent`) re-introduce it; the next cycle closes it again. Observed in production: individual beads "closed" 100+ times per 10k events while their actual status in dolt was `open`, with the reconciler driving the dolt sql-server to >700% CPU and bd CLI calls timing out at 120s.

This change is the smallest defensive step. Before any "missing from fresh" cache entry is treated as closed, re-fetch via `backing.Get`:

- `err == nil`, alive: merge into `freshByID` so the diff sees it as present. **No `bead.closed` synthesized.**
- `errors.Is(err, ErrNotFound)`: leave it absent so the diff path emits `bead.closed` as before.
- any other error: conservatively merge the cached entry into `freshByID`, deferring the close to a later, less-ambiguous scan. The `recordProblem` path notes the deferral.

Two follow-up PRs will harden the underlying List path:
1. Make `BdStore.List` surface parse errors instead of silently swallowing them.
2. Address whatever subset of beads `parseIssuesTolerant` is actually dropping (the `StringMap` unmarshaler already coerces non-string values, so the current drops have a different root cause that needs investigation).

## Testing

- [x] `make check` (`fmt-check`, `lint`, `vet` clean; one pre-existing `TestDocDirCoverage` failure on `test/docsync` is unrelated and reproduces on `origin/main`)
- [x] `go test ./internal/beads/...` — passes, including three new tests:
  - `TestReconcileSkipsCloseWhenListDropsAliveBead` — silent drop + alive `Get` → no close emitted
  - `TestReconcileEmitsCloseWhenBackingConfirmsNotFound` — drop + `ErrNotFound` → close still emitted
  - `TestReconcileDefersCloseOnBackingError` — drop + transient error → close deferred
- [ ] `make test-integration` — not run (this fixes a behavioral bug in cache reconcile; reviewer welcome to require it)

## Checklist

- [x] Linked an issue, or explained why one is not needed — no issue; root-cause investigation included above
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — not user-facing
- [ ] Called out breaking changes or migration notes — none; behavior strictly more conservative