### PR TITLE
fix: keep shipped pack routes binding-qualified

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -199,6 +199,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 	if cfgErr == nil {
 		d.Register(doctor.NewBDSplitStoreCheck(cityPath))
 		d.Register(doctor.NewBeadsStoreCheck(cityPath, storeFactory))
+		d.Register(newV2RoutedToNamespaceCheck(cfg, cityPath, storeFactory))
 		d.Register(&sessionModelDoctorCheck{cfg: cfg, cityPath: cityPath, newStore: storeFactory})
 	}
 	skipCityDoltCheck := os.Getenv("GC_DOLT") == "skip" || (!scopeUsesManagedBdStoreContract(cityPath, cityPath) && !workspaceNeedsCityDoltCheck(cityPath, cfg))

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -561,9 +561,11 @@ func findAgentByName(cfg *config.City, name string) (config.Agent, bool) {
 // to currentRigContext when run manually.
 func buildPrimeContext(cityPath, cityName string, a *config.Agent, rigs []config.Rig, stderr io.Writer) PromptContext {
 	ctx := PromptContext{
-		CityRoot:     cityPath,
-		TemplateName: a.Name,
-		Env:          a.Env,
+		CityRoot:      cityPath,
+		TemplateName:  a.Name,
+		BindingName:   a.BindingName,
+		BindingPrefix: a.BindingPrefix(),
+		Env:           a.Env,
 	}
 
 	// Agent identity: prefer GC_ALIAS, then GC_AGENT, else config.

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 func TestBuildPrimeContextFallsBackToConfiguredRigRoot(t *testing.T) {
@@ -65,6 +66,43 @@ func TestBuildPrimeContextLogsTemplateExpansionWarning(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "echo {{.Rig") {
 		t.Fatalf("stderr should redact raw template, got %q", stderr.String())
+	}
+}
+
+func TestBuildPrimeContextRendersBindingQualifiedRoute(t *testing.T) {
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Setenv("GC_DIR", "")
+	t.Setenv("GC_BRANCH", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_ALIAS", "")
+
+	cityPath := t.TempDir()
+	promptDir := filepath.Join(cityPath, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "polecat.template.md"), []byte("route={{ .RigName }}/{{ .BindingPrefix }}refinery\nbinding={{ .BindingName }}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+
+	ctx := buildPrimeContext(cityPath, "test-city", &config.Agent{
+		Name:        "polecat",
+		Dir:         "demo",
+		BindingName: "gastown",
+	}, []config.Rig{{Name: "demo", Path: filepath.Join(cityPath, "repos", "demo")}}, nil)
+
+	if ctx.BindingName != "gastown" {
+		t.Fatalf("BindingName = %q, want gastown", ctx.BindingName)
+	}
+	if ctx.BindingPrefix != "gastown." {
+		t.Fatalf("BindingPrefix = %q, want gastown.", ctx.BindingPrefix)
+	}
+	var stderr bytes.Buffer
+	got := renderPrompt(fsys.OSFS{}, cityPath, "test-city", "prompts/polecat.template.md", ctx, "", &stderr, nil, nil, nil)
+	want := "route=demo/gastown.refinery\nbinding=gastown\n"
+	if got != want {
+		t.Fatalf("rendered prompt = %q, want %q; stderr=%q", got, want, stderr.String())
 	}
 }
 

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -849,7 +849,7 @@ func collectConflictErrors(err error, visit func(*sourceworkflow.ConflictError))
 // buildSlingFormulaVars merges caller-provided vars with the runtime context
 // needed by common work formulas. Explicit --var entries always win.
 func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a config.Agent, deps slingDeps) map[string]string {
-	vars := make(map[string]string, len(userVars)+3)
+	vars := make(map[string]string, len(userVars)+6)
 	for _, v := range userVars {
 		key, value, ok := strings.Cut(v, "=")
 		if ok && key != "" {
@@ -870,6 +870,9 @@ func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 		// Attached work formulas conventionally expect issue=<bead-id>.
 		addVar("issue", beadID)
 	}
+	addVar("rig_name", a.Dir)
+	addVar("binding_name", a.BindingName)
+	addVar("binding_prefix", bindingPrefix(a.BindingName))
 
 	autoBranch := slingFormulaTargetBranch(beadID, deps, a)
 	if slingFormulaUsesBaseBranch(formulaName) {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -865,14 +865,20 @@ func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 		}
 		vars[key] = value
 	}
+	addRoutingVar := func(key, value string) {
+		if _, explicit := vars[key]; explicit {
+			return
+		}
+		vars[key] = value
+	}
 
 	if beadID != "" {
 		// Attached work formulas conventionally expect issue=<bead-id>.
 		addVar("issue", beadID)
 	}
-	addVar("rig_name", a.Dir)
-	addVar("binding_name", a.BindingName)
-	addVar("binding_prefix", bindingPrefix(a.BindingName))
+	addRoutingVar("rig_name", a.Dir)
+	addRoutingVar("binding_name", a.BindingName)
+	addRoutingVar("binding_prefix", a.BindingPrefix())
 
 	autoBranch := slingFormulaTargetBranch(beadID, deps, a)
 	if slingFormulaUsesBaseBranch(formulaName) {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -5734,6 +5734,22 @@ func TestBuildSlingFormulaVarsPreservesExplicitRoutingNamespace(t *testing.T) {
 	}
 }
 
+func TestBuildSlingFormulaVarsSeedsEmptyRoutingNamespaceForUnboundAgent(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+
+	vars := buildSlingFormulaVars("mol-deacon-patrol", "CITY-42", nil, config.Agent{
+		Name: "deacon",
+	}, deps)
+
+	for _, key := range []string{"rig_name", "binding_name", "binding_prefix"} {
+		got, ok := findVarValue(vars, key)
+		if !ok || got != "" {
+			t.Fatalf("%s var = %q, %v; want empty string, true", key, got, ok)
+		}
+	}
+}
+
 func TestBeadMetadataTargetStopsOnParentCycle(t *testing.T) {
 	store := &recordingStore{
 		Store: beads.NewMemStore(),

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -5688,6 +5688,52 @@ func TestBuildSlingFormulaVarsPreservesExplicitValues(t *testing.T) {
 	}
 }
 
+func TestBuildSlingFormulaVarsSeedsRoutingNamespace(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+
+	vars := buildSlingFormulaVars("mol-polecat-work", "HW-42", nil, config.Agent{
+		Name:        "polecat",
+		Dir:         "hw",
+		BindingName: "gastown",
+	}, deps)
+
+	if got, ok := findVarValue(vars, "rig_name"); !ok || got != "hw" {
+		t.Fatalf("rig_name var = %q, %v; want hw, true", got, ok)
+	}
+	if got, ok := findVarValue(vars, "binding_name"); !ok || got != "gastown" {
+		t.Fatalf("binding_name var = %q, %v; want gastown, true", got, ok)
+	}
+	if got, ok := findVarValue(vars, "binding_prefix"); !ok || got != "gastown." {
+		t.Fatalf("binding_prefix var = %q, %v; want gastown., true", got, ok)
+	}
+}
+
+func TestBuildSlingFormulaVarsPreservesExplicitRoutingNamespace(t *testing.T) {
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+
+	vars := buildSlingFormulaVars("mol-polecat-work", "HW-42", []string{
+		"rig_name=override-rig",
+		"binding_name=override-binding",
+		"binding_prefix=override.",
+	}, config.Agent{
+		Name:        "polecat",
+		Dir:         "hw",
+		BindingName: "gastown",
+	}, deps)
+
+	if got, ok := findVarValue(vars, "rig_name"); !ok || got != "override-rig" {
+		t.Fatalf("rig_name var = %q, %v; want override-rig, true", got, ok)
+	}
+	if got, ok := findVarValue(vars, "binding_name"); !ok || got != "override-binding" {
+		t.Fatalf("binding_name var = %q, %v; want override-binding, true", got, ok)
+	}
+	if got, ok := findVarValue(vars, "binding_prefix"); !ok || got != "override." {
+		t.Fatalf("binding_prefix var = %q, %v; want override., true", got, ok)
+	}
+}
+
 func TestBeadMetadataTargetStopsOnParentCycle(t *testing.T) {
 	store := &recordingStore{
 		Store: beads.NewMemStore(),

--- a/cmd/gc/doctor_routed_to_checks.go
+++ b/cmd/gc/doctor_routed_to_checks.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+type v2RoutedToNamespaceCheck struct {
+	cfg      *config.City
+	cityPath string
+	newStore func(string) (beads.Store, error)
+}
+
+func newV2RoutedToNamespaceCheck(cfg *config.City, cityPath string, newStore func(string) (beads.Store, error)) *v2RoutedToNamespaceCheck {
+	return &v2RoutedToNamespaceCheck{cfg: cfg, cityPath: cityPath, newStore: newStore}
+}
+
+func (c *v2RoutedToNamespaceCheck) Name() string { return "v2-routed-to-namespace" }
+
+func (c *v2RoutedToNamespaceCheck) CanFix() bool { return false }
+
+func (c *v2RoutedToNamespaceCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func (c *v2RoutedToNamespaceCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	aliases := boundRoutedToAliases(c.cfg)
+	if len(aliases) == 0 {
+		return okCheck(c.Name(), "no binding-qualified route targets configured")
+	}
+
+	var details []string
+	c.scanScope(&details, aliases, "city", c.cityPath)
+	if c.cfg != nil {
+		for _, rig := range c.cfg.Rigs {
+			if rig.Suspended || strings.TrimSpace(rig.Path) == "" {
+				continue
+			}
+			c.scanScope(&details, aliases, "rig "+rig.Name, rig.Path)
+		}
+	}
+
+	if len(details) == 0 {
+		return okCheck(c.Name(), "no short-form gc.routed_to values targeting bound agents found")
+	}
+	sort.Strings(details)
+	return warnCheck(c.Name(),
+		fmt.Sprintf("%d short-form gc.routed_to value(s) target bound PackV2 agents", len(details)),
+		"rewrite gc.routed_to to the binding-qualified agent name, then rerun gc doctor",
+		details)
+}
+
+func (c *v2RoutedToNamespaceCheck) scanScope(details *[]string, aliases map[string][]string, label, path string) {
+	if c.newStore == nil || strings.TrimSpace(path) == "" {
+		return
+	}
+	store, err := c.newStore(path)
+	if err != nil {
+		return
+	}
+	items, err := store.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		return
+	}
+	for _, bead := range items {
+		route := strings.TrimSpace(bead.Metadata["gc.routed_to"])
+		if route == "" {
+			continue
+		}
+		canonicals, ok := aliases[route]
+		if !ok {
+			continue
+		}
+		switch len(canonicals) {
+		case 1:
+			*details = append(*details, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use %q", label, bead.ID, route, canonicals[0]))
+		default:
+			*details = append(*details, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use one of %s", label, bead.ID, route, strings.Join(canonicals, ", ")))
+		}
+	}
+}
+
+func boundRoutedToAliases(cfg *config.City) map[string][]string {
+	aliases := map[string][]string{}
+	if cfg == nil {
+		return aliases
+	}
+	for i := range cfg.Agents {
+		agent := cfg.Agents[i]
+		if strings.TrimSpace(agent.BindingName) == "" {
+			continue
+		}
+		short := unboundRouteIdentity(agent)
+		canonical := strings.TrimSpace(agent.QualifiedName())
+		if short == "" || canonical == "" || short == canonical {
+			continue
+		}
+		aliases[short] = appendUniqueString(aliases[short], canonical)
+	}
+	for key := range aliases {
+		sort.Strings(aliases[key])
+	}
+	return aliases
+}
+
+func unboundRouteIdentity(agent config.Agent) string {
+	name := strings.TrimSpace(agent.Name)
+	if name == "" {
+		return ""
+	}
+	dir := strings.TrimSpace(agent.Dir)
+	if dir == "" {
+		return name
+	}
+	return dir + "/" + name
+}
+
+func appendUniqueString(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/cmd/gc/doctor_routed_to_checks.go
+++ b/cmd/gc/doctor_routed_to_checks.go
@@ -32,37 +32,54 @@ func (c *v2RoutedToNamespaceCheck) Run(_ *doctor.CheckContext) *doctor.CheckResu
 		return okCheck(c.Name(), "no binding-qualified route targets configured")
 	}
 
-	var details []string
-	c.scanScope(&details, aliases, "city", c.cityPath)
+	var findings []string
+	var skipped []string
+	c.scanScope(&findings, &skipped, aliases, "city", c.cityPath)
 	if c.cfg != nil {
 		for _, rig := range c.cfg.Rigs {
 			if rig.Suspended || strings.TrimSpace(rig.Path) == "" {
 				continue
 			}
-			c.scanScope(&details, aliases, "rig "+rig.Name, rig.Path)
+			c.scanScope(&findings, &skipped, aliases, "rig "+rig.Name, rig.Path)
 		}
 	}
 
-	if len(details) == 0 {
+	if len(findings) == 0 && len(skipped) == 0 {
 		return okCheck(c.Name(), "no short-form gc.routed_to values targeting bound agents found")
 	}
+	details := append([]string{}, findings...)
+	details = append(details, skipped...)
 	sort.Strings(details)
+	if len(findings) == 0 {
+		return warnCheck(c.Name(),
+			fmt.Sprintf("v2 routed_to namespace check skipped %d scope(s)", len(skipped)),
+			"fix bead store access, then rerun gc doctor",
+			details)
+	}
+	if len(skipped) > 0 {
+		return warnCheck(c.Name(),
+			fmt.Sprintf("%d short-form gc.routed_to value(s) target bound PackV2 agents; %d scope(s) skipped", len(findings), len(skipped)),
+			"rewrite gc.routed_to to the binding-qualified agent name, fix skipped store access, then rerun gc doctor",
+			details)
+	}
 	return warnCheck(c.Name(),
-		fmt.Sprintf("%d short-form gc.routed_to value(s) target bound PackV2 agents", len(details)),
+		fmt.Sprintf("%d short-form gc.routed_to value(s) target bound PackV2 agents", len(findings)),
 		"rewrite gc.routed_to to the binding-qualified agent name, then rerun gc doctor",
 		details)
 }
 
-func (c *v2RoutedToNamespaceCheck) scanScope(details *[]string, aliases map[string][]string, label, path string) {
+func (c *v2RoutedToNamespaceCheck) scanScope(findings, skipped *[]string, aliases map[string][]string, label, path string) {
 	if c.newStore == nil || strings.TrimSpace(path) == "" {
 		return
 	}
 	store, err := c.newStore(path)
 	if err != nil {
+		*skipped = append(*skipped, fmt.Sprintf("%s skipped: opening bead store: %v", label, err))
 		return
 	}
 	items, err := store.List(beads.ListQuery{AllowScan: true})
 	if err != nil {
+		*skipped = append(*skipped, fmt.Sprintf("%s skipped: listing beads: %v", label, err))
 		return
 	}
 	for _, bead := range items {
@@ -76,9 +93,9 @@ func (c *v2RoutedToNamespaceCheck) scanScope(details *[]string, aliases map[stri
 		}
 		switch len(canonicals) {
 		case 1:
-			*details = append(*details, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use %q", label, bead.ID, route, canonicals[0]))
+			*findings = append(*findings, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use %q", label, bead.ID, route, canonicals[0]))
 		default:
-			*details = append(*details, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use one of %s", label, bead.ID, route, strings.Join(canonicals, ", ")))
+			*findings = append(*findings, fmt.Sprintf("%s bead %s has gc.routed_to=%q; use one of %s", label, bead.ID, route, strings.Join(canonicals, ", ")))
 		}
 	}
 }
@@ -88,17 +105,28 @@ func boundRoutedToAliases(cfg *config.City) map[string][]string {
 	if cfg == nil {
 		return aliases
 	}
+	unbound := unboundRoutedToIdentities(cfg)
+	addAlias := func(short, canonical string) {
+		short = strings.TrimSpace(short)
+		canonical = strings.TrimSpace(canonical)
+		if short == "" || canonical == "" || short == canonical || unbound[short] {
+			return
+		}
+		aliases[short] = appendUniqueString(aliases[short], canonical)
+	}
 	for i := range cfg.Agents {
 		agent := cfg.Agents[i]
 		if strings.TrimSpace(agent.BindingName) == "" {
 			continue
 		}
-		short := unboundRouteIdentity(agent)
-		canonical := strings.TrimSpace(agent.QualifiedName())
-		if short == "" || canonical == "" || short == canonical {
+		addAlias(unboundRouteIdentity(agent), agent.QualifiedName())
+	}
+	for i := range cfg.NamedSessions {
+		session := cfg.NamedSessions[i]
+		if strings.TrimSpace(session.BindingName) == "" {
 			continue
 		}
-		aliases[short] = appendUniqueString(aliases[short], canonical)
+		addAlias(unboundNamedSessionRouteIdentity(session), session.QualifiedName())
 	}
 	for key := range aliases {
 		sort.Strings(aliases[key])
@@ -112,6 +140,44 @@ func unboundRouteIdentity(agent config.Agent) string {
 		return ""
 	}
 	dir := strings.TrimSpace(agent.Dir)
+	if dir == "" {
+		return name
+	}
+	return dir + "/" + name
+}
+
+func unboundRoutedToIdentities(cfg *config.City) map[string]bool {
+	identities := map[string]bool{}
+	for i := range cfg.Agents {
+		agent := cfg.Agents[i]
+		if strings.TrimSpace(agent.BindingName) != "" {
+			continue
+		}
+		if identity := unboundRouteIdentity(agent); identity != "" {
+			identities[identity] = true
+		}
+	}
+	for i := range cfg.NamedSessions {
+		session := cfg.NamedSessions[i]
+		if strings.TrimSpace(session.BindingName) != "" {
+			continue
+		}
+		if identity := unboundNamedSessionRouteIdentity(session); identity != "" {
+			identities[identity] = true
+		}
+	}
+	return identities
+}
+
+func unboundNamedSessionRouteIdentity(session config.NamedSession) string {
+	name := strings.TrimSpace(session.Name)
+	if name == "" {
+		name = strings.TrimSpace(session.Template)
+	}
+	if name == "" {
+		return ""
+	}
+	dir := strings.TrimSpace(session.Dir)
 	if dir == "" {
 		return name
 	}

--- a/cmd/gc/doctor_routed_to_checks_test.go
+++ b/cmd/gc/doctor_routed_to_checks_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestV2RoutedToNamespaceCheckWarnsOnShortBoundRoutes(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+			{Name: "polecat", Dir: "repo", BindingName: "gastown"},
+		},
+		Rigs: []config.Rig{
+			{Name: "repo", Path: rigDir},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "dog"}},
+	}, nil)
+	rigStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "RIG-1", Title: "work", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "repo/polecat"}},
+	}, nil)
+	stores := map[string]beads.Store{
+		cityDir: cityStore,
+		rigDir:  rigStore,
+	}
+
+	result := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		store, ok := stores[path]
+		if !ok {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return store, nil
+	}).Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning: %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	for _, want := range []string{
+		`city bead CITY-1 has gc.routed_to="dog"; use "gastown.dog"`,
+		`rig repo bead RIG-1 has gc.routed_to="repo/polecat"; use "repo/gastown.polecat"`,
+	} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("details missing %q:\n%s", want, details)
+		}
+	}
+}
+
+func TestV2RoutedToNamespaceCheckAllowsCanonicalRoutes(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+			{Name: "human"},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "gastown.dog"}},
+		{ID: "CITY-2", Title: "human", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "human"}},
+	}, nil)
+
+	result := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	}).Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok: %#v", result.Status, result)
+	}
+}

