### PR TITLE
fix(session): preserve pending pool session beads

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -784,13 +784,7 @@ func discoverSessionBeadsWithRoots(
 }
 
 func isPendingPoolCreate(b beads.Bead) bool {
-	if !isPoolManagedSessionBead(b) || strings.TrimSpace(b.Metadata["pending_create_claim"]) != boolMetadata(true) {
-		return false
-	}
-	if strings.TrimSpace(b.Metadata["state"]) != "creating" {
-		return false
-	}
-	return true
+	return isPoolManagedSessionBead(b) && strings.TrimSpace(b.Metadata["pending_create_claim"]) == boolMetadata(true)
 }
 
 func realizeDependencyFloors(

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1952,7 +1952,7 @@ func TestBuildDesiredState_PendingCreatePoolSessionStaysDesiredWithoutScaleDeman
 			"pool_managed":         boolMetadata(true),
 			"pool_slot":            "1",
 			"pending_create_claim": boolMetadata(true),
-			"state":                "creating",
+			"state":                "stopped",
 		},
 	}); err != nil {
 		t.Fatalf("create session bead: %v", err)

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -102,29 +102,35 @@ func beadOwnsPoolSessionName(b beads.Bead) bool {
 	return strings.HasSuffix(sn, "-"+id)
 }
 
-func findVisibleSessionBeadByName(store beads.Store, sessionName string) (beads.Bead, bool, error) {
-	sessionName = strings.TrimSpace(sessionName)
-	if store == nil || sessionName == "" {
-		return beads.Bead{}, false, nil
+func pendingPoolSessionName(template, instanceToken string) string {
+	base := targetBasename(template)
+	if base == "" {
+		base = "pool"
 	}
-	open, err := loadSessionBeads(store)
-	if err != nil {
-		return beads.Bead{}, false, err
+	token := strings.TrimSpace(instanceToken)
+	if token == "" {
+		token = session.NewInstanceToken()
 	}
-	var winner beads.Bead
-	found := false
+	return base + "-pending-" + token
+}
+
+func indexSessionBeadsByName(open []beads.Bead) map[string]beads.Bead {
+	byName := make(map[string]beads.Bead, len(open))
 	for _, b := range open {
-		if strings.TrimSpace(b.Metadata["session_name"]) != sessionName {
+		if b.Status == "closed" {
 			continue
 		}
-		if !found {
-			winner = b
-			found = true
+		sn := strings.TrimSpace(b.Metadata["session_name"])
+		if sn == "" {
 			continue
 		}
-		winner = canonicalDuplicateSessionBead(winner, b)
+		if incumbent, ok := byName[sn]; ok {
+			byName[sn] = canonicalDuplicateSessionBead(incumbent, b)
+			continue
+		}
+		byName[sn] = b
 	}
-	return winner, found, nil
+	return byName
 }
 
 func upsertOpenSessionBead(openBeads []beads.Bead, indexBySessionName map[string]int, b beads.Bead) []beads.Bead {
@@ -762,6 +768,22 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 
 	now := clk.Now().UTC()
 	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
+	var (
+		visibleBySessionName map[string]beads.Bead
+		visibleLoaded        bool
+	)
+	loadVisibleBySessionName := func() (map[string]beads.Bead, error) {
+		if visibleLoaded {
+			return visibleBySessionName, nil
+		}
+		open, err := loadSessionBeads(store)
+		if err != nil {
+			return nil, err
+		}
+		visibleBySessionName = indexSessionBeadsByName(open)
+		visibleLoaded = true
+		return visibleBySessionName, nil
+	}
 
 	blockedReconfiguredNamedIdentities := map[string]bool{}
 	if cfg != nil {
@@ -815,13 +837,14 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 
 		b, exists := bySessionName[sn]
 		if !exists && isPoolInstance {
-			recovered, ok, err := findVisibleSessionBeadByName(store, sn)
+			visible, err := loadVisibleBySessionName()
 			if err != nil {
 				fmt.Fprintf(stderr, "session beads: reloading visible bead for %s: %v\n", sn, err) //nolint:errcheck
-			} else if ok {
+			} else if recovered, ok := visible[sn]; ok {
 				b = recovered
 				exists = true
 				bySessionName[sn] = recovered
+				fmt.Fprintf(stderr, "session beads: recovered visible owner %s for session_name %q from store\n", recovered.ID, sn) //nolint:errcheck
 				for i, open := range openBeads {
 					if open.Status == "closed" || open.ID == recovered.ID {
 						continue
@@ -853,13 +876,14 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if createState != "active" {
 				createState = "creating"
 			}
+			instanceToken := session.NewInstanceToken()
 			meta := map[string]string{
 				"agent_name":         agentName,
 				"live_hash":          liveHash,
 				"session_origin":     origin,
 				"generation":         strconv.Itoa(session.DefaultGeneration),
 				"continuation_epoch": strconv.Itoa(session.DefaultContinuationEpoch),
-				"instance_token":     session.NewInstanceToken(),
+				"instance_token":     instanceToken,
 				"state":              createState,
 				"synced_at":          now.Format("2006-01-02T15:04:05Z07:00"),
 			}
@@ -903,6 +927,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			meta["template"] = qualifiedTemplate
 			if poolSlot > 0 {
 				meta["pool_slot"] = strconv.Itoa(poolSlot)
+				meta["session_name"] = pendingPoolSessionName(qualifiedTemplate, instanceToken)
 			}
 			// Store command and resume fields so gc session attach can
 			// reconstruct the resume command from bead metadata alone.
@@ -979,8 +1004,8 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				if isPoolInstance {
 					createdSessionName = PoolSessionName(qualifiedTemplate, newBead.ID)
 					if err := store.SetMetadata(newBead.ID, "session_name", createdSessionName); err != nil {
-						_ = store.Close(newBead.ID)
 						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck
+						closeFailedCreateBead(store, newBead.ID, now, stderr)
 						continue
 					}
 					if newBead.Metadata == nil {
@@ -1434,6 +1459,19 @@ func setMetaBatch(store beads.Store, id string, batch map[string]string, stderr 
 		return err
 	}
 	return nil
+}
+
+func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr io.Writer) bool {
+	patch := session.ClosePatch(now.UTC(), "failed-create")
+	patch["pending_create_claim"] = ""
+	if setMetaBatch(store, id, patch, stderr) != nil {
+		return false
+	}
+	if err := store.Close(id); err != nil {
+		fmt.Fprintf(stderr, "session beads: closing failed-create bead %s: %v\n", id, err) //nolint:errcheck
+		return false
+	}
+	return true
 }
 
 // reapStaleSessionBeads closes session beads that are stuck in the creating

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -77,6 +77,75 @@ func syncSessionCachedState(sessionName string, existing beads.Bead, exists bool
 	return "stopped"
 }
 
+func canonicalDuplicateSessionBead(incumbent, candidate beads.Bead) beads.Bead {
+	incumbentOwnsName := beadOwnsPoolSessionName(incumbent)
+	candidateOwnsName := beadOwnsPoolSessionName(candidate)
+	switch {
+	case candidateOwnsName && !incumbentOwnsName:
+		return candidate
+	case incumbentOwnsName && !candidateOwnsName:
+		return incumbent
+	default:
+		return candidate
+	}
+}
+
+func beadOwnsPoolSessionName(b beads.Bead) bool {
+	id := strings.TrimSpace(b.ID)
+	sn := strings.TrimSpace(b.Metadata["session_name"])
+	if id == "" || sn == "" {
+		return false
+	}
+	if template := strings.TrimSpace(b.Metadata["template"]); template != "" && sn == PoolSessionName(template, id) {
+		return true
+	}
+	return strings.HasSuffix(sn, "-"+id)
+}
+
+func findVisibleSessionBeadByName(store beads.Store, sessionName string) (beads.Bead, bool, error) {
+	sessionName = strings.TrimSpace(sessionName)
+	if store == nil || sessionName == "" {
+		return beads.Bead{}, false, nil
+	}
+	open, err := loadSessionBeads(store)
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	var winner beads.Bead
+	found := false
+	for _, b := range open {
+		if strings.TrimSpace(b.Metadata["session_name"]) != sessionName {
+			continue
+		}
+		if !found {
+			winner = b
+			found = true
+			continue
+		}
+		winner = canonicalDuplicateSessionBead(winner, b)
+	}
+	return winner, found, nil
+}
+
+func upsertOpenSessionBead(openBeads []beads.Bead, indexBySessionName map[string]int, b beads.Bead) []beads.Bead {
+	sn := strings.TrimSpace(b.Metadata["session_name"])
+	for i := range openBeads {
+		if openBeads[i].ID != b.ID {
+			continue
+		}
+		openBeads[i] = b
+		if sn != "" {
+			indexBySessionName[sn] = i
+		}
+		return openBeads
+	}
+	openBeads = append(openBeads, b)
+	if sn != "" {
+		indexBySessionName[sn] = len(openBeads) - 1
+	}
+	return openBeads
+}
+
 func stampResolvedProviderSessionMetadata(meta map[string]string, resolved *config.ResolvedProvider) {
 	if meta == nil || resolved == nil {
 		return
@@ -646,24 +715,25 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	indexBySessionName := make(map[string]int, len(existing))
 	openBeads := make([]beads.Bead, len(existing))
 	copy(openBeads, existing)
-	for _, b := range existing {
-		if b.Status == "closed" {
-			continue
-		}
-		if sn := b.Metadata["session_name"]; sn != "" {
-			bySessionName[sn] = b
-		}
-	}
 	for i, b := range openBeads {
 		if b.Status == "closed" {
 			continue
 		}
-		if sn := b.Metadata["session_name"]; sn != "" {
+		if sn := strings.TrimSpace(b.Metadata["session_name"]); sn != "" {
+			if incumbent, ok := bySessionName[sn]; ok {
+				winner := canonicalDuplicateSessionBead(incumbent, b)
+				bySessionName[sn] = winner
+				if winner.ID == b.ID {
+					indexBySessionName[sn] = i
+				}
+				continue
+			}
+			bySessionName[sn] = b
 			indexBySessionName[sn] = i
 		}
 	}
 
-	// Close duplicate open beads: only the last bead per session_name
+	// Close duplicate open beads: only the canonical bead per session_name
 	// (the one in bySessionName) should remain open. This prevents bead
 	// accumulation when multiple beads are created for the same session
 	// across restarts or config-drift cycles.
@@ -685,6 +755,10 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 
 	// Track open bead IDs for the returned index.
 	openIndex := make(map[string]string, len(desiredState))
+	desiredNames := make(map[string]bool, len(desiredState))
+	for sn := range desiredState {
+		desiredNames[sn] = true
+	}
 
 	now := clk.Now().UTC()
 	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
@@ -727,14 +801,41 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 
 		agentName := tp.TemplateName
 		// For pool instances, use the qualified instance name as the agent_name.
-		if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
+		poolSlot := tp.PoolSlot
+		if poolSlot <= 0 {
+			poolSlot = resolvePoolSlot(tp.InstanceName, tp.TemplateName)
+		}
+		if poolSlot > 0 {
 			agentName = tp.InstanceName
 		} else if tp.InstanceName != "" && tp.InstanceName != tp.TemplateName {
 			agentName = tp.InstanceName
 		}
 		isManagedPool := origin == "ephemeral"
+		isPoolInstance := poolSlot > 0
 
 		b, exists := bySessionName[sn]
+		if !exists && isPoolInstance {
+			recovered, ok, err := findVisibleSessionBeadByName(store, sn)
+			if err != nil {
+				fmt.Fprintf(stderr, "session beads: reloading visible bead for %s: %v\n", sn, err) //nolint:errcheck
+			} else if ok {
+				b = recovered
+				exists = true
+				bySessionName[sn] = recovered
+				for i, open := range openBeads {
+					if open.Status == "closed" || open.ID == recovered.ID {
+						continue
+					}
+					if strings.TrimSpace(open.Metadata["session_name"]) != sn {
+						continue
+					}
+					if closeSessionBeadIfUnassigned(store, rigStores, open, "duplicate", now, stderr) {
+						openBeads[i].Status = "closed"
+					}
+				}
+				openBeads = upsertOpenSessionBead(openBeads, indexBySessionName, recovered)
+			}
+		}
 		state := syncSessionCachedState(sn, b, exists, sp)
 		if !exists && isConfiguredNamed {
 			if reopened, ok := reopenClosedConfiguredNamedSessionBead(cityPath, store, cfg, cityName, tp.ConfiguredNamedIdentity, sn, state, now, nil, stderr); ok {
@@ -748,18 +849,24 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		if !exists {
 			// Create a new session bead.
+			createState := state
+			if createState != "active" {
+				createState = "creating"
+			}
 			meta := map[string]string{
-				"session_name":       sn,
 				"agent_name":         agentName,
 				"live_hash":          liveHash,
 				"session_origin":     origin,
 				"generation":         strconv.Itoa(session.DefaultGeneration),
 				"continuation_epoch": strconv.Itoa(session.DefaultContinuationEpoch),
 				"instance_token":     session.NewInstanceToken(),
-				"state":              state,
+				"state":              createState,
 				"synced_at":          now.Format("2006-01-02T15:04:05Z07:00"),
 			}
-			if state != "active" {
+			if !isPoolInstance {
+				meta["session_name"] = sn
+			}
+			if createState != "active" {
 				meta["pending_create_claim"] = "true"
 			}
 			if tp.DependencyOnly {
@@ -789,15 +896,13 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			}
 			// Store the qualified template name so the API can derive the
 			// rig from it (e.g., "tower-of-hanoi/polecat" not just "polecat").
+			qualifiedTemplate := tp.TemplateName
 			if tp.RigName != "" && !strings.Contains(tp.TemplateName, "/") {
-				meta["template"] = tp.RigName + "/" + tp.TemplateName
-			} else {
-				meta["template"] = tp.TemplateName
+				qualifiedTemplate = tp.RigName + "/" + tp.TemplateName
 			}
-			if tp.PoolSlot > 0 {
-				meta["pool_slot"] = strconv.Itoa(tp.PoolSlot)
-			} else if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
-				meta["pool_slot"] = strconv.Itoa(slot)
+			meta["template"] = qualifiedTemplate
+			if poolSlot > 0 {
+				meta["pool_slot"] = strconv.Itoa(poolSlot)
 			}
 			// Store command and resume fields so gc session attach can
 			// reconstruct the resume command from bead metadata alone.
@@ -870,11 +975,29 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if createErr != nil {
 				fmt.Fprintf(stderr, "session beads: creating bead for %s: %v\n", agentName, createErr) //nolint:errcheck
 			} else {
-				openIndex[sn] = newBead.ID
+				createdSessionName := strings.TrimSpace(newBead.Metadata["session_name"])
+				if isPoolInstance {
+					createdSessionName = PoolSessionName(qualifiedTemplate, newBead.ID)
+					if err := store.SetMetadata(newBead.ID, "session_name", createdSessionName); err != nil {
+						_ = store.Close(newBead.ID)
+						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck
+						continue
+					}
+					if newBead.Metadata == nil {
+						newBead.Metadata = make(map[string]string, 1)
+					}
+					newBead.Metadata["session_name"] = createdSessionName
+				}
+				if createdSessionName == "" {
+					createdSessionName = sn
+				}
+				desiredNames[createdSessionName] = true
+				openIndex[createdSessionName] = newBead.ID
 				openBeads = append(openBeads, newBead)
-				indexBySessionName[sn] = len(openBeads) - 1
+				bySessionName[createdSessionName] = newBead
+				indexBySessionName[createdSessionName] = len(openBeads) - 1
 				if liveAlias := strings.TrimSpace(meta["alias"]); liveAlias != "" && state == "active" {
-					if err := session.SyncRuntimeAlias(sp, sn, liveAlias); err != nil {
+					if err := session.SyncRuntimeAlias(sp, createdSessionName, liveAlias); err != nil {
 						fmt.Fprintf(stderr, "session beads: syncing runtime alias %q for %s: %v\n", liveAlias, agentName, err) //nolint:errcheck
 					}
 				}
@@ -1097,7 +1220,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if sn == "" {
 				continue
 			}
-			if _, hasDesired := desiredState[sn]; hasDesired {
+			if desiredNames[sn] {
 				continue
 			}
 			if b.Status == "closed" {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -52,6 +52,21 @@ func (p *stopHookProvider) Stop(name string) error {
 	return p.Fake.Stop(name)
 }
 
+type failingPoolSessionNameStore struct {
+	*beads.MemStore
+}
+
+func (s *failingPoolSessionNameStore) SetMetadata(id, key, value string) error {
+	if key == "session_name" {
+		return errors.New("session_name metadata failed")
+	}
+	return s.MemStore.SetMetadata(id, key, value)
+}
+
+func (s *failingPoolSessionNameStore) Close(_ string) error {
+	return errors.New("close failed")
+}
+
 func newCountingMetadataStore() *countingMetadataStore {
 	return &countingMetadataStore{MemStore: beads.NewMemStore()}
 }
@@ -2198,6 +2213,144 @@ func TestCloseBeadPreservesPendingCreateClaimWhenCloseFails(t *testing.T) {
 	}
 }
 
+func TestBeadOwnsPoolSessionName(t *testing.T) {
+	template := "pack/worker"
+	tests := []struct {
+		name string
+		bead beads.Bead
+		want bool
+	}{
+		{
+			name: "template derived name",
+			bead: beads.Bead{
+				ID: "gc-1",
+				Metadata: map[string]string{
+					"template":     template,
+					"session_name": PoolSessionName(template, "gc-1"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "legacy suffix without template",
+			bead: beads.Bead{
+				ID: "gc-2",
+				Metadata: map[string]string{
+					"session_name": "worker-gc-2",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "empty id",
+			bead: beads.Bead{
+				Metadata: map[string]string{
+					"template":     template,
+					"session_name": PoolSessionName(template, ""),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty session name",
+			bead: beads.Bead{
+				ID: "gc-3",
+				Metadata: map[string]string{
+					"template": template,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "unowned name",
+			bead: beads.Bead{
+				ID: "gc-4",
+				Metadata: map[string]string{
+					"template":     template,
+					"session_name": "worker-other",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := beadOwnsPoolSessionName(tt.bead); got != tt.want {
+				t.Fatalf("beadOwnsPoolSessionName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalDuplicateSessionBead(t *testing.T) {
+	template := "pack/worker"
+	incumbentOwner := beads.Bead{
+		ID: "gc-1",
+		Metadata: map[string]string{
+			"template":     template,
+			"session_name": PoolSessionName(template, "gc-1"),
+		},
+	}
+	candidateOwner := beads.Bead{
+		ID: "gc-2",
+		Metadata: map[string]string{
+			"template":     template,
+			"session_name": PoolSessionName(template, "gc-2"),
+		},
+	}
+	incumbentPlain := beads.Bead{
+		ID: "gc-3",
+		Metadata: map[string]string{
+			"session_name": "worker-shared",
+		},
+	}
+	candidatePlain := beads.Bead{
+		ID: "gc-4",
+		Metadata: map[string]string{
+			"session_name": "worker-shared",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		incumbent beads.Bead
+		candidate beads.Bead
+		wantID    string
+	}{
+		{
+			name:      "candidate owner beats non-owner",
+			incumbent: incumbentPlain,
+			candidate: candidateOwner,
+			wantID:    candidateOwner.ID,
+		},
+		{
+			name:      "incumbent owner beats non-owner",
+			incumbent: incumbentOwner,
+			candidate: candidatePlain,
+			wantID:    incumbentOwner.ID,
+		},
+		{
+			name:      "neither owner preserves last wins",
+			incumbent: incumbentPlain,
+			candidate: candidatePlain,
+			wantID:    candidatePlain.ID,
+		},
+		{
+			name:      "both owners preserves last wins",
+			incumbent: incumbentOwner,
+			candidate: candidateOwner,
+			wantID:    candidateOwner.ID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalDuplicateSessionBead(tt.incumbent, tt.candidate); got.ID != tt.wantID {
+				t.Fatalf("canonicalDuplicateSessionBead() = %s, want %s", got.ID, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestSyncSessionBeads_DuplicatePoolSessionNameKeepsVisibleOwner(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
@@ -2330,8 +2483,8 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 	syncSessionBeadsWithSnapshot("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false, staleSnapshot)
-	if stderr.Len() > 0 {
-		t.Fatalf("unexpected stderr: %s", stderr.String())
+	if !strings.Contains(stderr.String(), "recovered visible owner") {
+		t.Fatalf("stderr %q does not mention recovered visible owner", stderr.String())
 	}
 
 	all := allSessionBeads(t, store)
@@ -2347,6 +2500,68 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 				t.Fatalf("new pool bead session_name = %q, want %q", got, want)
 			}
 		}
+	}
+}
+
+func TestCreatePoolSessionBead_MetadataFailureLeavesReachablePlaceholder(t *testing.T) {
+	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
+	template := "pack/worker"
+
+	if _, err := createPoolSessionBead(store, template, nil); err == nil {
+		t.Fatal("createPoolSessionBead returned nil error, want session_name metadata failure")
+	}
+
+	all := allSessionBeads(t, store)
+	if len(all) != 1 {
+		t.Fatalf("created %d session beads, want 1 failed-create bead", len(all))
+	}
+	if got := strings.TrimSpace(all[0].Metadata["session_name"]); got == "" {
+		t.Fatalf("failed pool bead session_name is empty: %+v", all[0])
+	}
+	if got, final := all[0].Metadata["session_name"], PoolSessionName(template, all[0].ID); got == final {
+		t.Fatalf("failed pool bead session_name = final name %q even though SetMetadata failed", got)
+	}
+}
+
+func TestSyncSessionBeads_PoolSessionNameFailureLeavesReachableFailedCreate(t *testing.T) {
+	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	template := "pack/worker"
+	ds := map[string]TemplateParams{
+		"legacy-worker-1": {
+			TemplateName: template,
+			InstanceName: template + "-1",
+			PoolSlot:     1,
+			Command:      "codex",
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	all := allSessionBeads(t, store)
+	if len(all) != 1 {
+		t.Fatalf("created %d session beads, want 1 failed-create bead", len(all))
+	}
+	failed := all[0]
+	if failed.Status != "open" {
+		t.Fatalf("failed-create bead status = %q, want open because Close failed", failed.Status)
+	}
+	if got := strings.TrimSpace(failed.Metadata["session_name"]); got == "" {
+		t.Fatalf("failed-create bead session_name is empty: %+v", failed)
+	}
+	if got := failed.Metadata["close_reason"]; got != "failed-create" {
+		t.Fatalf("failed-create close_reason = %q, want failed-create", got)
+	}
+	if got := failed.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("failed-create pending_create_claim = %q, want cleared", got)
+	}
+	if !strings.Contains(stderr.String(), "session_name metadata failed") {
+		t.Fatalf("stderr %q does not mention session_name metadata failure", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "close failed") {
+		t.Fatalf("stderr %q does not mention failed cleanup close", stderr.String())
 	}
 }
 
@@ -2703,8 +2918,8 @@ func TestSyncSessionBeads_ResumedAfterSuspension(t *testing.T) {
 			closedCount++
 		case "open":
 			openCount++
-			if b.Metadata["state"] != "stopped" {
-				t.Errorf("resumed bead state = %q, want %q", b.Metadata["state"], "stopped")
+			if b.Metadata["state"] != "creating" {
+				t.Errorf("resumed bead state = %q, want %q", b.Metadata["state"], "creating")
 			}
 			if b.Metadata["pending_create_claim"] != "true" {
 				t.Errorf("resumed bead pending_create_claim = %q, want true", b.Metadata["pending_create_claim"])

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2198,6 +2198,158 @@ func TestCloseBeadPreservesPendingCreateClaimWhenCloseFails(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_DuplicatePoolSessionNameKeepsVisibleOwner(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	template := "pack/worker"
+
+	owner, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"agent_name":           template,
+			"state":                "creating",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerSessionName := PoolSessionName(template, owner.ID)
+	if err := store.SetMetadata(owner.ID, "session_name", ownerSessionName); err != nil {
+		t.Fatal(err)
+	}
+
+	duplicate, err := store.Create(beads.Bead{
+		Title:  "worker-2",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template + "-2"},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         ownerSessionName,
+			"agent_name":           template + "-2",
+			"pool_slot":            "2",
+			"state":                "active",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	visible, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerVisible := false
+	duplicateVisible := false
+	for _, b := range visible {
+		switch b.ID {
+		case owner.ID:
+			ownerVisible = true
+		case duplicate.ID:
+			duplicateVisible = true
+		}
+	}
+	if !ownerVisible || !duplicateVisible {
+		t.Fatalf("precondition failed: owner visible=%v duplicate visible=%v", ownerVisible, duplicateVisible)
+	}
+
+	ds := map[string]TemplateParams{
+		ownerSessionName: {
+			TemplateName: template,
+			InstanceName: template + "-2",
+			PoolSlot:     2,
+			Command:      "codex",
+		},
+	}
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	ownerAfter, err := store.Get(owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ownerAfter.Status == "closed" {
+		t.Fatalf("owner bead %s was closed even though it owns visible session_name %q", owner.ID, ownerSessionName)
+	}
+	duplicateAfter, err := store.Get(duplicate.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duplicateAfter.Status != "closed" {
+		t.Fatalf("duplicate bead %s status = %q, want closed", duplicate.ID, duplicateAfter.Status)
+	}
+	if got := duplicateAfter.Metadata["close_reason"]; got != "duplicate" {
+		t.Fatalf("duplicate close_reason = %q, want duplicate", got)
+	}
+}
+
+func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	template := "pack/worker"
+
+	owner, err := createPoolSessionBead(store, template, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerSessionName := owner.Metadata["session_name"]
+	visible, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerVisible := false
+	for _, b := range visible {
+		if b.ID == owner.ID {
+			ownerVisible = true
+			break
+		}
+	}
+	if !ownerVisible {
+		t.Fatalf("precondition failed: owner bead %s is not visible in the store", owner.ID)
+	}
+
+	staleSnapshot := newSessionBeadSnapshot(nil)
+	ds := map[string]TemplateParams{
+		ownerSessionName: {
+			TemplateName: template,
+			InstanceName: template + "-2",
+			PoolSlot:     2,
+			Command:      "codex",
+		},
+	}
+	var stderr bytes.Buffer
+	syncSessionBeadsWithSnapshot("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false, staleSnapshot)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	all := allSessionBeads(t, store)
+	if len(all) != 1 {
+		t.Fatalf("sync created %d session beads, want only the visible owner bead", len(all))
+	}
+	for _, b := range all {
+		if b.ID != owner.ID && b.Metadata["session_name"] == ownerSessionName {
+			t.Fatalf("new bead %s reused visible owner bead %s session_name %q", b.ID, owner.ID, ownerSessionName)
+		}
+		if b.ID != owner.ID && b.Metadata["pool_slot"] == "2" {
+			if got, want := b.Metadata["session_name"], PoolSessionName(template, b.ID); got != want {
+				t.Fatalf("new pool bead session_name = %q, want %q", got, want)
+			}
+		}
+	}
+}
+
 // TestSyncSessionBeads_RefreshesStoredCommandOnConfigChange reproduces an
 // observed bug where an agent that got an `[option_defaults] model = "opus"`
 // entry added to its config after its session bead was created never picked up
@@ -2408,8 +2560,8 @@ func TestSyncSessionBeads_StoppedAgent(t *testing.T) {
 	if len(all) != 1 {
 		t.Fatalf("expected 1 bead, got %d", len(all))
 	}
-	if all[0].Metadata["state"] != "stopped" {
-		t.Errorf("state = %q, want %q", all[0].Metadata["state"], "stopped")
+	if all[0].Metadata["state"] != "creating" {
+		t.Errorf("state = %q, want %q", all[0].Metadata["state"], "creating")
 	}
 	if all[0].Metadata["pending_create_claim"] != "true" {
 		t.Errorf("pending_create_claim = %q, want true", all[0].Metadata["pending_create_claim"])

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -30,6 +30,7 @@ func createPoolSessionBead(
 	if store == nil {
 		return beads.Bead{}, fmt.Errorf("session store unavailable for pool template %q", template)
 	}
+	instanceToken := sessionpkg.NewInstanceToken()
 	meta := map[string]string{
 		"template":             template,
 		"agent_name":           template,
@@ -38,7 +39,8 @@ func createPoolSessionBead(
 		"session_origin":       "ephemeral",
 		"generation":           "1",
 		"continuation_epoch":   "1",
-		"instance_token":       sessionpkg.NewInstanceToken(),
+		"instance_token":       instanceToken,
+		"session_name":         pendingPoolSessionName(template, instanceToken),
 		poolManagedMetadataKey: boolMetadata(true),
 	}
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3767,6 +3767,21 @@ func TestReconcileSessionBeads_PoolRecoveryAfterClosedBead(t *testing.T) {
 		t.Fatalf("closed bead status = %q, want closed", got.Status)
 	}
 
+	latestSnapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("load latest snapshot: %v", err)
+	}
+	result := DesiredStateResult{State: ds, BaseState: ds, BeaconTime: clk.Now().UTC()}
+	refreshed := refreshDesiredStateWithSessionBeads(result, "test-city", cityPath, cfg, sp, store, latestSnapshot, &stderr)
+	ds = refreshed.State
+	newSessionName := newBead.Metadata["session_name"]
+	if newSessionName == "" {
+		t.Fatal("fresh pool bead has empty session_name")
+	}
+	if _, ok := ds[newSessionName]; !ok {
+		t.Fatalf("refreshed desired state missing fresh pool session %q; keys=%v", newSessionName, mapKeys(ds))
+	}
+
 	// Now run the reconciler with the fresh bead — it should remain open
 	// (not be closed as orphan) since the pool slot is in the desired state.
 	// The session is not running, so the reconciler should wake it.
@@ -3793,8 +3808,8 @@ func TestReconcileSessionBeads_PoolRecoveryAfterClosedBead(t *testing.T) {
 	if woken != 1 {
 		t.Fatalf("woken = %d, want 1 (recovered pool session should be started)", woken)
 	}
-	if !sp.IsRunning(sessionName) {
-		t.Fatalf("session %q not running after reconcile — pool recovery did not trigger start", sessionName)
+	if !sp.IsRunning(newSessionName) {
+		t.Fatalf("session %q not running after reconcile — pool recovery did not trigger start", newSessionName)
 	}
 }
 


### PR DESCRIPTION
Follow-up PR for https://github.com/gastownhall/gascity/pull/1422 because maintainer edits are disabled on the original PR branch.

Original PR details:
- Original PR: https://github.com/gastownhall/gascity/pull/1422
- Original title: fix(session): preserve pending pool session beads
- Original state: OPEN
- Configured base branch: main
- Original GitHub base branch: main
- Base mismatch: none

Review outcome:
- Latest review attempt: 2
- Decision: approve
- Quality score: 908 / 1000, threshold 850
- Required changes: none

Adopted commits:
- f0c421546 fix(session): preserve pending pool session beads
- 196c52a77 fix(session): make failed pool bead creates recoverable

Validated fixes:
- Pending pool-create beads remain in desired state after leaving `creating`.
- Stale pool snapshots reuse the visible owner and close stale duplicates.
- Failed pool session-name writes leave a reachable placeholder instead of an invisible ghost bead.
- Pool session-name ownership and duplicate-selection helpers now have focused edge coverage.

Remaining review notes are minor or nit-level follow-ups and are not merge blockers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->