### PR TITLE
fix: scope assigned work demand to reachable stores

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func assignedWorkStoreRefForAgent(cityPath string, cfg *config.City, agentCfg *config.Agent) string {
+	if cfg == nil || agentCfg == nil {
+		return ""
+	}
+	return configuredRigName(cityPath, agentCfg, cfg.Rigs)
+}
+
+func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agentCfg *config.Agent, storeRefs []string, index int) bool {
+	if len(storeRefs) == 0 {
+		return true
+	}
+	if index < 0 || index >= len(storeRefs) {
+		return false
+	}
+	return storeRefs[index] == assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
+}
+
+func filterAssignedWorkBeadsForPoolDemand(
+	cfg *config.City,
+	cityPath string,
+	assignedWorkBeads []beads.Bead,
+	assignedWorkStoreRefs []string,
+) []beads.Bead {
+	if len(assignedWorkBeads) == 0 || len(assignedWorkStoreRefs) == 0 {
+		return assignedWorkBeads
+	}
+	if cfg == nil {
+		return assignedWorkBeads
+	}
+	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
+	for i, wb := range assignedWorkBeads {
+		template := strings.TrimSpace(wb.Metadata["gc.routed_to"])
+		if template == "" {
+			continue
+		}
+		agentCfg := findAgentByTemplate(cfg, template)
+		if agentCfg == nil {
+			continue
+		}
+		if assignedWorkIndexReachableFromAgent(cityPath, cfg, agentCfg, assignedWorkStoreRefs, i) {
+			filtered = append(filtered, wb)
+		}
+	}
+	return filtered
+}
+
+func filterAssignedWorkBeadsForSessionWake(
+	cfg *config.City,
+	cityPath string,
+	sessionBeads []beads.Bead,
+	assignedWorkBeads []beads.Bead,
+	assignedWorkStoreRefs []string,
+) []beads.Bead {
+	if len(assignedWorkBeads) == 0 || len(assignedWorkStoreRefs) == 0 {
+		return assignedWorkBeads
+	}
+	if cfg == nil {
+		return assignedWorkBeads
+	}
+	reachableRefsByAssignee := make(map[string]map[string]struct{})
+	add := func(identifier, storeRef string) {
+		identifier = strings.TrimSpace(identifier)
+		if identifier == "" {
+			return
+		}
+		refs := reachableRefsByAssignee[identifier]
+		if refs == nil {
+			refs = make(map[string]struct{})
+			reachableRefsByAssignee[identifier] = refs
+		}
+		refs[storeRef] = struct{}{}
+	}
+
+	for i := range cfg.NamedSessions {
+		identity := cfg.NamedSessions[i].QualifiedName()
+		spec, ok := findNamedSessionSpec(cfg, "", identity)
+		if !ok {
+			continue
+		}
+		add(identity, assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent))
+	}
+	for _, sb := range sessionBeads {
+		if sb.Status == "closed" {
+			continue
+		}
+		template := normalizedSessionTemplate(sb, cfg)
+		if template == "" {
+			template = strings.TrimSpace(sb.Metadata["template"])
+		}
+		agentCfg := findAgentByTemplate(cfg, template)
+		if agentCfg == nil {
+			continue
+		}
+		storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
+		add(sb.ID, storeRef)
+		add(sb.Metadata["session_name"], storeRef)
+		add(sb.Metadata["configured_named_identity"], storeRef)
+		add(template, storeRef)
+	}
+
+	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
+	for i, wb := range assignedWorkBeads {
+		if i >= len(assignedWorkStoreRefs) {
+			continue
+		}
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if refs := reachableRefsByAssignee[assignee]; refs != nil {
+			if _, ok := refs[assignedWorkStoreRefs[i]]; ok {
+				filtered = append(filtered, wb)
+			}
+		}
+	}
+	return filtered
+}

--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -27,6 +27,7 @@ func assignedWorkIndexReachableFromAgent(cityPath string, cfg *config.City, agen
 func filterAssignedWorkBeadsForPoolDemand(
 	cfg *config.City,
 	cityPath string,
+	sessionBeads []beads.Bead,
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStoreRefs []string,
 ) []beads.Bead {
@@ -36,9 +37,38 @@ func filterAssignedWorkBeadsForPoolDemand(
 	if cfg == nil {
 		return assignedWorkBeads
 	}
+	assigneeToSessionBeadID := make(map[string]string)
+	sessionBeadTemplate := make(map[string]string)
+	for _, sb := range sessionBeads {
+		if sb.Status == "closed" {
+			continue
+		}
+		template := normalizedSessionTemplate(sb, cfg)
+		if template == "" {
+			template = strings.TrimSpace(sb.Metadata["template"])
+		}
+		if template != "" {
+			sessionBeadTemplate[sb.ID] = template
+		}
+		assigneeToSessionBeadID[sb.ID] = sb.ID
+		if sessionName := strings.TrimSpace(sb.Metadata["session_name"]); sessionName != "" {
+			assigneeToSessionBeadID[sessionName] = sb.ID
+		}
+		if identity := strings.TrimSpace(sb.Metadata["configured_named_identity"]); identity != "" {
+			assigneeToSessionBeadID[identity] = sb.ID
+		}
+	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
 	for i, wb := range assignedWorkBeads {
 		template := strings.TrimSpace(wb.Metadata["gc.routed_to"])
+		if template == "" {
+			if sessionBeadID := assigneeToSessionBeadID[strings.TrimSpace(wb.Assignee)]; sessionBeadID != "" {
+				template = sessionBeadTemplate[sessionBeadID]
+				if template == "" && len(cfg.Agents) == 1 {
+					template = cfg.Agents[0].QualifiedName()
+				}
+			}
+		}
 		if template == "" {
 			continue
 		}

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestFilterAssignedWorkBeadsForSessionWakeKeepsOnlyReachableAssigneeSources(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name: "worker",
+			Dir:  "riga",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "worker",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+	sessions := []beads.Bead{{
+		ID:     "session-1",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":                  "riga/worker",
+			"session_name":              "worker-session",
+			"configured_named_identity": "riga/worker",
+		},
+	}}
+	work := []beads.Bead{
+		{ID: "city-named", Status: "open", Assignee: "riga/worker"},
+		{ID: "rig-named", Status: "open", Assignee: "riga/worker"},
+		{ID: "city-session", Status: "in_progress", Assignee: "session-1"},
+		{ID: "rig-session", Status: "in_progress", Assignee: "session-1"},
+	}
+	storeRefs := []string{"", "riga", "", "riga"}
+
+	got := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, sessions, work, storeRefs)
+
+	if len(got) != 2 {
+		t.Fatalf("filtered work length = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].ID != "rig-named" || got[1].ID != "rig-session" {
+		t.Fatalf("filtered work IDs = [%s %s], want [rig-named rig-session]", got[0].ID, got[1].ID)
+	}
+}
+
+func TestSessionHasOpenAssignedWorkUsesOnlyReachableStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name: "worker",
+			Dir:  "riga",
+		}},
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	session := beads.Bead{
+		ID:     "session-1",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"template":     "riga/worker",
+			"session_name": "worker-session",
+		},
+	}
+	if _, err := cityStore.Create(beads.Bead{
+		ID:       "city-work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create city work: %v", err)
+	}
+
+	has, err := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, session)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForReachableStore: %v", err)
+	}
+	if has {
+		t.Fatal("city-store assigned work should not count for a rig-scoped session")
+	}
+
+	if _, err := rigStore.Create(beads.Bead{
+		ID:       "rig-work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create rig work: %v", err)
+	}
+	has, err = sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, cityStore, map[string]beads.Store{"riga": rigStore}, session)
+	if err != nil {
+		t.Fatalf("sessionHasOpenAssignedWorkForReachableStore: %v", err)
+	}
+	if !has {
+		t.Fatal("rig-store assigned work should count for a rig-scoped session")
+	}
+}

