### PR TITLE
fix(runtime): replace bare select{} with sleep loop in request-restart

### DIFF
--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -459,7 +459,12 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 	fmt.Fprintln(stdout, "Restart requested. Blocking until controller kills this session...") //nolint:errcheck // best-effort stdout
 
 	// Block forever. The controller will kill the entire process tree.
-	select {}
+	// time.Sleep keeps a timer goroutine alive so the Go runtime does not
+	// detect a deadlock and panic ("all goroutines are asleep") — bare
+	// `select {}` does, because no other goroutine can wake the main one.
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 // doRuntimeDrainAck sets the drain-ack flag on the session. The controller


### PR DESCRIPTION
doRuntimeRequestRestart blocks via `select {}` to wait for the controller to kill the process tree. Go runtime detects this as a deadlock when no other goroutines exist:

```
fatal error: all goroutines are asleep - deadlock!
goroutine 1 [select (no cases)]:
```

This bypasses the controller hand-off — the agent crashes before `restart-requested` metadata propagates. Witnesses, refineries, and polecats relying on `gc runtime request-restart` to recycle on context exhaustion never trigger.

Replace with `for { time.Sleep(time.Hour) }`. Same intent (block forever; controller kills us), but the pending timer keeps a goroutine alive so the deadlock detector stays quiet.

## Test plan

- [x] `go build ./...`
- [x] Verified `gc runtime request-restart` no longer panics on agents with no other goroutines

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->