### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "37 5 * * 2"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: scorecard.sarif
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: openssf-scorecard-sarif
+          path: scorecard.sarif
+          retention-days: 5


### PR DESCRIPTION
## Summary
- add a weekly and main-branch OpenSSF Scorecard workflow
- publish results to the Scorecard API/badge path with `publish_results: true`
- upload SARIF results into GitHub code scanning and retain the SARIF artifact for short-term debugging
- keep actions SHA-pinned and use job-scoped permissions only (`contents: read`, `security-events: write`, `id-token: write`)

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/scorecard.yml
- git diff --check
- .githooks/pre-commit
- go test ./...
- go vet ./...

Refs ga-e8d0k.14