### PR TITLE
fix(session): scope session beads to rig stores; propagate GC_BEADS_PREFIX

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -40,6 +40,11 @@ type agentBuildParams struct {
 	// instead of the legacy SessionNameFor function.
 	beadStore beads.Store
 
+	// rigStores maps rig names to their rig-scoped bead stores.
+	// Used by storeForAgent to create session beads in the correct
+	// rig store instead of the city-level HQ store.
+	rigStores map[string]beads.Store
+
 	// sessionBeads caches the open session-bead snapshot for the current
 	// desired-state build so per-agent resolution does not rescan the store.
 	sessionBeads *sessionBeadSnapshot
@@ -219,6 +224,21 @@ func effectiveOverlayDirs(cityDirs []string, rigDirs map[string][]string, rigNam
 	merged = append(merged, cityDirs...)
 	merged = append(merged, rigSpecific...)
 	return merged
+}
+
+// storeForAgent returns the bead store where session beads for this agent
+// should be created. For rig-scoped agents, returns the rig's store when
+// available; otherwise falls back to the city-level HQ store.
+func (p *agentBuildParams) storeForAgent(cfgAgent *config.Agent) beads.Store {
+	if cfgAgent != nil && len(p.rigStores) > 0 {
+		rigName := configuredRigName(p.cityPath, cfgAgent, p.rigs)
+		if rigName != "" {
+			if rigStore := p.rigStores[rigName]; rigStore != nil {
+				return rigStore
+			}
+		}
+	}
+	return p.beadStore
 }
 
 // templateNameFor returns the configuration template name for an agent.

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -237,6 +237,7 @@ func buildDesiredStateWithSessionBeads(
 
 	bp := newAgentBuildParams(cityName, cityPath, cfg, sp, beaconTime, store, stderr)
 	bp.sessionBeads = sessionBeads
+	bp.rigStores = rigStores
 
 	// Pre-compute suspended rig paths.
 	suspendedRigPaths := buildSuspendedRigPaths(cfg)
@@ -2551,13 +2552,14 @@ func createPoolSessionBeadWithGuardedAlias(
 	if err := validateAgentSessionTransportForBuild(bp, cfgAgent, qualifiedInstance); err != nil {
 		return beads.Bead{}, err
 	}
+	store := bp.storeForAgent(cfgAgent)
 	identity := poolSessionCreateIdentity{
 		AgentName: qualifiedInstance,
 		Slot:      slot,
 	}
 	alias := strings.TrimSpace(qualifiedInstance)
-	if alias == "" || bp.beadStore == nil {
-		return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
+	if alias == "" || store == nil {
+		return createPoolSessionBead(store, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
 	}
 
 	var bead beads.Bead
@@ -2568,7 +2570,7 @@ func createPoolSessionBeadWithGuardedAlias(
 			createIdentity.Alias = alias
 		}
 		var err error
-		bead, err = createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), createIdentity)
+		bead, err = createPoolSessionBead(store, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), createIdentity)
 		createdWithLock = true
 		return err
 	})
