### PR TITLE
fix(workflow): close source chains across stores

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -164,6 +164,10 @@ func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store
 	switch bead.Metadata["gc.kind"] {
 	case "check", "fanout", "retry-eval", "retry", "ralph":
 		loadCfg = true
+	case "workflow-finalize":
+		// Need cfg to resolve "city:<name>" / "rig:<name>" store refs when
+		// closing parent source beads in their native stores.
+		loadCfg = true
 	}
 	if loadCfg {
 		cfg, err := loadCityConfig(cityPath, stderr)
@@ -171,6 +175,7 @@ func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store
 			return err
 		}
 		resolveRigPaths(cityPath, cfg.Rigs)
+		opts.ResolveStoreRef = makeStoreRefResolver(cityPath, cfg)
 		switch bead.Metadata["gc.kind"] {
 		case "check", "fanout":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)
@@ -212,6 +217,51 @@ func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store
 		fmt.Fprintln(stdout) //nolint:errcheck
 	}
 	return nil
+}
+
+// makeStoreRefResolver returns a dispatch.ProcessOptions.ResolveStoreRef
+// closure for the given city. The resolver maps "city:<name>" and
+// "rig:<name>" gc.source_store_ref values to a beads.Store rooted at the
+// matching scope. processWorkflowFinalize uses it to walk the source bead
+// chain across store boundaries so a successful rig-scope workflow closes
+// the city-scope source bead that spawned it (e.g. PR-review "Adopt PR"
+// requests).
+func makeStoreRefResolver(cityPath string, cfg *config.City) func(string) (beads.Store, error) {
+	cityName := loadedCityName(cfg, cityPath)
+	return func(ref string) (beads.Store, error) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			return nil, fmt.Errorf("empty store ref")
+		}
+		switch {
+		case strings.HasPrefix(ref, "city:"):
+			name := strings.TrimSpace(strings.TrimPrefix(ref, "city:"))
+			// "city:" without a name still resolves to this city's store -
+			// older callers stamp ambiguous refs and the only reachable city
+			// from a control-dispatcher is the one it was launched in.
+			if name != "" && cityName != "" && name != cityName {
+				return nil, fmt.Errorf("city ref %q does not match this city %q", ref, cityName)
+			}
+			return openStoreAtForCity(cityPath, cityPath)
+		case strings.HasPrefix(ref, "rig:"):
+			name := strings.TrimSpace(strings.TrimPrefix(ref, "rig:"))
+			if name == "" {
+				return nil, fmt.Errorf("rig ref %q missing rig name", ref)
+			}
+			if cfg == nil {
+				return nil, fmt.Errorf("no city config available to resolve %q", ref)
+			}
+			for _, rig := range cfg.Rigs {
+				if rig.Name != name {
+					continue
+				}
+				return openControlStoreAtForCity(rig.Path, cityPath, cfg)
+			}
+			return nil, fmt.Errorf("rig %q not found in city config", name)
+		default:
+			return nil, fmt.Errorf("unsupported store ref scheme: %q", ref)
+		}
+	}
 }
 
 func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (beads.Store, error) {
@@ -656,10 +706,12 @@ func deleteWorkflowMatches(matches []workflowStoreMatch) (int, error) {
 }
 
 type sourceWorkflowStoreMatch struct {
-	label string
-	store beads.Store
-	roots []beads.Bead
-	beads []beads.Bead
+	label  string
+	store  beads.Store
+	roots  []beads.Bead
+	beads  []beads.Bead
+	path   string
+	runner beads.CommandRunner
 }
 
 type sourceWorkflowStoreSelector struct {
@@ -784,13 +836,28 @@ func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads
 	if !deleteBeads {
 		return closed, deleted, incomplete
 	}
-	count, errs := deleteWorkflowBeads(match.store, ids)
+	count, errs := deleteSourceWorkflowMatchBeads(match, ids)
 	deleted += count
 	for _, deleteErr := range errs {
 		incomplete = true
 		_, _ = fmt.Fprintf(stderr, "store=%s delete_error=%v\n", match.label, deleteErr)
 	}
 	return closed, deleted, incomplete
+}
+
+func deleteSourceWorkflowMatchBeads(match sourceWorkflowStoreMatch, ids []string) (int, []error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if match.runner != nil && strings.TrimSpace(match.path) != "" {
+		args := append([]string{"delete"}, ids...)
+		args = append(args, "--cascade", "--force")
+		if _, err := match.runner(match.path, "bd", args...); err != nil {
+			return 0, []error{err}
+		}
+		return len(ids), nil
+	}
+	return deleteWorkflowBeads(match.store, ids)
 }
 
 func cmdWorkflowDeleteSource(sourceBeadID string, selector sourceWorkflowStoreSelector, apply, deleteBeads bool, stdout, stderr io.Writer) int {
@@ -1125,28 +1192,104 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 	if err != nil {
 		return nil, skips, err
 	}
-	matches := make([]sourceWorkflowStoreMatch, 0, len(stores))
-	for _, info := range stores {
-		rootStoreRef := workflowStoreRefForDir(info.path, cityPath, loadedCityName(cfg, cityPath), cfg)
-		roots, err := sourceworkflow.ListLiveRoots(info.store, sourceBeadID, sourceStoreRef, rootStoreRef)
-		if err != nil {
-			return nil, skips, err
+	matchesByLabel := map[string]sourceWorkflowStoreMatch{}
+	visited := map[string]struct{}{}
+	cityName := loadedCityName(cfg, cityPath)
+
+	var collect func(string, string) error
+	collect = func(currentSourceID, currentSourceStoreRef string) error {
+		currentSourceID = strings.TrimSpace(currentSourceID)
+		if currentSourceID == "" {
+			return nil
 		}
-		if len(roots) == 0 {
-			continue
+		for _, info := range stores {
+			rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cityName, cfg)
+			visitKey := rootStoreRef + "\x00" + currentSourceStoreRef + "\x00" + currentSourceID
+			if _, ok := visited[visitKey]; ok {
+				continue
+			}
+			visited[visitKey] = struct{}{}
+			roots, err := sourceworkflow.ListLiveRoots(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
+			if err != nil {
+				return err
+			}
+			if len(roots) > 0 {
+				beadSet := make([]beads.Bead, 0, len(roots))
+				for _, root := range roots {
+					beadSet = append(beadSet, findWorkflowBeads(info.store, root.ID)...)
+				}
+				mergeSourceWorkflowMatch(matchesByLabel, sourceWorkflowStoreMatch{
+					label:  workflowDeleteStoreLabel(cfg, cityPath, info.path),
+					store:  info.store,
+					roots:  roots,
+					beads:  uniqueBeads(beadSet),
+					path:   info.path,
+					runner: workflowDeleteRunnerForPath(cfg, cityPath, info.path),
+				})
+			}
+			children, err := sourceWorkflowChildSources(info.store, currentSourceID, currentSourceStoreRef, rootStoreRef)
+			if err != nil {
+				return err
+			}
+			for _, child := range children {
+				if err := collect(child.ID, rootStoreRef); err != nil {
+					return err
+				}
+			}
 		}
-		beadSet := make([]beads.Bead, 0, len(roots))
-		for _, root := range roots {
-			beadSet = append(beadSet, findWorkflowBeads(info.store, root.ID)...)
-		}
-		matches = append(matches, sourceWorkflowStoreMatch{
-			label: workflowDeleteStoreLabel(cfg, cityPath, info.path),
-			store: info.store,
-			roots: roots,
-			beads: uniqueBeads(beadSet),
-		})
+		return nil
+	}
+	if err := collect(sourceBeadID, sourceStoreRef); err != nil {
+		return nil, skips, err
+	}
+	matches := make([]sourceWorkflowStoreMatch, 0, len(matchesByLabel))
+	for _, match := range matchesByLabel {
+		match.roots = uniqueBeads(match.roots)
+		match.beads = uniqueBeads(match.beads)
+		matches = append(matches, match)
 	}
 	return matches, skips, nil
+}
+
+func mergeSourceWorkflowMatch(matches map[string]sourceWorkflowStoreMatch, next sourceWorkflowStoreMatch) {
+	if next.label == "" {
+		return
+	}
+	current := matches[next.label]
+	if current.label == "" {
+		matches[next.label] = next
+		return
+	}
+	current.roots = append(current.roots, next.roots...)
+	current.beads = append(current.beads, next.beads...)
+	matches[next.label] = current
+}
+
+func sourceWorkflowChildSources(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef string) ([]beads.Bead, error) {
+	sourceBeadID = strings.TrimSpace(sourceBeadID)
+	if store == nil || sourceBeadID == "" {
+		return nil, nil
+	}
+	candidates, err := store.List(beads.ListQuery{
+		IncludeClosed: true,
+		Metadata: map[string]string{
+			"gc.source_bead_id": sourceBeadID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	children := make([]beads.Bead, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ID == "" || sourceworkflow.IsWorkflowRoot(candidate) {
+			continue
+		}
+		if !sourceworkflow.WorkflowMatchesSource(candidate, sourceBeadID, sourceStoreRef, rootStoreRef) {
+			continue
+		}
+		children = append(children, candidate)
+	}
+	return children, nil
 }
 
 func sourceWorkflowMatchLabels(matches []sourceWorkflowStoreMatch) []string {

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -176,6 +176,12 @@ func runControlDispatcherWithStore(cityPath, storePath string, store beads.Store
 		}
 		resolveRigPaths(cityPath, cfg.Rigs)
 		opts.ResolveStoreRef = makeStoreRefResolver(cityPath, cfg)
+		if bead.Metadata["gc.kind"] == "workflow-finalize" {
+			sourceWorkflowCtx, cancelSourceWorkflowCtx := sourceWorkflowCommandContext()
+			defer cancelSourceWorkflowCtx()
+			opts.SourceWorkflowLock = makeSourceWorkflowLocker(sourceWorkflowCtx, cityPath, cfg, storePath)
+			opts.SourceWorkflowStores = makeSourceWorkflowStoresLister(cityPath, cfg)
+		}
 		switch bead.Metadata["gc.kind"] {
 		case "check", "fanout":
 			opts.FormulaSearchPaths = workflowFormulaSearchPaths(cfg, bead)
@@ -262,6 +268,66 @@ func makeStoreRefResolver(cityPath string, cfg *config.City) func(string) (beads
 			return nil, fmt.Errorf("unsupported store ref scheme: %q", ref)
 		}
 	}
+}
+
+func makeSourceWorkflowLocker(ctx context.Context, cityPath string, cfg *config.City, defaultStorePath string) func(storeRef, sourceBeadID string, fn func() error) error {
+	return func(storeRef, sourceBeadID string, fn func() error) error {
+		return sourceworkflow.WithLock(ctx, cityPath, sourceWorkflowLockScopeForStoreRef(cityPath, cfg, defaultStorePath, storeRef), sourceBeadID, fn)
+	}
+}
+
+func makeSourceWorkflowStoresLister(cityPath string, cfg *config.City) func() ([]dispatch.SourceWorkflowStore, error) {
+	return makeSourceWorkflowStoresListerWithOpenStore(cityPath, cfg, func(dir string) (beads.Store, error) {
+		return openStoreAtForCity(dir, cityPath)
+	})
+}
+
+func makeSourceWorkflowStoresListerWithOpenStore(cityPath string, cfg *config.City, openStore func(string) (beads.Store, error)) func() ([]dispatch.SourceWorkflowStore, error) {
+	var (
+		loaded  bool
+		stores  []dispatch.SourceWorkflowStore
+		loadErr error
+	)
+	return func() ([]dispatch.SourceWorkflowStore, error) {
+		if loaded {
+			return stores, loadErr
+		}
+		loaded = true
+		views, skips, err := openSourceWorkflowStoresWith(cfg, cityPath, "", openStore)
+		if err != nil {
+			loadErr = err
+			return nil, err
+		}
+		if len(skips) > 0 {
+			msg := formatSourceWorkflowStoreSkips(skips)
+			workflowTracef("source-workflow stores warning=%q", msg)
+			loadErr = errors.New(msg)
+			return nil, loadErr
+		}
+		cityName := loadedCityName(cfg, cityPath)
+		stores = make([]dispatch.SourceWorkflowStore, 0, len(views))
+		for _, view := range views {
+			stores = append(stores, dispatch.SourceWorkflowStore{
+				Store:    view.store,
+				StoreRef: workflowStoreRefForDir(view.path, cityPath, cityName, cfg),
+			})
+		}
+		return stores, nil
+	}
+}
+
+func sourceWorkflowLockScopeForStoreRef(cityPath string, cfg *config.City, defaultStorePath string, storeRef string) string {
+	return sourceworkflow.LockScopeForStoreRef(cityPath, defaultStorePath, storeRef, func(rigName string) (string, bool) {
+		if cfg != nil {
+			for _, rig := range cfg.Rigs {
+				if rig.Name != rigName {
+					continue
+				}
+				return rig.Path, true
+			}
+		}
+		return "", false
+	})
 }
 
 func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (beads.Store, error) {
@@ -849,14 +915,6 @@ func deleteSourceWorkflowMatchBeads(match sourceWorkflowStoreMatch, ids []string
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	if match.runner != nil && strings.TrimSpace(match.path) != "" {
-		args := append([]string{"delete"}, ids...)
-		args = append(args, "--cascade", "--force")
-		if _, err := match.runner(match.path, "bd", args...); err != nil {
-			return 0, []error{err}
-		}
-		return len(ids), nil
-	}
 	return deleteWorkflowBeads(match.store, ids)
 }
 
@@ -1204,6 +1262,9 @@ func collectSourceWorkflowMatches(cfg *config.City, cityPath, sourceBeadID, sour
 		}
 		for _, info := range stores {
 			rootStoreRef := workflowStoreRefForDir(info.path, cityPath, cityName, cfg)
+			// Downward delete-source walks key by root store plus source
+			// identity. The upward finalize walk in internal/dispatch only
+			// needs source store plus bead ID because each hop has one parent.
 			visitKey := rootStoreRef + "\x00" + currentSourceStoreRef + "\x00" + currentSourceID
 			if _, ok := visited[visitKey]; ok {
 				continue

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -492,6 +492,138 @@ func TestCmdWorkflowDeleteSourceClosesMatchedRootsAndClearsWorkflowID(t *testing
 	}
 }
 
+func TestCmdWorkflowDeleteSourceFollowsRigLaunchSourceChain(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rigDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "test-city"
+
+[daemon]
+formula_v2 = true
+
+[[rigs]]
+name = "alpha"
+path = "rigs/alpha"
+prefix = "BL"
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prevCityFlag := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = prevCityFlag })
+
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(city): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig .gc): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(rigDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(rig): %v", err)
+	}
+
+	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city): %v", err)
+	}
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	citySource, err := cityStore.Create(beads.Bead{Title: "City source", Type: "task", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(city source): %v", err)
+	}
+	if err := cityStore.SetMetadata(citySource.ID, "workflow_id", "wf-stale"); err != nil {
+		t.Fatalf("SetMetadata(city workflow_id): %v", err)
+	}
+	rigLaunch, err := rigStore.Create(beads.Bead{
+		Title:  "Rig launch",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.source_bead_id":                      citySource.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "city:test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(rig launch): %v", err)
+	}
+	root, err := rigStore.Create(beads.Bead{
+		Title:  "Workflow",
+		Type:   "task",
+		Status: "in_progress",
+		Metadata: map[string]string{
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      rigLaunch.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := rigStore.Create(beads.Bead{
+		Title:  "Child",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.root_bead_id": root.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	selector := sourceWorkflowStoreSelector{storeRef: "city:test-city"}
+	if code := cmdWorkflowDeleteSource(citySource.ID, selector, true, false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdWorkflowDeleteSource returned %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "result=cleaned") {
+		t.Fatalf("stdout = %q, want cleaned result", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	reloadedRig, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig reload): %v", err)
+	}
+	updatedRoot, err := reloadedRig.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get(root): %v", err)
+	}
+	if updatedRoot.Status != "closed" {
+		t.Fatalf("root status = %q, want closed", updatedRoot.Status)
+	}
+	updatedChild, err := reloadedRig.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get(child): %v", err)
+	}
+	if updatedChild.Status != "closed" {
+		t.Fatalf("child status = %q, want closed", updatedChild.Status)
+	}
+	reloadedCity, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(city reload): %v", err)
+	}
+	updatedCitySource, err := reloadedCity.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("Get(city source): %v", err)
+	}
+	if got := strings.TrimSpace(updatedCitySource.Metadata["workflow_id"]); got != "" {
+		t.Fatalf("city source workflow_id = %q, want empty", got)
+	}
+}
+
 func TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot(t *testing.T) {
 	// Regression: after the ListLiveRoots contract fix, the singleton
 	// scanner surfaces graph.v2-only roots (marked with
@@ -2622,6 +2754,63 @@ func TestDeleteWorkflowBeadsRemovesDepsBeforeDelete(t *testing.T) {
 		} else if len(up) != 0 {
 			t.Fatalf("up deps for %s = %#v, want none", id, up)
 		}
+	}
+}
+
+type depListFailStore struct {
+	*beads.MemStore
+	depListCalls int
+}
+
+func (s *depListFailStore) DepList(id, direction string) ([]beads.Dep, error) {
+	s.depListCalls++
+	return nil, fmt.Errorf("unexpected dep list for %s %s", id, direction)
+}
+
+func TestApplySourceWorkflowMatchCleanupUsesCascadeRunnerForDelete(t *testing.T) {
+	base := beads.NewMemStore()
+	first, err := base.Create(beads.Bead{Title: "workflow first", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(first): %v", err)
+	}
+	second, err := base.Create(beads.Bead{Title: "workflow second", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(second): %v", err)
+	}
+	store := &depListFailStore{MemStore: base}
+
+	var gotDir, gotName string
+	var gotArgs []string
+	runner := func(dir, name string, args ...string) ([]byte, error) {
+		gotDir = dir
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return []byte("ok"), nil
+	}
+
+	var stderr bytes.Buffer
+	closed, deleted, incomplete := applySourceWorkflowMatchCleanup(sourceWorkflowStoreMatch{
+		label:  "rig:gascity",
+		store:  store,
+		beads:  []beads.Bead{first, second},
+		path:   "/repo",
+		runner: runner,
+	}, true, &stderr)
+	if incomplete {
+		t.Fatalf("cleanup incomplete; stderr=%s", stderr.String())
+	}
+	if closed != 2 || deleted != 2 {
+		t.Fatalf("closed/deleted = %d/%d, want 2/2", closed, deleted)
+	}
+	if store.depListCalls != 0 {
+		t.Fatalf("dep list calls = %d, want 0", store.depListCalls)
+	}
+	if gotDir != "/repo" || gotName != "bd" {
+		t.Fatalf("runner target = %q %q, want /repo bd", gotDir, gotName)
+	}
+	wantArgs := []string{"delete", first.ID, second.ID, "--cascade", "--force"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("runner args = %#v, want %#v", gotArgs, wantArgs)
 	}
 }
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -98,6 +98,183 @@ func TestOpenSourceWorkflowStoresFailsOnlyWhenEverythingBroken(t *testing.T) {
 	}
 }
 
+func TestWorkflowFinalizeRetriesWhenSourceWorkflowStoreScanSkipsLiveRoot(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: "rigs/alpha"},
+			{Name: "broken", Path: "rigs/broken"},
+		},
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	brokenStore := beads.NewMemStore()
+
+	citySource, err := cityStore.Create(beads.Bead{Title: "Adopt PR", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(city source): %v", err)
+	}
+	rigLaunch, err := rigStore.Create(beads.Bead{
+		Title: "Rig launch",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(rig launch): %v", err)
+	}
+	workflow, err := rigStore.Create(beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   rigLaunch.ID,
+			"gc.source_store_ref": "rig:alpha",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(workflow): %v", err)
+	}
+	cleanup, err := rigStore.Create(beads.Bead{
+		Title: "cleanup",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(cleanup): %v", err)
+	}
+	if err := rigStore.Close(cleanup.ID); err != nil {
+		t.Fatalf("Close(cleanup): %v", err)
+	}
+	finalizer, err := rigStore.Create(beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(finalizer): %v", err)
+	}
+	if err := rigStore.DepAdd(finalizer.ID, cleanup.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(finalizer->cleanup): %v", err)
+	}
+	if err := rigStore.DepAdd(workflow.ID, finalizer.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(workflow->finalizer): %v", err)
+	}
+	hiddenRoot, err := brokenStore.Create(beads.Bead{
+		Title: "hidden live workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                                "workflow",
+			"gc.formula_contract":                    "graph.v2",
+			"gc.source_bead_id":                      citySource.ID,
+			sourceworkflow.SourceStoreRefMetadataKey: "city:test-city",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(hidden root): %v", err)
+	}
+
+	openStore := func(dir string) (beads.Store, error) {
+		switch filepath.Clean(dir) {
+		case filepath.Clean(cityPath):
+			return cityStore, nil
+		case filepath.Clean(filepath.Join(cityPath, "rigs/alpha")):
+			return rigStore, nil
+		case filepath.Clean(filepath.Join(cityPath, "rigs/broken")):
+			return nil, fmt.Errorf("simulated broken rig with live root %s", hiddenRoot.ID)
+		default:
+			return nil, fmt.Errorf("unexpected store path %s", dir)
+		}
+	}
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test-city":
+			return cityStore, nil
+		case "rig:alpha":
+			return rigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown ref %s", ref)
+		}
+	}
+
+	_, err = dispatch.ProcessControl(rigStore, finalizer, dispatch.ProcessOptions{
+		ResolveStoreRef:      resolver,
+		SourceWorkflowStores: makeSourceWorkflowStoresListerWithOpenStore(cityPath, cfg, openStore),
+		SourceWorkflowLock:   func(_ string, _ string, fn func() error) error { return fn() },
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) err = nil, want retryable skipped-store error")
+	}
+	if !strings.Contains(err.Error(), "source-workflow singleton scan skipped") {
+		t.Fatalf("ProcessControl error = %v, want skipped-store scan error", err)
+	}
+
+	workflowAfter, err := rigStore.Get(workflow.ID)
+	if err != nil {
+		t.Fatalf("Get(workflow): %v", err)
+	}
+	if workflowAfter.Status == "closed" {
+		t.Fatal("workflow status = closed; want open so singleton scans still see the retrying root")
+	}
+	finalizerAfter, err := rigStore.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("Get(finalizer): %v", err)
+	}
+	if finalizerAfter.Status == "closed" {
+		t.Fatal("finalizer status = closed; want open so source-chain closure retries after skipped scan")
+	}
+	rigLaunchAfter, err := rigStore.Get(rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("Get(rig launch): %v", err)
+	}
+	if rigLaunchAfter.Status == "closed" {
+		t.Fatal("rig launch status = closed; want open until all source-workflow stores are scanned")
+	}
+	citySourceAfter, err := cityStore.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("Get(city source): %v", err)
+	}
+	if citySourceAfter.Status == "closed" {
+		t.Fatal("city source status = closed; want open while a skipped store may contain a live root")
+	}
+	hiddenRootAfter, err := brokenStore.Get(hiddenRoot.ID)
+	if err != nil {
+		t.Fatalf("Get(hidden root): %v", err)
+	}
+	if hiddenRootAfter.Status == "closed" {
+		t.Fatal("hidden root status = closed; want unchanged")
+	}
+}
+
+func TestSourceWorkflowLockScopeForStoreRefUsesSharedHelper(t *testing.T) {
+	cityPath := "/city"
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "alpha", Path: "rigs/alpha"},
+		},
+	}
+
+	got := sourceWorkflowLockScopeForStoreRef(cityPath, cfg, "", "rig:alpha")
+	want := sourceworkflow.LockScopeForStoreRef(cityPath, "", "rig:alpha", func(rigName string) (string, bool) {
+		if rigName != "alpha" {
+			return "", false
+		}
+		return "rigs/alpha", true
+	})
+	if got != want {
+		t.Fatalf("sourceWorkflowLockScopeForStoreRef = %q, want shared helper scope %q", got, want)
+	}
+}
+
 type closeAllFailStore struct {
 	beads.Store
 	failOn map[string]struct{}
@@ -418,6 +595,7 @@ func TestCmdWorkflowDeleteSourceClosesMatchedRootsAndClearsWorkflowID(t *testing
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -513,6 +691,7 @@ prefix = "BL"
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -638,6 +817,7 @@ func TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot(t *testing.T) {
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -728,6 +908,7 @@ func TestCmdWorkflowReopenSourceClearsRoutedToForResling(t *testing.T) {
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -786,6 +967,7 @@ func TestCmdWorkflowReopenSourceConflictsWhenLiveRootExists(t *testing.T) {
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -827,6 +1009,7 @@ func TestCmdWorkflowDeleteSourcePreviewDoesNotClearStaleMetadata(t *testing.T) {
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -923,6 +1106,7 @@ func TestRunWorkflowReopenSourceConflictPropagatesExitCode(t *testing.T) {
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -2374,6 +2558,7 @@ prefix = "BL"
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -2492,6 +2677,7 @@ prefix = "BL"
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -2613,6 +2799,7 @@ prefix = "BL"
 	}
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	prevCityFlag := cityFlag
 	cityFlag = ""
 	t.Cleanup(func() { cityFlag = prevCityFlag })
@@ -2757,34 +2944,30 @@ func TestDeleteWorkflowBeadsRemovesDepsBeforeDelete(t *testing.T) {
 	}
 }
 
-type depListFailStore struct {
-	*beads.MemStore
-	depListCalls int
-}
-
-func (s *depListFailStore) DepList(id, direction string) ([]beads.Dep, error) {
-	s.depListCalls++
-	return nil, fmt.Errorf("unexpected dep list for %s %s", id, direction)
-}
-
-func TestApplySourceWorkflowMatchCleanupUsesCascadeRunnerForDelete(t *testing.T) {
-	base := beads.NewMemStore()
-	first, err := base.Create(beads.Bead{Title: "workflow first", Type: "task"})
+func TestApplySourceWorkflowMatchCleanupDeletesOnlyCollectedWorkflowBeads(t *testing.T) {
+	store := beads.NewMemStore()
+	first, err := store.Create(beads.Bead{Title: "workflow first", Type: "task"})
 	if err != nil {
 		t.Fatalf("Create(first): %v", err)
 	}
-	second, err := base.Create(beads.Bead{Title: "workflow second", Type: "task"})
+	second, err := store.Create(beads.Bead{Title: "workflow second", Type: "task"})
 	if err != nil {
 		t.Fatalf("Create(second): %v", err)
 	}
-	store := &depListFailStore{MemStore: base}
+	outside, err := store.Create(beads.Bead{Title: "outside follow-up", Type: "task"})
+	if err != nil {
+		t.Fatalf("Create(outside): %v", err)
+	}
+	if err := store.DepAdd(first.ID, outside.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(first->outside): %v", err)
+	}
+	if err := store.DepAdd(outside.ID, second.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd(outside->second): %v", err)
+	}
 
-	var gotDir, gotName string
-	var gotArgs []string
-	runner := func(dir, name string, args ...string) ([]byte, error) {
-		gotDir = dir
-		gotName = name
-		gotArgs = append([]string(nil), args...)
+	runnerCalled := false
+	runner := func(_ string, _ string, _ ...string) ([]byte, error) {
+		runnerCalled = true
 		return []byte("ok"), nil
 	}
 
@@ -2802,15 +2985,28 @@ func TestApplySourceWorkflowMatchCleanupUsesCascadeRunnerForDelete(t *testing.T)
 	if closed != 2 || deleted != 2 {
 		t.Fatalf("closed/deleted = %d/%d, want 2/2", closed, deleted)
 	}
-	if store.depListCalls != 0 {
-		t.Fatalf("dep list calls = %d, want 0", store.depListCalls)
+	if runnerCalled {
+		t.Fatal("cleanup used bd cascade runner; want explicit in-process deletion of collected IDs")
 	}
-	if gotDir != "/repo" || gotName != "bd" {
-		t.Fatalf("runner target = %q %q, want /repo bd", gotDir, gotName)
+	for _, id := range []string{first.ID, second.ID} {
+		if _, err := store.Get(id); err == nil {
+			t.Fatalf("Get(%s) succeeded after delete", id)
+		}
 	}
-	wantArgs := []string{"delete", first.ID, second.ID, "--cascade", "--force"}
-	if !slices.Equal(gotArgs, wantArgs) {
-		t.Fatalf("runner args = %#v, want %#v", gotArgs, wantArgs)
+	if got, err := store.Get(outside.ID); err != nil {
+		t.Fatalf("Get(outside): %v", err)
+	} else if got.Status != "open" {
+		t.Fatalf("outside status = %q, want open", got.Status)
+	}
+	if down, err := store.DepList(outside.ID, "down"); err != nil {
+		t.Fatalf("DepList(outside, down): %v", err)
+	} else if len(down) != 0 {
+		t.Fatalf("outside down deps = %#v, want none after collected bead deletion", down)
+	}
+	if up, err := store.DepList(outside.ID, "up"); err != nil {
+		t.Fatalf("DepList(outside, up): %v", err)
+	} else if len(up) != 0 {
+		t.Fatalf("outside up deps = %#v, want none after collected bead deletion", up)
 	}
 }
 

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -26,7 +26,15 @@ type ProcessOptions struct {
 	FormulaSearchPaths []string
 	PrepareFragment    func(*formula.FragmentRecipe, beads.Bead) error
 	RecycleSession     func(beads.Bead) error
-	Tracef             func(format string, args ...any)
+	// ResolveStoreRef opens the bead store identified by a gc.source_store_ref
+	// value (e.g. "city:foo", "rig:alpha"). Used by processWorkflowFinalize to
+	// propagate successful workflow completion across store boundaries: when
+	// a graph workflow finalizes with outcome=pass, every parent source bead
+	// linked via gc.source_bead_id+gc.source_store_ref is also closed in its
+	// native store. May be nil - in which case cross-store propagation is
+	// silently skipped (single-store callers, tests without resolvers, etc.).
+	ResolveStoreRef func(ref string) (beads.Store, error)
+	Tracef          func(format string, args ...any)
 }
 
 var (
@@ -77,7 +85,7 @@ func ProcessControl(store beads.Store, bead beads.Bead, opts ProcessOptions) (Co
 	case "scope-check":
 		return processScopeCheck(store, bead, opts)
 	case "workflow-finalize":
-		return processWorkflowFinalize(store, bead)
+		return processWorkflowFinalize(store, bead, opts)
 	default:
 		return ControlResult{}, fmt.Errorf("%s: unsupported control bead kind %q", bead.ID, bead.Metadata["gc.kind"])
 	}
@@ -467,7 +475,7 @@ func isRetryAttemptSubject(subject beads.Bead) bool {
 	return false
 }
 
-func processWorkflowFinalize(store beads.Store, bead beads.Bead) (ControlResult, error) {
+func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOptions) (ControlResult, error) {
 	rootID := bead.Metadata["gc.root_bead_id"]
 	if rootID == "" {
 		return ControlResult{}, fmt.Errorf("%s: missing gc.root_bead_id", bead.ID)
@@ -489,10 +497,76 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead) (ControlResult,
 	if err := setOutcomeAndClose(store, rootID, outcome); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: completing workflow head: %w", rootID, err)
 	}
+	// On success, propagate the closure across the gc.source_bead_id chain so
+	// parent source beads in other stores (e.g. the city-scope "Adopt PR"
+	// request that spawned a rig-scope mol-adopt-pr-v2 workflow) don't accumulate
+	// as orphans. Failures intentionally leave parent sources open so a human
+	// can investigate via list - the bead IS the audit handle.
+	if outcome == "pass" {
+		if err := closeSourceBeadChain(store, rootID, opts); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: closing source bead chain: %w", rootID, err)
+		}
+	}
 	if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
 		return ControlResult{}, fmt.Errorf("%s: completing workflow finalizer: %w", bead.ID, err)
 	}
 	return ControlResult{Processed: true, Action: "workflow-" + outcome}, nil
+}
+
+// closeSourceBeadChain walks gc.source_bead_id / gc.source_store_ref upward
+// from the just-finalized workflow root and closes every parent source bead
+// in its native store. The walk stops when a bead has no source pointer, when
+// a referenced store cannot be resolved, or when a bead has already been
+// closed (idempotent - a re-run of finalize after a partial crash converges
+// to the same state). This is what makes "Adopt PR" city-scope source beads
+// disappear from the human-visible queue once the rig-scope workflow merges.
+func closeSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions) error {
+	currentStore := rootStore
+	currentID := rootID
+	visited := make(map[string]bool) // store_ref|bead_id pairs to break any unexpected cycles
+	for hop := 0; hop < 32; hop++ {
+		current, err := currentStore.Get(currentID)
+		if err != nil {
+			// Missing intermediate is not fatal - the chain just stops here.
+			return nil
+		}
+		nextID := strings.TrimSpace(current.Metadata["gc.source_bead_id"])
+		if nextID == "" {
+			return nil
+		}
+		nextRef := strings.TrimSpace(current.Metadata["gc.source_store_ref"])
+		nextStore := currentStore
+		if nextRef != "" && opts.ResolveStoreRef != nil {
+			resolved, err := opts.ResolveStoreRef(nextRef)
+			if err != nil || resolved == nil {
+				// Cannot reach the parent store from here. Skip silently -
+				// callers without a resolver are single-store contexts where
+				// cross-store propagation is not expected.
+				return nil
+			}
+			nextStore = resolved
+		} else if nextRef != "" && opts.ResolveStoreRef == nil {
+			// Cross-store reference but no resolver: nothing to do.
+			return nil
+		}
+		key := nextRef + "|" + nextID
+		if visited[key] {
+			return nil
+		}
+		visited[key] = true
+		next, err := nextStore.Get(nextID)
+		if err != nil {
+			return nil
+		}
+		if next.Status != "closed" {
+			if err := setOutcomeAndClose(nextStore, nextID, "pass"); err != nil {
+				return fmt.Errorf("closing source bead %s in %s: %w", nextID, nextRef, err)
+			}
+		}
+		currentStore = nextStore
+		currentID = nextID
+	}
+	return nil
 }
 
 func reconcileTerminalScopedMember(store beads.Store, bead beads.Bead) (ControlResult, error) {

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -6,9 +6,11 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // ControlResult reports whether a control bead was processed and what it did.
@@ -17,6 +19,13 @@ type ControlResult struct {
 	Action    string
 	Created   int
 	Skipped   int
+}
+
+// SourceWorkflowStore identifies a store that may contain workflow roots for
+// source-workflow singleton checks.
+type SourceWorkflowStore struct {
+	Store    beads.Store
+	StoreRef string
 }
 
 // ProcessOptions provides control-dispatcher execution context.
@@ -34,13 +43,28 @@ type ProcessOptions struct {
 	// native store. May be nil - in which case cross-store propagation is
 	// silently skipped (single-store callers, tests without resolvers, etc.).
 	ResolveStoreRef func(ref string) (beads.Store, error)
-	Tracef          func(format string, args ...any)
+	// SourceWorkflowLock serializes source-bead mutation with graph workflow
+	// launch/recovery for the same store ref and source bead ID. May be nil
+	// for single-process tests and callers without cross-store propagation.
+	SourceWorkflowLock func(storeRef, sourceBeadID string, fn func() error) error
+	// SourceWorkflowStores returns every store that may contain live workflow
+	// roots. When set, workflow-finalize uses it to avoid closing a source bead
+	// while any live root in another store still references that source.
+	SourceWorkflowStores func() ([]SourceWorkflowStore, error)
+	Tracef               func(format string, args ...any)
 }
 
 var (
 	errFinalizePending  = errors.New("workflow finalize pending")
 	errScopeBodyMissing = errors.New("scope body missing")
 )
+
+const (
+	maxSourceChainHops               = 32
+	maxWorkflowFinalizeErrorMetadata = 512
+)
+
+const workflowFinalizeErrorMetadataKey = "gc.last_finalize_error"
 
 // ErrControlPending reports that a control bead is not yet processable but
 // should be retried later.
@@ -489,84 +513,356 @@ func processWorkflowFinalize(store beads.Store, bead beads.Bead, opts ProcessOpt
 		return ControlResult{}, fmt.Errorf("%s: resolving workflow outcome: %w", bead.ID, err)
 	}
 
-	// Close the root BEFORE the finalize bead. If the root close fails and
-	// the control-dispatcher crashes, the finalize bead stays open so the
-	// next serve cycle will retry. Closing the finalize first would make it
-	// non-retriable (ProcessControl skips closed beads), stranding the root
-	// as in_progress forever.
-	if err := setOutcomeAndClose(store, rootID, outcome); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: completing workflow head: %w", rootID, err)
-	}
 	// On success, propagate the closure across the gc.source_bead_id chain so
 	// parent source beads in other stores (e.g. the city-scope "Adopt PR"
 	// request that spawned a rig-scope mol-adopt-pr-v2 workflow) don't accumulate
 	// as orphans. Failures intentionally leave parent sources open so a human
 	// can investigate via list - the bead IS the audit handle.
 	if outcome == "pass" {
+		if err := preflightSourceBeadChain(store, rootID, opts); err != nil {
+			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: preflighting source bead chain: %w", rootID, err))
+		}
+	}
+	// Close the root BEFORE the finalize bead. If the root close fails and
+	// the control-dispatcher crashes, the finalize bead stays open so the
+	// next serve cycle will retry. Source-chain propagation is preflighted first
+	// so retryable scan failures keep the root live for singleton scans, but
+	// source beads are not mutated until the root is durably closed.
+	if err := setOutcomeAndClose(store, rootID, outcome); err != nil {
+		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow head: %w", rootID, err))
+	}
+	if outcome == "pass" {
 		if err := closeSourceBeadChain(store, rootID, opts); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: closing source bead chain: %w", rootID, err)
+			return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: closing source bead chain: %w", rootID, err))
 		}
 	}
 	if err := setOutcomeAndClose(store, bead.ID, "pass"); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: completing workflow finalizer: %w", bead.ID, err)
+		return ControlResult{}, recordWorkflowFinalizeError(store, bead.ID, fmt.Errorf("%s: completing workflow finalizer: %w", bead.ID, err))
 	}
 	return ControlResult{Processed: true, Action: "workflow-" + outcome}, nil
 }
 
+func preflightSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions) error {
+	return walkSourceBeadChain(rootStore, rootID, opts, false)
+}
+
 // closeSourceBeadChain walks gc.source_bead_id / gc.source_store_ref upward
 // from the just-finalized workflow root and closes every parent source bead
-// in its native store. The walk stops when a bead has no source pointer, when
-// a referenced store cannot be resolved, or when a bead has already been
-// closed (idempotent - a re-run of finalize after a partial crash converges
-// to the same state). This is what makes "Adopt PR" city-scope source beads
+// in its native store. A missing resolver for a cross-store ref, a deleted
+// parent, or a cycle stops the walk as a traced no-op.
+// Resolver, store read, and close failures are returned so the finalizer stays
+// open for retry. This is what makes "Adopt PR" city-scope source beads
 // disappear from the human-visible queue once the rig-scope workflow merges.
 func closeSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions) error {
+	return walkSourceBeadChain(rootStore, rootID, opts, true)
+}
+
+func walkSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptions, mutate bool) error {
 	currentStore := rootStore
 	currentID := rootID
-	visited := make(map[string]bool) // store_ref|bead_id pairs to break any unexpected cycles
-	for hop := 0; hop < 32; hop++ {
+	currentRef := ""
+	excludeRootSourceRef := ""
+	resolvedStores := make(map[string]beads.Store)
+	visited := make(map[string]bool)
+	for hop := 0; hop < maxSourceChainHops; hop++ {
 		current, err := currentStore.Get(currentID)
 		if err != nil {
-			// Missing intermediate is not fatal - the chain just stops here.
-			return nil
+			if errors.Is(err, beads.ErrNotFound) {
+				opts.tracef("close-source-chain root=%s stop reason=deleted_current at_id=%s ref=%s", rootID, currentID, sourceChainStoreLabel(currentRef))
+				return nil
+			}
+			return fmt.Errorf("getting source chain bead %s in %s: %w", currentID, sourceChainStoreLabel(currentRef), err)
+		}
+		if currentID == rootID && currentRef == "" {
+			excludeRootSourceRef = strings.TrimSpace(current.Metadata[sourceworkflow.SourceStoreRefMetadataKey])
 		}
 		nextID := strings.TrimSpace(current.Metadata["gc.source_bead_id"])
 		if nextID == "" {
+			opts.tracef("close-source-chain root=%s stop reason=no_source at_id=%s ref=%s", rootID, currentID, sourceChainStoreLabel(currentRef))
 			return nil
 		}
-		nextRef := strings.TrimSpace(current.Metadata["gc.source_store_ref"])
+		nextRef := strings.TrimSpace(current.Metadata[sourceworkflow.SourceStoreRefMetadataKey])
+		effectiveRef := currentRef
 		nextStore := currentStore
-		if nextRef != "" && opts.ResolveStoreRef != nil {
-			resolved, err := opts.ResolveStoreRef(nextRef)
-			if err != nil || resolved == nil {
-				// Cannot reach the parent store from here. Skip silently -
-				// callers without a resolver are single-store contexts where
-				// cross-store propagation is not expected.
+		if nextRef != "" {
+			effectiveRef = nextRef
+			if opts.ResolveStoreRef == nil {
+				opts.tracef("close-source-chain root=%s stop reason=missing_resolver source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
 				return nil
 			}
+			resolved, ok := resolvedStores[nextRef]
+			if !ok {
+				resolvedStore, err := opts.ResolveStoreRef(nextRef)
+				if err != nil {
+					return fmt.Errorf("resolving source store %q: %w", nextRef, err)
+				}
+				if resolvedStore == nil {
+					return fmt.Errorf("resolving source store %q: nil store", nextRef)
+				}
+				resolved = resolvedStore
+				resolvedStores[nextRef] = resolvedStore
+			}
 			nextStore = resolved
-		} else if nextRef != "" && opts.ResolveStoreRef == nil {
-			// Cross-store reference but no resolver: nothing to do.
-			return nil
 		}
-		key := nextRef + "|" + nextID
+		key := sourceChainKey(effectiveRef, nextID)
 		if visited[key] {
+			opts.tracef("close-source-chain root=%s stop reason=cycle source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
 			return nil
 		}
 		visited[key] = true
-		next, err := nextStore.Get(nextID)
-		if err != nil {
+
+		var stopWalk bool
+		loadAndClose := func() error {
+			loaded, err := nextStore.Get(nextID)
+			if err != nil {
+				if errors.Is(err, beads.ErrNotFound) {
+					opts.tracef("close-source-chain root=%s stop reason=deleted_parent source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
+					stopWalk = true
+					return nil
+				}
+				return fmt.Errorf("getting source bead %s in %s: %w", nextID, sourceChainStoreLabel(effectiveRef), err)
+			}
+			liveRoots, err := listLiveSourceWorkflowRoots(nextStore, nextID, effectiveRef, rootID, excludeRootSourceRef, opts)
+			if err != nil {
+				return fmt.Errorf("listing live workflows for source bead %s in %s: %w", nextID, sourceChainStoreLabel(effectiveRef), err)
+			}
+			if len(liveRoots) > 0 {
+				opts.tracef("close-source-chain root=%s stop reason=live_child_workflow source=%s ref=%s live_roots=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef), sourceChainRootIDs(liveRoots))
+				stopWalk = true
+				return nil
+			}
+			if loaded.Status == "closed" {
+				opts.tracef("close-source-chain root=%s skip reason=already_closed source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
+				return nil
+			}
+			if !mutate {
+				return nil
+			}
+			if err := closeSourceBeadPreservingOutcome(nextStore, loaded); err != nil {
+				return fmt.Errorf("closing source bead %s in %s: %w", nextID, sourceChainStoreLabel(effectiveRef), err)
+			}
+			opts.tracef("close-source-chain root=%s closed source=%s ref=%s preserved_outcome=%t", rootID, nextID, sourceChainStoreLabel(effectiveRef), strings.TrimSpace(loaded.Metadata["gc.outcome"]) != "")
 			return nil
 		}
-		if next.Status != "closed" {
-			if err := setOutcomeAndClose(nextStore, nextID, "pass"); err != nil {
-				return fmt.Errorf("closing source bead %s in %s: %w", nextID, nextRef, err)
+		if mutate && opts.SourceWorkflowLock != nil {
+			if err := opts.SourceWorkflowLock(effectiveRef, nextID, loadAndClose); err != nil {
+				return fmt.Errorf("locking source bead %s in %s: %w", nextID, sourceChainStoreLabel(effectiveRef), err)
 			}
+		} else if err := loadAndClose(); err != nil {
+			return err
+		}
+		if stopWalk {
+			return nil
 		}
 		currentStore = nextStore
 		currentID = nextID
+		currentRef = effectiveRef
 	}
-	return nil
+	err := fmt.Errorf("source chain depth limit reached after %d hops", maxSourceChainHops)
+	opts.tracef("close-source-chain root=%s stop reason=depth_limit max_hops=%d", rootID, maxSourceChainHops)
+	return err
+}
+
+func listLiveSourceWorkflowRoots(fallbackStore beads.Store, sourceBeadID, sourceStoreRef, excludeRootID, excludeRootSourceRef string, opts ProcessOptions) ([]beads.Bead, error) {
+	stores, err := sourceWorkflowStoresForLiveRootScan(fallbackStore, sourceStoreRef, opts)
+	if err != nil {
+		return nil, err
+	}
+	roots := make([]beads.Bead, 0)
+	seenRoots := make(map[string]struct{}, len(stores))
+	visitedSources := make(map[string]struct{})
+	var collect func(string, string) error
+	collect = func(currentSourceID, currentSourceStoreRef string) error {
+		currentSourceID = strings.TrimSpace(currentSourceID)
+		if currentSourceID == "" {
+			return nil
+		}
+		for i, info := range stores {
+			if info.Store == nil {
+				continue
+			}
+			rootStoreRef := strings.TrimSpace(info.StoreRef)
+			sourceVisitKey := sourceWorkflowScanKey(rootStoreRef, currentSourceStoreRef, currentSourceID, i)
+			if _, ok := visitedSources[sourceVisitKey]; ok {
+				continue
+			}
+			visitedSources[sourceVisitKey] = struct{}{}
+			matches, err := sourceworkflow.ListLiveRoots(info.Store, currentSourceID, currentSourceStoreRef, rootStoreRef)
+			if err != nil {
+				return fmt.Errorf("listing live workflows in %s: %w", sourceChainStoreLabel(rootStoreRef), err)
+			}
+			matches = withoutSourceWorkflowRoot(matches, excludeRootID, excludeRootSourceRef)
+			for _, root := range matches {
+				rootKey := sourceWorkflowRootKey(rootStoreRef, root.ID, i)
+				if _, ok := seenRoots[rootKey]; ok {
+					continue
+				}
+				seenRoots[rootKey] = struct{}{}
+				roots = append(roots, root)
+			}
+			children, err := sourceWorkflowChildSources(info.Store, currentSourceID, currentSourceStoreRef, rootStoreRef)
+			if err != nil {
+				return fmt.Errorf("listing source workflow children in %s: %w", sourceChainStoreLabel(rootStoreRef), err)
+			}
+			for _, child := range children {
+				if err := collect(child.ID, rootStoreRef); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	if err := collect(sourceBeadID, sourceStoreRef); err != nil {
+		return nil, err
+	}
+	return roots, nil
+}
+
+func sourceWorkflowStoresForLiveRootScan(fallbackStore beads.Store, sourceStoreRef string, opts ProcessOptions) ([]SourceWorkflowStore, error) {
+	if opts.SourceWorkflowStores == nil {
+		return []SourceWorkflowStore{{Store: fallbackStore, StoreRef: strings.TrimSpace(sourceStoreRef)}}, nil
+	}
+	stores, err := opts.SourceWorkflowStores()
+	if err != nil {
+		return nil, err
+	}
+	scanned := make([]SourceWorkflowStore, 0, len(stores))
+	for _, info := range stores {
+		if info.Store == nil {
+			continue
+		}
+		info.StoreRef = strings.TrimSpace(info.StoreRef)
+		scanned = append(scanned, info)
+	}
+	if len(scanned) == 0 {
+		return []SourceWorkflowStore{{Store: fallbackStore, StoreRef: strings.TrimSpace(sourceStoreRef)}}, nil
+	}
+	return scanned, nil
+}
+
+func sourceWorkflowChildSources(store beads.Store, sourceBeadID, sourceStoreRef, rootStoreRef string) ([]beads.Bead, error) {
+	sourceBeadID = strings.TrimSpace(sourceBeadID)
+	if store == nil || sourceBeadID == "" {
+		return nil, nil
+	}
+	candidates, err := store.List(beads.ListQuery{
+		IncludeClosed: true,
+		Metadata: map[string]string{
+			"gc.source_bead_id": sourceBeadID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	children := make([]beads.Bead, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ID == "" || sourceworkflow.IsWorkflowRoot(candidate) {
+			continue
+		}
+		if !sourceworkflow.WorkflowMatchesSource(candidate, sourceBeadID, sourceStoreRef, rootStoreRef) {
+			continue
+		}
+		children = append(children, candidate)
+	}
+	return children, nil
+}
+
+func sourceWorkflowScanKey(rootStoreRef, sourceStoreRef, sourceBeadID string, storeIndex int) string {
+	keyScope := strings.TrimSpace(rootStoreRef)
+	if keyScope == "" {
+		keyScope = fmt.Sprintf("store#%d", storeIndex)
+	}
+	return keyScope + "\x00" + strings.TrimSpace(sourceStoreRef) + "\x00" + strings.TrimSpace(sourceBeadID)
+}
+
+func sourceWorkflowRootKey(rootStoreRef, rootID string, storeIndex int) string {
+	keyScope := strings.TrimSpace(rootStoreRef)
+	if keyScope == "" {
+		keyScope = fmt.Sprintf("store#%d", storeIndex)
+	}
+	return keyScope + "\x00" + strings.TrimSpace(rootID)
+}
+
+func withoutSourceWorkflowRoot(roots []beads.Bead, rootID, rootSourceStoreRef string) []beads.Bead {
+	rootID = strings.TrimSpace(rootID)
+	if rootID == "" || len(roots) == 0 {
+		return roots
+	}
+	rootSourceStoreRef = strings.TrimSpace(rootSourceStoreRef)
+	out := roots[:0]
+	for _, root := range roots {
+		if root.ID != rootID {
+			out = append(out, root)
+			continue
+		}
+		// Legacy roots may not have gc.source_store_ref. In that case the
+		// exclusion is ID-only and relies on bead IDs being unique across scanned
+		// stores; modern roots use the source-store ref check below.
+		if rootSourceStoreRef != "" && strings.TrimSpace(root.Metadata[sourceworkflow.SourceStoreRefMetadataKey]) != rootSourceStoreRef {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+func sourceChainKey(storeRef, beadID string) string {
+	// Upward finalize walks only need the parent store and source bead. The
+	// downward delete-source walk also keys by querying root store because it
+	// recursively fans out across every source-workflow store.
+	return strings.TrimSpace(storeRef) + "\x00" + strings.TrimSpace(beadID)
+}
+
+func sourceChainStoreLabel(storeRef string) string {
+	storeRef = strings.TrimSpace(storeRef)
+	if storeRef == "" {
+		return "current store"
+	}
+	return storeRef
+}
+
+func sourceChainRootIDs(roots []beads.Bead) string {
+	ids := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root.ID != "" {
+			ids = append(ids, root.ID)
+		}
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+func closeSourceBeadPreservingOutcome(store beads.Store, bead beads.Bead) error {
+	status := "closed"
+	opts := beads.UpdateOpts{Status: &status}
+	if strings.TrimSpace(bead.Metadata["gc.outcome"]) == "" {
+		opts.Metadata = map[string]string{"gc.outcome": "pass"}
+	}
+	return store.Update(bead.ID, opts)
+}
+
+func recordWorkflowFinalizeError(store beads.Store, finalizerID string, err error) error {
+	if err == nil {
+		return nil
+	}
+	reason := strings.TrimSpace(err.Error())
+	if len(reason) > maxWorkflowFinalizeErrorMetadata {
+		reason = truncateWorkflowFinalizeErrorMetadata(reason)
+	}
+	if setErr := store.SetMetadata(finalizerID, workflowFinalizeErrorMetadataKey, reason); setErr != nil {
+		return errors.Join(err, fmt.Errorf("recording workflow finalize error on %s: %w", finalizerID, setErr))
+	}
+	return err
+}
+
+func truncateWorkflowFinalizeErrorMetadata(reason string) string {
+	limit := maxWorkflowFinalizeErrorMetadata
+	if len(reason) <= limit {
+		return reason
+	}
+	for limit > 0 && !utf8.ValidString(reason[:limit]) {
+		limit--
+	}
+	return reason[:limit]
 }
 
 func reconcileTerminalScopedMember(store beads.Store, bead beads.Bead) (ControlResult, error) {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -606,6 +606,206 @@ func TestProcessWorkflowFinalizeClosesWorkflow(t *testing.T) {
 	}
 }
 
+// TestProcessWorkflowFinalizeClosesCrossStoreSourceBead verifies that when a
+// graph workflow finalizes successfully, the engine closes any source bead
+// chain that crosses store boundaries. This is the PR-review case: the city
+// scope holds the human-visible "Adopt PR" source bead, and the rig scope
+// holds the launch bead + workflow root that the operator drives. Without
+// this propagation, the city source bead stays open forever even after the
+// PR is merged and the rig workflow is fully closed - the only way to know
+// the request finished is to read metadata, not list status.
+//
+// Wiring under test:
+//   - city store: city source bead (the original "Adopt PR" request)
+//   - rig store:  rig launch bead     gc.source_bead_id=<city-source>, gc.source_store_ref=city:test
+//     workflow root       gc.source_bead_id=<rig-launch>,  gc.source_store_ref=rig:test
+//     cleanup, finalizer
+//
+// On a successful (outcome=pass) finalize, the engine should close BOTH the
+// rig-store workflow root AND the city-store source bead.
+func TestProcessWorkflowFinalizeClosesCrossStoreSourceBead(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"pr_review.pr_number": "1",
+			"pr_review.repo_slug": "gastownhall/example",
+		},
+	})
+
+	rigLaunch := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Adopt PR workflow: gastownhall/example#1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   rigLaunch.ID,
+			"gc.source_store_ref": "rig:test",
+		},
+	})
+
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return cityStore, nil
+		case "rig:test":
+			return rigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{
+		ResolveStoreRef: resolver,
+	})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-pass" {
+		t.Fatalf("workflow result = %+v, want processed workflow-pass", result)
+	}
+
+	rigRootAfter, err := rigStore.Get(workflow.ID)
+	if err != nil {
+		t.Fatalf("get workflow root: %v", err)
+	}
+	if rigRootAfter.Status != "closed" {
+		t.Fatalf("workflow root status = %q, want closed", rigRootAfter.Status)
+	}
+
+	citySourceAfter, err := cityStore.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source bead: %v", err)
+	}
+	if citySourceAfter.Status != "closed" {
+		t.Fatalf("city source bead status = %q, want closed (cross-store closure on successful finalize)", citySourceAfter.Status)
+	}
+	if got := citySourceAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Errorf("city source bead gc.outcome = %q, want %q", got, "pass")
+	}
+}
+
+// TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure pins the
+// failure-side contract: a failed workflow should leave the city source bead
+// open so a human can see and act on the failure. Closure propagation only
+// happens on success.
+func TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure(t *testing.T) {
+	t.Parallel()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#2",
+		Type:  "task",
+	})
+
+	rigLaunch := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Adopt PR workflow: gastownhall/example#2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   rigLaunch.ID,
+			"gc.source_store_ref": "rig:test",
+		},
+	})
+
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "fail",
+		},
+	})
+
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return cityStore, nil
+		case "rig:test":
+			return rigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+
+	result, err := ProcessControl(rigStore, finalizer, ProcessOptions{
+		ResolveStoreRef: resolver,
+	})
+	if err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	if !result.Processed || result.Action != "workflow-fail" {
+		t.Fatalf("workflow result = %+v, want processed workflow-fail", result)
+	}
+
+	citySourceAfter, err := cityStore.Get(citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source bead: %v", err)
+	}
+	if citySourceAfter.Status == "closed" {
+		t.Fatalf("city source bead status = closed; want still open on failed workflow so the human can act on the failure")
+	}
+}
+
 func TestProcessRalphCheckRetriesThenPasses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -17,6 +20,7 @@ import (
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 func TestProcessScopeCheckClosesScopeOnSuccess(t *testing.T) {
@@ -707,6 +711,16 @@ func TestProcessWorkflowFinalizeClosesCrossStoreSourceBead(t *testing.T) {
 	if rigRootAfter.Status != "closed" {
 		t.Fatalf("workflow root status = %q, want closed", rigRootAfter.Status)
 	}
+	rigLaunchAfter, err := rigStore.Get(rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("get rig launch bead: %v", err)
+	}
+	if rigLaunchAfter.Status != "closed" {
+		t.Fatalf("rig launch bead status = %q, want closed", rigLaunchAfter.Status)
+	}
+	if got := rigLaunchAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Errorf("rig launch bead gc.outcome = %q, want %q", got, "pass")
+	}
 
 	citySourceAfter, err := cityStore.Get(citySource.ID)
 	if err != nil {
@@ -717,6 +731,801 @@ func TestProcessWorkflowFinalizeClosesCrossStoreSourceBead(t *testing.T) {
 	}
 	if got := citySourceAfter.Metadata["gc.outcome"]; got != "pass" {
 		t.Errorf("city source bead gc.outcome = %q, want %q", got, "pass")
+	}
+}
+
+type sourceChainFinalizeFixture struct {
+	cityStore  *beads.MemStore
+	rigStore   *beads.MemStore
+	citySource beads.Bead
+	rigLaunch  beads.Bead
+	workflow   beads.Bead
+	finalizer  beads.Bead
+}
+
+func newSourceChainFinalizeFixture(t *testing.T) sourceChainFinalizeFixture {
+	t.Helper()
+
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#3",
+		Type:  "task",
+	})
+	rigLaunch := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Adopt PR workflow: gastownhall/example#3",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id":   citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "mol-adopt-pr-v2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   rigLaunch.ID,
+			"gc.source_store_ref": "rig:test",
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+
+	return sourceChainFinalizeFixture{
+		cityStore:  cityStore,
+		rigStore:   rigStore,
+		citySource: citySource,
+		rigLaunch:  rigLaunch,
+		workflow:   workflow,
+		finalizer:  finalizer,
+	}
+}
+
+func (f sourceChainFinalizeFixture) resolver(ref string) (beads.Store, error) {
+	switch ref {
+	case "city:test":
+		return f.cityStore, nil
+	case "rig:test":
+		return f.rigStore, nil
+	default:
+		return nil, fmt.Errorf("unknown store ref: %s", ref)
+	}
+}
+
+func sourceChainFixtureStores(f sourceChainFinalizeFixture) func() ([]SourceWorkflowStore, error) {
+	return func() ([]SourceWorkflowStore, error) {
+		return []SourceWorkflowStore{
+			{Store: f.cityStore, StoreRef: "city:test"},
+			{Store: f.rigStore, StoreRef: "rig:test"},
+		}, nil
+	}
+}
+
+func TestProcessWorkflowFinalizeRetriesWhenSourceStoreResolverFails(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	resolver := func(ref string) (beads.Store, error) {
+		if ref == "city:test" {
+			return nil, errors.New("city store unavailable")
+		}
+		return f.resolver(ref)
+	}
+
+	_, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef: resolver,
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) err = nil, want retryable resolver error")
+	}
+	if !strings.Contains(err.Error(), "city store unavailable") {
+		t.Fatalf("ProcessControl error = %v, want city store resolver failure", err)
+	}
+	finalizerAfter, err := f.rigStore.Get(f.finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if finalizerAfter.Status == "closed" {
+		t.Fatal("finalizer status = closed; want open so source-chain resolver failure is retryable")
+	}
+	citySourceAfter, err := f.cityStore.Get(f.citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source: %v", err)
+	}
+	if citySourceAfter.Status == "closed" {
+		t.Fatal("city source status = closed; want open after failed source-chain propagation")
+	}
+}
+
+type getErrorStore struct {
+	beads.Store
+	failID string
+	err    error
+}
+
+func (s getErrorStore) Get(id string) (beads.Bead, error) {
+	if id == s.failID {
+		return beads.Bead{}, s.err
+	}
+	return s.Store.Get(id)
+}
+
+type updateErrorStore struct {
+	beads.Store
+	failID string
+	err    error
+}
+
+func (s updateErrorStore) Update(id string, opts beads.UpdateOpts) error {
+	if id == s.failID {
+		return s.err
+	}
+	return s.Store.Update(id, opts)
+}
+
+func TestProcessWorkflowFinalizeRetriesWhenSourceBeadLookupFails(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	lookupErr := errors.New("city source lookup failed")
+	resolver := func(ref string) (beads.Store, error) {
+		if ref == "city:test" {
+			return getErrorStore{Store: f.cityStore, failID: f.citySource.ID, err: lookupErr}, nil
+		}
+		return f.resolver(ref)
+	}
+
+	_, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef: resolver,
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) err = nil, want retryable parent lookup error")
+	}
+	if !strings.Contains(err.Error(), lookupErr.Error()) {
+		t.Fatalf("ProcessControl error = %v, want parent lookup failure", err)
+	}
+	finalizerAfter, err := f.rigStore.Get(f.finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if finalizerAfter.Status == "closed" {
+		t.Fatal("finalizer status = closed; want open so parent lookup failure is retryable")
+	}
+}
+
+func TestProcessWorkflowFinalizeClosesSourcesUnderProvidedLock(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	var locked []string
+	locker := func(storeRef, sourceBeadID string, fn func() error) error {
+		locked = append(locked, storeRef+"\x00"+sourceBeadID)
+		return fn()
+	}
+
+	if _, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef:    f.resolver,
+		SourceWorkflowLock: locker,
+	}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	want := []string{
+		"rig:test\x00" + f.rigLaunch.ID,
+		"city:test\x00" + f.citySource.ID,
+	}
+	if !slices.Equal(locked, want) {
+		t.Fatalf("locked source beads = %q, want %q", locked, want)
+	}
+}
+
+func TestProcessWorkflowFinalizeConvergesUnderConcurrentSharedAncestor(t *testing.T) {
+	t.Parallel()
+
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	citySource := mustCreateWorkflowBead(t, cityStore, beads.Bead{
+		Title: "Adopt PR: gastownhall/example#shared",
+		Type:  "task",
+	})
+	newRigWorkflow := func(name string) (beads.Bead, beads.Bead, beads.Bead) {
+		t.Helper()
+		launch := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+			Title: "Adopt PR workflow: " + name,
+			Type:  "task",
+			Metadata: map[string]string{
+				"gc.source_bead_id":   citySource.ID,
+				"gc.source_store_ref": "city:test",
+			},
+		})
+		workflow := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+			Title: "mol-adopt-pr-v2 " + name,
+			Type:  "task",
+			Metadata: map[string]string{
+				"gc.kind":             "workflow",
+				"gc.formula_contract": "graph.v2",
+				"gc.source_bead_id":   launch.ID,
+				"gc.source_store_ref": "rig:test",
+			},
+		})
+		cleanup := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+			Title:  "cleanup " + name,
+			Type:   "task",
+			Status: "closed",
+			Metadata: map[string]string{
+				"gc.outcome": "pass",
+			},
+		})
+		finalizer := mustCreateWorkflowBead(t, rigStore, beads.Bead{
+			Title: "Finalize workflow " + name,
+			Type:  "task",
+			Metadata: map[string]string{
+				"gc.kind":         "workflow-finalize",
+				"gc.root_bead_id": workflow.ID,
+			},
+		})
+		mustDepAdd(t, rigStore, finalizer.ID, cleanup.ID, "blocks")
+		mustDepAdd(t, rigStore, workflow.ID, finalizer.ID, "blocks")
+		return launch, workflow, finalizer
+	}
+	launchA, workflowA, finalizerA := newRigWorkflow("a")
+	launchB, workflowB, finalizerB := newRigWorkflow("b")
+
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return cityStore, nil
+		case "rig:test":
+			return rigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+	locker := func(storeRef, sourceBeadID string, fn func() error) error {
+		return sourceworkflow.WithLock(context.Background(), cityPath, storeRef, sourceBeadID, fn)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, finalizer := range []beads.Bead{finalizerA, finalizerB} {
+		wg.Add(1)
+		go func(finalizer beads.Bead) {
+			defer wg.Done()
+			<-start
+			result, err := ProcessControl(rigStore, finalizer, ProcessOptions{
+				ResolveStoreRef: resolver,
+				SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+					return []SourceWorkflowStore{
+						{Store: cityStore, StoreRef: "city:test"},
+						{Store: rigStore, StoreRef: "rig:test"},
+					}, nil
+				},
+				SourceWorkflowLock: locker,
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !result.Processed || result.Action != "workflow-pass" {
+				errs <- fmt.Errorf("ProcessControl(%s) = %+v, want workflow-pass", finalizer.ID, result)
+				return
+			}
+			errs <- nil
+		}(finalizer)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent ProcessControl: %v", err)
+		}
+	}
+
+	for _, bead := range []beads.Bead{launchA, launchB, workflowA, workflowB, finalizerA, finalizerB} {
+		after := mustGetBead(t, rigStore, bead.ID)
+		if after.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", bead.ID, after.Status)
+		}
+		if strings.TrimSpace(after.Metadata[workflowFinalizeErrorMetadataKey]) != "" {
+			t.Fatalf("%s has %s=%q, want none", bead.ID, workflowFinalizeErrorMetadataKey, after.Metadata[workflowFinalizeErrorMetadataKey])
+		}
+	}
+	citySourceAfter := mustGetBead(t, cityStore, citySource.ID)
+	if citySourceAfter.Status != "closed" {
+		t.Fatalf("city source status = %q, want closed after both shared descendants finalize", citySourceAfter.Status)
+	}
+	if got := citySourceAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("city source gc.outcome = %q, want pass", got)
+	}
+}
+
+func TestProcessWorkflowFinalizePreservesExistingParentOutcome(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	if err := f.cityStore.SetMetadata(f.citySource.ID, "gc.outcome", "quarantined"); err != nil {
+		t.Fatalf("SetMetadata(city outcome): %v", err)
+	}
+
+	if _, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef: f.resolver,
+	}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	citySourceAfter, err := f.cityStore.Get(f.citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source: %v", err)
+	}
+	if citySourceAfter.Status != "closed" {
+		t.Fatalf("city source status = %q, want closed", citySourceAfter.Status)
+	}
+	if got := citySourceAfter.Metadata["gc.outcome"]; got != "quarantined" {
+		t.Fatalf("city source gc.outcome = %q, want preexisting outcome %q", got, "quarantined")
+	}
+}
+
+func TestProcessWorkflowFinalizeDoesNotCloseSourcesWhenRootCloseFails(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	rootCloseErr := errors.New("root close failed")
+	rigStore := updateErrorStore{Store: f.rigStore, failID: f.workflow.ID, err: rootCloseErr}
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return f.cityStore, nil
+		case "rig:test":
+			return f.rigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+
+	_, err := ProcessControl(rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef:      resolver,
+		SourceWorkflowStores: sourceChainFixtureStores(f),
+		SourceWorkflowLock:   func(_ string, _ string, fn func() error) error { return fn() },
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) err = nil, want root close failure")
+	}
+	if !strings.Contains(err.Error(), rootCloseErr.Error()) {
+		t.Fatalf("ProcessControl error = %v, want root close failure", err)
+	}
+	for _, check := range []struct {
+		name  string
+		store beads.Store
+		id    string
+	}{
+		{name: "workflow root", store: f.rigStore, id: f.workflow.ID},
+		{name: "finalizer", store: f.rigStore, id: f.finalizer.ID},
+		{name: "rig launch", store: f.rigStore, id: f.rigLaunch.ID},
+		{name: "city source", store: f.cityStore, id: f.citySource.ID},
+	} {
+		got, getErr := check.store.Get(check.id)
+		if getErr != nil {
+			t.Fatalf("get %s: %v", check.name, getErr)
+		}
+		if got.Status == "closed" {
+			t.Fatalf("%s status = closed; want open after root close failure", check.name)
+		}
+	}
+	finalizerAfter, err := f.rigStore.Get(f.finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if got := finalizerAfter.Metadata["gc.last_finalize_error"]; !strings.Contains(got, rootCloseErr.Error()) {
+		t.Fatalf("finalizer gc.last_finalize_error = %q, want root close failure", got)
+	}
+}
+
+func TestProcessWorkflowFinalizeRecordsSourceWorkflowStoreScanFailure(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	scanErr := errors.New("skipped source-workflow store: rigs/broken")
+
+	_, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef: f.resolver,
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return nil, scanErr
+		},
+	})
+	if err == nil {
+		t.Fatal("ProcessControl(workflow-finalize) err = nil, want source-workflow store scan failure")
+	}
+	if !strings.Contains(err.Error(), scanErr.Error()) {
+		t.Fatalf("ProcessControl error = %v, want scan failure", err)
+	}
+	workflowAfter, err := f.rigStore.Get(f.workflow.ID)
+	if err != nil {
+		t.Fatalf("get workflow root: %v", err)
+	}
+	if workflowAfter.Status == "closed" {
+		t.Fatal("workflow root status = closed; want open when source-workflow scan preflight fails")
+	}
+	finalizerAfter, err := f.rigStore.Get(f.finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if finalizerAfter.Status == "closed" {
+		t.Fatal("finalizer status = closed; want open when source-workflow scan preflight fails")
+	}
+	if got := finalizerAfter.Metadata["gc.last_finalize_error"]; !strings.Contains(got, scanErr.Error()) {
+		t.Fatalf("finalizer gc.last_finalize_error = %q, want scan failure", got)
+	}
+}
+
+func TestRecordWorkflowFinalizeErrorTruncatesAtUTF8Boundary(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+	})
+	reason := strings.Repeat("a", maxWorkflowFinalizeErrorMetadata-1) + "é tail"
+
+	err := recordWorkflowFinalizeError(store, finalizer.ID, errors.New(reason))
+	if err == nil {
+		t.Fatal("recordWorkflowFinalizeError err = nil, want original error returned")
+	}
+	finalizerAfter := mustGetBead(t, store, finalizer.ID)
+	got := finalizerAfter.Metadata[workflowFinalizeErrorMetadataKey]
+	if len(got) > maxWorkflowFinalizeErrorMetadata {
+		t.Fatalf("recorded reason length = %d, want <= %d", len(got), maxWorkflowFinalizeErrorMetadata)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("recorded reason is invalid UTF-8: %q", got)
+	}
+}
+
+func TestProcessWorkflowFinalizeLeavesAncestorOpenWhenLiveRootExistsInAnotherStore(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	otherRoot := mustCreateWorkflowBead(t, f.rigStore, beads.Bead{
+		Title: "second live workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   f.citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	var trace bytes.Buffer
+
+	if _, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef: f.resolver,
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: f.cityStore, StoreRef: "city:test"},
+				{Store: f.rigStore, StoreRef: "rig:test"},
+			}, nil
+		},
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+		},
+	}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+
+	rigLaunchAfter, err := f.rigStore.Get(f.rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("get rig launch: %v", err)
+	}
+	if rigLaunchAfter.Status != "closed" {
+		t.Fatalf("rig launch status = %q, want closed", rigLaunchAfter.Status)
+	}
+	citySourceAfter, err := f.cityStore.Get(f.citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source: %v", err)
+	}
+	if citySourceAfter.Status != "open" {
+		t.Fatalf("city source status = %q, want open while %s is live", citySourceAfter.Status, otherRoot.ID)
+	}
+	traceText := trace.String()
+	for _, want := range []string{
+		"reason=live_child_workflow",
+		"source=" + f.citySource.ID,
+		"live_roots=" + otherRoot.ID,
+	} {
+		if !strings.Contains(traceText, want) {
+			t.Fatalf("trace missing %q:\n%s", want, traceText)
+		}
+	}
+}
+
+func TestProcessWorkflowFinalizeLeavesSharedAncestorOpenForIndirectLiveRoot(t *testing.T) {
+	t.Parallel()
+
+	f := newSourceChainFinalizeFixture(t)
+	otherRigStore := beads.NewMemStore()
+	otherLaunch := mustCreateWorkflowBead(t, otherRigStore, beads.Bead{
+		Title: "Second Adopt PR workflow launch",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id":   f.citySource.ID,
+			"gc.source_store_ref": "city:test",
+		},
+	})
+	otherRoot := mustCreateWorkflowBead(t, otherRigStore, beads.Bead{
+		Title: "second live workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   otherLaunch.ID,
+			"gc.source_store_ref": "rig:other",
+		},
+	})
+	resolver := func(ref string) (beads.Store, error) {
+		switch ref {
+		case "city:test":
+			return f.cityStore, nil
+		case "rig:test":
+			return f.rigStore, nil
+		case "rig:other":
+			return otherRigStore, nil
+		default:
+			return nil, fmt.Errorf("unknown store ref: %s", ref)
+		}
+	}
+	var trace bytes.Buffer
+
+	if _, err := ProcessControl(f.rigStore, f.finalizer, ProcessOptions{
+		ResolveStoreRef: resolver,
+		SourceWorkflowStores: func() ([]SourceWorkflowStore, error) {
+			return []SourceWorkflowStore{
+				{Store: f.cityStore, StoreRef: "city:test"},
+				{Store: f.rigStore, StoreRef: "rig:test"},
+				{Store: otherRigStore, StoreRef: "rig:other"},
+			}, nil
+		},
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+		},
+	}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+
+	rigLaunchAfter, err := f.rigStore.Get(f.rigLaunch.ID)
+	if err != nil {
+		t.Fatalf("get rig launch: %v", err)
+	}
+	if rigLaunchAfter.Status != "closed" {
+		t.Fatalf("rig launch status = %q, want closed", rigLaunchAfter.Status)
+	}
+	citySourceAfter, err := f.cityStore.Get(f.citySource.ID)
+	if err != nil {
+		t.Fatalf("get city source: %v", err)
+	}
+	if citySourceAfter.Status != "open" {
+		t.Fatalf("city source status = %q, want open while indirect live root %s is running", citySourceAfter.Status, otherRoot.ID)
+	}
+	traceText := trace.String()
+	for _, want := range []string{
+		"reason=live_child_workflow",
+		"source=" + f.citySource.ID,
+		"live_roots=" + otherRoot.ID,
+	} {
+		if !strings.Contains(traceText, want) {
+			t.Fatalf("trace missing %q:\n%s", want, traceText)
+		}
+	}
+}
+
+func TestProcessWorkflowFinalizeClosesIntraStoreSourceBeadWithoutResolver(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Same-store source",
+		Type:  "task",
+	})
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Same-store workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+			"gc.source_bead_id":   source.ID,
+		},
+	})
+	cleanup := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	if _, err := ProcessControl(store, finalizer, ProcessOptions{}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	sourceAfter, err := store.Get(source.ID)
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	if sourceAfter.Status != "closed" {
+		t.Fatalf("source status = %q, want closed", sourceAfter.Status)
+	}
+	if got := sourceAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("source gc.outcome = %q, want pass", got)
+	}
+}
+
+func TestProcessWorkflowFinalizeStopsOnSourceChainCycle(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Cyclic workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	parent := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Cyclic parent",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id": workflow.ID,
+		},
+	})
+	if err := store.SetMetadata(workflow.ID, "gc.source_bead_id", parent.ID); err != nil {
+		t.Fatalf("SetMetadata(workflow source): %v", err)
+	}
+	cleanup := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "Clean up worktree",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.outcome": "pass",
+		},
+	})
+	finalizer := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "workflow-finalize",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	mustDepAdd(t, store, finalizer.ID, cleanup.ID, "blocks")
+	mustDepAdd(t, store, workflow.ID, finalizer.ID, "blocks")
+
+	var trace bytes.Buffer
+	if _, err := ProcessControl(store, finalizer, ProcessOptions{
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+		},
+	}); err != nil {
+		t.Fatalf("ProcessControl(workflow-finalize): %v", err)
+	}
+	finalizerAfter, err := store.Get(finalizer.ID)
+	if err != nil {
+		t.Fatalf("get finalizer: %v", err)
+	}
+	if finalizerAfter.Status != "closed" {
+		t.Fatalf("finalizer status = %q, want closed", finalizerAfter.Status)
+	}
+	parentAfter, err := store.Get(parent.ID)
+	if err != nil {
+		t.Fatalf("get parent: %v", err)
+	}
+	if parentAfter.Status != "closed" {
+		t.Fatalf("parent status = %q, want closed before cycle stop", parentAfter.Status)
+	}
+	if got := strings.Count(trace.String(), "reason=cycle"); got != 2 {
+		t.Fatalf("cycle trace count = %d, want 2:\n%s", got, trace.String())
+	}
+}
+
+func TestPreflightSourceBeadChainReportsDepthLimitBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Workflow root",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.source_bead_id": "pending",
+		},
+	})
+	previousID := root.ID
+	sourceIDs := make([]string, 0, maxSourceChainHops+2)
+	for i := 0; i < 34; i++ {
+		source := mustCreateWorkflowBead(t, store, beads.Bead{
+			Title: fmt.Sprintf("Source %d", i),
+			Type:  "task",
+		})
+		sourceIDs = append(sourceIDs, source.ID)
+		if err := store.SetMetadata(previousID, "gc.source_bead_id", source.ID); err != nil {
+			t.Fatalf("SetMetadata(source %d): %v", i, err)
+		}
+		previousID = source.ID
+	}
+
+	var trace bytes.Buffer
+	err := preflightSourceBeadChain(store, root.ID, ProcessOptions{
+		Tracef: func(format string, args ...any) {
+			fmt.Fprintf(&trace, format+"\n", args...) //nolint:errcheck // test buffer
+		},
+	})
+	if err == nil {
+		t.Fatal("preflightSourceBeadChain err = nil, want depth-limit error")
+	}
+	if !strings.Contains(err.Error(), "depth limit") {
+		t.Fatalf("preflightSourceBeadChain error = %v, want depth-limit error", err)
+	}
+	closed := 0
+	for _, sourceID := range sourceIDs {
+		source, err := store.Get(sourceID)
+		if err != nil {
+			t.Fatalf("get source %s: %v", sourceID, err)
+		}
+		if source.Status == "closed" {
+			closed++
+		}
+	}
+	if closed != 0 {
+		t.Fatalf("closed source count = %d, want 0 before source-chain mutation", closed)
+	}
+	if !strings.Contains(trace.String(), "reason=depth_limit") {
+		t.Fatalf("trace missing depth_limit:\n%s", trace.String())
+	}
+}
+
+func TestWithoutSourceWorkflowRootLegacyFallbackExcludesMatchingIDOnly(t *testing.T) {
+	t.Parallel()
+
+	roots := []beads.Bead{
+		{
+			ID: "shared-root-id",
+			Metadata: map[string]string{
+				sourceworkflow.SourceStoreRefMetadataKey: "rig:other",
+			},
+		},
+		{ID: "other-root"},
+	}
+
+	got := withoutSourceWorkflowRoot(roots, "shared-root-id", "")
+	if len(got) != 1 || got[0].ID != "other-root" {
+		t.Fatalf("withoutSourceWorkflowRoot legacy fallback = %#v, want only other-root retained", got)
 	}
 }
 