--- a/cmd/gc/doctor_routed_to_checks_test.go
+++ b/cmd/gc/doctor_routed_to_checks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -78,4 +79,102 @@ func TestV2RoutedToNamespaceCheckAllowsCanonicalRoutes(t *testing.T) {
 	if result.Status != doctor.StatusOK {
 		t.Fatalf("status = %v, want ok: %#v", result.Status, result)
 	}
+}
+
+func TestV2RoutedToNamespaceCheckWarnsOnBoundNamedSessionShortRoutes(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		NamedSessions: []config.NamedSession{
+			{Name: "mayor", BindingName: "gastown"},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "mail", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "mayor"}},
+	}, nil)
+
+	result := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	}).Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning: %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	want := `city bead CITY-1 has gc.routed_to="mayor"; use "gastown.mayor"`
+	if !strings.Contains(details, want) {
+		t.Fatalf("details missing %q:\n%s", want, details)
+	}
+}
+
+func TestV2RoutedToNamespaceCheckAllowsAmbiguousShortRouteForUnboundAgent(t *testing.T) {
+	cityDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog"},
+			{Name: "dog", BindingName: "gastown"},
+		},
+	}
+	cityStore := beads.NewMemStoreFrom(0, []beads.Bead{
+		{ID: "CITY-1", Title: "warrant", Type: "task", Status: "open", Metadata: map[string]string{"gc.routed_to": "dog"}},
+	}, nil)
+
+	result := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		if path != cityDir {
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+		return cityStore, nil
+	}).Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok: %#v", result.Status, result)
+	}
+}
+
+func TestV2RoutedToNamespaceCheckWarnsOnSkippedStoreScopes(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "dog", BindingName: "gastown"},
+		},
+		Rigs: []config.Rig{
+			{Name: "repo", Path: rigDir},
+		},
+	}
+
+	result := newV2RoutedToNamespaceCheck(cfg, cityDir, func(path string) (beads.Store, error) {
+		switch path {
+		case cityDir:
+			return nil, errors.New("city offline")
+		case rigDir:
+			return routeListErrorStore{err: errors.New("rig offline")}, nil
+		default:
+			return nil, fmt.Errorf("unexpected store path %q", path)
+		}
+	}).Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning: %#v", result.Status, result)
+	}
+	details := strings.Join(result.Details, "\n")
+	for _, want := range []string{
+		"city skipped: opening bead store: city offline",
+		"rig repo skipped: listing beads: rig offline",
+	} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("details missing %q:\n%s", want, details)
+		}
+	}
+}
+
+type routeListErrorStore struct {
+	beads.Store
+	err error
+}
+
+func (s routeListErrorStore) List(beads.ListQuery) ([]beads.Bead, error) {
+	return nil, s.err
 }

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -234,14 +234,6 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	return m
 }
 
-func bindingPrefix(bindingName string) string {
-	bindingName = strings.TrimSpace(bindingName)
-	if bindingName == "" {
-		return ""
-	}
-	return bindingName + "."
-}
-
 // findRigPrefix returns the effective bead ID prefix for the named rig.
 // Returns empty string if rigName is empty or not found.
 func findRigPrefix(rigName string, rigs []config.Rig) string {

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -26,6 +26,8 @@ type PromptContext struct {
 	CityRoot      string
 	AgentName     string // qualified: "rig/polecat-1" or "mayor"
 	TemplateName  string // config name: "polecat" (template) or "mayor" (named backing template)
+	BindingName   string
+	BindingPrefix string
 	RigName       string
 	RigRoot       string
 	WorkDir       string
@@ -211,7 +213,7 @@ func effectivePromptFragments(global, inject, appendFragments, inherited, defaul
 // buildTemplateData merges Env (lower priority) with SDK fields (higher
 // priority) into a single map for template execution.
 func buildTemplateData(ctx PromptContext) map[string]string {
-	m := make(map[string]string, len(ctx.Env)+8)
+	m := make(map[string]string, len(ctx.Env)+10)
 	for k, v := range ctx.Env {
 		m[k] = v
 	}
@@ -219,6 +221,8 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["CityRoot"] = ctx.CityRoot
 	m["AgentName"] = ctx.AgentName
 	m["TemplateName"] = ctx.TemplateName
+	m["BindingName"] = ctx.BindingName
+	m["BindingPrefix"] = ctx.BindingPrefix
 	m["RigName"] = ctx.RigName
 	m["RigRoot"] = ctx.RigRoot
 	m["WorkDir"] = ctx.WorkDir
@@ -228,6 +232,14 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["WorkQuery"] = ctx.WorkQuery
 	m["SlingQuery"] = ctx.SlingQuery
 	return m
+}
+
+func bindingPrefix(bindingName string) string {
+	bindingName = strings.TrimSpace(bindingName)
+	if bindingName == "" {
+		return ""
+	}
+	return bindingName + "."
 }
 
 // findRigPrefix returns the effective bead ID prefix for the named rig.

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -302,12 +302,15 @@ Branch: {{ .Branch }}
 Run {{ cmd }} to start
 Session: {{ session "deacon" }}
 Custom: {{ .DefaultBranch }}
+Binding: {{ .BindingName }} {{ .BindingPrefix }}
 `
 	f.Files["/city/prompts/full.md.tmpl"] = []byte(tmpl)
 	ctx := PromptContext{
 		CityRoot:      "/home/user/city",
 		AgentName:     "myrig/polecat-1",
 		TemplateName:  "polecat",
+		BindingName:   "gastown",
+		BindingPrefix: "gastown.",
 		RigName:       "myrig",
 		WorkDir:       "/home/user/city/myrig/polecats/polecat-1",
 		IssuePrefix:   "mr-",
@@ -342,6 +345,9 @@ Custom: {{ .DefaultBranch }}
 	if !strings.Contains(got, "Custom: main") {
 		t.Errorf("missing env var: %q", got)
 	}
+	if !strings.Contains(got, "Binding: gastown gastown.") {
+		t.Errorf("missing binding namespace: %q", got)
+	}
 }
 
 func TestRenderPromptWorkQuery(t *testing.T) {
@@ -359,6 +365,8 @@ func TestBuildTemplateData(t *testing.T) {
 		CityRoot:      "/city",
 		AgentName:     "a/b",
 		TemplateName:  "b",
+		BindingName:   "dep",
+		BindingPrefix: "dep.",
 		RigName:       "a",
 		WorkDir:       "/city/a",
 		IssuePrefix:   "te-",
@@ -376,6 +384,12 @@ func TestBuildTemplateData(t *testing.T) {
 	}
 	if data["TemplateName"] != "b" {
 		t.Errorf("TemplateName = %q, want %q", data["TemplateName"], "b")
+	}
+	if data["BindingName"] != "dep" {
+		t.Errorf("BindingName = %q, want %q", data["BindingName"], "dep")
+	}
+	if data["BindingPrefix"] != "dep." {
+		t.Errorf("BindingPrefix = %q, want %q", data["BindingPrefix"], "dep.")
 	}
 	if data["DefaultBranch"] != "main" {
 		t.Errorf("DefaultBranch = %q, want %q", data["DefaultBranch"], "main")

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -276,6 +276,8 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		CityRoot:      p.cityPath,
 		AgentName:     qualifiedName,
 		TemplateName:  cfgAgent.Name,
+		BindingName:   cfgAgent.BindingName,
+		BindingPrefix: bindingPrefix(cfgAgent.BindingName),
 		RigName:       rigName,
 		RigRoot:       rigRoot,
 		WorkDir:       workDir,

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -277,7 +277,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		AgentName:     qualifiedName,
 		TemplateName:  cfgAgent.Name,
 		BindingName:   cfgAgent.BindingName,
-		BindingPrefix: bindingPrefix(cfgAgent.BindingName),
+		BindingPrefix: cfgAgent.BindingPrefix(),
 		RigName:       rigName,
 		RigRoot:       rigRoot,
 		WorkDir:       workDir,

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -626,6 +626,42 @@ func TestPromptGuidanceUsesConfiguredRigRootsAndNamespacedWorktrees(t *testing.T
 	}
 }
 
+func TestGastownRoutedToTargetsUseBindingPrefix(t *testing.T) {
+	dir := exampleDir()
+	checks := []struct {
+		rel  string
+		want string
+	}{
+		{"packs/gastown/formulas/mol-deacon-patrol.toml", "gc.routed_to={{binding_prefix}}dog"},
+		{"packs/gastown/formulas/mol-polecat-work.toml", "{{rig_name}}/{{binding_prefix}}refinery"},
+		{"packs/gastown/formulas/mol-refinery-patrol.toml", "gc.routed_to={{rig_name}}/{{binding_prefix}}polecat"},
+		{"packs/gastown/formulas/mol-idea-to-plan.toml", "$GC_RIG/{{binding_prefix}}polecat"},
+		{"packs/gastown/agents/mayor/prompt.template.md", "gc.routed_to=<rig>/{{ .BindingPrefix }}polecat"},
+		{"packs/gastown/agents/polecat/prompt.template.md", "{{ .RigName }}/{{ .BindingPrefix }}refinery"},
+		{"packs/gastown/template-fragments/approval-fallacy.template.md", "{{ .RigName }}/{{ .BindingPrefix }}refinery"},
+	}
+	for _, check := range checks {
+		data, err := os.ReadFile(filepath.Join(dir, check.rel))
+		if err != nil {
+			t.Fatalf("reading %s: %v", check.rel, err)
+		}
+		body := string(data)
+		if !strings.Contains(body, check.want) {
+			t.Errorf("%s missing %q", check.rel, check.want)
+		}
+		for _, bad := range []string{
+			"gc.routed_to=dog",
+			"gc.routed_to=<rig>/polecat",
+			"gc.routed_to=<rig>/refinery",
+			"gc.routed_to={{ .RigName }}/refinery",
+		} {
+			if strings.Contains(body, bad) {
+				t.Errorf("%s still contains short-form route %q", check.rel, bad)
+			}
+		}
+	}
+}
+
 func TestIdeaToPlanFormulaUsesSupportedPrimitives(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-idea-to-plan.toml")

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -218,7 +218,7 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 		`--set-metadata gc.routed_to=human`,
 		`--set-metadata blocked_reason="$reason"`,
 		`gc mail send mayor/ -s "ESCALATION: invalid existing_pr for $WORK"`,
-		`NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')`,
+		`NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')`,
 		`gc bd update "$NEXT" --assignee=$GC_AGENT`,
 		`CURRENT_WISP=${GC_BEAD_ID:-}`,
 		`gc bd mol burn "$CURRENT_WISP" --force`,
@@ -657,6 +657,73 @@ func TestGastownRoutedToTargetsUseBindingPrefix(t *testing.T) {
 		} {
 			if strings.Contains(body, bad) {
 				t.Errorf("%s still contains short-form route %q", check.rel, bad)
+			}
+		}
+	}
+}
+
+func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
+	dir := exampleDir()
+	checks := []struct {
+		rel     string
+		formula string
+		vars    []string
+	}{
+		{
+			rel:     "packs/gastown/agents/deacon/prompt.template.md",
+			formula: "mol-deacon-patrol",
+			vars:    []string{"--var binding_prefix="},
+		},
+		{
+			rel:     "packs/gastown/formulas/mol-deacon-patrol.toml",
+			formula: "mol-deacon-patrol",
+			vars:    []string{"--var binding_prefix="},
+		},
+		{
+			rel:     "packs/gastown/agents/refinery/prompt.template.md",
+			formula: "mol-refinery-patrol",
+			vars:    []string{"--var target_branch=", "--var rig_name=", "--var binding_prefix="},
+		},
+		{
+			rel:     "packs/gastown/formulas/mol-refinery-patrol.toml",
+			formula: "mol-refinery-patrol",
+			vars:    []string{"--var target_branch=", "--var rig_name=", "--var binding_prefix="},
+		},
+	}
+	for _, check := range checks {
+		data, err := os.ReadFile(filepath.Join(dir, check.rel))
+		if err != nil {
+			t.Fatalf("reading %s: %v", check.rel, err)
+		}
+		for lineNo, line := range strings.Split(string(data), "\n") {
+			if !strings.Contains(line, "gc bd mol wisp "+check.formula+" --root-only") {
+				continue
+			}
+			for _, want := range check.vars {
+				if !strings.Contains(line, want) {
+					t.Errorf("%s:%d wisp command missing %q:\n%s", check.rel, lineNo+1, want, line)
+				}
+			}
+		}
+	}
+
+	renderVars := map[string]string{
+		"binding_prefix": "gastown.",
+		"rig_name":       "gascity",
+		"target_branch":  "main",
+	}
+	for _, rel := range []string{
+		"packs/gastown/formulas/mol-deacon-patrol.toml",
+		"packs/gastown/formulas/mol-refinery-patrol.toml",
+	} {
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		rendered := formula.Substitute(string(data), renderVars)
+		for _, bad := range []string{"{{binding_prefix}}", "{{rig_name}}"} {
+			if strings.Contains(rendered, bad) {
+				t.Errorf("%s rendered patrol formula still contains %q", rel, bad)
 			}
 		}
 	}

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -65,7 +65,7 @@ gc bd list --assignee="$GC_ALIAS" --status=in_progress
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
 gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
@@ -155,7 +155,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only` |
+| Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }}` |
 | Context exhaustion | `gc runtime request-restart` |
 | Request target restart | `gc session kill <target>` |
 | Check gates | `gc bd gate check --type=timer --escalate` |

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -21,7 +21,7 @@ When you file a bead, default to immediately dispatching it to a polecat:
 
 ```bash
 gc bd create "Fix the auth timeout bug" -t task --json   # file it
-gc bd update <bead-id> --set-metadata gc.routed_to=<rig>/polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
+gc bd update <bead-id> --set-metadata gc.routed_to=<rig>/{{ .BindingPrefix }}polecat  # dispatch to polecat pool (pool reconciler picks up routed metadata)
 ```
 
 **Why this is the default:**

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -100,7 +100,7 @@ gc mail inbox
 When nudged after dispatch, run `gc hook` or `{{ .WorkQuery }}`. That lookup
 checks assigned work first (session bead ID, runtime session name, then
 alias) and only falls through to unassigned pool work routed to
-`{{ .RigName }}/polecat`.
+`{{ .RigName }}/{{ .BindingPrefix }}polecat`.
 
 **Hook/work query -> Read formula steps -> Follow in order -> done sequence.**
 
@@ -199,7 +199,7 @@ gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
+gc bd update <work-bead> --status=open --assignee={{ .RigName }}/{{ .BindingPrefix }}refinery --set-metadata gc.routed_to={{ .RigName }}/{{ .BindingPrefix }}refinery
 gc runtime drain-ack
 exit
 ```

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -53,7 +53,7 @@ Your formula: `mol-refinery-patrol`
 gc bd list --assignee="$GC_ALIAS" --status=in_progress
 
 # If none found, pour one (root-only — no child step beads) and assign it
-WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --json | jq -r '.new_epic_id')
+WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
 gc bd update "$WISP" --assignee="$GC_ALIAS"
 ```
 
@@ -172,7 +172,7 @@ alert the witness, not `gc mail send`.
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only` |
+| Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }}` |
 | Burn current wisp | `gc bd mol burn <wisp-id> --force` |
 | Find assigned work | `gc bd list --assignee="$GC_ALIAS" --status=open` |
 | Snapshot event position | `gc events --seq` |

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -1,7 +1,7 @@
 description = """
 Deacon patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-deacon-patrol --root-only
+  gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{binding_prefix}}
   gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check inbox, run town-wide coordination
@@ -340,7 +340,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --json | jq -r '.new_epic_id')
+NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -162,7 +162,7 @@ something is stuck. This is exactly why an LLM does it, not Go code.
 gc bd create --type=warrant \
   --title="Stuck: <rig>/<role>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --set-metadata gc.routed_to=dog
+  --set-metadata gc.routed_to={{binding_prefix}}dog
 ```
 
 The dog pool runs `mol-shutdown-dance` for due process.
@@ -186,7 +186,7 @@ wisp timestamps.
 
 **Step 1: Find active utility agent work:**
 ```bash
-gc bd list --status=in_progress --metadata-field gc.routed_to=dog --json --limit=0
+gc bd list --status=in_progress --metadata-field gc.routed_to={{binding_prefix}}dog --json --limit=0
 ```
 
 **Step 2: For each, assess progress:**
@@ -202,7 +202,7 @@ No hardcoded thresholds. Use judgment.
 gc bd create --type=warrant \
   --title="Stuck dog: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --set-metadata gc.routed_to=dog
+  --set-metadata gc.routed_to={{binding_prefix}}dog
 ```
 
 A different dog from the pool picks up the warrant and runs the

--- a/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-idea-to-plan.toml
@@ -44,7 +44,7 @@ description = "Additional context: constraints, prior decisions, related code, l
 default = ""
 
 [vars.review_target]
-description = "Agent or pool that should execute review legs (for example, my-rig/polecat). Empty means derive $GC_RIG/polecat."
+description = "Agent or pool that should execute review legs (for example, my-rig/{{binding_prefix}}polecat). Empty means derive $GC_RIG/{{binding_prefix}}polecat."
 default = ""
 
 [vars.review_formula]
@@ -78,9 +78,9 @@ cd "$REPO_ROOT"
 REVIEW_TARGET="{{review_target}}"
 if [ -z "$REVIEW_TARGET" ]; then
   if [ -n "$GC_RIG" ]; then
-    REVIEW_TARGET="$GC_RIG/polecat"
+    REVIEW_TARGET="$GC_RIG/{{binding_prefix}}polecat"
   else
-    echo "Pass --var review_target=<rig>/polecat when not running inside a rig session."
+    echo "Pass --var review_target=<rig>/{{binding_prefix}}polecat when not running inside a rig session."
   fi
 fi
 COORDINATOR="$GC_AGENT"

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -204,7 +204,7 @@ the PR is open and matches the branch, base, and origin repository.
 
 **5. Reassign to refinery:**
 ```bash
-gc bd update {{issue}} --status=open --assignee=<rig>/refinery --set-metadata gc.routed_to=<rig>/refinery
+gc bd update {{issue}} --status=open --assignee={{rig_name}}/{{binding_prefix}}refinery --set-metadata gc.routed_to={{rig_name}}/{{binding_prefix}}refinery
 ```
 
 Update both `assignee` AND `gc.routed_to` so the reconciler stops

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -1,7 +1,7 @@
 description = """
 Refinery patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-refinery-patrol --root-only
+  gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}}
   gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, merge one branch, pour
@@ -173,7 +173,7 @@ gc bd update $WORK \
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`
 6. Pour next patrol iteration before burning:
 ```bash
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 7. Burn this wisp: `gc bd mol burn <wisp-id> --force`
@@ -242,7 +242,7 @@ TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_bran
    - Clean up: `git checkout "$TARGET" && git branch -D temp`
    - Pour next patrol iteration before burning:
      ```bash
-     NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+     NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
      gc bd update "$NEXT" --assignee=$GC_AGENT
      ```
    - Burn this wisp: `gc bd mol burn <wisp-id> --force`
@@ -297,7 +297,7 @@ Work bead: $WORK
 Existing PR: $EXISTING_PR
 Branch: $BRANCH
 Target: $TARGET"
-  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+  NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
   gc bd update "$NEXT" --assignee=$GC_AGENT
   CURRENT_WISP=${GC_BEAD_ID:-}
   if [ -n "$CURRENT_WISP" ]; then
@@ -600,7 +600,7 @@ If auto_land = "false": skip this entirely.
 
 **2. Pour next iteration:**
 ```bash
-NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --json | jq -r '.new_epic_id')
+NEXT=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{target_branch}} --var rig_name={{rig_name}} --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -167,7 +167,7 @@ gc workflow delete-source $WORK --apply && gc workflow reopen-source $WORK
 ```bash
 gc bd update $WORK \
   --set-metadata rejection_reason="Conflicts with $TARGET at $(git rev-parse origin/$TARGET)" \
