### PR TITLE
perf(session): use targeted identifier lookups

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -896,6 +896,54 @@ func TestResolveSessionNameWithStore(t *testing.T) {
 	}
 }
 
+type noBroadSessionNameLookupStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s noBroadSessionNameLookupStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == sessionBeadLabel && len(query.Metadata) == 0 {
+		s.t.Fatalf("session name lookup used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
+func TestFindSessionNameByTemplateUsesTargetedLookup(t *testing.T) {
+	store := noBroadSessionNameLookupStore{MemStore: beads.NewMemStore(), t: t}
+	_, err := store.Create(beads.Bead{
+		Title:  "worker-pool",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":           "worker",
+			"template":             "worker",
+			"session_name":         "s-pool",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "worker",
+			"session_name": "s-worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := findSessionNameByTemplate(store, "worker")
+	if got != "s-worker" {
+		t.Fatalf("findSessionNameByTemplate(worker) = %q, want s-worker", got)
+	}
+}
+
 func TestFindSessionNameByTemplate_SkipsClosedBeads(t *testing.T) {
 	store := beads.NewMemStore()
 	b, err := store.Create(beads.Bead{

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -144,11 +144,66 @@ func normalizedSessionTemplate(bead beads.Bead, cfg *config.City) string {
 // beads with an agent_name field matching the query. If no agent_name match
 // is found, falls back to template/common_name matching.
 func findSessionNameByTemplate(store beads.Store, template string) string {
-	snapshot, err := loadSessionBeadSnapshot(store)
+	template = strings.TrimSpace(template)
+	if store == nil || template == "" {
+		return ""
+	}
+	if sn := findSessionNameByMetadata(store, "agent_name", template, true); sn != "" {
+		return sn
+	}
+	if sn := findSessionNameByAgentLabel(store, template); sn != "" {
+		return sn
+	}
+	if sn := findSessionNameByMetadata(store, "template", template, false); sn != "" {
+		return sn
+	}
+	return findSessionNameByMetadata(store, "common_name", template, false)
+}
+
+func findSessionNameByAgentLabel(store beads.Store, template string) string {
+	items, err := store.List(beads.ListQuery{Label: "agent:" + template})
 	if err != nil {
 		return ""
 	}
-	return snapshot.FindSessionNameByTemplate(template)
+	return chooseSessionNameForTemplate(store, items, true, "", "")
+}
+
+func findSessionNameByMetadata(store beads.Store, key, value string, agentNameMatch bool) string {
+	items, err := store.List(beads.ListQuery{Metadata: map[string]string{key: value}})
+	if err != nil {
+		return ""
+	}
+	return chooseSessionNameForTemplate(store, items, agentNameMatch, key, value)
+}
+
+func chooseSessionNameForTemplate(store beads.Store, items []beads.Bead, agentNameMatch bool, key, value string) string {
+	var fallback string
+	for _, b := range items {
+		if !sessionpkg.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
+			continue
+		}
+		sessionpkg.RepairEmptyType(store, &b)
+		if key != "" && strings.TrimSpace(b.Metadata[key]) != value {
+			continue
+		}
+		if agentNameMatch && isPoolManagedSessionBead(b) && sessionBeadAgentName(b) == b.Metadata["template"] {
+			continue
+		}
+		if !agentNameMatch && isPoolManagedSessionBead(b) {
+			continue
+		}
+		sessionName := strings.TrimSpace(b.Metadata["session_name"])
+		if sessionName == "" {
+			continue
+		}
+		if strings.TrimSpace(b.Metadata["configured_named_identity"]) != "" {
+			return sessionName
+		}
+		if fallback == "" {
+			fallback = sessionName
+		}
+	}
+	return fallback
 }
 
 // lookupSessionName resolves a qualified agent name to its bead-derived

--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -57,11 +57,11 @@ func resolveConfiguredNamedSessionID(
 	if !ok {
 		return "", false, fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 	}
-	snapshot, err := loadSessionBeadSnapshot(store)
+	candidates, err := session.NamedSessionResolutionCandidates(store, spec)
 	if err != nil {
 		return "", true, err
 	}
-	if bead, ok := findCanonicalNamedSessionBead(snapshot, spec); ok {
+	if bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec); ok {
 		return bead.ID, true, nil
 	}
 	// When materializing, check for a closed bead with this identity and
@@ -73,7 +73,7 @@ func resolveConfiguredNamedSessionID(
 			return bead.ID, true, nil
 		}
 	}
-	if bead, conflict := findNamedSessionConflict(snapshot, spec); conflict {
+	if bead, conflict := session.FindNamedSessionConflict(candidates, spec); conflict {
 		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errNamedSessionConflict, identifier, spec.Identity, bead.ID)
 	}
 	if !opts.materialize {

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -87,6 +87,44 @@ func TestResolveSessionID_QualifiedAliasBasename(t *testing.T) {
 	}
 }
 
+func TestResolveSessionIDWithConfig_UsesTargetedConfiguredNamedLookup(t *testing.T) {
+	store := noBroadSessionNameLookupStore{MemStore: beads.NewMemStore(), t: t}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+		}},
+	}
+	cityPath := t.TempDir()
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "mayor",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(canonical): %v", err)
+	}
+
+	id, err := resolveSessionIDWithConfig(cityPath, cfg, store, "mayor")
+	if err != nil {
+		t.Fatalf("resolveSessionIDWithConfig(mayor): %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveHistoricalAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -205,7 +205,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 	if sessionBeadID == "" && p.beadStore != nil {
-		if all, err := p.beadStore.List(beads.ListQuery{Label: "gc:session"}); err == nil {
+		if all, err := p.beadStore.List(beads.ListQuery{Metadata: map[string]string{"session_name": sessName}}); err == nil {
 			for _, b := range all {
 				if !session.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
 					continue

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -136,13 +136,11 @@ func (s *Server) findCanonicalNamedSession(store beads.Store, spec apiNamedSessi
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
+	candidates, err := session.NamedSessionResolutionCandidates(store, spec)
 	if err != nil {
-		return beads.Bead{}, false, fmt.Errorf("listing sessions: %w", err)
+		return beads.Bead{}, false, fmt.Errorf("listing named session candidates: %w", err)
 	}
-	bead, ok := session.FindCanonicalNamedSessionBead(all, spec)
+	bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec)
 	return bead, ok, nil
 }
 
@@ -150,9 +148,13 @@ func (s *Server) retireContinuityIneligibleNamedSessionIdentifiers(store beads.S
 	if store == nil {
 		return nil, nil
 	}
-	all, err := store.List(beads.ListQuery{Label: session.LabelSession})
+	all, err := store.List(beads.ListQuery{
+		Metadata: map[string]string{
+			session.NamedSessionIdentityMetadata: spec.Identity,
+		},
+	})
 	if err != nil {
-		return nil, fmt.Errorf("listing sessions: %w", err)
+		return nil, fmt.Errorf("listing named session candidates: %w", err)
 	}
 	retired := make([]beads.Bead, 0)
 	now := time.Now().UTC()
@@ -235,11 +237,9 @@ func (s *Server) resolveConfiguredNamedSessionIDWithContext(ctx context.Context,
 		return bead.ID, true, nil
 	}
 
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
+	all, err := session.NamedSessionResolutionCandidates(store, spec)
 	if err != nil {
-		return "", true, fmt.Errorf("listing sessions: %w", err)
+		return "", true, fmt.Errorf("listing named session candidates: %w", err)
 	}
 	if bead, conflict := session.FindNamedSessionConflict(all, spec); conflict {
 		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errConfiguredNamedSessionConflict, identifier, spec.Identity, bead.ID)

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -214,6 +214,59 @@ func BeadConflictsWithNamedSession(b beads.Bead, spec NamedSessionSpec) bool {
 	return false
 }
 
+// NamedSessionResolutionCandidates returns the live session beads that can own
+// or conflict with the configured named-session spec, using only exact
+// metadata lookups derived from the spec.
+func NamedSessionResolutionCandidates(store beads.Store, spec NamedSessionSpec) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	identity := NormalizeNamedSessionTarget(spec.Identity)
+	sessionName := strings.TrimSpace(spec.SessionName)
+	queries := []map[string]string{
+		{NamedSessionIdentityMetadata: identity},
+		{"session_name": sessionName},
+		{"session_name": identity},
+		{"alias": identity},
+	}
+
+	seenQueries := make(map[string]bool, len(queries))
+	seenBeads := make(map[string]bool)
+	candidates := make([]beads.Bead, 0, 4)
+	for _, metadata := range queries {
+		if len(metadata) != 1 {
+			continue
+		}
+		var key, value string
+		for k, v := range metadata {
+			key = k
+			value = strings.TrimSpace(v)
+		}
+		if key == "" || value == "" {
+			continue
+		}
+		queryKey := key + "\x00" + value
+		if seenQueries[queryKey] {
+			continue
+		}
+		seenQueries[queryKey] = true
+		items, err := store.List(beads.ListQuery{
+			Metadata: map[string]string{key: value},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range items {
+			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
+				continue
+			}
+			seenBeads[b.ID] = true
+			candidates = append(candidates, b)
+		}
+	}
+	return candidates, nil
+}
+
 // FindNamedSessionConflict finds the first live session bead that blocks a configured named session.
 func FindNamedSessionConflict(candidates []beads.Bead, spec NamedSessionSpec) (beads.Bead, bool) {
 	for _, b := range candidates {

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -325,10 +325,13 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 	if name == "" {
 		return nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
-		IncludeClosed: true,
-	})
+	all, err := sessionIdentifierCandidates(store, true,
+		map[string]string{"session_name": name},
+		map[string]string{"alias": name},
+		map[string]string{"agent_name": name},
+		map[string]string{"template": name},
+		map[string]string{"common_name": name},
+	)
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
@@ -515,10 +518,13 @@ func isConfiguredNamedSessionRuntimeName(cfg *config.City, name, owner string) b
 // ensureSessionNameAvailableForSelf so the legacy-bypass path cannot
 // suppress rejections from live alias or identifier collisions.
 func noLiveSessionNameCollisions(store beads.Store, name, selfID, selfOwner string) bool {
-	all, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
-		IncludeClosed: true,
-	})
+	all, err := sessionIdentifierCandidates(store, true,
+		map[string]string{"session_name": name},
+		map[string]string{"alias": name},
+		map[string]string{"agent_name": name},
+		map[string]string{"template": name},
+		map[string]string{"common_name": name},
+	)
 	if err != nil {
 		return false
 	}
@@ -565,9 +571,11 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			hasSelfBead = true
 		}
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: LabelSession,
-	})
+	all, err := sessionIdentifierCandidates(store, false,
+		map[string]string{"session_name": alias},
+		map[string]string{"alias": alias},
+		map[string]string{"agent_name": alias},
+	)
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
@@ -609,4 +617,46 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 		}
 	}
 	return nil
+}
+
+func sessionIdentifierCandidates(store beads.Store, includeClosed bool, filters ...map[string]string) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	seenQueries := make(map[string]bool, len(filters))
+	seenBeads := make(map[string]bool)
+	candidates := make([]beads.Bead, 0, len(filters))
+	for _, filter := range filters {
+		if len(filter) != 1 {
+			continue
+		}
+		var key, value string
+		for k, v := range filter {
+			key = strings.TrimSpace(k)
+			value = strings.TrimSpace(v)
+		}
+		if key == "" || value == "" {
+			continue
+		}
+		queryKey := key + "\x00" + value
+		if seenQueries[queryKey] {
+			continue
+		}
+		seenQueries[queryKey] = true
+		items, err := store.List(beads.ListQuery{
+			Metadata:      map[string]string{key: value},
+			IncludeClosed: includeClosed,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range items {
+			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
+				continue
+			}
+			seenBeads[b.ID] = true
+			candidates = append(candidates, b)
+		}
+	}
+	return candidates, nil
 }

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+type noBroadSessionIdentifierStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s *noBroadSessionIdentifierStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("session identifier availability used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
 func TestValidateExplicitName(t *testing.T) {
 	longName := strings.Repeat("a", explicitSessionNameMaxLen+1)
 	tests := []struct {
@@ -941,6 +953,42 @@ func TestEnsureSessionNameAvailableWithConfigForOwner_AllowsPoolManagedIdentifie
 	}
 	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "foreman"); !errors.Is(err, ErrSessionNameExists) {
 		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(wrong owner) = %v, want ErrSessionNameExists", err)
+	}
+}
+
+func TestEnsureSessionNameAvailableUsesTargetedIdentifierLookups(t *testing.T) {
+	store := &noBroadSessionIdentifierStore{MemStore: beads.NewMemStore(), t: t}
+	_, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias": "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(alias holder): %v", err)
+	}
+
+	if err := EnsureSessionNameAvailableWithConfig(store, nil, "sky", ""); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("EnsureSessionNameAvailableWithConfig(alias collision) = %v, want ErrSessionNameExists", err)
+	}
+}
+
+func TestEnsureAliasAvailableUsesTargetedIdentifierLookups(t *testing.T) {
+	store := &noBroadSessionIdentifierStore{MemStore: beads.NewMemStore(), t: t}
+	_, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session_name holder): %v", err)
+	}
+
+	if err := EnsureAliasAvailableWithConfig(store, nil, "sky", ""); !errors.Is(err, ErrSessionAliasExists) {
+		t.Fatalf("EnsureAliasAvailableWithConfig(session_name collision) = %v, want ErrSessionAliasExists", err)
 	}
 }
 

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -58,44 +58,13 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		return "", err
 	}
 
