### PR TITLE
fix(reconciler): orphan stale pending-create beads with no active lease

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -146,15 +146,44 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 		template = session.Metadata["template"]
 	}
 	agent := findAgentByTemplate(cfg, template)
-	if agent != nil {
-		return !agent.Suspended
+	if agent == nil {
+		// Config-snapshot catch-up grace: API config mutations and session
+		// creation can arrive in adjacent reconciler ticks. Preserve a fresh
+		// pending-create bead while the runtime config snapshot catches up
+		// so it is not falsely closed as orphaned. Once the bead ages past
+		// the staleCreatingState window the grace has elapsed and the bead
+		// falls through to orphan cleanup.
+		return strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
+			strings.TrimSpace(session.Metadata["state"]) == "creating" &&
+			!staleCreatingState(session, clk)
 	}
-	// API config mutations and session creation can arrive in adjacent
-	// reconciler ticks. Preserve a fresh pending-create bead while the runtime
-	// config snapshot catches up so it is not falsely closed as orphaned.
-	return strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
-		strings.TrimSpace(session.Metadata["state"]) == "creating" &&
-		!staleCreatingState(session, clk)
+	if agent.Suspended {
+		return false
+	}
+	// Lease-evidence requirement: even when the agent is matched, a
+	// pending_create_claim must be backed by an active lease, or the bead
+	// would be treated as "in-flight" forever — the reconciler would skip
+	// it on every tick, the alias it holds would block new spawn attempts
+	// ("alias already belongs to gm-XXXX"), and the session would never make
+	// progress.
+	//
+	// Two evidence sources count as a held lease:
+	//   1. last_woke_at within the startup window — the wake pipeline ran.
+	//   2. CreatedAt within staleCreatingStateTimeout — the bead was just
+	//      written and the wake pipeline hasn't fired yet (manual sessions,
+	//      or supervisor restart between bead-write and wake-fire).
+	//
+	// When neither holds, the lease has expired and the bead is orphan-
+	// eligible: falling through lets the reconciler clean up, release the
+	// alias, and spawn a fresh one.
+	var startupTimeout time.Duration
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
+	if pendingCreateStartInFlight(session, clk, startupTimeout) {
+		return true
+	}
+	return !staleCreatingState(session, clk)
 }
 
 func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2003,6 +2003,114 @@ func TestReconcileSessionBeads_DefersPendingCreateRecoveryWhileStartInFlight(t *
 	}
 }
 
