### PR TITLE
fix(build): prefer stable codesign identity for TCC permission persistence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,45 @@ Run `make help` for the full list. The most useful targets are:
 | `make dashboard-check` | Typecheck + build + test the dashboard |
 | `make cover` | Coverage run |
 
+## macOS Local Development
+
+The `build` target signs `gc` with a stable codesigning identity when one is
+available, so macOS TCC remembers permission grants (App Management, Apple
+Events, etc.) across rebuilds. Without this, ad-hoc-signed binaries get a
+fresh identity on every build and TCC re-prompts indefinitely while the
+supervisor and its child processes spawn.
+
+The build auto-detects the first valid certificate in your keychain, in
+order: `Apple Development:`, `Developer ID Application:`, then
+`GasCity Dev`. Override with `GC_SIGN_IDENTITY=<cert name>`. If no cert is
+found, the build falls back to ad-hoc signing.
+
+Getting a free certificate (no Apple Developer Program membership needed):
+
+- **Apple Development** — Xcode → Settings → Accounts → sign in with any
+  Apple ID → Manage Certificates → `+` → Apple Development. Valid one year
+  on the free tier.
+- **Self-signed** — Keychain Access → Certificate Assistant → Create a
+  Certificate. Name it whatever you like; set Identity Type to *Self
+  Signed Root* and Certificate Type to *Code Signing*. This stays valid
+  for as long as you set when creating it.
+
+A few macOS quirks worth knowing while iterating locally:
+
+- TCC keys denial records by **binary path**, not bundle identifier, for
+  CLI tools. `tccutil reset` does not accept paths or arbitrary
+  identifiers — it only resets entries keyed to a real `.app` bundle id.
+  If a stale "Don't Allow" decision is stuck, the practical escape hatch
+  is to install `gc` at a fresh path so TCC has no prior record there.
+- `cp -f` over a running binary inherits a `com.apple.provenance` xattr
+  that, combined with an unstable signature, can cause Gatekeeper to
+  kill the next invocation. Prefer the `make install` flow (which uses
+  atomic rename) or strip the xattr after copying.
+- Homebrew's `graphviz` ships a `/opt/homebrew/bin/gc` binary (a graph
+  coloring tool) that collides with our `gc`. If `which gc` resolves to
+  graphviz, install via `make install` and call `$(go env GOPATH)/bin/gc`
+  explicitly, or place your `gc` earlier in `PATH`.
+
 ## macOS Release Verification
 
 Before tagging a release, run the macOS smoke test on a Mac:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,25 @@ LDFLAGS := -X main.version=$(VERSION) \
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/gc
 ifeq ($(shell uname),Darwin)
-	@codesign -s - -f $(BUILD_DIR)/$(BINARY) 2>/dev/null || true
-	@echo "Signed $(BINARY) for macOS"
+	@# Prefer a stable codesigning identity over ad-hoc so TCC remembers
+	@# granted permissions across rebuilds. Ad-hoc signing produces a
+	@# fresh identity each build, which causes TCC to re-prompt forever
+	@# for App Management, Apple Events, etc. Override with
+	@# GC_SIGN_IDENTITY=<cert name>; otherwise auto-detect first valid
+	@# codesigning cert. Falls back to ad-hoc if none. The identifier is
+	@# pinned to com.gascity.gc so it stays stable across rebuilds.
+	@SIGN_ID="$${GC_SIGN_IDENTITY:-$$(security find-identity -p codesigning -v 2>/dev/null | awk -F'"' '/Apple Development:|Developer ID Application:|GasCity Dev/{print $$2; exit}')}"; \
+	if [ -n "$$SIGN_ID" ]; then \
+		codesign --sign "$$SIGN_ID" --identifier "com.gascity.gc" --options runtime --force $(BUILD_DIR)/$(BINARY) 2>/dev/null \
+			&& echo "Signed $(BINARY) with stable identity: $$SIGN_ID" \
+			|| (codesign -s - -f $(BUILD_DIR)/$(BINARY) 2>/dev/null && echo "Fell back to ad-hoc sign for $(BINARY)"); \
+	else \
+		codesign -s - -f $(BUILD_DIR)/$(BINARY) 2>/dev/null || true; \
+		echo "Ad-hoc signed $(BINARY) (set GC_SIGN_IDENTITY for stable TCC permissions)"; \
+	fi
+	@# Strip com.apple.provenance xattr; otherwise Gatekeeper kills the
+	@# binary when it's installed via `cp -f` over a running copy.
+	@xattr -d com.apple.provenance $(BUILD_DIR)/$(BINARY) 2>/dev/null || true
 endif
 
 ## install: build and install gc to GOPATH/bin (same location as go install)


### PR DESCRIPTION
Ad-hoc codesign (`codesign -s -`) produces a fresh code identity on every build because there is no certificate to anchor a stable Designated Requirement. macOS TCC keys permission grants on the binary path plus the resolved identity, so an ad-hoc-signed CLI tool that respawns frequently re-triggers permission prompts (App Management, Apple Events, etc.) on every invocation.

In practice this manifested for me as a continuous storm of `"gc" would like to access data from other apps` modals the moment the supervisor was running, because each spawned child registered as a fresh entity.

## Change

In the `build` target on Darwin:
- Auto-detect the first valid codesigning cert in the user keychain (`Apple Development:` / `Developer ID Application:` / self-signed `GasCity Dev`).
- Sign with that cert plus pinned identifier `com.gascity.gc` and `--options runtime` (hardened runtime).
- Override via `GC_SIGN_IDENTITY=<cert name>`.
- Fall back to ad-hoc when no cert is found so Linux + non-developer macOS environments keep working unchanged.
- Best-effort strip of `com.apple.provenance` xattr post-sign.

The pinned identifier means a TCC grant on one machine is keyed predictably across rebuilds and across different developer machines.

## Verified locally

- Two consecutive builds produce **identical Designated Requirement** (`identifier "com.gascity.gc" and anchor apple generic and certificate leaf[subject.CN] = "Apple Development: Jordan Baker (G78H35LQHW)"...`).
- Supervisor + spawned children no longer re-prompt TCC after the first grant.
- `GC_SIGN_IDENTITY="GasCity Dev"` override works.
- Falls back to ad-hoc with informative log when no cert matches.
- `make check` passes (only the pre-existing `TestCmdSessionNew_ACPTemplatePersistsStoredMCPMetadata` flake reproduces on `main`).

## Test plan

- [x] `make build` on Darwin with Apple Development cert → stable signing
- [x] `GC_SIGN_IDENTITY=...` override
- [x] No-cert path verified by reading the auto-detect awk and confirming the ad-hoc fallback branch executes
- [x] `make check` clean modulo pre-existing flake

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->