-	// Fall back to live alias/session_name resolution among session beads.
-	all, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
-		IncludeClosed: allowClosed,
-	})
+	openSessionNameMatches, err := sessionMatchesByMetadata(store, "session_name", identifier, "")
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
-
-	var openSessionNameMatches []beads.Bead
-	var openAliasMatches []beads.Bead
-	var closedSessionNameMatches []beads.Bead
-	var closedAliasMatches []beads.Bead
-	for _, b := range all {
-		if !IsSessionBeadOrRepairable(b) {
-			continue
-		}
-		RepairEmptyType(store, &b)
-		alias := strings.TrimSpace(b.Metadata["alias"])
-		sessionName := strings.TrimSpace(b.Metadata["session_name"])
-		if b.Status != "closed" {
-			switch {
-			case alias == identifier:
-				openAliasMatches = append(openAliasMatches, b)
-			case sessionName == identifier:
-				openSessionNameMatches = append(openSessionNameMatches, b)
-			}
-			continue
-		}
-		if !allowClosed {
-			continue
-		}
-		switch {
-		case alias == identifier:
-			closedAliasMatches = append(closedAliasMatches, b)
-		case sessionName == identifier:
-			closedSessionNameMatches = append(closedSessionNameMatches, b)
-		}
+	openAliasMatches, err := sessionMatchesByMetadata(store, "alias", identifier, "")
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
 	}
 
 	for _, matches := range [][]beads.Bead{
@@ -109,6 +78,14 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 	if !allowClosed {
 		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
 	}
+	closedSessionNameMatches, err := sessionMatchesByMetadata(store, "session_name", identifier, "closed")
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
+	}
+	closedAliasMatches, err := sessionMatchesByMetadata(store, "alias", identifier, "closed")
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
+	}
 	for _, matches := range [][]beads.Bead{
 		closedSessionNameMatches,
 		closedAliasMatches,
@@ -118,6 +95,34 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		}
 	}
 	return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
