### PR TITLE
feat(formula): add content-hash tracking + gc formula version-check command

### DIFF
--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -22,6 +23,7 @@ func newFormulaCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(newFormulaListCmd(stdout, stderr))
 	cmd.AddCommand(newFormulaShowCmd(stdout, stderr))
 	cmd.AddCommand(newFormulaCookCmd(stdout, stderr))
+	cmd.AddCommand(newFormulaVersionCheckCmd(stdout, stderr))
 	return cmd
 }
 
@@ -464,4 +466,118 @@ func allFormulaSearchPaths(warningWriter ...io.Writer) []string {
 		add(layers)
 	}
 	return all
+}
+
+// formulaVersionCheckResult holds the output for --json mode.
+type formulaVersionCheckResult struct {
+	BeadID       string `json:"bead_id"`
+	FormulaName  string `json:"formula_name"`
+	BeadHash     string `json:"bead_hash"`
+	DiskHash     string `json:"disk_hash"`
+	BeadVersion  string `json:"bead_version"`
+	DiskVersion  int    `json:"disk_version"`
+	Match        bool   `json:"match"`
+	FormulaPath  string `json:"formula_path,omitempty"`
+}
+
+func newFormulaVersionCheckCmd(stdout, stderr io.Writer) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "version-check <bead-id>",
+		Short: "Check if a bead's formula matches the current on-disk version",
+		Long: `Compare the formula content hash stored on a molecule/workflow bead
+against the current on-disk formula file. Exits 0 if they match, 1 if
+they diverge.
+
+The bead must have gc.formula_hash metadata (set during instantiation).
+The formula is located via the bead's Ref field and the current formula
+search paths.
+
+Use this to detect whether a running session's formula has been updated
+since it was spawned.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			beadID := args[0]
+
+			cityPath, err := resolveCity()
+			if err != nil {
+				return err
+			}
+			cfg, err := loadCityConfig(cityPath, stderr)
+			if err != nil {
+				return err
+			}
+			scope, err := resolveFormulaScope(cfg, cityPath)
+			if err != nil {
+				return err
+			}
+
+			store, err := openStoreAtForCity(scope.storeRoot, cityPath)
+			if err != nil {
+				return err
+			}
+
+			bead, err := store.Get(beadID)
+			if err != nil {
+				return fmt.Errorf("reading bead %s: %w", beadID, err)
+			}
+
+			beadHash := bead.Metadata["gc.formula_hash"]
+			if beadHash == "" {
+				return fmt.Errorf("bead %s has no gc.formula_hash metadata (created before hash tracking)", beadID)
+			}
+
+			formulaName := bead.Ref
+			if formulaName == "" {
+				return fmt.Errorf("bead %s has no Ref (formula name)", beadID)
+			}
+
+			recipe, err := formula.Compile(cmd.Context(), formulaName, scope.searchPaths, nil)
+			if err != nil {
+				return fmt.Errorf("compiling formula %q from disk: %w", formulaName, err)
+			}
+
+			diskHash := recipe.ContentHash
+			match := beadHash == diskHash
+
+			result := formulaVersionCheckResult{
+				BeadID:      beadID,
+				FormulaName: formulaName,
+				BeadHash:    beadHash,
+				DiskHash:    diskHash,
+				BeadVersion: bead.Metadata["gc.formula_version"],
+				DiskVersion: recipe.FormulaVersion,
+				Match:       match,
+				FormulaPath: recipe.FormulaSource,
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(stdout)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(result); err != nil {
+					return err
+				}
+			} else if match {
+				_, _ = fmt.Fprintf(stdout, "✓ formula %s: bead %s matches on-disk version (hash %s)\n", formulaName, beadID, beadHash[:12])
+			} else {
+				_, _ = fmt.Fprintf(stdout, "✗ formula %s: bead %s DIVERGES from on-disk version\n", formulaName, beadID)
+				_, _ = fmt.Fprintf(stdout, "  bead hash: %s\n", beadHash)
+				_, _ = fmt.Fprintf(stdout, "  disk hash: %s\n", diskHash)
+				if result.BeadVersion != "" {
+					_, _ = fmt.Fprintf(stdout, "  bead version: %s → disk version: %d\n", result.BeadVersion, result.DiskVersion)
+				}
+				if result.FormulaPath != "" {
+					_, _ = fmt.Fprintf(stdout, "  formula path: %s\n", result.FormulaPath)
+				}
+			}
+
+			if !match {
+				return errExit
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output result as JSON")
+	return cmd
 }

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -234,11 +234,14 @@ func collectStepConditionVarRefs(condition string, refs map[string]bool) {
 
 func toRecipeWithGraph(f *Formula, graphWorkflow bool) (*Recipe, error) {
 	r := &Recipe{
-		Name:        f.Formula,
-		Description: f.Description,
-		Vars:        f.Vars,
-		Phase:       f.Phase,
-		Pour:        f.Pour,
+		Name:           f.Formula,
+		Description:    f.Description,
+		Vars:           f.Vars,
+		Phase:          f.Phase,
+		Pour:           f.Pour,
+		ContentHash:    f.ContentHash,
+		FormulaVersion: f.Version,
+		FormulaSource:  f.Source,
 	}
 
 	// Determine root title: use {{title}} placeholder if the variable

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1959,3 +1959,42 @@ description = "Review the {{feature}} implementation."
 		}
 	})
 }
+
+func TestCompile_PropagatesContentHash(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+formula = "mol-hash-prop"
+description = "Hash propagation test"
+version = 7
+
+[[steps]]
+id = "work"
+title = "Do work"
+type = "task"
+`
+	path := filepath.Join(dir, "mol-hash-prop.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recipe, err := Compile(context.Background(), "mol-hash-prop", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	if recipe.ContentHash == "" {
+		t.Fatal("ContentHash should propagate from Formula to Recipe")
+	}
+	if recipe.FormulaVersion != 7 {
+		t.Errorf("FormulaVersion = %d, want 7", recipe.FormulaVersion)
+	}
+	if recipe.FormulaSource == "" {
+		t.Fatal("FormulaSource should propagate from Formula to Recipe")
+	}
+
+	// Verify hash matches direct computation
+	want := ContentHash([]byte(content))
+	if recipe.ContentHash != want {
+		t.Errorf("ContentHash = %q, want %q", recipe.ContentHash, want)
+	}
+}

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -1,6 +1,8 @@
 package formula
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -110,6 +112,7 @@ func (p *Parser) ParseFile(path string) (*Formula, error) {
 	}
 
 	formula.Source = absPath
