### PR TITLE
fix(formula): route root-only formulas as runnable wisps

### DIFF
--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2406,6 +2406,113 @@ func TestOnFormulaAttachesAndRoutes(t *testing.T) {
 	}
 }
 
+func TestOnRootOnlyFormulaKeepsAttachedWispPrivate(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "root-only.formula.toml"), []byte(`
+formula = "root-only"
+description = "Private attached root"
+version = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		FormulaLayers: config.FormulaLayers{City: []string{dir}},
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	deps.Store = beads.NewMemStoreFrom(1, []beads.Bead{
+		{ID: "BL-42", Title: "Work", Type: "task", Status: "open"},
+	}, nil)
+	opts := testOpts(a, "BL-42")
+	opts.OnFormula = "root-only"
+	code := doSling(opts, deps, deps.Store, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	source, err := deps.Store.Get("BL-42")
+	if err != nil {
+		t.Fatalf("store.Get(BL-42): %v", err)
+	}
+	if source.Metadata["gc.routed_to"] != "mayor" {
+		t.Errorf("source gc.routed_to = %q, want mayor", source.Metadata["gc.routed_to"])
+	}
+	rootID := source.Metadata["molecule_id"]
+	if rootID == "" {
+		t.Fatal("source bead missing molecule_id")
+	}
+	root, err := deps.Store.Get(rootID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", rootID, err)
+	}
+	if root.Type != "molecule" {
+		t.Fatalf("attached root type = %q, want molecule", root.Type)
+	}
+	if root.Metadata["gc.kind"] == "wisp" {
+		t.Fatalf("attached root leaked gc.kind=wisp metadata: %+v", root.Metadata)
+	}
+	ready, err := deps.Store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	for _, bead := range ready {
+		if bead.ID == rootID {
+			t.Fatalf("attached wisp root %s appeared in Ready(): %+v", rootID, ready)
+		}
+	}
+}
+
+func TestFormulaRootOnlyRoutesRunnableWispRoot(t *testing.T) {
+	runner := newFakeRunner()
+	sp := runtime.NewFake()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "root-only.formula.toml"), []byte(`
+formula = "root-only"
+description = "Standalone root"
+version = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		FormulaLayers: config.FormulaLayers{City: []string{dir}},
+	}
+	a := config.Agent{Name: "mayor", MaxActiveSessions: intPtr(1)}
+
+	deps, stdout, stderr := testDeps(cfg, sp, runner.run)
+	opts := testOpts(a, "root-only")
+	opts.IsFormula = true
+	code := doSling(opts, deps, deps.Store, stdout, stderr)
+
+	if code != 0 {
+		t.Fatalf("doSling returned %d, want 0; stderr: %s", code, stderr.String())
+	}
+	root, err := deps.Store.Get("gc-1")
+	if err != nil {
+		t.Fatalf("store.Get(gc-1): %v", err)
+	}
+	if root.Type != "task" {
+		t.Fatalf("root type = %q, want task", root.Type)
+	}
+	if root.Metadata["gc.kind"] != "wisp" {
+		t.Fatalf("root gc.kind = %q, want wisp", root.Metadata["gc.kind"])
+	}
+	if root.Metadata["gc.routed_to"] != "mayor" {
+		t.Fatalf("root gc.routed_to = %q, want mayor", root.Metadata["gc.routed_to"])
+	}
+	ready, err := deps.Store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(ready) != 1 || ready[0].ID != root.ID {
+		t.Fatalf("Ready() = %+v, want only routed root %s", ready, root.ID)
+	}
+}
+
 func TestOnFormulaCopiesSourcePriorityToCreatedBeads(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()

--- a/cmd/gc/wisp_gc.go
+++ b/cmd/gc/wisp_gc.go
@@ -51,9 +51,9 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 		return 0, fmt.Errorf("listing closed molecules: bead store unavailable")
 	}
 
