### PR TITLE
fix(dolt): quarantine retired replacement databases

### DIFF
--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -112,11 +112,13 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if !info.IsDir() {
 			continue
 		}
-		manifest := filepath.Join(doltDir, "noms", "manifest")
-		if _, err := os.Stat(manifest); err == nil {
-			continue
-		} else if !os.IsNotExist(err) {
-			return err
+		if !retiredManagedDoltDatabaseName(entry.Name()) {
+			manifest := filepath.Join(doltDir, "noms", "manifest")
+			if _, err := os.Stat(manifest); err == nil {
+				continue
+			} else if !os.IsNotExist(err) {
+				return err
+			}
 		}
 		if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {
 			return err
@@ -131,6 +133,11 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		fmt.Fprintf(os.Stderr, "gc dolt preflight: quarantined phantom database %s -> %s\n", dbDir, dest) //nolint:errcheck // best-effort warning
 	}
 	return nil
+}
+
+func retiredManagedDoltDatabaseName(name string) bool {
+	name = strings.TrimSpace(name)
+	return strings.Contains(name, ".replaced-")
 }
 
 func uniqueQuarantineDestination(root, stamp, name string) (string, error) {

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -106,6 +106,40 @@ func TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState(t *testing.T) 
 	}
 }
 
+func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t *testing.T) {
+	dataDir := t.TempDir()
+	activeManifest := filepath.Join(dataDir, "ga", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(activeManifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(activeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	retiredManifest := filepath.Join(dataDir, "ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(retiredManifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(retiredManifest, []byte("retired\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 29, 16, 20, 0, 0, time.UTC)
+	if err := quarantinePhantomManagedDoltDatabases(dataDir, now); err != nil {
+		t.Fatalf("quarantinePhantomManagedDoltDatabases: %v", err)
+	}
+
+	if _, err := os.Stat(activeManifest); err != nil {
+		t.Fatalf("active manifest stat: %v", err)
+	}
+	if _, err := os.Stat(retiredManifest); !os.IsNotExist(err) {
+		t.Fatalf("retired manifest stat err = %v, want moved out of data dir", err)
+	}
+	quarantined := filepath.Join(dataDir, ".quarantine", "20260429T162000-ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Fatalf("quarantined manifest stat: %v", err)
+	}
+}
+
 func TestRemoveStaleManagedDoltSocketsWithoutLsofKeepsSocket(t *testing.T) {
 	socketPath := filepath.Join("/tmp", "dolt-preflight-cleanup-live-test.sock")
 	_ = os.Remove(socketPath)


### PR DESCRIPTION
## Summary
- treat managed Dolt directories named *.replaced-* as retired replacement databases
- quarantine retired replacement directories even when they still contain a manifest
- keep active databases with manifests untouched

## Tests
- go test ./cmd/gc -run 'TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB|TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState'\n- pre-commit: golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->