### PR TITLE
chore: reduce workflow token permissions

### DIFF
--- a/.github/workflows/close-stale-needs.yml
+++ b/.github/workflows/close-stale-needs.yml
@@ -5,6 +5,8 @@ on:
     - cron: '37 9 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   close-needs-info:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,15 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: {}
 
 jobs:
   release:
     name: Release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -59,6 +58,10 @@ jobs:
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -108,6 +111,8 @@ jobs:
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     needs: [release, attest-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       HAS_HOMEBREW_APP: ${{ secrets.HOMEBREW_TAP_APP_ID != '' && secrets.HOMEBREW_TAP_APP_PRIVATE_KEY != '' }}
       HAS_HOMEBREW_PAT: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}

--- a/.github/workflows/remove-needs-info.yml
+++ b/.github/workflows/remove-needs-info.yml
@@ -6,12 +6,15 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions: {}
+
 jobs:
+  # pull_request_target is safe here because this job never checks out or runs
+  # pull request code; it only removes labels from the issue/PR metadata.
   remove-label:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Remove needs-info / needs-repro on author response
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/remove-needs-triage.yml
+++ b/.github/workflows/remove-needs-triage.yml
@@ -6,12 +6,15 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions: {}
+
 jobs:
+  # pull_request_target is safe here because this job never checks out or runs
+  # pull request code; it only removes labels from the issue/PR metadata.
   remove-triage-label:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Remove needs-triage when a non-status label is added
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -6,12 +6,15 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
+permissions: {}
+
 jobs:
+  # pull_request_target is safe here because this job never checks out or runs
+  # pull request code; it only labels the issue/PR from event metadata.
   add-triage-label:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Add needs-triage label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
## Summary
- move release workflow write scopes from workflow-wide defaults to the specific jobs that publish, attest, or read release assets
- default metadata-label workflows to `permissions: {}` and grant only `issues: write` where label changes are needed
- document that `pull_request_target` label workflows do not checkout or run PR code

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/triage-label.yml .github/workflows/remove-needs-info.yml .github/workflows/remove-needs-triage.yml .github/workflows/close-stale-needs.yml .github/workflows/release.yml`
- `git diff --check`