-	entries, err := store.List(beads.ListQuery{Status: "closed", Type: "molecule"})
+	entries, err := closedWispGCEntries(store)
 	if err != nil {
-		return 0, fmt.Errorf("listing closed molecules: %w", err)
+		return 0, err
 	}
 
 	cutoff := now.Add(-m.ttl)
@@ -69,6 +69,34 @@ func (m *memoryWispGC) runGC(store beads.Store, now time.Time) (int, error) {
 	}
 
 	return purged, deleteErr
+}
+
+func closedWispGCEntries(store beads.Store) ([]beads.Bead, error) {
+	entries := make([]beads.Bead, 0)
+	seen := make(map[string]struct{})
+	appendUnique := func(items []beads.Bead) {
+		for _, item := range items {
+			if item.ID == "" {
+				continue
+			}
+			if _, ok := seen[item.ID]; ok {
+				continue
+			}
+			seen[item.ID] = struct{}{}
+			entries = append(entries, item)
+		}
+	}
+	molecules, err := store.List(beads.ListQuery{Status: "closed", Type: "molecule"})
+	if err != nil {
+		return nil, fmt.Errorf("listing closed molecule roots: %w", err)
+	}
+	appendUnique(molecules)
+	wisps, err := store.List(beads.ListQuery{Status: "closed", Metadata: map[string]string{"gc.kind": "wisp"}})
+	if err != nil {
+		return nil, fmt.Errorf("listing closed wisp roots: %w", err)
+	}
+	appendUnique(wisps)
+	return entries, nil
 }
 
 func purgeExpiredBeadClosures(store beads.Store, entries []beads.Bead, cutoff time.Time) (int, error) {

--- a/cmd/gc/wisp_gc_test.go
+++ b/cmd/gc/wisp_gc_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,7 @@ func TestWispGC_PurgesExpiredMolecules(t *testing.T) {
 	now := time.Now()
 	store := newGCStore([]beads.Bead{
 		makeGCBead("mol-1", now.Add(-2*time.Hour), "closed", "molecule"),
+		makeGCBeadWithMetadata("wisp-1", now.Add(-2*time.Hour), "closed", "task", map[string]string{"gc.kind": "wisp"}),
 		makeGCBead("mol-2", now.Add(-30*time.Minute), "closed", "molecule"),
 		makeGCBead("mol-3", now.Add(-3*time.Hour), "closed", "molecule"),
 	})
@@ -59,10 +61,10 @@ func TestWispGC_PurgesExpiredMolecules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runGC: %v", err)
 	}
-	if purged != 2 {
-		t.Fatalf("purged = %d, want 2", purged)
+	if purged != 3 {
+		t.Fatalf("purged = %d, want 3", purged)
 	}
-	assertDeletedIDs(t, store.deletedIDs, "mol-1", "mol-3")
+	assertDeletedIDs(t, store.deletedIDs, "mol-1", "wisp-1", "mol-3")
 }
 
 func TestWispGC_NothingExpired(t *testing.T) {
@@ -427,9 +429,10 @@ func TestWispGC_ListErrorFailsRun(t *testing.T) {
 }
 
 type gcQueryKey struct {
-	Status string
-	Type   string
-	Label  string
+	Status   string
+	Type     string
+	Label    string
+	Metadata string
 }
 
 type gcTestStore struct {
@@ -448,7 +451,7 @@ func newGCStore(existing []beads.Bead) *gcTestStore {
 }
 
 func (s *gcTestStore) List(query beads.ListQuery) ([]beads.Bead, error) {
-	if err := s.listErrors[gcQueryKey{Status: query.Status, Type: query.Type, Label: query.Label}]; err != nil {
+	if err := s.listErrors[gcQueryKey{Status: query.Status, Type: query.Type, Label: query.Label, Metadata: metadataQueryKey(query.Metadata)}]; err != nil {
 		return nil, err
 	}
 	return s.MemStore.List(query)
@@ -478,6 +481,28 @@ func makeGCBeadWithLabels(id string, createdAt time.Time, status, beadType strin
 		CreatedAt: createdAt,
 		Labels:    labels,
 	}
+}
+
+func makeGCBeadWithMetadata(id string, createdAt time.Time, status, beadType string, metadata map[string]string) beads.Bead {
+	bead := makeGCBead(id, createdAt, status, beadType)
+	bead.Metadata = metadata
+	return bead
+}
+
+func metadataQueryKey(metadata map[string]string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+metadata[key])
+	}
+	return strings.Join(parts, "\x00")
 }
 
 func assertDeletedIDs(t *testing.T, deleted []string, want ...string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1775,6 +1775,8 @@ func (a *Agent) AttachEnabled() bool {
 //
 // State priority: in_progress+assigned (crash recovery) >
 // ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
+// Formula roots that are themselves executable must be represented as ready()
+// work (for example type=wisp); molecule containers are not routable demand.
 //
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
@@ -1811,10 +1813,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-			// Tier 4: open routed molecule roots. scale_check already counts
-			// these, so startup must be able to see them too.
-			`bd list --metadata-field gc.routed_to=` + target +
-			` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null'`
+			`printf "[]"'`
 	}
 	return `sh -c '` +
 		// Tier 1: in_progress assigned to any of my identifiers (crash recovery).
@@ -1913,8 +1912,7 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 
 // EffectiveScaleCheck returns the scale check command for this agent.
 // If ScaleCheck is set, returns it. Otherwise returns a default that
-// counts new unassigned work routed to this agent's template, including
-// standalone formula-dispatched molecule beads (which bd ready excludes).
+// counts new unassigned work routed to this agent's template via ready().
 // Assigned in-progress work is resumed from session beads, so it must not
 // create additional generic pool demand here.
 func (a *Agent) EffectiveScaleCheck() string {
@@ -1924,9 +1922,7 @@ func (a *Agent) EffectiveScaleCheck() string {
 	template := a.QualifiedName()
 	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
 		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`molecules=$(bd list --metadata-field gc.routed_to=` + template +
-		` --status=open --type=molecule --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`echo "$(( ${ready:-0} + ${molecules:-0} ))" || echo 0`
+		`echo "${ready:-0}" || echo 0`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1320,8 +1320,8 @@ func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
-	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/polecat --status=open --type=molecule --no-assignee --json --limit=1") {
-		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route: %q", got)
+	if strings.Contains(got, "--type=molecule") {
+		t.Errorf("EffectiveWorkQuery() should not route molecule containers: %q", got)
 	}
 }
 
@@ -1373,8 +1373,8 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to with pool name: %q", got)
 	}
-	if !strings.Contains(got, "bd list --metadata-field gc.routed_to=hello-world/dog --status=open --type=molecule --no-assignee --json --limit=1") {
-		t.Errorf("EffectiveWorkQuery() missing tier 4 molecule route with pool name: %q", got)
+	if strings.Contains(got, "--type=molecule") {
+		t.Errorf("EffectiveWorkQuery() should not route molecule containers with pool name: %q", got)
 	}
 }
 
@@ -1489,8 +1489,8 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("EffectiveScaleCheck() = %q, want bd ready for blocker-aware counting", check)
 	}
-	if !strings.Contains(check, "--type=molecule") {
-		t.Errorf("EffectiveScaleCheck() = %q, want --type=molecule for formula-dispatched work", check)
+	if strings.Contains(check, "--type=molecule") {
+		t.Errorf("EffectiveScaleCheck() = %q, should not count molecule containers as demand", check)
 	}
 	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
 		t.Errorf("EffectiveScaleCheck() = %q, should not count in-progress work as new demand", check)
@@ -1587,18 +1587,15 @@ func TestEffectiveScaleCheckDefaults(t *testing.T) {
 		MinActiveSessions: ptrInt(0), MaxActiveSessions: ptrInt(1),
 	}
 	check := a.EffectiveScaleCheck()
-	// Default check uses bd ready (blocker-aware) + molecule count via gc.routed_to.
+	// Default check uses bd ready for blocker-aware routed demand.
 	if !strings.Contains(check, "gc.routed_to=refinery") {
 		t.Errorf("EffectiveScaleCheck = %q, want gc.routed_to=refinery", check)
 	}
-	if !strings.Contains(check, "--no-assignee") {
-		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for new unassigned demand", check)
+	if !strings.Contains(check, "--unassigned") {
+		t.Errorf("EffectiveScaleCheck = %q, want --unassigned for new unassigned demand", check)
 	}
-	if !strings.Contains(check, "--type=molecule") {
-		t.Errorf("EffectiveScaleCheck = %q, want --type=molecule for formula-dispatched work", check)
-	}
-	if !strings.Contains(check, "${molecules:-0}") {
-		t.Errorf("EffectiveScaleCheck = %q, want ${molecules:-0} in arithmetic sum", check)
+	if strings.Contains(check, "--type=molecule") || strings.Contains(check, "${molecules:-0}") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count molecule containers as demand", check)
 	}
 	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
 		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
@@ -1616,20 +1613,20 @@ func TestEffectiveScaleCheckDefaultsQualified(t *testing.T) {
 	if !strings.Contains(check, "gc.routed_to=myproject/polecat") {
 		t.Errorf("EffectiveScaleCheck = %q, want gc.routed_to=myproject/polecat", check)
 	}
-	if !strings.Contains(check, "--no-assignee") {
-		t.Errorf("EffectiveScaleCheck = %q, want --no-assignee for new unassigned demand", check)
+	if !strings.Contains(check, "--unassigned") {
+		t.Errorf("EffectiveScaleCheck = %q, want --unassigned for new unassigned demand", check)
 	}
-	if !strings.Contains(check, "--type=molecule") {
-		t.Errorf("EffectiveScaleCheck = %q, want --type=molecule for formula-dispatched work", check)
+	if strings.Contains(check, "--type=molecule") {
+		t.Errorf("EffectiveScaleCheck = %q, should not count molecule containers as demand", check)
 	}
 	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
 		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 }
 
-func TestEffectiveScaleCheckMoleculeQuery(t *testing.T) {
-	// Regression test for GH #505: default scale check must detect
-	// formula-dispatched molecule beads that bd ready excludes.
+func TestEffectiveScaleCheckUsesReadyOnly(t *testing.T) {
+	// Formula-dispatched executable roots must be visible through ready()
+	// as runnable wisps/tasks; molecule containers are not demand.
 	a := Agent{
 		Name:              "worker",
 		Dir:               "myrig",
@@ -1637,28 +1634,24 @@ func TestEffectiveScaleCheckMoleculeQuery(t *testing.T) {
 	}
 	check := a.EffectiveScaleCheck()
 
-	// Must contain blocker-aware ready demand and standalone molecule demand.
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("missing bd ready query for blocker-aware task counting")
 	}
-	if !strings.Contains(check, "--status=open --type=molecule") {
-		t.Errorf("missing molecule query for formula-dispatched work (GH #505)")
+	if strings.Contains(check, "--status=open --type=molecule") {
+		t.Errorf("unexpected molecule query in scale check: %q", check)
 	}
 	if strings.Contains(check, "--status=in_progress") || strings.Contains(check, "${active:-0}") {
 		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 
-	// Both variables must appear in the arithmetic sum.
 	if !strings.Contains(check, "${ready:-0}") {
 		t.Errorf("missing ${ready:-0} in arithmetic sum")
 	}
-	if !strings.Contains(check, "${molecules:-0}") {
-		t.Errorf("missing ${molecules:-0} in arithmetic sum")
+	if strings.Contains(check, "${molecules:-0}") {
+		t.Errorf("unexpected ${molecules:-0} in arithmetic sum")
 	}
-
-	// Molecule query must use the qualified name for routing.
 	if !strings.Contains(check, "gc.routed_to=myrig/worker") {
-		t.Errorf("molecule query missing gc.routed_to=myrig/worker")
+		t.Errorf("ready query missing gc.routed_to=myrig/worker")
 	}
 }
 

--- a/internal/formula/compile.go
+++ b/internal/formula/compile.go
@@ -252,9 +252,17 @@ func toRecipeWithGraph(f *Formula, graphWorkflow bool) (*Recipe, error) {
 		rootDesc = "{{desc}}"
 	}
 
+	// Vapor formulas and formulas with no materialized steps are executable
+	// wisps: the root bead itself is the work. Poured formulas keep a molecule
+	// container root because their child steps are the routable units.
+	rootOnly := (!f.Pour && f.Phase == "vapor") || len(f.Steps) == 0
+
 	// Root step
 	rootType := "molecule"
-	if graphWorkflow {
+	switch {
+	case graphWorkflow:
+		rootType = "task"
+	case rootOnly:
 		rootType = "task"
 	}
 
@@ -268,16 +276,14 @@ func toRecipeWithGraph(f *Formula, graphWorkflow bool) (*Recipe, error) {
 	if graphWorkflow {
 		rootStep.Metadata = map[string]string{"gc.kind": "workflow"}
 		rootStep.Metadata["gc.formula_contract"] = "graph.v2"
+	} else if rootOnly {
+		rootStep.Metadata = map[string]string{"gc.kind": "wisp"}
 	}
 	defPriority := 2
 	rootStep.Priority = &defPriority
 	r.Steps = append(r.Steps, rootStep)
 
-	// Determine RootOnly: vapor-phase formulas that don't explicitly
-	// request pour get root-only by default.
-	if !f.Pour && f.Phase == "vapor" {
-		r.RootOnly = true
-	}
+	r.RootOnly = rootOnly
 
 	// Flatten step tree
 	idMapping := make(map[string]string) // step.ID -> namespaced ID

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -391,6 +391,42 @@ title = "Scan"
 	if !recipe.RootOnly {
 		t.Error("vapor formula should be RootOnly by default")
 	}
+	if recipe.RootStep().Type != "task" {
+		t.Errorf("root Type = %q, want %q", recipe.RootStep().Type, "task")
+	}
+	if got := recipe.RootStep().Metadata["gc.kind"]; got != "wisp" {
+		t.Errorf("root gc.kind = %q, want wisp", got)
+	}
+}
+
+func TestCompileStepLessFormulaUsesRunnableWispRoot(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "router"
+description = "Route pending work"
+version = 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "router.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recipe, err := Compile(context.Background(), "router", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	if len(recipe.Steps) != 1 {
+		t.Fatalf("len(Steps) = %d, want root only", len(recipe.Steps))
+	}
+	if !recipe.RootOnly {
+		t.Fatal("step-less formula should be RootOnly")
+	}
+	if recipe.RootStep().Type != "task" {
+		t.Fatalf("root Type = %q, want task", recipe.RootStep().Type)
+	}
+	if got := recipe.RootStep().Metadata["gc.kind"]; got != "wisp" {
+		t.Fatalf("root gc.kind = %q, want wisp", got)
+	}
 }
 
 // TestCompileExtendsPhasePour regresses the merge bug where the 'extends'

--- a/internal/molecule/graph_apply.go
+++ b/internal/molecule/graph_apply.go
@@ -134,7 +134,7 @@ func buildRecipeApplyPlan(recipe *formula.Recipe, opts Options) (*beads.GraphApp
 		}
 		if step.IsRoot {
 			rootIncluded = true
-			if !opts.PreserveRootType && step.Metadata["gc.kind"] != "workflow" {
+			if !opts.PreserveRootType && !preserveExecutableRootType(step) {
 				node.Type = "molecule"
 			}
 			if opts.Title != "" {

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -417,7 +417,7 @@ func Instantiate(ctx context.Context, store beads.Store, recipe *formula.Recipe,
 		}
 		// Root bead overrides.
 		if step.IsRoot {
-			if !opts.PreserveRootType && step.Metadata["gc.kind"] != "workflow" {
+			if !opts.PreserveRootType && !preserveExecutableRootType(step) {
 				b.Type = "molecule"
 			}
 			b.Ref = recipe.Name
@@ -817,6 +817,15 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 	}
 
 	return b
+}
+
+func preserveExecutableRootType(step formula.RecipeStep) bool {
+	switch step.Metadata["gc.kind"] {
+	case "workflow", "wisp":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateTimeoutMetadataVars(stepID string, metadata map[string]string) error {

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -1241,6 +1241,43 @@ func TestInstantiateRootOnly(t *testing.T) {
 	}
 }
 
+func TestInstantiateRunnableWispRootPreservesTaskType(t *testing.T) {
+	store := beads.NewMemStore()
+	recipe := &formula.Recipe{
+		Name:     "patrol",
+		RootOnly: true,
+		Steps: []formula.RecipeStep{
+			{ID: "patrol", Title: "Patrol", Type: "task", IsRoot: true, Metadata: map[string]string{"gc.kind": "wisp"}},
+			{ID: "patrol.scan", Title: "Scan", Type: "task"},
+		},
+		Deps: []formula.RecipeDep{
+			{StepID: "patrol.scan", DependsOnID: "patrol", Type: "parent-child"},
+		},
+	}
+
+	result, err := Instantiate(context.Background(), store, recipe, Options{})
+	if err != nil {
+		t.Fatalf("Instantiate: %v", err)
+	}
+	root, err := store.Get(result.RootID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", result.RootID, err)
+	}
+	if root.Type != "task" {
+		t.Fatalf("root Type = %q, want task", root.Type)
+	}
+	if got := root.Metadata["gc.kind"]; got != "wisp" {
+		t.Fatalf("root gc.kind = %q, want wisp", got)
+	}
+	ready, err := store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if len(ready) != 1 || ready[0].ID != result.RootID {
+		t.Fatalf("Ready() = %+v, want only root %s", ready, result.RootID)
+	}
+}
+
 func TestInstantiateVarDefaults(t *testing.T) {
 	store := beads.NewMemStore()
 	defaultVal := "default-branch"

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -805,6 +805,7 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 		SlingTracef("instantiate decorate-error formula=%s err=%v", formulaName, err)
 		return nil, err
 	}
+	privatizeAttachedRootOnlyWisp(recipe, sourceBeadID)
 	instantiateStart := time.Now()
 	result, err := molecule.Instantiate(ctx, deps.Store, recipe, opts)
 	if err != nil {
@@ -813,6 +814,35 @@ func InstantiateSlingFormula(ctx context.Context, formulaName string, searchPath
 	}
 	SlingTracef("instantiate done formula=%s dur=%s root=%s created=%d graph=%t", formulaName, time.Since(instantiateStart), result.RootID, result.Created, result.GraphWorkflow)
 	return result, nil
+}
+
+func privatizeAttachedRootOnlyWisp(recipe *formula.Recipe, sourceBeadID string) {
+	if recipe == nil || !recipe.RootOnly || strings.TrimSpace(sourceBeadID) == "" || len(recipe.Steps) == 0 {
+		return
+	}
+	root := &recipe.Steps[0]
+	if root.Metadata["gc.kind"] != "wisp" {
+		return
+	}
+	root.Type = "molecule"
+	root.Metadata = mapsCloneWithout(root.Metadata, "gc.kind")
+}
+
+func mapsCloneWithout(in map[string]string, drop string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		if key == drop {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // ShouldPromoteWorkflowLaunchStatus reports whether a bead's status should


### PR DESCRIPTION
## Summary
- Compile root-only and step-less formulas as runnable wisp task roots instead of inert molecule containers.
- Keep attached root-only wisps private when a formula is attached to a source bead.
- Remove molecule-container counting from default work_query/scale_check demand and teach wisp GC to purge closed wisp roots.

## Verification
- pre-commit hook ran in the PR worktree, including lint, vet, and GC_FAST_UNIT=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->