### PR TITLE
fix(packs): replace deprecated `gc nudge <target>` with `gc session nudge` (#1491)

### DIFF
--- a/docs/getting-started/coming-from-gastown.md
+++ b/docs/getting-started/coming-from-gastown.md
@@ -457,7 +457,7 @@ Two rules help a lot:
 | `gt` | Closest in Gas City | Notes |
 |---|---|---|
 | `gt mail` | `gc mail` | Near-direct mapping. |
-| `gt nudge` | `gc session nudge` or `gc nudge` | Use `gc session nudge` for a specific live session, `gc nudge` for deferred delivery controls. |
+| `gt nudge` | `gc session nudge` | Use `gc session nudge <target> "msg"` to send messages to a live session. The `gc nudge` subcommand only exposes deferred-delivery controls (`drain`, `status`, `poll`); it does not accept a positional `<target> "msg"` form. |
 | `gt peek` | `gc session peek` | Near-direct mapping. |
 | `gt broadcast` | no single direct equivalent | Usually modeled as `gc mail send` to a group or multiple explicit targets. |
 | `gt notify` | no direct equivalent | Notification policy is not a top-level SDK command family. |

--- a/examples/dolt/formulas/mol-dog-backup.toml
+++ b/examples/dolt/formulas/mol-dog-backup.toml
@@ -94,7 +94,7 @@ Generate summary and signal completion.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: backup — synced <count>/<total>, offsite: <status>"
+gc session nudge deacon/ "DOG_DONE: backup — synced <count>/<total>, offsite: <status>"
 ```
 
 **3. Close work and exit:**

--- a/examples/dolt/formulas/mol-dog-compactor.toml
+++ b/examples/dolt/formulas/mol-dog-compactor.toml
@@ -178,7 +178,7 @@ Generate summary of compaction cycle.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: compactor — compacted <count> databases, mode: {{mode}}"
+gc session nudge deacon/ "DOG_DONE: compactor — compacted <count> databases, mode: {{mode}}"
 ```
 
 **3. Close work and exit:**

--- a/examples/dolt/formulas/mol-dog-doctor.toml
+++ b/examples/dolt/formulas/mol-dog-doctor.toml
@@ -142,7 +142,7 @@ gc mail send mayor/ -s "ESCALATION: Dolt health critical [CRITICAL]" \\
 
 **3. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: doctor — server: <status>, conns: <count>/<max>, orphans: <count>"
+gc session nudge deacon/ "DOG_DONE: doctor — server: <status>, conns: <count>/<max>, orphans: <count>"
 ```
 
 **4. Close work and exit:**

--- a/examples/dolt/formulas/mol-dog-phantom-db.toml
+++ b/examples/dolt/formulas/mol-dog-phantom-db.toml
@@ -132,7 +132,7 @@ Generate summary and signal completion.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: phantom-db — scanned: <count>, phantoms: <count>"
+gc session nudge deacon/ "DOG_DONE: phantom-db — scanned: <count>, phantoms: <count>"
 ```
 
 **3. Close work and exit:**

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -143,12 +143,12 @@ Generate summary and signal completion.
 **2. Warn if above threshold:**
 If orphan count >= {{warn_threshold}}:
 ```bash
-gc nudge deacon/ "WARN: <count> orphan databases detected"
+gc session nudge deacon/ "WARN: <count> orphan databases detected"
 ```
 
 **3. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: stale-db — orphans: <count>, removed: <count>"
+gc session nudge deacon/ "DOG_DONE: stale-db — orphans: <count>, removed: <count>"
 ```
 
 **4. Close work and exit:**

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -83,7 +83,7 @@ Use judgment — there are no hardcoded thresholds. Consider:
 
 **Possibly stuck (stale wisp, no activity, but ambiguous):** Nudge:
 ```bash
-{{ cmd }} nudge deacon "Boot check: are you making progress?"
+{{ cmd }} session nudge deacon "Boot check: are you making progress?"
 ```
 Drain-ack and exit. Next Boot tick will re-evaluate.
 
@@ -123,7 +123,7 @@ up your session and spawns you again next tick.
 |------------|----------------|
 | View deacon output | `{{ cmd }} agent peek deacon 30` |
 | Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
-| Nudge deacon | `{{ cmd }} nudge deacon "message"` |
+| Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
 | File stuck warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
 | Check agents | `{{ cmd }} agent list` |
 

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -122,7 +122,7 @@ gc bd create --type=warrant \
 ```bash
 gc mail send mayor/ -s "Subject" -m "Message"       # Escalate to mayor
 gc mail send <rig>/witness -s "Subject" -m "..."     # Witness questions
-gc nudge <target> "message"                          # Nudge an agent
+gc session nudge <target> "message"                  # Nudge an agent
 gc session peek <target> 50                              # View agent output
 ```
 

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -142,7 +142,7 @@ Wrong. The issue is about beads code, so it goes in the beads rig.
 - **Strategic decisions**: Architecture, priorities, integration planning
 
 **NOT your job**: Per-worker cleanup, session killing, routine nudging (Witness handles that)
-**Exception**: If refinery/witness is stuck, use `{{ cmd }} nudge refinery "Process MQ"`
+**Exception**: If refinery/witness is stuck, use `{{ cmd }} session nudge refinery "Process MQ"`
 
 ## Rig Wake/Sleep Protocol
 
@@ -199,12 +199,12 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 {{ cmd }} mail inbox                                  # Check your messages
 {{ cmd }} mail read <id>                              # Read a specific message
 {{ cmd }} mail send <addr> -s "Subject" -m "Message"  # Send mail
-{{ cmd }} nudge <target> "message"                    # Wake an agent
+{{ cmd }} session nudge <target> "message"            # Wake an agent
 {{ cmd }} agent list                                  # List all agents
 {{ cmd }} rig list                                    # List all rigs
 ```
 
-**ALWAYS use gc nudge, NEVER tmux send-keys** (drops Enter key)
+**ALWAYS use `gc session nudge`, NEVER `tmux send-keys`** (drops Enter key)
 
 ---
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -166,7 +166,7 @@ After escalating: continue if possible, otherwise `gc bd update <bead> --status=
 ## Communication
 
 ```bash
-gc nudge {{ .RigName }}/witness "Quick question about bead status"   # Default: nudge
+gc session nudge {{ .RigName }}/witness "Quick question about bead status"   # Default: nudge
 gc mail send {{ .RigName }}/witness -s "HELP: Blocked on X" -m "..."  # Escalation: mail
 gc mail send mayor/ -s "BLOCKED: Need coordination" -m "..."          # Cross-rig: mail
 ```

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -176,7 +176,7 @@ gc mail send mayor/ -s "BLOCKED: Need coordination" -m "..."          # Cross-ri
 **Your mail budget is 0-1 messages per session.**
 
 - **Escalation**: Mail to witness as HELP — this is the ONE allowed mail use
-- **Everything else**: Use `gc nudge` — ephemeral, zero Dolt overhead
+- **Everything else**: Use `gc session nudge` — ephemeral, zero Dolt overhead
 - **Completion**: The done sequence handles notification — do NOT mail "I'm done"
 - **Status updates**: If asked for status, respond via nudge, not mail
 

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -145,7 +145,7 @@ and then ignored by landing directly to the target branch.
 
 ```bash
 gc mail inbox                                          # Check for messages
-gc nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
+gc session nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
 gc mail send mayor/ -s "ESCALATION: ..." -m "..."      # Escalate (mail — must survive)
 ```
 

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -161,7 +161,7 @@ work still arrives through bead assignment or pool routing.
 **Your only mail use:** Escalations to Mayor. Everything else is a nudge.
 
 MERGE_FAILED notifications are routine signals — the rejection metadata on
-the bead (`rejection_reason`) is the durable record. Use `gc nudge` to
+the bead (`rejection_reason`) is the durable record. Use `gc session nudge` to
 alert the witness, not `gc mail send`.
 
 ---

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -181,7 +181,7 @@ re-reads formula steps and resumes from context.
 ```bash
 gc mail send mayor/ -s "Subject" -m "Message"              # Escalate to mayor
 gc mail send {{ .RigName }}/refinery -s "Subject" -m "..."  # Refinery questions
-gc nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
+gc session nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
 gc session peek {{ .RigName }}/<polecat-name> 50             # View polecat output
 ```
 

--- a/examples/gastown/packs/gastown/assets/prompts/crew.template.md
+++ b/examples/gastown/packs/gastown/assets/prompts/crew.template.md
@@ -193,22 +193,22 @@ ONE exception where branches are created. But the rule still applies:
 - Submit to that rig's Refinery immediately when done
 - Never leave cross-rig work sitting on an unmerged branch
 
-## gc nudge: Waking Agents
+## gc session nudge: Waking Agents
 
-`{{ cmd }} nudge` is the **core mechanism for inter-agent communication**. It sends a message
+`{{ cmd }} session nudge` is the **core mechanism for inter-agent communication**. It sends a message
 directly to another agent's Claude Code session via tmux.
 
 **When to use nudge vs mail:**
 | Use Case | Tool | Why |
 |----------|------|-----|
-| Wake a sleeping agent | `{{ cmd }} nudge` | Immediate delivery to their session |
+| Wake a sleeping agent | `{{ cmd }} session nudge` | Immediate delivery to their session |
 | Send task for later | `{{ cmd }} mail send` | Queued, they'll see it on next check |
-| Both: assign + wake | `{{ cmd }} mail send` then `{{ cmd }} nudge` | Mail carries payload, nudge wakes them |
+| Both: assign + wake | `{{ cmd }} mail send` then `{{ cmd }} session nudge` | Mail carries payload, nudge wakes them |
 
 **Common patterns:**
 ```bash
-gc nudge {{ .RigName }}/crew/alice "Check your mail - PR review waiting"
-gc nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
+gc session nudge {{ .RigName }}/crew/alice "Check your mail - PR review waiting"
+gc session nudge {{ .RigName }}/<polecat-name> "Run gc hook; it checks assigned work before routed pool work"
 gc mail send {{ .RigName }}/alice -s "Urgent" -m "..." --notify
 ```
 
@@ -237,8 +237,8 @@ EOF
 - Forgetting the address format: `<rig>/<agent>` for rig agents, `mayor/` for city agents
 - Unquoted multi-line text (shell eats newlines) — use `"$(cat <<'EOF' ... EOF)"` pattern
 
-**Important:** `{{ cmd }} nudge` is the ONLY reliable way to send text to Claude sessions.
-Raw `tmux send-keys` is unreliable. Always use `{{ cmd }} nudge` for agent-to-agent communication.
+**Important:** `{{ cmd }} session nudge` is the ONLY reliable way to send text to Claude sessions.
+Raw `tmux send-keys` is unreliable. Always use `{{ cmd }} session nudge` for agent-to-agent communication.
 
 ### Nudge Delivery Modes
 

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -265,14 +265,14 @@ The compactor dog (`mol-dog-compactor`) may have failed. Log for awareness.
 If the compactor order is configured, it will self-dispatch. Otherwise
 nudge the dog pool:
 ```bash
-gc nudge dog/ "Compactor needed: <db_name> has <count> commits"
+gc session nudge dog/ "Compactor needed: <db_name> has <count> commits"
 ```
 
 **Stale backups:**
 The backup dog (`mol-dog-backup`) may have failed. Same pattern — log and
 nudge if order hasn't self-healed:
 ```bash
-gc nudge dog/ "Backup needed: dolt backup is <age> old"
+gc session nudge dog/ "Backup needed: dolt backup is <age> old"
 ```
 
 **Zombie processes:**

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -326,7 +326,7 @@ wisp is stale, the refinery may be stuck.
 
 **Step 3: Nudge if needed:**
 ```bash
-gc nudge <rig>/refinery "Work beads waiting for merge. Please check queue."
+gc session nudge <rig>/refinery "Work beads waiting for merge. Please check queue."
 ```
 
 **Step 4: Escalate if needed:**

--- a/examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/operational-awareness.template.md
@@ -89,15 +89,16 @@ server and degrade performance. Use `gc dolt cleanup` to remove them safely.
 
 ### Communication: Nudge First, Mail Rarely
 
-Every `gc mail send` creates a permanent bead with a Dolt commit. `gc nudge`
-is ephemeral and costs zero. **Default to nudge for all routine communication.**
+Every `gc mail send` creates a permanent bead with a Dolt commit. The
+`gc session nudge` path is ephemeral and costs zero. **Default to nudge for all
+routine communication.**
 
 **The litmus test:** "If the recipient dies and restarts, do they need this
 message?" If yes -> mail. If no -> nudge.
 
 **Ephemeral protocol messages:** MERGE_READY, MERGE_FAILED, RECOVERY_NEEDED,
-LIFECYCLE:Shutdown, and WORK_DONE are routine signals. Use `gc nudge` — the
-underlying bead state (assignee, status, metadata) is the durable record.
+LIFECYCLE:Shutdown, and WORK_DONE are routine signals. Use `gc session nudge`
+— the underlying bead state (assignee, status, metadata) is the durable record.
 
 **When you must mail**, use shell quoting for multi-line messages:
 

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -75,7 +75,7 @@ and the pool can't recycle your slot.
 ## Communication
 
 ```bash
-gc nudge <target> "message"                        # Nudge an agent
+gc session nudge <target> "message"                # Nudge an agent
 gc session peek <target> 50                        # View agent output
 gc session list                                    # Check agent status
 ```
@@ -84,7 +84,7 @@ gc session list                                    # Check agent status
 
 **Dogs NEVER send mail.** Your results go to:
 1. Event beads (for audit trail)
-2. `gc nudge deacon/ "DOG_DONE: <warrant> <result>"` (for immediate notification)
+2. `gc session nudge deacon/ "DOG_DONE: <warrant> <result>"` (for immediate notification)
 3. Escalation via `gc mail send mayor/` ONLY for unresolvable problems
 
 **Never use `gc mail send` for routine reporting.** Every mail creates a permanent
@@ -97,7 +97,7 @@ When you complete a warrant (pardon or execute), notify the requester
 via nudge:
 
 ```bash
-gc nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
+gc session nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 ```
 
 ---

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -42,7 +42,7 @@ before killing the session.
 
 | Attempt | Timeout | Message |
 |---------|---------|---------|
-| 1 | 60s | Health check via `gc nudge` |
+| 1 | 60s | Health check via `gc session nudge` |
 | 2 | 120s | Second health check |
 | 3 | 240s | Final warning |
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -116,7 +116,7 @@ for DB in $DATABASES; do
 done
 
 if [ "$HALTED" -eq 1 ]; then
-    gc nudge deacon/ "DOG_DONE: jsonl — HALTED on spike detection" 2>/dev/null || true
+    gc session nudge deacon/ "DOG_DONE: jsonl — HALTED on spike detection" 2>/dev/null || true
     exit 0
 fi
 
@@ -126,7 +126,7 @@ git add -A *.jsonl */ 2>/dev/null || true
 
 if git diff --cached --quiet 2>/dev/null; then
     # No changes.
-    gc nudge deacon/ "DOG_DONE: jsonl — no changes" 2>/dev/null || true
+    gc session nudge deacon/ "DOG_DONE: jsonl — no changes" 2>/dev/null || true
     exit 0
 fi
 
@@ -163,5 +163,5 @@ if [ -n "$FAILED_DBS" ]; then
     SUMMARY="$SUMMARY, failed: $FAILED_DBS"
 fi
 
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "jsonl-export: $SUMMARY"

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -157,5 +157,5 @@ if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY (dry run)"
 fi
 
-gc nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
+gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
 echo "reaper: $SUMMARY"

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-jsonl.toml
@@ -176,7 +176,7 @@ Generate summary and signal completion.
 
 **2. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: jsonl — exported <count>/<total>, push: <status>"
+gc session nudge deacon/ "DOG_DONE: jsonl — exported <count>/<total>, push: <status>"
 ```
 
 **3. Close work and exit:**

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -254,7 +254,7 @@ gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
 
 **3. Signal completion:**
 ```bash
-gc nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, mail:<count>, closed:<count>"
+gc session nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, mail:<count>, closed:<count>"
 ```
 
 **4. Close work and exit:**

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -104,7 +104,7 @@ First attempt to contact the stuck agent. Give it 60 seconds.
 
 **1. Send health check via nudge:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
+gc session nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 60s or face termination.
 Warrant: {{warrant_id}}
 Reason: {{reason}}
 Filed by: {{requester}}
@@ -143,7 +143,7 @@ got no response.
 
 **1. Send health check:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
+gc session nudge {{target}} "[DOG] HEALTH CHECK: Respond ALIVE within 120s or face termination.
 Warrant: {{warrant_id}}
 Reason: {{reason}}
 Filed by: {{requester}}
@@ -179,7 +179,7 @@ respond in 4 minutes after 3 attempts, it's genuinely stuck.
 
 **1. Send health check:**
 ```bash
-gc nudge {{target}} "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
+gc session nudge {{target}} "[DOG] HEALTH CHECK: FINAL WARNING. Respond ALIVE within 240s.
 Warrant: {{warrant_id}}
 Reason: {{reason}}
 Filed by: {{requester}}

--- a/test/packlint/gc_nudge_form_test.go
+++ b/test/packlint/gc_nudge_form_test.go
@@ -1,0 +1,220 @@
+// TestGcNudgeFormPositional guards issue #1491: the bare `gc nudge <target>
+// "msg"` form was retired when the `gc nudge` namespace was reduced to
+// `drain`/`status`/`poll`. The deprecated form falls through to help-text on
+// stderr and exits non-zero; every shipped call site wraps with
+// `2>/dev/null || true`, so it silently no-ops. The canonical send-form is
+// `gc session nudge <target> "msg"`. This test fails if a pack template,
+// formula, asset script, or shipped doc reintroduces the deprecated form.
+
+package packlint
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// nudgeScanDirs is the set of repo-root-relative directories whose embedded
+// shell text and command examples must use the canonical `gc session nudge`
+// form. Same set as `bd_show_jq_test.go` plus the user-facing docs tree,
+// which must not teach migrating users the deprecated form.
+var nudgeScanDirs = []string{
+	"examples",
+	"internal/bootstrap/packs",
+	"docs",
+}
+
+// nudgeScanExts limits walking to files that ship embedded shell text or
+// teach command syntax to agents and operators.
+var nudgeScanExts = map[string]bool{
+	".toml": true,
+	".md":   true,
+	".sh":   true,
+}
+
+// nudgeAllowlistFiles are repo-relative paths whose `gc nudge <target>`
+// occurrences are intentionally retained as historical or struck-through
+// documentation of the resolution itself.
+var nudgeAllowlistFiles = map[string]bool{
+	"examples/gastown/FUTURE.md": true,
+}
+
+// validNudgeSubcommands are the still-supported `gc nudge` subcommands.
+// `gc nudge drain`, `gc nudge status`, and `gc nudge poll` remain valid;
+// the bare positional form does not.
+var validNudgeSubcommands = map[string]bool{
+	"drain":  true,
+	"status": true,
+	"poll":   true,
+}
+
+func TestGcNudgeFormPositional(t *testing.T) {
+	root := repoRoot()
+	var violations []string
+	for _, dir := range nudgeScanDirs {
+		abs := filepath.Join(root, dir)
+		err := filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !nudgeScanExts[filepath.Ext(path)] {
+				return nil
+			}
+			rel, _ := filepath.Rel(root, path)
+			if nudgeAllowlistFiles[filepath.ToSlash(rel)] {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+			for lineNum, line := range strings.Split(string(data), "\n") {
+				if v := violatesNudgeForm(line); v != "" {
+					violations = append(violations,
+						filepath.ToSlash(rel)+":"+strconv.Itoa(lineNum+1)+": "+v)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", dir, err)
+		}
+	}
+	if len(violations) > 0 {
+		t.Errorf("deprecated `gc nudge <target> \"msg\"` (or `{{ cmd }} nudge ...`) form found"+
+			" — silently no-ops because the bare `gc nudge` namespace was reduced to"+
+			" `drain`/`status`/`poll` (issue #1491).\n"+
+			"Fix: replace with `gc session nudge <target> \"msg\"` (or"+
+			" `{{ cmd }} session nudge <target> \"msg\"`).\n\n%s",
+			strings.Join(violations, "\n"))
+	}
+}
+
+func TestViolatesNudgeForm(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		violation bool
+	}{
+		{name: "deprecated bare positional", line: `gc nudge deacon/ "DOG_DONE: ok"`, violation: true},
+		{name: "deprecated templated cmd", line: `{{ cmd }} nudge <target> "message"`, violation: true},
+		{name: "deprecated templated rig", line: `gc nudge {{ .RigName }}/refinery "msg"`, violation: true},
+		{name: "deprecated indented", line: `    gc nudge dog/ "Compactor needed"`, violation: true},
+		{name: "canonical session form", line: `gc session nudge deacon/ "DOG_DONE: ok"`, violation: false},
+		{name: "canonical templated session form", line: `{{ cmd }} session nudge <target> "message"`, violation: false},
+		{name: "still-valid drain subcommand", line: `gc nudge drain --inject`, violation: false},
+		{name: "still-valid status subcommand", line: `gc nudge status`, violation: false},
+		{name: "still-valid poll subcommand", line: `gc nudge poll --json`, violation: false},
+		{name: "markdown link to status", line: `[gc nudge status](#gc-nudge-status) | Show queued`, violation: false},
+		{name: "backticked bare command in prose", line: "Use `gc nudge` for deferred-delivery controls", violation: false},
+		{name: "prose mention without invocation", line: "The gc nudge namespace is for drain/status/poll only", violation: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := violatesNudgeForm(tc.line) != ""
+			if got != tc.violation {
+				t.Errorf("violatesNudgeForm(%q) = %v, want %v", tc.line, got, tc.violation)
+			}
+		})
+	}
+}
+
+// violatesNudgeForm returns the offending substring if the line contains a
+// `gc nudge <token>` or `{{ ... }} nudge <token>` invocation where <token>
+// is a positional target rather than one of the still-valid subcommands.
+// Returns empty when the line is clean.
+//
+// Heuristic for distinguishing real invocations from prose mentions: the
+// command prefix must occur at the start of the trimmed line, possibly
+// after a shell prompt. Mid-line occurrences are treated as prose
+// references (e.g., `Use the gc nudge namespace ...`).
+func violatesNudgeForm(line string) string {
+	for _, prefix := range nudgeCommandPrefixes(line) {
+		before := strings.TrimSpace(line[:prefix.start])
+		switch before {
+		case "", "$", ">", "#":
+		default:
+			continue
+		}
+		rest := strings.TrimLeft(line[prefix.end:], " \t")
+		if rest == "" {
+			continue
+		}
+		switch rest[0] {
+		case '`', '"', '\'':
+			continue
+		}
+		if isWordChar(rest[0]) {
+			if validNudgeSubcommands[firstToken(rest)] {
+				continue
+			}
+		}
+		return strings.TrimSpace(line[prefix.start:])
+	}
+	return ""
+}
+
+type nudgePrefix struct {
+	start, end int
+}
+
+// nudgeCommandPrefixes finds every occurrence of `gc nudge ` or
+// `{{ <expr> }} nudge ` on the line and returns the [start,end) byte ranges
+// of each prefix (start at the first letter of the command, end after the
+// trailing space).
+func nudgeCommandPrefixes(line string) []nudgePrefix {
+	var out []nudgePrefix
+	const literal = "gc nudge "
+	for i := 0; i+len(literal) <= len(line); i++ {
+		if line[i:i+len(literal)] != literal {
+			continue
+		}
+		if i > 0 && isWordChar(line[i-1]) {
+			continue
+		}
+		out = append(out, nudgePrefix{start: i, end: i + len(literal)})
+	}
+	const tmplOpen = "{{"
+	const tmplNudge = " nudge "
+	for i := 0; i+len(tmplOpen) <= len(line); i++ {
+		if line[i:i+len(tmplOpen)] != tmplOpen {
+			continue
+		}
+		closeIdx := strings.Index(line[i:], "}}")
+		if closeIdx < 0 {
+			continue
+		}
+		afterClose := i + closeIdx + len("}}")
+		if afterClose+len(tmplNudge) > len(line) {
+			continue
+		}
+		if line[afterClose:afterClose+len(tmplNudge)] != tmplNudge {
+			continue
+		}
+		out = append(out, nudgePrefix{start: i, end: afterClose + len(tmplNudge)})
+	}
+	return out
+}
+
+// firstToken returns the leading run of word characters. Stopping at any
+// non-word byte handles markdown link tails (`status](#...)`), trailing
+// punctuation (`drain.`), and quoted forms uniformly.
+func firstToken(s string) string {
+	for i := 0; i < len(s); i++ {
+		if !isWordChar(s[i]) {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func isWordChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}

--- a/test/packlint/gc_nudge_form_test.go
+++ b/test/packlint/gc_nudge_form_test.go
@@ -21,7 +21,8 @@ import (
 // nudgeScanDirs is the set of repo-root-relative directories whose embedded
 // shell text and command examples must use the canonical `gc session nudge`
 // form. Same set as `bd_show_jq_test.go` plus the user-facing docs tree,
-// which must not teach migrating users the deprecated form.
+// which must not teach migrating users the deprecated form. Design-history
+// files under engdocs are intentionally out of scope.
 var nudgeScanDirs = []string{
 	"examples",
 	"internal/bootstrap/packs",
@@ -107,13 +108,18 @@ func TestViolatesNudgeForm(t *testing.T) {
 		{name: "deprecated templated cmd", line: `{{ cmd }} nudge <target> "message"`, violation: true},
 		{name: "deprecated templated rig", line: `gc nudge {{ .RigName }}/refinery "msg"`, violation: true},
 		{name: "deprecated indented", line: `    gc nudge dog/ "Compactor needed"`, violation: true},
+		{name: "deprecated quoted positional target", line: `gc nudge "deacon/" "DOG_DONE: ok"`, violation: true},
 		{name: "canonical session form", line: `gc session nudge deacon/ "DOG_DONE: ok"`, violation: false},
 		{name: "canonical templated session form", line: `{{ cmd }} session nudge <target> "message"`, violation: false},
 		{name: "still-valid drain subcommand", line: `gc nudge drain --inject`, violation: false},
 		{name: "still-valid status subcommand", line: `gc nudge status`, violation: false},
 		{name: "still-valid poll subcommand", line: `gc nudge poll --json`, violation: false},
 		{name: "markdown link to status", line: `[gc nudge status](#gc-nudge-status) | Show queued`, violation: false},
-		{name: "backticked bare command in prose", line: "Use `gc nudge` for deferred-delivery controls", violation: false},
+		{name: "instructional backticked bare command", line: "Use `gc nudge` to alert the witness", violation: true},
+		{name: "instructional via backticked bare command", line: "Health check via `gc nudge`", violation: true},
+		{name: "instructional bare command dash", line: "Use `gc nudge` - ephemeral, zero Dolt overhead", violation: true},
+		{name: "backticked status prose", line: "Use `gc nudge status` to inspect queued nudges", violation: false},
+		{name: "backticked valid namespace prose", line: "The `gc nudge` subcommand only exposes deferred-delivery controls (`drain`, `status`, `poll`)", violation: false},
 		{name: "prose mention without invocation", line: "The gc nudge namespace is for drain/status/poll only", violation: false},
 	}
 	for _, tc := range cases {
@@ -136,6 +142,9 @@ func TestViolatesNudgeForm(t *testing.T) {
 // after a shell prompt. Mid-line occurrences are treated as prose
 // references (e.g., `Use the gc nudge namespace ...`).
 func violatesNudgeForm(line string) string {
+	if v := violatesBacktickedBareNudge(line); v != "" {
+		return v
+	}
 	for _, prefix := range nudgeCommandPrefixes(line) {
 		before := strings.TrimSpace(line[:prefix.start])
 		switch before {
@@ -147,10 +156,6 @@ func violatesNudgeForm(line string) string {
 		if rest == "" {
 			continue
 		}
-		switch rest[0] {
-		case '`', '"', '\'':
-			continue
-		}
 		if isWordChar(rest[0]) {
 			if validNudgeSubcommands[firstToken(rest)] {
 				continue
@@ -159,6 +164,22 @@ func violatesNudgeForm(line string) string {
 		return strings.TrimSpace(line[prefix.start:])
 	}
 	return ""
+}
+
+// violatesBacktickedBareNudge catches instructional prose that names the
+// retired send interface without an explicit target, such as "Use `gc nudge`".
+func violatesBacktickedBareNudge(line string) string {
+	const bare = "`gc nudge`"
+	if !strings.Contains(line, bare) {
+		return ""
+	}
+	lower := strings.ToLower(line)
+	if strings.Contains(lower, "drain") &&
+		strings.Contains(lower, "status") &&
+		strings.Contains(lower, "poll") {
+		return ""
+	}
+	return bare
 }
 
 type nudgePrefix struct {


### PR DESCRIPTION
## Summary

`gc nudge` was reduced to `drain`/`status`/`poll` subcommands; the bare positional form `gc nudge <target> "msg"` is no longer recognized and silently no-ops because every shipped call site wraps with `2>/dev/null || true`. Operational impact in this installation:

- **`mol-shutdown-dance` health-check warnings never delivered** — agents marked for shutdown never receive the 60/120/240s warnings before kill.
- **Patrol nudges silently fail** — `mol-witness-patrol` telling refinery about queued work, `mol-deacon-patrol` telling dog about compaction/backup needs.
- **`DOG_DONE` notifications never arrive** — every dog formula (compactor, reaper, jsonl, phantom-db, stale-db, doctor, backup) signals completion via the broken form.
- **Three prompt templates teach broken syntax to every Claude session** — mayor, deacon, dog (and the `{{ cmd }} nudge` form in mayor and boot).

`engdocs/design/session-model-unification.md` (Status: **Accepted**) endorses `gc session nudge` as the canonical send-form. This PR catches the shipped packs up to a settled design decision.

## What changed

- **12 functional formulas/scripts** in `examples/dolt/`, `examples/gastown/packs/gastown/formulas/`, and `examples/gastown/packs/maintenance/` — replaced `gc nudge X` with `gc session nudge X`. Includes the three escalating strikes in `mol-shutdown-dance` and `DOG_DONE` signals from every maintenance dog.
- **8 prompt templates** — agent prompts (mayor, deacon, witness, refinery, polecat, dog, boot, crew) for both literal `gc nudge` and templated `{{ cmd }} nudge` forms.
- **`docs/getting-started/coming-from-gastown.md`** — the migration table row for `gt nudge` was actively teaching migrating users that `gc nudge <target>` was a valid alternative.
- **`test/packlint/gc_nudge_form_test.go`** — new regression guard modeled on the existing `bd_show_jq_test.go`. Scans `examples/`, `internal/bootstrap/packs/`, and `docs/` for the deprecated form. Allows only `drain`/`status`/`poll` (still-valid subcommands) and `examples/gastown/FUTURE.md` (struck-through historical reference). 12-case unit table covers literal/templated/indented positives and prose/markdown-link/backticked-name negatives.

## Out of scope

- **Optional shim** (issue mentions a possible top-level `gc nudge <target>` shim that delegates to `session nudge`). That would need Go changes, command-tree wiring, and a positional-args design call. Filed as a follow-up.

## Test plan

- [x] `make build` — clean
- [x] `make check` — golangci-lint 0 issues, vet clean, full Go test suite passes
- [x] `make check-docs` — `test/docsync` passes
- [x] `go test ./test/packlint/... -count=1 -v` — `TestGcNudgeFormPositional` and `TestViolatesNudgeForm` (12 sub-cases) all pass
- [x] `go test ./cmd/gc -run 'TestMaterializeBuiltinPacks|TestDoInitGastownWritesCanonicalPackV2Shape|TestReadBuiltinPackFS'` — pack-load tests confirm TOML/template parse cleanly
- [x] `go test ./examples/gastown/... ./examples/dolt/...` — pack render tests pass
- [x] **Acceptance grep** `grep -rn 'gc nudge ' examples/ docs/ engdocs/ | grep -v 'drain\|status\|poll'` — zero hits outside the FUTURE.md historical reference

## Closes

#1491

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->