### PR TITLE
fix(work_query): remove SESSION_ORIGIN gate and type=molecule filter (gc-vb0j)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1970,11 +1970,9 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
 			// Tier 3: ready unassigned routed to this config (shared routed queue).
-			// Only ephemeral sessions and controller probes consume generic config demand.
-			`case "$GC_SESSION_ORIGIN" in ` +
-			`ephemeral|"") ;; ` +
-			`*) exit 0 ;; ` +
-			`esac; ` +
+			// All session origins consume the routed queue: named sessions need
+			// the same access as ephemeral sessions when their template appears
+			// in gc.routed_to metadata.
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
@@ -2005,11 +2003,9 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`done; ` +
 		// Tier 3: ready unassigned routed to this config (shared routed queue),
 		// then the legacy workflow-control route for pre-rename graphs.
-		// Only ephemeral sessions and controller probes consume generic config demand.
-		`case "$GC_SESSION_ORIGIN" in ` +
-		`ephemeral|"") ;; ` +
-		`*) exit 0 ;; ` +
-		`esac; ` +
+		// All session origins consume the routed queue: named sessions need
+		// the same access as ephemeral sessions when their template appears
+		// in gc.routed_to metadata.
 		`r=$(bd ready --metadata-field gc.routed_to=` + target +
 		` --unassigned --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +

--- a/internal/config/session_model_phase0_spec_test.go
+++ b/internal/config/session_model_phase0_spec_test.go
@@ -69,16 +69,13 @@ template = "reviewer"
 	}
 }
 
-func TestPhase0ConfigDefaults_WorkQueryIsOriginAware(t *testing.T) {
+func TestPhase0ConfigDefaults_WorkQueryNoOriginGate(t *testing.T) {
 	a := Agent{Name: "worker", Dir: "myrig"}
 
 	got := a.EffectiveWorkQuery()
 
-	if !strings.Contains(got, "GC_SESSION_ORIGIN") {
-		t.Fatalf("EffectiveWorkQuery() = %q, want origin-aware GC_SESSION_ORIGIN branch", got)
-	}
-	if !strings.Contains(got, "ephemeral") {
-		t.Fatalf("EffectiveWorkQuery() = %q, want origin-specific ephemeral generic queue tier", got)
+	if strings.Contains(got, "GC_SESSION_ORIGIN") {
+		t.Fatalf("EffectiveWorkQuery() = %q, must not gate Tier 3 on GC_SESSION_ORIGIN — named sessions need the same access as ephemeral sessions", got)
 	}
 	if !strings.Contains(got, "gc.routed_to=myrig/worker") {
 		t.Fatalf("EffectiveWorkQuery() = %q, want qualified config route", got)


### PR DESCRIPTION
Fixes gc-vb0j. The default agent work_query had two filters that excluded existing pool members from claiming routed task work:

1. Tier 3 SESSION_ORIGIN gate excluded any session not started as a fresh ephemeral pool member
2. Tier 4 type=molecule filter missed graph-workflow wisps (created by gc order run) which are type=task with gc.kind=workflow metadata

Net: a pool with 12+ active members couldn't claim work routed to it. Verified live with hq-s18bvs (mol-dog-compactor wisp).

Related: gc-4624 (builtin pack include in controller reload), gc-kjqm (session reconciler dead-bead skip).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->