### PR TITLE
fix(orders): EvalSymlinks on TempDir for TestCheckTriggerConditionUsesOptions (gc-i3zk)

### DIFF
--- a/internal/orders/triggers_test.go
+++ b/internal/orders/triggers_test.go
@@ -98,7 +98,10 @@ func TestCheckTriggerCondition(t *testing.T) {
 }
 
 func TestCheckTriggerConditionUsesOptions(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	a := Order{
 		Name:    "check",
 		Trigger: "condition",


### PR DESCRIPTION
## Summary

\`TestCheckTriggerConditionUsesOptions\` (\`internal/orders/triggers_test.go\`) fails on macOS.

Root cause: \`t.TempDir()\` returns paths under \`/var/folders/...\` but \`\$(pwd)\` in a subprocess resolves the \`/var → /private/var\` symlink via \`getcwd(2)\`. The test compared the test-supplied path to the shell-output path and they didn't match.

Fix: use \`filepath.EvalSymlinks\` so the expected path matches the shell output. No behavior change on Linux.

## Test plan

- [x] \`go test ./internal/orders/ -run TestCheckTriggerConditionUsesOptions\` passes on macOS
- [ ] CI green on Linux (no behavior change there)

Closes gc-i3zk. Single-bug split out of an earlier shared branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->