--- a/internal/sling/sling_core.go
+++ b/internal/sling/sling_core.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -802,30 +801,17 @@ func validateBatchSlingFormulaRuntimeVars(ctx context.Context, formulaName strin
 }
 
 func sourceWorkflowLockScope(deps SlingDeps) string {
-	cityPath := strings.TrimSpace(deps.CityPath)
-	if cityPath == "" {
-		return strings.TrimSpace(deps.StoreRef)
-	}
-	storeRef := strings.TrimSpace(deps.StoreRef)
-	switch {
-	case storeRef == "", strings.HasPrefix(storeRef, "city:"):
-		return filepath.Clean(cityPath)
-	case strings.HasPrefix(storeRef, "rig:"):
-		rigName := strings.TrimPrefix(storeRef, "rig:")
+	return sourceworkflow.LockScopeForStoreRef(deps.CityPath, "", deps.StoreRef, func(rigName string) (string, bool) {
 		if deps.Cfg != nil {
 			for _, rig := range deps.Cfg.Rigs {
 				if rig.Name != rigName {
 					continue
 				}
-				rigPath := rig.Path
-				if !filepath.IsAbs(rigPath) {
-					rigPath = filepath.Join(cityPath, rigPath)
-				}
-				return filepath.Clean(rigPath)
+				return rig.Path, true
 			}
 		}
-	}
-	return storeRef
+		return "", false
+	})
 }
 
 // DoSlingBatch handles convoy expansion before delegating to DoSling.

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2603,6 +2603,19 @@ func TestSourceWorkflowLockScopeUsesStorePath(t *testing.T) {
 	}); got != filepath.Join("/city", "rigs", "alpha") {
 		t.Fatalf("rig scope = %q, want %q", got, filepath.Join("/city", "rigs", "alpha"))
 	}
