### PR TITLE
fix(session): expire pending_create_claim once create lease elapses (#1460)

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1558,7 +1558,10 @@ func sweepUndesiredPoolSessionBeads(
 		// sessionStartRequested (session_reconcile.go) exactly so the two
 		// loops agree about ownership:
 		//   - pending_create_claim=true: in-flight create claim, protected
-		//     regardless of age until the lifecycle clears it.
+		//     while the create lease (staleCreatingStateTimeout) is fresh.
+		//     #1460: once the lease has elapsed with no live runtime, the
+		//     claim no longer protects — a crashed creator must not strand
+		//     the slot forever.
 		//   - state=creating: protected until staleCreatingState would
 		//     return true (i.e., until staleCreatingStateTimeout has
 		//     elapsed; zero CreatedAt is treated as stale, matching
@@ -1567,7 +1570,7 @@ func sweepUndesiredPoolSessionBeads(
 		// on the same tick it's created (no work assigned →
 		// GCSweepSessionBeads closes it), spinning the pool in a rapid
 		// create→sweep→recreate loop.
-		if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
+		if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" && !isStaleCreating(bead.CreatedAt) {
 			continue
 		}
 		if strings.TrimSpace(bead.Metadata["state"]) == "creating" && !isStaleCreating(bead) {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1539,6 +1539,7 @@ func sweepUndesiredPoolSessionBeads(
 	if store == nil || sessionBeads == nil || cfg == nil || storeQueryPartial {
 		return 0
 	}
+	startupTimeout := cfg.Session.StartupTimeoutDuration()
 	var candidates []beads.Bead
 	for _, bead := range sessionBeads.Open() {
 		if bead.Status == "closed" {
@@ -1554,14 +1555,11 @@ func sweepUndesiredPoolSessionBeads(
 			continue
 		}
 		// Don't sweep beads that the reconciler still considers "start
-		// requested" — their work assignment window hasn't opened. Mirrors
-		// sessionStartRequested (session_reconcile.go) exactly so the two
-		// loops agree about ownership:
-		//   - pending_create_claim=true: in-flight create claim, protected
-		//     while the create lease (staleCreatingStateTimeout) is fresh.
-		//     #1460: once the lease has elapsed with no live runtime, the
-		//     claim no longer protects — a crashed creator must not strand
-		//     the slot forever.
+		// requested" — their work assignment window hasn't opened. The
+		// pending_create_claim lease mirrors the reconciler's recovery model:
+		// fresh start-in-flight and never-started queue entries are protected,
+		// but once that lease expires the crashed creator must not strand the
+		// pool slot forever.
 		//   - state=creating: protected until staleCreatingState would
 		//     return true (i.e., until staleCreatingStateTimeout has
 		//     elapsed; zero CreatedAt is treated as stale, matching
@@ -1570,7 +1568,7 @@ func sweepUndesiredPoolSessionBeads(
 		// on the same tick it's created (no work assigned →
 		// GCSweepSessionBeads closes it), spinning the pool in a rapid
 		// create→sweep→recreate loop.
-		if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" && !isStaleCreating(bead.CreatedAt) {
+		if pendingCreateClaimStillLeasedForSweep(bead, startupTimeout) {
 			continue
 		}
 		if strings.TrimSpace(bead.Metadata["state"]) == "creating" && !isStaleCreating(bead) {
@@ -1634,6 +1632,14 @@ func sweepUndesiredPoolSessionBeads(
 		candidates = append(candidates, bead)
 	}
 	return len(GCSweepSessionBeads(store, rigStores, candidates))
+}
+
+// pendingCreateClaimStillLeasedForSweep keeps pending_create_claim protection
+// aligned with the reconciler: start-in-flight claims stay protected for the
+// provider-start lease, never-started creates get the longer queue lease, and
+// stale claims stop blocking pool-slot recovery.
+func pendingCreateClaimStillLeasedForSweep(bead beads.Bead, startupTimeout time.Duration) bool {
+	return pendingCreateLeaseActive(bead, nil, startupTimeout)
 }
 
 // isStaleCreating mirrors staleCreatingState in session_reconcile.go without

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1150,32 +1150,33 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 	}
 }
 
-// #1460: pending_create_claim is an in-flight ownership flag, but the
-// lease must expire. After the create lease elapses with no live runtime,
-// the claim no longer protects — otherwise a crashed creator strands the
-// pool slot indefinitely. The sweep aligns with the lifecycle projection,
-// which now heals stale-creating-with-claim to StateAsleep.
-func TestSweepUndesiredPoolSessionBeads_SweepsStalePendingCreateClaim(t *testing.T) {
+// #1460: pending_create_claim stays protected only for the pending-create
+// lease. Once a never-started create ages past that lease, the sweep must
+// reap it instead of preserving the pool slot forever.
+func TestSweepUndesiredPoolSessionBeads_SweepsExpiredPendingCreateClaimLease(t *testing.T) {
 	store := beads.NewMemStore()
+	now := time.Now().UTC()
 	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:worker"},
 		Metadata: map[string]string{
-			"session_name":         "worker-bd-stale-claim",
-			"template":             "worker",
-			"agent_name":           "worker",
-			"pool_slot":            "1",
-			poolManagedMetadataKey: boolMetadata(true),
-			"pending_create_claim": "true",
-			"continuation_epoch":   "1",
-			"generation":           "1",
+			"session_name":              "worker-bd-stale-claim",
+			"template":                  "worker",
+			"agent_name":                "worker",
+			"pool_slot":                 "1",
+			"state":                     "creating",
+			poolManagedMetadataKey:      boolMetadata(true),
+			"pending_create_claim":      "true",
+			"pending_create_started_at": pendingCreateStartedAtNow(now.Add(-(pendingCreateNeverStartedTimeout + time.Second))),
+			"continuation_epoch":        "1",
+			"generation":                "1",
 		},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	bead.CreatedAt = time.Now().Add(-2 * time.Minute)
+	bead.CreatedAt = now.Add(-24 * time.Hour)
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
 
 	closed := sweepUndesiredPoolSessionBeads(
@@ -1188,7 +1189,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsStalePendingCreateClaim(t *testing
 		false,
 	)
 	if closed != 1 {
-		t.Fatalf("closed = %d, want 1 — stale pending_create_claim must be reaped", closed)
+		t.Fatalf("closed = %d, want 1 — expired pending_create_claim lease must be reaped", closed)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1150,11 +1150,12 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 	}
 }
 
-// pending_create_claim is an authoritative ownership flag for the lifecycle
-// reconciler (sessionStartRequested in session_reconcile.go). The sweep must
-// honor that contract regardless of age — expiring it here would let the
-// sweep close a bead the reconciler still considers live.
-func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.T) {
+// #1460: pending_create_claim is an in-flight ownership flag, but the
+// lease must expire. After the create lease elapses with no live runtime,
+// the claim no longer protects — otherwise a crashed creator strands the
+// pool slot indefinitely. The sweep aligns with the lifecycle projection,
+// which now heals stale-creating-with-claim to StateAsleep.
+func TestSweepUndesiredPoolSessionBeads_SweepsStalePendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
@@ -1186,8 +1187,8 @@ func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.
 		runtime.NewFake(),
 		false,
 	)
-	if closed != 0 {
-		t.Fatalf("closed = %d, want 0 — pending_create_claim must remain authoritative regardless of age", closed)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 — stale pending_create_claim must be reaped", closed)
 	}
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -970,6 +970,17 @@ func staleCreatingState(session beads.Bead, clk clock.Clock) bool {
 	if strings.TrimSpace(session.Metadata["state"]) != string(sessionpkg.StateCreating) {
 		return false
 	}
+	return pendingCreateAttemptStale(session, clk)
+}
+
+// pendingCreateAttemptStale reports whether the current pending-create attempt
+// has aged past staleCreatingStateTimeout, regardless of the bead's current
+// projected state. This lets the reconciler keep never-started pending-create
+// leases alive after healState has already rewritten state=creating to asleep.
+func pendingCreateAttemptStale(session beads.Bead, clk clock.Clock) bool {
+	if clk == nil {
+		return false
+	}
 	now := clk.Now()
 	if started, ok := parseRFC3339Metadata(session.Metadata["pending_create_started_at"]); ok {
 		return !now.Before(started.Add(staleCreatingStateTimeout))

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1446,10 +1446,33 @@ func TestHealState_PreservesCreatingWhileStartRequested(t *testing.T) {
 		"state":                "creating",
 		"pending_create_claim": "true",
 	})
+	// #1460: pending_create_claim only short-circuits while the create
+	// lease is fresh. Pin CreatedAt to "now" so the bead is within the
+	// lease window — without this the zero CreatedAt is treated as stale
+	// and the bead correctly heals to asleep (covered by the test below).
+	session.CreatedAt = clk.Now().Add(-30 * time.Second)
 
 	healState(&session, false, store, clk)
 	if session.Metadata["state"] != "creating" {
 		t.Fatalf("state = %q, want creating", session.Metadata["state"])
+	}
+}
+
+// #1460: stale-creating + pending_create_claim must heal to asleep so a
+// crashed creator does not strand the pool slot indefinitely.
+func TestHealState_StaleCreatingWithPendingClaimHealsToAsleep(t *testing.T) {
+	store := newTestStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 29, 4, 0, 0, 0, time.UTC)}
+
+	session := makeBead("b1", map[string]string{
+		"state":                "creating",
+		"pending_create_claim": "true",
+	})
+	session.CreatedAt = clk.Now().Add(-2 * time.Minute)
+
+	healState(&session, false, store, clk)
+	if session.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", session.Metadata["state"])
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -138,6 +138,24 @@ func allDependenciesAlive(
 }
 
 func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk clock.Clock) bool {
+	var startupTimeout time.Duration
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" {
+		if !pendingCreateLeaseActive(session, clk, startupTimeout) {
+			return false
+		}
+		template := normalizedSessionTemplate(session, cfg)
+		if template == "" {
+			template = session.Metadata["template"]
+		}
+		agent := findAgentByTemplate(cfg, template)
+		if agent != nil {
+			return !agent.Suspended
+		}
+		return true
+	}
 	if !sessionStartRequested(session, clk) {
 		return false
 	}
@@ -145,29 +163,11 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 	if template == "" {
 		template = session.Metadata["template"]
 	}
-	var startupTimeout time.Duration
-	if cfg != nil {
-		startupTimeout = cfg.Session.StartupTimeoutDuration()
-	}
-	pendingCreate := strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
-		strings.TrimSpace(session.Metadata["state"]) == "creating"
-	// Configured templates without current demand are not preserved forever
-	// merely because their agent still exists. Once the pending-create lease
-	// expires, the bead falls through to orphan/rollback handling so its alias
-	// can be released.
-	if pendingCreate && pendingCreateLeaseExpiredForRollback(session, clk, startupTimeout) {
-		return false
-	}
 	agent := findAgentByTemplate(cfg, template)
 	if agent != nil {
 		return !agent.Suspended
 	}
-	// API config mutations and session creation can arrive in adjacent
-	// reconciler ticks. Empty-last_woke_at pending creates may also leave the
-	// desired set before preWakeCommit records a provider start lease, so use
-	// the same never-started rollback floor as the desired branch before
-	// marking them orphaned.
-	return pendingCreate
+	return false
 }
 
 func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
@@ -195,6 +195,19 @@ func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTime
 	return now.Before(started.Add(startupTimeout + staleKeyDetectDelay + 5*time.Second))
 }
 
+func pendingCreateLeaseActive(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+		return false
+	}
+	if pendingCreateStartInFlight(session, clk, startupTimeout) {
+		return true
+	}
+	if strings.TrimSpace(session.Metadata["last_woke_at"]) == "" {
+		return !pendingCreateNeverStartedLeaseExpired(session, clk)
+	}
+	return !pendingCreateAttemptStale(session, clk)
+}
+
 // pendingCreateNeverStartedTimeout is the rollback floor for pending creates
 // with no last_woke_at start lease. Production-created pending beads record
 // pending_create_started_at when they enter state=creating; use that timestamp
@@ -211,6 +224,13 @@ func pendingCreateNeverStartedExpired(session beads.Bead, clk clock.Clock) bool 
 		return false
 	}
 	if strings.TrimSpace(session.Metadata["state"]) != "creating" {
+		return false
+	}
+	return pendingCreateNeverStartedLeaseExpired(session, clk)
+}
+
+func pendingCreateNeverStartedLeaseExpired(session beads.Bead, clk clock.Clock) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
 		return false
 	}
 	if strings.TrimSpace(session.Metadata["last_woke_at"]) != "" {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2481,6 +2481,7 @@ func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.
 		"manual_session":       "true",
 		"pending_create_claim": "true",
 	})
