### PR TITLE
fix: ensure beads.role, issue_prefix, and custom types on gc init/start (#1295)

### DIFF
--- a/cmd/gc/bd_testscript_test.go
+++ b/cmd/gc/bd_testscript_test.go
@@ -63,6 +63,12 @@ func bdTestCmd() {
 		code = doBdShow(store, rest)
 	case "ready":
 		code = doBdReady(store, rest)
+	case "init", "config", "migrate":
+		// No-op stubs used by gc-beads-bd.sh during finalize. The
+		// file-backed store does not need schema seeding, so accept
+		// these and exit 0 to keep finalize green for tests that
+		// exercise the real localInitializer + finalizeInit path.
+		code = 0
 	default:
 		fmt.Fprintf(os.Stderr, "bd: unknown subcommand %q\n", subcmd)
 		code = 1

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -370,6 +370,13 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 	return nil
 }
 
+func shouldRetryExecBdInit(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "bd schema not visible")
+}
+
 // resolveRigPaths resolves relative rig paths to absolute (relative to
 // cityPath). Mutates rigs in place. Must be called after loading city config
 // and before any access to rigs[i].Path for filesystem operations. Required
@@ -492,7 +499,21 @@ func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
 					return err
 				}
 			}
-			if err := runProviderOpWithEnv(script, overlayEnvEntries(baseEnv, overrides), args...); err != nil {
+			env := overlayEnvEntries(baseEnv, overrides)
+			if err := runProviderOpWithEnv(script, env, args...); err != nil {
+				if shouldRetryExecBdInit(err) {
+					for attempt := 0; attempt < 3; attempt++ {
+						time.Sleep(time.Second)
+						retryErr := runProviderOpWithEnv(script, env, args...)
+						if retryErr == nil {
+							return finalizeCanonicalBdScopeInit(cityPath, dir, prefix, canonicalDoltDatabase)
+						}
+						if !shouldRetryExecBdInit(retryErr) {
+							return retryErr
+						}
+						err = retryErr
+					}
+				}
 				return err
 			}
 			return finalizeCanonicalBdScopeInit(cityPath, dir, prefix, canonicalDoltDatabase)
@@ -505,7 +526,23 @@ func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
 			env := overlayEnvEntries(baseEnv, map[string]string{
 				"BEADS_DIR": filepath.Join(dir, ".beads"),
 			})
-			return runProviderOpWithEnv(script, env, args...)
+			if err := runProviderOpWithEnv(script, env, args...); err != nil {
+				if shouldRetryExecBdInit(err) {
+					for attempt := 0; attempt < 3; attempt++ {
+						time.Sleep(time.Second)
+						retryErr := runProviderOpWithEnv(script, env, args...)
+						if retryErr == nil {
+							return nil
+						}
+						if !shouldRetryExecBdInit(retryErr) {
+							return retryErr
+						}
+						err = retryErr
+					}
+				}
+				return err
+			}
+			return nil
 		}
 		target, err := resolveConfiguredExecStoreTarget(cityPath, dir)
 		if err != nil {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -4747,7 +4747,7 @@ esac
 	}
 }
 
-func TestGcBeadsBdInitMetadataOnlyFallsThroughToForcedBdInitWhenSchemaMissing(t *testing.T) {
+func TestGcBeadsBdInitMetadataOnlyFallsThroughToForcedBdInitWithPinnedDatabaseWhenSchemaMissing(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -4771,6 +4771,7 @@ func TestGcBeadsBdInitMetadataOnlyFallsThroughToForcedBdInitWhenSchemaMissing(t 
 	}
 
 	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	initCountFile := filepath.Join(t.TempDir(), "bd-init-count")
 	sqlLogFile := filepath.Join(t.TempDir(), "dolt-sql-args")
 	fakeBd := filepath.Join(binDir, "bd")
 	fakeBdScript := fmt.Sprintf(`#!/bin/sh
@@ -4788,6 +4789,7 @@ case "$cmd" in
       echo "bd init fallback must force reinitialize existing workspace" >&2
       exit 2
     fi
+    printf '1\n' > %q
     printf '%%s\n' "$@" > %q
     exit 0
     ;;
@@ -4798,7 +4800,7 @@ case "$cmd" in
     exit 0
     ;;
 esac
-`, initArgsFile)
+`, initCountFile, initArgsFile)
 	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -4818,14 +4820,23 @@ done
 printf '%%s\n' "$query" >> %q
 case "$query" in
   'USE `+"`hq`"+`; SELECT 1 FROM config LIMIT 1')
-    echo "table not found: config" >&2
-    exit 1
+    if [ ! -f %q ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''issue_prefix'\'', '\''gc'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    exit 0
     ;;
   *)
     exit 0
     ;;
 esac
-`, sqlLogFile)
+`, sqlLogFile, initCountFile)
 	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -4845,9 +4856,394 @@ esac
 		t.Fatalf("expected bd init fallback to run: %v", err)
 	}
 	got := string(data)
-	for _, want := range []string{"--force", "--server", "-p", "hq", cityPath} {
+	for _, want := range []string{"--force", "--server", "-p", "gc", "--database", "hq", cityPath} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("bd init argv missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "-p hq") {
+		t.Fatalf("bd init should keep visible prefix gc while pinning database hq:\n%s", got)
+	}
+}
+
+func TestGcBeadsBdInitWaitsForSchemaVisibilityBeforeRuntimeRepair(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	probeCountFile := filepath.Join(t.TempDir(), "schema-probe-count")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := `#!/bin/sh
+set -eu
+case "${1:-}" in
+  init|config|migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	fakeDoltScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+query=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-q" ]; then
+    query="$arg"
+    break
+  fi
+  prev="$arg"
+done
+case "$query" in
+  'USE `+"`hq`"+`; SELECT 1 FROM config LIMIT 1')
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    count=$((count + 1))
+    printf '%%s\n' "$count" > %q
+    if [ "$count" -lt 3 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    if [ ! -f %q ] || [ "$(cat %q)" -lt 3 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''issue_prefix'\'', '\''gc'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    if [ ! -f %q ] || [ "$(cat %q)" -lt 3 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, probeCountFile, probeCountFile, probeCountFile, probeCountFile, probeCountFile, probeCountFile, probeCountFile)
+	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "hq")
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(probeCountFile)
+	if err != nil {
+		t.Fatalf("read schema probe count: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "3" {
+		t.Fatalf("schema probe count = %q, want 3", got)
+	}
+}
+
+func TestGcBeadsBdInitRetriesPlainInitWhenSchemaStillMissingAfterSuccess(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initCountFile := filepath.Join(t.TempDir(), "bd-init-count")
+	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+case "${1:-}" in
+  init)
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    count=$((count + 1))
+    printf '%%s\n' "$count" > %q
+    printf '%%s\n' "$*" >> %q
+    exit 0
+    ;;
+  config|migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initCountFile, initCountFile, initCountFile, initArgsFile)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	fakeDoltScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+query=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-q" ]; then
+    query="$arg"
+    break
+  fi
+  prev="$arg"
+done
+case "$query" in
+  'USE `+"`hq`"+`')
+    exit 0
+    ;;
+  'CREATE DATABASE IF NOT EXISTS `+"`hq`"+`')
+    exit 0
+    ;;
+  'DROP DATABASE IF EXISTS `+"`beads_gc`"+`')
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; SELECT 1 FROM config LIMIT 1')
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    if [ "$count" -lt 2 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    if [ "$count" -lt 2 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''issue_prefix'\'', '\''gc'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    if [ "$count" -lt 2 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initCountFile, initCountFile, initCountFile, initCountFile, initCountFile, initCountFile)
+	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "hq")
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	countData, err := os.ReadFile(initCountFile)
+	if err != nil {
+		t.Fatalf("read init count: %v", err)
+	}
+	if got := strings.TrimSpace(string(countData)); got != "2" {
+		t.Fatalf("bd init count = %q, want 2", got)
+	}
+
+	argsData, err := os.ReadFile(initArgsFile)
+	if err != nil {
+		t.Fatalf("read init args: %v", err)
+	}
+	gotArgs := string(argsData)
+	for _, want := range []string{"init --quiet --server -p gc --database hq"} {
+		if !strings.Contains(gotArgs, want) {
+			t.Fatalf("bd init retry args missing %q:\n%s", want, gotArgs)
+		}
+	}
+	if strings.Contains(gotArgs, "--force") {
+		t.Fatalf("post-init schema retry should rerun plain init, got:\n%s", gotArgs)
+	}
+}
+
+func TestGcBeadsBdInitDropsMetadataBeforeRetryingInitAfterForcedFallback(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initCountFile := filepath.Join(t.TempDir(), "bd-init-count")
+	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	initStateFile := filepath.Join(t.TempDir(), "bd-init-state")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+case "${1:-}" in
+  init)
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    count=$((count + 1))
+    printf '%%s\n' "$count" > %q
+    if [ -f "$BEADS_DIR/metadata.json" ]; then
+      printf 'metadata=yes args=%%s\n' "$*" >> %q
+    else
+      printf 'metadata=no args=%%s\n' "$*" >> %q
+    fi
+    printf '%%s\n' "$*" >> %q
+    exit 0
+    ;;
+  config|migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initCountFile, initCountFile, initCountFile, initStateFile, initStateFile, initArgsFile)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	fakeDoltScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+query=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-q" ]; then
+    query="$arg"
+    break
+  fi
+  prev="$arg"
+done
+case "$query" in
+  'USE `+"`hq`"+`')
+    exit 0
+    ;;
+  'CREATE DATABASE IF NOT EXISTS `+"`hq`"+`')
+    exit 0
+    ;;
+  'DROP DATABASE IF EXISTS `+"`beads_gc`"+`')
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; SELECT 1 FROM config LIMIT 1')
+    count=0
+    if [ -f %q ]; then
+      count=$(cat %q)
+    fi
+    if [ "$count" -lt 2 ]; then
+      echo "table not found: config" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''types.custom'\'', '\''molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    exit 0
+    ;;
+  'USE `+"`hq`"+`; INSERT INTO config (`+"`key`"+`, value) VALUES ('\''issue_prefix'\'', '\''gc'\'') ON DUPLICATE KEY UPDATE value = VALUES(value)')
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initCountFile, initCountFile)
+	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "hq")
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	stateData, err := os.ReadFile(initStateFile)
+	if err != nil {
+		t.Fatalf("read init state: %v", err)
+	}
+	gotState := string(stateData)
+	for _, want := range []string{
+		"metadata=yes args=init --force --quiet --server -p gc --database hq",
+		"metadata=no args=init --quiet --server -p gc --database hq",
+	} {
+		if !strings.Contains(gotState, want) {
+			t.Fatalf("init state missing %q:\n%s", want, gotState)
 		}
 	}
 }

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -2623,6 +2623,7 @@ esac
 		t.Fatal(err)
 	}
 
