### PR TITLE
fix: add gc handoff --auto for PreCompact

### DIFF
--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"io"
 
@@ -11,54 +10,59 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
-	"github.com/gastownhall/gascity/internal/session"
 	"github.com/spf13/cobra"
 )
 
 func newHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
 	var target string
+	var auto bool
 	cmd := &cobra.Command{
-		Use:   "handoff <subject> [message]",
-		Short: "Send handoff mail and restart controller-managed sessions",
+		Use:   "handoff [subject] [message]",
+		Short: "Send handoff mail and restart this session",
 		Long: `Convenience command for context handoff.
 
-Self-handoff (default): sends mail to self. If the current session is
-controller-restartable, requests a restart and blocks until the controller
-stops the session. For on-demand configured named sessions, sends mail and
-returns without requesting restart because the controller cannot restart the
-user-attended process.
-
-For controller-restartable sessions, equivalent to:
+Self-handoff (default): sends mail to self and blocks until controller
+restarts the session. Equivalent to:
 
   gc mail send $GC_ALIAS <subject> [message]
   gc runtime request-restart
 
-Remote handoff (--target): sends mail to a target session. If the target is
-controller-restartable, kills it so the reconciler restarts it with the handoff
-mail waiting. For on-demand configured named targets, sends mail and returns
-without killing the session.
+Auto handoff (--auto): sends mail to self and returns without requesting a
+restart. This is for PreCompact hooks, where the provider is already managing
+the context compaction lifecycle.
 
-For controller-restartable targets, equivalent to:
+Remote handoff (--target): sends mail to a target session and kills it so the
+reconciler restarts it with the handoff mail waiting. Equivalent to:
 
   gc mail send <target> <subject> [message]
   gc session kill <target>
 
 Self-handoff requires session context (GC_ALIAS or GC_SESSION_ID, plus
 GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or ID.`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if auto {
+				return cobra.MaximumNArgs(2)(cmd, args)
+			}
+			return cobra.RangeArgs(1, 2)(cmd, args)
+		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdHandoff(args, target, stdout, stderr) != 0 {
+			if cmdHandoff(args, target, auto, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&target, "target", "", "Remote session alias or ID to handoff (kills only controller-restartable sessions)")
+	cmd.Flags().StringVar(&target, "target", "", "Remote session alias or ID to handoff (sends mail + kills session)")
+	cmd.Flags().BoolVar(&auto, "auto", false, "Send handoff mail without requesting restart (for PreCompact hooks)")
 	return cmd
 }
 
-func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
+func cmdHandoff(args []string, target string, auto bool, stdout, stderr io.Writer) int {
 	if target != "" {
+		if auto {
+			fmt.Fprintln(stderr, "gc handoff: --auto cannot be used with --target") //nolint:errcheck // best-effort stderr
+			return 1
+		}
 		return cmdHandoffRemote(args, target, stdout, stderr)
 	}
 
@@ -74,26 +78,26 @@ func cmdHandoff(args []string, target string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	rec := openCityRecorderAt(current.cityPath, stderr)
+	if auto {
+		return doHandoffAuto(store, rec, current.display, args, stdout, stderr)
+	}
+
 	sp := newSessionProvider()
 	dops := newDrainOps(sp)
-	rec := openCityRecorderAt(current.cityPath, stderr)
 	cfg, _ := loadCityConfig(current.cityPath, stderr)
 	persistRestart := sessionRestartPersister(current.cityPath, store, sp, cfg, current.sessionName)
 
-	outcome := doHandoffWithOutcome(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr)
-	if outcome.code != 0 {
-		return outcome.code
-	}
-	if !outcome.restartRequested {
-		return 0
+	if code := doHandoff(store, rec, dops, persistRestart, current.display, current.sessionName, args, stdout, stderr); code != 0 {
+		return code
 	}
 
 	// Block forever. The controller will kill the entire process tree.
 	select {}
 }
 
-// cmdHandoffRemote sends handoff mail to a remote session and stops the target
-// only when the controller can restart it. Returns immediately.
+// cmdHandoffRemote sends handoff mail to a remote session and kills its runtime.
+// Returns immediately (non-blocking). The reconciler restarts the target.
 func cmdHandoffRemote(args []string, target string, stdout, stderr io.Writer) int {
 	targetInfo, err := resolveSessionRuntimeTarget(target, stderr)
 	if err != nil {
@@ -134,76 +138,19 @@ func sessionRestartPersister(cityPath string, store beads.Store, sp runtime.Prov
 	}
 }
 
-type handoffOutcome struct {
-	code             int
-	restartRequested bool
-}
-
-// doHandoff sends a handoff mail to self and requests restart when the
-// controller can restart the current session. Testable: does not block.
+// doHandoff sends a handoff mail to self and sets the restart-requested flag.
+// Testable: does not block.
 func doHandoff(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
 	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer,
 ) int {
-	return doHandoffWithOutcome(store, rec, dops, persistRestart, sessionAddress, sessionName, args, stdout, stderr).code
-}
-
-func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps, persistRestart func() error,
-	sessionAddress, sessionName string, args []string, stdout, stderr io.Writer,
-) handoffOutcome {
-	subject := args[0]
-	var message string
-	if len(args) > 1 {
-		message = args[1]
-	}
-	metadata, err := mailSenderRouteMetadata(store, sessionAddress)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: resolving sender route: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
-	}
-	senderDisplay := mailSenderDisplayFromMetadata(sessionAddress, metadata)
-
-	b, err := store.Create(beads.Bead{
-		Title:       subject,
-		Description: message,
-		Type:        "message",
-		Assignee:    sessionAddress,
-		From:        senderDisplay,
-		Labels:      []string{"thread:" + handoffThreadID()},
-		Metadata:    metadata,
-	})
-	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
-	}
-	rec.Record(events.Event{
-		Type:    events.MailSent,
-		Actor:   senderDisplay,
-		Subject: b.ID,
-		Message: sessionAddress,
-		Payload: mailEventPayload(nil),
-	})
-
-	restartable, err := sessionRestartableByController(store, sessionName)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
-	}
-	// On-demand named sessions are human-attended and the controller cannot
-	// respawn their process after a restart request. Preserve the handoff
-	// mail so context survives, but skip both restart flags. Regression
-	// guard: gastownhall/gascity#744.
-	if !restartable {
-		if err := clearRestartRequest(store, dops, sessionName); err != nil {
-			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-			return handoffOutcome{code: 1, restartRequested: false}
-		}
-		fmt.Fprintf(stdout, "Handoff: sent mail %s (named session; restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
-		return handoffOutcome{code: 0, restartRequested: false}
+	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "HANDOFF: context cycle", stderr)
+	if !ok {
+		return 1
 	}
 
 	if err := dops.setRestartRequested(sessionName); err != nil {
 		fmt.Fprintf(stderr, "gc handoff: setting restart flag: %v\n", err) //nolint:errcheck // best-effort stderr
-		return handoffOutcome{code: 1}
+		return 1
 	}
 	// Also persist the request through the worker boundary so it survives
 	// tmux session death. Non-fatal: the runtime flag above is primary.
@@ -220,111 +167,66 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 	})
 
 	fmt.Fprintf(stdout, "Handoff: sent mail %s, requesting restart...\n", b.ID) //nolint:errcheck // best-effort stdout
