### PR TITLE
fix(hooks): log on_close hook failures instead of swallowing them

### DIFF
--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -16,19 +16,36 @@ var beadHooks = map[string]string{
 }
 
 // hookScript returns the shell script content for a bd hook that forwards
-// events to the Gas City event log via gc event emit.
+// events to the Gas City event log via gc event emit. Failures are
+// captured to ${BEADS_DIR}/hooks.log so silent breakage (missing gc on
+// PATH, store-resolution errors) is diagnosable after the fact.
 func hookScript(eventType string) string {
 	return fmt.Sprintf(`#!/bin/sh
 # Installed by gc — forwards bd events to Gas City event log.
 # Args: $1=issue_id  $2=event_type  stdin=issue JSON
 GC_BIN="${GC_BIN:-gc}"
+HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"
 DATA=$(cat)
 PAYLOAD=$(printf '{"bead":%%s}' "$DATA")
 title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
 (
-  "$GC_BIN" event emit %s --subject "$1" --message "$title" --payload "$PAYLOAD" >/dev/null 2>&1 || true
+  "$GC_BIN" event emit %[1]s --subject "$1" --message "$title" --payload "$PAYLOAD" 2>>"$HOOK_LOG" \
+    || echo "[$(date -u +%%FT%%TZ)] %[2]s $1: gc event emit %[1]s failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
+    || true
 ) </dev/null >/dev/null 2>&1 &
-`, eventType)
+`, eventType, hookNameFromEventType(eventType))
+}
+
+// hookNameFromEventType maps event types back to the hook filename
+// (e.g. "bead.created" → "on_create") so diagnostic log lines name the
+// hook the operator can grep for.
+func hookNameFromEventType(eventType string) string {
+	for hook, evt := range beadHooks {
+		if evt == eventType {
+			return hook
+		}
+	}
+	return "hook"
 }
 
 // closeHookScript returns the on_close hook script. It forwards the
@@ -36,21 +53,33 @@ title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
 // parent convoy (if any), and auto-closes any open molecule/wisp
 // children attached to the closed bead. Workflow-control watches the city
 // event stream directly, so the close hook no longer sends a separate poke.
+//
+// Failures of any of the three gc invocations are logged with a dated
+// diagnostic line to ${BEADS_DIR}/hooks.log. Without this, missing gc
+// or a store-resolution error here leaves no record at all and the
+// cascade-close of sling scaffolding fails invisibly.
 func closeHookScript() string {
 	return `#!/bin/sh
 # Installed by gc — forwards bd close events, auto-closes completed convoys,
 # and auto-closes orphaned wisps.
 # Args: $1=issue_id  $2=event_type  stdin=issue JSON
 GC_BIN="${GC_BIN:-gc}"
+HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"
 DATA=$(cat)
 PAYLOAD=$(printf '{"bead":%s}' "$DATA")
 title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
 (
-  "$GC_BIN" event emit bead.closed --subject "$1" --message "$title" --payload "$PAYLOAD" >/dev/null 2>&1 || true
+  "$GC_BIN" event emit bead.closed --subject "$1" --message "$title" --payload "$PAYLOAD" 2>>"$HOOK_LOG" \
+    || echo "[$(date -u +%FT%TZ)] on_close $1: gc event emit bead.closed failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
+    || true
   # Auto-close parent convoy if all siblings are now closed.
-  "$GC_BIN" convoy autoclose "$1" >/dev/null 2>&1 || true
+  "$GC_BIN" convoy autoclose "$1" 2>>"$HOOK_LOG" \
+    || echo "[$(date -u +%FT%TZ)] on_close $1: gc convoy autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
+    || true
   # Auto-close open molecule/wisp children so they don't outlive the parent.
-  "$GC_BIN" wisp autoclose "$1" >/dev/null 2>&1 || true
+  "$GC_BIN" wisp autoclose "$1" 2>>"$HOOK_LOG" \
+    || echo "[$(date -u +%FT%TZ)] on_close $1: gc wisp autoclose failed (gc=$GC_BIN)" >>"$HOOK_LOG" 2>/dev/null \
+    || true
 ) </dev/null >/dev/null 2>&1 &
 `
 }

--- a/cmd/gc/hooks_test.go
+++ b/cmd/gc/hooks_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -69,6 +70,17 @@ func TestInstallBeadHooksCreatesScripts(t *testing.T) {
 			}
 			if !strings.Contains(content, `) </dev/null >/dev/null 2>&1 &`) {
 				t.Errorf("hook %s missing detached background redirect:\n%s", tc.filename, content)
+			}
+			// Failure diagnostics: stderr captured to a log file, and
+			// non-zero exit produces a dated diagnostic line.
+			if !strings.Contains(content, `HOOK_LOG="${BEADS_DIR:-.beads}/hooks.log"`) {
+				t.Errorf("hook %s missing HOOK_LOG definition:\n%s", tc.filename, content)
+			}
+			if !strings.Contains(content, `2>>"$HOOK_LOG"`) {
+				t.Errorf("hook %s does not capture gc stderr to HOOK_LOG:\n%s", tc.filename, content)
+			}
+			if !strings.Contains(content, `>>"$HOOK_LOG" 2>/dev/null`) {
+				t.Errorf("hook %s missing failure-diagnostic echo into HOOK_LOG:\n%s", tc.filename, content)
 			}
 			// on_close hook must also trigger convoy autoclose and wisp autoclose.
 			if tc.filename == "on_close" {
@@ -205,6 +217,67 @@ func TestInstallBeadHooksInitIntegration(t *testing.T) {
 	hookPath := filepath.Join(cityPath, ".beads", "hooks", "on_create")
 	if _, err := os.Stat(hookPath); err != nil {
 		t.Errorf("gc init did not install bd hooks: %v", err)
+	}
+}
+
+// TestCloseHookLogsFailureDiagnostic runs the installed on_close hook
+// under sh with a deliberately broken GC_BIN and asserts that a dated
+// diagnostic line lands in BEADS_DIR/hooks.log for each of the three
+// gc invocations the hook is supposed to make. This is the visibility
+// gap the script's `>/dev/null 2>&1 || true` pattern hid.
+func TestCloseHookLogsFailureDiagnostic(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	dir := t.TempDir()
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("installBeadHooks: %v", err)
+	}
+	hookPath := filepath.Join(dir, ".beads", "hooks", "on_close")
+	beadsDir := filepath.Join(dir, ".beads")
+
+	cmd := exec.Command("sh", hookPath, "test-bead-id", "bead.closed")
+	cmd.Stdin = strings.NewReader(`{"title":"hook diagnostic test"}`)
+	cmd.Env = append(os.Environ(),
+		"GC_BIN=/nonexistent/gc-bin-for-test",
+		"BEADS_DIR="+beadsDir,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hook exec failed: %v\nout: %s", err, out)
+	}
+
+	// Hook detaches into background; poll briefly for the log to be flushed.
+	logPath := filepath.Join(beadsDir, "hooks.log")
+	deadline := time.Now().Add(3 * time.Second)
+	var content string
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(logPath)
+		if err == nil && len(data) > 0 {
+			content = string(data)
+			// Wait until all three failure markers have been emitted, since
+			// the three gc calls run sequentially.
+			if strings.Contains(content, "gc event emit") &&
+				strings.Contains(content, "gc convoy autoclose") &&
+				strings.Contains(content, "gc wisp autoclose") {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if content == "" {
+		t.Fatalf("hooks.log not written or empty under %s", beadsDir)
+	}
+	for _, want := range []string{
+		"test-bead-id",
+		"/nonexistent/gc-bin-for-test",
+		"gc event emit bead.closed failed",
+		"gc convoy autoclose failed",
+		"gc wisp autoclose failed",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("hooks.log missing %q:\n%s", want, content)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The bd `on_close` hook is the only mechanism that cascade-closes sling
scaffolding (auto-convoy + molecule root + step beads) when a work bead
closes. Today every `gc` invocation in the hook redirects stderr to
`/dev/null` and swallows non-zero exits with `|| true`, and the whole
subshell is launched with `</dev/null >/dev/null 2>&1 &`. If any of the
three commands fails — `gc` not on the hook subshell's PATH,
`BEADS_DIR`/`GC_STORE_ROOT` not propagated to the subshell, transient
panic — there is no log entry, no event emit, no exit code surfaced to
bd. Operators see leaked sling scaffolding with **zero diagnostic
record** to distinguish "hook never fired" from "hook fired but `gc`
broke".

This PR captures each `gc` command's stderr to
`${BEADS_DIR:-.beads}/hooks.log`, and on non-zero exit appends a single
dated diagnostic line naming the hook, the bead id, the failed command,
and the resolved `$GC_BIN`. The leading `&` is preserved so `bd close`
remains non-blocking. The trailing `|| true` chain is preserved so a
logging-write failure (e.g. unwritable log path) can't propagate to bd.

The same treatment is applied to the `on_create` / `on_update`
generator for consistency.

## Test plan

- [x] `TestInstallBeadHooksCreatesScripts` — extended with assertions
  for `HOOK_LOG` definition, stderr-to-log redirect, and the
  failure-diagnostic echo into `HOOK_LOG`.
- [x] `TestCloseHookLogsFailureDiagnostic` (new) — actually runs the
  installed `on_close` hook under `sh` with `GC_BIN=/nonexistent/...`
  and asserts a dated diagnostic for **each** of the three gc calls
  (`event emit`, `convoy autoclose`, `wisp autoclose`) lands in
  `${BEADS_DIR}/hooks.log`. Without the fix, the test fails because
  the file is never written.
- [x] `go vet ./cmd/gc/...` clean.
- [x] `go build ./cmd/gc/...` clean.
- [x] `go test ./cmd/gc/ -run "TestInstallBead|TestCloseHook|TestHook|TestLifecycle"` passes.

## Notes

- Out of scope: changing **why** the hook subshell sometimes loses
  PATH or `GC_STORE_ROOT`. That's the next investigation, but it
  cannot start until failures are visible.
- Out of scope: the orthogonal close-validator-rejects-blocked-deps
  bug in `molecule.CloseSubtree` (filed separately as #1418, fix in
  separate PR).
- Out of scope: auto-closing molecule roots when step children close
  (issue #1039's territory).

Closes #1417