+	configureTestDoltIdentityEnv(t)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 	if err := initBeadsForDir(cityDir, cityDir, "gc", "hq"); err != nil {
@@ -2677,6 +2678,7 @@ esac
 		t.Fatal(err)
 	}
 
+	configureTestDoltIdentityEnv(t)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 	t.Setenv("GC_CITY_PATH", "/wrong-city")
@@ -2959,6 +2961,7 @@ esac
 		t.Fatal(err)
 	}
 
+	configureTestDoltIdentityEnv(t)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 
@@ -3605,10 +3608,10 @@ esac
 			}
 
 			cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-			cmd.Env = sanitizedBaseEnv(
+			cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 				"GC_CITY_PATH="+cityPath,
 				"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-			)
+			)...)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -3771,6 +3774,7 @@ esac
 		t.Fatal(err)
 	}
 
+	configureTestDoltIdentityEnv(t)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("PATH", strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 	t.Setenv("GC_DOLT_HOST", "rig-db.example.com")
@@ -4008,11 +4012,11 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4097,11 +4101,11 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+currentGCBinaryForTests(t),
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4161,10 +4165,10 @@ exit 0
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4287,11 +4291,11 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4431,11 +4435,11 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", strings.ToUpper(managedDoltProbeDatabase))
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+fakeGC,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4612,10 +4616,10 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4639,6 +4643,106 @@ esac
 	}
 	if strings.Contains(sqlText, "CREATE DATABASE IF NOT EXISTS `gc`") {
 		t.Fatalf("should not create prefix database when preserving metadata identity:\n%s", sqlText)
+	}
+}
+
+// TestGcBeadsBdInitFastPathRepairsIssuePrefixDirectly guards the fix for
+// bd v1.0.3 rejecting `bd config set issue_prefix`. The managed init fast path
+// must repair the DB-visible issue_prefix directly instead of falling back to
+// `bd init --database <db> -p <prefix>`, which real bd v1.0.3 rejects once the
+// orchestrator-created Dolt database already exists.
+func TestGcBeadsBdInitFastPathRepairsIssuePrefixDirectly(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed metadata.json, simulating seedDeferredManagedBeadsBeforeProviderReadiness
+	// writing it before Dolt starts (the trigger for the fast path on a fresh city).
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initArgsFile := filepath.Join(t.TempDir(), "unexpected-bd-init-args")
+	sqlLogFile := filepath.Join(t.TempDir(), "dolt-sql-args")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+cmd="${1:-}"
+case "$cmd" in
+  config)
+    sub="${2:-}"
+    key="${3:-}"
+    if [ "$sub" = "set" ] && [ "$key" = "issue_prefix" ]; then
+      echo "issue_prefix must not be set through bd config set" >&2
+      exit 2
+    fi
+    exit 0
+    ;;
+  init)
+    printf '%%s\n' "$@" > %q
+    echo "bd init fallback should not run" >&2
+    exit 2
+    ;;
+  migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initArgsFile)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	fakeDoltScript := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" >> %q\nexit 0\n", sqlLogFile)
+	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "hq")
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	if data, err := os.ReadFile(initArgsFile); err == nil {
+		t.Fatalf("bd init fallback unexpectedly ran with argv:\n%s", data)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat bd init argv: %v", err)
+	}
+
+	sqlData, err := os.ReadFile(sqlLogFile)
+	if err != nil {
+		t.Fatalf("read dolt SQL log: %v", err)
+	}
+	sqlText := string(sqlData)
+	for _, want := range []string{
+		"USE `hq`",
+		"VALUES ('issue_prefix', 'gc') ON DUPLICATE KEY UPDATE",
+	} {
+		if !strings.Contains(sqlText, want) {
+			t.Fatalf("dolt SQL log missing %q:\n%s", want, sqlText)
+		}
 	}
 }
 

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3882,11 +3882,11 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", cityPath, "gc", "gascity")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+currentGCBinaryForTests(t),
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
@@ -4646,12 +4646,11 @@ esac
 	}
 }
 
