### PR TITLE
fix(pool): pre-assign work bead to new pool session before spawn (ga-1ld)

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -732,6 +732,10 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		)
 	}
 
+	// preAssignedPoolBeads tracks work beads pre-assigned to new pool sessions
+	// this pass to ensure each session gets a distinct bead.
+	preAssignedPoolBeads := make(map[string]bool)
+
 	for sn, tp := range desiredState {
 		agentCfg := templateParamsToConfig(tp)
 		liveHash := runtime.LiveFingerprint(agentCfg)
@@ -761,6 +765,13 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			}
 		}
 		if !exists {
+			// For new ephemeral pool sessions, pre-assign an available work bead
+			// to eliminate the spawn race where concurrent sessions all compete
+			// for the same Tier 3 (pool-routed unassigned) bead. The session then
+			// finds its work via Tier 2 (bd ready --assignee="$GC_SESSION_NAME").
+			if isManagedPool && !tp.DependencyOnly {
+				preAssignPoolWorkBead(store, rigStores, tp.TemplateName, sn, preAssignedPoolBeads, stderr)
+			}
 			// Create a new session bead.
 			meta := map[string]string{
 				"session_name":       sn,
@@ -1472,4 +1483,67 @@ func resolvePoolSlot(agentName, template string) int {
 		return slot
 	}
 	return 0
+}
+
+// preAssignPoolWorkBead assigns an available ready unassigned work bead
+// routed to template to sessionName. This eliminates the spawn race where
+// multiple new pool sessions concurrently compete for the same Tier 3
+// (pool-routed unassigned) bead. Once assigned, the session finds its work
+// via Tier 2 (bd ready --assignee="$GC_SESSION_NAME") instead.
+//
+// alreadyAssigned tracks beads pre-assigned earlier in the same sync pass
+// to prevent two sessions from receiving the same bead.
+// Returns the assigned bead ID, or "" if no work bead is available.
+func preAssignPoolWorkBead(
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+	template string,
+	sessionName string,
+	alreadyAssigned map[string]bool,
+	stderr io.Writer,
+) string {
+	store := beadStoreForTemplate(cityStore, rigStores, template)
+	if store == nil {
+		return ""
+	}
+	candidates, err := beads.ReadyLive(store)
+	if err != nil {
+		if stderr != nil {
+			fmt.Fprintf(stderr, "session beads: querying pool work for %s: %v\n", sessionName, err) //nolint:errcheck
+		}
+		return ""
+	}
+	for _, wb := range candidates {
+		if strings.TrimSpace(wb.Metadata["gc.routed_to"]) != template {
+			continue
+		}
+		if strings.TrimSpace(wb.Assignee) != "" {
+			continue
+		}
+		if alreadyAssigned[wb.ID] {
+			continue
+		}
+		sn := sessionName
+		if err := store.Update(wb.ID, beads.UpdateOpts{Assignee: &sn}); err != nil {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "session beads: pre-assigning %s to %s: %v\n", wb.ID, sessionName, err) //nolint:errcheck
+			}
+			continue
+		}
+		alreadyAssigned[wb.ID] = true
+		return wb.ID
+	}
+	return ""
+}
+
+// beadStoreForTemplate returns the rig store for a qualified pool agent
+// template (e.g., "myrig/polecat" → rigStores["myrig"]). Falls back to
+// cityStore when no rig prefix is found or the rig store is absent.
+func beadStoreForTemplate(cityStore beads.Store, rigStores map[string]beads.Store, template string) beads.Store {
+	if slash := strings.IndexByte(template, '/'); slash > 0 {
+		if store, ok := rigStores[template[:slash]]; ok && store != nil {
+			return store
+		}
+	}
+	return cityStore
 }

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -3587,5 +3588,178 @@ func TestSyncSessionBeadsWithSnapshotAndRigStoresLeavesOrphanedSessionBeadOpenWh
 	}
 	if got.Status != "open" {
 		t.Fatalf("session bead status = %q, want open because rig-store work still owns it", got.Status)
+	}
+}
+
+func TestSyncSessionBeads_PreAssignsPoolWorkBeadOnNewSession(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"myrig": rigStore}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+
+	// Work bead in rig store routed to the pool template.
+	workBead, err := rigStore.Create(beads.Bead{
+		Title:    "some work",
+		Metadata: map[string]string{"gc.routed_to": "myrig/polecat"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "myrig",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+
+	sn := "test-city--polecat-1"
+	desiredState := map[string]TemplateParams{
+		sn: {TemplateName: "myrig/polecat", InstanceName: sn},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshotAndRigStores(
+		t.TempDir(), cityStore, rigStores, desiredState, nil, allConfiguredDS(desiredState), cfg, clk, &stderr, false, nil,
+	)
+
+	updated, err := rigStore.Get(workBead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Assignee != sn {
+		t.Errorf("work bead assignee = %q, want %q", updated.Assignee, sn)
+	}
+}
+
+func TestSyncSessionBeads_PreAssignsUniquePoolWorkBeadsForMultipleSessions(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"myrig": rigStore}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+
+	// Three work beads for three new pool sessions.
+	var beadIDs []string
+	for i := 0; i < 3; i++ {
+		wb, err := rigStore.Create(beads.Bead{
+			Title:    fmt.Sprintf("work-%d", i),
+			Metadata: map[string]string{"gc.routed_to": "myrig/polecat"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		beadIDs = append(beadIDs, wb.ID)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "myrig",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+
+	desiredState := map[string]TemplateParams{
+		"test-city--polecat-1": {TemplateName: "myrig/polecat", InstanceName: "test-city--polecat-1"},
+		"test-city--polecat-2": {TemplateName: "myrig/polecat", InstanceName: "test-city--polecat-2"},
+		"test-city--polecat-3": {TemplateName: "myrig/polecat", InstanceName: "test-city--polecat-3"},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshotAndRigStores(
+		t.TempDir(), cityStore, rigStores, desiredState, nil, allConfiguredDS(desiredState), cfg, clk, &stderr, false, nil,
+	)
+
+	// Each bead must be assigned to exactly one unique session.
+	beadAssignee := make(map[string]string) // bead ID → assignee
+	for _, id := range beadIDs {
+		wb, err := rigStore.Get(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wb.Assignee == "" {
+			t.Errorf("bead %s has no assignee (want a pool session name)", id)
+			continue
+		}
+		beadAssignee[id] = wb.Assignee
+	}
+	// Verify no two beads share the same assignee.
+	seen := make(map[string]string) // assignee → bead ID
+	for beadID, assignee := range beadAssignee {
+		if prev, ok := seen[assignee]; ok {
+			t.Errorf("assignee %s assigned to both %s and %s", assignee, prev, beadID)
+		}
+		seen[assignee] = beadID
+	}
+}
+
+func TestSyncSessionBeads_DoesNotPreAssignForExistingSession(t *testing.T) {
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	rigStores := map[string]beads.Store{"myrig": rigStore}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+
+	// Work bead in rig store.
+	workBead, err := rigStore.Create(beads.Bead{
+		Title:    "some work",
+		Metadata: map[string]string{"gc.routed_to": "myrig/polecat"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "polecat",
+			Dir:               "myrig",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+
+	sn := "test-city--polecat-1"
+	desiredState := map[string]TemplateParams{
+		sn: {TemplateName: "myrig/polecat", InstanceName: sn},
+	}
+
+	// First sync: creates the session bead and pre-assigns the work bead.
+	syncSessionBeadsWithSnapshotAndRigStores(
+		t.TempDir(), cityStore, rigStores, desiredState, nil, allConfiguredDS(desiredState), cfg, clk, io.Discard, false, nil,
+	)
+
+	// Second work bead added after first sync.
+	workBead2, err := rigStore.Create(beads.Bead{
+		Title:    "more work",
+		Metadata: map[string]string{"gc.routed_to": "myrig/polecat"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second sync: session bead exists; should not pre-assign workBead2.
+	syncSessionBeadsWithSnapshotAndRigStores(
+		t.TempDir(), cityStore, rigStores, desiredState, nil, allConfiguredDS(desiredState), cfg, clk, io.Discard, false, nil,
+	)
+
+	wb2, err := rigStore.Get(workBead2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wb2.Assignee != "" {
+		t.Errorf("second work bead assignee = %q, want empty (session already existed)", wb2.Assignee)
+	}
+	// First bead assignment is unchanged.
+	wb1, err := rigStore.Get(workBead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wb1.Assignee != sn {
+		t.Errorf("first work bead assignee = %q, want %q", wb1.Assignee, sn)
 	}
 }


### PR DESCRIPTION
## Problem

When slinging work to a pool target, the controller spawns a new polecat session but never assigns the bead to it. The polecat starts, checks for assigned work, finds none, and drains.

This caused spawn storms: multiple polecats start idle, escalate to mayor, witness gets stuck. Beads have `gc.routed_to` set but are never claimed.

Fixes #1117.

## Solution

In `syncSessionBeadsWithSnapshotAndRigStores`, for each **new** ephemeral pool session being created, pre-assign an available work bead routed to that template **before** the session bead is written. This eliminates the race: the session wakes up and finds its work via Tier 2 (`bd ready --assignee="$GC_SESSION_NAME"`) instead of competing for Tier 3 pool-routed unassigned beads.

Two helpers added:
- `preAssignPoolWorkBead` — finds a `gc.routed_to`-matched unassigned bead and assigns it atomically; uses an in-pass dedup map so concurrent new sessions each get a distinct bead.
- `beadStoreForTemplate` — resolves the rig store for a qualified template name, falling back to the city store.

Pre-assignment only happens for new sessions (`!exists`), so existing sessions are unaffected.

## Tests

Three new unit tests in `session_beads_test.go`:
- Single session gets its work bead pre-assigned
- Multiple simultaneous new sessions each receive a unique bead
- Existing sessions are not pre-assigned on subsequent sync passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->