### PR TITLE
fix: kickstart launchd supervisor after install

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -613,6 +613,27 @@ func supervisorLaunchdPlistPath() string {
 	return filepath.Join(home, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
 }
 
+func supervisorLaunchdServiceTarget(label string) string {
+	if label == "" {
+		label = supervisorLaunchdLabel()
+	}
+	return "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+}
+
+func loadAndStartSupervisorLaunchd(path, label string) error {
+	if err := supervisorLaunchctlRun("load", path); err != nil {
+		return fmt.Errorf("load %s: %w", path, err)
+	}
+	target := supervisorLaunchdServiceTarget(label)
+	if err := supervisorLaunchctlRun("enable", target); err != nil {
+		return fmt.Errorf("enable %s: %w", target, err)
+	}
+	if err := supervisorLaunchctlRun("kickstart", "-p", target); err != nil {
+		return fmt.Errorf("kickstart -p %s: %w", target, err)
+	}
+	return nil
+}
+
 func legacySupervisorLaunchdPlistPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "Library", "LaunchAgents", defaultSupervisorLaunchdLabel+".plist")
@@ -815,7 +836,7 @@ func rollbackNewSupervisorLaunchdInstall(path string, restoreLegacy bool) error 
 		errs = append(errs, fmt.Errorf("removing failed plist %s during rollback: %w", path, err))
 	}
 	if restoreLegacy {
-		if err := supervisorLaunchctlRun("load", legacySupervisorLaunchdPlistPath()); err != nil {
+		if err := loadAndStartSupervisorLaunchd(legacySupervisorLaunchdPlistPath(), defaultSupervisorLaunchdLabel); err != nil {
 			errs = append(errs, fmt.Errorf("restoring legacy plist %s: %w", legacySupervisorLaunchdPlistPath(), err))
 		}
 	}
@@ -827,7 +848,7 @@ func restorePreviousSupervisorLaunchdInstall(path string, previousContent []byte
 	_ = supervisorLaunchctlRun("unload", path)
 	if err := writeSupervisorServiceFile(path, previousContent); err != nil {
 		errs = append(errs, fmt.Errorf("restoring previous plist %s: %w", path, err))
-	} else if err := supervisorLaunchctlRun("load", path); err != nil {
+	} else if err := loadAndStartSupervisorLaunchd(path, supervisorLaunchdLabel()); err != nil {
 		errs = append(errs, fmt.Errorf("reloading previous plist %s: %w", path, err))
 	}
 	return errors.Join(errs...)
@@ -903,7 +924,7 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 	}
 
 	_ = supervisorLaunchctlRun("unload", path)
-	if err := supervisorLaunchctlRun("load", path); err != nil {
+	if err := loadAndStartSupervisorLaunchd(path, data.LaunchdLabel); err != nil {
 		var rollbackErr error
 		if hadCurrent {
 			rollbackErr = restorePreviousSupervisorLaunchdInstall(path, existing)
@@ -911,9 +932,9 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 			rollbackErr = rollbackNewSupervisorLaunchdInstall(path, legacyPresent)
 		}
 		if rollbackErr != nil {
-			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl load failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
 		}
-		fmt.Fprintf(stderr, "gc supervisor install: launchctl load: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc supervisor install: launchctl %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := unloadLegacySupervisorLaunchd(true); err != nil {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1515,6 +1515,54 @@ func TestInstallSupervisorLaunchdWritesPrivatePlist(t *testing.T) {
 	}
 }
 
+func TestInstallSupervisorLaunchdEnablesAndKickstartsLoadedService(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	label := supervisorLaunchdLabel()
+	data := &supervisorServiceData{
+		GCPath:       "/tmp/gc-new",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: label,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	path := supervisorLaunchdPlistPath()
+	target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+	wantSequence := []string{
+		"unload " + path,
+		"load " + path,
+		"enable " + target,
+		"kickstart -p " + target,
+	}
+	last := -1
+	for _, want := range wantSequence {
+		idx := slices.Index(calls[last+1:], want)
+		if idx < 0 {
+			t.Fatalf("launchctl calls = %v, want %q after index %d", calls, want, last)
+		}
+		last += idx + 1
+	}
+}
+
 func TestInstallSupervisorLaunchdIgnoresLegacyUnloadFailures(t *testing.T) {
 	homeDir := t.TempDir()
 	gcHome := filepath.Join(t.TempDir(), "isolated-home")
@@ -1630,6 +1678,77 @@ func TestInstallSupervisorLaunchdKeepsLegacyPlistWhenNewServiceFails(t *testing.
 		"unload " + legacyPath,
 		"load " + currentPath,
 		"load " + legacyPath,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdRestoresLegacyPlistWhenKickstartFails(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-legacy",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	label := supervisorLaunchdLabel()
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  label,
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", label+".plist")
+	currentTarget := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) == 3 && args[0] == "kickstart" && args[2] == currentTarget {
+			return errors.New("new plist failed to start")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("new launchd plist %q should be removed during rollback; err=%v", currentPath, err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy launchd plist %q should remain after failed install; err=%v", legacyPath, err)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"kickstart -p " + currentTarget,
+		"load " + legacyPath,
+		"kickstart -p gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("launchctl calls = %v, want %q", calls, want)


### PR DESCRIPTION
## Summary
- explicitly enable and kickstart the launchd supervisor service after loading the plist
- use the same load/start helper when restoring legacy or previous launchd plists during rollback
- add regression coverage for the launchctl sequence and kickstart rollback

## Verification
- go test ./cmd/gc -run 'TestInstallSupervisorLaunchd|TestRenderSupervisorLaunchdTemplate' -count=1\n- go vet ./...\n- go test ./...\n- git commit ran the configured .githooks/pre-commit hook successfully\n\nLocal bead: ga-wg6q6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->