-// TestGcBeadsBdInitFastPathRepairsIssuePrefixDirectly guards the fix for
-// bd v1.0.3 rejecting `bd config set issue_prefix`. The managed init fast path
-// must repair the DB-visible issue_prefix directly instead of falling back to
-// `bd init --database <db> -p <prefix>`, which real bd v1.0.3 rejects once the
-// orchestrator-created Dolt database already exists.
-func TestGcBeadsBdInitFastPathRepairsIssuePrefixDirectly(t *testing.T) {
+// TestGcBeadsBdInitFastPathRepairsRuntimeConfigDirectly guards the fix for
+// bd v1.0.3 rejecting DB-backed config writes during the managed fast path
+// after the schema already exists. In that state, the script should repair
+// issue_prefix and types.custom directly without falling back to bd init.
+func TestGcBeadsBdInitFastPathRepairsRuntimeConfigDirectly(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -4686,8 +4685,8 @@ case "$cmd" in
   config)
     sub="${2:-}"
     key="${3:-}"
-    if [ "$sub" = "set" ] && [ "$key" = "issue_prefix" ]; then
-      echo "issue_prefix must not be set through bd config set" >&2
+    if [ "$sub" = "set" ] && { [ "$key" = "issue_prefix" ] || [ "$key" = "types.custom" ]; }; then
+      echo "$key must not be set through bd config set" >&2
       exit 2
     fi
     exit 0
@@ -4737,11 +4736,118 @@ esac
 	}
 	sqlText := string(sqlData)
 	for _, want := range []string{
+		"SELECT 1 FROM config LIMIT 1",
 		"USE `hq`",
 		"VALUES ('issue_prefix', 'gc') ON DUPLICATE KEY UPDATE",
+		"VALUES ('types.custom', 'molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence') ON DUPLICATE KEY UPDATE",
 	} {
 		if !strings.Contains(sqlText, want) {
 			t.Fatalf("dolt SQL log missing %q:\n%s", want, sqlText)
+		}
+	}
+}
+
+func TestGcBeadsBdInitMetadataOnlyFallsThroughToForcedBdInitWhenSchemaMissing(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	script := gcBeadsBdScriptPath(cityPath)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initArgsFile := filepath.Join(t.TempDir(), "bd-init-args")
+	sqlLogFile := filepath.Join(t.TempDir(), "dolt-sql-args")
+	fakeBd := filepath.Join(binDir, "bd")
+	fakeBdScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+cmd="${1:-}"
+case "$cmd" in
+  init)
+    has_force=false
+    for arg in "$@"; do
+      if [ "$arg" = "--force" ]; then
+        has_force=true
+      fi
+    done
+    if [ "$has_force" != "true" ]; then
+      echo "bd init fallback must force reinitialize existing workspace" >&2
+      exit 2
+    fi
+    printf '%%s\n' "$@" > %q
+    exit 0
+    ;;
+  config|migrate|list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, initArgsFile)
+	if err := os.WriteFile(fakeBd, []byte(fakeBdScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeDolt := filepath.Join(binDir, "dolt")
+	fakeDoltScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+query=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-q" ]; then
+    query="$arg"
+    break
+  fi
+  prev="$arg"
+done
+printf '%%s\n' "$query" >> %q
+case "$query" in
+  'USE `+"`hq`"+`; SELECT 1 FROM config LIMIT 1')
+    echo "table not found: config" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, sqlLogFile)
+	if err := os.WriteFile(fakeDolt, []byte(fakeDoltScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "init", cityPath, "gc", "hq")
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
+		"GC_CITY_PATH="+cityPath,
+		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
+	)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(initArgsFile)
+	if err != nil {
+		t.Fatalf("expected bd init fallback to run: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"--force", "--server", "-p", "hq", cityPath} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("bd init argv missing %q:\n%s", want, got)
 		}
 	}
 }
@@ -7983,11 +8089,11 @@ esac
 	}
 
 	cmd := exec.Command(script, "init", rigPath, "fe", "fe")
-	cmd.Env = sanitizedBaseEnv(
+	cmd.Env = sanitizedBaseEnv(append(gcBeadsBdTestHomeEnv(t),
 		"GC_CITY_PATH="+cityPath,
 		"GC_BIN="+currentGCBinaryForTests(t),
 		"PATH="+strings.Join([]string{binDir, os.Getenv("PATH")}, string(os.PathListSeparator)),
-	)
+	)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)

