### PR TITLE
harden(hook): make inject mode non-intrusive

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -136,9 +136,8 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	// names; named-session context preserves the runtime-supplied owner
 	// env while selecting the backing config through GC_TEMPLATE.
 	resolvedAgentName := a.QualifiedName()
-	resolvedSessionName := cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
 	agentForQuery := resolvedAgentName
-	sessionForQuery := resolvedSessionName
+	sessionForQuery := ""
 	if sessionTemplateContext {
 		agentForQuery = os.Getenv("GC_ALIAS")
 		if agentForQuery == "" {
@@ -148,6 +147,8 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 			agentForQuery = os.Getenv("GC_AGENT")
 		}
 		sessionForQuery = os.Getenv("GC_SESSION_NAME")
+	} else {
+		sessionForQuery = cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
 	}
 	overrides := hookQueryEnv(cityPath, cfg, &a)
 	overrides["GC_AGENT"] = agentForQuery
@@ -240,10 +241,8 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	hasWork := workQueryHasReadyWork(normalized)
 
 	if inject {
-		if hasWork {
-			content := formatHookInjectReminder(normalized)
-			_ = writeProviderHookContextForEvent(stdout, hookFormat, "Stop", content)
-		}
+		_ = hasWork
+		_ = hookFormat
 		return 0 // --inject always exits 0
 	}
 
@@ -256,23 +255,6 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	}
 	fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
 	return 0
-}
-
-func formatHookInjectReminder(normalizedWork string) string {
-	return fmt.Sprintf(`<system-reminder>
-You have pending work. Pick up the next item:
-
-<work-items>
-%s
-</work-items>
-
-Use the bead id from the work item:
-- If the item is not assigned to you yet, run `+"`bd update <id> --claim`"+`.
-- Do the requested work.
-- When done, run `+"`bd close <id>`"+`.
-Run `+"`gc hook`"+` to see the full queue.
-</system-reminder>
-`, normalizedWork)
 }
 
 func workQueryHasReadyWork(output string) bool {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -86,38 +85,19 @@ func TestHookInjectSuppressesNoReadyMessage(t *testing.T) {
 	}
 }
 
-func TestHookInjectFormatsOutput(t *testing.T) {
+func TestHookInjectIsNonIntrusiveWithWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "hw-1  open  Fix the bug\n", nil }
 	var stdout, stderr bytes.Buffer
 	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("doHook(inject, work) = %d, want 0", code)
 	}
-	out := stdout.String()
-	if !strings.Contains(out, "<system-reminder>") {
-		t.Errorf("stdout missing <system-reminder>: %q", out)
-	}
-	if !strings.Contains(out, "</system-reminder>") {
-		t.Errorf("stdout missing </system-reminder>: %q", out)
-	}
-	if !strings.Contains(out, "<work-items>") {
-		t.Errorf("stdout missing <work-items>: %q", out)
-	}
-	if !strings.Contains(out, "hw-1") {
-		t.Errorf("stdout missing work item: %q", out)
-	}
-	if !strings.Contains(out, "gc hook") {
-		t.Errorf("stdout missing 'gc hook' hint: %q", out)
-	}
-	if !strings.Contains(out, "bd update <id> --claim") {
-		t.Errorf("stdout missing claim command: %q", out)
-	}
-	if !strings.Contains(out, "bd close <id>") {
-		t.Errorf("stdout missing close command: %q", out)
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty non-intrusive inject output", stdout.String())
 	}
 }
 
-func TestHookCommandCodexInjectEmitsSingleStopPayload(t *testing.T) {
+func TestHookCommandCodexInjectDoesNotBlockStop(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
@@ -141,19 +121,56 @@ work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("gc hook command failed: %v; stderr=%s", err, stderr.String())
 	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty non-blocking Stop hook output", stdout.String())
+	}
+}
 
-	var payload struct {
-		Decision string `json:"decision"`
-		Reason   string `json:"reason"`
+func TestCmdHookSessionTemplateContextDoesNotScanSessionsForName(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	fakeBin := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
-		t.Fatalf("stdout is not a single JSON payload: %v\n%s", err, stdout.String())
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if got, want := payload.Decision, "block"; got != want {
-		t.Fatalf("decision = %q, want %q", got, want)
+	fakeBD := filepath.Join(fakeBin, "bd")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nprintf '[]'\n", logPath)
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(payload.Reason, "hw-1") {
-		t.Fatalf("reason = %q, want pending work", payload.Reason)
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_ALIAS", "worker-1")
+	t.Setenv("GC_SESSION_ID", "mc-session")
+	t.Setenv("GC_SESSION_NAME", "runtime-session")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookWithFormat(nil, true, "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHookWithFormat() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", logPath, err)
+	}
+	logText := string(logData)
+	if strings.Contains(logText, "--label=gc:session") {
+		t.Fatalf("gc hook scanned all session beads before running work_query:\n%s", logText)
+	}
+	if !strings.Contains(logText, "--assignee=runtime-session") {
+		t.Fatalf("gc hook did not pass runtime session name into work_query; bd log:\n%s", logText)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop `gc hook --inject` from injecting bead-specific claim instructions
- keep routed work discovery inside the configured `gc hook` claim protocol
- preserve session-template identity handling without broad session scans

## Verification
- pre-commit hook ran: docgen, golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...
- go test ./cmd/gc -run 'TestHookInjectIsNonIntrusiveWithWork|TestCmdHookSessionTemplateContextDoesNotScanSessionsForName|TestHookInjectAlwaysExitsZero|TestCmdHookExportsResolvedIdentity'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->