+	session.CreatedAt = env.clk.Now().Add(-30 * time.Second)
 
 	woken := env.reconcile([]beads.Bead{session})
 	if woken != 0 {

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -487,14 +487,22 @@ func projectRuntimeProjection(input LifecycleInput, base BaseState, compat State
 	if base == BaseStateNone || base == BaseStateClosed || base == BaseStateClosing {
 		return RuntimeProjectionMissing, compat, false
 	}
-	if hasWakeCause(wakeCauses, WakeCausePendingCreate) {
-		return RuntimeProjectionStartRequested, StateCreating, false
-	}
+	// #1460: When base is BaseStateCreating, evaluate staleness first.
+	// pending_create_claim represents an in-flight create attempt and is
+	// honored only while the lease (StaleCreatingAfter) is fresh. Once the
+	// lease expires with no live runtime, the claim no longer protects the
+	// bead — otherwise a crashed creator strands the slot indefinitely.
 	if base == BaseStateCreating {
 		if !creatingStateIsStale(input) {
+			if hasWakeCause(wakeCauses, WakeCausePendingCreate) {
+				return RuntimeProjectionStartRequested, StateCreating, false
+			}
 			return RuntimeProjectionFreshCreating, StateCreating, false
 		}
 		return RuntimeProjectionStaleCreating, StateAsleep, shouldResetContinuation(base, input.Metadata, sleepReason)
+	}
+	if hasWakeCause(wakeCauses, WakeCausePendingCreate) {
+		return RuntimeProjectionStartRequested, StateCreating, false
 	}
 	return RuntimeProjectionMissing, StateAsleep, shouldResetContinuation(base, input.Metadata, sleepReason)
 }

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -462,6 +462,21 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 			wantRuntime:         RuntimeProjectionStartRequested,
 			wantReconciledState: StateCreating,
 		},
