### PR TITLE
Harden gascity container config scanning

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".dockerignore"
       - ".trivyignore.yaml"
+      - ".trivyignore-config"
       - ".github/requirements/mcp-agent-mail.in"
       - ".github/requirements/mcp-agent-mail.txt"
       - ".github/scripts/install-*.sh"
@@ -14,6 +15,7 @@ on:
       - "contrib/events-scripts/gc-events-k8s"
       - "contrib/k8s/**"
       - "contrib/mail-scripts/gc-mail-mcp-agent-mail"
+      - "contrib/session-scripts/gc-controller-k8s"
       - "deps.env"
       - "go.mod"
       - "go.sum"
@@ -22,6 +24,7 @@ on:
     paths:
       - ".dockerignore"
       - ".trivyignore.yaml"
+      - ".trivyignore-config"
       - ".github/requirements/mcp-agent-mail.in"
       - ".github/requirements/mcp-agent-mail.txt"
       - ".github/scripts/install-*.sh"
@@ -30,6 +33,7 @@ on:
       - "contrib/events-scripts/gc-events-k8s"
       - "contrib/k8s/**"
       - "contrib/mail-scripts/gc-mail-mcp-agent-mail"
+      - "contrib/session-scripts/gc-controller-k8s"
       - "deps.env"
       - "go.mod"
       - "go.sum"
@@ -70,6 +74,7 @@ jobs:
           mkdir -p trivy-results
           trivy config \
             --severity HIGH,CRITICAL \
+            --ignorefile .trivyignore-config \
             --format sarif \
             --output trivy-results/dockerfile-config.sarif \
             contrib/k8s
@@ -92,6 +97,16 @@ jobs:
         run: |
           trivy config \
             --severity HIGH,CRITICAL \
+            --ignorefile .trivyignore-config \
+            --format table \
+            contrib/k8s
+
+      - name: Enforce Dockerfile and manifest policy
+        run: |
+          trivy config \
+            --severity HIGH,CRITICAL \
+            --ignorefile .trivyignore-config \
+            --exit-code 1 \
             --format table \
             contrib/k8s
 

--- a/.trivyignore-config
+++ b/.trivyignore-config
@@ -1,0 +1,4 @@
+# Gas City controller implements the Kubernetes session protocol by execing
+# into namespace-local agent pods. Keep this exception narrow: do not add
+# wildcard pod verbs or cluster-wide roles.
+KSV-0053

--- a/contrib/k8s/Dockerfile.agent
+++ b/contrib/k8s/Dockerfile.agent
@@ -18,6 +18,10 @@
 ARG BASE_IMAGE=gc-agent-base:latest
 FROM ${BASE_IMAGE}
 
+# Build-time copies and ownership fixes require root; the final image drops
+# back to gcagent below.
+USER root
+
 # bd (beads) CLI — copied from build context.
 # Build with: cp $(which bd) . && docker build ...
 COPY bd /usr/local/bin/bd

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -53,3 +53,5 @@ RUN useradd -m -s /bin/bash gcagent \
     && echo "gcagent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/gcagent \
     && chmod 0440 /etc/sudoers.d/gcagent
 ENV HOME=/home/gcagent
+
+USER gcagent

--- a/contrib/k8s/Dockerfile.controller
+++ b/contrib/k8s/Dockerfile.controller
@@ -40,6 +40,7 @@ COPY contrib/events-scripts/gc-events-k8s /usr/local/bin/gc-events-k8s
 # COPY --from=dashboard dist/ /opt/dashboard/dist/
 
 WORKDIR /city
+USER gcagent
 
 # Wait for city directory to be copied in (via gc-controller-k8s deploy),
 # then init from it and wait for the deploy script to finish setup (bd init

--- a/contrib/k8s/Dockerfile.mail
+++ b/contrib/k8s/Dockerfile.mail
@@ -10,7 +10,9 @@
 
 FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TMPDIR=/tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/contrib/k8s/controller-rbac.yaml