@@ -2578,7 +2580,7 @@ func createPoolSessionBeadWithGuardedAlias(
 	if lockErr != nil && bp.stderr != nil {
 		fmt.Fprintf(bp.stderr, "createPoolSessionBeadWithGuardedAlias: locking alias %q for %s: %v; creating without alias\n", alias, template, lockErr) //nolint:errcheck
 	}
-	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
+	return createPoolSessionBead(store, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
 }
 
 func isFailedCreateSessionBead(bead beads.Bead) bool {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -8246,3 +8246,140 @@ func TestBuildDesiredState_NamedSessionWorkQueryDoesNotDriveControllerDemand(t *
 		t.Fatal("NamedSessionDemand[alpha/dog] came from controller-side work_query")
 	}
 }
+
+func TestStoreForAgent_ReturnsRigStoreForRigScopedAgent(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	bp := &agentBuildParams{
+		cityPath:  "/city",
+		beadStore: cityStore,
+		rigStores: map[string]beads.Store{"enterprise": rigStore},
+		rigs:      []config.Rig{{Name: "enterprise", Path: "/city/rigs/enterprise"}},
+	}
+	agent := &config.Agent{Name: "polecat", Dir: "enterprise"}
+	got := bp.storeForAgent(agent)
+	if got != rigStore {
+		t.Fatal("storeForAgent returned city store, want rig store for rig-scoped agent")
+	}
+}
+
+func TestStoreForAgent_FallsBackToCityStoreWhenNoRigMatch(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	bp := &agentBuildParams{
+		cityPath:  "/city",
+		beadStore: cityStore,
+		rigStores: map[string]beads.Store{"other": rigStore},
+		rigs:      []config.Rig{{Name: "other", Path: "/city/rigs/other"}},
+	}
+	agent := &config.Agent{Name: "controller"}
+	got := bp.storeForAgent(agent)
+	if got != cityStore {
+		t.Fatal("storeForAgent returned non-city store for city-scoped agent")
+	}
+}
+
+func TestStoreForAgent_FallsBackWhenNoRigStores(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	bp := &agentBuildParams{
+		cityPath:  "/city",
+		beadStore: cityStore,
+	}
+	agent := &config.Agent{Name: "polecat", Dir: "enterprise"}
+	got := bp.storeForAgent(agent)
+	if got != cityStore {
+		t.Fatal("storeForAgent should fall back to city store when rigStores is nil")
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_CreatesInRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	snapshot := &sessionBeadSnapshot{}
+	cfgAgent := config.Agent{
+		Name:              "polecat",
+		Dir:               "enterprise",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(5),
+	}
+	bp := &agentBuildParams{
+		cityPath:     "/city",
+		beadStore:    cityStore,
+		rigStores:    map[string]beads.Store{"enterprise": rigStore},
+		rigs:         []config.Rig{{Name: "enterprise", Path: "/city/rigs/enterprise"}},
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	bead, err := selectOrCreatePoolSessionBead(bp, "enterprise/polecat", nil, map[string]bool{})
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+	}
+
+	if _, err := rigStore.Get(bead.ID); err != nil {
+		t.Fatalf("session bead %s not found in rig store: %v", bead.ID, err)
+	}
+	if _, err := cityStore.Get(bead.ID); err == nil {
+		t.Fatalf("session bead %s should NOT exist in city store", bead.ID)
+	}
+}
+
+func TestSelectOrCreateDependencyPoolSessionBead_CreatesInRigStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	snapshot := &sessionBeadSnapshot{}
+	cfgAgent := config.Agent{
+		Name:              "polecat",
+		Dir:               "enterprise",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(5),
+	}
+	bp := &agentBuildParams{
+		cityPath:     "/city",
+		beadStore:    cityStore,
+		rigStores:    map[string]beads.Store{"enterprise": rigStore},
+		rigs:         []config.Rig{{Name: "enterprise", Path: "/city/rigs/enterprise"}},
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	bead, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "enterprise/polecat")
+	if err != nil {
+		t.Fatalf("selectOrCreateDependencyPoolSessionBead: %v", err)
+	}
+
+	if _, err := rigStore.Get(bead.ID); err != nil {
+		t.Fatalf("dep session bead %s not found in rig store: %v", bead.ID, err)
+	}
+	if _, err := cityStore.Get(bead.ID); err == nil {
+		t.Fatalf("dep session bead %s should NOT exist in city store", bead.ID)
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_CityAgentUsesCityStore(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	snapshot := &sessionBeadSnapshot{}
+	cfgAgent := config.Agent{
+		Name:              "controller",
+		MinActiveSessions: intPtr(1),
+		MaxActiveSessions: intPtr(5),
+	}
+	bp := &agentBuildParams{
+		cityPath:     "/city",
+		beadStore:    cityStore,
+		rigStores:    map[string]beads.Store{"enterprise": rigStore},
+		rigs:         []config.Rig{{Name: "enterprise", Path: "/city/rigs/enterprise"}},
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	bead, err := selectOrCreatePoolSessionBead(bp, "controller", nil, map[string]bool{})
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+	}
+
+	if _, err := cityStore.Get(bead.ID); err != nil {
+		t.Fatalf("session bead %s not found in city store: %v", bead.ID, err)
+	}
+}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -284,6 +284,11 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		agentEnv["GC_RIG_ROOT"] = rigRoot
 		agentEnv["BEADS_DIR"] = filepath.Join(rigRoot, ".beads")
 		agentEnv["GC_BEADS_SCOPE_ROOT"] = rigRoot
+		if p.city != nil {
+			if rig, ok := rigByName(p.city, rigName); ok {
+				agentEnv["GC_BEADS_PREFIX"] = rig.EffectivePrefix()
+			}
+		}
 	}
 
 	// Step 9: Render prompt with beacon.

--- a/cmd/gc/template_resolve_workdir_test.go
+++ b/cmd/gc/template_resolve_workdir_test.go
@@ -432,3 +432,73 @@ dolt.auto-start: false
 		t.Fatalf("HOME should be passed through to agent env")
 	}
 }
+
+func TestResolveTemplateSetsBeadsPrefixForRigScopedAgent(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	rigRoot := filepath.Join(cityPath, "enterprise")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rigs := []config.Rig{{Name: "enterprise", Path: rigRoot, Prefix: "sc"}}
+	params := &agentBuildParams{
+		city:       &config.City{Workspace: config.Workspace{Provider: "test"}, Rigs: rigs},
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		rigs:       rigs,
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	agent := &config.Agent{
+		Name: "polecat",
+		Dir:  "enterprise",
+	}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_BEADS_PREFIX"]; got != "sc" {
+		t.Fatalf("GC_BEADS_PREFIX = %q, want %q", got, "sc")
+	}
+	if got := tp.Env["GC_RIG"]; got != "enterprise" {
+		t.Fatalf("GC_RIG = %q, want enterprise", got)
+	}
+}
+
+func TestResolveTemplateOmitsBeadsPrefixForCityScopedAgent(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+
+	params := &agentBuildParams{
+		city:       &config.City{Workspace: config.Workspace{Provider: "test"}},
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	agent := &config.Agent{
+		Name: "controller",
+	}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_BEADS_PREFIX"]; got != "" {
+		t.Fatalf("GC_BEADS_PREFIX = %q for city-scoped agent, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Cherry-picked from a polecat workspace that completed the fix but
never opened an upstream PR. Brought forward onto current \`main\` so
it can be reviewed and merged independently of the stale workspace.

The fix routes per-rig session beads to the correct rig store
(rather than the city store), and ensures \`GC_BEADS_PREFIX\` is
propagated into the agent runtime env so the agent's bd CLI lands
in the same store the controller is talking to. Without this,
session beads for rig-scoped agents end up in the city store while
the agent reads/writes the rig store, breaking ownership queries
and slot recycling for rig pools.

## Test plan

- [x] Cherry-pick applied with auto-merge resolution for
  \`cmd/gc/build_desired_state.go\`, \`build_desired_state_test.go\`,
  \`template_resolve.go\`.
- [x] \`go vet ./...\` clean.
- [x] \`go build ./...\` clean.
- [x] Targeted tests pass (\`TestBuildDesiredState*\`,
  \`TestTemplateResolve*\`, \`TestSession*\`).

## Provenance

Originally authored by a polecat work session against bead gc-amr;
cherry-picked here onto current \`main\` for clean review.