+}
+
+func sessionMatchesByMetadata(store beads.Store, key, identifier, status string) ([]beads.Bead, error) {
+	query := beads.ListQuery{
+		Metadata: map[string]string{key: identifier},
+	}
+	if status != "" {
+		query.Status = status
+	}
+	items, err := store.List(query)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]beads.Bead, 0, len(items))
+	for _, b := range items {
+		if !IsSessionBeadOrRepairable(b) {
+			continue
+		}
+		RepairEmptyType(store, &b)
+		if strings.TrimSpace(b.Metadata[key]) != identifier {
+			continue
+		}
+		if status != "" && b.Status != status {
+			continue
+		}
+		matches = append(matches, b)
+	}
+	return matches, nil
 }
 
 func chooseSessionMatch(identifier string, matches []beads.Bead) (string, error) {

--- a/internal/session/resolve_test.go
+++ b/internal/session/resolve_test.go
@@ -80,6 +80,59 @@ func TestResolveSessionID_Alias(t *testing.T) {
 	}
 }
 
+type noBroadSessionListStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s *noBroadSessionListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("session resolution used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
+func TestResolveSessionID_UsesTargetedAliasLookup(t *testing.T) {
+	store := &noBroadSessionListStore{MemStore: beads.NewMemStore(), t: t}
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias": "overseer",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, "overseer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
+func TestResolveSessionIDAllowClosed_UsesTargetedSessionNameLookup(t *testing.T) {
+	store := &noBroadSessionListStore{MemStore: beads.NewMemStore(), t: t}
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	if err := store.Close(b.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := session.ResolveSessionIDAllowClosed(store, "sky")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveExactQualifiedTemplate(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{


### PR DESCRIPTION
## Summary
- replace broad session scans in CLI/API session-name resolution with exact metadata lookups
- add targeted configured named-session candidate lookup shared by CLI and API
- keep ambiguity checks while reducing resolver scan scope

## Verification
- pre-commit hook ran: docgen, golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...
- go test ./cmd/gc ./internal/session ./internal/api -run 'TestFindSessionNameByTemplateUsesTargetedLookup|TestResolveSessionIDWithConfig_UsesTargetedConfiguredNamedLookup|TestEnsureSessionNameAvailableUsesTargetedIdentifierLookups|TestEnsureAliasAvailableUsesTargetedIdentifierLookups|TestResolveSessionID_UsesTargetedAliasLookup|TestResolveSessionIDAllowClosed_UsesTargetedSessionNameLookup'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->