### PR TITLE
feat(reconciler): claimRoutedWorkForIdleSessions assigns routed beads to named sessions (gc-0t58)

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -26,14 +26,15 @@ func buildAwakeInputFromReconciler(
 	clk time.Time,
 ) AwakeInput {
 	input := AwakeInput{
-		ScaleCheckCounts: poolDesired,
-		WorkSet:          workSet,
-		ReadyWaitSet:     readyWaitSet,
-		RunningSessions:  make(map[string]bool),
-		AttachedSessions: make(map[string]bool),
-		PendingSessions:  make(map[string]bool),
-		ChatIdleTimeout:  cfg.ChatSessions.IdleTimeoutDuration(),
-		Now:              clk,
+		ScaleCheckCounts:    poolDesired,
+		WorkSet:             workSet,
+		ReadyWaitSet:        readyWaitSet,
+		RoutedWorkTemplates: workSet,
+		RunningSessions:     make(map[string]bool),
+		AttachedSessions:    make(map[string]bool),
+		PendingSessions:     make(map[string]bool),
+		ChatIdleTimeout:     cfg.ChatSessions.IdleTimeoutDuration(),
+		Now:                 clk,
 	}
 
 	// Agents
@@ -151,6 +152,8 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 				reasons = []WakeReason{WakeWait}
 			case "assigned-work", "work-query":
 				reasons = []WakeReason{WakeWork}
+			case "routed":
+				reasons = []WakeReason{WakeRouted}
 			default:
 				reasons = []WakeReason{WakeConfig}
 			}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -16,18 +16,19 @@ const defaultOnDemandIdleTimeout = 5 * time.Minute
 // should be awake. All external I/O (shell commands, tmux checks, store
 // queries) happens before this function is called.
 type AwakeInput struct {
-	Agents           []AwakeAgent
-	NamedSessions    []AwakeNamedSession
-	SessionBeads     []AwakeSessionBead
-	WorkBeads        []AwakeWorkBead
-	ScaleCheckCounts map[string]int  // agent template → desired count
-	WorkSet          map[string]bool // agent template → work_query found pending work
-	RunningSessions  map[string]bool // session name → tmux exists
-	AttachedSessions map[string]bool // session name → user attached
-	PendingSessions  map[string]bool // session name → pending interaction
-	ReadyWaitSet     map[string]bool // session bead ID → durable wait is ready
-	ChatIdleTimeout  time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
-	Now              time.Time
+	Agents              []AwakeAgent
+	NamedSessions       []AwakeNamedSession
+	SessionBeads        []AwakeSessionBead
+	WorkBeads           []AwakeWorkBead
+	ScaleCheckCounts    map[string]int  // agent template → desired count
+	WorkSet             map[string]bool // agent template → work_query found pending work
+	RunningSessions     map[string]bool // session name → tmux exists
+	AttachedSessions    map[string]bool // session name → user attached
+	PendingSessions     map[string]bool // session name → pending interaction
+	ReadyWaitSet        map[string]bool // session bead ID → durable wait is ready
+	ChatIdleTimeout     time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	RoutedWorkTemplates map[string]bool // agent template → has unprocessed gc.routed_to work
+	Now                 time.Time
 }
 
 // AwakeAgent represents an [[agent]] config entry.
@@ -185,6 +186,34 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		if creating := collectCreatingBeads(input.SessionBeads, template); len(creating) > 0 {
 			desired[creating[0].SessionName] = "work-query"
+		}
+	}
+
+	// RoutedWorkTemplates: when beads carry gc.routed_to for a template,
+	// ensure at least one session is desired with reason "routed". Fires
+	// only when ScaleCheckCounts hasn't caught up (same gate as WorkSet).
+	// The "routed" reason upgrades "work-query" from WorkSet so the
+	// bridge emits WakeRouted for tracing and nudge dispatch.
+	for template, hasWork := range input.RoutedWorkTemplates {
+		if !hasWork {
+			continue
+		}
+		if input.ScaleCheckCounts[template] > 0 {
+			continue
+		}
+		agent, ok := agentsByName[template]
+		if !ok || agent.Suspended {
+			continue
+		}
+		if isNamedSessionTemplate(input.NamedSessions, template) {
+			continue
+		}
+		if active := collectActiveBeads(input.SessionBeads, template); len(active) > 0 {
+			desired[active[0].SessionName] = "routed"
+			continue
+		}
+		if creating := collectCreatingBeads(input.SessionBeads, template); len(creating) > 0 {
+			desired[creating[0].SessionName] = "routed"
 		}
 	}
 

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1504,3 +1504,190 @@ func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	})
 	assertAsleep(t, result, "polecat-mc-1")
 }