+	formula.ContentHash = contentHash(data)
 
 	// Set source tracing info on all steps (gt-8tmz.18)
 	SetSourceInfo(formula)
@@ -657,4 +660,16 @@ func setSourceInfoRecursive(steps []*Step, formulaName, pathPrefix string) {
 			setSourceInfoRecursive(step.Loop.Body, formulaName, bodyPath)
 		}
 	}
+}
+
+func contentHash(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// ContentHash returns the SHA-256 hex digest of arbitrary bytes. Useful for
+// callers that need to compute a formula content hash from raw file data
+// outside the parser.
+func ContentHash(data []byte) string {
+	return contentHash(data)
 }

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -2855,3 +2855,93 @@ title = "Test"
 		}
 	}
 }
+
+func TestParseFile_ContentHash(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte(`formula = "mol-hash-test"
+version = 3
+
+[[steps]]
+id = "do-thing"
+title = "Do the thing"
+`)
+	path := filepath.Join(dir, "mol-hash-test.toml")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewParser(dir)
+	f, err := p.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	if f.ContentHash == "" {
+		t.Fatal("ContentHash should be set after ParseFile")
+	}
+
+	// Hash should be deterministic
+	want := ContentHash(content)
+	if f.ContentHash != want {
+		t.Errorf("ContentHash = %q, want %q", f.ContentHash, want)
+	}
+
+	// Hash should be 64 hex chars (SHA-256)
+	if len(f.ContentHash) != 64 {
+		t.Errorf("ContentHash length = %d, want 64", len(f.ContentHash))
+	}
+}
+
+func TestParseFile_ContentHashChangesWithContent(t *testing.T) {
+	dir := t.TempDir()
+	v1 := []byte(`formula = "mol-evolve"
+version = 1
+
+[[steps]]
+id = "step-a"
+title = "Step A"
+`)
+	v2 := []byte(`formula = "mol-evolve"
+version = 2
+
+[[steps]]
+id = "step-a"
+title = "Step A (updated)"
+`)
+	path := filepath.Join(dir, "mol-evolve.toml")
+	if err := os.WriteFile(path, v1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p1 := NewParser(dir)
+	f1, err := p1.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile v1: %v", err)
+	}
+
+	if err := os.WriteFile(path, v2, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p2 := NewParser(dir)
+	f2, err := p2.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile v2: %v", err)
+	}
+
+	if f1.ContentHash == f2.ContentHash {
+		t.Error("content hash should differ between v1 and v2")
+	}
+}
+
+func TestParse_InMemory_NoContentHash(t *testing.T) {
+	p := NewParser()
+	f, err := p.Parse([]byte(`{"formula":"mol-inmem","steps":[]}`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if f.ContentHash != "" {
+		t.Errorf("ContentHash should be empty for in-memory parse, got %q", f.ContentHash)
+	}
+}

--- a/internal/formula/recipe.go
+++ b/internal/formula/recipe.go
@@ -37,6 +37,16 @@ type Recipe struct {
 	// without materializing child steps. This is the default for
 	// vapor-phase formulas (patrol wisps).
 	RootOnly bool
+
+	// ContentHash is the SHA-256 hex digest of the source formula file.
+	// Propagated from Formula.ContentHash during compilation.
+	ContentHash string
+
+	// FormulaVersion is the semantic version from the formula definition.
+	FormulaVersion int
+
+	// FormulaSource is the file path from which the formula was loaded.
+	FormulaSource string
 }
 
 // RecipeStep represents a single step in a compiled recipe.

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -123,6 +123,10 @@ type Formula struct {
 
 	// Source tracks where this formula was loaded from (set by parser).
 	Source string `json:"source,omitempty"`
+
+	// ContentHash is the SHA-256 hex digest of the raw formula file bytes.
+	// Set by ParseFile; empty for formulas parsed from in-memory bytes.
+	ContentHash string `json:"content_hash,omitempty"`
 }
 
 // VarDef defines a template variable with optional validation.

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -427,10 +427,19 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 			if opts.ParentID != "" && step.Metadata["gc.kind"] != "workflow" {
 				b.ParentID = opts.ParentID
 			}
+			if b.Metadata == nil {
+				b.Metadata = make(map[string]string, 4)
+			}
+			if recipe.ContentHash != "" {
+				b.Metadata["gc.formula_hash"] = recipe.ContentHash
+			}
+			if recipe.FormulaVersion > 0 {
+				b.Metadata["gc.formula_version"] = strconv.Itoa(recipe.FormulaVersion)
+			}
+			if recipe.FormulaSource != "" {
+				b.Metadata["gc.formula_source"] = recipe.FormulaSource
+			}
 			if opts.IdempotencyKey != "" {
-				if b.Metadata == nil {
-					b.Metadata = make(map[string]string, 1)
-				}
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
 		} else {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2170,3 +2170,78 @@ func TestBuildRecipeApplyPlan_PreserveRootTypeKeepsTaskRoot(t *testing.T) {
 		t.Fatalf("plan root type = %q, want task", plan.Nodes[0].Type)
 	}
 }
+
+func TestInstantiateStampsFormulaHash(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name:           "mol-hash-check",
+		Description:    "Test hash stamping",
+		ContentHash:    "abc123def456",
+		FormulaVersion: 5,
+		FormulaSource:  "/path/to/mol-hash-check.toml",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-hash-check", Title: "Root", Type: "molecule", IsRoot: true},
+			{ID: "mol-hash-check.step-a", Title: "Step A", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "mol-hash-check.step-a", DependsOnID: "mol-hash-check", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	root, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("Get root: %v", err)
+	}
+
+	if got := root.Metadata["gc.formula_hash"]; got != "abc123def456" {
+		t.Errorf("gc.formula_hash = %q, want %q", got, "abc123def456")
+	}
+	if got := root.Metadata["gc.formula_version"]; got != "5" {
+		t.Errorf("gc.formula_version = %q, want %q", got, "5")
+	}
+	if got := root.Metadata["gc.formula_source"]; got != "/path/to/mol-hash-check.toml" {
+		t.Errorf("gc.formula_source = %q, want %q", got, "/path/to/mol-hash-check.toml")
+	}
+
+	// Non-root beads should NOT have formula hash metadata
+	stepAID := result.IDMapping["mol-hash-check.step-a"]
+	stepA, err := store.Get(stepAID)
+	if err != nil {
+		t.Fatalf("Get step-a: %v", err)
+	}
+	if _, ok := stepA.Metadata["gc.formula_hash"]; ok {
+		t.Error("non-root bead should not have gc.formula_hash")
+	}
+}
+
+func TestInstantiateNoHashWhenEmpty(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "mol-no-hash",
+		Steps: []formula.RecipeStep{
+			{ID: "mol-no-hash", Title: "Root", Type: "molecule", IsRoot: true},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	root, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("Get root: %v", err)
+	}
+
+	if _, ok := root.Metadata["gc.formula_hash"]; ok {
+		t.Error("gc.formula_hash should not be set when ContentHash is empty")
+	}
+	if _, ok := root.Metadata["gc.formula_version"]; ok {
+		t.Error("gc.formula_version should not be set when FormulaVersion is 0")
+	}
+}


### PR DESCRIPTION
## Summary

Cherry-picked from a polecat workspace that completed the feature
but never opened an upstream PR. Brought forward onto current \`main\`
for clean review.

Adds a content hash to compiled formulas and a \`gc formula version-check\`
command that surfaces drift between the formula version a molecule
was instantiated with and the current installed formula. Useful for
spotting in-flight molecules that were started before a formula edit
and need to be re-cooked vs. completed as-is.

## Test plan

- [x] Cherry-pick applied with auto-merge resolutions for
  \`cmd/gc/cmd_formula.go\`, \`internal/formula/{compile,parser}.go\`,
  \`internal/molecule/molecule.go\`, and their test files.
- [x] \`go vet ./...\` clean.
- [x] \`go build ./...\` clean.
- [x] \`go test ./internal/formula/... ./internal/molecule/...\` all pass.

## Provenance

Originally authored by a polecat work session against bead gc-v9uf;
cherry-picked here onto current \`main\`.