### PR TITLE
fix(handoff): replace select{} with bounded poll loop in cmdHandoff

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -110,8 +113,33 @@ func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdo
 		return 0
 	}
 
-	// Block forever. The controller will kill the entire process tree.
-	select {}
+	// Wait for the controller to act on the restart request. Mirrors the
+	// poll-and-signal loop in doRuntimeRequestRestart (cmd_runtime_drain.go)
+	// so a transient API failure or dead controller doesn't trip Go's
+	// deadlock detector or hang silently. Under normal operation the
+	// controller SIGKILLs the whole process tree before this returns.
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	deadline := time.Now().Add(controllerRestartTimeout(cfg))
+	ticker := time.NewTicker(controllerRestartPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sigCtx.Done():
+			// Signal received; leave the flag set so the controller still acts on its next tick.
+			return 0
+		case <-ticker.C:
+			requested, err := dops.isRestartRequested(current.sessionName)
+			if err == nil && !requested {
+				// Reconciler cleared the flag; restart is in flight.
+				return 0
+			}
+			if time.Now().After(deadline) {
+				fmt.Fprintf(stderr, "gc handoff: controller did not act within %s; check `gc dashboard` or `gc trace`\n", controllerRestartTimeout(cfg)) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
+	}
 }
 
 // cmdHandoffRemote sends handoff mail to a remote session and kills its runtime.

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -37,6 +36,12 @@ For controller-restartable sessions, equivalent to:
 
   gc mail send $GC_ALIAS <subject> [message]
   gc runtime request-restart
+
+Under normal operation the controller stops controller-restartable
+self-handoff sessions before this command returns. If the controller does not
+act within a bounded timeout, gc handoff exits 1 with a diagnostic instead of
+blocking indefinitely. If interrupted, the restart request remains set for the
+controller to process on its next reconcile tick.
 
 Auto handoff (--auto): sends mail to self and returns without requesting a
 restart. This is for PreCompact hooks, where the provider is already managing
@@ -113,33 +118,10 @@ func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdo
 		return 0
 	}
 
-	// Wait for the controller to act on the restart request. Mirrors the
-	// poll-and-signal loop in doRuntimeRequestRestart (cmd_runtime_drain.go)
-	// so a transient API failure or dead controller doesn't trip Go's
-	// deadlock detector or hang silently. Under normal operation the
-	// controller SIGKILLs the whole process tree before this returns.
 	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	deadline := time.Now().Add(controllerRestartTimeout(cfg))
-	ticker := time.NewTicker(controllerRestartPollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-sigCtx.Done():
-			// Signal received; leave the flag set so the controller still acts on its next tick.
-			return 0
-		case <-ticker.C:
-			requested, err := dops.isRestartRequested(current.sessionName)
-			if err == nil && !requested {
-				// Reconciler cleared the flag; restart is in flight.
-				return 0
-			}
-			if time.Now().After(deadline) {
-				fmt.Fprintf(stderr, "gc handoff: controller did not act within %s; check `gc dashboard` or `gc trace`\n", controllerRestartTimeout(cfg)) //nolint:errcheck // best-effort stderr
-				return 1
-			}
-		}
-	}
+	return waitForControllerRestart(sigCtx, dops, current.sessionName, "gc handoff",
+		controllerRestartPollInterval, controllerRestartTimeout(cfg), stderr)
 }
 
 // cmdHandoffRemote sends handoff mail to a remote session and kills its runtime.

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -76,6 +76,98 @@ func TestHandoffSuccess(t *testing.T) {
 	}
 }
 
