### PR TITLE
perf(reconciler): use cached demand snapshots

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -139,19 +139,11 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 	if ctx.Done() == nil {
 		return cs
 	}
-	// Full prime runs async — backfills remaining beads for List()
-	// callers (convergence reconcile, sweep, API handlers).
-	go func() {
-		log.Printf("caching-store: priming ...")
-		if err := cs.Prime(ctx); err != nil {
-			log.Printf("caching-store: prime FAILED: %v (reads will use bd subprocess)", err)
-			return
-		}
-		if ctx.Err() != nil {
-			return
-		}
-		cs.StartReconciler(ctx)
-	}()
+	// Defer full scans to the watchdog interval. Launching a full Prime for
+	// every city/rig store at startup can saturate bd/dolt exactly when the
+	// controller needs fast ticks; PrimeActive already gives controller paths
+	// a complete active-bead read model.
+	cs.StartReconciler(ctx)
 	return cs
 }
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -426,6 +427,86 @@ func TestControllerStateAppliesCacheReconcileBeadEventsToStores(t *testing.T) {
 	}
 	if items[0].Status != "in_progress" {
 		t.Fatalf("status after cache-reconcile event = %q, want in_progress", items[0].Status)
+	}
+}
+
+func TestWrapWithCachingStoreDefersFullPrime(t *testing.T) {
+	fullPrimeSeen := make(chan struct{}, 1)
+	runner := func(_ string, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) > 0 && args[0] == "list" && !strings.HasPrefix(strings.Join(args, " "), "list --json --status=") {
+			select {
+			case fullPrimeSeen <- struct{}{}:
+			default:
+			}
+		}
+		return []byte(`[]`), nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := wrapWithCachingStore(ctx, beads.NewBdStore(t.TempDir(), runner), nil)
+	if _, ok := store.(*beads.CachingStore); !ok {
+		t.Fatalf("wrapped store = %T, want *beads.CachingStore", store)
+	}
+
+	select {
+	case <-fullPrimeSeen:
+		t.Fatal("wrapWithCachingStore launched an immediate full cache prime")
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestControllerStateBeadEventsRespectStorePrefixes(t *testing.T) {
+	cityBacking := beads.NewMemStore()
+	rigBacking := beads.NewMemStore()
+	cityCache := beads.NewCachingStoreForTestWithPrefix(cityBacking, "mc", nil)
+	rigCache := beads.NewCachingStoreForTestWithPrefix(rigBacking, "ga", nil)
+	for name, cache := range map[string]*beads.CachingStore{
+		"city": cityCache,
+		"rig":  rigCache,
+	} {
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime(%s): %v", name, err)
+		}
+	}
+
+	payload, err := json.Marshal(beads.Bead{
+		ID:     "mc-source",
+		Title:  "city source",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("marshal city bead: %v", err)
+	}
+	cs := &controllerState{
+		cityBeadStore: cityCache,
+		beadStores:    map[string]beads.Store{"gascity": rigCache},
+		pokeCh:        make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadCreated,
+		Actor:   "bd-hook",
+		Subject: "mc-source",
+		Payload: payload,
+	})
+
+	cityItems, err := cityCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List city cache: %v", err)
+	}
+	if len(cityItems) != 1 || cityItems[0].ID != "mc-source" {
+		t.Fatalf("city cache items = %+v, want mc-source", cityItems)
+	}
+	rigItems, err := rigCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List rig cache: %v", err)
+	}
+	if len(rigItems) != 0 {
+		t.Fatalf("rig cache items = %+v, want no city bead", rigItems)
 	}
 }
 

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -83,6 +83,9 @@ func isRetryableManagedDoltLifecycleError(err error) bool {
 // Called by gc start and controller config reload. Rigs must have absolute
 // paths before calling (resolve relative paths first).
 func startBeadsLifecycle(cityPath, _ string, cfg *config.City, _ io.Writer) error {
+	if err := recoverManagedLocalEndpointMirror(cityPath, cfg); err != nil {
+		return err
+	}
 	if err := validateCanonicalCompatDoltDrift(cityPath, cfg); err != nil {
 		return err
 	}
@@ -1076,6 +1079,57 @@ func syncConfiguredDoltPortFiles(cityPath string, cityDolt config.DoltConfig, ci
 		}
 	}
 	return nil
+}
+
+func recoverManagedLocalEndpointMirror(cityPath string, cfg *config.City) error {
+	if cfg == nil || !workspaceUsesManagedBdStoreContract(cityPath, cfg.Rigs) {
+		return nil
+	}
+	resolveRigPaths(cityPath, cfg.Rigs)
+	cityState := desiredCityDoltConfigState(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg))
+	if scopeUsesManagedBdStoreContract(cityPath, cityPath) {
+		if err := recoverScopeManagedLocalEndpointMirror(cityPath, cityState); err != nil {
+			return fmt.Errorf("recovering managed city endpoint mirror: %w", err)
+		}
+	}
+	for i := range cfg.Rigs {
+		rig := normalizedRigConfig(cityPath, cfg.Rigs[i])
+		if strings.TrimSpace(rig.Path) == "" || !rigUsesManagedBdStoreContract(cityPath, rig) {
+			continue
+		}
+		rigState := desiredRigDoltConfigState(cityPath, rig, cityState)
+		if err := recoverScopeManagedLocalEndpointMirror(rig.Path, rigState); err != nil {
+			return fmt.Errorf("recovering managed rig endpoint mirror for %q: %w", cfg.Rigs[i].Name, err)
+		}
+	}
+	return nil
+}
+
+func recoverScopeManagedLocalEndpointMirror(scopePath string, desired contract.ConfigState) error {
+	switch desired.EndpointOrigin {
+	case contract.EndpointOriginManagedCity, contract.EndpointOriginInheritedCity:
+	default:
+		return nil
+	}
+	existing, ok, err := contract.ReadConfigState(fsys.OSFS{}, filepath.Join(scopePath, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		return err
+	}
+	if existing.EndpointOrigin != desired.EndpointOrigin {
+		return nil
+	}
+	if strings.TrimSpace(existing.DoltUser) != "" {
+		return nil
+	}
+	host := strings.TrimSpace(existing.DoltHost)
+	port := strings.TrimSpace(existing.DoltPort)
+	if host == "" && port == "" {
+		return nil
+	}
+	if !managedLocalDoltHost(host) {
+		return nil
+	}
+	return normalizeScopeDoltConfig(scopePath, desired)
 }
 
 func syncDesiredCityDoltConfigState(cityPath string, cityDolt config.DoltConfig, cityPrefix string) (contract.ConfigState, error) {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -7970,6 +7970,71 @@ dolt.port: 3307
 	}
 }
 
+func TestRecoverManagedLocalEndpointMirrorClearsManagedCityPortMirror(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: gc
+issue-prefix: gc
+dolt.auto-start: false
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.port: 21792
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	if err := recoverManagedLocalEndpointMirror(cityPath, cfg); err != nil {
+		t.Fatalf("recoverManagedLocalEndpointMirror: %v", err)
+	}
+
+	data := mustReadFile(t, filepath.Join(cityPath, ".beads", "config.yaml"))
+	text := string(data)
+	for _, want := range []string{
+		"gc.endpoint_origin: managed_city",
+		"gc.endpoint_status: verified",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("recovered config missing %q:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{"dolt.host:", "dolt.port:", "dolt.user:"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("recovered config still contains %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestRecoverManagedLocalEndpointMirrorDoesNotHideExternalManagedDrift(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: gc
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: stale-db.example.com
+dolt.port: 3307
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
+	if err := recoverManagedLocalEndpointMirror(cityPath, cfg); err != nil {
+		t.Fatalf("recoverManagedLocalEndpointMirror: %v", err)
+	}
+	data := mustReadFile(t, filepath.Join(cityPath, ".beads", "config.yaml"))
+	if !strings.Contains(string(data), "dolt.host: stale-db.example.com") {
+		t.Fatalf("external drift was unexpectedly rewritten:\n%s", data)
+	}
+	if err := validateCanonicalCompatDoltDrift(cityPath, cfg); err == nil || !strings.Contains(err.Error(), "invalid canonical city endpoint state") {
+		t.Fatalf("validateCanonicalCompatDoltDrift() error = %v, want invalid canonical city endpoint state", err)
+	}
+}
+
 func TestConfiguredCityDoltTargetDoesNotFallbackToCompatRegistrationWhenManagedCanonicalTracksEndpoint(t *testing.T) {
 	t.Setenv("GC_DOLT_HOST", "env-db.example.com")
 	t.Setenv("GC_DOLT_PORT", "5510")

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -56,6 +56,12 @@ type poolEvalWork struct {
 	newDemand bool
 }
 
+type defaultScaleCheckTarget struct {
+	template string
+	storeKey string
+	store    beads.Store
+}
+
 func evaluatePendingPools(
 	cfg *config.City,
 	pendingPools []poolEvalWork,
@@ -202,6 +208,7 @@ func buildDesiredStateWithSessionBeads(
 
 	desired := make(map[string]TemplateParams)
 	var pendingPools []poolEvalWork
+	var defaultScaleTargets []defaultScaleCheckTarget
 
 	for i := range cfg.Agents {
 		if cfg.Agents[i].Suspended {
@@ -229,9 +236,15 @@ func buildDesiredStateWithSessionBeads(
 				continue
 			}
 			// Named-session materialization is handled in the named-session pass,
-			// but generic scale_check/min demand for the backing template still
-			// creates ephemeral capacity through the pool pipeline.
+			// but explicit scale_check/min demand for the backing template still
+			// creates ephemeral capacity through the pool pipeline. The default
+			// routed-work scale_check is intentionally skipped here: routed
+			// metadata alone must not materialize an on-demand named session or
+			// a parallel generic worker for the same backing template.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+			if store != nil && strings.TrimSpace(cfg.Agents[i].ScaleCheck) == "" {
+				continue
+			}
 			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
 			continue
 		}
@@ -244,12 +257,12 @@ func buildDesiredStateWithSessionBeads(
 		// them as desired counts; bead-backed mode uses them as authoritative
 		// new unassigned demand while assigned work drives resume requests.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+		if store != nil && strings.TrimSpace(cfg.Agents[i].ScaleCheck) == "" {
+			defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores))
+			continue
+		}
 		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i]), newDemand: store != nil})
 	}
-
-	// scale_check runs in parallel for all pool agents — the authoritative
-	// demand signal for new sessions. Computed once, returned in result.
-	scaleCheckCounts := evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 
 	// Collect work beads with assignees — used for both pool demand and
 	// named session on_demand wake. Hoisted out of the store block so
@@ -257,6 +270,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkBeads []beads.Bead
 	var assignedWorkStores []beads.Store
 	var storePartial bool
+	var scaleCheckCounts map[string]int
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
 		if storePartial {
@@ -269,6 +283,16 @@ func buildDesiredStateWithSessionBeads(
 			}
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
+		}
+		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		if len(defaultScaleTargets) > 0 {
+			defaultCounts, errs := defaultScaleCheckCounts(defaultScaleTargets)
+			for _, err := range errs {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", err) //nolint:errcheck
+			}
+			for template, count := range defaultCounts {
+				scaleCheckCounts[template] = count
+			}
 		}
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, assignedWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		for _, poolState := range poolDesiredStates {
@@ -283,6 +307,8 @@ func buildDesiredStateWithSessionBeads(
 			realizePoolDesiredSessions(bp, cfgAgent, poolState, desired, stderr)
 		}
 	} else {
+		// No store: scale_check is the only demand source.
+		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		// No store — use scale_check counts directly.
 		for _, pw := range pendingPools {
 			desiredCount := scaleCheckCounts[cfg.Agents[pw.agentIdx].QualifiedName()]
@@ -529,30 +555,158 @@ func collectAssignedWorkBeadsWithStores(
 		}
 	}
 
+	type storeAssignedWorkResult struct {
+		beads  []beads.Bead
+		stores []beads.Store
+		errs   []error
+	}
+	results := make([]storeAssignedWorkResult, len(stores))
+	var wg sync.WaitGroup
+	for idx, s := range stores {
+		idx, s := idx, s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var result []beads.Bead
+			var resultStores []beads.Store
+			var errs []error
+			seen := make(map[string]struct{})
+			// In-progress beads with an assignee (active work), plus stranded
+			// unassigned pool work that needs to be reopened.
+			if inProgress, err := listForControllerDemand(s, beads.ListQuery{Status: "in_progress"}); err == nil {
+				appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
+			} else {
+				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
+			}
+			// Ready beads with an assignee (queued direct handoff work that is
+			// actually runnable, not merely open). This is a lifecycle gate, so
+			// bypass the cache when a CachingStore wrapper is present.
+			if ready, err := readyForControllerDemand(s); err == nil {
+				appendAssignedUnique(&result, &resultStores, ready, seen, s)
+			} else {
+				errs = append(errs, fmt.Errorf("Ready(): %w", err))
+			}
+			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, errs: errs}
+		}()
+	}
+	wg.Wait()
+
 	var result []beads.Bead
 	var resultStores []beads.Store
 	var partial bool
-	for _, s := range stores {
-		seen := make(map[string]struct{})
-		// In-progress beads with an assignee (active work), plus stranded
-		// unassigned pool work that needs to be reopened.
-		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
-			appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
-		} else {
-			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
-			partial = true
-		}
-		// Ready beads with an assignee (queued direct handoff work that is
-		// actually runnable, not merely open). This is a lifecycle gate, so
-		// bypass the cache when a CachingStore wrapper is present.
-		if ready, err := beads.ReadyLive(s); err == nil {
-			appendAssignedUnique(&result, &resultStores, ready, seen, s)
-		} else {
-			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
+	for _, r := range results {
+		result = append(result, r.beads...)
+		resultStores = append(resultStores, r.stores...)
+		for _, err := range r.errs {
+			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}
 	return result, resultStores, partial
+}
+
+func defaultScaleCheckTargetForAgent(
+	cityPath string,
+	cfg *config.City,
+	agentCfg *config.Agent,
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+) defaultScaleCheckTarget {
+	target := defaultScaleCheckTarget{
+		template: agentCfg.QualifiedName(),
+		storeKey: "city",
+		store:    cityStore,
+	}
+	rigName := configuredRigName(cityPath, agentCfg, cfg.Rigs)
+	if rigName == "" {
+		return target
+	}
+	target.storeKey = "rig:" + rigName
+	if rigStores != nil {
+		if rigStore := rigStores[rigName]; rigStore != nil {
+			target.store = rigStore
+		}
+	}
+	return target
+}
+
+func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int, []error) {
+	counts := make(map[string]int, len(targets))
+	if len(targets) == 0 {
+		return counts, nil
+	}
+
+	type scaleStoreGroup struct {
+		store     beads.Store
+		templates map[string]struct{}
+	}
+	groups := make(map[string]*scaleStoreGroup)
+	var errs []error
+	for _, target := range targets {
+		template := strings.TrimSpace(target.template)
+		if template == "" {
+			continue
+		}
+		counts[template] = 0
+		if target.store == nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s: store unavailable", template))
+			continue
+		}
+		key := strings.TrimSpace(target.storeKey)
+		if key == "" {
+			key = fmt.Sprintf("%p", target.store)
+		}
+		group := groups[key]
+		if group == nil {
+			group = &scaleStoreGroup{store: target.store, templates: make(map[string]struct{})}
+			groups[key] = group
+		}
+		group.templates[template] = struct{}{}
+	}
+
+	for key, group := range groups {
+		ready, err := readyForControllerDemand(group.store)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s: Ready(): %w", key, err))
+		} else {
+			for _, b := range ready {
+				if strings.TrimSpace(b.Assignee) != "" {
+					continue
+				}
+				template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+				if _, ok := group.templates[template]; ok {
+					counts[template]++
+				}
+			}
+		}
+	}
+	return counts, errs
+}
+
+func listForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
+	if cached, ok := store.(interface {
+		CachedList(beads.ListQuery) ([]beads.Bead, bool)
+	}); ok {
+		cachedQuery := query
+		cachedQuery.Live = false
+		if items, ok := cached.CachedList(cachedQuery); ok {
+			return items, nil
+		}
+	}
+	liveQuery := query
+	liveQuery.Live = true
+	return store.List(liveQuery)
+}
+
+func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
+	if cached, ok := store.(interface {
+		CachedReady() ([]beads.Bead, bool)
+	}); ok {
+		if ready, ok := cached.CachedReady(); ok {
+			return ready, nil
+		}
+	}
+	return beads.ReadyLive(store)
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is
@@ -717,10 +871,11 @@ func discoverSessionBeadsWithRoots(
 			manualSession := isManualSessionBeadForAgent(b, cfgAgent)
 			creating := b.Metadata["state"] == "creating"
 			pendingCreate := isPendingPoolCreate(b)
-			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating && !pendingCreate {
+			poolDemanded := desiredHasTemplate(desired, template)
+			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating && (!pendingCreate || !poolDemanded) {
 				continue
 			}
-			if !manualSession && !desiredHasTemplate(desired, template) && !pendingCreate {
+			if !manualSession && !poolDemanded {
 				continue
 			}
 		}
@@ -944,7 +1099,8 @@ func realizePoolDesiredSessions(
 				prefer = &bead
 			}
 		}
-		sessionBead, err := selectOrCreatePoolSessionBead(bp, qualifiedName, prefer, used)
+		reuseRunning := request.Tier == "new"
+		sessionBead, err := selectOrCreatePoolSessionBead(bp, qualifiedName, prefer, used, reuseRunning)
 		if err != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 			continue
@@ -1170,15 +1326,16 @@ func selectOrCreatePoolSessionBead(
 	template string,
 	preferred *beads.Bead,
 	used map[string]bool,
+	reuseRunning bool,
 ) (beads.Bead, error) {
 	cfgAgent := findAgentByTemplate(&config.City{Agents: bp.agents}, template)
 	// Resume tier: reuse the session that has in-progress work assigned.
 	if preferred != nil && preferred.ID != "" && !used[preferred.ID] {
 		return *preferred, nil
 	}
-	// Reuse an existing active/creating session bead. Skip drained, closed,
-	// and asleep — asleep ephemerals are not restarted; a fresh session is
-	// created instead. The reconciler closes orphaned asleep beads.
+	// Reuse an existing creating or running session bead for new demand. A
+	// just-started workflow lane must get a chance to run its startup hook and
+	// claim or drain before another empty worker is spawned for the same demand.
 	for _, bead := range bp.sessionBeads.Open() {
 		if bead.Status == "closed" {
 			continue
@@ -1186,8 +1343,18 @@ func selectOrCreatePoolSessionBead(
 		if isDrainedSessionBead(bead) {
 			continue
 		}
-		if bead.Metadata["state"] == "asleep" {
+		state := strings.TrimSpace(bead.Metadata["state"])
+		if state == "asleep" {
 			continue
+		}
+		if state == "active" || state == "awake" {
+			if !reuseRunning {
+				continue
+			}
+		} else if state != "creating" {
+			if !reuseRunning {
+				continue
+			}
 		}
 		if isManualSessionBeadForAgent(bead, cfgAgent) {
 			continue

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -28,6 +28,45 @@ func (s listFailStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
 	return nil, errors.New("list failed")
 }
 
+type readyFailStore struct {
+	beads.Store
+	readyCalls int
+}
+
+func (s *readyFailStore) Ready() ([]beads.Bead, error) {
+	s.readyCalls++
+	return nil, errors.New("backing ready should not be used")
+}
+
+type readyStaticStore struct {
+	beads.Store
+	ready      []beads.Bead
+	readyCalls int
+}
+
+func (s *readyStaticStore) Ready() ([]beads.Bead, error) {
+	s.readyCalls++
+	out := make([]beads.Bead, len(s.ready))
+	copy(out, s.ready)
+	return out, nil
+}
+
+type demandListCountingStore struct {
+	beads.Store
+	liveInProgressLists int
+	liveOpenMolecules   int
+}
+
+func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Live && query.Status == "in_progress" {
+		s.liveInProgressLists++
+	}
+	if query.Live && query.Status == "open" && query.Type == "molecule" {
+		s.liveOpenMolecules++
+	}
+	return s.Store.List(query)
+}
+
 func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T) {
 	store := beads.NewMemStore()
 	handoff, err := store.Create(beads.Bead{
@@ -59,6 +98,62 @@ func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T)
 	}
 }
 
+func TestCollectAssignedWorkBeadsUsesCachedReadyReadModel(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	handoff, err := backing.Create(beads.Bead{
+		Title:    "merge me",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create handoff bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	got, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, cache, nil, nil)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores returned partial=true")
+	}
+	if len(got) != 1 || got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeadsWithStores = %+v, want %s", got, handoff.ID)
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	}
+}
+
+func TestCollectAssignedWorkBeadsUsesCachedInProgressReadModel(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	work, err := backing.Create(beads.Bead{
+		Title:    "active handoff",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create active work: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	got, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, cache, nil, nil)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores returned partial=true")
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeadsWithStores = %+v, want %s", got, work.ID)
+	}
+	if backing.liveInProgressLists != 0 {
+		t.Fatalf("live in-progress list calls = %d, want cached demand read", backing.liveInProgressLists)
+	}
+}
+
 func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.T) {
 	store := beads.NewMemStore()
 	blocker, err := store.Create(beads.Bead{
@@ -85,6 +180,152 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 0 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0: %#v", len(got), got)
+	}
+}
+
+func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "queued routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create ready bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 1", got)
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	}
+}
+
+func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "workflow root",
+		Type:   "molecule",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create molecule bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want molecule container ignored", got)
+	}
+	if backing.liveOpenMolecules != 0 {
+		t.Fatalf("live open molecule list calls = %d, want no molecule demand query", backing.liveOpenMolecules)
+	}
+}
+
+func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	blocker, err := backing.Create(beads.Bead{
+		Title:  "blocked earlier step",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("create blocker bead: %v", err)
+	}
+	blocked, err := backing.Create(beads.Bead{
+		Title:  "future routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-max",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create blocked bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := cache.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-max",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-max"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want blocked future work excluded", got)
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	}
+}
+
+func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T) {
+	backing := &readyStaticStore{
+		Store: beads.NewMemStore(),
+		ready: []beads.Bead{{
+			ID:     "gc-ready",
+			Title:  "ready routed work",
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": "gascity/workflows.codex-max",
+			},
+		}},
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-blocked","title":"future routed work","status":"open","issue_type":"task","metadata":{"gc.routed_to":"gascity/workflows.codex-max"}}`))
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-max",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-max"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want live ready fallback count only", got)
+	}
+	if backing.readyCalls != 1 {
+		t.Fatalf("backing Ready calls = %d, want one live ready fallback", backing.readyCalls)
 	}
 }
 
@@ -597,6 +838,124 @@ func TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession(
 	}
 	if polecatSessions != 1 {
 		t.Fatalf("polecat desired sessions = %d, want 1 for min=0 routed ready work; stderr:\n%s", polecatSessions, stderr.String())
+	}
+}
+
+func TestBuildDesiredState_DefaultScaleCheckDoesNotDoubleCountAssignedResume(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"session_name":         "worker-mc-1",
+			"agent_name":           "worker-1",
+			"state":                "active",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "claimed worker job",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "worker-mc-1",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create assigned work bead: %v", err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	if got := dsResult.ScaleCheckCounts["worker"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[worker] = %d, want 0 for already-assigned work", got)
+	}
+	if len(dsResult.AssignedWorkBeads) != 1 {
+		t.Fatalf("AssignedWorkBeads = %d, want 1", len(dsResult.AssignedWorkBeads))
+	}
+	workerSessions := 0
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "worker" {
+			workerSessions++
+		}
+	}
+	if workerSessions != 1 {
+		t.Fatalf("worker desired sessions = %d, want 1 resume session", workerSessions)
+	}
+}
+
+func TestDefaultScaleCheckCountsUsesReadyRoutedWorkOnly(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "ready task",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create ready task: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "ready wisp",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.kind":      "wisp",
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create ready wisp: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "open molecule",
+		Type:   "molecule",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create molecule: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:    "assigned task",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker-mc-1",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create assigned task: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "worker",
+		storeKey: "city",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errors = %v", errs)
+	}
+	if got := counts["worker"]; got != 2 {
+		t.Fatalf("counts[worker] = %d, want ready task plus ready wisp only", got)
 	}
 }
 
@@ -1883,6 +2242,69 @@ func TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings(t
 	}
 }
 
