### PR TITLE
fix(dispatch): close orphaned workflow finalizers instead of crashing serve loop

### DIFF
--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -613,6 +613,12 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 	// so retryable scan failures keep the root live for singleton scans, but
 	// source beads are not mutated until the root is durably closed.
 	if err := setOutcomeAndClose(store, rootID, outcome); err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			if closeErr := setOutcomeAndClose(store, bead.ID, "missing_root"); closeErr != nil {
+				return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing orphaned finalizer (root %s missing): %w", bead.ID, rootID, closeErr))
+			}
+			return ControlResult{Processed: true, Action: "workflow-missing_root"}, nil
+		}
 		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow head: %w", rootID, err))
 	}
 	if outcome == "pass" {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -692,10 +692,22 @@ type countingListStore struct {
 	queries   []beads.ListQuery
 }
 
+type workflowFinalizeCloseFailStore struct {
+	beads.Store
+	finalizerID string
+}
+
 func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	s.listCalls++
 	s.queries = append(s.queries, query)
 	return s.MemStore.List(query)
+}
+
+func (s *workflowFinalizeCloseFailStore) Update(id string, opts beads.UpdateOpts) error {
+	if id == s.finalizerID && opts.Status != nil && *opts.Status == "closed" {
+		return errors.New("finalizer close failed")
+	}
+	return s.Store.Update(id, opts)
 }
 
 type scopeSnapshotQueryGuardStore struct {
@@ -804,6 +816,74 @@ func TestProcessWorkflowFinalizeClosesWorkflow(t *testing.T) {
 	}
 	if got := rootAfter.Metadata["gc.outcome"]; got != "fail" {
 		t.Fatalf("workflow outcome = %q, want fail", got)
+	}
+}
+
+func TestProcessWorkflowFinalizeOrphanedRootClosesFinalizerWithoutError(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": "missing-root-id",
+		},
+	})
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(orphan finalize): %v", err)
+	}
+	if !result.Processed {
+		t.Fatalf("result = %+v, want processed", result)
+	}
+	if result.Action != "workflow-missing_root" {
+		t.Fatalf("result.Action = %q, want workflow-missing_root", result.Action)
+	}
+
+	finalizerAfter, err := store.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if finalizerAfter.Status != "closed" {
+		t.Fatalf("finalizer status = %q, want closed", finalizerAfter.Status)
+	}
+	if got := finalizerAfter.Metadata["gc.outcome"]; got != "missing_root" {
+		t.Fatalf("finalizer outcome = %q, want missing_root", got)
+	}
+}
+
+func TestProcessWorkflowFinalizeOrphanedRootReportsFinalizerCloseFailure(t *testing.T) {
+	t.Parallel()
+
+	mem := beads.NewMemStore()
+	finalizer := mustCreateWorkflowBead(t, mem, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": "missing-root-id",
+		},
+	})
+	store := &workflowFinalizeCloseFailStore{
+		Store:       mem,
+		finalizerID: finalizer.ID,
+	}
+
+	result, err := ProcessControl(store, finalizer, ProcessOptions{})
+	if err == nil {
+		t.Fatalf("ProcessControl(orphan finalize) error = nil, want finalizer close failure")
+	}
+	if result.Processed {
+		t.Fatalf("result = %+v, want not processed when finalizer close fails", result)
+	}
+	if !strings.Contains(err.Error(), "closing orphaned finalizer") {
+		t.Fatalf("error = %q, want orphaned finalizer context", err)
+	}
+	if !strings.Contains(err.Error(), "missing-root-id") {
+		t.Fatalf("error = %q, want missing root ID context", err)
 	}
 }
 


### PR DESCRIPTION
Found while investigating the user-visible symptom of #1460 in the wild.

## Symptom

A single workflow-finalize bead whose `gc.root_bead_id` references a deleted bead crashes `gc convoy control --serve` with:

```
processing control bead hq-340b2204: fo-dwg5ga: completing workflow head: updating bead "fo-dwg5ga": bead not found
```

The dispatcher process exits → its tmux session ends → the lifecycle reconciler observes the session never reached `active` → the pool spawns a replacement → which immediately hits the same orphan and crashes again. Result: a control-dispatcher pool stuck in a spawn-fail loop, all dispatch work blocked.

## Fix

In `processWorkflowFinalize`, detect `beads.ErrNotFound` on the root close, mark the finalizer with `gc.outcome="missing_root"`, close it, and return `Action="workflow-missing_root"` so the serve loop advances past the orphan.

The serve loop already tolerates `dispatch.ErrControlPending` and the legacy-oversized-event path; this slots in as a third "advance and continue" outcome.

## Test

- New: `TestProcessWorkflowFinalizeOrphanedRootClosesFinalizerWithoutError`
- Existing `TestProcessWorkflowFinalizeClosesWorkflow` still passes — fresh finalizers with valid roots are unchanged.

## Relationship to #1460

Independent fix. #1460 is the lifecycle-side "stuck-creating heal/sweep" issue (PR #1467). This is the dispatch-side resilience gap that produces the upstream session-start failures #1460 mentions in passing as "the start path silently abandons the bead before reaching commit". Cleaner with both PRs in.

## Test plan

- [x] `go test ./internal/dispatch/... ./cmd/gc/...`
- [x] `go vet ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->