--- a/cmd/gc/cityinit_impl_test.go
+++ b/cmd/gc/cityinit_impl_test.go
@@ -300,6 +300,7 @@ func TestLocalInitializerScaffoldPreservesExistingDirectoryWhenRegisterFails(t *
 func TestLocalInitializerInitScaffoldsAndFinalizes(t *testing.T) {
 	skipSlowCmdGCTest(t, "runs the full local init scaffold/finalize path; run make test-cmd-gc-process for full coverage")
 	configureTestDoltIdentityEnv(t)
+	configureRealBdAndDoltPath(t)
 	cityPath := filepath.Join(t.TempDir(), "init-city")
 
 	result, err := localInitializer{}.Init(context.Background(), cityinit.InitRequest{

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -172,6 +172,12 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	d.Register(doctor.NewBinaryCheck("jq", "", exec.LookPath))
 	d.Register(doctor.NewBinaryCheck("pgrep", "", exec.LookPath))
 	d.Register(doctor.NewBinaryCheck("lsof", "", exec.LookPath))
+	// beads.role must be set before any bd command runs; check it here so
+	// the missing-role error appears before the downstream data/Dolt checks
+	// that will all fail for the same root cause.
+	if initNeedsBdTooling(cityPath) {
+		d.Register(&doctor.BeadsRoleCheck{})
+	}
 
 	// Controller check + session checks (gated by controller state).
 	controllerRunning := doctor.IsControllerRunning(cityPath)

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -84,21 +84,16 @@ func waitTestRealBDPath(t *testing.T) string {
 	t.Helper()
 	skipSlowCmdGCTest(t, "requires a managed bd lifecycle city; run make test-cmd-gc-process for full coverage")
 	waitTestRealBDPathOnce.Do(func() {
-		for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-			if strings.TrimSpace(dir) == "" {
-				continue
-			}
-			candidate := filepath.Join(dir, "bd")
-			info, err := os.Stat(candidate)
-			if err != nil || info.IsDir() {
-				continue
-			}
-			cmd := exec.Command(candidate, "init", "--help")
-			out, err := cmd.CombinedOutput()
-			if err == nil || !strings.Contains(string(out), `unknown subcommand "init"`) {
-				waitTestRealBDCached = candidate
-				return
-			}
+		candidate, err := findPreferredBinary("bd")
+		if err != nil {
+			waitTestRealBDErr = errors.New("bd with init not installed")
+			return
+		}
+		cmd := exec.Command(candidate, "init", "--help")
+		out, err := cmd.CombinedOutput()
+		if err == nil || !strings.Contains(string(out), `unknown subcommand "init"`) {
+			waitTestRealBDCached = candidate
+			return
 		}
 		waitTestRealBDErr = errors.New("bd with init not installed")
 	})

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -59,8 +59,28 @@ func installTestProviderStubs() (string, error) {
 
 func writeTestGitIdentity(homeDir string) error {
 	gitConfig := filepath.Join(homeDir, ".gitconfig")
-	data := []byte("[user]\n\tname = gc-test\n\temail = gc-test@test.local\n")
+	data := []byte("[user]\n\tname = gc-test\n\temail = gc-test@test.local\n[beads]\n\trole = maintainer\n")
 	return os.WriteFile(gitConfig, data, 0o644)
+}
+
+// gcBeadsBdTestHomeEnv creates a temp HOME with a .gitconfig containing user
+// identity and beads.role = maintainer, then returns extra env entries suitable
+// for appending to sanitizedBaseEnv. Use this for any test that runs the real
+// gc-beads-bd.sh op_init, which calls ensure_beads_role and requires a writable
+// global git config.
+func gcBeadsBdTestHomeEnv(t *testing.T) []string {
+	t.Helper()
+	homeDir := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(beads-bd test home): %v", err)
+	}
+	if err := writeTestGitIdentity(homeDir); err != nil {
+		t.Fatalf("write test git identity for beads-bd: %v", err)
+	}
+	return []string{
+		"HOME=" + homeDir,
+		"GIT_CONFIG_GLOBAL=" + filepath.Join(homeDir, ".gitconfig"),
+	}
 }
 
 func writeTestDoltIdentity(homeDir string) error {

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -108,4 +110,19 @@ func configureTestDoltIdentityEnv(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(homeDir, ".gitconfig"))
 	t.Setenv("DOLT_ROOT_PATH", homeDir)
+}
+
+func configureRealBdAndDoltPath(t *testing.T) {
+	t.Helper()
+
+	bdPath := waitTestRealBDPath(t)
+	doltPath, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skip("dolt not installed")
+	}
+	t.Setenv("PATH", strings.Join([]string{
+		filepath.Dir(bdPath),
+		filepath.Dir(doltPath),
+		os.Getenv("PATH"),
+	}, string(os.PathListSeparator)))
 }

--- a/contrib/beads-scripts/gc-beads-k8s
+++ b/contrib/beads-scripts/gc-beads-k8s
@@ -102,8 +102,6 @@ runner_workdir_for_scope() {
 }
 
 # run_bd executes bd inside the beads runner pod for the projected store root.
-# When GC_BEADS_PREFIX is set, the prefix switch and bd command run in a
-# single kubectl exec to avoid interleave from concurrent invocations.
 #
 # BEADS_DIR is exported for every in-pod bd invocation so the runner always
 # targets the scope-local .beads store, including the post-init config-set
@@ -111,26 +109,15 @@ runner_workdir_for_scope() {
 # `bd config set issue_prefix` before `bd init`, because a fresh scope has no
 # database for config writes yet.
 run_bd() {
-  local scope_root workdir want
+  local scope_root workdir
   scope_root=$(scope_root_arg_or_env "")
   workdir=$(runner_workdir_for_scope "$scope_root") || return 1
-  want="${GC_BEADS_PREFIX:-}"
-  if [ -n "$want" ]; then
-    if [ "${1:-}" = "init" ]; then
-      "${KUBECTL[@]}" exec "$POD_NAME" -- sh -c \
-        'workdir="$1"; shift; mkdir -p "$workdir" && cd "$workdir" && export BEADS_DIR="$workdir/.beads" && bd "$@"' -- "$workdir" "$@"
-    else
-      "${KUBECTL[@]}" exec "$POD_NAME" -- sh -c \
-        'workdir="$1"; prefix="$2"; shift 2; mkdir -p "$workdir" && cd "$workdir" && export BEADS_DIR="$workdir/.beads" && bd config set issue_prefix "$prefix" >/dev/null 2>&1 && bd "$@"' -- "$workdir" "$want" "$@"
-    fi
+  if [ "${1:-}" = "init" ]; then
+    "${KUBECTL[@]}" exec "$POD_NAME" -- sh -c \
+      'workdir="$1"; shift; mkdir -p "$workdir" && cd "$workdir" && export BEADS_DIR="$workdir/.beads" && if ! git config --global beads.role >/dev/null 2>&1; then git config --global beads.role maintainer >/dev/null 2>&1 || exit 1; fi && bd "$@"' -- "$workdir" "$@"
   else
-    if [ "${1:-}" = "init" ]; then
-      "${KUBECTL[@]}" exec "$POD_NAME" -- sh -c \
-        'workdir="$1"; shift; mkdir -p "$workdir" && cd "$workdir" && export BEADS_DIR="$workdir/.beads" && bd "$@"' -- "$workdir" "$@"
-    else
-      "${KUBECTL[@]}" exec "$POD_NAME" -- sh -c \
-        'workdir="$1"; shift; mkdir -p "$workdir" && cd "$workdir" && export BEADS_DIR="$workdir/.beads" && bd "$@"' -- "$workdir" "$@"
-    fi
+    "${KUBECTL[@]}" exec "$POD_NAME" -- sh -c \
+      'workdir="$1"; shift; mkdir -p "$workdir" && cd "$workdir" && export BEADS_DIR="$workdir/.beads" && if ! git config --global beads.role >/dev/null 2>&1; then git config --global beads.role maintainer >/dev/null 2>&1 || exit 1; fi && bd "$@"' -- "$workdir" "$@"
   fi
 }
 
@@ -294,7 +281,6 @@ case "$op" in
     # for the scope-local workspace root.
     GC_STORE_ROOT="$scope_root" run_bd init --server --server-host "$DOLT_HOST" --server-port "$DOLT_PORT" \
       -p "$prefix" --skip-hooks >/dev/null 2>&1 || true
-    GC_STORE_ROOT="$scope_root" run_bd config set issue_prefix "$prefix" >/dev/null 2>&1 || true
     # Register custom bead types required by Gas City (mirrors gc-beads-bd
     # and doctor.RequiredCustomTypes). Without this, bd rejects creates for
     # types like "session" that aren't in the default set. "convergence" is

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -166,6 +166,8 @@ is_retryable_error() {
         *"lock wait timeout"*) return 0 ;;
         *"try restarting transaction"*) return 0 ;;
         *"Unknown database"*) return 0 ;;
+        *"table not found"*) return 0 ;;
+        *"Unknown table"*) return 0 ;;
     esac
     return 1
 }
@@ -297,6 +299,19 @@ backfill_project_id_if_missing() {
     fi
     host=$(connect_host)
     "$gc_bin" dolt-state ensure-project-id         --metadata "$meta_file"         --host "$host"         --port "$DOLT_PORT"         --user "$DOLT_USER"         --database "$dolt_database" >/dev/null || die "failed to ensure project identity for $dir"
+}
+
+ensure_bd_runtime_issue_prefix() {
+    local db="$1"
+    local prefix="$2"
+    [ -n "$db" ] || return 0
+    [ -n "$prefix" ] || return 0
+    valid_sql_name "$db" || die "invalid dolt database name: $db"
+    valid_sql_name "$prefix" || die "invalid beads prefix: $prefix"
+
+    # bd v1.0.3 rejects `bd config set issue_prefix`; GC still needs raw
+    # bd commands to see the city prefix in the DB-backed config table.
+    server_sql_retry "USE \`$db\`; INSERT INTO config (\`key\`, value) VALUES ('issue_prefix', '$prefix') ON DUPLICATE KEY UPDATE value = VALUES(value)" >/dev/null || die "failed to set bd runtime issue_prefix for $db"
 }
 
 # --- Robustness Helpers ---
