### PR TITLE
fix(molecule): close subtree in topological order so step blocks chain doesn't reject batch

### DIFF
--- a/internal/beads/closeorder/closeorder.go
+++ b/internal/beads/closeorder/closeorder.go
@@ -1,0 +1,84 @@
+// Package closeorder computes blocker-first close batches for bead stores.
+package closeorder
+
+import (
+	"fmt"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// Order returns ids reordered so that, for any "blocks" edge whose blocker and
+// blocked bead are both in ids, the blocker appears first. Input order is the
+// priority among nodes that are not constrained relative to each other. Cycles
+// or otherwise unresolvable nodes are appended in input order so the close
+// cascade never deadlocks.
+func Order(store beads.Store, ids []string) ([]string, error) {
+	if store == nil || len(ids) <= 1 {
+		return ids, nil
+	}
+
+	inSet := make(map[string]bool, len(ids))
+	priority := make(map[string]int, len(ids))
+	for i, id := range ids {
+		inSet[id] = true
+		priority[id] = i
+	}
+
+	blockedBy := make(map[string]map[string]struct{}, len(ids))
+	for _, id := range ids {
+		deps, err := store.DepList(id, "down")
+		if err != nil {
+			return nil, fmt.Errorf("listing close dependencies for %q: %w", id, err)
+		}
+		for _, d := range deps {
+			if d.IssueID != id || d.Type != "blocks" {
+				continue
+			}
+			if !inSet[d.DependsOnID] || d.DependsOnID == id {
+				continue
+			}
+			if blockedBy[id] == nil {
+				blockedBy[id] = make(map[string]struct{})
+			}
+			blockedBy[id][d.DependsOnID] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(ids))
+	emitted := make(map[string]bool, len(ids))
+	for len(out) < len(ids) {
+		var pick string
+		pickPrio := -1
+		for _, id := range ids {
+			if emitted[id] {
+				continue
+			}
+			ready := true
+			for blocker := range blockedBy[id] {
+				if !emitted[blocker] {
+					ready = false
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			if pick == "" || priority[id] < pickPrio {
+				pick = id
+				pickPrio = priority[id]
+			}
+		}
+		if pick == "" {
+			for _, id := range ids {
+				if !emitted[id] {
+					out = append(out, id)
+					emitted[id] = true
+				}
+			}
+			break
+		}
+		out = append(out, pick)
+		emitted[pick] = true
+	}
+	return out, nil
+}

--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -64,9 +64,14 @@ func ListSubtree(store beads.Store, rootID string) ([]beads.Bead, error) {
 	return out, nil
 }
 
-// CloseSubtree closes the root bead and every open descendant. Descendants are
-// closed before the root so stores with stricter parent/child close rules can
-// still accept the operation.
+// CloseSubtree closes the root bead and every open descendant.
+// Descendants are closed before the root so stores with stricter
+// parent/child close rules can still accept the operation. Within the
+// open set, closes are emitted in topological order honoring "blocks"
+// dependency edges between subtree members (blockers first), so that
+// the bd close validator does not reject a bead while its in-batch
+// blocker is still open. Parent/child depth (deepest first) is used as
+// the tie-breaker when no blocks edge constrains the order.
 func CloseSubtree(store beads.Store, rootID string) (int, error) {
 	matched, err := ListSubtree(store, rootID)
 	if err != nil {
@@ -122,5 +127,96 @@ func CloseSubtree(store beads.Store, rootID string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	return store.CloseAll(ids, nil)
+	ordered := orderForClose(store, ids)
+	return store.CloseAll(ordered, nil)
+}
+
+// orderForClose returns ids reordered so that, for any "blocks" edge
+// whose blocker and blocked are both in ids, the blocker appears
+// first. Input order is treated as the priority among nodes that are
+// not constrained relative to each other (preserving the depth-then-id
+// tie-break the caller computed). Cycles or unresolvable nodes are
+// appended in input order so the cascade never deadlocks.
+func orderForClose(store beads.Store, ids []string) []string {
+	if len(ids) <= 1 {
+		return ids
+	}
+	inSet := make(map[string]bool, len(ids))
+	priority := make(map[string]int, len(ids))
+	for i, id := range ids {
+		inSet[id] = true
+		priority[id] = i
+	}
+	// blockedBy[x] = ids in the batch that x must wait for (blockers).
+	// blocks[x]    = ids in the batch that x is a blocker for.
+	blockedBy := make(map[string]map[string]struct{}, len(ids))
+	blocks := make(map[string]map[string]struct{}, len(ids))
+	for _, id := range ids {
+		deps, err := store.DepList(id, "down")
+		if err != nil {
+			continue
+		}
+		for _, d := range deps {
+			if d.IssueID != id || d.Type != "blocks" {
+				continue
+			}
+			if !inSet[d.DependsOnID] {
+				continue
+			}
+			if d.DependsOnID == id {
+				continue
+			}
+			if blockedBy[id] == nil {
+				blockedBy[id] = make(map[string]struct{})
+			}
+			blockedBy[id][d.DependsOnID] = struct{}{}
+			if blocks[d.DependsOnID] == nil {
+				blocks[d.DependsOnID] = make(map[string]struct{})
+			}
+			blocks[d.DependsOnID][id] = struct{}{}
+		}
+	}
+	// Kahn's algorithm: repeatedly emit a node with no remaining
+	// in-batch blockers, breaking ties on the caller-supplied priority
+	// (depth-descending, id-ascending).
+	out := make([]string, 0, len(ids))
+	emitted := make(map[string]bool, len(ids))
+	for len(out) < len(ids) {
+		var pick string
+		pickPrio := -1
+		for _, id := range ids {
+			if emitted[id] {
+				continue
+			}
+			ready := true
+			for blocker := range blockedBy[id] {
+				if !emitted[blocker] {
+					ready = false
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			if pick == "" || priority[id] < pickPrio {
+				pick = id
+				pickPrio = priority[id]
+			}
+		}
+		if pick == "" {
+			// Cycle (or unresolvable graph): append remaining nodes in
+			// input order. CloseAll will still try them; the bd
+			// validator may reject some, but we never deadlock here.
+			for _, id := range ids {
+				if !emitted[id] {
+					out = append(out, id)
+					emitted[id] = true
+				}
+			}
+			break
+		}
+		out = append(out, pick)
+		emitted[pick] = true
+	}
+	return out
 }

--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/closeorder"
 )
 
 // ListSubtree returns the root bead and all transitive parent-child
@@ -68,10 +69,10 @@ func ListSubtree(store beads.Store, rootID string) ([]beads.Bead, error) {
 // Descendants are closed before the root so stores with stricter
 // parent/child close rules can still accept the operation. Within the
 // open set, closes are emitted in topological order honoring "blocks"
-// dependency edges between subtree members (blockers first), so that
-// the bd close validator does not reject a bead while its in-batch
-// blocker is still open. Parent/child depth (deepest first) is used as
-// the tie-breaker when no blocks edge constrains the order.
+// dependency edges between subtree members (blockers first), so strict
+// stores do not reject a bead while its in-batch blocker is still open.
+// Parent/child depth (deepest first) is used as the tie-breaker when no
+// blocks edge constrains the order.
 func CloseSubtree(store beads.Store, rootID string) (int, error) {
 	matched, err := ListSubtree(store, rootID)
 	if err != nil {
@@ -127,96 +128,9 @@ func CloseSubtree(store beads.Store, rootID string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	ordered := orderForClose(store, ids)
+	ordered, err := closeorder.Order(store, ids)
+	if err != nil {
+		return 0, err
+	}
 	return store.CloseAll(ordered, nil)
-}
-
-// orderForClose returns ids reordered so that, for any "blocks" edge
-// whose blocker and blocked are both in ids, the blocker appears
-// first. Input order is treated as the priority among nodes that are
-// not constrained relative to each other (preserving the depth-then-id
-// tie-break the caller computed). Cycles or unresolvable nodes are
-// appended in input order so the cascade never deadlocks.
-func orderForClose(store beads.Store, ids []string) []string {
-	if len(ids) <= 1 {
-		return ids
-	}
-	inSet := make(map[string]bool, len(ids))
-	priority := make(map[string]int, len(ids))
-	for i, id := range ids {
-		inSet[id] = true
-		priority[id] = i
-	}
-	// blockedBy[x] = ids in the batch that x must wait for (blockers).
-	// blocks[x]    = ids in the batch that x is a blocker for.
-	blockedBy := make(map[string]map[string]struct{}, len(ids))
-	blocks := make(map[string]map[string]struct{}, len(ids))
-	for _, id := range ids {
-		deps, err := store.DepList(id, "down")
-		if err != nil {
-			continue
-		}
-		for _, d := range deps {
-			if d.IssueID != id || d.Type != "blocks" {
-				continue
-			}
-			if !inSet[d.DependsOnID] {
-				continue
-			}
-			if d.DependsOnID == id {
-				continue
-			}
-			if blockedBy[id] == nil {
-				blockedBy[id] = make(map[string]struct{})
-			}
-			blockedBy[id][d.DependsOnID] = struct{}{}
-			if blocks[d.DependsOnID] == nil {
-				blocks[d.DependsOnID] = make(map[string]struct{})
-			}
-			blocks[d.DependsOnID][id] = struct{}{}
-		}
-	}
-	// Kahn's algorithm: repeatedly emit a node with no remaining
-	// in-batch blockers, breaking ties on the caller-supplied priority
-	// (depth-descending, id-ascending).
-	out := make([]string, 0, len(ids))
-	emitted := make(map[string]bool, len(ids))
-	for len(out) < len(ids) {
-		var pick string
-		pickPrio := -1
-		for _, id := range ids {
-			if emitted[id] {
-				continue
-			}
-			ready := true
-			for blocker := range blockedBy[id] {
-				if !emitted[blocker] {
-					ready = false
-					break
-				}
-			}
-			if !ready {
-				continue
-			}
-			if pick == "" || priority[id] < pickPrio {
-				pick = id
-				pickPrio = priority[id]
-			}
-		}
-		if pick == "" {
-			// Cycle (or unresolvable graph): append remaining nodes in
-			// input order. CloseAll will still try them; the bd
-			// validator may reject some, but we never deadlock here.
-			for _, id := range ids {
-				if !emitted[id] {
-					out = append(out, id)
-					emitted[id] = true
-				}
-			}
-			break
-		}
-		out = append(out, pick)
-		emitted[pick] = true
-	}
-	return out
 }

--- a/internal/molecule/cleanup_test.go
+++ b/internal/molecule/cleanup_test.go
@@ -23,10 +23,10 @@ func (b *blockValidatingStore) Close(id string) error {
 	return b.Store.Close(id)
 }
 
-func (b *blockValidatingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+func (b *blockValidatingStore) CloseAll(ids []string, _ map[string]string) (int, error) {
 	closed := 0
 	for _, id := range ids {
-		bead, err := b.Store.Get(id)
+		bead, err := b.Get(id)
 		if err != nil {
 			return closed, err
 		}
@@ -45,7 +45,7 @@ func (b *blockValidatingStore) CloseAll(ids []string, metadata map[string]string
 }
 
 func (b *blockValidatingStore) assertNoOpenBlockers(id string) error {
-	deps, err := b.Store.DepList(id, "down")
+	deps, err := b.DepList(id, "down")
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (b *blockValidatingStore) assertNoOpenBlockers(id string) error {
 		if d.IssueID != id || d.Type != "blocks" {
 			continue
 		}
-		blocker, err := b.Store.Get(d.DependsOnID)
+		blocker, err := b.Get(d.DependsOnID)
 		if err != nil {
 			continue
 		}

--- a/internal/molecule/cleanup_test.go
+++ b/internal/molecule/cleanup_test.go
@@ -1,10 +1,68 @@
 package molecule
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
+
+// blockValidatingStore wraps a beads.Store and rejects Close (and the
+// per-id fallback inside CloseAll) when the target has any open
+// "blocks"-type blocker still in the store. This mirrors the bd CLI
+// close validator's upfront check, which is what production CloseSubtree
+// runs into when a subtree contains a blocks-chained step set.
+type blockValidatingStore struct {
+	beads.Store
+}
+
+func (b *blockValidatingStore) Close(id string) error {
+	if err := b.assertNoOpenBlockers(id); err != nil {
+		return err
+	}
+	return b.Store.Close(id)
+}
+
+func (b *blockValidatingStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	closed := 0
+	for _, id := range ids {
+		bead, err := b.Store.Get(id)
+		if err != nil {
+			return closed, err
+		}
+		if bead.Status == "closed" {
+			continue
+		}
+		if err := b.assertNoOpenBlockers(id); err != nil {
+			return closed, err
+		}
+		if err := b.Store.Close(id); err != nil {
+			return closed, err
+		}
+		closed++
+	}
+	return closed, nil
+}
+
+func (b *blockValidatingStore) assertNoOpenBlockers(id string) error {
+	deps, err := b.Store.DepList(id, "down")
+	if err != nil {
+		return err
+	}
+	for _, d := range deps {
+		if d.IssueID != id || d.Type != "blocks" {
+			continue
+		}
+		blocker, err := b.Store.Get(d.DependsOnID)
+		if err != nil {
+			continue
+		}
+		if blocker.Status != "closed" {
+			return fmt.Errorf("cannot close %s: blocked by open %s", id, d.DependsOnID)
+		}
+	}
+	return nil
+}
 
 func TestCloseSubtreeClosesOpenDescendantThroughClosedParent(t *testing.T) {
 	store := beads.NewMemStore()
@@ -83,6 +141,86 @@ func TestCloseSubtreeClosesLogicalRootMembersAndTheirChildren(t *testing.T) {
 			t.Fatalf("%s status = %q, want closed", id, b.Status)
 		}
 	}
+}
+
+// TestCloseSubtreeOrdersBlockersBeforeBlocked models the typical
+// formula step subtree: a molecule root with N child step beads chained
+// by depends_on. A real bd store rejects closing a bead while any of
+// its blockers is still open, even when the blocker is in the same
+// batch. CloseSubtree must emit closes in topological (blockers-first)
+// order; otherwise the validator rejects mid-cascade and leaves
+// orphaned step beads.
+//
+// To make this test exercise the topological-vs-id-order distinction
+// regardless of how MemStore assigns IDs, the chain is built so the
+// blocker-first execution order is the *reverse* of the natural
+// depth-then-id ordering CloseSubtree currently uses.
+func TestCloseSubtreeOrdersBlockersBeforeBlocked(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	// Create steps in *reverse* of execution order: the last-to-run
+	// (submit-and-exit) gets the smallest child ID, the first-to-run
+	// (load-context) gets the largest. The depth-only sort visits
+	// children ID-ascending, so it sees blocked beads before their
+	// blockers.
+	stepNames := []string{
+		"submit-and-exit",
+		"self-review",
+		"implement",
+		"preflight-tests",
+		"workspace-setup",
+		"load-context",
+	}
+	steps := make([]beads.Bead, 0, len(stepNames))
+	for _, name := range stepNames {
+		s, err := store.Create(beads.Bead{Title: name, ParentID: root.ID})
+		if err != nil {
+			t.Fatalf("create step %q: %v", name, err)
+		}
+		steps = append(steps, s)
+	}
+	// Each earlier-to-execute step is the blocker of the next-to-execute
+	// step (the classic depends_on chain a formula emits): load-context
+	// blocks workspace-setup blocks preflight-tests blocks implement
+	// blocks self-review blocks submit-and-exit.
+	for i := 0; i < len(steps)-1; i++ {
+		blocked := steps[i]   // later in execution
+		blocker := steps[i+1] // earlier in execution
+		if err := store.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd(%s blocks-on %s): %v", blocked.ID, blocker.ID, err)
+		}
+	}
+
+	guarded := &blockValidatingStore{Store: store}
+	closed, err := CloseSubtree(guarded, root.ID)
+	if err != nil {
+		t.Fatalf("CloseSubtree: %v", err)
+	}
+	wantClosed := 1 + len(steps)
+	if closed != wantClosed {
+		t.Fatalf("CloseSubtree closed %d beads, want %d", closed, wantClosed)
+	}
+
+	for _, id := range append([]string{root.ID}, idsOf(steps)...) {
+		b, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if b.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, b.Status)
+		}
+	}
+}
+
+func idsOf(bs []beads.Bead) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.ID
+	}
+	return out
 }
 
 func TestCloseSubtreeHandlesParentCycles(t *testing.T) {

--- a/internal/molecule/cleanup_test.go
+++ b/internal/molecule/cleanup_test.go
@@ -7,11 +7,10 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
-// blockValidatingStore wraps a beads.Store and rejects Close (and the
-// per-id fallback inside CloseAll) when the target has any open
-// "blocks"-type blocker still in the store. This mirrors the bd CLI
-// close validator's upfront check, which is what production CloseSubtree
-// runs into when a subtree contains a blocks-chained step set.
+// blockValidatingStore wraps a beads.Store and rejects CloseAll when the
+// target has any open "blocks"-type blocker still in the store. This models a
+// strict Store implementation so CloseSubtree's ordering contract stays covered
+// even when the concrete store permits force-closing blocked beads.
 type blockValidatingStore struct {
 	beads.Store
 }
@@ -145,11 +144,9 @@ func TestCloseSubtreeClosesLogicalRootMembersAndTheirChildren(t *testing.T) {
 
 // TestCloseSubtreeOrdersBlockersBeforeBlocked models the typical
 // formula step subtree: a molecule root with N child step beads chained
-// by depends_on. A real bd store rejects closing a bead while any of
-// its blockers is still open, even when the blocker is in the same
-// batch. CloseSubtree must emit closes in topological (blockers-first)
-// order; otherwise the validator rejects mid-cascade and leaves
-// orphaned step beads.
+// by depends_on. CloseSubtree must emit closes in topological
+// (blockers-first) order so strict stores can close the whole subtree in
+// one pass without rejecting a bead whose in-batch blocker is still open.
 //
 // To make this test exercise the topological-vs-id-order distinction
 // regardless of how MemStore assigns IDs, the chain is built so the
@@ -212,6 +209,35 @@ func TestCloseSubtreeOrdersBlockersBeforeBlocked(t *testing.T) {
 		if b.Status != "closed" {
 			t.Fatalf("%s status = %q, want closed", id, b.Status)
 		}
+	}
+}
+
+type depListFailingStore struct {
+	beads.Store
+	failID string
+}
+
+func (s *depListFailingStore) DepList(id, direction string) ([]beads.Dep, error) {
+	if id == s.failID {
+		return nil, fmt.Errorf("dependency list unavailable for %s", id)
+	}
+	return s.Store.DepList(id, direction)
+}
+
+func TestCloseSubtreeReturnsDepListError(t *testing.T) {
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	child, err := store.Create(beads.Bead{Title: "child", ParentID: root.ID})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	guarded := &depListFailingStore{Store: store, failID: child.ID}
+	if _, err := CloseSubtree(guarded, root.ID); err == nil {
+		t.Fatalf("CloseSubtree succeeded, want dependency list error")
 	}
 }
 

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/beads/closeorder"
 	"github.com/gastownhall/gascity/internal/citylayout"
 )
 
@@ -371,8 +372,10 @@ func ListWorkflowBeads(store beads.Store, rootID string) ([]beads.Bead, error) {
 }
 
 // CloseWorkflowSubtree closes the root and every open descendant of a
-// workflow, marking each gc.outcome=skipped. Returns the count of newly
-// closed beads.
+// workflow, marking each gc.outcome=skipped. It closes descendants before the
+// root and honors in-batch "blocks" dependencies so strict stores can close
+// workflow step chains without rejecting blocked-before-blocker order. Returns
+// the count of newly closed beads.
 func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 	matched, err := ListWorkflowBeads(store, rootID)
 	if err != nil {
@@ -427,7 +430,11 @@ func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	return store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
+	ordered, err := closeorder.Order(store, ids)
+	if err != nil {
+		return 0, err
+	}
+	return store.CloseAll(ordered, map[string]string{"gc.outcome": "skipped"})
 }
 
 // WorkflowBeadSnapshot captures the mutable fields of a workflow subtree

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -339,6 +339,52 @@ func (s *parentLastCloseStore) CloseAll(ids []string, metadata map[string]string
 	return s.MemStore.CloseAll(ids, metadata)
 }
 
+type blockValidatingWorkflowStore struct {
+	*beads.MemStore
+}
+
+func (s *blockValidatingWorkflowStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	closed := 0
+	for _, id := range ids {
+		bead, err := s.Get(id)
+		if err != nil {
+			return closed, err
+		}
+		if bead.Status == "closed" {
+			continue
+		}
+		if err := s.assertNoOpenBlockers(id); err != nil {
+			return closed, err
+		}
+		n, err := s.MemStore.CloseAll([]string{id}, metadata)
+		closed += n
+		if err != nil {
+			return closed, err
+		}
+	}
+	return closed, nil
+}
+
+func (s *blockValidatingWorkflowStore) assertNoOpenBlockers(id string) error {
+	deps, err := s.DepList(id, "down")
+	if err != nil {
+		return err
+	}
+	for _, d := range deps {
+		if d.IssueID != id || d.Type != "blocks" {
+			continue
+		}
+		blocker, err := s.Get(d.DependsOnID)
+		if err != nil {
+			continue
+		}
+		if blocker.Status != "closed" {
+			return fmt.Errorf("cannot close %s: blocked by open %s", id, d.DependsOnID)
+		}
+	}
+	return nil
+}
+
 func TestCloseWorkflowSubtreeClosesDeepestChildrenFirst(t *testing.T) {
 	store := &parentLastCloseStore{MemStore: beads.NewMemStore()}
 
@@ -387,6 +433,80 @@ func TestCloseWorkflowSubtreeClosesDeepestChildrenFirst(t *testing.T) {
 			t.Fatalf("bead %s status = %q, want closed", id, bead.Status)
 		}
 	}
+}
+
+func TestCloseWorkflowSubtreeOrdersBlockersBeforeBlocked(t *testing.T) {
+	store := &blockValidatingWorkflowStore{MemStore: beads.NewMemStore()}
+
+	root, err := store.Create(beads.Bead{
+		Title: "root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind": "workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	stepNames := []string{
+		"submit-and-exit",
+		"self-review",
+		"implement",
+		"preflight-tests",
+		"workspace-setup",
+		"load-context",
+	}
+	steps := make([]beads.Bead, 0, len(stepNames))
+	for _, name := range stepNames {
+		step, err := store.Create(beads.Bead{
+			Title:    name,
+			Type:     "task",
+			ParentID: root.ID,
+			Metadata: map[string]string{
+				"gc.root_bead_id": root.ID,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+		steps = append(steps, step)
+	}
+	for i := 0; i < len(steps)-1; i++ {
+		blocked := steps[i]
+		blocker := steps[i+1]
+		if err := store.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd(%s blocks-on %s): %v", blocked.ID, blocker.ID, err)
+		}
+	}
+
+	closed, err := CloseWorkflowSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseWorkflowSubtree: %v", err)
+	}
+	wantClosed := 1 + len(steps)
+	if closed != wantClosed {
+		t.Fatalf("CloseWorkflowSubtree closed %d beads, want %d", closed, wantClosed)
+	}
+	for _, id := range append([]string{root.ID}, workflowIDsOf(steps)...) {
+		bead, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if bead.Status != "closed" {
+			t.Fatalf("bead %s status = %q, want closed", id, bead.Status)
+		}
+		if got := bead.Metadata["gc.outcome"]; got != "skipped" {
+			t.Fatalf("bead %s gc.outcome = %q, want skipped", id, got)
+		}
+	}
+}
+
+func workflowIDsOf(bs []beads.Bead) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.ID
+	}
+	return out
 }
 
 func TestCloseWorkflowSubtreeHandlesParentCycles(t *testing.T) {


### PR DESCRIPTION
## Summary

`molecule.CloseSubtree` (`internal/molecule/cleanup.go`) sorted
descendants by parent-child depth only, then handed every open ID to
`store.CloseAll` in one batch. Step beads from formulas commonly carry
an internal `blocks` chain between siblings (e.g.
`load-context → workspace-setup → ... → submit-and-exit`), so the
depth-only ordering routinely visited a blocked bead before its blocker.
The bd close validator rejects any bead whose blocker is still open,
even when the blocker is in the same batch — and `BdStore.CloseAll`'s
per-id fallback walks the same wrong order. Net effect: the cascade
aborts mid-way and leaves orphaned step beads, which is the most common
failure mode for the auto-cleanup the on_close hook is supposed to do.

This PR adds `orderForClose`: a Kahn-style topological reordering that
honors `blocks` edges restricted to the in-batch set, using the
existing depth-then-id ordering as the priority among unconstrained
nodes (so behavior is unchanged for subtrees with no internal blocks
deps). Cycles fall back to input order so the cascade never deadlocks.
The reordered IDs are then passed to `store.CloseAll`; both the batch
path and the per-id fallback succeed because every bead's in-batch
blockers are already closed by the time it is presented to bd.

## Test plan

- [x] `TestCloseSubtreeOrdersBlockersBeforeBlocked` (new) constructs a
  6-step chain modeling `mol-polecat-work` and uses a test-local
  `blockValidatingStore` wrapper that mirrors the bd CLI's
  reject-close-while-blocked check. Steps are created in **reverse**
  of execution order so the depth-then-id order is the *opposite* of
  topological order — exposing the bug regardless of MemStore's id
  assignment scheme. Without the fix the test reports
  `cannot close gc-2: blocked by open gc-3`. With the fix it passes.
- [x] Existing `TestCloseSubtreeClosesOpenDescendantThroughClosedParent`,
  `TestCloseSubtreeClosesLogicalRootMembersAndTheirChildren`,
  `TestCloseSubtreeHandlesParentCycles` all still pass — the topo
  reorder is a no-op for subtrees without internal `blocks` edges.
- [x] `go vet ./internal/molecule/...` clean.
- [x] `go build ./internal/molecule/...` clean.
- [x] `go test ./internal/beads/...` (incl. exec) all pass.

## Notes

- The `blockValidatingStore` wrapper is test-local (in
  `cleanup_test.go`); no behavior change to `MemStore` itself, so other
  callers and tests are unaffected.
- Out of scope: changing `BdStore.CloseAll` to detect blocked-by errors
  on individual fallback closes and retry. With this ordering fix the
  fallback walks the right order, so the existing per-id fallback
  succeeds without further change.
- Out of scope: the orthogonal hook-silently-fails bug (#1417, fix in
  separate PR #1419). Either bug independently breaks the cascade —
  both fixes are needed for clean sling cleanup.

Closes #1418