### PR TITLE
fix(beads): surface PartialResultError from BdStore.List/Ready

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -315,6 +315,37 @@ type bdIssueDep struct {
 	DependencyType string `json:"dependency_type"`
 }
 
+// PartialResultError indicates that a list-style bd command succeeded for some
+// entries but its output included entries that failed to parse. The successful
+// entries are still returned alongside this error; callers that handle dropped
+// beads defensively (e.g. the cache reconciler verifying via Get) may proceed
+// with the partial result, while callers that require a complete picture
+// should treat this as a hard failure.
+type PartialResultError struct {
+	// Op identifies the bd subcommand that produced the partial result
+	// (e.g. "bd list", "bd ready").
+	Op string
+	// Err wraps the joined per-entry parse errors from parseIssuesTolerant.
+	Err error
+}
+
+// Error reports the operation and underlying parse failures.
+func (e *PartialResultError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%s: %v", e.Op, e.Err)
+}
+
+// Unwrap returns the joined parse error so errors.Is / errors.As traversal
+// continues into the underlying causes.
+func (e *PartialResultError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // parseIssuesTolerant unmarshals a JSON array of bdIssue objects, skipping
 // any entries that fail to parse (e.g. corrupt metadata with non-string values).
 // This prevents a single bad bead from breaking all list operations.
@@ -760,10 +791,12 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	}
 	filtered := applyListQuery(result, query)
 	if parseErr != nil {
-		if len(filtered) > 0 {
-			return filtered, nil
-		}
-		return filtered, fmt.Errorf("bd list: %w", parseErr)
+		// Surface partial-parse outcomes so callers can distinguish a complete
+		// list from one that silently dropped entries. Treating a partial list
+		// as authoritative has driven a runaway cache-reconcile loop in the
+		// past (synthesizing bead.closed for beads that were merely dropped
+		// by parseIssuesTolerant).
+		return filtered, &PartialResultError{Op: "bd list", Err: parseErr}
 	}
 	return filtered, nil
 }
@@ -838,10 +871,7 @@ func (s *BdStore) Ready() ([]Bead, error) {
 		result = append(result, bead)
 	}
 	if parseErr != nil {
-		if len(result) > 0 {
-			return result, nil
-		}
-		return result, fmt.Errorf("bd ready: %w", parseErr)
+		return result, &PartialResultError{Op: "bd ready", Err: parseErr}
 	}
 	return result, nil
 }

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -612,8 +612,42 @@ func TestBdStoreListReturnsPartialResultsOnCorruptEntries(t *testing.T) {
 	if len(got) != 1 || got[0].ID != "bd-good" {
 		t.Fatalf("ListOpen() = %v, want only bd-good", got)
 	}
-	if err != nil {
-		t.Fatalf("ListOpen() error = %v, want nil with usable partial results", err)
+	var partial *beads.PartialResultError
+	if !errors.As(err, &partial) {
+		t.Fatalf("ListOpen() error = %v, want *beads.PartialResultError so callers can distinguish complete from partial results", err)
+	}
+	if partial.Op != "bd list" {
+		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd list")
+	}
+	if partial.Err == nil {
+		t.Errorf("PartialResultError.Err is nil; want wrapped parse error")
+	}
+}
+
+func TestBdStoreReadyReturnsPartialResultErrorOnCorruptEntries(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-good","title":"good","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time"}
+			]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready()
+	if len(got) != 1 || got[0].ID != "bd-good" {
+		t.Fatalf("Ready() = %v, want only bd-good", got)
+	}
+	var partial *beads.PartialResultError
+	if !errors.As(err, &partial) {
+		t.Fatalf("Ready() error = %v, want *beads.PartialResultError", err)
+	}
+	if partial.Op != "bd ready" {
+		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd ready")
 	}
 }
 


### PR DESCRIPTION
## Summary

`BdStore.List` and `BdStore.Ready` use `parseIssuesTolerant`, which silently drops bd-CLI output entries that fail per-element JSON parse. The callers then **swallow the parse error whenever at least one bead survives** — returning `(partial, nil)` — so downstream code cannot distinguish a complete result from one that quietly lost beads.

This was the structural cause of a recently-observed cache-reconcile spiral: dropped-but-alive beads were "closed" every reconcile cycle, re-introduced via `Get`/`Create`/event paths, and "closed" again, with the dolt sql-server pegged at 700%+ CPU.

## Change

Wrap the parse error in a typed `PartialResultError` instead of nil-ing it out:

```go
type PartialResultError struct {
    Op  string // "bd list" or "bd ready"
    Err error  // joined per-entry parse errors
}
```

Callers that handle partial results defensively (e.g. the cache reconciler's `backing.Get` verification, in #1412) detect this via `errors.As`; callers that require a complete picture treat it like any other `List` failure. Backward-compatible with the common `if err != nil { return nil, err }` idiom — those callers now correctly propagate instead of silently dropping data.

## Pairs with #1412

- #1412 added defensive `Get`-verification before the reconciler synthesizes `bead.closed` events.
- This PR makes the underlying drop **visible** so it shows up in cache-stats `Problems` rather than as silent data loss.
- Either PR alone is a strict improvement. Together they form a defense-in-depth around partial parse results.

## Testing

- [x] `make check` (`fmt-check`, `lint`, `vet` clean; pre-existing `TestDocDirCoverage` failure on `test/docsync` is unrelated and reproduces on plain `origin/main`)
- [x] Updated `TestBdStoreListReturnsPartialResultsOnCorruptEntries` to assert the new contract (partial result + non-nil `*PartialResultError`)
- [x] Added `TestBdStoreReadyReturnsPartialResultErrorOnCorruptEntries`
- [x] Full unit suite passes (`GC_FAST_UNIT=1 go test ./...`) modulo the pre-existing docsync failure
- [ ] `make test-integration` — not run; reviewer welcome to require it

## Checklist

- [x] Linked an issue, or explained why one is not needed — no issue; root-cause investigation and incident detail are in #1412
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — not user-facing
- [x] Called out breaking changes or migration notes — `BdStore.List` and `BdStore.Ready` now return a non-nil error when input has corrupt entries (previously they returned `(partial, nil)`). Callers that depended on the silent-success contract will start seeing `*PartialResultError`. The fix is to either propagate the error or `errors.As` to opt into using the partial result deliberately.