### PR TITLE
fix: ignore foreign bead cache events

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -213,7 +213,7 @@ func (cs *controllerState) openRigStore(provider, rigName, rigPath, prefix strin
 		}
 		return store
 	default: // "bd" or unrecognized
-		return bdStoreForRig(scopeRoot, cs.cityPath, cfg)
+		return bdStoreForRig(scopeRoot, cs.cityPath, cfg, prefix)
 	}
 }
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -429,6 +429,57 @@ func TestControllerStateAppliesCacheReconcileBeadEventsToStores(t *testing.T) {
 	}
 }
 
+func TestControllerStateBeadEventsRespectStorePrefixes(t *testing.T) {
+	cityBacking := beads.NewMemStore()
+	rigBacking := beads.NewMemStore()
+	cityCache := beads.NewCachingStoreForTestWithPrefix(cityBacking, "mc", nil)
+	rigCache := beads.NewCachingStoreForTestWithPrefix(rigBacking, "ga", nil)
+	for name, cache := range map[string]*beads.CachingStore{
+		"city": cityCache,
+		"rig":  rigCache,
+	} {
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime(%s): %v", name, err)
+		}
+	}
+
+	payload, err := json.Marshal(beads.Bead{
+		ID:     "mc-source",
+		Title:  "city source",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("marshal city bead: %v", err)
+	}
+	cs := &controllerState{
+		cityBeadStore: cityCache,
+		beadStores:    map[string]beads.Store{"gascity": rigCache},
+		pokeCh:        make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadCreated,
+		Actor:   "bd-hook",
+		Subject: "mc-source",
+		Payload: payload,
+	})
+
+	cityItems, err := cityCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List city cache: %v", err)
+	}
+	if len(cityItems) != 1 || cityItems[0].ID != "mc-source" {
+		t.Fatalf("city cache items = %+v, want mc-source", cityItems)
+	}
+	rigItems, err := rigCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List rig cache: %v", err)
+	}
+	if len(rigItems) != 0 {
+		t.Fatalf("rig cache items = %+v, want no city bead", rigItems)
+	}
+}
+
 func TestControllerStateBuildStoresUsesScopeLocalFileStores(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -478,6 +478,82 @@ func TestControllerStateBeadEventsRespectStorePrefixes(t *testing.T) {
 	if len(rigItems) != 0 {
 		t.Fatalf("rig cache items = %+v, want no city bead", rigItems)
 	}
+
+	payload, err = json.Marshal(beads.Bead{
+		ID:     "ga-rig",
+		Title:  "rig work",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("marshal rig bead: %v", err)
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadCreated,
+		Actor:   "bd-hook",
+		Subject: "ga-rig",
+		Payload: payload,
+	})
+
+	cityItems, err = cityCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List city cache after rig event: %v", err)
+	}
+	if len(cityItems) != 1 || cityItems[0].ID != "mc-source" {
+		t.Fatalf("city cache items after rig event = %+v, want only mc-source", cityItems)
+	}
+	rigItems, err = rigCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List rig cache after rig event: %v", err)
+	}
+	if len(rigItems) != 1 || rigItems[0].ID != "ga-rig" {
+		t.Fatalf("rig cache items after rig event = %+v, want ga-rig", rigItems)
+	}
+}
+
+func TestControllerStateBeadEventsUseScopePrefixWhenConfiguredPrefixDrifts(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte("issue_prefix: repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: "rigs/repo", Prefix: "ga"}}}
+	bdStore := bdStoreForRig(rigDir, cityDir, cfg, cfg.Rigs[0].EffectivePrefix())
+	rigCache := beads.NewCachingStoreForTestWithPrefix(beads.NewMemStore(), bdStore.IDPrefix(), nil)
+	if err := rigCache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime rig cache: %v", err)
+	}
+
+	payload, err := json.Marshal(beads.Bead{
+		ID:     "repo-owned",
+		Title:  "rig-owned work",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("marshal rig bead: %v", err)
+	}
+	cs := &controllerState{
+		beadStores: map[string]beads.Store{"repo": rigCache},
+		pokeCh:     make(chan struct{}, 1),
+	}
+
+	cs.applyBeadEventToStores(events.Event{
+		Type:    events.BeadCreated,
+		Actor:   "bd-hook",
+		Subject: "repo-owned",
+		Payload: payload,
+	})
+
+	rigItems, err := rigCache.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List rig cache: %v", err)
+	}
+	if len(rigItems) != 1 || rigItems[0].ID != "repo-owned" {
+		t.Fatalf("rig cache items = %+v, want repo-owned", rigItems)
+	}
 }
 
 func TestControllerStateBuildStoresUsesScopeLocalFileStores(t *testing.T) {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,14 +31,56 @@ func bdCommandRunnerForCity(cityPath string) beads.CommandRunner {
 }
 
 func bdStoreForCity(dir, cityPath string) *beads.BdStore {
-	return beads.NewBdStore(dir, bdCommandRunnerForCity(cityPath))
+	cfg, err := loadCityConfig(cityPath, io.Discard)
+	if err != nil {
+		cfg = nil
+	}
+	return beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
 }
 
 // bdStoreForRig opens a bead store at rigDir using rig-level Dolt config
 // when available, falling back to city-level config. Use this when the rig
 // may have its own Dolt server (e.g., shared from another city).
-func bdStoreForRig(rigDir, cityPath string, cfg *config.City) *beads.BdStore {
-	return beads.NewBdStore(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir))
+func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...string) *beads.BdStore {
+	prefix := ""
+	for _, candidate := range knownPrefix {
+		if strings.TrimSpace(candidate) != "" {
+			prefix = candidate
+			break
+		}
+	}
+	if prefix == "" {
+		prefix = issuePrefixForScope(rigDir, cityPath, cfg)
+	}
+	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+}
+
+func issuePrefixForScope(scopeRoot, cityPath string, cfg *config.City) string {
+	if prefix := readScopeIssuePrefix(scopeRoot); prefix != "" {
+		return prefix
+	}
+	if cfg == nil {
+		return ""
+	}
+	scopeRoot = filepath.Clean(scopeRoot)
+	if filepath.Clean(cityPath) == scopeRoot {
+		return config.EffectiveHQPrefix(cfg)
+	}
+	for i := range cfg.Rigs {
+		rigPath := resolveStoreScopeRoot(cityPath, cfg.Rigs[i].Path)
+		if filepath.Clean(rigPath) == scopeRoot {
+			return cfg.Rigs[i].EffectivePrefix()
+		}
+	}
+	return ""
+}
+
+func readScopeIssuePrefix(scopeRoot string) string {
+	prefix, ok, err := contract.ReadIssuePrefix(fsys.OSFS{}, filepath.Join(scopeRoot, ".beads", "config.yaml"))
+	if err != nil || !ok {
+		return ""
+	}
+	return prefix
 }
 
 func bdCommandRunnerForRig(cityPath string, cfg *config.City, rigDir string) beads.CommandRunner {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -42,15 +42,14 @@ func bdStoreForCity(dir, cityPath string) *beads.BdStore {
 // when available, falling back to city-level config. Use this when the rig
 // may have its own Dolt server (e.g., shared from another city).
 func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...string) *beads.BdStore {
-	prefix := ""
-	for _, candidate := range knownPrefix {
-		if strings.TrimSpace(candidate) != "" {
-			prefix = candidate
-			break
-		}
-	}
+	prefix := issuePrefixForScope(rigDir, cityPath, cfg)
 	if prefix == "" {
-		prefix = issuePrefixForScope(rigDir, cityPath, cfg)
+		for _, candidate := range knownPrefix {
+			if strings.TrimSpace(candidate) != "" {
+				prefix = candidate
+				break
+			}
+		}
 	}
 	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
 }

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -32,6 +32,75 @@ func TestCityRuntimeProcessEnvStripsAmbientGCDolt(t *testing.T) {
 	}
 }
 