--- a/cmd/gc/assigned_work_scope_test.go
+++ b/cmd/gc/assigned_work_scope_test.go
@@ -51,6 +51,67 @@ func TestFilterAssignedWorkBeadsForSessionWakeKeepsOnlyReachableAssigneeSources(
 	}
 }
 
+func TestFilterAssignedWorkBeadsForPoolDemandKeepsDirectAssigneeAfterTemplateFallback(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+	}
+	sessions := []beads.Bead{{
+		ID:     "session-1",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-session",
+		},
+	}}
+	work := []beads.Bead{{
+		ID:       "direct-assigned",
+		Status:   "in_progress",
+		Assignee: "session-1",
+		Metadata: map[string]string{},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, "", sessions, work, []string{""})
+
+	if len(got) != 1 || got[0].ID != "direct-assigned" {
+		t.Fatalf("filtered work = %#v, want direct-assigned work preserved through template fallback", got)
+	}
+}
+
+func TestFilterAssignedWorkBeadsForPoolDemandDropsDirectAssigneeFromUnreachableStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	cfg := &config.City{
+		Rigs: []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+	}
+	sessions := []beads.Bead{{
+		ID:     "session-1",
+		Status: "open",
+		Type:   sessionBeadType,
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-session",
+		},
+	}}
+	work := []beads.Bead{{
+		ID:       "rig-direct-assigned",
+		Status:   "in_progress",
+		Assignee: "session-1",
+		Metadata: map[string]string{},
+	}}
+
+	got := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessions, work, []string{"riga"})
+
+	if len(got) != 0 {
+		t.Fatalf("filtered work = %#v, want unreachable rig-store direct assignment dropped", got)
+	}
+}
+
 func TestSessionHasOpenAssignedWorkUsesOnlyReachableStore(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "riga")

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -33,6 +33,11 @@ type DesiredStateResult struct {
 	// mutation paths update rig-owned work in the right store even when
 	// independent stores produce overlapping bead IDs.
 	AssignedWorkStores []beads.Store
+	// AssignedWorkStoreRefs is aligned by index with AssignedWorkBeads.
+	// The empty string means city store; non-empty values are rig names.
+	// Consumers that decide whether a specific agent should run must use
+	// this scope before treating a bead as reachable work for that agent.
+	AssignedWorkStoreRefs []string
 	// NamedSessionDemand records which named-session identities have active
 	// demand — either direct assignee demand (Assignee == identity) or
 	// work_query-detected ready work. The reconciler merges this into
@@ -269,9 +274,10 @@ func buildDesiredStateWithSessionBeads(
 	// the named session section can also use it.
 	var assignedWorkBeads []beads.Bead
 	var assignedWorkStores []beads.Store
+	var assignedWorkStoreRefs []string
 	var storePartial bool
 	if store != nil {
-		assignedWorkBeads, assignedWorkStores, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
+		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -283,7 +289,8 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
-		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, assignedWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, assignedWorkBeads, assignedWorkStoreRefs)
+		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		for _, poolState := range poolDesiredStates {
 			cfgAgent := findAgentByTemplate(cfg, poolState.Template)
 			if cfgAgent == nil {
@@ -345,17 +352,21 @@ func buildDesiredStateWithSessionBeads(
 	// on-demand session only materializes from that path once the work is
 	// actually actionable. This keeps blocked or merely routed work from
 	// waking/materializing the named session prematurely.
-	for identity := range namedSpecs {
-		for _, wb := range assignedWorkBeads {
+	for identity, spec := range namedSpecs {
+		for i, wb := range assignedWorkBeads {
 			if wb.Status != "open" && wb.Status != "in_progress" {
 				continue
 			}
 			assignee := strings.TrimSpace(wb.Assignee)
-			if assignee == identity {
-				fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck
-				namedWorkReady[identity] = true
-				break
+			if assignee != identity {
+				continue
 			}
+			if !assignedWorkIndexReachableFromAgent(cityPath, cfg, spec.Agent, assignedWorkStoreRefs, i) {
+				continue
+			}
+			fmt.Fprintf(stderr, "namedWorkReady: %s matched by bead %s (assignee=%s status=%s)\n", identity, wb.ID, assignee, wb.Status) //nolint:errcheck
+			namedWorkReady[identity] = true
+			break
 		}
 	}
 	if len(assignedWorkBeads) > 0 {
@@ -436,14 +447,15 @@ func buildDesiredStateWithSessionBeads(
 	applySessionBeadDesiredOverlay(bp, cfg, desired, suspendedRigPaths, stderr)
 
 	return DesiredStateResult{
-		State:              desired,
-		BaseState:          baseDesired,
-		ScaleCheckCounts:   scaleCheckCounts,
-		AssignedWorkBeads:  assignedWorkBeads,
-		AssignedWorkStores: assignedWorkStores,
-		NamedSessionDemand: namedWorkReady,
-		StoreQueryPartial:  storePartial,
-		BeaconTime:         beaconTime,
+		State:                 desired,
+		BaseState:             baseDesired,
+		ScaleCheckCounts:      scaleCheckCounts,
+		AssignedWorkBeads:     assignedWorkBeads,
+		AssignedWorkStores:    assignedWorkStores,
+		AssignedWorkStoreRefs: assignedWorkStoreRefs,
+		NamedSessionDemand:    namedWorkReady,
+		StoreQueryPartial:     storePartial,
+		BeaconTime:            beaconTime,
 	}
 }
 
@@ -520,7 +532,7 @@ func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
 ) ([]beads.Bead, bool) {
-	result, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil)
+	result, _, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil)
 	return result, partial
 }
 
@@ -529,39 +541,45 @@ func collectAssignedWorkBeadsWithStores(
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
-) ([]beads.Bead, []beads.Store, bool) {
+) ([]beads.Bead, []beads.Store, []string, bool) {
 	// Use CachingStore-wrapped stores. Creating raw bdStoreForCity per rig
 	// spawns bd subprocesses on every tick, saturating dolt.
-	stores := []beads.Store{cityStore}
+	type workStore struct {
+		store beads.Store
+		ref   string
+	}
+	stores := []workStore{{store: cityStore}}
 	for _, rig := range cfg.Rigs {
 		if suspendedRigPaths[filepath.Clean(rig.Path)] {
 			continue
 		}
 		if s, ok := rigStores[rig.Name]; ok {
-			stores = append(stores, s)
+			stores = append(stores, workStore{store: s, ref: rig.Name})
 		}
 	}
 
 	type storeAssignedWorkResult struct {
-		beads  []beads.Bead
-		stores []beads.Store
-		errs   []error
+		beads     []beads.Bead
+		stores    []beads.Store
+		storeRefs []string
+		errs      []error
 	}
 	results := make([]storeAssignedWorkResult, len(stores))
 	var wg sync.WaitGroup
-	for idx, s := range stores {
-		idx, s := idx, s
+	for idx, source := range stores {
+		idx, source := idx, source
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			var result []beads.Bead
 			var resultStores []beads.Store
+			var resultStoreRefs []string
 			var errs []error
 			seen := make(map[string]struct{})
 			// In-progress beads with an assignee (active work), plus stranded
 			// unassigned pool work that needs to be reopened.
-			if inProgress, err := s.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
-				appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
+			if inProgress, err := source.store.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
+				appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
 				if beads.IsPartialResult(err) && len(inProgress) > 0 {
@@ -571,31 +589,33 @@ func collectAssignedWorkBeadsWithStores(
 			// Ready beads with an assignee (queued direct handoff work that is
 			// actually runnable, not merely open). This is a lifecycle gate, so
 			// bypass the cache when a CachingStore wrapper is present.
-			if ready, err := beads.ReadyLive(s); err == nil {
-				appendAssignedUnique(&result, &resultStores, ready, seen, s)
+			if ready, err := beads.ReadyLive(source.store); err == nil {
+				appendAssignedUnique(&result, &resultStores, &resultStoreRefs, ready, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("Ready(): %w", err))
 				if beads.IsPartialResult(err) && len(ready) > 0 {
 					appendAssignedUnique(&result, &resultStores, ready, seen, s)
 				}
 			}
-			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, errs: errs}
+			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, errs: errs}
 		}()
 	}
 	wg.Wait()
 
 	var result []beads.Bead
 	var resultStores []beads.Store
+	var resultStoreRefs []string
 	var partial bool
 	for _, r := range results {
 		result = append(result, r.beads...)
 		resultStores = append(resultStores, r.stores...)
+		resultStoreRefs = append(resultStoreRefs, r.storeRefs...)
 		for _, err := range r.errs {
 			log.Printf("collectAssignedWorkBeads: %v", err)
 			partial = true
 		}
 	}
-	return result, resultStores, partial
+	return result, resultStores, resultStoreRefs, partial
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is
@@ -623,25 +643,25 @@ func mergeNamedSessionDemand(poolDesired map[string]int, namedDemand map[string]
 	}
 }
 
-func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
+func appendInProgressWorkUnique(cfg *config.City, dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" && !isRecoverableUnassignedInProgressPoolWork(cfg, b) {
 			continue
 		}
-		appendWorkUnique(dst, stores, b, seen, store)
+		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
 	}
 }
 
-func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, beadList []beads.Bead, seen map[string]struct{}, store beads.Store) {
+func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, beadList []beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	for _, b := range beadList {
 		if strings.TrimSpace(b.Assignee) == "" {
 			continue
 		}
-		appendWorkUnique(dst, stores, b, seen, store)
+		appendWorkUnique(dst, stores, storeRefs, b, seen, store, storeRef)
 	}
 }
 
-func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, b beads.Bead, seen map[string]struct{}, store beads.Store) {
+func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, b beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
 	// Session beads are not actionable work — filter them at the source
 	// so all consumers see only real tasks. Message beads are NOT filtered
 	// here because they represent mail that should wake/materialize sessions;
@@ -657,6 +677,9 @@ func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, b beads.Bead, se
 	*dst = append(*dst, b)
 	if stores != nil {
 		*stores = append(*stores, store)
+	}
+	if storeRefs != nil {
+		*storeRefs = append(*storeRefs, storeRef)
 	}
 }
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -289,7 +289,7 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
-		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, assignedWorkBeads, assignedWorkStoreRefs)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		for _, poolState := range poolDesiredStates {
 			cfgAgent := findAgentByTemplate(cfg, poolState.Template)
@@ -583,7 +583,7 @@ func collectAssignedWorkBeadsWithStores(
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
 				if beads.IsPartialResult(err) && len(inProgress) > 0 {
-					appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
+					appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 				}
 			}
 			// Ready beads with an assignee (queued direct handoff work that is
@@ -594,7 +594,7 @@ func collectAssignedWorkBeadsWithStores(
 			} else {
 				errs = append(errs, fmt.Errorf("Ready(): %w", err))
 				if beads.IsPartialResult(err) && len(ready) > 0 {
-					appendAssignedUnique(&result, &resultStores, ready, seen, s)
+					appendAssignedUnique(&result, &resultStores, &resultStoreRefs, ready, seen, source.store, source.ref)
 				}
 			}
 			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, errs: errs}
@@ -662,6 +662,8 @@ func appendAssignedUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[
 }
 
 func appendWorkUnique(dst *[]beads.Bead, stores *[]beads.Store, storeRefs *[]string, b beads.Bead, seen map[string]struct{}, store beads.Store, storeRef string) {
+	// Invariant: dst, stores, and storeRefs are kept index-aligned by this
+	// shared growth path and the shared seen guard.
 	// Session beads are not actionable work — filter them at the source
 	// so all consumers see only real tasks. Message beads are NOT filtered
 	// here because they represent mail that should wake/materialize sessions;

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -204,7 +204,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialInProgressSurvivors(t *testing
 		t.Fatalf("reload work bead: %v", err)
 	}
 
-	got, stores, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
+	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -213,6 +213,9 @@ func TestCollectAssignedWorkBeads_PreservesPartialInProgressSurvivors(t *testing
 	}
 	if len(stores) != 1 || stores[0] != store {
 		t.Fatalf("stores = %#v, want source store for partial survivor", stores)
+	}
+	if len(storeRefs) != 1 || storeRefs[0] != "" {
+		t.Fatalf("storeRefs = %#v, want city store ref for partial survivor", storeRefs)
 	}
 }
 
@@ -232,7 +235,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
 		t.Fatalf("create work bead: %v", err)
 	}
 
-	got, stores, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
+	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -241,6 +244,9 @@ func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
 	}
 	if len(stores) != 1 || stores[0] != store {
 		t.Fatalf("stores = %#v, want source store for partial survivor", stores)
+	}
+	if len(storeRefs) != 1 || storeRefs[0] != "" {
+		t.Fatalf("storeRefs = %#v, want city store ref for partial survivor", storeRefs)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -264,7 +264,7 @@ func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
 		t.Fatalf("reload rig work bead: %v", err)
 	}
 