+	wantShared := sourceworkflow.LockScopeForStoreRef("/city", "", "rig:alpha", func(rigName string) (string, bool) {
+		if rigName != "alpha" {
+			return "", false
+		}
+		return "rigs/alpha", true
+	})
+	if got := sourceWorkflowLockScope(SlingDeps{
+		CityPath: "/city",
+		StoreRef: "rig:alpha",
+		Cfg:      cfg,
+	}); got != wantShared {
+		t.Fatalf("rig scope = %q, want shared helper scope %q", got, wantShared)
+	}
 }
 
 func TestSlingExpandConvoy(t *testing.T) {

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -76,6 +76,45 @@ func NormalizeSourceStoreRef(sourceStoreRef string) string {
 	return strings.TrimSpace(sourceStoreRef)
 }
 
+// LockScopeForStoreRef returns the filesystem scope used for source-workflow
+// locks for a source bead's resident store ref.
+func LockScopeForStoreRef(cityPath, defaultStorePath, storeRef string, rigPath func(string) (string, bool)) string {
+	cityPath = strings.TrimSpace(cityPath)
+	defaultStorePath = strings.TrimSpace(defaultStorePath)
+	storeRef = strings.TrimSpace(storeRef)
+	if storeRef == "" {
+		switch {
+		case defaultStorePath != "":
+			return filepath.Clean(defaultStorePath)
+		case cityPath != "":
+			return filepath.Clean(cityPath)
+		default:
+			return ""
+		}
+	}
+	if cityPath == "" {
+		return filepath.Clean(storeRef)
+	}
+	switch {
+	case strings.HasPrefix(storeRef, "city:"):
+		return filepath.Clean(cityPath)
+	case strings.HasPrefix(storeRef, "rig:"):
+		rigName := strings.TrimSpace(strings.TrimPrefix(storeRef, "rig:"))
+		if rigPath != nil {
+			if path, ok := rigPath(rigName); ok {
+				path = strings.TrimSpace(path)
+				if path != "" {
+					if !filepath.IsAbs(path) {
+						path = filepath.Join(cityPath, path)
+					}
+					return filepath.Clean(path)
+				}
+			}
+		}
+	}
+	return filepath.Clean(storeRef)
+}
+
 // WorkflowMatchesSource reports whether a workflow root belongs to the
 // given source bead and (optionally) a specific source store ref. Legacy
 // roots without SourceStoreRefMetadataKey are treated as belonging to the

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -102,6 +102,37 @@ func TestLockIdentityCanonicalizesScopeRefSymlinks(t *testing.T) {
 	}
 }
 