@@ -1290,6 +1305,20 @@ clean_stale_sockets() {
     done
 }
 
+# ensure_beads_role ensures beads.role is set in global git config.
+# bd exits non-zero with "beads.role not configured" (gastownhall/beads#2950)
+# when this key is absent. That non-zero exit causes the `run_bd_pinned … ||
+# true` calls in op_init to fail silently, leaving issue_prefix and
+# types.custom unset in the Dolt database and making every subsequent
+# bd-create call fail with "database not initialized". Defaulting to
+# "maintainer" matches the role that gc-managed agents use to create beads.
+ensure_beads_role() {
+    if git config --global beads.role >/dev/null 2>&1; then
+        return 0
+    fi
+    git config --global beads.role maintainer || die "failed to set git config beads.role"
+}
+
 # ensure_dolt_identity ensures dolt has user.name and user.email configured.
 ensure_dolt_identity() {
     # Check if already configured.
@@ -1703,6 +1732,7 @@ op_init() {
     unset BEADS_DIR
     export BEADS_DIR="$beads_dir"
     ensure_beads_dir_permissions "$dir"
+    ensure_beads_role
 
     if [ -z "$dolt_database" ]; then
         # Compatibility fallback for direct gc-beads-bd invocations.
@@ -1746,8 +1776,8 @@ op_init() {
             # and bd-specific bootstrap only.
             ensure_beads_dir_permissions "$dir"
             normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
-            run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null || true
             run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+            ensure_bd_runtime_issue_prefix "$dolt_database" "$prefix"
             backfill_project_id_if_missing "$dir"
             exit 0
         fi
@@ -1789,12 +1819,12 @@ op_init() {
     # bridge returns. Keep bd-specific config/migration here only.
     ensure_beads_dir_permissions "$dir"
 
-    # Keep bd's runtime config in sync with GC's canonical prefix. This is
-    # compatibility state for raw bd operations, not a second GC authority.
-    run_bd_pinned "$dir" config set issue_prefix "$prefix" 2>/dev/null || true
-
     # Configure custom bead types (required since beads v0.46.0).
     run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+
+    # Keep bd's runtime config in sync with GC's canonical prefix. This is
+    # compatibility state for raw bd operations, not a second GC authority.
+    ensure_bd_runtime_issue_prefix "$dolt_database" "$prefix"
 
     # Ensure database has repository fingerprint (upstream GH #25).
     # Fresh bd init already writes project_id on current upstream; only pay the

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -166,8 +166,6 @@ is_retryable_error() {
         *"lock wait timeout"*) return 0 ;;
         *"try restarting transaction"*) return 0 ;;
         *"Unknown database"*) return 0 ;;
-        *"table not found"*) return 0 ;;
-        *"Unknown table"*) return 0 ;;
     esac
     return 1
 }
@@ -304,14 +302,57 @@ backfill_project_id_if_missing() {
 ensure_bd_runtime_issue_prefix() {
     local db="$1"
     local prefix="$2"
+    ensure_bd_runtime_config_value "$db" "issue_prefix" "$prefix"
+}
+
+valid_custom_types_value() {
+    local types="$1" old_ifs typ
+    [ -n "$types" ] || return 1
+    old_ifs=$IFS
+    IFS=','
+    for typ in $types; do
+        [ -n "$typ" ] || { IFS=$old_ifs; return 1; }
+        valid_sql_name "$typ" || { IFS=$old_ifs; return 1; }
+    done
+    IFS=$old_ifs
+    return 0
+}
+
+ensure_bd_runtime_custom_types() {
+    local db="$1"
+    local types="$2"
+    ensure_bd_runtime_config_value "$db" "types.custom" "$types"
+}
+
+ensure_bd_runtime_config_value() {
+    local db="$1"
+    local key="$2"
+    local value="$3"
     [ -n "$db" ] || return 0
-    [ -n "$prefix" ] || return 0
+    [ -n "$value" ] || return 0
     valid_sql_name "$db" || die "invalid dolt database name: $db"
-    valid_sql_name "$prefix" || die "invalid beads prefix: $prefix"
+    case "$key" in
+        issue_prefix)
+            valid_sql_name "$value" || die "invalid beads prefix: $value"
+            ;;
+        types.custom)
+            valid_custom_types_value "$value" || die "invalid custom bead types: $value"
+            ;;
+        *)
+            die "unsupported bd runtime config key: $key"
+            ;;
+    esac
 
     # bd v1.0.3 rejects `bd config set issue_prefix`; GC still needs raw
-    # bd commands to see the city prefix in the DB-backed config table.
-    server_sql_retry "USE \`$db\`; INSERT INTO config (\`key\`, value) VALUES ('issue_prefix', '$prefix') ON DUPLICATE KEY UPDATE value = VALUES(value)" >/dev/null || die "failed to set bd runtime issue_prefix for $db"
+    # bd commands to see GC's config in the DB-backed config table.
+    server_sql_retry "USE \`$db\`; INSERT INTO config (\`key\`, value) VALUES ('$key', '$value') ON DUPLICATE KEY UPDATE value = VALUES(value)" >/dev/null || die "failed to set bd runtime $key for $db"
+}
+
+bd_runtime_schema_ready() {
+    local db="$1"
+    [ -n "$db" ] || return 1
+    valid_sql_name "$db" || return 1
+    server_sql "USE \`$db\`; SELECT 1 FROM config LIMIT 1" >/dev/null 2>&1
 }
 
 # --- Robustness Helpers ---
@@ -1316,6 +1357,7 @@ ensure_beads_role() {
     if git config --global beads.role >/dev/null 2>&1; then
         return 0
     fi
+    echo "gc-beads-bd: setting git config --global beads.role maintainer" >&2
     git config --global beads.role maintainer || die "failed to set git config beads.role"
 }
 
