### PR TITLE
test: extend GC_BEADS/GC_BIN isolation to remaining TestCityRuntimeReload tests (gc-gs02z)

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2566,8 +2566,6 @@ func TestCityRuntimeReloadAllowsRegistryAliasDifferentFromWorkspaceName(t *testi
 }
 
 func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -2653,8 +2651,6 @@ func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
 }
 
 func TestCityRuntimeReloadRetriesTransientLifecycleFailure(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -2743,8 +2739,6 @@ func TestCityRuntimeReloadRetriesTransientLifecycleFailure(t *testing.T) {
 }
 
 func TestCityRuntimeReloadStrictWarningsReturnedOnFailure(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	oldStrict := strictMode
 	strictMode = true
 	t.Cleanup(func() { strictMode = oldStrict })
@@ -2820,8 +2814,6 @@ install_agent_hooks = ["codex"]
 }
 
 func TestCityRuntimeReloadNonStrictWarningsReturnedOnValidationFailure(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	oldStrict := strictMode
 	strictMode = false
 	t.Cleanup(func() { strictMode = oldStrict })
@@ -2954,8 +2946,6 @@ func TestCityRuntimeHandleReloadRequestInitializesConfigDirty(t *testing.T) {
 }
 
 func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -3228,8 +3218,6 @@ func TestNewCityRuntimeUsesRegisteredAliasForEffectiveIdentity(t *testing.T) {
 }
 
 func TestCityRuntimeReloadKeepsRegisteredAliasForEffectiveIdentity(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfigNamed(t, tomlPath, "declared-city", "fake")
@@ -3334,8 +3322,6 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 }
 
 func TestCityRuntimeReloadRestartsConfigWatcherWithNewPackTargets(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond
 	t.Cleanup(func() { debounceDelay = old })
@@ -3524,8 +3510,6 @@ func TestCityRuntimeWatchReloadPanicRestoresDirty(t *testing.T) {
 }
 
 func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -3644,8 +3628,6 @@ func TestCityRuntimeSafeTick_PassesThroughWhenNoPanic(t *testing.T) {
 // startup-poke branch invokes cr.tick(), which calls BuildFn a second
 // time; that call cancels ctx and run() exits cleanly.
 func TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity(t *testing.T) {
-	t.Setenv("GC_BEADS", "")
-	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2566,6 +2566,8 @@ func TestCityRuntimeReloadAllowsRegistryAliasDifferentFromWorkspaceName(t *testi
 }
 
 func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -2651,6 +2653,8 @@ func TestCityRuntimeReloadLifecycleFailureKeepsOldConfig(t *testing.T) {
 }
 
 func TestCityRuntimeReloadRetriesTransientLifecycleFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -2739,6 +2743,8 @@ func TestCityRuntimeReloadRetriesTransientLifecycleFailure(t *testing.T) {
 }
 
 func TestCityRuntimeReloadStrictWarningsReturnedOnFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	oldStrict := strictMode
 	strictMode = true
 	t.Cleanup(func() { strictMode = oldStrict })
@@ -2814,6 +2820,8 @@ install_agent_hooks = ["codex"]
 }
 
 func TestCityRuntimeReloadNonStrictWarningsReturnedOnValidationFailure(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	oldStrict := strictMode
 	strictMode = false
 	t.Cleanup(func() { strictMode = oldStrict })
@@ -2946,6 +2954,8 @@ func TestCityRuntimeHandleReloadRequestInitializesConfigDirty(t *testing.T) {
 }
 
 func TestCityRuntimeReloadSameRevisionIsNoOp(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -3218,6 +3228,8 @@ func TestNewCityRuntimeUsesRegisteredAliasForEffectiveIdentity(t *testing.T) {
 }
 
 func TestCityRuntimeReloadKeepsRegisteredAliasForEffectiveIdentity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfigNamed(t, tomlPath, "declared-city", "fake")
@@ -3322,6 +3334,8 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 }
 
 func TestCityRuntimeReloadRestartsConfigWatcherWithNewPackTargets(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	old := debounceDelay
 	debounceDelay = 5 * time.Millisecond
 	t.Cleanup(func() { debounceDelay = old })
@@ -3510,6 +3524,8 @@ func TestCityRuntimeWatchReloadPanicRestoresDirty(t *testing.T) {
 }
 
 func TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
@@ -3628,6 +3644,8 @@ func TestCityRuntimeSafeTick_PassesThroughWhenNoPanic(t *testing.T) {
 // startup-poke branch invokes cr.tick(), which calls BuildFn a second
 // time; that call cancels ctx and run() exits cleanly.
 func TestCityRuntimeRun_PanicInStartupDoesNotShutdownCity(t *testing.T) {
+	t.Setenv("GC_BEADS", "")
+	t.Setenv("GC_BIN", "")
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -35,6 +35,7 @@ func clearInheritedBeadsEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
 		"GC_BEADS",
+		"GC_BIN",
 		"GC_DOLT",
 		"GC_DOLT_HOST",
 		"GC_DOLT_PORT",


### PR DESCRIPTION
## Summary

- Adds `t.Setenv("GC_BEADS", "")` and `t.Setenv("GC_BIN", "")` to 9 remaining `TestCityRuntimeReload*`, `TestCityRuntimeRun*`, and `TestCityRuntimeWatchReload*` test functions
- Prevents tests from inheriting environment variables when run from within a gc worktree, which was causing orphan dolt sql-server processes
- The core fix (TestMain stripping all `GC_*` vars) was already merged in 409a551d; this adds per-test defensive guards to document intent and prevent future regressions

## Test plan
- [ ] CI passes
- [ ] AI review comments addressed

Resolves: gc-gs02z

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->