### PR TITLE
fix: ignore foreign bead cache events

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -213,7 +213,7 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 		}
 		return store
 	default: // "bd" or unrecognized
-		return bdStoreForRig(scopeRoot, cs.cityPath, cfg)
+		return bdStoreForRig(scopeRoot, cs.cityPath, cfg, prefix)
 	}
 }
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -429,6 +429,57 @@ func TestControllerStateAppliesCacheReconcileBeadEventsToStores(t *testing.T) {
 	}
 }
 
+func TestControllerStateBeadEventsRespectStorePrefixes(t *testing.T) {
+	cityBacking := beads.NewMemStore()
+	rigBacking := beads.NewMemStore()
+	cityCache := beads.NewCachingStoreForTestWithPrefix(cityBacking, "mc", nil)
+	rigCache := beads.NewCachingStoreForTestWithPrefix(rigBacking, "ga", nil)
+	for name, cache := range map[string]*beads.CachingStore{
+		"city": cityCache,
+		"rig":  rigCache,
+	} {
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime(%s): %v", name, err)
+		}
+	}
+
+	payload, err := json.Marshal(beads.Bead{
+		ID:     "mc-source",
+		Title:  "city source",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("marshal city bead: %v", err)
+	}
+	cs := &controllerState{
+		cityBeadStore: cityCache,
+		beadStores:    map[string]beads.Store{"gascity": rigCache},
+		pokeCh:        make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadCreated,
+		Actor:   "bd-hook",
+		Subject: "mc-source",
+		Payload: payload,
+	})
+
+	cityItems, err := cityCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List city cache: %v", err)
+	}
+	if len(cityItems) != 1 || cityItems[0].ID != "mc-source" {
+		t.Fatalf("city cache items = %+v, want mc-source", cityItems)
+	}
+	rigItems, err := rigCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List rig cache: %v", err)
+	}
+	if len(rigItems) != 0 {
+		t.Fatalf("rig cache items = %+v, want no city bead", rigItems)
+	}
+}
+
 func TestControllerStateBuildStoresUsesScopeLocalFileStores(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,14 +31,56 @@ func bdCommandRunnerForCity(cityPath string) beads.CommandRunner {
 }
 
 func bdStoreForCity(dir, cityPath string) *beads.BdStore {
-	return beads.NewBdStore(dir, bdCommandRunnerForCity(cityPath))
+	cfg, err := loadCityConfig(cityPath, io.Discard)
+	if err != nil {
+		cfg = nil
+	}
+	return beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
 }
 
 // bdStoreForRig opens a bead store at rigDir using rig-level Dolt config
 // when available, falling back to city-level config. Use this when the rig
 // may have its own Dolt server (e.g., shared from another city).
-func bdStoreForRig(rigDir, cityPath string, cfg *config.City) *beads.BdStore {
-	return beads.NewBdStore(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir))
+func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...string) *beads.BdStore {
+	prefix := ""
+	for _, candidate := range knownPrefix {
+		if strings.TrimSpace(candidate) != "" {
+			prefix = candidate
+			break
+		}
+	}
+	if prefix == "" {
+		prefix = issuePrefixForScope(rigDir, cityPath, cfg)
+	}
+	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+}
+
+func issuePrefixForScope(scopeRoot, cityPath string, cfg *config.City) string {
+	if prefix := readScopeIssuePrefix(scopeRoot); prefix != "" {
+		return prefix
+	}
+	if cfg == nil {
+		return ""
+	}
+	scopeRoot = filepath.Clean(scopeRoot)
+	if filepath.Clean(cityPath) == scopeRoot {
+		return config.EffectiveHQPrefix(cfg)
+	}
+	for i := range cfg.Rigs {
+		rigPath := resolveStoreScopeRoot(cityPath, cfg.Rigs[i].Path)
+		if filepath.Clean(rigPath) == scopeRoot {
+			return cfg.Rigs[i].EffectivePrefix()
+		}
+	}
+	return ""
+}
+
+func readScopeIssuePrefix(scopeRoot string) string {
+	prefix, ok, err := contract.ReadIssuePrefix(fsys.OSFS{}, filepath.Join(scopeRoot, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		return ""
+	}
+	return prefix
 }
 
 func bdCommandRunnerForRig(cityPath string, cfg *config.City, rigDir string) beads.CommandRunner {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -102,11 +102,25 @@ type BdStore struct {
 	dir         string          // city root directory (where .beads/ lives)
 	runner      CommandRunner   // injectable for testing
 	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
+	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
 }
 
 // NewBdStore creates a BdStore rooted at dir using the given runner.
 func NewBdStore(dir string, runner CommandRunner) *BdStore {
-	return &BdStore{dir: dir, runner: runner}
+	return NewBdStoreWithPrefix(dir, runner, "")
+}
+
+// NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
+func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string) *BdStore {
+	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+}
+
+// IDPrefix returns the bead ID prefix owned by this store, without trailing "-".
+func (s *BdStore) IDPrefix() string {
+	if s == nil {
+		return ""
+	}
+	return s.idPrefix
 }
 
 // Init initializes a beads database via bd init --server. This is an admin

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,7 +23,8 @@ import (
 //
 // Only wraps BdStore because the event hook path requires dolt/bd.
 type CachingStore struct {
-	backing Store // runtime: always *BdStore; tests may use MemStore
+	backing  Store // runtime: always *BdStore; tests may use MemStore
+	idPrefix string
 
 	mu          sync.RWMutex
 	beads       map[string]Bead
@@ -84,18 +86,29 @@ const (
 // Only BdStore is supported because the event hook path (bd hooks ->
 // gc event emit -> event bus -> ApplyEvent) requires dolt infrastructure.
 func NewCachingStore(backing *BdStore, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, onChange)
+	prefix := ""
+	if backing != nil {
+		prefix = backing.IDPrefix()
+	}
+	return newCachingStore(backing, prefix, onChange)
 }
 
 // NewCachingStoreForTest wraps any Store for testing. Production code
 // must use NewCachingStore with a *BdStore.
 func NewCachingStoreForTest(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, onChange)
+	return newCachingStore(backing, "", onChange)
 }
 
-func newCachingStore(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+// NewCachingStoreForTestWithPrefix wraps any Store for tests that need
+// production-style bead ID ownership filtering.
+func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+	return newCachingStore(backing, idPrefix, onChange)
+}
+
+func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:    backing,
+		idPrefix:   normalizeIDPrefix(idPrefix),
 		beads:      make(map[string]Bead),
 		deps:       make(map[string][]Dep),
 		dirty:      make(map[string]struct{}),
@@ -106,6 +119,18 @@ func newCachingStore(backing Store, onChange func(eventType, beadID string, payl
 			log.Printf("beads cache: %s", msg)
 		},
 	}
+}
+
+func normalizeIDPrefix(prefix string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(prefix)), "-")
+}
+
+func (c *CachingStore) ownsBeadID(id string) bool {
+	if c.idPrefix == "" {
+		return true
+	}
+	id = strings.ToLower(strings.TrimSpace(id))
+	return strings.HasPrefix(id, c.idPrefix+"-")
 }
 
 func (c *CachingStore) noteMutationLocked(ids ...string) uint64 {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -2,7 +2,6 @@ package beads
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -23,24 +22,18 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		c.recordProblem(fmt.Sprintf("apply %s event", eventType), err)
 		return
 	}