@@ -1699,6 +1741,7 @@ op_init() {
     local metadata_path="$dir/.beads/metadata.json"
     local existing_db=""
     local allow_reserved_existing=false
+    local bd_init_force=""
     if [ -z "$dir" ] || [ -z "$prefix" ]; then
         die "usage: gc-beads-bd init <dir> <prefix> [dolt_database]"
     fi
@@ -1771,18 +1814,24 @@ op_init() {
     # directory but the server was restarted (or the database was quarantined).
     if [ -f "$dir/.beads/metadata.json" ]; then
         if ensure_database_registered "$dolt_database"; then
-            # GC owns canonical metadata/config normalization after this backend
-            # bridge returns. Keep the backend focused on database registration
-            # and bd-specific bootstrap only.
-            ensure_beads_dir_permissions "$dir"
-            normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
-            run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
-            ensure_bd_runtime_issue_prefix "$dolt_database" "$prefix"
-            backfill_project_id_if_missing "$dir"
-            exit 0
+            if bd_runtime_schema_ready "$dolt_database"; then
+                # GC owns canonical metadata/config normalization after this backend
+                # bridge returns. Keep the backend focused on database registration
+                # and bd-specific bootstrap only.
+                ensure_beads_dir_permissions "$dir"
+                normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
+                run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+                ensure_bd_runtime_custom_types "$dolt_database" "$custom_types"
+                ensure_bd_runtime_issue_prefix "$dolt_database" "$prefix"
+                backfill_project_id_if_missing "$dir"
+                exit 0
+            fi
+            echo "warning: database '$dolt_database' missing bd schema; re-initializing" >&2
+            bd_init_force="--force"
+        else
+            echo "warning: database '$dolt_database' not registered; re-initializing" >&2
+            bd_init_force="--force"
         fi
-        # Database registration failed — fall through to full init.
-        echo "warning: database '$dolt_database' not registered; re-initializing" >&2
     fi
 
     local host
@@ -1804,8 +1853,17 @@ op_init() {
         init_prefix="$dolt_database"
     fi
 
-    # Run bd init in server mode.
-    (cd "$dir" && bd init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents         --server-host "$host" --server-port "$DOLT_PORT"         "$dir") || die "bd init failed for $dir"
+    # Run bd init in server mode through the pinned wrapper so the fallback
+    # path uses the same authenticated Dolt target as the rest of init.
+    # Metadata-only scopes already look initialized to bd, so schema-repair
+    # fallback must force reinit to seed the missing tables into the pinned DB.
+    if [ -n "$bd_init_force" ]; then
+        run_bd_pinned "$dir" init --force --quiet --server -p "$init_prefix" --skip-hooks --skip-agents \
+            --server-host "$host" --server-port "$DOLT_PORT" "$dir" || die "bd init failed for $dir"
+    else
+        run_bd_pinned "$dir" init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents \
+            --server-host "$host" --server-port "$DOLT_PORT" "$dir" || die "bd init failed for $dir"
+    fi
 
     # Drop orphan database created by bd init (upstream gt-sv1h).
     # bd init --prefix creates beads_<prefix> on the Dolt server, but we
@@ -1821,6 +1879,7 @@ op_init() {
 
     # Configure custom bead types (required since beads v0.46.0).
     run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+    ensure_bd_runtime_custom_types "$dolt_database" "$custom_types"
 
     # Keep bd's runtime config in sync with GC's canonical prefix. This is
     # compatibility state for raw bd operations, not a second GC authority.

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -355,6 +355,26 @@ bd_runtime_schema_ready() {
     server_sql "USE \`$db\`; SELECT 1 FROM config LIMIT 1" >/dev/null 2>&1
 }
 
+wait_for_bd_runtime_schema() {
+    local db="$1"
+    local attempt backoff_ms
+    [ -n "$db" ] || return 1
+    valid_sql_name "$db" || return 1
+
+    backoff_ms=100
+    for attempt in 1 2 3 4 5; do
+        if bd_runtime_schema_ready "$db"; then
+            return 0
+        fi
+        if [ "$attempt" -lt 5 ]; then
+            sleep "$(awk "BEGIN{printf \"%.3f\", $backoff_ms/1000}")" 2>/dev/null || sleep 1
+            backoff_ms=$((backoff_ms * 2))
+        fi
+    done
+
+    return 1
+}
+
 # --- Robustness Helpers ---
 
 # save_state writes the private provider runtime state atomically (no jq dependency).
@@ -1708,6 +1728,22 @@ run_bd_pinned() {
     )
 }
 
+run_bd_init_pinned() {
+    local dir="$1"
+    local prefix="$2"
+    local dolt_database="$3"
+    local host="$4"
+    local force_init="${5:-false}"
+    if [ "$force_init" = "true" ]; then
+        run_bd_pinned "$dir" init --force --quiet --server -p "$prefix" --database "$dolt_database" --skip-hooks --skip-agents \
+            --server-host "$host" --server-port "$DOLT_PORT" "$dir" || die "bd init failed for $dir"
+        return 0
+    fi
+
+    run_bd_pinned "$dir" init --quiet --server -p "$prefix" --database "$dolt_database" --skip-hooks --skip-agents \
+        --server-host "$host" --server-port "$DOLT_PORT" "$dir" || die "bd init failed for $dir"
+}
+
 ensure_beads_dir_permissions() {
     local dir="$1"
     local beads_dir="$dir/.beads"
@@ -1843,39 +1879,35 @@ op_init() {
     # server is running, always go through SQL rather than dolt init on disk.
     ensure_database_registered "$dolt_database" || true
 
-    local init_prefix="$prefix"
-    if [ "$dolt_database" != "$prefix" ]; then
-        # When the pinned Dolt database differs from the routing prefix
-        # (for example city prefix gc -> database hq), initialize bd against
-        # the actual database name and then rewrite issue_prefix afterward.
-        # Otherwise bd seeds schema into <prefix> and leaves the pinned
-        # database empty.
-        init_prefix="$dolt_database"
-    fi
-
     # Run bd init in server mode through the pinned wrapper so the fallback
     # path uses the same authenticated Dolt target as the rest of init.
     # Metadata-only scopes already look initialized to bd, so schema-repair
     # fallback must force reinit to seed the missing tables into the pinned DB.
-    if [ -n "$bd_init_force" ]; then
-        run_bd_pinned "$dir" init --force --quiet --server -p "$init_prefix" --skip-hooks --skip-agents \
-            --server-host "$host" --server-port "$DOLT_PORT" "$dir" || die "bd init failed for $dir"
-    else
-        run_bd_pinned "$dir" init --quiet --server -p "$init_prefix" --skip-hooks --skip-agents \
-            --server-host "$host" --server-port "$DOLT_PORT" "$dir" || die "bd init failed for $dir"
-    fi
+    # Always pass the pinned server database explicitly; `-p` controls the
+    # visible issue prefix, while `--database` tells bd which existing Dolt
+    # database to initialize. Without `--database`, bd can seed beads_<prefix>
+    # and leave the pinned database schema-less.
+    run_bd_init_pinned "$dir" "$prefix" "$dolt_database" "$host" "${bd_init_force:+true}"
 
-    # Drop orphan database created by bd init (upstream gt-sv1h).
-    # bd init --prefix creates beads_<prefix> on the Dolt server, but we
-    # use <prefix> as the database name. Without cleanup, orphans accumulate.
-    local orphan_db="beads_${init_prefix}"
-    if [ "$orphan_db" != "$init_prefix" ]; then
-        server_sql "DROP DATABASE IF EXISTS \`$orphan_db\`" >/dev/null 2>&1 || true
-    fi
+    ensure_database_registered "$dolt_database" || true
 
     # GC owns canonical metadata/config normalization after this backend
     # bridge returns. Keep bd-specific config/migration here only.
     ensure_beads_dir_permissions "$dir"
+    if ! wait_for_bd_runtime_schema "$dolt_database"; then
+        if [ "${GC_BD_INIT_RETRY:-0}" != "1" ]; then
+            if [ -n "$bd_init_force" ]; then
+                # Metadata-only scopes can still confuse bd's first forced server init.
+                # Drop the preseeded metadata and retry through a fresh top-level
+                # invocation, matching the successful manual recovery path.
+                rm -f "$dir/.beads/metadata.json"
+            fi
+            echo "warning: bd schema for '$dolt_database' not visible after init; retrying init" >&2
+            GC_BD_INIT_RETRY=1 exec "$0" init "$dir" "$prefix" "$dolt_database"
+            die "failed to re-exec init for $dir"
+        fi
+        die "bd schema not visible for $dolt_database after init"
+    fi
 
     # Configure custom bead types (required since beads v0.46.0).
     run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
@@ -1889,6 +1921,15 @@ op_init() {
     # Fresh bd init already writes project_id on current upstream; only pay the
     # migration cost when metadata still lacks it.
     backfill_project_id_if_missing "$dir"
+
+    # Drop orphan database created by bd init (upstream gt-sv1h) only after
+    # the pinned database schema is visible. Some bd builds appear to stage
+    # schema work before the pinned catalog entry is fully adopted; deleting
+    # beads_<prefix> too early can discard the only initialized schema.
+    local orphan_db="beads_${prefix}"
+    if [ "$orphan_db" != "$dolt_database" ]; then
+        server_sql "DROP DATABASE IF EXISTS \`$orphan_db\`" >/dev/null 2>&1 || true
+    fi
 
     normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
 }

--- a/internal/doctor/checks_beads_role.go
+++ b/internal/doctor/checks_beads_role.go
@@ -38,12 +38,27 @@ func (c *BeadsRoleCheck) CanFix() bool { return true }
 // Fix sets beads.role to "maintainer" in global git config if it is not
 // already set. A non-empty existing value is left unchanged.
 func (c *BeadsRoleCheck) Fix(_ *CheckContext) error {
-	out, err := exec.Command("git", "config", "--global", "beads.role").Output()
+	out, err := exec.Command("git", "config", "--global", "beads.role").CombinedOutput()
 	if err == nil && strings.TrimSpace(string(out)) != "" {
 		return nil
 	}
-	if err := exec.Command("git", "config", "--global", "beads.role", "maintainer").Run(); err != nil {
-		return fmt.Errorf("setting beads.role: %w", err)
+	writeOut, writeErr := exec.Command("git", "config", "--global", "beads.role", "maintainer").CombinedOutput()
+	if writeErr != nil {
+		writeMsg := strings.TrimSpace(string(writeOut))
+		if err != nil {
+			readMsg := strings.TrimSpace(string(out))
+			if readMsg == "" {
+				readMsg = err.Error()
+			}
+			if writeMsg != "" {
+				return fmt.Errorf("setting beads.role after reading current value failed (%s): %s: %w", readMsg, writeMsg, writeErr)
+			}
+			return fmt.Errorf("setting beads.role after reading current value failed (%s): %w", readMsg, writeErr)
+		}
+		if writeMsg != "" {
+			return fmt.Errorf("setting beads.role: %s: %w", writeMsg, writeErr)
+		}
+		return fmt.Errorf("setting beads.role: %w", writeErr)
 	}
 	return nil
 }

--- a/internal/doctor/checks_beads_role.go
+++ b/internal/doctor/checks_beads_role.go
@@ -1,0 +1,49 @@
+package doctor
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// BeadsRoleCheck verifies that beads.role is set in global git config.
+// bd exits non-zero with "beads.role not configured" (gastownhall/beads#2950)
+// when this key is absent, causing the config-set calls in gc-beads-bd's
+// op_init to fail silently (they use || true). The silent failures leave
+// issue_prefix and types.custom unset in the Dolt database, making every
+// subsequent bd-create call fail with "database not initialized".
+type BeadsRoleCheck struct{}
+
+// Name returns the check identifier.
+func (c *BeadsRoleCheck) Name() string { return "beads-role" }
+
+// Run checks that beads.role is set in global git config.
+func (c *BeadsRoleCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	out, err := exec.Command("git", "config", "--global", "beads.role").Output()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		r.Status = StatusError
+		r.Message = "beads.role not set in global git config"
+		r.FixHint = "run: git config --global beads.role maintainer"
+		return r
+	}
+	r.Status = StatusOK
+	r.Message = fmt.Sprintf("beads.role = %q", strings.TrimSpace(string(out)))
+	return r
+}
+
+// CanFix returns true — the missing role can be set automatically.
+func (c *BeadsRoleCheck) CanFix() bool { return true }
+
+// Fix sets beads.role to "maintainer" in global git config if it is not
+// already set. A non-empty existing value is left unchanged.
+func (c *BeadsRoleCheck) Fix(_ *CheckContext) error {
+	out, err := exec.Command("git", "config", "--global", "beads.role").Output()
+	if err == nil && strings.TrimSpace(string(out)) != "" {
+		return nil
+	}
+	if err := exec.Command("git", "config", "--global", "beads.role", "maintainer").Run(); err != nil {
+		return fmt.Errorf("setting beads.role: %w", err)
+	}
+	return nil
+}

--- a/internal/doctor/checks_beads_role_test.go
+++ b/internal/doctor/checks_beads_role_test.go
@@ -110,3 +110,23 @@ func TestBeadsRoleCheck_Fix_PreservesExistingRole(t *testing.T) {
 		t.Errorf("beads.role = %q, want %q (Fix should preserve existing value)", got, "contributor")
 	}
 }
+
+func TestBeadsRoleCheck_Fix_PreservesReadFailureContext(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	home := setupFakeGitConfig(t)
+	cfg := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(cfg, []byte("not valid\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &BeadsRoleCheck{}
+	err := c.Fix(&CheckContext{})
+	if err == nil {
+		t.Fatal("Fix error = nil, want read failure context")
+	}
+	if !strings.Contains(err.Error(), "bad config line 1") {
+		t.Fatalf("Fix error = %q, want preserved git read failure", err)
+	}
+}

--- a/internal/doctor/checks_beads_role_test.go
+++ b/internal/doctor/checks_beads_role_test.go
@@ -1,0 +1,112 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupFakeGitConfig returns a HOME override that points to an empty temp dir,
+// so git config --global reads/writes go there without touching the real user config.
+func setupFakeGitConfig(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Windows / macOS also respect GIT_CONFIG_GLOBAL:
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, ".gitconfig"))
+	return home
+}
+
+func TestBeadsRoleCheck_NotSet(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	setupFakeGitConfig(t)
+
+	c := &BeadsRoleCheck{}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusError {
+		t.Fatalf("status = %v, want StatusError (beads.role unset)", r.Status)
+	}
+	if !strings.Contains(r.Message, "beads.role") {
+		t.Errorf("message %q should mention beads.role", r.Message)
+	}
+	if r.FixHint == "" {
+		t.Error("FixHint should be set when beads.role is missing")
+	}
+}
+
+func TestBeadsRoleCheck_Set(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	home := setupFakeGitConfig(t)
+
+	cfg := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(cfg, []byte("[beads]\n\trole = maintainer\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &BeadsRoleCheck{}
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %v, want StatusOK (beads.role = maintainer)", r.Status)
+	}
+	if !strings.Contains(r.Message, "maintainer") {
+		t.Errorf("message %q should include the role value", r.Message)
+	}
+}
+
+func TestBeadsRoleCheck_CanFix(t *testing.T) {
+	c := &BeadsRoleCheck{}
+	if !c.CanFix() {
+		t.Fatal("CanFix should return true")
+	}
+}
+
+func TestBeadsRoleCheck_Fix_SetsRole(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	setupFakeGitConfig(t)
+
+	c := &BeadsRoleCheck{}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	// After Fix, Run should pass.
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("after Fix: status = %v, want StatusOK", r.Status)
+	}
+	if !strings.Contains(r.Message, "maintainer") {
+		t.Errorf("after Fix: message %q should contain 'maintainer'", r.Message)
+	}
+}
+
+func TestBeadsRoleCheck_Fix_PreservesExistingRole(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	home := setupFakeGitConfig(t)
+
+	cfg := filepath.Join(home, ".gitconfig")
+	if err := os.WriteFile(cfg, []byte("[beads]\n\trole = contributor\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &BeadsRoleCheck{}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	// Should not have overwritten the existing "contributor" value.
+	out, err := exec.Command("git", "config", "--global", "beads.role").Output()
+	if err != nil {
+		t.Fatalf("git config --global beads.role: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "contributor" {
+		t.Errorf("beads.role = %q, want %q (Fix should preserve existing value)", got, "contributor")
+	}
+}

--- a/internal/runtime/k8s/beads_script_test.go
+++ b/internal/runtime/k8s/beads_script_test.go
@@ -77,6 +77,7 @@ func TestBeadsScriptInitSetsBEADSDIR(t *testing.T) {
 		t.Fatalf("gc-beads-k8s init error = %v\noutput:\n%s", result.err, result.output)
 	}
 	assertCallContains(t, result.callLog, `export BEADS_DIR="$workdir/.beads"`)
+	assertCallContains(t, result.callLog, `git config --global beads.role`)
 	assertCallContains(t, result.callLog, "init --server")
 }
 
@@ -102,8 +103,8 @@ func TestBeadsScriptInitDoesNotPreseedIssuePrefixBeforeBdInit(t *testing.T) {
 	if !strings.Contains(lines[0], "init --server") {
 		t.Fatalf("first init call = %q, want init --server", lines[0])
 	}
-	if strings.Contains(lines[0], "config set issue_prefix") {
-		t.Fatalf("first init call should not preseed issue_prefix before bd init:\n%s", lines[0])
+	if strings.Contains(result.callLog, "config set issue_prefix") {
+		t.Fatalf("init flow should not rewrite issue_prefix around bd init:\n%s", result.callLog)
 	}
 }
 
@@ -159,6 +160,23 @@ func TestBeadsScriptListUsesScopedWorkdir(t *testing.T) {
 	assertCallContains(t, result.callLog, "/workspace/frontend")
 	assertCallContains(t, result.callLog, "list --json --limit 0 --all")
 	assertCallContains(t, result.callLog, `export BEADS_DIR="$workdir/.beads"`)
+	assertCallContains(t, result.callLog, `git config --global beads.role`)
+}
+
+func TestBeadsScriptListDoesNotRewriteIssuePrefixPerCommand(t *testing.T) {
+	result := runBeadsScript(t, beadsScriptOptions{
+		Op: "list",
+		Env: map[string]string{
+			"GC_CITY_PATH":    "/city",
+			"GC_STORE_ROOT":   "/city/frontend",
+			"GC_BEADS_PREFIX": "fe",
+		},
+		ListOutput: "[]",
+	})
+	if result.err != nil {
+		t.Fatalf("gc-beads-k8s list error = %v\noutput:\n%s", result.err, result.output)
+	}
+	assertCallNotContains(t, result.callLog, "config set issue_prefix")
 }
 
 func TestBeadsScriptConfigSetKeepsBEADSDIRScoped(t *testing.T) {


### PR DESCRIPTION
Supersedes #1354 by @dstengle. Carries his commits forward (preserved with `Co-Authored-By`) and adds one fixup commit on top so CI lands green.

## Summary

Closes #1295. New user-account installs of Gas City are non-functional after `gc init` + `gc start` because three setup steps are required but never performed automatically:

1. `git config --global beads.role maintainer` — silently fails every `bd create`
2. `bd init --prefix <prefix>` — `issue_prefix` not seeded into DB scope
3. Custom type registration (12 required types) — typed beads cannot be created

This PR addresses all three:

- **`internal/doctor/checks_beads_role.go`** (new) — fail-fast doctor check that surfaces a missing `beads.role`. Wired in alongside the rest of the infrastructure checks so the failure mode the issue describes ("everything looks healthy, nothing materializes") becomes a loud diagnostic instead of a silent stall.
- **`cmd/gc/testenv_test.go`** — `writeTestGitIdentity` now seeds `[beads] role = maintainer` into test gitconfigs, and a new `gcBeadsBdTestHomeEnv` helper lets subprocess tests pass a controlled HOME with the role set.
- **`cmd/gc/cmd_doctor.go`** — adds the role check to the registry.
- **`examples/bd/assets/scripts/gc-beads-bd.sh`** — when the fast path's `bd config set issue_prefix` fails (empty server-side schema after `seedDeferredManagedBeadsBeforeProviderReadiness` wrote `metadata.json` before Dolt started), fall through to `bd init --quiet --server --database <db> -p <prefix> ...` to seed the schema in place. Adopting `--database <db>` keeps the orchestrator-registered DB instead of creating an orphan `beads_<prefix>`.

## What changed vs. #1354

The original PR's fall-through used `bd init --reinit-local`, which doesn't exist in `bd v1.0.0` (the version pinned by `BD_VERSION` in CI). On v1.0.0 the local-data safety check doesn't fire on the metadata-only state we fall through from, so plain `bd init --database --server ...` succeeds. Specifically in this PR's fixup commit:

- Drop `--reinit-local` from the `bd init` invocation (was failing CI with `unknown flag`).
- Add `init`, `config`, `migrate` as no-op subcommands on the `bdTestCmd` testscript shim. Without these, any test exercising the real `localInitializer.Init → finalizeInit → gc-beads-bd.sh init` path failed at `bd: unknown subcommand "init"` — that's why `TestLocalInitializerInitScaffoldsAndFinalizes` was red.
- Drop `TestGcBeadsBdInitFastPathFallsThroughCreatesSchemaAgainstRealDolt`. The end-to-end test relied on `bd config set issue_prefix` failing against an empty DB to enter the fall-through, but bd `v1.0.2+` writes to local `config.yaml` regardless and the fast path succeeds. The unit test `TestGcBeadsBdInitFastPathFallsThroughWhenBdConfigSetFails` still guards the script-level argv contract; the version-specific bd behavior is better tracked in a follow-up against bd directly.

## Test plan

- [x] `go vet ./...` clean
- [x] `GC_FAST_UNIT=0 go test ./cmd/gc -count=1 -timeout=900s` passes (full process suite, including the previously-failing `TestLocalInitializerInitScaffoldsAndFinalizes` and `TestGcBeadsBdInitFastPathFallsThroughWhenBdConfigSetFails`)
- [x] `go test ./internal/doctor -count=1` passes (covers new `checks_beads_role.go`)
- [ ] CI (`Integration / packages` and `cmd/gc process suite`) green
- [ ] Manual repro on a fresh user account confirms `gc init` + `gc start` brings up a working city without manual `git config beads.role` / `bd init --prefix` / `gc doctor --fix` steps

cc @csells @dstengle @julianknutsen

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->