+func TestBdStoreForCityResolvesIDPrefixFromScopeConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "Metro City"
+prefix = "mc"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".beads", "config.yaml"), []byte("issue_prefix: hq\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := bdStoreForCity(cityDir, cityDir)
+	if got := store.IDPrefix(); got != "hq" {
+		t.Fatalf("IDPrefix() = %q, want hq", got)
+	}
+}
+
+func TestBdStoreForRigResolvesIDPrefixFromScopeConfig(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte("issue_prefix: repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: "rigs/repo", Prefix: "ga"}}}
+
+	store := bdStoreForRig(rigDir, cityDir, cfg)
+	if got := store.IDPrefix(); got != "repo" {
+		t.Fatalf("IDPrefix() = %q, want repo", got)
+	}
+}
+
+func TestBdStoreForRigPrefersScopeConfigOverKnownPrefix(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "repo")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte("issue_prefix: repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: "rigs/repo", Prefix: "ga"}}}
+
+	store := bdStoreForRig(rigDir, cityDir, cfg, "stale")
+	if got := store.IDPrefix(); got != "repo" {
+		t.Fatalf("IDPrefix() = %q, want repo", got)
+	}
+}
+
+func TestBdStoreForRigFallsBackToConfiguredEffectivePrefix(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "repo")
+	if err := os.MkdirAll(rigDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: "rigs/repo", Prefix: "ga"}}}
+
+	store := bdStoreForRig(rigDir, cityDir, cfg)
+	if got := store.IDPrefix(); got != "ga" {
+		t.Fatalf("IDPrefix() = %q, want ga", got)
+	}
+}
+
 func TestBdRuntimeEnvIncludesDoltHost(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT_HOST", "mini2.hippo-tilapia.ts.net")

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -102,11 +102,25 @@ type BdStore struct {
 	dir         string          // city root directory (where .beads/ lives)
 	runner      CommandRunner   // injectable for testing
 	purgeRunner PurgeRunnerFunc // injectable for testing; nil uses exec default
+	idPrefix    string          // bead ID prefix owned by this store, without trailing "-"
 }
 
 // NewBdStore creates a BdStore rooted at dir using the given runner.
 func NewBdStore(dir string, runner CommandRunner) *BdStore {
-	return &BdStore{dir: dir, runner: runner}
+	return NewBdStoreWithPrefix(dir, runner, "")
+}
+
+// NewBdStoreWithPrefix creates a BdStore with an explicit owned bead ID prefix.
+func NewBdStoreWithPrefix(dir string, runner CommandRunner, idPrefix string) *BdStore {
+	return &BdStore{dir: dir, runner: runner, idPrefix: normalizeIDPrefix(idPrefix)}
+}
+
+// IDPrefix returns the bead ID prefix owned by this store, without trailing "-".
+func (s *BdStore) IDPrefix() string {
+	if s == nil {
+		return ""
+	}
+	return s.idPrefix
 }
 
 // Init initializes a beads database via bd init --server. This is an admin

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,7 +23,8 @@ import (
 //
 // Only wraps BdStore because the event hook path requires dolt/bd.
 type CachingStore struct {
-	backing Store // runtime: always *BdStore; tests may use MemStore
+	backing  Store // runtime: always *BdStore; tests may use MemStore
+	idPrefix string
 
 	mu          sync.RWMutex
 	beads       map[string]Bead
@@ -84,18 +86,29 @@ const (
 // Only BdStore is supported because the event hook path (bd hooks ->
 // gc event emit -> event bus -> ApplyEvent) requires dolt infrastructure.
 func NewCachingStore(backing *BdStore, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, onChange)
+	prefix := ""
+	if backing != nil {
+		prefix = backing.IDPrefix()
+	}
+	return newCachingStore(backing, prefix, onChange)
 }
 
 // NewCachingStoreForTest wraps any Store for testing. Production code
 // must use NewCachingStore with a *BdStore.
 func NewCachingStoreForTest(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
-	return newCachingStore(backing, onChange)
+	return newCachingStore(backing, "", onChange)
 }
 
-func newCachingStore(backing Store, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+// NewCachingStoreForTestWithPrefix wraps any Store for tests that need
+// production-style bead ID ownership filtering.
+func NewCachingStoreForTestWithPrefix(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
+	return newCachingStore(backing, idPrefix, onChange)
+}
+
+func newCachingStore(backing Store, idPrefix string, onChange func(eventType, beadID string, payload json.RawMessage)) *CachingStore {
 	return &CachingStore{
 		backing:    backing,
+		idPrefix:   normalizeIDPrefix(idPrefix),
 		beads:      make(map[string]Bead),
 		deps:       make(map[string][]Dep),
 		dirty:      make(map[string]struct{}),
@@ -106,6 +119,18 @@ func newCachingStore(backing Store, onChange func(eventType, beadID string, payl
 			log.Printf("beads cache: %s", msg)
 		},
 	}
+}
+
+func normalizeIDPrefix(prefix string) string {
+	return strings.Trim(strings.ToLower(strings.TrimSpace(prefix)), "-")
+}
+
+func (c *CachingStore) ownsBeadID(id string) bool {
+	if c.idPrefix == "" {
+		return true
+	}
+	id = strings.ToLower(strings.TrimSpace(id))
+	return strings.HasPrefix(id, c.idPrefix+"-")
 }
 
 func (c *CachingStore) noteMutationLocked(ids ...string) uint64 {

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -90,7 +91,11 @@ func NewCachingStore(backing *BdStore, onChange func(eventType, beadID string, p
 	if backing != nil {
 		prefix = backing.IDPrefix()
 	}
-	return newCachingStore(backing, prefix, onChange)
+	cs := newCachingStore(backing, prefix, onChange)
+	if cs.idPrefix == "" {
+		cs.recordProblem("bd cache ownership", errors.New("missing issue prefix; foreign bead event filtering disabled"))
+	}
+	return cs
 }
 
 // NewCachingStoreForTest wraps any Store for testing. Production code

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -2,7 +2,6 @@ package beads
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -23,24 +22,18 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		c.recordProblem(fmt.Sprintf("apply %s event", eventType), err)
 		return
 	}
+	if !c.ownsBeadID(patch.ID) {
+		return
+	}
 
 	c.mu.RLock()
 	if c.state != cacheLive {
 		c.mu.RUnlock()
 		return
 	}
-	_, cached := c.beads[patch.ID]
 	c.mu.RUnlock()
 
 	b := patch
-	if !cached {
-		if fresh, err := c.backing.Get(patch.ID); err == nil {
-			b = fresh
-		} else if !errors.Is(err, ErrNotFound) {
-			c.recordProblem(fmt.Sprintf("refresh %s event", eventType), err)
-		}
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.state != cacheLive {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -31,9 +32,18 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		c.mu.RUnlock()
 		return
 	}
+	_, cached := c.beads[patch.ID]
 	c.mu.RUnlock()
 
 	b := patch
+	if !cached {
+		if fresh, err := c.backing.Get(patch.ID); err == nil {
+			b = fresh
+		} else if !errors.Is(err, ErrNotFound) {
+			c.recordProblem(fmt.Sprintf("refresh %s event", eventType), err)
+		}
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.state != cacheLive {

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -921,12 +921,13 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 		t.Fatalf("Prime: %v", err)
 	}
 
-	// Apply a create event for a bead that doesn't exist in cache yet.
-	newBead := beads.Bead{ID: "ext-1", Title: "External", Status: "open"}
-	payload, _ := json.Marshal(newBead)
+	// Apply a create event for a bead that exists in the backing store but
+	// doesn't exist in cache yet.
+	external, _ := mem.Create(beads.Bead{Title: "External"})
+	payload, _ := json.Marshal(beads.Bead{ID: external.ID, Title: "External", Status: "open"})
 	cs.ApplyEvent("bead.created", payload)
 
-	got := requireCachedBead(t, cs, "ext-1", false)
+	got := requireCachedBead(t, cs, external.ID, false)
 	if got.Title != "External" {
 		t.Fatalf("title = %q, want External", got.Title)
 	}
@@ -988,6 +989,61 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 	}
 	if got.Metadata["gc.step_ref"] != "" {
 		t.Fatalf("close event should replace stale metadata, got %v", got.Metadata)
+	}
+}
+
+func TestCachingStoreApplyEventIgnoresUnknownForeignBead(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	cs := beads.NewCachingStoreForTestWithPrefix(mem, "gc", nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	for _, eventType := range []string{"bead.created", "bead.updated", "bead.closed"} {
+		payload, err := json.Marshal(beads.Bead{
+			ID:     "foreign-" + eventType,
+			Title:  "belongs to another store",
+			Status: "open",
+		})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		cs.ApplyEvent(eventType, payload)
+	}
+
+	items, err := cs.List(beads.ListQuery{AllowScan: true, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("List cached beads: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("cached foreign beads = %#v, want none", items)
+	}
+}
+
+func TestCachingStoreApplyEventAcceptsOwnedUnknownBeadWithoutBackingGet(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	backing := &eventGetFailStore{Store: mem, failGet: true}
+	cs := beads.NewCachingStoreForTestWithPrefix(backing, "gc", nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	payload, err := json.Marshal(beads.Bead{
+		ID:     "gc-external",
+		Title:  "owned external bead",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	cs.ApplyEvent("bead.created", payload)
+
+	got := requireCachedBead(t, cs, "gc-external", false)
+	if got.Title != "owned external bead" {
+		t.Fatalf("title = %q, want owned external bead", got.Title)
 	}
 }
 
@@ -1065,6 +1121,10 @@ func (s *eventGetFailStore) Get(id string) (beads.Bead, error) {
 func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
+	created, err := mem.Create(beads.Bead{Title: "mayor"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 
 	cs := beads.NewCachingStoreForTest(mem, nil)
 	if err := cs.Prime(context.Background()); err != nil {
@@ -1072,7 +1132,7 @@ func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 	}
 
 	payload, err := json.Marshal(map[string]any{
-		"id":         "ext-1",
+		"id":         created.ID,
 		"title":      "mayor",
 		"status":     "open",
 		"issue_type": "session",
@@ -1094,7 +1154,7 @@ func TestCachingStoreApplyEventCoercesNonStringMetadata(t *testing.T) {
 		t.Fatalf("ProblemCount = %d, want 0 (last problem: %s)", stats.ProblemCount, stats.LastProblem)
 	}
 
-	got := requireCachedBead(t, cs, "ext-1", false)
+	got := requireCachedBead(t, cs, created.ID, false)
 	if got.Type != "session" {
 		t.Fatalf("Type = %q, want session", got.Type)
 	}

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -995,7 +996,8 @@ func TestCachingStoreApplyEvent(t *testing.T) {
 func TestCachingStoreApplyEventIgnoresUnknownForeignBead(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
-	cs := beads.NewCachingStoreForTestWithPrefix(mem, "gc", nil)
+	backing := &eventGetFailStore{Store: mem, failGet: true}
+	cs := beads.NewCachingStoreForTestWithPrefix(backing, "gc", nil)
 	if err := cs.Prime(context.Background()); err != nil {
 		t.Fatalf("Prime: %v", err)
 	}
@@ -1019,31 +1021,64 @@ func TestCachingStoreApplyEventIgnoresUnknownForeignBead(t *testing.T) {
 	if len(items) != 0 {
 		t.Fatalf("cached foreign beads = %#v, want none", items)
 	}
+	if stats := cs.Stats(); stats.ProblemCount != 0 {
+		t.Fatalf("ProblemCount = %d, want 0 (last problem: %s)", stats.ProblemCount, stats.LastProblem)
+	}
 }
 
-func TestCachingStoreApplyEventAcceptsOwnedUnknownBeadWithoutBackingGet(t *testing.T) {
+func TestCachingStoreApplyEventRefreshesOwnedUnknownBeadFromBacking(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
-	backing := &eventGetFailStore{Store: mem, failGet: true}
+	backing := &eventGetFailStore{Store: mem}
 	cs := beads.NewCachingStoreForTestWithPrefix(backing, "gc", nil)
 	if err := cs.Prime(context.Background()); err != nil {
 		t.Fatalf("Prime: %v", err)
 	}
+	created, err := mem.Create(beads.Bead{
+		Title:    "owned external bead",
+		Labels:   []string{"from-backing"},
+		Metadata: map[string]string{"gc.step_ref": "mol.review"},
+	})
+	if err != nil {
+		t.Fatalf("Create backing bead: %v", err)
+	}
 
-	payload, err := json.Marshal(beads.Bead{
-		ID:     "gc-external",
-		Title:  "owned external bead",
-		Status: "open",
+	payload, err := json.Marshal(map[string]any{
+		"id":     created.ID,
+		"status": "open",
 	})
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
 
-	cs.ApplyEvent("bead.created", payload)
+	cs.ApplyEvent("bead.updated", payload)
 
-	got := requireCachedBead(t, cs, "gc-external", false)
+	got := requireCachedBead(t, cs, created.ID, false)
 	if got.Title != "owned external bead" {
 		t.Fatalf("title = %q, want owned external bead", got.Title)
+	}
+	if len(got.Labels) != 1 || got.Labels[0] != "from-backing" {
+		t.Fatalf("labels = %#v, want [from-backing]", got.Labels)
+	}
+	if got.Metadata["gc.step_ref"] != "mol.review" {
+		t.Fatalf("metadata = %#v, want gc.step_ref=mol.review", got.Metadata)
+	}
+}
+
+func TestNewCachingStoreRecordsProblemForMissingProductionPrefix(t *testing.T) {
+	t.Parallel()
+	backing := beads.NewBdStore(t.TempDir(), func(string, string, ...string) ([]byte, error) {
+		t.Fatal("runner should not be called")
+		return nil, nil
+	})
+	cs := beads.NewCachingStore(backing, nil)
+
+	stats := cs.Stats()
+	if stats.ProblemCount != 1 {
+		t.Fatalf("ProblemCount = %d, want 1", stats.ProblemCount)
+	}
+	if !strings.Contains(stats.LastProblem, "missing issue prefix") {
+		t.Fatalf("LastProblem = %q, want missing issue prefix", stats.LastProblem)
 	}
 }
 


### PR DESCRIPTION
Adopted follow-up for PR #1426 because the original PR has maintainer edits disabled and the approved review/fix loop added a maintainer fix.

Original PR URL: https://github.com/gastownhall/gascity/pull/1426
Original PR title: fix: ignore foreign bead cache events
Original PR state: OPEN
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

This branch preserves the contributor-authored change and adds the approved maintainer fix from the adopt-pr review loop.

Review TL;DR:
PR #1426 `fix: ignore foreign bead cache events` reached approval after 2 fix iteration(s). Latest attempt 3 is `approve` with score 930 / 1000 against threshold 850.

Iteration 1:
- Decision: request_changes (scorecard: request_changes, 760 / 1000, threshold 850)
- Findings:
  - No top risks recorded.
- Required changes:
  - Restore the backing `Get` fallback for owned unknown events after the ownership check, or make the full-payload event contract explicit and enforce it so partial unknown `bead.updated` payloads cannot populate the cache.
  - Make empty-prefix production store construction observable or explicitly handled so foreign-event filtering is not silently disabled when prefix resolution fails.
  - Add focused production-shaped coverage for `bdStoreForCity`/`bdStoreForRig` prefix resolution from temp city, rig, and `.beads/config.yaml` state, including fallback behavior.
  - Rewrite or squash the commit message to remove the `# Conflicts:` boilerplate before merge.

Iteration 2:
- Decision: request_changes (scorecard: request_changes, 795 / 1000, threshold 850)
- Findings:
  - No top risks recorded.
- Required changes:
  - Make rig bd store construction prefer the rig scope's `.beads/config.yaml` prefix via `issuePrefixForScope` or `readScopeIssuePrefix`, using the configured hint only when scope/config prefix resolution is empty.
  - Add regression coverage where the configured rig prefix differs from the rig `.beads/config.yaml` issue prefix and verify owned rig events still update the rig cache.
  - Add symmetric fanout coverage proving rig-prefixed events are accepted by the rig cache and rejected by the city cache.

Fix Applied:
- 970818c8c fix: restore cache event fallback
- 23e82dbdd fix: ignore foreign bead cache events
- Final diff: 8 files changed, 395 insertions(+), 15 deletions(-)

Iteration 3:
- Decision: approve (scorecard: approve, 930 / 1000, threshold 850)
- Validated:
  - **Foreign bead events polluting per-store caches:** correct - Production caching stores now carry an owned ID prefix and `ApplyEvent` rejects events outside that prefix before cache mutation or backing-store refresh.
  - **Rig-store prefix precedence:** correct - City and rig stores resolve prefixes from scope-local `.beads/config.yaml` before falling back to configured/effective prefixes, so stale controller hints no longer override scope reality.
  - **Owned unknown event fallback:** correct - The follow-up commit restores the existing backing-store refresh path for uncached owned events and adds regression coverage for it.
  - **Gemini partial-payload blocker premise:** incomplete as a PR finding - `ErrNotFound` still falls through to cache the event patch, but the same behavior exists in upstream base and is not introduced by this PR.

Approval Status:
- Approved: latest attempt 3, decision `approve`, score 930 / 1000, required changes: None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->