### PR TITLE
Fix gc status session inventory hot path

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -109,8 +110,8 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			scaleLabel := fmt.Sprintf("scaled (min=%d, %s)", sp0.Min, maxDisplay)
 			headerShown := false
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, snapshot.CityName, cfg.Workspace.SessionTemplate, sp) {
-				sn := cliSessionName(cityPath, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
-				obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
+				sn := statusSessionName(store, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
+				obs := observeSessionTargetWithWarning("gc status", cityPath, nil, sp, cfg, sn, stderr)
 				_, instanceName := config.ParseQualifiedName(qualifiedInstance)
 				row := cityStatusAgentRow{
 					Agent: StatusAgentJSON{
@@ -139,8 +140,8 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			continue
 		}
 
-		sn := cliSessionName(cityPath, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-		obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
+		sn := statusSessionName(store, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
+		obs := observeSessionTargetWithWarning("gc status", cityPath, nil, sp, cfg, sn, stderr)
 		snapshot.Agents = append(snapshot.Agents, cityStatusAgentRow{
 			Agent: StatusAgentJSON{
 				Name:          a.Name,
@@ -197,27 +198,115 @@ func namedSessionStatusForCity(
 	mode string,
 	suspendedRigs map[string]bool,
 ) string {
+	timeout := statusNamedSessionLookupTimeout
+	if timeout <= 0 {
+		return namedSessionStatusForCityDirect(cityPath, cfg, store, cityName, identity, mode, suspendedRigs)
+	}
+	statusCh := make(chan string, 1)
+	go func() {
+		statusCh <- namedSessionStatusForCityDirect(cityPath, cfg, store, cityName, identity, mode, suspendedRigs)
+	}()
+	select {
+	case status := <-statusCh:
+		return status
+	case <-time.After(timeout):
+		return "lookup timeout"
+	}
+}
+
+func statusSessionName(store beads.Store, cityName, qualifiedName, sessionTemplate string) string {
+	fallback := agent.SessionNameFor(cityName, qualifiedName, sessionTemplate)
+	if store == nil {
+		return fallback
+	}
+	timeout := statusSessionNameLookupTimeout
+	if timeout <= 0 {
+		if name := lookupSessionNameForStatus(store, qualifiedName); name != "" {
+			return name
+		}
+		return fallback
+	}
+
+	nameCh := make(chan string, 1)
+	go func() {
+		nameCh <- lookupSessionNameForStatus(store, qualifiedName)
+	}()
+	select {
+	case name := <-nameCh:
+		if name != "" {
+			return name
+		}
+		return fallback
+	case <-time.After(timeout):
+		return fallback
+	}
+}
+
+func lookupSessionNameForStatus(store beads.Store, qualifiedName string) string {
+	queries := []beads.ListQuery{
+		{
+			Label: session.LabelSession,
+			Metadata: map[string]string{
+				"agent_name": qualifiedName,
+			},
+			Limit: statusNamedSessionLookupLimit,
+			Sort:  beads.SortCreatedDesc,
+		},
+		{
+			Label: session.LabelSession,
+			Metadata: map[string]string{
+				"template": qualifiedName,
+			},
+			Limit: statusNamedSessionLookupLimit,
+			Sort:  beads.SortCreatedDesc,
+		},
+		{
+			Label: session.LabelSession,
+			Metadata: map[string]string{
+				"common_name": qualifiedName,
+			},
+			Limit: statusNamedSessionLookupLimit,
+			Sort:  beads.SortCreatedDesc,
+		},
+	}
+	for _, query := range queries {
+		candidates, err := store.List(query)
+		if err != nil {
+			return ""
+		}
+		if sn := newSessionBeadSnapshot(candidates).FindSessionNameByTemplate(qualifiedName); sn != "" {
+			return sn
+		}
+	}
+	return ""
+}
+
+func namedSessionStatusForCityDirect(
+	_ string,
+	cfg *config.City,
+	store beads.Store,
+	cityName string,
+	identity string,
+	mode string,
+	suspendedRigs map[string]bool,
+) string {
 	status := "reserved-unmaterialized"
-	if spec, ok := findNamedSessionSpec(cfg, cityName, identity); ok {
+	spec, hasSpec := findNamedSessionSpec(cfg, cityName, identity)
+	if hasSpec {
 		if mode == "always" && namedSessionBlockedBySuspension(cfg, spec.Agent, suspendedRigs) {
 			status = "degraded blocked"
 		}
 	}
-	if store == nil {
+	if store == nil || !hasSpec {
 		return status
 	}
 
-	id, err := resolveSessionIDWithConfig(cityPath, cfg, store, identity)
+	bead, ok, err := namedSessionBeadForStatus(store, spec)
 	if err != nil {
-		if errors.Is(err, session.ErrSessionNotFound) {
-			return status
-		}
 		return "lookup error: " + err.Error()
 	}
-
-	bead, err := store.Get(id)
-	if err != nil {
-		return "lookup error: " + err.Error()
+	if !ok {
+		return status
 	}
 	if state := strings.TrimSpace(bead.Metadata["state"]); state != "" {
 		return state
@@ -225,36 +314,37 @@ func namedSessionStatusForCity(
 	return "materialized"
 }
 
-func collectCitySessionCounts(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City) (StatusSummaryJSON, error) {
-	summary := StatusSummaryJSON{}
-	if store == nil {
-		return summary, nil
+const statusNamedSessionLookupLimit = 5
+
+func namedSessionBeadForStatus(store beads.Store, spec namedSessionSpec) (beads.Bead, bool, error) {
+	queries := []beads.ListQuery{
+		{
+			Label: session.LabelSession,
+			Metadata: map[string]string{
+				namedSessionIdentityMetadata: spec.Identity,
+			},
+			Limit: statusNamedSessionLookupLimit,
+			Sort:  beads.SortCreatedDesc,
+		},
+		{
+			Label: session.LabelSession,
+			Metadata: map[string]string{
+				"session_name": spec.SessionName,
+			},
+			Limit: statusNamedSessionLookupLimit,
+			Sort:  beads.SortCreatedDesc,
+		},
 	}
-	if cityPath != "" {
-		if _, err := os.Stat(cityPath); err != nil {
-			return summary, nil
+	for _, query := range queries {
+		candidates, err := store.List(query)
+		if err != nil {
+			return beads.Bead{}, false, err
+		}
+		if bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec); ok {
+			return bead, true, nil
 		}
 	}
-	if store == nil {
-		return summary, nil
-	}
-	catalog, err := workerSessionCatalogWithConfig(cityPath, store, sp, cfg)
-	if err != nil {
-		return summary, err
-	}
-	sessions, err := catalog.List("", "")
-	if err != nil {
-		return summary, err
-	}
-	for _, s := range sessions {
-		switch s.State {
-		case session.StateActive:
-			summary.ActiveSessions++
-		case session.StateSuspended:
-			summary.SuspendedSessions++
-		}
-	}
-	return summary, nil
+	return beads.Bead{}, false, nil
 }
 
 func cityStatusJSONFromSnapshot(snapshot cityStatusSnapshot, summary StatusSummaryJSON) StatusJSON {

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -83,15 +84,14 @@ func TestCityStatusJSONPreservesNilAgentsWhenEmpty(t *testing.T) {
 
 type failingStatusStore struct {
 	*beads.MemStore
-	failID string
-	err    error
+	err error
 }
 
-func (s *failingStatusStore) Get(id string) (beads.Bead, error) {
-	if id == s.failID {
-		return beads.Bead{}, s.err
+func (s *failingStatusStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) > 0 {
+		return nil, s.err
 	}
-	return s.MemStore.Get(id)
+	return s.MemStore.List(query)
 }
 
 func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
@@ -99,7 +99,6 @@ func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
 	dops := newFakeDrainOps()
 	store := &failingStatusStore{
 		MemStore: beads.NewMemStore(),
-		failID:   "refinery",
 		err:      errors.New("store offline"),
 	}
 
@@ -111,6 +110,7 @@ func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
 
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "city"},
+		Agents:    []config.Agent{{Name: "refinery"}},
 		NamedSessions: []config.NamedSession{{
 			Template: "refinery",
 		}},
@@ -132,5 +132,54 @@ func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "lookup error:") || !strings.Contains(out, "store offline") {
 		t.Fatalf("stdout = %q, want surfaced store error", out)
+	}
+}
+
+type blockingStatusListStore struct {
+	*beads.MemStore
+	block chan struct{}
+}
+
+func (s *blockingStatusListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession {
+		<-s.block
+	}
+	return s.MemStore.List(query)
+}
+
+func TestCityStatusNamedSessionLookupTimeoutDegradesGracefully(t *testing.T) {
+	sp := runtime.NewFake()
+	store := &blockingStatusListStore{
+		MemStore: beads.NewMemStore(),
+		block:    make(chan struct{}),
+	}
+	oldTimeout := statusNamedSessionLookupTimeout
+	oldNameTimeout := statusSessionNameLookupTimeout
+	statusNamedSessionLookupTimeout = 10 * time.Millisecond
+	statusSessionNameLookupTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		statusNamedSessionLookupTimeout = oldTimeout
+		statusSessionNameLookupTimeout = oldNameTimeout
+		close(store.block)
+	})
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents:    []config.Agent{{Name: "refinery"}},
+		NamedSessions: []config.NamedSession{{
+			Template: "refinery",
+		}},
+	}
+
+	start := time.Now()
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("collectCityStatusSnapshot took %s, want bounded named-session lookup", elapsed)
+	}
+	if len(snapshot.NamedSessions) != 1 {
+		t.Fatalf("named sessions = %d, want 1", len(snapshot.NamedSessions))
+	}
+	if got := snapshot.NamedSessions[0].Status; got != "lookup timeout" {
+		t.Fatalf("named session status = %q, want lookup timeout", got)
 	}
 }

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -65,8 +66,11 @@ type StatusSummaryJSON struct {
 }
 
 var (
-	observeSessionTargetForStatus = workerObserveSessionTargetWithConfig
-	openCityStoreAtForStatus      = openCityStoreAt
+	observeSessionTargetForStatus   = workerObserveSessionTargetWithConfig
+	openCityStoreAtForStatus        = openCityStoreAt
+	statusObservationTimeout        = 250 * time.Millisecond
+	statusNamedSessionLookupTimeout = 250 * time.Millisecond
+	statusSessionNameLookupTimeout  = 100 * time.Millisecond
 )
 
 var controllerStatusStandaloneFallbackTimeout = 250 * time.Millisecond
@@ -105,12 +109,21 @@ func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int
 		return 1
 	}
 
-	sp := newSessionProvider()
+	sp, err := newSessionProviderForStatus(cfg, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc status: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	dops := newDrainOps(sp)
 	if jsonOutput {
 		return doCityStatusJSON(sp, cfg, cityPath, stdout, stderr)
 	}
 	return doCityStatus(sp, dops, cfg, cityPath, stdout, stderr)
+}
+
+func newSessionProviderForStatus(cfg *config.City, cityPath string) (runtime.Provider, error) {
+	ctx := sessionProviderContextForCity(cfg, cityPath, os.Getenv("GC_SESSION"))
+	return newSessionProviderFromContextWithError(ctx, nil)
 }
 
 func observeSessionTargetWithWarning(
@@ -122,11 +135,39 @@ func observeSessionTargetWithWarning(
 	target string,
 	stderr io.Writer,
 ) worker.LiveObservation {
-	obs, err := observeSessionTargetForStatus(cityPath, store, sp, cfg, target)
-	if err != nil && stderr != nil {
-		fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName, target, err) //nolint:errcheck // best-effort stderr
+	type observationResult struct {
+		obs worker.LiveObservation
+		err error
 	}
-	return obs
+
+	observe := observeSessionTargetForStatus
+	timeout := statusObservationTimeout
+	if timeout <= 0 {
+		obs, err := observe(cityPath, store, sp, cfg, target)
+		if err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName, target, err) //nolint:errcheck // best-effort stderr
+		}
+		return obs
+	}
+
+	resultCh := make(chan observationResult, 1)
+	go func() {
+		obs, err := observe(cityPath, store, sp, cfg, target)
+		resultCh <- observationResult{obs: obs, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil && stderr != nil {
+			fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName, target, result.err) //nolint:errcheck // best-effort stderr
+		}
+		return result.obs
+	case <-time.After(timeout):
+		if stderr != nil {
+			fmt.Fprintf(stderr, "%s: observing %q timed out after %s\n", cmdName, target, timeout) //nolint:errcheck // best-effort stderr
+		}
+		return worker.LiveObservation{}
+	}
 }
 
 func namedSessionBlockedBySuspension(cfg *config.City, agentCfg *config.Agent, suspendedRigs map[string]bool) bool {
@@ -159,18 +200,6 @@ func doCityStatus(
 	snapshot := collectCityStatusSnapshot(sp, cfg, cityPath, store, stderr)
 	renderCityStatusText(snapshot, dops, stdout)
 
-	if store != nil {
-		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc status: building session catalog: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		if sessions.ActiveSessions > 0 || sessions.SuspendedSessions > 0 {
-			fmt.Fprintln(stdout)                                                                                            //nolint:errcheck // best-effort stdout
-			fmt.Fprintf(stdout, "Sessions: %d active, %d suspended\n", sessions.ActiveSessions, sessions.SuspendedSessions) //nolint:errcheck // best-effort stdout
-		}
-	}
-
 	return 0
 }
 
@@ -188,15 +217,6 @@ func doCityStatusJSON(
 	}
 
 	snapshot := collectCityStatusSnapshot(sp, cfg, cityPath, store, stderr)
-	if store != nil {
-		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc status: building session catalog: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		snapshot.Summary.ActiveSessions = sessions.ActiveSessions
-		snapshot.Summary.SuspendedSessions = sessions.SuspendedSessions
-	}
 
 	status := cityStatusJSONFromSnapshot(snapshot, snapshot.Summary)
 	data, err := json.MarshalIndent(status, "", "  ")

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -383,7 +383,7 @@ func TestCityStatusJSONReportsStoreOpenError(t *testing.T) {
 	}
 }
 
-func TestCityStatusJSONReportsCatalogListError(t *testing.T) {
+func TestCityStatusJSONDoesNotRequireSessionInventory(t *testing.T) {
 	sp := runtime.NewFake()
 	oldOpen := openCityStoreAtForStatus
 	openCityStoreAtForStatus = func(string) (beads.Store, error) {
@@ -396,11 +396,145 @@ func TestCityStatusJSONReportsCatalogListError(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := doCityStatusJSON(sp, cfg, t.TempDir(), &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("code = %d, want 1", code)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "gc status: building session catalog") || !strings.Contains(stderr.String(), "catalog unavailable") {
-		t.Fatalf("stderr = %q, want catalog list error", stderr.String())
+	if strings.Contains(stderr.String(), "building session catalog") || strings.Contains(stderr.String(), "catalog unavailable") {
+		t.Fatalf("stderr = %q, want no session catalog error", stderr.String())
+	}
+	var status StatusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("unmarshal: %v; output: %s", err, stdout.String())
+	}
+}
+
+func TestCityStatusDoesNotBlockOnSlowSessionInventory(t *testing.T) {
+	sp := runtime.NewFake()
+	dops := newFakeDrainOps()
+	store := &blockingStatusListStore{
+		MemStore: beads.NewMemStore(),
+		block:    make(chan struct{}),
+	}
+	oldOpen := openCityStoreAtForStatus
+	oldNameTimeout := statusSessionNameLookupTimeout
+	openCityStoreAtForStatus = func(string) (beads.Store, error) {
+		return store, nil
+	}
+	statusSessionNameLookupTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		openCityStoreAtForStatus = oldOpen
+		statusSessionNameLookupTimeout = oldNameTimeout
+		close(store.block)
+	})
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "runner", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- doCityStatus(sp, dops, cfg, "/home/user/city", &stdout, &stderr)
+	}()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("doCityStatus blocked on session inventory")
+	}
+	if !strings.Contains(stdout.String(), "0/1 agents running") {
+		t.Fatalf("stdout = %q, want agent summary", stdout.String())
+	}
+}
+
+func TestCmdCityStatusDoesNotLoadProviderSessionSnapshot(t *testing.T) {
+	t.Setenv("GC_SESSION", "fake")
+	cityDir := t.TempDir()
+	writePhase0InterfaceCity(t, cityDir, `[workspace]
+name = "city"
+
+[beads]
+provider = "file"
+
+[[agent]]
+name = "runner"
+`)
+
+	providerSnapshotBlock := make(chan struct{})
+	oldProviderStore := openSessionProviderStore
+	openSessionProviderStore = func(string) (beads.Store, error) {
+		<-providerSnapshotBlock
+		return nil, errors.New("provider snapshot should not be loaded")
+	}
+	oldStatusStore := openCityStoreAtForStatus
+	openCityStoreAtForStatus = func(string) (beads.Store, error) {
+		return beads.NewMemStore(), nil
+	}
+	t.Cleanup(func() {
+		openSessionProviderStore = oldProviderStore
+		openCityStoreAtForStatus = oldStatusStore
+		close(providerSnapshotBlock)
+	})
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- cmdCityStatus([]string{cityDir}, false, &stdout, &stderr)
+	}()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("cmdCityStatus blocked while loading provider session snapshot")
+	}
+	if !strings.Contains(stdout.String(), "city") {
+		t.Fatalf("stdout = %q, want city status output", stdout.String())
+	}
+}
+
+func TestCityStatusObservationTimeoutDegradesGracefully(t *testing.T) {
+	sp := runtime.NewFake()
+	dops := newFakeDrainOps()
+	oldObserve := observeSessionTargetForStatus
+	oldTimeout := statusObservationTimeout
+	observeBlock := make(chan struct{})
+	observeSessionTargetForStatus = func(string, beads.Store, runtime.Provider, *config.City, string) (worker.LiveObservation, error) {
+		<-observeBlock
+		return worker.LiveObservation{Running: true}, nil
+	}
+	statusObservationTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		observeSessionTargetForStatus = oldObserve
+		statusObservationTimeout = oldTimeout
+		close(observeBlock)
+	})
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "runner", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doCityStatus(sp, dops, cfg, "/home/user/city", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "observing") || !strings.Contains(stderr.String(), "timed out") {
+		t.Fatalf("stderr = %q, want observation timeout warning", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "0/1 agents running") {
+		t.Fatalf("stdout = %q, want degraded agent summary", stdout.String())
 	}
 }
 

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -128,7 +128,10 @@ func doRigStatus(
 
 // agentStatusLine returns a human-readable status string for an agent session.
 func agentStatusLine(running bool, dops drainOps, sn string, suspended bool) string {
-	draining, _ := dops.isDraining(sn)
+	draining := false
+	if running {
+		draining, _ = dops.isDraining(sn)
+	}
 
 	switch {
 	case running && draining:

--- a/internal/graphroute/graphroute.go
+++ b/internal/graphroute/graphroute.go
@@ -474,13 +474,15 @@ func DecorateGraphWorkflowRecipe(recipe *formula.Recipe, routeVars map[string]st
 // ApplyGraphRouting decorates a compiled recipe with routing metadata.
 // For graph.v2 workflows it delegates to DecorateGraphWorkflowRecipe. For
 // standalone legacy [[steps]] recipes it stamps gc.routed_to on every
-// non-root step so EffectiveWorkQuery tier-3 and pool scale_check can see
-// the work (fixes #796). Attached legacy formulas intentionally stay on the
-// molecule_id flow: only the source bead is routed, and the internal molecule
-// steps remain private instructions for the assignee. Pool demand for attached
-// legacy formulas comes from the already-routed source bead via the ready and
-// in_progress tiers; the molecule count is only for standalone routed roots.
-// Returns early with no effect when cfg is nil.
+// non-root step that does not already declare an explicit route, so
+// Agent.EffectiveWorkQuery tier-3 and pool scale_check can see formula work
+// while still allowing formula authors to fan a DAG out to specific routes.
+// Attached legacy formulas intentionally stay on the molecule_id flow: only
+// the source bead is routed, and the internal molecule steps remain private
+// instructions for the assignee. Pool demand for attached legacy formulas comes
+// from the already-routed source bead via the ready and in_progress tiers; the
+// molecule count is only for standalone routed roots. Returns early with no
+// effect when cfg is nil.
 func ApplyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string, vars map[string]string, sourceBeadID, scopeKind, scopeRef, storeRef string, store beads.Store, cityName string, cfg *config.City, deps Deps) error {
 	if recipe == nil || cfg == nil {
 		return nil
@@ -526,10 +528,10 @@ func ApplyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string,
 	return DecorateGraphWorkflowRecipe(recipe, routeVars, sourceBeadID, scopeKind, scopeRef, storeRef, routedTo, sessionName, store, cityName, cfg, deps)
 }
 
-// stampLegacyRecipeRouting mirrors the graph.v2 path in ApplyGraphRouteBinding:
-// routing is set unconditionally on every non-root, non-topology step. The
-// root bead is excluded because InstantiateSlingFormula stamps it via the
-// SlingResult path.
+// stampLegacyRecipeRouting mirrors the graph.v2 path in ApplyGraphRouteBinding
+// for unrouted legacy steps: routing is set on every non-root, non-topology
+// step that does not already carry gc.routed_to. The root bead is excluded
+// because InstantiateSlingFormula stamps it via the SlingResult path.
 func stampLegacyRecipeRouting(recipe *formula.Recipe, routedTo string) {
 	routedTo = strings.TrimSpace(routedTo)
 	if recipe == nil || routedTo == "" {
@@ -545,6 +547,9 @@ func stampLegacyRecipeRouting(recipe *formula.Recipe, routedTo string) {
 		}
 		if step.Metadata == nil {
 			step.Metadata = make(map[string]string, 1)
+		}
+		if strings.TrimSpace(step.Metadata["gc.routed_to"]) != "" {
+			continue
 		}
 		step.Metadata["gc.routed_to"] = routedTo
 	}

--- a/internal/graphroute/graphroute_test.go
+++ b/internal/graphroute/graphroute_test.go
@@ -168,14 +168,15 @@ func TestApplyGraphRouting_LegacyNilCfg(t *testing.T) {
 	}
 }
 
-func TestApplyGraphRouting_LegacyOverwritesExistingRouting(t *testing.T) {
-	// Legacy stamping mirrors graph.v2 AssignGraphStepRoute: unconditional
-	// overwrite on every non-topology step.
+func TestApplyGraphRouting_LegacyPreservesExplicitRouting(t *testing.T) {
+	// Legacy stamping supplies a fallback route, but formula-authored routes
+	// are intentional fan-out and must survive the sling target route.
 	r := &formula.Recipe{
 		Name: "mol-legacy",
 		Steps: []formula.RecipeStep{
 			{IsRoot: true, Metadata: map[string]string{}},
-			{ID: "step1", Metadata: map[string]string{"gc.routed_to": "stale-agent"}},
+			{ID: "step1", Metadata: map[string]string{"gc.routed_to": "reviewer"}},
+			{ID: "step2", Metadata: map[string]string{}},
 		},
 	}
 	a := config.Agent{Name: "worker", MaxActiveSessions: intPtr(1)}
@@ -183,8 +184,11 @@ func TestApplyGraphRouting_LegacyOverwritesExistingRouting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := r.Steps[1].Metadata["gc.routed_to"]; got != "worker" {
-		t.Errorf("expected overwrite to worker, got %q", got)
+	if got := r.Steps[1].Metadata["gc.routed_to"]; got != "reviewer" {
+		t.Errorf("explicit route = %q, want reviewer", got)
+	}
+	if got := r.Steps[2].Metadata["gc.routed_to"]; got != "worker" {
+		t.Errorf("fallback route = %q, want worker", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve explicit `gc.routed_to` metadata on legacy formula steps so formula-authored fan-out survives sling fallback routing
- keep `gc status` off the expensive full session inventory/catalog path
- add bounded targeted lookups and graceful degradation for slow session observation/named-session reads

## Verification
- `go test ./internal/graphroute ./internal/sling ./internal/molecule`
- `go test ./cmd/gc -run 'Test(CityStatus|CmdCityStatus|AgentStatusLine)' -count=1`
- `go test ./cmd/gc`
- `go vet ./cmd/gc`
- `go vet ./...`
- rebuilt `~/.local/bin/gc-dev`
- `timeout 10s ~/.local/bin/gc-dev --city /home/agent101/gc-dev status`
- `timeout 10s ~/.local/bin/gc-dev --city /home/agent101/gc-dev status --json`

## Notes
Broad `go test ./...` / pre-commit still fail in unrelated existing `internal/api` order-history timestamp tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->