### PR TITLE
fix(reconciler): exempt sessions with in_progress work from idle-sleep override

### DIFF
--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -320,9 +320,23 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 
 		// Idle sleep: desired sessions idle too long should sleep.
-		// Attached, pinned, and mode=always named sessions are exempt.
+		// Attached, pinned, mode=always named, and sessions actively
+		// executing in_progress work are exempt. The in_progress
+		// exemption matters for pool workers in mid-task: a slow
+		// upstream API call between two of the agent's own bd writes
+		// can drive IdleSince past the threshold while the underlying
+		// CLI process is still alive. Without this exemption, the gate
+		// would flip ShouldWake back to false even though the
+		// assigned-work loop above tagged the session "must stay awake
+		// because it owns active work" — and downstream consumers (the
+		// session.stranded diagnostic and any witness-style recovery)
+		// would see a false positive. Queued ("open") work is
+		// intentionally not exempted: on-demand named sessions are
+		// allowed to idle-sleep with queued work and wake on the next
+		// on-demand trigger.
 		if decision.ShouldWake && !input.AttachedSessions[name] && !input.PendingSessions[name] && !bead.Pinned && !bead.IdleSince.IsZero() &&
-			!isAlwaysNamedSession(input.NamedSessions, bead) {
+			!isAlwaysNamedSession(input.NamedSessions, bead) &&
+			!sessionHasAssignedInProgressWork(input.WorkBeads, bead) {
 			agent, hasAgent := agentsByName[bead.Template]
 			var idleTimeout time.Duration
 			switch {
@@ -362,6 +376,35 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	}
 
 	return result
+}
+
+// sessionHasAssignedInProgressWork reports whether any in_progress work
+// bead in workBeads is assigned to the given session bead. Matches by
+// concrete bead ID, the session's current SessionName token, or its
+// configured NamedIdentity — the same set of acceptable assignee values
+// used by the assigned-work gate at compute_awake_set.go:230-254.
+//
+// Status is restricted to "in_progress" specifically (not "open"). An
+// open assigned bead is queued work the agent has not yet claimed; an
+// on-demand named session is allowed to idle-sleep with queued work
+// pending and wake on the next on-demand trigger. An in_progress
+// assigned bead means the agent is actively executing it, and the
+// session must not be classified as idle while that's true.
+func sessionHasAssignedInProgressWork(workBeads []AwakeWorkBead, bead AwakeSessionBead) bool {
+	for _, wb := range workBeads {
+		if wb.Status != "in_progress" {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if assignee == bead.ID || assignee == bead.SessionName ||
+			(bead.NamedIdentity != "" && assignee == bead.NamedIdentity) {
+			return true
+		}
+	}
+	return false
 }
 
 func findNamedSessionName(beads []AwakeSessionBead, identity string) string {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1114,6 +1114,48 @@ func TestRegression_SessionWithWorkByAlias_DoesNotWake(t *testing.T) {
 // Asleep ephemeral with assigned work (e2e regression)
 // ---------------------------------------------------------------------------
 
+// TestRegression_IdleSleepDoesNotOverrideAssignedWork covers issue #1427:
+// a session that holds an open in_progress work bead must not be flipped
+// to ShouldWake=false / Reason="idle-sleep" by the idle-sleep gate, even
+// when its IdleSince is past the agent's SleepAfterIdle threshold.
+//
+// Production scenario: a pool worker is mid-task, blocked on a slow
+// upstream API response between two of its own bd writes. From the
+// outside, IdleSince walks past the threshold while the underlying CLI
+// process is still very much alive. The assigned-work gate marked it
+// "must stay awake because it owns active work"; the idle-sleep gate
+// then over-rode that and labeled the session asleep — handing
+// downstream recovery agents and #1425's session.stranded diagnostic a
+// false positive.
+func TestRegression_IdleSleepDoesNotOverrideAssignedWork(t *testing.T) {
+	idleTimeout := 10 * time.Minute
+	idleSince := now.Add(-(idleTimeout + time.Minute)) // 11 min ago: past threshold
+
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{
+			QualifiedName:  "hello-world/polecat",
+			SleepAfterIdle: idleTimeout,
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:          "mc-sctve",
+			SessionName: "polecat-mc-sctve",
+			Template:    "hello-world/polecat",
+			State:       "active",
+			IdleSince:   idleSince,
+		}},
+		WorkBeads: []AwakeWorkBead{
+			{ID: "hw-8lb", Assignee: "mc-sctve", Status: "in_progress"},
+		},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 0},
+		Now:              now,
+	})
+
+	assertAwake(t, result, "polecat-mc-sctve")
+	if got := result["polecat-mc-sctve"].Reason; got == "idle-sleep" {
+		t.Errorf("reason = %q, want non-idle-sleep — assigned-work must veto idle-sleep override", got)
+	}
+}
+
 func TestRegression_AsleepEphemeralWithAssignedWork_WakesViaAssignedWork(t *testing.T) {
 	// An asleep polecat that has in_progress work assigned to its bead ID
 	// must wake via the assigned-work path, even though scaleCheck alone


### PR DESCRIPTION
## Summary

`ComputeAwakeSet`'s idle-sleep gate at `cmd/gc/compute_awake_set.go`
flips `decision.ShouldWake` from `true` to `false` once a session is
past its `SleepAfterIdle` threshold. The exemption list covers
attached, pending, pinned, and always-named sessions — but **not**
\"the session is actively executing assigned in_progress work.\"

The assigned-work loop a few stanzas earlier explicitly tags those
sessions `desired[name] = \"assigned-work\"` because they have a
load-bearing reason to stay awake. The idle-sleep override then
ignored that signal and slept them anyway.

The dominant production failure mode is a pool worker mid-task,
blocked on a slow upstream API response between two of its own bd
writes. From the outside, `IdleSince` walks past the threshold while
the underlying CLI process is still alive. Until now, the controller
labeled that session `asleep`/`sleep_reason=idle`, then any downstream
consumer reading \"asleep + has in_progress work\" as a signal — the
`session.stranded` diagnostic from #1424 / #1425 in particular —
got a false positive.

This PR adds `sessionHasAssignedInProgressWork` as an exemption to
the idle-sleep gate. Restricted to `in_progress` (not `open`) so
on-demand named sessions retain the existing behavior of idle-sleeping
with queued work and waking on the next on-demand trigger —
preserving `TestIdleSleep_OnDemandNamed`.

## Test plan

- [x] **`TestRegression_IdleSleepDoesNotOverrideAssignedWork`** (new):
  pure-function unit test against `ComputeAwakeSet` that constructs
  the exact scenario — `state=active` session, `IdleSince` 11 minutes
  ago against a 10-minute `SleepAfterIdle`, and an `in_progress`
  work bead assigned — and asserts `ShouldWake` stays true and
  `Reason` is not `\"idle-sleep\"`. Without the fix the test reports
  `should be awake but isn't (reason: idle-sleep)`. With the fix it
  passes.
- [x] **`TestIdleSleep_OnDemandNamed`** (existing) still passes —
  the exemption deliberately ignores `open` (queued) work, so the
  intended on-demand-named idle-sleep behavior is unchanged.
- [x] All other `TestIdleSleep_*`, `TestRegression_*`,
  `TestComputeAwakeSet*`, `TestNamed*`, `TestWorkSet*`, `TestPin*`,
  `TestQuarantine*`, `TestAttached*`, `TestHold*` pass without
  modification — the new exemption only fires on the previously-buggy
  path.
- [x] All `TestReconcileSessionBeads_*` tests pass (downstream
  consumer of the awake decision).
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.

## Notes / out of scope

- Out of scope: changing the close-gate behavior at
  `session_reconciler.go:1110-1136` (preserved by #1424's design and
  unaffected here).
- Out of scope: process-alive heartbeat metadata, OS-level liveness
  probes — useful follow-up but a separate primitive. The fix here
  is purely a pure-function correction and ships independently.
- Out of scope: CLI-side transient-API-retry behavior (lives outside
  the gascity SDK).

## Code citations

- `cmd/gc/compute_awake_set.go` — assigned-work gate (sets
  `desired[name] = \"assigned-work\"`) and the idle-sleep override
  (now exempts in_progress assigned work).
- `cmd/gc/compute_awake_set.go` — new `sessionHasAssignedInProgressWork`
  helper.
- `cmd/gc/compute_awake_set_test.go` — new
  `TestRegression_IdleSleepDoesNotOverrideAssignedWork`.

Closes #1427