### PR TITLE
fix: replace select{} with bounded poll loop in doRuntimeRequestRestart

### DIFF
--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/spf13/cobra"
@@ -431,13 +434,38 @@ func cmdRuntimeRequestRestart(stdout, stderr io.Writer) int {
 			return handle.Reset(context.Background())
 		}
 	}
-	return doRuntimeRequestRestart(dops, persistRestart, rec, current.display, current.sessionName, stdout, stderr)
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return doRuntimeRequestRestart(sigCtx, dops, persistRestart, rec, current.display, current.sessionName,
+		controllerRestartPollInterval, controllerRestartTimeout(cfg), stdout, stderr)
 }
 
-// doRuntimeRequestRestart sets the restart-requested flag and blocks forever.
-// The controller will kill and restart the session on its next tick.
-func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec events.Recorder,
-	targetName, sn string, stdout, stderr io.Writer,
+const controllerRestartPollInterval = 1 * time.Second
+
+// controllerRestartTimeout computes the bounded timeout for waiting on the
+// controller to act on a restart request: max(5*PatrolInterval, 5min), capped at 30min.
+func controllerRestartTimeout(cfg *config.City) time.Duration {
+	const floor = 5 * time.Minute
+	const ceil = 30 * time.Minute
+	patrol := 30 * time.Second
+	if cfg != nil {
+		patrol = cfg.Daemon.PatrolIntervalDuration()
+	}
+	d := 5 * patrol
+	if d < floor {
+		d = floor
+	}
+	if d > ceil {
+		d = ceil
+	}
+	return d
+}
+
+// doRuntimeRequestRestart sets the restart-requested flag then polls until the
+// controller clears it (exit 0), the context is cancelled by a signal (exit 0),
+// or the bounded timeout expires (exit 1 with diagnostic).
+func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart func() error, rec events.Recorder,
+	targetName, sn string, pollInterval, timeout time.Duration, stdout, stderr io.Writer,
 ) int {
 	if err := dops.setRestartRequested(sn); err != nil {
 		fmt.Fprintf(stderr, "gc runtime request-restart: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -458,8 +486,27 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 	})
 	fmt.Fprintln(stdout, "Restart requested. Blocking until controller kills this session...") //nolint:errcheck // best-effort stdout
 
-	// Block forever. The controller will kill the entire process tree.
-	select {}
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Signal received; leave the flag set so the controller still acts on its next tick.
+			return 0
+		case <-ticker.C:
+			requested, err := dops.isRestartRequested(sn)
+			if err == nil && !requested {
+				// Reconciler cleared the flag; restart is in flight.
+				return 0
+			}
+			if time.Now().After(deadline) {
+				fmt.Fprintf(stderr, "gc runtime request-restart: controller did not act within %s; check `gc dashboard` or `gc trace`\n", timeout) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
+	}
 }
 
 // doRuntimeDrainAck sets the drain-ack flag on the session. The controller

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -98,6 +98,9 @@ func (o *providerDrainOps) setRestartRequested(sessionName string) error {
 func (o *providerDrainOps) isRestartRequested(sessionName string) (bool, error) {
 	val, err := o.sp.GetMeta(sessionName, "GC_RESTART_REQUESTED")
 	if err != nil {
+		if runtime.IsSessionGone(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("reading GC_RESTART_REQUESTED: %w", err)
 	}
 	return val != "", nil
@@ -378,11 +381,11 @@ fresh. The wait keeps the agent idle so it does not consume more context
 in the interim.
 
 Under normal operation the controller SIGKILLs the process tree before
-this command returns. If the controller clears the flag without killing
-(or a SIGINT/SIGTERM is received), the command exits 0 cleanly. If the
-controller has not acted within a bounded timeout (max(5*PatrolInterval,
-5min), capped at 30min) the command exits 1 with a diagnostic pointing
-at controller health.
+this command returns. If the controller accepts the stop handoff, the
+runtime is already gone, or a SIGINT/SIGTERM is received, the command
+exits 0 cleanly. If the controller has not acted within a bounded
+timeout (max(5*PatrolInterval, 5min), capped at 30min) the command exits
+1 with a diagnostic pointing at controller health.
 
 For on-demand configured named sessions, the controller cannot restart
 the user-attended process. In that case this command reports that
@@ -469,8 +472,8 @@ func controllerRestartTimeout(cfg *config.City) time.Duration {
 }
 
 // doRuntimeRequestRestart sets the restart-requested flag then polls until the
-// controller clears it (exit 0), the context is canceled by a signal (exit 0),
-// or the bounded timeout expires (exit 1 with diagnostic).
+// controller accepts the stop handoff (exit 0), the context is canceled by a
+// signal (exit 0), or the bounded timeout expires (exit 1 with diagnostic).
 func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart func() error, rec events.Recorder,
 	targetName, sn string, pollInterval, timeout time.Duration, stdout, stderr io.Writer,
 ) int {
@@ -491,25 +494,36 @@ func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart 
 		Subject: targetName,
 		Message: "restart requested by session",
 	})
-	fmt.Fprintln(stdout, "Restart requested. Blocking until controller kills this session...") //nolint:errcheck // best-effort stdout
+	fmt.Fprintf(stdout, "Restart requested. Waiting up to %s for controller to stop this session...\n", timeout) //nolint:errcheck // best-effort stdout
 
 	deadline := time.Now().Add(timeout)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
+	var lastPollErr error
 
 	for {
 		select {
 		case <-ctx.Done():
 			// Signal received; leave the flag set so the controller still acts on its next tick.
+			fmt.Fprintln(stderr, "gc runtime request-restart: signal received; restart request remains set; controller will stop this session on its next reconcile tick") //nolint:errcheck // best-effort stderr
 			return 0
 		case <-ticker.C:
 			requested, err := dops.isRestartRequested(sn)
-			if err == nil && !requested {
-				// Reconciler cleared the flag; restart is in flight.
+			switch {
+			case err != nil:
+				lastPollErr = err
+			case !requested:
+				// The controller accepted the stop handoff or the runtime is already gone.
 				return 0
+			default:
+				lastPollErr = nil
 			}
 			if time.Now().After(deadline) {
-				fmt.Fprintf(stderr, "gc runtime request-restart: controller did not act within %s; check `gc dashboard` or `gc trace`\n", timeout) //nolint:errcheck // best-effort stderr
+				if lastPollErr != nil {
+					fmt.Fprintf(stderr, "gc runtime request-restart: controller did not act within %s; last poll error: %v; check `gc dashboard` or `gc trace`\n", timeout, lastPollErr) //nolint:errcheck // best-effort stderr
+				} else {
+					fmt.Fprintf(stderr, "gc runtime request-restart: controller did not act within %s; check `gc dashboard` or `gc trace`\n", timeout) //nolint:errcheck // best-effort stderr
+				}
 				return 1
 			}
 		}

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -469,7 +469,7 @@ func controllerRestartTimeout(cfg *config.City) time.Duration {
 }
 
 // doRuntimeRequestRestart sets the restart-requested flag then polls until the
-// controller clears it (exit 0), the context is cancelled by a signal (exit 0),
+// controller clears it (exit 0), the context is canceled by a signal (exit 0),
 // or the bounded timeout expires (exit 1 with diagnostic).
 func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart func() error, rec events.Recorder,
 	targetName, sn string, pollInterval, timeout time.Duration, stdout, stderr io.Writer,

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -369,21 +369,28 @@ func cmdRuntimeDrainAck(args []string, stdout, stderr io.Writer) int {
 func newRuntimeRequestRestartCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "request-restart",
-		Short: "Request controller restart this session (blocks until killed)",
+		Short: "Request controller restart this session (waits to be killed)",
 		Long: `Signal the controller to stop and restart this session.
 
-Sets GC_RESTART_REQUESTED metadata on the session, then blocks forever.
-The controller will stop the session on its next reconcile tick and
-restart it fresh. The blocking prevents the agent from consuming more
-context while waiting.
+Sets GC_RESTART_REQUESTED metadata on the session, then waits while the
+controller stops the session on its next reconcile tick and restarts it
+fresh. The wait keeps the agent idle so it does not consume more context
+in the interim.
 
-For on-demand configured named sessions, the controller cannot restart the
-user-attended process. In that case this command reports that restart was
-skipped and returns without blocking. No session.draining event is emitted
-when restart is skipped.
+Under normal operation the controller SIGKILLs the process tree before
+this command returns. If the controller clears the flag without killing
+(or a SIGINT/SIGTERM is received), the command exits 0 cleanly. If the
+controller has not acted within a bounded timeout (max(5*PatrolInterval,
+5min), capped at 30min) the command exits 1 with a diagnostic pointing
+at controller health.
+
+For on-demand configured named sessions, the controller cannot restart
+the user-attended process. In that case this command reports that
+restart was skipped and returns immediately. No session.draining event
+is emitted when restart is skipped.
 
 This command is designed to be called from within a session context.
-It emits a session.draining event before blocking.`,
+It emits a session.draining event before waiting.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if cmdRuntimeRequestRestart(stdout, stderr) != 0 {

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +18,20 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+// drainOpsWithCountdown wraps fakeDrainOps and returns false for isRestartRequested
+// after N calls, simulating the reconciler clearing the flag without concurrent map access.
+type drainOpsWithCountdown struct {
+	*fakeDrainOps
+	remaining atomic.Int32
+}
+
+func (c *drainOpsWithCountdown) isRestartRequested(_ string) (bool, error) {
+	if c.remaining.Add(-1) < 0 {
+		return false, nil
+	}
+	return true, nil
+}
 
 // fakeDrainOps is a test double for drainOps.
 type fakeDrainOps struct {
@@ -479,12 +494,74 @@ func TestDoRuntimeRequestRestartError(t *testing.T) {
 	dops := newFakeDrainOps()
 	dops.err = errors.New("tmux borked")
 	var stdout, stderr bytes.Buffer
-	code := doRuntimeRequestRestart(dops, nil, events.Discard, "worker", "worker", &stdout, &stderr)
+	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+		time.Millisecond, time.Second, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if got := stderr.String(); got != "gc runtime request-restart: tmux borked\n" {
 		t.Errorf("stderr = %q", got)
+	}
+}
+
+func TestDoRuntimeRequestRestartFlagCleared(t *testing.T) {
+	dops := &drainOpsWithCountdown{fakeDrainOps: newFakeDrainOps()}
+	dops.remaining.Store(2) // true for first 2 polls, then false (reconciler cleared)
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+		10*time.Millisecond, 5*time.Second, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0 when flag cleared; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestDoRuntimeRequestRestartTimeout(t *testing.T) {
+	dops := newFakeDrainOps()
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+		10*time.Millisecond, 25*time.Millisecond, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 on timeout", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "controller did not act within") {
+		t.Errorf("stderr = %q, want timeout diagnostic", got)
+	}
+	if !strings.Contains(stderr.String(), "gc dashboard") {
+		t.Errorf("stderr = %q, want gc dashboard hint", stderr.String())
+	}
+}
+
+func TestDoRuntimeRequestRestartContextCancel(t *testing.T) {
+	dops := newFakeDrainOps()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan int, 1)
+	go func() {
+		var stdout, stderr bytes.Buffer
+		done <- doRuntimeRequestRestart(ctx, dops, nil, events.Discard, "worker", "worker",
+			10*time.Millisecond, 30*time.Second, &stdout, &stderr)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0 on context cancel", code)
+		}
+		// Flag must remain set so the controller can still act on its next tick.
+		if !dops.restartRequested["worker"] {
+			t.Error("restart flag should remain set after context cancel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("doRuntimeRequestRestart did not exit on context cancel")
 	}
 }
 

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,24 +23,41 @@ import (
 // after N calls, simulating the reconciler clearing the flag without concurrent map access.
 type drainOpsWithCountdown struct {
 	*fakeDrainOps
-	remaining atomic.Int32
+	remaining int
+	cleared   bool
 }
 
-func (c *drainOpsWithCountdown) isRestartRequested(_ string) (bool, error) {
-	if c.remaining.Add(-1) < 0 {
+func (c *drainOpsWithCountdown) isRestartRequested(sessionName string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return false, c.err
+	}
+	if !c.restartRequested[sessionName] {
+		if c.cleared {
+			return false, nil
+		}
+		return false, errors.New("restart flag was not set before polling")
+	}
+	if c.remaining <= 0 {
+		delete(c.restartRequested, sessionName)
+		c.cleared = true
 		return false, nil
 	}
+	c.remaining--
 	return true, nil
 }
 
 // fakeDrainOps is a test double for drainOps.
 type fakeDrainOps struct {
+	mu               sync.Mutex
 	draining         map[string]bool
 	drainTimes       map[string]time.Time // when drain was set
 	acked            map[string]bool
 	restartRequested map[string]bool
 	driftRestart     map[string]bool
 	err              error // injected error for all ops
+	restartReadErr   error
 	setDrainCalls    []string
 	clearDrainCalls  []string
 }
@@ -56,6 +73,8 @@ func newFakeDrainOps() *fakeDrainOps {
 }
 
 func (f *fakeDrainOps) setDrain(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.setDrainCalls = append(f.setDrainCalls, sessionName)
 	if f.err != nil {
 		return f.err
@@ -66,6 +85,8 @@ func (f *fakeDrainOps) setDrain(sessionName string) error {
 }
 
 func (f *fakeDrainOps) clearDrain(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.clearDrainCalls = append(f.clearDrainCalls, sessionName)
 	if f.err != nil {
 		return f.err
@@ -76,6 +97,8 @@ func (f *fakeDrainOps) clearDrain(sessionName string) error {
 }
 
 func (f *fakeDrainOps) isDraining(sessionName string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return false, f.err
 	}
@@ -83,6 +106,8 @@ func (f *fakeDrainOps) isDraining(sessionName string) (bool, error) {
 }
 
 func (f *fakeDrainOps) drainStartTime(sessionName string) (time.Time, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return time.Time{}, f.err
 	}
@@ -94,6 +119,8 @@ func (f *fakeDrainOps) drainStartTime(sessionName string) (time.Time, error) {
 }
 
 func (f *fakeDrainOps) setDrainAck(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return f.err
 	}
@@ -102,6 +129,8 @@ func (f *fakeDrainOps) setDrainAck(sessionName string) error {
 }
 
 func (f *fakeDrainOps) isDrainAcked(sessionName string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return false, f.err
 	}
@@ -109,6 +138,8 @@ func (f *fakeDrainOps) isDrainAcked(sessionName string) (bool, error) {
 }
 
 func (f *fakeDrainOps) setRestartRequested(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return f.err
 	}
@@ -117,13 +148,20 @@ func (f *fakeDrainOps) setRestartRequested(sessionName string) error {
 }
 
 func (f *fakeDrainOps) isRestartRequested(sessionName string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return false, f.err
+	}
+	if f.restartReadErr != nil {
+		return false, f.restartReadErr
 	}
 	return f.restartRequested[sessionName], nil
 }
 
 func (f *fakeDrainOps) clearRestartRequested(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return f.err
 	}
@@ -132,6 +170,8 @@ func (f *fakeDrainOps) clearRestartRequested(sessionName string) error {
 }
 
 func (f *fakeDrainOps) setDriftRestart(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return f.err
 	}
@@ -140,6 +180,8 @@ func (f *fakeDrainOps) setDriftRestart(sessionName string) error {
 }
 
 func (f *fakeDrainOps) isDriftRestart(sessionName string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return false, f.err
 	}
@@ -147,6 +189,8 @@ func (f *fakeDrainOps) isDriftRestart(sessionName string) (bool, error) {
 }
 
 func (f *fakeDrainOps) clearDriftRestart(sessionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.err != nil {
 		return f.err
 	}
@@ -505,8 +549,7 @@ func TestDoRuntimeRequestRestartError(t *testing.T) {
 }
 
 func TestDoRuntimeRequestRestartFlagCleared(t *testing.T) {
-	dops := &drainOpsWithCountdown{fakeDrainOps: newFakeDrainOps()}
-	dops.remaining.Store(2) // true for first 2 polls, then false (reconciler cleared)
+	dops := &drainOpsWithCountdown{fakeDrainOps: newFakeDrainOps(), remaining: 2}
 
 	var stdout, stderr bytes.Buffer
 	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
@@ -516,6 +559,12 @@ func TestDoRuntimeRequestRestartFlagCleared(t *testing.T) {
 	}
 	if stderr.Len() > 0 {
 		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "Waiting up to 5s") {
+		t.Errorf("stdout = %q, want bounded wait banner", got)
+	}
+	if dops.restartRequested["worker"] {
+		t.Error("restart flag should be cleared by the simulated reconciler")
 	}
 }
 
@@ -536,14 +585,29 @@ func TestDoRuntimeRequestRestartTimeout(t *testing.T) {
 	}
 }
 
+func TestDoRuntimeRequestRestartTimeoutReportsLastPollError(t *testing.T) {
+	dops := newFakeDrainOps()
+	dops.restartReadErr = errors.New("metadata read failed")
+
+	var stdout, stderr bytes.Buffer
+	code := doRuntimeRequestRestart(context.Background(), dops, nil, events.Discard, "worker", "worker",
+		10*time.Millisecond, 25*time.Millisecond, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 on timeout", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "last poll error: metadata read failed") {
+		t.Errorf("stderr = %q, want last poll error", got)
+	}
+}
+
 func TestDoRuntimeRequestRestartContextCancel(t *testing.T) {
 	dops := newFakeDrainOps()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	var stdout, stderr bytes.Buffer
 
 	done := make(chan int, 1)
 	go func() {
-		var stdout, stderr bytes.Buffer
 		done <- doRuntimeRequestRestart(ctx, dops, nil, events.Discard, "worker", "worker",
 			10*time.Millisecond, 30*time.Second, &stdout, &stderr)
 	}()
@@ -560,8 +624,57 @@ func TestDoRuntimeRequestRestartContextCancel(t *testing.T) {
 		if !dops.restartRequested["worker"] {
 			t.Error("restart flag should remain set after context cancel")
 		}
+		if got := stderr.String(); !strings.Contains(got, "restart request remains set") {
+			t.Errorf("stderr = %q, want pending restart warning", got)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("doRuntimeRequestRestart did not exit on context cancel")
+	}
+}
+
+func TestControllerRestartTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.City
+		want time.Duration
+	}{
+		{name: "nil config uses floor", cfg: nil, want: 5 * time.Minute},
+		{name: "empty interval uses floor", cfg: &config.City{}, want: 5 * time.Minute},
+		{name: "below floor clamps up", cfg: &config.City{Daemon: config.DaemonConfig{PatrolInterval: "15s"}}, want: 5 * time.Minute},
+		{name: "middle range uses multiplier", cfg: &config.City{Daemon: config.DaemonConfig{PatrolInterval: "2m"}}, want: 10 * time.Minute},
+		{name: "ceiling edge", cfg: &config.City{Daemon: config.DaemonConfig{PatrolInterval: "6m"}}, want: 30 * time.Minute},
+		{name: "above ceiling clamps down", cfg: &config.City{Daemon: config.DaemonConfig{PatrolInterval: "10m"}}, want: 30 * time.Minute},
+		{name: "invalid duration uses default floor", cfg: &config.City{Daemon: config.DaemonConfig{PatrolInterval: "later"}}, want: 5 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := controllerRestartTimeout(tt.cfg); got != tt.want {
+				t.Fatalf("controllerRestartTimeout() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+type getMetaErrorProvider struct {
+	*runtime.Fake
+	err error
+}
+
+func (p *getMetaErrorProvider) GetMeta(_, _ string) (string, error) {
+	return "", p.err
+}
+
+func TestProviderDrainOpsIsRestartRequestedTreatsGoneSessionAsCleared(t *testing.T) {
+	dops := newDrainOps(&getMetaErrorProvider{
+		Fake: runtime.NewFake(),
+		err:  runtime.ErrSessionNotFound,
+	})
+	requested, err := dops.isRestartRequested("worker")
+	if err != nil {
+		t.Fatalf("isRestartRequested returned gone-session error: %v", err)
+	}
+	if requested {
+		t.Fatal("isRestartRequested = true, want false for gone session")
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -672,8 +672,11 @@ func reconcileSessionBeadsTraced(
 			}
 			beadRequested := session.Metadata["restart_requested"] == "true"
 			if tmuxRequested || beadRequested {
-				if tmuxRequested && dops != nil {
-					_ = dops.clearRestartRequested(name)
+				if alive {
+					if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
+						fmt.Fprintf(stderr, "session reconciler: stopping restart-requested %s: %v\n", name, err) //nolint:errcheck
+						continue
+					}
 				}
 				// Providers that can inject a fresh session ID get a
 				// rotated key here so the next wake starts a brand-new
@@ -688,7 +691,10 @@ func reconcileSessionBeadsTraced(
 				if hasCapability && newSessionKey == "" {
 					batch["session_key"] = ""
 				}
-				_ = store.SetMetadataBatch(session.ID, batch)
+				if err := store.SetMetadataBatch(session.ID, batch); err != nil {
+					fmt.Fprintf(stderr, "session reconciler: recording restart handoff for %s: %v\n", name, err) //nolint:errcheck
+					continue
+				}
 				if session.Metadata == nil {
 					session.Metadata = make(map[string]string, len(batch))
 				}
@@ -696,11 +702,10 @@ func reconcileSessionBeadsTraced(
 					session.Metadata[key] = value
 				}
 				if alive {
-					if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
-						fmt.Fprintf(stderr, "session reconciler: stopping restart-requested %s: %v\n", name, err) //nolint:errcheck
-					} else {
-						fmt.Fprintf(stdout, "Stopped restart-requested session '%s'\n", name) //nolint:errcheck
+					if tmuxRequested && dops != nil {
+						_ = dops.clearRestartRequested(name)
 					}
+					fmt.Fprintf(stdout, "Stopped restart-requested session '%s'\n", name) //nolint:errcheck
 				}
 				continue
 			}

--- a/cmd/gc/session_reconciler_restart_request_test.go
+++ b/cmd/gc/session_reconciler_restart_request_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,7 +39,7 @@ func newRestartRequestTestEnv() *restartRequestTestEnv {
 	}
 }
 
-func (e *restartRequestTestEnv) createSessionBead(name, template string) beads.Bead {
+func (e *restartRequestTestEnv) createSessionBead(name string) beads.Bead {
 	b, err := e.store.Create(beads.Bead{
 		Title:  name,
 		Type:   sessionBeadType,
@@ -45,7 +47,7 @@ func (e *restartRequestTestEnv) createSessionBead(name, template string) beads.B
 		Metadata: map[string]string{
 			"session_name":   name,
 			"agent_name":     name,
-			"template":       template,
+			"template":       "worker",
 			"generation":     "1",
 			"instance_token": "test-token",
 			"state":          "asleep",
@@ -115,7 +117,7 @@ func TestReconcileSessionBeads_RestartRequestRotatesKeyForSessionIDProviders(t *
 		},
 	}
 
-	session := env.createSessionBead(sessionName, "worker")
+	session := env.createSessionBead(sessionName)
 	env.setSessionMetadata(&session, map[string]string{
 		namedSessionMetadataKey:      "true",
 		namedSessionIdentityMetadata: "worker",
@@ -160,7 +162,7 @@ func TestReconcileSessionBeads_RestartRequestClearsKeyForResumeOnlyProviders(t *
 		},
 	}
 
-	session := env.createSessionBead(sessionName, "worker")
+	session := env.createSessionBead(sessionName)
 	env.setSessionMetadata(&session, map[string]string{
 		namedSessionMetadataKey:      "true",
 		namedSessionIdentityMetadata: "worker",
@@ -201,7 +203,7 @@ func TestReconcileSessionBeads_RestartRequestPreservesLiveHashesDuringHandoff(t 
 		},
 	}
 
-	session := env.createSessionBead(sessionName, "worker")
+	session := env.createSessionBead(sessionName)
 	env.setSessionMetadata(&session, map[string]string{
 		namedSessionMetadataKey:      "true",
 		namedSessionIdentityMetadata: "worker",
@@ -241,6 +243,64 @@ func TestReconcileSessionBeads_RestartRequestPreservesLiveHashesDuringHandoff(t 
 	}
 	if got.Metadata["startup_dialog_verified"] != "true" {
 		t.Fatalf("startup_dialog_verified = %q, want preserved until next successful start", got.Metadata["startup_dialog_verified"])
+	}
+}
+
+func TestReconcileSessionBeads_RestartRequestPreservesIntentWhenKillFails(t *testing.T) {
+	env := newRestartRequestTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true", MaxActiveSessions: restartRequestTestIntPtr(1)}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:      "true",
+		SessionName:  sessionName,
+		TemplateName: "worker",
+		ResolvedProvider: &config.ResolvedProvider{
+			SessionIDFlag: "--session-id",
+		},
+	}
+
+	session := env.createSessionBead(sessionName)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "on_demand",
+		"state":                      "active",
+		"restart_requested":          "true",
+		"session_key":                "original-key",
+		"started_config_hash":        "hash-before-restart",
+	})
+	if err := env.sp.Start(context.Background(), sessionName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	if err := env.sp.SetMeta(sessionName, "GC_SESSION_ID", session.ID); err != nil {
+		t.Fatalf("SetMeta(GC_SESSION_ID): %v", err)
+	}
+	env.sp.StopErrors[sessionName] = errors.New("kill denied")
+
+	env.reconcile([]beads.Bead{session})
+
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatal("session should remain running when kill fails")
+	}
+	got, _ := env.store.Get(session.ID)
+	if got.Metadata["restart_requested"] != "true" {
+		t.Fatalf("restart_requested = %q, want preserved", got.Metadata["restart_requested"])
+	}
+	if got.Metadata["session_key"] != "original-key" {
+		t.Fatalf("session_key = %q, want original-key", got.Metadata["session_key"])
+	}
+	if got.Metadata["started_config_hash"] != "hash-before-restart" {
+		t.Fatalf("started_config_hash = %q, want preserved", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["continuation_reset_pending"] != "" {
+		t.Fatalf("continuation_reset_pending = %q, want empty until kill succeeds", got.Metadata["continuation_reset_pending"])
+	}
+	if got := env.stderr.String(); !strings.Contains(got, "stopping restart-requested") || !strings.Contains(got, "kill denied") {
+		t.Fatalf("stderr = %q, want kill failure diagnostic", got)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1940,7 +1940,7 @@ gc runtime
 | [gc runtime drain](#gc-runtime-drain) | Signal a session to drain (wind down gracefully) |
 | [gc runtime drain-ack](#gc-runtime-drain-ack) | Acknowledge drain — signal the controller to stop this session |
 | [gc runtime drain-check](#gc-runtime-drain-check) | Check if a session is draining (exit 0 = draining) |
-| [gc runtime request-restart](#gc-runtime-request-restart) | Request controller restart this session (blocks until killed) |
+| [gc runtime request-restart](#gc-runtime-request-restart) | Request controller restart this session (waits to be killed) |
 | [gc runtime undrain](#gc-runtime-undrain) | Cancel drain on a session |
 
 ## gc runtime drain
@@ -1984,18 +1984,25 @@ gc runtime drain-check [name]
 
 Signal the controller to stop and restart this session.
 
-Sets GC_RESTART_REQUESTED metadata on the session, then blocks forever.
-The controller will stop the session on its next reconcile tick and
-restart it fresh. The blocking prevents the agent from consuming more
-context while waiting.
+Sets GC_RESTART_REQUESTED metadata on the session, then waits while the
+controller stops the session on its next reconcile tick and restarts it
+fresh. The wait keeps the agent idle so it does not consume more context
+in the interim.
 
-For on-demand configured named sessions, the controller cannot restart the
-user-attended process. In that case this command reports that restart was
-skipped and returns without blocking. No session.draining event is emitted
-when restart is skipped.
+Under normal operation the controller SIGKILLs the process tree before
+this command returns. If the controller accepts the stop handoff, the
+runtime is already gone, or a SIGINT/SIGTERM is received, the command
+exits 0 cleanly. If the controller has not acted within a bounded
+timeout (max(5*PatrolInterval, 5min), capped at 30min) the command exits
+1 with a diagnostic pointing at controller health.
+
+For on-demand configured named sessions, the controller cannot restart
+the user-attended process. In that case this command reports that
+restart was skipped and returns immediately. No session.draining event
+is emitted when restart is skipped.
 
 This command is designed to be called from within a session context.
-It emits a session.draining event before blocking.
+It emits a session.draining event before waiting.
 
 ```
 gc runtime request-restart


### PR DESCRIPTION
## Summary

`gc runtime request-restart` ended in `select {}` (cmd_runtime_drain.go:462), a textbook Go deadlock-detector trip. Two failure modes:

1. **Go runtime panics** with `fatal error: all goroutines are asleep - deadlock!` when no other goroutines have observable progress, dumping a stack trace that Cobra renders on top of its usage banner.
2. **No exit when the controller doesn't act** — if the controller is dead, paused, or this command was invoked outside a controller-managed context, the process hangs indefinitely with no diagnostic.

This was filed twice as separate issues (`hq-qwg9b`, `hq-zl5eo` in the SafetyChain HQ tracker) before being recognized as one root cause.

## Fix

Replace the bare `select {}` with a bounded poll-and-signal loop in `doRuntimeRequestRestart`:

- **Poll** \`dops.isRestartRequested(sn)\` on a 1s ticker. When the reconciler clears the flag (session_reconciler.go ~L578 — its way of signaling "I've decided to kill this session") → exit 0 cleanly.
- **Signal handling** via \`signal.NotifyContext(ctx, SIGINT, SIGTERM)\` → exit 0, leave the flag set so the controller still acts on its next tick.
- **Bounded timeout** = \`max(5 * Daemon.PatrolInterval, 5min)\`, capped at 30min. After that → exit 1 with stderr: \`controller did not act within X; check 'gc dashboard' or 'gc trace'\`.

The new exit paths only fire when the existing design hangs. Under normal operation the controller still SIGKILLs the process tree before the poll observes the cleared flag — same observable behavior as today.

The bead-metadata path (\`session.Metadata["restart_requested"]\`) is untouched; the reconciler still picks it up across tmux death.

## Tests

Four new tests in \`cmd_runtime_drain_test.go\`:

- \`TestDoRuntimeRequestRestartError\` (signature update) — error path returns 1 with diagnostic
- \`TestDoRuntimeRequestRestartFlagCleared\` — concurrent-safe via \`atomic.Int32\` countdown; flag flips to false → exit 0, no stderr
- \`TestDoRuntimeRequestRestartTimeout\` — timeout fires → exit 1, stderr contains \"controller did not act within\" and \"gc dashboard\"
- \`TestDoRuntimeRequestRestartContextCancel\` — goroutine + context cancel → exit 0, flag remains set

\`session_lifecycle_chaos_test.go\` continues to pass without modification (it sets the bead-metadata flag, not the runtime flag, so its path is independent of \`doRuntimeRequestRestart\`'s poll loop).

\`cmd_handoff_test.go\` continues to pass (handoff calls \`setRestartRequested\` directly without invoking \`doRuntimeRequestRestart\`).

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./cmd/gc/...\` passes (drain unit tests verified locally)
- [ ] CI green
- [ ] Manually exercise the timeout path: stop the controller, run \`gc runtime request-restart\` from a managed session, confirm a diagnostic exit (not a Go stack dump)