### PR TITLE
fix(maintenance): orphan-sweep walks every rig, not just HQ (#1391)

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -97,6 +97,92 @@ exit 0
 	}
 }
 
+func TestOrphanSweepPreservesQualifiedRigAssignees(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+case "$1" in
+  config)
+    if [ "$2" = "explain" ]; then
+      cat <<'EOF'
+Agent: gastown.deacon
+  source: pack
+Agent: project/gastown.refinery
+  source: pack
+Agent: project/gastown.polecat
+  source: pack
+EOF
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+      printf '{"rigs":[{"name":"hq","hq":true},{"name":"project","hq":false}]}\n'
+      exit 0
+    fi
+    ;;
+  bd)
+    if [ "$2" = "list" ]; then
+      case "$*" in
+        *"--rig project"*)
+          cat <<'EOF'
+[
+  {"id":"ga-valid","status":"in_progress","assignee":"project/gastown.refinery"},
+  {"id":"ga-pool","status":"in_progress","assignee":"project/gastown.polecat-3"},
+  {"id":"ga-orphan","status":"in_progress","assignee":"project/gastown.missing"}
+]
+EOF
+          ;;
+        *)
+          printf '[]\n'
+          ;;
+      esac
+      exit 0
+    fi
+    if [ "$2" = "update" ]; then
+      exit 0
+    fi
+    ;;
+esac
+exit 1
+`)
+
+	env := map[string]string{
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"GC_CALL_LOG":  gcLog,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "orphan-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+	if !strings.Contains(string(out), "orphan-sweep: reset 1 orphaned beads") {
+		t.Fatalf("unexpected orphan-sweep output:\n%s", out)
+	}
+
+	logData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "bd update ga-orphan --status=open --assignee=") {
+		t.Fatalf("orphan bead was not reset:\n%s", log)
+	}
+	for _, preserved := range []string{"ga-valid", "ga-pool"} {
+		if strings.Contains(log, "bd update "+preserved+" ") {
+			t.Fatalf("valid assignee %s was reset:\n%s", preserved, log)
+		}
+	}
+}
+
 func TestMaintenanceDoltScriptsFallbackToManagedRuntimePorts(t *testing.T) {
 	scripts := []struct {
 		name   string

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -13,9 +13,25 @@ set -euo pipefail
 
 CITY="${GC_CITY:-.}"
 
-# Step 1: Get all in-progress beads with assignees.
-IN_PROGRESS=$(bd list --status=in_progress --json --limit=0 2>/dev/null) || exit 0
-if [ -z "$IN_PROGRESS" ] || [ "$IN_PROGRESS" = "[]" ]; then
+# Step 1: Collect in-progress beads from HQ and every rig.
+# `gc bd list` without --rig is HQ-scoped from the city cwd, so per-rig
+# beads are invisible to a bare query — walk every rig explicitly.
+TMP=$(mktemp) || exit 0
+trap 'rm -f "$TMP"' EXIT
+
+gc bd list --status=in_progress --json --limit=0 2>/dev/null >>"$TMP" || true
+
+RIG_LIST=$(gc rig list --json 2>/dev/null) || RIG_LIST=""
+if [ -n "$RIG_LIST" ]; then
+    RIG_NAMES=$(echo "$RIG_LIST" | jq -r '.rigs[] | select(.hq == false) | .name' 2>/dev/null) || RIG_NAMES=""
+    while IFS= read -r rig; do
+        [ -z "$rig" ] && continue
+        gc bd list --rig "$rig" --status=in_progress --json --limit=0 2>/dev/null >>"$TMP" || true
+    done <<<"$RIG_NAMES"
+fi
+
+IN_PROGRESS=$(jq -c -s 'add // []' "$TMP" 2>/dev/null) || IN_PROGRESS="[]"
+if [ "$IN_PROGRESS" = "[]" ]; then
     exit 0
 fi
 
@@ -47,7 +63,9 @@ is_known_agent() {
 ORPHANED=0
 echo "$IN_PROGRESS" | jq -r '.[] | select(.assignee != null and .assignee != "") | "\(.id)\t\(.assignee)"' 2>/dev/null | while IFS=$'\t' read -r bead_id assignee; do
     if ! is_known_agent "$assignee"; then
-        bd update "$bead_id" --status=open --assignee="" 2>/dev/null || true
+        # `gc bd update` auto-resolves the bead's prefix to the right rig
+        # store, so HQ and rig beads update in the correct database.
+        gc bd update "$bead_id" --status=open --assignee="" 2>/dev/null || true
         ORPHANED=$((ORPHANED + 1))
     fi
 done

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -35,8 +35,13 @@ if [ "$IN_PROGRESS" = "[]" ]; then
     exit 0
 fi
 
-# Step 2: Get all known agent names (from config, scoped to [[agent]] blocks).
-AGENTS=$(gc config show 2>/dev/null | awk '/^\[\[agent\]\]/{a=1} a && /^\s*name\s*=/{print; a=0}' | sed 's/.*=\s*"\(.*\)"/\1/') || exit 0
+# Step 2: Get all known agent identities from resolved config.
+# `gc config explain` prints Agent.QualifiedName(), including import binding
+# and rig scope. Fall back to the older config-show parser for older binaries.
+AGENTS=$(gc config explain 2>/dev/null | awk '/^Agent: /{print $2}') || AGENTS=""
+if [ -z "$AGENTS" ]; then
+    AGENTS=$(gc config show 2>/dev/null | awk '/^\[\[agent\]\]/{a=1} a && /^\s*name\s*=/{print; a=0}' | sed 's/.*=\s*"\(.*\)"/\1/') || exit 0
+fi
 if [ -z "$AGENTS" ]; then
     exit 0
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -61,14 +61,16 @@ is_known_agent() {
 }
 
 ORPHANED=0
-echo "$IN_PROGRESS" | jq -r '.[] | select(.assignee != null and .assignee != "") | "\(.id)\t\(.assignee)"' 2>/dev/null | while IFS=$'\t' read -r bead_id assignee; do
+# Process substitution (not a pipe) keeps the loop body in the parent
+# shell so $ORPHANED survives for the summary message below.
+while IFS=$'\t' read -r bead_id assignee; do
     if ! is_known_agent "$assignee"; then
         # `gc bd update` auto-resolves the bead's prefix to the right rig
         # store, so HQ and rig beads update in the correct database.
         gc bd update "$bead_id" --status=open --assignee="" 2>/dev/null || true
         ORPHANED=$((ORPHANED + 1))
     fi
-done
+done < <(echo "$IN_PROGRESS" | jq -r '.[] | select(.assignee != null and .assignee != "") | "\(.id)\t\(.assignee)"' 2>/dev/null)
 
 if [ "$ORPHANED" -gt 0 ]; then
     echo "orphan-sweep: reset $ORPHANED orphaned beads"


### PR DESCRIPTION
## Summary

Fixes #1391. The orphan-sweep maintenance order was a silent no-op for every rig-level bead because both halves of its bd interaction were HQ-scoped:

- **Discovery** — `bd list --status=in_progress` from city cwd inherits HQ scope; rig-level in-progress beads (e.g. `vfps-wisp-zak4`) were invisible.
- **Reset** — even after fixing discovery, `bd update <rig-prefixed-id>` from city cwd would still target HQ and silently no-op for rig beads.

This PR walks `gc rig list --json` to enumerate every non-HQ rig, queries each one with `gc bd list --rig "$name"`, and unions the per-rig results via a temp file plus `jq -s 'add // []'`. The reset call switches from bare `bd update` to `gc bd update`, which auto-resolves the bead's prefix to the correct rig store via `cmd_bd.go:241-246` (`bdRigForArg` + `findRigByPrefix`). HQ-prefixed IDs fall through prefix lookup and land on city scope, preserving existing HQ behavior.

Reported from a downstream city after observing rig orphans accumulate while orphan-sweep ran on schedule with no effect.

## Files

- `examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh` (+22 / −4)

## Test plan

- [x] `bash -n` syntax check
- [x] `make build` / `go vet ./...` / `go test ./test/packlint/...` — green
- [x] `jq -s 'add // []'` semantics verified against `(populated, populated)`, `(empty, populated)`, `(populated, empty)`, and empty-file inputs
- [x] Confirmed `gc bd <subcmd> <prefixed-id>` auto-routes via `bdRigForArg` (`cmd_bd.go:241-246`) — works for both HQ and rig beads
- [x] Cross-provider review (Claude reuse/quality/efficiency + GPT-5.4 codex + GPT-5.3-codex copilot): 0 blockers, 0 majors
- [x] 29-rule contributor audit (mechanical gates green, B23 self-completeness fix landed in this PR)

Manual repro on a multi-rig city is the highest-confidence verification (no testscript coverage exists today for any maintenance script in this directory; staying with repo convention).

## Sibling scripts with the same blind spot (follow-up)

The contributor audit (B23) flagged that three sibling scripts use the same HQ-only `bd list` pattern this PR fixes for orphan-sweep:

- `examples/gastown/packs/maintenance/assets/scripts/spawn-storm-detect.sh:31`
- `examples/gastown/packs/maintenance/assets/scripts/cross-rig-deps.sh:26`
- `examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh:22`

Each has different cleanup semantics (closed-bead replays, dep conversions, wisp pruning), so a single mechanical fix isn't safe — each needs its own per-rig design. Happy to file separate issues if useful.

## Notes for reviewers

- The `--limit=500`/`bd_safe`/`flock` hardening from PR #544 is orthogonal and does not conflict with this fix; that PR currently targets a since-renamed path (`scripts/` vs the new `assets/scripts/`) and will need rebase regardless.
- During the audit, prune-branches.sh:15 was observed parsing `gc rig list --json` as `.[].path` (top-level array) — that's the wrong shape against the current envelope `{"rigs": [...]}`. Out of scope for this PR; will file as a follow-up bug.