+
+// ---------------------------------------------------------------------------
+// RoutedWorkTemplates — gc.routed_to wake signal + nudge enabler
+// ---------------------------------------------------------------------------
+
+func TestRoutedWork_WakesActiveSession(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "routed")
+}
+
+func TestRoutedWork_NoOpWhenScaleCheckCovers(t *testing.T) {
+	// When ScaleCheckCounts already covers the template, RoutedWork defers
+	// to ScaleCheck (same gate as WorkSet). Nudge dispatch in the
+	// reconciler handles alive sessions independently.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-2", SessionName: "polecat-mc-2", Template: "hello-world/polecat", State: "active"},
+		},
+		ScaleCheckCounts:    map[string]int{"hello-world/polecat": 1},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true, "polecat-mc-2": true},
+		Now:                 now,
+	})
+	awake := 0
+	for _, d := range result {
+		if d.ShouldWake {
+			awake++
+		}
+	}
+	if awake != 1 {
+		t.Errorf("ScaleCheck=1 should cap to 1, RoutedWork should not add more, got %d awake", awake)
+	}
+	assertReason(t, result, "polecat-mc-1", "scaled:demand")
+}
+
+func TestRoutedWork_DoesNotOverrideExistingReason(t *testing.T) {
+	// When a session is already desired (e.g. via ScaleCheck), RoutedWork
+	// should not overwrite the existing reason.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		ScaleCheckCounts:    map[string]int{"hello-world/polecat": 1},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "scaled:demand")
+}
+
+func TestRoutedWork_SkipsSuspendedAgent(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", Suspended: true}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsDrained(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active", Drained: true},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsDependencyOnly(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active", DependencyOnly: true},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_SkipsNamedSession(t *testing.T) {
+	// RoutedWorkTemplates skips named-session templates. The named-session
+	// pass handles those independently.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "hello-world/worker"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "hello-world/worker", Template: "hello-world/worker", Mode: "on_demand"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "worker", Template: "hello-world/worker", State: "asleep", NamedIdentity: "hello-world/worker"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/worker": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "worker")
+}
+
+func TestRoutedWork_FallsBackToCreating(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "creating"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		Now:                 now,
+	})
+	assertAwake(t, result, "polecat-mc-1")
+	assertReason(t, result, "polecat-mc-1", "routed")
+}
+
+func TestRoutedWork_SuppressedByHeldUntil(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active",
+				HeldUntil: now.Add(5 * time.Minute),
+			},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": true},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_FalseValue_NoEffect(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: map[string]bool{"hello-world/polecat": false},
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_NilMap_NoEffect(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat", State: "active"},
+		},
+		RoutedWorkTemplates: nil,
+		RunningSessions:     map[string]bool{"polecat-mc-1": true},
+		Now:                 now,
+	})
+	assertAsleep(t, result, "polecat-mc-1")
+}
+
+func TestRoutedWork_BridgeMapsToWakeRouted(t *testing.T) {
+	decisions := map[string]AwakeDecision{
+		"polecat-mc-1": {ShouldWake: true, Reason: "routed"},
+	}
+	beads := []AwakeSessionBead{
+		{ID: "mc-1", SessionName: "polecat-mc-1", Template: "hello-world/polecat"},
+	}
+	evals := awakeSetToWakeEvals(decisions, beads)
+	eval, ok := evals["mc-1"]
+	if !ok {
+		t.Fatal("expected eval for mc-1")
+	}
+	if len(eval.Reasons) != 1 || eval.Reasons[0] != WakeRouted {
+		t.Errorf("reasons = %v, want [%s]", eval.Reasons, WakeRouted)
+	}
+}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -445,6 +445,57 @@ func computeWorkSet(cfg *config.City, runner ScaleCheckRunner, cityName, cityDir
 	return work
 }
 
