### PR TITLE
fix: require canonical routed_to labels in example pools

### DIFF
--- a/examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh
+++ b/examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 cd "$GC_DIR"
 
 AGENT_SHORT=$(basename "$GC_AGENT")
-POOL_LABEL="${GC_TEMPLATE:-worker}"
+POOL_LABEL="${GC_TEMPLATE:?GC_TEMPLATE must be set to canonical pool route target}"
 echo "[$AGENT_SHORT] Starting up"
 
 # Jitter to avoid 100 workers racing on the same bead.

--- a/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
@@ -5,9 +5,10 @@
 # file, commits on the branch, then hands off to the refinery for merge.
 #
 # Required env vars (set by gc start):
-#   GC_AGENT — this agent's name (e.g., "demo-repo/polecat-1")
-#   GC_CITY  — path to the city directory
-#   GC_DIR   — working directory (rig repo path)
+#   GC_AGENT    — this agent's session name
+#   GC_TEMPLATE — canonical pool route target (e.g., "demo-repo/lifecycle.polecat")
+#   GC_CITY     — path to the city directory
+#   GC_DIR      — working directory (rig repo path)
 
 set -euo pipefail
 
@@ -35,13 +36,7 @@ git config --global user.name 2>/dev/null || git config --global user.name "gc-a
 git pull --ff-only origin main 2>/dev/null || true
 
 AGENT_SHORT=$(basename "$GC_AGENT")
-
-# Pool label is the agent name without the instance suffix (-1, -2, etc.).
-# For pool max=1 the name has no suffix, so we only strip if it ends in -N.
-POOL_LABEL="$GC_AGENT"
-if [[ "$POOL_LABEL" =~ -[0-9]+$ ]]; then
-    POOL_LABEL="${POOL_LABEL%-*}"
-fi
+POOL_LABEL="${GC_TEMPLATE:?GC_TEMPLATE must be set to canonical pool route target}"
 
 echo "[$AGENT_SHORT] Starting up in rig dir: $GC_DIR"
 # Jitter startup to avoid pool members racing on the same bead.
@@ -158,7 +153,7 @@ echo "[$AGENT_SHORT] Worktree cleaned up. Branch $BRANCH persists."
 # ── Step 7: Hand off to refinery ──────────────────────────────────────────
 
 # Set branch metadata and reassign to the refinery for merge.
-REFINERY="${GC_AGENT%/*}/refinery"
+REFINERY="${GC_TEMPLATE%polecat}refinery"
 bd update "$BEAD_ID" --metadata "{\"branch\":\"$BRANCH\"}" --assignee="$REFINERY" 2>/dev/null || true
 
 gc mail send --all "READY FOR MERGE: $BRANCH ($BEAD_TITLE) → $REFINERY" 2>/dev/null || true

--- a/examples/routing_namespace_test.go
+++ b/examples/routing_namespace_test.go
@@ -42,3 +42,56 @@ func TestShippedExamplesDoNotHardcodeShortRoutedToPools(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestExamplePoolScriptsUseCanonicalGCTemplateRoutes(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filename)
+
+	checks := []struct {
+		rel      string
+		required []string
+		banned   []string
+	}{
+		{
+			rel: "hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh",
+			required: []string{
+				`POOL_LABEL="${GC_TEMPLATE:?`,
+				`gc.routed_to=$POOL_LABEL`,
+			},
+			banned: []string{
+				`POOL_LABEL="${GC_TEMPLATE:-worker}"`,
+			},
+		},
+		{
+			rel: "lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh",
+			required: []string{
+				`POOL_LABEL="${GC_TEMPLATE:?`,
+				`REFINERY="${GC_TEMPLATE%polecat}refinery"`,
+				`gc.routed_to=$POOL_LABEL`,
+			},
+			banned: []string{
+				`POOL_LABEL="$GC_AGENT"`,
+				`REFINERY="${GC_AGENT%/*}/refinery"`,
+			},
+		},
+	}
+
+	for _, check := range checks {
+		path := filepath.Join(root, check.rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", check.rel, err)
+		}
+		body := string(data)
+		for _, required := range check.required {
+			if !strings.Contains(body, required) {
+				t.Errorf("%s missing canonical route pattern %q", check.rel, required)
+			}
+		}
+		for _, banned := range check.banned {
+			if strings.Contains(body, banned) {
+				t.Errorf("%s still contains short-form route pattern %q", check.rel, banned)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- require hyperscale and lifecycle example pool scripts to use canonical GC_TEMPLATE route labels instead of short-form fallbacks or session-derived labels
- preserve the lifecycle binding namespace when polecat work is handed to refinery
- add regression coverage so example pool scripts cannot reintroduce short-form routed_to searches

Closes #1110.

## Test plan
- `go test ./examples -run 'TestShippedExamplesDoNotHardcodeShortRoutedToPools|TestExamplePoolScriptsUseCanonicalGCTemplateRoutes' -count=1`
- `go test ./examples ./internal/bootstrap -count=1`
- `bash -n examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh`
- `make test`