### PR TITLE
feat: suppress bd description advisory in gc-managed scopes

### DIFF
--- a/engdocs/design/beads-dolt-contract-redesign.md
+++ b/engdocs/design/beads-dolt-contract-redesign.md
@@ -661,6 +661,8 @@ Canonical keys owned by GC:
 
 - `issue_prefix`
 - `dolt.auto-start`
+- `validation.on-create` — suppresses advisory noise in agent-driven workspaces where description-less creates are intentional.
+- `create.require-description` — suppresses advisory noise in agent-driven workspaces where description-less creates are intentional.
 - `gc.endpoint_origin`
 - `gc.endpoint_status`
 - external-only:
@@ -700,6 +702,8 @@ interoperability.
 issue_prefix: gc
 issue-prefix: gc
 dolt.auto-start: false
+validation.on-create: off
+create.require-description: false
 gc.endpoint_origin: managed_city
 gc.endpoint_status: verified
 ```
@@ -723,6 +727,8 @@ gc.endpoint_status: verified
 issue_prefix: gc
 issue-prefix: gc
 dolt.auto-start: false
+validation.on-create: off
+create.require-description: false
 gc.endpoint_origin: city_canonical
 gc.endpoint_status: verified
 dolt.host: db.example.com
@@ -749,6 +755,8 @@ dolt.user: root
 issue_prefix: fe
 issue-prefix: fe
 dolt.auto-start: false
+validation.on-create: off
+create.require-description: false
 gc.endpoint_origin: inherited_city
 gc.endpoint_status: verified
 ```
@@ -772,6 +780,8 @@ gc.endpoint_status: verified
 issue_prefix: fe
 issue-prefix: fe
 dolt.auto-start: false
+validation.on-create: off
+create.require-description: false
 gc.endpoint_origin: inherited_city
 gc.endpoint_status: verified
 dolt.host: db.example.com
@@ -798,6 +808,8 @@ dolt.user: root
 issue_prefix: fe
 issue-prefix: fe
 dolt.auto-start: false
+validation.on-create: off
+create.require-description: false
 gc.endpoint_origin: explicit
 gc.endpoint_status: unverified
 dolt.host: rig-db.example.com

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -219,6 +219,8 @@ func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, er
 		changed = setString(root, "issue-prefix", prefix) || changed
 	}
 	changed = setBool(root, "dolt.auto-start", false) || changed
+	changed = setString(root, "validation.on-create", "off") || changed
+	changed = setBool(root, "create.require-description", false) || changed
 	if state.EndpointOrigin != "" {
 		changed = setString(root, "gc.endpoint_origin", string(state.EndpointOrigin)) || changed
 	}
@@ -319,7 +321,9 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	}
 
 	replacements := map[string]string{
-		"dolt.auto-start": "dolt.auto-start: false",
+		"dolt.auto-start":            "dolt.auto-start: false",
+		"validation.on-create":       "validation.on-create: off",
+		"create.require-description": "create.require-description: false",
 	}
 	if prefix != "" {
 		replacements["issue_prefix"] = "issue_prefix: " + prefix
@@ -393,6 +397,8 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		"issue_prefix",
 		"issue-prefix",
 		"dolt.auto-start",
+		"validation.on-create",
+		"create.require-description",
 		"gc.endpoint_origin",
 		"gc.endpoint_status",
 		"dolt.host",

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -110,6 +110,8 @@ func TestEnsureCanonicalConfigCreatesManagedShape(t *testing.T) {
 		"issue_prefix: gc",
 		"issue-prefix: gc",
 		"dolt.auto-start: false",
+		"validation.on-create: off",
+		"create.require-description: false",
 		"gc.endpoint_origin: managed_city",
 		"gc.endpoint_status: verified",
 	} {
@@ -335,6 +337,8 @@ func TestEnsureCanonicalConfigFallsBackToLineRewriteOnMalformedYAML(t *testing.T
 		"issue_prefix: gc",
 		"issue-prefix: gc",
 		"dolt.auto-start: false",
+		"validation.on-create: off",
+		"create.require-description: false",
 		"gc.endpoint_origin: managed_city",
 		"gc.endpoint_status: verified",
 		": not yaml",


### PR DESCRIPTION
## Summary
- Adds `validation.on-create=off` and `create.require-description=false` as managed invariants in `EnsureCanonicalConfig`, so every gc-managed scope (city + rig) suppresses bd's "Creating issue without description" advisory.
- gc agents create many step beads, eval beads, and ephemeral coordination beads without descriptions intentionally; the advisory is noise in those scopes.
- Fallback-path parity preserved: both new keys appear in the `replacements` map and `orderedKeys` slice in `ensureCanonicalConfigFallback`, matching the structural symmetry every other managed key (`dolt.auto-start`, `gc.endpoint_origin`, `gc.endpoint_status`, `dolt.{host,port,user}`) maintains.

Closes #54

## Test plan
- [x] `go test ./internal/beads/contract/...` — both new keys gated by extended needle assertions in `TestEnsureCanonicalConfigCreatesManagedShape` and `TestEnsureCanonicalConfigFallsBackToLineRewriteOnMalformedYAML`
- [x] `TestEnsureCanonicalConfigIsIdempotent` continues to pass (round-trip with `changed=false` on second call)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Manual verification on a fresh `gc start` against a managed city: `bd create --title="x"` produces no advisory; `.beads/config.yaml` contains both new keys; `bd config list` surfaces them in the "Also set in config.yaml" block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #54