### PR TITLE
fix(session): target named session mail lookups

### DIFF
--- a/internal/api/handler_mail.go
+++ b/internal/api/handler_mail.go
@@ -142,8 +142,14 @@ func (s *Server) resolveMailQueryRecipientsWithContext(ctx context.Context, reci
 }
 
 func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedSessionSpec) ([]string, error) {
+	identity := apiNormalizeSessionTarget(spec.Identity)
+	if identity == "" {
+		return nil, nil
+	}
 	candidates, err := store.List(beads.ListQuery{
-		Label:         session.LabelSession,
+		Metadata: map[string]string{
+			session.NamedSessionIdentityMetadata: identity,
+		},
 		IncludeClosed: true,
 	})
 	if err != nil {
@@ -165,6 +171,32 @@ func (s *Server) mailRecipientsForNamedSession(store beads.Store, spec apiNamedS
 	}
 	sort.Strings(recipients)
 	return recipients, nil
+}
+
+func (s *Server) configuredNamedMailIdentities(identifier string) []string {
+	identifier = apiNormalizeSessionTarget(identifier)
+	seen := make(map[string]bool)
+	identities := make([]string, 0, 2)
+	add := func(identity string) {
+		identity = apiNormalizeSessionTarget(identity)
+		if identity == "" || seen[identity] {
+			return
+		}
+		seen[identity] = true
+		identities = append(identities, identity)
+	}
+	add(identifier)
+	cfg := s.state.Config()
+	if cfg == nil {
+		return identities
+	}
+	for i := range cfg.NamedSessions {
+		identity := cfg.NamedSessions[i].QualifiedName()
+		if session.TargetBasename(identity) == identifier {
+			add(identity)
+		}
+	}
+	return identities
 }
 
 type apiResolvedMailTarget struct {
@@ -209,11 +241,25 @@ func (s *Server) resolveLiveConfiguredNamedMailTarget(store beads.Store, identif
 	if store == nil || identifier == "" || identifier == "human" || strings.Contains(identifier, "/") {
 		return apiResolvedMailTarget{}, false, nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
-	if err != nil {
-		return apiResolvedMailTarget{}, false, err
+	identities := s.configuredNamedMailIdentities(identifier)
+	all := make([]beads.Bead, 0, len(identities))
+	seenBeads := make(map[string]bool)
+	for _, identity := range identities {
+		items, err := store.List(beads.ListQuery{
+			Metadata: map[string]string{
+				session.NamedSessionIdentityMetadata: identity,
+			},
+		})
+		if err != nil {
+			return apiResolvedMailTarget{}, false, err
+		}
+		for _, b := range items {
+			if b.ID != "" && seenBeads[b.ID] {
+				continue
+			}
+			seenBeads[b.ID] = true
+			all = append(all, b)
+		}
 	}
 
 	matches := make(map[string]apiResolvedMailTarget)

--- a/internal/api/session_model_phase0_interface_spec_test.go
+++ b/internal/api/session_model_phase0_interface_spec_test.go
@@ -11,6 +11,18 @@ import (
 	"github.com/gastownhall/gascity/internal/session"
 )
 
+type noBroadAPISessionListStore struct {
+	beads.Store
+	t *testing.T
+}
+
+func (s noBroadAPISessionListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.t.Fatalf("API mail used broad session label scan: %+v", query)
+	}
+	return s.Store.List(query)
+}
+
 // Phase 0 spec coverage from engdocs/design/session-model-unification.md:
 // - Surface matrix / session-targeting API
 // - template: scope is factory-targeting only
@@ -245,6 +257,88 @@ func TestPhase0APIMailSend_BareNamedSessionUsesExistingLiveMailboxWithoutMateria
 	}
 	if count := phase0APISessionCount(t, fs.cityBeadStore); count != 1 {
 		t.Fatalf("POST /v0/mail left %d session(s), want only existing live session %s", count, live.ID)
+	}
+}
+
+func TestPhase0APIMailSend_BareNamedSessionUsesTargetedLiveMailboxLookup(t *testing.T) {
+	fs := newPhase0APINamedWorkerState(t)
+	baseStore := fs.cityBeadStore
+	if _, err := baseStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			apiNamedSessionMetadataKey: "true",
+			apiNamedSessionIdentityKey: "myrig/worker",
+			apiNamedSessionModeKey:     "always",
+			"alias":                    "live-worker",
+			"session_name":             "s-gc-test-city-worker",
+			"state":                    "asleep",
+		},
+	}); err != nil {
+		t.Fatalf("create live named session: %v", err)
+	}
+	fs.cityBeadStore = noBroadAPISessionListStore{Store: baseStore, t: t}
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	body := `{"from":"human","to":"worker","subject":"hello","body":"test"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(fs, "/mail"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST /v0/mail status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	msgs, err := fs.cityMailProv.Inbox("live-worker")
+	if err != nil {
+		t.Fatalf("Inbox(live-worker): %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("live named mailbox got %d message(s), want 1", len(msgs))
+	}
+}
+
+func TestPhase0APIMailQuery_BareNamedSessionUsesTargetedRecipientLookup(t *testing.T) {
+	fs := newPhase0APINamedWorkerState(t)
+	baseStore := fs.cityBeadStore
+	live, err := baseStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			apiNamedSessionMetadataKey: "true",
+			apiNamedSessionIdentityKey: "myrig/worker",
+			apiNamedSessionModeKey:     "always",
+			"alias":                    "live-worker",
+			"session_name":             "s-gc-test-city-worker",
+			"state":                    "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create live named session: %v", err)
+	}
+	closed, err := baseStore.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			apiNamedSessionMetadataKey: "true",
+			apiNamedSessionIdentityKey: "myrig/worker",
+			apiNamedSessionModeKey:     "always",
+			"session_name":             "s-gc-test-city-worker-old",
+			"state":                    "closed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed named session: %v", err)
+	}
+	if err := baseStore.Close(closed.ID); err != nil {
+		t.Fatalf("close named session: %v", err)
+	}
+	fs.cityBeadStore = noBroadAPISessionListStore{Store: baseStore, t: t}
+	srv := New(fs)
+
+	recipients := srv.resolveMailQueryRecipientsWithContext(t.Context(), "worker")
+	want := []string{live.ID, closed.ID, "worker"}
+	if strings.Join(recipients, ",") != strings.Join(want, ",") {
+		t.Fatalf("recipients = %#v, want %#v", recipients, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace API mail resolution for bare named-session recipients with targeted metadata lookups.
- Add regression coverage that fails on broad session-label scans for live named mailbox routing and query recipient expansion.

## Verification
- pre-commit hook ran in the PR worktree, including lint, vet, and GC_FAST_UNIT=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->