### PR TITLE
Adopt PR #1430: fix(session): skip orphan release on partial work snapshots

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -45,7 +45,16 @@ type DesiredStateResult struct {
 	// store failure would cause running sessions to be falsely orphaned
 	// and interrupted via Ctrl-C.
 	StoreQueryPartial bool
-	BeaconTime        time.Time
+	// SessionQueryPartial is true when session-bead snapshot loading failed.
+	// Orphan-release and drain decisions must treat this like an incomplete
+	// work snapshot because missing live session beads make assigned work look
+	// orphaned.
+	SessionQueryPartial bool
+	BeaconTime          time.Time
+}
+
+func (r DesiredStateResult) snapshotQueryPartial() bool {
+	return r.StoreQueryPartial || r.SessionQueryPartial
 }
 
 type poolEvalWork struct {
@@ -169,14 +178,18 @@ func buildDesiredState(
 	stderr io.Writer,
 ) DesiredStateResult {
 	var sessionBeads *sessionBeadSnapshot
+	var sessionQueryPartial bool
 	if store != nil {
 		var err error
 		sessionBeads, err = loadSessionBeadSnapshot(store)
 		if err != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: listing session beads: %v\n", err) //nolint:errcheck
+			sessionQueryPartial = true
 		}
 	}
-	return buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, store, nil, sessionBeads, nil, stderr)
+	result := buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, store, nil, sessionBeads, nil, stderr)
+	result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
+	return result
 }
 
 func buildDesiredStateWithSessionBeads(

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1184,7 +1184,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
-	if released := releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores, rigStores); len(released) > 0 {
+	var released []releasedPoolAssignment
+	if !result.StoreQueryPartial {
+		released = releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores, rigStores)
+	}
+	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1184,10 +1184,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
-	var released []releasedPoolAssignment
-	if !result.StoreQueryPartial {
-		released = releaseOrphanedPoolAssignments(store, cr.cfg, sessionBeads.Open(), assignedWorkBeads, result.AssignedWorkStores, rigStores)
-	}
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotComplete(store, cr.cfg, sessionBeads.Open(), result, rigStores)
 	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1180,11 +1180,13 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 
 	if sessionBeads == nil {
-		sessionBeads = cr.loadSessionBeadSnapshot()
+		var sessionQueryPartial bool
+		sessionBeads, sessionQueryPartial = cr.loadSessionBeadSnapshotWithPartial()
+		result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotComplete(store, cr.cfg, sessionBeads.Open(), result, rigStores)
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, sessionBeads.Open(), result, rigStores)
 	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
@@ -1223,9 +1225,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		desiredState,
 		cr.cfg,
 		cr.sp,
-		result.StoreQueryPartial,
+		result.snapshotQueryPartial(),
 	) > 0 {
-		sessionBeads = cr.loadSessionBeadSnapshot()
+		var sessionQueryPartial bool
+		sessionBeads, sessionQueryPartial = cr.loadSessionBeadSnapshotWithPartial()
+		result.SessionQueryPartial = result.SessionQueryPartial || sessionQueryPartial
 	}
 	open := sessionBeads.Open()
 
@@ -1291,13 +1295,15 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			})
 		}
 		trace.RecordCycleInputSnapshot(map[string]any{
-			"desired_session_count": len(desiredState),
-			"open_session_count":    len(open),
-			"scale_check_counts":    result.ScaleCheckCounts,
-			"pool_desired":          poolDesired,
-			"ready_wait_count":      len(readyWaitSet),
-			"work_set_count":        len(workSet),
-			"store_query_partial":   result.StoreQueryPartial,
+			"desired_session_count":  len(desiredState),
+			"open_session_count":     len(open),
+			"scale_check_counts":     result.ScaleCheckCounts,
+			"pool_desired":           poolDesired,
+			"ready_wait_count":       len(readyWaitSet),
+			"work_set_count":         len(workSet),
+			"store_query_partial":    result.StoreQueryPartial,
+			"session_query_partial":  result.SessionQueryPartial,
+			"snapshot_query_partial": result.snapshotQueryPartial(),
 		})
 		for _, agent := range cr.cfg.Agents {
 			template := agent.QualifiedName()
@@ -1328,7 +1334,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, store,
 		cr.dops,
 		assignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, poolDesired,
-		result.StoreQueryPartial,
+		result.snapshotQueryPartial(),
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
 		cr.cfg.Daemon.DriftDrainTimeoutDuration(),
@@ -1675,16 +1681,21 @@ func (cr *CityRuntime) rigBeadStores() map[string]beads.Store {
 }
 
 func (cr *CityRuntime) loadSessionBeadSnapshot() *sessionBeadSnapshot {
+	sessionBeads, _ := cr.loadSessionBeadSnapshotWithPartial()
+	return sessionBeads
+}
+
+func (cr *CityRuntime) loadSessionBeadSnapshotWithPartial() (*sessionBeadSnapshot, bool) {
 	store := cr.cityBeadStore()
 	if store == nil {
-		return nil
+		return nil, false
 	}
 	sessionBeads, err := loadSessionBeadSnapshot(store)
 	if err != nil {
 		fmt.Fprintf(cr.stderr, "%s: loading session beads: %v\n", cr.logPrefix, err) //nolint:errcheck
-		return nil
+		return nil, true
 	}
-	return sessionBeads
+	return sessionBeads, false
 }
 
 func filterSessionBeadsByName(snapshot *sessionBeadSnapshot, names map[string]bool) []beads.Bead {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1077,6 +1077,56 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 	}
 }
 
