### PR TITLE
fix(doctor): warn on bloated worktrees and prune safe nested ones (#1326)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -215,6 +215,10 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	d.Register(doctor.NewScopedDoltVersionCheckForConfig(cityPath, skipManagedDoltCheck, cfg, cfgErr))
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
+	if cfgErr == nil {
+		d.Register(doctor.NewWorktreeDiskSizeCheck(cfg.Doctor))
+		d.Register(doctor.NewNestedWorktreePruneCheck(cfg.Doctor))
+	}
 
 	// Custom types check — city store.
 	d.Register(doctor.NewCustomTypesCheck(cityPath, "city"))

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -215,10 +215,16 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	d.Register(doctor.NewScopedDoltVersionCheckForConfig(cityPath, skipManagedDoltCheck, cfg, cfgErr))
 	d.Register(&doctor.EventsLogCheck{})
 	d.Register(doctor.NewEventLogSizeCheck())
-	if cfgErr == nil {
-		d.Register(doctor.NewWorktreeDiskSizeCheck(cfg.Doctor))
-		d.Register(doctor.NewNestedWorktreePruneCheck(cfg.Doctor))
+	// Worktree checks deliberately run even when cfgErr != nil — they
+	// only need the city path, and a broken city.toml is exactly when
+	// silent disk-fill is most likely. The zero-value DoctorConfig
+	// produces sensible 10/50 GB defaults via its accessor methods.
+	var doctorCfg config.DoctorConfig
+	if cfg != nil {
+		doctorCfg = cfg.Doctor
 	}
+	d.Register(doctor.NewWorktreeDiskSizeCheck(doctorCfg))
+	d.Register(doctor.NewNestedWorktreePruneCheck(doctorCfg))
 
 	// Custom types check — city store.
 	d.Register(doctor.NewCustomTypesCheck(cityPath, "city"))

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -31,6 +31,7 @@ City is the top-level configuration for a Gas City instance.
 | `chat_sessions` | ChatSessionsConfig |  |  | ChatSessions configures chat session behavior (auto-suspend). |
 | `session_sleep` | SessionSleepConfig |  |  | SessionSleep configures idle sleep policy defaults for managed sessions. |
 | `convergence` | ConvergenceConfig |  |  | Convergence configures convergence loop limits. |
+| `doctor` | DoctorConfig |  |  | Doctor configures gc doctor thresholds and policy toggles (worktree size warnings, nested-worktree auto-prune). |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
 | `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies default_sling_formula and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
 
@@ -268,6 +269,16 @@ DaemonConfig holds controller daemon settings.
 | `observe_paths` | []string |  |  | ObservePaths lists extra directories to search for Claude JSONL session files (e.g., aimux session paths). The default search path (~/.claude/projects/) is always included. |
 | `probe_concurrency` | integer |  | `8` | ProbeConcurrency bounds the number of concurrent bd subprocess probes issued by the pool scale_check and work_query paths. bd serializes on a shared dolt sql-server, so unbounded parallelism causes contention. Nil (unset) defaults to 8. Set higher for workspaces with a fast dedicated dolt server, or lower to reduce contention on slow storage. |
 | `max_wakes_per_tick` | integer |  | `5` | MaxWakesPerTick caps how many sessions the reconciler may start in a single tick. Nil (unset) defaults to 5. Values &lt;= 0 are treated as the default — set a positive integer to override. |
+
+## DoctorConfig
+
+DoctorConfig holds settings for the gc doctor surface.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `worktree_rig_warn_size` | string |  | `10GB` | WorktreeRigWarnSize is the per-rig warning threshold for the total disk footprint under .gc/worktrees/&lt;rig&gt;/. Reported by the worktree-disk-size check. Go-style human size string ("10GB", "500MB"). Empty or unparseable falls back to the default (10 GB). |
+| `worktree_rig_error_size` | string |  | `50GB` | WorktreeRigErrorSize is the per-rig error threshold. When any rig exceeds this, the worktree-disk-size check reports an error rather than a warning. Empty or unparseable falls back to the default (50 GB). |
+| `nested_worktree_prune` | boolean |  | `false` | NestedWorktreePrune enables the nested-worktree-prune check to remove safely-prunable nested worktrees on every doctor run, not just under --fix. Safety is enforced by mechanical checks (no uncommitted changes, no unpushed commits, no stashes) — never by role identity. Default false: doctor reports findings but only removes them under --fix. |
 
 ## DoltConfig
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -278,7 +278,7 @@ DoctorConfig holds settings for the gc doctor surface.
 |-------|------|----------|---------|-------------|
 | `worktree_rig_warn_size` | string |  | `10GB` | WorktreeRigWarnSize is the per-rig warning threshold for the total disk footprint under .gc/worktrees/&lt;rig&gt;/. Reported by the worktree-disk-size check. Go-style human size string ("10GB", "500MB"). Empty or unparseable falls back to the default (10 GB). |
 | `worktree_rig_error_size` | string |  | `50GB` | WorktreeRigErrorSize is the per-rig error threshold. When any rig exceeds this, the worktree-disk-size check reports an error rather than a warning. Empty or unparseable falls back to the default (50 GB). |
-| `nested_worktree_prune` | boolean |  | `false` | NestedWorktreePrune enables the nested-worktree-prune check to remove safely-prunable nested worktrees on every doctor run, not just under --fix. Safety is enforced by mechanical checks (no uncommitted changes, no unpushed commits, no stashes) — never by role identity. Default false: doctor reports findings but only removes them under --fix. |
+| `nested_worktree_prune` | boolean |  | `false` | NestedWorktreePrune escalates the nested-worktree-prune check from warning to error severity when safely-prunable nested worktrees are present, so CI / scripted doctor runs fail until the operator runs `gc doctor --fix`. Actual removal still requires --fix; this flag does not auto-prune. Safety is enforced by mechanical checks (no uncommitted changes, no unpushed commits, no stashes) — never by role identity. |
 
 ## DoltConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1103,7 +1103,7 @@
         },
         "nested_worktree_prune": {
           "type": "boolean",
-          "description": "NestedWorktreePrune enables the nested-worktree-prune check to\nremove safely-prunable nested worktrees on every doctor run, not\njust under --fix. Safety is enforced by mechanical checks\n(no uncommitted changes, no unpushed commits, no stashes) — never\nby role identity. Default false: doctor reports findings but only\nremoves them under --fix.",
+          "description": "NestedWorktreePrune escalates the nested-worktree-prune check\nfrom warning to error severity when safely-prunable nested\nworktrees are present, so CI / scripted doctor runs fail until\nthe operator runs `gc doctor --fix`. Actual removal still\nrequires --fix; this flag does not auto-prune. Safety is\nenforced by mechanical checks (no uncommitted changes, no\nunpushed commits, no stashes) — never by role identity.",
           "default": false
         }
       },

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -983,6 +983,10 @@
           "$ref": "#/$defs/ConvergenceConfig",
           "description": "Convergence configures convergence loop limits."
         },
+        "doctor": {
+          "$ref": "#/$defs/DoctorConfig",
+          "description": "Doctor configures gc doctor thresholds and policy toggles\n(worktree size warnings, nested-worktree auto-prune)."
+        },
         "service": {
           "items": {
             "$ref": "#/$defs/Service"
@@ -1084,6 +1088,28 @@
       "additionalProperties": false,
       "type": "object",
       "description": "DaemonConfig holds controller daemon settings."
+    },
+    "DoctorConfig": {
+      "properties": {
+        "worktree_rig_warn_size": {
+          "type": "string",
+          "description": "WorktreeRigWarnSize is the per-rig warning threshold for the total\ndisk footprint under .gc/worktrees/\u003crig\u003e/. Reported by the\nworktree-disk-size check. Go-style human size string (\"10GB\", \"500MB\").\nEmpty or unparseable falls back to the default (10 GB).",
+          "default": "10GB"
+        },
+        "worktree_rig_error_size": {
+          "type": "string",
+          "description": "WorktreeRigErrorSize is the per-rig error threshold. When any rig\nexceeds this, the worktree-disk-size check reports an error rather\nthan a warning. Empty or unparseable falls back to the default\n(50 GB).",
+          "default": "50GB"
+        },
+        "nested_worktree_prune": {
+          "type": "boolean",
+          "description": "NestedWorktreePrune enables the nested-worktree-prune check to\nremove safely-prunable nested worktrees on every doctor run, not\njust under --fix. Safety is enforced by mechanical checks\n(no uncommitted changes, no unpushed commits, no stashes) — never\nby role identity. Default false: doctor reports findings but only\nremoves them under --fix.",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DoctorConfig holds settings for the gc doctor surface."
     },
     "DoltConfig": {
       "properties": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1103,7 +1103,7 @@
         },
         "nested_worktree_prune": {
           "type": "boolean",
-          "description": "NestedWorktreePrune enables the nested-worktree-prune check to\nremove safely-prunable nested worktrees on every doctor run, not\njust under --fix. Safety is enforced by mechanical checks\n(no uncommitted changes, no unpushed commits, no stashes) — never\nby role identity. Default false: doctor reports findings but only\nremoves them under --fix.",
+          "description": "NestedWorktreePrune escalates the nested-worktree-prune check\nfrom warning to error severity when safely-prunable nested\nworktrees are present, so CI / scripted doctor runs fail until\nthe operator runs `gc doctor --fix`. Actual removal still\nrequires --fix; this flag does not auto-prune. Safety is\nenforced by mechanical checks (no uncommitted changes, no\nunpushed commits, no stashes) — never by role identity.",
           "default": false
         }
       },

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -983,6 +983,10 @@
           "$ref": "#/$defs/ConvergenceConfig",
           "description": "Convergence configures convergence loop limits."
         },
+        "doctor": {
+          "$ref": "#/$defs/DoctorConfig",
+          "description": "Doctor configures gc doctor thresholds and policy toggles\n(worktree size warnings, nested-worktree auto-prune)."
+        },
         "service": {
           "items": {
             "$ref": "#/$defs/Service"
@@ -1084,6 +1088,28 @@
       "additionalProperties": false,
       "type": "object",
       "description": "DaemonConfig holds controller daemon settings."
+    },
+    "DoctorConfig": {
+      "properties": {
+        "worktree_rig_warn_size": {
+          "type": "string",
+          "description": "WorktreeRigWarnSize is the per-rig warning threshold for the total\ndisk footprint under .gc/worktrees/\u003crig\u003e/. Reported by the\nworktree-disk-size check. Go-style human size string (\"10GB\", \"500MB\").\nEmpty or unparseable falls back to the default (10 GB).",
+          "default": "10GB"
+        },
+        "worktree_rig_error_size": {
+          "type": "string",
+          "description": "WorktreeRigErrorSize is the per-rig error threshold. When any rig\nexceeds this, the worktree-disk-size check reports an error rather\nthan a warning. Empty or unparseable falls back to the default\n(50 GB).",
+          "default": "50GB"
+        },
+        "nested_worktree_prune": {
+          "type": "boolean",
+          "description": "NestedWorktreePrune enables the nested-worktree-prune check to\nremove safely-prunable nested worktrees on every doctor run, not\njust under --fix. Safety is enforced by mechanical checks\n(no uncommitted changes, no unpushed commits, no stashes) — never\nby role identity. Default false: doctor reports findings but only\nremoves them under --fix.",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DoctorConfig holds settings for the gc doctor surface."
     },
     "DoltConfig": {
       "properties": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1212,12 +1212,13 @@ type DoctorConfig struct {
 	// (50 GB).
 	WorktreeRigErrorSize string `toml:"worktree_rig_error_size,omitempty" jsonschema:"default=50GB"`
 
-	// NestedWorktreePrune enables the nested-worktree-prune check to
-	// remove safely-prunable nested worktrees on every doctor run, not
-	// just under --fix. Safety is enforced by mechanical checks
-	// (no uncommitted changes, no unpushed commits, no stashes) — never
-	// by role identity. Default false: doctor reports findings but only
-	// removes them under --fix.
+	// NestedWorktreePrune escalates the nested-worktree-prune check
+	// from warning to error severity when safely-prunable nested
+	// worktrees are present, so CI / scripted doctor runs fail until
+	// the operator runs `gc doctor --fix`. Actual removal still
+	// requires --fix; this flag does not auto-prune. Safety is
+	// enforced by mechanical checks (no uncommitted changes, no
+	// unpushed commits, no stashes) — never by role identity.
 	NestedWorktreePrune bool `toml:"nested_worktree_prune,omitempty" jsonschema:"default=false"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -171,6 +172,9 @@ type City struct {
 	SessionSleep SessionSleepConfig `toml:"session_sleep,omitempty"`
 	// Convergence configures convergence loop limits.
 	Convergence ConvergenceConfig `toml:"convergence,omitempty"`
+	// Doctor configures gc doctor thresholds and policy toggles
+	// (worktree size warnings, nested-worktree auto-prune).
+	Doctor DoctorConfig `toml:"doctor,omitempty"`
 	// Services declares workspace-owned HTTP services mounted on the
 	// controller edge under /svc/{name}.
 	Services []Service `toml:"service,omitempty"`
@@ -1189,6 +1193,94 @@ func (c ChatSessionsConfig) IdleTimeoutDuration() time.Duration {
 		return 0
 	}
 	return d
+}
+
+// DoctorConfig holds settings for the gc doctor surface. Operator-tunable
+// thresholds and policy toggles live here; mechanical structural checks
+// (broken-worktree pointers, missing files) remain hardcoded since they
+// cannot be operator-tuned in any meaningful sense.
+type DoctorConfig struct {
+	// WorktreeRigWarnSize is the per-rig warning threshold for the total
+	// disk footprint under .gc/worktrees/<rig>/. Reported by the
+	// worktree-disk-size check. Go-style human size string ("10GB", "500MB").
+	// Empty or unparseable falls back to the default (10 GB).
+	WorktreeRigWarnSize string `toml:"worktree_rig_warn_size,omitempty" jsonschema:"default=10GB"`
+
+	// WorktreeRigErrorSize is the per-rig error threshold. When any rig
+	// exceeds this, the worktree-disk-size check reports an error rather
+	// than a warning. Empty or unparseable falls back to the default
+	// (50 GB).
+	WorktreeRigErrorSize string `toml:"worktree_rig_error_size,omitempty" jsonschema:"default=50GB"`
+
+	// NestedWorktreePrune enables the nested-worktree-prune check to
+	// remove safely-prunable nested worktrees on every doctor run, not
+	// just under --fix. Safety is enforced by mechanical checks
+	// (no uncommitted changes, no unpushed commits, no stashes) — never
+	// by role identity. Default false: doctor reports findings but only
+	// removes them under --fix.
+	NestedWorktreePrune bool `toml:"nested_worktree_prune,omitempty" jsonschema:"default=false"`
+}
+
+const (
+	defaultWorktreeRigWarnBytes  = int64(10) * 1024 * 1024 * 1024 // 10 GB
+	defaultWorktreeRigErrorBytes = int64(50) * 1024 * 1024 * 1024 // 50 GB
+)
+
+// WorktreeRigWarnBytes returns the warning threshold in bytes. Falls
+// back to defaultWorktreeRigWarnBytes when unset, unparseable, or
+// non-positive.
+func (c DoctorConfig) WorktreeRigWarnBytes() int64 {
+	if n, ok := parseHumanSize(c.WorktreeRigWarnSize); ok && n > 0 {
+		return n
+	}
+	return defaultWorktreeRigWarnBytes
+}
+
+// WorktreeRigErrorBytes returns the error threshold in bytes. Falls
+// back to defaultWorktreeRigErrorBytes when unset, unparseable, or
+// non-positive. The error threshold is clamped to at least the warn
+// threshold to keep the two-tier semantics monotonic; if the operator
+// configures error < warn, the warn value wins.
+func (c DoctorConfig) WorktreeRigErrorBytes() int64 {
+	warn := c.WorktreeRigWarnBytes()
+	n, ok := parseHumanSize(c.WorktreeRigErrorSize)
+	if !ok || n <= 0 {
+		n = defaultWorktreeRigErrorBytes
+	}
+	if n < warn {
+		return warn
+	}
+	return n
+}
+
+// parseHumanSize parses sizes like "10GB", "500 MB", "1024" (bytes
+// implied) into a byte count. Whitespace tolerant, case-insensitive.
+// Returns ok=false when the string is empty or unparseable so callers
+// can apply their own default.
+func parseHumanSize(s string) (int64, bool) {
+	s = strings.TrimSpace(strings.ToUpper(s))
+	if s == "" {
+		return 0, false
+	}
+	var unit int64 = 1
+	switch {
+	case strings.HasSuffix(s, "GB"):
+		unit = 1024 * 1024 * 1024
+		s = strings.TrimSpace(strings.TrimSuffix(s, "GB"))
+	case strings.HasSuffix(s, "MB"):
+		unit = 1024 * 1024
+		s = strings.TrimSpace(strings.TrimSuffix(s, "MB"))
+	case strings.HasSuffix(s, "KB"):
+		unit = 1024
+		s = strings.TrimSpace(strings.TrimSuffix(s, "KB"))
+	case strings.HasSuffix(s, "B"):
+		s = strings.TrimSpace(strings.TrimSuffix(s, "B"))
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n * unit, true
 }
 
 // ConvergenceConfig holds convergence loop limits.

--- a/internal/config/doctor_config_test.go
+++ b/internal/config/doctor_config_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseDoctorSection(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[doctor]
+worktree_rig_warn_size = "5GB"
+worktree_rig_error_size = "30GB"
+nested_worktree_prune = true
+
+[[agent]]
+name = "mayor"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.Doctor.WorktreeRigWarnSize != "5GB" {
+		t.Errorf("WorktreeRigWarnSize = %q, want %q", cfg.Doctor.WorktreeRigWarnSize, "5GB")
+	}
+	if cfg.Doctor.WorktreeRigErrorSize != "30GB" {
+		t.Errorf("WorktreeRigErrorSize = %q, want %q", cfg.Doctor.WorktreeRigErrorSize, "30GB")
+	}
+	if !cfg.Doctor.NestedWorktreePrune {
+		t.Error("NestedWorktreePrune = false, want true")
+	}
+}
+
+func TestParseNoDoctorSection(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.Doctor.WorktreeRigWarnSize != "" || cfg.Doctor.WorktreeRigErrorSize != "" {
+		t.Errorf("Doctor section should be zero-valued; got %+v", cfg.Doctor)
+	}
+	if cfg.Doctor.NestedWorktreePrune {
+		t.Error("NestedWorktreePrune defaults to true; want false")
+	}
+
+	// Unset Doctor must still return real defaults via accessor methods.
+	if got := cfg.Doctor.WorktreeRigWarnBytes(); got != defaultWorktreeRigWarnBytes {
+		t.Errorf("WorktreeRigWarnBytes() = %d, want %d", got, defaultWorktreeRigWarnBytes)
+	}
+	if got := cfg.Doctor.WorktreeRigErrorBytes(); got != defaultWorktreeRigErrorBytes {
+		t.Errorf("WorktreeRigErrorBytes() = %d, want %d", got, defaultWorktreeRigErrorBytes)
+	}
+}
+
+func TestMarshalOmitsEmptyDoctorSection(t *testing.T) {
+	c := DefaultCity("test")
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "[doctor]") {
+		t.Errorf("Marshal output should not contain '[doctor]' when empty:\n%s", data)
+	}
+}
+
+func TestDoctorConfigByteAccessors(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       DoctorConfig
+		wantWarn  int64
+		wantError int64
+	}{
+		{
+			name:      "empty falls back to defaults",
+			cfg:       DoctorConfig{},
+			wantWarn:  defaultWorktreeRigWarnBytes,
+			wantError: defaultWorktreeRigErrorBytes,
+		},
+		{
+			name:      "explicit GB values",
+			cfg:       DoctorConfig{WorktreeRigWarnSize: "5GB", WorktreeRigErrorSize: "20GB"},
+			wantWarn:  5 * 1024 * 1024 * 1024,
+			wantError: 20 * 1024 * 1024 * 1024,
+		},
+		{
+			name:      "MB and KB units",
+			cfg:       DoctorConfig{WorktreeRigWarnSize: "500MB", WorktreeRigErrorSize: "2048MB"},
+			wantWarn:  500 * 1024 * 1024,
+			wantError: 2048 * 1024 * 1024,
+		},
+		{
+			name:      "unparseable warn falls back to default; error still parses",
+			cfg:       DoctorConfig{WorktreeRigWarnSize: "junk", WorktreeRigErrorSize: "100GB"},
+			wantWarn:  defaultWorktreeRigWarnBytes,
+			wantError: 100 * 1024 * 1024 * 1024,
+		},
+		{
+			name:      "error < warn is clamped up to warn (monotonic)",
+			cfg:       DoctorConfig{WorktreeRigWarnSize: "10GB", WorktreeRigErrorSize: "1GB"},
+			wantWarn:  10 * 1024 * 1024 * 1024,
+			wantError: 10 * 1024 * 1024 * 1024,
+		},
+		{
+			name:      "negative or zero bytes treated as unset",
+			cfg:       DoctorConfig{WorktreeRigWarnSize: "0GB", WorktreeRigErrorSize: "0"},
+			wantWarn:  defaultWorktreeRigWarnBytes,
+			wantError: defaultWorktreeRigErrorBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.WorktreeRigWarnBytes(); got != tt.wantWarn {
+				t.Errorf("WorktreeRigWarnBytes() = %d, want %d", got, tt.wantWarn)
+			}
+			if got := tt.cfg.WorktreeRigErrorBytes(); got != tt.wantError {
+				t.Errorf("WorktreeRigErrorBytes() = %d, want %d", got, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestParseHumanSize(t *testing.T) {
+	tests := []struct {
+		input  string
+		want   int64
+		wantOK bool
+	}{
+		{"", 0, false},
+		{"   ", 0, false},
+		{"junk", 0, false},
+		{"10", 10, true},        // bytes implied
+		{"1024B", 1024, true},   // explicit B suffix
+		{"1KB", 1024, true},
+		{"5 mb", 5 * 1024 * 1024, true},  // case-insensitive, whitespace tolerant
+		{"  10gb ", 10 * 1024 * 1024 * 1024, true},
+		{"-5GB", -5 * 1024 * 1024 * 1024, true}, // accessor treats negative as unset; parser is permissive
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := parseHumanSize(tt.input)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v (input %q)", ok, tt.wantOK, tt.input)
+			}
+			if got != tt.want {
+				t.Errorf("value = %d, want %d (input %q)", got, tt.want, tt.input)
+			}
+		})
+	}
+}

--- a/internal/config/doctor_config_test.go
+++ b/internal/config/doctor_config_test.go
@@ -138,10 +138,10 @@ func TestParseHumanSize(t *testing.T) {
 		{"", 0, false},
 		{"   ", 0, false},
 		{"junk", 0, false},
-		{"10", 10, true},        // bytes implied
-		{"1024B", 1024, true},   // explicit B suffix
+		{"10", 10, true},      // bytes implied
+		{"1024B", 1024, true}, // explicit B suffix
 		{"1KB", 1024, true},
-		{"5 mb", 5 * 1024 * 1024, true},  // case-insensitive, whitespace tolerant
+		{"5 mb", 5 * 1024 * 1024, true}, // case-insensitive, whitespace tolerant
 		{"  10gb ", 10 * 1024 * 1024 * 1024, true},
 		{"-5GB", -5 * 1024 * 1024 * 1024, true}, // accessor treats negative as unset; parser is permissive
 	}

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -275,7 +275,7 @@ func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
 	errBytes := c.cfg.WorktreeRigErrorBytes()
 
 	var details []string
-	var status CheckStatus = StatusOK
+	status := StatusOK
 	for _, s := range sizes {
 		switch {
 		case s.bytes >= errBytes:

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -254,11 +255,15 @@ func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	if len(sizes) == 0 {
-		r.Status = StatusOK
 		if len(measureErrs) > 0 {
-			r.Message = "no rig worktree directories measurable"
+			// "We can't tell" must not look like "we're fine". Matches
+			// DoltNomsSize's policy of escalating on measurement failure.
+			r.Status = StatusWarning
+			r.Message = "could not measure any rig worktree directory"
 			r.Details = measureErrs
+			r.FixHint = "check filesystem permissions on .gc/worktrees/<rig>/"
 		} else {
+			r.Status = StatusOK
 			r.Message = "no rig worktree directories"
 		}
 		return r
@@ -492,21 +497,25 @@ func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
 // CanFix returns true — Fix removes the safely-prunable findings.
 func (c *NestedWorktreePruneCheck) CanFix() bool { return true }
 
-// Fix removes each safely-prunable nested worktree found by Run. Stops
-// on first failure so the caller sees a clear error rather than partial
-// state with a vague aggregate. Worktrees marked unsafe (uncommitted /
-// unpushed / stashed) are never touched.
+// Fix removes each safely-prunable nested worktree found by Run.
+// Continues past per-entry failures so a single locked or transiently
+// broken worktree does not strand the rest — operators run --fix to
+// reclaim disk, and partial success is more useful than zero progress.
+// Returns the joined errors of all failed removals, or nil on full
+// success. Worktrees marked unsafe (uncommitted / unpushed / stashed)
+// are never touched.
 func (c *NestedWorktreePruneCheck) Fix(_ *CheckContext) error {
+	var errs []error
 	for _, f := range c.findings {
 		if !f.safeToRm {
 			continue
 		}
 		gw := c.newGit(f.path)
 		if err := gw.WorktreeRemove(f.path, true); err != nil {
-			return fmt.Errorf("removing nested worktree %s: %w", f.path, err)
+			errs = append(errs, fmt.Errorf("removing nested worktree %s: %w", f.path, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // classifyNested runs the safety gates on a candidate nested worktree
@@ -557,8 +566,12 @@ func readGitAdminDir(home string) string {
 		return ""
 	}
 	target := pathutil.NormalizePathForCompare(strings.TrimPrefix(line, prefix))
+	// The admin-dir's "/worktrees/" segment is always the last one in
+	// the gitdir path: <admin>/worktrees/<name>. Using LastIndex keeps
+	// the dedup correct when the repo's own path contains a literal
+	// "/worktrees/" segment (e.g. /x/worktrees/y/.git/worktrees/wt).
 	const sep = string(filepath.Separator) + "worktrees" + string(filepath.Separator)
-	if i := strings.Index(target, sep); i > 0 {
+	if i := strings.LastIndex(target, sep); i > 0 {
 		return target[:i]
 	}
 	return target

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -308,6 +308,9 @@ func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
 	for _, e := range measureErrs {
 		details = append(details, "measure error: "+e)
 	}
+	if len(measureErrs) > 0 && status < StatusWarning {
+		status = StatusWarning
+	}
 
 	r.Status = status
 	switch status {
@@ -317,10 +320,16 @@ func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
 		r.Details = details
 		r.FixHint = "investigate .gc/worktrees/<rig>/ for build-artifact accumulation; consider routing builds out of worktrees, periodic clean steps, or running `gc doctor --fix` to remove safely-prunable nested worktrees"
 	case StatusWarning:
-		r.Message = fmt.Sprintf("%d rig(s) approaching worktree size limit (largest: %q at %s)",
-			overThreshold, sizes[0].name, humanSize(sizes[0].bytes))
+		if overThreshold > 0 {
+			r.Message = fmt.Sprintf("%d rig(s) approaching worktree size limit (largest: %q at %s)",
+				overThreshold, sizes[0].name, humanSize(sizes[0].bytes))
+			r.FixHint = "see fix hint for nested-worktree-prune; tune [doctor].worktree_rig_warn_size if 10 GB is too tight for this install"
+		} else {
+			r.Message = fmt.Sprintf("could not measure %d rig worktree path(s) (largest measured: %q at %s)",
+				len(measureErrs), sizes[0].name, humanSize(sizes[0].bytes))
+			r.FixHint = "check filesystem permissions on .gc/worktrees/<rig>/"
+		}
 		r.Details = details
-		r.FixHint = "see fix hint for nested-worktree-prune; tune [doctor].worktree_rig_warn_size if 10 GB is too tight for this install"
 	default:
 		// All under thresholds: report the worst rig as info.
 		r.Message = fmt.Sprintf("largest rig worktree: %q at %s (under %s warn)",
@@ -346,6 +355,7 @@ type nestedWorktreeFinding struct {
 	parent   string // agent home that contains it
 	branch   string // branch name (best-effort; empty for detached)
 	reason   string // why it was rejected (empty if safe)
+	probeErr bool   // rejected because a safety probe failed
 	safeToRm bool
 }
 
@@ -356,8 +366,8 @@ type gitWorktree interface {
 	IsRepo() bool
 	WorktreeList() ([]git.Worktree, error)
 	HasUncommittedWork() bool
-	HasUnpushedCommits() bool
-	HasStashes() bool
+	HasUnpushedCommitsResult() (bool, error)
+	HasStashesResult() (bool, error)
 	WorktreeRemove(path string, force bool) error
 }
 
@@ -509,11 +519,15 @@ func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	var safe, unsafe []string
+	var probeErrs int
 	for _, f := range c.findings {
 		line := fmt.Sprintf("%s (branch %q)", f.path, f.branch)
 		if f.safeToRm {
 			safe = append(safe, line)
 		} else {
+			if f.probeErr {
+				probeErrs++
+			}
 			unsafe = append(unsafe, fmt.Sprintf("%s — %s", line, f.reason))
 		}
 	}
@@ -524,9 +538,15 @@ func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
 	details = append(details, listingErrs...)
 
 	if len(safe) == 0 {
-		r.Status = StatusOK
-		r.Message = fmt.Sprintf("%d nested worktree(s); none safely prunable",
-			len(c.findings))
+		if len(listingErrs) > 0 || probeErrs > 0 {
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("%d nested worktree(s); none safely prunable; %d inspection failure(s)",
+				len(c.findings), len(listingErrs)+probeErrs)
+		} else {
+			r.Status = StatusOK
+			r.Message = fmt.Sprintf("%d nested worktree(s); none safely prunable",
+				len(c.findings))
+		}
 		details = append(details, unsafe...)
 		r.Details = details
 		return r
@@ -566,6 +586,15 @@ func (c *NestedWorktreePruneCheck) Fix(_ *CheckContext) error {
 		// being removed: git refuses to remove a worktree whose path
 		// equals cwd in some configurations, and operating from cwd of
 		// a directory we're about to delete is fragile in general.
+		current := classifyNested(c.newGit, f.path, f.parent, f.branch)
+		if !current.safeToRm {
+			reason := current.reason
+			if reason == "" {
+				reason = "safety revalidation failed"
+			}
+			errs = append(errs, fmt.Errorf("nested worktree %s no longer safe to remove: %s", f.path, reason))
+			continue
+		}
 		gw := c.newGit(f.parent)
 		if err := gw.WorktreeRemove(f.path, true); err != nil {
 			errs = append(errs, fmt.Errorf("removing nested worktree %s: %w", f.path, err))
@@ -578,10 +607,8 @@ func (c *NestedWorktreePruneCheck) Fix(_ *CheckContext) error {
 // and returns a finding describing whether it is safe to remove and,
 // if not, the first reason it was rejected. Order of checks matches
 // the user's manual recovery procedure: probe git, then status, log,
-// stash. The IsRepo probe defends against fail-open semantics in
-// HasUnpushedCommits / HasStashes (which return false on git error);
-// without it, a corrupt admin dir on the candidate would let all
-// safety gates pass.
+// stash. Any probe error rejects the candidate with a visible reason:
+// "can't tell" is not safe enough for a destructive fix.
 func classifyNested(newGit func(string) gitWorktree, path, parent, branch string) nestedWorktreeFinding {
 	f := nestedWorktreeFinding{path: path, parent: parent, branch: branch}
 	gw := newGit(path)
@@ -593,11 +620,23 @@ func classifyNested(newGit func(string) gitWorktree, path, parent, branch string
 		f.reason = "has uncommitted changes"
 		return f
 	}
-	if gw.HasUnpushedCommits() {
+	hasUnpushed, err := gw.HasUnpushedCommitsResult()
+	if err != nil {
+		f.reason = fmt.Sprintf("unpushed commit probe failed: %v", err)
+		f.probeErr = true
+		return f
+	}
+	if hasUnpushed {
 		f.reason = "has unpushed commits"
 		return f
 	}
-	if gw.HasStashes() {
+	hasStashes, err := gw.HasStashesResult()
+	if err != nil {
+		f.reason = fmt.Sprintf("stash probe failed: %v", err)
+		f.probeErr = true
+		return f
+	}
+	if hasStashes {
 		f.reason = "has stashed work"
 		return f
 	}

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -207,7 +207,17 @@ type WorktreeDiskSizeCheck struct {
 // The cfg is read for thresholds and policy at Run time, so reload-time
 // changes propagate naturally.
 func NewWorktreeDiskSizeCheck(cfg config.DoctorConfig) *WorktreeDiskSizeCheck {
-	return &WorktreeDiskSizeCheck{cfg: cfg, measureDir: duDirBytes}
+	// Wrap duDirBytes so its dolt-flavored error messages
+	// ("measure dolt data dir: ...") get re-tagged as worktree
+	// measurement failures when surfaced through this check.
+	measure := func(path string) (int64, bool, error) {
+		n, ok, err := duDirBytes(path)
+		if err != nil {
+			return n, ok, fmt.Errorf("measure worktree dir %q: %w", path, err)
+		}
+		return n, ok, nil
+	}
+	return &WorktreeDiskSizeCheck{cfg: cfg, measureDir: measure}
 }
 
 // Name returns the check identifier.
@@ -275,18 +285,21 @@ func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
 	errBytes := c.cfg.WorktreeRigErrorBytes()
 
 	var details []string
+	var overThreshold int
 	status := StatusOK
 	for _, s := range sizes {
 		switch {
 		case s.bytes >= errBytes:
 			details = append(details, fmt.Sprintf("rig %q: %s (exceeds %s error threshold)",
 				s.name, humanSize(s.bytes), humanSize(errBytes)))
+			overThreshold++
 			if status < StatusError {
 				status = StatusError
 			}
 		case s.bytes >= warn:
 			details = append(details, fmt.Sprintf("rig %q: %s (exceeds %s warn threshold)",
 				s.name, humanSize(s.bytes), humanSize(warn)))
+			overThreshold++
 			if status < StatusWarning {
 				status = StatusWarning
 			}
@@ -300,12 +313,12 @@ func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
 	switch status {
 	case StatusError:
 		r.Message = fmt.Sprintf("%d rig(s) over worktree size threshold (largest: %q at %s)",
-			len(details), sizes[0].name, humanSize(sizes[0].bytes))
+			overThreshold, sizes[0].name, humanSize(sizes[0].bytes))
 		r.Details = details
 		r.FixHint = "investigate .gc/worktrees/<rig>/ for build-artifact accumulation; consider routing builds out of worktrees, periodic clean steps, or running `gc doctor --fix` to remove safely-prunable nested worktrees"
 	case StatusWarning:
 		r.Message = fmt.Sprintf("%d rig(s) approaching worktree size limit (largest: %q at %s)",
-			len(details), sizes[0].name, humanSize(sizes[0].bytes))
+			overThreshold, sizes[0].name, humanSize(sizes[0].bytes))
 		r.Details = details
 		r.FixHint = "see fix hint for nested-worktree-prune; tune [doctor].worktree_rig_warn_size if 10 GB is too tight for this install"
 	default:
@@ -340,6 +353,7 @@ type nestedWorktreeFinding struct {
 // Defined as an interface so tests can inject a fake without standing up real
 // repositories.
 type gitWorktree interface {
+	IsRepo() bool
 	WorktreeList() ([]git.Worktree, error)
 	HasUncommittedWork() bool
 	HasUnpushedCommits() bool
@@ -426,41 +440,71 @@ func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
 		return r
 	}
 
-	seen := make(map[string]bool)
-	adminSeen := make(map[string]bool)
+	// Group homes by their shared git admin dir so each admin's
+	// WorktreeList runs exactly once but every entry is evaluated
+	// against ALL homes in that admin group. Admin-less homes (parse
+	// failure, main checkout) keep one group per home.
+	adminGroups := make(map[string][]string)
+	var adminOrder []string
 	for _, home := range homes {
-		// Agent homes inside the same rig typically share one git
-		// admin dir, so WorktreeList from each returns identical
-		// output. Dedup at the admin-dir level to skip the redundant
-		// subprocess. Falls through on parse failure (best-effort).
-		if admin := readGitAdminDir(home); admin != "" {
-			if adminSeen[admin] {
-				continue
-			}
-			adminSeen[admin] = true
+		key := readGitAdminDir(home)
+		if key == "" {
+			key = "home:" + home
 		}
-		gw := c.newGit(home)
+		if _, seen := adminGroups[key]; !seen {
+			adminOrder = append(adminOrder, key)
+		}
+		adminGroups[key] = append(adminGroups[key], home)
+	}
+
+	seen := make(map[string]bool)
+	var listingErrs []string
+	for _, key := range adminOrder {
+		group := adminGroups[key]
+		// Pick the first home as the WorktreeList source. All homes
+		// in a group share the admin dir, so any of them returns the
+		// same content.
+		source := group[0]
+		gw := c.newGit(source)
 		entries, err := gw.WorktreeList()
 		if err != nil {
-			r.Details = append(r.Details, fmt.Sprintf("listing worktrees from %s: %v", home, err))
+			listingErrs = append(listingErrs, fmt.Sprintf("listing worktrees from %s: %v", source, err))
 			continue
 		}
 		for _, wt := range entries {
 			candidate := pathutil.NormalizePathForCompare(wt.Path)
-			if !pathStrictlyInside(candidate, home) {
-				continue
-			}
 			if seen[candidate] {
 				continue
 			}
+			// A candidate is nested if it lives strictly inside ANY
+			// home in this admin group. Skipping homes other than
+			// `source` would have lost coverage for entries nested
+			// under those homes.
+			parent := ""
+			for _, home := range group {
+				if pathStrictlyInside(candidate, home) {
+					parent = home
+					break
+				}
+			}
+			if parent == "" {
+				continue
+			}
 			seen[candidate] = true
-			c.findings = append(c.findings, classifyNested(c.newGit, candidate, home, wt.Branch))
+			c.findings = append(c.findings, classifyNested(c.newGit, candidate, parent, wt.Branch))
 		}
 	}
 
 	if len(c.findings) == 0 {
 		r.Status = StatusOK
 		r.Message = "no nested worktrees found"
+		// Surface listing errors even when no findings were classified
+		// — partial inspection failures must not be silent.
+		if len(listingErrs) > 0 {
+			r.Status = StatusWarning
+			r.Message = fmt.Sprintf("no nested worktrees classified; %d listing failure(s)", len(listingErrs))
+			r.Details = listingErrs
+		}
 		return r
 	}
 
@@ -474,11 +518,17 @@ func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
+	// Build details with listing errors first so operators see partial
+	// failures alongside the classified findings.
+	details := make([]string, 0, len(listingErrs)+len(safe)+len(unsafe))
+	details = append(details, listingErrs...)
+
 	if len(safe) == 0 {
 		r.Status = StatusOK
 		r.Message = fmt.Sprintf("%d nested worktree(s); none safely prunable",
 			len(c.findings))
-		r.Details = unsafe
+		details = append(details, unsafe...)
+		r.Details = details
 		return r
 	}
 
@@ -489,7 +539,9 @@ func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 	r.Message = fmt.Sprintf("%d nested worktree(s) safely prunable (%d kept due to local work)",
 		len(safe), len(unsafe))
-	r.Details = append(append([]string(nil), safe...), unsafe...)
+	details = append(details, safe...)
+	details = append(details, unsafe...)
+	r.Details = details
 	r.FixHint = "run `gc doctor --fix` to remove safely-prunable nested worktrees (mechanical: only those with clean work tree, no unpushed commits, no stashes)"
 	return r
 }
@@ -510,7 +562,11 @@ func (c *NestedWorktreePruneCheck) Fix(_ *CheckContext) error {
 		if !f.safeToRm {
 			continue
 		}
-		gw := c.newGit(f.path)
+		// Run the removal from the parent home rather than the worktree
+		// being removed: git refuses to remove a worktree whose path
+		// equals cwd in some configurations, and operating from cwd of
+		// a directory we're about to delete is fragile in general.
+		gw := c.newGit(f.parent)
 		if err := gw.WorktreeRemove(f.path, true); err != nil {
 			errs = append(errs, fmt.Errorf("removing nested worktree %s: %w", f.path, err))
 		}
@@ -521,10 +577,18 @@ func (c *NestedWorktreePruneCheck) Fix(_ *CheckContext) error {
 // classifyNested runs the safety gates on a candidate nested worktree
 // and returns a finding describing whether it is safe to remove and,
 // if not, the first reason it was rejected. Order of checks matches
-// the user's manual recovery procedure: status, log, stash.
+// the user's manual recovery procedure: probe git, then status, log,
+// stash. The IsRepo probe defends against fail-open semantics in
+// HasUnpushedCommits / HasStashes (which return false on git error);
+// without it, a corrupt admin dir on the candidate would let all
+// safety gates pass.
 func classifyNested(newGit func(string) gitWorktree, path, parent, branch string) nestedWorktreeFinding {
 	f := nestedWorktreeFinding{path: path, parent: parent, branch: branch}
 	gw := newGit(path)
+	if !gw.IsRepo() {
+		f.reason = "git status unreadable"
+		return f
+	}
 	if gw.HasUncommittedWork() {
 		f.reason = "has uncommitted changes"
 		return f

--- a/internal/doctor/checks_semantic.go
+++ b/internal/doctor/checks_semantic.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // --- Duration reasonableness check ---
@@ -177,6 +181,397 @@ func (c *EventLogSizeCheck) CanFix() bool { return false }
 
 // Fix is a no-op.
 func (c *EventLogSizeCheck) Fix(_ *CheckContext) error { return nil }
+
+// --- Worktree disk size check ---
+
+// rigSize pairs a rig directory name with its measured byte footprint
+// under .gc/worktrees/<rig>/. Used as the sort key for ordered output.
+type rigSize struct {
+	name  string
+	bytes int64
+}
+
+// WorktreeDiskSizeCheck warns when a per-rig footprint under
+// .gc/worktrees/<rig>/ exceeds the configured threshold. Build
+// artifacts, nested task worktrees, and accumulated state can grow
+// unboundedly here; without this check the disk fills silently.
+type WorktreeDiskSizeCheck struct {
+	cfg config.DoctorConfig
+	// measureDir is injectable so tests can avoid shelling out to du.
+	// Production uses duDirBytes from checks.go.
+	measureDir func(string) (int64, bool, error)
+}
+
+// NewWorktreeDiskSizeCheck creates a worktree disk-footprint check.
+// The cfg is read for thresholds and policy at Run time, so reload-time
+// changes propagate naturally.
+func NewWorktreeDiskSizeCheck(cfg config.DoctorConfig) *WorktreeDiskSizeCheck {
+	return &WorktreeDiskSizeCheck{cfg: cfg, measureDir: duDirBytes}
+}
+
+// Name returns the check identifier.
+func (c *WorktreeDiskSizeCheck) Name() string { return "worktree-disk-size" }
+
+// Run measures each rig's worktree footprint and reports any rigs
+// exceeding the configured warn or error thresholds.
+func (c *WorktreeDiskSizeCheck) Run(ctx *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	wtRoot := filepath.Join(ctx.CityPath, ".gc", "worktrees")
+
+	rigEntries, err := os.ReadDir(wtRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			r.Status = StatusOK
+			r.Message = "no .gc/worktrees directory"
+			return r
+		}
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("reading .gc/worktrees: %v", err)
+		return r
+	}
+
+	measure := c.measureDir
+	if measure == nil {
+		measure = duDirBytes
+	}
+
+	var sizes []rigSize
+	var measureErrs []string
+	for _, e := range rigEntries {
+		if !e.IsDir() {
+			continue
+		}
+		root := filepath.Join(wtRoot, e.Name())
+		bytes, exists, err := measure(root)
+		if err != nil {
+			measureErrs = append(measureErrs, fmt.Sprintf("%s: %v", e.Name(), err))
+			continue
+		}
+		if !exists {
+			continue
+		}
+		sizes = append(sizes, rigSize{name: e.Name(), bytes: bytes})
+	}
+
+	if len(sizes) == 0 {
+		r.Status = StatusOK
+		if len(measureErrs) > 0 {
+			r.Message = "no rig worktree directories measurable"
+			r.Details = measureErrs
+		} else {
+			r.Message = "no rig worktree directories"
+		}
+		return r
+	}
+
+	sort.Slice(sizes, func(i, j int) bool { return sizes[i].bytes > sizes[j].bytes })
+
+	warn := c.cfg.WorktreeRigWarnBytes()
+	errBytes := c.cfg.WorktreeRigErrorBytes()
+
+	var details []string
+	var status CheckStatus = StatusOK
+	for _, s := range sizes {
+		switch {
+		case s.bytes >= errBytes:
+			details = append(details, fmt.Sprintf("rig %q: %s (exceeds %s error threshold)",
+				s.name, humanSize(s.bytes), humanSize(errBytes)))
+			if status < StatusError {
+				status = StatusError
+			}
+		case s.bytes >= warn:
+			details = append(details, fmt.Sprintf("rig %q: %s (exceeds %s warn threshold)",
+				s.name, humanSize(s.bytes), humanSize(warn)))
+			if status < StatusWarning {
+				status = StatusWarning
+			}
+		}
+	}
+	for _, e := range measureErrs {
+		details = append(details, "measure error: "+e)
+	}
+
+	r.Status = status
+	switch status {
+	case StatusError:
+		r.Message = fmt.Sprintf("%d rig(s) over worktree size threshold (largest: %q at %s)",
+			len(details), sizes[0].name, humanSize(sizes[0].bytes))
+		r.Details = details
+		r.FixHint = "investigate .gc/worktrees/<rig>/ for build-artifact accumulation; consider routing builds out of worktrees, periodic clean steps, or running `gc doctor --fix` to remove safely-prunable nested worktrees"
+	case StatusWarning:
+		r.Message = fmt.Sprintf("%d rig(s) approaching worktree size limit (largest: %q at %s)",
+			len(details), sizes[0].name, humanSize(sizes[0].bytes))
+		r.Details = details
+		r.FixHint = "see fix hint for nested-worktree-prune; tune [doctor].worktree_rig_warn_size if 10 GB is too tight for this install"
+	default:
+		// All under thresholds: report the worst rig as info.
+		r.Message = fmt.Sprintf("largest rig worktree: %q at %s (under %s warn)",
+			sizes[0].name, humanSize(sizes[0].bytes), humanSize(warn))
+	}
+	return r
+}
+
+// CanFix returns false — pruning is the responsibility of
+// NestedWorktreePruneCheck, which has the safety logic. This check is
+// observation-only.
+func (c *WorktreeDiskSizeCheck) CanFix() bool { return false }
+
+// Fix is a no-op; see CanFix.
+func (c *WorktreeDiskSizeCheck) Fix(_ *CheckContext) error { return nil }
+
+// --- Nested-worktree prune check ---
+
+// nestedWorktreeFinding describes one nested worktree under an agent
+// home and whether it is mechanically safe to remove.
+type nestedWorktreeFinding struct {
+	path     string // absolute, canonical
+	parent   string // agent home that contains it
+	branch   string // branch name (best-effort; empty for detached)
+	reason   string // why it was rejected (empty if safe)
+	safeToRm bool
+}
+
+// gitWorktree is the slice of internal/git.Git used by NestedWorktreePruneCheck.
+// Defined as an interface so tests can inject a fake without standing up real
+// repositories.
+type gitWorktree interface {
+	WorktreeList() ([]git.Worktree, error)
+	HasUncommittedWork() bool
+	HasUnpushedCommits() bool
+	HasStashes() bool
+	WorktreeRemove(path string, force bool) error
+}
+
+// NestedWorktreePruneCheck identifies nested git worktrees inside agent
+// home worktrees that are safely reclaimable: no uncommitted changes,
+// no unpushed commits, no stashed work. These reproduce from the remote
+// via `git worktree add path origin/<branch>`, so removing the local
+// directory is non-destructive.
+//
+// The rule is mechanical, never role-coupled: any nested worktree whose
+// branch tip is reachable from a remote and whose working tree is clean
+// is reclaimable, regardless of which agent created it.
+type NestedWorktreePruneCheck struct {
+	cfg config.DoctorConfig
+	// newGit produces a gitWorktree handle for a given path. Production
+	// uses git.New; tests inject fakes.
+	newGit func(path string) gitWorktree
+	// findings is populated by Run for Fix to consume.
+	findings []nestedWorktreeFinding
+}
+
+// NewNestedWorktreePruneCheck creates the prune check using real git.
+func NewNestedWorktreePruneCheck(cfg config.DoctorConfig) *NestedWorktreePruneCheck {
+	return &NestedWorktreePruneCheck{
+		cfg:    cfg,
+		newGit: func(p string) gitWorktree { return git.New(p) },
+	}
+}
+
+// Name returns the check identifier.
+func (c *NestedWorktreePruneCheck) Name() string { return "nested-worktree-prune" }
+
+// Run walks .gc/worktrees/<rig>/<agent>/ for each agent home that is a
+// git worktree, lists its sibling worktrees, and classifies each
+// nested entry as safe-to-prune or rejected with a reason.
+func (c *NestedWorktreePruneCheck) Run(ctx *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	c.findings = nil
+
+	wtRoot := filepath.Join(ctx.CityPath, ".gc", "worktrees")
+	rigEntries, err := os.ReadDir(wtRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			r.Status = StatusOK
+			r.Message = "no .gc/worktrees directory"
+			return r
+		}
+		r.Status = StatusError
+		r.Message = fmt.Sprintf("reading .gc/worktrees: %v", err)
+		return r
+	}
+
+	// Discover agent homes: <wtRoot>/<rig>/<agent>/ that hold a .git
+	// pointer. Multiple rigs may share a single repo, so we deduplicate
+	// nested findings by canonical path below.
+	var homes []string
+	for _, rigEntry := range rigEntries {
+		if !rigEntry.IsDir() {
+			continue
+		}
+		rigDir := filepath.Join(wtRoot, rigEntry.Name())
+		agentEntries, err := os.ReadDir(rigDir)
+		if err != nil {
+			continue
+		}
+		for _, agentEntry := range agentEntries {
+			if !agentEntry.IsDir() {
+				continue
+			}
+			home := filepath.Join(rigDir, agentEntry.Name())
+			if isGitWorktreePath(home) {
+				homes = append(homes, pathutil.NormalizePathForCompare(home))
+			}
+		}
+	}
+
+	if len(homes) == 0 {
+		r.Status = StatusOK
+		r.Message = "no agent worktrees to inspect"
+		return r
+	}
+
+	seen := make(map[string]bool)
+	adminSeen := make(map[string]bool)
+	for _, home := range homes {
+		// Agent homes inside the same rig typically share one git
+		// admin dir, so WorktreeList from each returns identical
+		// output. Dedup at the admin-dir level to skip the redundant
+		// subprocess. Falls through on parse failure (best-effort).
+		if admin := readGitAdminDir(home); admin != "" {
+			if adminSeen[admin] {
+				continue
+			}
+			adminSeen[admin] = true
+		}
+		gw := c.newGit(home)
+		entries, err := gw.WorktreeList()
+		if err != nil {
+			r.Details = append(r.Details, fmt.Sprintf("listing worktrees from %s: %v", home, err))
+			continue
+		}
+		for _, wt := range entries {
+			candidate := pathutil.NormalizePathForCompare(wt.Path)
+			if !pathStrictlyInside(candidate, home) {
+				continue
+			}
+			if seen[candidate] {
+				continue
+			}
+			seen[candidate] = true
+			c.findings = append(c.findings, classifyNested(c.newGit, candidate, home, wt.Branch))
+		}
+	}
+
+	if len(c.findings) == 0 {
+		r.Status = StatusOK
+		r.Message = "no nested worktrees found"
+		return r
+	}
+
+	var safe, unsafe []string
+	for _, f := range c.findings {
+		line := fmt.Sprintf("%s (branch %q)", f.path, f.branch)
+		if f.safeToRm {
+			safe = append(safe, line)
+		} else {
+			unsafe = append(unsafe, fmt.Sprintf("%s — %s", line, f.reason))
+		}
+	}
+
+	if len(safe) == 0 {
+		r.Status = StatusOK
+		r.Message = fmt.Sprintf("%d nested worktree(s); none safely prunable",
+			len(c.findings))
+		r.Details = unsafe
+		return r
+	}
+
+	if c.cfg.NestedWorktreePrune {
+		r.Status = StatusError
+	} else {
+		r.Status = StatusWarning
+	}
+	r.Message = fmt.Sprintf("%d nested worktree(s) safely prunable (%d kept due to local work)",
+		len(safe), len(unsafe))
+	r.Details = append(append([]string(nil), safe...), unsafe...)
+	r.FixHint = "run `gc doctor --fix` to remove safely-prunable nested worktrees (mechanical: only those with clean work tree, no unpushed commits, no stashes)"
+	return r
+}
+
+// CanFix returns true — Fix removes the safely-prunable findings.
+func (c *NestedWorktreePruneCheck) CanFix() bool { return true }
+
+// Fix removes each safely-prunable nested worktree found by Run. Stops
+// on first failure so the caller sees a clear error rather than partial
+// state with a vague aggregate. Worktrees marked unsafe (uncommitted /
+// unpushed / stashed) are never touched.
+func (c *NestedWorktreePruneCheck) Fix(_ *CheckContext) error {
+	for _, f := range c.findings {
+		if !f.safeToRm {
+			continue
+		}
+		gw := c.newGit(f.path)
+		if err := gw.WorktreeRemove(f.path, true); err != nil {
+			return fmt.Errorf("removing nested worktree %s: %w", f.path, err)
+		}
+	}
+	return nil
+}
+
+// classifyNested runs the safety gates on a candidate nested worktree
+// and returns a finding describing whether it is safe to remove and,
+// if not, the first reason it was rejected. Order of checks matches
+// the user's manual recovery procedure: status, log, stash.
+func classifyNested(newGit func(string) gitWorktree, path, parent, branch string) nestedWorktreeFinding {
+	f := nestedWorktreeFinding{path: path, parent: parent, branch: branch}
+	gw := newGit(path)
+	if gw.HasUncommittedWork() {
+		f.reason = "has uncommitted changes"
+		return f
+	}
+	if gw.HasUnpushedCommits() {
+		f.reason = "has unpushed commits"
+		return f
+	}
+	if gw.HasStashes() {
+		f.reason = "has stashed work"
+		return f
+	}
+	f.safeToRm = true
+	return f
+}
+
+// isGitWorktreePath reports whether path holds a .git file or .git
+// directory, indicating it is either the main repo or a worktree of one.
+func isGitWorktreePath(path string) bool {
+	gitPath := filepath.Join(path, ".git")
+	_, err := os.Stat(gitPath)
+	return err == nil
+}
+
+// readGitAdminDir returns the shared git admin directory that backs the
+// worktree at home. For a worktree, .git is a file containing
+// "gitdir: <repo>/.git/worktrees/<name>"; the admin root is the prefix
+// before "/worktrees/". Returns "" if the file is missing, malformed,
+// or not a worktree pointer (e.g. a main checkout where .git is a dir).
+// Used to dedup WorktreeList calls across agent homes that share a repo.
+func readGitAdminDir(home string) string {
+	data, err := os.ReadFile(filepath.Join(home, ".git"))
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir: "
+	if !strings.HasPrefix(line, prefix) {
+		return ""
+	}
+	target := pathutil.NormalizePathForCompare(strings.TrimPrefix(line, prefix))
+	const sep = string(filepath.Separator) + "worktrees" + string(filepath.Separator)
+	if i := strings.Index(target, sep); i > 0 {
+		return target[:i]
+	}
+	return target
+}
+
+// pathStrictlyInside reports whether child is a strict subpath of
+// parent. Wraps the package-local isSubpath with an equal-paths check
+// so a worktree home isn't mistakenly classified as nested under
+// itself. Inputs must already be canonical (use
+// pathutil.NormalizePathForCompare).
+func pathStrictlyInside(child, parent string) bool {
+	return child != parent && isSubpath(parent, child)
+}
 
 // humanSize returns a human-readable file size string.
 func humanSize(bytes int64) string {

--- a/internal/doctor/checks_semantic_test.go
+++ b/internal/doctor/checks_semantic_test.go
@@ -369,6 +369,33 @@ func TestWorktreeDiskSizeCheck_AllUnderThreshold(t *testing.T) {
 	}
 }
 
+func TestWorktreeDiskSizeCheck_UnderThresholdWithMeasurementErrorReturnsWarning(t *testing.T) {
+	dir := t.TempDir()
+	rigOK := filepath.Join(dir, ".gc", "worktrees", "ok")
+	rigBroken := filepath.Join(dir, ".gc", "worktrees", "broken")
+	for _, p := range []string{rigOK, rigBroken} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{WorktreeRigWarnSize: "10GB", WorktreeRigErrorSize: "50GB"},
+		measureDir: fakeMeasure(map[string]int64{
+			rigOK: 1 * 1024 * 1024 * 1024,
+		}, map[string]error{
+			rigBroken: errors.New("permission denied"),
+		}),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg=%s details=%v", r.Status, r.Message, r.Details)
+	}
+	if !strings.Contains(strings.Join(r.Details, "\n"), "measure error: broken: permission denied") {
+		t.Errorf("details should surface measurement error; got %v", r.Details)
+	}
+}
+
 func TestWorktreeDiskSizeCheck_OverWarnThreshold(t *testing.T) {
 	dir := t.TempDir()
 	rigA := filepath.Join(dir, ".gc", "worktrees", "rig-a")
@@ -537,7 +564,9 @@ type fakeGitWorktree struct {
 	notRepo     map[string]bool // paths where IsRepo returns false
 	uncommitted map[string]bool
 	unpushed    map[string]bool
+	unpushedErr map[string]error
 	stashed     map[string]bool
+	stashedErr  map[string]error
 	removeCalls *[]string // path argument of each WorktreeRemove call
 	removeFrom  *[]string // currentPath (cwd-equivalent) at each remove call
 	removeErr   map[string]error
@@ -553,8 +582,20 @@ func (f *fakeGitWorktree) WorktreeList() ([]git.Worktree, error) {
 	return f.listResp, f.listErr
 }
 func (f *fakeGitWorktree) HasUncommittedWork() bool { return f.uncommitted[f.currentPath] }
-func (f *fakeGitWorktree) HasUnpushedCommits() bool { return f.unpushed[f.currentPath] }
-func (f *fakeGitWorktree) HasStashes() bool         { return f.stashed[f.currentPath] }
+func (f *fakeGitWorktree) HasUnpushedCommitsResult() (bool, error) {
+	if err := f.unpushedErr[f.currentPath]; err != nil {
+		return false, err
+	}
+	return f.unpushed[f.currentPath], nil
+}
+
+func (f *fakeGitWorktree) HasStashesResult() (bool, error) {
+	if err := f.stashedErr[f.currentPath]; err != nil {
+		return false, err
+	}
+	return f.stashed[f.currentPath], nil
+}
+
 func (f *fakeGitWorktree) WorktreeRemove(path string, _ bool) error {
 	if f.removeCalls != nil {
 		*f.removeCalls = append(*f.removeCalls, path)
@@ -771,6 +812,45 @@ func TestNestedWorktreePruneCheck_AllUnsafeReturnsOK(t *testing.T) {
 	}
 }
 
+func TestNestedWorktreePruneCheck_AllUnsafeWithListingErrorReturnsWarning(t *testing.T) {
+	dir := t.TempDir()
+	homeA := makeAgentHomeAdmin(t, dir, "rig-a", "agent-1", "/repo-a/.git")
+	homeB := makeAgentHomeAdmin(t, dir, "rig-b", "agent-2", "/repo-b/.git")
+	dirty := pathutil.NormalizePathForCompare(filepath.Join(homeA, "worktrees", "task"))
+	if err := os.MkdirAll(dirty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			switch path {
+			case homeB:
+				return &fakeGitWorktree{
+					listErr:     errors.New("cannot list worktrees"),
+					currentPath: path,
+				}
+			default:
+				return &fakeGitWorktree{
+					listResp: []git.Worktree{
+						{Path: homeA, Branch: "home-a"},
+						{Path: dirty, Branch: "task"},
+					},
+					uncommitted: map[string]bool{dirty: true},
+					currentPath: path,
+				}
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg=%s details=%v", r.Status, r.Message, r.Details)
+	}
+	if !strings.Contains(strings.Join(r.Details, "\n"), "cannot list worktrees") {
+		t.Errorf("details should include listing error; got %v", r.Details)
+	}
+}
+
 func TestNestedWorktreePruneCheck_DeduplicatesAcrossHomes(t *testing.T) {
 	// Two agent homes that share the same git repo would each list the
 	// same nested worktree. The check must not classify or remove it
@@ -864,6 +944,94 @@ func TestNestedWorktreePruneCheck_FixContinuesPastError(t *testing.T) {
 	// call.
 	if len(removes) != 3 {
 		t.Errorf("removes = %v, want all three attempted", removes)
+	}
+}
+
+func TestNestedWorktreePruneCheck_FixRevalidatesBeforeRemove(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "agent-1")
+	nested := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task"))
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	uncommitted := map[string]bool{}
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "h"},
+					{Path: nested, Branch: "task"},
+				},
+				uncommitted: uncommitted,
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	if r := c.Run(&CheckContext{CityPath: dir}); r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	uncommitted[nested] = true
+	err := c.Fix(&CheckContext{})
+	if err == nil {
+		t.Fatal("Fix should fail closed when revalidation finds new local work")
+	}
+	if len(removes) != 0 {
+		t.Errorf("removes = %v, want none after failed revalidation", removes)
+	}
+}
+
+func TestNestedWorktreePruneCheck_ProbeErrorsAreUnsafe(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "agent-1")
+	unpushedErr := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "unpushed-error"))
+	stashErr := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "stash-error"))
+	for _, p := range []string{unpushedErr, stashErr} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "h"},
+					{Path: unpushedErr, Branch: "unpushed-error"},
+					{Path: stashErr, Branch: "stash-error"},
+				},
+				unpushedErr: map[string]error{unpushedErr: errors.New("log failed")},
+				stashedErr:  map[string]error{stashErr: errors.New("stash failed")},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning because probe errors are inspection failures; msg=%s details=%v", r.Status, r.Message, r.Details)
+	}
+	if len(c.findings) != 2 {
+		t.Fatalf("findings = %d, want 2", len(c.findings))
+	}
+	for _, f := range c.findings {
+		if f.safeToRm {
+			t.Fatalf("%s should not be safe after probe error", f.path)
+		}
+		if !strings.Contains(f.reason, "probe failed") {
+			t.Errorf("reason for %s = %q, want probe failure", f.path, f.reason)
+		}
+	}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix should skip unsafe probe-error findings without error: %v", err)
+	}
+	if len(removes) != 0 {
+		t.Errorf("removes = %v, want none", removes)
 	}
 }
 

--- a/internal/doctor/checks_semantic_test.go
+++ b/internal/doctor/checks_semantic_test.go
@@ -457,25 +457,36 @@ func TestWorktreeDiskSizeCheck_DetailsSortedDescending(t *testing.T) {
 	}
 }
 
-func TestWorktreeDiskSizeCheck_MeasureErrorSurfaced(t *testing.T) {
+func TestWorktreeDiskSizeCheck_AllMeasurementsFailedReturnsWarning(t *testing.T) {
+	// "We can't tell" must not look like "we're fine". When every rig
+	// fails to measure (e.g. permission denied), the check escalates
+	// to Warning and surfaces the errors — matches DoltNomsSize policy.
 	dir := t.TempDir()
-	rig := filepath.Join(dir, ".gc", "worktrees", "broken")
-	if err := os.MkdirAll(rig, 0o755); err != nil {
+	rigA := filepath.Join(dir, ".gc", "worktrees", "broken-a")
+	rigB := filepath.Join(dir, ".gc", "worktrees", "broken-b")
+	if err := os.MkdirAll(rigA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigB, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	c := &WorktreeDiskSizeCheck{
 		cfg: config.DoctorConfig{},
 		measureDir: fakeMeasure(nil, map[string]error{
-			rig: errors.New("permission denied"),
+			rigA: errors.New("permission denied"),
+			rigB: errors.New("io error"),
 		}),
 	}
 	r := c.Run(&CheckContext{CityPath: dir})
-	if r.Status != StatusOK {
-		t.Errorf("status = %d, want OK", r.Status)
+	if r.Status != StatusWarning {
+		t.Errorf("status = %d, want Warning", r.Status)
 	}
-	if len(r.Details) == 0 || !strings.Contains(r.Details[0], "permission denied") {
-		t.Errorf("expected measure error in details; got %v", r.Details)
+	if r.FixHint == "" {
+		t.Error("expected fix hint pointing at filesystem permissions")
+	}
+	if len(r.Details) != 2 {
+		t.Errorf("len(Details) = %d, want 2 (one per failed rig)", len(r.Details))
 	}
 }
 
@@ -507,7 +518,9 @@ func (f *fakeGitWorktree) HasUncommittedWork() bool { return f.uncommitted[f.cur
 func (f *fakeGitWorktree) HasUnpushedCommits() bool { return f.unpushed[f.currentPath] }
 func (f *fakeGitWorktree) HasStashes() bool         { return f.stashed[f.currentPath] }
 func (f *fakeGitWorktree) WorktreeRemove(path string, _ bool) error {
-	*f.removeCalls = append(*f.removeCalls, path)
+	if f.removeCalls != nil {
+		*f.removeCalls = append(*f.removeCalls, path)
+	}
 	if f.removeErr != nil {
 		if e, ok := f.removeErr[path]; ok {
 			return e
@@ -762,16 +775,20 @@ func TestNestedWorktreePruneCheck_DeduplicatesAcrossHomes(t *testing.T) {
 	}
 }
 
-func TestNestedWorktreePruneCheck_FixStopsOnError(t *testing.T) {
+// TestNestedWorktreePruneCheck_FixContinuesPastError pins the
+// reclaim-as-much-as-possible semantic: a single locked worktree must
+// not strand later safe entries. The returned error joins all per-entry
+// failures so the operator sees what was missed.
+func TestNestedWorktreePruneCheck_FixContinuesPastError(t *testing.T) {
 	dir := t.TempDir()
 	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
 	first := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "first"))
 	second := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "second"))
-	if err := os.MkdirAll(first, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(second, 0o755); err != nil {
-		t.Fatal(err)
+	third := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "third"))
+	for _, p := range []string{first, second, third} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	var removes []string
@@ -783,9 +800,10 @@ func TestNestedWorktreePruneCheck_FixStopsOnError(t *testing.T) {
 					{Path: home, Branch: "home"},
 					{Path: first, Branch: "first"},
 					{Path: second, Branch: "second"},
+					{Path: third, Branch: "third"},
 				},
 				removeCalls: &removes,
-				removeErr:   map[string]error{first: errors.New("git locked")},
+				removeErr:   map[string]error{second: errors.New("git locked")},
 				currentPath: path,
 			}
 		},
@@ -795,10 +813,38 @@ func TestNestedWorktreePruneCheck_FixStopsOnError(t *testing.T) {
 	}
 	err := c.Fix(&CheckContext{})
 	if err == nil {
-		t.Fatal("Fix should propagate the remove error")
+		t.Fatal("Fix should surface the remove error")
 	}
 	if !strings.Contains(err.Error(), "git locked") {
 		t.Errorf("error should wrap original; got %v", err)
+	}
+	// All three were attempted; only the failing one is missing from a
+	// successful-removal perspective — but accumulator records every
+	// call.
+	if len(removes) != 3 {
+		t.Errorf("removes = %v, want all three attempted", removes)
+	}
+}
+
+func TestReadGitAdminDir_RepoPathContainsWorktreesSegment(t *testing.T) {
+	// Regression: if the repo's own path contains "/worktrees/" as a
+	// literal segment (e.g. user keeps repos under ~/worktrees/), the
+	// admin-dir extraction must still find the LAST "/worktrees/"
+	// (the one git inserts before the per-worktree subdir), not the
+	// user's path component.
+	dir := t.TempDir()
+	tricky := filepath.Join(dir, "worktrees", "myproj")
+	if err := os.MkdirAll(tricky, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitdir := tricky + "/.git/worktrees/agentA"
+	if err := os.WriteFile(filepath.Join(tricky, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readGitAdminDir(tricky)
+	want := pathutil.NormalizePathForCompare(tricky + "/.git")
+	if got != want {
+		t.Errorf("readGitAdminDir = %q, want %q (must use LastIndex of /worktrees/)", got, want)
 	}
 }
 

--- a/internal/doctor/checks_semantic_test.go
+++ b/internal/doctor/checks_semantic_test.go
@@ -496,16 +496,18 @@ func TestWorktreeDiskSizeCheck_AllMeasurementsFailedReturnsWarning(t *testing.T)
 // shared admin dir of a multi-worktree repo: list returns the same
 // entries regardless of which path is used to construct it. Per-path
 // "uncommitted/unpushed/stashed" flags drive classifyNested.
+var _ gitWorktree = (*fakeGitWorktree)(nil)
+
 type fakeGitWorktree struct {
-	listResp     []git.Worktree
-	listErr      error
-	uncommitted  map[string]bool
-	unpushed     map[string]bool
-	stashed      map[string]bool
-	removeCalls  *[]string // accumulator across handle instances
-	removeErr    map[string]error
-	currentPath  string
-	onList       func(callerPath string) // optional probe; fires per WorktreeList call
+	listResp    []git.Worktree
+	listErr     error
+	uncommitted map[string]bool
+	unpushed    map[string]bool
+	stashed     map[string]bool
+	removeCalls *[]string // accumulator across handle instances
+	removeErr   map[string]error
+	currentPath string
+	onList      func(callerPath string) // optional probe; fires per WorktreeList call
 }
 
 func (f *fakeGitWorktree) WorktreeList() ([]git.Worktree, error) {
@@ -529,16 +531,16 @@ func (f *fakeGitWorktree) WorktreeRemove(path string, _ bool) error {
 	return nil
 }
 
-// makeAgentHome creates dir/.gc/worktrees/<rig>/<agent>/ with a stub
+// makeAgentHome creates dir/.gc/worktrees/rig-a/<agent>/ with a stub
 // .git file so isGitWorktreePath returns true. Returns the agent home
 // path (canonicalized via pathutil.NormalizePathForCompare to match
 // what the check stores). The .git stub uses a shared gitdir so all
 // homes created via this helper appear to belong to the same admin
 // dir; tests that need distinct admin dirs should use
 // makeAgentHomeAdmin.
-func makeAgentHome(t *testing.T, dir, rig, agent string) string {
+func makeAgentHome(t *testing.T, dir, agent string) string {
 	t.Helper()
-	return makeAgentHomeAdmin(t, dir, rig, agent, "/tmp/none")
+	return makeAgentHomeAdmin(t, dir, "rig-a", agent, "/tmp/none")
 }
 
 // makeAgentHomeAdmin is like makeAgentHome but lets the test specify
@@ -567,7 +569,7 @@ func TestNestedWorktreePruneCheck_NoWorktreesDir(t *testing.T) {
 
 func TestNestedWorktreePruneCheck_NoNestedWorktrees(t *testing.T) {
 	dir := t.TempDir()
-	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	home := makeAgentHome(t, dir, "polecat-1")
 	var removes []string
 	c := &NestedWorktreePruneCheck{
 		cfg: config.DoctorConfig{},
@@ -594,7 +596,7 @@ func TestNestedWorktreePruneCheck_NoNestedWorktrees(t *testing.T) {
 
 func TestNestedWorktreePruneCheck_ClassifiesSafeAndUnsafe(t *testing.T) {
 	dir := t.TempDir()
-	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	home := makeAgentHome(t, dir, "polecat-1")
 	safe := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-clean"))
 	dirty := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-dirty"))
 	unpushed := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-unpushed"))
@@ -672,7 +674,7 @@ func TestNestedWorktreePruneCheck_ClassifiesSafeAndUnsafe(t *testing.T) {
 
 func TestNestedWorktreePruneCheck_PruneTrueEscalatesSeverity(t *testing.T) {
 	dir := t.TempDir()
-	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	home := makeAgentHome(t, dir, "polecat-1")
 	safe := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-clean"))
 	if err := os.MkdirAll(safe, 0o755); err != nil {
 		t.Fatal(err)
@@ -700,7 +702,7 @@ func TestNestedWorktreePruneCheck_PruneTrueEscalatesSeverity(t *testing.T) {
 
 func TestNestedWorktreePruneCheck_AllUnsafeReturnsOK(t *testing.T) {
 	dir := t.TempDir()
-	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	home := makeAgentHome(t, dir, "polecat-1")
 	dirty := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task"))
 	if err := os.MkdirAll(dirty, 0o755); err != nil {
 		t.Fatal(err)
@@ -735,8 +737,8 @@ func TestNestedWorktreePruneCheck_DeduplicatesAcrossHomes(t *testing.T) {
 	// same nested worktree. The check must not classify or remove it
 	// twice.
 	dir := t.TempDir()
-	homeA := makeAgentHome(t, dir, "rig-a", "polecat-1")
-	homeB := makeAgentHome(t, dir, "rig-a", "polecat-2")
+	homeA := makeAgentHome(t, dir, "polecat-1")
+	homeB := makeAgentHome(t, dir, "polecat-2")
 
 	// Nested under homeA. homeB will also list it because they share a repo.
 	nested := pathutil.NormalizePathForCompare(filepath.Join(homeA, "worktrees", "task"))
@@ -781,7 +783,7 @@ func TestNestedWorktreePruneCheck_DeduplicatesAcrossHomes(t *testing.T) {
 // failures so the operator sees what was missed.
 func TestNestedWorktreePruneCheck_FixContinuesPastError(t *testing.T) {
 	dir := t.TempDir()
-	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	home := makeAgentHome(t, dir, "polecat-1")
 	first := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "first"))
 	second := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "second"))
 	third := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "third"))
@@ -890,8 +892,8 @@ func TestPathStrictlyInside(t *testing.T) {
 		want          bool
 	}{
 		{"/a/b/c", "/a/b", true},
-		{"/a/b", "/a/b", false},               // equal — strict
-		{"/a/b", "/a/bc", false},              // prefix-but-not-subpath
+		{"/a/b", "/a/b", false},  // equal — strict
+		{"/a/b", "/a/bc", false}, // prefix-but-not-subpath
 		{"/x/y", "/a/b", false},
 		{"/a/b/c/d", "/a/b", true},
 	}

--- a/internal/doctor/checks_semantic_test.go
+++ b/internal/doctor/checks_semantic_test.go
@@ -457,6 +457,39 @@ func TestWorktreeDiskSizeCheck_DetailsSortedDescending(t *testing.T) {
 	}
 }
 
+// TestWorktreeDiskSizeCheck_CountExcludesMeasurementErrors pins the
+// fix for a count bug: the message reports "<N> rig(s) over threshold"
+// where N must be the threshold-violation count, NOT
+// `len(details)` (which also includes measurement errors).
+func TestWorktreeDiskSizeCheck_CountExcludesMeasurementErrors(t *testing.T) {
+	dir := t.TempDir()
+	rigOver := filepath.Join(dir, ".gc", "worktrees", "over")
+	rigBroken := filepath.Join(dir, ".gc", "worktrees", "broken")
+	for _, p := range []string{rigOver, rigBroken} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{WorktreeRigWarnSize: "5GB", WorktreeRigErrorSize: "100GB"},
+		measureDir: fakeMeasure(map[string]int64{
+			rigOver: 8 * 1024 * 1024 * 1024,
+		}, map[string]error{
+			rigBroken: errors.New("permission denied"),
+		}),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	// Exactly one rig is over threshold; the broken one is a
+	// measurement error, not a threshold violation.
+	if !strings.Contains(r.Message, "1 rig(s)") {
+		t.Errorf("message should report 1 rig over threshold (not 2); got %q", r.Message)
+	}
+}
+
 func TestWorktreeDiskSizeCheck_AllMeasurementsFailedReturnsWarning(t *testing.T) {
 	// "We can't tell" must not look like "we're fine". When every rig
 	// fails to measure (e.g. permission denied), the check escalates
@@ -501,15 +534,18 @@ var _ gitWorktree = (*fakeGitWorktree)(nil)
 type fakeGitWorktree struct {
 	listResp    []git.Worktree
 	listErr     error
+	notRepo     map[string]bool // paths where IsRepo returns false
 	uncommitted map[string]bool
 	unpushed    map[string]bool
 	stashed     map[string]bool
-	removeCalls *[]string // accumulator across handle instances
+	removeCalls *[]string // path argument of each WorktreeRemove call
+	removeFrom  *[]string // currentPath (cwd-equivalent) at each remove call
 	removeErr   map[string]error
 	currentPath string
 	onList      func(callerPath string) // optional probe; fires per WorktreeList call
 }
 
+func (f *fakeGitWorktree) IsRepo() bool { return !f.notRepo[f.currentPath] }
 func (f *fakeGitWorktree) WorktreeList() ([]git.Worktree, error) {
 	if f.onList != nil {
 		f.onList(f.currentPath)
@@ -522,6 +558,9 @@ func (f *fakeGitWorktree) HasStashes() bool         { return f.stashed[f.current
 func (f *fakeGitWorktree) WorktreeRemove(path string, _ bool) error {
 	if f.removeCalls != nil {
 		*f.removeCalls = append(*f.removeCalls, path)
+	}
+	if f.removeFrom != nil {
+		*f.removeFrom = append(*f.removeFrom, f.currentPath)
 	}
 	if f.removeErr != nil {
 		if e, ok := f.removeErr[path]; ok {
@@ -883,6 +922,141 @@ func TestNestedWorktreePruneCheck_DedupsWorktreeListAcrossSharedAdminDir(t *test
 	}
 	if len(listCalls) != 2 {
 		t.Errorf("WorktreeList calls = %v, want 2 (one per distinct admin dir; homeA and homeB share)", listCalls)
+	}
+}
+
+// TestNestedWorktreePruneCheck_DedupCoversNestedUnderEveryHome pins the
+// fix for a correctness bug introduced by the admin-dir dedup: when
+// homes A and B share an admin dir, only A's WorktreeList runs, but
+// nested entries living under B must still be classified. Iterating
+// the shared list against EVERY home in the admin group preserves
+// coverage; the previous implementation only checked containment
+// against the source home and silently dropped B's nested entries.
+func TestNestedWorktreePruneCheck_DedupCoversNestedUnderEveryHome(t *testing.T) {
+	dir := t.TempDir()
+	homeA := makeAgentHomeAdmin(t, dir, "rig-a", "polecat-1", "/repo/.git")
+	homeB := makeAgentHomeAdmin(t, dir, "rig-a", "polecat-2", "/repo/.git")
+	nestedUnderA := pathutil.NormalizePathForCompare(filepath.Join(homeA, "worktrees", "task-a"))
+	nestedUnderB := pathutil.NormalizePathForCompare(filepath.Join(homeB, "worktrees", "task-b"))
+	for _, p := range []string{nestedUnderA, nestedUnderB} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var listCalls []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: homeA, Branch: "a"},
+					{Path: homeB, Branch: "b"},
+					{Path: nestedUnderA, Branch: "task-a"},
+					{Path: nestedUnderB, Branch: "task-b"},
+				},
+				currentPath: path,
+				onList:      func(p string) { listCalls = append(listCalls, p) },
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	if len(listCalls) != 1 {
+		t.Errorf("WorktreeList calls = %v, want 1 (admin-dir dedup)", listCalls)
+	}
+	if len(c.findings) != 2 {
+		t.Errorf("findings = %d, want 2 (one nested under each home, even though only one WorktreeList ran)",
+			len(c.findings))
+	}
+	parents := map[string]bool{}
+	for _, f := range c.findings {
+		parents[f.parent] = true
+	}
+	if !parents[homeA] || !parents[homeB] {
+		t.Errorf("findings should attribute parents to both homes; got %v", parents)
+	}
+}
+
+// TestNestedWorktreePruneCheck_FixUsesParentForGitContext pins the fix
+// for the cwd-removal pattern: WorktreeRemove must run from the parent
+// home, not from the worktree being removed.
+func TestNestedWorktreePruneCheck_FixUsesParentForGitContext(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "polecat-1")
+	nested := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task"))
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes, removeFrom []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "h"},
+					{Path: nested, Branch: "task"},
+				},
+				removeCalls: &removes,
+				removeFrom:  &removeFrom,
+				currentPath: path,
+			}
+		},
+	}
+	if r := c.Run(&CheckContext{CityPath: dir}); r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if len(removeFrom) != 1 || removeFrom[0] != home {
+		t.Errorf("WorktreeRemove ran from %v, want exactly [%q] (parent home, not the worktree being removed)",
+			removeFrom, home)
+	}
+}
+
+// TestNestedWorktreePruneCheck_BrokenRepoGate pins the IsRepo gate that
+// defends against fail-open semantics in HasUnpushedCommits / HasStashes
+// (which return false on git error). A candidate whose admin dir is
+// corrupt must not be classified as safe to remove.
+func TestNestedWorktreePruneCheck_BrokenRepoGate(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "polecat-1")
+	broken := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "broken"))
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "h"},
+					{Path: broken, Branch: "broken"},
+				},
+				notRepo:     map[string]bool{broken: true},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK (broken candidate marked unsafe)", r.Status)
+	}
+	if len(c.findings) != 1 {
+		t.Fatalf("findings = %d, want 1", len(c.findings))
+	}
+	if c.findings[0].safeToRm {
+		t.Error("broken candidate should NOT be safeToRm")
+	}
+	if c.findings[0].reason != "git status unreadable" {
+		t.Errorf("reason = %q, want %q", c.findings[0].reason, "git status unreadable")
 	}
 }
 

--- a/internal/doctor/checks_semantic_test.go
+++ b/internal/doctor/checks_semantic_test.go
@@ -1,12 +1,15 @@
 package doctor
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/git"
+	"github.com/gastownhall/gascity/internal/pathutil"
 )
 
 // --- DurationRangeCheck ---
@@ -305,6 +308,551 @@ func TestHumanSize(t *testing.T) {
 		got := humanSize(tt.bytes)
 		if got != tt.want {
 			t.Errorf("humanSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+		}
+	}
+}
+
+// --- WorktreeDiskSizeCheck ---
+
+// fakeMeasure returns a deterministic byte count per directory path so
+// tests don't shell out to du. Returns sizes[path] when present; treats
+// missing keys as not-existent (mirrors duDirBytes signature).
+func fakeMeasure(sizes map[string]int64, errs map[string]error) func(string) (int64, bool, error) {
+	return func(path string) (int64, bool, error) {
+		if e, ok := errs[path]; ok {
+			return 0, true, e
+		}
+		n, ok := sizes[path]
+		if !ok {
+			return 0, false, nil
+		}
+		return n, true, nil
+	}
+}
+
+func TestWorktreeDiskSizeCheck_NoWorktreesDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	c := NewWorktreeDiskSizeCheck(config.DoctorConfig{})
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg=%s", r.Status, r.Message)
+	}
+}
+
+func TestWorktreeDiskSizeCheck_AllUnderThreshold(t *testing.T) {
+	dir := t.TempDir()
+	rigA := filepath.Join(dir, ".gc", "worktrees", "rig-a")
+	rigB := filepath.Join(dir, ".gc", "worktrees", "rig-b")
+	if err := os.MkdirAll(rigA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{WorktreeRigWarnSize: "10GB", WorktreeRigErrorSize: "50GB"},
+		measureDir: fakeMeasure(map[string]int64{
+			rigA: 1 * 1024 * 1024 * 1024, // 1 GB
+			rigB: 500 * 1024 * 1024,      // 500 MB
+		}, nil),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg=%s details=%v", r.Status, r.Message, r.Details)
+	}
+	if !strings.Contains(r.Message, "rig-a") {
+		t.Errorf("message should name largest rig (rig-a); got %q", r.Message)
+	}
+}
+
+func TestWorktreeDiskSizeCheck_OverWarnThreshold(t *testing.T) {
+	dir := t.TempDir()
+	rigA := filepath.Join(dir, ".gc", "worktrees", "rig-a")
+	rigB := filepath.Join(dir, ".gc", "worktrees", "rig-b")
+	if err := os.MkdirAll(rigA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{WorktreeRigWarnSize: "5GB", WorktreeRigErrorSize: "50GB"},
+		measureDir: fakeMeasure(map[string]int64{
+			rigA: 8 * 1024 * 1024 * 1024, // 8 GB — over warn
+			rigB: 1 * 1024 * 1024 * 1024, // 1 GB — under
+		}, nil),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg=%s details=%v", r.Status, r.Message, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Errorf("len(Details) = %d, want 1; details=%v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], "rig-a") {
+		t.Errorf("details should flag rig-a; got %q", r.Details[0])
+	}
+	if strings.Contains(strings.Join(r.Details, "\n"), "rig-b") {
+		t.Errorf("details should not flag rig-b (under threshold); got %v", r.Details)
+	}
+	if r.FixHint == "" {
+		t.Error("expected fix hint")
+	}
+}
+
+func TestWorktreeDiskSizeCheck_OverErrorThreshold(t *testing.T) {
+	dir := t.TempDir()
+	rig := filepath.Join(dir, ".gc", "worktrees", "huge")
+	if err := os.MkdirAll(rig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{WorktreeRigWarnSize: "5GB", WorktreeRigErrorSize: "20GB"},
+		measureDir: fakeMeasure(map[string]int64{
+			rig: 100 * 1024 * 1024 * 1024, // 100 GB
+		}, nil),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusError {
+		t.Fatalf("status = %d, want Error", r.Status)
+	}
+	if !strings.Contains(r.Details[0], "error threshold") {
+		t.Errorf("details should mention error threshold; got %q", r.Details[0])
+	}
+}
+
+func TestWorktreeDiskSizeCheck_DetailsSortedDescending(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"small", "huge", "medium"} {
+		if err := os.MkdirAll(filepath.Join(dir, ".gc", "worktrees", name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{WorktreeRigWarnSize: "1GB", WorktreeRigErrorSize: "100GB"},
+		measureDir: fakeMeasure(map[string]int64{
+			filepath.Join(dir, ".gc", "worktrees", "small"):  500 * 1024 * 1024,
+			filepath.Join(dir, ".gc", "worktrees", "medium"): 5 * 1024 * 1024 * 1024,
+			filepath.Join(dir, ".gc", "worktrees", "huge"):   30 * 1024 * 1024 * 1024,
+		}, nil),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; details=%v", r.Status, r.Details)
+	}
+	// The largest should appear first in details. The "small" rig is
+	// under threshold and should not appear at all.
+	if !strings.HasPrefix(r.Details[0], `rig "huge"`) {
+		t.Errorf("details[0] should start with huge rig; got %q", r.Details[0])
+	}
+	if strings.Contains(strings.Join(r.Details, "\n"), `rig "small"`) {
+		t.Errorf("under-threshold rig should be omitted from details; got %v", r.Details)
+	}
+}
+
+func TestWorktreeDiskSizeCheck_MeasureErrorSurfaced(t *testing.T) {
+	dir := t.TempDir()
+	rig := filepath.Join(dir, ".gc", "worktrees", "broken")
+	if err := os.MkdirAll(rig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &WorktreeDiskSizeCheck{
+		cfg: config.DoctorConfig{},
+		measureDir: fakeMeasure(nil, map[string]error{
+			rig: errors.New("permission denied"),
+		}),
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK", r.Status)
+	}
+	if len(r.Details) == 0 || !strings.Contains(r.Details[0], "permission denied") {
+		t.Errorf("expected measure error in details; got %v", r.Details)
+	}
+}
+
+// --- NestedWorktreePruneCheck ---
+
+// fakeGitWorktree implements gitWorktree for tests. Behaves like the
+// shared admin dir of a multi-worktree repo: list returns the same
+// entries regardless of which path is used to construct it. Per-path
+// "uncommitted/unpushed/stashed" flags drive classifyNested.
+type fakeGitWorktree struct {
+	listResp     []git.Worktree
+	listErr      error
+	uncommitted  map[string]bool
+	unpushed     map[string]bool
+	stashed      map[string]bool
+	removeCalls  *[]string // accumulator across handle instances
+	removeErr    map[string]error
+	currentPath  string
+	onList       func(callerPath string) // optional probe; fires per WorktreeList call
+}
+
+func (f *fakeGitWorktree) WorktreeList() ([]git.Worktree, error) {
+	if f.onList != nil {
+		f.onList(f.currentPath)
+	}
+	return f.listResp, f.listErr
+}
+func (f *fakeGitWorktree) HasUncommittedWork() bool { return f.uncommitted[f.currentPath] }
+func (f *fakeGitWorktree) HasUnpushedCommits() bool { return f.unpushed[f.currentPath] }
+func (f *fakeGitWorktree) HasStashes() bool         { return f.stashed[f.currentPath] }
+func (f *fakeGitWorktree) WorktreeRemove(path string, _ bool) error {
+	*f.removeCalls = append(*f.removeCalls, path)
+	if f.removeErr != nil {
+		if e, ok := f.removeErr[path]; ok {
+			return e
+		}
+	}
+	return nil
+}
+
+// makeAgentHome creates dir/.gc/worktrees/<rig>/<agent>/ with a stub
+// .git file so isGitWorktreePath returns true. Returns the agent home
+// path (canonicalized via pathutil.NormalizePathForCompare to match
+// what the check stores). The .git stub uses a shared gitdir so all
+// homes created via this helper appear to belong to the same admin
+// dir; tests that need distinct admin dirs should use
+// makeAgentHomeAdmin.
+func makeAgentHome(t *testing.T, dir, rig, agent string) string {
+	t.Helper()
+	return makeAgentHomeAdmin(t, dir, rig, agent, "/tmp/none")
+}
+
+// makeAgentHomeAdmin is like makeAgentHome but lets the test specify
+// the gitdir admin root, so two homes can simulate distinct repos.
+func makeAgentHomeAdmin(t *testing.T, dir, rig, agent, adminRoot string) string {
+	t.Helper()
+	home := filepath.Join(dir, ".gc", "worktrees", rig, agent)
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitdir := adminRoot + "/worktrees/" + agent
+	if err := os.WriteFile(filepath.Join(home, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return pathutil.NormalizePathForCompare(home)
+}
+
+func TestNestedWorktreePruneCheck_NoWorktreesDir(t *testing.T) {
+	dir := t.TempDir()
+	c := NewNestedWorktreePruneCheck(config.DoctorConfig{})
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK", r.Status)
+	}
+}
+
+func TestNestedWorktreePruneCheck_NoNestedWorktrees(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "home-branch"},
+					// sibling worktree at unrelated path — not nested
+					{Path: filepath.Join(dir, "external"), Branch: "external"},
+				},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg=%s", r.Status, r.Message)
+	}
+	if len(c.findings) != 0 {
+		t.Errorf("findings = %d, want 0", len(c.findings))
+	}
+}
+
+func TestNestedWorktreePruneCheck_ClassifiesSafeAndUnsafe(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	safe := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-clean"))
+	dirty := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-dirty"))
+	unpushed := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-unpushed"))
+	stashed := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-stashed"))
+	if err := os.MkdirAll(safe, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dirty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(unpushed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(stashed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "home-branch"},
+					{Path: safe, Branch: "task-clean"},
+					{Path: dirty, Branch: "task-dirty"},
+					{Path: unpushed, Branch: "task-unpushed"},
+					{Path: stashed, Branch: "task-stashed"},
+				},
+				uncommitted: map[string]bool{dirty: true},
+				unpushed:    map[string]bool{unpushed: true},
+				stashed:     map[string]bool{stashed: true},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg=%s details=%v", r.Status, r.Message, r.Details)
+	}
+
+	var safeCount, unsafeCount int
+	for _, f := range c.findings {
+		if f.safeToRm {
+			safeCount++
+		} else {
+			unsafeCount++
+		}
+	}
+	if safeCount != 1 {
+		t.Errorf("safeCount = %d, want 1", safeCount)
+	}
+	if unsafeCount != 3 {
+		t.Errorf("unsafeCount = %d, want 3", unsafeCount)
+	}
+
+	for _, f := range c.findings {
+		if f.path == home {
+			t.Errorf("agent home %q should not be a nested finding", home)
+		}
+	}
+
+	// Fix removes only the safe one.
+	if err := c.Fix(&CheckContext{CityPath: dir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if len(removes) != 1 {
+		t.Fatalf("removes = %v, want exactly one (the safe entry)", removes)
+	}
+	if removes[0] != safe {
+		t.Errorf("removed %q, want %q", removes[0], safe)
+	}
+}
+
+func TestNestedWorktreePruneCheck_PruneTrueEscalatesSeverity(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	safe := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task-clean"))
+	if err := os.MkdirAll(safe, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{NestedWorktreePrune: true},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "home-branch"},
+					{Path: safe, Branch: "task-clean"},
+				},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusError {
+		t.Errorf("status = %d, want Error (NestedWorktreePrune=true escalates)", r.Status)
+	}
+}
+
+func TestNestedWorktreePruneCheck_AllUnsafeReturnsOK(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	dirty := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "task"))
+	if err := os.MkdirAll(dirty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "home-branch"},
+					{Path: dirty, Branch: "task"},
+				},
+				uncommitted: map[string]bool{dirty: true},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK (nothing safely prunable)", r.Status)
+	}
+	if !strings.Contains(r.Message, "none safely prunable") {
+		t.Errorf("message should say 'none safely prunable'; got %q", r.Message)
+	}
+}
+
+func TestNestedWorktreePruneCheck_DeduplicatesAcrossHomes(t *testing.T) {
+	// Two agent homes that share the same git repo would each list the
+	// same nested worktree. The check must not classify or remove it
+	// twice.
+	dir := t.TempDir()
+	homeA := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	homeB := makeAgentHome(t, dir, "rig-a", "polecat-2")
+
+	// Nested under homeA. homeB will also list it because they share a repo.
+	nested := pathutil.NormalizePathForCompare(filepath.Join(homeA, "worktrees", "task"))
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: homeA, Branch: "a"},
+					{Path: homeB, Branch: "b"},
+					{Path: nested, Branch: "task"},
+				},
+				removeCalls: &removes,
+				currentPath: path,
+			}
+		},
+	}
+	r := c.Run(&CheckContext{CityPath: dir})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	if len(c.findings) != 1 {
+		t.Errorf("findings = %d, want 1 (deduplicated)", len(c.findings))
+	}
+
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if len(removes) != 1 {
+		t.Errorf("removes = %v, want exactly one", removes)
+	}
+}
+
+func TestNestedWorktreePruneCheck_FixStopsOnError(t *testing.T) {
+	dir := t.TempDir()
+	home := makeAgentHome(t, dir, "rig-a", "polecat-1")
+	first := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "first"))
+	second := pathutil.NormalizePathForCompare(filepath.Join(home, "worktrees", "second"))
+	if err := os.MkdirAll(first, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(second, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: home, Branch: "home"},
+					{Path: first, Branch: "first"},
+					{Path: second, Branch: "second"},
+				},
+				removeCalls: &removes,
+				removeErr:   map[string]error{first: errors.New("git locked")},
+				currentPath: path,
+			}
+		},
+	}
+	if r := c.Run(&CheckContext{CityPath: dir}); r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	err := c.Fix(&CheckContext{})
+	if err == nil {
+		t.Fatal("Fix should propagate the remove error")
+	}
+	if !strings.Contains(err.Error(), "git locked") {
+		t.Errorf("error should wrap original; got %v", err)
+	}
+}
+
+// TestNestedWorktreePruneCheck_DedupsWorktreeListAcrossSharedAdminDir
+// pins the optimization that skips redundant `git worktree list` calls
+// for agent homes that share a single admin dir. Two homes pointing at
+// the same admin dir must trigger exactly one WorktreeList call; two
+// homes pointing at distinct admin dirs must trigger two.
+func TestNestedWorktreePruneCheck_DedupsWorktreeListAcrossSharedAdminDir(t *testing.T) {
+	dir := t.TempDir()
+	homeA := makeAgentHomeAdmin(t, dir, "rig-a", "polecat-1", "/repo/.git")
+	homeB := makeAgentHomeAdmin(t, dir, "rig-a", "polecat-2", "/repo/.git")
+	homeC := makeAgentHomeAdmin(t, dir, "rig-b", "polecat-3", "/other/.git")
+
+	var listCalls []string
+	var removes []string
+	c := &NestedWorktreePruneCheck{
+		cfg: config.DoctorConfig{},
+		newGit: func(path string) gitWorktree {
+			return &fakeGitWorktree{
+				listResp: []git.Worktree{
+					{Path: homeA, Branch: "a"},
+					{Path: homeB, Branch: "b"},
+					{Path: homeC, Branch: "c"},
+				},
+				removeCalls: &removes,
+				currentPath: path,
+				onList:      func(p string) { listCalls = append(listCalls, p) },
+			}
+		},
+	}
+	if r := c.Run(&CheckContext{CityPath: dir}); r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK; msg=%s", r.Status, r.Message)
+	}
+	if len(listCalls) != 2 {
+		t.Errorf("WorktreeList calls = %v, want 2 (one per distinct admin dir; homeA and homeB share)", listCalls)
+	}
+}
+
+func TestPathStrictlyInside(t *testing.T) {
+	tests := []struct {
+		child, parent string
+		want          bool
+	}{
+		{"/a/b/c", "/a/b", true},
+		{"/a/b", "/a/b", false},               // equal — strict
+		{"/a/b", "/a/bc", false},              // prefix-but-not-subpath
+		{"/x/y", "/a/b", false},
+		{"/a/b/c/d", "/a/b", true},
+	}
+	for _, tt := range tests {
+		got := pathStrictlyInside(tt.child, tt.parent)
+		if got != tt.want {
+			t.Errorf("pathStrictlyInside(%q, %q) = %v, want %v", tt.child, tt.parent, got, tt.want)
 		}
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -103,21 +103,43 @@ func (g *Git) HasUncommittedWork() bool {
 // HasUnpushedCommits reports whether HEAD has commits not reachable from
 // any remote tracking branch. Used as a safety check before removing a
 // worktree — unpushed commits represent completed work that would be lost.
+// If the probe fails, it returns true to fail closed.
 func (g *Git) HasUnpushedCommits() bool {
+	has, err := g.HasUnpushedCommitsResult()
+	if err != nil {
+		return true
+	}
+	return has
+}
+
+// HasUnpushedCommitsResult is like HasUnpushedCommits but preserves git
+// probe errors for callers that need to expose the precise failure reason.
+func (g *Git) HasUnpushedCommitsResult() (bool, error) {
 	out, err := g.run("log", "HEAD", "--oneline", "--not", "--remotes")
 	if err != nil {
-		return false // can't determine; assume clean
+		return false, fmt.Errorf("checking unpushed commits: %w", err)
 	}
-	return strings.TrimSpace(out) != ""
+	return strings.TrimSpace(out) != "", nil
 }
 
 // HasStashes reports whether the repository has stashed work.
+// If the probe fails, it returns true to fail closed.
 func (g *Git) HasStashes() bool {
+	has, err := g.HasStashesResult()
+	if err != nil {
+		return true
+	}
+	return has
+}
+
+// HasStashesResult is like HasStashes but preserves git probe errors for
+// callers that need to expose the precise failure reason.
+func (g *Git) HasStashesResult() (bool, error) {
 	out, err := g.run("stash", "list")
 	if err != nil {
-		return false // can't determine; assume clean
+		return false, fmt.Errorf("checking stashes: %w", err)
 	}
-	return strings.TrimSpace(out) != ""
+	return strings.TrimSpace(out) != "", nil
 }
 
 // SubmoduleInit initializes and updates submodules recursively.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -192,6 +192,75 @@ func TestWorktreeList(t *testing.T) {
 	}
 }
 
+// TestWorktreeList_NestedSiblings verifies the algorithmic assumption used
+// by NestedWorktreePruneCheck: when worktree B is created at a path that
+// lies inside worktree A's working tree, git treats them as siblings in
+// the same admin dir. WorktreeList() from any of A, B, or the main repo
+// returns all three entries with each entry's true on-disk path.
+//
+// This is the foundation for "find nested worktrees" — we walk per-agent
+// homes, list siblings, and filter by path containment to identify nested
+// entries.
+func TestWorktreeList_NestedSiblings(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// Outer worktree (the "agent home").
+	home := filepath.Join(t.TempDir(), "home")
+	runGit(t, repo, "worktree", "add", "-b", "home-branch", home)
+
+	// Nested worktree, path lies inside `home`. Equivalent to the polecat
+	// "$(pwd)/worktrees/<issue>" pattern from mol-polecat-work.toml.
+	nested := filepath.Join(home, "worktrees", "task-x")
+	runGit(t, home, "worktree", "add", "-b", "task-x-branch", nested)
+
+	// Listing from the home worktree returns all three siblings.
+	gHome := New(home)
+	wts, err := gHome.WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList from home: %v", err)
+	}
+	gotPaths := make(map[string]string)
+	for _, wt := range wts {
+		gotPaths[testutil.CanonicalPath(wt.Path)] = wt.Branch
+	}
+
+	wantHome := testutil.CanonicalPath(home)
+	wantNested := testutil.CanonicalPath(nested)
+	wantRepo := testutil.CanonicalPath(repo)
+
+	if _, ok := gotPaths[wantHome]; !ok {
+		t.Errorf("home worktree %q missing from list; got %v", wantHome, gotPaths)
+	}
+	if br := gotPaths[wantNested]; br != "task-x-branch" {
+		t.Errorf("nested worktree branch = %q (path %q), want task-x-branch; full list: %v",
+			br, wantNested, gotPaths)
+	}
+	if _, ok := gotPaths[wantRepo]; !ok {
+		t.Errorf("main repo %q missing from list; got %v", wantRepo, gotPaths)
+	}
+
+	// Listing from inside the nested worktree must produce the same set.
+	gNested := New(nested)
+	wts2, err := gNested.WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList from nested: %v", err)
+	}
+	if len(wts2) != len(wts) {
+		t.Errorf("WorktreeList from nested returned %d entries; from home returned %d (must match)",
+			len(wts2), len(wts))
+	}
+
+	// Path containment is the discriminator the doctor check uses to
+	// classify "nested" vs "agent home" vs "main repo". Verify it works
+	// on canonical paths.
+	if !strings.HasPrefix(wantNested+string(filepath.Separator), wantHome+string(filepath.Separator)) {
+		t.Errorf("nested path %q is not a strict subpath of home %q", wantNested, wantHome)
+	}
+	if strings.HasPrefix(wantHome+string(filepath.Separator), wantNested+string(filepath.Separator)) {
+		t.Errorf("home %q must not be classified as inside nested %q", wantHome, wantNested)
+	}
+}
+
 func TestHasUncommittedWork_Clean(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -332,6 +332,18 @@ func TestHasUnpushedCommits_NoRemote(t *testing.T) {
 	}
 }
 
+func TestHasUnpushedCommitsResult_ReturnsProbeError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(dir))
+	g := New(dir)
+	if _, err := g.HasUnpushedCommitsResult(); err == nil {
+		t.Fatal("HasUnpushedCommitsResult() error = nil, want probe error")
+	}
+	if !g.HasUnpushedCommits() {
+		t.Error("HasUnpushedCommits() should fail closed on probe errors")
+	}
+}
+
 func TestHasStashes_NoneWhenClean(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)
@@ -352,6 +364,18 @@ func TestHasStashes_DetectsStash(t *testing.T) {
 	g := New(repo)
 	if !g.HasStashes() {
 		t.Error("HasStashes() = false for repo with stash, want true")
+	}
+}
+
+func TestHasStashesResult_ReturnsProbeError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(dir))
+	g := New(dir)
+	if _, err := g.HasStashesResult(); err == nil {
+		t.Fatal("HasStashesResult() error = nil, want probe error")
+	}
+	if !g.HasStashes() {
+		t.Error("HasStashes() should fail closed on probe errors")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1326. Adds a `[doctor]` config block with two new checks that
catch the failure mode that filled a 244 GB disk in the issue report:

- `worktree-disk-size` — walks `.gc/worktrees/<rig>/` per rig and
  warns/errors when the per-rig footprint exceeds the configured
  threshold (defaults: 10 GB warn, 50 GB error). Mirrors
  `EventLogSizeCheck` (#1118) but at the worktree-tree level.
- `nested-worktree-prune` — identifies nested git worktrees inside
  agent home worktrees that are mechanically safe to remove (no
  uncommitted changes, no unpushed commits, no stashed work). `CanFix`
  removes them via `git worktree remove --force`. The rule is
  mechanical, never role-coupled — it codifies the manual recovery
  procedure the issue reporter ran by hand to reclaim 85 GB.

The `[doctor]` block is the first operator surface for doctor knobs;
`nested_worktree_prune = true` escalates findings from warning to error
for ops that want a hard fail on stale nested worktrees.

## Why not auto-prune in the SDK?

The issue's "fix #1" (auto-prune nested worktrees on bead close) would
require the SDK to know about polecat-as-role and "task vs identity"
worktrees. That's user-formula territory under the ZERO-hardcoded-roles
invariant — polecat is a user-configured agent name, nested worktrees
are created in user formulas like `mol-polecat-work.toml`. This PR
delivers the mechanical equivalent (recover what's safe to recover)
without crossing the role-hardcoding line.

## Implementation notes

- `WorktreeList` is dedup'd at the git admin-dir level via
  `readGitAdminDir` — N agent homes sharing one repo trigger one
  subprocess, not N. Uses `strings.LastIndex` of `/worktrees/` so the
  dedup stays correct when the repo's own path contains a literal
  `/worktrees/` segment.
- Reuses `pathutil.NormalizePathForCompare` for canonicalization
  (handles macOS `/private/*` aliases) and the package-local
  `isSubpath` for path containment.
- `Fix()` continues past per-entry failures and returns
  `errors.Join` — partial reclaim beats zero progress when one
  worktree happens to be locked.
- Both checks register unconditionally — they only need the city path,
  and a broken `city.toml` is exactly when silent disk-fill is most
  likely. Zero-value `DoctorConfig` produces sensible defaults.

## Test plan

- [x] `go test ./internal/doctor/ ./internal/config/ ./internal/git/`
      — 16 new tests, all pass with `-race`
- [x] `make build` clean
- [x] `make check` (fmt-check + lint + vet + test) clean
- [x] `make check-docs` clean (schema + reference/config.md regenerated)
- [x] Manual smoke: `gc doctor` against a city with the new `[doctor]`
      block reports both new checks correctly
- [x] Multi-model review iterated to convergence — Copilot flagged a
      real `strings.Index` vs `strings.LastIndex` bug in
      `readGitAdminDir`; fixed with regression test in commit
      5349b7ef

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->