+// nudgeRoutedWorkSessions queues nudges for alive sessions whose templates
+// have pending routed work. This bridges the gap where scale_check/pool
+// desired correctly wake or keep sessions alive, but the session itself
+// hasn't polled its hook for newly arrived gc.routed_to work.
+func nudgeRoutedWorkSessions(
+	cityPath string,
+	cfg *config.City,
+	_ runtime.Provider,
+	store beads.Store,
+	targets []wakeTarget,
+	awakeDecisions map[string]AwakeDecision,
+	workSet map[string]bool,
+	stdout, stderr io.Writer,
+) {
+	if len(workSet) == 0 || len(targets) == 0 {
+		return
+	}
+	nudged := make(map[string]bool)
+	for _, target := range targets {
+		if !target.alive {
+			continue
+		}
+		template := normalizedSessionTemplate(*target.session, cfg)
+		if !workSet[template] {
+			continue
+		}
+		if nudged[template] {
+			continue
+		}
+		name := strings.TrimSpace(target.session.Metadata["session_name"])
+		if name == "" {
+			continue
+		}
+		decision, ok := awakeDecisions[name]
+		if !ok || !decision.ShouldWake {
+			continue
+		}
+		ref := &nudgeReference{Kind: "routed-work", ID: template}
+		item := newQueuedNudgeWithOptions(name, "routed work available", "reconciler", time.Now(), queuedNudgeOptions{
+			SessionID: target.session.ID,
+			Reference: ref,
+		})
+		if err := enqueueQueuedNudgeWithStore(cityPath, store, item); err != nil {
+			fmt.Fprintf(stderr, "nudgeRoutedWork: %s: %v\n", name, err) //nolint:errcheck
+			continue
+		}
+		fmt.Fprintf(stdout, "Queued routed-work nudge for %s (%s)\n", name, template) //nolint:errcheck
+		nudged[template] = true
+	}
+}
+
 // findAgentByTemplate looks up a config agent by template name.
 // Returns nil if not found.
 func findAgentByTemplate(cfg *config.City, template string) *config.Agent {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -496,6 +496,84 @@ func nudgeRoutedWorkSessions(
 	}
 }
 
+// claimRoutedWorkForIdleSessions assigns unassigned routed beads to alive
+// sessions whose templates have pending routed work. This complements
+// nudgeRoutedWorkSessions: the nudge tells the session to re-check its hook,
+// but named sessions can't see routed-unassigned beads via work_query Tier 3
+// (which gates on GC_SESSION_ORIGIN=ephemeral). By explicitly assigning the
+// bead, it becomes visible in Tier 1/2 (assigned work), which all session
+// types can see.
+func claimRoutedWorkForIdleSessions(
+	cfg *config.City,
+	store beads.Store,
+	targets []wakeTarget,
+	awakeDecisions map[string]AwakeDecision,
+	workSet map[string]bool,
+	stdout, stderr io.Writer,
+) {
+	if store == nil || cfg == nil || len(workSet) == 0 || len(targets) == 0 {
+		return
+	}
+	claimed := make(map[string]bool)
+	for _, target := range targets {
+		if !target.alive {
+			continue
+		}
+		template := normalizedSessionTemplate(*target.session, cfg)
+		if !workSet[template] {
+			continue
+		}
+		if claimed[template] {
+			continue
+		}
+		name := strings.TrimSpace(target.session.Metadata["session_name"])
+		if name == "" {
+			continue
+		}
+		decision, ok := awakeDecisions[name]
+		if !ok || !decision.ShouldWake {
+			continue
+		}
+
+		agent := findAgentByTemplate(cfg, template)
+		if agent == nil {
+			continue
+		}
+		routingTarget := agent.QualifiedName()
+		if agent.PoolName != "" {
+			routingTarget = agent.PoolName
+		}
+
+		candidates, err := store.List(beads.ListQuery{
+			Status:   "open",
+			Metadata: map[string]string{"gc.routed_to": routingTarget},
+			Limit:    1,
+		})
+		if err != nil || len(candidates) == 0 {
+			continue
+		}
+		// Skip beads that already have an assignee.
+		var unassigned *beads.Bead
+		for i := range candidates {
+			if candidates[i].Assignee == "" {
+				unassigned = &candidates[i]
+				break
+			}
+		}
+		if unassigned == nil {
+			continue
+		}
+
+		assignee := target.session.ID
+		if err := store.Update(unassigned.ID, beads.UpdateOpts{Assignee: &assignee}); err != nil {
+			fmt.Fprintf(stderr, "claimRoutedWork: assign %s to %s: %v\n", unassigned.ID, name, err) //nolint:errcheck
+			continue
+		}
+		fmt.Fprintf(stdout, "Assigned routed bead %s to %s (%s)\n", unassigned.ID, name, template) //nolint:errcheck
+		claimed[template] = true
+	}
+}
+
 // findAgentByTemplate looks up a config agent by template name.
 // Returns nil if not found.
 func findAgentByTemplate(cfg *config.City, template string) *config.Agent {

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2440,3 +2440,55 @@ func TestNudgeRoutedWorkSessions_SkipsMissingDecision(t *testing.T) {
 		t.Errorf("should not nudge when session is missing from decisions map, got: %q", stdout.String())
 	}
 }