-	got, stores, partial := collectAssignedWorkBeadsWithStores(
+	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -278,6 +278,9 @@ func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
 	}
 	if len(stores) != 1 || stores[0] != rigStore {
 		t.Fatalf("stores = %#v, want [rig store]", stores)
+	}
+	if len(storeRefs) != 1 || storeRefs[0] != "repo" {
+		t.Fatalf("storeRefs = %#v, want [repo]", storeRefs)
 	}
 }
 
@@ -320,7 +323,7 @@ func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *t
 		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
 	}
 
-	got, stores, partial := collectAssignedWorkBeadsWithStores(
+	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
@@ -335,11 +338,20 @@ func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *t
 	if len(stores) != len(got) {
 		t.Fatalf("stores length = %d, want %d", len(stores), len(got))
 	}
+	if len(storeRefs) != len(got) {
+		t.Fatalf("storeRefs length = %d, want %d", len(storeRefs), len(got))
+	}
 	if got[0].ID != cityWork.ID || stores[0] != cityStore {
 		t.Fatalf("first collected work = (%s, %#v), want city work/store", got[0].ID, stores[0])
 	}
+	if storeRefs[0] != "" {
+		t.Fatalf("first store ref = %q, want city ref", storeRefs[0])
+	}
 	if got[1].ID != rigWork.ID || stores[1] != rigStore {
 		t.Fatalf("second collected work = (%s, %#v), want rig work/store", got[1].ID, stores[1])
+	}
+	if storeRefs[1] != "repo" {
+		t.Fatalf("second store ref = %q, want repo", storeRefs[1])
 	}
 }
 