+++ b/contrib/k8s/controller-rbac.yaml
@@ -24,6 +24,8 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Pod exec — run commands inside agent containers (nudge, peek, meta).
+  # Gas City requires pods/exec to implement the k8s session protocol; the
+  # Trivy exception for this namespace-local Role lives in .trivyignore-config.
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]

--- a/contrib/k8s/dolt-statefulset.yaml
+++ b/contrib/k8s/dolt-statefulset.yaml
@@ -17,9 +17,24 @@ spec:
       labels:
         app: dolt
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
       - name: init-user
-        image: dolthub/dolt:1.85.0
+        image: dolthub/dolt:1.86.6
+        env:
+        - name: HOME
+          value: /tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          readOnlyRootFilesystem: true
         command:
         - sh
         - -c
@@ -37,9 +52,19 @@ spec:
         volumeMounts:
         - name: dolt-data
           mountPath: /var/lib/dolt
+        - name: tmp
+          mountPath: /tmp
       containers:
       - name: dolt
-        image: dolthub/dolt:1.85.0
+        image: dolthub/dolt:1.86.6
+        env:
+        - name: HOME
+          value: /tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          readOnlyRootFilesystem: true
         command:
         - dolt
         - sql-server
@@ -56,6 +81,8 @@ spec:
         volumeMounts:
         - name: dolt-data
           mountPath: /var/lib/dolt
+        - name: tmp
+          mountPath: /tmp
         livenessProbe:
           tcpSocket:
             port: mysql
@@ -76,6 +103,9 @@ spec:
           limits:
             cpu: "2"
             memory: 4Gi
+      volumes:
+      - name: tmp
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: dolt-data

--- a/contrib/k8s/event-cleanup-cronjob.yaml
+++ b/contrib/k8s/event-cleanup-cronjob.yaml
@@ -28,9 +28,24 @@ spec:
         spec:
           serviceAccountName: gc-controller
           restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: cleanup
-            image: bitnami/kubectl:latest
+            image: bitnami/kubectl:1.36.0
+            env:
+            - name: HOME
+              value: /tmp
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
             command:
             - sh
             - -c
@@ -53,3 +68,9 @@ spec:
               limits:
                 cpu: 200m
                 memory: 128Mi
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: tmp
+            emptyDir: {}

--- a/contrib/k8s/mcp-mail-deployment.yaml
+++ b/contrib/k8s/mcp-mail-deployment.yaml
@@ -28,10 +28,19 @@ spec:
       labels:
         app: mcp-mail
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: mcp-mail
         image: gc-mcp-mail:latest
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 8765
           name: http
@@ -59,3 +68,13 @@ spec:
           limits:
             cpu: "1"
             memory: 1Gi
+        volumeMounts:
+        - name: mail-data
+          mountPath: /var/lib/mcp-mail
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: mail-data
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}

--- a/contrib/session-scripts/gc-controller-k8s
+++ b/contrib/session-scripts/gc-controller-k8s
@@ -122,6 +122,18 @@ derive_prefix() {
   fi
 }
 
