### PR TITLE
fix(dolt): quarantine retired replacement databases

### DIFF
--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -112,11 +112,13 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if !info.IsDir() {
 			continue
 		}
-		manifest := filepath.Join(doltDir, "noms", "manifest")
-		if _, err := os.Stat(manifest); err == nil {
-			continue
-		} else if !os.IsNotExist(err) {
-			return err
+		if !retiredManagedDoltDatabaseName(entry.Name()) {
+			manifest := filepath.Join(doltDir, "noms", "manifest")
+			if _, err := os.Stat(manifest); err == nil {
+				continue
+			} else if !os.IsNotExist(err) {
+				return err
+			}
 		}
 		if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {
 			return err
@@ -131,6 +133,11 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		fmt.Fprintf(os.Stderr, "gc dolt preflight: quarantined phantom database %s -> %s\n", dbDir, dest) //nolint:errcheck // best-effort warning
 	}
 	return nil
+}
+
+func retiredManagedDoltDatabaseName(name string) bool {
+	name = strings.TrimSpace(name)
+	return strings.Contains(name, ".replaced-")
 }
 
 func uniqueQuarantineDestination(root, stamp, name string) (string, error) {

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -8,13 +8,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
 
-var managedDoltPreflightCleanupFn = preflightManagedDoltCleanup
+var (
+	managedDoltPreflightCleanupFn     = preflightManagedDoltCleanup
+	retiredManagedDoltDatabasePattern = regexp.MustCompile(`^.+\.replaced-[0-9]{8}T[0-9]{6}Z$`)
+)
 
 const managedDoltLsofTimeout = 500 * time.Millisecond
 
@@ -112,7 +116,9 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if !info.IsDir() {
 			continue
 		}
+		reason := "retired replacement"
 		if !retiredManagedDoltDatabaseName(entry.Name()) {
+			reason = "missing noms/manifest"
 			manifest := filepath.Join(doltDir, "noms", "manifest")
 			if _, err := os.Stat(manifest); err == nil {
 				continue
@@ -130,14 +136,14 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if err := os.Rename(dbDir, dest); err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "gc dolt preflight: quarantined phantom database %s -> %s\n", dbDir, dest) //nolint:errcheck // best-effort warning
+		fmt.Fprintf(os.Stderr, "gc dolt preflight: quarantined unservable database (%s) %s -> %s\n", reason, dbDir, dest) //nolint:errcheck // best-effort warning
 	}
 	return nil
 }
 
 func retiredManagedDoltDatabaseName(name string) bool {
 	name = strings.TrimSpace(name)
-	return strings.Contains(name, ".replaced-")
+	return retiredManagedDoltDatabasePattern.MatchString(name)
 }
 
 func uniqueQuarantineDestination(root, stamp, name string) (string, error) {

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -106,6 +106,40 @@ func TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState(t *testing.T) 
 	}
 }
 