-  --set-metadata gc.routed_to=<rig>/polecat
+  --set-metadata gc.routed_to={{rig_name}}/{{binding_prefix}}polecat
 ```
 4. Do NOT delete the branch (new polecat needs it for conflict resolution).
 5. Clean up temp branch: `git checkout {{target_branch}} && git branch -D temp`

--- a/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/approval-fallacy.template.md
@@ -41,7 +41,7 @@ gc bd update <work-bead> \
   --set-metadata branch=$(git branch --show-current) \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
-gc bd update <work-bead> --status=open --assignee={{ .RigName }}/refinery --set-metadata gc.routed_to={{ .RigName }}/refinery
+gc bd update <work-bead> --status=open --assignee={{ .RigName }}/{{ .BindingPrefix }}refinery --set-metadata gc.routed_to={{ .RigName }}/{{ .BindingPrefix }}refinery
 gc runtime drain-ack
 exit
 ```

--- a/examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh
+++ b/examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh
@@ -5,13 +5,15 @@
 # 100 of these run in parallel on K8s to demonstrate pool scaling.
 #
 # Required env vars (set by gc start):
-#   GC_AGENT — this agent's name (e.g., "worker-42")
-#   GC_DIR   — working directory
+#   GC_AGENT    — this agent's name (e.g., "worker-42")
+#   GC_TEMPLATE — canonical pool route target (e.g., "demo/worker")
+#   GC_DIR      — working directory
 
 set -euo pipefail
 cd "$GC_DIR"
 
 AGENT_SHORT=$(basename "$GC_AGENT")
