### PR TITLE
fix: align boot prompt lifecycle

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -880,6 +880,40 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 	}
 }
 
+func TestBootPromptMatchesNamedSessionLifecycle(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "boot", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading boot prompt: %v", err)
+	}
+	body := string(data)
+
+	for _, stale := range []string{
+		"{{ cmd }} agent peek",
+		"Spawn Boot (fresh session each time)",
+		"always fresh",
+		"no persistent state",
+	} {
+		if strings.Contains(body, stale) {
+			t.Fatalf("boot prompt still contains stale lifecycle or command guidance %q:\n%s", stale, body)
+		}
+	}
+
+	for _, want := range []string{
+		"{{ cmd }} session peek deacon --lines 1",
+		"{{ cmd }} session peek deacon --lines 30",
+		"configured `boot` named session",
+		"`mode = \"always\"` keeps the `boot` identity present",
+		"`wake_mode = \"fresh\"`",
+		"gives each wake a new provider context",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("boot prompt missing current lifecycle or command guidance %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestIdeaToPlanFormulaUsesSupportedPrimitives(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-idea-to-plan.toml")

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -881,6 +881,22 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 }
 
 func TestBootPromptMatchesNamedSessionLifecycle(t *testing.T) {
+	cfg := loadExpanded(t)
+	bootSession := config.FindNamedSession(cfg, "boot")
+	if bootSession == nil {
+		t.Fatal("boot named_session missing; prompt documents its lifecycle")
+	}
+	if got := bootSession.ModeOrDefault(); got != "always" {
+		t.Fatalf("boot named_session mode = %q, want %q because prompt documents that lifecycle", got, "always")
+	}
+	bootAgent := config.FindAgent(cfg, bootSession.TemplateQualifiedName())
+	if bootAgent == nil {
+		t.Fatalf("boot agent template %q missing; named_session and prompt must refer to a real agent", bootSession.TemplateQualifiedName())
+	}
+	if got := bootAgent.EffectiveWakeMode(); got != "fresh" {
+		t.Fatalf("boot agent wake_mode = %q, want %q because prompt documents fresh provider context", got, "fresh")
+	}
+
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "agents", "boot", "prompt.template.md")
 	data, err := os.ReadFile(path)