+func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t *testing.T) {
+	dataDir := t.TempDir()
+	activeManifest := filepath.Join(dataDir, "ga", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(activeManifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(activeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	retiredManifest := filepath.Join(dataDir, "ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(retiredManifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(retiredManifest, []byte("retired\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 29, 16, 20, 0, 0, time.UTC)
+	if err := quarantinePhantomManagedDoltDatabases(dataDir, now); err != nil {
+		t.Fatalf("quarantinePhantomManagedDoltDatabases: %v", err)
+	}
+
+	if _, err := os.Stat(activeManifest); err != nil {
+		t.Fatalf("active manifest stat: %v", err)
+	}
+	if _, err := os.Stat(retiredManifest); !os.IsNotExist(err) {
+		t.Fatalf("retired manifest stat err = %v, want moved out of data dir", err)
+	}
+	quarantined := filepath.Join(dataDir, ".quarantine", "20260429T162000-ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Fatalf("quarantined manifest stat: %v", err)
+	}
+}
+
 func TestRemoveStaleManagedDoltSocketsWithoutLsofKeepsSocket(t *testing.T) {
 	socketPath := filepath.Join("/tmp", "dolt-preflight-cleanup-live-test.sock")
 	_ = os.Remove(socketPath)

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -122,6 +122,13 @@ func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t 
 	if err := os.WriteFile(retiredManifest, []byte("retired\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	replacementLikeManifest := filepath.Join(dataDir, "ga.replaced-pending", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(replacementLikeManifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(replacementLikeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	now := time.Date(2026, 4, 29, 16, 20, 0, 0, time.UTC)
 	if err := quarantinePhantomManagedDoltDatabases(dataDir, now); err != nil {
@@ -131,12 +138,35 @@ func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t 
 	if _, err := os.Stat(activeManifest); err != nil {
 		t.Fatalf("active manifest stat: %v", err)
 	}
+	if _, err := os.Stat(replacementLikeManifest); err != nil {
+		t.Fatalf("replacement-like active manifest stat: %v", err)
+	}
 	if _, err := os.Stat(retiredManifest); !os.IsNotExist(err) {
 		t.Fatalf("retired manifest stat err = %v, want moved out of data dir", err)
 	}
 	quarantined := filepath.Join(dataDir, ".quarantine", "20260429T162000-ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
 	if _, err := os.Stat(quarantined); err != nil {
 		t.Fatalf("quarantined manifest stat: %v", err)
+	}
+}
+
+func TestRetiredManagedDoltDatabaseNameRequiresTimestampSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "ga.replaced-20260428T100722Z", want: true},
+		{name: "ga.replaced-20260428T100722Z.bak", want: false},
+		{name: "ga.replaced-20260428T100722", want: false},
+		{name: "ga.replaced-pending", want: false},
+		{name: "replaced-20260428T100722Z", want: false},
+		{name: ".replaced-20260428T100722Z", want: false},
+		{name: "ga", want: false},
+	}
+	for _, tt := range tests {
+		if got := retiredManagedDoltDatabaseName(tt.name); got != tt.want {
+			t.Fatalf("retiredManagedDoltDatabaseName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }
 

--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -123,3 +123,32 @@ func TestGCBeadsBDScript_UsesPortableSleepMS(t *testing.T) {
 		t.Fatalf("gc-beads-bd.sh must allow slow bd runtime schema visibility after init")
 	}
 }
+
+func TestGCBeadsBDScript_QuarantinesRetiredReplacementDatabases(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	scriptPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptPath, err)
+	}
+	script := string(data)
+
+	required := []string{
+		"retired_replacement_db_name()",
+		"?*.replaced-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]Z)",
+		`reason="retired replacement"`,
+		`quarantining unservable database`,
+		`mv -f "$dir" "$quarantine_dir"`,
+	}
+	for _, want := range required {
+		if !strings.Contains(script, want) {
+			t.Fatalf("gc-beads-bd.sh missing retired replacement fallback fragment %q", want)
+		}
+	}
+	if strings.Contains(script, "quarantining phantom database") {
+		t.Fatal("gc-beads-bd.sh still logs the broader fallback as phantom-only")
+	}
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -797,23 +797,41 @@ kill_imposter() {
     sleep 1
 }
 
-# quarantine_phantom_dbs moves dirs with .dolt/ but missing noms/manifest
-# to a quarantine directory. A phantom database crashes the entire dolt
-# server on startup, so it must be removed from DATA_DIR. The data is
-# preserved in case recovery is possible.
+retired_replacement_db_name() {
+    case "$1" in
+        ?*.replaced-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]Z)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# quarantine_phantom_dbs moves unservable database dirs to quarantine.
+# This includes missing-manifest phantom dirs and Dolt-retired replacement
+# dirs that still have manifests but are no longer the active database.
 quarantine_phantom_dbs() {
     [ -d "$DATA_DIR" ] || return 0
     local dir
     for dir in "$DATA_DIR"/*/; do
         [ -d "$dir" ] || continue
-        if [ -d "$dir/.dolt" ] && [ ! -f "$dir/.dolt/noms/manifest" ]; then
-            local name
-            name=$(basename "$dir")
-            local quarantine_dir="$DATA_DIR/.quarantine/$(date +%Y%m%dT%H%M%S)-$name"
-            mkdir -p "$DATA_DIR/.quarantine"
-            echo "quarantining phantom database: $name (missing noms/manifest) → $quarantine_dir" >&2
-            mv "$dir" "$quarantine_dir"
+        [ -d "$dir/.dolt" ] || continue
+
+        local name reason
+        name=$(basename "$dir")
+        if retired_replacement_db_name "$name"; then
+            reason="retired replacement"
+        elif [ ! -f "$dir/.dolt/noms/manifest" ]; then
+            reason="missing noms/manifest"
+        else
+            continue
         fi
+
+        local quarantine_dir="$DATA_DIR/.quarantine/$(date +%Y%m%dT%H%M%S)-$name"
+        mkdir -p "$DATA_DIR/.quarantine"
+        echo "quarantining unservable database: $name ($reason) -> $quarantine_dir" >&2
+        mv -f "$dir" "$quarantine_dir"
     done
 }
 

--- a/examples/dolt/formulas/mol-dog-phantom-db.toml
+++ b/examples/dolt/formulas/mol-dog-phantom-db.toml
@@ -1,20 +1,26 @@
 description = """
-Detect phantom databases in .dolt-data/ that can crash the Dolt server.
+Detect unservable databases in .dolt-data/ that can crash or confuse the Dolt server.
 
 A phantom database is a directory in .dolt-data/ that has a .dolt/ subdirectory
 but is missing the noms/manifest file. When Dolt auto-discovers these dirs at
 startup, the broken noms store crashes INFORMATION_SCHEMA and can take down
 the entire server.
 
+A retired replacement database is a directory whose name ends with
+.replaced-YYYYMMDDTHHMMSSZ. Dolt can leave these behind with a valid manifest
+after a replacement operation fails to cleanly remove the old directory. They
+must not be auto-discovered as active databases on the next start.
+
 This formula adds continuous monitoring: detect phantoms that appear between
 server restarts (e.g., from DROP DATABASE + branch_control re-materialization),
-and escalate before the next restart hits them.
+and retired replacements left by Dolt, then escalate before the next restart
+hits them.
 
 ## Dog Contract
 
 This is infrastructure work. You:
-1. Scan the .dolt-data/ directory for phantom databases
-2. Quarantine any phantoms found (remove corrupted dirs)
+1. Scan the .dolt-data/ directory for unservable databases
+2. Quarantine any phantoms or retired replacements found
 3. Report findings and exit
 4. Return to kennel
 
@@ -27,7 +33,8 @@ This is infrastructure work. You:
 ## Safety
 
 Phantom database directories have NO valid data (missing noms/manifest).
-Removing them is safe and prevents server crashes.
+Retired replacement directories may contain recoverable data, so move both
+cases into .quarantine/ instead of deleting them.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-phantom-db"
@@ -40,66 +47,74 @@ default = ".dolt-data"
 
 [[steps]]
 id = "scan"
-title = "Scan for phantom databases"
+title = "Scan for unservable databases"
 description = """
-Scan the .dolt-data/ directory for phantom database directories.
+Scan the .dolt-data/ directory for unservable database directories.
 
 **1. List all directories in {{data_dir}}/:**
 ```bash
 ls -d {{data_dir}}/*/
 ```
 
-**2. For each directory, check for phantom condition:**
+**2. For each directory, check for unservable conditions:**
 A phantom database has:
 - A `.dolt/` subdirectory (looks like a database)
 - But NO `noms/manifest` file (broken/corrupted)
+
+A retired replacement database has:
+- A `.dolt/` subdirectory
+- A basename matching `*.replaced-YYYYMMDDTHHMMSSZ`
 
 ```bash
 # For each dir in {{data_dir}}/:
 #   if <dir>/.dolt/ exists AND <dir>/.dolt/noms/manifest does NOT exist:
 #     -> phantom detected
+#   if basename matches *.replaced-[0-9]{8}T[0-9]{6}Z:
+#     -> retired replacement detected
 ```
 
 **3. Record findings:**
 - Total directories scanned
 - Phantom databases found (names and paths)
+- Retired replacement databases found (names and paths)
 - Valid databases found
 
-**Exit criteria:** Scan complete, phantoms identified."""
+**Exit criteria:** Scan complete, unservable databases identified."""
 
 [[steps]]
 id = "quarantine"
-title = "Quarantine phantom databases"
+title = "Quarantine unservable databases"
 needs = ["scan"]
 description = """
-Remove phantom database directories to prevent server crashes.
+Move unservable database directories to quarantine before Dolt auto-discovers them.
 
-**1. If no phantoms found:**
+**1. If no unservable databases were found:**
 Skip this step — nothing to quarantine.
 
-**2. For each phantom database:**
-Remove the corrupted directory:
+**2. For each phantom or retired replacement database:**
+Move the directory into .quarantine/:
 ```bash
-rm -rf {{data_dir}}/<phantom-name>
+mkdir -p {{data_dir}}/.quarantine
+mv -f {{data_dir}}/<database-name> {{data_dir}}/.quarantine/$(date +%Y%m%dT%H%M%S)-<database-name>
 ```
 
 This is safe because:
-- The directory has no valid noms store (no manifest)
-- It contains no recoverable data
-- Leaving it would crash the server on next restart
+- Missing-manifest phantoms cannot be served by Dolt
+- Retired replacements are no longer the active database
+- The move preserves data for later inspection or recovery
 
 **3. Record results:**
-- Count of phantoms quarantined
+- Count of unservable databases quarantined
 - Any errors during removal
 
-**4. Escalate if phantoms were found:**
-Phantom databases indicate a Dolt bug that should be investigated:
+**4. Escalate if unservable databases were found:**
+Unservable databases indicate a Dolt cleanup or data-dir hygiene issue that should be investigated:
 ```bash
-gc mail send mayor/ -s "ESCALATION: Quarantined phantom databases [HIGH]" \\
-  -m "Found and quarantined <count> phantom database(s): <names>"
+gc mail send mayor/ -s "ESCALATION: Quarantined unservable databases [HIGH]" \\
+  -m "Found and quarantined <count> unservable database(s): <names>"
 ```
 
-**Exit criteria:** All phantoms quarantined (or none found)."""
+**Exit criteria:** All unservable databases quarantined (or none found)."""
 
 [[steps]]
 id = "report"
@@ -111,7 +126,8 @@ Generate summary and signal completion.
 **1. Generate report summary:**
 - Directories scanned
 - Phantoms found
-- Phantoms quarantined
+- Retired replacements found
+- Unservable databases quarantined
 - Valid databases
 
 **2. Signal completion:**


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1521 because the original PR has maintainer edits disabled.

Original PR metadata:
- URL: https://github.com/gastownhall/gascity/pull/1521
- Title: fix(dolt): quarantine retired replacement databases
- State at adoption finalize: OPEN
- Configured base: main
- Original GitHub base: main
- Base mismatch: none

This follow-up preserves the reviewed content from the original contributor branch and includes the approved review fixup commit:
- 7ab8e4a2b fix(dolt): quarantine retired replacement databases
- e27272656 fix(dolt): address preflight review findings

Review synthesis:
- Latest review attempt: 2
- Decision: approve
- Quality score: 915 / 1000, threshold 850
- Required changes: none

Validated:
- Retired Dolt replacement directories with valid manifests are quarantined by the Go preflight when they match the strict `.replaced-YYYYMMDDTHHMMSSZ` suffix.
- The matcher is anchored to Dolt's timestamp suffix shape and has negative coverage for non-retired `.replaced-` names.
- Active managed Dolt databases with manifests remain untouched.
- The shell fallback and operator formula were updated for parity; remaining notes are minor follow-ups only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->