### PR TITLE
fix(gastown): expose pack namespace to prompt templates

### DIFF
--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -424,250 +424,40 @@ Binding: {{ .BindingName }} {{ .BindingPrefix }}
 	}
 }
 
-func TestRenderPromptGastownBoundPeerAddresses(t *testing.T) {
-	cityRoot := filepath.Join("..", "..", "examples", "gastown")
-	packDir := filepath.Join(cityRoot, "packs", "gastown")
+func TestRenderPromptBindingPrefixReachesTemplate(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/peer.template.md"] = []byte("peer={{ .RigName }}/{{ .BindingPrefix }}worker\nbinding={{ .BindingName }}\n")
 	cases := []struct {
-		name         string
-		templatePath string
-		ctx          PromptContext
-		wants        []string
-		bads         []string
+		name string
+		ctx  PromptContext
+		want string
 	}{
 		{
-			name:         "mayor",
-			templatePath: filepath.Join("packs", "gastown", "agents", "mayor", "prompt.template.md"),
+			name: "bound",
 			ctx: PromptContext{
-				AgentName:     "gastown.mayor",
-				TemplateName:  "mayor",
 				BindingName:   "gastown",
 				BindingPrefix: "gastown.",
-				CityRoot:      "/city",
-			},
-			wants: []string{
-				"gc sling <rig>/gastown.polecat <bead>",
-				"session nudge <rig>/gastown.refinery",
-			},
-			bads: []string{
-				"--label=pool:<rig>/polecat",
-				"nudge refinery",
-			},
-		},
-		{
-			name:         "mayor-unbound",
-			templatePath: filepath.Join("packs", "gastown", "agents", "mayor", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:    "mayor",
-				TemplateName: "mayor",
-				CityRoot:     "/city",
-			},
-			wants: []string{
-				"gc sling <rig>/polecat <bead>",
-				"session nudge <rig>/refinery",
-			},
-			bads: []string{
-				"gc sling <rig>/gastown.polecat <bead>",
-				"session nudge <rig>/gastown.refinery",
-			},
-		},
-		{
-			name:         "witness",
-			templatePath: filepath.Join("packs", "gastown", "agents", "witness", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:     "demo/gastown.witness",
-				TemplateName:  "witness",
-				BindingName:   "gastown",
-				BindingPrefix: "gastown.",
-				CityRoot:      "/city",
 				RigName:       "demo",
 			},
-			wants: []string{
-				"gc mail send demo/gastown.refinery",
-				"gc session nudge demo/gastown.<polecat-suffix>",
-				"not `gastown.furiosa`",
-				"Your mail address: demo/gastown.witness",
-			},
-			bads: []string{
-				"gc mail send demo/refinery",
-				"gc session nudge demo/<polecat-name>",
-				"Your mail address: demo/witness",
-			},
+			want: "peer=demo/gastown.worker\nbinding=gastown\n",
 		},
 		{
-			name:         "witness-unbound",
-			templatePath: filepath.Join("packs", "gastown", "agents", "witness", "prompt.template.md"),
+			name: "unbound",
 			ctx: PromptContext{
-				AgentName:    "demo/witness",
-				TemplateName: "witness",
-				CityRoot:     "/city",
-				RigName:      "demo",
+				RigName: "demo",
 			},
-			wants: []string{
-				"gc mail send demo/refinery",
-				"gc session nudge demo/<polecat-suffix>",
-				"Your mail address: demo/witness",
-			},
-			bads: []string{
-				"gc mail send demo/gastown.refinery",
-				"gc session nudge demo/gastown.<polecat-suffix>",
-				"Your mail address: demo/gastown.witness",
-				"not `furiosa`",
-			},
-		},
-		{
-			name:         "deacon",
-			templatePath: filepath.Join("packs", "gastown", "agents", "deacon", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:     "gastown.deacon",
-				TemplateName:  "deacon",
-				BindingName:   "gastown",
-				BindingPrefix: "gastown.",
-				CityRoot:      "/city",
-			},
-			wants: []string{
-				"gc mail send <rig>/gastown.witness",
-				"Your mail address: gastown.deacon",
-			},
-			bads: []string{
-				"gc mail send <rig>/witness",
-				"Your mail address: deacon/",
-			},
-		},
-		{
-			name:         "deacon-unbound",
-			templatePath: filepath.Join("packs", "gastown", "agents", "deacon", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:    "deacon",
-				TemplateName: "deacon",
-				CityRoot:     "/city",
-			},
-			wants: []string{
-				"gc mail send <rig>/witness",
-				"Your mail address: deacon",
-			},
-			bads: []string{
-				"gc mail send <rig>/gastown.witness",
-				"Your mail address: deacon/",
-				"Your mail address: gastown.deacon",
-			},
-		},
-		{
-			name:         "polecat",
-			templatePath: filepath.Join("packs", "gastown", "agents", "polecat", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:     "demo/gastown.furiosa",
-				TemplateName:  "polecat",
-				BindingName:   "gastown",
-				BindingPrefix: "gastown.",
-				CityRoot:      "/city",
-				RigName:       "demo",
-			},
-			wants: []string{
-				"${GC_RIG:+$GC_RIG/}gastown.witness",
-				"gc session nudge \"$WITNESS_TARGET\"",
-			},
-			bads: []string{
-				"${GC_RIG:+$GC_RIG/}witness",
-				"gc session nudge demo/witness",
-			},
-		},
-		{
-			name:         "polecat-unbound",
-			templatePath: filepath.Join("packs", "gastown", "agents", "polecat", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:    "demo/furiosa",
-				TemplateName: "polecat",
-				CityRoot:     "/city",
-				RigName:      "demo",
-			},
-			wants: []string{
-				"${GC_RIG:+$GC_RIG/}witness",
-				"gc session nudge \"$WITNESS_TARGET\"",
-			},
-			bads: []string{
-				"${GC_RIG:+$GC_RIG/}gastown.witness",
-			},
-		},
-		{
-			name:         "refinery",
-			templatePath: filepath.Join("packs", "gastown", "agents", "refinery", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:     "demo/gastown.refinery",
-				TemplateName:  "refinery",
-				BindingName:   "gastown",
-				BindingPrefix: "gastown.",
-				CityRoot:      "/city",
-				RigName:       "demo",
-			},
-			wants: []string{
-				"gc session nudge demo/gastown.<polecat-suffix>",
-				"Mail identity: demo/gastown.refinery",
-				"not `gastown.furiosa`",
-			},
-			bads: []string{
-				"gc session nudge demo/<polecat-suffix>",
-				"Mail identity: demo/refinery",
-			},
-		},
-		{
-			name:         "refinery-unbound",
-			templatePath: filepath.Join("packs", "gastown", "agents", "refinery", "prompt.template.md"),
-			ctx: PromptContext{
-				AgentName:    "demo/refinery",
-				TemplateName: "refinery",
-				CityRoot:     "/city",
-				RigName:      "demo",
-			},
-			wants: []string{
-				"gc session nudge demo/<polecat-suffix>",
-				"Mail identity: demo/refinery",
-			},
-			bads: []string{
-				"gc session nudge demo/gastown.<polecat-suffix>",
-				"Mail identity: demo/gastown.refinery",
-				"not `furiosa`",
-			},
-		},
-		{
-			name:         "crew",
-			templatePath: filepath.Join("packs", "gastown", "assets", "prompts", "crew.template.md"),
-			ctx: PromptContext{
-				AgentName:     "demo/gastown.alice",
-				TemplateName:  "crew",
-				BindingName:   "gastown",
-				BindingPrefix: "gastown.",
-				CityRoot:      "/city",
-				RigName:       "demo",
-			},
-			wants: []string{
-				"gc sling <rig>/<binding>.polecat <bead>",
-				"gc session nudge demo/<binding>.<polecat-suffix>",
-				"e.g. `<rig>/gastown.witness`",
-			},
-			bads: []string{
-				"gc bd update <bead> --label=pool:<rig>/polecat",
-				"gc session nudge demo/<polecat-name>",
-				"`<rig>/<agent>` for rig agents",
-				"gc session nudge demo/<polecat-suffix>",
-			},
+			want: "peer=demo/worker\nbinding=\n",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr strings.Builder
-			got := renderPrompt(fsys.OSFS{}, cityRoot, "gastown", tc.templatePath, tc.ctx, "", &stderr, []string{packDir}, nil, nil)
+			got := renderPrompt(f, "/city", "", "prompts/peer.template.md", tc.ctx, "", &stderr, nil, nil, nil)
 			if stderr.Len() > 0 {
 				t.Fatalf("renderPrompt stderr: %s", stderr.String())
 			}
-			for _, want := range tc.wants {
-				if !strings.Contains(got, want) {
-					t.Errorf("rendered prompt missing %q", want)
-				}
-			}
-			for _, bad := range tc.bads {
-				if strings.Contains(got, bad) {
-					t.Errorf("rendered prompt still contains %q", bad)
-				}
+			if got != tc.want {
+				t.Errorf("renderPrompt() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -424,6 +424,255 @@ Binding: {{ .BindingName }} {{ .BindingPrefix }}
 	}
 }
 
+func TestRenderPromptGastownBoundPeerAddresses(t *testing.T) {
+	cityRoot := filepath.Join("..", "..", "examples", "gastown")
+	packDir := filepath.Join(cityRoot, "packs", "gastown")
+	cases := []struct {
+		name         string
+		templatePath string
+		ctx          PromptContext
+		wants        []string
+		bads         []string
+	}{
+		{
+			name:         "mayor",
+			templatePath: filepath.Join("packs", "gastown", "agents", "mayor", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:     "gastown.mayor",
+				TemplateName:  "mayor",
+				BindingName:   "gastown",
+				BindingPrefix: "gastown.",
+				CityRoot:      "/city",
+			},
+			wants: []string{
+				"gc sling <rig>/gastown.polecat <bead>",
+				"session nudge <rig>/gastown.refinery",
+			},
+			bads: []string{
+				"--label=pool:<rig>/polecat",
+				"nudge refinery",
+			},
+		},
+		{
+			name:         "mayor-unbound",
+			templatePath: filepath.Join("packs", "gastown", "agents", "mayor", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:    "mayor",
+				TemplateName: "mayor",
+				CityRoot:     "/city",
+			},
+			wants: []string{
+				"gc sling <rig>/polecat <bead>",
+				"session nudge <rig>/refinery",
+			},
+			bads: []string{
+				"gc sling <rig>/gastown.polecat <bead>",
+				"session nudge <rig>/gastown.refinery",
+			},
+		},
+		{
+			name:         "witness",
+			templatePath: filepath.Join("packs", "gastown", "agents", "witness", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:     "demo/gastown.witness",
+				TemplateName:  "witness",
+				BindingName:   "gastown",
+				BindingPrefix: "gastown.",
+				CityRoot:      "/city",
+				RigName:       "demo",
+			},
+			wants: []string{
+				"gc mail send demo/gastown.refinery",
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"not `gastown.furiosa`",
+				"Your mail address: demo/gastown.witness",
+			},
+			bads: []string{
+				"gc mail send demo/refinery",
+				"gc session nudge demo/<polecat-name>",
+				"Your mail address: demo/witness",
+			},
+		},
+		{
+			name:         "witness-unbound",
+			templatePath: filepath.Join("packs", "gastown", "agents", "witness", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:    "demo/witness",
+				TemplateName: "witness",
+				CityRoot:     "/city",
+				RigName:      "demo",
+			},
+			wants: []string{
+				"gc mail send demo/refinery",
+				"gc session nudge demo/<polecat-suffix>",
+				"Your mail address: demo/witness",
+			},
+			bads: []string{
+				"gc mail send demo/gastown.refinery",
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"Your mail address: demo/gastown.witness",
+				"not `furiosa`",
+			},
+		},
+		{
+			name:         "deacon",
+			templatePath: filepath.Join("packs", "gastown", "agents", "deacon", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:     "gastown.deacon",
+				TemplateName:  "deacon",
+				BindingName:   "gastown",
+				BindingPrefix: "gastown.",
+				CityRoot:      "/city",
+			},
+			wants: []string{
+				"gc mail send <rig>/gastown.witness",
+				"Your mail address: gastown.deacon",
+			},
+			bads: []string{
+				"gc mail send <rig>/witness",
+				"Your mail address: deacon/",
+			},
+		},
+		{
+			name:         "deacon-unbound",
+			templatePath: filepath.Join("packs", "gastown", "agents", "deacon", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:    "deacon",
+				TemplateName: "deacon",
+				CityRoot:     "/city",
+			},
+			wants: []string{
+				"gc mail send <rig>/witness",
+				"Your mail address: deacon",
+			},
+			bads: []string{
+				"gc mail send <rig>/gastown.witness",
+				"Your mail address: deacon/",
+				"Your mail address: gastown.deacon",
+			},
+		},
+		{
+			name:         "polecat",
+			templatePath: filepath.Join("packs", "gastown", "agents", "polecat", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:     "demo/gastown.furiosa",
+				TemplateName:  "polecat",
+				BindingName:   "gastown",
+				BindingPrefix: "gastown.",
+				CityRoot:      "/city",
+				RigName:       "demo",
+			},
+			wants: []string{
+				"${GC_RIG:+$GC_RIG/}gastown.witness",
+				"gc session nudge \"$WITNESS_TARGET\"",
+			},
+			bads: []string{
+				"${GC_RIG:+$GC_RIG/}witness",
+				"gc session nudge demo/witness",
+			},
+		},
+		{
+			name:         "polecat-unbound",
+			templatePath: filepath.Join("packs", "gastown", "agents", "polecat", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:    "demo/furiosa",
+				TemplateName: "polecat",
+				CityRoot:     "/city",
+				RigName:      "demo",
+			},
+			wants: []string{
+				"${GC_RIG:+$GC_RIG/}witness",
+				"gc session nudge \"$WITNESS_TARGET\"",
+			},
+			bads: []string{
+				"${GC_RIG:+$GC_RIG/}gastown.witness",
+			},
+		},
+		{
+			name:         "refinery",
+			templatePath: filepath.Join("packs", "gastown", "agents", "refinery", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:     "demo/gastown.refinery",
+				TemplateName:  "refinery",
+				BindingName:   "gastown",
+				BindingPrefix: "gastown.",
+				CityRoot:      "/city",
+				RigName:       "demo",
+			},
+			wants: []string{
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"Mail identity: demo/gastown.refinery",
+				"not `gastown.furiosa`",
+			},
+			bads: []string{
+				"gc session nudge demo/<polecat-suffix>",
+				"Mail identity: demo/refinery",
+			},
+		},
+		{
+			name:         "refinery-unbound",
+			templatePath: filepath.Join("packs", "gastown", "agents", "refinery", "prompt.template.md"),
+			ctx: PromptContext{
+				AgentName:    "demo/refinery",
+				TemplateName: "refinery",
+				CityRoot:     "/city",
+				RigName:      "demo",
+			},
+			wants: []string{
+				"gc session nudge demo/<polecat-suffix>",
+				"Mail identity: demo/refinery",
+			},
+			bads: []string{
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"Mail identity: demo/gastown.refinery",
+				"not `furiosa`",
+			},
+		},
+		{
+			name:         "crew",
+			templatePath: filepath.Join("packs", "gastown", "assets", "prompts", "crew.template.md"),
+			ctx: PromptContext{
+				AgentName:     "demo/gastown.alice",
+				TemplateName:  "crew",
+				BindingName:   "gastown",
+				BindingPrefix: "gastown.",
+				CityRoot:      "/city",
+				RigName:       "demo",
+			},
+			wants: []string{
+				"gc sling <rig>/<binding>.polecat <bead>",
+				"gc session nudge demo/<binding>.<polecat-suffix>",
+				"e.g. `<rig>/gastown.witness`",
+			},
+			bads: []string{
+				"gc bd update <bead> --label=pool:<rig>/polecat",
+				"gc session nudge demo/<polecat-name>",
+				"`<rig>/<agent>` for rig agents",
+				"gc session nudge demo/<polecat-suffix>",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr strings.Builder
+			got := renderPrompt(fsys.OSFS{}, cityRoot, "gastown", tc.templatePath, tc.ctx, "", &stderr, []string{packDir}, nil, nil)
+			if stderr.Len() > 0 {
+				t.Fatalf("renderPrompt stderr: %s", stderr.String())
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(got, want) {
+					t.Errorf("rendered prompt missing %q", want)
+				}
+			}
+			for _, bad := range tc.bads {
+				if strings.Contains(got, bad) {
+					t.Errorf("rendered prompt still contains %q", bad)
+				}
+			}
+		})
+	}
+}
+
 func TestRenderPromptWorkQuery(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files["/city/prompts/test.md.tmpl"] = []byte("Work: {{ .WorkQuery }}")

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -55,7 +55,7 @@ func assertContainsInOrder(t *testing.T, body string, wants ...string) {
 	}
 }
 
-func renderGastownPromptForBoundPack(t *testing.T, rel, agentName, templateName, rigName string) string {
+func renderGastownPromptForPack(t *testing.T, rel, agentName, templateName, rigName, bindingName, bindingPrefix string) string {
 	t.Helper()
 	dir := exampleDir()
 	tmpl := template.New(filepath.Base(rel)).
@@ -97,8 +97,8 @@ func renderGastownPromptForBoundPack(t *testing.T, rel, agentName, templateName,
 
 	ctx := map[string]string{
 		"AgentName":     agentName,
-		"BindingName":   "gastown",
-		"BindingPrefix": "gastown.",
+		"BindingName":   bindingName,
+		"BindingPrefix": bindingPrefix,
 		"CityRoot":      "/city",
 		"DefaultBranch": "main",
 		"IssuePrefix":   "demo",
@@ -1064,9 +1064,48 @@ func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
 		agentName    string
 		templateName string
 		rigName      string
+		unbound      bool
 		wants        []string
 		bads         []string
 	}{
+		{
+			rel:          "packs/gastown/agents/boot/prompt.template.md",
+			agentName:    "gastown.boot",
+			templateName: "boot",
+			wants: []string{
+				"gc session peek gastown.deacon --lines 1",
+				"gc bd list --assignee=gastown.deacon --status=in_progress --json --limit=5",
+				"gc mail count gastown.deacon",
+				"gc session nudge gastown.deacon",
+				`--title="Stuck: gastown.deacon"`,
+				`"target":"gastown.deacon"`,
+			},
+			bads: []string{
+				"gc session peek deacon",
+				"--assignee=deacon",
+				"gc mail count deacon",
+				"gc session nudge deacon",
+				`--title="Stuck: deacon"`,
+				`"target":"deacon"`,
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/boot/prompt.template.md",
+			agentName:    "boot",
+			templateName: "boot",
+			unbound:      true,
+			wants: []string{
+				"gc session peek deacon --lines 1",
+				"gc bd list --assignee=deacon --status=in_progress --json --limit=5",
+				"gc mail count deacon",
+				"gc session nudge deacon",
+				`--title="Stuck: deacon"`,
+				`"target":"deacon"`,
+			},
+			bads: []string{
+				"gastown.deacon",
+			},
+		},
 		{
 			rel:          "packs/gastown/agents/mayor/prompt.template.md",
 			agentName:    "gastown.mayor",
@@ -1078,6 +1117,20 @@ func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
 			bads: []string{
 				"--label=pool:<rig>/polecat",
 				"gc nudge refinery",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/mayor/prompt.template.md",
+			agentName:    "mayor",
+			templateName: "mayor",
+			unbound:      true,
+			wants: []string{
+				"gc sling <rig>/polecat <bead>",
+				"session nudge <rig>/refinery",
+			},
+			bads: []string{
+				"gc sling <rig>/gastown.polecat <bead>",
+				"session nudge <rig>/gastown.refinery",
 			},
 		},
 		{
@@ -1094,15 +1147,45 @@ func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
 			},
 		},
 		{
+			rel:          "packs/gastown/agents/deacon/prompt.template.md",
+			agentName:    "deacon",
+			templateName: "deacon",
+			unbound:      true,
+			wants: []string{
+				"gc mail send <rig>/witness",
+				"Your mail address: deacon",
+			},
+			bads: []string{
+				"gc mail send <rig>/gastown.witness",
+				"Your mail address: deacon/",
+			},
+		},
+		{
 			rel:          "packs/gastown/agents/polecat/prompt.template.md",
 			agentName:    "demo/gastown.furiosa",
 			templateName: "polecat",
 			rigName:      "demo",
 			wants: []string{
 				"gastown.witness",
+				"Mail identity: demo/gastown.furiosa",
 			},
 			bads: []string{
 				"${GC_RIG:+$GC_RIG/}witness",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/polecat/prompt.template.md",
+			agentName:    "demo/furiosa",
+			templateName: "polecat",
+			rigName:      "demo",
+			unbound:      true,
+			wants: []string{
+				"${GC_RIG:+$GC_RIG/}witness",
+				"Mail identity: demo/furiosa",
+			},
+			bads: []string{
+				"${GC_RIG:+$GC_RIG/}gastown.witness",
+				"Mail identity: demo/gastown.furiosa",
 			},
 		},
 		{
@@ -1122,6 +1205,23 @@ func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
 			},
 		},
 		{
+			rel:          "packs/gastown/agents/refinery/prompt.template.md",
+			agentName:    "demo/refinery",
+			templateName: "refinery",
+			rigName:      "demo",
+			unbound:      true,
+			wants: []string{
+				"gc session nudge demo/<polecat-suffix>",
+				"Mail identity: demo/refinery",
+				"Use the bare polecat suffix",
+			},
+			bads: []string{
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"Mail identity: demo/gastown.refinery",
+				"demo/gastown.<polecat-name>",
+			},
+		},
+		{
 			rel:          "packs/gastown/agents/witness/prompt.template.md",
 			agentName:    "demo/gastown.witness",
 			templateName: "witness",
@@ -1137,6 +1237,26 @@ func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
 				"gc session nudge demo/<polecat-name>",
 				"gc session peek demo/<polecat-name>",
 				"Your mail address: demo/witness",
+				"demo/gastown.<polecat-name>",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/witness/prompt.template.md",
+			agentName:    "demo/witness",
+			templateName: "witness",
+			rigName:      "demo",
+			unbound:      true,
+			wants: []string{
+				"demo/refinery",
+				"demo/<polecat-suffix>",
+				"Your mail address: demo/witness",
+				"Use the bare polecat suffix",
+			},
+			bads: []string{
+				"gc mail send demo/gastown.refinery",
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"gc session peek demo/gastown.<polecat-suffix>",
+				"Your mail address: demo/gastown.witness",
 				"demo/gastown.<polecat-name>",
 			},
 		},
@@ -1162,9 +1282,37 @@ func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
 				"demo/gastown.<polecat-name>",
 			},
 		},
+		{
+			rel:          "packs/gastown/assets/prompts/crew.template.md",
+			agentName:    "demo/alice",
+			templateName: "crew",
+			rigName:      "demo",
+			unbound:      true,
+			wants: []string{
+				"demo/<binding>.<polecat-suffix>",
+				"gc sling <rig>/<binding>.polecat <bead>",
+				"Use the import binding plus the bare polecat suffix",
+			},
+			bads: []string{
+				"gc bd update --label=pool:<rig>/polecat",
+				"gc bd update <bead> --label=pool:<rig>/polecat",
+				"gc session nudge demo/<polecat-name>",
+				"`<rig>/<agent>` for rig agents",
+				"gc.routed_to=demo/polecat",
+				"gc session nudge demo/polecat",
+				"demo/<polecat-suffix>",
+				"demo/gastown.<polecat-name>",
+			},
+		},
 	}
 	for _, check := range checks {
-		body := renderGastownPromptForBoundPack(t, check.rel, check.agentName, check.templateName, check.rigName)
+		bindingName := "gastown"
+		bindingPrefix := "gastown."
+		if check.unbound {
+			bindingName = ""
+			bindingPrefix = ""
+		}
+		body := renderGastownPromptForPack(t, check.rel, check.agentName, check.templateName, check.rigName, bindingName, bindingPrefix)
 		for _, want := range check.wants {
 			if !strings.Contains(body, want) {
 				t.Errorf("%s missing %q", check.rel, want)
@@ -1276,6 +1424,40 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 	}
 }
 
+func TestGastownFormulasUsingBindingPrefixDefaultToUnbound(t *testing.T) {
+	dir := exampleDir()
+	paths, err := filepath.Glob(filepath.Join(dir, "packs", "gastown", "formulas", "*.toml"))
+	if err != nil {
+		t.Fatalf("glob gastown formulas: %v", err)
+	}
+	parser := formula.NewParser()
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		if !strings.Contains(string(data), "{{binding_prefix}}") {
+			continue
+		}
+		f, err := parser.ParseFile(path)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		varDef, ok := f.Vars["binding_prefix"]
+		if !ok {
+			t.Errorf("%s uses {{binding_prefix}} without declaring [vars.binding_prefix]", filepath.Base(path))
+			continue
+		}
+		if varDef.Default == nil {
+			t.Errorf("%s binding_prefix var has no explicit default", filepath.Base(path))
+			continue
+		}
+		if *varDef.Default != "" {
+			t.Errorf("%s binding_prefix default = %q, want empty string", filepath.Base(path), *varDef.Default)
+		}
+	}
+}
+
 func TestBootPromptMatchesNamedSessionLifecycle(t *testing.T) {
 	cfg := loadExpanded(t)
 	bootSession := config.FindNamedSession(cfg, "boot")
@@ -1317,8 +1499,8 @@ func TestBootPromptMatchesNamedSessionLifecycle(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"{{ cmd }} session peek deacon --lines 1",
-		"{{ cmd }} session peek deacon --lines 30",
+		"{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 1",
+		"{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 30",
 		"configured `boot` named session",
 		"`mode = \"always\"` keeps the `boot` identity present",
 		"`wake_mode = \"fresh\"`",

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -6,12 +6,14 @@
 package gastown_test
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/config"
@@ -51,6 +53,67 @@ func assertContainsInOrder(t *testing.T, body string, wants ...string) {
 		}
 		offset += idx + len(want)
 	}
+}
+
+func renderGastownPromptForBoundPack(t *testing.T, rel, agentName, templateName, rigName string) string {
+	t.Helper()
+	dir := exampleDir()
+	tmpl := template.New(filepath.Base(rel)).
+		Funcs(template.FuncMap{
+			"basename": func(qualifiedName string) string {
+				_, name := config.ParseQualifiedName(qualifiedName)
+				return name
+			},
+			"cmd": func() string {
+				return "gc"
+			},
+			"session": func(agentName string) string {
+				return agentName
+			},
+		}).
+		Option("missingkey=zero")
+
+	fragmentPaths, err := filepath.Glob(filepath.Join(dir, "packs", "gastown", "template-fragments", "*.template.md"))
+	if err != nil {
+		t.Fatalf("glob template fragments: %v", err)
+	}
+	for _, fragmentPath := range fragmentPaths {
+		data, err := os.ReadFile(fragmentPath)
+		if err != nil {
+			t.Fatalf("reading %s: %v", fragmentPath, err)
+		}
+		if _, err := tmpl.Parse(string(data)); err != nil {
+			t.Fatalf("parsing %s: %v", fragmentPath, err)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatalf("reading %s: %v", rel, err)
+	}
+	if _, err := tmpl.Parse(string(data)); err != nil {
+		t.Fatalf("parsing %s: %v", rel, err)
+	}
+
+	ctx := map[string]string{
+		"AgentName":     agentName,
+		"BindingName":   "gastown",
+		"BindingPrefix": "gastown.",
+		"CityRoot":      "/city",
+		"DefaultBranch": "main",
+		"IssuePrefix":   "demo",
+		"RigName":       rigName,
+		"RigRoot":       "/repos/" + rigName,
+		"SlingQuery":    "bd ready --metadata-field gc.routed_to=<canonical> --unassigned",
+		"TemplateName":  templateName,
+		"WorkDir":       "/repos/" + rigName,
+		"WorkQuery":     "bd ready",
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, ctx); err != nil {
+		t.Fatalf("rendering %s: %v", rel, err)
+	}
+	return buf.String()
 }
 
 // loadExpanded loads city.toml with full pack expansion.
@@ -995,6 +1058,126 @@ func TestGastownRefineryPatrolRejectionCommandsReturnWorkToPolecatPool(t *testin
 	}
 }
 
+func TestGastownPromptPeerAddressesUseBindingPrefix(t *testing.T) {
+	checks := []struct {
+		rel          string
+		agentName    string
+		templateName string
+		rigName      string
+		wants        []string
+		bads         []string
+	}{
+		{
+			rel:          "packs/gastown/agents/mayor/prompt.template.md",
+			agentName:    "gastown.mayor",
+			templateName: "mayor",
+			wants: []string{
+				"gc sling <rig>/gastown.polecat <bead>",
+				"session nudge <rig>/gastown.refinery",
+			},
+			bads: []string{
+				"--label=pool:<rig>/polecat",
+				"gc nudge refinery",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/deacon/prompt.template.md",
+			agentName:    "gastown.deacon",
+			templateName: "deacon",
+			wants: []string{
+				"gc mail send <rig>/gastown.witness",
+				"Your mail address: gastown.deacon",
+			},
+			bads: []string{
+				"gc mail send <rig>/witness",
+				"Your mail address: deacon/",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/polecat/prompt.template.md",
+			agentName:    "demo/gastown.furiosa",
+			templateName: "polecat",
+			rigName:      "demo",
+			wants: []string{
+				"gastown.witness",
+			},
+			bads: []string{
+				"${GC_RIG:+$GC_RIG/}witness",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/refinery/prompt.template.md",
+			agentName:    "demo/gastown.refinery",
+			templateName: "refinery",
+			rigName:      "demo",
+			wants: []string{
+				"gc session nudge demo/gastown.<polecat-suffix>",
+				"Mail identity: demo/gastown.refinery",
+				"Use the bare polecat suffix",
+			},
+			bads: []string{
+				"gc session nudge demo/<polecat-name>",
+				"Mail identity: demo/refinery",
+				"demo/gastown.<polecat-name>",
+			},
+		},
+		{
+			rel:          "packs/gastown/agents/witness/prompt.template.md",
+			agentName:    "demo/gastown.witness",
+			templateName: "witness",
+			rigName:      "demo",
+			wants: []string{
+				"demo/gastown.refinery",
+				"demo/gastown.<polecat-suffix>",
+				"Your mail address: demo/gastown.witness",
+				"Use the bare polecat suffix",
+			},
+			bads: []string{
+				"gc mail send demo/refinery",
+				"gc session nudge demo/<polecat-name>",
+				"gc session peek demo/<polecat-name>",
+				"Your mail address: demo/witness",
+				"demo/gastown.<polecat-name>",
+			},
+		},
+		{
+			rel:          "packs/gastown/assets/prompts/crew.template.md",
+			agentName:    "demo/gastown.alice",
+			templateName: "crew",
+			rigName:      "demo",
+			wants: []string{
+				"demo/<binding>.<polecat-suffix>",
+				"gc sling <rig>/<binding>.polecat <bead>",
+				"e.g. `<rig>/gastown.witness`",
+				"Use the import binding plus the bare polecat suffix",
+			},
+			bads: []string{
+				"gc bd update --label=pool:<rig>/polecat",
+				"gc bd update <bead> --label=pool:<rig>/polecat",
+				"gc session nudge demo/<polecat-name>",
+				"`<rig>/<agent>` for rig agents",
+				"gc.routed_to=demo/polecat",
+				"gc session nudge demo/polecat",
+				"demo/<polecat-suffix>",
+				"demo/gastown.<polecat-name>",
+			},
+		},
+	}
+	for _, check := range checks {
+		body := renderGastownPromptForBoundPack(t, check.rel, check.agentName, check.templateName, check.rigName)
+		for _, want := range check.wants {
+			if !strings.Contains(body, want) {
+				t.Errorf("%s missing %q", check.rel, want)
+			}
+		}
+		for _, bad := range check.bads {
+			if strings.Contains(body, bad) {
+				t.Errorf("%s still contains binding-blind peer address %q", check.rel, bad)
+			}
+		}
+	}
+}
+
 func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 	dir := exampleDir()
 	checks := []struct {
@@ -1018,14 +1201,14 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 			vars:    []string{"--var target_branch=", "--var rig_name=", "--var binding_prefix="},
 		},
 		{
-			rel:     "packs/gastown/formulas/mol-refinery-patrol.toml",
-			formula: "mol-refinery-patrol",
-			vars:    []string{"--var target_branch=", "--var rig_name=", "--var binding_prefix="},
-		},
-		{
 			rel:     "packs/gastown/agents/witness/prompt.template.md",
 			formula: "mol-witness-patrol",
 			vars:    []string{"--var binding_prefix="},
+		},
+		{
+			rel:     "packs/gastown/formulas/mol-refinery-patrol.toml",
+			formula: "mol-refinery-patrol",
+			vars:    []string{"--var target_branch=", "--var rig_name=", "--var binding_prefix="},
 		},
 		{
 			rel:     "packs/gastown/formulas/mol-witness-patrol.toml",
@@ -1068,6 +1251,26 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 		for _, bad := range []string{"{{binding_prefix}}", "{{rig_name}}"} {
 			if strings.Contains(rendered, bad) {
 				t.Errorf("%s rendered patrol formula still contains %q", rel, bad)
+			}
+		}
+		if rel == "packs/gastown/formulas/mol-witness-patrol.toml" {
+			for _, want := range []string{
+				"<rig>/gastown.<polecat-suffix>",
+				"--assignee=<rig>/gastown.refinery",
+				"gc session nudge <rig>/gastown.refinery",
+			} {
+				if !strings.Contains(rendered, want) {
+					t.Errorf("%s rendered witness patrol missing %q", rel, want)
+				}
+			}
+			for _, bad := range []string{
+				"<rig>/polecats/<name>",
+				"--assignee=<rig>/refinery",
+				"gc session nudge <rig>/refinery",
+			} {
+				if strings.Contains(rendered, bad) {
+					t.Errorf("%s rendered witness patrol still contains %q", rel, bad)
+				}
 			}
 		}
 	}

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -41,7 +41,7 @@ lifecycle.
 ### Step 1: Check if deacon session exists
 
 ```bash
-{{ cmd }} session peek deacon --lines 1
+{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 1
 ```
 
 If the deacon session doesn't exist: do nothing and exit. The controller
@@ -51,13 +51,13 @@ detects dead agents and restarts them — that's its job, not yours.
 
 ```bash
 # Recent pane output — is the deacon actively working?
-{{ cmd }} session peek deacon --lines 30
+{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 30
 
 # Deacon's current patrol wisp — how fresh is it?
-gc bd list --assignee=deacon --status=in_progress --json --limit=5
+gc bd list --assignee={{ .BindingPrefix }}deacon --status=in_progress --json --limit=5
 
 # Does the deacon have unread mail? (may explain idle state)
-gc mail count deacon 2>/dev/null
+gc mail count {{ .BindingPrefix }}deacon 2>/dev/null
 ```
 
 Read the wisp timestamps and pane output. Build a picture:
@@ -88,15 +88,15 @@ Use judgment — there are no hardcoded thresholds. Consider:
 
 **Possibly stuck (stale wisp, no activity, but ambiguous):** Nudge:
 ```bash
-{{ cmd }} session nudge deacon "Boot check: are you making progress?"
+{{ cmd }} session nudge {{ .BindingPrefix }}deacon "Boot check: are you making progress?"
 ```
 Drain-ack and exit. Next Boot wake will re-evaluate.
 
 **Clearly stuck (very stale wisp, no output, errors visible):** File a warrant:
 ```bash
 gc bd create --type=task \
-  --title="Stuck: deacon" \
-  --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
+  --title="Stuck: {{ .BindingPrefix }}deacon" \
+  --metadata '{"target":"{{ .BindingPrefix }}deacon","reason":"Stale patrol wisp, no activity","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
   --label=warrant
 ```
 The dog pool picks up the warrant and runs the shutdown dance.
@@ -127,10 +127,10 @@ with a fresh provider context.
 
 | Want to... | Correct command |
 |------------|----------------|
-| View deacon output | `{{ cmd }} session peek deacon --lines 30` |
-| Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
-| Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
-| File stuck warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"deacon","reason":"...","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
+| View deacon output | `{{ cmd }} session peek {{ .BindingPrefix }}deacon --lines 30` |
+| Check deacon work | `gc bd list --assignee={{ .BindingPrefix }}deacon --status=in_progress --json` |
+| Nudge deacon | `{{ cmd }} session nudge {{ .BindingPrefix }}deacon "message"` |
+| File stuck warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"{{ .BindingPrefix }}deacon","reason":"...","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -126,9 +126,9 @@ gc bd create --type=task \
 
 ```bash
 gc mail send mayor/ -s "Subject" -m "Message"       # Escalate to mayor
-gc mail send <rig>/witness -s "Subject" -m "..."     # Witness questions
+gc mail send <rig>/{{ .BindingPrefix }}witness -s "Subject" -m "..."     # Witness questions
 gc session nudge <target> "message"                  # Nudge an agent
-gc session peek <target> --lines 50                      # View agent output
+gc session peek <target> --lines 50                  # View agent output
 ```
 
 ### Deacon Communication Rules
@@ -176,5 +176,5 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | Compact wisps | `gc bd mol wisp gc --age 24h` |
 
 Working directory: {{ .WorkDir }}
-Your mail address: deacon/
+Your mail address: {{ .AgentName }}
 Formula: mol-deacon-patrol

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -26,6 +26,11 @@ POLECAT_TARGET="${TARGET_RIG:+$TARGET_RIG/}{{ .BindingPrefix }}polecat"
 gc sling "$POLECAT_TARGET" <bead-id>                     # dispatch to polecat pool (sets gc.routed_to metadata for controller scale_check)
 ```
 
+**Pool dispatch leaves the assignee empty.** The polecat that picks the bead up sets the
+assignee on claim. If you set `--assignee` yourself, the supervisor's scale_check
+(`bd ready --metadata-field gc.routed_to=<canonical> --unassigned`) won't count the bead as
+pool demand and no session will spawn. Set `gc.routed_to` only.
+
 **Why this is the default:**
 - Every polecat completion is a ledger entry — transparent, auditable work
 - Polecats preserve YOUR context for coordination and strategic decisions
@@ -144,7 +149,8 @@ Wrong. The issue is about beads code, so it goes in the beads rig.
 - **Strategic decisions**: Architecture, priorities, integration planning
 
 **NOT your job**: Per-worker cleanup, session killing, routine nudging (Witness handles that)
-**Exception**: If refinery/witness is stuck, use `{{ cmd }} session nudge refinery "Process MQ"`
+**Exception**: If refinery/witness is stuck, nudge the concrete rig-scoped session,
+e.g. `{{ cmd }} session nudge <rig>/{{ .BindingPrefix }}refinery "Process MQ"`
 
 ## Rig Wake/Sleep Protocol
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -161,7 +161,7 @@ When blocked, you MUST escalate. Do NOT wait for human input.
 **How:**
 ```bash
 # Blocking issues
-WITNESS_TARGET="${GC_RIG:+$GC_RIG/}witness"
+WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
 gc mail send "$WITNESS_TARGET" -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 # Cross-rig or strategic
@@ -175,7 +175,7 @@ After escalating: continue if possible, otherwise `gc bd update <bead> --status=
 ## Communication
 
 ```bash
-WITNESS_TARGET="${GC_RIG:+$GC_RIG/}witness"
+WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"
 gc session nudge "$WITNESS_TARGET" "Quick question about bead status" # Default: nudge
 gc mail send "$WITNESS_TARGET" -s "HELP: Blocked on X" -m "..."       # Escalation: mail
 gc mail send mayor/ -s "BLOCKED: Need coordination" -m "..."          # Cross-rig: mail
@@ -232,7 +232,7 @@ is the "Idle Polecat heresy."
 |------------|----------------|
 | Signal work complete | Done sequence (push, set metadata, reassign, wake refinery, nudge refinery, `gc runtime drain-ack`, exit) |
 | Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
-| Escalate blocker | `WITNESS_TARGET="${GC_RIG:+$GC_RIG/}witness"; gc mail send "$WITNESS_TARGET" -s "ESCALATION: desc [HIGH]" -m "..."` |
+| Escalate blocker | `WITNESS_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}witness"; gc mail send "$WITNESS_TARGET" -s "ESCALATION: desc [HIGH]" -m "..."` |
 | Context exhaustion | `gc runtime request-restart` |
 | Handoff to next session | `gc mail send -s "HANDOFF: ..." -m "..."` then `gc runtime drain-ack && exit` |
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -239,5 +239,5 @@ is the "Idle Polecat heresy."
 Polecat: {{ basename .AgentName }}
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}
-Mail identity: {{ .RigName }}/{{ basename .AgentName }}
+Mail identity: {{ .AgentName }}
 Formula: mol-polecat-work

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -164,13 +164,13 @@ and then ignored by landing directly to the target branch.
 
 ```bash
 gc mail inbox                                          # Check for messages
-gc session nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
+gc session nudge {{ .RigName }}/{{ .BindingPrefix }}<polecat-suffix> "Run gc hook; it checks assigned work before routed pool work"
 gc mail send mayor/ -s "ESCALATION: ..." -m "..."      # Escalate (mail — must survive)
 ```
 
-Use the concrete polecat name from `gc status` or `gc session list`;
-Gastown's default namepool yields names like `furiosa` or `nux`. There is no
-`{{ .RigName }}/polecats/<name>` address form.
+Use the bare polecat suffix after the binding prefix; Gastown's default
+namepool yields suffixes like `furiosa` or `nux`{{ if .BindingPrefix }}, not `{{ .BindingPrefix }}furiosa`{{ end }}.
+There is no `{{ .RigName }}/polecats/<name>` address form.
 
 Nudging a polecat does not assign work. It only wakes that session; actual
 work still arrives through bead assignment or pool routing.
@@ -206,5 +206,5 @@ alert the witness, not `gc mail send`.
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}
-Mail identity: {{ .RigName }}/refinery
+Mail identity: {{ .AgentName }}
 Formula: mol-refinery-patrol

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -183,14 +183,14 @@ re-reads formula steps and resumes from context.
 
 ```bash
 gc mail send mayor/ -s "Subject" -m "Message"              # Escalate to mayor
-gc mail send {{ .RigName }}/refinery -s "Subject" -m "..."  # Refinery questions
-gc session nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
-gc session peek {{ .RigName }}/<polecat-name> --lines 50     # View polecat output
+gc mail send {{ .RigName }}/{{ .BindingPrefix }}refinery -s "Subject" -m "..."  # Refinery questions
+gc session nudge {{ .RigName }}/{{ .BindingPrefix }}<polecat-suffix> "Run gc hook; it checks assigned work before routed pool work"
+gc session peek {{ .RigName }}/{{ .BindingPrefix }}<polecat-suffix> --lines 50     # View polecat output
 ```
 
-Use the concrete polecat name from `gc status` or `gc session list`;
-Gastown's default namepool yields names like `furiosa` or `nux`. There is no
-`{{ .RigName }}/polecats/<name>` address form.
+Use the bare polecat suffix after the binding prefix; Gastown's default
+namepool yields suffixes like `furiosa` or `nux`{{ if .BindingPrefix }}, not `{{ .BindingPrefix }}furiosa`{{ end }}.
+There is no `{{ .RigName }}/polecats/<name>` address form.
 
 Nudging a polecat does not assign work. It only wakes that session; actual
 work still arrives through bead assignment or pool routing.
@@ -257,5 +257,5 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}
-Your mail address: {{ .RigName }}/witness
+Your mail address: {{ .AgentName }}
 Formula: mol-witness-patrol

--- a/examples/gastown/packs/gastown/assets/prompts/crew.template.md
+++ b/examples/gastown/packs/gastown/assets/prompts/crew.template.md
@@ -100,7 +100,7 @@ git worktree remove {{ .CityRoot }}/.gc/worktrees/$TARGET_RIG/crew/{{ basename .
 |----------|----------|
 | Quick fix in another rig | Use `git worktree add` |
 | Substantial work in another rig | Use `git worktree add` |
-| Work should be done by target rig's workers | `{{ cmd }} convoy create` + `gc bd update --label=pool:<rig>/polecat` |
+| Work should be done by target rig's workers | `{{ cmd }} convoy create` + `gc sling <rig>/<binding>.polecat <bead>` |
 | Infrastructure task | Leave it to the Deacon's dogs |
 
 **Note**: Dogs are utility agents that handle infrastructure tasks (warrants,
@@ -208,13 +208,14 @@ directly to another agent's Claude Code session via tmux.
 **Common patterns:**
 ```bash
 gc session nudge {{ .RigName }}/crew/alice "Check your mail - PR review waiting"
-gc session nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
+gc session nudge {{ .RigName }}/<binding>.<polecat-suffix> "Run gc hook; it checks assigned work before routed pool work"
 gc mail send {{ .RigName }}/alice -s "Urgent" -m "..." --notify
 ```
 
-Use the concrete polecat name from `gc status` or `gc session list`;
-Gastown's default namepool yields names like `furiosa` or `nux`. There is no
-`{{ .RigName }}/polecats/<name>` address form.
+Use the import binding plus the bare polecat suffix; Gastown's default
+namepool yields suffixes like `furiosa` or `nux`, so an import bound as
+`gastown` targets `gastown.furiosa`, not `gastown.gastown.furiosa`.
+There is no `{{ .RigName }}/polecats/<name>` address form.
 
 Nudging a polecat does not assign work. It only wakes that session; actual
 work still arrives through bead assignment or pool routing.
@@ -234,7 +235,9 @@ EOF
 
 **Common mail mistakes:**
 - Sending mail when a nudge would suffice (every mail = permanent Dolt commit)
-- Forgetting the address format: `<rig>/<agent>` for rig agents, `mayor/` for city agents
+- Forgetting the address format: rig agents need the canonical configured identity,
+  e.g. `<rig>/gastown.witness` for Gastown imported as `gastown`; city agents
+  can use named-session aliases like `mayor/`
 - Unquoted multi-line text (shell eats newlines) — use `"$(cat <<'EOF' ... EOF)"` pattern
 
 **Important:** `{{ cmd }} session nudge` is the ONLY reliable way to send text to Claude sessions.
@@ -399,7 +402,7 @@ See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Dispatch work to polecat | `gc sling <rig>/<binding>.polecat <bead>` | ~~gc bd update --label=pool:...~~ / ~~--assignee=<rig>/polecat~~ |
 | Stop my session | `{{ cmd }} runtime drain {{ basename .AgentName }}` | ~~gc rig stop~~ (stops rig agents, not crew) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -49,6 +49,10 @@ formula = "mol-deacon-patrol"
 version = 13
 
 [vars]
+[vars.binding_prefix]
+description = "Import binding prefix for gastown agent identities, including trailing dot when bound."
+default = ""
+
 [vars.event_timeout]
 description = "Seconds to wait for events before re-checking (exponential backoff)"
 default = "30"

--- a/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
@@ -35,6 +35,10 @@ version = 2
 contract = "graph.v2"
 
 [vars]
+[vars.binding_prefix]
+description = "Import binding prefix for gastown agent identities, including trailing dot when bound."
+default = ""
+
 [vars.problem]
 description = "Raw feature idea, problem statement, or request"
 required = true

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -39,6 +39,11 @@ formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
 version = 9
 
+[vars]
+[vars.binding_prefix]
+description = "Import binding prefix for gastown agent identities, including trailing dot when bound."
+default = ""
+
 [[steps]]
 id = "workspace-setup"
 title = "Set up worktree and feature branch"

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -33,6 +33,10 @@ version = 4
 contract = "graph.v2"
 
 [vars]
+[vars.binding_prefix]
+description = "Import binding prefix for gastown agent identities, including trailing dot when bound."
+default = ""
+
 [vars.run_tests]
 description = "Whether to run tests before merging"
 default = "true"

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -61,6 +61,10 @@ formula = "mol-witness-patrol"
 version = 9
 
 [vars]
+[vars.binding_prefix]
+description = "Import binding prefix for gastown agent identities, including trailing dot when bound."
+default = ""
+
 [vars.event_timeout]
 description = "Seconds to wait for events before re-checking (exponential backoff)"
 default = "30"
@@ -150,7 +154,8 @@ gc bd list --status=open --json --limit=0
 Filter for beads with an assignee (skip unassigned beads). This pass does not
 solve the controller race where orphaned work may already have been released to
 open/unassigned before witness observes it; that requires a separate
-worktree-salvage scan keyed by `metadata.work_dir`.
+worktree-salvage scan keyed by `metadata.work_dir`. Bound Gastown polecat
+assignees use the shape `<rig>/{{binding_prefix}}<polecat-suffix>`.
 
 Get the full session roster for liveness checks:
 ```bash
@@ -371,7 +376,7 @@ Ensure the refinery is processing work and the queue is healthy.
 
 **Step 1: Check work beads assigned to refinery:**
 ```bash
-gc bd list --assignee=<rig>/refinery --status=open --json
+gc bd list --assignee=<rig>/{{binding_prefix}}refinery --status=open --json
 ```
 
 These are work beads with `metadata.branch` and `metadata.target` that
@@ -391,7 +396,7 @@ wisp is stale, the refinery may be stuck.
 
 **Step 3: Nudge if needed:**
 ```bash
-gc session nudge <rig>/refinery "Work beads waiting for merge. Please check queue."
+gc session nudge <rig>/{{binding_prefix}}refinery "Work beads waiting for merge. Please check queue."
 ```
 
 **Step 4: Escalate if needed:**


### PR DESCRIPTION
## Summary

- Refs: gastownhall/gascity#1397.
- The original failure was binding-blind peer addressing in the Gastown pack when a city imports it via `[rigs.imports.<name>]` and agents receive a `<name>.` identity prefix.
- Main already fixed the core polecat→refinery done-sequence route via the newer binding-prefix pattern; this PR finishes the remaining prompt and witness-patrol surfaces that agents copy into commands.
- Reuse the existing `PromptContext.BindingPrefix` and `{{ .AgentName }}` values to render canonical identities in the mayor, deacon, polecat, refinery, witness, and crew prompts. `BindingPrefix` is empty for non-imported agents, so the city-pack-as-default case stays unchanged.
- Add a `binding_prefix` formula var to `mol-witness-patrol` and propagate it through witness bootstrap and self-repour commands so recovery paths preserve the imported-pack namespace.
- Clarify that pool dispatch should set `gc.routed_to=<canonical>` while leaving `assignee` empty, matching the supervisor demand-counting path.

## Testing

- [x] `go test ./cmd/gc -run 'TestRenderPromptGastownBoundPeerAddresses' -count=1`
- [x] `go test ./examples/gastown -run 'TestGastownPromptPeerAddressesUseBindingPrefix' -count=1`
- [x] `make test`
- [x] pre-commit hook on amended commit
- [x] `$review-pr` dual-model review (Claude + Codex; Gemini unavailable in this environment)

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
