### PR TITLE
fix(spawn): prepend gc bin dir to agent PATH so bare 'gc' resolves correctly

### DIFF
--- a/cmd/gc/agent_env_path.go
+++ b/cmd/gc/agent_env_path.go
@@ -37,8 +37,7 @@ func prependGCBinDirToPATH(env map[string]string, gcBin string) {
 	}
 
 	parts := strings.Split(base, sep)
-	entries := make([]string, 0, len(parts)+1)
-	entries = append(entries, dir)
+	entries := []string{dir}
 	for _, p := range parts {
 		if p == dir {
 			continue

--- a/cmd/gc/agent_env_path.go
+++ b/cmd/gc/agent_env_path.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// prependGCBinDirToPATH ensures that the directory containing the gc binary
+// is the first entry in env["PATH"]. If env["PATH"] is unset, falls back to
+// the calling process's PATH as the base.
+//
+// This protects spawned agents (which may write `gc` in shell prompts) from
+// PATH collisions with unrelated binaries — notably Homebrew's `graphviz`
+// package, which ships /opt/homebrew/bin/gc and breaks bare `gc` invocations
+// for any agent whose PATH happens to put /opt/homebrew/bin first.
+//
+// gcBin is the absolute path to the gc binary (typically the value the caller
+// also writes to env["GC_BIN"]). If empty or has no directory component, the
+// function is a no-op.
+func prependGCBinDirToPATH(env map[string]string, gcBin string) {
+	if gcBin == "" {
+		return
+	}
+	dir := filepath.Dir(gcBin)
+	if dir == "" || dir == "." {
+		return
+	}
+	sep := string(os.PathListSeparator)
+	base, ok := env["PATH"]
+	if !ok {
+		base = os.Getenv("PATH")
+	}
+	parts := strings.Split(base, sep)
+	// Drop any existing occurrences of dir; we'll re-insert at the front.
+	filtered := parts[:0]
+	for _, p := range parts {
+		if p == dir {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	if len(filtered) == 0 || filtered[0] != "" {
+		// Standard case: prepend dir + sep + remaining.
+		env["PATH"] = dir + sep + strings.Join(filtered, sep)
+		return
+	}
+	env["PATH"] = dir + sep + strings.Join(filtered, sep)
+}

--- a/cmd/gc/agent_env_path.go
+++ b/cmd/gc/agent_env_path.go
@@ -31,19 +31,19 @@ func prependGCBinDirToPATH(env map[string]string, gcBin string) {
 	if !ok {
 		base = os.Getenv("PATH")
 	}
+	if base == "" {
+		env["PATH"] = dir
+		return
+	}
+
 	parts := strings.Split(base, sep)
-	// Drop any existing occurrences of dir; we'll re-insert at the front.
-	filtered := parts[:0]
+	entries := make([]string, 0, len(parts)+1)
+	entries = append(entries, dir)
 	for _, p := range parts {
 		if p == dir {
 			continue
 		}
-		filtered = append(filtered, p)
+		entries = append(entries, p)
 	}
-	if len(filtered) == 0 || filtered[0] != "" {
-		// Standard case: prepend dir + sep + remaining.
-		env["PATH"] = dir + sep + strings.Join(filtered, sep)
-		return
-	}
-	env["PATH"] = dir + sep + strings.Join(filtered, sep)
+	env["PATH"] = strings.Join(entries, sep)
 }

--- a/cmd/gc/agent_env_path_test.go
+++ b/cmd/gc/agent_env_path_test.go
@@ -72,6 +72,17 @@ func TestPrependGCBinDirToPATH_PresentNotFirst_MovesToFront(t *testing.T) {
 	}
 }
 
+func TestPrependGCBinDirToPATH_PreservesLeadingEmptyEntry(t *testing.T) {
+	dir := "/Users/jbb/go/bin"
+	sep := string(os.PathListSeparator)
+	env := map[string]string{"PATH": sep + "/usr/bin"}
+	prependGCBinDirToPATH(env, filepath.Join(dir, "gc"))
+	want := dir + sep + sep + "/usr/bin"
+	if env["PATH"] != want {
+		t.Fatalf("PATH=%q, want %q", env["PATH"], want)
+	}
+}
+
 func TestPrependGCBinDirToPATH_EmptyDir_NoOp(t *testing.T) {
 	// edge: GC_BIN is just "gc" with no directory part — skip prepend.
 	env := map[string]string{"PATH": "/usr/bin"}

--- a/cmd/gc/agent_env_path_test.go
+++ b/cmd/gc/agent_env_path_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrependGCBinDirToPATH_NoGCBin_NoOp(t *testing.T) {
+	env := map[string]string{"PATH": "/usr/bin:/bin"}
+	prependGCBinDirToPATH(env, "")
+	if env["PATH"] != "/usr/bin:/bin" {
+		t.Fatalf("PATH should be unchanged when GC_BIN empty, got %q", env["PATH"])
+	}
+}
+
+func TestPrependGCBinDirToPATH_AddsToExistingPATH(t *testing.T) {
+	env := map[string]string{"PATH": "/usr/bin:/bin"}
+	prependGCBinDirToPATH(env, "/Users/jbb/go/bin/gc")
+	want := "/Users/jbb/go/bin" + string(os.PathListSeparator) + "/usr/bin:/bin"
+	if env["PATH"] != want {
+		t.Fatalf("PATH=%q, want %q", env["PATH"], want)
+	}
+}
+
+func TestPrependGCBinDirToPATH_FallsBackToOSPATH(t *testing.T) {
+	env := map[string]string{}
+	t.Setenv("PATH", "/usr/bin:/bin")
+	prependGCBinDirToPATH(env, "/opt/gc/bin/gc")
+	want := "/opt/gc/bin" + string(os.PathListSeparator) + "/usr/bin:/bin"
+	if env["PATH"] != want {
+		t.Fatalf("PATH=%q, want %q", env["PATH"], want)
+	}
+}
+
+func TestPrependGCBinDirToPATH_AlreadyFirst_NoDuplicate(t *testing.T) {
+	dir := "/Users/jbb/go/bin"
+	env := map[string]string{"PATH": dir + string(os.PathListSeparator) + "/usr/bin"}
+	prependGCBinDirToPATH(env, filepath.Join(dir, "gc"))
+	parts := strings.Split(env["PATH"], string(os.PathListSeparator))
+	if parts[0] != dir {
+		t.Fatalf("first PATH entry %q, want %q", parts[0], dir)
+	}
+	count := 0
+	for _, p := range parts {
+		if p == dir {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("dir %q should appear exactly once, found %d times in %q", dir, count, env["PATH"])
+	}
+}
+
+func TestPrependGCBinDirToPATH_PresentNotFirst_MovesToFront(t *testing.T) {
+	dir := "/Users/jbb/go/bin"
+	env := map[string]string{"PATH": "/opt/homebrew/bin" + string(os.PathListSeparator) + dir + string(os.PathListSeparator) + "/usr/bin"}
+	prependGCBinDirToPATH(env, filepath.Join(dir, "gc"))
+	parts := strings.Split(env["PATH"], string(os.PathListSeparator))
+	if parts[0] != dir {
+		t.Fatalf("first PATH entry %q, want %q (full PATH=%q)", parts[0], dir, env["PATH"])
+	}
+	count := 0
+	for _, p := range parts {
+		if p == dir {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("dir %q should appear exactly once, found %d times in %q", dir, count, env["PATH"])
+	}
+}
+
+func TestPrependGCBinDirToPATH_EmptyDir_NoOp(t *testing.T) {
+	// edge: GC_BIN is just "gc" with no directory part — skip prepend.
+	env := map[string]string{"PATH": "/usr/bin"}
+	prependGCBinDirToPATH(env, "gc")
+	if env["PATH"] != "/usr/bin" {
+		t.Fatalf("PATH should be unchanged when GC_BIN has no dir, got %q", env["PATH"])
+	}
+}

--- a/cmd/gc/agent_env_path_test.go
+++ b/cmd/gc/agent_env_path_test.go
@@ -34,6 +34,25 @@ func TestPrependGCBinDirToPATH_FallsBackToOSPATH(t *testing.T) {
 	}
 }
 
+func TestPrependGCBinDirToPATH_ExplicitEmptyPATHUsesOnlyGCBinDir(t *testing.T) {
+	dir := "/opt/gc/bin"
+	env := map[string]string{"PATH": ""}
+	prependGCBinDirToPATH(env, filepath.Join(dir, "gc"))
+	if env["PATH"] != dir {
+		t.Fatalf("PATH=%q, want only gc bin dir %q", env["PATH"], dir)
+	}
+}
+
+func TestPrependGCBinDirToPATH_UnsetPATHWithEmptyOSPATHUsesOnlyGCBinDir(t *testing.T) {
+	dir := "/opt/gc/bin"
+	env := map[string]string{}
+	t.Setenv("PATH", "")
+	prependGCBinDirToPATH(env, filepath.Join(dir, "gc"))
+	if env["PATH"] != dir {
+		t.Fatalf("PATH=%q, want only gc bin dir %q", env["PATH"], dir)
+	}
+}
+
 func TestPrependGCBinDirToPATH_AlreadyFirst_NoDuplicate(t *testing.T) {
 	dir := "/Users/jbb/go/bin"
 	env := map[string]string{"PATH": dir + string(os.PathListSeparator) + "/usr/bin"}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -249,6 +249,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	agentEnv["GC_BEADS"] = rawBeadsProviderForScope(rigRoot, p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe
+		prependGCBinDirToPATH(agentEnv, exe)
 	}
 	for key, value := range sessionDoltEnv(p.cityPath, rigRoot, p.rigs) {
 		agentEnv[key] = value

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -249,7 +249,6 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	agentEnv["GC_BEADS"] = rawBeadsProviderForScope(rigRoot, p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe
-		prependGCBinDirToPATH(agentEnv, exe)
 	}
 	for key, value := range sessionDoltEnv(p.cityPath, rigRoot, p.rigs) {
 		agentEnv[key] = value
@@ -345,7 +344,9 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	}
 
 	// Step 10: Merge environment layers.
-	env := convergence.ScrubTokenEnv(mergeEnv(passthroughEnv(), expandEnvMap(resolved.Env), expandEnvMap(cfgAgent.Env), agentEnv))
+	env := mergeEnv(passthroughEnv(), expandEnvMap(resolved.Env), expandEnvMap(cfgAgent.Env), agentEnv)
+	prependGCBinDirToPATH(env, env["GC_BIN"])
+	env = convergence.ScrubTokenEnv(env)
 
 	// Step 11: Expand session setup templates.
 	configDir := p.cityPath

--- a/cmd/gc/template_resolve_env_test.go
+++ b/cmd/gc/template_resolve_env_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+func TestResolveTemplatePrependsGCBinDirToPATH(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	sep := string(os.PathListSeparator)
+	t.Setenv("PATH", "/opt/homebrew/bin"+sep+"/usr/bin")
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	agent := &config.Agent{Name: "runner"}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	gcBin := tp.Env["GC_BIN"]
+	if gcBin == "" {
+		t.Fatal("GC_BIN is empty")
+	}
+	wantDir := filepath.Dir(gcBin)
+	parts := strings.Split(tp.Env["PATH"], sep)
+	if len(parts) == 0 || parts[0] != wantDir {
+		t.Fatalf("PATH first entry = %q, want gc bin dir %q (PATH=%q)", parts[0], wantDir, tp.Env["PATH"])
+	}
+	count := 0
+	for _, part := range parts {
+		if part == wantDir {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("gc bin dir %q should appear exactly once, found %d in PATH=%q", wantDir, count, tp.Env["PATH"])
+	}
+}
+
+func TestResolveTemplatePrependsGCBinDirToConfiguredAgentPATH(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	sep := string(os.PathListSeparator)
+	t.Setenv("PATH", "/opt/homebrew/bin"+sep+"/usr/bin")
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	configuredPATH := "/custom/tools" + sep + "/usr/local/bin"
+	agent := &config.Agent{
+		Name: "runner",
+		Env:  map[string]string{"PATH": configuredPATH},
+	}
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	gcBin := tp.Env["GC_BIN"]
+	if gcBin == "" {
+		t.Fatal("GC_BIN is empty")
+	}
+	wantDir := filepath.Dir(gcBin)
+	parts := strings.Split(tp.Env["PATH"], sep)
+	wantPrefix := []string{wantDir, "/custom/tools", "/usr/local/bin"}
+	if len(parts) < len(wantPrefix) {
+		t.Fatalf("PATH=%q has fewer entries than expected prefix %v", tp.Env["PATH"], wantPrefix)
+	}
+	for i, want := range wantPrefix {
+		if parts[i] != want {
+			t.Fatalf("PATH entry %d = %q, want %q (PATH=%q)", i, parts[i], want, tp.Env["PATH"])
+		}
+	}
+}


### PR DESCRIPTION
## Why

Spawned agent sessions inherit PATH from the controller. On macOS Homebrew the default PATH puts `/opt/homebrew/bin` ahead of any gascity install, and **Homebrew's `graphviz` package ships `/opt/homebrew/bin/gc`** (a graph-coloring tool). Any agent that writes bare `gc` in a shell command hits graphviz, not gascity.

In practice every fresh agent burns ~200k tokens (~$1.37/15min/spawn) running through this dance:

```
gc agent peek deacon  -> "Can't open agent / Can't open peek / Can't open deacon"
which gc              -> /opt/homebrew/bin/gc
file gc               -> graphviz
find / -name gc       -> ... /Users/jbb/go/bin/gc
/Users/jbb/go/bin/gc agent peek deacon  -> finally works
```

Captured this happening live on `gastown.boot` and `intervaltree/refinery` sessions, ~$464/day sustained burn from agents idling on this discovery.

## What

`prependGCBinDirToPATH(env, gcBin)` ensures `filepath.Dir(GC_BIN)` is the first entry in the agent shell's PATH. Called from `resolveTemplate` immediately after `agentEnv["GC_BIN"]` is set.

- Idempotent: if the directory already appears anywhere in PATH it is moved to the front rather than duplicated.
- Falls back to `os.Getenv("PATH")` when the env map has no PATH yet.
- No-op when GC_BIN is empty or has no directory component.

Companion follow-up tracked in **hq-7xsno** migrates prompt templates from bare `gc` to `${GC_BIN}` for belt-and-suspenders defense against PATH drift in nested shells/hooks.

Closes **hq-ltp6k**.

## Test plan

- [x] `cmd/gc/agent_env_path_test.go` — 6 unit tests covering: no-op on empty GC_BIN, prepend with existing PATH, fall back to `os.Getenv("PATH")`, no-double-prepend when already first, move-to-front when present elsewhere, no-op for bare 'gc' filename
- [x] Standalone `make check` clean modulo pre-existing flakes (`TestCmdSessionNew_ACPTemplatePersistsStoredMCPMetadata`, `TestCheckTriggerConditionUsesOptions`) which reproduce on clean `origin/main` with the diff stashed
- [ ] Live verify on running supervisor: rebuild gc, restart, watch fresh boot session for absence of "Can't open agent" dance

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->