### PR TITLE
docs: add Chrome CDP browser automation guidance to DEVELOPMENT.md (ga-shh)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,37 @@
+# Gas City Development
+
+## Browser Automation (Chrome CDP)
+
+When a task requires browser interaction — configuring third-party portals, UAT against
+web UIs, scraping authenticated pages — use Playwright with Chrome DevTools Protocol
+(CDP) instead of asking the user for manual steps.
+
+**Prerequisite:** Chrome must be running with remote debugging enabled. On Linux,
+`--user-data-dir` must be a non-default path:
+
+```bash
+google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug
+```
+
+**Connecting from a script:**
+
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp("http://localhost:9222")
+    page = browser.contexts[0].pages[0]
+    # ... interact with the page
+```
+
+**Division of labor:** The user handles login and 2FA in the Chrome session. The agent
+does everything after authentication is complete.
+
+**Debugging:** Take a screenshot at each step so failures are diagnosable:
+
+```python
+page.screenshot(path="step-01-loaded.png")
+```
+
+**Dependency:** Add `playwright` as a dev dependency (`pip install --dev playwright` or
+equivalent for your project).


### PR DESCRIPTION
## Summary

Adds a new `DEVELOPMENT.md` documenting how to use Playwright with Chrome DevTools Protocol (CDP) for browser automation tasks that require interacting with third-party portals or authenticated web UIs.

- Documents the Chrome remote debugging prerequisite and startup command
- Provides a minimal Python/Playwright snippet for connecting over CDP
- Clarifies the user/agent division of labor (user handles auth, agent does the rest)
- Includes a debugging tip (take screenshots at each step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->