@@ -761,6 +773,169 @@ func TestBuildDesiredState_OnDemandNamedSession_DirectAssigneeMaterializes(t *te
 	}
 	if !found {
 		t.Fatal("direct assignee should materialize on-demand named session")
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_IgnoresUnreachableAssignedWork(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("create rig dir: %v", err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	if _, err := cityStore.Create(beads.Bead{
+		Title:    "assigned mayor work in city store",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "riga/mayor",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			Dir:               "riga",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
+	)
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "riga/mayor" || tp.ConfiguredNamedIdentity == "riga/mayor" {
+			t.Fatalf("unreachable city-store assignee should not materialize rig named session: %+v", tp)
+		}
+	}
+	if dsResult.NamedSessionDemand["riga/mayor"] {
+		t.Fatal("unreachable city-store assignee should not record named-session demand")
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_ReachabilityUsesPerBeadSourceNotID(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("create rig dir: %v", err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	cityWork, err := cityStore.Create(beads.Bead{
+		Title:    "phantom city work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "riga/mayor",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rigWork, err := rigStore.Create(beads.Bead{
+		Title:    "same ID rig work for another session",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "riga/other",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cityWork.ID != rigWork.ID {
+		t.Fatalf("test setup expected overlapping city/rig IDs, got city %q rig %q", cityWork.ID, rigWork.ID)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			Dir:               "riga",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Template: "mayor",
+			Dir:      "riga",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": rigStore}, nil, nil, io.Discard,
+	)
+	if dsResult.NamedSessionDemand["riga/mayor"] {
+		t.Fatal("same-ID rig bead should not make the city-store assignment reachable")
+	}
+}
+
+func TestBuildDesiredState_RigPoolIgnoresAssignedWorkInUnreachableStore(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "riga")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("create rig dir: %v", err)
+	}
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	sessionBead, err := cityStore.Create(beads.Bead{
+		Title:  "asleep rig worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:riga/worker"},
+		Metadata: map[string]string{
+			"template":     "riga/worker",
+			"session_name": "worker-gc-1",
+			"state":        "asleep",
+			"pool_managed": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := cityStore.Create(beads.Bead{
+		Title:    "unreachable city work for rig worker",
+		Type:     "task",
+		Assignee: sessionBead.ID,
+		Metadata: map[string]string{"gc.routed_to": "riga/worker"},
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := cityStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set work in_progress: %v", err)
+	}
+	sessionSnapshot, err := loadSessionBeadSnapshot(cityStore)
+	if err != nil {
+		t.Fatalf("load session snapshot: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "riga", Path: rigPath}},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "riga",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(5),
+			ScaleCheck:        "printf 0",
+		}},
+	}
+
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		cityStore, map[string]beads.Store{"riga": rigStore}, sessionSnapshot, nil, io.Discard,
+	)
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == "riga/worker" {
+			t.Fatalf("unreachable city-store work should not resume rig pool session: %+v", tp)
+		}
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1225,7 +1225,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
 	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
-	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, sessionBeads.Open(), result, rigStores)
+	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, cr.cityPath, sessionBeads.Open(), result, rigStores)
 	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
@@ -1238,7 +1238,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// work beads + new tier from scale_check + min fill.
 	poolDesired := result.PoolDesiredCounts
 	if poolDesired == nil {
-		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, assignedWorkBeads, assignedWorkStoreRefs)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesired = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
 			cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
 	}
@@ -1432,6 +1432,8 @@ func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assigned
 	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads)-len(releasedIndexes))
 	var filteredStoreRefs []string
+	// Preserve AssignedWorkBeads/AssignedWorkStoreRefs index alignment when
+	// both slices are complete; otherwise drop refs rather than guess.
 	if len(assignedWorkStoreRefs) == len(assignedWorkBeads) {
 		filteredStoreRefs = make([]string, 0, len(assignedWorkStoreRefs)-len(releasedIndexes))
 	}
@@ -1676,7 +1678,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		sessionBeads,
 	)
 	open := filterSessionBeadsByName(updated, cfgNames)
-	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
+	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, open, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
 		filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts))
 	if poolDesired == nil {
@@ -1793,7 +1795,7 @@ func (cr *CityRuntime) loadDemandSnapshot(
 		if sessionBeads != nil {
 			openSessionBeads = sessionBeads.Open()
 		}
-		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 		result.PoolDesiredCounts = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
 			cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace))
 		if result.PoolDesiredCounts == nil {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1224,12 +1224,13 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 	rigStores := cr.rigBeadStores()
 	assignedWorkBeads := result.AssignedWorkBeads
+	assignedWorkStoreRefs := result.AssignedWorkStoreRefs
 	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(store, cr.cfg, sessionBeads.Open(), result, rigStores)
 	if len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(cr.stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
-		assignedWorkBeads = filterReleasedAssignedWorkBeads(assignedWorkBeads, released)
+		assignedWorkBeads, assignedWorkStoreRefs = filterReleasedAssignedWorkSnapshot(assignedWorkBeads, assignedWorkStoreRefs, released)
 	}
 	// poolDesired determines how many sessions should be AWAKE. Uses the
 	// same scale_check counts that buildDesiredState already computed (no
@@ -1237,8 +1238,9 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// work beads + new tier from scale_check + min fill.
 	poolDesired := result.PoolDesiredCounts
 	if poolDesired == nil {
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesired = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-			cr.cfg, assignedWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
+			cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
 	}
 	// Merge named-session assignee demand so on-demand named sessions with
 	// direct work (Assignee match, no gc.routed_to) stay config-eligible.
@@ -1368,10 +1370,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		}
 	}
 
+	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, open, assignedWorkBeads, assignedWorkStoreRefs)
 	reconcileSessionBeadsTraced(
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, store,
 		cr.dops,
-		assignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, poolDesired,
+		awakeAssignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, poolDesired,
 		result.snapshotQueryPartial(),
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
@@ -1406,8 +1409,13 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 }
 
 func filterReleasedAssignedWorkBeads(assignedWorkBeads []beads.Bead, released []releasedPoolAssignment) []beads.Bead {
+	filtered, _ := filterReleasedAssignedWorkSnapshot(assignedWorkBeads, nil, released)
+	return filtered
+}
+
+func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assignedWorkStoreRefs []string, released []releasedPoolAssignment) ([]beads.Bead, []string) {
 	if len(assignedWorkBeads) == 0 || len(released) == 0 {
-		return assignedWorkBeads
+		return assignedWorkBeads, assignedWorkStoreRefs
 	}
 	releasedIndexes := make(map[int]struct{}, len(released))
 	for _, r := range released {
@@ -1420,16 +1428,26 @@ func filterReleasedAssignedWorkBeads(assignedWorkBeads []beads.Bead, released []
 		}
 	}
 	if len(releasedIndexes) == 0 {
-		return assignedWorkBeads
+		return assignedWorkBeads, assignedWorkStoreRefs
 	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads)-len(releasedIndexes))
