### PR TITLE
examples/lifecycle: add hello-world quickstart and pack auto-include

### DIFF
--- a/examples/lifecycle/README.md
+++ b/examples/lifecycle/README.md
@@ -1,0 +1,46 @@
+# Lifecycle Example
+
+Demonstrates a polecat/refinery pool: polecats create feature branches and
+commit work; the refinery merges to main. All agents use bash scripts for
+deterministic, reproducible demo recordings.
+
+## Quickstart
+
+### 1. Init from this example
+
+```bash
+gc init --from examples/lifecycle ~/demo-city
+cd ~/demo-city
+gc start
+```
+
+### 2. Add a demo repo as a rig
+
+```bash
+mkdir ~/demo-repo && cd ~/demo-repo && git init
+cd ~/demo-city
+gc rig add ~/demo-repo   # lifecycle pack is included automatically
+```
+
+### 3. Route a hello-world task to the polecat pool
+
+```bash
+gc sling demo-repo/polecat "Write hello world"
+```
+
+`gc sling` stamps `gc.routed_to=demo-repo/polecat` on the bead. On the
+next patrol tick (<= 10 s) the controller runs `scale_check`, counts one
+unassigned routed bead, and starts a polecat session. The polecat creates
+a feature branch, commits a file, and hands off to the refinery.
+
+> **Note:** bare `bd create "Write hello world"` does **not** trigger agent
+> spawn — `gc sling` is the routing entry point. The polecat's work-finding
+> loop filters by `gc.routed_to` metadata; beads without it are invisible
+> to the pool.
+
+### 4. Watch it run
+
+```bash
+bd show <bead-id> --watch
+gc session list
+```

--- a/examples/lifecycle/city.toml
+++ b/examples/lifecycle/city.toml
@@ -7,13 +7,25 @@
 # All agents use start_command (gc agent-script, driven by YAML
 # agent-scripts) for deterministic, reproducible demo recordings.
 #
-# To use: gc init --from examples/lifecycle ~/demo-city
+# To use:
+#   gc init --from examples/lifecycle ~/demo-city
+#   cd ~/demo-city
+#   gc start
+#
+#   # Add a rig (lifecycle pack is included automatically):
+#   gc rig add ~/demo-repo
+#
+#   # Route work to the polecat pool:
+#   gc sling demo-repo/polecat "Write hello world"
+#   bd show <bead-id> --watch
 
 [workspace]
 name = "lifecycle-demo"
 start_command = "true"
 # No workspace pack — all agents are rig-scoped.
-# Use: gc rig add <repo> --include packs/lifecycle
+
+[defaults.rig.imports.lifecycle]
+source = "packs/lifecycle"
 
 [daemon]
 patrol_interval = "10s"

--- a/test/acceptance/example_cities_test.go
+++ b/test/acceptance/example_cities_test.go
@@ -126,6 +126,24 @@ func TestExamplePacks_PackArtifacts(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Lifecycle", func(t *testing.T) {
+		c := helpers.NewCity(t, testEnv)
+		c.InitFrom(filepath.Join(helpers.ExamplesDir(), "lifecycle"))
+
+		expected := []string{
+			"packs/lifecycle/pack.toml",
+			"packs/lifecycle/agents/polecat/agent.toml",
+			"packs/lifecycle/agents/refinery/agent.toml",
+			"packs/lifecycle/assets/scripts/lifecycle-polecat-claim-handoff.yaml",
+			"packs/lifecycle/assets/scripts/lifecycle-refinery-merge.yaml",
+		}
+		for _, rel := range expected {
+			if !c.HasFile(rel) {
+				t.Errorf("missing expected artifact: %s", rel)
+			}
+		}
+	})
 }
 
 // TestExampleDoctor_AllCities_RunWithoutCrash verifies that gc doctor


### PR DESCRIPTION
  ## Summary

  - `examples/lifecycle/city.toml`: expanded comment to document the full `gc sling demo-repo/polecat "Write hello
  world"` flow; added `default_rig_includes = ["packs/lifecycle"]` so `gc rig add` wires the pack automatically without
  `--include`
  - `examples/lifecycle/README.md` (new): ~30-line quickstart covering init, rig add, the `gc sling` routing step, and a
   callout that bare `bd create` does **not** trigger agent spawn
  - `test/acceptance/example_cities_test.go`: added `"Lifecycle"` subtest to `TestExamplePacks_PackArtifacts` asserting
  the five expected pack artifacts exist after `gc init --from`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->