### PR TITLE
fix(sling): stamp gc.routed_to on graph workflow root at launch

### DIFF
--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -3792,6 +3792,63 @@ title = "Do work"
 	}
 }
 
+func TestGraphWorkflowRootGetsRoutedTo(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	cfg.Daemon.FormulaV2 = true
+	applyFeatureFlags(cfg)
+	t.Cleanup(func() { applyFeatureFlags(&config.City{}) })
+	cfg.FormulaLayers.City = []string{testFormulaDir(t)}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	graphFormula := `
+formula = "graph-route-test"
+version = 2
+contract = "graph.v2"
+
+[[steps]]
+id = "step"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-route-test.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "BL-99", Title: "Work", Type: "task", Status: "open"},
+	}, nil)
+	config.InjectImplicitAgents(cfg)
+	opts := testOpts(a, "BL-99")
+	opts.OnFormula = "graph-route-test"
+	code := doSling(opts, deps, nil, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	parent, err := deps.Store.Get("BL-99")
+	if err != nil {
+		t.Fatalf("get parent: %v", err)
+	}
+	rootID := parent.Metadata["workflow_id"]
+	if rootID == "" {
+		t.Fatal("parent workflow_id missing")
+	}
+
+	root, err := deps.Store.Get(rootID)
+	if err != nil {
+		t.Fatalf("get workflow root: %v", err)
+	}
+	if got := root.Status; got != "in_progress" {
+		t.Fatalf("root status = %q, want in_progress", got)
+	}
+	if got := root.Metadata["gc.routed_to"]; got != "mayor" {
+		t.Fatalf("root gc.routed_to = %q, want mayor — workflow root must have gc.routed_to set so pool hooks can discover it (gc-6smo)", got)
+	}
+}
+
 func TestDoSlingGraphWorkflowConflictReturnsExit3(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -442,6 +442,24 @@ func finalize(opts SlingOpts, deps SlingDeps, beadID, method string, result Slin
 	return result, nil
 }
 
+// routeWorkflowRoot sets gc.routed_to on a graph workflow root so pool hooks
+// can discover it. Without this, the root sits in_progress with no assignee
+// and no gc.routed_to — invisible to the pool hook query.
+func routeWorkflowRoot(rootID string, a config.Agent, deps SlingDeps) error {
+	if deps.Router != nil {
+		return deps.Router.Route(context.Background(), RouteRequest{
+			BeadID:  rootID,
+			Target:  a.QualifiedName(),
+			WorkDir: SlingDirForBead(deps.Cfg, deps.CityPath, rootID),
+			Env:     ResolveSlingEnv(a, deps, rootID),
+		})
+	}
+	if deps.Store != nil {
+		return deps.Store.SetMetadata(rootID, "gc.routed_to", a.QualifiedName())
+	}
+	return nil
+}
+
 // doStartGraphWorkflow performs post-instantiation graph workflow setup.
 func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method string, deps SlingDeps) (SlingResult, error) {
 	var result SlingResult
@@ -454,6 +472,9 @@ func doStartGraphWorkflow(rootID, sourceBeadID string, a config.Agent, method st
 
 	if err := PromoteWorkflowLaunchBead(deps.Store, rootID); err != nil {
 		return result, fmt.Errorf("setting workflow root %s in_progress: %w", rootID, err)
+	}
+	if err := routeWorkflowRoot(rootID, a, deps); err != nil {
+		return result, fmt.Errorf("routing workflow root %s to %s: %w", rootID, a.QualifiedName(), err)
 	}
 	if sourceBeadID != "" {
 		if err := deps.Store.SetMetadata(rootID, "gc.source_bead_id", sourceBeadID); err != nil {


### PR DESCRIPTION
## Summary

Cherry-picked from a polecat workspace that completed the fix but never
got a PR opened against upstream. Brings the change forward onto
current `main` and ships it as an isolated, focused PR.

The fix: graph-workflow attachments need `gc.routed_to` stamped on
the **root** bead when the workflow launches, not just on the work
bead being routed. Without this, the reconciler's routed-work signals
miss graph workflows on the first tick after launch and the next tick
spawns a duplicate worker against the same root.

## Test plan

- [x] Cherry-pick applied cleanly with the auto-merge resolution for
  `cmd/gc/cmd_sling_test.go` and `internal/sling/sling_core.go`.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] `go test ./internal/sling/...` and the relevant `cmd/gc/` tests
  pass (`TestSling*`, `TestGraph*`).

## Provenance

Originally authored by polecat work session against bead gc-6smo;
cherry-picked here onto current `main` so it can be reviewed and
merged independently of the stale polecat workspace.