+strip_leading_space() {
+  local value="$1"
+  printf '%s\n' "${value#"${value%%[![:space:]]*}"}"
+}
+
+extract_quoted_value() {
+  local value="${1#*=}"
+  value="$(strip_leading_space "$value")"
+  value="${value#\"}"
+  printf '%s\n' "${value%%\"*}"
+}
+
 bootstrap_controller_scope() {
   local label="$1"
   local command="$2"
@@ -184,7 +196,7 @@ init_controller_beads() {
   }
 
   while IFS= read -r line; do
-    line=$(echo "$line" | sed 's/^[[:space:]]*//')
+    line="$(strip_leading_space "$line")"
     if [ "$line" = "[[rigs]]" ]; then
       flush_rig
       in_rig=true
@@ -197,9 +209,9 @@ init_controller_beads() {
     esac
     if $in_rig; then
       case "$line" in
-        name\ =*|name=*) rig_name=$(echo "$line" | sed 's/.*= *"\([^"]*\)".*/\1/') ;;
-        prefix\ =*|prefix=*) rig_prefix=$(echo "$line" | sed 's/.*= *"\([^"]*\)".*/\1/') ;;
-        beads_prefix\ =*|beads_prefix=*) rig_prefix=$(echo "$line" | sed 's/.*= *"\([^"]*\)".*/\1/') ;;
+        name\ =*|name=*) rig_name="$(extract_quoted_value "$line")" ;;
+        prefix\ =*|prefix=*) rig_prefix="$(extract_quoted_value "$line")" ;;
+        beads_prefix\ =*|beads_prefix=*) rig_prefix="$(extract_quoted_value "$line")" ;;
       esac
     fi
   done <<< "$resolved_config"
@@ -259,6 +271,13 @@ case "$op" in
         spec: {
           serviceAccountName: $sa,
           restartPolicy: "Never",
+          securityContext: {
+            runAsNonRoot: true,
+            runAsUser: 1000,
+            runAsGroup: 1000,
+            fsGroup: 1000,
+            seccompProfile: {type: "RuntimeDefault"}
+          },
           containers: [{
             name: "controller",
             image: $image,
@@ -282,16 +301,30 @@ case "$op" in
               + (if $dolt_host != "" then [{name: "GC_DOLT_HOST", value: $dolt_host}] else [] end)
               + (if $dolt_port != "" then [{name: "GC_DOLT_PORT", value: $dolt_port}] else [] end)
             ),
+            securityContext: {
+              allowPrivilegeEscalation: false,
+              capabilities: {drop: ["ALL"]},
+              readOnlyRootFilesystem: true
+            },
             resources: {
               requests: {cpu: $cpu_req, memory: $mem_req},
               limits: {cpu: $cpu_lim, memory: $mem_lim}
             },
-            volumeMounts: [{name: "city", mountPath: "/city"}]
+            volumeMounts: [
+              {name: "city", mountPath: "/city"},
+              {name: "tmp", mountPath: "/tmp"}
+            ]
           }],
-          volumes: [{
-            name: "city",
-            emptyDir: {}
-          }]
+          volumes: [
+            {
+              name: "city",
+              emptyDir: {}
+            },
+            {
+              name: "tmp",
+              emptyDir: {}
+            }
+          ]
         }
       }')
 


### PR DESCRIPTION
## Summary
- harden gascity Dockerfiles and Kubernetes manifests so Trivy config scanning can fail on HIGH/CRITICAL findings
- add a narrow `.trivyignore-config` exception for the controller's namespace-local `pods/exec` requirement
- make `container-scan.yml` enforce Dockerfile/Kubernetes config policy and include the controller deploy script in path filters

## Repo settings touched
- disabled Dependabot automated security-fix PR creation for gascity; vulnerability alerts remain enabled
- restricted gascity Actions to selected actions with SHA pinning required and the existing third-party workflow actions allowlisted
- synced gascity Homebrew tap GitHub App secrets from OpenBao; `HOMEBREW_TAP_TOKEN` is absent from OpenBao and GitHub repo secrets

## Validation
- `go test ./...`
- `go vet ./...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/container-scan.yml`
- `yq .` on modified workflow/manifests
- `shellcheck contrib/session-scripts/gc-controller-k8s`
- `bash -n contrib/session-scripts/gc-controller-k8s`
- `trivy config --severity HIGH,CRITICAL --ignorefile .trivyignore-config --exit-code 1 --format table contrib/k8s`
- local Docker builds for `gc-agent-base`, `gc-agent`, `gc-controller`, `gc-mcp-mail`
- Trivy image vulnerability scans for all four local images using the existing `.trivyignore.yaml`
- non-root `docker run --entrypoint id` smoke checks for all four local images

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->