### PR TITLE
Adopt PR #1455: perf(reconciler): avoid broad tick-time store scans

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -529,26 +529,50 @@ func collectAssignedWorkBeadsWithStores(
 		}
 	}
 
+	type storeAssignedWorkResult struct {
+		beads  []beads.Bead
+		stores []beads.Store
+		errs   []error
+	}
+	results := make([]storeAssignedWorkResult, len(stores))
+	var wg sync.WaitGroup
+	for idx, s := range stores {
+		idx, s := idx, s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var result []beads.Bead
+			var resultStores []beads.Store
+			var errs []error
+			seen := make(map[string]struct{})
+			// In-progress beads with an assignee (active work), plus stranded
+			// unassigned pool work that needs to be reopened.
+			if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
+				appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
+			} else {
+				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
+			}
+			// Ready beads with an assignee (queued direct handoff work that is
+			// actually runnable, not merely open). This is a lifecycle gate, so
+			// bypass the cache when a CachingStore wrapper is present.
+			if ready, err := beads.ReadyLive(s); err == nil {
+				appendAssignedUnique(&result, &resultStores, ready, seen, s)
+			} else {
+				errs = append(errs, fmt.Errorf("Ready(): %w", err))
+			}
+			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, errs: errs}
+		}()
+	}
+	wg.Wait()
+
 	var result []beads.Bead
 	var resultStores []beads.Store
 	var partial bool
