### PR TITLE
perf(reconciler): avoid broad tick-time store scans

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -529,26 +529,50 @@ func collectAssignedWorkBeadsWithStores(
 		}
 	}
 
+	type storeAssignedWorkResult struct {
+		beads  []beads.Bead
+		stores []beads.Store
+		errs   []error
+	}
+	results := make([]storeAssignedWorkResult, len(stores))
+	var wg sync.WaitGroup
+	for idx, s := range stores {
+		idx, s := idx, s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var result []beads.Bead
+			var resultStores []beads.Store
+			var errs []error
+			seen := make(map[string]struct{})
+			// In-progress beads with an assignee (active work), plus stranded
+			// unassigned pool work that needs to be reopened.
+			if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
+				appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
+			} else {
+				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
+			}
+			// Ready beads with an assignee (queued direct handoff work that is
+			// actually runnable, not merely open). This is a lifecycle gate, so
+			// bypass the cache when a CachingStore wrapper is present.
+			if ready, err := beads.ReadyLive(s); err == nil {
+				appendAssignedUnique(&result, &resultStores, ready, seen, s)
+			} else {
+				errs = append(errs, fmt.Errorf("Ready(): %w", err))
+			}
+			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, errs: errs}
+		}()
+	}
+	wg.Wait()
+
 	var result []beads.Bead
 	var resultStores []beads.Store
 	var partial bool
-	for _, s := range stores {
-		seen := make(map[string]struct{})
-		// In-progress beads with an assignee (active work), plus stranded
-		// unassigned pool work that needs to be reopened.
-		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
-			appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
-		} else {
-			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
-			partial = true
-		}
-		// Ready beads with an assignee (queued direct handoff work that is
-		// actually runnable, not merely open). This is a lifecycle gate, so
-		// bypass the cache when a CachingStore wrapper is present.
-		if ready, err := beads.ReadyLive(s); err == nil {
-			appendAssignedUnique(&result, &resultStores, ready, seen, s)
-		} else {
-			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
+	for _, r := range results {
+		result = append(result, r.beads...)
+		resultStores = append(resultStores, r.stores...)
+		for _, err := range r.errs {
+			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -587,8 +587,15 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		}
 		sessionBead, ok := sessionBeads.FindByID(sessionID)
 		if !ok {
-			if anySessionBead, found := sessionBeads.findByIDIncludingClosed(sessionID); found {
-				sessionBead = anySessionBead
+			if wait.Metadata["registered_epoch"] != "" {
+				var found bool
+				sessionBead, found, err = lookupSessionBeadIncludingClosed(store, sessionBeads, sessionID)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					continue
+				}
 			} else {
 				continue
 			}
@@ -668,6 +675,28 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		}
 	}
 	return readyWaitSet, nil
+}
+
+func lookupSessionBeadIncludingClosed(store beads.Store, sessionBeads *sessionBeadSnapshot, id string) (beads.Bead, bool, error) {
+	if sessionBeads != nil {
+		if bead, ok := sessionBeads.findByIDIncludingClosed(id); ok {
+			return bead, true, nil
+		}
+	}
+	if store == nil || strings.TrimSpace(id) == "" {
+		return beads.Bead{}, false, nil
+	}
+	bead, err := store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return beads.Bead{}, false, nil
+		}
+		return beads.Bead{}, false, err
+	}
+	if !sessionpkg.IsSessionBeadOrRepairable(bead) {
+		return beads.Bead{}, false, nil
+	}
+	return bead, true, nil
 }
 
 func dispatchReadyWaitNudges(cityPath string, store beads.Store, _ runtime.Provider, now time.Time) error {

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -442,7 +442,7 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 	}
 }
 
