### PR TITLE
fix: add bounded control-dispatcher ready queries

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -52,7 +52,7 @@ func openCityStatusStore(cityPath string, stderr io.Writer) (beads.Store, int) {
 		fmt.Fprintf(stderr, "gc status: opening bead store: %v\n", err) //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
-	return opened, 0
+	return wrapSessionListCache(opened), 0
 }
 
 func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath string, store beads.Store, stderr io.Writer) cityStatusSnapshot {

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -92,6 +94,61 @@ func (s *failingStatusStore) Get(id string) (beads.Bead, error) {
 		return beads.Bead{}, s.err
 	}
 	return s.MemStore.Get(id)
+}
+
+func TestCityStatusCoalescesSessionLabelListCalls(t *testing.T) {
+	sp := runtime.NewFake()
+	dops := newFakeDrainOps()
+
+	mem := beads.NewMemStore()
+	counter := &sessionLabelListCounter{Store: mem}
+
+	oldOpen := openCityStoreAtForStatus
+	openCityStoreAtForStatus = func(string) (beads.Store, error) { return counter, nil }
+	t.Cleanup(func() { openCityStoreAtForStatus = oldOpen })
+
+	// Many agents -> each one would otherwise resolve via store.List(Label=gc:session).
+	agents := make([]config.Agent, 0, 25)
+	for i := 0; i < 25; i++ {
+		name := "agent" + strconv.Itoa(i)
+		agents = append(agents, config.Agent{Name: name, MaxActiveSessions: intPtr(1)})
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents:    agents,
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	var stdout, stderr bytes.Buffer
+	if code := doCityStatus(sp, dops, cfg, cityPath, &stdout, &stderr); code != 0 {
+		t.Fatalf("doCityStatus code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	if got := counter.sessionLabelCalls(); got != 1 {
+		t.Fatalf("session-label List calls = %d, want 1 (caching collapses redundant scans)", got)
+	}
+}
+
+type sessionLabelListCounter struct {
+	beads.Store
+	mu    sync.Mutex
+	count int
+}
+
+func (s *sessionLabelListCounter) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if isCanonicalSessionListQuery(q) || (q.Label == session.LabelSession && q.IncludeClosed) {
+		s.mu.Lock()
+		s.count++
+		s.mu.Unlock()
+	}
+	return s.Store.List(q)
+}
+
+func (s *sessionLabelListCounter) sessionLabelCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.count
 }
 
 func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1028,6 +1028,7 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1037,26 +1038,21 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
 	})
 
-	cdAgent := config.Agent{Name: config.ControlDispatcherAgentName}
-	wantQuery := workflowServeWorkQuery(cdAgent)
-	var gotQueries []string
 	var gotDirs []string
-	var gotEnv []map[string]string
 	var controlled []string
 	sequence := [][]hookBead{
 		{{ID: "gc-ctrl-1", Metadata: map[string]string{"gc.kind": "scope-check"}}},
 		{{ID: "gc-ctrl-2", Metadata: map[string]string{"gc.kind": "workflow-finalize"}}},
 	}
 
