### PR TITLE
fix: skip dolt restart when managed server is already healthy at recovery time

### DIFF
--- a/cmd/gc/cmd_dolt_state.go
+++ b/cmd/gc/cmd_dolt_state.go
@@ -433,7 +433,7 @@ func newDoltStateCmd(stdout, stderr io.Writer) *cobra.Command {
 
 	recoverManaged := &cobra.Command{
 		Use:    "recover-managed",
-		Short:  "Recover the managed Dolt process for a city",
+		Short:  "Recover or reuse the managed Dolt process for a city",
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -2768,6 +2768,9 @@ esac
 	if got["healthy"] != "true" {
 		t.Fatalf("healthy = %q, want true", got["healthy"])
 	}
+	if got["restarted"] != "true" {
+		t.Fatalf("restarted = %q, want true", got["restarted"])
+	}
 	invocation, err := os.ReadFile(invocationFile)
 	if err != nil {
 		t.Fatalf("ReadFile(invocation): %v", err)
@@ -3141,7 +3144,11 @@ INNERPY
     fi
     count=$((count + 1))
     printf '%s\n' "$count" > "$ACTIVE_BRANCH_COUNT"
-    if [ "$count" -le 4 ]; then
+    if [ "$count" -eq 1 ]; then
+      echo "pre-recovery probe failed" >&2
+      exit 1
+    fi
+    if [ "$count" -le 3 ]; then
       exit 0
     fi
     echo "final health probe failed" >&2

--- a/cmd/gc/dolt_project_id_test.go
+++ b/cmd/gc/dolt_project_id_test.go
@@ -258,7 +258,7 @@ func TestManagedDoltWaitReadyWithPasswordUsesDirectQueryProbe(t *testing.T) {
 	}
 }
 
-func TestRecoverManagedDoltProcessWithPasswordUsesDirectHelpersAgainstRealServer(t *testing.T) {
+func TestRecoverManagedDoltProcessWithPasswordReusesHealthyRealServer(t *testing.T) {
 	skipSlowCmdGCTest(t, "requires a managed dolt server; run make test-cmd-gc-process for full coverage")
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
@@ -300,8 +300,17 @@ func TestRecoverManagedDoltProcessWithPasswordUsesDirectHelpersAgainstRealServer
 	if !report.Ready || !report.Healthy {
 		t.Fatalf("recoverManagedDoltProcess() = %+v, want ready healthy", report)
 	}
-	if report.PID == 0 || report.PID == pid {
-		t.Fatalf("recoverManagedDoltProcess() pid = %d, want new pid", report.PID)
+	if !report.HadPID {
+		t.Fatalf("recoverManagedDoltProcess() HadPID = false, want true")
+	}
+	if report.PID != pid {
+		t.Fatalf("recoverManagedDoltProcess() pid = %d, want reused pid %d", report.PID, pid)
+	}
+	if report.Port != port {
+		t.Fatalf("recoverManagedDoltProcess() port = %d, want %d", report.Port, port)
+	}
+	if report.Restarted {
+		t.Fatalf("recoverManagedDoltProcess() Restarted = true, want false")
 	}
 }
 

--- a/cmd/gc/dolt_recover_managed.go
+++ b/cmd/gc/dolt_recover_managed.go
@@ -92,6 +92,13 @@ func recoverManagedDoltProcess(cityPath, host, port, user, logLevel string, time
 		health, healthErr := managedDoltHealthCheck(host, port, user, true)
 		if healthErr == nil && health.ReadOnly == "true" {
 			report.DiagnosedReadOnly = true
+		} else if healthErr == nil && health.QueryReady {
+			report.Ready = true
+			report.Healthy = true
+			if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
+				return report, fmt.Errorf("publish managed dolt runtime state: %w", err)
+			}
+			return report, nil
 		}
 	}
 

--- a/cmd/gc/dolt_recover_managed.go
+++ b/cmd/gc/dolt_recover_managed.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ type managedDoltRecoverReport struct {
 	PID               int
 	Port              int
 	Healthy           bool
+	Restarted         bool
 }
 
 func recoverManagedDoltProcess(cityPath, host, port, user, logLevel string, timeout time.Duration) (managedDoltRecoverReport, error) {
@@ -92,12 +94,16 @@ func recoverManagedDoltProcess(cityPath, host, port, user, logLevel string, time
 		health, healthErr := managedDoltHealthCheck(host, port, user, true)
 		if healthErr == nil && health.ReadOnly == "true" {
 			report.DiagnosedReadOnly = true
-		} else if healthErr == nil && health.QueryReady {
+		} else if healthErr == nil && health.QueryReady && health.ReadOnly == "false" {
 			report.Ready = true
 			report.Healthy = true
+			if err := recoverManagedDoltRepairRuntimeStateForHealthyPort(cityPath, port); err != nil {
+				return report, err
+			}
 			if err := publishManagedDoltRuntimeStateIfOwned(cityPath); err != nil {
 				return report, fmt.Errorf("publish managed dolt runtime state: %w", err)
 			}
+			recoverManagedDoltPopulateReportFromRuntimeState(cityPath, port, &report)
 			return report, nil
 		}
 	}
@@ -117,6 +123,7 @@ func recoverManagedDoltProcess(cityPath, host, port, user, logLevel string, time
 	time.Sleep(time.Second)
 
 	startReport, err := startManagedDoltProcessWithOptions(cityPath, host, port, user, logLevel, -1, timeout, false)
+	report.Restarted = true
 	report.Ready = startReport.Ready
 	if startReport.PID > 0 {
 		report.PID = startReport.PID
@@ -189,6 +196,7 @@ func managedDoltRecoverFields(report managedDoltRecoverReport) []string {
 		"pid\t" + strconv.Itoa(report.PID),
 		"port\t" + strconv.Itoa(report.Port),
 		"healthy\t" + strconv.FormatBool(report.Healthy),
+		"restarted\t" + strconv.FormatBool(report.Restarted),
 	}
 }
 
@@ -228,6 +236,64 @@ func recoverManagedDoltObservedRebindPossible(cityPath, requestedPort string) bo
 		}
 	}
 	return false
+}
+
+func recoverManagedDoltRepairRuntimeStateForHealthyPort(cityPath, requestedPort string) error {
+	owned, err := managedDoltLifecycleOwned(cityPath)
+	if err != nil || !owned {
+		return err
+	}
+	portNum, err := strconv.Atoi(strings.TrimSpace(requestedPort))
+	if err != nil || portNum <= 0 {
+		return nil
+	}
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		return err
+	}
+	state := doltRuntimeState{
+		Running: true,
+		Port:    portNum,
+		DataDir: layout.DataDir,
+	}
+	repaired, ok := repairedManagedDoltRuntimeState(cityPath, layout, state)
+	if !ok {
+		return nil
+	}
+	if err := writeDoltRuntimeStateFile(layout.StateFile, repaired); err != nil {
+		return fmt.Errorf("repair provider dolt runtime state: %w", err)
+	}
+	return nil
+}
+
+func recoverManagedDoltPopulateReportFromRuntimeState(cityPath, requestedPort string, report *managedDoltRecoverReport) {
+	if report == nil {
+		return
+	}
+	for _, path := range []string{providerManagedDoltStatePath(cityPath), managedDoltStatePath(cityPath)} {
+		state, err := readDoltRuntimeStateFile(path)
+		if err != nil || !recoverManagedDoltRuntimeStateMatchesRequest(cityPath, requestedPort, state) {
+			continue
+		}
+		report.HadPID = true
+		report.PID = state.PID
+		report.Port = state.Port
+		return
+	}
+}
+
+func recoverManagedDoltRuntimeStateMatchesRequest(cityPath, requestedPort string, state doltRuntimeState) bool {
+	if !state.Running || state.PID <= 0 || state.Port <= 0 {
+		return false
+	}
+	requestedPort = strings.TrimSpace(requestedPort)
+	if requestedPort != "" && strconv.Itoa(state.Port) != requestedPort {
+		return false
+	}
+	if dataDir := strings.TrimSpace(state.DataDir); dataDir != "" && !samePath(dataDir, filepath.Join(cityPath, ".beads", "dolt")) {
+		return false
+	}
+	return true
 }
 
 func waitForManagedDoltLifecycleOrReady(cityPath, host, port, user string, timeout time.Duration, lockFile *os.File, _ managedDoltRuntimeLayout, report *managedDoltRecoverReport) (bool, bool, error) {

--- a/cmd/gc/dolt_recover_managed_test.go
+++ b/cmd/gc/dolt_recover_managed_test.go
@@ -62,6 +62,7 @@ func TestManagedDoltRecoverFields(t *testing.T) {
 		PID:               9876,
 		Port:              3311,
 		Healthy:           true,
+		Restarted:         true,
 	}
 	fields := managedDoltRecoverFields(report)
 	want := []string{
@@ -72,6 +73,7 @@ func TestManagedDoltRecoverFields(t *testing.T) {
 		"pid\t9876",
 		"port\t3311",
 		"healthy\ttrue",
+		"restarted\ttrue",
 	}
 	if len(fields) != len(want) {
 		t.Fatalf("got %d fields, want %d", len(fields), len(want))
@@ -133,7 +135,6 @@ func TestRecoverManagedDoltObservedRebindPossible(t *testing.T) {
 	})
 }
 
-
 func setupRecoveryTestCity(t *testing.T) string {
 	t.Helper()
 	cityPath := t.TempDir()
@@ -146,11 +147,26 @@ func setupRecoveryTestCity(t *testing.T) string {
 	}
 	t.Setenv("GC_DOLT_PASSWORD", "test")
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 	return cityPath
+}
+
+func writeRecoveryRuntimeState(t *testing.T, cityPath string, pid, port int) {
+	t.Helper()
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   true,
+		PID:       pid,
+		Port:      port,
+		DataDir:   filepath.Join(cityPath, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDoltRuntimeStateFile: %v", err)
+	}
 }
 
 func TestRecoverManagedDolt_SkipsRestartWhenProbeHealthy(t *testing.T) {
 	cityPath := setupRecoveryTestCity(t)
+	writeRecoveryRuntimeState(t, cityPath, 4321, 3306)
 
 	oldProbe := managedDoltQueryProbeDirectFn
 	oldReadOnly := managedDoltReadOnlyStateDirectFn
@@ -177,6 +193,18 @@ func TestRecoverManagedDolt_SkipsRestartWhenProbeHealthy(t *testing.T) {
 	}
 	if report.DiagnosedReadOnly {
 		t.Error("expected DiagnosedReadOnly=false for healthy server")
+	}
+	if !report.HadPID {
+		t.Error("expected HadPID=true from runtime state")
+	}
+	if report.PID != 4321 {
+		t.Errorf("expected PID=4321 from runtime state, got %d", report.PID)
+	}
+	if report.Port != 3306 {
+		t.Errorf("expected Port=3306 from runtime state, got %d", report.Port)
+	}
+	if report.Restarted {
+		t.Error("expected Restarted=false when healthy server is reused")
 	}
 }
 
@@ -236,6 +264,41 @@ func TestRecoverManagedDolt_ProceedsWhenProbeUnreachable(t *testing.T) {
 	}
 	if report.Ready {
 		t.Error("expected Ready=false when probe fails")
+	}
+}
+
+func TestRecoverManagedDolt_ProceedsWhenReadOnlyUnknown(t *testing.T) {
+	cityPath := setupRecoveryTestCity(t)
+
+	oldProbe := managedDoltQueryProbeDirectFn
+	oldReadOnly := managedDoltReadOnlyStateDirectFn
+	oldConnCount := managedDoltConnectionCountDirectFn
+	oldPreflight := managedDoltPreflightCleanupFn
+	t.Cleanup(func() {
+		managedDoltQueryProbeDirectFn = oldProbe
+		managedDoltReadOnlyStateDirectFn = oldReadOnly
+		managedDoltConnectionCountDirectFn = oldConnCount
+		managedDoltPreflightCleanupFn = oldPreflight
+	})
+
+	managedDoltQueryProbeDirectFn = func(_, _, _ string) error { return nil }
+	managedDoltReadOnlyStateDirectFn = func(_, _, _ string) (string, error) {
+		return "unknown", errManagedDoltNoUserDatabase
+	}
+	managedDoltConnectionCountDirectFn = func(_, _, _ string) (string, error) { return "5", nil }
+	managedDoltPreflightCleanupFn = func(_ string) error {
+		return fmt.Errorf("stop: expected - no real dolt process")
+	}
+
+	report, err := recoverManagedDoltProcess(cityPath, "127.0.0.1", "3306", "root", "warning", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error when read-only state is unknown and recovery proceeds to stop/start")
+	}
+	if report.DiagnosedReadOnly {
+		t.Error("expected DiagnosedReadOnly=false for unknown read-only state")
+	}
+	if report.Ready {
+		t.Error("expected Ready=false when recovery proceeds past unknown read-only health")
 	}
 }
 

--- a/cmd/gc/dolt_recover_managed_test.go
+++ b/cmd/gc/dolt_recover_managed_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -128,4 +131,139 @@ func TestRecoverManagedDoltObservedRebindPossible(t *testing.T) {
 			t.Error("same port should return false")
 		}
 	})