@@ -891,7 +907,11 @@ func TestBootPromptMatchesNamedSessionLifecycle(t *testing.T) {
 
 	for _, stale := range []string{
 		"{{ cmd }} agent peek",
+		"Controller tick",
 		"Spawn Boot (fresh session each time)",
+		"on each tick",
+		"Next Boot tick",
+		"Narrow scope makes restarts cheap",
 		"always fresh",
 		"no persistent state",
 	} {
@@ -907,6 +927,8 @@ func TestBootPromptMatchesNamedSessionLifecycle(t *testing.T) {
 		"`mode = \"always\"` keeps the `boot` identity present",
 		"`wake_mode = \"fresh\"`",
 		"gives each wake a new provider context",
+		"Narrow scope keeps each wake cheap.",
+		"Next Boot wake will re-evaluate.",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("boot prompt missing current lifecycle or command guidance %q:\n%s", want, body)

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -4,8 +4,9 @@
 
 ## Your Role: BOOT (Deacon Watchdog)
 
-You are **Boot** — the deacon's watchdog. You are spawned fresh by the
-controller on each tick to answer one question: **is the deacon stuck?**
+You are **Boot** — the deacon's watchdog. You run as the controller-managed
+configured `boot` named session. Each wake answers one question: **is the
+deacon stuck?**
 
 The controller knows if the deacon is alive (process liveness). But it
 can't judge whether the deacon is *working* — that requires domain
@@ -17,17 +18,21 @@ bridges that gap.
 ## Your Lifecycle
 
 ```
-Controller tick
-    +-- Spawn Boot (fresh session each time)
+Controller reconciliation
+    +-- Keep configured `boot` named session present (`mode = "always"`)
+        +-- Wake Boot with fresh provider context (`wake_mode = "fresh"`)
         +-- Boot runs triage
             |-- Observe (deacon wisp freshness, pane output, mail)
             |-- Decide (healthy / idle / stuck)
             |-- Act (nothing / nudge / file warrant)
-            +-- Exit
+            +-- Drain-ack and exit
 ```
 
-You are always fresh — no persistent state, no handoff mail needed.
-Narrow scope makes restarts cheap. The controller manages your lifecycle.
+`mode = "always"` keeps the `boot` identity present. `wake_mode = "fresh"`
+gives each wake a new provider context, so treat every run as single-pass
+triage over live state. Do not rely on prior conversation context or handoff
+mail. Narrow scope makes restarts cheap. The controller manages your
+lifecycle.
 
 ---
 
@@ -104,7 +109,8 @@ exit
 ```
 
 `drain-ack` tells the controller you're finished. The controller cleans
-up your session and spawns you again next tick.
+up this provider session and can wake the configured `boot` identity again
+with a fresh provider context.
 
 ---
 
@@ -113,7 +119,7 @@ up your session and spawns you again next tick.
 - Kill or restart the deacon directly (file warrants, dog pool handles it)
 - Start the deacon if it's dead (controller handles liveness)
 - Monitor witnesses, refineries, or polecats (deacon and witnesses do that)
-- Maintain state between invocations (you are always fresh)
+- Rely on prior conversation context or handoff mail (read live state each wake)
 
 ---
 
@@ -128,4 +134,4 @@ up your session and spawns you again next tick.
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}
-Formula: none (ephemeral triage, no patrol loop)
+Formula: none (single-pass deacon watchdog, no patrol loop)

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -21,17 +21,17 @@ bridges that gap.
 Controller reconciliation
     +-- Keep configured `boot` named session present (`mode = "always"`)
         +-- Wake Boot with fresh provider context (`wake_mode = "fresh"`)
-        +-- Boot runs triage
-            |-- Observe (deacon wisp freshness, pane output, mail)
-            |-- Decide (healthy / idle / stuck)
-            |-- Act (nothing / nudge / file warrant)
-            +-- Drain-ack and exit
+            +-- Boot runs triage
+                |-- Observe (deacon wisp freshness, pane output, mail)
+                |-- Decide (healthy / idle / stuck)
+                |-- Act (nothing / nudge / file warrant)
+                +-- Drain-ack and exit
 ```
 
 `mode = "always"` keeps the `boot` identity present. `wake_mode = "fresh"`
 gives each wake a new provider context, so treat every run as single-pass
 triage over live state. Do not rely on prior conversation context or handoff
-mail. Narrow scope makes restarts cheap. The controller manages your
+mail. Narrow scope keeps each wake cheap. The controller manages your
 lifecycle.
 
 ---
@@ -90,7 +90,7 @@ Use judgment — there are no hardcoded thresholds. Consider:
 ```bash
 {{ cmd }} session nudge deacon "Boot check: are you making progress?"
 ```
-Drain-ack and exit. Next Boot tick will re-evaluate.
+Drain-ack and exit. Next Boot wake will re-evaluate.
 
 **Clearly stuck (very stale wisp, no output, errors visible):** File a warrant:
 ```bash


### PR DESCRIPTION
Fixes #1494.

## Summary

- Update the Gastown Boot prompt to describe the configured `boot` named session lifecycle correctly: `mode = "always"` keeps the identity present, while `wake_mode = "fresh"` gives each wake a new provider context.
- Replace stale `{{ cmd }} agent peek deacon ...` examples with the current `{{ cmd }} session peek deacon --lines ...` command surface.
- Add a regression test that rejects the stale Boot lifecycle and peek command guidance.

## Validation

- `go test ./examples/gastown -run TestBootPromptMatchesNamedSessionLifecycle`
- `go test ./examples/gastown`
- `go test -tags acceptance_a ./test/acceptance -run TestDrainAckBeforeExit`
- `go vet ./...`
- `.githooks/pre-commit` ran formatting, lint, codegen, and vet successfully, then failed in `make test` on unrelated existing failures in `cmd/gc` and `internal/orders`.
- `go test ./...` also failed on unrelated existing failures in `cmd/gc`, `internal/orders`, and one worker timing bound.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->