### PR TITLE
fix(routing): accept unbound short-form routing names for V2 imported agents (gc-n7gi)

### DIFF
--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -972,6 +972,42 @@ func TestResolveAgentIdentityUnambiguous(t *testing.T) {
 	}
 }
 
+func TestResolveAgentIdentityV2ShortForm(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity", BindingName: "gastown",
+				MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(3)},
+			{Name: "refinery", Dir: "gascity", BindingName: "gastown"},
+		},
+	}
+	tests := []struct {
+		name      string
+		input     string
+		wantFound bool
+		wantName  string
+	}{
+		{"canonical V2 qualified", "gascity/gastown.polecat", true, "polecat"},
+		{"short form V2 qualified", "gascity/polecat", true, "polecat"},
+		{"canonical V2 refinery", "gascity/gastown.refinery", true, "refinery"},
+		{"short form V2 refinery", "gascity/refinery", true, "refinery"},
+		{"wrong dir", "enterprise/polecat", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := resolveAgentIdentity(cfg, tt.input, "")
+			if found != tt.wantFound {
+				t.Fatalf("resolveAgentIdentity(%q) found = %v, want %v", tt.input, found, tt.wantFound)
+			}
+			if !found {
+				return
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // findAgentByName unit tests (pool suffix stripping for gc prime)
 // ---------------------------------------------------------------------------

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -204,7 +204,7 @@ the PR is open and matches the branch, base, and origin repository.
 
 **5. Reassign to refinery:**
 ```bash
-gc bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
+gc bd update {{issue}} --status=open --assignee={{rig_name}}/gastown.refinery --set-metadata gc.routed_to={{rig_name}}/gastown.refinery
 ```
 
 Update both `assignee` AND `gc.routed_to` so the reconciler stops

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,30 @@ func (a *Agent) QualifiedName() string {
 	return a.Dir + "/" + name
 }
 
+// UnboundQualifiedName returns the agent identity without binding prefix.
+// For V2 agents this strips the binding: "gascity/gastown.polecat" →
+// "gascity/polecat". For V1 agents this equals QualifiedName().
+func (a *Agent) UnboundQualifiedName() string {
+	if a.Dir == "" {
+		return a.Name
+	}
+	return a.Dir + "/" + a.Name
+}
+
+// unbindQualifiedName strips the binding prefix from a qualified agent name
+// string. "gascity/gastown.polecat" → "gascity/polecat". Names without a
+// binding dot are returned as-is.
+func unbindQualifiedName(qualified string) string {
+	dir, name := ParseQualifiedName(qualified)
+	if idx := strings.Index(name, "."); idx >= 0 {
+		name = name[idx+1:]
+	}
+	if dir == "" {
+		return name
+	}
+	return dir + "/" + name
+}
+
 // ParseQualifiedName splits an agent identity into (dir, name).
 // "hello-world/polecat" → ("hello-world", "polecat").
 // "hello-world/gastown.polecat" → ("hello-world", "gastown.polecat").
@@ -92,24 +116,19 @@ func (a *Agent) QualifiedInstanceName(instanceName string) string {
 
 // AgentMatchesIdentity returns true if the agent's qualified name matches
 // the given identity string. Handles both V1 format ("dir/name") and V2
-// format ("dir/binding.name", "binding.name"). This is the canonical way
-// to match user-supplied identity strings against agents; prefer it over
-// manual Dir+Name comparisons. The V1 fallback only applies to agents
-// without a BindingName — imported V2 agents must be addressed by their
-// qualified name.
+// format ("dir/binding.name", "binding.name"). V2 agents also match their
+// dir-qualified short form ("dir/name") for routing compatibility, but bare
+// names without a dir prefix require the binding-qualified form to avoid
+// ambiguity across packs.
 func AgentMatchesIdentity(a *Agent, identity string) bool {
-	// Try V2 qualified name first (includes binding).
 	if a.QualifiedName() == identity {
 		return true
 	}
-	// Fallback: V1-style dir+name match. Only allowed when the agent
-	// has no binding name — imported V2 agents must be addressed by
-	// their qualified name (binding.name), not bare name.
-	if a.BindingName == "" {
-		dir, name := ParseQualifiedName(identity)
-		return a.Dir == dir && a.Name == name
+	dir, name := ParseQualifiedName(identity)
+	if a.BindingName != "" && dir == "" {
+		return false
 	}
-	return false
+	return a.Dir == dir && a.Name == name
 }
 
 // City is the top-level configuration for a Gas City instance.
@@ -1787,10 +1806,23 @@ func (a *Agent) EffectiveWorkQuery() string {
 	if a.PoolName != "" {
 		target = a.PoolName
 	}
+	// V2 agents also accept the unbound short form (e.g., "gascity/polecat"
+	// instead of "gascity/gastown.polecat") so beads routed with either
+	// form are discovered.
+	shortTarget := ""
+	if a.BindingName != "" {
+		if a.PoolName != "" {
+			shortTarget = unbindQualifiedName(a.PoolName)
+		} else {
+			shortTarget = a.UnboundQualifiedName()
+		}
+		if shortTarget == target {
+			shortTarget = ""
+		}
+	}
 	legacyTarget := legacyWorkflowControlQualifiedName(target)
 	if legacyTarget == "" {
-		return `sh -c '` +
-			// Tier 1: in_progress assigned to any of my identifiers (crash recovery)
+		tiers12 := // Tier 1: in_progress assigned to any of my identifiers (crash recovery)
 			`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 			`[ -z "$id" ] && continue; ` +
 			`r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
@@ -1807,7 +1839,23 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`case "$GC_SESSION_ORIGIN" in ` +
 			`ephemeral|"") ;; ` +
 			`*) exit 0 ;; ` +
-			`esac; ` +
+			`esac; `
+		if shortTarget != "" {
+			return `sh -c '` + tiers12 +
+				`r=$(bd ready --metadata-field gc.routed_to=` + target +
+				` --unassigned --json --limit=1 2>/dev/null); ` +
+				`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+				`r=$(bd ready --metadata-field gc.routed_to=` + shortTarget +
+				` --unassigned --json --limit=1 2>/dev/null); ` +
+				`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+				// Tier 4: open routed molecule roots.
+				`r=$(bd list --metadata-field gc.routed_to=` + target +
+				` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null); ` +
+				`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
+				`bd list --metadata-field gc.routed_to=` + shortTarget +
+				` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null'`
+		}
+		return `sh -c '` + tiers12 +
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1452,6 +1452,102 @@ esac
 	}
 }
 
+func TestEffectiveWorkQueryV2BindingShortFormAlias(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "gascity", BindingName: "gastown"}
+	got := a.EffectiveWorkQuery()
+	if !strings.Contains(got, "gc.routed_to=gascity/gastown.polecat") {
+		t.Errorf("EffectiveWorkQuery() missing canonical routed_to: %q", got)
+	}
+	if !strings.Contains(got, "gc.routed_to=gascity/polecat") {
+		t.Errorf("EffectiveWorkQuery() missing short-form routed_to alias: %q", got)
+	}
+}
+
+func TestEffectiveWorkQueryV2BindingPoolInstanceShortForm(t *testing.T) {
+	a := Agent{
+		Name:              "gastown.polecat-1",
+		Dir:               "gascity",
+		BindingName:       "gastown",
+		PoolName:          "gascity/gastown.polecat",
+		MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3),
+	}
+	got := a.EffectiveWorkQuery()
+	if !strings.Contains(got, "gc.routed_to=gascity/gastown.polecat") {
+		t.Errorf("EffectiveWorkQuery() missing canonical routed_to: %q", got)
+	}
+	if !strings.Contains(got, "gc.routed_to=gascity/polecat") {
+		t.Errorf("EffectiveWorkQuery() missing short-form routed_to alias: %q", got)
+	}
+}
+
+func TestEffectiveWorkQueryV2ShortFormFindsWork(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "gascity", BindingName: "gastown"}
+	out := runEffectiveWorkQuery(t, a, nil, `#!/bin/sh
+set -eu
+case "$*" in
+  "ready --metadata-field gc.routed_to=gascity/gastown.polecat --unassigned --json --limit=1")
+    printf '[]'
+    ;;
+  "ready --metadata-field gc.routed_to=gascity/polecat --unassigned --json --limit=1")
+    printf '[{"id":"short-form-hit"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if got, want := strings.TrimSpace(out), `[{"id":"short-form-hit"}]`; got != want {
+		t.Fatalf("short-form routed work query output = %q, want %q", got, want)
+	}
+}
+
+func TestEffectiveWorkQueryNoBindingNoShortForm(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "gascity"}
+	got := a.EffectiveWorkQuery()
+	count := strings.Count(got, "gc.routed_to=gascity/polecat")
+	if count < 2 {
+		t.Errorf("EffectiveWorkQuery() should have routed_to in tier 3 + 4, got %d occurrences", count)
+	}
+	if strings.Contains(got, "gc.routed_to=gascity/gastown") {
+		t.Errorf("EffectiveWorkQuery() should not have binding-qualified form without BindingName")
+	}
+}
+
+func TestUnboundQualifiedName(t *testing.T) {
+	tests := []struct {
+		agent Agent
+		want  string
+	}{
+		{Agent{Name: "polecat", Dir: "gascity", BindingName: "gastown"}, "gascity/polecat"},
+		{Agent{Name: "polecat", Dir: "gascity"}, "gascity/polecat"},
+		{Agent{Name: "mayor"}, "mayor"},
+		{Agent{Name: "mayor", BindingName: "gastown"}, "mayor"},
+	}
+	for _, tt := range tests {
+		got := tt.agent.UnboundQualifiedName()
+		if got != tt.want {
+			t.Errorf("Agent{Name:%q,Dir:%q,BindingName:%q}.UnboundQualifiedName() = %q, want %q",
+				tt.agent.Name, tt.agent.Dir, tt.agent.BindingName, got, tt.want)
+		}
+	}
+}
+
+func TestAgentMatchesIdentityV2ShortForm(t *testing.T) {
+	a := Agent{Name: "polecat", Dir: "gascity", BindingName: "gastown"}
+	if !AgentMatchesIdentity(&a, "gascity/gastown.polecat") {
+		t.Error("should match canonical V2 name")
+	}
+	if !AgentMatchesIdentity(&a, "gascity/polecat") {
+		t.Error("should match unbound short form")
+	}
+	if AgentMatchesIdentity(&a, "enterprise/polecat") {
+		t.Error("should not match wrong dir")
+	}
+	if AgentMatchesIdentity(&a, "polecat") {
+		t.Error("should not match bare name without dir")
+	}
+}
+
 func TestEffectiveSlingQueryPoolNameOverride(t *testing.T) {
 	a := Agent{
 		Name:              "dog-1",

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -709,6 +709,7 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 	if beadID != "" {
 		addVar("issue", beadID)
 	}
+	addVar("rig_name", a.Dir)
 
 	autoBranch := SlingFormulaTargetBranch(beadID, deps, a)
 	if SlingFormulaUsesBaseBranch(formulaName) {

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2632,3 +2632,39 @@ func TestDoSlingForceSkipsCrossRig(t *testing.T) {
 		t.Fatalf("DoSling with --force should not error on cross-rig: %v", err)
 	}
 }
+
+func TestBuildSlingFormulaVarsRigName(t *testing.T) {
+	a := config.Agent{Name: "polecat", Dir: "enterprise", BindingName: "gastown"}
+	deps := SlingDeps{
+		Store: beads.NewMemStore(),
+	}
+	vars := BuildSlingFormulaVars("mol-polecat-work", "gc-1234", nil, a, deps)
+	if got, want := vars["rig_name"], "enterprise"; got != want {
+		t.Errorf("rig_name = %q, want %q", got, want)
+	}
+	if got, want := vars["issue"], "gc-1234"; got != want {
+		t.Errorf("issue = %q, want %q", got, want)
+	}
+}
+
+func TestBuildSlingFormulaVarsRigNameNotOverridden(t *testing.T) {
+	a := config.Agent{Name: "polecat", Dir: "enterprise", BindingName: "gastown"}
+	deps := SlingDeps{
+		Store: beads.NewMemStore(),
+	}
+	vars := BuildSlingFormulaVars("mol-polecat-work", "gc-1234", []string{"rig_name=custom"}, a, deps)
+	if got, want := vars["rig_name"], "custom"; got != want {
+		t.Errorf("explicit rig_name should win: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildSlingFormulaVarsNoDirNoRigName(t *testing.T) {
+	a := config.Agent{Name: "polecat"}
+	deps := SlingDeps{
+		Store: beads.NewMemStore(),
+	}
+	vars := BuildSlingFormulaVars("mol-polecat-work", "gc-1234", nil, a, deps)
+	if _, ok := vars["rig_name"]; ok {
+		t.Error("rig_name should not be set when agent has no Dir")
+	}
+}


### PR DESCRIPTION
## Summary

After the PackV2 binding migration, agents imported via `[imports]` get binding-qualified names (e.g., `gascity/gastown.polecat`). When humans or formulas stamp `gc.routed_to` with the short form (`gascity/polecat`), the agent's work query never finds the bead.

Three-pronged fix:
- `EffectiveWorkQuery` checks both canonical and unbound short form in Tier 3 and Tier 4, so beads routed with either form are discovered.
- `AgentMatchesIdentity` accepts dir-qualified short form for V2 agents (`gascity/polecat` matches agent with binding `gastown`), while still rejecting bare names to avoid cross-pack ambiguity.
- Sling formula vars now include `rig_name` so templates can construct canonical routing targets; `mol-polecat-work` updated to use long form.

## Test plan

- [x] `go test ./internal/config/ ./internal/sling/` passes
- [x] `go build ./...` clean
- [ ] Verify `gc sling --target gascity/polecat` resolves to bound polecat agent (manual)

Closes gc-n7gi. Cherry-picked from `polecat/gc-m7qm` (commit dcf484a3) onto current `upstream/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)