### PR TITLE
feat: stamp formula input vars as gc.var.* metadata on root beads (gc-inwk)

### DIFF
--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -149,6 +149,16 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 				}
 				node.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
+			if len(vars) > 0 {
+				if node.Metadata == nil {
+					node.Metadata = make(map[string]string, len(vars))
+				}
+				for k, v := range vars {
+					if v != "" {
+						node.Metadata[formulaVarMetadataPrefix+k] = v
+					}
+				}
+			}
 		} else {
 			if node.Metadata == nil {
 				node.Metadata = make(map[string]string, 1)

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -433,6 +433,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 				}
 				b.Metadata["idempotency_key"] = opts.IdempotencyKey
 			}
+			stampFormulaVars(vars, &b)
 		} else {
 			// Non-root beads: resolve ParentID from the parent-child deps.
 			for _, dep := range recipe.Deps {
@@ -880,6 +881,23 @@ func deferBeadMetadataValue(b *beads.Bead, sourceKey, deferredKey string) {
 func ensureBeadMetadata(b *beads.Bead) {
 	if b.Metadata == nil {
 		b.Metadata = make(map[string]string, 1)
+	}
+}
+
+const formulaVarMetadataPrefix = "gc.var."
+
+// stampFormulaVars records non-empty formula input vars on the root bead as
+// gc.var.<name> metadata so they are discoverable from the parent alone
+// without traversing sub-step descriptions.
+func stampFormulaVars(vars map[string]string, b *beads.Bead) {
+	if len(vars) == 0 {
+		return
+	}
+	ensureBeadMetadata(b)
+	for k, v := range vars {
+		if v != "" {
+			b.Metadata[formulaVarMetadataPrefix+k] = v
+		}
 	}
 }
 

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -2170,3 +2170,114 @@ func TestBuildRecipeApplyPlan_PreserveRootTypeKeepsTaskRoot(t *testing.T) {
 		t.Fatalf("plan root type = %q, want task", plan.Nodes[0].Type)
 	}
 }
+
+func TestInstantiateStampsFormulaVarsOnRoot(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "test-formula",
+		Steps: []formula.RecipeStep{
+			{ID: "test-formula", Title: "Root", Type: "molecule", IsRoot: true},
+			{ID: "test-formula.step-a", Title: "Step A: {{problem}}", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "test-formula.step-a", DependsOnID: "test-formula", Type: "parent-child"},
+		},
+		Vars: map[string]*formula.VarDef{
+			"problem":   {Description: "Problem statement"},
+			"linear_id": {Description: "Linear ID"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{
+		Vars: map[string]string{
+			"problem":   "SAF-88 API Guidelines",
+			"linear_id": "SAF-88",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	root, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("Get root: %v", err)
+	}
+	if got := root.Metadata["gc.var.problem"]; got != "SAF-88 API Guidelines" {
+		t.Errorf("gc.var.problem = %q, want %q", got, "SAF-88 API Guidelines")
+	}
+	if got := root.Metadata["gc.var.linear_id"]; got != "SAF-88" {
+		t.Errorf("gc.var.linear_id = %q, want %q", got, "SAF-88")
+	}
+}
+
+func TestInstantiateDoesNotStampEmptyVars(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name: "test-formula",
+		Steps: []formula.RecipeStep{
+			{ID: "test-formula", Title: "Root", Type: "molecule", IsRoot: true},
+		},
+		Vars: map[string]*formula.VarDef{
+			"problem":   {Description: "Problem statement"},
+			"linear_id": {Description: "Linear ID"},
+		},
+	}
+
+	emptyDefault := ""
+	recipe.Vars["linear_id"].Default = &emptyDefault
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{
+		Vars: map[string]string{
+			"problem": "real problem",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+
+	root, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("Get root: %v", err)
+	}
+	if got := root.Metadata["gc.var.problem"]; got != "real problem" {
+		t.Errorf("gc.var.problem = %q, want %q", got, "real problem")
+	}
+	if _, exists := root.Metadata["gc.var.linear_id"]; exists {
+		t.Errorf("gc.var.linear_id should not be stamped for empty value")
+	}
+}
+
+func TestBuildRecipeApplyPlanStampsFormulaVarsOnRoot(t *testing.T) {
+	recipe := &formula.Recipe{
+		Name: "test-formula",
+		Steps: []formula.RecipeStep{
+			{ID: "test-formula", Title: "Root", Type: "molecule", IsRoot: true},
+			{ID: "test-formula.step-a", Title: "Step A", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "test-formula.step-a", DependsOnID: "test-formula", Type: "parent-child"},
+		},
+	}
+
+	plan, _, _, err := buildRecipeApplyPlan(recipe, Options{
+		Vars: map[string]string{
+			"problem":   "SAF-88 API Guidelines",
+			"linear_id": "SAF-88",
+			"context":   "",
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRecipeApplyPlan: %v", err)
+	}
+
+	rootNode := plan.Nodes[0]
+	if got := rootNode.Metadata["gc.var.problem"]; got != "SAF-88 API Guidelines" {
+		t.Errorf("gc.var.problem = %q, want %q", got, "SAF-88 API Guidelines")
+	}
+	if got := rootNode.Metadata["gc.var.linear_id"]; got != "SAF-88" {
+		t.Errorf("gc.var.linear_id = %q, want %q", got, "SAF-88")
+	}
+	if _, exists := rootNode.Metadata["gc.var.context"]; exists {
+		t.Errorf("gc.var.context should not be stamped for empty value")
+	}
+}


### PR DESCRIPTION
## Summary

Formula vars are now persisted on the root bead as `gc.var.<name>` metadata, making them discoverable by downstream steps without having to traverse sub-step descriptions or reparse the formula. Both the sequential (`Instantiate`) and graph-apply (`buildRecipeApplyPlan`) paths are covered. Empty values are skipped.

## Test plan

- [x] `go test ./internal/molecule/...` passes (new `molecule_test.go` cases)
- [ ] CI green

Bead: gc-inwk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->