+func TestBuildDesiredState_ScaleDemandReusesActivePoolSession(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	sessionName := "workflows__codex-min-mc-active"
+	session, err := store.Create(beads.Bead{
+		Title:  "codex-min",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/workflows.codex-min"},
+		Metadata: map[string]string{
+			"template":              "gascity/workflows.codex-min",
+			"session_name":          sessionName,
+			"session_name_explicit": boolMetadata(true),
+			"agent_name":            "gascity/workflows.codex-min-1",
+			"alias":                 "gascity/workflows.codex-min-1",
+			"state":                 "active",
+			"session_origin":        "ephemeral",
+			"pool_managed":          boolMetadata(true),
+			"pool_slot":             "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued preflight",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create routed work bead: %v", err)
+	}
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "gascity", Path: filepath.Join(cityPath, "repos", "gascity")}},
+		Agents: []config.Agent{{
+			Name:              "workflows.codex-min",
+			Dir:               "gascity",
+			Provider:          "test-agent",
+			StartCommand:      "true",
+			WorkDir:           ".",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State[sessionName]
+	if !ok {
+		t.Fatalf("desired state missing existing active pool session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.SessionName != sessionName {
+		t.Fatalf("SessionName = %q, want %q", got.SessionName, sessionName)
+	}
+	all, err := store.List(beads.ListQuery{Type: sessionBeadType})
+	if err != nil {
+		t.Fatalf("List(session): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != session.ID {
+		t.Fatalf("session beads = %+v, want only existing active session %s", all, session.ID)
+	}
+}
+
 func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
@@ -1936,7 +2358,7 @@ func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *t
 	}
 }
 
-func TestBuildDesiredState_PendingCreatePoolSessionStaysDesiredWithoutScaleDemand(t *testing.T) {
+func TestBuildDesiredState_PendingCreatePoolSessionWithoutScaleDemandIsNotDesired(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
 	sessionName := "workflows__codex-max-mc-new"
@@ -1975,15 +2397,8 @@ func TestBuildDesiredState_PendingCreatePoolSessionStaysDesiredWithoutScaleDeman
 	if got := dsResult.ScaleCheckCounts["gascity/workflows.codex-max"]; got != 0 {
 		t.Fatalf("ScaleCheckCounts[gascity/workflows.codex-max] = %d, want 0", got)
 	}
-	got, ok := dsResult.State[sessionName]
-	if !ok {
-		t.Fatalf("desired state missing pending-create pool session: keys=%v", mapKeys(dsResult.State))
-	}
-	if got.TemplateName != "gascity/workflows.codex-max" {
-		t.Fatalf("TemplateName = %q, want gascity/workflows.codex-max", got.TemplateName)
-	}
-	if got.InstanceName != sessionName {
-		t.Fatalf("InstanceName = %q, want existing session name %q", got.InstanceName, sessionName)
+	if _, ok := dsResult.State[sessionName]; ok {
+		t.Fatalf("desired state included pending-create pool session with no scale demand: keys=%v", mapKeys(dsResult.State))
 	}
 }
 
@@ -2388,7 +2803,7 @@ func TestSelectOrCreatePoolSessionBead_SkipsDrained(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{}, false)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -2423,7 +2838,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesPreferredDrained(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", &drained, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "claude", &drained, map[string]bool{}, false)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -2469,10 +2884,11 @@ func TestSelectOrCreateDependencyPoolSessionBead_SkipsDrained(t *testing.T) {
 	}
 }
 
-func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
+func TestSelectOrCreatePoolSessionBead_SkipsRunningForScaleDemand(t *testing.T) {
 	store := beads.NewMemStore()
-	// Existing awake session bead without assigned work — should be reused
-	// for new-tier to prevent session bead duplication across ticks.
+	// Existing awake session bead without assigned work should not satisfy
+	// scale/ready-work demand. That demand needs a start hook so the new
+	// session sees and claims the work.
 	awake, err := store.Create(beads.Bead{
 		Title:  "claude",
 		Type:   sessionBeadType,
@@ -2497,12 +2913,12 @@ func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{}, false)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
-	if result.ID != awake.ID {
-		t.Fatal("new-tier should reuse available (non-drained) session bead")
+	if result.ID == awake.ID {
+		t.Fatal("scale demand should create a fresh session bead instead of reusing an awake one")
 	}
 }
 
@@ -2537,7 +2953,7 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepBeads(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{}, false)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -2546,8 +2962,9 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepBeads(t *testing.T) {
 	}
 }
 
-func TestSelectOrCreatePoolSessionBead_ReusesActiveBeforeCreatingNew(t *testing.T) {
-	// An active (awake) pool session IS reused — no fresh bead created.
+func TestSelectOrCreatePoolSessionBead_SkipsActiveForScaleDemand(t *testing.T) {
+	// An active pool session without assigned work must not satisfy scale
+	// demand, because no start hook will run for an already-running session.
 	store := beads.NewMemStore()
 	cfgAgent := config.Agent{Name: "polecat", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
 
@@ -2573,12 +2990,47 @@ func TestSelectOrCreatePoolSessionBead_ReusesActiveBeforeCreatingNew(t *testing.
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{}, false)
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+	}
+	if result.ID == active.ID {
+		t.Fatalf("scale demand should not reuse active pool session %s", active.ID)
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_ReusesActiveForMinFill(t *testing.T) {
+	store := beads.NewMemStore()
+	cfgAgent := config.Agent{Name: "polecat", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)}
+
+	active, err := store.Create(beads.Bead{
+		Title:  "polecat",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:polecat"},
+		Metadata: map[string]string{
+			"template":     "polecat",
+			"session_name": "polecat-mc-live",
+			"state":        "active",
+			"pool_managed": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{active})
+	bp := &agentBuildParams{
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{}, true)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
 	if result.ID != active.ID {
-		t.Fatalf("active pool session should be reused, got %s want %s", result.ID, active.ID)
+		t.Fatalf("min-fill should reuse active pool session, got %s want %s", result.ID, active.ID)
 	}
 }
 
@@ -2609,7 +3061,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesCreatingBeforeCreatingNew(t *testin
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{}, false)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -2618,9 +3070,9 @@ func TestSelectOrCreatePoolSessionBead_ReusesCreatingBeforeCreatingNew(t *testin
 	}
 }
 
-func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) {
-	// With both an asleep and active bead for the same template,
-	// the active one is reused and the asleep one is ignored.
+func TestSelectOrCreatePoolSessionBead_SkipsAsleepAndActiveForScaleDemand(t *testing.T) {
+	// With both an asleep and active bead for the same template, scale demand
+	// skips both and creates a fresh bead whose startup hook can claim work.
 	store := beads.NewMemStore()
 	cfgAgent := config.Agent{Name: "polecat", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
 
@@ -2660,15 +3112,15 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) 
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{}, false)
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
 	if result.ID == asleep.ID {
 		t.Fatal("should skip asleep bead")
 	}
-	if result.ID != active.ID {
-		t.Fatalf("should reuse active bead, got %s want %s", result.ID, active.ID)
+	if result.ID == active.ID {
+		t.Fatalf("scale demand should skip active bead %s", active.ID)
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -93,6 +93,7 @@ const runtimeDemandSnapshotMaxAge = 30 * time.Second
 type runtimeDemandSnapshot struct {
 	createdAt          time.Time
 	sessionFingerprint string
+	storeFingerprint   string
 	result             DesiredStateResult
 }
 
@@ -435,6 +436,14 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			return
 		}
 
+		// Dispatch due orders before startup session reconciliation. A cold-start
+		// reconcile can take minutes when it has stale or config-drifted sessions;
+		// due event/condition formulas should not wait behind that maintenance work.
+		cr.dispatchOrders(ctx, cityRoot)
+		if ctx.Err() != nil {
+			return
+		}
+
 		if cr.sessionDrains != nil {
 			cr.beadReconcileTick(ctx, result, sessionBeads, startupTrace)
 		}
@@ -663,6 +672,7 @@ func (cr *CityRuntime) tick(
 		cr.activeReload = nil
 	}()
 	configChanged := dirty.Swap(false)
+	demandConfigChanged := configChanged
 	if configChanged {
 		dirtyCleared = true
 		source := reloadSourceWatch
@@ -674,11 +684,16 @@ func (cr *CityRuntime) tick(
 		if manualReload != nil {
 			manualReloadCompleted = true
 		}
+		if manualReply.Outcome != reloadOutcomeApplied {
+			demandConfigChanged = false
+		}
 	}
 
 	// Order dispatch is intentionally before the expensive session reconcile
 	// phases so due formulas are not starved by slow startup/config drift work.
-	cr.dispatchOrders(ctx, cityRoot)
+	if cr.dispatchOrders(ctx, cityRoot) {
+		return
+	}
 
 	// Session bead sync BEFORE reconciliation (one-tick state lag; see run()).
 	// Post-reconcile sync was intentionally removed: the daemon's next tick
@@ -689,7 +704,7 @@ func (cr *CityRuntime) tick(
 	if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
 		sessionBeads = cr.loadSessionBeadSnapshot()
 	}
-	demand := cr.loadDemandSnapshot(sessionBeads, trace, trigger, configChanged)
+	demand := cr.loadDemandSnapshot(sessionBeads, trace, trigger, demandConfigChanged)
 	result := demand.result
 	sessionBeads = cr.loadSessionBeadSnapshot()
 	result = refreshDesiredStateWithSessionBeads(
@@ -764,10 +779,11 @@ func (cr *CityRuntime) tick(
 	tickCompleted = true
 }
 
-func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
+func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) bool {
 	if cr.od != nil {
-		cr.od.dispatch(ctx, cityRoot, time.Now())
+		return cr.od.dispatch(ctx, cityRoot, time.Now())
 	}
+	return false
 }
 
 func (cr *CityRuntime) handleReloadRequest(req *reloadRequest) {
@@ -1184,7 +1200,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
-	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores, rigStores); len(released) > 0 {
+	var released []releasedPoolAssignment
+	if !result.StoreQueryPartial {
+		released = releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores, rigStores)
+	}
+	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
@@ -1239,12 +1259,12 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		readyWaitSet = nil
 	}
 
-	// workSet: defense-in-depth wake signal from work_query. When work_query
-	// detects pending work but scale_check hasn't caught up yet, workSet
-	// ensures at least one session wakes without waiting for the next tick.
+	// Controller ticks must not shell out through agent work_query. Routed work
+	// demand comes from the cached store read model; agents run gc hook after
+	// start to claim exactly one routed bead.
 	workSet := result.WorkSet
 	if workSet == nil {
-		workSet = computeWorkSet(cr.cfg, shellScaleCheck, cityName, cr.cityPath, store, sessionBeads, cr.stderr)
+		workSet = map[string]bool{}
 	}
 	if trace != nil {
 		templateNames := make(map[string]struct{})
@@ -1350,10 +1370,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			})
 		}
 	}
-	dispatchSessionBeads, err := loadSessionBeadSnapshot(store)
-	if err != nil {
-		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
-	} else if err := dispatchReadyWaitNudgesWithSnapshot(cr.cityPath, store, time.Now(), dispatchSessionBeads); err != nil {
+	if err := dispatchReadyWaitNudgesWithSnapshot(cr.cityPath, store, time.Now(), sessionBeads); err != nil {
 		fmt.Fprintf(cr.stderr, "%s: dispatching wait nudges: %v\n", cr.logPrefix, err) //nolint:errcheck
 	}
 
@@ -1461,23 +1478,18 @@ func sweepUndesiredPoolSessionBeads(
 		if running, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, bead.ID); err == nil && running {
 			continue
 		}
-		// Don't sweep beads that the reconciler still considers "start
-		// requested" — their work assignment window hasn't opened. Mirrors
-		// sessionStartRequested (session_reconcile.go) exactly so the two
-		// loops agree about ownership:
-		//   - pending_create_claim=true: in-flight create claim, protected
-		//     regardless of age until the lifecycle clears it.
-		//   - state=creating: protected until staleCreatingState would
-		//     return true (i.e., until staleCreatingStateTimeout has
-		//     elapsed; zero CreatedAt is treated as stale, matching
-		//     staleCreatingState in session_reconcile.go).
+		// Don't sweep fresh creating beads. Their work assignment window
+		// hasn't opened yet, and closing them during the same tick that
+		// created them spins the pool in a create→sweep→recreate loop.
+		//
+		// A pending_create_claim alone is not demand. If the session no
+		// longer appears in desiredState, the pool scaled back to zero or a
+		// retry abandoned this start; the sweep/reconciler may retire it once
+		// the fresh creating grace below no longer applies.
 		// Without this, a pool's freshly-created session bead gets swept
 		// on the same tick it's created (no work assigned →
 		// GCSweepSessionBeads closes it), spinning the pool in a rapid
 		// create→sweep→recreate loop.
-		if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
-			continue
-		}
 		if strings.TrimSpace(bead.Metadata["state"]) == "creating" && !isStaleCreating(bead.CreatedAt) {
 			continue
 		}
@@ -1715,7 +1727,8 @@ func (cr *CityRuntime) loadDemandSnapshot(
 	configChanged bool,
 ) runtimeDemandSnapshot {
 	sessionFingerprint := sessionBeadSnapshotFingerprint(sessionBeads)
-	if cr.shouldRefreshDemandSnapshot(trigger, configChanged, sessionFingerprint) {
+	storeFingerprint := cr.demandStoreFingerprint()
+	if cr.shouldRefreshDemandSnapshot(trigger, configChanged, sessionFingerprint, storeFingerprint) {
 		result := cr.buildDesiredState(sessionBeads, trace)
 		var openSessionBeads []beads.Bead
 		if sessionBeads != nil {
@@ -1727,10 +1740,11 @@ func (cr *CityRuntime) loadDemandSnapshot(
 			result.PoolDesiredCounts = make(map[string]int)
 		}
 		mergeNamedSessionDemand(result.PoolDesiredCounts, result.NamedSessionDemand, cr.cfg)
-		result.WorkSet = computeWorkSet(cr.cfg, shellScaleCheck, cr.cityName, cr.cityPath, cr.cityBeadStore(), sessionBeads, cr.stderr)
+		result.WorkSet = map[string]bool{}
 		cr.demandSnapshot = &runtimeDemandSnapshot{
 			createdAt:          time.Now(),
 			sessionFingerprint: sessionFingerprint,
+			storeFingerprint:   storeFingerprint,
 			result:             result,
 		}
 	}
@@ -1746,11 +1760,12 @@ func (cr *CityRuntime) shouldRefreshDemandSnapshot(
 	trigger string,
 	configChanged bool,
 	sessionFingerprint string,
+	storeFingerprint string,
 ) bool {
 	if !cr.demandSnapshotsEnabled() {
 		return true
 	}
-	if configChanged || trigger != "patrol" {
+	if configChanged {
 		return true
 	}
 	if cr.demandSnapshot == nil {
@@ -1759,11 +1774,48 @@ func (cr *CityRuntime) shouldRefreshDemandSnapshot(
 	if cr.demandSnapshot.sessionFingerprint != sessionFingerprint {
 		return true
 	}
+	if cr.demandSnapshot.storeFingerprint != storeFingerprint {
+		return true
+	}
+	if storeFingerprint != "" {
+		return false
+	}
+	if trigger != "patrol" {
+		return true
+	}
 	return time.Since(cr.demandSnapshot.createdAt) >= runtimeDemandSnapshotMaxAge
 }
 
 func (cr *CityRuntime) demandSnapshotsEnabled() bool {
-	return cr.cs != nil && cr.cs.EventProvider() != nil && demandSnapshotDemandSourcesEventBacked(cr.cfg)
+	if !demandSnapshotDemandSourcesEventBacked(cr.cfg) {
+		return false
+	}
+	if cr.demandStoreFingerprint() != "" {
+		return true
+	}
+	return cr.cs != nil && cr.cs.EventProvider() != nil
+}
+
+func (cr *CityRuntime) demandStoreFingerprint() string {
+	var parts []string
+	if seq, ok := cachedStoreMutationSeq(cr.cityBeadStore()); ok {
+		parts = append(parts, fmt.Sprintf("%s=%d", cr.cityName, seq))
+	}
+	for name, store := range cr.rigBeadStores() {
+		if seq, ok := cachedStoreMutationSeq(store); ok {
+			parts = append(parts, fmt.Sprintf("%s=%d", name, seq))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+func cachedStoreMutationSeq(store beads.Store) (uint64, bool) {
+	cached, ok := store.(*beads.CachingStore)
+	if !ok || cached == nil {
+		return 0, false
+	}
+	return cached.MutationSeq(), true
 }
 
 func demandSnapshotDemandSourcesEventBacked(cfg *config.City) bool {
@@ -1771,7 +1823,7 @@ func demandSnapshotDemandSourcesEventBacked(cfg *config.City) bool {
 		return false
 	}
 	for i := range cfg.Agents {
-		if strings.TrimSpace(cfg.Agents[i].ScaleCheck) != "" || strings.TrimSpace(cfg.Agents[i].WorkQuery) != "" {
+		if strings.TrimSpace(cfg.Agents[i].ScaleCheck) != "" {
 			return false
 		}
 	}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -132,6 +132,68 @@ func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	}
 }
 
+type sessionLabelCountingStore struct {
+	beads.Store
+	sessionLabelLists int
+}
+
+func (s *sessionLabelCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == sessionBeadLabel {
+		s.sessionLabelLists++
+	}
+	return s.Store.List(query)
+}
+
+func TestCityRuntimeBeadReconcileTick_ReusesSessionSnapshotForWaitDispatch(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &sessionLabelCountingStore{Store: base}
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":       "worker-mc-live",
+			"template":           "worker",
+			"agent_name":         "worker",
+			"state":              "awake",
+			"continuation_epoch": "1",
+			"generation":         "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "worker"}}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+	result := DesiredStateResult{
+		State: map[string]TemplateParams{
+			"worker-mc-live": {
+				TemplateName: "worker",
+				SessionName:  "worker-mc-live",
+			},
+		},
+		ScaleCheckCounts:  map[string]int{"worker": 0},
+		PoolDesiredCounts: map[string]int{"worker": 0},
+	}
+
+	cr.beadReconcileTick(context.Background(), result, newSessionBeadSnapshot([]beads.Bead{session}), nil)
+
+	if store.sessionLabelLists != 0 {
+		t.Fatalf("session label list calls = %d, want 0 after caller supplied snapshot", store.sessionLabelLists)
+	}
+}
+
 func TestCityRuntimeShutdownMarksCityStopSleepReason(t *testing.T) {
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{
@@ -234,12 +296,109 @@ func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	}
 }
 
-type recordingOrderDispatcher struct {
-	called atomic.Bool
+func TestCityRuntimeDemandSnapshotReusesCachedStoreFingerprintWithoutEventProvider(t *testing.T) {
+	backing := beads.NewMemStore()
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	buildCalls := 0
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+		},
+		cs: &controllerState{
+			cityName:      "test-city",
+			cityBeadStore: cache,
+		},
+		stderr: io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		buildCalls++
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	sessionBeads := newSessionBeadSnapshot(nil)
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	cr.demandSnapshot.createdAt = time.Now().Add(-2 * runtimeDemandSnapshotMaxAge)
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	if buildCalls != 1 {
+		t.Fatalf("buildDesiredState call count = %d, want stable cached-store patrol reuse", buildCalls)
+	}
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "poke", false)
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "config_watch", false)
+	if buildCalls != 1 {
+		t.Fatalf("buildDesiredState call count after non-patrol cache hits = %d, want 1", buildCalls)
+	}
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "config_watch", true)
+	if buildCalls != 2 {
+		t.Fatalf("buildDesiredState call count after applied config change = %d, want 2", buildCalls)
+	}
+
+	work, err := cache.Create(beads.Bead{Title: "new work"})
+	if err != nil {
+		t.Fatalf("Create work: %v", err)
+	}
+	_ = work
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	if buildCalls != 3 {
+		t.Fatalf("buildDesiredState call count = %d, want refresh after cached store mutation", buildCalls)
+	}
 }
 
-func (r *recordingOrderDispatcher) dispatch(context.Context, string, time.Time) {
+func TestCityRuntimeDemandSnapshotRefreshesAfterCachedWorkMutation(t *testing.T) {
+	backing := beads.NewMemStore()
+	work, err := backing.Create(beads.Bead{Title: "ready work"})
+	if err != nil {
+		t.Fatalf("Create work: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	buildCalls := 0
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+		},
+		cs: &controllerState{
+			cityName:      "test-city",
+			cityBeadStore: cache,
+			eventProv:     events.NewFake(),
+		},
+		stderr: io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		buildCalls++
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	sessionBeads := newSessionBeadSnapshot(nil)
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	if err := cache.SetMetadata(work.ID, "assignee", "worker-1"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+
+	if buildCalls != 2 {
+		t.Fatalf("buildDesiredState call count = %d, want 2 after cached work mutation", buildCalls)
+	}
+}
+
+type recordingOrderDispatcher struct {
+	called atomic.Bool
+	busy   bool
+}
+
+func (r *recordingOrderDispatcher) dispatch(context.Context, string, time.Time) bool {
 	r.called.Store(true)
+	return r.busy
 }
 
 func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
@@ -272,6 +431,34 @@ func TestCityRuntimeTickDispatchesOrdersBeforeDemandSnapshot(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeTickSkipsDemandWhileOrderDispatchBusy(t *testing.T) {
+	store := beads.NewMemStore()
+	od := &recordingOrderDispatcher{busy: true}
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cityPath:            t.TempDir(),
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		od:                  od,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		t.Fatal("demand snapshot build should wait until order dispatch finishes")
+		return DesiredStateResult{}
+	}
+
+	var dirty atomic.Bool
+	var lastProviderName string
+	var prevPoolRunning map[string]bool
+	cr.tick(context.Background(), &dirty, &lastProviderName, cr.cityPath, &prevPoolRunning, "patrol")
+
+	if !od.called.Load() {
+		t.Fatal("order dispatcher was not called")
+	}
+}
+
 func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -282,13 +469,6 @@ func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testin
 			agent: config.Agent{
 				Name:       "worker",
 				ScaleCheck: "test -f external-queue && echo 1 || echo 0",
-			},
-		},
-		{
-			name: "custom work_query",
-			agent: config.Agent{
-				Name:      "worker",
-				WorkQuery: "gh issue list --json number --limit 1",
 			},
 		},
 	}
@@ -321,6 +501,37 @@ func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testin
 				t.Fatalf("buildDesiredState call count = %d, want 2 when demand command is not event-backed", buildCalls)
 			}
 		})
+	}
+}
+
+func TestCityRuntimeDemandSnapshotIgnoresCustomWorkQueryForControllerDemand(t *testing.T) {
+	buildCalls := 0
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Agents: []config.Agent{{
+				Name:      "worker",
+				WorkQuery: "gh issue list --json number --limit 1",
+			}},
+		},
+		cs: &controllerState{
+			eventProv: events.NewFake(),
+		},
+		stderr: io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		buildCalls++
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	sessionBeads := newSessionBeadSnapshot(nil)
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+	_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
+
+	if buildCalls != 1 {
+		t.Fatalf("buildDesiredState call count = %d, want cached patrol reuse for custom work_query", buildCalls)
 	}
 }
 
@@ -775,7 +986,7 @@ func TestSweepUndesiredPoolSessionBeads_SweepsCrashedActiveBead(t *testing.T) {
 	}
 }
 
-func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
+func TestSweepUndesiredPoolSessionBeads_ClosesPendingCreateClaimWithoutDemand(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
@@ -806,30 +1017,27 @@ func TestSweepUndesiredPoolSessionBeads_SkipsPendingCreateClaim(t *testing.T) {
 		runtime.NewFake(),
 		false,
 	)
-	if closed != 0 {
-		t.Fatalf("closed = %d, want 0 — pending_create_claim must be preserved", closed)
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1 — pending_create_claim without demand must not preserve pool sessions", closed)
 	}
 	got, err := store.Get(bead.ID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Status == "closed" {
-		t.Fatalf("bead with pending_create_claim was swept closed: %+v", got)
+	if got.Status != "closed" {
+		t.Fatalf("bead with undesired pending_create_claim status = %q, want closed", got.Status)
 	}
 }
 
-// pending_create_claim is an authoritative ownership flag for the lifecycle
-// reconciler (sessionStartRequested in session_reconcile.go). The sweep must
-// honor that contract regardless of age — expiring it here would let the
-// sweep close a bead the reconciler still considers live.
-func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.T) {
+func TestSweepUndesiredPoolSessionBeads_KeepsDesiredPendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()
+	sessionName := "worker-bd-stale-claim"
 	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:worker"},
 		Metadata: map[string]string{
-			"session_name":         "worker-bd-stale-claim",
+			"session_name":         sessionName,
 			"template":             "worker",
 			"agent_name":           "worker",
 			"pool_slot":            "1",
@@ -844,18 +1052,21 @@ func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.
 	}
 	bead.CreatedAt = time.Now().Add(-2 * time.Minute)
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+	desired := map[string]TemplateParams{
+		sessionName: {TemplateName: "worker", SessionName: sessionName},
+	}
 
 	closed := sweepUndesiredPoolSessionBeads(
 		store,
 		nil,
 		sessionBeads,
-		nil,
+		desired,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		runtime.NewFake(),
 		false,
 	)
 	if closed != 0 {
-		t.Fatalf("closed = %d, want 0 — pending_create_claim must remain authoritative regardless of age", closed)
+		t.Fatalf("closed = %d, want 0 — desired pending_create_claim must remain open", closed)
 	}
 }
 
@@ -1074,6 +1285,56 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 	}
 	if !sp.IsRunning("worker-bd-123") {
 		t.Fatal("recovered tick should keep the worker running")
+	}
+}
+
+func TestCityRuntimeBeadReconcileTick_StoreQueryPartialDoesNotReleaseAssignedWork(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		ID:       "ga-live",
+		Title:    "live assigned work from partial snapshot",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "worker-session",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work.Status = inProgress
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	cr.beadReconcileTick(context.Background(), DesiredStateResult{
+		State:              map[string]TemplateParams{},
+		ScaleCheckCounts:   map[string]int{"worker": 0},
+		AssignedWorkBeads:  []beads.Bead{work},
+		AssignedWorkStores: []beads.Store{store},
+		StoreQueryPartial:  true,
+	}, newSessionBeadSnapshot(nil), nil)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work after partial tick: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-session" {
+		t.Fatalf("partial assigned-work snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
 	}
 }
 

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -587,8 +587,15 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		}
 		sessionBead, ok := sessionBeads.FindByID(sessionID)
 		if !ok {
-			if anySessionBead, found := sessionBeads.findByIDIncludingClosed(sessionID); found {
-				sessionBead = anySessionBead
+			if wait.Metadata["registered_epoch"] != "" {
+				var found bool
+				sessionBead, found, err = lookupSessionBeadIncludingClosed(store, sessionBeads, sessionID)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					continue
+				}
 			} else {
 				continue
 			}
@@ -607,6 +614,18 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 			continue
 		}
 		if !ok {
+			if sessionBead.Status == "closed" {
+				if err := setWaitTerminalState(store, wait.ID, map[string]string{
+					"state":       waitStateCanceled,
+					"canceled_at": now.UTC().Format(time.RFC3339),
+					"last_error":  "session-closed",
+				}); err != nil {
+					return nil, err
+				}
+				if err := clearSessionWaitHoldIfIdle(store, sessionID); err != nil {
+					return nil, err
+				}
+			}
 			continue
 		}
 		if expiresAt := wait.Metadata["expires_at"]; expiresAt != "" {
@@ -668,6 +687,28 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		}
 	}
 	return readyWaitSet, nil
+}
+
+func lookupSessionBeadIncludingClosed(store beads.Store, sessionBeads *sessionBeadSnapshot, id string) (beads.Bead, bool, error) {
+	if sessionBeads != nil {
+		if bead, ok := sessionBeads.findByIDIncludingClosed(id); ok {
+			return bead, true, nil
+		}
+	}
+	if store == nil || strings.TrimSpace(id) == "" {
+		return beads.Bead{}, false, nil
+	}
+	bead, err := store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return beads.Bead{}, false, nil
+		}
+		return beads.Bead{}, false, err
+	}
+	if !sessionpkg.IsSessionBeadOrRepairable(bead) {
+		return beads.Bead{}, false, nil
+	}
+	return bead, true, nil
 }
 
 func dispatchReadyWaitNudges(cityPath string, store beads.Store, _ runtime.Provider, now time.Time) error {

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -437,7 +437,7 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 	}
 }
 