+
+// createErrStore wraps a beads.Store and forces Create to fail. Used to
+// exercise the error branch inside nudgeRoutedWorkSessions where the
+// underlying nudge enqueue fails to persist its bead.
+type createErrStore struct {
+	beads.Store
+	err error
+}
+
+func (s *createErrStore) Create(_ beads.Bead) (beads.Bead, error) {
+	return beads.Bead{}, s.err
+}
+
+func TestNudgeRoutedWorkSessions_LogsEnqueueFailure(t *testing.T) {
+	// When the nudge enqueue fails (e.g., underlying bead Create errors
+	// from a broken store view), the loop must log to stderr and move on
+	// rather than panic or mark the template as nudged.
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	store := &createErrStore{Store: beads.NewMemStore(), err: fmt.Errorf("simulated store failure")}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, store, targets, decisions, workSet, &stdout, &stderr)
+
+	if !strings.Contains(stderr.String(), "nudgeRoutedWork") {
+		t.Errorf("expected stderr to log enqueue failure under nudgeRoutedWork prefix; got: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "simulated store failure") {
+		t.Errorf("expected stderr to include underlying error text; got: %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Queued routed-work nudge") {
+		t.Errorf("stdout should not log a successful nudge when enqueue fails; got: %q", stdout.String())
+	}
+}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2173,3 +2173,270 @@ func TestComputeWorkSet_RigScopedWorkQueryExpandsRigTemplate(t *testing.T) {
 		t.Errorf("beta probe command = %q, want expanded gc.routed_to=beta/worker", got)
 	}
 }
