### PR TITLE
fix(polecat): remove close authority — only refinery closes work beads (gc-vto4)

### DIFF
--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -6,6 +6,14 @@
 
 ---
 
+## CRITICAL: Never Close Beads
+
+**You MUST NOT close beads. EVER. No exceptions.**
+
+Do not run `bd close`, `gc bd close`, or set `--status=closed`. Only the
+Refinery closes beads after verifying the merge. If code appears already
+merged, reassign to refinery with a note — do not close.
+
 ## CRITICAL: Directory Discipline
 
 Your branch-setup step creates a git worktree and records it in `metadata.work_dir`

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -16,6 +16,10 @@ merge review.
 **No MR beads.** Work beads flow directly: pool → polecat → refinery → closed.
 The polecat sets `metadata.branch` and `metadata.target` on the work bead
 and reassigns it to the refinery. The refinery merges and closes.
+
+**NEVER CLOSE BEADS.** You must not run `bd close` or set status=closed.
+Even if you believe the code is already merged, reassign to refinery —
+only the refinery verifies merges and closes beads.
 `{{base_branch}}` may come from the work bead's own `metadata.target` or
 be inherited from a parent convoy with `metadata.target` set.
 

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -64,7 +64,21 @@ There is no "idle" state. There is no "waiting for more work."
 
 **Polecats do NOT:**
 - Push directly to main (Refinery merges)
-- Close the work bead (Refinery closes after merge)
+- **EVER run `bd close`** (Refinery closes after merge — see below)
 - Create MR beads (metadata on the work bead replaces this)
 - Wait around after running the done sequence
+
+### ABSOLUTE RESTRICTION: No Bead Closing
+
+**You MUST NOT close beads. EVER. Under ANY circumstances.**
+
+Do not run `bd close`, `gc bd close`, or set `--status=closed` on any bead.
+This applies even if you believe the code is "already merged" or "already on
+the target branch." Your merge verification is unreliable — you check commit
+messages and file diffs, not patch identity. Only the Refinery can verify a
+true merge via PR state or `git cherry`.
+
+If you encounter a bead whose work appears already done, reassign it to the
+Refinery with a note explaining what you observed. The Refinery will verify
+and close if appropriate.
 {{ end }}


### PR DESCRIPTION
## Summary

Today the polecat can close its own work bead at submit-and-exit. That removes the refinery's authoritative position as the merge gate: a polecat that pushes a branch but whose CI/tests fail post-push has already marked the work done.

This restricts close authority to the refinery. Polecats reassign to refinery and exit; refinery's merge success closes the bead. Updates the polecat prompt template, the `mol-polecat-work` formula, and the approval-fallacy template-fragment so polecats reassign-not-close even when the diff appears already merged.

## Test plan

- [x] `go test ./examples/gastown/...` passes
- [ ] Verify a polecat completing work reassigns to refinery (not closes)
- [ ] Verify refinery's merge success still closes the bead

Closes gc-vto4. Cherry-picked from `polecat/gc-m7qm` (commit f640c776) onto current `upstream/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)