### PR TITLE
harden(hook): keep claim flow non-intrusive

### DIFF
--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -25,6 +25,9 @@ gc hook
 
 # Step 4: If gc hook returned an unassigned routed bead, claim it atomically
 bd update <id> --claim
+
+# Step 5: Verify the claim before doing work
+bd show <id> --json
 ```
 
 If you have no work after all three checks, run:
@@ -39,14 +42,17 @@ gc runtime drain-ack
 2. If the bead came from `gc hook`, claim it with `bd update <id> --claim`
    before doing any work. Do not start work with `bd update --status in_progress`;
    only `--claim` sets both assignee and in-progress state atomically.
-3. Read it with `bd show <id>`.
-4. **Claim continuation group** (see below).
-5. Execute exactly that bead's description.
-6. On success, close it:
+3. Verify the claimed bead is assigned to `$GC_SESSION_NAME` and routed to
+   `$GC_TEMPLATE`. If either check fails, do not work that bead; run `gc hook`
+   again or drain if no valid work is available.
+4. Read it with `bd show <id>`.
+5. **Claim continuation group** (see below).
+6. Execute exactly that bead's description.
+7. On success, close it:
    ```bash
    bd update <id> --set-metadata gc.outcome=pass --status closed
    ```
-7. On transient failure, mark it transient and close it:
+8. On transient failure, mark it transient and close it:
    ```bash
    bd update <id> \
      --set-metadata gc.outcome=fail \
@@ -54,7 +60,7 @@ gc runtime drain-ack
      --set-metadata gc.failure_reason=<short_reason> \
      --status closed
    ```
-8. On unrecoverable failure, mark it hard-failed and close it:
+9. On unrecoverable failure, mark it hard-failed and close it:
    ```bash
    bd update <id> \
      --set-metadata gc.outcome=fail \
@@ -62,11 +68,11 @@ gc runtime drain-ack
      --set-metadata gc.failure_reason=<short_reason> \
      --status closed
    ```
-9. After closing, check for more assigned work:
+10. After closing, check for more assigned work:
    ```bash
    bd ready --assignee="$GC_SESSION_NAME" --json --limit=1
    ```
-10. If more work exists, go to step 2. If not, poll briefly (see below).
+11. If more work exists, go to step 2. If not, poll briefly (see below).
 
 ## Continuation Group — Session Affinity
 

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -20,17 +20,23 @@ bd list --assignee="$GC_SESSION_NAME" --status=in_progress
 # Step 2: If nothing in-progress, check for assigned ready work
 bd ready --assignee="$GC_SESSION_NAME"
 
-# Step 3: If still nothing, check the pool queue
-bd ready --metadata-field gc.routed_to=$GC_TEMPLATE --unassigned
+# Step 3: If still nothing, check the routed queue
+gc hook
 
 # Step 4: Claim it
 bd update <id> --claim
 
-# Step 5: Read the bead and check for molecule_id in METADATA
+# Step 5: Verify the claim before doing work
+bd show <id> --json
+
+# Step 6: Read the bead and check for molecule_id in METADATA
 bd show <id>
 ```
 
 If nothing is available, run `gc runtime drain-ack` to end your session.
+After claiming, verify `assignee` is `$GC_SESSION_NAME` and
+`metadata.gc.routed_to` is `$GC_TEMPLATE`. If either check fails, do not work
+that bead; run `gc hook` again or drain if no valid work is available.
 
 ## Following Your Formula
 
@@ -72,7 +78,7 @@ the bead description directly.
 ## Your Tools
 
 - `bd ready --assignee="$GC_SESSION_NAME"` — find pre-assigned work
-- `bd ready --metadata-field gc.routed_to=$GC_TEMPLATE --unassigned` — find pool work
+- `gc hook` — find routed pool work through the configured hook
 - `bd update <id> --claim` — claim a work item
 - `bd show <id>` — see details of a work item or step
 - `bd mol current <molecule-id>` — show position in molecule workflow
@@ -83,13 +89,14 @@ the bead description directly.
 
 ## How to Work
 
-1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --assignee="$GC_SESSION_NAME"` or `bd ready --metadata-field gc.routed_to=$GC_TEMPLATE --unassigned`
+1. Find work: `bd list --assignee="$GC_SESSION_NAME" --status=in_progress` or `bd ready --assignee="$GC_SESSION_NAME"` or `gc hook`
 2. Claim if unclaimed: `bd update <id> --claim`
-3. **Check for molecule:** `bd show <id>` — look for `molecule_id` in METADATA
-4. **If molecule exists:** `bd mol current <mol-id>` → work each step in order (show → do → close → repeat)
-5. **If no molecule:** execute the work directly from the bead description
-6. When all work is done, close the bead: `bd close <id>`
-7. **MANDATORY — run this exact command as your final action:**
+3. Verify the claimed bead is assigned to `$GC_SESSION_NAME` and routed to `$GC_TEMPLATE`
+4. **Check for molecule:** `bd show <id>` — look for `molecule_id` in METADATA
+5. **If molecule exists:** `bd mol current <mol-id>` → work each step in order (show → do → close → repeat)
+6. **If no molecule:** execute the work directly from the bead description
+7. When all work is done, close the bead: `bd close <id>`
+8. **MANDATORY — run this exact command as your final action:**
    ```bash
    gc runtime drain-ack
    ```


### PR DESCRIPTION
## Summary
- Make hook inject mode non-intrusive so it never emits a work-item payload that encourages random claiming.
- Harden pool/graph worker prompts to find routed work through gc hook, verify the claim, and retry/drain on claim mismatch.

## Verification
- pre-commit hook ran in the PR worktree, including lint, vet, GC_FAST_UNIT=1 go test ./..., and docsync.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->