+func TestWaitForControllerRestartHandoffFlagCleared(t *testing.T) {
+	dops := &drainOpsWithCountdown{fakeDrainOps: newFakeDrainOps(), remaining: 2}
+	if err := dops.setRestartRequested("worker"); err != nil {
+		t.Fatalf("setRestartRequested: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	code := waitForControllerRestart(context.Background(), dops, "worker", "gc handoff",
+		10*time.Millisecond, 5*time.Second, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0 when flag cleared; stderr: %s", code, stderr.String())
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+	if dops.restartRequested["worker"] {
+		t.Error("restart flag should be cleared by the simulated reconciler")
+	}
+}
+
+func TestWaitForControllerRestartHandoffTimeout(t *testing.T) {
+	dops := newFakeDrainOps()
+	if err := dops.setRestartRequested("worker"); err != nil {
+		t.Fatalf("setRestartRequested: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	code := waitForControllerRestart(context.Background(), dops, "worker", "gc handoff",
+		10*time.Millisecond, 25*time.Millisecond, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 on timeout", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "gc handoff: controller did not act within") {
+		t.Errorf("stderr = %q, want handoff timeout diagnostic", got)
+	}
+	if !strings.Contains(stderr.String(), "gc dashboard") {
+		t.Errorf("stderr = %q, want gc dashboard hint", stderr.String())
+	}
+}
+
+func TestWaitForControllerRestartHandoffTimeoutReportsLastPollError(t *testing.T) {
+	dops := newFakeDrainOps()
+	if err := dops.setRestartRequested("worker"); err != nil {
+		t.Fatalf("setRestartRequested: %v", err)
+	}
+	dops.restartReadErr = errors.New("metadata read failed")
+
+	var stderr bytes.Buffer
+	code := waitForControllerRestart(context.Background(), dops, "worker", "gc handoff",
+		10*time.Millisecond, 25*time.Millisecond, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 on timeout", code)
+	}
+	if got := stderr.String(); !strings.Contains(got, "last poll error: metadata read failed") {
+		t.Errorf("stderr = %q, want last poll error", got)
+	}
+}
+
+func TestWaitForControllerRestartHandoffContextCancel(t *testing.T) {
+	dops := newFakeDrainOps()
+	if err := dops.setRestartRequested("worker"); err != nil {
+		t.Fatalf("setRestartRequested: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var stderr bytes.Buffer
+
+	done := make(chan int, 1)
+	go func() {
+		done <- waitForControllerRestart(ctx, dops, "worker", "gc handoff",
+			10*time.Millisecond, 30*time.Second, &stderr)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0 on context cancel", code)
+		}
+		if !dops.restartRequested["worker"] {
+			t.Error("restart flag should remain set after context cancel")
+		}
+		if got := stderr.String(); !strings.Contains(got, "gc handoff: signal received; restart request remains set") {
+			t.Errorf("stderr = %q, want pending restart warning", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForControllerRestart did not exit on context cancel")
+	}
+}
+
 func TestCmdHandoffAutoSendsMailWithoutBlocking(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -496,6 +496,10 @@ func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart 
 	})
 	fmt.Fprintf(stdout, "Restart requested. Waiting up to %s for controller to stop this session...\n", timeout) //nolint:errcheck // best-effort stdout
 
+	return waitForControllerRestart(ctx, dops, sn, "gc runtime request-restart", pollInterval, timeout, stderr)
+}
+
+func waitForControllerRestart(ctx context.Context, dops drainOps, sn, command string, pollInterval, timeout time.Duration, stderr io.Writer) int {
 	deadline := time.Now().Add(timeout)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -505,7 +509,7 @@ func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart 
 		select {
 		case <-ctx.Done():
 			// Signal received; leave the flag set so the controller still acts on its next tick.
-			fmt.Fprintln(stderr, "gc runtime request-restart: signal received; restart request remains set; controller will stop this session on its next reconcile tick") //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "%s: signal received; restart request remains set; controller will stop this session on its next reconcile tick\n", command) //nolint:errcheck // best-effort stderr
 			return 0
 		case <-ticker.C:
 			requested, err := dops.isRestartRequested(sn)
@@ -520,9 +524,9 @@ func doRuntimeRequestRestart(ctx context.Context, dops drainOps, persistRestart 
 			}
 			if time.Now().After(deadline) {
 				if lastPollErr != nil {
-					fmt.Fprintf(stderr, "gc runtime request-restart: controller did not act within %s; last poll error: %v; check `gc dashboard` or `gc trace`\n", timeout, lastPollErr) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: controller did not act within %s; last poll error: %v; check `gc dashboard` or `gc trace`\n", command, timeout, lastPollErr) //nolint:errcheck // best-effort stderr
 				} else {
-					fmt.Fprintf(stderr, "gc runtime request-restart: controller did not act within %s; check `gc dashboard` or `gc trace`\n", timeout) //nolint:errcheck // best-effort stderr
+					fmt.Fprintf(stderr, "%s: controller did not act within %s; check `gc dashboard` or `gc trace`\n", command, timeout) //nolint:errcheck // best-effort stderr
 				}
 				return 1
 			}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1148,6 +1148,12 @@ For controller-restartable sessions, equivalent to:
   gc mail send $GC_ALIAS &lt;subject&gt; [message]
   gc runtime request-restart
 
+Under normal operation the controller stops controller-restartable
+self-handoff sessions before this command returns. If the controller does not
+act within a bounded timeout, gc handoff exits 1 with a diagnostic instead of
+blocking indefinitely. If interrupted, the restart request remains set for the
+controller to process on its next reconcile tick.
+
 Auto handoff (--auto): sends mail to self and returns without requesting a
 restart. This is for PreCompact hooks, where the provider is already managing
 the context compaction lifecycle.


### PR DESCRIPTION
## Summary

**⚠️ Stacks on PR #1414** (`fix/runtime-request-restart-deadlock`). Will not cleanly merge until #1414 lands — at that point this PR's diff reduces to just the `cmd_handoff.go` change.

`cmdHandoff` had the same anti-pattern that PR #1414 fixed in `doRuntimeRequestRestart`: `select {}` to block forever waiting for the controller to kill the process tree. A transient API failure or dead controller would hang silently (or trip Go's deadlock detector when goroutines exited).

This patch ports the same poll-and-signal loop into `cmdHandoff` so it exits cleanly on signal or timeout.

## Test plan

- [x] `go build ./cmd/gc/...` clean

Cherry-picked / re-applied from local WIP. Companion to PR #1414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->