-func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testing.T) {
+func TestPrepareWaitWakeState_UsesTargetedLookupForMissingSessionEpoch(t *testing.T) {
 	base := beads.NewMemStore()
 	store := &waitGetSpyStore{Store: base}
 	sessionBead, err := store.Create(beads.Bead{
@@ -456,7 +456,7 @@ func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testin
 	if err := store.Close(sessionBead.ID); err != nil {
 		t.Fatalf("close session bead: %v", err)
 	}
-	if _, err := store.Create(beads.Bead{
+	waitBead, err := store.Create(beads.Bead{
 		Type:   waitBeadType,
 		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
 		Metadata: map[string]string{
@@ -465,6 +465,63 @@ func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testin
 			"kind":             "deps",
 			"state":            waitStateReady,
 			"registered_epoch": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if len(readyWaitSet) != 0 {
+		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
+	}
+	if len(store.getIDs) < 1 || store.getIDs[0] != sessionBead.ID {
+		t.Fatalf("Get IDs = %v, want targeted lookup for %s", store.getIDs, sessionBead.ID)
+	}
+	updated, err := store.Get(waitBead.ID)
+	if err != nil {
+		t.Fatalf("store.Get(wait): %v", err)
+	}
+	if got := updated.Metadata["state"]; got != waitStateCanceled {
+		t.Fatalf("wait state = %q, want %q", got, waitStateCanceled)
+	}
+	if got := updated.Metadata["last_error"]; got != "session-closed" {
+		t.Fatalf("last_error = %q, want session-closed", got)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("wait status = %q, want closed", updated.Status)
+	}
+}
+
+func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutEpochLookup(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"agent_name":   "worker",
+			"state":        string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":   sessionBead.ID,
+			"session_name": "worker",
+			"kind":         "deps",
+			"state":        waitStateReady,
 		},
 	}); err != nil {
 		t.Fatalf("create wait bead: %v", err)
@@ -477,10 +534,8 @@ func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testin
 	if len(readyWaitSet) != 0 {
 		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
 	}
-	for _, id := range store.getIDs {
-		if id == sessionBead.ID {
-			t.Fatalf("prepare used Get for non-open session %s; getIDs=%v", sessionBead.ID, store.getIDs)
-		}
+	if len(store.getIDs) != 0 {
+		t.Fatalf("Get IDs = %v, want no closed-session lookup without an epoch", store.getIDs)
 	}
 }
 

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -157,6 +157,7 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 		}
 		evals[bead.ID] = wakeEvaluation{
 			Reasons:          reasons,
+			Reason:           d.Reason,
 			ConfigSuppressed: d.Reason == "idle-sleep",
 		}
 	}

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -712,14 +712,13 @@ func shouldIgnoreConfigWatchEvent(path string) bool {
 	if clean == "" || clean == "." {
 		return false
 	}
-	sepGC := string(filepath.Separator) + ".gc"
-	sepBeads := string(filepath.Separator) + ".beads"
-	return clean == ".gc" ||
-		clean == ".beads" ||
-		strings.HasSuffix(clean, sepGC) ||
-		strings.HasSuffix(clean, sepBeads) ||
-		strings.Contains(clean, sepGC+string(filepath.Separator)) ||
-		strings.Contains(clean, sepBeads+string(filepath.Separator))
+	for _, part := range strings.FieldsFunc(filepath.ToSlash(clean), func(r rune) bool { return r == '/' }) {
+		switch part {
+		case ".beads", ".cache", ".gc", ".git", "__pycache__", "state":
+			return true
+		}
+	}
+	return false
 }
 
 // reloadResult holds the result of a config reload attempt.

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -752,6 +752,62 @@ func TestWatchConfigDirs_DetectsFileChangeAndSetsDirty(t *testing.T) {
 	}
 }
 
+func TestWatchConfigDirs_IgnoresRuntimeOutputInRecursivePack(t *testing.T) {
+	old := debounceDelay
+	debounceDelay = 5 * time.Millisecond
+	t.Cleanup(func() { debounceDelay = old })
+
+	dir := t.TempDir()
+	packDir := filepath.Join(dir, "packs", "randy")
+	stateDir := filepath.Join(packDir, "state", "triage")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(state): %v", err)
+	}
+	promptPath := filepath.Join(packDir, "prompts", "agent.md")
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(prompts): %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte("prompt\n"), 0o644); err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+
+	var dirty atomic.Bool
+	pokeCh := make(chan struct{}, 4)
+	var stderr bytes.Buffer
+	cleanup := watchConfigTargets([]config.WatchTarget{{Path: packDir, Recursive: true}}, &dirty, pokeCh, &stderr)
+	defer cleanup()
+
+	select {
+	case <-pokeCh:
+	default:
+	}
+	dirty.Store(false)
+
+	if err := os.WriteFile(filepath.Join(stateDir, "audit.json"), []byte(`{"status":"running"}`), 0o644); err != nil {
+		t.Fatalf("write runtime state: %v", err)
+	}
+	select {
+	case <-pokeCh:
+		t.Fatalf("unexpected watcher poke after runtime state write; stderr=%q", stderr.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+	if dirty.Load() {
+		t.Fatalf("dirty flag set after runtime state write; stderr=%q", stderr.String())
+	}
+
+	if err := os.WriteFile(promptPath, []byte("prompt v2\n"), 0o644); err != nil {
+		t.Fatalf("rewrite prompt: %v", err)
+	}
+	select {
+	case <-pokeCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for watcher poke after prompt rewrite; stderr=%q", stderr.String())
+	}
+	if !dirty.Load() {
+		t.Fatalf("dirty flag not set after prompt rewrite; stderr=%q", stderr.String())
+	}
+}
+
 func TestWatchConfigDirs_FileSeedStillWatchesFile(t *testing.T) {
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
-func TestCollectAssignedWorkBeads_UsesLiveReadyForAssignedOpenHandoff(t *testing.T) {
+func TestCollectAssignedWorkBeads_UsesCachedReadyEventForAssignedOpenHandoff(t *testing.T) {
 	t.Parallel()
 
 	backing := beads.NewMemStore()
@@ -46,10 +47,19 @@ func TestCollectAssignedWorkBeads_UsesLiveReadyForAssignedOpenHandoff(t *testing
 	if err := backing.Update(blocker.ID, beads.UpdateOpts{Status: &closed}); err != nil {
 		t.Fatalf("Update(%s, closed): %v", blocker.ID, err)
 	}
+	eventBead, err := backing.Get(blocker.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", blocker.ID, err)
+	}
+	payload, err := json.Marshal(eventBead)
+	if err != nil {
+		t.Fatalf("Marshal(%s): %v", blocker.ID, err)
+	}
+	cache.ApplyEvent("bead.closed", payload)
 
 	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
 	if len(got) != 1 || got[0].ID != handoff.ID {
-		t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] from live ready state", got, handoff.ID)
+		t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] from cached ready event state", got, handoff.ID)
 	}
 }
 

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -31,7 +32,7 @@ const labelOrderTracking = "order-tracking"
 // order's dispatch action runs in its own goroutine. The tracking bead
 // is created before the goroutine launches to prevent re-fire on the next tick.
 type orderDispatcher interface {
-	dispatch(ctx context.Context, cityPath string, now time.Time)
+	dispatch(ctx context.Context, cityPath string, now time.Time) bool
 }
 
 // ExecRunner runs a shell command with context, working directory, and
@@ -81,6 +82,7 @@ type memoryOrderDispatcher struct {
 
 	cacheMu      sync.Mutex
 	lastRunCache map[string]time.Time
+	active       atomic.Int32
 }
 
 // buildOrderDispatcher scans formula layers for orders and returns a
@@ -132,13 +134,17 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 	}
 }
 
-func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, now time.Time) {
+func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, now time.Time) bool {
 	// Skip all order dispatch when the city is suspended.
 	if m.cfg != nil && citySuspended(m.cfg) {
-		return
+		return false
+	}
+	if m.active.Load() > 0 {
+		return true
 	}
 
 	stores := make(map[string]beads.Store)
+	dispatched := false
 
 	for _, a := range m.aa {
 		// Skip orders targeting suspended rigs.
@@ -251,8 +257,14 @@ func (m *memoryOrderDispatcher) dispatch(ctx context.Context, cityPath string, n
 
 		// Fire and forget with timeout.
 		a := a // capture loop variable
-		go m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
+		dispatched = true
+		m.active.Add(1)
+		go func() {
+			defer m.active.Add(-1)
+			m.dispatchOne(ctx, store, target, a, cityPath, trackingBead.ID)
+		}()
 	}
+	return dispatched
 }
 
 func (m *memoryOrderDispatcher) legacyCityStoreForTarget(cityPath string, target execStoreTarget, stores map[string]beads.Store) (beads.Store, bool) {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -176,6 +176,48 @@ func TestOrderDispatchCooldownDue(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchReturnsBusyWhileAsyncDispatchRuns(t *testing.T) {
+	store := beads.NewMemStore()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	execRun := func(ctx context.Context, _ string, _ string, _ []string) ([]byte, error) {
+		close(started)
+		select {
+		case <-release:
+			return nil, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	aa := []orders.Order{{
+		Name:     "slow-order",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Exec:     "slow-command",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, execRun, events.Discard)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	if busy := ad.dispatch(context.Background(), t.TempDir(), time.Now()); !busy {
+		t.Fatal("dispatch returned false, want busy after firing async order")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async order to start")
+	}
+	if busy := ad.dispatch(context.Background(), t.TempDir(), time.Now()); !busy {
+		t.Fatal("dispatch returned false while async order was still running")
+	}
+	all := trackingBeads(t, store, "order-run:slow-order")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads while busy = %d, want 1", len(all))
+	}
+	close(release)
+}
+
 // TestOrderDispatchResolvesPackBindingForPool reproduces issue #1268: a
 // pack-imported agent has BindingName set, so its qualified name is
 // "binding.name". A city-level order with pool="<name>" must resolve to the

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -90,6 +90,33 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 	}
 }
 
+func TestComputePoolDesiredStates_ResumeAndUnassignedDemandAddUp(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("codex-min", "gascity", intPtr(5), 0)},
+	}
+	work := []beads.Bead{
+		workBead("ga-preflight", "gascity/codex-min", "mc-claimed", "in_progress", 5),
+	}
+	sessions := []beads.Bead{sessionBead("mc-claimed", "open")}
+	scaleCheck := map[string]int{"gascity/codex-min": 1}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, scaleCheck)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 2 {
+		t.Fatalf("len(requests) = %d, want one assigned resume request plus one new request", len(reqs))
+	}
+	if reqs[0].Tier != "resume" || reqs[0].SessionBeadID != "mc-claimed" {
+		t.Fatalf("request = %+v, want resume for mc-claimed", reqs[0])
+	}
+	if reqs[1].Tier != "new" {
+		t.Fatalf("second request tier = %q, want new", reqs[1].Tier)
+	}
+}
+
 func TestComputePoolDesiredStates_MaxCapsTotal(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -106,6 +106,9 @@ func releaseOrphanedPoolAssignments(
 			if assigneePreservesNamedSessionRoute(cfg, template, assignee) {
 				continue
 			}
+			if !storeAware && sessionAssigneeVisibleInStore(store, assignee) {
+				continue
+			}
 		}
 
 		var ownerStore beads.Store
@@ -127,6 +130,24 @@ func releaseOrphanedPoolAssignments(
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	return released
+}
+
+func sessionAssigneeVisibleInStore(store beads.Store, assignee string) bool {
+	assignee = strings.TrimSpace(assignee)
+	if store == nil || assignee == "" {
+		return false
+	}
+	matches, err := store.ListByMetadata(map[string]string{"session_name": assignee}, 0)
+	if err != nil {
+		return true
+	}
+	for _, match := range matches {
+		if match.Status == "closed" || !isSessionBead(match) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func storeForPoolAssignment(cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, wb beads.Bead) beads.Store {

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -546,6 +546,64 @@ func TestReleaseOrphanedPoolAssignments_KeepsOpenSessionOwnership(t *testing.T) 
 	}
 }
 
+func TestReleaseOrphanedPoolAssignments_FreshLookupKeepsVisibleSessionOwnership(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionName := "worker-live"
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         sessionName,
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "live pool work",
+		Assignee: sessionName,
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		nil,
+		[]beads.Bead{work},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none while session bead %s is visible", released, session.ID)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != sessionName {
+		t.Fatalf("assignee = %q, want %q", got.Assignee, sessionName)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_ReopensStaleDirectAssigneeForNamedBackedTemplate(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -8,9 +8,11 @@ import (
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
-// sessionBeadSnapshot caches session-bead state for a single reconcile cycle.
-// Open-session lookups stay open-only; closed records are retained by ID for
-// lifecycle guards such as stale wait epoch cancellation.
+// sessionBeadSnapshot caches active session-bead state for a single reconcile
+// cycle. Closed-session history is intentionally not loaded here: the
+// reconciler calls this several times per tick, and closed history grows
+// without bound. Callers that need a closed record must fetch that one ID
+// explicitly.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
 	recordByID                map[string]beads.Bead
@@ -23,8 +25,7 @@ func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
 		return newSessionBeadSnapshot(nil), nil
 	}
 	all, err := store.List(beads.ListQuery{
-		Label:         sessionBeadLabel,
-		IncludeClosed: true,
+		Label: sessionBeadLabel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing session beads: %w", err)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -74,7 +74,7 @@ func syncSessionCachedState(sessionName string, existing beads.Bead, exists bool
 	if sp != nil && strings.TrimSpace(sessionName) != "" && sp.IsRunning(sessionName) {
 		return string(session.StateActive)
 	}
-	return "stopped"
+	return string(session.StateCreating)
 }
 
 func stampResolvedProviderSessionMetadata(meta map[string]string, resolved *config.ResolvedProvider) {
@@ -283,14 +283,9 @@ func retireDuplicateConfiguredNamedSessionBeads(
 			}
 			b := openBeads[idx]
 			oldSessionName := strings.TrimSpace(b.Metadata["session_name"])
-			running := false
-			if oldSessionName != "" && oldSessionName != winnerSessionName && sp != nil {
-				running, _ = workerSessionTargetRunningWithConfig("", store, sp, cfg, oldSessionName)
-			}
-			if running {
-				if err := workerKillSessionTargetWithConfig("", store, sp, cfg, oldSessionName); err != nil {
-					fmt.Fprintf(stderr, "session beads: stopping duplicate named session %q: %v\n", oldSessionName, err) //nolint:errcheck
-				}
+			if oldSessionName != "" && oldSessionName != winnerSessionName &&
+				!stopRuntimeBeforeSessionBeadMutation(store, sp, cfg, b, "duplicate named session", stderr) {
+				continue
 			}
 			batch := session.RetireNamedSessionPatch(now, "duplicate-repair", identity)
 			if setMetaBatch(store, b.ID, batch, stderr) != nil {
@@ -359,15 +354,8 @@ func retireRemovedConfiguredNamedSessionBead(
 	if store == nil {
 		return false
 	}
-	oldSessionName := strings.TrimSpace(b.Metadata["session_name"])
-	running := false
-	if oldSessionName != "" && sp != nil {
-		running, _ = workerSessionTargetRunningWithConfig("", store, sp, nil, oldSessionName)
-	}
-	if running {
-		if err := workerKillSessionTargetWithConfig("", store, sp, nil, oldSessionName); err != nil {
-			fmt.Fprintf(stderr, "session beads: stopping removed named session %q: %v\n", oldSessionName, err) //nolint:errcheck
-		}
+	if !stopRuntimeBeforeSessionBeadMutation(store, sp, nil, b, "removed named session", stderr) {
+		return false
 	}
 	batch := session.RetireNamedSessionPatch(now, "removed-configured-named-session", namedSessionIdentity(b))
 	if setMetaBatch(store, b.ID, batch, stderr) != nil {
@@ -701,6 +689,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	now := clk.Now().UTC()
 	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
 
+	blockedReconfiguredNamedIdentities := map[string]bool{}
 	if cfg != nil {
 		for i, b := range openBeads {
 			if b.Status == "closed" || !isNamedSessionBead(b) {
@@ -714,18 +703,12 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if strings.TrimSpace(b.Metadata["session_name"]) == spec.SessionName {
 				continue
 			}
-			if closeSessionBeadIfUnassigned(store, rigStores, b, "reconfigured", now, stderr) {
-				if sn := strings.TrimSpace(b.Metadata["session_name"]); sn != "" {
-					running, _ := workerSessionTargetRunningWithConfig("", store, sp, cfg, sn)
-					if running {
-						if err := workerKillSessionTargetWithConfig("", store, sp, cfg, sn); err != nil {
-							fmt.Fprintf(stderr, "session beads: stopping drifted named session %q: %v\n", sn, err) //nolint:errcheck
-						}
-					}
-				}
-				existing[i].Status = "closed"
-				openBeads[i].Status = "closed"
+			if !closeSessionBeadIfRuntimeStoppedAndUnassigned(store, rigStores, sp, cfg, b, "reconfigured", "reconfigured named session", now, stderr) {
+				blockedReconfiguredNamedIdentities[identity] = true
+				continue
 			}
+			existing[i].Status = "closed"
+			openBeads[i].Status = "closed"
 		}
 		openBeads = retireDuplicateConfiguredNamedSessionBeads(
 			store, rigStores, sp, cfg, cityName, openBeads, bySessionName, indexBySessionName, now, stderr,
@@ -737,6 +720,9 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		liveHash := runtime.LiveFingerprint(agentCfg)
 		managedAlias := strings.TrimSpace(tp.Alias)
 		isConfiguredNamed := strings.TrimSpace(tp.ConfiguredNamedIdentity) != ""
+		if isConfiguredNamed && blockedReconfiguredNamedIdentities[strings.TrimSpace(tp.ConfiguredNamedIdentity)] {
+			continue
+		}
 		origin := templateParamsSessionOrigin(tp)
 
 		agentName := tp.TemplateName
@@ -1144,7 +1130,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				continue
 			}
 			if configuredNames[sn] {
-				if closeSessionBeadIfUnassigned(store, rigStores, b, "suspended", now, stderr) {
+				if closeSessionBeadIfRuntimeStoppedAndUnassigned(store, rigStores, sp, cfg, b, "suspended", "suspended session", now, stderr) {
 					if idx, ok := indexBySessionName[sn]; ok {
 						openBeads[idx].Status = "closed"
 					}
@@ -1158,7 +1144,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 						}
 					}
 				}
-				if closeSessionBeadIfUnassigned(store, rigStores, b, "orphaned", now, stderr) {
+				if closeSessionBeadIfRuntimeStoppedAndUnassigned(store, rigStores, sp, cfg, b, "orphaned", "orphaned session", now, stderr) {
 					if idx, ok := indexBySessionName[sn]; ok {
 						openBeads[idx].Status = "closed"
 					}
@@ -1365,14 +1351,13 @@ func reapStaleSessionBeads(
 		if sn == "" {
 			continue
 		}
-		// Only reap beads stuck in the creating state after their one-shot
-		// pending_create_claim has already been cleared. The pending create
-		// claim is authoritative across the lifecycle model: it keeps an
-		// in-flight or partially-healed start eligible for retry even when
-		// the bead's cached state has already moved past creating.
+		// Only reap beads stuck in the creating state. A fresh creating bead
+		// may still be in the provider start window, but pending_create_claim
+		// is not a permanent lease: after the startup grace expires and no
+		// runtime exists, keeping it open creates stale pool slots that block
+		// clean retries.
 		state := strings.TrimSpace(b.Metadata["state"])
-		pendingCreate := strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true"
-		if state != "creating" || pendingCreate {
+		if state != "creating" {
 			continue
 		}
 		// Don't reap beads with an active drain — the drainTracker is
@@ -1403,6 +1388,63 @@ func reapStaleSessionBeads(
 		}
 	}
 	return reaped
+}
+
+func closeSessionBeadIfRuntimeStoppedAndUnassigned(
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	sp runtime.Provider,
+	cfg *config.City,
+	b beads.Bead,
+	closeReason string,
+	stopReason string,
+	now time.Time,
+	stderr io.Writer,
+) bool {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	hasAssignedWork, err := sessionHasOpenAssignedWork(store, rigStores, b)
+	if err != nil {
+		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", b.ID, err) //nolint:errcheck
+		return false
+	}
+	if hasAssignedWork {
+		return false
+	}
+	if !stopRuntimeBeforeSessionBeadMutation(store, sp, cfg, b, stopReason, stderr) {
+		return false
+	}
+	return closeBead(store, b.ID, closeReason, now, stderr)
+}
+
+func stopRuntimeBeforeSessionBeadMutation(
+	store beads.Store,
+	sp runtime.Provider,
+	cfg *config.City,
+	b beads.Bead,
+	reason string,
+	stderr io.Writer,
+) bool {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	sessionName := strings.TrimSpace(b.Metadata["session_name"])
+	if sessionName == "" || sp == nil {
+		return true
+	}
+	if !sp.IsRunning(sessionName) {
+		return true
+	}
+	if err := workerKillSessionTargetWithConfig("", store, sp, cfg, sessionName); err != nil {
+		fmt.Fprintf(stderr, "session beads: stopping %s %q: %v\n", reason, sessionName, err) //nolint:errcheck
+		return false
+	}
+	if sp.IsRunning(sessionName) {
+		fmt.Fprintf(stderr, "session beads: stopping %s %q: still running after stop\n", reason, sessionName) //nolint:errcheck
+		return false
+	}
+	return true
 }
 
 // closeBead sets final metadata on a session bead and closes it.

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -32,6 +32,16 @@ type sessionGetSpyStore struct {
 	getIDs []string
 }
 
+type sessionSnapshotListSpyStore struct {
+	beads.Store
+	queries []beads.ListQuery
+}
+
+func (s *sessionSnapshotListSpyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.queries = append(s.queries, query)
+	return s.Store.List(query)
+}
+
 type failingCloseStore struct {
 	*beads.MemStore
 }
@@ -1278,6 +1288,162 @@ func TestRetireDuplicateConfiguredNamedSessionBeads_DoesNotStopWinnerSharingSess
 	}
 }
 
+func TestRetireDuplicateConfiguredNamedSessionBeads_StopFailureKeepsRuntimeOwner(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "worker", StartCommand: "true"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Name: "reviewer", Template: "worker", Mode: "on_demand"},
+		},
+	}
+	winnerSessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "reviewer")
+	loserSessionName := "old-reviewer-runtime"
+	if err := sp.Start(context.Background(), loserSessionName, runtime.Config{}); err != nil {
+		t.Fatalf("start loser runtime %s: %v", loserSessionName, err)
+	}
+	sp.StopErrors[loserSessionName] = errors.New("stop failed")
+	loser, err := store.Create(beads.Bead{
+		Title:  "reviewer old",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               loserSessionName,
+			"template":                   "worker",
+			"generation":                 "1",
+			"state":                      "active",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "reviewer",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create loser: %v", err)
+	}
+	winner, err := store.Create(beads.Bead{
+		Title:  "reviewer",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               winnerSessionName,
+			"template":                   "worker",
+			"generation":                 "2",
+			"state":                      "active",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "reviewer",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create winner: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "owned work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: loser.ID,
+	})
+	if err != nil {
+		t.Fatalf("create loser-owned work: %v", err)
+	}
+
+	openBeads := []beads.Bead{loser, winner}
+	bySessionName := map[string]beads.Bead{
+		loserSessionName:  loser,
+		winnerSessionName: winner,
+	}
+	indexBySessionName := map[string]int{
+		loserSessionName:  0,
+		winnerSessionName: 1,
+	}
+
+	retired := retireDuplicateConfiguredNamedSessionBeads(
+		store, nil, sp, cfg, "test-city", openBeads, bySessionName, indexBySessionName, time.Now().UTC(), io.Discard,
+	)
+
+	if !sp.IsRunning(loserSessionName) {
+		t.Fatalf("loser runtime %q unexpectedly stopped", loserSessionName)
+	}
+	if retired[0].Metadata["session_name"] != loserSessionName {
+		t.Fatalf("loser session_name = %q, want %q", retired[0].Metadata["session_name"], loserSessionName)
+	}
+	if retired[0].Metadata["state"] == "archived" {
+		t.Fatal("loser was archived even though its runtime stop failed")
+	}
+	updatedWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get loser-owned work: %v", err)
+	}
+	if updatedWork.Assignee != loser.ID {
+		t.Fatalf("loser-owned work assignee = %q, want unchanged loser %q", updatedWork.Assignee, loser.ID)
+	}
+}
+
+func TestRetireRemovedConfiguredNamedSessionBead_StopFailureKeepsRuntimeOwner(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	sessionName := "removed-reviewer-runtime"
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatalf("start runtime %s: %v", sessionName, err)
+	}
+	sp.StopErrors[sessionName] = errors.New("stop failed")
+	b, err := store.Create(beads.Bead{
+		Title:  "retired reviewer",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"template":                   "worker",
+			"state":                      "active",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "reviewer",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create named session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "owned work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: b.ID,
+	})
+	if err != nil {
+		t.Fatalf("create owned work: %v", err)
+	}
+
+	retired := retireRemovedConfiguredNamedSessionBead(store, nil, sp, b, now, io.Discard)
+
+	if retired {
+		t.Fatal("retireRemovedConfiguredNamedSessionBead returned true after runtime stop failed")
+	}
+	got, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", b.ID, err)
+	}
+	if got.Metadata["session_name"] != sessionName {
+		t.Fatalf("session_name = %q, want %q", got.Metadata["session_name"], sessionName)
+	}
+	if got.Metadata["state"] != "active" {
+		t.Fatalf("state = %q, want active", got.Metadata["state"])
+	}
+	updatedWork, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("get owned work: %v", err)
+	}
+	if updatedWork.Assignee != b.ID {
+		t.Fatalf("owned work assignee = %q, want unchanged %q", updatedWork.Assignee, b.ID)
+	}
+}
+
 func TestSyncSessionBeads_PreservesConfiguredNamedSessionWithoutDesiredEntry(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
@@ -1406,6 +1572,83 @@ func TestSyncSessionBeads_RecreatesDriftedNamedSessionRuntimeName(t *testing.T) 
 	}
 	if sp.IsRunning(oldName) {
 		t.Fatalf("drifted runtime %q still running after reconcile", oldName)
+	}
+}
+
+func TestSyncSessionBeads_ReconfiguredNamedSessionStopFailureKeepsOldBeadOpen(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "witness", Dir: "myrig", StartCommand: "true"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "witness", Dir: "myrig"},
+		},
+	}
+	identity := "myrig/witness"
+	expectedName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, identity)
+	oldName := "s-gc-old"
+
+	oldBead, err := store.Create(beads.Bead{
+		Title:  identity,
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               oldName,
+			"alias":                      identity,
+			"template":                   identity,
+			"state":                      "active",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("creating drifted canonical bead: %v", err)
+	}
+	if err := sp.Start(context.Background(), oldName, runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("starting drifted runtime: %v", err)
+	}
+	sp.StopErrors[oldName] = errors.New("stop failed")
+
+	ds := map[string]TemplateParams{
+		expectedName: {
+			TemplateName:            identity,
+			InstanceName:            identity,
+			Alias:                   identity,
+			Command:                 "true",
+			ConfiguredNamedIdentity: identity,
+			ConfiguredNamedMode:     "on_demand",
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), cfg, clk, &stderr, false)
+
+	gotOld, err := store.Get(oldBead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", oldBead.ID, err)
+	}
+	if gotOld.Status != "open" {
+		t.Fatalf("old bead status = %q, want open while runtime is still running", gotOld.Status)
+	}
+	if gotOld.Metadata["session_name"] != oldName {
+		t.Fatalf("old bead session_name = %q, want %q", gotOld.Metadata["session_name"], oldName)
+	}
+	if gotOld.Metadata["close_reason"] != "" {
+		t.Fatalf("old bead close_reason = %q, want empty", gotOld.Metadata["close_reason"])
+	}
+	if !sp.IsRunning(oldName) {
+		t.Fatalf("old runtime %q unexpectedly stopped", oldName)
+	}
+	for _, b := range allSessionBeads(t, store) {
+		if b.ID != oldBead.ID && strings.TrimSpace(b.Metadata["session_name"]) == expectedName {
+			t.Fatalf("created replacement bead %s while old runtime %q still has an open owner", b.ID, oldName)
+		}
 	}
 }
 
@@ -1851,7 +2094,7 @@ func TestCloseBeadPreservesPendingCreateClaimWhenCloseFails(t *testing.T) {
 // TestSyncSessionBeads_RefreshesStoredCommandOnConfigChange reproduces an
 // observed bug where an agent that got an `[option_defaults] model = "opus"`
 // entry added to its config after its session bead was created never picked up
-// the resulting `--model claude-opus-4-6` flag — even across `gc restart`.
+// the resulting `--model claude-opus-4-7` flag — even across `gc restart`.
 //
 // Root cause: session_beads.go only wrote `metadata.command` when it was empty
 // ("backfill") so the stored value was frozen at first-create time. If any
@@ -1886,9 +2129,9 @@ func TestSyncSessionBeads_RefreshesStoredCommandOnConfigChange(t *testing.T) {
 	}
 
 	// Tick 2: agent config grows an option_defaults.model entry. Fresh
-	// tp.Command now includes --model claude-opus-4-6. This is the scenario
+	// tp.Command now includes --model claude-opus-4-7. This is the scenario
 	// that broke in production: stored metadata.command was never updated.
-	afterCmd := "claude --dangerously-skip-permissions --effort max --model claude-opus-4-6"
+	afterCmd := "claude --dangerously-skip-permissions --effort max --model claude-opus-4-7"
 	ds["mayor"] = TemplateParams{TemplateName: "mayor", Command: afterCmd}
 	clk.Advance(3 * 24 * time.Hour) // 2026-04-17 → 2026-04-20
 	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
@@ -1990,6 +2233,49 @@ func TestSyncSessionBeads_OrphanDetection(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_OrphanStopFailureKeepsRunningBeadOpen(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "old-agent", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start old-agent: %v", err)
+	}
+	sp.StopErrors["old-agent"] = errors.New("stop failed")
+
+	ds := map[string]TemplateParams{
+		"old-agent": {TemplateName: "old-agent", Command: "true"},
+	}
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	ds2 := map[string]TemplateParams{
+		"new-agent": {TemplateName: "new-agent", Command: "true"},
+	}
+	clk.Advance(5 * time.Second)
+	syncSessionBeads("", store, ds2, sp, allConfiguredDS(ds2), nil, clk, &stderr, false)
+
+	all := allSessionBeads(t, store)
+	var oldBead beads.Bead
+	for _, b := range all {
+		if b.Metadata["session_name"] == "old-agent" {
+			oldBead = b
+			break
+		}
+	}
+	if oldBead.ID == "" {
+		t.Fatal("old-agent bead was not found by session_name while runtime is still running")
+	}
+	if oldBead.Status != "open" {
+		t.Fatalf("old-agent status = %q, want open", oldBead.Status)
+	}
+	if oldBead.Metadata["close_reason"] != "" {
+		t.Fatalf("old-agent close_reason = %q, want empty", oldBead.Metadata["close_reason"])
+	}
+	if !sp.IsRunning("old-agent") {
+		t.Fatal("old-agent runtime unexpectedly stopped")
+	}
+}
+
 func TestSyncSessionBeads_NilStore(t *testing.T) {
 	// Verify nil store does not panic.
 	var stderr bytes.Buffer
@@ -2015,8 +2301,8 @@ func TestSyncSessionBeads_StoppedAgent(t *testing.T) {
 	if len(all) != 1 {
 		t.Fatalf("expected 1 bead, got %d", len(all))
 	}
-	if all[0].Metadata["state"] != "stopped" {
-		t.Errorf("state = %q, want %q", all[0].Metadata["state"], "stopped")
+	if all[0].Metadata["state"] != "creating" {
+		t.Errorf("state = %q, want %q", all[0].Metadata["state"], "creating")
 	}
 	if all[0].Metadata["pending_create_claim"] != "true" {
 		t.Errorf("pending_create_claim = %q, want true", all[0].Metadata["pending_create_claim"])
@@ -2158,8 +2444,11 @@ func TestSyncSessionBeads_ResumedAfterSuspension(t *testing.T) {
 			closedCount++
 		case "open":
 			openCount++
-			if b.Metadata["state"] != "active" {
-				t.Errorf("resumed bead state = %q, want %q", b.Metadata["state"], "active")
+			if b.Metadata["state"] != "creating" {
+				t.Errorf("resumed bead state = %q, want %q", b.Metadata["state"], "creating")
+			}
+			if b.Metadata["pending_create_claim"] != "true" {
+				t.Errorf("resumed bead pending_create_claim = %q, want true", b.Metadata["pending_create_claim"])
 			}
 			if b.Metadata["generation"] != "1" {
 				t.Errorf("resumed bead generation = %q, want %q (fresh lifecycle)", b.Metadata["generation"], "1")
@@ -2257,6 +2546,54 @@ func TestSyncSessionBeads_SuspendedAgentNotOrphaned(t *testing.T) {
 	}
 	if workerBead.Metadata["close_reason"] != "suspended" {
 		t.Errorf("worker close_reason = %q, want %q", workerBead.Metadata["close_reason"], "suspended")
+	}
+}
+
+func TestSyncSessionBeads_SuspendedStopFailureKeepsRunningBeadOpen(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker", runtime.Config{Command: "true"}); err != nil {
+		t.Fatalf("start worker: %v", err)
+	}
+	sp.StopErrors["worker"] = errors.New("stop failed")
+
+	ds := map[string]TemplateParams{
+		"coordinator": {TemplateName: "coordinator", Command: "true"},
+		"worker":      {TemplateName: "worker", Command: "true"},
+	}
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	dsOnlyCoordinator := map[string]TemplateParams{
+		"coordinator": {TemplateName: "coordinator", Command: "true"},
+	}
+	configuredNames := map[string]bool{
+		"coordinator": true,
+		"worker":      true,
+	}
+	clk.Advance(5 * time.Second)
+	syncSessionBeads("", store, dsOnlyCoordinator, sp, configuredNames, nil, clk, &stderr, false)
+
+	all := allSessionBeads(t, store)
+	var workerBead beads.Bead
+	for _, b := range all {
+		if b.Metadata["session_name"] == "worker" {
+			workerBead = b
+			break
+		}
+	}
+	if workerBead.ID == "" {
+		t.Fatal("worker bead was not found by session_name while runtime is still running")
+	}
+	if workerBead.Status != "open" {
+		t.Fatalf("worker status = %q, want open", workerBead.Status)
+	}
+	if workerBead.Metadata["close_reason"] != "" {
+		t.Fatalf("worker close_reason = %q, want empty", workerBead.Metadata["close_reason"])
+	}
+	if !sp.IsRunning("worker") {
+		t.Fatal("worker runtime unexpectedly stopped")
 	}
 }
 
@@ -2737,6 +3074,55 @@ func TestLoadSessionBeads_SkipsClosedBeads(t *testing.T) {
 	}
 }
 
+func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &sessionSnapshotListSpyStore{Store: base}
+	open, err := store.Create(beads.Bead{
+		Title:  "open",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create open session bead: %v", err)
+	}
+	closed, err := store.Create(beads.Bead{
+		Title:  "closed",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "old-worker",
+			"state":        string(session.StateClosed),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed session bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeadSnapshot: %v", err)
+	}
+	if len(store.queries) != 1 {
+		t.Fatalf("List query count = %d, want 1", len(store.queries))
+	}
+	if store.queries[0].IncludeClosed {
+		t.Fatalf("loadSessionBeadSnapshot used IncludeClosed query: %+v", store.queries[0])
+	}
+	if _, ok := snapshot.FindByID(open.ID); !ok {
+		t.Fatalf("snapshot missing open session bead %s", open.ID)
+	}
+	if _, ok := snapshot.findByIDIncludingClosed(closed.ID); ok {
+		t.Fatalf("snapshot retained closed session bead %s", closed.ID)
+	}
+}
+
 // TestFindClosedNamedSessionBead_ReopensOnRestart verifies that when a named
 // session bead is closed (e.g., after gc stop), findClosedNamedSessionBead
 // finds it by identity so the caller can reopen it. This preserves the bead
@@ -2924,7 +3310,7 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			wantOpen:   0,
 		},
 		{
-			name: "pending_create_creating_kept",
+			name: "stale_pending_create_creating_reaped",
 			beads: []beads.Bead{{
 				Title:  "worker",
 				Type:   sessionBeadType,
@@ -2937,6 +3323,23 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			}},
 			running:    nil,
 			clock:      clockPastGrace,
+			wantReaped: 1,
+			wantOpen:   0,
+		},
+		{
+			name: "fresh_pending_create_creating_kept",
+			beads: []beads.Bead{{
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":         "worker-1",
+					"state":                "creating",
+					"pending_create_claim": "true",
+				},
+			}},
+			running:    nil,
+			clock:      clockWithinGrace,
 			wantReaped: 0,
 			wantOpen:   1,
 		},

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -35,9 +35,10 @@ const (
 )
 
 type startCandidate struct {
-	session *beads.Bead
-	tp      TemplateParams
-	order   int
+	session    *beads.Bead
+	tp         TemplateParams
+	wakeReason string
+	order      int
 }
 
 func (c startCandidate) name() string {
@@ -512,29 +513,10 @@ func buildPreparedStart(
 	} else if wd := session.Metadata["work_dir"]; wd != "" {
 		agentCfg.WorkDir = wd
 	}
-	if session.Metadata["session_key"] == "" && tp.ResolvedProvider != nil && tp.ResolvedProvider.SessionIDFlag != "" {
-		sessionKey, err := sessionpkg.GenerateSessionKey()
-		if err != nil {
-			return nil, fmt.Errorf("generating session key: %w", err)
-		}
-		if store != nil && session.ID != "" {
-			if err := store.SetMetadata(session.ID, "session_key", sessionKey); err != nil {
-				return nil, fmt.Errorf("storing session key: %w", err)
-			}
-		}
-		if session.Metadata == nil {
-			session.Metadata = make(map[string]string)
-		}
-		session.Metadata["session_key"] = sessionKey
-	}
-	if sk := session.Metadata["session_key"]; sk != "" && tp.ResolvedProvider != nil {
-		firstStart := session.Metadata["started_config_hash"] == ""
-		forceFresh := session.Metadata["wake_mode"] == "fresh"
-		agentCfg.Command = resolveSessionCommand(agentCfg.Command, sk, tp.ResolvedProvider, firstStart, forceFresh)
-	}
 	firstStart := session.Metadata["started_config_hash"] == ""
 	forceFresh := session.Metadata["wake_mode"] == "fresh"
-	if !firstStart && !forceFresh {
+	replayStartupPrompt := shouldReplayStartupPromptForWake(candidate)
+	if !firstStart && !forceFresh && !replayStartupPrompt {
 		agentCfg.PromptSuffix = ""
 		agentCfg.PromptFlag = ""
 		agentCfg.Nudge = tp.Hints.Nudge
@@ -624,6 +606,25 @@ func buildPreparedStart(
 		coreBreakdown: coreBreakdown,
 		liveHash:      liveHash,
 	}, nil
+}
+
+func shouldReplayStartupPromptForWake(candidate startCandidate) bool {
+	// Direct assignment is the one wake path where a dormant ephemeral worker
+	// already owns work. It needs the workflow startup prompt so the prompt-side
+	// claim/verify protocol can run instead of launching at a bare provider REPL.
+	if strings.TrimSpace(candidate.wakeReason) != "assigned-work" {
+		return false
+	}
+	if candidate.session == nil {
+		return false
+	}
+	if !isPoolManagedSessionBead(*candidate.session) {
+		return false
+	}
+	if sessionOrigin(*candidate.session) != "ephemeral" {
+		return false
+	}
+	return true
 }
 
 func executePreparedStartWave(
@@ -944,11 +945,42 @@ func clearPendingStartInFlightLease(session *beads.Bead, store beads.Store, stde
 	if session == nil || store == nil {
 		return
 	}
+	batchErr := func() (err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				err = fmt.Errorf("panic: %v", recovered)
+			}
+		}()
+		return store.SetMetadataBatch(session.ID, map[string]string{
+			"last_woke_at":    "",
+			"start_in_flight": "",
+		})
+	}()
+	if batchErr == nil {
+		if session.Metadata == nil {
+			session.Metadata = make(map[string]string)
+		}
+		session.Metadata["last_woke_at"] = ""
+		session.Metadata["start_in_flight"] = ""
+		return
+	}
+	fmt.Fprintf(stderr, "session reconciler: clearing start lease for %s: %v\n", session.Metadata["session_name"], batchErr) //nolint:errcheck
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			fmt.Fprintf(stderr, "session reconciler: clearing start lease for %s: panic: %v\n", session.Metadata["session_name"], recovered) //nolint:errcheck
+		}
+	}()
 	if setMeta(store, session.ID, "last_woke_at", "", stderr) == nil {
 		if session.Metadata == nil {
 			session.Metadata = make(map[string]string)
 		}
 		session.Metadata["last_woke_at"] = ""
+	}
+	if setMeta(store, session.ID, "start_in_flight", "", stderr) == nil {
+		if session.Metadata == nil {
+			session.Metadata = make(map[string]string)
+		}
+		session.Metadata["start_in_flight"] = ""
 	}
 }
 
@@ -960,7 +992,20 @@ func stopStaleAsyncStartRuntime(result startResult, sp runtime.Provider, stderr 
 	if !runningSessionMatchesPendingCreate(result.prepared.candidate.session, name, sp) {
 		return
 	}
-	if err := sp.Stop(name); err != nil && !runtime.IsSessionGone(err) {
+	providerName := strings.TrimSpace(result.prepared.candidate.session.Metadata["provider_kind"])
+	if providerName == "" {
+		providerName = strings.TrimSpace(result.prepared.candidate.session.Metadata["provider"])
+	}
+	handle, err := worker.NewRuntimeHandle(worker.RuntimeHandleConfig{
+		Provider:     sp,
+		SessionName:  name,
+		ProviderName: providerName,
+		ProcessNames: result.prepared.candidate.tp.Hints.ProcessNames,
+	})
+	if err == nil {
+		err = handle.Kill(context.Background())
+	}
+	if err != nil && !runtime.IsSessionGone(err) {
 		fmt.Fprintf(stderr, "session reconciler: stopping stale async start runtime %s: %v\n", name, err) //nolint:errcheck
 	}
 }
@@ -977,13 +1022,13 @@ func asyncStartSessionStillCurrent(prepared, current beads.Bead) bool {
 	if preparedToken != "" && strings.TrimSpace(current.Metadata["instance_token"]) != preparedToken {
 		return false
 	}
+	currentState := sessionpkg.State(strings.TrimSpace(current.Metadata["state"]))
 	if shouldRollbackPendingCreate(&prepared) && !shouldRollbackPendingCreate(&current) {
-		return false
+		return currentState == sessionpkg.StateAwake || currentState == sessionpkg.StateActive
 	}
-	currentState := strings.TrimSpace(current.Metadata["state"])
-	return confirmPendingStart(currentState) ||
-		sessionpkg.State(currentState) == sessionpkg.StateAwake ||
-		sessionpkg.State(currentState) == sessionpkg.StateActive
+	return confirmPendingStart(string(currentState)) ||
+		currentState == sessionpkg.StateAwake ||
+		currentState == sessionpkg.StateActive
 }
 
 func asyncStartStaleRuntimeCleanupAllowed(prepared, current beads.Bead) bool {
@@ -1034,26 +1079,13 @@ func startPreparedStartCandidate(
 	cfg *config.City,
 ) (bool, error) {
 	if store == nil || item.candidate.session == nil || strings.TrimSpace(item.candidate.session.ID) == "" {
-		handle, err := runtimeWorkerHandleWithConfig(
-			cityPath,
-			store,
-			sp,
-			cfg,
-			item.candidate.name(),
-			item.candidate.name(),
-			"",
-			nil,
-		)
-		if err != nil {
-			return false, err
-		}
-		return true, handle.StartResolved(ctx, item.cfg.Command, item.cfg)
+		return false, fmt.Errorf("%w: start requires a bead-backed session", worker.ErrOperationUnsupported)
 	}
-	handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, item.candidate.session.ID)
+	handle, err := workerHandleForPreparedStartWithConfig(cityPath, store, sp, cfg, item)
 	if err != nil {
 		return true, err
 	}
-	return true, handle.StartResolved(ctx, item.cfg.Command, item.cfg)
+	return true, handle.Start(ctx)
 }
 
 func commitStartResult(
@@ -1114,11 +1146,7 @@ func commitStartResultTraced(
 			return false
 		}
 		fmt.Fprintf(stderr, "session reconciler: starting %s: %s\n", name, formatLifecycleError(result.err)) //nolint:errcheck
-		if err := store.SetMetadata(session.ID, "last_woke_at", ""); err != nil {
-			fmt.Fprintf(stderr, "session reconciler: clearing last_woke_at for %s: %v\n", name, err) //nolint:errcheck
-		} else {
-			session.Metadata["last_woke_at"] = ""
-		}
+		clearPendingStartInFlightLease(session, store, stderr)
 		recordWakeFailure(session, store, clk)
 		if trace != nil {
 			trace.recordOperation("reconciler.start.failed", tp.TemplateName, name, "", "start", result.outcome, traceRecordPayload{

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -733,7 +733,154 @@ func TestExecutePlannedStarts_FreshWakeAfterDrainRetainsStartupContext(t *testin
 	}
 }
 
-func TestPrepareStartCandidate_GeneratesMissingSessionKeyBeforeWake(t *testing.T) {
+func TestPrepareStartCandidate_AssignedWorkWakeReplaysStartupPrompt(t *testing.T) {
+	store := beads.NewMemStore()
+	rawOverrides, err := json.Marshal(map[string]string{
+		"initial_message": "Do not replay this on assigned-work wake.",
+	})
+	if err != nil {
+		t.Fatalf("Marshal(template_overrides): %v", err)
+	}
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":        "worker-mc-test",
+			"template":            "worker",
+			"state":               "asleep",
+			"session_origin":      "ephemeral",
+			"pool_managed":        boolMetadata(true),
+			"session_key":         "existing-provider-session",
+			"started_config_hash": "previous-start",
+			"template_overrides":  string(rawOverrides),
+			"generation":          "1",
+			"continuation_epoch":  "1",
+			"instance_token":      "test-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	prepared, err := prepareStartCandidate(startCandidate{
+		session:    &session,
+		wakeReason: "assigned-work",
+		tp: TemplateParams{
+			Command:      "codex",
+			SessionName:  "worker-mc-test",
+			TemplateName: "worker",
+			Prompt:       "BASE CLAIM PROMPT",
+			Hints: agent.StartupHints{
+				Nudge: "Check assigned work and act.",
+			},
+			ResolvedProvider: &config.ResolvedProvider{
+				Name:       "codex",
+				Command:    "codex",
+				PromptMode: "arg",
+			},
+		},
+		order: 0,
+	}, &config.City{}, store, &clock.Fake{Time: time.Date(2026, 4, 29, 19, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("prepareStartCandidate: %v", err)
+	}
+
+	if prepared.cfg.PromptSuffix == "" {
+		t.Fatal("PromptSuffix should be present for assigned-work wake of an ephemeral pool session")
+	}
+	parts := shellquote.Split(prepared.cfg.PromptSuffix)
+	if len(parts) != 1 {
+		t.Fatalf("PromptSuffix parsed parts = %#v, want single prompt payload", parts)
+	}
+	if got := parts[0]; got != "BASE CLAIM PROMPT" {
+		t.Fatalf("prompt payload = %q, want base startup prompt only", got)
+	}
+	if strings.Contains(parts[0], "Do not replay this") || strings.Contains(parts[0], "User message:") {
+		t.Fatalf("prompt payload replayed initial_message on assigned-work wake: %q", parts[0])
+	}
+	if got := prepared.cfg.Env[startupPromptDeliveredEnv]; got != "1" {
+		t.Fatalf("%s = %q, want 1", startupPromptDeliveredEnv, got)
+	}
+	if got := prepared.cfg.Nudge; got != "Check assigned work and act." {
+		t.Fatalf("Nudge = %q, want configured nudge preserved", got)
+	}
+	stored, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := stored.Metadata["session_key"]; got != "existing-provider-session" {
+		t.Fatalf("stored session_key = %q, want preserved for assigned-work resume", got)
+	}
+	if got := stored.Metadata["started_config_hash"]; got != "previous-start" {
+		t.Fatalf("started_config_hash = %q, want assigned-work wake to preserve non-fresh start history", got)
+	}
+}
+
+func TestPrepareStartCandidate_NonAssignedResumeStripsStartupPrompt(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":        "worker-mc-test",
+			"template":            "worker",
+			"state":               "asleep",
+			"session_origin":      "ephemeral",
+			"pool_managed":        boolMetadata(true),
+			"session_key":         "existing-provider-session",
+			"started_config_hash": "previous-start",
+			"generation":          "1",
+			"continuation_epoch":  "1",
+			"instance_token":      "test-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	prepared, err := prepareStartCandidate(startCandidate{
+		session: &session,
+		tp: TemplateParams{
+			Command:      "codex",
+			SessionName:  "worker-mc-test",
+			TemplateName: "worker",
+			Prompt:       "BASE CLAIM PROMPT",
+			Hints: agent.StartupHints{
+				Nudge: "Check assigned work and act.",
+			},
+			ResolvedProvider: &config.ResolvedProvider{
+				Name:       "codex",
+				Command:    "codex",
+				PromptMode: "arg",
+			},
+		},
+		order: 0,
+	}, &config.City{}, store, &clock.Fake{Time: time.Date(2026, 4, 29, 19, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("prepareStartCandidate: %v", err)
+	}
+
+	if prepared.cfg.PromptSuffix != "" {
+		t.Fatalf("PromptSuffix = %q, want stripped for ordinary resume", prepared.cfg.PromptSuffix)
+	}
+	if got := prepared.cfg.Env[startupPromptDeliveredEnv]; got != "" {
+		t.Fatalf("%s = %q, want unset for ordinary resume", startupPromptDeliveredEnv, got)
+	}
+	if got := prepared.cfg.Nudge; got != "Check assigned work and act." {
+		t.Fatalf("Nudge = %q, want configured nudge preserved", got)
+	}
+	stored, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := stored.Metadata["session_key"]; got != "existing-provider-session" {
+		t.Fatalf("stored session_key = %q, want preserved for ordinary resume", got)
+	}
+}
+
+func TestPrepareStartCandidate_DefersMissingSessionKeyToWorkerStart(t *testing.T) {
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{
 		Title:  "wendy",
@@ -769,19 +916,19 @@ func TestPrepareStartCandidate_GeneratesMissingSessionKeyBeforeWake(t *testing.T
 	}
 
 	sessionKey := session.Metadata["session_key"]
-	if sessionKey == "" {
-		t.Fatal("session_key should be generated before wake")
+	if sessionKey != "" {
+		t.Fatalf("session_key = %q, want preparation to leave key generation to worker start", sessionKey)
 	}
-	if !strings.Contains(prepared.cfg.Command, "--session-id "+sessionKey) {
-		t.Fatalf("prepared.cfg.Command = %q, want --session-id %s", prepared.cfg.Command, sessionKey)
+	if strings.Contains(prepared.cfg.Command, "--session-id") {
+		t.Fatalf("prepared.cfg.Command = %q, want unresolved base command", prepared.cfg.Command)
 	}
 
 	stored, err := store.Get(session.ID)
 	if err != nil {
 		t.Fatalf("store.Get: %v", err)
 	}
-	if stored.Metadata["session_key"] != sessionKey {
-		t.Fatalf("stored session_key = %q, want %q", stored.Metadata["session_key"], sessionKey)
+	if stored.Metadata["session_key"] != "" {
+		t.Fatalf("stored session_key = %q, want empty before worker start", stored.Metadata["session_key"])
 	}
 }
 
@@ -1348,6 +1495,119 @@ func TestExecutePlannedStartsTraced_AsyncLimiterDeferredStartDoesNotRunAfterCanc
 	}
 }
 
+func TestReconcileSessionBeads_AsyncExistingWakeLeasePreventsDuplicateStart(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 23, 0, time.UTC)}
+	sp := newGatedStartProvider()
+	dt := newDrainTracker()
+	cfg := &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "worker")
+	t.Cleanup(func() { sp.release(sessionName) })
+	tp := TemplateParams{
+		Command:                 "worker",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+	}
+	desired := map[string]TemplateParams{sessionName: tp}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"template":                   "worker",
+			"generation":                 "1",
+			"continuation_epoch":         "1",
+			"instance_token":             "tok-worker",
+			"state":                      "asleep",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "worker",
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := reconcileSessionBeadsTraced(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		desired,
+		configuredSessionNames(cfg, "", store),
+		cfg,
+		sp,
+		store,
+		nil,
+		nil,
+		nil,
+		nil,
+		dt,
+		map[string]int{"worker": 1},
+		false,
+		nil,
+		"test-city",
+		nil,
+		clk,
+		events.Discard,
+		time.Minute,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+	); got != 1 {
+		t.Fatalf("first reconcile woken = %d, want 1", got)
+	}
+	sp.waitForStarts(t, 1)
+	inFlight, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inFlight.Metadata["start_in_flight"] != "true" {
+		t.Fatalf("start_in_flight = %q, want true", inFlight.Metadata["start_in_flight"])
+	}
+
+	if got := reconcileSessionBeadsTraced(
+		context.Background(),
+		"",
+		[]beads.Bead{inFlight},
+		desired,
+		configuredSessionNames(cfg, "", store),
+		cfg,
+		sp,
+		store,
+		nil,
+		nil,
+		nil,
+		nil,
+		dt,
+		map[string]int{"worker": 1},
+		false,
+		nil,
+		"test-city",
+		nil,
+		clk,
+		events.Discard,
+		time.Minute,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+	); got != 0 {
+		t.Fatalf("second reconcile woken = %d, want 0 while wake start is still in flight", got)
+	}
+	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
+}
+
 func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 25, 0, time.UTC)}
@@ -1437,7 +1697,7 @@ func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *test
 	}
 }
 
-func TestExecutePlannedStartsTraced_AsyncPrepareFailureClearsPreWakeLease(t *testing.T) {
+func TestExecutePlannedStartsTraced_AsyncStartFailureClearsPreWakeLease(t *testing.T) {
 	store := &failSetMetadataStore{MemStore: beads.NewMemStore(), failKey: "session_key"}
 	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 27, 0, time.UTC)}
 	session, err := store.Create(beads.Bead{
@@ -1482,8 +1742,8 @@ func TestExecutePlannedStartsTraced_AsyncPrepareFailureClearsPreWakeLease(t *tes
 		ioDiscard{},
 		nil,
 		withAsyncStartExecution(),
-	); got != 0 {
-		t.Fatalf("woken = %d, want 0 when async preparation fails after preWake", got)
+	); got != 1 {
+		t.Fatalf("woken = %d, want 1 when async start is enqueued before worker start failure", got)
 	}
 	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
 	updated, err := store.Get(session.ID)
@@ -1914,6 +2174,79 @@ func TestCommitAsyncStartResult_IgnoresStaleSessionSnapshot(t *testing.T) {
 	}
 	if got := updated.Metadata["instance_token"]; got != "tok-new" {
 		t.Fatalf("instance_token = %q, want tok-new", got)
+	}
+}
+
+func TestCommitAsyncStartResult_AcceptsWorkerBoundaryPendingCreateCommit(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 2, 15, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+			"start_in_flight":      "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadataBatch(session.ID, map[string]string{
+		"state":                string(sessionpkg.StateActive),
+		"state_reason":         "creation_complete",
+		"creation_complete_at": clk.Now().Add(time.Second).Format(time.RFC3339),
+		"pending_create_claim": "",
+		"start_in_flight":      "",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "worker",
+					SessionName:  "worker",
+					TemplateName: "worker",
+				},
+			},
+			coreHash: "core-hash",
+			liveHash: "live-hash",
+		},
+		outcome:  "success",
+		started:  clk.Now(),
+		finished: clk.Now(),
+	}
+
+	if !commitAsyncStartResultWithContext(context.Background(), result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("worker-boundary commit should still accept the async start result")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Metadata["state"]; got != string(sessionpkg.StateActive) {
+		t.Fatalf("state = %q, want active", got)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got)
+	}
+	if got := updated.Metadata["start_in_flight"]; got != "" {
+		t.Fatalf("start_in_flight = %q, want cleared", got)
+	}
+	if got := updated.Metadata["started_config_hash"]; got != "core-hash" {
+		t.Fatalf("started_config_hash = %q, want core-hash", got)
+	}
+	if got := updated.Metadata["started_live_hash"]; got != "live-hash" {
+		t.Fatalf("started_live_hash = %q, want live-hash", got)
 	}
 }
 
@@ -2674,7 +3007,7 @@ func TestRefreshConfiguredNamedStartCandidateAddsCurrentSkillFingerprint(t *test
 }
 
 func TestExecutePlannedStartsClearsLegacyDrainAckAfterProviderStartBeforeMetadataRetry(t *testing.T) {
-	store := &failNthMetadataBatchStore{MemStore: beads.NewMemStore(), failOn: 2}
+	store := &failNthMetadataBatchStore{MemStore: beads.NewMemStore(), failOn: 3}
 	sp := runtime.NewFake()
 	clk := &clock.Fake{Time: time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)}
 	tp := TemplateParams{
@@ -3583,14 +3916,33 @@ func TestInterruptTargetsBounded_StopsPoolManagedSessions(t *testing.T) {
 }
 
 func TestExecutePreparedStartWave_PanicIncludesStackTrace(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"template":     "worker",
+			"state":        "creating",
+			"command":      "panic-provider",
+			"work_dir":     t.TempDir(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	results := executePreparedStartWave(
 		context.Background(),
 		[]preparedStart{{
-			candidate: startCandidate{session: &beads.Bead{Metadata: map[string]string{"session_name": "worker"}}},
-			cfg:       runtime.Config{Command: "panic-provider"},
+			candidate: startCandidate{
+				session: &session,
+				tp:      TemplateParams{TemplateName: "worker"},
+			},
+			cfg: runtime.Config{Command: "panic-provider", WorkDir: session.Metadata["work_dir"]},
 		}},
 		&panicStartProvider{Fake: runtime.NewFake()},
-		nil,
+		store,
 		time.Second,
 	)
 	if len(results) != 1 {
@@ -3830,16 +4182,28 @@ func (p *zombieAfterStartProvider) Start(ctx context.Context, name string, cfg r
 func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 	skipSlowCmdGCTest(t, "waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
 	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-99",
+		Title:  "test-agent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "test-agent",
+			"session_key":  "stale-key-abc",
+			"resume_flag":  "--resume",
+			"template":     "worker",
+			"state":        "creating",
+			"command":      "claude",
+			"work_dir":     t.TempDir(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	item := preparedStart{
 		candidate: startCandidate{
-			session: &beads.Bead{
-				ID: "gc-99",
-				Metadata: map[string]string{
-					"session_name": "test-agent",
-					"session_key":  "stale-key-abc",
-					"template":     "worker",
-				},
-			},
+			session: &session,
 			tp: TemplateParams{
 				Command:      "claude --resume stale-key-abc",
 				SessionName:  "test-agent",
@@ -3853,7 +4217,7 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 		context.Background(),
 		[]preparedStart{item},
 		sp,
-		nil,
+		store,
 		10*time.Second,
 	)
 
@@ -3870,17 +4234,30 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetected(t *testing.T) {
 }
 
 func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *testing.T) {
+	skipSlowCmdGCTest(t, "waits through worker and reconciler stale session-key detection")
 	sp := &zombieAfterStartProvider{Fake: runtime.NewFake()}
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-99",
+		Title:  "test-agent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "test-agent",
+			"session_key":  "stale-key-abc",
+			"resume_flag":  "--resume",
+			"template":     "worker",
+			"state":        "creating",
+			"command":      "claude",
+			"work_dir":     t.TempDir(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	item := preparedStart{
 		candidate: startCandidate{
-			session: &beads.Bead{
-				ID: "gc-99",
-				Metadata: map[string]string{
-					"session_name": "test-agent",
-					"session_key":  "stale-key-abc",
-					"template":     "worker",
-				},
-			},
+			session: &session,
 			tp: TemplateParams{
 				Command:      "claude --resume stale-key-abc",
 				SessionName:  "test-agent",
@@ -3897,7 +4274,7 @@ func TestExecutePreparedStartWave_StaleSessionKeyDetectedWhenPaneSurvives(t *tes
 		context.Background(),
 		[]preparedStart{item},
 		sp,
-		nil,
+		store,
 		10*time.Second,
 	)
 
@@ -3917,15 +4294,26 @@ func TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey(t *testing.T) {
 	// Session without a session_key should not trigger stale detection,
 	// even if the session dies after start.
 	sp := &dieAfterStartProvider{Fake: runtime.NewFake()}
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-99",
+		Title:  "test-agent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "test-agent",
+			"template":     "worker",
+			"state":        "creating",
+			"command":      "claude",
+			"work_dir":     t.TempDir(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	item := preparedStart{
 		candidate: startCandidate{
-			session: &beads.Bead{
-				ID: "gc-99",
-				Metadata: map[string]string{
-					"session_name": "test-agent",
-					"template":     "worker",
-				},
-			},
+			session: &session,
 			tp: TemplateParams{
 				Command:      "claude",
 				SessionName:  "test-agent",
@@ -3939,7 +4327,7 @@ func TestExecutePreparedStartWave_NoStaleCheckWithoutSessionKey(t *testing.T) {
 		context.Background(),
 		[]preparedStart{item},
 		sp,
-		nil,
+		store,
 		10*time.Second,
 	)
 

--- a/cmd/gc/session_lifecycle_start_boundary_test.go
+++ b/cmd/gc/session_lifecycle_start_boundary_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,22 +51,22 @@ func TestExecutePreparedStartWaveUsesWorkerBoundaryForKnownSession(t *testing.T)
 	if err != nil {
 		t.Fatalf("Get session: %v", err)
 	}
-	if got.State != sessionpkg.StateCreating {
-		t.Fatalf("state = %q, want %q before commit", got.State, sessionpkg.StateCreating)
+	if got.State != sessionpkg.StateActive {
+		t.Fatalf("state = %q, want %q after worker start", got.State, sessionpkg.StateActive)
 	}
 	updatedBead, err := store.Get(info.ID)
 	if err != nil {
 		t.Fatalf("Get updated bead: %v", err)
 	}
-	if updatedBead.Metadata["pending_create_claim"] != "true" {
-		t.Fatalf("pending_create_claim = %q, want preserved before commit", updatedBead.Metadata["pending_create_claim"])
+	if updatedBead.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want worker start to clear claim", updatedBead.Metadata["pending_create_claim"])
 	}
 	if !sp.IsRunning(info.SessionName) {
 		t.Fatal("session should be running after prepared start")
 	}
 }
 
-func TestStartPreparedStartCandidateUsesWorkerBoundaryForRuntimeOnlyTarget(t *testing.T) {
+func TestStartPreparedStartCandidateRejectsRuntimeOnlyTarget(t *testing.T) {
 	sp := runtime.NewFake()
 	sessionBead := &beads.Bead{
 		Metadata: map[string]string{
@@ -91,30 +92,13 @@ func TestStartPreparedStartCandidateUsesWorkerBoundaryForRuntimeOnlyTarget(t *te
 		nil,
 	)
 	if err != nil {
-		t.Fatalf("startPreparedStartCandidate: %v", err)
-	}
-	if !usedWorker {
-		t.Fatal("usedWorker = false, want true")
-	}
-	if !sp.IsRunning("legacy-runtime-only") {
-		t.Fatal("legacy-runtime-only should be running after prepared start")
-	}
-	var start runtime.Call
-	foundStart := false
-	for _, call := range sp.Calls {
-		if call.Method == "Start" {
-			start = call
-			foundStart = true
-			break
+		if usedWorker {
+			t.Fatal("usedWorker = true, want false for runtime-only start rejection")
 		}
+		if !strings.Contains(err.Error(), "start requires a bead-backed session") {
+			t.Fatalf("err = %v, want bead-backed session rejection", err)
+		}
+		return
 	}
-	if !foundStart {
-		t.Fatalf("runtime calls = %#v, want Start", sp.Calls)
-	}
-	if start.Name != "legacy-runtime-only" {
-		t.Fatalf("start name = %q, want legacy-runtime-only", start.Name)
-	}
-	if start.Config.Command != "claude --resume seeded" {
-		t.Fatalf("start command = %q, want claude --resume seeded", start.Config.Command)
-	}
+	t.Fatal("startPreparedStartCandidate succeeded for runtime-only target")
 }

--- a/cmd/gc/session_overrides_test.go
+++ b/cmd/gc/session_overrides_test.go
@@ -28,9 +28,9 @@ func TestReplaceSchemaFlags_ClaudeModelOverride(t *testing.T) {
 	got := replaceSchemaFlags(
 		"claude --dangerously-skip-permissions",
 		claude.OptionsSchema,
-		[]string{"--dangerously-skip-permissions", "--model", "claude-opus-4-6"},
+		[]string{"--dangerously-skip-permissions", "--model", "claude-opus-4-7"},
 	)
-	want := "claude --dangerously-skip-permissions --model claude-opus-4-6"
+	want := "claude --dangerously-skip-permissions --model claude-opus-4-7"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -29,6 +29,7 @@ import (
 
 type wakeEvaluation struct {
 	Reasons          []WakeReason
+	Reason           string
 	Policy           resolvedSessionSleepPolicy
 	ConfigSuppressed bool
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -150,7 +150,8 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 }
 
 func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
-	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" &&
+		strings.TrimSpace(session.Metadata["start_in_flight"]) != "true" {
 		return false
 	}
 	lastWoke := strings.TrimSpace(session.Metadata["last_woke_at"])
@@ -382,7 +383,7 @@ func reconcileSessionBeadsTraced(
 						"degraded":       err != nil,
 					}, nil, "")
 				}
-			case pendingCreateSessionStillLeased(*session, cfg, clk):
+			case pendingCreateSessionStillLeased(*session, cfg, clk) && !isPoolManagedSessionBead(*session):
 				template := normalizedSessionTemplate(*session, cfg)
 				if template == "" {
 					template = session.Metadata["template"]
@@ -462,6 +463,25 @@ func reconcileSessionBeadsTraced(
 					reason := "orphaned"
 					if configuredNames[name] {
 						reason = "suspended"
+					}
+					hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
+					if assignedErr != nil {
+						fmt.Fprintf(stderr, "session reconciler: checking assigned work for %s %s: %v\n", reason, name, assignedErr) //nolint:errcheck
+						hasAssignedWork = true
+					}
+					if hasAssignedWork {
+						if trace != nil {
+							template := normalizedSessionTemplate(*session, cfg)
+							if template == "" {
+								template = session.Metadata["template"]
+							}
+							trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "kept_open_assigned_work", traceRecordPayload{
+								"store_query_partial":  storeQueryPartial,
+								"provider_alive":       providerAlive,
+								"assigned_query_error": assignedErr != nil,
+							}, nil, "")
+						}
+						continue
 					}
 					if beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout) {
 						if trace != nil {
@@ -1036,12 +1056,14 @@ func reconcileSessionBeadsTraced(
 			if trace != nil {
 				trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "start_candidate", traceRecordPayload{
 					"should_wake": shouldWake,
+					"wake_reason": decision.Reason,
 				}, nil, "")
 			}
 			startCandidates = append(startCandidates, startCandidate{
-				session: target.session,
-				tp:      target.tp,
-				order:   len(startCandidates),
+				session:    target.session,
+				tp:         target.tp,
+				wakeReason: decision.Reason,
+				order:      len(startCandidates),
 			})
 		}
 
@@ -1607,39 +1629,4 @@ func resolveTaskWorkDir(store beads.Store, assignees ...string) string {
 		}
 	}
 	return ""
-}
-
-// resolveSessionCommand returns the command to use when starting a session.
-// On a fresh provider start (first boot or wake_mode=fresh), it uses
-// SessionIDFlag to create a new provider conversation with the given key as
-// its ID. Otherwise it resumes the existing conversation.
-func resolveSessionCommand(command, sessionKey string, rp *config.ResolvedProvider, firstStart, forceFresh bool) string {
-	if (firstStart || forceFresh) && rp.SessionIDFlag != "" {
-		return command + " " + rp.SessionIDFlag + " " + sessionKey
-	}
-	return resolveResumeCommand(command, sessionKey, rp)
-}
-
-// resolveResumeCommand returns the command to use when resuming a session.
-// Priority: explicit resume_command (with {{.SessionKey}} expansion) >
-// ResumeFlag/ResumeStyle auto-construction > original command unchanged.
-func resolveResumeCommand(command, sessionKey string, rp *config.ResolvedProvider) string {
-	// Explicit resume_command takes precedence.
-	if rp.ResumeCommand != "" {
-		return strings.ReplaceAll(rp.ResumeCommand, "{{.SessionKey}}", sessionKey)
-	}
-	// Fall back to ResumeFlag/ResumeStyle auto-construction.
-	if rp.ResumeFlag == "" {
-		return command
-	}
-	switch rp.ResumeStyle {
-	case "subcommand":
-		parts := strings.SplitN(command, " ", 2)
-		if len(parts) == 2 {
-			return parts[0] + " " + rp.ResumeFlag + " " + sessionKey + " " + parts[1]
-		}
-		return command + " " + rp.ResumeFlag + " " + sessionKey
-	default: // "flag"
-		return command + " " + rp.ResumeFlag + " " + sessionKey
-	}
 }

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1798,6 +1798,33 @@ func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.
 	}
 }
 
+func TestReconcileSessionBeads_UndesiredPoolPendingCreateClosesOrphan(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}}
+	session := env.createSessionBead("worker-mc-stale", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "creating",
+		"pool_slot":            "1",
+		poolManagedMetadataKey: boolMetadata(true),
+		"pending_create_claim": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 without desired-state membership", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("undesired pool pending-create session status = %q, want closed", got.Status)
+	}
+	if got.Metadata["close_reason"] != "orphaned" {
+		t.Fatalf("close_reason = %q, want orphaned", got.Metadata["close_reason"])
+	}
+}
+
 func TestReconcileSessionBeads_DependencyOrdering_DepDeadBlocksWake(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -1905,6 +1932,40 @@ func TestReconcileSessionBeads_OrphanSessionDrained(t *testing.T) {
 	}
 	if ds.reason != "orphaned" {
 		t.Errorf("drain reason = %q, want %q", ds.reason, "orphaned")
+	}
+}
+
+func TestReconcileSessionBeads_RunningOrphanWithAssignedWorkNotDrained(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "other"}}}
+	if err := env.sp.Start(context.Background(), "orphan", runtime.Config{}); err != nil {
+		t.Fatalf("Start(orphan): %v", err)
+	}
+	session := env.createSessionBead("orphan", "orphan")
+	env.markSessionActive(&session)
+	if _, err := env.store.Create(beads.Bead{
+		Title:    "claimed work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "orphan",
+	}); err != nil {
+		t.Fatalf("Create(claimed work): %v", err)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("unexpected drain for session with assigned work: %+v", ds)
+	}
+	if got := env.stdout.String(); strings.Contains(got, "Draining session 'orphan'") {
+		t.Fatalf("stdout contains unexpected drain log:\n%s", got)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("session bead closed unexpectedly: metadata=%v", got.Metadata)
 	}
 }
 
@@ -3891,112 +3952,6 @@ func TestResolvePoolSlot_NamepoolThemedName(t *testing.T) {
 	if tp.PoolSlot == 0 {
 		t.Fatal("TemplateParams.PoolSlot should carry the slot from buildDesiredState")
 	}
-}
-
-func TestResolveResumeCommand(t *testing.T) {
-	tests := []struct {
-		name       string
-		command    string
-		sessionKey string
-		provider   *config.ResolvedProvider
-		want       string
-	}{
-		{
-			name:       "no resume flag → unchanged",
-			command:    "claude --dangerously-skip-permissions",
-			sessionKey: "abc-123",
-			provider:   &config.ResolvedProvider{},
-			want:       "claude --dangerously-skip-permissions",
-		},
-		{
-			name:       "flag style",
-			command:    "claude --dangerously-skip-permissions",
-			sessionKey: "abc-123",
-			provider:   &config.ResolvedProvider{ResumeFlag: "--resume"},
-			want:       "claude --dangerously-skip-permissions --resume abc-123",
-		},
-		{
-			name:       "subcommand style",
-			command:    "codex --model o3",
-			sessionKey: "def-456",
-			provider:   &config.ResolvedProvider{ResumeFlag: "resume", ResumeStyle: "subcommand"},
-			want:       "codex resume def-456 --model o3",
-		},
-		{
-			name:       "subcommand style no args",
-			command:    "codex",
-			sessionKey: "def-456",
-			provider:   &config.ResolvedProvider{ResumeFlag: "resume", ResumeStyle: "subcommand"},
-			want:       "codex resume def-456",
-		},
-		{
-			name:       "explicit resume_command takes precedence",
-			command:    "claude --dangerously-skip-permissions",
-			sessionKey: "abc-123",
-			provider: &config.ResolvedProvider{
-				ResumeFlag:    "--resume",
-				ResumeCommand: "claude --resume {{.SessionKey}} --dangerously-skip-permissions",
-			},
-			want: "claude --resume abc-123 --dangerously-skip-permissions",
-		},
-		{
-			name:       "resume_command without SessionKey placeholder",
-			command:    "my-agent",
-			sessionKey: "xyz",
-			provider: &config.ResolvedProvider{
-				ResumeCommand: "my-agent --continue",
-			},
-			want: "my-agent --continue",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := resolveResumeCommand(tt.command, tt.sessionKey, tt.provider)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestResolveSessionCommand(t *testing.T) {
-	claude := &config.ResolvedProvider{
-		ResumeFlag:    "--resume",
-		SessionIDFlag: "--session-id",
-	}
-
-	t.Run("first start uses --session-id", func(t *testing.T) {
-		got := resolveSessionCommand("claude --dangerously-skip-permissions", "abc-123", claude, true, false)
-		want := "claude --dangerously-skip-permissions --session-id abc-123"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-	})
-
-	t.Run("resume uses --resume", func(t *testing.T) {
-		got := resolveSessionCommand("claude --dangerously-skip-permissions", "abc-123", claude, false, false)
-		want := "claude --dangerously-skip-permissions --resume abc-123"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-	})
-
-	t.Run("fresh wake uses --session-id", func(t *testing.T) {
-		got := resolveSessionCommand("claude --dangerously-skip-permissions", "abc-123", claude, false, true)
-		want := "claude --dangerously-skip-permissions --session-id abc-123"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-	})
-
-	t.Run("first start without SessionIDFlag falls back to resume", func(t *testing.T) {
-		noSessionID := &config.ResolvedProvider{ResumeFlag: "--resume"}
-		got := resolveSessionCommand("agent run", "key-1", noSessionID, true, false)
-		want := "agent run --resume key-1"
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-	})
 }
 
 func TestDrainedIsKnownState(t *testing.T) {

--- a/cmd/gc/session_reconciler_trace_store.go
+++ b/cmd/gc/session_reconciler_trace_store.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -31,6 +32,8 @@ const (
 	sessionReconcilerTraceMaxAge           = 7 * 24 * time.Hour
 	sessionReconcilerTracePruneInterval    = 5 * time.Minute
 )
+
+var errTraceSegmentCorrupt = errors.New("trace segment corrupt")
 
 type SessionReconcilerTraceStore struct {
 	mu             sync.Mutex
@@ -612,6 +615,9 @@ func ReadTraceRecords(rootDir string, filter TraceFilter) ([]SessionReconcilerTr
 		for i := len(paths) - 1; i >= 0; i-- {
 			maxSeq, ok, scanErr := scanTraceSegment(paths[i])
 			if scanErr != nil {
+				if errors.Is(scanErr, errTraceSegmentCorrupt) {
+					continue
+				}
 				return nil, fmt.Errorf("reading trace file %s: %w", paths[i], scanErr)
 			}
 			if !ok {
@@ -631,6 +637,9 @@ func ReadTraceRecords(rootDir string, filter TraceFilter) ([]SessionReconcilerTr
 	for _, path := range paths {
 		fileRecords, _, err := readTraceRecordsFile(path, filter, true)
 		if err != nil {
+			if errors.Is(err, errTraceSegmentCorrupt) {
+				continue
+			}
 			return nil, fmt.Errorf("reading trace file %s: %w", path, err)
 		}
 		records = append(records, fileRecords...)
@@ -671,14 +680,14 @@ func readTraceRecordsFile(path string, filter TraceFilter, tolerateTail bool) ([
 			if tolerateTail && readErr == io.EOF {
 				break
 			}
-			return nil, 0, fmt.Errorf("unmarshal trace record %s: %w", path, parseErr)
+			return nil, 0, fmt.Errorf("%w: unmarshal trace record %s: %w", errTraceSegmentCorrupt, path, parseErr)
 		}
 		if rec.RecordType == TraceRecordBatchCommit {
 			if rec.RecordCount != len(batchRecords) {
-				return nil, 0, fmt.Errorf("trace batch %s: commit record_count=%d does not match buffered records=%d", path, rec.RecordCount, len(batchRecords))
+				return nil, 0, fmt.Errorf("%w: trace batch %s: commit record_count=%d does not match buffered records=%d", errTraceSegmentCorrupt, path, rec.RecordCount, len(batchRecords))
 			}
 			if rec.BatchCRC32 != batchCRC {
-				return nil, 0, fmt.Errorf("trace batch %s: crc32 mismatch", path)
+				return nil, 0, fmt.Errorf("%w: trace batch %s: crc32 mismatch", errTraceSegmentCorrupt, path)
 			}
 			for _, buffered := range batchRecords {
 				if matchesTraceFilter(buffered, filter) {

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -221,6 +221,61 @@ func TestTraceReaderFiltersAndRecoveryIgnoresTail(t *testing.T) {
 	}
 }
 
+func TestTraceReaderSkipsCorruptHistoricalSegment(t *testing.T) {
+	cityDir := t.TempDir()
+	store, err := newSessionReconcilerTraceStore(cityDir, io.Discard)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	decision := SessionReconcilerTraceRecord{
+		TraceSchemaVersion: sessionReconcilerTraceSchemaVersion,
+		TraceID:            "cycle-valid",
+		TickID:             "trace-valid",
+		RecordType:         TraceRecordDecision,
+		Template:           "repo/polecat",
+		SessionName:        "polecat-1",
+		SiteCode:           TraceSiteReconcilerWakeDecision,
+		TraceMode:          TraceModeDetail,
+		TraceSource:        TraceSourceManual,
+		Ts:                 time.Now().UTC(),
+	}
+	if err := store.AppendBatch([]SessionReconcilerTraceRecord{decision}, TraceDurabilityDurable); err != nil {
+		t.Fatalf("append batch: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	root := filepath.Join(cityDir, ".gc", "runtime", sessionReconcilerTraceRootDir)
+	corruptDir := filepath.Join(root, sessionReconcilerTraceSegments, "2026", "04", "28")
+	if err := os.MkdirAll(corruptDir, sessionReconcilerTraceOwnerDirPerm); err != nil {
+		t.Fatalf("mkdir corrupt segment dir: %v", err)
+	}
+	corruptPath := filepath.Join(corruptDir, "segment-999999.jsonl")
+	if err := os.WriteFile(corruptPath, []byte("{not-json\n"), sessionReconcilerTraceOwnerFilePerm); err != nil {
+		t.Fatalf("write corrupt segment: %v", err)
+	}
+
+	records, err := ReadTraceRecords(root, TraceFilter{})
+	if err != nil {
+		t.Fatalf("ReadTraceRecords: %v", err)
+	}
+	var found bool
+	for _, rec := range records {
+		if rec.TraceID == "cycle-valid" && rec.RecordType == TraceRecordDecision {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("valid trace record missing after corrupt segment skip: %#v", records)
+	}
+
+	if _, err := ReadTraceRecords(root, TraceFilter{SeqAfter: 1}); err != nil {
+		t.Fatalf("ReadTraceRecords(seq-after): %v", err)
+	}
+}
+
 func TestTraceAutoArmPromotesBufferedDetail(t *testing.T) {
 	cityDir := t.TempDir()
 	tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -232,6 +232,12 @@ func cancelSessionDrainForPending(session beads.Bead, sp runtime.Provider, dt *d
 	return cancelSessionDrainIf(session, sp, dt, pendingDrainReasonCancelable)
 }
 
+func cancelOrphanedSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
+	return cancelSessionDrainIf(session, sp, dt, func(reason string) bool {
+		return reason == "orphaned"
+	})
+}
+
 func cancelSessionDrainIf(session beads.Bead, sp runtime.Provider, dt *drainTracker, canCancel func(string) bool) bool {
 	ds := dt.get(session.ID)
 	if ds == nil {
@@ -449,6 +455,18 @@ func advanceSessionDrainsWithSessionsTraced(
 			}
 		}
 
+		if eval, ok := wakeEvals[session.ID]; ok &&
+			eval.Reason == "assigned-work" &&
+			containsWakeReason(eval.Reasons, WakeWork) &&
+			ds.reason == "orphaned" {
+			if cancelOrphanedSessionDrainForAssignedWork(*session, sp, dt) {
+				if trace != nil {
+					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplate(*session, cfg), name, ds.reason, "cancel_assigned_work", nil, nil, "")
+				}
+				continue
+			}
+		}
+
 		// Cancelation check: if wake reasons reappeared, cancel the in-memory
 		// drain. Orphaned, suspended, and ordinary config-drift drains are not
 		// canceled here.
@@ -476,8 +494,9 @@ func advanceSessionDrainsWithSessionsTraced(
 		//
 		// Uses the same GC_DRAIN_ACK env var that agents set via
 		// `gc runtime drain-ack`. The reconciler's Phase 1 drain-ack check
-		// sees it on the next tick and calls sp.Stop() for a clean
-		// SIGTERM/SIGKILL — no Ctrl-C keystroke injection into the pane.
+		// sees it on the next tick and routes the stop through the worker
+		// boundary for a clean SIGTERM/SIGKILL — no Ctrl-C keystroke injection
+		// into the pane.
 		if !ds.ackSet {
 			if os.Getenv("GC_TMUX_TRACE") == "1" {
 				log.Printf("[DRAIN-TRACE] advanceSessionDrains: setting GC_DRAIN_ACK session=%s reason=%s", name, ds.reason)

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -95,6 +95,9 @@ func TestPreWakeCommit(t *testing.T) {
 	if got.Metadata["last_woke_at"] == "" {
 		t.Error("expected last_woke_at to be set")
 	}
+	if got.Metadata["start_in_flight"] != "true" {
+		t.Errorf("start_in_flight = %q, want true", got.Metadata["start_in_flight"])
+	}
 	if got.Metadata["sleep_reason"] != "" {
 		t.Error("expected sleep_reason to be cleared")
 	}
@@ -1019,6 +1022,54 @@ func TestAdvanceSessionDrains_DeferredInterrupt_CanceledBeforeSignal(t *testing.
 		if c.Method == "Interrupt" {
 			t.Error("Interrupt (Ctrl-C) should never be sent — use GC_DRAIN_ACK instead")
 		}
+	}
+}
+
+func TestAdvanceSessionDrains_OrphanedDrainCanceledByAssignedWork(t *testing.T) {
+	now := time.Date(2026, 4, 29, 19, 18, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	dt := newDrainTracker()
+
+	_ = sp.Start(context.Background(), "worker-mc-1", runtime.Config{})
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":   "worker-mc-1",
+			"template":       "worker",
+			"session_origin": "ephemeral",
+			"pool_managed":   boolMetadata(true),
+			"generation":     "2",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	beginSessionDrain(session, sp, dt, "orphaned", clk, 30*time.Second)
+
+	wakeEvals := map[string]wakeEvaluation{
+		session.ID: {
+			Reasons: []WakeReason{WakeWork},
+			Reason:  "assigned-work",
+		},
+	}
+	advanceSessionDrainsWithSessions(dt, sp, store, func(id string) *beads.Bead {
+		got, _ := store.Get(id)
+		return &got
+	}, []beads.Bead{session}, wakeEvals, &config.City{}, nil, nil, nil, clk)
+
+	if dt.get(session.ID) != nil {
+		t.Fatal("orphaned drain should be canceled when direct assigned work appears")
+	}
+	ack, _ := sp.GetMeta("worker-mc-1", "GC_DRAIN_ACK")
+	if ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want unset after assigned-work cancel", ack)
+	}
+	if !sp.IsRunning("worker-mc-1") {
+		t.Fatal("session should remain running after assigned-work cancel")
 	}
 }
 

--- a/cmd/gc/worker_boundary_import_test.go
+++ b/cmd/gc/worker_boundary_import_test.go
@@ -40,6 +40,16 @@ func TestGCNonTestFilesStayOnWorkerBoundary(t *testing.T) {
 			"session.NewManagerWithCityPath(",
 			"session.NewManagerWithTransportResolverAndCityPath(",
 			"sp.Start(ctx,",
+			"sp.Stop(",
+			"sp.Attach(",
+			"sp.Nudge(",
+			"sp.NudgeNow(",
+			"sp.SendKeys(",
+			"sp.Interrupt(",
+			"sp.WaitForIdle(",
+			"sp.Pending(",
+			"sp.Respond(",
+			".StartResolved(",
 			"setBeadRestartRequested(",
 		} {
 			if strings.Contains(content, needle) {

--- a/cmd/gc/worker_handle.go
+++ b/cmd/gc/worker_handle.go
@@ -306,6 +306,61 @@ func workerHandleForSessionWithConfig(cityPath string, store beads.Store, sp run
 	return factory.SessionByID(id)
 }
 
+func workerHandleForPreparedStartWithConfig(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, item preparedStart) (worker.Handle, error) {
+	if item.candidate.session == nil {
+		return nil, session.ErrSessionNotFound
+	}
+	factory, err := workerFactoryWithConfig(cityPath, store, sp, cfg)
+	if err != nil {
+		return nil, err
+	}
+	meta := item.candidate.session.Metadata
+	tp := item.candidate.tp
+	resume := session.ProviderResume{
+		ResumeFlag:    meta["resume_flag"],
+		ResumeStyle:   meta["resume_style"],
+		ResumeCommand: meta["resume_command"],
+	}
+	provider := strings.TrimSpace(meta["provider"])
+	if tp.ResolvedProvider != nil {
+		resume = session.ProviderResume{
+			ResumeFlag:    tp.ResolvedProvider.ResumeFlag,
+			ResumeStyle:   tp.ResolvedProvider.ResumeStyle,
+			ResumeCommand: tp.ResolvedProvider.ResumeCommand,
+			SessionIDFlag: tp.ResolvedProvider.SessionIDFlag,
+		}
+		if provider == "" {
+			provider = strings.TrimSpace(tp.ResolvedProvider.Name)
+		}
+	}
+	if provider == "" {
+		provider = strings.TrimSpace(tp.TemplateName)
+	}
+	if provider == "" {
+		provider = firstCommandField(item.cfg.Command)
+	}
+	return factory.SessionForResolvedRuntime(worker.ResolvedSessionConfig{
+		ID:       item.candidate.session.ID,
+		Template: firstNonEmptyGCString(meta["template"], tp.TemplateName),
+		Title:    item.candidate.session.Title,
+		Runtime: worker.ResolvedRuntime{
+			Command:  item.cfg.Command,
+			WorkDir:  item.cfg.WorkDir,
+			Provider: provider,
+			Resume:   resume,
+			Hints:    item.cfg,
+		},
+	})
+}
+
+func firstCommandField(command string) string {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
 func workerHandleForSessionTargetWithConfig(cityPath string, store beads.Store, sp runtime.Provider, cfg *config.City, target string) (worker.Handle, error) {
 	return workerHandleForSessionTargetWithRuntimeHintsWithConfig(cityPath, store, sp, cfg, target, nil)
 }

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -102,11 +102,25 @@ type BdStore struct {
 	dir         string          // city root directory (where .beads/ lives)
 	runner      CommandRunner   // injectable for testing
 	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
+	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
 }
 
 // NewBdStore creates a BdStore rooted at dir using the given runner.
 func NewBdStore(dir string, runner CommandRunner) *BdStore {
-	return &BdStore{dir: dir, runner: runner}
+	return NewBdStoreWithPrefix(dir, runner, "")
+}
+
+// NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
+func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string) *BdStore {
+	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+}
+
+// IDPrefix returns the bead ID prefix owned by this store, without trailing "-".
+func (s *BdStore) IDPrefix() string {
+	if s == nil {
+		return ""
+	}
+	return s.idPrefix
 }
 
 // Init initializes a beads database via bd init --server. This is an admin

--- a/internal/beads/boundary_test.go
+++ b/internal/beads/boundary_test.go
@@ -53,7 +53,7 @@ func TestNoBdExecOutsideBeads(t *testing.T) {
 		}
 		if info.IsDir() {
 			base := filepath.Base(path)
-			if base == ".git" || base == "vendor" || base == ".claude" || strings.HasPrefix(base, ".beads-src") {
+			if base == ".git" || base == "vendor" || base == ".claude" || base == "worktrees" || base == "_wt" || strings.HasPrefix(base, ".beads-src") {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,17 +23,19 @@ import (
 //
 // Only wraps BdStore because the event hook path requires dolt/bd.
 type CachingStore struct {
-	backing Store // runtime: always *BdStore; tests may use MemStore
+	backing  Store // runtime: always *BdStore; tests may use MemStore
+	idPrefix string
 
-	mu          sync.RWMutex
-	beads       map[string]Bead
-	deps        map[string][]Dep
-	dirty       map[string]struct{}
-	beadSeq     map[string]uint64
-	deletedSeq  map[string]uint64
-	state       cacheState
-	lastFreshAt time.Time
-	mutationSeq uint64
+	mu           sync.RWMutex
+	beads        map[string]Bead
+	deps         map[string][]Dep
+	depsComplete bool
+	dirty        map[string]struct{}
+	beadSeq      map[string]uint64
+	deletedSeq   map[string]uint64
+	state        cacheState
+	lastFreshAt  time.Time
+	mutationSeq  uint64
 
 	reconciling  atomic.Bool
 	syncFailures int
@@ -84,18 +87,29 @@ const (
 // Only BdStore is supported because the event hook path (bd hooks ->
 // gc event emit -> event bus -> ApplyEvent) requires dolt infrastructure.
 func NewCachingStore(backing *BdStore, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, onChange)
+	prefix := ""
+	if backing != nil {
+		prefix = backing.IDPrefix()
+	}
+	return newCachingStore(backing, prefix, onChange)
 }
 
 // NewCachingStoreForTest wraps any Store for testing. Production code
 // must use NewCachingStore with a *BdStore.
 func NewCachingStoreForTest(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, onChange)
+	return newCachingStore(backing, "", onChange)
 }
 
-func newCachingStore(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+// NewCachingStoreForTestWithPrefix wraps any Store for tests that need
+// production-style bead ID ownership filtering.
+func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+	return newCachingStore(backing, idPrefix, onChange)
+}
+
+func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:    backing,
+		idPrefix:   normalizeIDPrefix(idPrefix),
 		beads:      make(map[string]Bead),
 		deps:       make(map[string][]Dep),
 		dirty:      make(map[string]struct{}),
@@ -106,6 +120,18 @@ func newCachingStore(backing Store, onChange func(eventType, beadID string, payl
 			log.Printf("beads cache: %s", msg)
 		},
 	}
+}
+
+func normalizeIDPrefix(prefix string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(prefix)), "-")
+}
+
+func (c *CachingStore) ownsBeadID(id string) bool {
+	if c.idPrefix == "" {
+		return true
+	}
+	id = strings.ToLower(strings.TrimSpace(id))
+	return strings.HasPrefix(id, c.idPrefix+"-")
 }
 
 func (c *CachingStore) noteMutationLocked(ids ...string) uint64 {
@@ -151,6 +177,7 @@ func (c *CachingStore) PrimeActive() error {
 			}
 		}
 		c.beads[b.ID] = cloneBead(b)
+		c.deps[b.ID] = cloneDeps(b.Dependencies)
 		delete(c.deletedSeq, b.ID)
 	}
 	if c.state == cacheUninitialized {
@@ -190,7 +217,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 		beadMap[b.ID] = cloneBead(b)
 	}
 
-	depMap, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
 	if depErr != nil {
 		c.recordProblem("prime dep cache", depErr)
 	}
@@ -200,7 +227,8 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	defer c.mu.Unlock()
 	if c.mutationSeq == startSeq {
 		c.beads = beadMap
-		c.deps = depMap
+		c.deps = depsFromBeads(beadMap, depMap, depsComplete && depErr == nil)
+		c.depsComplete = depsComplete && depErr == nil
 		c.dirty = make(map[string]struct{})
 		c.beadSeq = make(map[string]uint64)
 		c.deletedSeq = make(map[string]uint64)
@@ -215,10 +243,13 @@ func (c *CachingStore) Prime(_ context.Context) error {
 			c.beads[id] = b
 			delete(c.deletedSeq, id)
 			delete(c.beadSeq, id)
-			if deps, ok := depMap[id]; ok {
-				c.deps[id] = deps
+			if depsComplete && depErr == nil {
+				c.deps[id] = cloneDeps(depMap[id])
+			} else {
+				c.deps[id] = cloneDeps(b.Dependencies)
 			}
 		}
+		c.depsComplete = false
 	}
 	c.state = cacheLive
 	c.syncFailures = 0
@@ -259,6 +290,13 @@ func (c *CachingStore) Stats() CacheStats {
 		s.State = "uninitialized"
 	}
 	return s
+}
+
+// MutationSeq returns the in-memory cache mutation sequence.
+func (c *CachingStore) MutationSeq() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mutationSeq
 }
 
 // IsLive reports whether reads are served from the cache.
@@ -316,31 +354,36 @@ func beadIDs(beadMap map[string]Bead) []string {
 	return ids
 }
 
-func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, error) {
+func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, bool, error) {
 	depMap := make(map[string][]Dep)
 	if len(ids) == 0 {
-		return depMap, nil
+		return depMap, true, nil
 	}
 
-	if bdStore, ok := c.backing.(*BdStore); ok {
-		batchDeps, err := bdStore.DepListBatch(ids)
-		if err != nil {
-			return depMap, err
-		}
-		for id, deps := range batchDeps {
-			depMap[id] = cloneDeps(deps)
-		}
-		return depMap, nil
+	if _, ok := c.backing.(*BdStore); ok {
+		return depMap, false, nil
 	}
 
 	for _, id := range ids {
 		deps, err := c.backing.DepList(id, "down")
 		if err != nil {
-			return depMap, fmt.Errorf("listing deps for %s: %w", id, err)
+			return depMap, false, fmt.Errorf("listing deps for %s: %w", id, err)
 		}
 		depMap[id] = cloneDeps(deps)
 	}
-	return depMap, nil
+	return depMap, true, nil
+}
+
+func depsFromBeads(beadMap map[string]Bead, depMap map[string][]Dep, useDepMap bool) map[string][]Dep {
+	deps := make(map[string][]Dep, len(beadMap))
+	for id, b := range beadMap {
+		if useDepMap {
+			deps[id] = cloneDeps(depMap[id])
+			continue
+		}
+		deps[id] = cloneDeps(b.Dependencies)
+	}
+	return deps
 }
 
 func cloneDeps(deps []Dep) []Dep {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -2,7 +2,6 @@ package beads
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -23,27 +22,21 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		c.recordProblem(fmt.Sprintf("apply %s event", eventType), err)
 		return
 	}
+	if !c.ownsBeadID(patch.ID) {
+		return
+	}
 
 	c.mu.RLock()
-	if c.state != cacheLive {
+	if c.state != cacheLive && c.state != cachePartial {
 		c.mu.RUnlock()
 		return
 	}
-	_, cached := c.beads[patch.ID]
 	c.mu.RUnlock()
 
 	b := patch
-	if !cached {
-		if fresh, err := c.backing.Get(patch.ID); err == nil {
-			b = fresh
-		} else if !errors.Is(err, ErrNotFound) {
-			c.recordProblem(fmt.Sprintf("refresh %s event", eventType), err)
-		}
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.state != cacheLive {
+	if c.state != cacheLive && c.state != cachePartial {
 		return
 	}
 	if current, ok := c.beads[patch.ID]; ok {
@@ -56,6 +49,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		if _, exists := c.beads[b.ID]; !exists {
 			c.noteMutationLocked(b.ID)
 			c.beads[b.ID] = cloneBead(b)
+			c.updateEventDepsLocked(b, fields)
 			delete(c.dirty, b.ID)
 			delete(c.deletedSeq, b.ID)
 		}
@@ -64,6 +58,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	case "bead.updated":
 		c.noteMutationLocked(b.ID)
 		c.beads[b.ID] = cloneBead(b)
+		c.updateEventDepsLocked(b, fields)
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
@@ -73,6 +68,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			c.updateStatsLocked()
 		}
 		c.beads[b.ID] = cloneBead(b)
+		c.updateEventDepsLocked(b, fields)
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
@@ -85,12 +81,24 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	}
 }
 
+func (c *CachingStore) updateEventDepsLocked(b Bead, fields map[string]json.RawMessage) {
+	if hasCacheEventField(fields, "dependencies") {
+		c.deps[b.ID] = cloneDeps(b.Dependencies)
+		return
+	}
+	if _, ok := c.deps[b.ID]; ok {
+		return
+	}
+	delete(c.deps, b.ID)
+	c.depsComplete = false
+}
+
 // ApplyDepEvent updates the dep cache for a bead. Call after dep
 // mutations are detected via events or write-through.
 func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.state != cacheLive {
+	if c.state != cacheLive && c.state != cachePartial {
 		return
 	}
 	c.noteMutationLocked(beadID)

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -780,3 +780,50 @@ func TestCachingStoreRunReconciliationDoesNotEmitBeadClosedForAlreadyClosedCache
 		}
 	}
 }
+
+func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
+	t.Parallel()
+
+	var depListCalls int
+	var readyCalls int
+	issueJSON := []byte(`[{
+		"id":"bd-1",
+		"title":"task",
+		"status":"open",
+		"issue_type":"task",
+		"created_at":"2026-01-01T00:00:00Z",
+		"labels":["task"],
+		"metadata":{}
+	}]`)
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) > 0 && args[0] == "dep" {
+			depListCalls++
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		if len(args) > 0 && args[0] == "ready" {
+			readyCalls++
+			return issueJSON, nil
+		}
+		if len(args) > 0 && args[0] == "list" {
+			return issueJSON, nil
+		}
+		return []byte(`[]`), nil
+	}
+	cache := NewCachingStore(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	cache.runReconciliation()
+	if depListCalls != 0 {
+		t.Fatalf("dep list calls = %d, want 0", depListCalls)
+	}
+	if _, err := cache.Ready(); err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if readyCalls != 1 {
+		t.Fatalf("Ready calls = %d, want backing Ready fallback when deps are incomplete", readyCalls)
+	}
+}

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -143,6 +143,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			continue
 		}
 		c.beads[item.ID] = cloneBead(item)
+		c.deps[item.ID] = cloneDeps(item.Dependencies)
 		delete(c.dirty, item.ID)
 		delete(c.deletedSeq, item.ID)
 		delete(c.beadSeq, item.ID)
@@ -155,6 +156,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			continue
 		}
 		c.beads[id] = bead
+		c.deps[id] = cloneDeps(bead.Dependencies)
 		delete(c.dirty, id)
 		delete(c.deletedSeq, id)
 		delete(c.beadSeq, id)
@@ -245,6 +247,7 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 				return Bead{}, ErrNotFound
 			}
 			c.beads[id] = cloneBead(fresh)
+			c.deps[id] = cloneDeps(fresh.Dependencies)
 			delete(c.dirty, id)
 			delete(c.deletedSeq, id)
 			delete(c.beadSeq, id)
@@ -267,7 +270,7 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 // Ready returns open beads whose blocking deps are all closed.
 func (c *CachingStore) Ready() ([]Bead, error) {
 	c.mu.RLock()
-	if c.state == cacheLive {
+	if c.state == cacheLive && c.depsComplete {
 		if len(c.dirty) > 0 {
 			c.mu.RUnlock()
 			return c.backing.Ready()
@@ -309,6 +312,56 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 	}
 	c.mu.RUnlock()
 	return c.backing.Ready()
+}
+
+// CachedReady returns ready beads from the in-memory active read model.
+// The boolean reports whether the cache was initialized enough to answer
+// without touching the backing store. Unlike Ready, this can answer from a
+// partial active cache only when each open bead has known dependency coverage.
+func (c *CachingStore) CachedReady() ([]Bead, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return nil, false
+	}
+	statusByID := make(map[string]string, len(c.beads))
+	openBeads := make([]Bead, 0, len(c.beads))
+	for _, b := range c.beads {
+		statusByID[b.ID] = b.Status
+		if b.Status == "open" && !IsReadyExcludedType(b.Type) {
+			openBeads = append(openBeads, cloneBead(b))
+		}
+	}
+	result := make([]Bead, 0, len(openBeads))
+	for _, b := range openBeads {
+		deps, ok := c.deps[b.ID]
+		switch {
+		case ok:
+			// Per-bead dependency coverage is known, even when the slice is nil.
+		case c.depsComplete:
+			deps = nil
+		default:
+			return nil, false
+		}
+		if cachedBeadReady(statusByID, deps) {
+			result = append(result, cloneBead(b))
+		}
+	}
+	return result, true
+}
+
+func cachedBeadReady(statusByID map[string]string, deps []Dep) bool {
+	for _, dep := range deps {
+		switch dep.Type {
+		case "blocks", "waits-for", "conditional-blocks":
+		default:
+			continue
+		}
+		if status, ok := statusByID[dep.DependsOnID]; ok && status != "closed" {
+			return false
+		}
+	}
+	return true
 }
 
 // Children returns beads with the given parent ID.

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -85,10 +85,11 @@ func (c *CachingStore) runReconciliation() {
 		freshByID[b.ID] = cloneBead(b)
 	}
 
-	depMap, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
 	if depErr != nil {
 		c.recordProblem("refresh dep cache during reconcile", depErr)
 	}
+	useFreshDeps := depsComplete && depErr == nil
 
 	c.mu.Lock()
 	if c.mutationSeq != startSeq {
@@ -114,7 +115,7 @@ func (c *CachingStore) runReconciliation() {
 					eventType: "bead.updated",
 					bead:      cloneBead(freshBead),
 				})
-			case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+			case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
 				updates++
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.updated",
@@ -123,8 +124,10 @@ func (c *CachingStore) runReconciliation() {
 			}
 
 			c.beads[id] = cloneBead(freshBead)
-			if depErr == nil {
+			if useFreshDeps {
 				c.deps[id] = cloneDeps(depMap[id])
+			} else {
+				c.deps[id] = cloneDeps(freshBead.Dependencies)
 			}
 			delete(c.dirty, id)
 			delete(c.deletedSeq, id)
@@ -155,6 +158,7 @@ func (c *CachingStore) runReconciliation() {
 		}
 
 		c.syncFailures = 0
+		c.depsComplete = c.depsComplete && useFreshDeps
 		if c.state == cacheDegraded {
 			c.state = cacheLive
 		}
@@ -177,10 +181,10 @@ func (c *CachingStore) runReconciliation() {
 	nextDeps := make(map[string][]Dep, len(freshByID))
 
 	for id, freshBead := range freshByID {
-		if depErr == nil {
+		if useFreshDeps {
 			nextDeps[id] = cloneDeps(depMap[id])
-		} else if deps, ok := c.deps[id]; ok {
-			nextDeps[id] = cloneDeps(deps)
+		} else {
+			nextDeps[id] = cloneDeps(freshBead.Dependencies)
 		}
 
 		old, exists := c.beads[id]
@@ -197,7 +201,7 @@ func (c *CachingStore) runReconciliation() {
 				eventType: "bead.updated",
 				bead:      cloneBead(freshBead),
 			})
-		case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+		case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
 			updates++
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.updated",
@@ -223,6 +227,7 @@ func (c *CachingStore) runReconciliation() {
 
 	c.beads = freshByID
 	c.deps = nextDeps
+	c.depsComplete = useFreshDeps
 	c.dirty = make(map[string]struct{})
 	c.beadSeq = make(map[string]uint64)
 	c.deletedSeq = make(map[string]uint64)

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -706,6 +706,21 @@ func (s *countingGetStore) getCount() int {
 	return s.gets
 }
 
+type staticListStore struct {
+	beads.Store
+	items []beads.Bead
+}
+
+func (s *staticListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	var out []beads.Bead
+	for _, item := range s.items {
+		if query.Matches(item) {
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+
 func TestCachingStoreReadyTreatsMissingDepTargetAsClosedWithoutBackingGet(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
@@ -740,6 +755,119 @@ func TestCachingStoreReadyTreatsMissingDepTargetAsClosedWithoutBackingGet(t *tes
 	}
 	if gets := backing.getCount(); gets != 0 {
 		t.Fatalf("Ready() performed %d backing Get calls, want 0", gets)
+	}
+}
+
+func TestCachingStoreCachedReadyUsesEmbeddedDependencies(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	blocker := beads.Bead{ID: "gc-1", Title: "Blocker", Status: "open", Type: "task", CreatedAt: now}
+	blocked := beads.Bead{
+		ID:        "gc-2",
+		Title:     "Blocked",
+		Status:    "open",
+		Type:      "task",
+		CreatedAt: now.Add(time.Second),
+		Dependencies: []beads.Dep{{
+			IssueID:     "gc-2",
+			DependsOnID: "gc-1",
+			Type:        "blocks",
+		}},
+	}
+	ready := beads.Bead{ID: "gc-3", Title: "Ready", Status: "open", Type: "task", CreatedAt: now.Add(2 * time.Second)}
+
+	cache := beads.NewCachingStoreForTest(&staticListStore{
+		Store: beads.NewMemStore(),
+		items: []beads.Bead{blocker, blocked, ready},
+	}, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	got, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(got) != 2 {
+		t.Fatalf("CachedReady len = %d, want blocker and ready: %+v", len(got), got)
+	}
+	ids := map[string]bool{}
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids[blocker.ID] || !ids[ready.ID] || ids[blocked.ID] {
+		t.Fatalf("CachedReady ids = %v, want blocker and ready only", ids)
+	}
+}
+
+func TestCachingStoreCachedReadyUsesWriteThroughDependencies(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	blocked, err := mem.Create(beads.Bead{Title: "Blocked"})
+	if err != nil {
+		t.Fatalf("Create(blocked): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := cache.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	got, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	ids := map[string]bool{}
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids[blocker.ID] || ids[blocked.ID] {
+		t.Fatalf("CachedReady ids = %v, want blocker only", ids)
+	}
+}
+
+func TestCachingStoreCachedReadyUnavailableForUnknownEventDependencies(t *testing.T) {
+	t.Parallel()
+	cache := beads.NewCachingStoreForTest(beads.NewMemStore(), nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-1","title":"Event task","status":"open","issue_type":"task"}`))
+
+	if ready, ok := cache.CachedReady(); ok {
+		t.Fatalf("CachedReady ok with unknown event dependency coverage, ready=%v", ready)
+	}
+}
+
+func TestCachingStoreCachedReadyUnavailableForUnknownEventDependenciesAfterFullPrime(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	if _, err := mem.Create(beads.Bead{ID: "gc-1", Title: "Primed task", Type: "task", Status: "open"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-2","title":"Event task","status":"open","issue_type":"task"}`))
+
+	if ready, ok := cache.CachedReady(); ok {
+		t.Fatalf("CachedReady ok with unknown event dependency coverage after full prime, ready=%v", ready)
+	}
+	cache.ApplyDepEvent("gc-2", nil)
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady should recover after event dependency coverage becomes known")
+	}
+	if len(ready) != 2 {
+		t.Fatalf("CachedReady len = %d, want both ready beads: %+v", len(ready), ready)
 	}
 }
 
@@ -779,6 +907,46 @@ func TestCachingStoreListPartialAllowScanReturnsCompleteActiveSnapshot(t *testin
 	}
 	if got[0].ID != openBead.ID || got[1].ID != inProgress.ID {
 		t.Fatalf("List(AllowScan) IDs = [%s %s], want [%s %s]", got[0].ID, got[1].ID, openBead.ID, inProgress.ID)
+	}
+}
+
+func TestCachingStoreApplyEventUpdatesPartialCache(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	created, err := mem.Create(beads.Bead{Title: "Open"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cs := beads.NewCachingStoreForTest(mem, nil)
+	if err := cs.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if cs.IsLive() {
+		t.Fatal("cache should be partial after PrimeActive")
+	}
+
+	updatedTitle := "claimed externally"
+	payload, err := json.Marshal(beads.Bead{
+		ID:     created.ID,
+		Title:  updatedTitle,
+		Status: "in_progress",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	cs.ApplyEvent("bead.updated", payload)
+
+	items, err := cs.List(beads.ListQuery{Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("List(in_progress): %v", err)
+	}
+	if len(items) != 1 || items[0].ID != created.ID {
+		t.Fatalf("List(in_progress) = %#v, want updated bead %s", items, created.ID)
+	}
+	if items[0].Title != updatedTitle {
+		t.Fatalf("Title = %q, want %q", items[0].Title, updatedTitle)
 	}
 }
 

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -22,6 +22,7 @@ func (c *CachingStore) Create(b Bead) (Bead, error) {
 	c.mu.Lock()
 	c.noteMutationLocked(created.ID)
 	c.beads[created.ID] = cloneBead(created)
+	c.deps[created.ID] = cloneDeps(created.Dependencies)
 	delete(c.dirty, created.ID)
 	delete(c.deletedSeq, created.ID)
 	c.markFreshLocked(time.Now())
@@ -52,6 +53,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 	c.mu.Lock()
 	c.noteMutationLocked(id)
 	c.beads[id] = cloneBead(fresh)
+	c.deps[id] = cloneDeps(fresh.Dependencies)
 	delete(c.dirty, id)
 	delete(c.deletedSeq, id)
 	c.markFreshLocked(time.Now())
@@ -140,6 +142,7 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 	for _, item := range refreshed {
 		previous, hadPrevious := c.beads[item.id]
 		c.beads[item.id] = cloneBead(item.bead)
+		c.deps[item.id] = cloneDeps(item.bead.Dependencies)
 		delete(c.dirty, item.id)
 		delete(c.deletedSeq, item.id)
 		if item.bead.Status == "closed" {

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -599,6 +599,40 @@ func TestReadLatestSeqEmpty(t *testing.T) {
 	}
 }
 
+func TestReadLatestSeqUsesTailOfAppendOnlyLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	hugeMalformed := append(bytes.Repeat([]byte("x"), 2*1024*1024), '\n')
+	validTail := []byte(`{"seq":42,"type":"bead.updated","ts":"2026-01-01T00:00:00Z","actor":"test"}` + "\n")
+	if err := os.WriteFile(path, append(hugeMalformed, validTail...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	seq, err := ReadLatestSeq(path)
+	if err != nil {
+		t.Fatalf("ReadLatestSeq: %v", err)
+	}
+	if seq != 42 {
+		t.Fatalf("ReadLatestSeq = %d, want 42", seq)
+	}
+
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatalf("NewFileRecorder: %v", err)
+	}
+	rec.Record(Event{Type: BeadClosed, Actor: "test"})
+	rec.Close() //nolint:errcheck // test cleanup
+
+	seq, err = ReadLatestSeq(path)
+	if err != nil {
+		t.Fatalf("ReadLatestSeq(after record): %v", err)
+	}
+	if seq != 43 {
+		t.Fatalf("ReadLatestSeq(after record) = %d, want 43", seq)
+	}
+}
+
 func TestReadFrom(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
@@ -800,6 +834,59 @@ func TestFileRecorderWatch(t *testing.T) {
 	}
 	if e.Type != BeadClosed {
 		t.Errorf("Type = %q, want %q", e.Type, BeadClosed)
+	}
+}
+
+func TestFileRecorderWatchAfterLatestStartsAtEOF(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "gc-1"})
+	rec.Record(Event{Type: BeadUpdated, Actor: "human", Subject: "gc-1"})
+	seq, err := rec.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, seq)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	fw, ok := w.(*fileWatcher)
+	if !ok {
+		t.Fatalf("Watch returned %T, want *fileWatcher", w)
+	}
+	if fw.offset != info.Size() {
+		t.Fatalf("watch offset = %d, want EOF %d", fw.offset, info.Size())
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "gc-1"})
+	}()
+	e, err := w.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if e.Seq != seq+1 {
+		t.Fatalf("Seq = %d, want %d", e.Seq, seq+1)
+	}
+	if e.Type != BeadClosed {
+		t.Fatalf("Type = %q, want %q", e.Type, BeadClosed)
 	}
 }
 

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -73,8 +74,10 @@ func ReadFiltered(path string, filter Filter) ([]Event, error) {
 	return result, nil
 }
 
-// ReadLatestSeq returns the highest Seq in the events file, or 0 if
-// the file is missing or empty.
+// ReadLatestSeq returns the latest complete event Seq in the events file, or
+// 0 if the file is missing or empty. Event logs are append-only and sequence
+// numbers are monotonic, so this reads backward from the tail instead of
+// parsing historical events on every recorder open.
 func ReadLatestSeq(path string) (uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -85,19 +88,89 @@ func ReadLatestSeq(path string) (uint64, error) {
 	}
 	defer f.Close() //nolint:errcheck // read-only file
 
-	var maxSeq uint64
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // handle lines up to 1MB
-	for scanner.Scan() {
-		var e Event
-		if json.Unmarshal(scanner.Bytes(), &e) == nil && e.Seq > maxSeq {
-			maxSeq = e.Seq
+	info, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat events: %w", err)
+	}
+	return readLatestSeqFromTail(f, info.Size())
+}
+
+func readLatestSeqFromTail(f *os.File, size int64) (uint64, error) {
+	if size <= 0 {
+		return 0, nil
+	}
+	const chunkSize int64 = 64 * 1024
+	var suffix []byte
+	end := size
+	first := true
+	for end > 0 {
+		n := chunkSize
+		if end < n {
+			n = end
+		}
+		start := end - n
+		chunk := make([]byte, n)
+		if _, err := f.ReadAt(chunk, start); err != nil && err != io.EOF {
+			return 0, fmt.Errorf("reading latest seq: %w", err)
+		}
+		data := make([]byte, 0, len(chunk)+len(suffix))
+		data = append(data, chunk...)
+		data = append(data, suffix...)
+		searchEnd := len(data)
+		if first && len(data) > 0 && data[len(data)-1] != '\n' {
+			idx := bytes.LastIndexByte(data, '\n')
+			if idx < 0 {
+				suffix = data
+				end = start
+				first = false
+				continue
+			}
+			searchEnd = idx
+		}
+		searchStart := 0
+		if start > 0 {
+			idx := bytes.IndexByte(data, '\n')
+			if idx < 0 {
+				suffix = data
+				end = start
+				first = false
+				continue
+			}
+			searchStart = idx + 1
+		}
+		if seq, ok := latestSeqInCompleteLines(data[searchStart:searchEnd]); ok {
+			return seq, nil
+		}
+		suffix = data
+		end = start
+		first = false
+	}
+	return 0, nil
+}
+
+func latestSeqInCompleteLines(data []byte) (uint64, bool) {
+	for len(data) > 0 {
+		idx := bytes.LastIndexByte(data, '\n')
+		var line []byte
+		if idx >= 0 {
+			line = data[idx+1:]
+			data = data[:idx]
+		} else {
+			line = data
+			data = nil
+		}
+		line = bytes.TrimSuffix(line, []byte{'\r'})
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var header struct {
+			Seq uint64 `json:"seq"`
+		}
+		if err := json.Unmarshal(line, &header); err == nil && header.Seq > 0 {
+			return header.Seq, true
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return maxSeq, fmt.Errorf("scanning events: %w", err)
-	}
-	return maxSeq, nil
+	return 0, false
 }
 
 // ReadFrom reads events starting at the given byte offset in the file.

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -26,30 +25,17 @@ type FileRecorder struct {
 	closed bool
 }
 
-// NewFileRecorder opens (or creates) the event log at path. It scans any
-// existing file to find the maximum sequence number so new events continue
+// NewFileRecorder opens (or creates) the event log at path. It reads the tail
+// sequence from any existing append-only log so new events continue
 // monotonically. Parent directories are created as needed.
 func NewFileRecorder(path string, stderr io.Writer) (*FileRecorder, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("creating event log directory: %w", err)
 	}
 
-	// Scan existing file for max seq before opening for append.
-	var maxSeq uint64
-	if f, err := os.Open(path); err == nil {
-		scanner := bufio.NewScanner(f)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // handle lines up to 1MB
-		for scanner.Scan() {
-			var e Event
-			if json.Unmarshal(scanner.Bytes(), &e) == nil && e.Seq > maxSeq {
-				maxSeq = e.Seq
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			f.Close() //nolint:errcheck // closing after scan error
-			return nil, fmt.Errorf("scanning event log: %w", err)
-		}
-		f.Close() //nolint:errcheck // read-only scan
+	maxSeq, err := ReadLatestSeq(path)
+	if err != nil {
+		return nil, err
 	}
 
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
@@ -107,11 +93,20 @@ func (r *FileRecorder) LatestSeq() (uint64, error) {
 
 // Watch returns a Watcher that polls the event file for new events.
 func (r *FileRecorder) Watch(ctx context.Context, afterSeq uint64) (Watcher, error) {
+	var offset int64
+	r.mu.Lock()
+	if afterSeq >= r.seq {
+		if info, err := r.file.Stat(); err == nil {
+			offset = info.Size()
+		}
+	}
+	r.mu.Unlock()
 	return &fileWatcher{
 		path:     r.path,
 		afterSeq: afterSeq,
 		ctx:      ctx,
 		poll:     250 * time.Millisecond,
+		offset:   offset,
 		done:     make(chan struct{}),
 	}, nil
 }

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -1,9 +1,11 @@
 package session
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -197,6 +199,13 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 	transport, transportVerified := m.transportForBead(b, sessName)
 	unroute := m.routeACPIfNeeded(b.Metadata["provider"], transport, sessName)
 	if State(b.Metadata["state"]) != StateSuspended && m.sp.IsRunning(sessName) {
+		if runtimeSessionOwnershipConflict(m.sp, sessName, id, b.Metadata["instance_token"]) ||
+			(strictRuntimeOwnershipRequired(b) && !runtimeSessionMatchesBead(m.sp, sessName, id, b.Metadata["instance_token"])) {
+			if unroute != nil {
+				unroute()
+			}
+			return fmt.Errorf("%w: %q already active in runtime", ErrSessionNameExists, sessName)
+		}
 		if b.Metadata["transport"] == "" && transportVerified {
 			m.persistTransport(id, b.Metadata["provider"], transport)
 		}
@@ -249,16 +258,25 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 	cfg = runtime.SyncWorkDirEnv(cfg)
 	started := false
 	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
-		if errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "" {
+		switch {
+		case errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "":
 			retried, err := m.retryFreshStartAfterStaleKey(ctx, id, &b, sessName, resumeCommand, cfg, unroute)
 			if err != nil {
 				return err
 			}
 			started = retried
-		} else if !errors.Is(err, runtime.ErrSessionExists) || !m.sp.IsRunning(sessName) {
-			// Another caller may have resumed the same session after we loaded the
-			// bead but before we reached Start. If the runtime is already up, treat
+		case errors.Is(err, runtime.ErrSessionExists) && m.sp.IsRunning(sessName):
+			if runtimeSessionOwnershipConflict(m.sp, sessName, id, b.Metadata["instance_token"]) ||
+				(strictRuntimeOwnershipRequired(b) && !runtimeSessionMatchesBead(m.sp, sessName, id, b.Metadata["instance_token"])) {
+				if unroute != nil {
+					unroute()
+				}
+				return fmt.Errorf("%w: %q already active in runtime", ErrSessionNameExists, sessName)
+			}
+			// Another caller may have resumed the same bead after we loaded it but
+			// before we reached Start. If runtime metadata proves ownership, treat
 			// the resume as converged and only persist active state below.
+		default:
 			if unroute != nil {
 				unroute()
 			}
@@ -307,104 +325,22 @@ func (m *Manager) ensureRunning(ctx context.Context, id string, b beads.Bead, se
 	return nil
 }
 
-func (m *Manager) ensureRunningRuntimeOnly(ctx context.Context, id string, b beads.Bead, sessName, resumeCommand string, hints runtime.Config) error {
-	transport, _ := m.transportForBead(b, sessName)
-	unroute := m.routeACPIfNeeded(b.Metadata["provider"], transport, sessName)
-	if m.sp.IsRunning(sessName) {
-		return nil
-	}
-	if resumeCommand == "" {
-		return fmt.Errorf("%w: %s", ErrResumeRequired, id)
-	}
-
-	cfg := hints
-	cfg.Command = resumeCommand
-	if cfg.WorkDir == "" {
-		cfg.WorkDir = b.Metadata["work_dir"]
-	}
-	generation, err := strconv.Atoi(b.Metadata["generation"])
-	if err != nil || generation <= 0 {
-		generation = DefaultGeneration
-	}
-	continuationEpoch, err := strconv.Atoi(b.Metadata["continuation_epoch"])
-	if err != nil || continuationEpoch <= 0 {
-		continuationEpoch = DefaultContinuationEpoch
-	}
-	instanceToken := b.Metadata["instance_token"]
-	if instanceToken == "" {
-		instanceToken = NewInstanceToken()
-		if err := m.store.SetMetadata(id, "instance_token", instanceToken); err != nil {
-			return fmt.Errorf("storing instance token: %w", err)
-		}
-		if b.Metadata == nil {
-			b.Metadata = make(map[string]string)
-		}
-		b.Metadata["instance_token"] = instanceToken
-	}
-	cfg.Env = mergeEnv(cfg.Env, RuntimeEnvWithSessionContext(
-		id,
-		sessName,
-		strings.TrimSpace(b.Metadata["alias"]),
-		strings.TrimSpace(b.Metadata["template"]),
-		strings.TrimSpace(b.Metadata["session_origin"]),
-		generation,
-		continuationEpoch,
-		instanceToken,
-	))
-	if gcProvider := strings.TrimSpace(b.Metadata["provider_kind"]); gcProvider != "" {
-		cfg.Env = mergeEnv(cfg.Env, map[string]string{"GC_PROVIDER": gcProvider})
-	} else if provider := strings.TrimSpace(b.Metadata["provider"]); provider != "" {
-		cfg.Env = mergeEnv(cfg.Env, map[string]string{"GC_PROVIDER": provider})
-	}
-	cfg = runtime.SyncWorkDirEnv(cfg)
-	started := false
-	if err := m.sp.Start(ctx, sessName, cfg); err != nil {
-		switch {
-		case errors.Is(err, runtime.ErrSessionDiedDuringStartup) && b.Metadata["session_key"] != "":
-			retried, err := m.retryFreshStartAfterStaleKey(ctx, id, &b, sessName, resumeCommand, cfg, unroute)
-			if err != nil {
-				return err
-			}
-			started = retried
-		case errors.Is(err, runtime.ErrSessionExists) && m.sp.IsRunning(sessName):
-			return err
-		default:
-			if unroute != nil {
-				unroute()
-			}
-			return fmt.Errorf("resuming session: %w", err)
-		}
-	} else {
-		started = true
-	}
-	if started && b.Metadata["session_key"] != "" {
-		if err := sleepWithContext(ctx, staleKeyDetectDelay); err != nil {
-			if unroute != nil {
-				unroute()
-			}
-			return err
-		}
-		if !m.sp.IsRunning(sessName) {
-			if _, err := m.retryFreshStartAfterStaleKey(ctx, id, &b, sessName, resumeCommand, cfg, unroute); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func (m *Manager) confirmLiveSessionState(id string, b *beads.Bead) error {
 	if b == nil {
 		return nil
 	}
 	batch := make(map[string]string)
-	switch State(b.Metadata["state"]) {
+	state := State(strings.TrimSpace(b.Metadata["state"]))
+	needsTransition := false
+	switch state {
 	case "", StateCreating, StateAsleep, StateSuspended:
-		batch["state"] = string(StateActive)
-		batch["state_reason"] = "creation_complete"
+		needsTransition = true
 	}
-	if strings.TrimSpace(b.Metadata["pending_create_claim"]) != "" {
-		batch["pending_create_claim"] = ""
+	needsCleanup := strings.TrimSpace(b.Metadata["pending_create_claim"]) != "" ||
+		strings.TrimSpace(b.Metadata["start_in_flight"]) != "" ||
+		strings.TrimSpace(b.Metadata["sleep_reason"]) != ""
+	if needsTransition || ((state == StateActive || state == StateAwake) && needsCleanup) {
+		batch = ConfirmStartedPatch(time.Now())
 	}
 	if len(batch) == 0 {
 		return nil
@@ -630,20 +566,6 @@ func (m *Manager) Start(ctx context.Context, id, resumeCommand string, hints run
 	})
 }
 
-// StartRuntimeOnly brings the runtime live for a bead-backed session without
-// mutating persisted lifecycle metadata. Legacy reconciler callers use this
-// bridge while they still own commit/rollback bookkeeping above the worker
-// boundary.
-func (m *Manager) StartRuntimeOnly(ctx context.Context, id, resumeCommand string, hints runtime.Config) error {
-	return withSessionMutationLock(id, func() error {
-		b, sessName, err := m.sessionBead(id)
-		if err != nil {
-			return err
-		}
-		return m.ensureRunningRuntimeOnly(ctx, id, b, sessName, resumeCommand, hints)
-	})
-}
-
 // Send resumes a suspended session if needed, then nudges the runtime with a
 // new user message.
 func (m *Manager) Send(ctx context.Context, id, message, resumeCommand string, hints runtime.Config) error {
@@ -807,27 +729,49 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 	if len(searchPaths) == 0 {
 		searchPaths = sessionlog.DefaultSearchPaths()
 	}
-	if path := workertranscript.DiscoverKeyedPath(searchPaths, provider, workDir, b.Metadata["session_key"]); path != "" {
+	if path := workertranscript.DiscoverKeyedPath(searchPaths, provider, workDir, b.Metadata["session_key"]); transcriptPathFreshEnoughForProvider(path, b.CreatedAt, provider) {
 		return path, nil
 	}
 
-	all, err := m.store.List(beads.ListQuery{
-		Label: LabelSession,
-	})
-	if err != nil {
-		return "", fmt.Errorf("listing sessions: %w", err)
+	candidates := make(map[string]beads.Bead)
+	addCandidates := func(filters map[string]string) error {
+		found, listErr := m.store.ListByMetadata(filters, 0)
+		if listErr != nil {
+			return listErr
+		}
+		for _, candidate := range found {
+			candidates[candidate.ID] = candidate
+		}
+		return nil
 	}
-	matches := 0
-	for _, other := range all {
+	if provider == "" {
+		err = addCandidates(map[string]string{"work_dir": workDir})
+	} else {
+		err = addCandidates(map[string]string{"work_dir": workDir, "provider": provider})
+		if err == nil {
+			err = addCandidates(map[string]string{"work_dir": workDir, "provider_kind": provider})
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("listing sessions by work_dir: %w", err)
+	}
+	targetLive := m.transcriptFallbackCandidateLive(b)
+	matches := 1
+	for _, other := range candidates {
 		if !IsSessionBeadOrRepairable(other) {
 			continue
 		}
-		// Only count active sessions — closed historical sessions should not
-		// make the lookup ambiguous for the one live session.
-		if other.Status == "closed" {
+		if other.ID == b.ID {
 			continue
 		}
-		if provider != "" && strings.TrimSpace(other.Metadata["provider"]) != provider {
+		if targetLive && !m.transcriptFallbackCandidateLive(other) {
+			continue
+		}
+		otherProvider := strings.TrimSpace(other.Metadata["provider_kind"])
+		if otherProvider == "" {
+			otherProvider = strings.TrimSpace(other.Metadata["provider"])
+		}
+		if provider != "" && otherProvider != provider {
 			continue
 		}
 		if other.Metadata["work_dir"] == workDir {
@@ -839,5 +783,108 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 			}
 		}
 	}
-	return workertranscript.DiscoverPath(searchPaths, provider, workDir, ""), nil
+	path := workertranscript.DiscoverPath(searchPaths, provider, workDir, "")
+	if !transcriptPathFreshEnoughForProvider(path, b.CreatedAt, provider) {
+		return "", nil
+	}
+	if strings.TrimSpace(b.Metadata["session_key"]) == "" &&
+		providerRequiresIdentityForKeylessFallback(provider) &&
+		!transcriptContainsSessionIdentity(path, b) {
+		return "", nil
+	}
+	return path, nil
+}
+
+func (m *Manager) transcriptFallbackCandidateLive(b beads.Bead) bool {
+	if b.Status == "closed" {
+		return false
+	}
+	state := State(strings.TrimSpace(b.Metadata["state"]))
+	switch state {
+	case StateActive, StateAwake, StateCreating, StateDraining:
+	default:
+		return false
+	}
+	if m.sp == nil {
+		return true
+	}
+	return m.sp.IsRunning(sessionName(b.ID, b))
+}
+
+func transcriptPathFreshEnough(path string, sessionCreatedAt time.Time) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	if sessionCreatedAt.IsZero() {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.ModTime().Before(sessionCreatedAt.Add(-2 * time.Second))
+}
+
+func transcriptPathFreshEnoughForProvider(path string, sessionCreatedAt time.Time, provider string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	if !providerRequiresFreshTranscript(provider) {
+		return true
+	}
+	return transcriptPathFreshEnough(path, sessionCreatedAt)
+}
+
+func providerRequiresFreshTranscript(provider string) bool {
+	lower := strings.ToLower(strings.TrimSpace(provider))
+	return strings.Contains(lower, "codex")
+}
+
+func providerRequiresIdentityForKeylessFallback(provider string) bool {
+	lower := strings.ToLower(strings.TrimSpace(provider))
+	return strings.Contains(lower, "codex")
+}
+
+func transcriptContainsSessionIdentity(path string, b beads.Bead) bool {
+	needles := sessionTranscriptIdentityNeedles(b)
+	if len(needles) == 0 {
+		return false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close() //nolint:errcheck // read-only
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	const maxLines = 64
+	for lineNo := 0; lineNo < maxLines && scanner.Scan(); lineNo++ {
+		line := scanner.Text()
+		for _, needle := range needles {
+			if strings.Contains(line, needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sessionTranscriptIdentityNeedles(b beads.Bead) []string {
+	candidates := []string{
+		strings.TrimSpace(b.Metadata["session_name"]),
+		strings.TrimSpace(b.Metadata["alias"]),
+		strings.TrimSpace(b.Metadata["agent_name"]),
+		strings.TrimSpace(b.ID),
+	}
+	seen := make(map[string]bool, len(candidates))
+	var needles []string
+	for _, candidate := range candidates {
+		if candidate == "" || seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		needles = append(needles, candidate)
+	}
+	return needles
 }

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -86,6 +86,7 @@ func PreWakePatch(input PreWakePatchInput) MetadataPatch {
 		"continuation_reset_pending": "",
 		"detached_at":                "",
 		"last_woke_at":               input.Now.UTC().Format(time.RFC3339),
+		"start_in_flight":            "true",
 		"sleep_reason":               input.SleepReason,
 		"sleep_intent":               "",
 		"generation":                 fmt.Sprintf("%d", input.Generation),
@@ -156,6 +157,7 @@ func ConfirmStartedPatch(now time.Time) MetadataPatch {
 		"state_reason":         "creation_complete",
 		"creation_complete_at": now.UTC().Format(time.RFC3339),
 		"pending_create_claim": "",
+		"start_in_flight":      "",
 		"sleep_reason":         "",
 	}
 }
@@ -210,6 +212,7 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	if input.ClearPendingCreateClaim {
 		patch["pending_create_claim"] = ""
 	}
+	patch["start_in_flight"] = ""
 	return patch
 }
 
@@ -229,6 +232,7 @@ func SleepPatch(now time.Time, reason string) MetadataPatch {
 		"sleep_reason":         reason,
 		"last_woke_at":         "",
 		"pending_create_claim": "",
+		"start_in_flight":      "",
 		"sleep_intent":         "",
 		"slept_at":             now.UTC().Format(time.RFC3339),
 	}
@@ -242,6 +246,7 @@ func AcknowledgeDrainPatch(freshWake bool) MetadataPatch {
 		"state":                string(StateDrained),
 		"last_woke_at":         "",
 		"pending_create_claim": "",
+		"start_in_flight":      "",
 	}
 	if freshWake {
 		patch["session_key"] = ""
@@ -275,6 +280,7 @@ func RestartRequestPatch(sessionKey string) MetadataPatch {
 		"continuation_reset_pending": "true",
 		"last_woke_at":               "",
 		"pending_create_claim":       "",
+		"start_in_flight":            "",
 	}
 	if sessionKey != "" {
 		patch["session_key"] = sessionKey
@@ -292,6 +298,7 @@ func ConfigDriftResetPatch(nextState State, sessionKey string) MetadataPatch {
 		"restart_requested":          "",
 		"continuation_reset_pending": "true",
 		"pending_create_claim":       "",
+		"start_in_flight":            "",
 	}
 	applyFreshWakeConversationReset(patch)
 	if nextState == StateCreating {
@@ -315,6 +322,7 @@ func ArchivePatch(now time.Time, reason string, continuityEligible bool) Metadat
 		"archived_at":          now.UTC().Format(time.RFC3339),
 		"continuity_eligible":  continuity,
 		"pending_create_claim": "",
+		"start_in_flight":      "",
 	}
 }
 
@@ -356,6 +364,7 @@ func QuarantinePatch(until time.Time, cycle int) MetadataPatch {
 		"quarantined_until": until.UTC().Format(time.RFC3339),
 		"quarantine_cycle":  fmt.Sprintf("%d", cycle),
 		"last_woke_at":      "",
+		"start_in_flight":   "",
 	}
 }
 
@@ -371,6 +380,7 @@ func ReactivatePatch(continuityEligible bool) MetadataPatch {
 		"state":                string(StateAsleep),
 		"state_reason":         "reactivated",
 		"pending_create_claim": "",
+		"start_in_flight":      "",
 		"continuity_eligible":  continuity,
 		"quarantined_until":    "",
 		"crash_count":          "0",

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -47,6 +47,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_reset_pending": "",
 				"detached_at":                "",
 				"last_woke_at":               now.UTC().Format(time.RFC3339),
+				"start_in_flight":            "true",
 				"sleep_reason":               "idle-timeout",
 				"sleep_intent":               "",
 				"generation":                 "3",
@@ -67,6 +68,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_reset_pending": "",
 				"detached_at":                "",
 				"last_woke_at":               now.UTC().Format(time.RFC3339),
+				"start_in_flight":            "true",
 				"sleep_reason":               "",
 				"sleep_intent":               "",
 				"generation":                 "4",
@@ -85,6 +87,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"state_reason":         "creation_complete",
 				"creation_complete_at": now.UTC().Format(time.RFC3339),
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 				"sleep_reason":         "",
 			},
 		},
@@ -105,6 +108,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"sleep_reason":         "idle-timeout",
 				"last_woke_at":         "",
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 				"sleep_intent":         "",
 				"slept_at":             now.Format(time.RFC3339),
 			},
@@ -116,6 +120,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"state":                "drained",
 				"last_woke_at":         "",
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 			},
 		},
 		{
@@ -125,6 +130,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"state":                      "drained",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"start_in_flight":            "",
 				"session_key":                "",
 				"started_config_hash":        "",
 				"started_live_hash":          "",
@@ -141,6 +147,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"sleep_reason":               "idle",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"start_in_flight":            "",
 				"sleep_intent":               "",
 				"slept_at":                   now.Format(time.RFC3339),
 				"session_key":                "",
@@ -160,6 +167,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_reset_pending": "true",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"start_in_flight":            "",
 				"session_key":                "new-session-key",
 			},
 		},
@@ -172,6 +180,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_reset_pending": "true",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"start_in_flight":            "",
 			},
 		},
 		{
@@ -187,6 +196,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"restart_requested":          "",
 				"continuation_reset_pending": "true",
 				"pending_create_claim":       "true",
+				"start_in_flight":            "",
 				"session_key":                "new-session-key",
 			},
 		},
@@ -203,6 +213,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"restart_requested":          "",
 				"continuation_reset_pending": "true",
 				"pending_create_claim":       "",
+				"start_in_flight":            "",
 				"session_key":                "new-session-key",
 			},
 		},
@@ -219,6 +230,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"restart_requested":          "",
 				"continuation_reset_pending": "true",
 				"pending_create_claim":       "",
+				"start_in_flight":            "",
 			},
 		},
 		{
@@ -230,6 +242,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"archived_at":          now.Format(time.RFC3339),
 				"continuity_eligible":  "true",
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 			},
 		},
 		{
@@ -241,6 +254,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"archived_at":          now.Format(time.RFC3339),
 				"continuity_eligible":  "false",
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 			},
 		},
 		{
@@ -265,6 +279,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"session_name":           "",
 				"session_name_explicit":  "",
 				"pending_create_claim":   "",
+				"start_in_flight":        "",
 				"retired_named_identity": "worker",
 				"synced_at":              now.Format(time.RFC3339),
 				"held_until":             "",
@@ -283,6 +298,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"quarantined_until": later.Format(time.RFC3339),
 				"quarantine_cycle":  "3",
 				"last_woke_at":      "",
+				"start_in_flight":   "",
 			},
 		},
 		{
@@ -292,6 +308,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"state":                string(StateAsleep),
 				"state_reason":         "reactivated",
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 				"continuity_eligible":  "true",
 				"quarantined_until":    "",
 				"crash_count":          "0",
@@ -305,6 +322,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"state":                string(StateAsleep),
 				"state_reason":         "reactivated",
 				"pending_create_claim": "",
+				"start_in_flight":      "",
 				"continuity_eligible":  "false",
 				"quarantined_until":    "",
 				"crash_count":          "0",
@@ -407,6 +425,7 @@ func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 		"creation_complete_at": now.Format(time.RFC3339),
 		"sleep_reason":         "",
 		"pending_create_claim": "",
+		"start_in_flight":      "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)
@@ -449,6 +468,7 @@ func TestCommitStartedPatchCanPersistHashesWithoutRestampingState(t *testing.T) 
 		"live_hash":           "live-hash",
 		"started_live_hash":   "live-hash",
 		"sleep_reason":        "",
+		"start_in_flight":     "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -537,6 +537,36 @@ func runtimeSessionMatchesBead(sp runtime.Provider, sessionName, beadID, instanc
 	return strings.TrimSpace(liveToken) == instanceToken
 }
 
+func runtimeSessionOwnershipConflict(sp runtime.Provider, sessionName, beadID, instanceToken string) bool {
+	if sp == nil {
+		return false
+	}
+	if liveID, err := sp.GetMeta(sessionName, "GC_SESSION_ID"); err == nil {
+		liveID = strings.TrimSpace(liveID)
+		if liveID != "" {
+			return liveID != beadID
+		}
+	}
+	instanceToken = strings.TrimSpace(instanceToken)
+	if instanceToken == "" {
+		return false
+	}
+	liveToken, err := sp.GetMeta(sessionName, "GC_INSTANCE_TOKEN")
+	if err != nil {
+		return false
+	}
+	liveToken = strings.TrimSpace(liveToken)
+	return liveToken != "" && liveToken != instanceToken
+}
+
+func strictRuntimeOwnershipRequired(b beads.Bead) bool {
+	if strings.TrimSpace(b.Metadata["session_name_explicit"]) != "true" {
+		return false
+	}
+	return State(strings.TrimSpace(b.Metadata["state"])) == StateCreating ||
+		strings.TrimSpace(b.Metadata["pending_create_claim"]) != ""
+}
+
 // CreateBeadOnly creates a session bead without starting the runtime process.
 // The bead is created with state "creating" — the controller's reconciler
 // will detect it in buildDesiredState and start the process on its next tick.
@@ -1290,6 +1320,36 @@ func (m *Manager) PersistSessionKey(id, sessionKey string) error {
 		}
 		return nil
 	})
+}
+
+// EnsureSessionKey returns the existing provider resume key for a session, or
+// generates and persists one when the session does not have a key yet.
+func (m *Manager) EnsureSessionKey(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", nil
+	}
+	var sessionKey string
+	err := withSessionMutationLock(id, func() error {
+		b, _, err := m.sessionBead(id)
+		if err != nil {
+			return err
+		}
+		if existing := strings.TrimSpace(b.Metadata["session_key"]); existing != "" {
+			sessionKey = existing
+			return nil
+		}
+		generatedKey, genErr := GenerateSessionKey()
+		if genErr != nil {
+			return fmt.Errorf("generating session key: %w", genErr)
+		}
+		if err := m.store.SetMetadata(id, "session_key", generatedKey); err != nil {
+			return fmt.Errorf("storing session key: %w", err)
+		}
+		sessionKey = generatedKey
+		return nil
+	})
+	return sessionKey, err
 }
 
 // sessionNameFor derives the tmux session name from a bead ID.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1911,6 +1911,56 @@ func TestSendResumesSuspendedSession(t *testing.T) {
 	}
 }
 
+func TestStartClearsInFlightLeaseAndPendingCreate(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"session_name":         "worker",
+			"state":                string(StateCreating),
+			"pending_create_claim": "true",
+			"start_in_flight":      "true",
+			"sleep_reason":         "idle-timeout",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       NewInstanceToken(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.Start(context.Background(), bead.ID, "worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["state"] != string(StateActive) {
+		t.Fatalf("state = %q, want active", got.Metadata["state"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["start_in_flight"] != "" {
+		t.Fatalf("start_in_flight = %q, want cleared", got.Metadata["start_in_flight"])
+	}
+	if got.Metadata["sleep_reason"] != "" {
+		t.Fatalf("sleep_reason = %q, want cleared", got.Metadata["sleep_reason"])
+	}
+	if got.Metadata["creation_complete_at"] == "" {
+		t.Fatal("creation_complete_at is empty")
+	}
+}
+
 func TestSendImmediateUsesImmediateNudge(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()
@@ -2849,6 +2899,193 @@ func TestTranscriptPathSkipsAmbiguousWorkDirFallback(t *testing.T) {
 	}
 }
 
+type noFullScanTranscriptStore struct {
+	*beads.MemStore
+}
+
+func (s *noFullScanTranscriptStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
+	return nil, errors.New("unexpected full session scan")
+}
+
+func TestTranscriptPathFallbackUsesTargetedWorkDirLookup(t *testing.T) {
+	store := &noFullScanTranscriptStore{MemStore: beads.NewMemStore()}
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "helper", "codex", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fallbackPath := filepath.Join(dayDir, "rollout-current.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	identity := `{"type":"event_msg","payload":{"message":"` + info.SessionName + `"}}`
+	if err := os.WriteFile(fallbackPath, []byte(meta+"\n"+identity+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(info.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != fallbackPath {
+		t.Errorf("TranscriptPath = %q, want %q", path, fallbackPath)
+	}
+}
+
+func TestTranscriptPathKeylessCodexFallbackRequiresSessionIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "helper", "codex", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	wrongPath := filepath.Join(dayDir, "rollout-wrong.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	wrongIdentity := `{"type":"event_msg","payload":{"message":"other-session"}}`
+	if err := os.WriteFile(wrongPath, []byte(meta+"\n"+wrongIdentity+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(info.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != "" {
+		t.Errorf("TranscriptPath = %q, want empty for keyless Codex transcript without session identity", path)
+	}
+}
+
+func TestTranscriptPathFallbackIgnoresAsleepSameWorkDirSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	old, err := mgr.Create(context.Background(), "helper", "old", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create old: %v", err)
+	}
+	if err := mgr.Suspend(old.ID); err != nil {
+		t.Fatalf("Suspend old: %v", err)
+	}
+	info, err := mgr.Create(context.Background(), "helper", "new", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create new: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fallbackPath := filepath.Join(dayDir, "rollout-current.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	identity := `{"type":"event_msg","payload":{"message":"` + info.SessionName + `"}}`
+	if err := os.WriteFile(fallbackPath, []byte(meta+"\n"+identity+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(info.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != fallbackPath {
+		t.Errorf("TranscriptPath = %q, want %q", path, fallbackPath)
+	}
+}
+
+func TestTranscriptPathClosedSessionWithoutKeySkipsActiveSameWorkDirFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	closed, err := mgr.Create(context.Background(), "helper", "old", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create old: %v", err)
+	}
+	if err := mgr.Close(closed.ID); err != nil {
+		t.Fatalf("Close old: %v", err)
+	}
+	if _, err := mgr.Create(context.Background(), "helper", "new", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{}); err != nil {
+		t.Fatalf("Create new: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fallbackPath := filepath.Join(dayDir, "rollout-current.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	if err := os.WriteFile(fallbackPath, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(closed.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != "" {
+		t.Errorf("TranscriptPath = %q, want empty for closed keyless session sharing an active workdir", path)
+	}
+}
+
+func TestTranscriptPathSkipsFallbackOlderThanSession(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "helper", "fresh", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	bead, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get session bead: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "03", "27")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fallbackPath := filepath.Join(dayDir, "rollout-old.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	if err := os.WriteFile(fallbackPath, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	old := bead.CreatedAt.Add(-time.Hour)
+	if err := os.Chtimes(fallbackPath, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(info.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != "" {
+		t.Errorf("TranscriptPath = %q, want empty when only fallback transcript predates session", path)
+	}
+}
+
 func TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()
@@ -2870,7 +3107,8 @@ func TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback
 	}
 	codexPath := filepath.Join(dayDir, "rollout-current.jsonl")
 	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
-	if err := os.WriteFile(codexPath, []byte(meta+"\n"), 0o644); err != nil {
+	identity := `{"type":"event_msg","payload":{"message":"` + info.SessionName + `"}}`
+	if err := os.WriteFile(codexPath, []byte(meta+"\n"+identity+"\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/internal/sessionlog/gemini_reader.go
+++ b/internal/sessionlog/gemini_reader.go
@@ -243,6 +243,38 @@ func FindGeminiSessionFile(searchPaths []string, workDir string) string {
 	return bestPath
 }
 
+// FindGeminiSessionFileByID searches Gemini's project chat directory for a
+// known provider session id.
+func FindGeminiSessionFileByID(searchPaths []string, workDir, sessionID string) string {
+	if workDir == "" {
+		return ""
+	}
+	fileName := safeSessionJSONFileName(sessionID)
+	if fileName == "" {
+		return ""
+	}
+
+	var (
+		bestPath string
+		bestTime time.Time
+	)
+	for _, root := range mergeGeminiSearchPaths(searchPaths) {
+		path := findGeminiSessionFileByIDIn(root, workDir, fileName)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if bestPath == "" || info.ModTime().After(bestTime) {
+			bestPath = path
+			bestTime = info.ModTime()
+		}
+	}
+	return bestPath
+}
+
 func findGeminiSessionFileIn(root, workDir string) string {
 	info, err := os.Stat(root)
 	if err != nil || !info.IsDir() {
@@ -292,6 +324,51 @@ func findGeminiSessionFileIn(root, workDir string) string {
 		}
 	}
 
+	return bestPath
+}
+
+func findGeminiSessionFileByIDIn(root, workDir, fileName string) string {
+	info, err := os.Stat(root)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	var candidates []string
+	if candidate := geminiProjectDir(root, workDir); candidate != "" {
+		candidates = append(candidates, candidate)
+	}
+	if geminiProjectRoot(root) == workDir {
+		candidates = append(candidates, root)
+	}
+	entries, err := os.ReadDir(root)
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dir := filepath.Join(root, entry.Name())
+			if geminiProjectRoot(dir) == workDir {
+				candidates = append(candidates, dir)
+			}
+		}
+	}
+	candidates = uniqueStrings(candidates)
+
+	var (
+		bestPath string
+		bestTime time.Time
+	)
+	for _, candidate := range candidates {
+		path := filepath.Join(candidate, "chats", fileName)
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if bestPath == "" || info.ModTime().After(bestTime) {
+			bestPath = path
+			bestTime = info.ModTime()
+		}
+	}
 	return bestPath
 }
 

--- a/internal/sessionlog/reader.go
+++ b/internal/sessionlog/reader.go
@@ -463,6 +463,19 @@ func FindSessionFileByID(searchPaths []string, workDir, sessionID string) string
 	return findSessionFileByIDForCandidates(searchPaths, claudeProjectSlugCandidates(workDir), fileName)
 }
 
+// FindSessionFileByIDForProvider resolves a provider-native transcript path
+// from a known provider session identifier.
+func FindSessionFileByIDForProvider(searchPaths []string, provider, workDir, sessionID string) string {
+	switch providerFamily(provider) {
+	case "codex":
+		return FindCodexSessionFileByID(searchPaths, workDir, sessionID)
+	case "gemini":
+		return FindGeminiSessionFileByID(searchPaths, workDir, sessionID)
+	default:
+		return FindSessionFileByID(searchPaths, workDir, sessionID)
+	}
+}
+
 func findSessionFileByIDForCandidates(searchPaths, slugs []string, fileName string) string {
 	for _, base := range searchPaths {
 		var bestPath string
@@ -522,6 +535,18 @@ func safeSessionLogFileName(sessionID string) string {
 		return ""
 	}
 	return filepath.Base(sessionID) + ".jsonl"
+}
+
+func safeSessionJSONFileName(sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || strings.Contains(sessionID, "..") || strings.ContainsAny(sessionID, `/\`) {
+		return ""
+	}
+	base := filepath.Base(sessionID)
+	if strings.HasSuffix(base, ".json") {
+		return base
+	}
+	return base + ".json"
 }
 
 // findSlugSessionFile searches slug-organized search paths for the most
@@ -590,6 +615,36 @@ func FindCodexSessionFile(searchPaths []string, workDir string) string {
 	return bestPath
 }
 
+// FindCodexSessionFileByID searches Codex's date-organized session directory
+// for a transcript whose filename contains the known provider session id and
+// whose embedded cwd matches workDir.
+func FindCodexSessionFileByID(searchPaths []string, workDir, sessionID string) string {
+	if workDir == "" {
+		return ""
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || strings.Contains(sessionID, "..") || strings.ContainsAny(sessionID, `/\`) {
+		return ""
+	}
+	var bestPath string
+	var bestTime int64
+	for _, root := range mergeCodexSearchPaths(searchPaths) {
+		path := findCodexSessionFileByIDIn(root, workDir, sessionID)
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if mt := info.ModTime().UnixNano(); mt > bestTime {
+			bestTime = mt
+			bestPath = path
+		}
+	}
+	return bestPath
+}
+
 // findCodexSessionFileIn searches a Codex sessions directory for the most
 // recent session matching workDir. Scans date directories in reverse
 // chronological order for efficiency. Also recurses into symlinked
@@ -637,6 +692,43 @@ func findCodexSessionFileIn(sessDir, workDir string) string {
 	return ""
 }
 
+func findCodexSessionFileByIDIn(sessDir, workDir, sessionID string) string {
+	entries, err := os.ReadDir(sessDir)
+	if err != nil {
+		return ""
+	}
+
+	var yearDirs []string
+	var extraRoots []string
+	for _, e := range entries {
+		if !e.IsDir() && e.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		name := e.Name()
+		if len(name) == 4 && name >= "2000" && name <= "2099" {
+			yearDirs = append(yearDirs, name)
+		} else if e.Type()&os.ModeSymlink != 0 {
+			extraRoots = append(extraRoots, name)
+		}
+	}
+
+	sort.Sort(sort.Reverse(sort.StringSlice(yearDirs)))
+	if path := scanYearDirsForCodexID(sessDir, yearDirs, workDir, sessionID); path != "" {
+		return path
+	}
+
+	for _, root := range extraRoots {
+		resolved, err := filepath.EvalSymlinks(filepath.Join(sessDir, root))
+		if err != nil {
+			continue
+		}
+		if path := findCodexSessionFileByIDIn(resolved, workDir, sessionID); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
 // scanYearDirs scans YYYY/MM/DD date tree for matching Codex sessions.
 func scanYearDirs(base string, years []string, workDir string) string {
 	for _, year := range years {
@@ -648,6 +740,24 @@ func scanYearDirs(base string, years []string, workDir string) string {
 			for _, day := range days {
 				dayDir := filepath.Join(monthDir, day)
 				if path := findCodexSessionInDir(dayDir, workDir); path != "" {
+					return path
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func scanYearDirsForCodexID(base string, years []string, workDir, sessionID string) string {
+	for _, year := range years {
+		yearDir := filepath.Join(base, year)
+		months := listDirsReverse(yearDir)
+		for _, month := range months {
+			monthDir := filepath.Join(yearDir, month)
+			days := listDirsReverse(monthDir)
+			for _, day := range days {
+				dayDir := filepath.Join(monthDir, day)
+				if path := findCodexSessionIDInDir(dayDir, workDir, sessionID); path != "" {
 					return path
 				}
 			}
@@ -687,6 +797,41 @@ func findCodexSessionInDir(dir, workDir string) string {
 		return files[i].modTime > files[j].modTime
 	})
 
+	for _, f := range files {
+		if codexSessionCWD(f.path) == workDir {
+			return f.path
+		}
+	}
+	return ""
+}
+
+func findCodexSessionIDInDir(dir, workDir, sessionID string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+
+	type fileInfo struct {
+		path    string
+		modTime int64
+	}
+	var files []fileInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") || !strings.Contains(e.Name(), sessionID) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, fileInfo{
+			path:    filepath.Join(dir, e.Name()),
+			modTime: info.ModTime().UnixNano(),
+		})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].modTime > files[j].modTime
+	})
 	for _, f := range files {
 		if codexSessionCWD(f.path) == workDir {
 			return f.path

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -1341,6 +1341,29 @@ func TestFindCodexSessionFileIn(t *testing.T) {
 	}
 }
 
+func TestFindCodexSessionFileByID(t *testing.T) {
+	sessDir := t.TempDir()
+	workDir := "/data/projects/myproject"
+	dayDir := filepath.Join(sessDir, "2026", "01", "25")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := fmt.Sprintf(`{"type":"session_meta","payload":{"cwd":"%s"}}`, workDir)
+	matchFile := filepath.Join(dayDir, "rollout-2026-01-25T07-00-00-abc123.jsonl")
+	if err := os.WriteFile(matchFile, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	otherFile := filepath.Join(dayDir, "rollout-2026-01-25T07-00-01-other.jsonl")
+	if err := os.WriteFile(otherFile, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindCodexSessionFileByID([]string{sessDir}, workDir, "abc123")
+	if got != matchFile {
+		t.Errorf("got %q, want %q", got, matchFile)
+	}
+}
+
 func TestFindCodexSessionFileInNoMatch(t *testing.T) {
 	sessDir := t.TempDir()
 
@@ -1478,6 +1501,47 @@ func TestFindGeminiSessionFileUsesObservedRoots(t *testing.T) {
 	}
 
 	got := FindGeminiSessionFile([]string{root}, workDir)
+	if got != sessionFile {
+		t.Errorf("got %q, want %q", got, sessionFile)
+	}
+}
+
+func TestFindGeminiSessionFileByID(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "tmp")
+	workDir := "/data/projects/myproject"
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projects := map[string]any{
+		"projects": map[string]string{
+			workDir: "myproject",
+		},
+	}
+	data, err := json.Marshal(projects)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "projects.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := filepath.Join(root, "myproject")
+	if err := os.MkdirAll(filepath.Join(projectDir, "chats"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".project_root"), []byte(workDir), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessionFile := filepath.Join(projectDir, "chats", "session-abc123.json")
+	if err := os.WriteFile(sessionFile, []byte(`{"messages":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	otherFile := filepath.Join(projectDir, "chats", "session-other.json")
+	if err := os.WriteFile(otherFile, []byte(`{"messages":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindGeminiSessionFileByID([]string{root}, workDir, "session-abc123")
 	if got != sessionFile {
 		t.Errorf("got %q, want %q", got, sessionFile)
 	}

--- a/internal/worker/factory_resolved.go
+++ b/internal/worker/factory_resolved.go
@@ -22,6 +22,7 @@ type ResolvedRuntime struct {
 // ResolvedSessionConfig describes a new session-backed worker handle whose
 // runtime inputs have already been resolved by the caller.
 type ResolvedSessionConfig struct {
+	ID           string
 	Alias        string
 	ExplicitName string
 	Template     string
@@ -87,6 +88,7 @@ func SessionSpecForResolvedRuntime(cfg ResolvedSessionConfig) (SessionSpec, erro
 	}
 
 	return SessionSpec{
+		ID:           strings.TrimSpace(cfg.ID),
 		Alias:        cfg.Alias,
 		ExplicitName: cfg.ExplicitName,
 		Template:     cfg.Template,

--- a/internal/worker/handle.go
+++ b/internal/worker/handle.go
@@ -28,7 +28,6 @@ type StateHandle interface {
 // LifecycleHandle exposes worker lifecycle control operations.
 type LifecycleHandle interface {
 	Start(context.Context) error
-	StartResolved(context.Context, string, runtime.Config) error
 	Attach(context.Context) error
 	Create(context.Context, CreateMode) (sessionpkg.Info, error)
 	Reset(context.Context) error

--- a/internal/worker/handle_lifecycle.go
+++ b/internal/worker/handle_lifecycle.go
@@ -22,35 +22,11 @@ func (h *SessionHandle) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	err = h.manager.Start(ctx, id, startCommand, h.runtimeHints())
-	return err
-}
-
-// StartResolved starts or resumes the worker using a caller-supplied runtime
-// command and hints. This is a migration bridge for higher layers that already
-// materialize provider-specific runtime config but should still delegate the
-// provider-specific runtime bring-up through the worker boundary.
-func (h *SessionHandle) StartResolved(ctx context.Context, startCommand string, hints runtime.Config) (err error) {
-	event := h.beginOperationEvent(ctx, workerOperationStartResolved)
-	defer func() { event.finish(err) }()
-
-	id, err := h.ensureSessionID()
-	if err != nil {
+	if err = h.manager.Start(ctx, id, startCommand, h.runtimeHints()); err != nil {
 		return err
 	}
-	command := strings.TrimSpace(startCommand)
-	if command == "" {
-		command, err = h.startCommand(id)
-		if err != nil {
-			return err
-		}
-	}
-	startHints := hints
-	if strings.TrimSpace(startHints.Command) == "" {
-		startHints = h.runtimeHints()
-	}
-	err = h.manager.StartRuntimeOnly(ctx, id, command, startHints)
-	return err
+	h.tryPersistDerivedSessionKey(ctx, id)
+	return nil
 }
 
 // Attach ensures the worker runtime is live and then attaches the caller's
@@ -423,7 +399,15 @@ func (h *SessionHandle) startCommand(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if info.State == sessionpkg.StateCreating && h.session.Resume.SessionIDFlag != "" && strings.TrimSpace(info.SessionKey) != "" {
+	if info.State == sessionpkg.StateCreating && h.session.Resume.SessionIDFlag != "" {
+		sessionKey := strings.TrimSpace(info.SessionKey)
+		if sessionKey == "" {
+			generatedKey, genErr := h.manager.EnsureSessionKey(id)
+			if genErr != nil {
+				return "", genErr
+			}
+			sessionKey = generatedKey
+		}
 		command := strings.TrimSpace(info.Command)
 		if command == "" {
 			command = strings.TrimSpace(h.session.Command)
@@ -437,7 +421,7 @@ func (h *SessionHandle) startCommand(id string) (string, error) {
 		if command == "" {
 			return "", fmt.Errorf("%w: command is required for first start", ErrHandleConfig)
 		}
-		return command + " " + h.session.Resume.SessionIDFlag + " " + info.SessionKey, nil
+		return command + " " + h.session.Resume.SessionIDFlag + " " + sessionKey, nil
 	}
 	resumeInfo := info
 	if command := strings.TrimSpace(h.session.Command); command != "" {
@@ -456,6 +440,20 @@ func (h *SessionHandle) startCommand(id string) (string, error) {
 		resumeInfo.ResumeCommand = resumeCommand
 	}
 	return sessionpkg.BuildResumeCommand(resumeInfo), nil
+}
+
+func (h *SessionHandle) tryPersistDerivedSessionKey(ctx context.Context, id string) {
+	info, err := h.manager.Get(id)
+	if err != nil || strings.TrimSpace(info.SessionKey) != "" {
+		return
+	}
+	if !canDeriveResumeSessionKey(h.historyProvider(info)) {
+		return
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+	_, _ = h.historyWithRequest(HistoryRequest{TailCompactions: 1})
 }
 
 func (h *SessionHandle) providerLabel() string {

--- a/internal/worker/handle_test.go
+++ b/internal/worker/handle_test.go
@@ -789,6 +789,63 @@ func TestSessionHandleLiveObservationTracksProcessLiveness(t *testing.T) {
 	}
 }
 
+func TestSessionHandleLiveObservationPersistsLateCodexResumeKey(t *testing.T) {
+	base := t.TempDir()
+	dayDir := filepath.Join(base, "2026", "04", "14")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("mkdir dayDir: %v", err)
+	}
+
+	workDir := "/tmp/codex-project"
+	resumeID := "019d8afb-efe8-7280-abf9-5901fd92e0cd"
+	handle, store, _, _ := newTestSessionHandle(t, SessionSpec{
+		Profile:  ProfileCodexTmuxCLI,
+		Template: "probe",
+		Title:    "Probe",
+		Command:  "codex --dangerously-bypass-approvals-and-sandbox",
+		WorkDir:  workDir,
+		Provider: "codex",
+		Resume: sessionpkg.ProviderResume{
+			ResumeFlag:  "resume",
+			ResumeStyle: "subcommand",
+		},
+	})
+	handle.adapter.SearchPaths = []string{base}
+
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	bead, err := store.Get(handle.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%q): %v", handle.sessionID, err)
+	}
+	if bead.Metadata["session_key"] != "" {
+		t.Fatalf("session_key after Start = %q, want empty before transcript exists", bead.Metadata["session_key"])
+	}
+
+	transcriptPath := filepath.Join(dayDir, "rollout-2026-04-14T09-54-20-"+resumeID+".jsonl")
+	transcript := strings.Join([]string{
+		fmt.Sprintf(`{"timestamp":"2026-04-14T09:54:20Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		fmt.Sprintf(`{"timestamp":"2026-04-14T09:54:20Z","type":"event_msg","payload":{"message":%q}}`, bead.Metadata["session_name"]),
+		`{"timestamp":"2026-04-14T09:54:21Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"remember alpha"}]}}`,
+		`{"timestamp":"2026-04-14T09:54:22Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"remembered"}]}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	if _, err := ObserveHandle(context.Background(), handle); err != nil {
+		t.Fatalf("ObserveHandle: %v", err)
+	}
+	bead, err = store.Get(handle.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%q): %v", handle.sessionID, err)
+	}
+	if bead.Metadata["session_key"] != resumeID {
+		t.Fatalf("session_key after LiveObservation = %q, want %q", bead.Metadata["session_key"], resumeID)
+	}
+}
+
 func TestSessionHandleNudgeWaitIdleLiveOnlyDoesNotResumeStoppedSession(t *testing.T) {
 	handle, _, sp, _ := newTestSessionHandle(t, SessionSpec{
 		Profile:  ProfileClaudeTmuxCLI,
@@ -896,6 +953,22 @@ func TestSessionHandlePendingRespondAndBlockedState(t *testing.T) {
 }
 
 func TestSessionHandleHistoryLoadsNormalizedTranscript(t *testing.T) {
+	sourceRoot := filepath.Join("workertest", "testdata", "fixtures", "claude", "fresh")
+	sourceRel := filepath.Join("-tmp-gascity-phase1-claude", "session-claude-phase1.jsonl")
+	sourcePath := filepath.Join(sourceRoot, sourceRel)
+	fixtureRoot := t.TempDir()
+	fixturePath := filepath.Join(fixtureRoot, sourceRel)
+	if err := os.MkdirAll(filepath.Dir(fixturePath), 0o755); err != nil {
+		t.Fatalf("mkdir fixture dir: %v", err)
+	}
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
 	handle, _, _, _ := newTestSessionHandle(t, SessionSpec{
 		ID:       "",
 		Profile:  ProfileClaudeTmuxCLI,
@@ -905,9 +978,7 @@ func TestSessionHandleHistoryLoadsNormalizedTranscript(t *testing.T) {
 		WorkDir:  "/tmp/gascity/phase1/claude",
 		Provider: "claude",
 	})
-	handle.adapter.SearchPaths = []string{
-		filepath.Join("workertest", "testdata", "fixtures", "claude", "fresh"),
-	}
+	handle.adapter.SearchPaths = []string{fixtureRoot}
 
 	if err := handle.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -940,9 +1011,11 @@ func TestSessionHandleHistoryPersistsCodexResumeKeyForLaterRestart(t *testing.T)
 
 	workDir := "/tmp/codex-project"
 	resumeID := "019d8afb-efe8-7280-abf9-5901fd92e0cd"
+	alias := "codex-probe-history"
 	transcriptPath := filepath.Join(dayDir, "rollout-2026-04-14T09-54-20-"+resumeID+".jsonl")
 	transcript := strings.Join([]string{
 		fmt.Sprintf(`{"timestamp":"2026-04-14T09:54:20Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		fmt.Sprintf(`{"timestamp":"2026-04-14T09:54:20Z","type":"event_msg","payload":{"message":%q}}`, alias),
 		`{"timestamp":"2026-04-14T09:54:21Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"remember alpha"}]}}`,
 		`{"timestamp":"2026-04-14T09:54:22Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"remembered"}]}}`,
 	}, "\n") + "\n"
@@ -951,6 +1024,7 @@ func TestSessionHandleHistoryPersistsCodexResumeKeyForLaterRestart(t *testing.T)
 	}
 
 	handle, store, sp, _ := newTestSessionHandle(t, SessionSpec{
+		Alias:    alias,
 		Profile:  ProfileCodexTmuxCLI,
 		Template: "probe",
 		Title:    "Probe",
@@ -994,7 +1068,7 @@ func TestSessionHandleHistoryPersistsCodexResumeKeyForLaterRestart(t *testing.T)
 		t.Fatalf("Start(second): %v", err)
 	}
 
-	secondStart := lastCall(sp.Calls, "Start")
+	secondStart := lastCall(sp.Calls)
 	if secondStart == nil {
 		t.Fatalf("runtime calls = %#v, want second Start", sp.Calls)
 	}
@@ -1013,9 +1087,11 @@ func TestSessionHandleStatePersistsCodexResumeKeyWithoutPrimingHistoryCache(t *t
 
 	workDir := "/tmp/codex-project"
 	resumeID := "019d8afb-efe8-7280-abf9-5901fd92e0cd"
+	alias := "codex-probe-state"
 	transcriptPath := filepath.Join(dayDir, "rollout-2026-04-14T09-54-20-"+resumeID+".jsonl")
 	transcript := strings.Join([]string{
 		fmt.Sprintf(`{"timestamp":"2026-04-14T09:54:20Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		fmt.Sprintf(`{"timestamp":"2026-04-14T09:54:20Z","type":"event_msg","payload":{"message":%q}}`, alias),
 		`{"timestamp":"2026-04-14T09:54:21Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"remember alpha"}]}}`,
 		`{"timestamp":"2026-04-14T09:54:22Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"remembered"}]}}`,
 	}, "\n") + "\n"
@@ -1024,6 +1100,7 @@ func TestSessionHandleStatePersistsCodexResumeKeyWithoutPrimingHistoryCache(t *t
 	}
 
 	handle, store, sp, _ := newTestSessionHandle(t, SessionSpec{
+		Alias:    alias,
 		Profile:  ProfileCodexTmuxCLI,
 		Template: "probe",
 		Title:    "Probe",
@@ -1067,13 +1144,124 @@ func TestSessionHandleStatePersistsCodexResumeKeyWithoutPrimingHistoryCache(t *t
 		t.Fatalf("Start(second): %v", err)
 	}
 
-	secondStart := lastCall(sp.Calls, "Start")
+	secondStart := lastCall(sp.Calls)
 	if secondStart == nil {
 		t.Fatalf("runtime calls = %#v, want second Start", sp.Calls)
 	}
 	wantResume := "codex resume " + resumeID
 	if !strings.Contains(secondStart.Config.Command, wantResume) {
 		t.Fatalf("second start command = %q, want %q", secondStart.Config.Command, wantResume)
+	}
+}
+
+func TestSessionHandleStartPersistsGeminiResumeKeyFromTranscript(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(base, "workspace")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workDir: %v", err)
+	}
+
+	searchRoot := filepath.Join(base, ".gemini", "tmp")
+	projectDir := filepath.Join(searchRoot, "project-a")
+	chatsDir := filepath.Join(projectDir, "chats")
+	for _, dir := range []string{searchRoot, projectDir, chatsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".project_root"), []byte(workDir), 0o644); err != nil {
+		t.Fatalf("write .project_root: %v", err)
+	}
+
+	sessionKey := "gemini-provider-session"
+	alias := "gemini-probe-start"
+	transcriptPath := filepath.Join(chatsDir, "session-2026-04-17T03-12.json")
+	writeGeminiHistoryFixtureWithIdentity(t, transcriptPath, sessionKey, alias, []string{
+		`{"id":"u1","timestamp":"2026-04-17T03:12:00Z","type":"user","content":"remember alpha"}`,
+		`{"id":"a1","timestamp":"2026-04-17T03:12:01Z","type":"gemini","content":"remembered alpha"}`,
+	})
+
+	handle, store, sp, _ := newTestSessionHandle(t, SessionSpec{
+		Alias:    alias,
+		Profile:  ProfileGeminiTmuxCLI,
+		Template: "probe",
+		Title:    "Probe",
+		Command:  "gemini",
+		WorkDir:  workDir,
+		Provider: "gemini",
+		Resume: sessionpkg.ProviderResume{
+			ResumeFlag:  "--resume",
+			ResumeStyle: "flag",
+		},
+	})
+	handle.adapter.SearchPaths = []string{searchRoot}
+
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start(first): %v", err)
+	}
+
+	bead, err := store.Get(handle.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%q): %v", handle.sessionID, err)
+	}
+	if bead.Metadata["session_key"] != sessionKey {
+		t.Fatalf("session_key = %q, want %q", bead.Metadata["session_key"], sessionKey)
+	}
+
+	if err := handle.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start(second): %v", err)
+	}
+
+	secondStart := lastCall(sp.Calls)
+	if secondStart == nil {
+		t.Fatalf("runtime calls = %#v, want second Start", sp.Calls)
+	}
+	wantResume := "gemini --resume " + sessionKey
+	if secondStart.Config.Command != wantResume {
+		t.Fatalf("second start command = %q, want %q", secondStart.Config.Command, wantResume)
+	}
+}
+
+func TestSessionHandleStartGeneratesMissingCreateSessionKey(t *testing.T) {
+	handle, store, sp, _ := newTestSessionHandle(t, SessionSpec{
+		Template: "probe",
+		Title:    "Probe",
+		Command:  "claude --dangerously-skip-permissions",
+		WorkDir:  t.TempDir(),
+		Provider: "claude",
+		Resume: sessionpkg.ProviderResume{
+			ResumeFlag:    "--resume",
+			ResumeStyle:   "flag",
+			SessionIDFlag: "--session-id",
+		},
+	})
+	info, err := handle.Create(context.Background(), CreateModeDeferred)
+	if err != nil {
+		t.Fatalf("Create(deferred): %v", err)
+	}
+	if err := store.SetMetadata(info.ID, "session_key", ""); err != nil {
+		t.Fatalf("clear session_key: %v", err)
+	}
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	bead, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", info.ID, err)
+	}
+	sessionKey := bead.Metadata["session_key"]
+	if sessionKey == "" {
+		t.Fatal("session_key = empty, want generated key")
+	}
+	start := lastCall(sp.Calls)
+	if start == nil {
+		t.Fatalf("runtime calls = %#v, want Start", sp.Calls)
+	}
+	if !strings.Contains(start.Config.Command, "--session-id "+sessionKey) {
+		t.Fatalf("start command = %q, want generated --session-id %s", start.Config.Command, sessionKey)
 	}
 }
 
@@ -1211,8 +1399,8 @@ func TestRuntimeHandleExpandedWorkerSurface(t *testing.T) {
 	if err := handle.Attach(context.Background()); err != nil {
 		t.Fatalf("Attach: %v", err)
 	}
-	if err := handle.StartResolved(context.Background(), "/bin/echo", runtime.Config{}); err != nil {
-		t.Fatalf("StartResolved: %v", err)
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
 	pending, supported, err := handle.PendingStatus(context.Background())
 	if err != nil {
@@ -1318,7 +1506,7 @@ func TestRuntimeHandleLiveObservationUsesRuntimeMetadataAndLiveness(t *testing.T
 	}
 }
 
-func TestRuntimeHandleStartResolvedStartsLegacyRuntimeSession(t *testing.T) {
+func TestRuntimeHandleStartRejectsRuntimeOnlyLaunch(t *testing.T) {
 	sp := runtime.NewFake()
 
 	handle, err := NewRuntimeHandle(RuntimeHandleConfig{
@@ -1330,23 +1518,12 @@ func TestRuntimeHandleStartResolvedStartsLegacyRuntimeSession(t *testing.T) {
 		t.Fatalf("NewRuntimeHandle: %v", err)
 	}
 
-	if err := handle.StartResolved(context.Background(), "legacy --resume seeded", runtime.Config{
-		WorkDir: "/tmp/runtime-worker",
-	}); err != nil {
-		t.Fatalf("StartResolved: %v", err)
+	err = handle.Start(context.Background())
+	if !errors.Is(err, ErrOperationUnsupported) {
+		t.Fatalf("Start error = %v, want ErrOperationUnsupported", err)
 	}
-	if !sp.IsRunning("legacy-worker") {
-		t.Fatal("legacy-worker should be running after StartResolved")
-	}
-	start := firstCall(sp.Calls, "Start")
-	if start == nil {
-		t.Fatalf("runtime calls = %#v, want Start", sp.Calls)
-	}
-	if start.Config.Command != "legacy --resume seeded" {
-		t.Fatalf("start command = %q, want legacy --resume seeded", start.Config.Command)
-	}
-	if start.Config.WorkDir != "/tmp/runtime-worker" {
-		t.Fatalf("start workdir = %q, want /tmp/runtime-worker", start.Config.WorkDir)
+	if sp.IsRunning("legacy-worker") {
+		t.Fatal("legacy-worker should not be started by runtime-only handle")
 	}
 }
 
@@ -1640,17 +1817,19 @@ func TestSessionHandleHistoryStitchesGeminiRotatedTranscriptAcrossRestart(t *tes
 		t.Fatalf("write .project_root: %v", err)
 	}
 
+	alias := "gemini-probe-stitch"
 	firstTranscript := filepath.Join(chatsDir, "session-2026-04-17T03-12-before.json")
-	writeGeminiHistoryFixture(t, firstTranscript, "before-session", []string{
+	writeGeminiHistoryFixtureWithIdentity(t, firstTranscript, "before-session", alias, []string{
 		`{"id":"u1","timestamp":"2026-04-17T03:12:00Z","type":"user","content":"remember alpha"}`,
 		`{"id":"a1","timestamp":"2026-04-17T03:12:01Z","type":"gemini","content":"remembered alpha"}`,
 	})
-	firstTime := time.Now().Add(-2 * time.Minute)
+	firstTime := time.Now()
 	if err := os.Chtimes(firstTranscript, firstTime, firstTime); err != nil {
 		t.Fatalf("chtimes(first transcript): %v", err)
 	}
 
 	handle, _, _, _ := newTestSessionHandle(t, SessionSpec{
+		Alias:    alias,
 		Profile:  ProfileGeminiTmuxCLI,
 		Template: "probe",
 		Title:    "Probe",
@@ -1676,11 +1855,11 @@ func TestSessionHandleHistoryStitchesGeminiRotatedTranscriptAcrossRestart(t *tes
 	}
 
 	secondTranscript := filepath.Join(chatsDir, "session-2026-04-17T03-15-after.json")
-	writeGeminiHistoryFixture(t, secondTranscript, "after-session", []string{
+	writeGeminiHistoryFixtureWithIdentity(t, secondTranscript, "after-session", alias, []string{
 		`{"id":"u2","timestamp":"2026-04-17T03:15:00Z","type":"user","content":"recall the earlier phrase"}`,
 		`{"id":"a2","timestamp":"2026-04-17T03:15:01Z","type":"gemini","content":"alpha"}`,
 	})
-	secondTime := time.Now().Add(-1 * time.Minute)
+	secondTime := time.Now().Add(time.Minute)
 	if err := os.Chtimes(secondTranscript, secondTime, secondTime); err != nil {
 		t.Fatalf("chtimes(second transcript): %v", err)
 	}
@@ -1742,36 +1921,34 @@ func TestSessionHandleStartPassesSessionEnv(t *testing.T) {
 	}
 }
 
-func TestSessionHandleStartResolvedUsesProvidedRuntime(t *testing.T) {
+func TestSessionHandleStartUsesResolvedRuntimeFromSpec(t *testing.T) {
 	handle, _, sp, _ := newTestSessionHandle(t, SessionSpec{
 		Profile:  ProfileGeminiTmuxCLI,
 		Template: "probe",
 		Title:    "Probe",
-		Command:  "gemini",
+		Command:  "gemini --resume existing-session",
 		WorkDir:  t.TempDir(),
 		Provider: "gemini",
+		Hints: runtime.Config{
+			Env: map[string]string{
+				"GC_WORKER_BOUNDARY": "start",
+			},
+		},
 	})
 
-	resolved := runtime.Config{
-		Command: "gemini --resume existing-session",
-		WorkDir: t.TempDir(),
-		Env: map[string]string{
-			"GC_WORKER_BOUNDARY": "start_resolved",
-		},
-	}
-	if err := handle.StartResolved(context.Background(), resolved.Command, resolved); err != nil {
-		t.Fatalf("StartResolved: %v", err)
+	if err := handle.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
 
 	start := firstCall(sp.Calls, "Start")
 	if start == nil {
 		t.Fatalf("runtime calls = %#v, want Start call", sp.Calls)
 	}
-	if got := start.Config.Command; got != resolved.Command {
-		t.Fatalf("StartResolved command = %q, want %q", got, resolved.Command)
+	if got, want := start.Config.Command, "gemini --resume existing-session"; got != want {
+		t.Fatalf("Start command = %q, want %q", got, want)
 	}
-	if got := start.Config.Env["GC_WORKER_BOUNDARY"]; got != "start_resolved" {
-		t.Fatalf("StartResolved env GC_WORKER_BOUNDARY = %q, want start_resolved", got)
+	if got := start.Config.Env["GC_WORKER_BOUNDARY"]; got != "start" {
+		t.Fatalf("Start env GC_WORKER_BOUNDARY = %q, want start", got)
 	}
 }
 
@@ -1814,7 +1991,7 @@ func TestSessionHandleStartUsesSessionIDOnFirstStartAndResumeAfterSuspend(t *tes
 	if len(sp.Calls) < 3 {
 		t.Fatalf("runtime calls = %#v, want second Start after Stop", sp.Calls)
 	}
-	secondStart := lastCall(sp.Calls, "Start")
+	secondStart := lastCall(sp.Calls)
 	if secondStart == nil {
 		t.Fatalf("runtime calls = %#v, want second Start", sp.Calls)
 	}
@@ -1920,9 +2097,9 @@ func newTestSessionHandleWithRecorder(t *testing.T, spec SessionSpec, recorder e
 	return handle, store, sp, manager
 }
 
-func lastCall(calls []runtime.Call, method string) *runtime.Call {
+func lastCall(calls []runtime.Call) *runtime.Call {
 	for i := len(calls) - 1; i >= 0; i-- {
-		if calls[i].Method == method {
+		if calls[i].Method == "Start" {
 			return &calls[i]
 		}
 	}
@@ -1972,10 +2149,14 @@ func hasCall(calls []runtime.Call, method, message string) bool {
 	return false
 }
 
-func writeGeminiHistoryFixture(t *testing.T, path, sessionID string, messages []string) {
+func writeGeminiHistoryFixtureWithIdentity(t *testing.T, path, sessionID, identity string, messages []string) {
 	t.Helper()
 
-	body := fmt.Sprintf("{\n  \"sessionId\": %q,\n  \"messages\": [\n    %s\n  ]\n}\n", sessionID, strings.Join(messages, ",\n    "))
+	identityField := ""
+	if identity != "" {
+		identityField = fmt.Sprintf("  \"gcSessionName\": %q,\n", identity)
+	}
+	body := fmt.Sprintf("{\n  \"sessionId\": %q,\n%s  \"messages\": [\n    %s\n  ]\n}\n", sessionID, identityField, strings.Join(messages, ",\n    "))
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write gemini transcript %s: %v", path, err)
 	}

--- a/internal/worker/observe.go
+++ b/internal/worker/observe.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
@@ -32,7 +33,7 @@ func ObserveHandle(ctx context.Context, h LiveObservationHandle) (LiveObservatio
 
 // LiveObservation reports runtime presence and attachment metadata for a
 // bead-backed session handle.
-func (h *SessionHandle) LiveObservation(_ context.Context) (LiveObservation, error) {
+func (h *SessionHandle) LiveObservation(ctx context.Context) (LiveObservation, error) {
 	id := h.currentSessionID()
 	if id == "" {
 		return LiveObservation{}, nil
@@ -44,6 +45,9 @@ func (h *SessionHandle) LiveObservation(_ context.Context) (LiveObservation, err
 	runtimeObs, err := h.manager.ObserveRuntime(id, h.runtimeHints().ProcessNames)
 	if err != nil {
 		return LiveObservation{}, err
+	}
+	if runtimeObs.Running && strings.TrimSpace(info.SessionKey) == "" {
+		h.tryPersistDerivedSessionKey(ctx, id)
 	}
 	obs := LiveObservation{
 		Running:          runtimeObs.Running,

--- a/internal/worker/operation_events.go
+++ b/internal/worker/operation_events.go
@@ -15,19 +15,18 @@ import (
 type workerOperation string
 
 const (
-	workerOperationStart         workerOperation = "start"
-	workerOperationStartResolved workerOperation = "start_resolved"
-	workerOperationAttach        workerOperation = "attach"
-	workerOperationCreate        workerOperation = "create"
-	workerOperationReset         workerOperation = "reset"
-	workerOperationStop          workerOperation = "stop"
-	workerOperationKill          workerOperation = "kill"
-	workerOperationClose         workerOperation = "close"
-	workerOperationRename        workerOperation = "rename"
-	workerOperationMessage       workerOperation = "message"
-	workerOperationInterrupt     workerOperation = "interrupt"
-	workerOperationNudge         workerOperation = "nudge"
-	workerOperationHistory       workerOperation = "history"
+	workerOperationStart     workerOperation = "start"
+	workerOperationAttach    workerOperation = "attach"
+	workerOperationCreate    workerOperation = "create"
+	workerOperationReset     workerOperation = "reset"
+	workerOperationStop      workerOperation = "stop"
+	workerOperationKill      workerOperation = "kill"
+	workerOperationClose     workerOperation = "close"
+	workerOperationRename    workerOperation = "rename"
+	workerOperationMessage   workerOperation = "message"
+	workerOperationInterrupt workerOperation = "interrupt"
+	workerOperationNudge     workerOperation = "nudge"
+	workerOperationHistory   workerOperation = "history"
 )
 
 type operationResult string

--- a/internal/worker/provider_resume.go
+++ b/internal/worker/provider_resume.go
@@ -7,17 +7,27 @@ import (
 
 var codexThreadIDPattern = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 
+func canDeriveResumeSessionKey(provider string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	return strings.Contains(provider, "codex") || strings.Contains(provider, "gemini")
+}
+
 func derivedResumeSessionKey(provider, providerSessionID string) string {
 	providerSessionID = strings.TrimSpace(providerSessionID)
 	if providerSessionID == "" {
 		return ""
 	}
-	if !strings.Contains(strings.ToLower(strings.TrimSpace(provider)), "codex") {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	switch {
+	case strings.Contains(provider, "codex"):
+		matches := codexThreadIDPattern.FindAllString(providerSessionID, -1)
+		if len(matches) == 0 {
+			return ""
+		}
+		return matches[len(matches)-1]
+	case strings.Contains(provider, "gemini"):
+		return providerSessionID
+	default:
 		return ""
 	}
-	matches := codexThreadIDPattern.FindAllString(providerSessionID, -1)
-	if len(matches) == 0 {
-		return ""
-	}
-	return matches[len(matches)-1]
 }

--- a/internal/worker/runtime_handle.go
+++ b/internal/worker/runtime_handle.go
@@ -75,26 +75,6 @@ func (h *RuntimeHandle) Start(ctx context.Context) (err error) {
 	return err
 }
 
-// StartResolved starts a runtime-only handle using the provided resolved command.
-func (h *RuntimeHandle) StartResolved(ctx context.Context, startCommand string, cfg runtime.Config) (err error) {
-	event := h.beginOperationEvent(ctx, workerOperationStartResolved)
-	defer func() { event.finish(err) }()
-
-	if h.provider.IsRunning(h.sessionName) {
-		return nil
-	}
-	startCfg := cfg
-	if strings.TrimSpace(startCfg.Command) == "" {
-		startCfg.Command = strings.TrimSpace(startCommand)
-	}
-	if strings.TrimSpace(startCfg.Command) == "" {
-		err = fmt.Errorf("%w: start requires a runtime command", ErrOperationUnsupported)
-		return err
-	}
-	err = h.provider.Start(ctx, h.sessionName, startCfg)
-	return err
-}
-
 // Attach attaches to the live runtime session if it is currently running.
 func (h *RuntimeHandle) Attach(ctx context.Context) (err error) {
 	event := h.beginOperationEvent(ctx, workerOperationAttach)

--- a/internal/worker/transcript/discovery.go
+++ b/internal/worker/transcript/discovery.go
@@ -12,7 +12,7 @@ import (
 func SupportsIDLookup(provider string) bool {
 	switch providerFamily(provider) {
 	case "codex", "gemini":
-		return false
+		return true
 	default:
 		return true
 	}
@@ -34,7 +34,7 @@ func DiscoverKeyedPath(searchPaths []string, provider, workDir, gcSessionID stri
 	if strings.TrimSpace(gcSessionID) == "" || !SupportsIDLookup(provider) {
 		return ""
 	}
-	return sessionlog.FindSessionFileByID(searchPaths, workDir, gcSessionID)
+	return sessionlog.FindSessionFileByIDForProvider(searchPaths, provider, workDir, gcSessionID)
 }
 
 // DiscoverFallbackPath resolves the narrow provider-specific fallback path to

--- a/internal/worker/transcript/discovery_test.go
+++ b/internal/worker/transcript/discovery_test.go
@@ -93,7 +93,7 @@ func TestDiscoverFallbackPathUsesNewestClaudeLatestSessionAcrossAliases(t *testi
 	}
 }
 
-func TestDiscoverPathCodexIgnoresGCSessionID(t *testing.T) {
+func TestDiscoverPathCodexUsesGCSessionID(t *testing.T) {
 	base := t.TempDir()
 	workDir := filepath.Join(t.TempDir(), "codex-project")
 
@@ -119,8 +119,19 @@ func TestDiscoverPathCodexIgnoresGCSessionID(t *testing.T) {
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	codexPath := filepath.Join(codexDir, "session.jsonl")
+	codexPath := filepath.Join(codexDir, "rollout-2026-04-18T00-00-00-gc-123.jsonl")
 	if err := os.WriteFile(codexPath, append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newerOther := filepath.Join(codexDir, "rollout-2026-04-18T00-00-01-other.jsonl")
+	if err := os.WriteFile(newerOther, append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	if err := os.Chtimes(codexPath, now.Add(-time.Minute), now.Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newerOther, now, now); err != nil {
 		t.Fatal(err)
 	}
 
@@ -164,8 +175,8 @@ func TestSupportsIDLookup(t *testing.T) {
 		want     bool
 	}{
 		{provider: "claude/tmux-cli", want: true},
-		{provider: "codex/tmux-cli", want: false},
-		{provider: "gemini/tmux-cli", want: false},
+		{provider: "codex/tmux-cli", want: true},
+		{provider: "gemini/tmux-cli", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- use cached session/work demand snapshots in reconciler paths to keep ticks bounded
- route lifecycle start/wake through the worker/session handle boundary and preserve pending create semantics
- add targeted transcript/session lookup coverage and cache/backfill tests

## Verification
- pre-commit hook passed: lint, go vet, GC_FAST_UNIT=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->