### PR TITLE
fix(dolt): use du -sk for portable size calc on macOS

### DIFF
--- a/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
+++ b/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
@@ -606,7 +606,8 @@ for d in "$data_dir"/*/; do
   name="$(basename "$d")"
   case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|__gc_probe) continue ;; esac
   case "$referenced" in *" $name "*) continue ;; esac
-  size_bytes=$(du -sb "$d" 2>/dev/null | cut -f1 || echo 0)
+  size_kb=$(du -sk "$d" 2>/dev/null | cut -f1)
+  size_bytes=$(( ${size_kb:-0} * 1024 ))
   size="${size_bytes} B"
   orphans="$orphans$name|$size|$d
 "

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -101,8 +101,11 @@ for d in "$data_dir"/*/; do
   case "$referenced" in
     *" $name "*) continue ;; # referenced, not orphan
   esac
-  # Calculate size.
-  size_bytes=$(du -sb "$d" 2>/dev/null | cut -f1 || echo 0)
+  # Calculate size. Use du -sk (POSIX, KB) and multiply — du -sb is GNU-only;
+  # macOS BSD du has no -b flag, which would leave size_bytes empty and break
+  # the integer comparisons below.
+  size_kb=$(du -sk "$d" 2>/dev/null | cut -f1)
+  size_bytes=$(( ${size_kb:-0} * 1024 ))
   if [ "$size_bytes" -ge 1073741824 ]; then
     size=$(awk "BEGIN {printf \"%.1f GB\", $size_bytes/1073741824}")
   elif [ "$size_bytes" -ge 1048576 ]; then

--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -215,7 +215,8 @@ if [ -d "$data_dir" ]; then
     name="$(basename "$d")"
     case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     case "$referenced" in *" $name "*) continue ;; esac
-    size_bytes=$(du -sb "$d" 2>/dev/null | cut -f1 || echo 0)
+    size_kb=$(du -sk "$d" 2>/dev/null | cut -f1)
+    size_bytes=$(( ${size_kb:-0} * 1024 ))
     if [ "$size_bytes" -ge 1048576 ]; then
       size=$(awk "BEGIN {printf \"%.1f MB\", $size_bytes/1048576}")
     elif [ "$size_bytes" -ge 1024 ]; then


### PR DESCRIPTION
`du -sb` is GNU coreutils only. macOS BSD `du` has no `-b` flag and leaves `size_bytes` empty, breaking integer comparisons in `cleanup.sh` and `health.sh` (`integer expression expected` at the size-tier checks).

Side effect: orphan size displays as `" B"` with a leading space, and the tiered size formatter never matches, so cleanup/health reports lose the size column on macOS hosts.

Replace with `du -sk` (POSIX, KB on both BSDs and Linux) multiplied by 1024 for bytes. KB precision is sufficient — orphan display formatting already rounds at MB. Mirrored to runtime pack copies.

## Test plan

- [x] Verified `cleanup.sh` and `health.sh` size tiers compute correctly on macOS
- [x] No behavior change on Linux (`du -sk` is POSIX)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->