### PR TITLE
feat(gastown/polecat): default scale_check formula for parallel claims

### DIFF
--- a/examples/gastown/packs/gastown/agents/polecat/agent.toml
+++ b/examples/gastown/packs/gastown/agents/polecat/agent.toml
@@ -6,3 +6,11 @@ pre_start = ["{{.ConfigDir}}/assets/scripts/worktree-setup.sh {{.RigRoot}} {{.Wo
 idle_timeout = "2h"
 min_active_sessions = 0
 max_active_sessions = 5
+default_sling_formula = "mol-polecat-work"
+# Accept either gc.routed_to=polecat metadata (canonical) or pool:polecat label (convenience).
+# Takes max within each phase (ready / in-progress) to avoid double-counting
+# beads that carry both signals. Sums the two phases — the reconciler treats
+# this number as TOTAL desired pool size, so we have to include in-progress
+# beads (each one occupies a polecat slot) or a single in-flight task starves
+# parallel claims to the rest of the queue.
+scale_check = "rm=$(bd ready --metadata-field gc.routed_to=polecat --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null || echo 0); rl=$(bd ready --label pool:polecat --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null || echo 0); am=$(bd list --metadata-field gc.routed_to=polecat --status=in_progress --json 2>/dev/null | jq 'length' 2>/dev/null || echo 0); al=$(bd list --label pool:polecat --status=in_progress --json 2>/dev/null | jq 'length' 2>/dev/null || echo 0); ready=$rm; [ \"${rl:-0}\" -gt \"$ready\" ] && ready=$rl; active=$am; [ \"${al:-0}\" -gt \"$active\" ] && active=$al; echo $(( ready + active ))"


### PR DESCRIPTION
Related to #1512 (canonicalization epic) — same class of bug as the routing-target one, just a different observable: pool-scaling semantics that don't match what the formula returns.

## Problem

The gastown pack's polecat \`agent.toml\` ships with \`min_active_sessions=0, max_active_sessions=5\` but no \`scale_check\`. Cities that want demand-driven scaling have to write their own formula. The natural one to write — \"count unassigned ready beads routed to polecat\" — is wrong, because the reconciler treats \`scale_check\` output as **total desired pool size**, not **additional polecats needed beyond active ones**.

The result, observed on dewey: a single polecat claims a bead and starts work. \`scale_check\` returns N (count of remaining unassigned beads) but the reconciler sees N polecats already active on N beads… no, actually it sees 1 active vs scale_check=N-1 = remaining queue, except scale_check semantics are total so it computes desired=N-1 and decides 1 active is enough. **The pool never scales past 1** even with max=5 and a queue of work.

(Confirmed on dewey via \`gc trace show --template polecat\`: \`pool_desired: 1, work_requested: true\` with one active polecat on a bead, one unassigned bead in the queue, and scale_check returning 1.)

## Fix

Add a default \`scale_check\` to the pack's polecat \`agent.toml\` that returns the **total polecat slot demand**: \`max(unassigned-ready-by-metadata, unassigned-ready-by-label) + max(in-progress-by-metadata, in-progress-by-label)\`. The in-progress count includes beads with assignees — each one represents a polecat slot already in use, so the reconciler keeps those existing sessions alive while spawning enough additional ones to claim the remaining ready beads.

Also adds \`default_sling_formula = \"mol-polecat-work\"\` so cities using this pack don't have to set it explicitly.

## Why this is one PR not many

The simplest formulation makes the bug visible only with concurrent dispatch + nontrivial work duration. dewey hit it because polecats here take 30 min – 2 h (writing meaningful code, not toy work) and we routinely dispatch 2-3 parallel beads. Cities with shorter polecat lifetimes (test fixtures, demo work) wouldn't notice — their polecats finish before the queue accumulates.

## Related

- Epic: #1512 (canonicalization + scale-check semantics)
- Sibling fix: #1513 (mol-polecat-work \`<rig>/refinery\` template)
- Downstream change: dewey's \`city.toml\` updated locally with the same formula (HQ-only setup that also needed this fix immediately)

## Test plan

- [ ] Apply this pack to a multi-rig city, dispatch 3 beads to polecat pool, verify reconciler scales to 3 active sessions
- [ ] With 1 polecat active on a bead and 0 unassigned, verify pool stays at 1 (no over-scaling)
- [ ] With 5 unassigned beads, verify pool caps at \`max_active_sessions=5\` (not 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->