-	return handoffOutcome{code: 0, restartRequested: true}
+	return 0
 }
 
-func sessionRestartableByController(store beads.Store, sessionName string) (bool, error) {
-	if store == nil || sessionName == "" {
-		return true, nil
+// doHandoffAuto sends handoff mail to self without requesting restart.
+func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string, args []string, stdout, stderr io.Writer) int {
+	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "context cycle", stderr)
+	if !ok {
+		return 1
 	}
-	id, err := resolveSessionID(store, sessionName)
-	if err != nil {
-		if errors.Is(err, session.ErrSessionNotFound) {
-			return true, nil
-		}
-		return false, fmt.Errorf("resolving session %q: %w", sessionName, err)
-	}
-	b, err := store.Get(id)
-	if err != nil {
-		return false, fmt.Errorf("loading session %q: %w", id, err)
-	}
-	if !isNamedSessionBead(b) {
-		return true, nil
-	}
-	return namedSessionMode(b) == "always", nil
+	fmt.Fprintf(stdout, "Handoff: sent auto mail %s (restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
+	return 0
 }
 
-func clearRestartRequest(store beads.Store, dops drainOps, sessionName string) error {
-	if sessionName == "" {
-		return nil
+func createHandoffMail(store beads.Store, rec events.Recorder, senderAddress, recipientAddress string, args []string, defaultSubject string, stderr io.Writer) (beads.Bead, bool) {
+	subject := defaultSubject
+	if len(args) > 0 {
+		subject = args[0]
 	}
-	var errs []error
-	if dops != nil {
-		if err := dops.clearRestartRequested(sessionName); err != nil {
-			errs = append(errs, fmt.Errorf("clearing runtime restart flag: %w", err))
-		}
-	}
-	if store == nil {
-		return errors.Join(errs...)
-	}
-	id, err := resolveSessionID(store, sessionName)
-	if err != nil {
-		if errors.Is(err, session.ErrSessionNotFound) {
-			return errors.Join(errs...)
-		}
-		errs = append(errs, fmt.Errorf("resolving session %q: %w", sessionName, err))
-		return errors.Join(errs...)
-	}
-	if err := store.SetMetadataBatch(id, map[string]string{
-		"restart_requested":          "",
-		"continuation_reset_pending": "",
-	}); err != nil {
-		errs = append(errs, fmt.Errorf("clearing bead restart flag: %w", err))
-	}
-	return errors.Join(errs...)
-}
-
-// doHandoffRemote sends handoff mail to a remote session and stops the target
-// only when the controller can restart it.
-func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider,
-	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
-) int {
-	subject := args[0]
 	var message string
 	if len(args) > 1 {
 		message = args[1]
 	}
-	metadata, err := mailSenderRouteMetadata(store, sender)
+	metadata, err := mailSenderRouteMetadata(store, senderAddress)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: resolving sender route: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return beads.Bead{}, false
 	}
-	senderDisplay := mailSenderDisplayFromMetadata(sender, metadata)
+	senderDisplay := mailSenderDisplayFromMetadata(senderAddress, metadata)
 
-	// Send mail to target.
 	b, err := store.Create(beads.Bead{
 		Title:       subject,
 		Description: message,
 		Type:        "message",
-		Assignee:    targetAddress,
+		Assignee:    recipientAddress,
 		From:        senderDisplay,
 		Labels:      []string{"thread:" + handoffThreadID()},
 		Metadata:    metadata,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "gc handoff: creating mail: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+		return beads.Bead{}, false
 	}
 	rec.Record(events.Event{
 		Type:    events.MailSent,
 		Actor:   senderDisplay,
 		Subject: b.ID,
-		Message: targetAddress,
+		Message: recipientAddress,
 		Payload: mailEventPayload(nil),
 	})
+	return b, true
+}
 
-	restartable, err := sessionRestartableByController(store, sessionName)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc handoff: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
+// doHandoffRemote sends handoff mail to a remote session and kills its runtime.
+// Non-blocking: returns immediately after killing the session.
+func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider,
+	sessionName, targetAddress, sender string, args []string, stdout, stderr io.Writer,
+) int {
+	b, ok := createHandoffMail(store, rec, sender, targetAddress, args, "HANDOFF: context cycle", stderr)
+	if !ok {
 		return 1
-	}
-	if !restartable {
-		if err := clearRestartRequest(store, newDrainOps(sp), sessionName); err != nil {
-			fmt.Fprintf(stderr, "gc handoff: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		fmt.Fprintf(stdout, "Handoff: sent mail %s to %s (named session; kill skipped because the controller cannot restart it)\n", b.ID, targetAddress) //nolint:errcheck // best-effort stdout
-		return 0
 	}
 
 	// Kill target session (reconciler restarts it).
@@ -343,7 +245,7 @@ func doHandoffRemote(store beads.Store, rec events.Recorder, sp runtime.Provider
 	}
 	rec.Record(events.Event{
 		Type:    events.SessionStopped,
-		Actor:   sender,
+		Actor:   b.From,
 		Subject: targetAddress,
 		Message: "handoff",
 	})

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -3,12 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
@@ -75,195 +73,7 @@ func TestHandoffSuccess(t *testing.T) {
 	}
 }
 
-// Regression for gastownhall/gascity#744:
-// gc handoff on a named (human-attended) session used to call
-// setRestartRequested unconditionally. The controller cannot respawn a
-// user-started session, so the PreCompact hook crashed the mayor to the
-// user's shell on every context compaction. doHandoff must recognize the
-// named-session case, still send the handoff mail, and skip both the
-// tmux and bead restart flags.
-func TestDoHandoff_Regression744_NamedSessionSkipsRestart(t *testing.T) {
-	store := beads.NewMemStore()
-	rec := events.NewFake()
-	dops := newFakeDrainOps()
-	var stdout, stderr bytes.Buffer
-
-	// Seed a session bead marked as a configured named session (i.e. the
-	// mayor). IsNamedSessionBead returns true for beads whose metadata
-	// contains configured_named_session="true".
-	b, err := store.Create(beads.Bead{
-		Type:   sessionBeadType,
-		Labels: []string{"gc:session"},
-	})
-	if err != nil {
-		t.Fatalf("seeding session bead: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
-		t.Fatalf("set session_name: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
-		t.Fatalf("set configured_named_session: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
-		t.Fatalf("set configured_named_mode: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "restart_requested", "true"); err != nil {
-		t.Fatalf("set restart_requested: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "continuation_reset_pending", "true"); err != nil {
-		t.Fatalf("set continuation_reset_pending: %v", err)
-	}
-	dops.restartRequested["mayor"] = true
-
-	persistCalled := false
-	outcome := doHandoffWithOutcome(store, rec, dops, func() error {
-		persistCalled = true
-		return nil
-	}, "mayor", "mayor",
-		[]string{"HANDOFF: context full"}, &stdout, &stderr)
-	if outcome.code != 0 {
-		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
-	}
-	if outcome.restartRequested {
-		t.Fatal("restartRequested = true, want false for on-demand named session")
-	}
-
-	// Mail must still be sent — context preservation is the whole point.
-	mailFound := false
-	all, _ := store.ListOpen()
-	for _, got := range all {
-		if got.Title == "HANDOFF: context full" && got.Type == "message" {
-			mailFound = true
-			break
-		}
-	}
-	if !mailFound {
-		t.Fatalf("handoff mail not created; beads=%v", all)
-	}
-
-	// Restart must NOT be requested — the controller can't respawn a
-	// user-started named session.
-	if dops.restartRequested["mayor"] {
-		t.Errorf("restart-requested flag is still set — named sessions must skip restart (gascity#744)")
-	}
-	if persistCalled {
-		t.Error("persistRestart was called — named sessions must skip persisted restart requests")
-	}
-
-	// Bead-level restart flags must also be absent, including stale flags
-	// left behind by older handoff implementations.
-	refreshed, err := store.Get(b.ID)
-	if err != nil {
-		t.Fatalf("fetching seeded bead: %v", err)
-	}
-	if refreshed.Metadata["restart_requested"] != "" {
-		t.Errorf("bead restart_requested = %q, want cleared for named session", refreshed.Metadata["restart_requested"])
-	}
-	if refreshed.Metadata["continuation_reset_pending"] != "" {
-		t.Errorf("continuation_reset_pending = %q, want cleared for named session", refreshed.Metadata["continuation_reset_pending"])
-	}
-
-	// Stdout should not promise a restart the controller can't deliver.
-	if strings.Contains(stdout.String(), "requesting restart") {
-		t.Errorf("stdout = %q, must not promise a restart for named sessions", stdout.String())
-	}
-	if len(rec.Events) != 1 {
-		t.Fatalf("got %d events, want 1", len(rec.Events))
-	}
-	if rec.Events[0].Type != events.MailSent {
-		t.Fatalf("event[0].Type = %q, want %q", rec.Events[0].Type, events.MailSent)
-	}
-}
-
-func TestDoHandoff_NamedSessionClearRestartFailureReturnsError(t *testing.T) {
-	store := beads.NewMemStore()
-	rec := events.NewFake()
-	dops := newFakeDrainOps()
-	dops.err = errors.New("tmux borked")
-	var stdout, stderr bytes.Buffer
-
-	b, err := store.Create(beads.Bead{
-		Type:   sessionBeadType,
-		Labels: []string{"gc:session"},
-	})
-	if err != nil {
-		t.Fatalf("seeding session bead: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
-		t.Fatalf("set session_name: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
-		t.Fatalf("set configured_named_session: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
-		t.Fatalf("set configured_named_mode: %v", err)
-	}
-
-	outcome := doHandoffWithOutcome(store, rec, dops, nil, "mayor", "mayor",
-		[]string{"HANDOFF: context full"}, &stdout, &stderr)
-	if outcome.code != 1 {
-		t.Fatalf("code = %d, want 1", outcome.code)
-	}
-	if outcome.restartRequested {
-		t.Fatal("restartRequested = true, want false")
-	}
-	if !strings.Contains(stderr.String(), "clearing stale restart request") {
-		t.Fatalf("stderr = %q, want stale restart cleanup error", stderr.String())
-	}
-	if strings.Contains(stdout.String(), "restart skipped") {
-		t.Fatalf("stdout = %q, must not report success when cleanup fails", stdout.String())
-	}
-}
-
-func TestDoHandoff_NamedAlwaysSessionRequestsRestart(t *testing.T) {
-	store := beads.NewMemStore()
-	rec := events.NewFake()
-	dops := newFakeDrainOps()
-	var stdout, stderr bytes.Buffer
-
-	b, err := store.Create(beads.Bead{
-		Type:   sessionBeadType,
-		Labels: []string{"gc:session"},
-	})
-	if err != nil {
-		t.Fatalf("seeding session bead: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
-		t.Fatalf("set session_name: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
-		t.Fatalf("set configured_named_session: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_mode", "always"); err != nil {
-		t.Fatalf("set configured_named_mode: %v", err)
-	}
-
-	persistCalled := false
-	outcome := doHandoffWithOutcome(store, rec, dops, func() error {
-		persistCalled = true
-		return nil
-	}, "mayor", "mayor", []string{"HANDOFF: context full"}, &stdout, &stderr)
-	if outcome.code != 0 {
-		t.Fatalf("code = %d, want 0; stderr: %s", outcome.code, stderr.String())
-	}
-	if !outcome.restartRequested {
-		t.Fatal("restartRequested = false, want true for always-mode named session")
-	}
-	if !dops.restartRequested["mayor"] {
-		t.Error("restart-requested flag not set for always-mode named session")
-	}
-	if !persistCalled {
-		t.Error("persistRestart was not called for always-mode named session")
-	}
-	if len(rec.Events) != 2 {
-		t.Fatalf("got %d events, want 2", len(rec.Events))
-	}
-	if rec.Events[1].Type != events.SessionDraining {
-		t.Fatalf("event[1].Type = %q, want %q", rec.Events[1].Type, events.SessionDraining)
-	}
-}
-
-func TestCmdHandoff_Regression744_NamedSessionReturnsWithoutBlocking(t *testing.T) {
+func TestCmdHandoffAutoSendsMailWithoutBlocking(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -274,10 +84,92 @@ func TestCmdHandoff_Regression744_NamedSessionReturnsWithoutBlocking(t *testing.
 	t.Setenv("GC_ALIAS", "mayor")
 	t.Setenv("GC_SESSION_NAME", "mayor")
 
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto", "context cycle"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc handoff --auto failed: %v; stderr=%s", err, stderr.String())
+	}
+
 	store, err := openCityStoreAt(cityDir)
 	if err != nil {
 		t.Fatalf("openCityStoreAt: %v", err)
 	}
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("got %d open beads, want 1", len(all))
+	}
+	if got := all[0].Title; got != "context cycle" {
+		t.Fatalf("mail title = %q, want context cycle", got)
+	}
+	if got := all[0].Type; got != "message" {
+		t.Fatalf("mail type = %q, want message", got)
+	}
+	if strings.Contains(stdout.String(), "requesting restart") {
+		t.Fatalf("stdout = %q, --auto must not request restart", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "auto") {
+		t.Fatalf("stdout = %q, want auto handoff confirmation", stdout.String())
+	}
+}
+
+func TestCmdHandoffAutoUsesDefaultSubject(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc handoff --auto failed: %v; stderr=%s", err, stderr.String())
+	}
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	all, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("got %d open beads, want 1", len(all))
+	}
+	if got := all[0].Title; got != "context cycle" {
+		t.Fatalf("mail title = %q, want context cycle", got)
+	}
+}
+
+func TestCmdHandoffAutoRejectsTarget(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := cmdHandoff([]string{"context cycle"}, "mayor", true, &stdout, &stderr); code == 0 {
+		t.Fatal("cmdHandoff returned 0 for --auto with --target")
+	}
+	if !strings.Contains(stderr.String(), "--auto cannot be used with --target") {
+		t.Fatalf("stderr = %q, want --auto/--target conflict", stderr.String())
+	}
+}
+
+func TestDoHandoffNamedSessionRequestsRestart(t *testing.T) {
+	store := beads.NewMemStore()
+	rec := events.NewFake()
+	dops := newFakeDrainOps()
+	var stdout, stderr bytes.Buffer
+
 	b, err := store.Create(beads.Bead{
 		Type:   sessionBeadType,
 		Labels: []string{"gc:session"},
@@ -295,22 +187,25 @@ func TestCmdHandoff_Regression744_NamedSessionReturnsWithoutBlocking(t *testing.
 		t.Fatalf("set configured_named_mode: %v", err)
 	}
 
-	var stdout, stderr bytes.Buffer
-	done := make(chan int, 1)
-	go func() {
-		done <- cmdHandoff([]string{"HANDOFF: context full"}, "", &stdout, &stderr)
-	}()
-
-	select {
-	case code := <-done:
-		if code != 0 {
-			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
-		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("cmdHandoff blocked for named on-demand session")
+	persistCalled := false
+	code := doHandoff(store, rec, dops, func() error {
+		persistCalled = true
+		return nil
+	}, "mayor", "mayor", []string{"HANDOFF: context full"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "restart skipped") {
-		t.Fatalf("stdout = %q, want restart skipped confirmation", stdout.String())
+	if !dops.restartRequested["mayor"] {
+		t.Error("restart-requested flag not set for named session")
+	}
+	if !persistCalled {
+		t.Error("persistRestart was not called for named session")
+	}
+	if len(rec.Events) != 2 {
+		t.Fatalf("got %d events, want 2", len(rec.Events))
+	}
+	if rec.Events[1].Type != events.SessionDraining {
+		t.Fatalf("event[1].Type = %q, want %q", rec.Events[1].Type, events.SessionDraining)
 	}
 }
 
@@ -435,75 +330,6 @@ func TestHandoffRemoteRunning(t *testing.T) {
 	// Verify stdout says killed.
 	if !strings.Contains(stdout.String(), "killed session") {
 		t.Errorf("stdout = %q, want 'killed session'", stdout.String())
-	}
-}
-
-func TestHandoffRemoteNamedOnDemandSkipsKill(t *testing.T) {
-	store := beads.NewMemStore()
-	rec := events.NewFake()
-	sp := runtime.NewFake()
-	if err := sp.Start(context.Background(), "mayor", runtime.Config{Command: "echo"}); err != nil {
-		t.Fatal(err)
-	}
-	b, err := store.Create(beads.Bead{
-		Type:   sessionBeadType,
-		Labels: []string{"gc:session"},
-	})
-	if err != nil {
-		t.Fatalf("seeding session bead: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
-		t.Fatalf("set session_name: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
-		t.Fatalf("set configured_named_session: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
-		t.Fatalf("set configured_named_mode: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "restart_requested", "true"); err != nil {
-		t.Fatalf("set restart_requested: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "continuation_reset_pending", "true"); err != nil {
-		t.Fatalf("set continuation_reset_pending: %v", err)
-	}
-	if err := sp.SetMeta("mayor", "GC_RESTART_REQUESTED", "1"); err != nil {
-		t.Fatalf("set runtime restart meta: %v", err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	code := doHandoffRemote(store, rec, sp, "mayor", "mayor", "deacon",
-		[]string{"Context refresh", "Please pick this up manually"}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
-	}
-	if !sp.IsRunning("mayor") {
-		t.Error("named on-demand target should still be running")
-	}
-	if len(rec.Events) != 1 {
-		t.Fatalf("got %d events, want 1", len(rec.Events))
-	}
-	if rec.Events[0].Type != events.MailSent {
-		t.Fatalf("event[0].Type = %q, want %q", rec.Events[0].Type, events.MailSent)
-	}
-	if strings.Contains(stdout.String(), "killed session") {
-		t.Errorf("stdout = %q, must not report killing a named on-demand session", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), "named session") {
-		t.Errorf("stdout = %q, want named-session skip confirmation", stdout.String())
-	}
-	refreshed, err := store.Get(b.ID)
-	if err != nil {
-		t.Fatalf("fetching seeded bead: %v", err)
-	}
-	if refreshed.Metadata["restart_requested"] != "" {
-		t.Errorf("bead restart_requested = %q, want cleared for named target", refreshed.Metadata["restart_requested"])
-	}
-	if refreshed.Metadata["continuation_reset_pending"] != "" {
-		t.Errorf("continuation_reset_pending = %q, want cleared for named target", refreshed.Metadata["continuation_reset_pending"])
-	}
-	if got, err := sp.GetMeta("mayor", "GC_RESTART_REQUESTED"); err != nil || got != "" {
-		t.Errorf("runtime restart meta = %q, err=%v; want cleared", got, err)
 	}
 }
 

--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -101,11 +101,7 @@ func (o *providerDrainOps) isRestartRequested(sessionName string) (bool, error) 
 }
 
 func (o *providerDrainOps) clearRestartRequested(sessionName string) error {
-	err := o.sp.RemoveMeta(sessionName, "GC_RESTART_REQUESTED")
-	if runtime.IsSessionGone(err) {
-		return nil
-	}
-	return err
+	return o.sp.RemoveMeta(sessionName, "GC_RESTART_REQUESTED")
 }
 
 func (o *providerDrainOps) setDriftRestart(sessionName string) error {
@@ -374,11 +370,6 @@ The controller will stop the session on its next reconcile tick and
 restart it fresh. The blocking prevents the agent from consuming more
 context while waiting.
 
-For on-demand configured named sessions, the controller cannot restart the
-user-attended process. In that case this command reports that restart was
-skipped and returns without blocking. No session.draining event is emitted
-when restart is skipped.
-
 This command is designed to be called from within a session context.
 It emits a session.draining event before blocking.`,
 		Args: cobra.NoArgs,
@@ -403,21 +394,6 @@ func cmdRuntimeRequestRestart(stdout, stderr io.Writer) int {
 	store, storeErr := openCityStoreAt(current.cityPath)
 	if storeErr != nil {
 		fmt.Fprintf(stderr, "gc runtime request-restart: opening store: %v\n", storeErr) //nolint:errcheck // best-effort stderr
-	}
-	if store != nil {
-		restartable, err := sessionRestartableByController(store, current.sessionName)
-		if err != nil {
-			fmt.Fprintf(stderr, "gc runtime request-restart: checking session type: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
-		if !restartable {
-			if err := clearRestartRequest(store, dops, current.sessionName); err != nil {
-				fmt.Fprintf(stderr, "gc runtime request-restart: clearing stale restart request: %v\n", err) //nolint:errcheck // best-effort stderr
-				return 1
-			}
-			fmt.Fprintln(stdout, "Restart skipped for named session; controller cannot restart on-demand named sessions.") //nolint:errcheck // best-effort stdout
-			return 0
-		}
 	}
 	rec := openCityRecorderAt(current.cityPath, stderr)
 	cfg, _ := loadCityConfig(current.cityPath, stderr)

--- a/cmd/gc/cmd_runtime_drain_test.go
+++ b/cmd/gc/cmd_runtime_drain_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -507,77 +506,6 @@ func TestRequestRestartAcceptsNoArgs(t *testing.T) {
 	}
 }
 
-func TestRuntimeRequestRestartNamedOnDemandReturnsWithoutBlocking(t *testing.T) {
-	cityDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
-		t.Fatalf("write city.toml: %v", err)
-	}
-	t.Setenv("GC_BEADS", "file")
-	t.Setenv("GC_CITY", cityDir)
-	t.Setenv("GC_CITY_PATH", cityDir)
-	t.Setenv("GC_ALIAS", "mayor")
-	t.Setenv("GC_SESSION_NAME", "mayor")
-
-	store, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("openCityStoreAt: %v", err)
-	}
-	b, err := store.Create(beads.Bead{
-		Type:   sessionBeadType,
-		Labels: []string{"gc:session"},
-	})
-	if err != nil {
-		t.Fatalf("seeding session bead: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "session_name", "mayor"); err != nil {
-		t.Fatalf("set session_name: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_session", "true"); err != nil {
-		t.Fatalf("set configured_named_session: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "configured_named_mode", "on_demand"); err != nil {
-		t.Fatalf("set configured_named_mode: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "restart_requested", "true"); err != nil {
-		t.Fatalf("set restart_requested: %v", err)
-	}
-	if err := store.SetMetadata(b.ID, "continuation_reset_pending", "true"); err != nil {
-		t.Fatalf("set continuation_reset_pending: %v", err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	done := make(chan int, 1)
-	go func() {
-		done <- cmdRuntimeRequestRestart(&stdout, &stderr)
-	}()
-
-	select {
-	case code := <-done:
-		if code != 0 {
-			t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("cmdRuntimeRequestRestart blocked for named on-demand session")
-	}
-	if !strings.Contains(stdout.String(), "Restart skipped for named session") {
-		t.Fatalf("stdout = %q, want restart skipped confirmation", stdout.String())
-	}
-	freshStore, err := openCityStoreAt(cityDir)
-	if err != nil {
-		t.Fatalf("reopen store: %v", err)
-	}
-	refreshed, err := freshStore.Get(b.ID)
-	if err != nil {
-		t.Fatalf("fetching seeded bead: %v", err)
-	}
-	if refreshed.Metadata["restart_requested"] != "" {
-		t.Fatalf("restart_requested = %q, want cleared", refreshed.Metadata["restart_requested"])
-	}
-	if refreshed.Metadata["continuation_reset_pending"] != "" {
-		t.Fatalf("continuation_reset_pending = %q, want cleared", refreshed.Metadata["continuation_reset_pending"])
-	}
-}
-
 func TestProviderDrainOpsRestartRequestedRoundTrip(t *testing.T) {
 	sp := runtime.NewFake()
 	_ = sp.Start(context.Background(), "worker", runtime.Config{})
@@ -605,35 +533,6 @@ func TestProviderDrainOpsRestartRequestedRoundTrip(t *testing.T) {
 	requested, _ = dops.isRestartRequested("worker")
 	if requested {
 		t.Error("should not be restart-requested after clear")
-	}
-}
-
-type removeMetaErrorProvider struct {
-	*runtime.Fake
-	err error
-}
-
-func (p *removeMetaErrorProvider) RemoveMeta(_, _ string) error {
-	return p.err
-}
-
-func TestProviderDrainOpsClearRestartRequestedIgnoresGoneSession(t *testing.T) {
-	dops := newDrainOps(&removeMetaErrorProvider{
-		Fake: runtime.NewFake(),
-		err:  errors.New("no tmux server running"),
-	})
-	if err := dops.clearRestartRequested("worker"); err != nil {
-		t.Fatalf("clearRestartRequested returned gone-session error: %v", err)
-	}
-}
-
-func TestProviderDrainOpsClearRestartRequestedReturnsCleanupErrors(t *testing.T) {
-	dops := newDrainOps(&removeMetaErrorProvider{
-		Fake: runtime.NewFake(),
-		err:  errors.New("permission denied"),
-	})
-	if err := dops.clearRestartRequested("worker"); err == nil {
-		t.Fatal("clearRestartRequested should return non-gone cleanup errors")
 	}
 }
 

--- a/cmd/gc/testdata/gastown-handoff.txtar
+++ b/cmd/gc/testdata/gastown-handoff.txtar
@@ -16,11 +16,11 @@ cd $WORK/handofftown
 ! exec gc handoff 'Context refresh'
 stderr 'not in session context'
 
-# --- 2. Remote handoff to existing on-demand named agent ---
+# --- 2. Remote handoff to existing agent (session not running) ---
 
 exec gc handoff --target mayor 'Context refresh' 'Please review inbox for latest status'
 stdout 'Handoff.*sent mail.*to mayor'
-stdout 'named session; kill skipped'
+stdout 'session not running'
 
 # --- 3. Remote handoff creates mail ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,7 +34,7 @@ gc [flags]
 | [gc events](#gc-events) | Show events from the GC API |
 | [gc formula](#gc-formula) | Manage and inspect formulas |
 | [gc graph](#gc-graph) | Show dependency graph for beads |
-| [gc handoff](#gc-handoff) | Send handoff mail and restart controller-managed sessions |
+| [gc handoff](#gc-handoff) | Send handoff mail and restart this session |
 | [gc help](#gc-help) | Help about any command |
 | [gc hook](#gc-hook) | Check for available work (use --inject for Stop hook output) |
 | [gc import](#gc-import) | Manage pack imports |
@@ -1081,23 +1081,18 @@ gc graph gc-42               # expand convoy children
 
 Convenience command for context handoff.
 
-Self-handoff (default): sends mail to self. If the current session is
-controller-restartable, requests a restart and blocks until the controller
-stops the session. For on-demand configured named sessions, sends mail and
-returns without requesting restart because the controller cannot restart the
-user-attended process.
-
-For controller-restartable sessions, equivalent to:
+Self-handoff (default): sends mail to self and blocks until controller
+restarts the session. Equivalent to:
 
   gc mail send $GC_ALIAS &lt;subject&gt; [message]
   gc runtime request-restart
 
-Remote handoff (--target): sends mail to a target session. If the target is
-controller-restartable, kills it so the reconciler restarts it with the handoff
-mail waiting. For on-demand configured named targets, sends mail and returns
-without killing the session.
+Auto handoff (--auto): sends mail to self and returns without requesting a
+restart. This is for PreCompact hooks, where the provider is already managing
+the context compaction lifecycle.
 
-For controller-restartable targets, equivalent to:
+Remote handoff (--target): sends mail to a target session and kills it so the
+reconciler restarts it with the handoff mail waiting. Equivalent to:
 
   gc mail send &lt;target&gt; &lt;subject&gt; [message]
   gc session kill &lt;target&gt;
@@ -1106,12 +1101,13 @@ Self-handoff requires session context (GC_ALIAS or GC_SESSION_ID, plus
 GC_SESSION_NAME and city context env). Remote handoff accepts a session alias or ID.
 
 ```
-gc handoff <subject> [message] [flags]
+gc handoff [subject] [message] [flags]
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--target` | string |  | Remote session alias or ID to handoff (kills only controller-restartable sessions) |
+| `--auto` | bool |  | Send handoff mail without requesting restart (for PreCompact hooks) |
+| `--target` | string |  | Remote session alias or ID to handoff (sends mail + kills session) |
 
 ## gc help
 
@@ -1989,11 +1985,6 @@ Sets GC_RESTART_REQUESTED metadata on the session, then blocks forever.
 The controller will stop the session on its next reconcile tick and
 restart it fresh. The blocking prevents the agent from consuming more
 context while waiting.
-
-For on-demand configured named sessions, the controller cannot restart the
-user-attended process. In that case this command reports that restart was
-skipped and returns without blocking. No session.draining event is emitted
-when restart is skipped.
 
 This command is designed to be called from within a session context.
 It emits a session.draining event before blocking.

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff \"context cycle\""
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto \"context cycle\""
           }
         ]
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -477,7 +477,10 @@ func claudeFileNeedsUpgrade(existing []byte) bool {
 	}
 	transforms := []func(string) string{
 		func(s string) string {
-			return strings.Replace(s, `gc handoff \"context cycle\"`, `gc prime --hook`, 1)
+			return strings.Replace(s, `gc handoff --auto \"context cycle\"`, `gc handoff \"context cycle\"`, 1)
+		},
+		func(s string) string {
+			return strings.Replace(s, `gc handoff --auto \"context cycle\"`, `gc prime --hook`, 1)
 		},
 		func(s string) string {
 			return strings.Replace(s, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -121,8 +121,8 @@ func TestInstallClaude(t *testing.T) {
 			return entries[0].Matcher
 		}())
 	}
-	if !strings.Contains(claudeHookCommand(t, runtimeData, "PreCompact"), `gc handoff "context cycle"`) {
-		t.Error("claude PreCompact hook should use gc handoff (not gc prime) to avoid context accumulation on compaction")
+	if !strings.Contains(claudeHookCommand(t, runtimeData, "PreCompact"), `gc handoff --auto "context cycle"`) {
+		t.Error("claude PreCompact hook should use gc handoff --auto (not gc prime or restart handoff) on compaction")
 	}
 	if !strings.Contains(s, "gc nudge drain --inject") {
 		t.Error("claude settings should contain gc nudge drain --inject")
@@ -147,7 +147,7 @@ func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
 	// Build a realistic stale fixture: the embedded file stores the command
 	// as JSON, so the literal bytes contain escaped quotes. Matching that
 	// shape is what claudeFileNeedsUpgrade expects.
-	stale := strings.Replace(string(current), `gc handoff \"context cycle\"`, `gc prime --hook`, 1)
+	stale := strings.Replace(string(current), `gc handoff --auto \"context cycle\"`, `gc prime --hook`, 1)
 	if stale == string(current) {
 		t.Fatal("stale fixture did not diverge from current embedded config — check stale pattern")
 	}
@@ -160,11 +160,34 @@ func TestInstallClaudeUpgradesStaleGeneratedFile(t *testing.T) {
 
 	hookData := fs.Files["/city/hooks/claude.json"]
 	runtimeData := fs.Files["/city/.gc/settings.json"]
-	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff "context cycle"`) {
+	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff --auto "context cycle"`) {
 		t.Fatalf("upgraded claude hook missing gc handoff:\n%s", string(hookData))
 	}
 	if string(runtimeData) != string(hookData) {
 		t.Fatalf("runtime Claude settings should mirror upgraded hook settings:\n%s", string(runtimeData))
+	}
+}
+
+func TestInstallClaudeUpgradesRestartingPreCompactHandoff(t *testing.T) {
+	fs := fsys.NewFake()
+	current, err := readEmbedded("config/claude.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	stale := strings.Replace(string(current), `gc handoff --auto \"context cycle\"`, `gc handoff \"context cycle\"`, 1)
+	if stale == string(current) {
+		t.Fatal("stale fixture did not diverge from current embedded config — check stale pattern")
+	}
+	fs.Files["/city/hooks/claude.json"] = []byte(stale)
+	fs.Files["/city/.gc/settings.json"] = []byte(stale)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	hookData := fs.Files["/city/hooks/claude.json"]
+	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff --auto "context cycle"`) {
+		t.Fatalf("upgraded claude hook missing gc handoff --auto:\n%s", string(hookData))
 	}
 }
 
@@ -332,7 +355,7 @@ func TestInstallClaudeUpgradesGeneratedFileWithAllKnownDrift(t *testing.T) {
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}
-	stale := strings.Replace(string(current), `gc handoff \"context cycle\"`, `gc prime --hook`, 1)
+	stale := strings.Replace(string(current), `gc handoff --auto \"context cycle\"`, `gc prime --hook`, 1)
 	stale = strings.Replace(stale, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
 	stale = strings.Replace(stale, `"matcher": "startup"`, `"matcher": ""`, 1)
 	if stale == string(current) {
@@ -362,7 +385,7 @@ func TestInstallClaudeUpgradesGeneratedFileWithAllKnownDrift(t *testing.T) {
 			return entries[0].Matcher
 		}())
 	}
-	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff "context cycle"`) {
+	if !strings.Contains(claudeHookCommand(t, hookData, "PreCompact"), `gc handoff --auto "context cycle"`) {
 		t.Fatalf("upgraded all-drift PreCompact hook missing gc handoff:\n%s", string(hookData))
 	}
 	if string(runtimeData) != string(hookData) {

--- a/internal/overlay/merge_test.go
+++ b/internal/overlay/merge_test.go
@@ -70,7 +70,7 @@ func TestMergeSettingsJSON_SameMatcherReplacement(t *testing.T) {
 	}`
 	over := `{
 		"hooks": {
-			"PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "gc handoff \"context cycle\""}]}]
+			"PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "gc handoff --auto \"context cycle\""}]}]
 		}
 	}`
 
@@ -91,7 +91,7 @@ func TestMergeSettingsJSON_SameMatcherReplacement(t *testing.T) {
 	entry := arr[0].(map[string]any)
 	innerHooks := entry["hooks"].([]any)
 	cmd := innerHooks[0].(map[string]any)["command"].(string)
-	if cmd != `gc handoff "context cycle"` {
+	if cmd != `gc handoff --auto "context cycle"` {
 		t.Errorf("PreCompact command = %q, want gc handoff", cmd)
 	}
 }
@@ -333,7 +333,7 @@ func TestMergeSettingsJSON_CrewScenario(t *testing.T) {
 	}`
 	over := `{
 		"hooks": {
-			"PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "gc handoff \"context cycle\""}]}]
+			"PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "gc handoff --auto \"context cycle\""}]}]
 		}
 	}`
 
@@ -362,7 +362,7 @@ func TestMergeSettingsJSON_CrewScenario(t *testing.T) {
 	entry := arr[0].(map[string]any)
 	innerHooks := entry["hooks"].([]any)
 	cmd := innerHooks[0].(map[string]any)["command"].(string)
-	if cmd != `gc handoff "context cycle"` {
+	if cmd != `gc handoff --auto "context cycle"` {
 		t.Errorf("PreCompact command = %q, want gc handoff", cmd)
 	}
 }
@@ -372,7 +372,7 @@ func TestMergeSettingsJSON_BackwardCompat_FullOverlay(t *testing.T) {
 	full := `{
 		"hooks": {
 			"SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "gc prime"}]}],
-			"PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "gc handoff \"context cycle\""}]}],
+			"PreCompact": [{"matcher": "", "hooks": [{"type": "command", "command": "gc handoff --auto \"context cycle\""}]}],
 			"UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "gc mail check --inject"}]}],
 			"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "gc hook --inject"}]}]
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -58,8 +58,7 @@ func IsSessionGone(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "session not found") ||
 		strings.Contains(msg, "not running") ||
-		strings.Contains(msg, "not found") ||
-		strings.Contains(msg, "no tmux server running")
+		strings.Contains(msg, "not found")
 }
 
 // ContentBlock represents a content element in a message.


### PR DESCRIPTION
## Summary
- add `gc handoff --auto` for PreCompact/state-only handoff mail without restart
- restore normal `gc handoff` / `gc runtime request-restart` restart semantics by removing the named-session skip behavior from PR #927
- update Claude PreCompact hooks, stale hook upgrades, CLI docs, and regression coverage

## Tests
- pre-commit hook: golangci-lint, go vet, generated docs/schema, `GC_FAST_UNIT=1 go test ./...`, and docsync
- targeted before commit: `go test ./cmd/gc -run 'TestHandoff|TestDoHandoff|TestCmdHandoffAuto|TestRuntimeRequestRestart|TestRequestRestartAcceptsNoArgs|TestProviderDrainOpsRestartRequestedRoundTrip|TestProviderDrainOpsDriftRestartRoundTrip|TestGenDocProducesMarkdown' -count=1`
- targeted before commit: `go test ./internal/hooks ./internal/overlay -count=1`
- targeted before commit: `go test ./test/docsync -count=1`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->