### PR TITLE
fix(formulas): emit fully-qualified gc.routed_to in molecule prompts

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -204,7 +204,7 @@ the PR is open and matches the branch, base, and origin repository.
 
 **5. Reassign to refinery:**
 ```bash
-gc bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
+gc bd update {{issue}} --status=open --assignee=<rig>/gastown.refinery --set-metadata gc.routed_to=<rig>/gastown.refinery
 ```
 
 Update both `assignee` AND `gc.routed_to` so the reconciler stops

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -167,7 +167,7 @@ gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 ```bash
 gc bd update $WORK \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
-  --set-metadata gc.routed_to=<rig>/polecat
+  --set-metadata gc.routed_to=<rig>/gastown.polecat
 ```
 4. Do NOT delete the branch (new polecat needs it for conflict resolution).
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`


### PR DESCRIPTION
## Problem

The polecat→refinery handoff (`mol-polecat-work` step 5) and the refinery rejection step (`mol-refinery-patrol` rebase failure) instruct the agent to write:

```bash
gc bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
```

After the agent substitutes `<rig>` with its rig name, the result is `cashmaster/refinery` — a **short-form** identifier that doesn't match any agent's `QualifiedName()` (which is `cashmaster/gastown.refinery` for the gastown pack).

The reconciler at `cmd/gc/pool_desired_state.go:137` matches `gc.routed_to` against `QualifiedName()` exactly:
```go
if routedTo != template { continue }  // template = agent.QualifiedName()
```

So short-form routed beads sit unmatched. The reconciler keeps reassigning rejected beads back to the polecat pool, producing handoff loops the mayor has to manually break by rewriting metadata.

This is a sibling of #1268 / #1299 (`fix(orders): qualify pool name with pack binding at dispatch`), which fixed the same class of bug for the order-dispatch path. This PR covers the formula self-handoff path, which doesn't go through `qualifyPool`.

## Fix

Hardcode the pack namespace in the template strings so substitution produces qualified names directly:

- `<rig>/refinery` → `<rig>/gastown.refinery`
- `<rig>/polecat` → `<rig>/gastown.polecat`

The formulas live under `examples/gastown/packs/gastown/`, so pinning `gastown.` is consistent with their scope.

## Empirical evidence (from a recent operator session)

- Polecat completed work on `ca-36n`, ran step 5, set `gc.routed_to=cashmaster/refinery`. Refinery never picked it up. Reconciler kept reassigning back to polecat pool. Manual rewrite to `cashmaster/gastown.refinery` unstuck the bead immediately.
- Identical pattern observed for refinery rejection writing `cashmaster/polecat` instead of `cashmaster/gastown.polecat`.

## Files changed

- `examples/gastown/packs/gastown/formulas/mol-polecat-work.toml` (step 5 reassign-to-refinery)
- `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml` (rebase-conflict reject path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)