### PR TITLE
fix(reconciler): stabilize startup ordering and dolt port retry

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2904,6 +2904,118 @@ func TestGcBeadsBdStartUsesRootBeadsDataDir(t *testing.T) {
 	}
 }
 
+func TestGcBeadsBdStartRetriesAutoPortBindConflict(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := t.TempDir()
+	attemptsFile := filepath.Join(stateDir, "attempts")
+	portsFile := filepath.Join(stateDir, "ports")
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	fakeDoltScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+attempts_file=%q
+ports_file=%q
+cmd="${1:-}"
+case "$cmd" in
+  config)
+    exit 0
+    ;;
+  --host)
+    exit 0
+    ;;
+  sql-server)
+    config_file=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --config)
+          shift
+          config_file="$1"
+          ;;
+      esac
+      shift || true
+    done
+    port=$(awk '/^[[:space:]]*port:/{print $2; exit}' "$config_file")
+    printf '%%s\n' "$port" >> "$ports_file"
+    count=0
+    if [ -f "$attempts_file" ]; then
+      count=$(cat "$attempts_file")
+    fi
+    count=$((count + 1))
+    printf '%%s\n' "$count" > "$attempts_file"
+    if [ "$count" -eq 1 ]; then
+      echo "Starting server with Config HP=\"0.0.0.0:${port}\"|T=\"300000\"|R=\"false\"|L=\"warning\""
+      echo "listen tcp 0.0.0.0:${port}: bind: address already in use"
+      exit 1
+    fi
+    sleep 60
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, attemptsFile, portsFile)
+	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeNC := filepath.Join(binDir, "nc")
+	if err := os.WriteFile(fakeNC, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	scriptEnv := sanitizedBaseEnv(
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)
+	t.Cleanup(func() {
+		cmd := exec.Command(script, "stop")
+		cmd.Env = scriptEnv
+		_ = cmd.Run()
+	})
+
+	cmd := exec.Command(script, "start")
+	cmd.Env = scriptEnv
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(portsFile)
+	if err != nil {
+		t.Fatalf("read attempted ports: %v", err)
+	}
+	ports := strings.Fields(string(data))
+	if len(ports) != 2 {
+		t.Fatalf("attempted ports = %v, want two startup attempts", ports)
+	}
+	if ports[0] == ports[1] {
+		t.Fatalf("retry reused busy port %s", ports[0])
+	}
+
+	state, err := readDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("read provider state: %v", err)
+	}
+	if got := strconv.Itoa(state.Port); got != ports[1] {
+		t.Fatalf("provider state port = %q, want retry port %q", got, ports[1])
+	}
+}
+
 func TestGcBeadsBdInitRetriesRootStoreVerification(t *testing.T) {
 	cityPath := t.TempDir()
 	writeMinimalCityToml(t, cityPath)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -382,6 +382,11 @@ func (cr *CityRuntime) run(ctx context.Context) {
 		return
 	}
 
+	// Dispatch due orders before startup session reconciliation. A cold-start
+	// reconcile can take minutes when it has stale or config-drifted sessions;
+	// due event/condition formulas should not wait behind that maintenance work.
+	cr.dispatchOrders(ctx, cityRoot)
+
 	// Session bead sync BEFORE reconciliation: ensures beads exist for
 	// the reconciler to read/write hashes. Uses ListByLabel (indexed,
 	// fast even before CachingStore is primed).

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -911,6 +911,63 @@ func TestCachingStoreCloseNotifiesWhenBeadIsMissingFromCache(t *testing.T) {
 	}
 }
 
+func TestCachingStoreListByLabelSeesCreatedBeadAfterMetadataWrite(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		prime func(*beads.CachingStore) error
+	}{
+		{
+			name:  "partial",
+			prime: func(cs *beads.CachingStore) error { return cs.PrimeActive() },
+		},
+		{
+			name:  "live",
+			prime: func(cs *beads.CachingStore) error { return cs.Prime(context.Background()) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mem := beads.NewMemStore()
+			cs := beads.NewCachingStoreForTest(mem, nil)
+			if err := tc.prime(cs); err != nil {
+				t.Fatalf("prime: %v", err)
+			}
+
+			created, err := cs.Create(beads.Bead{
+				Title:  "worker",
+				Type:   "session",
+				Labels: []string{"gc.session", "agent:worker"},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if err := cs.SetMetadata(created.ID, "session_name", "s-"+created.ID); err != nil {
+				t.Fatalf("SetMetadata(session_name): %v", err)
+			}
+
+			got, err := cs.List(beads.ListQuery{
+				Label: "gc.session",
+				Sort:  beads.SortCreatedAsc,
+			})
+			if err != nil {
+				t.Fatalf("List(label): %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("List(label) len = %d, want 1", len(got))
+			}
+			if got[0].ID != created.ID {
+				t.Fatalf("List(label) ID = %q, want %q", got[0].ID, created.ID)
+			}
+			if got[0].Metadata["session_name"] != "s-"+created.ID {
+				t.Fatalf("session_name = %q, want %q", got[0].Metadata["session_name"], "s-"+created.ID)
+			}
+		})
+	}
+}
+
 func TestCachingStoreApplyEvent(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()


### PR DESCRIPTION
## Summary
- dispatch orders before session reconcile work can start sessions
- retry managed Dolt auto-port bind conflicts
- add cache label read-after-write coverage

## Verification
- go test ./cmd/gc ./internal/beads -run 'TestGcBeadsBdStartRetriesAutoPortBindConflict|TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot|TestCachingStoreListByLabelSeesCreatedBeadAfterMetadataWrite'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->