+func TestPendingCreateSessionStillLeased_StaleBeadWithoutLeaseIsOrphan(t *testing.T) {
+	// Regression test: a bead that has pending_create_claim=true but
+	// last_woke_at empty AND was created more than the staleCreatingState
+	// window ago must NOT be considered leased. Otherwise the bead lives
+	// forever, holding its alias and blocking new spawn attempts. (This was
+	// the symptom: "alias already belongs to gm-XXXX" errors with a
+	// gm-XXXX bead stuck in state=creating that never advanced.)
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	bead := beads.Bead{
+		CreatedAt: now.Add(-5 * time.Minute), // older than 1m staleCreatingStateTimeout
+		Metadata: map[string]string{
+			"template":             "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+			// last_woke_at deliberately empty — preWakeCommit never fired.
+		},
+	}
+	if pendingCreateSessionStillLeased(bead, cfg, clk) {
+		t.Fatal("bead with no last_woke_at lease and old CreatedAt must not be considered leased")
+	}
+}
+
+func TestPendingCreateSessionStillLeased_RecentBeadWithoutLeaseIsLeased(t *testing.T) {
+	// Defensive: a bead just written with pcc=true but no last_woke_at yet
+	// (e.g., manual sessions or the gap between bead-create and the next
+	// reconciler tick that runs preWakeCommit) must still be considered
+	// leased while CreatedAt is within the staleCreatingState window. This
+	// preserves the original intent of the leased branch.
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	bead := beads.Bead{
+		CreatedAt: now.Add(-5 * time.Second), // well within staleCreatingState window
+		Metadata: map[string]string{
+			"template":             "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+		},
+	}
+	if !pendingCreateSessionStillLeased(bead, cfg, clk) {
+		t.Fatal("recently-created pending-create bead must be considered leased even without last_woke_at")
+	}
+}
+
+func TestPendingCreateSessionStillLeased_FreshLeaseIsLeased(t *testing.T) {
+	// A bead with last_woke_at within the startup window is leased,
+	// regardless of CreatedAt.
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	bead := beads.Bead{
+		CreatedAt: now.Add(-1 * time.Hour), // very old, but lease is fresh
+		Metadata: map[string]string{
+			"template":             "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+			"last_woke_at":         now.Add(-10 * time.Second).Format(time.RFC3339),
+		},
+	}
+	if !pendingCreateSessionStillLeased(bead, cfg, clk) {
+		t.Fatal("fresh last_woke_at lease must keep the bead leased even if CreatedAt is old")
+	}
+}
+
+func TestPendingCreateSessionStillLeased_ConfigCatchUpGracePreservesFreshBead(t *testing.T) {
+	// Coexistence pin: a config-catch-up scenario (agent template not yet
+	// visible in the loaded config because an API mutation and the next
+	// reconciler tick race) must NOT get orphaned by the lease-evidence
+	// requirement. The grace path is gated on agent==nil; when the agent
+	// reappears in a later snapshot, the lease-evidence path takes over.
+	cfg := &config.City{Agents: []config.Agent{{Name: "other-template"}}}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	bead := beads.Bead{
+		CreatedAt: now.Add(-5 * time.Second), // within staleCreatingState window
+		Metadata: map[string]string{
+			"template":             "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+		},
+	}
+	if !pendingCreateSessionStillLeased(bead, cfg, clk) {
+		t.Fatal("fresh pending-create bead with agent missing from config must remain leased via catch-up grace")
+	}
+}
+
+func TestPendingCreateSessionStillLeased_ConfigCatchUpExpiresWhenStale(t *testing.T) {
+	// The catch-up grace window is bounded by staleCreatingState. Once the
+	// bead ages past that window without the agent appearing, the bead is
+	// orphan-eligible and the grace path returns false.
+	cfg := &config.City{Agents: []config.Agent{{Name: "other-template"}}}
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	bead := beads.Bead{
+		CreatedAt: now.Add(-5 * time.Minute), // past staleCreatingStateTimeout (1m)
+		Metadata: map[string]string{
+			"template":             "worker",
+			"state":                "creating",
+			"pending_create_claim": "true",
+		},
+	}
+	if pendingCreateSessionStillLeased(bead, cfg, clk) {
+		t.Fatal("stale pending-create bead with missing agent must orphan after grace window")
+	}
+}
+
 func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}


### PR DESCRIPTION
## Summary

`pendingCreateSessionStillLeased` (cmd/gc/session_reconciler.go:140) treated **any** bead with `pending_create_claim=true` and an existing agent template as "in-flight" forever. A bead written with `pcc=true` that never reached `preWakeCommit` (so `last_woke_at` stayed empty) and sat past the `staleCreatingState` window was skipped on every reconciler tick. The alias it held blocked new spawn attempts (`alias already belongs to gm-XXXX`), and the session never made progress.

## Symptom

```
session beads: alias "deep-investigator" for deep-investigator unavailable: session alias already exists: "deep-investigator" conflicts with session name on gm-0irxojg
session beads: creating bead for deep-investigator: session alias already exists: "deep-investigator" conflicts with session name on gm-0irxojg
```

`gm-0irxojg` here is a stuck creating bead with `pcc=true` and `last_woke_at=NULL`. The reconciler considered it leased forever; supervisor couldn't materialize a new deep-investigator no matter how many times the work queue demanded one.

## Fix

A pending-create lease must be backed by either:
1. `last_woke_at` within the startup window — the wake pipeline ran.
2. `CreatedAt` within `staleCreatingStateTimeout` — the bead was just written and the wake pipeline hasn't fired yet (manual sessions, or supervisor restart between bead-write and wake-fire).

Without either, the bead is treated as orphaned: cleanup runs, the alias is released, and the supervisor can spawn a fresh slot.

Recently-created beads that haven't yet recorded `last_woke_at` remain protected by (2), so the existing `TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose` contract is preserved.

## Tests

Three new table-style tests:
- `TestPendingCreateSessionStillLeased_StaleBeadWithoutLeaseIsOrphan` — the bug.
- `TestPendingCreateSessionStillLeased_RecentBeadWithoutLeaseIsLeased` — recent beads without `last_woke_at` remain leased.
- `TestPendingCreateSessionStillLeased_FreshLeaseIsLeased` — fresh `last_woke_at` keeps lease alive even if `CreatedAt` is old.

All existing PendingCreate / Reconcile / Lifecycle tests still pass.

## Test plan

- [x] Unit tests pass (`go test -run "PendingCreate|Reconcile|Lifecycle" ./cmd/gc/...`)
- [x] Build clean (`go build ./cmd/gc`)
- [ ] Live verification — observe stuck creating beads get cleaned up and new spawns succeed

## Related

This is the second of a pair of fixes for stuck-creating recovery; the other is #1531 (`asyncStartSessionStillCurrent` permissive commit when state advanced). Both are independent and either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->