### PR TITLE
Adopt PR #1456: perf(session): use targeted identifier lookups

### DIFF
--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -896,6 +896,54 @@ func TestResolveSessionNameWithStore(t *testing.T) {
 	}
 }
 
+type noBroadSessionNameLookupStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s noBroadSessionNameLookupStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == sessionBeadLabel && len(query.Metadata) == 0 {
+		s.t.Fatalf("session name lookup used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
+func TestFindSessionNameByTemplateUsesTargetedLookup(t *testing.T) {
+	store := noBroadSessionNameLookupStore{MemStore: beads.NewMemStore(), t: t}
+	_, err := store.Create(beads.Bead{
+		Title:  "worker-pool",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":           "worker",
+			"template":             "worker",
+			"session_name":         "s-pool",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "worker",
+			"session_name": "s-worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := findSessionNameByTemplate(store, "worker")
+	if got != "s-worker" {
+		t.Fatalf("findSessionNameByTemplate(worker) = %q, want s-worker", got)
+	}
+}
+
 func TestFindSessionNameByTemplate_SkipsClosedBeads(t *testing.T) {
 	store := beads.NewMemStore()
 	b, err := store.Create(beads.Bead{

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -944,6 +944,47 @@ func TestFindSessionNameByTemplateUsesTargetedLookup(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateSessionBeadIDUsesTargetedLookup(t *testing.T) {
+	store := noBroadSessionNameLookupStore{MemStore: beads.NewMemStore(), t: t}
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "worker",
+			"session_name": "s-worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := &agentBuildParams{
+		cityName:   "phase0-city",
+		cityPath:   t.TempDir(),
+		workspace:  &config.Workspace{Provider: "test-agent"},
+		providers:  map[string]config.ProviderSpec{"test-agent": {DisplayName: "Test Agent", Command: "true"}},
+		lookPath:   func(string) (string, error) { return filepath.Join("/usr/bin", "true"), nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		beadStore:  store,
+		stderr:     io.Discard,
+	}
+	agentCfg := &config.Agent{
+		Name:     "worker",
+		Provider: "test-agent",
+	}
+
+	tp, err := resolveTemplate(params, agentCfg, agentCfg.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if got := tp.Env["GC_SESSION_ID"]; got != bead.ID {
+		t.Fatalf("GC_SESSION_ID = %q, want %q", got, bead.ID)
+	}
+}
+
 func TestFindSessionNameByTemplate_SkipsClosedBeads(t *testing.T) {
 	store := beads.NewMemStore()
 	b, err := store.Create(beads.Bead{

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -144,11 +144,66 @@ func normalizedSessionTemplate(bead beads.Bead, cfg *config.City) string {
 // beads with an agent_name field matching the query. If no agent_name match
 // is found, falls back to template/common_name matching.
 func findSessionNameByTemplate(store beads.Store, template string) string {
-	snapshot, err := loadSessionBeadSnapshot(store)
+	template = strings.TrimSpace(template)
+	if store == nil || template == "" {
+		return ""
+	}
+	if sn := findSessionNameByMetadata(store, "agent_name", template, true); sn != "" {
+		return sn
+	}
+	if sn := findSessionNameByAgentLabel(store, template); sn != "" {
+		return sn
+	}
+	if sn := findSessionNameByMetadata(store, "template", template, false); sn != "" {
+		return sn
+	}
+	return findSessionNameByMetadata(store, "common_name", template, false)
+}
+
+func findSessionNameByAgentLabel(store beads.Store, template string) string {
+	items, err := store.List(beads.ListQuery{Label: "agent:" + template})
 	if err != nil {
 		return ""
 	}
-	return snapshot.FindSessionNameByTemplate(template)
+	return chooseSessionNameForTemplate(store, items, true, "", "")
+}
+
+func findSessionNameByMetadata(store beads.Store, key, value string, agentNameMatch bool) string {
+	items, err := store.List(beads.ListQuery{Metadata: map[string]string{key: value}})
+	if err != nil {
+		return ""
+	}
+	return chooseSessionNameForTemplate(store, items, agentNameMatch, key, value)
+}
+
+func chooseSessionNameForTemplate(store beads.Store, items []beads.Bead, agentNameMatch bool, key, value string) string {
+	var fallback string
+	for _, b := range items {
+		if !sessionpkg.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
+			continue
+		}
+		sessionpkg.RepairEmptyType(store, &b)
+		if key != "" && strings.TrimSpace(b.Metadata[key]) != value {
+			continue
+		}
+		if agentNameMatch && isPoolManagedSessionBead(b) && sessionBeadAgentName(b) == b.Metadata["template"] {
+			continue
+		}
+		if !agentNameMatch && isPoolManagedSessionBead(b) {
+			continue
+		}
+		sessionName := strings.TrimSpace(b.Metadata["session_name"])
+		if sessionName == "" {
+			continue
+		}
+		if strings.TrimSpace(b.Metadata["configured_named_identity"]) != "" {
+			return sessionName
+		}
+		if fallback == "" {
+			fallback = sessionName
+		}
+	}
+	return fallback
 }
 
 // lookupSessionName resolves a qualified agent name to its bead-derived

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -169,7 +169,7 @@ func findSessionNameByAgentLabel(store beads.Store, template string) string {
 }
 
 func findSessionNameByMetadata(store beads.Store, key, value string, agentNameMatch bool) string {
-	items, err := store.List(beads.ListQuery{Metadata: map[string]string{key: value}})
+	items, err := sessionpkg.ExactMetadataSessionCandidates(store, false, map[string]string{key: value})
 	if err != nil {
 		return ""
 	}

--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -57,11 +57,11 @@ func resolveConfiguredNamedSessionID(
 	if !ok {
 		return "", false, fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
 	}
-	snapshot, err := loadSessionBeadSnapshot(store)
+	candidates, err := session.NamedSessionResolutionCandidates(store, spec)
 	if err != nil {
 		return "", true, err
 	}
-	if bead, ok := findCanonicalNamedSessionBead(snapshot, spec); ok {
+	if bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec); ok {
 		return bead.ID, true, nil
 	}
 	// When materializing, check for a closed bead with this identity and
@@ -73,7 +73,7 @@ func resolveConfiguredNamedSessionID(
 			return bead.ID, true, nil
 		}
 	}
-	if bead, conflict := findNamedSessionConflict(snapshot, spec); conflict {
+	if bead, conflict := session.FindNamedSessionConflict(candidates, spec); conflict {
 		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errNamedSessionConflict, identifier, spec.Identity, bead.ID)
 	}
 	if !opts.materialize {

--- a/cmd/gc/session_resolve_test.go
+++ b/cmd/gc/session_resolve_test.go
@@ -87,6 +87,44 @@ func TestResolveSessionID_QualifiedAliasBasename(t *testing.T) {
 	}
 }
 
+func TestResolveSessionIDWithConfig_UsesTargetedConfiguredNamedLookup(t *testing.T) {
+	store := noBroadSessionNameLookupStore{MemStore: beads.NewMemStore(), t: t}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:         "mayor",
+			StartCommand: "true",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+		}},
+	}
+	cityPath := t.TempDir()
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+	b, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "mayor",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "mayor",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(canonical): %v", err)
+	}
+
+	id, err := resolveSessionIDWithConfig(cityPath, cfg, store, "mayor")
+	if err != nil {
+		t.Fatalf("resolveSessionIDWithConfig(mayor): %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveHistoricalAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -205,7 +205,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 	if sessionBeadID == "" && p.beadStore != nil {
-		if all, err := p.beadStore.List(beads.ListQuery{Label: "gc:session"}); err == nil {
+		if all, err := p.beadStore.List(beads.ListQuery{Metadata: map[string]string{"session_name": sessName}}); err == nil {
 			for _, b := range all {
 				if !session.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
 					continue

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/agent"
-	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/convergence"
@@ -205,7 +204,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 	if sessionBeadID == "" && p.beadStore != nil {
-		if all, err := p.beadStore.List(beads.ListQuery{Metadata: map[string]string{"session_name": sessName}}); err == nil {
+		if all, err := session.ExactMetadataSessionCandidates(p.beadStore, false, map[string]string{"session_name": sessName}); err == nil {
 			for _, b := range all {
 				if !session.IsSessionBeadOrRepairable(b) || b.Status == "closed" {
 					continue

--- a/internal/api/session_model_phase0_lifecycle_spec_test.go
+++ b/internal/api/session_model_phase0_lifecycle_spec_test.go
@@ -14,6 +14,18 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+type noBroadAPISessionRetireStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s *noBroadAPISessionRetireStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("continuity retirement used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
 // Phase 0 spec coverage from engdocs/design/session-model-unification.md:
 // - Materialization contract
 // - Wake, Suspend, and Pin
@@ -275,9 +287,11 @@ func TestPhase0HandleSessionWake_NamedIdentitySkipsContinuityIneligibleHistorica
 
 func TestPhase0RetireContinuityIneligibleNamedSessionIdentifiersDoesNotRestampRetiredHistory(t *testing.T) {
 	fs := newSessionFakeState(t)
+	store := &noBroadAPISessionRetireStore{MemStore: beads.NewMemStore(), t: t}
+	fs.cityBeadStore = store
 	srv := New(fs)
 	archivedAt := "2026-03-01T12:00:00Z"
-	historical, err := fs.cityBeadStore.Create(beads.Bead{
+	historical, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
 		Metadata: map[string]string{
@@ -296,7 +310,7 @@ func TestPhase0RetireContinuityIneligibleNamedSessionIdentifiersDoesNotRestampRe
 		t.Fatalf("Create(historical): %v", err)
 	}
 
-	retired, err := srv.retireContinuityIneligibleNamedSessionIdentifiers(fs.cityBeadStore, apiNamedSessionSpec{Identity: "worker"})
+	retired, err := srv.retireContinuityIneligibleNamedSessionIdentifiers(store, apiNamedSessionSpec{Identity: "worker"})
 	if err != nil {
 		t.Fatalf("retireContinuityIneligibleNamedSessionIdentifiers: %v", err)
 	}

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -136,13 +136,11 @@ func (s *Server) findCanonicalNamedSession(store beads.Store, spec apiNamedSessi
 	if store == nil {
 		return beads.Bead{}, false, nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
+	candidates, err := session.NamedSessionResolutionCandidates(store, spec)
 	if err != nil {
-		return beads.Bead{}, false, fmt.Errorf("listing sessions: %w", err)
+		return beads.Bead{}, false, fmt.Errorf("listing named session candidates: %w", err)
 	}
-	bead, ok := session.FindCanonicalNamedSessionBead(all, spec)
+	bead, ok := session.FindCanonicalNamedSessionBead(candidates, spec)
 	return bead, ok, nil
 }
 
@@ -150,9 +148,13 @@ func (s *Server) retireContinuityIneligibleNamedSessionIdentifiers(store beads.S
 	if store == nil {
 		return nil, nil
 	}
-	all, err := store.List(beads.ListQuery{Label: session.LabelSession})
+	all, err := store.List(beads.ListQuery{
+		Metadata: map[string]string{
+			session.NamedSessionIdentityMetadata: spec.Identity,
+		},
+	})
 	if err != nil {
-		return nil, fmt.Errorf("listing sessions: %w", err)
+		return nil, fmt.Errorf("listing named session candidates: %w", err)
 	}
 	retired := make([]beads.Bead, 0)
 	now := time.Now().UTC()
@@ -235,11 +237,9 @@ func (s *Server) resolveConfiguredNamedSessionIDWithContext(ctx context.Context,
 		return bead.ID, true, nil
 	}
 
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
+	all, err := session.NamedSessionResolutionCandidates(store, spec)
 	if err != nil {
-		return "", true, fmt.Errorf("listing sessions: %w", err)
+		return "", true, fmt.Errorf("listing named session candidates: %w", err)
 	}
 	if bead, conflict := session.FindNamedSessionConflict(all, spec); conflict {
 		return "", true, fmt.Errorf("%w: %q conflicts with configured named session %q via live bead %s", errConfiguredNamedSessionConflict, identifier, spec.Identity, bead.ID)

--- a/internal/api/session_resolution.go
+++ b/internal/api/session_resolution.go
@@ -148,10 +148,8 @@ func (s *Server) retireContinuityIneligibleNamedSessionIdentifiers(store beads.S
 	if store == nil {
 		return nil, nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Metadata: map[string]string{
-			session.NamedSessionIdentityMetadata: spec.Identity,
-		},
+	all, err := session.ExactMetadataSessionCandidates(store, false, map[string]string{
+		session.NamedSessionIdentityMetadata: spec.Identity,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing named session candidates: %w", err)

--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -714,7 +714,7 @@ func resolveAttemptRouteBinding(target string, cfg *config.City, store beads.Sto
 		if named := config.FindNamedSession(cfg, target); named != nil {
 			if spec, ok := session.FindNamedSessionSpec(cfg, cfg.EffectiveCityName(), named.QualifiedName()); ok {
 				if store != nil {
-					if candidates, err := store.List(beads.ListQuery{Label: session.LabelSession}); err == nil {
+					if candidates, err := session.NamedSessionResolutionCandidates(store, spec); err == nil {
 						if bead, found := session.FindCanonicalNamedSessionBead(candidates, spec); found {
 							return attemptRouteBinding{directSessionID: bead.ID}, true
 						}

--- a/internal/dispatch/control_integration_test.go
+++ b/internal/dispatch/control_integration_test.go
@@ -871,7 +871,7 @@ func TestResolveAttemptRouteBinding_ConfigTargetBeatsCollidingSessionAlias(t *te
 func TestResolveAttemptRouteBinding_NamedSessionTargetUsesCanonicalBeadID(t *testing.T) {
 	t.Parallel()
 
-	store := beads.NewMemStore()
+	store := &noBroadAttemptRouteStore{MemStore: beads.NewMemStore(), t: t}
 	named, err := store.Create(beads.Bead{
 		Title:  "worker",
 		Type:   session.BeadType,
@@ -912,6 +912,18 @@ func TestResolveAttemptRouteBinding_NamedSessionTargetUsesCanonicalBeadID(t *tes
 	if binding.qualifiedName != "" || binding.sessionName != "" {
 		t.Fatalf("binding = %+v, want direct named session only", binding)
 	}
+}
+
+type noBroadAttemptRouteStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s *noBroadAttemptRouteStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("attempt route binding used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
 }
 
 func TestResolveAttemptRouteBinding_NamedSessionTargetWithoutCanonicalBeadUsesSessionName(t *testing.T) {

--- a/internal/session/metadata_candidates.go
+++ b/internal/session/metadata_candidates.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+// ExactMetadataSessionCandidates returns session beads matching any exact
+// metadata filter. Each filter must contain exactly one key/value pair; empty
+// filters are ignored. Results are deduplicated by bead ID in query order.
+func ExactMetadataSessionCandidates(store beads.Store, includeClosed bool, filters ...map[string]string) ([]beads.Bead, error) {
+	return exactMetadataSessionCandidates(store, includeClosed, "", filters...)
+}
+
+// ExactMetadataSessionCandidatesWithStatus returns session beads matching any
+// exact metadata filter and the requested bead status.
+func ExactMetadataSessionCandidatesWithStatus(store beads.Store, status string, filters ...map[string]string) ([]beads.Bead, error) {
+	return exactMetadataSessionCandidates(store, false, strings.TrimSpace(status), filters...)
+}
+
+func exactMetadataSessionCandidates(store beads.Store, includeClosed bool, status string, filters ...map[string]string) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	seenQueries := make(map[string]bool, len(filters))
+	seenBeads := make(map[string]bool)
+	candidates := make([]beads.Bead, 0, len(filters))
+	for _, filter := range filters {
+		if len(filter) != 1 {
+			continue
+		}
+		var key, value string
+		for k, v := range filter {
+			key = strings.TrimSpace(k)
+			value = strings.TrimSpace(v)
+		}
+		if key == "" || value == "" {
+			continue
+		}
+		queryKey := key + "\x00" + value
+		if seenQueries[queryKey] {
+			continue
+		}
+		seenQueries[queryKey] = true
+		query := beads.ListQuery{
+			Metadata: map[string]string{key: value},
+		}
+		if status != "" {
+			query.Status = status
+		} else {
+			query.IncludeClosed = includeClosed
+		}
+		items, err := store.List(query)
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range items {
+			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
+				continue
+			}
+			RepairEmptyType(store, &b)
+			seenBeads[b.ID] = true
+			candidates = append(candidates, b)
+		}
+	}
+	return candidates, nil
+}

--- a/internal/session/metadata_candidates_test.go
+++ b/internal/session/metadata_candidates_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+)
+
+func TestExactMetadataSessionCandidatesDeduplicatesAndFiltersSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+			"alias":        "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type: "task",
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	}); err != nil {
+		t.Fatalf("Create(task): %v", err)
+	}
+
+	candidates, err := ExactMetadataSessionCandidates(store, false,
+		map[string]string{"session_name": "sky"},
+		map[string]string{"alias": "sky"},
+		map[string]string{"session_name": ""},
+		map[string]string{"": "sky"},
+		map[string]string{"session_name": "sky", "alias": "sky"},
+	)
+	if err != nil {
+		t.Fatalf("ExactMetadataSessionCandidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != sessionBead.ID {
+		t.Fatalf("candidates = %#v, want only %s", candidates, sessionBead.ID)
+	}
+}
+
+func TestExactMetadataSessionCandidatesWithStatusReturnsOnlyStatus(t *testing.T) {
+	store := beads.NewMemStore()
+	open, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(open): %v", err)
+	}
+	closed, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(closed): %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close(%s): %v", closed.ID, err)
+	}
+
+	candidates, err := ExactMetadataSessionCandidatesWithStatus(store, "closed",
+		map[string]string{"session_name": "sky"},
+	)
+	if err != nil {
+		t.Fatalf("ExactMetadataSessionCandidatesWithStatus: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != closed.ID {
+		t.Fatalf("candidates = %#v, want closed %s and not open %s", candidates, closed.ID, open.ID)
+	}
+}

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -214,6 +214,59 @@ func BeadConflictsWithNamedSession(b beads.Bead, spec NamedSessionSpec) bool {
 	return false
 }
 
+// NamedSessionResolutionCandidates returns the live session beads that can own
+// or conflict with the configured named-session spec, using only exact
+// metadata lookups derived from the spec.
+func NamedSessionResolutionCandidates(store beads.Store, spec NamedSessionSpec) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	identity := NormalizeNamedSessionTarget(spec.Identity)
+	sessionName := strings.TrimSpace(spec.SessionName)
+	queries := []map[string]string{
+		{NamedSessionIdentityMetadata: identity},
+		{"session_name": sessionName},
+		{"session_name": identity},
+		{"alias": identity},
+	}
+
+	seenQueries := make(map[string]bool, len(queries))
+	seenBeads := make(map[string]bool)
+	candidates := make([]beads.Bead, 0, 4)
+	for _, metadata := range queries {
+		if len(metadata) != 1 {
+			continue
+		}
+		var key, value string
+		for k, v := range metadata {
+			key = k
+			value = strings.TrimSpace(v)
+		}
+		if key == "" || value == "" {
+			continue
+		}
+		queryKey := key + "\x00" + value
+		if seenQueries[queryKey] {
+			continue
+		}
+		seenQueries[queryKey] = true
+		items, err := store.List(beads.ListQuery{
+			Metadata: map[string]string{key: value},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range items {
+			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
+				continue
+			}
+			seenBeads[b.ID] = true
+			candidates = append(candidates, b)
+		}
+	}
+	return candidates, nil
+}
+
 // FindNamedSessionConflict finds the first live session bead that blocks a configured named session.
 func FindNamedSessionConflict(candidates []beads.Bead, spec NamedSessionSpec) (beads.Bead, bool) {
 	for _, b := range candidates {

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -223,48 +223,12 @@ func NamedSessionResolutionCandidates(store beads.Store, spec NamedSessionSpec) 
 	}
 	identity := NormalizeNamedSessionTarget(spec.Identity)
 	sessionName := strings.TrimSpace(spec.SessionName)
-	queries := []map[string]string{
-		{NamedSessionIdentityMetadata: identity},
-		{"session_name": sessionName},
-		{"session_name": identity},
-		{"alias": identity},
-	}
-
-	seenQueries := make(map[string]bool, len(queries))
-	seenBeads := make(map[string]bool)
-	candidates := make([]beads.Bead, 0, 4)
-	for _, metadata := range queries {
-		if len(metadata) != 1 {
-			continue
-		}
-		var key, value string
-		for k, v := range metadata {
-			key = k
-			value = strings.TrimSpace(v)
-		}
-		if key == "" || value == "" {
-			continue
-		}
-		queryKey := key + "\x00" + value
-		if seenQueries[queryKey] {
-			continue
-		}
-		seenQueries[queryKey] = true
-		items, err := store.List(beads.ListQuery{
-			Metadata: map[string]string{key: value},
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, b := range items {
-			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
-				continue
-			}
-			seenBeads[b.ID] = true
-			candidates = append(candidates, b)
-		}
-	}
-	return candidates, nil
+	return ExactMetadataSessionCandidates(store, false,
+		map[string]string{NamedSessionIdentityMetadata: identity},
+		map[string]string{"session_name": sessionName},
+		map[string]string{"session_name": identity},
+		map[string]string{"alias": identity},
+	)
 }
 
 // FindNamedSessionConflict finds the first live session bead that blocks a configured named session.

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -325,10 +325,13 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 	if name == "" {
 		return nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
-		IncludeClosed: true,
-	})
+	all, err := sessionIdentifierCandidates(store, true,
+		map[string]string{"session_name": name},
+		map[string]string{"alias": name},
+		map[string]string{"agent_name": name},
+		map[string]string{"template": name},
+		map[string]string{"common_name": name},
+	)
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
@@ -515,10 +518,13 @@ func isConfiguredNamedSessionRuntimeName(cfg *config.City, name, owner string) b
 // ensureSessionNameAvailableForSelf so the legacy-bypass path cannot
 // suppress rejections from live alias or identifier collisions.
 func noLiveSessionNameCollisions(store beads.Store, name, selfID, selfOwner string) bool {
-	all, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
-		IncludeClosed: true,
-	})
+	all, err := sessionIdentifierCandidates(store, true,
+		map[string]string{"session_name": name},
+		map[string]string{"alias": name},
+		map[string]string{"agent_name": name},
+		map[string]string{"template": name},
+		map[string]string{"common_name": name},
+	)
 	if err != nil {
 		return false
 	}
@@ -565,9 +571,11 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			hasSelfBead = true
 		}
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: LabelSession,
-	})
+	all, err := sessionIdentifierCandidates(store, false,
+		map[string]string{"session_name": alias},
+		map[string]string{"alias": alias},
+		map[string]string{"agent_name": alias},
+	)
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
@@ -609,4 +617,46 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 		}
 	}
 	return nil
+}
+
+func sessionIdentifierCandidates(store beads.Store, includeClosed bool, filters ...map[string]string) ([]beads.Bead, error) {
+	if store == nil {
+		return nil, nil
+	}
+	seenQueries := make(map[string]bool, len(filters))
+	seenBeads := make(map[string]bool)
+	candidates := make([]beads.Bead, 0, len(filters))
+	for _, filter := range filters {
+		if len(filter) != 1 {
+			continue
+		}
+		var key, value string
+		for k, v := range filter {
+			key = strings.TrimSpace(k)
+			value = strings.TrimSpace(v)
+		}
+		if key == "" || value == "" {
+			continue
+		}
+		queryKey := key + "\x00" + value
+		if seenQueries[queryKey] {
+			continue
+		}
+		seenQueries[queryKey] = true
+		items, err := store.List(beads.ListQuery{
+			Metadata:      map[string]string{key: value},
+			IncludeClosed: includeClosed,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range items {
+			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
+				continue
+			}
+			seenBeads[b.ID] = true
+			candidates = append(candidates, b)
+		}
+	}
+	return candidates, nil
 }

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -325,7 +325,7 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 	if name == "" {
 		return nil
 	}
-	all, err := sessionIdentifierCandidates(store, true,
+	all, err := ExactMetadataSessionCandidates(store, true,
 		map[string]string{"session_name": name},
 		map[string]string{"alias": name},
 		map[string]string{"agent_name": name},
@@ -518,7 +518,7 @@ func isConfiguredNamedSessionRuntimeName(cfg *config.City, name, owner string) b
 // ensureSessionNameAvailableForSelf so the legacy-bypass path cannot
 // suppress rejections from live alias or identifier collisions.
 func noLiveSessionNameCollisions(store beads.Store, name, selfID, selfOwner string) bool {
-	all, err := sessionIdentifierCandidates(store, true,
+	all, err := ExactMetadataSessionCandidates(store, true,
 		map[string]string{"session_name": name},
 		map[string]string{"alias": name},
 		map[string]string{"agent_name": name},
@@ -571,7 +571,7 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 			hasSelfBead = true
 		}
 	}
-	all, err := sessionIdentifierCandidates(store, false,
+	all, err := ExactMetadataSessionCandidates(store, false,
 		map[string]string{"session_name": alias},
 		map[string]string{"alias": alias},
 		map[string]string{"agent_name": alias},
@@ -617,46 +617,4 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 		}
 	}
 	return nil
-}
-
-func sessionIdentifierCandidates(store beads.Store, includeClosed bool, filters ...map[string]string) ([]beads.Bead, error) {
-	if store == nil {
-		return nil, nil
-	}
-	seenQueries := make(map[string]bool, len(filters))
-	seenBeads := make(map[string]bool)
-	candidates := make([]beads.Bead, 0, len(filters))
-	for _, filter := range filters {
-		if len(filter) != 1 {
-			continue
-		}
-		var key, value string
-		for k, v := range filter {
-			key = strings.TrimSpace(k)
-			value = strings.TrimSpace(v)
-		}
-		if key == "" || value == "" {
-			continue
-		}
-		queryKey := key + "\x00" + value
-		if seenQueries[queryKey] {
-			continue
-		}
-		seenQueries[queryKey] = true
-		items, err := store.List(beads.ListQuery{
-			Metadata:      map[string]string{key: value},
-			IncludeClosed: includeClosed,
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, b := range items {
-			if seenBeads[b.ID] || !IsSessionBeadOrRepairable(b) {
-				continue
-			}
-			seenBeads[b.ID] = true
-			candidates = append(candidates, b)
-		}
-	}
-	return candidates, nil
 }

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+type noBroadSessionIdentifierStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s *noBroadSessionIdentifierStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("session identifier availability used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
 func TestValidateExplicitName(t *testing.T) {
 	longName := strings.Repeat("a", explicitSessionNameMaxLen+1)
 	tests := []struct {
@@ -941,6 +953,42 @@ func TestEnsureSessionNameAvailableWithConfigForOwner_AllowsPoolManagedIdentifie
 	}
 	if err := EnsureSessionNameAvailableWithConfigForOwner(store, cfg, "mayor", "", "foreman"); !errors.Is(err, ErrSessionNameExists) {
 		t.Fatalf("EnsureSessionNameAvailableWithConfigForOwner(wrong owner) = %v, want ErrSessionNameExists", err)
+	}
+}
+
+func TestEnsureSessionNameAvailableUsesTargetedIdentifierLookups(t *testing.T) {
+	store := &noBroadSessionIdentifierStore{MemStore: beads.NewMemStore(), t: t}
+	_, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"alias": "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(alias holder): %v", err)
+	}
+
+	if err := EnsureSessionNameAvailableWithConfig(store, nil, "sky", ""); !errors.Is(err, ErrSessionNameExists) {
+		t.Fatalf("EnsureSessionNameAvailableWithConfig(alias collision) = %v, want ErrSessionNameExists", err)
+	}
+}
+
+func TestEnsureAliasAvailableUsesTargetedIdentifierLookups(t *testing.T) {
+	store := &noBroadSessionIdentifierStore{MemStore: beads.NewMemStore(), t: t}
+	_, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session_name holder): %v", err)
+	}
+
+	if err := EnsureAliasAvailableWithConfig(store, nil, "sky", ""); !errors.Is(err, ErrSessionAliasExists) {
+		t.Fatalf("EnsureAliasAvailableWithConfig(session_name collision) = %v, want ErrSessionAliasExists", err)
 	}
 }
 

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -58,44 +58,13 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		return "", err
 	}
 
-	// Fall back to live alias/session_name resolution among session beads.
-	all, err := store.List(beads.ListQuery{
-		Label:         LabelSession,
-		IncludeClosed: allowClosed,
-	})
+	openSessionNameMatches, err := sessionMatchesByMetadata(store, "session_name", identifier, "")
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
-
-	var openSessionNameMatches []beads.Bead
-	var openAliasMatches []beads.Bead
-	var closedSessionNameMatches []beads.Bead
-	var closedAliasMatches []beads.Bead
-	for _, b := range all {
-		if !IsSessionBeadOrRepairable(b) {
-			continue
-		}
-		RepairEmptyType(store, &b)
-		alias := strings.TrimSpace(b.Metadata["alias"])
-		sessionName := strings.TrimSpace(b.Metadata["session_name"])
-		if b.Status != "closed" {
-			switch {
-			case alias == identifier:
-				openAliasMatches = append(openAliasMatches, b)
-			case sessionName == identifier:
-				openSessionNameMatches = append(openSessionNameMatches, b)
-			}
-			continue
-		}
-		if !allowClosed {
-			continue
-		}
-		switch {
-		case alias == identifier:
-			closedAliasMatches = append(closedAliasMatches, b)
-		case sessionName == identifier:
-			closedSessionNameMatches = append(closedSessionNameMatches, b)
-		}
+	openAliasMatches, err := sessionMatchesByMetadata(store, "alias", identifier, "")
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
 	}
 
 	for _, matches := range [][]beads.Bead{
@@ -109,6 +78,14 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 	if !allowClosed {
 		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
 	}
+	closedSessionNameMatches, err := sessionMatchesByMetadata(store, "session_name", identifier, "closed")
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
+	}
+	closedAliasMatches, err := sessionMatchesByMetadata(store, "alias", identifier, "closed")
+	if err != nil {
+		return "", fmt.Errorf("listing sessions: %w", err)
+	}
 	for _, matches := range [][]beads.Bead{
 		closedSessionNameMatches,
 		closedAliasMatches,
@@ -118,6 +95,34 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		}
 	}
 	return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
+}
+
+func sessionMatchesByMetadata(store beads.Store, key, identifier, status string) ([]beads.Bead, error) {
+	query := beads.ListQuery{
+		Metadata: map[string]string{key: identifier},
+	}
+	if status != "" {
+		query.Status = status
+	}
+	items, err := store.List(query)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]beads.Bead, 0, len(items))
+	for _, b := range items {
+		if !IsSessionBeadOrRepairable(b) {
+			continue
+		}
+		RepairEmptyType(store, &b)
+		if strings.TrimSpace(b.Metadata[key]) != identifier {
+			continue
+		}
+		if status != "" && b.Status != status {
+			continue
+		}
+		matches = append(matches, b)
+	}
+	return matches, nil
 }
 
 func chooseSessionMatch(identifier string, matches []beads.Bead) (string, error) {

--- a/internal/session/resolve.go
+++ b/internal/session/resolve.go
@@ -58,11 +58,11 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		return "", err
 	}
 
-	openSessionNameMatches, err := sessionMatchesByMetadata(store, "session_name", identifier, "")
+	openSessionNameMatches, err := ExactMetadataSessionCandidates(store, false, map[string]string{"session_name": identifier})
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
-	openAliasMatches, err := sessionMatchesByMetadata(store, "alias", identifier, "")
+	openAliasMatches, err := ExactMetadataSessionCandidates(store, false, map[string]string{"alias": identifier})
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
@@ -78,11 +78,11 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 	if !allowClosed {
 		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
 	}
-	closedSessionNameMatches, err := sessionMatchesByMetadata(store, "session_name", identifier, "closed")
+	closedSessionNameMatches, err := ExactMetadataSessionCandidatesWithStatus(store, "closed", map[string]string{"session_name": identifier})
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
-	closedAliasMatches, err := sessionMatchesByMetadata(store, "alias", identifier, "closed")
+	closedAliasMatches, err := ExactMetadataSessionCandidatesWithStatus(store, "closed", map[string]string{"alias": identifier})
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
 	}
@@ -95,34 +95,6 @@ func resolveSessionID(store beads.Store, identifier string, allowClosed bool) (s
 		}
 	}
 	return "", fmt.Errorf("%w: %q", ErrSessionNotFound, identifier)
-}
-
-func sessionMatchesByMetadata(store beads.Store, key, identifier, status string) ([]beads.Bead, error) {
-	query := beads.ListQuery{
-		Metadata: map[string]string{key: identifier},
-	}
-	if status != "" {
-		query.Status = status
-	}
-	items, err := store.List(query)
-	if err != nil {
-		return nil, err
-	}
-	matches := make([]beads.Bead, 0, len(items))
-	for _, b := range items {
-		if !IsSessionBeadOrRepairable(b) {
-			continue
-		}
-		RepairEmptyType(store, &b)
-		if strings.TrimSpace(b.Metadata[key]) != identifier {
-			continue
-		}
-		if status != "" && b.Status != status {
-			continue
-		}
-		matches = append(matches, b)
-	}
-	return matches, nil
 }
 
 func chooseSessionMatch(identifier string, matches []beads.Bead) (string, error) {

--- a/internal/session/resolve_test.go
+++ b/internal/session/resolve_test.go
@@ -80,6 +80,59 @@ func TestResolveSessionID_Alias(t *testing.T) {
 	}
 }
 
+type noBroadSessionListStore struct {
+	*beads.MemStore
+	t *testing.T
+}
+
+func (s *noBroadSessionListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("session resolution used broad session label scan: %+v", query)
+	}
+	return s.MemStore.List(query)
+}
+
+func TestResolveSessionID_UsesTargetedAliasLookup(t *testing.T) {
+	store := &noBroadSessionListStore{MemStore: beads.NewMemStore(), t: t}
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias": "overseer",
+		},
+	})
+
+	id, err := session.ResolveSessionID(store, "overseer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
+func TestResolveSessionIDAllowClosed_UsesTargetedSessionNameLookup(t *testing.T) {
+	store := &noBroadSessionListStore{MemStore: beads.NewMemStore(), t: t}
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "sky",
+		},
+	})
+	if err := store.Close(b.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := session.ResolveSessionIDAllowClosed(store, "sky")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != b.ID {
+		t.Fatalf("got %q, want %q", id, b.ID)
+	}
+}
+
 func TestResolveSessionID_DoesNotResolveExactQualifiedTemplate(t *testing.T) {
 	store := beads.NewMemStore()
 	_, _ = store.Create(beads.Bead{


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1456 because the original PR has maintainer edits disabled.

Original PR metadata:
- Original PR URL: https://github.com/gastownhall/gascity/pull/1456
- Original PR title: perf(session): use targeted identifier lookups
- Original PR state at finalization: OPEN
- Configured base: main
- Original GitHub base: main
- Base mismatch: none
- Original head: 7319e93d0d4e49e3fef514236e34b7aba60a2bfe
- Adopted branch: adopt-pr/1456-followup

This branch preserves the contributor's change rebased onto the recorded upstream base and adds the reviewed maintainer fixup:
- e43411486 perf(session): use targeted identifier lookups
- d01df2fa0 fix: share targeted session candidate lookups

Review synthesis:
- Decision: approve
- No new findings in the final review pass.
- The prior blocker was fixed by centralizing exact metadata candidate lookup and routing the named-session, resolver, availability, API, dispatch, and CLI template paths through the shared helpers.
- Added sentinel coverage for the shared helper and the previously identified resolver/API/dispatch/template paths.

CI must be visible and passing before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->