### PR TITLE
fix: witness + deacon prime templates pour next wisp at end of cycle (gc-0wu)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1551,6 +1551,63 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 	}
 }
 
+func TestGastownPatrolPromptFallbackPreservesLifecycle(t *testing.T) {
+	checks := []struct {
+		rel       string
+		agentName string
+		template  string
+		formula   string
+		pourLine  string
+	}{
+		{
+			rel:       "packs/gastown/agents/deacon/prompt.template.md",
+			agentName: "gascity/gastown.deacon",
+			template:  "deacon",
+			formula:   "mol-deacon-patrol",
+			pourLine:  `NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix=gastown. --json | jq -r '.new_epic_id // empty')`,
+		},
+		{
+			rel:       "packs/gastown/agents/witness/prompt.template.md",
+			agentName: "gascity/gastown.witness",
+			template:  "witness",
+			formula:   "mol-witness-patrol",
+			pourLine:  `NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='gastown.' --json | jq -r '.new_epic_id // empty')`,
+		},
+	}
+
+	for _, check := range checks {
+		body := renderGastownPromptForPack(t, check.rel, check.agentName, check.template, "gascity", "gastown", "gastown.")
+		section := sectionBetween(t, body, "## CRITICAL: No Idle State Between Cycles", "## Context Exhaustion")
+		assertContainsInOrder(t, section,
+			`run `+"`gc hook`"+` immediately`,
+			`CURRENT_WISP=${GC_BEAD_ID:-}`,
+			`if [ -z "$CURRENT_WISP" ]; then`,
+			`CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+			`ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')`,
+			`if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then`,
+			check.pourLine,
+			`if [ -z "$NEXT" ]; then`,
+			`if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then`,
+			`gc bd mol burn "$CURRENT_WISP" --force`,
+			`elif [ -n "$CURRENT_WISP" ]; then`,
+			`gc bd mol burn "$CURRENT_WISP" --force`,
+			`elif [ -z "$ASSIGNED_WISP" ]; then`,
+			check.pourLine,
+			`if [ -z "$NEXT" ]; then`,
+			`if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then`,
+			`gc hook`,
+		)
+		for _, bad := range []string{`--assignee="$GC_ALIAS"`, "sleep 5"} {
+			if strings.Contains(section, bad) {
+				t.Fatalf("%s no-idle fallback still contains %q", check.rel, bad)
+			}
+		}
+		if !strings.Contains(section, check.formula) {
+			t.Fatalf("%s no-idle fallback does not mention %s", check.rel, check.formula)
+		}
+	}
+}
+
 func TestRefineryPatrolRestartGuidanceAssignsSuccessor(t *testing.T) {
 	dir := exampleDir()
 	promptPath := filepath.Join(dir, "packs", "gastown", "agents", "refinery", "prompt.template.md")

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -76,7 +76,25 @@ gc bd formula show mol-deacon-patrol
 # Step 5: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration.**
+**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> return to Step 1.**
+
+## CRITICAL: No Idle State Between Cycles
+
+After every patrol cycle, the formula's `next-iteration` step pours the
+next `mol-deacon-patrol` wisp before burning the current one. When it
+finishes, run `gc hook` immediately — the new wisp is already assigned
+to you.
+
+**Do NOT enter "Standing by for the next hook" idle state.** That phrase
+is a bug indicator. If you ever find yourself about to print it, pour
+the next wisp first:
+
+```bash
+NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEXT" --assignee="$GC_ALIAS"
+```
+
+Then run `gc hook` to execute it immediately.
 
 ## Context Exhaustion
 

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -76,7 +76,7 @@ gc bd formula show mol-deacon-patrol
 # Step 5: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> return to Step 1.**
+**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration -> run `gc hook`.**
 
 ## CRITICAL: No Idle State Between Cycles
 
@@ -86,15 +86,42 @@ finishes, run `gc hook` immediately — the new wisp is already assigned
 to you.
 
 **Do NOT enter "Standing by for the next hook" idle state.** That phrase
-is a bug indicator. If you ever find yourself about to print it, pour
-the next wisp first:
+is a bug indicator. Use this fallback only if you exited the cycle
+without running `next-iteration` (crash recovery or formula misread).
+If `next-iteration` already ran, do not pour again; run `gc hook`.
 
 ```bash
-NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEXT" --assignee="$GC_ALIAS"
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+fi
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not pour next deacon wisp; not burning."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign next deacon wisp; not burning."
+    exit 1
+  fi
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -n "$CURRENT_WISP" ]; then
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not bootstrap next deacon wisp."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign bootstrap deacon wisp."
+    exit 1
+  fi
+fi
+gc hook
 ```
-
-Then run `gc hook` to execute it immediately.
 
 ## Context Exhaustion
 

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -166,7 +166,25 @@ gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 # Step 4: Execute — read formula steps and work through them in order
 ```
 
-**Hook -> Read formula steps -> Follow in order -> pour next iteration.**
+**Hook -> Read formula steps -> Follow in order -> pour next iteration -> return to Step 1.**
+
+## CRITICAL: No Idle State Between Cycles
+
+After every patrol cycle, the formula's `next-iteration` step pours the
+next `mol-witness-patrol` wisp before burning the current one. When it
+finishes, run `gc hook` immediately — the new wisp is already assigned
+to you.
+
+**Do NOT enter "Standing by for the next hook" idle state.** That phrase
+is a bug indicator. If you ever find yourself about to print it, pour
+the next wisp first:
+
+```bash
+NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+gc bd update "$NEXT" --assignee="$GC_ALIAS"
+```
+
+Then run `gc hook` to execute it immediately.
 
 ## Context Exhaustion
 

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -166,7 +166,7 @@ gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 # Step 4: Execute — read formula steps and work through them in order
 ```
 
-**Hook -> Read formula steps -> Follow in order -> pour next iteration -> return to Step 1.**
+**Hook -> Read formula steps -> Follow in order -> pour next iteration -> run `gc hook`.**
 
 ## CRITICAL: No Idle State Between Cycles
 
@@ -176,15 +176,42 @@ finishes, run `gc hook` immediately — the new wisp is already assigned
 to you.
 
 **Do NOT enter "Standing by for the next hook" idle state.** That phrase
-is a bug indicator. If you ever find yourself about to print it, pour
-the next wisp first:
+is a bug indicator. Use this fallback only if you exited the cycle
+without running `next-iteration` (crash recovery or formula misread).
+If `next-iteration` already ran, do not pour again; run `gc hook`.
 
 ```bash
-NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
-gc bd update "$NEXT" --assignee="$GC_ALIAS"
+CURRENT_WISP=${GC_BEAD_ID:-}
+if [ -z "$CURRENT_WISP" ]; then
+  CURRENT_WISP=$(gc bd list --assignee="$GC_AGENT" --status=in_progress --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+fi
+ASSIGNED_WISP=$(gc bd list --assignee="$GC_AGENT" --status=open --type=wisp --limit=1 --json | jq -r '.[0].id // empty')
+if [ -n "$CURRENT_WISP" ] && [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not pour next witness wisp; not burning."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign next witness wisp; not burning."
+    exit 1
+  fi
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -n "$CURRENT_WISP" ]; then
+  gc bd mol burn "$CURRENT_WISP" --force
+elif [ -z "$ASSIGNED_WISP" ]; then
+  NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id // empty')
+  if [ -z "$NEXT" ]; then
+    echo "Could not bootstrap next witness wisp."
+    exit 1
+  fi
+  if ! gc bd update "$NEXT" --assignee="$GC_AGENT"; then
+    echo "Could not assign bootstrap witness wisp."
+    exit 1
+  fi
+fi
+gc hook
 ```
-
-Then run `gc hook` to execute it immediately.
 
 ## Context Exhaustion
 


### PR DESCRIPTION
## Summary

Adds explicit cycle-loop instructions to the witness and deacon prime templates so those agents pour the next wisp immediately after each cycle completes, rather than entering an idle "Standing by for the next hook" state.

Fixes gc-635.

## Changes

- `examples/gastown/packs/gastown/agents/deacon/prompt.template.md`
- `examples/gastown/packs/gastown/agents/witness/prompt.template.md`

Both templates now include a CRITICAL section telling agents to run `gc hook` immediately after cycle completion, never enter idle state, and include the emergency pour command if needed.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./examples/... ./internal/agent/...` passes
- [ ] Witness/deacon agents observed to loop without idle stalls in a live city

🤖 Refined by gascity/refinery from polecat work [gc-0wu]