### PR TITLE
perf(mail): route session recipients with targeted lookups

### DIFF
--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -388,19 +388,118 @@ func (p *Provider) recipientRoutes(recipient string) []string {
 	if recipient == "human" || p.store == nil {
 		return routes
 	}
-	sessions, err := p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+
+	liveMatches, err := p.recipientSessionMatchesByCurrentAddress(recipient, false)
 	if err != nil {
 		log.Printf("beadmail: listing sessions for recipient route %q: %v", recipient, err)
+		return routes
+	}
+	if len(liveMatches) > 1 {
+		return []string{recipient}
+	}
+	if len(liveMatches) == 1 {
+		return appendSessionRecipientRoutes(routes, liveMatches[0])
+	}
+
+	closedMatches, err := p.recipientSessionMatchesByCurrentAddress(recipient, true)
+	if err != nil {
+		log.Printf("beadmail: listing closed sessions for recipient route %q: %v", recipient, err)
+		return routes
+	}
+	if len(closedMatches) > 1 {
+		return []string{recipient}
+	}
+	if len(closedMatches) == 1 {
+		return appendSessionRecipientRoutes(routes, closedMatches[0])
+	}
+	return p.recipientRoutesByHistoricalAlias(recipient, routes)
+}
+
+func (p *Provider) recipientSessionMatchesByCurrentAddress(recipient string, closed bool) ([]beads.Bead, error) {
+	var matches []beads.Bead
+	b, err := p.store.Get(recipient)
+	if err == nil && session.IsSessionBeadOrRepairable(b) && sessionRouteStatusMatches(b, closed) {
+		session.RepairEmptyType(p.store, &b)
+		matches = appendUniqueSessionRecipientMatch(matches, b)
+	} else if err != nil && !errors.Is(err, beads.ErrNotFound) {
+		return nil, fmt.Errorf("looking up session %q: %w", recipient, err)
+	}
+
+	status := ""
+	if closed {
+		status = "closed"
+	}
+	for _, key := range []string{"alias", "session_name"} {
+		keyMatches, err := p.recipientSessionMatchesByMetadata(key, recipient, status)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range keyMatches {
+			matches = appendUniqueSessionRecipientMatch(matches, match)
+		}
+	}
+	return matches, nil
+}
+
+func (p *Provider) recipientSessionMatchesByMetadata(key, recipient, status string) ([]beads.Bead, error) {
+	query := beads.ListQuery{Metadata: map[string]string{key: recipient}}
+	if status != "" {
+		query.Status = status
+	}
+	items, err := p.store.List(query)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]beads.Bead, 0, len(items))
+	for _, b := range items {
+		if !session.IsSessionBeadOrRepairable(b) {
+			continue
+		}
+		session.RepairEmptyType(p.store, &b)
+		if !sessionRouteStatusMatches(b, status == "closed") {
+			continue
+		}
+		if strings.TrimSpace(b.Metadata[key]) != recipient {
+			continue
+		}
+		matches = append(matches, b)
+	}
+	return matches, nil
+}
+
+func sessionRouteStatusMatches(b beads.Bead, closed bool) bool {
+	if closed {
+		return b.Status == "closed"
+	}
+	return b.Status != "closed"
+}
+
+func appendUniqueSessionRecipientMatch(matches []beads.Bead, b beads.Bead) []beads.Bead {
+	for _, match := range matches {
+		if match.ID == b.ID {
+			return matches
+		}
+	}
+	return append(matches, b)
+}
+
+func appendSessionRecipientRoutes(routes []string, b beads.Bead) []string {
+	for _, address := range sessionAddressesForRecipientRouting(b) {
+		routes = appendRecipientRoute(routes, address)
+	}
+	return routes
+}
+
+func (p *Provider) recipientRoutesByHistoricalAlias(recipient string, routes []string) []string {
+	sessions, err := p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	if err != nil {
+		log.Printf("beadmail: listing sessions for historical recipient route %q: %v", recipient, err)
 		return routes
 	}
 	var liveMatches []beads.Bead
 	var closedMatches []beads.Bead
 	for _, b := range sessions {
-		if !session.IsSessionBeadOrRepairable(b) {
-			continue
-		}
-		addresses := sessionAddressesForRecipientRouting(b)
-		if !containsRecipientRoute(addresses, recipient) {
+		if !session.IsSessionBeadOrRepairable(b) || !containsRecipientRoute(session.AliasHistory(b.Metadata), recipient) {
 			continue
 		}
 		if b.Status == "closed" {
@@ -416,10 +515,8 @@ func (p *Provider) recipientRoutes(recipient string) []string {
 	if len(matches) > 1 {
 		return []string{recipient}
 	}
-	for _, b := range matches {
-		for _, address := range sessionAddressesForRecipientRouting(b) {
-			routes = appendRecipientRoute(routes, address)
-		}
+	if len(matches) == 1 {
+		return appendSessionRecipientRoutes(routes, matches[0])
 	}
 	return routes
 }

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -23,6 +23,18 @@ func (s noListScanStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	return s.MemStore.List(query)
 }
 
+type noBroadSessionRouteStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s noBroadSessionRouteStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("recipient routing used broad session scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
 func TestInboxDoesNotCallBroadList(t *testing.T) {
 	base := beads.NewMemStore()
 	p := New(noListScanStore{MemStore: base})
@@ -1021,6 +1033,67 @@ func TestReplyToClosedSenderSessionIsDiscoverableByHistoricalAlias(t *testing.T)
 
 func TestRecipientRoutesPreferLiveSessionOverClosedHistory(t *testing.T) {
 	store := beads.NewMemStore()
+	p := New(store)
+
+	closed, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "old-worker",
+			"alias_history": "worker",
+			"session_name":  "workflows__codex-min-mc-old",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create closed session: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close session: %v", err)
+	}
+	live, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "workflows__codex-min-mc-live",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live session: %v", err)
+	}
+	closedReply, err := store.Create(beads.Bead{
+		Title:    "old reply",
+		Type:     "message",
+		Assignee: closed.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create closed reply: %v", err)
+	}
+	liveMail, err := store.Create(beads.Bead{
+		Title:    "live mail",
+		Type:     "message",
+		Assignee: live.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create live mail: %v", err)
+	}
+
+	msgs, err := p.Inbox("worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != liveMail.ID {
+		t.Fatalf("Inbox returned %s, want live message %s; closed reply was %s", msgs[0].ID, liveMail.ID, closedReply.ID)
+	}
+}
+
+func TestInboxByCurrentSessionAliasAvoidsBroadSessionScan(t *testing.T) {
+	store := noBroadSessionRouteStore{MemStore: beads.NewMemStore(), t: t}
 	p := New(store)
 
 	closed, err := store.Create(beads.Bead{

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1153,6 +1153,203 @@ func TestInboxByCurrentSessionAliasAvoidsBroadSessionScan(t *testing.T) {
 	}
 }
 
+func TestInboxByClosedCurrentSessionAliasAvoidsBroadSessionScan(t *testing.T) {
+	store := noBroadSessionRouteStore{MemStore: beads.NewMemStore(), t: t}
+	p := New(store)
+
+	closed, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "workflows__codex-min-mc-closed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create closed session: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close session: %v", err)
+	}
+	closedMail, err := store.Create(beads.Bead{
+		Title:    "closed mail",
+		Type:     "message",
+		Assignee: closed.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create closed mail: %v", err)
+	}
+
+	msgs, err := p.Inbox("worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != closedMail.ID {
+		t.Fatalf("Inbox returned %s, want closed mail %s", msgs[0].ID, closedMail.ID)
+	}
+}
+
+func TestInboxByHistoricalAliasFallsBackToSessionScan(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	live, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "new-worker",
+			"alias_history": "worker",
+			"session_name":  "workflows__codex-min-mc-live",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live session: %v", err)
+	}
+	liveMail, err := store.Create(beads.Bead{
+		Title:    "live mail",
+		Type:     "message",
+		Assignee: live.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create live mail: %v", err)
+	}
+
+	msgs, err := p.Inbox("worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != liveMail.ID {
+		t.Fatalf("Inbox returned %s, want live message %s", msgs[0].ID, liveMail.ID)
+	}
+}
+
+func TestRecipientRoutesPreferCurrentAddressOverHistoricalAliasAmbiguity(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	historical, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "new-worker",
+			"alias_history": "worker",
+			"session_name":  "workflows__codex-min-mc-history",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create historical session: %v", err)
+	}
+	current, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "workflows__codex-min-mc-current",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create current session: %v", err)
+	}
+	historicalMail, err := store.Create(beads.Bead{
+		Title:    "historical mail",
+		Type:     "message",
+		Assignee: historical.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create historical mail: %v", err)
+	}
+	currentMail, err := store.Create(beads.Bead{
+		Title:    "current mail",
+		Type:     "message",
+		Assignee: current.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create current mail: %v", err)
+	}
+
+	msgs, err := p.Inbox("worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != currentMail.ID {
+		t.Fatalf("Inbox returned %s, want current mail %s; historical mail was %s", msgs[0].ID, currentMail.ID, historicalMail.ID)
+	}
+}
+
+func TestRecipientRoutesPreferClosedCurrentAddressOverLiveHistoricalAlias(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	liveHistorical, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "new-worker",
+			"alias_history": "worker",
+			"session_name":  "workflows__codex-min-mc-live",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create live historical session: %v", err)
+	}
+	closedCurrent, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"session_name": "workflows__codex-min-mc-closed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create closed current session: %v", err)
+	}
+	if err := store.Close(closedCurrent.ID); err != nil {
+		t.Fatalf("Close current session: %v", err)
+	}
+	liveMail, err := store.Create(beads.Bead{
+		Title:    "live historical mail",
+		Type:     "message",
+		Assignee: liveHistorical.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create live mail: %v", err)
+	}
+	closedMail, err := store.Create(beads.Bead{
+		Title:    "closed current mail",
+		Type:     "message",
+		Assignee: closedCurrent.ID,
+		From:     "human",
+	})
+	if err != nil {
+		t.Fatalf("Create closed mail: %v", err)
+	}
+
+	msgs, err := p.Inbox("worker")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox returned %d messages, want 1", len(msgs))
+	}
+	if msgs[0].ID != closedMail.ID {
+		t.Fatalf("Inbox returned %s, want closed current mail %s; live historical mail was %s", msgs[0].ID, closedMail.ID, liveMail.ID)
+	}
+}
+
 // --- Thread ---
 
 func TestThread(t *testing.T) {


### PR DESCRIPTION
## Summary
- route current session recipient aliases/names with direct id and metadata lookups
- keep broad historical alias fallback only for alias-history compatibility
- add coverage that current alias inbox routing avoids broad session scans

## Verification
- pre-commit hook ran: docgen, golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...
- go test ./internal/mail/beadmail -run 'TestInboxByCurrentSessionAliasAvoidsBroadSessionScan|TestRecipientRoutesPreferLiveSessionOverClosedHistory|TestInboxDoesNotCallBroadList|TestCountDoesNotCallBroadList|TestAllDoesNotCallBroadList'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->