+	if !c.ownsBeadID(patch.ID) {
+		return
+	}
 
 	c.mu.RLock()
 	if c.state != cacheLive {
 		c.mu.RUnlock()
 		return
 	}
-	_, cached := c.beads[patch.ID]
 	c.mu.RUnlock()
 
 	b := patch
-	if !cached {
-		if fresh, err := c.backing.Get(patch.ID); err == nil {
-			b = fresh
-		} else if !errors.Is(err, ErrNotFound) {
-			c.recordProblem(fmt.Sprintf("refresh %s event", eventType), err)
-		}
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.state != cacheLive {

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -921,12 +921,13 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 		t.Fatalf("Prime: %v", err)
 	}
 
-	// Apply a create event for a bead that doesn't exist in cache yet.
-	newBead := beads.Bead{ID: "ext-1", Title: "External", Status: "open"}
-	payload, _ := json.Marshal(newBead)
+	// Apply a create event for a bead that exists in the backing store but
+	// doesn't exist in cache yet.
+	external, _ := mem.Create(beads.Bead{Title: "External"})
+	payload, _ := json.Marshal(beads.Bead{ID: external.ID, Title: "External", Status: "open"})
 	cs.ApplyEvent("bead.created", payload)
 
-	got := requireCachedBead(t, cs, "ext-1", false)
+	got := requireCachedBead(t, cs, external.ID, false)
 	if got.Title != "External" {
 		t.Fatalf("title = %q, want External", got.Title)
 	}
@@ -988,6 +989,61 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 	if got.Metadata["gc.step_ref"] != "" {
 		t.Fatalf("close event should replace stale metadata, got %v", got.Metadata)
+	}
+}
+
+func TestCachingStoreApplyEventIgnoresUnknownForeignBead(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	cs := beads.NewCachingStoreForTestWithPrefix(mem, "gc", nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	for _, eventType := range []string{"bead.created", "bead.updated", "bead.closed"} {
+		payload, err := json.Marshal(beads.Bead{
+			ID:     "foreign-" + eventType,
+			Title:  "belongs to another store",
+			Status: "open",
+		})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		cs.ApplyEvent(eventType, payload)
+	}
+
+	items, err := cs.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List cached beads: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("cached foreign beads = %#v, want none", items)
+	}
+}
+
+func TestCachingStoreApplyEventAcceptsOwnedUnknownBeadWithoutBackingGet(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	backing := &eventGetFailStore{Store: mem, failGet: true}
+	cs := beads.NewCachingStoreForTestWithPrefix(backing, "gc", nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	payload, err := json.Marshal(beads.Bead{
+		ID:     "gc-external",
+		Title:  "owned external bead",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	cs.ApplyEvent("bead.created", payload)
+
+	got := requireCachedBead(t, cs, "gc-external", false)
+	if got.Title != "owned external bead" {
+		t.Fatalf("title = %q, want owned external bead", got.Title)
 	}
 }
 
@@ -1065,6 +1121,10 @@ func (s *eventGetFailStore) Get(id string) (beads.Bead, error) {
 func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
+	created, err := mem.Create(beads.Bead{Title: "mayor"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 
 	cs := beads.NewCachingStoreForTest(mem, nil)
 	if err := cs.Prime(context.Background()); err != nil {
@@ -1072,7 +1132,7 @@ func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 	}
 
 	payload, err := json.Marshal(map[string]any{
-		"id":         "ext-1",
+		"id":         created.ID,
 		"title":      "mayor",
 		"status":     "open",
 		"issue_type": "session",
@@ -1094,7 +1154,7 @@ func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 		t.Fatalf("ProblemCount = %d, want 0 (last problem: %s)", stats.ProblemCount, stats.LastProblem)
 	}
 
-	got := requireCachedBead(t, cs, "ext-1", false)
+	got := requireCachedBead(t, cs, created.ID, false)
 	if got.Type != "session" {
 		t.Fatalf("Type = %q, want session", got.Type)
 	}


### PR DESCRIPTION
## Summary
- give BdStore/CachingStore an owned bead ID prefix
- ignore bead events for foreign prefixes so rig cache reconciliation cannot evict city session beads
- add controller/cache regressions for cross-store event routing

## Tests
- go test ./internal/beads ./cmd/gc -run 'TestCachingStoreApplyEvent|TestCachingStoreApplyEventIgnoresUnknownForeignBead|TestCachingStoreApplyEventAcceptsOwnedUnknownBeadWithoutBackingGet|TestCachingStoreApplyEventCoercesNonStringMetadata|TestControllerStateBeadEventsRespectStorePrefixes'
- make install