-func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testing.T) {
+func TestPrepareWaitWakeState_UsesTargetedLookupForMissingSessionEpoch(t *testing.T) {
 	base := beads.NewMemStore()
 	store := &waitGetSpyStore{Store: base}
 	sessionBead, err := store.Create(beads.Bead{
@@ -482,10 +482,51 @@ func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testin
 	if len(readyWaitSet) != 0 {
 		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
 	}
-	for _, id := range store.getIDs {
-		if id == sessionBead.ID {
-			t.Fatalf("prepare used Get for non-open session %s; getIDs=%v", sessionBead.ID, store.getIDs)
-		}
+	if len(store.getIDs) != 1 || store.getIDs[0] != sessionBead.ID {
+		t.Fatalf("Get IDs = %v, want targeted lookup for %s", store.getIDs, sessionBead.ID)
+	}
+}
+
+func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutEpochLookup(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"agent_name":   "worker",
+			"state":        string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":   sessionBead.ID,
+			"session_name": "worker",
+			"kind":         "deps",
+			"state":        waitStateReady,
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if len(readyWaitSet) != 0 {
+		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
+	}
+	if len(store.getIDs) != 0 {
+		t.Fatalf("Get IDs = %v, want no closed-session lookup without an epoch", store.getIDs)
 	}
 }
 

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -8,9 +8,11 @@ import (
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
-// sessionBeadSnapshot caches session-bead state for a single reconcile cycle.
-// Open-session lookups stay open-only; closed records are retained by ID for
-// lifecycle guards such as stale wait epoch cancellation.
+// sessionBeadSnapshot caches active session-bead state for a single reconcile
+// cycle. Closed-session history is intentionally not loaded here: the
+// reconciler calls this several times per tick, and closed history grows
+// without bound. Callers that need a closed record must fetch that one ID
+// explicitly.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
 	recordByID                map[string]beads.Bead
@@ -23,8 +25,7 @@ func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
 		return newSessionBeadSnapshot(nil), nil
 	}
 	all, err := store.List(beads.ListQuery{
-		Label:         sessionBeadLabel,
-		IncludeClosed: true,
+		Label: sessionBeadLabel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing session beads: %w", err)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -32,6 +32,16 @@ type sessionGetSpyStore struct {
 	getIDs []string
 }
 
+type sessionSnapshotListSpyStore struct {
+	beads.Store
+	queries []beads.ListQuery
+}
+
+func (s *sessionSnapshotListSpyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.queries = append(s.queries, query)
+	return s.Store.List(query)
+}
+
 type failingCloseStore struct {
 	*beads.MemStore
 }
@@ -2734,6 +2744,55 @@ func TestLoadSessionBeads_SkipsClosedBeads(t *testing.T) {
 	}
 	if len(result) != 0 {
 		t.Errorf("expected 0 beads (closed), got %d", len(result))
+	}
+}
+
+func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &sessionSnapshotListSpyStore{Store: base}
+	open, err := store.Create(beads.Bead{
+		Title:  "open",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create open session bead: %v", err)
+	}
+	closed, err := store.Create(beads.Bead{
+		Title:  "closed",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "old-worker",
+			"state":        string(session.StateClosed),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed session bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeadSnapshot: %v", err)
+	}
+	if len(store.queries) != 1 {
+		t.Fatalf("List query count = %d, want 1", len(store.queries))
+	}
+	if store.queries[0].IncludeClosed {
+		t.Fatalf("loadSessionBeadSnapshot used IncludeClosed query: %+v", store.queries[0])
+	}
+	if _, ok := snapshot.FindByID(open.ID); !ok {
+		t.Fatalf("snapshot missing open session bead %s", open.ID)
+	}
+	if _, ok := snapshot.findByIDIncludingClosed(closed.ID); ok {
+		t.Fatalf("snapshot retained closed session bead %s", closed.ID)
 	}
 }
 

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -24,15 +24,16 @@ import (
 type CachingStore struct {
 	backing Store // runtime: always *BdStore; tests may use MemStore
 
-	mu          sync.RWMutex
-	beads       map[string]Bead
-	deps        map[string][]Dep
-	dirty       map[string]struct{}
-	beadSeq     map[string]uint64
-	deletedSeq  map[string]uint64
-	state       cacheState
-	lastFreshAt time.Time
-	mutationSeq uint64
+	mu           sync.RWMutex
+	beads        map[string]Bead
+	deps         map[string][]Dep
+	depsComplete bool
+	dirty        map[string]struct{}
+	beadSeq      map[string]uint64
+	deletedSeq   map[string]uint64
+	state        cacheState
+	lastFreshAt  time.Time
+	mutationSeq  uint64
 
 	reconciling  atomic.Bool
 	syncFailures int
@@ -190,7 +191,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 		beadMap[b.ID] = cloneBead(b)
 	}
 
-	depMap, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
 	if depErr != nil {
 		c.recordProblem("prime dep cache", depErr)
 	}
@@ -201,6 +202,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	if c.mutationSeq == startSeq {
 		c.beads = beadMap
 		c.deps = depMap
+		c.depsComplete = depsComplete && depErr == nil
 		c.dirty = make(map[string]struct{})
 		c.beadSeq = make(map[string]uint64)
 		c.deletedSeq = make(map[string]uint64)
@@ -219,6 +221,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 				c.deps[id] = deps
 			}
 		}
+		c.depsComplete = false
 	}
 	c.state = cacheLive
 	c.syncFailures = 0
@@ -316,31 +319,24 @@ func beadIDs(beadMap map[string]Bead) []string {
 	return ids
 }
 
-func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, error) {
+func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, bool, error) {
 	depMap := make(map[string][]Dep)
 	if len(ids) == 0 {
-		return depMap, nil
+		return depMap, true, nil
 	}
 
-	if bdStore, ok := c.backing.(*BdStore); ok {
-		batchDeps, err := bdStore.DepListBatch(ids)
-		if err != nil {
-			return depMap, err
-		}
-		for id, deps := range batchDeps {
-			depMap[id] = cloneDeps(deps)
-		}
-		return depMap, nil
+	if _, ok := c.backing.(*BdStore); ok {
+		return depMap, false, nil
 	}
 
 	for _, id := range ids {
 		deps, err := c.backing.DepList(id, "down")
 		if err != nil {
-			return depMap, fmt.Errorf("listing deps for %s: %w", id, err)
+			return depMap, false, fmt.Errorf("listing deps for %s: %w", id, err)
 		}
 		depMap[id] = cloneDeps(deps)
 	}
-	return depMap, nil
+	return depMap, true, nil
 }
 
 func cloneDeps(deps []Dep) []Dep {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -780,3 +780,50 @@ func TestCachingStoreRunReconciliationDoesNotEmitBeadClosedForAlreadyClosedCache
 		}
 	}
 }
+
+func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
+	t.Parallel()
+
+	var depListCalls int
+	var readyCalls int
+	issueJSON := []byte(`[{
+		"id":"bd-1",
+		"title":"task",
+		"status":"open",
+		"issue_type":"task",
+		"created_at":"2026-01-01T00:00:00Z",
+		"labels":["task"],
+		"metadata":{}
+	}]`)
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) > 0 && args[0] == "dep" {
+			depListCalls++
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		if len(args) > 0 && args[0] == "ready" {
+			readyCalls++
+			return issueJSON, nil
+		}
+		if len(args) > 0 && args[0] == "list" {
+			return issueJSON, nil
+		}
+		return []byte(`[]`), nil
+	}
+	cache := NewCachingStore(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	cache.runReconciliation()
+	if depListCalls != 0 {
+		t.Fatalf("dep list calls = %d, want 0", depListCalls)
+	}
+	if _, err := cache.Ready(); err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if readyCalls != 1 {
+		t.Fatalf("Ready calls = %d, want backing Ready fallback when deps are incomplete", readyCalls)
+	}
+}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -267,7 +267,7 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 // Ready returns open beads whose blocking deps are all closed.
 func (c *CachingStore) Ready() ([]Bead, error) {
 	c.mu.RLock()
-	if c.state == cacheLive {
+	if c.state == cacheLive && c.depsComplete {
 		if len(c.dirty) > 0 {
 			c.mu.RUnlock()
 			return c.backing.Ready()

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -85,10 +85,11 @@ func (c *CachingStore) runReconciliation() {
 		freshByID[b.ID] = cloneBead(b)
 	}
 
-	depMap, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
 	if depErr != nil {
 		c.recordProblem("refresh dep cache during reconcile", depErr)
 	}
+	useFreshDeps := depsComplete && depErr == nil
 
 	c.mu.Lock()
 	if c.mutationSeq != startSeq {
@@ -114,7 +115,7 @@ func (c *CachingStore) runReconciliation() {
 					eventType: "bead.updated",
 					bead:      cloneBead(freshBead),
 				})
-			case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+			case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
 				updates++
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.updated",
@@ -123,7 +124,7 @@ func (c *CachingStore) runReconciliation() {
 			}
 
 			c.beads[id] = cloneBead(freshBead)
-			if depErr == nil {
+			if useFreshDeps {
 				c.deps[id] = cloneDeps(depMap[id])
 			}
 			delete(c.dirty, id)
@@ -155,6 +156,7 @@ func (c *CachingStore) runReconciliation() {
 		}
 
 		c.syncFailures = 0
+		c.depsComplete = c.depsComplete && useFreshDeps
 		if c.state == cacheDegraded {
 			c.state = cacheLive
 		}
@@ -177,7 +179,7 @@ func (c *CachingStore) runReconciliation() {
 	nextDeps := make(map[string][]Dep, len(freshByID))
 
 	for id, freshBead := range freshByID {
-		if depErr == nil {
+		if useFreshDeps {
 			nextDeps[id] = cloneDeps(depMap[id])
 		} else if deps, ok := c.deps[id]; ok {
 			nextDeps[id] = cloneDeps(deps)
@@ -197,7 +199,7 @@ func (c *CachingStore) runReconciliation() {
 				eventType: "bead.updated",
 				bead:      cloneBead(freshBead),
 			})
-		case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+		case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
 			updates++
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.updated",
@@ -223,6 +225,7 @@ func (c *CachingStore) runReconciliation() {
 
 	c.beads = freshByID
 	c.deps = nextDeps
+	c.depsComplete = useFreshDeps
 	c.dirty = make(map[string]struct{})
 	c.beadSeq = make(map[string]uint64)
 	c.deletedSeq = make(map[string]uint64)


### PR DESCRIPTION
## Summary
- load active session beads only during reconcile snapshots
- avoid broad dependency cache priming for bd-backed stores; fall back to backing Ready when deps are incomplete
- query assigned work across stores concurrently and use targeted closed-session lookups for stale wait cleanup

## Verification
- pre-commit hook ran: docgen, golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...
- go test ./cmd/gc ./internal/beads -run 'TestCollectAssignedWork|TestPrepareWaitWakeState_|TestLoadSessionBeadSnapshotUsesActiveOnlyQuery|TestCachingStoreBdPrimeAndReconcileSkipFullDepScan|TestCachingStoreReadyTreatsMissingDepTargetAsClosedWithoutBackingGet|TestReadyLive'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->