### PR TITLE
fix(cmd/gc): EvalSymlinks on TempDir for TestOrderDispatchConditionUsesScopedEnv (gc-q4h)

### DIFF
--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2841,7 +2841,10 @@ func TestOrderDispatchSkipsRigConditionWhenLegacyOpenWorkReadFails(t *testing.T)
 }
 
 func TestOrderDispatchConditionUsesScopedEnv(t *testing.T) {
-	cityDir := t.TempDir()
+	cityDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	store := beads.NewMemStore()
 	check := fmt.Sprintf(
 		`test "$GC_CITY_PATH" = '%s' && test "$GC_STORE_ROOT" = '%s' && test "$GC_STORE_SCOPE" = city && test "$(pwd)" = '%s'`,


### PR DESCRIPTION
## Summary

\`TestOrderDispatchConditionUsesScopedEnv\` (\`cmd/gc/order_dispatch_test.go\`) fails on macOS — same root cause as gc-i3zk.

\`t.TempDir()\` returns paths under \`/var/folders/...\` but \`\$(pwd)\` in a subprocess resolves the \`/var → /private/var\` symlink via \`getcwd(2)\`.

Fix: use \`filepath.EvalSymlinks\` so the expected path matches the shell output. No behavior change on Linux.

## Test plan

- [x] \`go test ./cmd/gc/ -run TestOrderDispatchConditionUsesScopedEnv\` passes on macOS
- [ ] CI green on Linux

Closes gc-q4h. Single-bug split out of an earlier shared branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->