### PR TITLE
fix(sling): set bead assignee in addition to gc.routed_to metadata

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -495,8 +495,18 @@ func (r cliBeadRouter) Route(_ context.Context, req sling.RouteRequest) error {
 	if r.deps.Store == nil {
 		return fmt.Errorf("built-in sling routing requires a store")
 	}
-	if err := r.deps.Store.SetMetadata(req.BeadID, "gc.routed_to", req.Target); err != nil {
-		return fmt.Errorf("setting gc.routed_to on %s: %w", req.BeadID, err)
+	// Set assignee in addition to gc.routed_to. Without an assignee, the
+	// supervisor's assignedWorkBeads query (which filters by Bead.Assignee)
+	// cannot see the slung bead and the target agent never materializes —
+	// gc.routed_to alone is informational. Update writes both atomically so a
+	// concurrent reader never observes a half-routed bead. This mirrors the
+	// behavior of the textual default sling query (see Agent.DefaultSlingQuery).
+	target := req.Target
+	if err := r.deps.Store.Update(req.BeadID, beads.UpdateOpts{
+		Assignee: &target,
+		Metadata: map[string]string{"gc.routed_to": req.Target},
+	}); err != nil {
+		return fmt.Errorf("routing %s to %s: %w", req.BeadID, req.Target, err)
 	}
 	return nil
 }

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4106,7 +4106,7 @@ func TestDryRunSingleBead(t *testing.T) {
 	if !strings.Contains(out, "Agent:       mayor (non-expanding template)") {
 		t.Errorf("stdout missing agent info: %s", out)
 	}
-	if !strings.Contains(out, "Sling query: bd update {} --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "Sling query: bd update {} --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing sling query: %s", out)
 	}
 	// Work section.
@@ -4117,7 +4117,7 @@ func TestDryRunSingleBead(t *testing.T) {
 		t.Errorf("stdout missing bead title: %s", out)
 	}
 	// Route command.
-	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "bd update 'BL-42' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing route command: %s", out)
 	}
 	// Footer.