+POOL_LABEL="${GC_TEMPLATE:-worker}"
 echo "[$AGENT_SHORT] Starting up"
 
 # Jitter to avoid 100 workers racing on the same bead.
@@ -22,7 +24,7 @@ sleep "$JITTER"
 
 BEAD_ID=""
 for attempt in $(seq 1 10); do
-    ready=$(bd ready --metadata-field gc.routed_to=worker --unassigned 2>/dev/null || true)
+    ready=$(bd ready --metadata-field "gc.routed_to=$POOL_LABEL" --unassigned 2>/dev/null || true)
     if echo "$ready" | grep -qE '[a-z]{2}-[a-z0-9]'; then
         BEAD_ID=$(echo "$ready" | head -1 | awk '{print $2}')
         if bd update "$BEAD_ID" --claim --actor="$GC_AGENT" 2>/dev/null; then

--- a/examples/routing_namespace_test.go
+++ b/examples/routing_namespace_test.go
@@ -1,0 +1,44 @@
+package examples_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestShippedExamplesDoNotHardcodeShortRoutedToPools(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filename)
+	badRoutes := []string{
+		"gc.routed_to=dog",
+		"gc.routed_to=worker",
+		"gc.routed_to=<rig>/polecat",
+		"gc.routed_to=<rig>/refinery",
+		"gc.routed_to={{ .RigName }}/refinery",
+	}
+
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		body := string(data)
+		for _, bad := range badRoutes {
+			if strings.Contains(body, bad) {
+				t.Errorf("%s contains short-form routed_to target %q", path, bad)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/examples/testenv_import_test.go
+++ b/examples/testenv_import_test.go
@@ -1,0 +1,3 @@
+package examples_test
+
+import _ "github.com/gastownhall/gascity/internal/testenv"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,16 @@ func (a *Agent) BindingQualifiedName() string {
 	return a.BindingName + "." + a.Name
 }
 
+// BindingPrefix returns the import binding prefix for route/template
+// interpolation, including the trailing dot when a binding is present.
+func (a *Agent) BindingPrefix() string {
+	bindingName := strings.TrimSpace(a.BindingName)
+	if bindingName == "" {
+		return ""
+	}
+	return bindingName + "."
+}
+
 // QualifiedName returns the agent's canonical identity, including the rig
 // prefix when present. Examples: "mayor", "gastown.mayor",
 // "hello-world/polecat", and "hello-world/gastown.polecat".

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -689,7 +689,7 @@ func SlingFormulaTargetBranch(beadID string, deps SlingDeps, a config.Agent) str
 
 // BuildSlingFormulaVars builds the variable map for formula instantiation.
 func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a config.Agent, deps SlingDeps) map[string]string {
-	vars := make(map[string]string, len(userVars)+3)
+	vars := make(map[string]string, len(userVars)+6)
 	for _, v := range userVars {
 		key, value, ok := strings.Cut(v, "=")
 		if ok && key != "" {
@@ -709,6 +709,9 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 	if beadID != "" {
 		addVar("issue", beadID)
 	}
+	addVar("rig_name", a.Dir)
+	addVar("binding_name", a.BindingName)
+	addVar("binding_prefix", slingBindingPrefix(a.BindingName))
 
 	autoBranch := SlingFormulaTargetBranch(beadID, deps, a)
 	if SlingFormulaUsesBaseBranch(formulaName) {
@@ -719,6 +722,14 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 	}
 
 	return vars
+}
+
+func slingBindingPrefix(bindingName string) string {
+	bindingName = strings.TrimSpace(bindingName)
+	if bindingName == "" {
+		return ""
+	}
+	return bindingName + "."
 }
 
 // ResolveSlingEnv returns extra env vars for the sling command.

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -705,13 +705,19 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 		}
 		vars[key] = value
 	}
+	addRoutingVar := func(key, value string) {
+		if _, explicit := vars[key]; explicit {
+			return
+		}
+		vars[key] = value
+	}
 
 	if beadID != "" {
 		addVar("issue", beadID)
 	}
-	addVar("rig_name", a.Dir)
-	addVar("binding_name", a.BindingName)
-	addVar("binding_prefix", slingBindingPrefix(a.BindingName))
+	addRoutingVar("rig_name", a.Dir)
+	addRoutingVar("binding_name", a.BindingName)
+	addRoutingVar("binding_prefix", a.BindingPrefix())
 
 	autoBranch := SlingFormulaTargetBranch(beadID, deps, a)
 	if SlingFormulaUsesBaseBranch(formulaName) {
@@ -722,14 +728,6 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 	}
 
 	return vars
-}
-
-func slingBindingPrefix(bindingName string) string {
-	bindingName = strings.TrimSpace(bindingName)
-	if bindingName == "" {
-		return ""
-	}
-	return bindingName + "."
 }
 
 // ResolveSlingEnv returns extra env vars for the sling command.

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -422,6 +422,50 @@ func TestDoSlingFormulaToAgent(t *testing.T) {
 	}
 }
 