+}
+
+
+func setupRecoveryTestCity(t *testing.T) string {
+	t.Helper()
+	cityPath := t.TempDir()
+	packStateDir := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt")
+	if err := os.MkdirAll(packStateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	t.Setenv("GC_DOLT_PASSWORD", "test")
+	t.Setenv("GC_BEADS", "file")
+	return cityPath
+}
+
+func TestRecoverManagedDolt_SkipsRestartWhenProbeHealthy(t *testing.T) {
+	cityPath := setupRecoveryTestCity(t)
+
+	oldProbe := managedDoltQueryProbeDirectFn
+	oldReadOnly := managedDoltReadOnlyStateDirectFn
+	oldConnCount := managedDoltConnectionCountDirectFn
+	t.Cleanup(func() {
+		managedDoltQueryProbeDirectFn = oldProbe
+		managedDoltReadOnlyStateDirectFn = oldReadOnly
+		managedDoltConnectionCountDirectFn = oldConnCount
+	})
+
+	managedDoltQueryProbeDirectFn = func(_, _, _ string) error { return nil }
+	managedDoltReadOnlyStateDirectFn = func(_, _, _ string) (string, error) { return "false", nil }
+	managedDoltConnectionCountDirectFn = func(_, _, _ string) (string, error) { return "5", nil }
+
+	report, err := recoverManagedDoltProcess(cityPath, "127.0.0.1", "3306", "root", "warning", 10*time.Second)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !report.Ready {
+		t.Error("expected Ready=true when probe succeeds")
+	}
+	if !report.Healthy {
+		t.Error("expected Healthy=true when probe succeeds")
+	}
+	if report.DiagnosedReadOnly {
+		t.Error("expected DiagnosedReadOnly=false for healthy server")
+	}
+}
+
+func TestRecoverManagedDolt_ProceedsWhenReadOnly(t *testing.T) {
+	cityPath := setupRecoveryTestCity(t)
+
+	oldProbe := managedDoltQueryProbeDirectFn
+	oldReadOnly := managedDoltReadOnlyStateDirectFn
+	oldConnCount := managedDoltConnectionCountDirectFn
+	oldPreflight := managedDoltPreflightCleanupFn
+	t.Cleanup(func() {
+		managedDoltQueryProbeDirectFn = oldProbe
+		managedDoltReadOnlyStateDirectFn = oldReadOnly
+		managedDoltConnectionCountDirectFn = oldConnCount
+		managedDoltPreflightCleanupFn = oldPreflight
+	})
+
+	managedDoltQueryProbeDirectFn = func(_, _, _ string) error { return nil }
+	managedDoltReadOnlyStateDirectFn = func(_, _, _ string) (string, error) { return "true", nil }
+	managedDoltConnectionCountDirectFn = func(_, _, _ string) (string, error) { return "5", nil }
+	managedDoltPreflightCleanupFn = func(_ string) error {
+		return fmt.Errorf("stop: expected — no real dolt process")
+	}
+
+	report, err := recoverManagedDoltProcess(cityPath, "127.0.0.1", "3306", "root", "warning", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error when read-only server recovery proceeds to stop/start")
+	}
+	if !report.DiagnosedReadOnly {
+		t.Error("expected DiagnosedReadOnly=true for read-only server")
+	}
+	if report.Ready {
+		t.Error("expected Ready=false when recovery proceeds past probe")
+	}
+}
+
+func TestRecoverManagedDolt_ProceedsWhenProbeUnreachable(t *testing.T) {
+	cityPath := setupRecoveryTestCity(t)
+
+	oldProbe := managedDoltQueryProbeDirectFn
+	oldPreflight := managedDoltPreflightCleanupFn
+	t.Cleanup(func() {
+		managedDoltQueryProbeDirectFn = oldProbe
+		managedDoltPreflightCleanupFn = oldPreflight
+	})
+
+	managedDoltQueryProbeDirectFn = func(_, _, _ string) error {
+		return fmt.Errorf("connection refused")
+	}
+	managedDoltPreflightCleanupFn = func(_ string) error {
+		return fmt.Errorf("stop: expected — no real dolt process")
+	}
+
+	report, err := recoverManagedDoltProcess(cityPath, "127.0.0.1", "3306", "root", "warning", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error when unreachable server recovery proceeds to stop/start")
+	}
+	if report.Ready {
+		t.Error("expected Ready=false when probe fails")
+	}
+}
+
+func TestRecoverManagedDolt_ProceedsWhenHealthCheckErrors(t *testing.T) {
+	cityPath := setupRecoveryTestCity(t)
+
+	oldProbe := managedDoltQueryProbeDirectFn
+	oldReadOnly := managedDoltReadOnlyStateDirectFn
+	oldPreflight := managedDoltPreflightCleanupFn
+	t.Cleanup(func() {
+		managedDoltQueryProbeDirectFn = oldProbe
+		managedDoltReadOnlyStateDirectFn = oldReadOnly
+		managedDoltPreflightCleanupFn = oldPreflight
+	})
+
+	managedDoltQueryProbeDirectFn = func(_, _, _ string) error { return nil }
+	managedDoltReadOnlyStateDirectFn = func(_, _, _ string) (string, error) {
+		return "", fmt.Errorf("broken pipe")
+	}
+	managedDoltPreflightCleanupFn = func(_ string) error {
+		return fmt.Errorf("stop: expected — no real dolt process")
+	}
+
+	report, err := recoverManagedDoltProcess(cityPath, "127.0.0.1", "3306", "root", "warning", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error when health check fails and recovery proceeds to stop/start")
+	}
+	if report.Ready {
+		t.Error("expected Ready=false when health check errors")
+	}
 }

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1462,6 +1462,7 @@ load_recover_managed_from_gc() {
     GC_RECOVER_PID=""
     GC_RECOVER_PORT="$DOLT_PORT"
     GC_RECOVER_HEALTHY="false"
+    GC_RECOVER_RESTARTED="false"
     [ -n "$gc_bin" ] || return 1
     GC_RECOVER_MANAGED_USED="true"
     output=$("$gc_bin" dolt-state recover-managed --city "$GC_CITY_PATH" --host "$DOLT_HOST" --port "$DOLT_PORT" --user "$DOLT_USER" --log-level "$DOLT_LOGLEVEL" --timeout-ms 30000 </dev/null 2>/dev/null)
@@ -1494,6 +1495,10 @@ load_recover_managed_from_gc() {
                 ;;
             healthy)
                 GC_RECOVER_HEALTHY="$value"
+                parsed=true
+                ;;
+            restarted)
+                GC_RECOVER_RESTARTED="$value"
                 parsed=true
                 ;;
         esac


### PR DESCRIPTION
## Summary

When `recoverManagedDolt` runs and the managed dolt server is already healthy
on its expected port, skip the restart and reuse the existing server. The
prior behavior unconditionally restarted, which:

- Tore down a perfectly healthy server (added latency to recovery)
- Created a brief window where dependent code paths saw a missing server
- Made test runs flakier when an earlier test had already brought a server up

The fix adds an early healthy-probe in `recoverManagedDolt` and bypasses
restart when the probe succeeds. Read-only servers, unreachable probes, and
probe errors all still proceed to the full restart path.

## Test plan

- [x] `go build ./...` clean
- [x] New table-driven tests in `dolt_recover_managed_test.go`:
  - `TestRecoverManagedDolt_SkipsRestartWhenProbeHealthy` (the new path)
  - `TestRecoverManagedDolt_ProceedsWhenReadOnly`
  - `TestRecoverManagedDolt_ProceedsWhenProbeUnreachable`
  - `TestRecoverManagedDolt_ProceedsWhenHealthCheckErrors`
- [x] All four pass: `go test ./cmd/gc/ -run TestRecoverManagedDolt -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->