@@ -4221,7 +4221,7 @@ func TestDryRunOnFormula(t *testing.T) {
 	if !strings.Contains(out, "Pre-check: BL-42 has no existing molecule/wisp children") {
 		t.Errorf("stdout missing pre-check: %s", out)
 	}
-	if !strings.Contains(out, "bd update 'BL-42' --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "bd update 'BL-42' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing route command: %s", out)
 	}
 	if len(runner.calls) != 0 {
@@ -4252,7 +4252,7 @@ func TestDryRunMultiSessionConfig(t *testing.T) {
 	if !strings.Contains(out, "Session config: hw/polecat (min=1 max=3)") {
 		t.Errorf("stdout missing multi-session config info: %s", out)
 	}
-	if !strings.Contains(out, "bd update {} --set-metadata gc.routed_to=hw/polecat") {
+	if !strings.Contains(out, "bd update {} --assignee hw/polecat --set-metadata gc.routed_to=hw/polecat") {
 		t.Errorf("stdout missing sling query: %s", out)
 	}
 	if !strings.Contains(out, "Multi-session configs share a routed work queue via gc.routed_to") {
@@ -4307,13 +4307,13 @@ func TestDryRunConvoy(t *testing.T) {
 		t.Errorf("stdout missing skip indicator: %s", out)
 	}
 	// Route commands.
-	if !strings.Contains(out, "bd update 'BL-1' --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "bd update 'BL-1' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing BL-1 route command: %s", out)
 	}
-	if !strings.Contains(out, "bd update 'BL-3' --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "bd update 'BL-3' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing BL-3 route command: %s", out)
 	}
-	if strings.Contains(out, "bd update 'BL-2' --set-metadata gc.routed_to=mayor") {
+	if strings.Contains(out, "bd update 'BL-2' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout should not route closed BL-2: %s", out)
 	}
 	// Zero mutations.
@@ -4357,10 +4357,10 @@ func TestDryRunBatchOnFormula(t *testing.T) {
 		t.Errorf("stdout should not cook for closed BL-2: %s", out)
 	}
 	// Route commands.
-	if !strings.Contains(out, "bd update 'BL-1' --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "bd update 'BL-1' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing BL-1 route: %s", out)
 	}
-	if !strings.Contains(out, "bd update 'BL-3' --set-metadata gc.routed_to=mayor") {
+	if !strings.Contains(out, "bd update 'BL-3' --assignee mayor --set-metadata gc.routed_to=mayor") {
 		t.Errorf("stdout missing BL-3 route: %s", out)
 	}
 	if len(runner.calls) != 0 {
@@ -6054,5 +6054,49 @@ func TestSlingStdinWithExtraArg(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "--stdin requires exactly 1 argument") {
 		t.Errorf("stderr = %q, want to contain '--stdin requires exactly 1 argument'", stderr.String())
+	}
+}
+
+// TestCliBeadRouter_BuiltinPathSetsAssigneeAndMetadata pins the bug fix:
+// when a slung bead falls through the built-in fast path (no custom
+// sling_query), the bead must end up with BOTH the assignee and the
+// gc.routed_to metadata. Without the assignee, the supervisor's
+// assignedWorkBeads query (which filters by Bead.Assignee) cannot see
+// the bead, and on_demand agents like deep-investigator never materialize.
+func TestCliBeadRouter_BuiltinPathSetsAssigneeAndMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		ID:     "BL-99",
+		Title:  "investigate stale starts",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			// Default sling query (no SlingQuery override) — the built-in
+			// fast path should be selected for this agent.
+			{Name: "deep-investigator"},
+		},
+	}
+	router := cliBeadRouter{deps: &slingDeps{Cfg: cfg, Store: store, Stderr: io.Discard}}
+	if err := router.Route(context.Background(), sling.RouteRequest{
+		BeadID: bead.ID,
+		Target: "deep-investigator",
+	}); err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	updated, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.Assignee; got != "deep-investigator" {
+		t.Errorf("Assignee = %q, want %q (without this the supervisor cannot see the slung bead)", got, "deep-investigator")
+	}
+	if got := updated.Metadata["gc.routed_to"]; got != "deep-investigator" {
+		t.Errorf("gc.routed_to = %q, want %q", got, "deep-investigator")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1882,8 +1882,16 @@ func (a *Agent) EffectiveSlingQuery() string {
 // DefaultSlingQuery returns the built-in metadata-routing sling query for
 // this agent. Callers outside config should prefer this helper over rebuilding
 // the command string to preserve the bd boundary invariant.
+//
+// The default sets BOTH the assignee and the gc.routed_to metadata. The
+// supervisor's pool/desired-state computation matches by assignee, so a slung
+// bead is invisible to demand without it; metadata alone causes the target
+// agent to never materialize. Setting both keeps the long-standing
+// gc.routed_to history (which other queries and the dashboard inspect) while
+// making the bead visible to the reconciler.
 func (a *Agent) DefaultSlingQuery() string {
-	return "bd update {} --set-metadata gc.routed_to=" + a.QualifiedName()
+	q := a.QualifiedName()
+	return "bd update {} --assignee " + q + " --set-metadata gc.routed_to=" + q
 }
 
 // EffectiveDefaultSlingFormula returns the default sling formula for

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1328,7 +1328,7 @@ func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 func TestEffectiveSlingQueryFixedAgent(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveSlingQuery()
-	want := "bd update {} --set-metadata gc.routed_to=mayor"
+	want := "bd update {} --assignee mayor --set-metadata gc.routed_to=mayor"
 	if got != want {
 		t.Errorf("EffectiveSlingQuery() = %q, want %q", got, want)
 	}
@@ -1337,7 +1337,7 @@ func TestEffectiveSlingQueryFixedAgent(t *testing.T) {
 func TestEffectiveSlingQueryFixedAgentWithDir(t *testing.T) {
 	a := Agent{Name: "refinery", Dir: "hello-world"}
 	got := a.EffectiveSlingQuery()
-	want := "bd update {} --set-metadata gc.routed_to=hello-world/refinery"
+	want := "bd update {} --assignee hello-world/refinery --set-metadata gc.routed_to=hello-world/refinery"
 	if got != want {
 		t.Errorf("EffectiveSlingQuery() = %q, want %q", got, want)
 	}
@@ -1346,7 +1346,7 @@ func TestEffectiveSlingQueryFixedAgentWithDir(t *testing.T) {
 func TestEffectiveSlingQueryPoolDefault(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveSlingQuery()
-	want := "bd update {} --set-metadata gc.routed_to=hello-world/polecat"
+	want := "bd update {} --assignee hello-world/polecat --set-metadata gc.routed_to=hello-world/polecat"
 	if got != want {
 		t.Errorf("EffectiveSlingQuery() = %q, want %q", got, want)
 	}
@@ -1460,7 +1460,7 @@ func TestEffectiveSlingQueryPoolNameOverride(t *testing.T) {
 		PoolName: "hello-world/dog",
 	}
 	got := a.EffectiveSlingQuery()
-	want := "bd update {} --set-metadata gc.routed_to=hello-world/dog-1"
+	want := "bd update {} --assignee hello-world/dog-1 --set-metadata gc.routed_to=hello-world/dog-1"
 	if got != want {
 		t.Errorf("EffectiveSlingQuery() = %q, want %q", got, want)
 	}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -276,7 +276,7 @@ func TestCheckBeadStatePinnedDefaultBDQueryRemainsIdempotent(t *testing.T) {
 
 	result := CheckBeadState(store, bead.ID, config.Agent{
 		Name:       "mayor",
-		SlingQuery: "bd   update {}   --set-metadata gc.routed_to=mayor",
+		SlingQuery: "bd   update {}   --assignee mayor   --set-metadata gc.routed_to=mayor",
 	}, SlingDeps{})
 
 	if !result.Idempotent {


### PR DESCRIPTION
## Summary
- Slung beads were invisible to the supervisor's pool/desired-state computation, so on_demand agents like `deep-investigator` never materialized even when their `work_query` would match the bead.
- The supervisor's `assignedWorkBeads` query (`build_desired_state.go appendAssignedUnique` + `pool_desired_state.go`) filters strictly by `Bead.Assignee` — `gc.routed_to` metadata is informational only.
- `work_query` is a wake signal for sessions that already exist; it does not create demand.
- Result: a bead with valid `gc.routed_to` could appear \"routed\" in `bd show` while remaining invisible to the reconciler. The dispatch follow-up bead gm-2p7j0rw described exactly this symptom (\"dispatch returns 0 beads despite valid gc.routed_to\").

## Approach
Set both atomically:

- `Agent.DefaultSlingQuery` now emits `bd update {} --assignee <name> --set-metadata gc.routed_to=<name>` so the textual sling query matches what the engine actually does.
- `cliBeadRouter.Route`'s built-in fast path now calls `Store.Update` with both `Assignee` and `Metadata` in a single `UpdateOpts` so a concurrent reader cannot observe a half-routed bead.
- Custom `sling_query` callers are unaffected — they keep running their configured command.

## Test plan
- [x] Updated `TestEffectiveSlingQuery*` (3 tests) and `TestEffectiveSlingQueryPoolNameOverride` to reflect the new default string.
- [x] Updated dry-run output assertions in `TestDryRun_*` for the route command appearance.
- [x] New `TestCliBeadRouter_BuiltinPathSetsAssigneeAndMetadata` pins the post-route bead state — the bead has both `Assignee` and `gc.routed_to` set after `cliBeadRouter.Route`.

## Reproducer
1. Define an on_demand agent with a `work_query` that filters by label.
2. Create a bead, add the matching label, and `gc sling <agent> <bead-id>`.
3. Pre-fix: bead has `gc.routed_to` but no `Assignee`. Supervisor logs show `scaleCheck: <agent> = 1` but agent is never started; `gc session peek <agent>` reports \"not found\".
4. Post-fix: bead has both. Reconciler picks it up, agent materializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->