### PR TITLE
fix(reconciler): creating-state sessions don't consume pool slots in capWakeConfigByDemand (gc-2llq)

### DIFF
--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -5465,3 +5465,46 @@ func TestStopTargetThroughWorkerBoundary_CityStopLeavesSessionAsleep(t *testing.
 		t.Fatalf("suspended_at = %q, want empty", got.Metadata["suspended_at"])
 	}
 }
+
+func TestCommitStartResult_FailedSpawnClearsLastWokeAndRecordsFailure(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker-session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-1",
+			"state":        "creating",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := startCandidate{
+		session: &session,
+		tp:      TemplateParams{TemplateName: "worker", InstanceName: "worker-1"},
+	}
+	result := startResult{
+		prepared: preparedStart{candidate: candidate},
+		err:      fmt.Errorf("tmux spawn failed"),
+		outcome:  "provider_error",
+		started:  time.Unix(100, 0),
+		finished: time.Unix(101, 0),
+	}
+	rec := events.NewFake()
+	ok := commitStartResult(result, store, &clock.Fake{Time: time.Unix(102, 0)}, rec, 0, ioDiscard{}, ioDiscard{})
+	if ok {
+		t.Fatal("commitStartResult returned true for failed start")
+	}
+	got, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["last_woke_at"] != "" {
+		t.Errorf("last_woke_at = %q, want cleared after failed spawn", got.Metadata["last_woke_at"])
+	}
+	if got.Metadata["wake_attempts"] != "1" {
+		t.Errorf("wake_attempts = %q, want %q after failed spawn", got.Metadata["wake_attempts"], "1")
+	}
+}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -222,7 +222,7 @@ func capWakeConfigByDemand(sessions []beads.Bead, cfg *config.City, evals map[st
 	// Group sessions by template and count how many already need to be awake.
 	type templateBudget struct {
 		desired int
-		active  int      // creating/awake — already consuming a slot
+		active  int      // running (active/awake) — consuming a slot
 		wakeIDs []string // sessions with WakeConfig that are asleep
 	}
 	budgets := make(map[string]*templateBudget)
@@ -257,11 +257,14 @@ func capWakeConfigByDemand(sessions []beads.Bead, cfg *config.City, evals map[st
 
 		state := sessionMetadataState(session)
 		switch state {
-		case "active", "creating":
-			// Already running or starting — counts against desired.
+		case "active":
+			// Running — counts against desired.
 			b.active++
 		default:
-			// Asleep — candidate for wake, subject to budget.
+			// Asleep or creating — candidate for wake, subject to budget.
+			// Creating sessions are NOT counted as active because a failed
+			// tmux spawn leaves the row in creating state indefinitely,
+			// blocking the pool from reaching its desired count.
 			b.wakeIDs = append(b.wakeIDs, session.ID)
 		}
 	}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1333,11 +1333,11 @@ func TestCapWakeConfigByDemand_ActiveCountsAgainstBudget(t *testing.T) {
 	}
 	poolDesired := map[string]int{"worker": 3}
 
-	// 1 active (creating), 4 asleep. Desired is 3.
+	// 1 active, 4 asleep. Desired is 3.
 	// Active counts against budget: 3 - 1 = 2 asleep should wake.
 	sessions := []beads.Bead{
 		makeBead("s0", map[string]string{
-			"template": "worker", "session_name": "worker-0", "state": "creating",
+			"template": "worker", "session_name": "worker-0", "state": "active",
 		}),
 		makeBead("s1", map[string]string{
 			"template": "worker", "session_name": "worker-1", "state": "asleep",
@@ -1363,6 +1363,45 @@ func TestCapWakeConfigByDemand_ActiveCountsAgainstBudget(t *testing.T) {
 	}
 	if asleepWakes != 2 {
 		t.Errorf("asleep sessions with WakeConfig = %d, want 2 (desired 3 minus 1 active)", asleepWakes)
+	}
+}
+
+func TestCapWakeConfigByDemand_CreatingDoesNotConsumeSlot(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(10)},
+		},
+	}
+	poolDesired := map[string]int{"worker": 2}
+
+	// 1 creating (failed spawn), 3 asleep. Desired is 2.
+	// Creating does NOT count against budget, so all 4 non-active sessions
+	// compete for 2 slots. 2 should get WakeConfig.
+	sessions := []beads.Bead{
+		makeBead("s0", map[string]string{
+			"template": "worker", "session_name": "worker-0", "state": "creating",
+		}),
+		makeBead("s1", map[string]string{
+			"template": "worker", "session_name": "worker-1", "state": "asleep",
+		}),
+		makeBead("s2", map[string]string{
+			"template": "worker", "session_name": "worker-2", "state": "asleep",
+		}),
+		makeBead("s3", map[string]string{
+			"template": "worker", "session_name": "worker-3", "state": "asleep",
+		}),
+	}
+
+	evals := computeWakeEvaluations(sessions, cfg, nil, poolDesired, nil, nil, &clock.Fake{Time: time.Now()})
+
+	wakeCount := 0
+	for _, eval := range evals {
+		if containsWakeReason(eval.Reasons, WakeConfig) {
+			wakeCount++
+		}
+	}
+	if wakeCount != 2 {
+		t.Errorf("sessions with WakeConfig = %d, want 2 (creating should not consume slot)", wakeCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Failed tmux spawns leave session rows in `creating` state. `capWakeConfigByDemand` previously counted these against the pool's desired count alongside `active`, so a stuck `creating` session prevented the controller from spawning a replacement. Now only `state=active` sessions consume pool slots; stuck `creating` rows don't block new capacity.

## Test plan

- [x] Build clean
- [x] New test `TestCommitStartResult_FailedSpawnClearsLastWokeAndRecordsFailure` covers the failure path
- [x] Existing `TestCommitStartResult_*` and pool-cap tests pass

Closes gc-2llq. Cherry-picked from `polecat/gc-m7qm` (commit 6350936d) onto current `upstream/main`. Resolved conflict in `session_lifecycle_parallel_test.go` — upstream added two unrelated tests at the same EOF location; this PR appends the polecat's new test function below them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)