-	workflowServeList = func(workQuery, dir string, env map[string]string) ([]hookBead, error) {
-		gotQueries = append(gotQueries, workQuery)
-		gotDirs = append(gotDirs, dir)
-		gotEnv = append(gotEnv, maps.Clone(env))
+	workflowServeListInProcess = func(storePath, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
+		gotDirs = append(gotDirs, storePath)
 		if len(sequence) == 0 {
 			return nil, nil
 		}
@@ -1076,137 +1072,11 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 	if !slices.Equal(controlled, []string{"gc-ctrl-1", "gc-ctrl-2"}) {
 		t.Fatalf("controlled beads = %#v, want two ready control beads in order", controlled)
 	}
-	if len(gotQueries) != 3 {
-		t.Fatalf("workflowServeList calls = %d, want 3", len(gotQueries))
-	}
-	for i, got := range gotQueries {
-		if got != wantQuery {
-			t.Fatalf("workflowServeList query[%d] = %q, want %q", i, got, wantQuery)
-		}
-	}
 	for i, got := range gotDirs {
 		if canonicalTestPath(got) != canonicalTestPath(cityDir) {
-			t.Fatalf("workflowServeList dir[%d] = %q, want %q", i, got, cityDir)
+			t.Fatalf("workflowServeListInProcess dir[%d] = %q, want %q", i, got, cityDir)
 		}
 	}
-	for i, env := range gotEnv {
-		if env["GC_STORE_ROOT"] != cityDir {
-			t.Fatalf("workflowServeList env[%d] GC_STORE_ROOT = %q, want %q", i, env["GC_STORE_ROOT"], cityDir)
-		}
-		if env["GC_STORE_SCOPE"] != "city" {
-			t.Fatalf("workflowServeList env[%d] GC_STORE_SCOPE = %q, want city", i, env["GC_STORE_SCOPE"])
-		}
-	}
-}
-
-func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
-	if strings.Contains(query, "GC_SESSION_ORIGIN") {
-		t.Fatalf("workflowServeControlReadyQuery should not gate legacy routes on session origin: %q", query)
-	}
-	if strings.Contains(query, "bd list --status in_progress") {
-		t.Fatalf("workflowServeControlReadyQuery should not return in-progress control beads: %q", query)
-	}
-	for _, want := range []string{
-		`bd ready --assignee="$cand"`,
-		`bd ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned`,
-		`bd ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned`,
-	} {
-		if !strings.Contains(query, want) {
-			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
-		}
-	}
-	if !strings.Contains(query, `--limit=20`) {
-		t.Fatalf("workflowServeControlReadyQuery missing scan limit: %q", query)
-	}
-}
-
-func TestWorkflowServeControlReadyQueryIgnoresInProgressAssigned(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME":   "gascity--control-dispatcher",
-		"GC_ALIAS":          "gascity/control-dispatcher",
-		"GC_SESSION_ORIGIN": "named",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=20")
-    printf '[{"id":"ga-in-progress"}]'
-    ;;
-  "ready --assignee=gascity--control-dispatcher --json --limit=20")
-    printf '[{"id":"ga-ready"}]'
-    ;;
-  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=20")
-    printf '[{"id":"ga-routed"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	if got, want := strings.TrimSpace(out), `[{"id":"ga-ready"}]`; got != want {
-		t.Fatalf("control query output = %q, want %q", got, want)
-	}
-}
-
-func TestWorkflowServeControlReadyQueryQuotesMetadataFallbackTarget(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "my rig"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{}, `#!/bin/sh
-set -eu
-case "$1|$2|$3|$4|$5|$6" in
-  "ready|--metadata-field|gc.routed_to=my rig/control-dispatcher|--unassigned|--json|--limit=20")
-    printf '[{"id":"ga-routed"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	if got, want := strings.TrimSpace(out), `[{"id":"ga-routed"}]`; got != want {
-		t.Fatalf("control query output = %q, want %q", got, want)
-	}
-}
-
-func TestWorkflowServeControlReadyQueryUsesLegacyRouteForNamedSessions(t *testing.T) {
-	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
-		"GC_SESSION_NAME":   "gascity--control-dispatcher",
-		"GC_ALIAS":          "gascity/control-dispatcher",
-		"GC_SESSION_ORIGIN": "named",
-	}, `#!/bin/sh
-set -eu
-case "$*" in
-  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=20")
-    printf '[{"id":"ga-legacy-route"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
-`)
-	if got, want := strings.TrimSpace(out), `[{"id":"ga-legacy-route"}]`; got != want {
-		t.Fatalf("control query output = %q, want %q", got, want)
-	}
-}
-
-func runWorkflowServeShellQueryForTest(t *testing.T, query string, env map[string]string, bdScript string) string {
-	t.Helper()
-
-	tmp := t.TempDir()
-	bdPath := filepath.Join(tmp, "bd")
-	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
-		t.Fatalf("write fake bd: %v", err)
-	}
-
-	queryEnv := []string{"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH")}
-	for key, value := range env {
-		queryEnv = append(queryEnv, key+"="+value)
-	}
-	out, err := shellWorkQueryWithEnv(query, t.TempDir(), queryEnv)
-	if err != nil {
-		t.Fatalf("run workflow serve query: %v", err)
-	}
-	return out
 }
 
 // TestRunWorkflowServeOverridesInheritedCityBeadsDir is a regression test for
@@ -1237,6 +1107,7 @@ func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1246,6 +1117,7 @@ func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
@@ -1309,6 +1181,7 @@ path = %q
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1318,6 +1191,7 @@ path = %q
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
@@ -1325,9 +1199,9 @@ path = %q
 
 	calls := 0
 	var queryDir string
-	workflowServeList = func(_, dir string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(storePath, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		calls++
-		queryDir = dir
+		queryDir = storePath
 		if calls == 1 {
 			return []hookBead{{ID: "gc-rig-control", Metadata: map[string]string{"gc.kind": "scope-check"}}}, nil
 		}
@@ -1397,6 +1271,7 @@ max = 5
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1406,6 +1281,7 @@ max = 5
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
@@ -1443,6 +1319,7 @@ func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1452,6 +1329,7 @@ func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
@@ -1459,7 +1337,7 @@ func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.
 
 	var controlled []string
 	calls := 0
-	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -1495,6 +1373,7 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1504,6 +1383,7 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
@@ -1512,7 +1392,7 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 	var attempted []string
 	var processed []string
 	calls := 0
-	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -1554,6 +1434,7 @@ func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *te
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevInterval := workflowServeIdlePollInterval
 	prevAttempts := workflowServeIdlePollAttempts
@@ -1563,6 +1444,7 @@ func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *te
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeIdlePollInterval = prevInterval
 		workflowServeIdlePollAttempts = prevAttempts
@@ -1571,7 +1453,7 @@ func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *te
 	var attempted []string
 	var processed []string
 	calls := 0
-	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -1613,15 +1495,17 @@ func TestRunWorkflowServeReturnsQueryError(t *testing.T) {
 
 	prevCityFlag := cityFlag
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	cityFlag = ""
 	t.Cleanup(func() {
 		cityFlag = prevCityFlag
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 	})
 
-	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		return nil, os.ErrDeadlineExceeded
 	}
 	controlDispatcherServe = func(_, _, _ string, _ io.Writer, _ io.Writer) error {
@@ -1683,12 +1567,14 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 	ep := newTestProvider(t, eventsDir)
 
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevProvider := workflowServeOpenEventsProvider
 	prevSweep := workflowServeWakeSweepInterval
 	workflowServeWakeSweepInterval = time.Millisecond
 	t.Cleanup(func() {
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeOpenEventsProvider = prevProvider
 		workflowServeWakeSweepInterval = prevSweep
@@ -1700,7 +1586,7 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 
 	var processed []string
 	calls := 0
-	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1:
@@ -1721,6 +1607,7 @@ func TestRunWorkflowServeFollowUsesSweepFallback(t *testing.T) {
 		wfcAgent,
 		t.TempDir(),
 		t.TempDir(),
+		nil,
 		wfcAgent.EffectiveWorkQuery(),
 		nil,
 		io.Discard,
@@ -1738,6 +1625,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	ep := newTestProvider(t, eventsDir)
 
 	prevList := workflowServeList
+	prevInProcess := workflowServeListInProcess
 	prevControl := controlDispatcherServe
 	prevProvider := workflowServeOpenEventsProvider
 	prevWait := workflowServeWaitForWake
@@ -1745,6 +1633,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	prevAttempts := workflowServeIdlePollAttempts
 	t.Cleanup(func() {
 		workflowServeList = prevList
+		workflowServeListInProcess = prevInProcess
 		controlDispatcherServe = prevControl
 		workflowServeOpenEventsProvider = prevProvider
 		workflowServeWaitForWake = prevWait
@@ -1780,7 +1669,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	}
 
 	calls := 0
-	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
 		calls++
 		switch calls {
 		case 1, 2, 4, 5, 7:
@@ -1802,7 +1691,7 @@ func TestRunWorkflowServeFollowResetsBackoffForProcessedEventAndPending(t *testi
 	}
 
 	agent := config.Agent{Name: "control-dispatcher"}
-	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), agent.EffectiveWorkQuery(), nil, io.Discard)
+	err := runWorkflowServeFollow(agent, t.TempDir(), t.TempDir(), nil, agent.EffectiveWorkQuery(), nil, io.Discard)
 	if !errors.Is(err, stopErr) {
 		t.Fatalf("runWorkflowServeFollow error = %v, want %v", err, stopErr)
 	}

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -5,13 +5,29 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/spf13/cobra"
 )
+
+// runtimeRequestRestartBlock blocks until the controller kills this process.
+// It is a package var so tests can override it to avoid blocking forever.
+// Default: park on a signal channel so the Go runtime's deadlock detector
+// (which fires when *all* goroutines are asleep) does not trip — os/signal
+// keeps a live goroutine in syscall. The controller normally SIGKILLs the
+// process tree before any caught signal arrives, but SIGTERM/SIGINT/SIGHUP
+// are honored as a graceful path.
+var runtimeRequestRestartBlock = func() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+	<-sigCh
+}
 
 // drainOps abstracts drain signal operations for testability.
 type drainOps interface {
@@ -458,8 +474,11 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 	})
 	fmt.Fprintln(stdout, "Restart requested. Blocking until controller kills this session...") //nolint:errcheck // best-effort stdout
 
-	// Block forever. The controller will kill the entire process tree.
-	select {}
+	// Block until the controller kills the process tree (or a termination
+	// signal arrives). Using signal.Notify rather than a bare `select {}`
+	// avoids the Go runtime's all-goroutines-asleep deadlock panic.
+	runtimeRequestRestartBlock()
+	return 0
 }
 
 // doRuntimeDrainAck sets the drain-ack flag on the session. The controller

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -488,6 +488,50 @@ func TestDoRuntimeRequestRestartError(t *testing.T) {
 	}
 }
 
+// TestDoRuntimeRequestRestartDoesNotDeadlock guards against the regression
+// in gc-6rm: a bare `select {}` after writing the restart flag tripped the
+// Go runtime's all-goroutines-asleep deadlock detector and aborted the
+// process with exit 2, so the controller never observed the request in
+// time. doRuntimeRequestRestart must block via a live waiter (signal park)
+// and return 0 once unblocked.
+func TestDoRuntimeRequestRestartDoesNotDeadlock(t *testing.T) {
+	prev := runtimeRequestRestartBlock
+	unblock := make(chan struct{})
+	runtimeRequestRestartBlock = func() { <-unblock }
+	t.Cleanup(func() { runtimeRequestRestartBlock = prev })
+
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
+	done := make(chan int, 1)
+	go func() {
+		done <- doRuntimeRequestRestart(dops, nil, events.Discard, "worker", "worker", &stdout, &stderr)
+	}()
+
+	// Should have set the restart flag and be parked in the block func.
+	select {
+	case code := <-done:
+		t.Fatalf("returned without blocking, code=%d stderr=%q", code, stderr.String())
+	case <-time.After(50 * time.Millisecond):
+	}
+	if !dops.restartRequested["worker"] {
+		t.Fatalf("restart_requested flag not set on dops")
+	}
+
+	close(unblock)
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("code = %d, want 0; stderr=%q", code, stderr.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("doRuntimeRequestRestart did not return after unblock")
+	}
+	if !strings.Contains(stdout.String(), "Blocking until controller kills this session") {
+		t.Errorf("stdout = %q, want blocking notice", stdout.String())
+	}
+}
+
 func TestRequestRestartAcceptsNoArgs(t *testing.T) {
 	// Verify the cobra command accepts no args.
 	var stdout, stderr bytes.Buffer

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gastownhall/gascity/internal/dispatch"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/formula"
-	"github.com/gastownhall/gascity/internal/shellquote"
 	"github.com/gastownhall/gascity/internal/sling"
 )
 
@@ -66,6 +65,8 @@ func applyGraphRouting(recipe *formula.Recipe, a *config.Agent, routedTo string,
 
 var (
 	workflowServeList               = nextWorkflowServeBeads
+	workflowServeListInProcess      = nextWorkflowServeBeadsInProcess
+	openControlStoreForReady        = openControlStoreAtForCity
 	controlDispatcherServe          = runControlDispatcherInStore
 	workflowServeOpenEventsProvider = func(stderr io.Writer) (events.Provider, error) {
 		ep, code := openCityEventsProvider(stderr, "gc convoy control --serve")
@@ -195,10 +196,10 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	workQuery := expandAgentCommandTemplate(cityPath, loadedCityName(cfg, cityPath), &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
-		_, err := drainWorkflowServeWork(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
+		_, err := drainWorkflowServeWork(agentCfg, cityPath, workDir, cfg, workQuery, workEnv, stderr)
 		return err
 	}
-	return runWorkflowServeFollow(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
+	return runWorkflowServeFollow(agentCfg, cityPath, workDir, cfg, workQuery, workEnv, stderr)
 }
 
 type workflowServeDrainResult struct {
@@ -210,11 +211,11 @@ type workflowServeDrainResult struct {
 // for a single invocation. Returns whether it advanced a control bead and
 // whether the queue still contains only pending work so the --follow caller
 // can distinguish blocked work from genuine idle.
-func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) (workflowServeDrainResult, error) {
+func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath string, cfg *config.City, workQuery string, workEnv map[string]string, stderr io.Writer) (workflowServeDrainResult, error) {
 	result := workflowServeDrainResult{}
 	idlePolls := 0
 	for {
-		queue, err := workflowServeList(workflowServeWorkQuery(agentCfg, workQuery), storePath, workEnv)
+		queue, err := workflowServeQueue(agentCfg, cityPath, storePath, cfg, workQuery, workEnv)
 		if err != nil {
 			workflowTracef("serve query-error agent=%s err=%v", agentCfg.QualifiedName(), err)
 			return result, fmt.Errorf("querying control work for %s: %w", agentCfg.QualifiedName(), err)
@@ -283,6 +284,23 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 	}
 }
 
+func workflowServeQueue(agentCfg config.Agent, cityPath, storePath string, cfg *config.City, workQuery string, workEnv map[string]string) ([]hookBead, error) {
+	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
+		target := strings.TrimSpace(agentCfg.QualifiedName())
+		if target == "" {
+			target = config.ControlDispatcherAgentName
+		}
+		sessionVals := []string{
+			os.Getenv("GC_SESSION_ID"),
+			os.Getenv("GC_SESSION_NAME"),
+			os.Getenv("GC_ALIAS"),
+			target,
+		}
+		return workflowServeListInProcess(storePath, cityPath, cfg, target, workflowServeLegacyControlRoute(target), sessionVals, workflowServeScanLimit)
+	}
+	return workflowServeList(workflowServeWorkQuery(agentCfg, workQuery), storePath, workEnv)
+}
+
 func isLegacyOversizedControlEventError(err error) bool {
 	if err == nil {
 		return false
@@ -293,7 +311,7 @@ func isLegacyOversizedControlEventError(err error) bool {
 		strings.Contains(msg, "too large")
 }
 
-func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuery string, workEnv map[string]string, stderr io.Writer) error {
+func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath string, cfg *config.City, workQuery string, workEnv map[string]string, stderr io.Writer) error {
 	ep, err := workflowServeOpenEventsProvider(stderr)
 	if err != nil {
 		return err
@@ -317,7 +335,7 @@ func runWorkflowServeFollow(agentCfg config.Agent, cityPath, storePath, workQuer
 
 	idleSweeps := 0
 	for {
-		drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, storePath, workQuery, workEnv, stderr)
+		drainResult, err := drainWorkflowServeWork(agentCfg, cityPath, storePath, cfg, workQuery, workEnv, stderr)
 		if err != nil {
 			return err
 		}
@@ -422,9 +440,6 @@ func workflowServeQuery(workQuery string) string {
 }
 
 func workflowServeWorkQuery(agentCfg config.Agent, expandedWorkQuery ...string) string {
-	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
-		return workflowServeControlReadyQuery(agentCfg)
-	}
 	workQuery := agentCfg.EffectiveWorkQuery()
 	if len(expandedWorkQuery) > 0 {
 		workQuery = expandedWorkQuery[0]
@@ -438,36 +453,6 @@ func isWorkflowServeControlDispatcherAgent(agentCfg config.Agent) bool {
 		strings.HasSuffix(qualified, "/"+config.ControlDispatcherAgentName)
 }
 
-func workflowServeControlReadyQuery(agentCfg config.Agent) string {
-	target := strings.TrimSpace(agentCfg.QualifiedName())
-	if target == "" {
-		target = config.ControlDispatcherAgentName
-	}
-	limit := fmt.Sprintf("%d", workflowServeScanLimit)
-	queryPrefix := `GC_CONTROL_TARGET=` + shellquote.Quote(target)
-	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
-		queryPrefix += ` GC_CONTROL_LEGACY_TARGET=` + shellquote.Quote(legacy)
-	}
-	query := queryPrefix + ` sh -c '` +
-		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS" "$GC_CONTROL_TARGET"; do ` +
-		`[ -z "$id" ] && continue; ` +
-		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
-		`for cand in "$id" "$legacy"; do ` +
-		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd ready --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
-		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-		`done; ` +
-		`done; ` +
-		`r=$(bd ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null); ` +
-		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `
-	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
-		query += `bd ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null'`
-	} else {
-		query += `printf "[]"` + `'`
-	}
-	return query
-}
-
 func workflowServeLegacyControlRoute(target string) string {
 	target = strings.TrimSpace(target)
 	if target == config.ControlDispatcherAgentName {
@@ -478,6 +463,81 @@ func workflowServeLegacyControlRoute(target string) string {
 		return strings.TrimSuffix(target, suffix) + "/workflow-control"
 	}
 	return ""
+}
+
+func controlReadyCandidates(sessionVals []string) []string {
+	seen := map[string]bool{}
+	var candidates []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			return
+		}
+		seen[value] = true
+		candidates = append(candidates, value)
+	}
+	for _, value := range sessionVals {
+		value = strings.TrimSpace(value)
+		add(value)
+		if strings.HasSuffix(value, config.ControlDispatcherAgentName) {
+			add(strings.TrimSuffix(value, config.ControlDispatcherAgentName) + "workflow-control")
+		}
+	}
+	return candidates
+}
+
+func nextWorkflowServeBeadsInProcess(storePath, cityPath string, cfg *config.City, target, legacyTarget string, sessionVals []string, limit int) ([]hookBead, error) {
+	store, err := openControlStoreForReady(storePath, cityPath, cfg)
+	if err != nil {
+		return nil, err
+	}
+	candidates := controlReadyCandidates(sessionVals)
+	for _, candidate := range candidates {
+		matches, err := store.ReadyQuery(beads.ReadyQuery{Assignee: candidate, Limit: limit})
+		if err != nil {
+			return nil, err
+		}
+		workflowTracef("serve query candidate=%s stage=assignee hits=%d", candidate, len(matches))
+		if len(matches) > 0 {
+			return hookBeadsFromBeads(matches), nil
+		}
+	}
+	matches, err := store.ReadyQuery(beads.ReadyQuery{
+		Metadata:   map[string]string{"gc.routed_to": target},
+		Unassigned: true,
+		Limit:      limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	workflowTracef("serve query candidate=%s stage=routed_to hits=%d", target, len(matches))
+	if len(matches) > 0 {
+		return hookBeadsFromBeads(matches), nil
+	}
+	if strings.TrimSpace(legacyTarget) == "" {
+		return nil, nil
+	}
+	matches, err = store.ReadyQuery(beads.ReadyQuery{
+		Metadata:   map[string]string{"gc.routed_to": legacyTarget},
+		Unassigned: true,
+		Limit:      limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	workflowTracef("serve query candidate=%s stage=legacy_routed_to hits=%d", legacyTarget, len(matches))
+	if len(matches) > 0 {
+		return hookBeadsFromBeads(matches), nil
+	}
+	return nil, nil
+}
+
+func hookBeadsFromBeads(in []beads.Bead) []hookBead {
+	out := make([]hookBead, 0, len(in))
+	for _, b := range in {
+		out = append(out, hookBead{ID: b.ID, Metadata: hookBeadMetadata(b.Metadata)})
+	}
+	return out
 }
 
 func nextWorkflowServeBeads(workQuery, dir string, env map[string]string) ([]hookBead, error) {

--- a/cmd/gc/dispatch_runtime_inprocess_test.go
+++ b/cmd/gc/dispatch_runtime_inprocess_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestControlReadyCandidates_OrderDedupEmpty(t *testing.T) {
+	got := controlReadyCandidates([]string{"", "sess-1", "alias", "sess-1", "target"})
+	want := []string{"sess-1", "alias", "target"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("controlReadyCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestControlReadyCandidates_LegacySuffixExpansion(t *testing.T) {
+	got := controlReadyCandidates([]string{"gascity/control-dispatcher", "control-dispatcher"})
+	want := []string{
+		"gascity/control-dispatcher",
+		"gascity/workflow-control",
+		"control-dispatcher",
+		"workflow-control",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("controlReadyCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestControlReadyCandidates_TargetIncludedWhenSessionsEmpty(t *testing.T) {
+	got := controlReadyCandidates([]string{"", "", "", "gascity/control-dispatcher"})
+	want := []string{"gascity/control-dispatcher", "gascity/workflow-control"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("controlReadyCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestControlReadyCandidates_NoLegacyForNonControlSuffix(t *testing.T) {
+	got := controlReadyCandidates([]string{"foo/workflow-control"})
+	want := []string{"foo/workflow-control"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("controlReadyCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestInProcessReady_AssigneeFirstCandidateWins(t *testing.T) {
+	store := beads.NewMemStore()
+	for i := 0; i < 25; i++ {
+		createReadyBead(t, store, "A", nil)
+	}
+	for i := 0; i < 5; i++ {
+		createReadyBead(t, store, "B", nil)
+	}
+
+	got := runInProcessReadyForTest(t, store, "target", "", []string{"A", "B"}, 20)
+	if len(got) != 20 {
+		t.Fatalf("len(got) = %d, want 20", len(got))
+	}
+	for i, b := range got {
+		if b.ID != "gc-"+strconv.Itoa(i+1) {
+			t.Fatalf("got[%d].ID = %q, want gc-%d from first candidate only", i, b.ID, i+1)
+		}
+	}
+}
+
+func TestInProcessReady_LegacyAssigneeFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	want := createReadyBead(t, store, "gascity/workflow-control", nil)
+
+	got := runInProcessReadyForTest(t, store, "gascity/control-dispatcher", "", []string{"gascity/control-dispatcher"}, 20)
+	if gotIDs(got) != want.ID {
+		t.Fatalf("got IDs = %q, want %q", gotIDs(got), want.ID)
+	}
+}
+
+func TestInProcessReady_RoutedToFallback_RequiresEmptyAssignee(t *testing.T) {
+	store := beads.NewMemStore()
+	createReadyBead(t, store, "someone-else", map[string]string{"gc.routed_to": "gascity/control-dispatcher"})
+	want := createReadyBead(t, store, "", map[string]string{"gc.routed_to": "gascity/control-dispatcher"})
+
+	got := runInProcessReadyForTest(t, store, "gascity/control-dispatcher", "", []string{"no-match"}, 20)
+	if gotIDs(got) != want.ID {
+		t.Fatalf("got IDs = %q, want only unassigned routed bead %q", gotIDs(got), want.ID)
+	}
+}
+
+func TestInProcessReady_LegacyRoutedToFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	want := createReadyBead(t, store, "", map[string]string{"gc.routed_to": "gascity/workflow-control"})
+
+	got := runInProcessReadyForTest(t, store, "gascity/control-dispatcher", "gascity/workflow-control", []string{"no-match"}, 20)
+	if gotIDs(got) != want.ID {
+		t.Fatalf("got IDs = %q, want %q", gotIDs(got), want.ID)
+	}
+}
+
+func TestInProcessReady_LimitPerStage(t *testing.T) {
+	store := beads.NewMemStore()
+	for i := 0; i < 25; i++ {
+		createReadyBead(t, store, "A", nil)
+	}
+
+	got := runInProcessReadyForTest(t, store, "target", "", []string{"A"}, 7)
+	if len(got) != 7 {
+		t.Fatalf("len(got) = %d, want 7", len(got))
+	}
+}
+
+func TestInProcessReady_UsesFilteredReadyQueries(t *testing.T) {
+	store := &recordingReadyQueryStore{
+		responses: [][]beads.Bead{
+			nil,
+			{{ID: "gc-legacy", Status: "open", Type: "task", Assignee: "gascity/workflow-control"}},
+		},
+	}
+	prev := openControlStoreForReady
+	openControlStoreForReady = func(string, string, *config.City) (beads.Store, error) {
+		return store, nil
+	}
+	t.Cleanup(func() { openControlStoreForReady = prev })
+
+	got, err := nextWorkflowServeBeadsInProcess(
+		"/store",
+		"/city",
+		nil,
+		"gascity/control-dispatcher",
+		"gascity/workflow-control",
+		[]string{"gascity/control-dispatcher"},
+		20,
+	)
+	if err != nil {
+		t.Fatalf("nextWorkflowServeBeadsInProcess: %v", err)
+	}
+	if gotIDs(got) != "gc-legacy" {
+		t.Fatalf("got IDs = %q, want gc-legacy", gotIDs(got))
+	}
+	want := []beads.ReadyQuery{
+		{Assignee: "gascity/control-dispatcher", Limit: 20},
+		{Assignee: "gascity/workflow-control", Limit: 20},
+	}
+	if !slices.EqualFunc(store.queries, want, readyQueryEqual) {
+		t.Fatalf("queries = %#v, want %#v", store.queries, want)
+	}
+}
+
+func TestInProcessReady_StoreOpenError_Surfaces(t *testing.T) {
+	openErr := errors.New("open failed")
+	prev := openControlStoreForReady
+	openControlStoreForReady = func(string, string, *config.City) (beads.Store, error) {
+		return nil, openErr
+	}
+	t.Cleanup(func() { openControlStoreForReady = prev })
+
+	_, err := nextWorkflowServeBeadsInProcess("/store", "/city", nil, "target", "", nil, 20)
+	if !errors.Is(err, openErr) {
+		t.Fatalf("err = %v, want %v", err, openErr)
+	}
+}
+
+func TestInProcessReady_ReadyQueryError_Surfaces(t *testing.T) {
+	readyErr := errors.New("ready failed")
+	prev := openControlStoreForReady
+	openControlStoreForReady = func(string, string, *config.City) (beads.Store, error) {
+		return unavailableStore{err: readyErr}, nil
+	}
+	t.Cleanup(func() { openControlStoreForReady = prev })
+
+	_, err := nextWorkflowServeBeadsInProcess("/store", "/city", nil, "target", "", nil, 20)
+	if !errors.Is(err, readyErr) {
+		t.Fatalf("err = %v, want %v", err, readyErr)
+	}
+}
+
+type recordingReadyQueryStore struct {
+	unavailableStore
+	queries   []beads.ReadyQuery
+	responses [][]beads.Bead
+}
+
+func (s *recordingReadyQueryStore) ReadyQuery(query beads.ReadyQuery) ([]beads.Bead, error) {
+	s.queries = append(s.queries, query)
+	if len(s.responses) == 0 {
+		return nil, nil
+	}
+	next := s.responses[0]
+	s.responses = s.responses[1:]
+	return next, nil
+}
+
+func readyQueryEqual(a, b beads.ReadyQuery) bool {
+	return a.Assignee == b.Assignee &&
+		a.Unassigned == b.Unassigned &&
+		a.Limit == b.Limit &&
+		maps.Equal(a.Metadata, b.Metadata)
+}
+
+func TestDrainWorkflowServeWork_ControlAgentRoutesInProcess(t *testing.T) {
+	prevInProcess := workflowServeListInProcess
+	prevShell := workflowServeList
+	prevControl := controlDispatcherServe
+	t.Cleanup(func() {
+		workflowServeListInProcess = prevInProcess
+		workflowServeList = prevShell
+		controlDispatcherServe = prevControl
+	})
+
+	inProcessCalls := 0
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
+		inProcessCalls++
+		return nil, nil
+	}
+	workflowServeList = func(string, string, map[string]string) ([]hookBead, error) {
+		t.Fatal("shell workflowServeList called for control-dispatcher")
+		return nil, nil
+	}
+	controlDispatcherServe = func(_, _, _ string, _ io.Writer, _ io.Writer) error {
+		t.Fatal("controlDispatcherServe should not run with empty queue")
+		return nil
+	}
+
+	_, err := drainWorkflowServeWork(config.Agent{Name: config.ControlDispatcherAgentName}, "/city", "/store", nil, "", nil, io.Discard)
+	if err != nil {
+		t.Fatalf("drainWorkflowServeWork: %v", err)
+	}
+	if inProcessCalls != 1 {
+		t.Fatalf("inProcessCalls = %d, want 1", inProcessCalls)
+	}
+}
+
+func TestDrainWorkflowServeWork_NonControlAgentUsesShell(t *testing.T) {
+	prevInProcess := workflowServeListInProcess
+	prevShell := workflowServeList
+	prevControl := controlDispatcherServe
+	t.Cleanup(func() {
+		workflowServeListInProcess = prevInProcess
+		workflowServeList = prevShell
+		controlDispatcherServe = prevControl
+	})
+
+	shellCalls := 0
+	workflowServeListInProcess = func(_, _ string, _ *config.City, _, _ string, _ []string, _ int) ([]hookBead, error) {
+		t.Fatal("in-process path called for non-control agent")
+		return nil, nil
+	}
+	workflowServeList = func(string, string, map[string]string) ([]hookBead, error) {
+		shellCalls++
+		return nil, nil
+	}
+	controlDispatcherServe = func(_, _, _ string, _ io.Writer, _ io.Writer) error {
+		t.Fatal("controlDispatcherServe should not run with empty queue")
+		return nil
+	}
+
+	_, err := drainWorkflowServeWork(config.Agent{Name: "worker", WorkQuery: "bd ready --assignee=worker"}, "/city", "/store", nil, "bd ready --assignee=worker", nil, io.Discard)
+	if err != nil {
+		t.Fatalf("drainWorkflowServeWork: %v", err)
+	}
+	if shellCalls != 1 {
+		t.Fatalf("shellCalls = %d, want 1", shellCalls)
+	}
+}
+
+func createReadyBead(t *testing.T, store beads.Store, assignee string, metadata map[string]string) beads.Bead {
+	t.Helper()
+	b, err := store.Create(beads.Bead{Title: "ready", Metadata: metadata})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if assignee != "" {
+		if err := store.Update(b.ID, beads.UpdateOpts{Assignee: &assignee}); err != nil {
+			t.Fatalf("Update assignee: %v", err)
+		}
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	return got
+}
+
+func runInProcessReadyForTest(t *testing.T, store beads.Store, target, legacyTarget string, sessionVals []string, limit int) []hookBead {
+	t.Helper()
+	prev := openControlStoreForReady
+	openControlStoreForReady = func(string, string, *config.City) (beads.Store, error) {
+		return store, nil
+	}
+	t.Cleanup(func() { openControlStoreForReady = prev })
+
+	got, err := nextWorkflowServeBeadsInProcess("/store", "/city", nil, target, legacyTarget, sessionVals, limit)
+	if err != nil {
+		t.Fatalf("nextWorkflowServeBeadsInProcess: %v", err)
+	}
+	return got
+}
+
+func gotIDs(beads []hookBead) string {
+	ids := make([]string, 0, len(beads))
+	for _, b := range beads {
+		ids = append(ids, b.ID)
+	}
+	return strings.Join(ids, ",")
+}

--- a/cmd/gc/error_store.go
+++ b/cmd/gc/error_store.go
@@ -14,6 +14,7 @@ func (s unavailableStore) CloseAll([]string, map[string]string) (int, error) { r
 func (s unavailableStore) List(beads.ListQuery) ([]beads.Bead, error)        { return nil, s.err }
 func (s unavailableStore) ListOpen(...string) ([]beads.Bead, error)          { return nil, s.err }
 func (s unavailableStore) Ready() ([]beads.Bead, error)                      { return nil, s.err }
+func (s unavailableStore) ReadyQuery(beads.ReadyQuery) ([]beads.Bead, error) { return nil, s.err }
 func (s unavailableStore) Children(string, ...beads.QueryOpt) ([]beads.Bead, error) {
 	return nil, s.err
 }

--- a/cmd/gc/session_list_cache.go
+++ b/cmd/gc/session_list_cache.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// sessionListCache wraps a beads.Store and memoizes the canonical
+// session-label list query for the lifetime of a single command
+// invocation. The status renderer resolves 25+ agents, each of which
+// triggers session.ResolveSessionID + loadSessionBeadSnapshot. Without
+// memoization every agent issues an identical Label="gc:session" list
+// scan against Dolt, costing ~500-900ms per call. The wrapper collapses
+// all of those into a single backing fetch.
+//
+// The wrapper only intercepts queries whose only selector is the
+// session label (with optional IncludeClosed + Sort). Any query that
+// adds a Status, Type, Assignee, ParentID, Metadata, CreatedBefore, or
+// AllowScan filter — or that sets Live to bypass caching — is passed
+// straight through.
+type sessionListCache struct {
+	beads.Store
+	once   sync.Once
+	closed []beads.Bead
+	err    error
+}
+
+// wrapSessionListCache returns a Store that memoizes the canonical
+// session-label list query. A nil store passes through.
+func wrapSessionListCache(s beads.Store) beads.Store {
+	if s == nil {
+		return nil
+	}
+	return &sessionListCache{Store: s}
+}
+
+// List intercepts canonical session-label queries and serves them from
+// a single backing fetch; other queries delegate to the wrapped store.
+func (c *sessionListCache) List(q beads.ListQuery) ([]beads.Bead, error) {
+	if !isCanonicalSessionListQuery(q) {
+		return c.Store.List(q)
+	}
+	c.once.Do(func() {
+		c.closed, c.err = c.Store.List(beads.ListQuery{
+			Label:         session.LabelSession,
+			IncludeClosed: true,
+		})
+	})
+	if c.err != nil {
+		return nil, c.err
+	}
+	return beads.ApplyListQuery(c.closed, q), nil
+}
+
+// isCanonicalSessionListQuery reports whether q is one of the
+// session-bead lookup shapes used on the status hot path. Other
+// selectors disqualify the cache so we never accidentally serve a
+// narrowed query from a wider snapshot.
+func isCanonicalSessionListQuery(q beads.ListQuery) bool {
+	if q.Live || q.Label != session.LabelSession {
+		return false
+	}
+	if q.Status != "" || q.Type != "" || q.Assignee != "" || q.ParentID != "" {
+		return false
+	}
+	if len(q.Metadata) > 0 || !q.CreatedBefore.IsZero() || q.AllowScan {
+		return false
+	}
+	return true
+}

--- a/cmd/gc/session_list_cache_test.go
+++ b/cmd/gc/session_list_cache_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+type listCountingStore struct {
+	beads.Store
+	calls atomic.Int64
+}
+
+func (s *listCountingStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	s.calls.Add(1)
+	return s.Store.List(q)
+}
+
+func newSessionCacheTestStore(t *testing.T) (*listCountingStore, beads.Bead) {
+	t.Helper()
+	mem := beads.NewMemStore()
+	openBead, err := mem.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "open-session-1",
+			"alias":        "rig/open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create open bead: %v", err)
+	}
+	closedBead, err := mem.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "closed-session-1",
+			"alias":        "rig/closed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed bead: %v", err)
+	}
+	if err := mem.Close(closedBead.ID); err != nil {
+		t.Fatalf("close closed bead: %v", err)
+	}
+	return &listCountingStore{Store: mem}, openBead
+}
+
+func TestSessionListCacheCoalescesCanonicalQueries(t *testing.T) {
+	store, openBead := newSessionCacheTestStore(t)
+	cache := wrapSessionListCache(store)
+
+	// Two redundant open-only queries (the resolveSessionID shape).
+	for i := 0; i < 2; i++ {
+		got, err := cache.List(beads.ListQuery{Label: session.LabelSession})
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if len(got) != 1 || got[0].ID != openBead.ID {
+			t.Fatalf("call %d: got %+v, want only open bead %s", i, got, openBead.ID)
+		}
+	}
+
+	// One include-closed query (the loadSessionBeadSnapshot shape).
+	got, err := cache.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("include-closed: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("include-closed: got %d beads, want 2", len(got))
+	}
+
+	// One sort-desc query (the Manager.ListFull shape).
+	got, err = cache.List(beads.ListQuery{Label: session.LabelSession, Sort: beads.SortCreatedDesc})
+	if err != nil {
+		t.Fatalf("sort-desc: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("sort-desc: got %d open beads, want 1", len(got))
+	}
+
+	if got := store.calls.Load(); got != 1 {
+		t.Fatalf("backing List call count = %d, want 1 (queries should coalesce)", got)
+	}
+}
+
+func TestSessionListCacheBypassesForNonCanonicalQueries(t *testing.T) {
+	store, _ := newSessionCacheTestStore(t)
+	cache := wrapSessionListCache(store)
+
+	cases := []struct {
+		name string
+		q    beads.ListQuery
+	}{
+		{"different label", beads.ListQuery{Label: "other-label"}},
+		{"with status filter", beads.ListQuery{Label: session.LabelSession, Status: "open"}},
+		{"with metadata", beads.ListQuery{Label: session.LabelSession, Metadata: map[string]string{"foo": "bar"}}},
+		{"with type", beads.ListQuery{Label: session.LabelSession, Type: "task"}},
+		{"with assignee", beads.ListQuery{Label: session.LabelSession, Assignee: "x"}},
+		{"with parent", beads.ListQuery{Label: session.LabelSession, ParentID: "x"}},
+		{"live bypass", beads.ListQuery{Label: session.LabelSession, Live: true}},
+	}
+
+	before := store.calls.Load()
+	for _, tc := range cases {
+		if _, err := cache.List(tc.q); err != nil && !errors.Is(err, beads.ErrQueryRequiresScan) {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+	}
+	delta := store.calls.Load() - before
+	if delta != int64(len(cases)) {
+		t.Fatalf("non-canonical queries hit backing %d times, want %d", delta, len(cases))
+	}
+}
+
+func TestSessionListCachePropagatesErrors(t *testing.T) {
+	mem := beads.NewMemStore()
+	failing := &failingListStore{Store: mem, err: errors.New("dolt offline")}
+	cache := wrapSessionListCache(failing)
+
+	if _, err := cache.List(beads.ListQuery{Label: session.LabelSession}); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// Second call should not re-hit backing (cached error).
+	if _, err := cache.List(beads.ListQuery{Label: session.LabelSession}); err == nil {
+		t.Fatalf("expected cached error, got nil")
+	}
+	if failing.calls != 1 {
+		t.Fatalf("backing call count = %d, want 1 (error must be cached)", failing.calls)
+	}
+}
+
+func TestSessionListCacheNilStore(t *testing.T) {
+	if got := wrapSessionListCache(nil); got != nil {
+		t.Fatalf("wrapSessionListCache(nil) = %#v, want nil", got)
+	}
+}
+
+type failingListStore struct {
+	beads.Store
+	err   error
+	calls int
+}
+
+func (s *failingListStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
+	s.calls++
+	return nil, s.err
+}

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -200,6 +200,18 @@ func (s *prefixedAliasStore) Ready() ([]beads.Bead, error) {
 	return out, nil
 }
 
+func (s *prefixedAliasStore) ReadyQuery(query beads.ReadyQuery) ([]beads.Bead, error) {
+	items, err := s.base.ReadyQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]beads.Bead, 0, len(items))
+	for _, item := range items {
+		out = append(out, s.beadToAlias(item))
+	}
+	return out, nil
+}
+
 func (s *prefixedAliasStore) Children(parentID string, opts ...beads.QueryOpt) ([]beads.Bead, error) {
 	s.childrenCalls++
 	items, err := s.base.Children(s.aliasToBase(parentID), opts...)

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -828,6 +828,37 @@ func (s *BdStore) Ready() ([]Bead, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bd ready: %w", err)
 	}
+	return parseReadyOutput(out)
+}
+
+// ReadyQuery returns ready beads matching the query filters.
+func (s *BdStore) ReadyQuery(query ReadyQuery) ([]Bead, error) {
+	args := []string{"ready", "--json"}
+	if query.Assignee != "" {
+		args = append(args, "--assignee", query.Assignee)
+	}
+	if query.Unassigned {
+		args = append(args, "--unassigned")
+	}
+	if len(query.Metadata) > 0 {
+		keys := make([]string, 0, len(query.Metadata))
+		for k := range query.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "--metadata-field", k+"="+query.Metadata[k])
+		}
+	}
+	args = append(args, "--limit", strconv.Itoa(query.Limit))
+	out, err := s.runner(s.dir, "bd", args...)
+	if err != nil {
+		return nil, fmt.Errorf("bd ready: %w", err)
+	}
+	return parseReadyOutput(out)
+}
+
+func parseReadyOutput(out []byte) ([]Bead, error) {
 	issues, parseErr := parseIssuesTolerant(extractJSON(out))
 	result := make([]Bead, 0, len(issues))
 	for i := range issues {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -698,6 +698,48 @@ func TestBdStoreReadyEmpty(t *testing.T) {
 	}
 }
 
+func TestBdStoreReadyQueryAssigneeLimit(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --assignee gascity/control-dispatcher --limit 20`: {
+			out: []byte(`[{"id":"bd-aaa","title":"ready one","status":"open","issue_type":"task","assignee":"gascity/control-dispatcher","created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ReadyQuery(beads.ReadyQuery{Assignee: "gascity/control-dispatcher", Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "bd-aaa" {
+		t.Fatalf("ReadyQuery() = %+v, want bd-aaa", got)
+	}
+}
+
+func TestBdStoreReadyQueryMetadataUnassigned(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --unassigned --metadata-field gc.routed_to=gascity/control-dispatcher --limit 20`: {
+			out: []byte(`[{"id":"bd-routed","title":"routed","status":"open","issue_type":"task","metadata":{"gc.routed_to":"gascity/control-dispatcher"},"created_at":"2025-01-15T10:30:00Z"}]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ReadyQuery(beads.ReadyQuery{
+		Metadata:   map[string]string{"gc.routed_to": "gascity/control-dispatcher"},
+		Unassigned: true,
+		Limit:      20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "bd-routed" {
+		t.Fatalf("ReadyQuery() = %+v, want bd-routed", got)
+	}
+}
+
 func TestBdStoreReadyError(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1")

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -30,6 +30,18 @@ type Bead struct {
 	Dependencies []Dep             `json:"dependencies,omitempty"`
 }
 
+// ReadyQuery describes a filtered ready-work lookup.
+//
+// Queries are conjunctive: every populated field must match. Limit controls
+// the maximum number of returned beads, with 0 meaning unlimited. Unassigned
+// requires an empty Assignee.
+type ReadyQuery struct {
+	Assignee   string
+	Metadata   map[string]string
+	Unassigned bool
+	Limit      int
+}
+
 // UpdateOpts specifies which fields to change. Nil pointers are skipped.
 type UpdateOpts struct {
 	Title        *string // set title (nil = no change)
@@ -169,6 +181,11 @@ type Store interface {
 	// to match the bd CLI's GetReadyWork semantics. Same ordering note
 	// as List.
 	Ready() ([]Bead, error)
+
+	// ReadyQuery returns ready beads matching the query filters. Stores should
+	// push filters into the backend where possible; in-memory stores may filter
+	// Ready() results directly.
+	ReadyQuery(query ReadyQuery) ([]Bead, error)
 
 	// Legacy helper; prefer List with ListQuery in new code.
 	// Children returns all beads whose ParentID matches the given ID,

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -311,6 +311,21 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 	return c.backing.Ready()
 }
 
+// ReadyQuery returns ready beads matching the query filters.
+func (c *CachingStore) ReadyQuery(query ReadyQuery) ([]Bead, error) {
+	c.mu.RLock()
+	useBacking := c.state != cacheLive || len(c.dirty) > 0
+	c.mu.RUnlock()
+	if useBacking {
+		return c.backing.ReadyQuery(query)
+	}
+	ready, err := c.Ready()
+	if err != nil {
+		return nil, err
+	}
+	return ApplyReadyQuery(ready, query), nil
+}
+
 // Children returns beads with the given parent ID.
 func (c *CachingStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
 	return c.List(ListQuery{

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -341,6 +341,15 @@ func (s *Store) Ready() ([]beads.Bead, error) {
 	return result, nil
 }
 
+// ReadyQuery returns ready beads matching the query filters.
+func (s *Store) ReadyQuery(query beads.ReadyQuery) ([]beads.Bead, error) {
+	ready, err := s.Ready()
+	if err != nil {
+		return nil, err
+	}
+	return beads.ApplyReadyQuery(ready, query), nil
+}
+
 // Children returns non-closed beads whose ParentID matches by default:
 // script children <parent-id>
 func (s *Store) Children(parentID string, opts ...beads.QueryOpt) ([]beads.Bead, error) {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -270,6 +270,15 @@ func (m *MemStore) Ready() ([]Bead, error) {
 	return result, nil
 }
 
+// ReadyQuery returns ready beads matching the query filters.
+func (m *MemStore) ReadyQuery(query ReadyQuery) ([]Bead, error) {
+	ready, err := m.Ready()
+	if err != nil {
+		return nil, err
+	}
+	return ApplyReadyQuery(ready, query), nil
+}
+
 // Get retrieves a bead by ID. Returns a wrapped ErrNotFound if the ID does
 // not exist.
 func (m *MemStore) Get(id string) (Bead, error) {

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -113,6 +113,37 @@ func ApplyListQuery(items []Bead, q ListQuery) []Bead {
 	return filtered
 }
 
+// ApplyReadyQuery filters ready-work results while preserving input order.
+func ApplyReadyQuery(items []Bead, q ReadyQuery) []Bead {
+	filtered := make([]Bead, 0, len(items))
+	for _, b := range items {
+		if !readyQueryMatches(b, q) {
+			continue
+		}
+		filtered = append(filtered, b)
+		if q.Limit > 0 && len(filtered) >= q.Limit {
+			return filtered
+		}
+	}
+	return filtered
+}
+
+func readyQueryMatches(b Bead, q ReadyQuery) bool {
+	if b.Status != "open" || IsReadyExcludedType(b.Type) {
+		return false
+	}
+	if q.Assignee != "" && b.Assignee != q.Assignee {
+		return false
+	}
+	if q.Unassigned && b.Assignee != "" {
+		return false
+	}
+	if len(q.Metadata) > 0 && !matchesMetadata(b, q.Metadata) {
+		return false
+	}
+	return true
+}
+
 func applyListQuery(items []Bead, q ListQuery) []Bead {
 	return ApplyListQuery(items, q)
 }


### PR DESCRIPTION
## Summary

- Add `beads.ReadyQuery`, a typed filtered ready lookup with assignee, metadata, unassigned, and limit filters.
- Push `ReadyQuery` filters into `BdStore` as `bd ready --assignee/--metadata-field --unassigned --limit`, preserving bounded row counts.
- Route the control-dispatcher default serve loop through staged bounded ready queries in Go, preserving candidate order, legacy fallback, and routed fallback behavior.
- Keep non-control agents on their configured shell `work_query` path.

## Why

The old control-dispatcher serve query could issue up to 9 `bd ready` commands per drain: identity candidates plus current and legacy routed fallbacks. Each `bd` process opens a Dolt SQL connection, making idle control-dispatcher loops expensive under load.

The first version of this PR collapsed that to one `Ready()` snapshot but fetched all ready beads, which could regress large ready queues. This revision keeps the query bounded by adding a typed store API and pushing filters down to `BdStore`. The dispatcher no longer builds shell snippets, and the provider decides how to execute the ready query.

## Validation

Passed after the bounded-query revision:

- `go test ./cmd/gc -run 'Test(ControlReadyCandidates|InProcessReady|DrainWorkflowServeWork|RunWorkflowServe)' -count=1 -timeout=60s`
- `go test ./internal/beads/...`
- `go test ./internal/api -run '^TestBead' -count=1`
- `go vet ./cmd/gc ./internal/beads/... ./internal/api`
- `/Users/jbb/go/bin/golangci-lint run ./cmd/gc ./internal/beads/... ./internal/api`
- `git diff --check`

`go test ./...` still fails in this local environment on broad existing failures unrelated to this change, including:

- `TestCmdSessionNew_ACPTemplatePersistsStoredMCPMetadata`: Unix socket bind `invalid argument` under a long temp path.
- `TestBuiltinDoltDoctorBoundsVersionProbe` / `TestBuiltinDoltDoctorReportsTimedOutVersionProbe`: timeout-probe shim not taking effect; local Dolt is accepted.
- `TestOrderDispatchConditionUsesScopedEnv` and `internal/orders TestCheckTriggerConditionUsesOptions`: scoped condition command exits non-zero.
- Timeout-sensitive runtime/worker tests in broad runs, including runtime exec startup-watch cases and `internal/worker/workertest TestPhase2StartupOutcomeBounds`.

## Notes

For `BdStore`, this still shells out to `bd ready` per selector stage, so it is not the zero-fork managed-Dolt path. It is intentionally safer than the one-snapshot version: each stage remains filtered and limited, so a large global ready queue should not be pulled into the control loop. A future optimization can batch selector stages or use direct managed-Dolt access to reduce forks while keeping bounded rows.

Closes part of hq-mjf8k.