+
+func TestNudgeRoutedWorkSessions_NudgesAliveSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID:     "ses-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{
+		{session: session, alive: true},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if !strings.Contains(stdout.String(), "Queued routed-work nudge") {
+		t.Errorf("expected nudge queued output, got: %q", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsDeadSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID:     "ses-1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{
+		{session: session, alive: false},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "routed"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge dead session, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_NudgesOncePerTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	targets := []wakeTarget{
+		{
+			session: &beads.Bead{
+				ID: "ses-1", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-1",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+		{
+			session: &beads.Bead{
+				ID: "ses-2", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-2",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+		"polecat-2": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	nudgeCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "Queued routed-work nudge") {
+			nudgeCount++
+		}
+	}
+	if nudgeCount != 1 {
+		t.Errorf("expected exactly 1 nudge per template, got %d", nudgeCount)
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsNoWorkTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "config"},
+	}
+	workSet := map[string]bool{} // no routed work
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when no routed work, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsTemplateNotInWorkSet(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+			{Name: "refinery", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	// workSet has routed work, but for a different template than the target.
+	workSet := map[string]bool{"gascity/refinery": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when target template has no routed work, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsEmptySessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "", // missing session_name -> cannot queue a nudge
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge session with empty session_name, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsShouldNotWakeDecision(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	// Session IS alive and matches routed work, but the awake decision says
+	// it should not wake (e.g., held under churn/quarantine rules). Don't nudge.
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: false, Reason: "quarantined"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when decision.ShouldWake=false, got: %q", stdout.String())
+	}
+}
+
+func TestNudgeRoutedWorkSessions_SkipsMissingDecision(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	// No entry for "polecat-1" in the decisions map — treat as "no desire to wake".
+	decisions := map[string]AwakeDecision{}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	nudgeRoutedWorkSessions(cityPath, cfg, nil, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not nudge when session is missing from decisions map, got: %q", stdout.String())
+	}
+}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -2492,3 +2492,269 @@ func TestNudgeRoutedWorkSessions_LogsEnqueueFailure(t *testing.T) {
 		t.Errorf("stdout should not log a successful nudge when enqueue fails; got: %q", stdout.String())
 	}
 }
+func TestClaimRoutedWork_AssignsBeadToAliveSession(t *testing.T) {
+	store := beads.NewMemStore()
+	workBead, _ := store.Create(beads.Bead{
+		Title:    "routed task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/polecat"},
+	})
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, store, targets, decisions, workSet, &stdout, &stderr)
+
+	updated, err := store.Get(workBead.ID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	if updated.Assignee != "ses-1" {
+		t.Errorf("expected assignee ses-1, got %q", updated.Assignee)
+	}
+	if !strings.Contains(stdout.String(), "Assigned routed bead") {
+		t.Errorf("expected assignment output, got: %q", stdout.String())
+	}
+}
+
+func TestClaimRoutedWork_SkipsAlreadyAssigned(t *testing.T) {
+	store := beads.NewMemStore()
+	store.Create(beads.Bead{
+		Title:    "already assigned",
+		Status:   "open",
+		Assignee: "other-session",
+		Metadata: map[string]string{"gc.routed_to": "gascity/polecat"},
+	})
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, store, targets, decisions, workSet, &stdout, &stderr)
+
+	if strings.Contains(stdout.String(), "Assigned") {
+		t.Errorf("should not assign already-assigned bead, got: %q", stdout.String())
+	}
+}
+
+func TestClaimRoutedWork_SkipsDeadSession(t *testing.T) {
+	store := beads.NewMemStore()
+	workBead, _ := store.Create(beads.Bead{
+		Title:    "routed task",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/polecat"},
+	})
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: false}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, store, targets, decisions, workSet, &stdout, &stderr)
+
+	updated, _ := store.Get(workBead.ID)
+	if updated.Assignee != "" {
+		t.Errorf("should not assign to dead session, got assignee %q", updated.Assignee)
+	}
+}
+
+func TestClaimRoutedWork_ClaimsOncePerTemplate(t *testing.T) {
+	store := beads.NewMemStore()
+	store.Create(beads.Bead{
+		Title:    "routed task 1",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/polecat"},
+	})
+	store.Create(beads.Bead{
+		Title:    "routed task 2",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/polecat"},
+	})
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	targets := []wakeTarget{
+		{
+			session: &beads.Bead{
+				ID: "ses-1", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-1",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+		{
+			session: &beads.Bead{
+				ID: "ses-2", Status: "open",
+				Metadata: map[string]string{
+					"session_name": "polecat-2",
+					"template":     "gascity/polecat",
+					"state":        "active",
+				},
+			},
+			alive: true,
+		},
+	}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+		"polecat-2": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, store, targets, decisions, workSet, &stdout, &stderr)
+
+	assignCount := strings.Count(stdout.String(), "Assigned routed bead")
+	if assignCount != 1 {
+		t.Errorf("expected exactly 1 assignment per template per tick, got %d", assignCount)
+	}
+}
+
+func TestClaimRoutedWork_NoWorkSet(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "config"},
+	}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, store, targets, decisions, map[string]bool{}, &stdout, &stderr)
+
+	if stdout.Len() > 0 {
+		t.Errorf("should not assign when no work, got: %q", stdout.String())
+	}
+}
+
+func TestClaimRoutedWork_UsesPoolName(t *testing.T) {
+	store := beads.NewMemStore()
+	workBead, _ := store.Create(beads.Bead{
+		Title:    "routed to pool",
+		Status:   "open",
+		Metadata: map[string]string{"gc.routed_to": "gascity/worker"},
+	})
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker-1", Dir: "gascity"},
+		},
+	}
+	cfg.Agents[0].PoolName = "gascity/worker"
+
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"template":     "gascity/worker-1",
+			"state":        "active",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"worker-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/worker-1": true}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, store, targets, decisions, workSet, &stdout, &stderr)
+
+	updated, err := store.Get(workBead.ID)
+	if err != nil {
+		t.Fatalf("get bead: %v", err)
+	}
+	if updated.Assignee != "ses-1" {
+		t.Errorf("expected assignee ses-1, got %q", updated.Assignee)
+	}
+}
+
+func TestClaimRoutedWork_NilStore(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "polecat", Dir: "gascity"},
+		},
+	}
+	session := &beads.Bead{
+		ID: "ses-1", Status: "open",
+		Metadata: map[string]string{
+			"session_name": "polecat-1",
+			"template":     "gascity/polecat",
+		},
+	}
+	targets := []wakeTarget{{session: session, alive: true}}
+	decisions := map[string]AwakeDecision{
+		"polecat-1": {ShouldWake: true, Reason: "scaled:demand"},
+	}
+	workSet := map[string]bool{"gascity/polecat": true}
+
+	var stdout, stderr strings.Builder
+	claimRoutedWorkForIdleSessions(cfg, nil, targets, decisions, workSet, &stdout, &stderr)
+
+	if stdout.Len() > 0 || stderr.Len() > 0 {
+		t.Errorf("nil store should no-op, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1046,6 +1046,8 @@ func reconcileSessionBeadsTraced(
 		clk, rec, startupTimeout, stdout, stderr, trace,
 	)
 
+	nudgeRoutedWorkSessions(cityPath, cfg, sp, store, wakeTargets, awakeDecisions, workSet, stdout, stderr)
+
 	// Phase 2: Advance all in-flight drains.
 	sessionLookup := func(id string) *beads.Bead {
 		return beadByID[id]

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1047,6 +1047,7 @@ func reconcileSessionBeadsTraced(
 	)
 
 	nudgeRoutedWorkSessions(cityPath, cfg, sp, store, wakeTargets, awakeDecisions, workSet, stdout, stderr)
+	claimRoutedWorkForIdleSessions(cfg, store, wakeTargets, awakeDecisions, workSet, stdout, stderr)
 
 	// Phase 2: Advance all in-flight drains.
 	sessionLookup := func(id string) *beads.Bead {

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -35,6 +35,9 @@ const (
 	WakePin WakeReason = "pin"
 	// WakeDependency means another awake session depends on this template.
 	WakeDependency WakeReason = "dependency"
+	// WakeRouted means unprocessed routed work (gc.routed_to) targets this
+	// template. Triggers nudge dispatch for alive sessions.
+	WakeRouted WakeReason = "routed"
 )
 
 // ExecSpec defines a validated command for process creation.


### PR DESCRIPTION
## Summary

**⚠️ Stacks on PR #1139** (`feat/routed-work-autonudge`). This PR adds `claimRoutedWorkForIdleSessions` on top of the `nudgeRoutedWorkSessions` foundation introduced in #1139. **Will not cleanly merge until #1139 lands** — at that point this PR's diff will reduce to just the new claim logic + tests.

Named sessions can't see routed-unassigned beads via work_query Tier 3 (which gates on ephemeral origin). This new reconciler step explicitly assigns unassigned `gc.routed_to` beads to alive named sessions, making them visible in Tier 1/2 (assigned work). Claims once per template per tick to avoid overloading a single session.

Complements #1139's auto-nudge: nudge wakes a session, claim makes the work visible to it.

## Test plan

- [x] 7 new `TestClaimRoutedWork_*` tests pass
- [x] Existing `TestNudgeRoutedWorkSessions_*` (from #1139) still pass — no regression
- [x] `go vet ./cmd/gc/` clean

Closes gc-0t58. Cherry-picked from `polecat/gc-m7qm` (commit fa7e290b). Conflict in `session_reconcile_test.go` resolved by keeping #1139's polished nudge tests as-is and appending the new claim tests below them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)