+	var filteredStoreRefs []string
+	if len(assignedWorkStoreRefs) == len(assignedWorkBeads) {
+		filteredStoreRefs = make([]string, 0, len(assignedWorkStoreRefs)-len(releasedIndexes))
+	}
 	for i, wb := range assignedWorkBeads {
 		if _, ok := releasedIndexes[i]; ok {
 			continue
 		}
 		filtered = append(filtered, wb)
+		if filteredStoreRefs != nil {
+			filteredStoreRefs = append(filteredStoreRefs, assignedWorkStoreRefs[i])
+		}
 	}
-	return filtered
+	if filteredStoreRefs == nil {
+		filteredStoreRefs = assignedWorkStoreRefs
+	}
+	return filtered, filteredStoreRefs
 }
 
 func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {
@@ -1658,8 +1676,9 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		sessionBeads,
 	)
 	open := filterSessionBeadsByName(updated, cfgNames)
+	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
-		filteredCfg, wfcResult.AssignedWorkBeads, open, wfcResult.ScaleCheckCounts))
+		filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
@@ -1774,8 +1793,9 @@ func (cr *CityRuntime) loadDemandSnapshot(
 		if sessionBeads != nil {
 			openSessionBeads = sessionBeads.Open()
 		}
+		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 		result.PoolDesiredCounts = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-			cr.cfg, result.AssignedWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace))
+			cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace))
 		if result.PoolDesiredCounts == nil {
 			result.PoolDesiredCounts = make(map[string]int)
 		}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -615,15 +615,17 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	}
 
 	dt := newDrainTracker()
+	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
-		cfg, dsResult.AssignedWorkBeads, open, dsResult.ScaleCheckCounts))
+		cfg, poolWorkBeads, open, dsResult.ScaleCheckCounts))
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	reconcileSessionBeadsAtPath(
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
-		nil, dsResult.AssignedWorkBeads, rigStores, nil, dt, poolDesired,
+		nil, awakeAssignedWorkBeads, rigStores, nil, dt, poolDesired,
 		dsResult.snapshotQueryPartial(),
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -598,7 +598,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	)
 
 	open := sessionBeads.Open()
-	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, cfg, open, dsResult, rigStores); len(released) > 0 {
+	if released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(oneShotStore, cfg, cityPath, open, dsResult, rigStores); len(released) > 0 {
 		for _, r := range released {
 			fmt.Fprintf(stderr, "released orphaned pool work: %s\n", r.ID) //nolint:errcheck
 		}
@@ -615,7 +615,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	}
 
 	dt := newDrainTracker()
-	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
+	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
 	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
 		cfg, poolWorkBeads, open, dsResult.ScaleCheckCounts))
 	if poolDesired == nil {

--- a/cmd/gc/cmd_start_test.go
+++ b/cmd/gc/cmd_start_test.go
@@ -146,6 +146,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 	released := releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		"",
 		nil,
 		DesiredStateResult{
 			AssignedWorkBeads:  []beads.Bead{work},
@@ -168,6 +169,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 	released = releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		"",
 		nil,
 		DesiredStateResult{
 			AssignedWorkBeads:   []beads.Bead{work},
@@ -190,6 +192,7 @@ func TestReleaseOrphanedPoolAssignmentsWhenSnapshotsComplete_PartialSkipsComplet
 	released = releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}}},
+		"",
 		nil,
 		DesiredStateResult{
 			AssignedWorkBeads:  []beads.Bead{work},

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -50,6 +50,7 @@ func GCSweepSessionBeads(store beads.Store, rigStores map[string]beads.Store, se
 func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	store beads.Store,
 	cfg *config.City,
+	cityPath string,
 	openSessionBeads []beads.Bead,
 	result DesiredStateResult,
 	rigStores map[string]beads.Store,
@@ -60,7 +61,7 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 	if result.snapshotQueryPartial() {
 		return nil
 	}
-	return releaseOrphanedPoolAssignments(store, cfg, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStores, rigStores)
+	return releaseOrphanedPoolAssignments(store, cfg, cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStores, result.AssignedWorkStoreRefs, rigStores)
 }
 
 // releaseOrphanedPoolAssignments reopens active pool-routed work whose
@@ -70,9 +71,11 @@ func releaseOrphanedPoolAssignmentsWhenSnapshotsComplete(
 func releaseOrphanedPoolAssignments(
 	store beads.Store,
 	cfg *config.City,
+	cityPath string,
 	openSessionBeads []beads.Bead,
 	assignedWorkBeads []beads.Bead,
 	assignedWorkStores []beads.Store,
+	assignedWorkStoreRefs []string,
 	rigStores map[string]beads.Store,
 ) []releasedPoolAssignment {
 	if store == nil || cfg == nil || len(assignedWorkBeads) == 0 {
@@ -82,20 +85,25 @@ func releaseOrphanedPoolAssignments(
 	if storeAware && len(assignedWorkStores) != len(assignedWorkBeads) {
 		log.Printf("releaseOrphanedPoolAssignments: assigned work/store length mismatch: work=%d stores=%d", len(assignedWorkBeads), len(assignedWorkStores))
 	}
+	storeRefAware := len(assignedWorkStoreRefs) == len(assignedWorkBeads)
+	if len(assignedWorkStoreRefs) > 0 && !storeRefAware {
+		log.Printf("releaseOrphanedPoolAssignments: assigned work/store-ref length mismatch: work=%d storeRefs=%d", len(assignedWorkBeads), len(assignedWorkStoreRefs))
+	}
 
-	openIdentifiers := make(map[string]struct{}, len(openSessionBeads)*3)
+	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, openSessionBeads, storeRefAware)
+	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionBeads)*3)
 	for _, sb := range openSessionBeads {
 		if sb.Status == "closed" {
 			continue
 		}
 		if id := strings.TrimSpace(sb.ID); id != "" {
-			openIdentifiers[id] = struct{}{}
+			legacyOpenIdentifiers[id] = struct{}{}
 		}
 		if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" {
-			openIdentifiers[sn] = struct{}{}
+			legacyOpenIdentifiers[sn] = struct{}{}
 		}
 		if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" {
-			openIdentifiers[ni] = struct{}{}
+			legacyOpenIdentifiers[ni] = struct{}{}
 		}
 	}
 