+func TestCityRuntimeBeadReconcileTick_StoreQueryPartialDoesNotReleaseAssignedWork(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		ID:       "ga-live",
+		Title:    "live assigned work from partial snapshot",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "worker-session",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work.Status = inProgress
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	cr.beadReconcileTick(context.Background(), DesiredStateResult{
+		State:              map[string]TemplateParams{},
+		ScaleCheckCounts:   map[string]int{"worker": 0},
+		AssignedWorkBeads:  []beads.Bead{work},
+		AssignedWorkStores: []beads.Store{store},
+		StoreQueryPartial:  true,
+	}, newSessionBeadSnapshot(nil), nil)
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work after partial tick: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-session" {
+		t.Fatalf("partial assigned-work snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
 func TestCityRuntimeTick_LogsWispGCPurgeCountWithNonFatalError(t *testing.T) {
 	store := beads.NewMemStore()
 	var stdout, stderr bytes.Buffer

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -104,6 +104,17 @@ func TestFilterReleasedAssignedWorkBeads_IgnoresMismatchedReleasedIndex(t *testi
 	}
 }
 
+type sessionSnapshotListFailStore struct {
+	beads.Store
+}
+
+func (s sessionSnapshotListFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == sessionBeadLabel {
+		return nil, errors.New("session snapshot unavailable")
+	}
+	return s.Store.List(query)
+}
+
 func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	cr := &CityRuntime{
 		sessionDrains: newDrainTracker(),
@@ -1124,6 +1135,56 @@ func TestCityRuntimeBeadReconcileTick_StoreQueryPartialDoesNotReleaseAssignedWor
 	}
 	if got.Status != "in_progress" || got.Assignee != "worker-session" {
 		t.Fatalf("partial assigned-work snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
+func TestCityRuntimeBeadReconcileTick_SessionQueryPartialDoesNotReleaseAssignedWork(t *testing.T) {
+	base := beads.NewMemStore()
+	store := sessionSnapshotListFailStore{Store: base}
+	work, err := base.Create(beads.Bead{
+		ID:       "ga-live",
+		Title:    "live assigned work from partial session snapshot",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "worker-session",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := base.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work.Status = inProgress
+
+	cr := &CityRuntime{
+		cityPath:            t.TempDir(),
+		cityName:            "maintainer-city",
+		cfg:                 &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	cr.beadReconcileTick(context.Background(), DesiredStateResult{
+		State:              map[string]TemplateParams{},
+		ScaleCheckCounts:   map[string]int{"worker": 0},
+		AssignedWorkBeads:  []beads.Bead{work},
+		AssignedWorkStores: []beads.Store{store},
+	}, nil, nil)
+
+	got, err := base.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work after partial tick: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-session" {
+		t.Fatalf("partial session snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
 	}
 }
 

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -582,12 +582,15 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	rigStores := buildStandaloneRigStores(cfg, cityPath, stderr)
 
 	// One-shot bead reconciliation: same code path as the daemon.
+	sessionQueryPartial := false
 	sessionBeads, err := loadSessionBeadSnapshot(oneShotStore)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: loading session beads: %v\n", err) //nolint:errcheck
 		sessionBeads = nil
+		sessionQueryPartial = true
 	}
 	dsResult := buildDesiredStateWithSessionBeads(cityName, cityPath, beaconTime, cfg, sp, oneShotStore, rigStores, sessionBeads, nil, stderr)
+	dsResult.SessionQueryPartial = dsResult.SessionQueryPartial || sessionQueryPartial
 	ds := dsResult.State
 	cfgNames := configuredSessionNamesWithSnapshot(cfg, cityName, sessionBeads)
 	_, sessionBeads = syncSessionBeadsWithSnapshotAndRigStores(
@@ -595,7 +598,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	)
 
 	open := sessionBeads.Open()
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotComplete(oneShotStore, cfg, open, dsResult, rigStores); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, cfg, open, dsResult, rigStores); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
@@ -621,7 +624,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	reconcileSessionBeadsAtPath(
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
 		nil, dsResult.AssignedWorkBeads, rigStores, nil, dt, poolDesired,
-		dsResult.StoreQueryPartial,
+		dsResult.snapshotQueryPartial(),
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,
 		stdout, stderr,

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -595,7 +595,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	)
 
 	open := sessionBeads.Open()
-	if released := releaseOrphanedPoolAssignments(oneShotStore, cfg, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStores, rigStores); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotComplete(oneShotStore, cfg, open, dsResult, rigStores); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -123,6 +123,70 @@ func TestStandaloneBuildAgentsFnWithSessionBeads_UsesRigStoresForAssignedWork(t 
 	}
 }
 
+func TestStandaloneOneShotSkipsPoolOrphanReleaseWhenStoreQueryPartial(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		ID:       "ga-live",
+		Title:    "live assigned work from partial snapshot",
+		Type:     "task",
+		Assignee: "worker-session",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	inProgress := "in_progress"
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: &inProgress}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work.Status = inProgress
+
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotComplete(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		nil,
+		DesiredStateResult{
+			AssignedWorkBeads:  []beads.Bead{work},
+			AssignedWorkStores: []beads.Store{store},
+			StoreQueryPartial:  true,
+		},
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released %d work bead(s) from a partial snapshot, want none", len(released))
+	}
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work after partial one-shot release: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-session" {
+		t.Fatalf("partial one-shot snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+
+	released = releaseOrphanedPoolAssignmentsWhenSnapshotComplete(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		nil,
+		DesiredStateResult{
+			AssignedWorkBeads:  []beads.Bead{work},
+			AssignedWorkStores: []beads.Store{store},
+		},
+		nil,
+	)
+	if len(released) != 1 {
+		t.Fatalf("complete one-shot snapshot released %d work bead(s), want 1", len(released))
+	}
+	got, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work after complete one-shot release: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("complete one-shot snapshot did not release orphaned work: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+}
+
 func TestMergeEnvOverrideOrder(t *testing.T) {
 	a := map[string]string{"KEY": "first", "A": "a"}
 	b := map[string]string{"KEY": "second", "B": "b"}

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -123,7 +123,7 @@ func TestStandaloneBuildAgentsFnWithSessionBeads_UsesRigStoresForAssignedWork(t 
 	}
 }
 
-func TestStandaloneOneShotSkipsPoolOrphanReleaseWhenStoreQueryPartial(t *testing.T) {
+func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsCompleteReleases(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{
 		ID:       "ga-live",
@@ -143,7 +143,7 @@ func TestStandaloneOneShotSkipsPoolOrphanReleaseWhenStoreQueryPartial(t *testing
 	}
 	work.Status = inProgress
 
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotComplete(
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
 		nil,
@@ -165,7 +165,29 @@ func TestStandaloneOneShotSkipsPoolOrphanReleaseWhenStoreQueryPartial(t *testing
 		t.Fatalf("partial one-shot snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
 	}
 
-	released = releaseOrphanedPoolAssignmentsWhenSnapshotComplete(
+	released = releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		nil,
+		DesiredStateResult{
+			AssignedWorkBeads:   []beads.Bead{work},
+			AssignedWorkStores:  []beads.Store{store},
+			SessionQueryPartial: true,
+		},
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released %d work bead(s) from a partial session snapshot, want none", len(released))
+	}
+	got, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work after partial session snapshot release: %v", err)
+	}
+	if got.Status != "in_progress" || got.Assignee != "worker-session" {
+		t.Fatalf("partial session snapshot released work: status=%q assignee=%q", got.Status, got.Assignee)
+	}
+
+	released = releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
 		nil,

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -45,6 +45,23 @@ func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, se
 	return closed
 }
 
+// releaseOrphanedPoolAssignmentsWhenSnapshotComplete skips orphan release when
+// the desired-state work snapshot is incomplete.
+func releaseOrphanedPoolAssignmentsWhenSnapshotComplete(
+	store beads.Store,
+	cfg *config.City,
+	openSessionBeads []beads.Bead,
+	result DesiredStateResult,
+	rigStores map[string]beads.Store,
+) []releasedPoolAssignment {
+	// A partial work snapshot can hide live session beads behind a transient
+	// store failure, making active work look orphaned for this tick only.
+	if result.StoreQueryPartial {
+		return nil
+	}
+	return releaseOrphanedPoolAssignments(store, cfg, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStores, rigStores)
+}
+
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
 // assignee no longer maps to any open session bead. This also recovers
 // pool-routed work left in_progress with no assignee, which cannot be claimed

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -45,18 +45,19 @@ func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, se
 	return closed
 }
 
-// releaseOrphanedPoolAssignmentsWhenSnapshotComplete skips orphan release when
-// the desired-state work snapshot is incomplete.
-func releaseOrphanedPoolAssignmentsWhenSnapshotComplete(
+// releaseOrphanedPoolAssignmentsWhenSnapshotsComplete skips orphan release
+// unless both the assigned-work and open-session snapshots are complete.
+func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	store beads.Store,
 	cfg *config.City,
 	openSessionBeads []beads.Bead,
 	result DesiredStateResult,
 	rigStores map[string]beads.Store,
 ) []releasedPoolAssignment {
-	// A partial work snapshot can hide live session beads behind a transient
-	// store failure, making active work look orphaned for this tick only.
-	if result.StoreQueryPartial {
+	// Partial input snapshots can make active work look orphaned for this
+	// tick only: missing work affects drain decisions, and missing sessions
+	// affects assigned-work orphan release.
+	if result.snapshotQueryPartial() {
 		return nil
 	}
 	return releaseOrphanedPoolAssignments(store, cfg, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStores, rigStores)


### PR DESCRIPTION
Adopts and finalizes https://github.com/gastownhall/gascity/pull/1430 through the maintainer follow-up path because the original PR has maintainer edits disabled.

Original PR: https://github.com/gastownhall/gascity/pull/1430
Original title: fix(session): skip orphan release on partial work snapshots
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This branch contains the rebased contributor change plus reviewed maintainer fixups from the adopt-pr workflow. Commit authorship is preserved as Julian Knutsen <julianknutsen@users.noreply.github.com>.

Review TL;DR:
PR #1430 `fix(session): skip orphan release on partial work snapshots` reached approval after 2 fix iteration(s). Latest attempt 3 is `approve` with score 930 / 1000 against threshold 850.

Iteration 1:
- Decision: request_changes (scorecard: request_changes, 785 / 1000, threshold 850)
- Findings:
  - One-shot `gc start` can still falsely reopen active pool-routed work during a partial assigned-work snapshot - major / high / all
- Required changes:
  - Guard `cmd/gc/cmd_start.go:598` with `if !dsResult.StoreQueryPartial { ... }`, matching the daemon path.
  - Add one-shot `gc start` regression coverage showing a partial assigned-work snapshot does not release assigned work.

Iteration 2:
- Decision: block (scorecard: block, 650 / 1000, threshold 850)
- Findings:
  - A failed session-bead snapshot can still make all assigned pool work look orphaned - blocker / high / claude+gemini
  - The one-shot regression test does not exercise the production one-shot call site - minor / high / claude
- Required changes:
  - Track session-bead snapshot load failure explicitly and skip orphan pool-work release when either assigned-work collection or session-bead loading is partial; apply this in both daemon reconciliation and one-shot start.
  - Update the helper name/comment to state the exact completeness contract once session-bead partial state is represented.
  - Strengthen or rename the one-shot test so its scope is honest, and add regression coverage for the failed session-bead snapshot path that currently leaves `openSessionBeads` empty.

Fix Applied:
- 549cd20e6 fix: guard orphan release on session snapshot failures
- e2f7df280 fix: skip one-shot orphan release on partial snapshots
- 88104297c fix(session): skip orphan release on partial work snapshots
- Final diff: 6 files changed, 262 insertions(+), 19 deletions(-)

Iteration 3:
- Decision: approve (scorecard: approve, 930 / 1000, threshold 850)
- Validated:
  - Partial assigned-work snapshots could falsely release live pool work: correct - `DesiredStateResult.snapshotQueryPartial()` now includes `StoreQueryPartial`, and `releaseOrphanedPoolAssignmentsWhenSnapshotsComplete` skips release before delegating to the existing release path.
  - Session-bead snapshot failures made all assigned work look orphaned: correct - `SessionQueryPartial` is captured in the build, daemon, and standalone start paths, then used before orphan release, session sweep, and reconcile drain/close decisions.
  - Complete snapshots still recover truly orphaned work: correct - when neither partial flag is set, the wrapper delegates to `releaseOrphanedPoolAssignments`, and the tests cover the complete-snapshot release path.
- Remaining non-gating findings:
  - Combined snapshot partiality is still named `storeQueryPartial` in reconciler parameters and one trace payload - minor / high / claude+gemini
  - The new union guard lacks a direct session-partial sweep/reconcile regression test - minor / medium / claude

Approval Status:
- Approved: latest attempt 3, decision `approve`, score 930 / 1000, required changes: None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->