### PR TITLE
fix(reconciler): roll back stale pending-create beads in desired branch

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -527,6 +527,27 @@ func reconcileSessionBeadsTraced(
 			rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
 			continue
 		}
+		// Desired-branch counterpart to pendingCreateSessionStillLeased: a
+		// session bead in the desired set with pending_create_claim=true but
+		// no live runtime AND no active lease is stuck. Without this rollback,
+		// the bead lives forever holding its alias, blocking new spawn
+		// attempts ("alias already belongs to gm-XXXX") for any session whose
+		// template still has demand. Rolling back closes the dead bead so the
+		// next reconciler tick can allocate a fresh slot under the same alias.
+		if !alive && shouldRollbackPendingCreate(session) {
+			var startupTimeout time.Duration
+			if cfg != nil {
+				startupTimeout = cfg.Session.StartupTimeoutDuration()
+			}
+			if !pendingCreateStartInFlight(*session, clk, startupTimeout) && staleCreatingState(*session, clk) {
+				fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: lease expired and no live runtime\n", name) //nolint:errcheck
+				if trace != nil {
+					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_lease_expired", "rollback", nil, nil, "")
+				}
+				rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
+				continue
+			}
+		}
 
 		// Drain-ack: agent signaled it's done (gc runtime drain-ack).
 		// Honor the ack even if the agent exited before this tick; otherwise

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2622,6 +2622,126 @@ func TestReconcileSessionBeads_ConvergesPendingCreateWhenRuntimeMatchesBead(t *t
 	}
 }
 
+func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime(t *testing.T) {
+	// Regression test: a session bead in the desired set with
+	// pending_create_claim=true but no live runtime AND no active lease
+	// (last_woke_at empty AND CreatedAt past staleCreatingState window) is
+	// stuck. Without this rollback, the bead lives forever holding its alias,
+	// blocking new spawn attempts ("alias already belongs to gm-XXXX") for
+	// any session whose template still has demand.
+	store := beads.NewMemStore()
+	sp := runtime.NewFake() // no runtime started
+	clk := &clock.Fake{Time: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}
+	cfg := &config.City{Agents: []config.Agent{{Name: "helper"}}}
+	desired := map[string]TemplateParams{
+		"helper": {
+			Command:      "test-cmd",
+			SessionName:  "helper",
+			TemplateName: "helper",
+		},
+	}
+
+	bead, err := store.Create(beads.Bead{
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:helper"},
+		Metadata: map[string]string{
+			"session_name":          "helper",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"template":              "helper",
+			"state":                 "creating",
+			"generation":            "1",
+			"continuation_epoch":    "1",
+			"instance_token":        "test-token",
+			// last_woke_at deliberately empty — preWakeCommit never fired.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(bead): %v", err)
+	}
+	// Force CreatedAt past the staleCreatingState window so the lease check
+	// flips from "fresh" to "expired". The reconciler reads CreatedAt from
+	// the passed bead slice, so modifying the local copy is sufficient.
+	bead.CreatedAt = clk.Now().Add(-5 * time.Minute)
+
+	var stdout, stderr bytes.Buffer
+	cfgNames := configuredSessionNames(cfg, "", store)
+	_ = reconcileSessionBeads(
+		context.Background(), []beads.Bead{bead}, desired, cfgNames,
+		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{}, false, nil, "",
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(bead): %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed (stale lease + no runtime should rollback)", got.Status)
+	}
+	if got.Metadata["close_reason"] != "failed-create" {
+		t.Fatalf("close_reason = %q, want failed-create", got.Metadata["close_reason"])
+	}
+}
+
+func TestReconcileSessionBeads_PreservesPendingCreateWhenLeaseRecentNoRuntime(t *testing.T) {
+	// Defensive: a session bead with pending_create_claim=true and no live
+	// runtime but a *fresh* last_woke_at lease (or recently CreatedAt) must
+	// NOT be rolled back — the spawn is genuinely in flight, just not yet
+	// observable. Rolling back here would race with the async start pipeline.
+	store := beads.NewMemStore()
+	sp := runtime.NewFake() // no runtime
+	clk := &clock.Fake{Time: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}
+	cfg := &config.City{Agents: []config.Agent{{Name: "helper"}}}
+	desired := map[string]TemplateParams{
+		"helper": {
+			Command:      "test-cmd",
+			SessionName:  "helper",
+			TemplateName: "helper",
+		},
+	}
+
+	bead, err := store.Create(beads.Bead{
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:helper"},
+		Metadata: map[string]string{
+			"session_name":          "helper",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"template":              "helper",
+			"state":                 "creating",
+			"generation":            "1",
+			"continuation_epoch":    "1",
+			"instance_token":        "test-token",
+			"last_woke_at":          clk.Now().Add(-10 * time.Second).Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(bead): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cfgNames := configuredSessionNames(cfg, "", store)
+	_ = reconcileSessionBeads(
+		context.Background(), []beads.Bead{bead}, desired, cfgNames,
+		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{}, false, nil, "",
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(bead): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed, want preserved (lease still fresh)")
+	}
+	if strings.TrimSpace(got.Metadata["pending_create_claim"]) != "true" {
+		t.Fatalf("pending_create_claim = %q, want still 'true'", got.Metadata["pending_create_claim"])
+	}
+}
+
 func TestReconcileSessionBeads_RollsBackPendingCreateWhenConflictingRuntimeAlreadyRunning(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary

Sister fix to #1531 (async start commit) and #1532 (orphan-side stale lease). Closes the last gap that left desired-set sessions stuck in `state=creating` forever.

## Problem

The desired branch of `reconcileSessionBeads` (cmd/gc/session_reconciler.go:547) already rolls back `pending_create_claim` when a *live* runtime is observed to belong to a different session. It does **not** roll back when no runtime is alive at all and the lease has expired — even though that combination is exactly "the spawn died, the bead is dead, please clean up so the alias frees up."

## Symptom

```
session beads: alias "deep-investigator" already belongs to gm-0irxojg
```

`gm-0irxojg` is a desired-set session bead with `pending_create_claim=true` and `last_woke_at=NULL`, sitting 25 minutes past `staleCreatingStateTimeout`. Any template with demand never spawns because the alias is held forever.

## Fix

Mirror the lease check from #1532. When:
- `pending_create_claim=true`, AND
- no runtime is alive, AND
- `pendingCreateStartInFlight` returns false (lease expired), AND
- `staleCreatingState` returns true (`CreatedAt` past window),

call `rollbackPendingCreate` so the bead is closed with `close_reason=failed-create`. The next reconciler tick then allocates a fresh slot under the same alias.

Recently-created beads or fresh leases are protected (no rollback) — that protects in-flight async starts.

## Tests

Two regression tests:
- `TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime` — the bug.
- `TestReconcileSessionBeads_PreservesPendingCreateWhenLeaseRecentNoRuntime` — fresh leases must not race with async start.

All existing PendingCreate / Reconcile / Lifecycle / Async tests still pass.

## Test plan

- [x] Unit tests pass (`go test -run "PendingCreate|Reconcile|Lifecycle|Async" ./cmd/gc/`)
- [x] Build clean (`go build ./cmd/gc`)
- [ ] Live verification — desired-set sessions stuck in creating get reaped on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->