+		{
+			name: "non-creating pending_create_claim remains start requested",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":                "active",
+					"session_name":         "s-worker",
+					"pending_create_claim": "true",
+				},
+				Runtime: RuntimeFacts{Observed: true, Alive: false},
+				Now:     now,
+			},
+			wantRuntime:         RuntimeProjectionStartRequested,
+			wantReconciledState: StateCreating,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -420,7 +420,33 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 			wantReset:           true,
 		},
 		{
-			name: "pending create claim keeps stale creating state in creating",
+			// Regression for #1460: a pending_create_claim left behind by a
+			// crashed creator must not protect a stale-creating bead forever.
+			// Once the lease window (StaleCreatingAfter) elapses with no live
+			// runtime, the bead heals to asleep and the claim no longer wins.
+			name: "stale creating heals to asleep even with pending_create_claim",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":                "creating",
+					"session_name":         "s-worker",
+					"session_key":          "old-provider-conversation",
+					"pending_create_claim": "true",
+				},
+				Runtime:            RuntimeFacts{Observed: true, Alive: false},
+				CreatedAt:          now.Add(-2 * time.Minute),
+				StaleCreatingAfter: time.Minute,
+				Now:                now,
+			},
+			wantRuntime:         RuntimeProjectionStaleCreating,
+			wantReconciledState: StateAsleep,
+			wantReset:           true,
+		},
+		{
+			// Counterpart: while the lease is still fresh, pending_create_claim
+			// continues to short-circuit so an in-flight create attempt is not
+			// raced.
+			name: "fresh creating with pending_create_claim stays in creating",
 			input: LifecycleInput{
 				Status: "open",
 				Metadata: map[string]string{
@@ -429,7 +455,7 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 					"pending_create_claim": "true",
 				},
 				Runtime:            RuntimeFacts{Observed: true, Alive: false},
-				CreatedAt:          now.Add(-2 * time.Minute),
+				CreatedAt:          now.Add(-30 * time.Second),
 				StaleCreatingAfter: time.Minute,
 				Now:                now,
 			},


### PR DESCRIPTION
## Summary

Fixes #1460. A session bead in `state=creating` with `pending_create_claim=true` was preserved indefinitely when its creator crashed mid-flight — both the lifecycle projection and the city-runtime sweep short-circuited before the staleness check.

- `internal/session/lifecycle_projection.go`: reorder so `creatingStateIsStale` runs first when `base==BaseStateCreating`. `WakeCausePendingCreate` only short-circuits while the lease is fresh.
- `cmd/gc/city_runtime.go`: add the same age check to the sweep's `pending_create_claim` preservation.

Once `staleCreatingStateTimeout` elapses with no live runtime, the bead heals to `asleep` and the sweep can reap it. Fresh-create protection is preserved for in-flight attempts within the lease window.

## Tests

- Flipped the two existing test cases that locked in the buggy behavior (one in `lifecycle_projection_test.go`, one in `city_runtime_test.go`) and added parallel cases covering both sides of the lease boundary.
- New: `TestHealState_StaleCreatingWithPendingClaimHealsToAsleep` to cover the heal path end-to-end.
- Existing `TestHealState_PreservesCreatingWhileStartRequested` updated to pin a fresh `CreatedAt` so it asserts the in-lease semantics it was always meant to.

5 files changed, 74 insertions(+), 13 deletions(-). Full session/runtime suites pass; the 3 unrelated failures (TestBuiltinDoltDoctor*, TestOrderDispatchConditionUsesScopedEnv) reproduce on a clean `main`.

## Note on issue scope

#1460's analysis identifies two halves:
1. heal/sweep paths skip the stuck bead (this PR)
2. start path silently abandons the bead pre-commit

This PR is scoped to (1). For (2), at least one user-visible manifestation is `convoy control --serve` exiting on the first per-bead error (e.g. orphaned `gc.root_bead_id`) instead of skipping; that surfaces as repeated stale-async-start outcomes in the lifecycle. Happy to file/follow-up separately if useful.

## Test plan

- [x] Unit tests pass (`go test ./internal/session/... ./cmd/gc/...`)
- [x] `go vet ./...` clean
- [x] Verified live: a 2-day-old stuck `pending_create_claim=true` bead healed to asleep within one patrol tick after deploying the patched binary

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->