+func TestLockScopeForStoreRefResolvesCityRigAndDefaultScopes(t *testing.T) {
+	cityPath := filepath.Clean("/city")
+	rigPath := filepath.Join("rigs", "alpha")
+	resolveRig := func(name string) (string, bool) {
+		if name != "alpha" {
+			return "", false
+		}
+		return rigPath, true
+	}
+
+	tests := []struct {
+		name             string
+		defaultStorePath string
+		storeRef         string
+		want             string
+	}{
+		{name: "default store path", defaultStorePath: "/city/rigs/default", want: filepath.Clean("/city/rigs/default")},
+		{name: "city store ref", storeRef: "city:test", want: cityPath},
+		{name: "rig store ref", storeRef: "rig:alpha", want: filepath.Join(cityPath, rigPath)},
+		{name: "unknown store ref", storeRef: "external:one", want: filepath.Clean("external:one")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LockScopeForStoreRef(cityPath, tt.defaultStorePath, tt.storeRef, resolveRig)
+			if got != tt.want {
+				t.Fatalf("LockScopeForStoreRef() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWorkflowMatchesSourceUsesSourceStoreRefWhenPresent(t *testing.T) {
 	root := beads.Bead{
 		ID: "wf-1",


### PR DESCRIPTION
## Summary
- close successful workflow source bead chains across city/rig store refs
- make workflow delete-source follow source launch chains into rig workflows
- use bd delete --cascade for source cleanup when a scoped store runner is available

## Tests
- go test ./internal/dispatch ./cmd/gc -run 'TestProcessWorkflowFinalizeClosesCrossStoreSourceBead|TestProcessWorkflowFinalizeLeavesCrossStoreSourceBeadOpenOnFailure|TestCmdWorkflowDeleteSourceFollowsRigLaunchSourceChain|TestApplySourceWorkflowMatchCleanupUsesCascadeRunnerForDelete|TestCmdWorkflowDeleteSourceClosesMatchedRootsAndClearsWorkflowID|TestCmdWorkflowDeleteSourceClosesGraphV2OnlyRoot|TestDeleteWorkflowBeadsRemovesDepsBeforeDelete'\n- pre-commit: golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->