### PR TITLE
Adopt PR #1499: fix launchd supervisor kickstart

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -613,6 +613,27 @@ func supervisorLaunchdPlistPath() string {
 	return filepath.Join(home, "Library", "LaunchAgents", supervisorLaunchdLabel()+".plist")
 }
 
+func supervisorLaunchdServiceTarget(label string) string {
+	if label == "" {
+		label = supervisorLaunchdLabel()
+	}
+	return "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+}
+
+func loadAndStartSupervisorLaunchd(path, label string) error {
+	if err := supervisorLaunchctlRun("load", path); err != nil {
+		return fmt.Errorf("load %s: %w", path, err)
+	}
+	target := supervisorLaunchdServiceTarget(label)
+	if err := supervisorLaunchctlRun("enable", target); err != nil {
+		return fmt.Errorf("enable %s: %w", target, err)
+	}
+	if err := supervisorLaunchctlRun("kickstart", "-p", target); err != nil {
+		return fmt.Errorf("kickstart -p %s: %w", target, err)
+	}
+	return nil
+}
+
 func legacySupervisorLaunchdPlistPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "Library", "LaunchAgents", defaultSupervisorLaunchdLabel+".plist")
@@ -815,7 +836,7 @@ func rollbackNewSupervisorLaunchdInstall(path string, restoreLegacy bool) error 
 		errs = append(errs, fmt.Errorf("removing failed plist %s during rollback: %w", path, err))
 	}
 	if restoreLegacy {
-		if err := supervisorLaunchctlRun("load", legacySupervisorLaunchdPlistPath()); err != nil {
+		if err := loadAndStartSupervisorLaunchd(legacySupervisorLaunchdPlistPath(), defaultSupervisorLaunchdLabel); err != nil {
 			errs = append(errs, fmt.Errorf("restoring legacy plist %s: %w", legacySupervisorLaunchdPlistPath(), err))
 		}
 	}
@@ -827,7 +848,7 @@ func restorePreviousSupervisorLaunchdInstall(path string, previousContent []byte
 	_ = supervisorLaunchctlRun("unload", path)
 	if err := writeSupervisorServiceFile(path, previousContent); err != nil {
 		errs = append(errs, fmt.Errorf("restoring previous plist %s: %w", path, err))
-	} else if err := supervisorLaunchctlRun("load", path); err != nil {
+	} else if err := loadAndStartSupervisorLaunchd(path, supervisorLaunchdLabel()); err != nil {
 		errs = append(errs, fmt.Errorf("reloading previous plist %s: %w", path, err))
 	}
 	return errors.Join(errs...)
@@ -903,7 +924,7 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 	}
 
 	_ = supervisorLaunchctlRun("unload", path)
-	if err := supervisorLaunchctlRun("load", path); err != nil {
+	if err := loadAndStartSupervisorLaunchd(path, data.LaunchdLabel); err != nil {
 		var rollbackErr error
 		if hadCurrent {
 			rollbackErr = restorePreviousSupervisorLaunchdInstall(path, existing)
@@ -911,9 +932,9 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 			rollbackErr = rollbackNewSupervisorLaunchdInstall(path, legacyPresent)
 		}
 		if rollbackErr != nil {
-			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl load failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
+			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
 		}
-		fmt.Fprintf(stderr, "gc supervisor install: launchctl load: %v\n", err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc supervisor install: launchctl %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	if err := unloadLegacySupervisorLaunchd(true); err != nil {

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -634,6 +634,27 @@ func loadAndStartSupervisorLaunchd(path, label string) error {
 	return nil
 }
 
+func loadAndStartSupervisorLaunchdForRollback(path, label string, stderr io.Writer) error {
+	if err := supervisorLaunchctlRun("load", path); err != nil {
+		return fmt.Errorf("load %s: %w", path, err)
+	}
+	target := supervisorLaunchdServiceTarget(label)
+	if err := supervisorLaunchctlRun("enable", target); err != nil {
+		warnSupervisorLaunchdRollback(stderr, "enable %s: %v", target, err)
+	}
+	if err := supervisorLaunchctlRun("kickstart", "-p", target); err != nil {
+		warnSupervisorLaunchdRollback(stderr, "kickstart -p %s: %v", target, err)
+	}
+	return nil
+}
+
+func warnSupervisorLaunchdRollback(stderr io.Writer, format string, args ...any) {
+	if stderr == nil {
+		return
+	}
+	fmt.Fprintf(stderr, "gc supervisor install: warning: restoring launchd service: "+format+"\n", args...) //nolint:errcheck // best-effort stderr
+}
+
 func legacySupervisorLaunchdPlistPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "Library", "LaunchAgents", defaultSupervisorLaunchdLabel+".plist")
@@ -807,6 +828,7 @@ func unloadLegacySupervisorLaunchd(remove bool) error {
 	}
 	_ = supervisorLaunchctlRun("unload", path)
 	if remove {
+		_ = supervisorLaunchctlRun("disable", supervisorLaunchdServiceTarget(defaultSupervisorLaunchdLabel))
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing legacy plist %s: %w", path, err)
 		}
@@ -829,26 +851,26 @@ func unloadLegacySupervisorSystemd(remove bool) error {
 	return nil
 }
 
-func rollbackNewSupervisorLaunchdInstall(path string, restoreLegacy bool) error {
+func rollbackNewSupervisorLaunchdInstall(path string, restoreLegacy bool, stderr io.Writer) error {
 	var errs []error
 	_ = supervisorLaunchctlRun("unload", path)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		errs = append(errs, fmt.Errorf("removing failed plist %s during rollback: %w", path, err))
 	}
 	if restoreLegacy {
-		if err := loadAndStartSupervisorLaunchd(legacySupervisorLaunchdPlistPath(), defaultSupervisorLaunchdLabel); err != nil {
+		if err := loadAndStartSupervisorLaunchdForRollback(legacySupervisorLaunchdPlistPath(), defaultSupervisorLaunchdLabel, stderr); err != nil {
 			errs = append(errs, fmt.Errorf("restoring legacy plist %s: %w", legacySupervisorLaunchdPlistPath(), err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-func restorePreviousSupervisorLaunchdInstall(path string, previousContent []byte) error {
+func restorePreviousSupervisorLaunchdInstall(path string, previousContent []byte, stderr io.Writer) error {
 	var errs []error
 	_ = supervisorLaunchctlRun("unload", path)
 	if err := writeSupervisorServiceFile(path, previousContent); err != nil {
 		errs = append(errs, fmt.Errorf("restoring previous plist %s: %w", path, err))
-	} else if err := loadAndStartSupervisorLaunchd(path, supervisorLaunchdLabel()); err != nil {
+	} else if err := loadAndStartSupervisorLaunchdForRollback(path, supervisorLaunchdLabel(), stderr); err != nil {
 		errs = append(errs, fmt.Errorf("reloading previous plist %s: %w", path, err))
 	}
 	return errors.Join(errs...)
@@ -927,9 +949,9 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 	if err := loadAndStartSupervisorLaunchd(path, data.LaunchdLabel); err != nil {
 		var rollbackErr error
 		if hadCurrent {
-			rollbackErr = restorePreviousSupervisorLaunchdInstall(path, existing)
+			rollbackErr = restorePreviousSupervisorLaunchdInstall(path, existing, stderr)
 		} else {
-			rollbackErr = rollbackNewSupervisorLaunchdInstall(path, legacyPresent)
+			rollbackErr = rollbackNewSupervisorLaunchdInstall(path, legacyPresent, stderr)
 		}
 		if rollbackErr != nil {
 			fmt.Fprintf(stderr, "gc supervisor install: rollback after launchctl failure: %v\n", rollbackErr) //nolint:errcheck // best-effort stderr
@@ -948,6 +970,7 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 func uninstallSupervisorLaunchd(_ *supervisorServiceData, stdout, stderr io.Writer) int {
 	path := supervisorLaunchdPlistPath()
 	_ = supervisorLaunchctlRun("unload", path)
+	_ = supervisorLaunchctlRun("disable", supervisorLaunchdServiceTarget(supervisorLaunchdLabel()))
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(stderr, "gc supervisor uninstall: removing plist: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1515,6 +1515,54 @@ func TestInstallSupervisorLaunchdWritesPrivatePlist(t *testing.T) {
 	}
 }
 
+func TestInstallSupervisorLaunchdEnablesAndKickstartsLoadedService(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	label := supervisorLaunchdLabel()
+	data := &supervisorServiceData{
+		GCPath:       "/tmp/gc-new",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: label,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	path := supervisorLaunchdPlistPath()
+	target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+	wantSequence := []string{
+		"unload " + path,
+		"load " + path,
+		"enable " + target,
+		"kickstart -p " + target,
+	}
+	last := -1
+	for _, want := range wantSequence {
+		idx := slices.Index(calls[last+1:], want)
+		if idx < 0 {
+			t.Fatalf("launchctl calls = %v, want %q after index %d", calls, want, last)
+		}
+		last += idx + 1
+	}
+}
+
 func TestInstallSupervisorLaunchdIgnoresLegacyUnloadFailures(t *testing.T) {
 	homeDir := t.TempDir()
 	gcHome := filepath.Join(t.TempDir(), "isolated-home")
@@ -1630,6 +1678,77 @@ func TestInstallSupervisorLaunchdKeepsLegacyPlistWhenNewServiceFails(t *testing.
 		"unload " + legacyPath,
 		"load " + currentPath,
 		"load " + legacyPath,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdRestoresLegacyPlistWhenKickstartFails(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-legacy",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	label := supervisorLaunchdLabel()
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  label,
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", label+".plist")
+	currentTarget := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) == 3 && args[0] == "kickstart" && args[2] == currentTarget {
+			return errors.New("new plist failed to start")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("new launchd plist %q should be removed during rollback; err=%v", currentPath, err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy launchd plist %q should remain after failed install; err=%v", legacyPath, err)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"kickstart -p " + currentTarget,
+		"load " + legacyPath,
+		"kickstart -p gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("launchctl calls = %v, want %q", calls, want)

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -1678,6 +1678,90 @@ func TestInstallSupervisorLaunchdKeepsLegacyPlistWhenNewServiceFails(t *testing.
 		"unload " + legacyPath,
 		"load " + currentPath,
 		"load " + legacyPath,
+		"enable gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
+		"kickstart -p gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
+	}
+}
+
+func TestInstallSupervisorLaunchdRestoresLegacyPlistWhenEnableFails(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "isolated-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	legacyPath := legacySupervisorLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := renderSupervisorTemplate(supervisorLaunchdTemplate, &supervisorServiceData{
+		GCPath:       "/tmp/gc-legacy",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: defaultSupervisorLaunchdLabel,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	label := supervisorLaunchdLabel()
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		LaunchdLabel:  label,
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	currentPath := filepath.Join(homeDir, "Library", "LaunchAgents", label+".plist")
+	currentTarget := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
+	legacyTarget := "gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) == 2 && args[0] == "enable" && args[1] == currentTarget {
+			return errors.New("new plist failed to enable")
+		}
+		if len(args) == 3 && args[0] == "kickstart" && args[2] == legacyTarget {
+			return errors.New("legacy plist failed to restart")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		supervisorLaunchctlRun = oldRun
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 1 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 1; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(currentPath); !os.IsNotExist(err) {
+		t.Fatalf("new launchd plist %q should be removed during rollback; err=%v", currentPath, err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy launchd plist %q should remain after failed install; err=%v", legacyPath, err)
+	}
+	if strings.Contains(stderr.String(), "rollback after launchctl failure") {
+		t.Fatalf("stderr = %q, want rollback restart failure to be warning-only", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "warning: restoring launchd service: kickstart -p "+legacyTarget) {
+		t.Fatalf("stderr = %q, want warning for best-effort legacy restart", stderr.String())
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"enable " + currentTarget,
+		"load " + legacyPath,
+		"enable " + legacyTarget,
+		"kickstart -p " + legacyTarget,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("launchctl calls = %v, want %q", calls, want)
@@ -1748,6 +1832,7 @@ func TestInstallSupervisorLaunchdRestoresLegacyPlistWhenKickstartFails(t *testin
 	for _, want := range []string{
 		"kickstart -p " + currentTarget,
 		"load " + legacyPath,
+		"enable gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
 		"kickstart -p gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
 	} {
 		if !strings.Contains(joined, want) {
@@ -1780,6 +1865,8 @@ func TestInstallSupervisorLaunchdRestoresPreviousCurrentPlistWhenUpdateFails(t *
 		Path:          "/usr/local/bin:/usr/bin:/bin",
 	}
 
+	label := supervisorLaunchdLabel()
+	target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + label
 	oldRun := supervisorLaunchctlRun
 	var calls []string
 	loadCalls := 0
@@ -1817,6 +1904,17 @@ func TestInstallSupervisorLaunchdRestoresPreviousCurrentPlistWhenUpdateFails(t *
 	}
 	if loadCalls != 2 {
 		t.Fatalf("launchctl load call count = %d, want 2 (failed install + rollback restore); calls=%v", loadCalls, calls)
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"unload " + currentPath,
+		"load " + currentPath,
+		"enable " + target,
+		"kickstart -p " + target,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("launchctl calls = %v, want %q", calls, want)
+		}
 	}
 }
 
@@ -1873,7 +1971,9 @@ func TestUninstallSupervisorLaunchdRemovesMatchingLegacyDefaultPlistForIsolatedG
 	joined := strings.Join(calls, "\n")
 	for _, want := range []string{
 		"unload " + currentPath,
+		"disable gui/" + strconv.Itoa(os.Getuid()) + "/" + supervisorLaunchdLabel(),
 		"unload " + legacyPath,
+		"disable gui/" + strconv.Itoa(os.Getuid()) + "/" + defaultSupervisorLaunchdLabel,
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("launchctl calls = %v, want %q", calls, want)


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1499.

Original PR title: fix: kickstart launchd supervisor after install
Original PR state at finalization: OPEN
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none; both configured and GitHub bases are main. Reviewed base snapshot was 7aaa9f1f25748a4ee379a4e5bb7a1e1ba39c88ee, while origin/main had advanced to d18530cca at finalization.

Why this follow-up exists: the original PR has maintainer edits disabled, and the reviewed branch includes a maintainer fixup on top of the contributor change.

Included commits:
- c38c21ea3 fix: kickstart launchd supervisor after install
- ccf00a249 fix: complete launchd supervisor lifecycle cleanup

Review status: approved by adopt-pr review attempt 2, score 923 / 1000, threshold 850. Required changes: none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->