+func TestBuildSlingFormulaVarsSeedsRoutingNamespace(t *testing.T) {
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), newFakeRunner().run)
+
+	vars := BuildSlingFormulaVars("mol-polecat-work", "HW-42", nil, config.Agent{
+		Name:        "polecat",
+		Dir:         "hw",
+		BindingName: "gastown",
+	}, deps)
+
+	if got := vars["rig_name"]; got != "hw" {
+		t.Fatalf("rig_name var = %q, want hw", got)
+	}
+	if got := vars["binding_name"]; got != "gastown" {
+		t.Fatalf("binding_name var = %q, want gastown", got)
+	}
+	if got := vars["binding_prefix"]; got != "gastown." {
+		t.Fatalf("binding_prefix var = %q, want gastown.", got)
+	}
+}
+
+func TestBuildSlingFormulaVarsPreservesExplicitRoutingNamespace(t *testing.T) {
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), newFakeRunner().run)
+
+	vars := BuildSlingFormulaVars("mol-polecat-work", "HW-42", []string{
+		"rig_name=override-rig",
+		"binding_name=override-binding",
+		"binding_prefix=override.",
+	}, config.Agent{
+		Name:        "polecat",
+		Dir:         "hw",
+		BindingName: "gastown",
+	}, deps)
+
+	if got := vars["rig_name"]; got != "override-rig" {
+		t.Fatalf("rig_name var = %q, want override-rig", got)
+	}
+	if got := vars["binding_name"]; got != "override-binding" {
+		t.Fatalf("binding_name var = %q, want override-binding", got)
+	}
+	if got := vars["binding_prefix"]; got != "override." {
+		t.Fatalf("binding_prefix var = %q, want override.", got)
+	}
+}
+
 func TestDoSlingCrossRigBlocks(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -466,6 +466,21 @@ func TestBuildSlingFormulaVarsPreservesExplicitRoutingNamespace(t *testing.T) {
 	}
 }
 
+func TestBuildSlingFormulaVarsSeedsEmptyRoutingNamespaceForUnboundAgent(t *testing.T) {
+	deps := testDeps(&config.City{Workspace: config.Workspace{Name: "test"}}, runtime.NewFake(), newFakeRunner().run)
+
+	vars := BuildSlingFormulaVars("mol-deacon-patrol", "CITY-42", nil, config.Agent{
+		Name: "deacon",
+	}, deps)
+
+	for _, key := range []string{"rig_name", "binding_name", "binding_prefix"} {
+		got, ok := vars[key]
+		if !ok || got != "" {
+			t.Fatalf("%s var = %q, %v; want empty string, true", key, got, ok)
+		}
+	}
+}
+
 func TestDoSlingCrossRigBlocks(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary
- seed binding namespace vars for sling formulas and prompt templates
- update shipped Gastown and hyperscale routes to emit binding-qualified gc.routed_to values
- add gc doctor and shipped-example guards for short-form routed_to pool names

Supersedes and closes #1444 by @boylec.

## Tests
- go test ./...
- git diff --check origin/main..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->