### PR TITLE
fix(hooks): forward-only installBeadHooks via version stamps (gc-67p7)

### DIFF
--- a/cmd/gc/hooks.go
+++ b/cmd/gc/hooks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,10 +16,34 @@ var beadHooks = map[string]string{
 	"on_update": "bead.updated",
 }
 
+// hookStampLine returns a version-stamp comment for hook scripts. The stamp
+// embeds the build date and commit so that installBeadHooks can enforce
+// forward-only writes — a stale gc binary will not overwrite hooks installed
+// by a newer binary.
+func hookStampLine() string {
+	return fmt.Sprintf("# gc-hook-stamp: %s %s", date, commit)
+}
+
+// parseHookStampDate extracts the build date from a hook script's stamp line.
+// Returns empty string if no stamp is found.
+func parseHookStampDate(content []byte) string {
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("# gc-hook-stamp: ")) {
+			parts := bytes.Fields(line)
+			if len(parts) >= 3 {
+				return string(parts[2])
+			}
+		}
+	}
+	return ""
+}
+
 // hookScript returns the shell script content for a bd hook that forwards
 // events to the Gas City event log via gc event emit.
 func hookScript(eventType string) string {
 	return fmt.Sprintf(`#!/bin/sh
+%s
 # Installed by gc — forwards bd events to Gas City event log.
 # Args: $1=issue_id  $2=event_type  stdin=issue JSON
 GC_BIN="${GC_BIN:-gc}"
@@ -28,7 +53,7 @@ title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
 (
   "$GC_BIN" event emit %s --subject "$1" --message "$title" --payload "$PAYLOAD" >/dev/null 2>&1 || true
 ) </dev/null >/dev/null 2>&1 &
-`, eventType)
+`, hookStampLine(), eventType)
 }
 
 // closeHookScript returns the on_close hook script. It forwards the
@@ -37,7 +62,8 @@ title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
 // children attached to the closed bead. Workflow-control watches the city
 // event stream directly, so the close hook no longer sends a separate poke.
 func closeHookScript() string {
-	return `#!/bin/sh
+	return fmt.Sprintf(`#!/bin/sh
+%s
 # Installed by gc — forwards bd close events, auto-closes completed convoys,
 # and auto-closes orphaned wisps.
 # Args: $1=issue_id  $2=event_type  stdin=issue JSON
@@ -52,12 +78,13 @@ title=$(echo "$DATA" | grep -o '"title":"[^"]*"' | head -1 | cut -d'"' -f4)
   # Auto-close open molecule/wisp children so they don't outlive the parent.
   "$GC_BIN" wisp autoclose "$1" >/dev/null 2>&1 || true
 ) </dev/null >/dev/null 2>&1 &
-`
+`, hookStampLine())
 }
 
 // installBeadHooks writes bd hook scripts into dir/.beads/hooks/ so that
 // bd mutations (create, close, update) emit events to the Gas City event
-// log. Idempotent — leaves matching hooks in place. Returns nil on success.
+// log. Forward-only — a stale gc binary will not overwrite hooks installed
+// by a newer binary. Returns nil on success.
 func installBeadHooks(dir string) error {
 	hooksDir := filepath.Join(dir, ".beads", "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
@@ -70,6 +97,16 @@ func installBeadHooks(dir string) error {
 		if filename == "on_close" {
 			content = closeHookScript()
 		}
+
+		if existing, err := os.ReadFile(path); err == nil {
+			if date != "unknown" {
+				onDiskDate := parseHookStampDate(existing)
+				if onDiskDate != "" && onDiskDate != "unknown" && date < onDiskDate {
+					continue
+				}
+			}
+		}
+
 		if err := fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, path, []byte(content), 0o755); err != nil {
 			return fmt.Errorf("writing hook %s: %w", filename, err)
 		}

--- a/cmd/gc/hooks_test.go
+++ b/cmd/gc/hooks_test.go
@@ -9,6 +9,148 @@ import (
 	"time"
 )
 
+func TestHookScriptsContainStamp(t *testing.T) {
+	oldDate, oldCommit := date, commit
+	t.Cleanup(func() { date, commit = oldDate, oldCommit })
+
+	date = "2026-04-29T10:00:00Z"
+	commit = "abc1234"
+
+	for name, eventType := range beadHooks {
+		t.Run(name, func(t *testing.T) {
+			var content string
+			if name == "on_close" {
+				content = closeHookScript()
+			} else {
+				content = hookScript(eventType)
+			}
+			if !strings.Contains(content, "# gc-hook-stamp: 2026-04-29T10:00:00Z abc1234") {
+				t.Errorf("hook %s missing stamp line:\n%s", name, content)
+			}
+		})
+	}
+}
+
+func TestParseHookStampDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"with stamp", "#!/bin/sh\n# gc-hook-stamp: 2026-04-29T10:00:00Z abc1234\n", "2026-04-29T10:00:00Z"},
+		{"no stamp", "#!/bin/sh\n# Installed by gc\n", ""},
+		{"empty", "", ""},
+		{"unknown date", "#!/bin/sh\n# gc-hook-stamp: unknown unknown\n", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseHookStampDate([]byte(tt.content))
+			if got != tt.want {
+				t.Errorf("parseHookStampDate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallBeadHooksForwardOnly(t *testing.T) {
+	oldDate, oldCommit := date, commit
+	t.Cleanup(func() { date, commit = oldDate, oldCommit })
+
+	dir := t.TempDir()
+
+	// Install with a "newer" binary.
+	date = "2026-06-01T00:00:00Z"
+	commit = "new1111"
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("newer install: %v", err)
+	}
+
+	path := filepath.Join(dir, ".beads", "hooks", "on_create")
+	newerContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(newerContent), "2026-06-01") {
+		t.Fatalf("newer hook missing expected stamp")
+	}
+
+	// Now run with an "older" binary — should NOT overwrite.
+	date = "2025-01-01T00:00:00Z"
+	commit = "old2222"
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("older install: %v", err)
+	}
+
+	afterContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(newerContent, afterContent) {
+		t.Errorf("stale binary overwrote newer hook.\nwant stamp from 2026-06-01, got:\n%s", afterContent)
+	}
+}
+
+func TestInstallBeadHooksUpgradesLegacyHooks(t *testing.T) {
+	oldDate, oldCommit := date, commit
+	t.Cleanup(func() { date, commit = oldDate, oldCommit })
+
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".beads", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a legacy hook (no stamp).
+	legacy := "#!/bin/sh\n# Installed by gc — old version\necho old\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "on_create"), []byte(legacy), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	date = "2026-01-01T00:00:00Z"
+	commit = "aaa1111"
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("installBeadHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(hooksDir, "on_create"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "gc-hook-stamp") {
+		t.Errorf("legacy hook was not upgraded to stamped version:\n%s", data)
+	}
+}
+
+func TestInstallBeadHooksDevBuildAlwaysWrites(t *testing.T) {
+	oldDate, oldCommit := date, commit
+	t.Cleanup(func() { date, commit = oldDate, oldCommit })
+
+	dir := t.TempDir()
+
+	// Install with a stamped binary.
+	date = "2099-01-01T00:00:00Z"
+	commit = "future1"
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("stamped install: %v", err)
+	}
+
+	// Dev build (unknown date) should still overwrite — dev builds always win.
+	date = "unknown"
+	commit = "unknown"
+	if err := installBeadHooks(dir); err != nil {
+		t.Fatalf("dev install: %v", err)
+	}
+
+	path := filepath.Join(dir, ".beads", "hooks", "on_create")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "gc-hook-stamp: unknown unknown") {
+		t.Errorf("dev build did not overwrite stamped hook:\n%s", data)
+	}
+}
+
 func TestInstallBeadHooksCreatesScripts(t *testing.T) {
 	dir := t.TempDir()
 	if err := installBeadHooks(dir); err != nil {

--- a/engdocs/contributors/stale-worktree-binaries.md
+++ b/engdocs/contributors/stale-worktree-binaries.md
@@ -1,0 +1,54 @@
+# Stale Per-Worktree gc Binaries
+
+## The problem
+
+When git worktrees are created for polecat agents, the `gc` binary
+that created the worktree may be copied into the worktree directory.
+If the canonical `gc` binary is later rebuilt (e.g., `make install`
+from a newer commit), the per-worktree copies are **not** refreshed.
+
+Any `gc` invocation that initializes a bead provider calls
+`installBeadHooks`, which writes hook scripts from templates compiled
+into that specific binary. A stale binary writes old templates,
+silently overwriting hooks installed by the canonical (newer) binary.
+
+## The fix: forward-only hook stamps
+
+Each hook script now contains a version stamp:
+
+```sh
+#!/bin/sh
+# gc-hook-stamp: 2026-04-29T10:01:25Z abc1234
+```
+
+`installBeadHooks` reads the on-disk stamp before writing. If the
+on-disk hook was installed by a newer binary (later build date), the
+write is skipped. This makes hook installation forward-only — stale
+binaries cannot regress hook content.
+
+Rules:
+- Dev builds (`date=unknown`) always write (most permissive for development)
+- Legacy hooks (no stamp) are always upgraded
+- Stamped hooks are only overwritten by equal-or-newer builds
+
+## Remaining gap: stale binaries themselves
+
+The version stamp prevents stale hooks, but stale per-worktree `gc`
+binaries still exist. They will silently use old versions of any
+*other* compiled-in template or behavior. The stamp only protects
+hook scripts.
+
+To fully resolve this, per-worktree `gc` binaries should be either:
+- **Symlinked** to the canonical binary (so `make install` updates them)
+- **Replaced with thin shims** that `exec` the canonical binary
+- **Refreshed** by a post-install step
+
+Until one of these is implemented, `make install` alone does not
+propagate to worktrees. After rebuilding `gc`, manually update or
+remove stale copies:
+
+```bash
+find .gc/worktrees -name gc -type f | while read f; do
+  ln -sf "$(which gc)" "$f"
+done
+```


### PR DESCRIPTION
## Summary

Per-worktree \`gc\` binaries don't get refreshed when the canonical \`gc\` is rebuilt via \`make install\`. When any of those stale binaries runs and triggers \`installBeadHooks\`, it overwrites the on-disk hook script with the OLD template compiled into the stale binary — silently undoing newer hook logic.

This patch makes \`installBeadHooks\` forward-only by version-stamping the hook content. Legacy unstamped hooks are always upgraded; stamped hooks are only overwritten by equal-or-newer builds.

Also adds \`engdocs/contributors/stale-worktree-binaries.md\` documenting the workflow gap and workaround for stale per-worktree gc copies.

## Test plan

- [x] \`go test ./cmd/gc/ -run TestInstallBeadHooks\` passes
- [x] Build clean

Closes gc-67p7. Originally landed as direct-merge \`39022589\` on the boylec fork; this PR upstreams it properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->