-	for _, s := range stores {
-		seen := make(map[string]struct{})
-		// In-progress beads with an assignee (active work), plus stranded
-		// unassigned pool work that needs to be reopened.
-		if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
-			appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
-		} else {
-			log.Printf("collectAssignedWorkBeads: List(in_progress) failed: %v", err)
-			partial = true
-		}
-		// Ready beads with an assignee (queued direct handoff work that is
-		// actually runnable, not merely open). This is a lifecycle gate, so
-		// bypass the cache when a CachingStore wrapper is present.
-		if ready, err := beads.ReadyLive(s); err == nil {
-			appendAssignedUnique(&result, &resultStores, ready, seen, s)
-		} else {
-			log.Printf("collectAssignedWorkBeads: Ready() failed: %v", err)
+	for _, r := range results {
+		result = append(result, r.beads...)
+		resultStores = append(resultStores, r.stores...)
+		for _, err := range r.errs {
+			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -587,8 +587,15 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		}
 		sessionBead, ok := sessionBeads.FindByID(sessionID)
 		if !ok {
-			if anySessionBead, found := sessionBeads.findByIDIncludingClosed(sessionID); found {
-				sessionBead = anySessionBead
+			if wait.Metadata["registered_epoch"] != "" {
+				var found bool
+				sessionBead, found, err = lookupSessionBeadIncludingClosed(store, sessionBeads, sessionID)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					continue
+				}
 			} else {
 				continue
 			}
@@ -668,6 +675,28 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		}
 	}
 	return readyWaitSet, nil
+}
+
+func lookupSessionBeadIncludingClosed(store beads.Store, sessionBeads *sessionBeadSnapshot, id string) (beads.Bead, bool, error) {
+	if sessionBeads != nil {
+		if bead, ok := sessionBeads.findByIDIncludingClosed(id); ok {
+			return bead, true, nil
+		}
+	}
+	if store == nil || strings.TrimSpace(id) == "" {
+		return beads.Bead{}, false, nil
+	}
+	bead, err := store.Get(id)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return beads.Bead{}, false, nil
+		}
+		return beads.Bead{}, false, err
+	}
+	if !sessionpkg.IsSessionBeadOrRepairable(bead) {
+		return beads.Bead{}, false, nil
+	}
+	return bead, true, nil
 }
 
 func dispatchReadyWaitNudges(cityPath string, store beads.Store, _ runtime.Provider, now time.Time) error {

--- a/cmd/gc/cmd_wait.go
+++ b/cmd/gc/cmd_wait.go
@@ -589,7 +589,7 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 		if !ok {
 			if wait.Metadata["registered_epoch"] != "" {
 				var found bool
-				sessionBead, found, err = lookupSessionBeadIncludingClosed(store, sessionBeads, sessionID)
+				sessionBead, found, err = lookupSessionBeadByID(store, sessionID)
 				if err != nil {
 					return nil, err
 				}
@@ -677,12 +677,7 @@ func prepareWaitWakeStateForCityWithSnapshot(cityPath string, store beads.Store,
 	return readyWaitSet, nil
 }
 
-func lookupSessionBeadIncludingClosed(store beads.Store, sessionBeads *sessionBeadSnapshot, id string) (beads.Bead, bool, error) {
-	if sessionBeads != nil {
-		if bead, ok := sessionBeads.findByIDIncludingClosed(id); ok {
-			return bead, true, nil
-		}
-	}
+func lookupSessionBeadByID(store beads.Store, id string) (beads.Bead, bool, error) {
 	if store == nil || strings.TrimSpace(id) == "" {
 		return beads.Bead{}, false, nil
 	}

--- a/cmd/gc/cmd_wait_test.go
+++ b/cmd/gc/cmd_wait_test.go
@@ -437,7 +437,7 @@ func TestPrepareWaitWakeState_FinalizesFromNudge(t *testing.T) {
 	}
 }
 
-func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testing.T) {
+func TestPrepareWaitWakeState_UsesTargetedLookupForMissingSessionEpoch(t *testing.T) {
 	base := beads.NewMemStore()
 	store := &waitGetSpyStore{Store: base}
 	sessionBead, err := store.Create(beads.Bead{
@@ -477,10 +477,51 @@ func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutBackingGet(t *testin
 	if len(readyWaitSet) != 0 {
 		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
 	}
-	for _, id := range store.getIDs {
-		if id == sessionBead.ID {
-			t.Fatalf("prepare used Get for non-open session %s; getIDs=%v", sessionBead.ID, store.getIDs)
-		}
+	if len(store.getIDs) != 1 || store.getIDs[0] != sessionBead.ID {
+		t.Fatalf("Get IDs = %v, want targeted lookup for %s", store.getIDs, sessionBead.ID)
+	}
+}
+
+func TestPrepareWaitWakeState_SkipsMissingOpenSessionWithoutEpochLookup(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &waitGetSpyStore{Store: base}
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"agent_name":   "worker",
+			"state":        string(sessionpkg.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(sessionBead.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   waitBeadType,
+		Labels: []string{waitBeadLabel, "session:" + sessionBead.ID},
+		Metadata: map[string]string{
+			"session_id":   sessionBead.ID,
+			"session_name": "worker",
+			"kind":         "deps",
+			"state":        waitStateReady,
+		},
+	}); err != nil {
+		t.Fatalf("create wait bead: %v", err)
+	}
+
+	readyWaitSet, err := prepareWaitWakeState(store, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("prepareWaitWakeState: %v", err)
+	}
+	if len(readyWaitSet) != 0 {
+		t.Fatalf("readyWaitSet = %#v, want empty for non-open session", readyWaitSet)
+	}
+	if len(store.getIDs) != 0 {
+		t.Fatalf("Get IDs = %v, want no closed-session lookup without an epoch", store.getIDs)
 	}
 }
 

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -28,14 +28,19 @@ func trackingBeads(t *testing.T, store beads.Store, label string) []beads.Bead {
 
 func workBeadByOrderLabel(t *testing.T, store beads.Store, label string) beads.Bead {
 	t.Helper()
-	all := trackingBeads(t, store, label)
-	for _, b := range all {
-		if !strings.HasPrefix(b.Title, "order:") {
-			return b
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		all := trackingBeads(t, store, label)
+		for _, b := range all {
+			if !strings.HasPrefix(b.Title, "order:") {
+				return b
+			}
 		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no non-tracking bead found for %q", label)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("no non-tracking bead found for %q", label)
-	return beads.Bead{}
 }
 
 type selectiveUpdateFailStore struct {
@@ -2495,6 +2500,7 @@ func TestQualifyPool(t *testing.T) {
 
 func TestBuildOrderDispatcherUsesProviderAwareFileStore(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 	cityDir := t.TempDir()
 	layerDir := filepath.Join(cityDir, "formulas")
@@ -2541,6 +2547,7 @@ pool = "worker"
 
 func TestBuildOrderDispatcherRigOrderUsesRigFileStore(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "frontend")
@@ -2618,6 +2625,7 @@ pool = "worker"
 
 func TestBuildOrderDispatcherRigOrderHonorsLegacyCityRunHistory(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "frontend")
@@ -2921,6 +2929,7 @@ func TestOrderDispatchSkipsRigCooldownWhenLegacyLastRunReadFails(t *testing.T) {
 
 func TestBuildOrderDispatcherReopensStoreForScopedFileReads(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 	cityDir := t.TempDir()
 	layerDir := filepath.Join(cityDir, "formulas")

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -8,9 +8,11 @@ import (
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
-// sessionBeadSnapshot caches session-bead state for a single reconcile cycle.
-// Open-session lookups stay open-only; closed records are retained by ID for
-// lifecycle guards such as stale wait epoch cancellation.
+// sessionBeadSnapshot caches active session-bead state for a single reconcile
+// cycle. Closed-session history is intentionally not loaded here: the
+// reconciler calls this several times per tick, and closed history grows
+// without bound. Callers that need a closed record must fetch that one ID
+// explicitly.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
 	recordByID                map[string]beads.Bead
@@ -23,8 +25,7 @@ func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
 		return newSessionBeadSnapshot(nil), nil
 	}
 	all, err := store.List(beads.ListQuery{
-		Label:         sessionBeadLabel,
-		IncludeClosed: true,
+		Label: sessionBeadLabel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing session beads: %w", err)

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -15,7 +15,6 @@ import (
 // explicitly.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
-	recordByID                map[string]beads.Bead
 	sessionNameByAgentName    map[string]string
 	sessionNameByTemplateHint map[string]string
 }
@@ -41,14 +40,10 @@ func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
 
 func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 	filtered := make([]beads.Bead, 0, len(beadsIn))
-	byID := make(map[string]beads.Bead)
 	sessionNameByAgentName := make(map[string]string)
 	sessionNameByTemplateHint := make(map[string]string)
 
 	for _, b := range beadsIn {
-		if b.ID != "" {
-			byID[b.ID] = b
-		}
 		if b.Status == "closed" {
 			continue
 		}
@@ -90,7 +85,6 @@ func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 
 	return &sessionBeadSnapshot{
 		open:                      filtered,
-		recordByID:                byID,
 		sessionNameByAgentName:    sessionNameByAgentName,
 		sessionNameByTemplateHint: sessionNameByTemplateHint,
 	}
@@ -103,7 +97,6 @@ func (s *sessionBeadSnapshot) replaceOpen(open []beads.Bead) {
 	rebuilt := newSessionBeadSnapshot(open)
 	if rebuilt == nil {
 		s.open = nil
-		s.recordByID = nil
 		s.sessionNameByAgentName = nil
 		s.sessionNameByTemplateHint = nil
 		return
@@ -149,17 +142,6 @@ func (s *sessionBeadSnapshot) FindByID(id string) (beads.Bead, bool) {
 		}
 	}
 	return beads.Bead{}, false
-}
-
-func (s *sessionBeadSnapshot) findByIDIncludingClosed(id string) (beads.Bead, bool) {
-	if s == nil || strings.TrimSpace(id) == "" {
-		return beads.Bead{}, false
-	}
-	bead, ok := s.recordByID[id]
-	if !ok {
-		return beads.Bead{}, false
-	}
-	return bead, true
 }
 
 func (s *sessionBeadSnapshot) FindSessionNameByNamedIdentity(identity string) string {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -32,6 +32,16 @@ type sessionGetSpyStore struct {
 	getIDs []string
 }
 
+type sessionSnapshotListSpyStore struct {
+	beads.Store
+	queries []beads.ListQuery
+}
+
+func (s *sessionSnapshotListSpyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.queries = append(s.queries, query)
+	return s.Store.List(query)
+}
+
 type failingCloseStore struct {
 	*beads.MemStore
 }
@@ -2734,6 +2744,55 @@ func TestLoadSessionBeads_SkipsClosedBeads(t *testing.T) {
 	}
 	if len(result) != 0 {
 		t.Errorf("expected 0 beads (closed), got %d", len(result))
+	}
+}
+
+func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
+	base := beads.NewMemStore()
+	store := &sessionSnapshotListSpyStore{Store: base}
+	open, err := store.Create(beads.Bead{
+		Title:  "open",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"state":        string(session.StateActive),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create open session bead: %v", err)
+	}
+	closed, err := store.Create(beads.Bead{
+		Title:  "closed",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "old-worker",
+			"state":        string(session.StateClosed),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed session bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("close session bead: %v", err)
+	}
+
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeadSnapshot: %v", err)
+	}
+	if len(store.queries) != 1 {
+		t.Fatalf("List query count = %d, want 1", len(store.queries))
+	}
+	if store.queries[0].IncludeClosed {
+		t.Fatalf("loadSessionBeadSnapshot used IncludeClosed query: %+v", store.queries[0])
+	}
+	if _, ok := snapshot.FindByID(open.ID); !ok {
+		t.Fatalf("snapshot missing open session bead %s", open.ID)
+	}
+	if _, ok := snapshot.findByIDIncludingClosed(closed.ID); ok {
+		t.Fatalf("snapshot retained closed session bead %s", closed.ID)
 	}
 }
 

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2791,7 +2791,7 @@ func TestLoadSessionBeadSnapshotUsesActiveOnlyQuery(t *testing.T) {
 	if _, ok := snapshot.FindByID(open.ID); !ok {
 		t.Fatalf("snapshot missing open session bead %s", open.ID)
 	}
-	if _, ok := snapshot.findByIDIncludingClosed(closed.ID); ok {
+	if _, ok := snapshot.FindByID(closed.ID); ok {
 		t.Fatalf("snapshot retained closed session bead %s", closed.ID)
 	}
 }

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -24,15 +24,16 @@ import (
 type CachingStore struct {
 	backing Store // runtime: always *BdStore; tests may use MemStore
 
-	mu          sync.RWMutex
-	beads       map[string]Bead
-	deps        map[string][]Dep
-	dirty       map[string]struct{}
-	beadSeq     map[string]uint64
-	deletedSeq  map[string]uint64
-	state       cacheState
-	lastFreshAt time.Time
-	mutationSeq uint64
+	mu           sync.RWMutex
+	beads        map[string]Bead
+	deps         map[string][]Dep
+	depsComplete bool
+	dirty        map[string]struct{}
+	beadSeq      map[string]uint64
+	deletedSeq   map[string]uint64
+	state        cacheState
+	lastFreshAt  time.Time
+	mutationSeq  uint64
 
 	reconciling  atomic.Bool
 	syncFailures int
@@ -190,7 +191,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 		beadMap[b.ID] = cloneBead(b)
 	}
 
-	depMap, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
 	if depErr != nil {
 		c.recordProblem("prime dep cache", depErr)
 	}
@@ -201,6 +202,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	if c.mutationSeq == startSeq {
 		c.beads = beadMap
 		c.deps = depMap
+		c.depsComplete = depsComplete && depErr == nil
 		c.dirty = make(map[string]struct{})
 		c.beadSeq = make(map[string]uint64)
 		c.deletedSeq = make(map[string]uint64)
@@ -219,6 +221,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 				c.deps[id] = deps
 			}
 		}
+		c.depsComplete = false
 	}
 	c.state = cacheLive
 	c.syncFailures = 0
@@ -316,31 +319,24 @@ func beadIDs(beadMap map[string]Bead) []string {
 	return ids
 }
 
-func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, error) {
+func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, bool, error) {
 	depMap := make(map[string][]Dep)
 	if len(ids) == 0 {
-		return depMap, nil
+		return depMap, true, nil
 	}
 
-	if bdStore, ok := c.backing.(*BdStore); ok {
-		batchDeps, err := bdStore.DepListBatch(ids)
-		if err != nil {
-			return depMap, err
-		}
-		for id, deps := range batchDeps {
-			depMap[id] = cloneDeps(deps)
-		}
-		return depMap, nil
+	if _, ok := c.backing.(*BdStore); ok {
+		return depMap, false, nil
 	}
 
 	for _, id := range ids {
 		deps, err := c.backing.DepList(id, "down")
 		if err != nil {
-			return depMap, fmt.Errorf("listing deps for %s: %w", id, err)
+			return depMap, false, fmt.Errorf("listing deps for %s: %w", id, err)
 		}
 		depMap[id] = cloneDeps(deps)
 	}
-	return depMap, nil
+	return depMap, true, nil
 }
 
 func cloneDeps(deps []Dep) []Dep {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -780,3 +780,50 @@ func TestCachingStoreRunReconciliationDoesNotEmitBeadClosedForAlreadyClosedCache
 		}
 	}
 }
+
+func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
+	t.Parallel()
+
+	var depListCalls int
+	var readyCalls int
+	issueJSON := []byte(`[{
+		"id":"bd-1",
+		"title":"task",
+		"status":"open",
+		"issue_type":"task",
+		"created_at":"2026-01-01T00:00:00Z",
+		"labels":["task"],
+		"metadata":{}
+	}]`)
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) > 0 && args[0] == "dep" {
+			depListCalls++
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		if len(args) > 0 && args[0] == "ready" {
+			readyCalls++
+			return issueJSON, nil
+		}
+		if len(args) > 0 && args[0] == "list" {
+			return issueJSON, nil
+		}
+		return []byte(`[]`), nil
+	}
+	cache := NewCachingStore(NewBdStore("/city", runner), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	cache.runReconciliation()
+	if depListCalls != 0 {
+		t.Fatalf("dep list calls = %d, want 0", depListCalls)
+	}
+	if _, err := cache.Ready(); err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if readyCalls != 1 {
+		t.Fatalf("Ready calls = %d, want backing Ready fallback when deps are incomplete", readyCalls)
+	}
+}

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -826,4 +827,208 @@ func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
 	if readyCalls != 1 {
 		t.Fatalf("Ready calls = %d, want backing Ready fallback when deps are incomplete", readyCalls)
 	}
+}
+
+func TestCachingStoreBdIncompleteDepsUseBackingForDownDepList(t *testing.T) {
+	t.Parallel()
+
+	runner := newCachingStoreBdDepRunner(t)
+	cache := NewCachingStore(NewBdStore("/city", runner.run), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	deps, err := cache.DepList("bd-1", "down")
+	if err != nil {
+		t.Fatalf("initial DepList: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("initial deps = %v, want empty", deps)
+	}
+
+	runner.deps["bd-1"] = []Dep{{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"}}
+	cache.runReconciliation()
+
+	deps, err = cache.DepList("bd-1", "down")
+	if err != nil {
+		t.Fatalf("DepList after external dep add: %v", err)
+	}
+	if !hasDep(deps, "bd-2") {
+		t.Fatalf("deps after external dep add = %v, want bd-1 -> bd-2 from backing store", deps)
+	}
+	if runner.depScanCalls != 0 {
+		t.Fatalf("dep scan calls = %d, want 0", runner.depScanCalls)
+	}
+}
+
+func TestCachingStoreBdIncompleteDepsDepAddDoesNotDropExistingBackingDeps(t *testing.T) {
+	t.Parallel()
+
+	runner := newCachingStoreBdDepRunner(t)
+	runner.deps["bd-1"] = []Dep{{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"}}
+	cache := NewCachingStore(NewBdStore("/city", runner.run), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	if err := cache.DepAdd("bd-1", "bd-3", "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	deps, err := cache.DepList("bd-1", "down")
+	if err != nil {
+		t.Fatalf("DepList after DepAdd: %v", err)
+	}
+	if !hasDep(deps, "bd-2") || !hasDep(deps, "bd-3") {
+		t.Fatalf("deps after DepAdd = %v, want existing bd-2 and added bd-3", deps)
+	}
+}
+
+func TestCachingStoreBdIncompleteDepsDepRemoveDoesNotDropExternalBackingDeps(t *testing.T) {
+	t.Parallel()
+
+	runner := newCachingStoreBdDepRunner(t)
+	runner.deps["bd-1"] = []Dep{
+		{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"},
+		{IssueID: "bd-1", DependsOnID: "bd-3", Type: "blocks"},
+	}
+	cache := NewCachingStore(NewBdStore("/city", runner.run), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	if _, err := cache.DepList("bd-1", "down"); err != nil {
+		t.Fatalf("DepList before external add: %v", err)
+	}
+	runner.deps["bd-1"] = append(runner.deps["bd-1"], Dep{IssueID: "bd-1", DependsOnID: "bd-4", Type: "blocks"})
+
+	if err := cache.DepRemove("bd-1", "bd-3"); err != nil {
+		t.Fatalf("DepRemove: %v", err)
+	}
+
+	deps, err := cache.DepList("bd-1", "down")
+	if err != nil {
+		t.Fatalf("DepList after DepRemove: %v", err)
+	}
+	if hasDep(deps, "bd-3") {
+		t.Fatalf("deps after DepRemove = %v, still contains removed bd-3", deps)
+	}
+	if !hasDep(deps, "bd-2") || !hasDep(deps, "bd-4") {
+		t.Fatalf("deps after DepRemove = %v, want retained bd-2 and external bd-4", deps)
+	}
+}
+
+type cachingStoreBdDepRunner struct {
+	t            *testing.T
+	deps         map[string][]Dep
+	depScanCalls int
+}
+
+func newCachingStoreBdDepRunner(t *testing.T) *cachingStoreBdDepRunner {
+	t.Helper()
+	return &cachingStoreBdDepRunner{
+		t:    t,
+		deps: make(map[string][]Dep),
+	}
+}
+
+func (r *cachingStoreBdDepRunner) run(_, name string, args ...string) ([]byte, error) {
+	r.t.Helper()
+	if name != "bd" {
+		r.t.Fatalf("command name = %q, want bd", name)
+	}
+	if len(args) == 0 {
+		r.t.Fatal("empty bd command")
+	}
+	switch args[0] {
+	case "list":
+		return []byte(`[
+			{"id":"bd-1","title":"task","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+			{"id":"bd-2","title":"dep 2","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+			{"id":"bd-3","title":"dep 3","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+			{"id":"bd-4","title":"dep 4","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}}
+		]`), nil
+	case "ready":
+		return []byte(`[]`), nil
+	case "dep":
+		return r.runDep(args[1:]...)
+	default:
+		return []byte(`[]`), nil
+	}
+}
+
+func (r *cachingStoreBdDepRunner) runDep(args ...string) ([]byte, error) {
+	r.t.Helper()
+	if len(args) == 0 {
+		r.t.Fatal("empty bd dep command")
+	}
+	switch args[0] {
+	case "list":
+		if len(args) > 1 && args[1] == "bd-1" {
+			return r.depListOutput("bd-1"), nil
+		}
+		r.depScanCalls++
+		r.t.Fatalf("unexpected dep scan command: %v", args)
+	case "add":
+		if len(args) < 5 || args[3] != "--type" {
+			r.t.Fatalf("unexpected dep add args: %v", args)
+		}
+		r.addDep(args[1], args[2], args[4])
+		return []byte(`[]`), nil
+	case "remove":
+		if len(args) < 3 {
+			r.t.Fatalf("unexpected dep remove args: %v", args)
+		}
+		r.removeDep(args[1], args[2])
+		return []byte(`[]`), nil
+	}
+	r.t.Fatalf("unexpected dep command: %v", args)
+	return nil, nil
+}
+
+func (r *cachingStoreBdDepRunner) depListOutput(issueID string) []byte {
+	deps := r.deps[issueID]
+	if len(deps) == 0 {
+		return []byte(`[]`)
+	}
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, dep := range deps {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%q,"title":"dep","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","dependency_type":%q}`, dep.DependsOnID, dep.Type)
+	}
+	b.WriteByte(']')
+	return []byte(b.String())
+}
+
+func (r *cachingStoreBdDepRunner) addDep(issueID, dependsOnID, depType string) {
+	deps := r.deps[issueID]
+	for i, dep := range deps {
+		if dep.DependsOnID == dependsOnID {
+			deps[i].Type = depType
+			r.deps[issueID] = deps
+			return
+		}
+	}
+	r.deps[issueID] = append(deps, Dep{IssueID: issueID, DependsOnID: dependsOnID, Type: depType})
+}
+
+func (r *cachingStoreBdDepRunner) removeDep(issueID, dependsOnID string) {
+	deps := r.deps[issueID]
+	for i, dep := range deps {
+		if dep.DependsOnID == dependsOnID {
+			r.deps[issueID] = append(deps[:i], deps[i+1:]...)
+			return
+		}
+	}
+}
+
+func hasDep(deps []Dep, dependsOnID string) bool {
+	for _, dep := range deps {
+		if dep.IssueID == "bd-1" && dep.DependsOnID == dependsOnID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -267,7 +267,7 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 // Ready returns open beads whose blocking deps are all closed.
 func (c *CachingStore) Ready() ([]Bead, error) {
 	c.mu.RLock()
-	if c.state == cacheLive {
+	if c.state == cacheLive && c.depsComplete {
 		if len(c.dirty) > 0 {
 			c.mu.RUnlock()
 			return c.backing.Ready()

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -368,6 +368,10 @@ func (c *CachingStore) DepList(id, direction string) ([]Dep, error) {
 	c.mu.RLock()
 	if c.state == cacheLive {
 		if direction == "down" || direction == "" {
+			if !c.depsComplete {
+				c.mu.RUnlock()
+				return c.backing.DepList(id, direction)
+			}
 			if deps, ok := c.deps[id]; ok {
 				c.mu.RUnlock()
 				return cloneDeps(deps), nil

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -85,10 +85,11 @@ func (c *CachingStore) runReconciliation() {
 		freshByID[b.ID] = cloneBead(b)
 	}
 
-	depMap, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(freshByID))
 	if depErr != nil {
 		c.recordProblem("refresh dep cache during reconcile", depErr)
 	}
+	useFreshDeps := depsComplete && depErr == nil
 
 	c.mu.Lock()
 	if c.mutationSeq != startSeq {
@@ -114,7 +115,7 @@ func (c *CachingStore) runReconciliation() {
 					eventType: "bead.updated",
 					bead:      cloneBead(freshBead),
 				})
-			case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+			case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
 				updates++
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.updated",
@@ -123,7 +124,7 @@ func (c *CachingStore) runReconciliation() {
 			}
 
 			c.beads[id] = cloneBead(freshBead)
-			if depErr == nil {
+			if useFreshDeps {
 				c.deps[id] = cloneDeps(depMap[id])
 			}
 			delete(c.dirty, id)
@@ -155,6 +156,7 @@ func (c *CachingStore) runReconciliation() {
 		}
 
 		c.syncFailures = 0
+		c.depsComplete = c.depsComplete && useFreshDeps
 		if c.state == cacheDegraded {
 			c.state = cacheLive
 		}
@@ -177,7 +179,7 @@ func (c *CachingStore) runReconciliation() {
 	nextDeps := make(map[string][]Dep, len(freshByID))
 
 	for id, freshBead := range freshByID {
-		if depErr == nil {
+		if useFreshDeps {
 			nextDeps[id] = cloneDeps(depMap[id])
 		} else if deps, ok := c.deps[id]; ok {
 			nextDeps[id] = cloneDeps(deps)
@@ -197,7 +199,7 @@ func (c *CachingStore) runReconciliation() {
 				eventType: "bead.updated",
 				bead:      cloneBead(freshBead),
 			})
-		case depErr == nil && depsChanged(c.deps[id], depMap[id]):
+		case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
 			updates++
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.updated",
@@ -223,6 +225,7 @@ func (c *CachingStore) runReconciliation() {
 
 	c.beads = freshByID
 	c.deps = nextDeps
+	c.depsComplete = useFreshDeps
 	c.dirty = make(map[string]struct{})
 	c.beadSeq = make(map[string]uint64)
 	c.deletedSeq = make(map[string]uint64)

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -156,7 +156,7 @@ func (c *CachingStore) runReconciliation() {
 		}
 
 		c.syncFailures = 0
-		c.depsComplete = c.depsComplete && useFreshDeps
+		c.depsComplete = useFreshDeps
 		if c.state == cacheDegraded {
 			c.state = cacheLive
 		}

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -215,6 +215,15 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 
 	c.mu.Lock()
 	c.noteMutationLocked(issueID)
+	if !c.depsComplete {
+		delete(c.deps, issueID)
+		delete(c.dirty, issueID)
+		delete(c.deletedSeq, issueID)
+		c.markFreshLocked(time.Now())
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		return nil
+	}
 	deps := c.deps[issueID]
 	for i, d := range deps {
 		if d.DependsOnID == dependsOnID {
@@ -245,6 +254,15 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 
 	c.mu.Lock()
 	c.noteMutationLocked(issueID)
+	if !c.depsComplete {
+		delete(c.deps, issueID)
+		delete(c.dirty, issueID)
+		delete(c.deletedSeq, issueID)
+		c.markFreshLocked(time.Now())
+		c.updateStatsLocked()
+		c.mu.Unlock()
+		return nil
+	}
 	deps := c.deps[issueID]
 	for i, d := range deps {
 		if d.DependsOnID == dependsOnID {


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1455.

The original PR needs one maintainer fixup from the adopt-review loop, but maintainer edits are disabled on the original branch, so this PR carries the reviewed branch under a maintainer-owned branch.

Original PR metadata:
- Original PR: https://github.com/gastownhall/gascity/pull/1455
- Original title: perf(reconciler): avoid broad tick-time store scans
- Original state at finalize: OPEN
- Configured base branch: main
- Original GitHub base branch: main
- Base branch mismatch: none; both are main
- Reviewed upstream-base snapshot: 283a82dc5de247a3ba4d0305ab1a39a43d73f388
- Live main at follow-up creation: 22de50ec164a93c497d520f13f082724ec952645
- Original PR head reviewed: d0335929a53278b46132c9df63c89fd7cc7343a1
- Follow-up head: b20950b91b6d8c5755e696630eaf2c54c91da3e0

Review outcome:
- Latest review attempt: 2
- Decision: approve
- Score: 873 / 1000, threshold 850
- Required changes: none

Included commits:
- d4046d75e perf(reconciler): avoid broad tick-time store scans
- b20950b91 fix: avoid stale incomplete dependency cache reads

This branch preserves the original contributor commit author information. CI on this follow-up PR is the merge gate for the live base branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->