@@ -118,10 +126,14 @@ func releaseOrphanedPoolAssignments(
 				continue
 			}
 		} else {
-			if _, ok := openIdentifiers[assignee]; ok {
+			workStoreRef := ""
+			if storeRefAware {
+				workStoreRef = assignedWorkStoreRefs[i]
+			}
+			if openSessionOwnsWork(legacyOpenIdentifiers, openIdentifiers, assignee, workStoreRef, storeRefAware) {
 				continue
 			}
-			if assigneePreservesNamedSessionRoute(cfg, template, assignee) {
+			if assigneePreservesNamedSessionRoute(cfg, cityPath, template, assignee, workStoreRef, storeRefAware) {
 				continue
 			}
 		}
@@ -145,6 +157,57 @@ func releaseOrphanedPoolAssignments(
 		released = append(released, releasedPoolAssignment{ID: wb.ID, Index: i})
 	}
 	return released
+}
+
+const unresolvedOpenSessionStoreRef = "\x00unresolved"
+
+func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSessionBeads []beads.Bead, storeRefAware bool) map[string]map[string]struct{} {
+	index := make(map[string]map[string]struct{}, len(openSessionBeads)*3)
+	if !storeRefAware {
+		return index
+	}
+	for _, sb := range openSessionBeads {
+		if sb.Status == "closed" {
+			continue
+		}
+		storeRef, ok := assignedWorkStoreRefForSession(cityPath, cfg, sb)
+		if !ok {
+			storeRef = unresolvedOpenSessionStoreRef
+		}
+		addOpenSessionStoreRef(index, sb.ID, storeRef)
+		addOpenSessionStoreRef(index, sb.Metadata["session_name"], storeRef)
+		addOpenSessionStoreRef(index, sb.Metadata["configured_named_identity"], storeRef)
+	}
+	return index
+}
+
+func addOpenSessionStoreRef(index map[string]map[string]struct{}, identifier, storeRef string) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return
+	}
+	refs := index[identifier]
+	if refs == nil {
+		refs = make(map[string]struct{}, 1)
+		index[identifier] = refs
+	}
+	refs[storeRef] = struct{}{}
+}
+
+func openSessionOwnsWork(legacyIdentifiers map[string]struct{}, scopedIdentifiers map[string]map[string]struct{}, assignee, workStoreRef string, storeRefAware bool) bool {
+	if !storeRefAware {
+		_, ok := legacyIdentifiers[assignee]
+		return ok
+	}
+	refs := scopedIdentifiers[assignee]
+	if refs == nil {
+		return false
+	}
+	if _, ok := refs[unresolvedOpenSessionStoreRef]; ok {
+		return true
+	}
+	_, ok := refs[workStoreRef]
+	return ok
 }
 
 func storeForPoolAssignment(cfg *config.City, cityStore beads.Store, rigStores map[string]beads.Store, wb beads.Bead) beads.Store {
@@ -200,7 +263,7 @@ func releaseOrphanedPoolAssignment(store beads.Store, id string) bool {
 	return store.Update(id, opts) == nil
 }
 
-func assigneePreservesNamedSessionRoute(cfg *config.City, template, assignee string) bool {
+func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, assignee, workStoreRef string, storeRefAware bool) bool {
 	if cfg == nil {
 		return false
 	}
@@ -208,7 +271,13 @@ func assigneePreservesNamedSessionRoute(cfg *config.City, template, assignee str
 	if !ok {
 		return false
 	}
-	return namedSessionBackingTemplate(spec) == template
+	if namedSessionBackingTemplate(spec) != template {
+		return false
+	}
+	if !storeRefAware {
+		return true
+	}
+	return assignedWorkStoreRefForAgent(cityPath, cfg, spec.Agent) == workStoreRef
 }
 
 func stringPtr(s string) *string { return &s }

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -240,7 +240,7 @@ func TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery
 		t.Fatalf("Set work status: %v", err)
 	}
 
-	found, stores, partial := collectAssignedWorkBeadsWithStores(
+	found, stores, _, partial := collectAssignedWorkBeadsWithStores(
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
 		store,
 		nil,

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -162,8 +162,10 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 	released := releaseOrphanedPoolAssignments(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
 		nil,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		nil,
 	)
@@ -206,8 +208,10 @@ func TestReleaseOrphanedPoolAssignments_ReopensUnassignedInProgressPoolWork(t *t
 	released := releaseOrphanedPoolAssignments(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
 		nil,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		nil,
 	)
@@ -282,8 +286,10 @@ func TestReleaseOrphanedPoolAssignments_UpdatesRigStoreFallback(t *testing.T) {
 			Rigs:   []config.Rig{{Name: "rig", Prefix: "ga"}},
 			Agents: []config.Agent{{Name: "worker", Dir: "rig", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
 		},
+		"",
 		nil,
 		[]beads.Bead{work},
+		nil,
 		nil,
 		map[string]beads.Store{"rig": rigStore},
 	)
@@ -348,9 +354,11 @@ func TestReleaseOrphanedPoolAssignments_ReopensRigStoreMissingPoolAssignee(t *te
 			Rigs:   []config.Rig{{Name: "repo"}},
 			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
 		},
+		"",
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{rigStore},
+		nil,
 		nil,
 	)
 	if len(released) != 1 || released[0].ID != work.ID {
@@ -427,9 +435,11 @@ func TestReleaseOrphanedPoolAssignments_ReopensCrossStoreIDCollisions(t *testing
 			Rigs:   []config.Rig{{Name: "repo"}},
 			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
 		},
+		"",
 		nil,
 		[]beads.Bead{cityWork, rigWork},
 		[]beads.Store{cityStore, rigStore},
+		nil,
 		nil,
 	)
 	if len(released) != 2 || released[0].ID != cityWork.ID || released[1].ID != rigWork.ID {
@@ -473,9 +483,11 @@ func TestReleaseOrphanedPoolAssignments_SkipsStoreAwareEntryWithoutOwnerStore(t 
 	released := releaseOrphanedPoolAssignments(
 		cityStore,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
 		nil,
 		[]beads.Bead{work},
 		[]beads.Store{nil},
+		nil,
 		nil,
 	)
 	if len(released) != 0 {
@@ -525,9 +537,140 @@ func TestReleaseOrphanedPoolAssignments_KeepsOpenSessionOwnership(t *testing.T) 
 	released := releaseOrphanedPoolAssignments(
 		store,
 		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
 		[]beads.Bead{session},
 		[]beads.Bead{work},
 		nil,
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != "worker-live" {
+		t.Fatalf("assignee = %q, want worker-live", got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ReleasesRigWorkAssignedToUnreachableOpenSession(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	session, err := cityStore.Create(beads.Bead{
+		Title:  "city worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-live",
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create city session bead: %v", err)
+	}
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "misassigned rig pool work",
+		Assignee: "worker-live",
+		Metadata: map[string]string{"gc.routed_to": "repo/worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		&config.City{
+			Rigs: []config.Rig{{Name: "repo", Path: t.TempDir()}},
+			Agents: []config.Agent{
+				{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)},
+				{Name: "worker", Dir: "repo", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)},
+			},
+		},
+		cityPath,
+		[]beads.Bead{session},
+		[]beads.Bead{work},
+		[]beads.Store{rigStore},
+		[]string{"repo"},
+		map[string]beads.Store{"repo": rigStore},
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("rig work = status %q assignee %q, want open/unassigned", got.Status, got.Assignee)
+	}
+	gotSession, err := cityStore.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get city session bead: %v", err)
+	}
+	if gotSession.Status != "open" || gotSession.Metadata["session_name"] != "worker-live" {
+		t.Fatalf("city session changed: status=%q metadata=%#v", gotSession.Status, gotSession.Metadata)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_KeepsSameStoreScopedOpenSessionOwnership(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-live",
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "live pool work",
+		Assignee: "worker-live",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		cityPath,
+		[]beads.Bead{session},
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		[]string{""},
 		nil,
 	)
 	if len(released) != 0 {
@@ -574,7 +717,7 @@ func TestReleaseOrphanedPoolAssignments_ReopensStaleDirectAssigneeForNamedBacked
 		ResolvedWorkspaceName: "test-city",
 	}
 
-	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil, nil)
+	released := releaseOrphanedPoolAssignments(store, cfg, "", nil, []beads.Bead{work}, nil, nil, nil)
 	if len(released) != 1 || released[0].ID != work.ID {
 		t.Fatalf("released = %v, want [%s]", released, work.ID)
 	}
@@ -619,7 +762,116 @@ func TestReleaseOrphanedPoolAssignments_PreservesCanonicalNamedIdentity(t *testi
 		ResolvedWorkspaceName: "test-city",
 	}
 
-	released := releaseOrphanedPoolAssignments(store, cfg, nil, []beads.Bead{work}, nil, nil)
+	released := releaseOrphanedPoolAssignments(store, cfg, "", nil, []beads.Bead{work}, nil, nil, nil)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != "reviewer" {
+		t.Fatalf("assignee = %q, want reviewer", got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_ReleasesNamedIdentityForUnreachableStore(t *testing.T) {
+	cityPath := t.TempDir()
+	cityStore := beads.NewMemStore()
+	rigStore := beads.NewMemStore()
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "misassigned named work",
+		Assignee: "reviewer",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set rig work status: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload rig work bead: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs:   []config.Rig{{Name: "repo", Path: t.TempDir()}},
+		Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "reviewer",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+		ResolvedWorkspaceName: "test-city",
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		cityStore,
+		cfg,
+		cityPath,
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{rigStore},
+		[]string{"repo"},
+		map[string]beads.Store{"repo": rigStore},
+	)
+	if len(released) != 1 || released[0].ID != work.ID {
+		t.Fatalf("released = %v, want [%s]", released, work.ID)
+	}
+
+	got, err := rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get rig work bead: %v", err)
+	}
+	if got.Status != "open" || got.Assignee != "" {
+		t.Fatalf("rig work = status %q assignee %q, want open/unassigned", got.Status, got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_PreservesNamedIdentityForSameStore(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "named owner work",
+		Assignee: "reviewer",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "reviewer",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+		ResolvedWorkspaceName: "test-city",
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		cfg,
+		cityPath,
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		[]string{""},
+		nil,
+	)
 	if len(released) != 0 {
 		t.Fatalf("released = %v, want none", released)
 	}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -452,7 +452,9 @@ func reconcileSessionBeadsTraced(
 								dt.clearIdleProbe(session.ID)
 								dt.remove(session.ID)
 							}
-							closeSessionBeadIfUnassigned(store, rigStores, *session, "drained", clk.Now().UTC(), stderr)
+							if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, "drained", clk.Now().UTC(), stderr) {
+								session.Status = "closed"
+							}
 						}
 						continue
 					}
@@ -500,7 +502,9 @@ func reconcileSessionBeadsTraced(
 					if storeQueryPartial {
 						continue
 					}
-					closeSessionBeadIfUnassigned(store, rigStores, *session, reason, clk.Now().UTC(), stderr)
+					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, reason, clk.Now().UTC(), stderr) {
+						session.Status = "closed"
+					}
 				}
 				continue
 			}
@@ -1240,7 +1244,12 @@ func resolvePreservedConfiguredNamedSessionTemplate(
 }
 
 // sessionHasOpenAssignedWork reports whether any open or in-progress work bead
-// is assigned to the given session across all known stores.
+// is assigned to the given session across all known stores. Use this
+// cross-store query for cleanup-of-record paths that must not orphan work in
+// any attached store; callers preserve fail-closed behavior by refusing close
+// decisions on query errors. Reconciler close paths that should honor the
+// session's configured store reachability must use
+// sessionHasOpenAssignedWorkForReachableStore instead.
 func sessionHasOpenAssignedWork(store beads.Store, rigStores map[string]beads.Store, session beads.Bead) (bool, error) {
 	if has, err := sessionHasOpenAssignedWorkInStore(store, session); err != nil || has {
 		return has, err

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -426,7 +426,7 @@ func reconcileSessionBeadsTraced(
 								Subject: template,
 								Message: "drain acknowledged by agent",
 							})
-							hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
+							hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
 							if assignedErr != nil {
 								fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
 								hasAssignedWork = true
@@ -628,7 +628,7 @@ func reconcileSessionBeadsTraced(
 						// the bead from the close gate and stranded new
 						// queue work on a ghost slot. Re-query the store
 						// so the decision reflects reality.
-						hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
+						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
 						sleepReason := "idle"
 						if assignedErr != nil {
 							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
@@ -1153,7 +1153,7 @@ func reconcileSessionBeadsTraced(
 		poolFreeable := !shouldWake && !target.alive && isPoolSessionSlotFreeable(*target.session) && isPoolManagedSessionBead(*target.session)
 		if poolFreeable {
 			var assignedErr error
-			hasAssignedWork, assignedErr = sessionHasOpenAssignedWork(store, rigStores, *target.session)
+			hasAssignedWork, assignedErr = sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *target.session)
 			if assignedErr != nil {
 				fmt.Fprintf(stderr, "session reconciler: checking assigned work for drained %s: %v\n", target.session.Metadata["session_name"], assignedErr) //nolint:errcheck
 				hasAssignedWork = true
@@ -1239,17 +1239,8 @@ func resolvePreservedConfiguredNamedSessionTemplate(
 	return tp, nil
 }
 
-// sessionHasOpenAssignedWork reports whether any open or in-progress
-// work bead is assigned to the given session across the primary store
-// AND any attached rig stores. This preserves cross-store ownership
-// coverage that used to come from the retired ownership snapshot.
-//
-// A session's work bead can live in a rig store (e.g., a city-stored
-// session whose work was routed to a rig), so the close gate and
-// drain-ack must check every store the bead could live in before
-// recycling the session's slot. Live queries are used throughout:
-// any individual store failure fails the whole check closed so
-// transient errors cannot cause premature close.
+// sessionHasOpenAssignedWork reports whether any open or in-progress work bead
+// is assigned to the given session across all known stores.
 func sessionHasOpenAssignedWork(store beads.Store, rigStores map[string]beads.Store, session beads.Bead) (bool, error) {
 	if has, err := sessionHasOpenAssignedWorkInStore(store, session); err != nil || has {
 		return has, err
@@ -1260,6 +1251,51 @@ func sessionHasOpenAssignedWork(store beads.Store, rigStores map[string]beads.St
 		}
 	}
 	return false, nil
+}
+
+// sessionHasOpenAssignedWorkForReachableStore reports whether any open or
+// in-progress work bead is assigned to the given session in the store its
+// configured agent can query and claim from.
+func sessionHasOpenAssignedWorkForReachableStore(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session beads.Bead,
+) (bool, error) {
+	storeRef, ok := assignedWorkStoreRefForSession(cityPath, cfg, session)
+	if !ok {
+		return sessionHasOpenAssignedWork(store, rigStores, session)
+	}
+	if storeRef == "" {
+		return sessionHasOpenAssignedWorkInStore(store, session)
+	}
+	rigStore, ok := rigStores[storeRef]
+	if !ok || rigStore == nil {
+		return false, fmt.Errorf("rig store %q unavailable for session %q", storeRef, session.Metadata["session_name"])
+	}
+	return sessionHasOpenAssignedWorkInStore(rigStore, session)
+}
+
+func assignedWorkStoreRefForSession(cityPath string, cfg *config.City, session beads.Bead) (string, bool) {
+	if cfg == nil {
+		return "", false
+	}
+	template := normalizedSessionTemplate(session, cfg)
+	if template == "" {
+		template = strings.TrimSpace(session.Metadata["template"])
+	}
+	if template == "" {
+		template = strings.TrimSpace(session.Metadata["common_name"])
+	}
+	if template == "" {
+		return "", false
+	}
+	agentCfg := findAgentByTemplate(cfg, template)
+	if agentCfg == nil {
+		return "", false
+	}
+	return assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg), true
 }
 
 func sessionHasOpenAssignedWorkInStore(store beads.Store, session beads.Bead) (bool, error) {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -755,12 +755,12 @@ func TestReconcileSessionBeads_CloseGateLiveStoreErrorKeepsSlot(t *testing.T) {
 	}
 }
 
-// TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork
-// verifies that the close gate's live ownership check looks across the
-// primary store AND any attached rig stores. A city-stored asleep+idle
-// pool session with work assigned to it in a rig store must NOT get
-// its slot freed — the rig-stored work would be orphaned.
-func TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork(t *testing.T) {
+// TestReconcileSessionBeads_CloseGateIgnoresUnreachableRigAssignedWork
+// verifies that the close gate's live ownership check only considers the
+// store scope the session's configured agent can query and claim from. A
+// city-scoped pool session must not be retained by unrelated rig-store work
+// that happens to share one of its assignment identifiers.
+func TestReconcileSessionBeads_CloseGateIgnoresUnreachableRigAssignedWork(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
 		Agents: []config.Agent{{Name: "worker"}},
@@ -773,11 +773,11 @@ func TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork(t *testin
 		poolManagedMetadataKey: boolMetadata(true),
 	})
 
-	// Work assigned to the session lives in a rig store, not the city
-	// store. The live cross-store query must find it and veto the close.
+	// Work assigned to the session lives in a rig store, not the city store.
+	// This city-scoped session cannot claim it, so it must not veto close.
 	rigStore := beads.NewMemStore()
 	if _, err := rigStore.Create(beads.Bead{
-		Title:    "cross-store work",
+		Title:    "unreachable rig work",
 		Type:     "task",
 		Status:   "open",
 		Assignee: session.ID,
@@ -817,8 +817,8 @@ func TestReconcileSessionBeads_CloseGateRespectsCrossStoreAssignedWork(t *testin
 	if err != nil {
 		t.Fatalf("Get(%s): %v", session.ID, err)
 	}
-	if got.Status == "closed" {
-		t.Fatalf("status = %q, want open — close gate must honor cross-store assigned work and leave the pool slot for the rig-stored work to drain", got.Status)
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed — unreachable rig-store assigned work must not retain a city-scoped pool slot", got.Status)
 	}
 }
 

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -822,6 +822,118 @@ func TestReconcileSessionBeads_CloseGateIgnoresUnreachableRigAssignedWork(t *tes
 	}
 }
 
+func TestReconcileSessionBeads_DrainAckedOrphanCloseIgnoresUnreachableRigAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "unreachable rig work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("worker"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		nil,
+		map[string]beads.Store{"some-rig": rigStore},
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed — drain-acked close must ignore work in stores the session cannot reach", got.Status)
+	}
+}
+
+func TestReconcileSessionBeads_SuspendedCloseIgnoresUnreachableRigAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	session := env.createSessionBead("worker", "worker")
+	env.markSessionActive(&session)
+
+	rigStore := beads.NewMemStore()
+	if _, err := rigStore.Create(beads.Bead{
+		Title:    "unreachable rig work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create rig work bead: %v", err)
+	}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		env.desiredState,
+		map[string]bool{"worker": true},
+		env.cfg,
+		env.sp,
+		env.store,
+		newFakeDrainOps(),
+		nil,
+		map[string]beads.Store{"some-rig": rigStore},
+		nil,
+		env.dt,
+		nil,
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed — suspended close must ignore work in stores the session cannot reach", got.Status)
+	}
+}
+
 // TestReconcileSessionBeads_CloseGatePreservesSleepReason verifies that the
 // close gate carries the session's existing sleep_reason (idle,
 // idle-timeout, drained) into the closed bead's close reason. Losing this

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -6,16 +6,21 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
-// closeSessionBeadIfUnassigned closes a session bead only when the live
-// store confirms no open or in-progress work is assigned to it across
-// the primary store AND any attached rig stores. Callers must NOT pass
-// a pre-computed work snapshot — this helper queries the stores itself
-// so its decision cannot be poisoned by a stale snapshot taken earlier
-// in the tick (see the PR that retired the snapshot-based variant).
-// Live-query failures fail closed: the bead stays open until assignment
-// can be re-verified.
+// closeSessionBeadIfUnassigned closes a session bead only when the live store
+// confirms no open or in-progress work is assigned to it across the primary
+// store AND any attached rig stores. Use this cross-store guard for cleanup
+// paths that must not orphan work in any attached store. Reconciler paths that
+// close a session according to its configured agent reachability should use
+// closeSessionBeadIfReachableStoreUnassigned instead.
+//
+// Callers must NOT pass a pre-computed work snapshot — this helper queries the
+// stores itself so its decision cannot be poisoned by a stale snapshot taken
+// earlier in the tick (see the PR that retired the snapshot-based variant).
+// Live-query failures fail closed: the bead stays open until assignment can be
+// re-verified.
 func closeSessionBeadIfUnassigned(
 	store beads.Store,
 	rigStores map[string]beads.Store,
@@ -30,6 +35,34 @@ func closeSessionBeadIfUnassigned(
 	hasAssignedWork, err := sessionHasOpenAssignedWork(store, rigStores, session)
 	if err != nil {
 		fmt.Fprintf(stderr, "session work guard: checking assigned work for %s: %v\n", session.ID, err) //nolint:errcheck
+		return false
+	}
+	if hasAssignedWork {
+		return false
+	}
+	return closeBead(store, session.ID, reason, now, stderr)
+}
+
+// closeSessionBeadIfReachableStoreUnassigned closes a session bead only when
+// the live store scope its configured agent can query has no open or
+// in-progress work assigned to the session. It returns whether the close
+// succeeded, matching closeSessionBeadIfUnassigned's contract.
+func closeSessionBeadIfReachableStoreUnassigned(
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	session beads.Bead,
+	reason string,
+	now time.Time,
+	stderr io.Writer,
+) bool {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	hasAssignedWork, err := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, session)
+	if err != nil {
+		fmt.Fprintf(stderr, "session work guard: checking reachable assigned work for %s: %v\n", session.ID, err) //nolint:errcheck
 		return false
 	}
 	if hasAssignedWork {


### PR DESCRIPTION
## Summary
- carry an aligned assigned-work store ref (city = empty, rig = rig name) alongside each collected assigned-work bead
- filter named-session demand, pool demand, demand snapshots, wake inputs, and drain/close live assigned-work checks to the store scope the target agent can actually query and claim
- preserve cross-store bead ID collisions by making source scope part of the decision instead of treating bead IDs as globally unique

Supersedes #564.

## Tests
- go test ./cmd/gc -run 'Test(SessionHasOpenAssignedWorkUsesOnlyReachableStore|ReconcileSessionBeads_CloseGateIgnoresUnreachableRigAssignedWork|FilterAssignedWorkBeadsForSessionWakeKeepsOnlyReachableAssigneeSources|BuildDesiredState_(OnDemandNamedSession_IgnoresUnreachableAssignedWork|OnDemandNamedSession_ReachabilityUsesPerBeadSourceNotID|RigPoolIgnoresAssignedWorkInUnreachableStore)|CollectAssignedWorkBeadsWithStores)'
- make check
- pre-commit hook via git commit --amend --no-edit