### PR TITLE
fix(rig): auto-detect default branch in gc rig add (ga-962)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/extmsg"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -813,12 +814,30 @@ func (cs *controllerState) DeleteAgent(name string) error {
 
 // CreateRig adds a new rig to city.toml.
 func (cs *controllerState) CreateRig(r config.Rig) error {
+	r = detectRigDefaultBranch(cs.cityPath, r)
 	if err := cs.initializeRigStoreForCreate(r); err != nil {
 		return err
 	}
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.CreateRig(r)
 	})
+}
+
+func detectRigDefaultBranch(cityPath string, r config.Rig) config.Rig {
+	r.DefaultBranch = strings.TrimSpace(r.DefaultBranch)
+	if r.DefaultBranch != "" {
+		return r
+	}
+	rigPath := strings.TrimSpace(r.Path)
+	if rigPath == "" {
+		return r
+	}
+	rigPath = resolveStoreScopeRoot(cityPath, rigPath)
+	if _, err := os.Stat(filepath.Join(rigPath, ".git")); err != nil {
+		return r
+	}
+	r.DefaultBranch = git.New(rigPath).ProbeDefaultBranch()
+	return r
 }
 
 func (cs *controllerState) initializeRigStoreForCreate(r config.Rig) error {

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -850,9 +850,10 @@ func (cs *controllerState) initializeRigStoreForCreate(r config.Rig) error {
 func (cs *controllerState) UpdateRig(name string, patch api.RigUpdate) error {
 	return cs.mutateAndPoke(func() error {
 		return cs.editor.UpdateRig(name, configedit.RigUpdate{
-			Path:      patch.Path,
-			Prefix:    patch.Prefix,
-			Suspended: patch.Suspended,
+			Path:          patch.Path,
+			Prefix:        patch.Prefix,
+			DefaultBranch: patch.DefaultBranch,
+			Suspended:     patch.Suspended,
 		})
 	})
 }

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -605,6 +605,82 @@ func TestControllerStateCreateRigPokesReconciler(t *testing.T) {
 	}
 }
 
+func TestControllerStateCreateRigDetectsDefaultBranch(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	rigDir := newRepoWithOriginHead(t, "master")
+	if err := cs.CreateRig(config.Rig{Name: "rig1", Path: rigDir}); err != nil {
+		t.Fatalf("CreateRig: %v", err)
+	}
+
+	got := cs.Config()
+	if got == nil || len(got.Rigs) != 1 {
+		t.Fatalf("Config() rigs = %+v, want one rig", got.Rigs)
+	}
+	if got.Rigs[0].DefaultBranch != "master" {
+		t.Fatalf("DefaultBranch = %q, want %q", got.Rigs[0].DefaultBranch, "master")
+	}
+}
+
+func TestControllerStateCreateRigDetectsDefaultBranchForRelativePath(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	cityRigDir := filepath.Join(cityDir, "rig")
+	if err := os.MkdirAll(cityRigDir, 0o755); err != nil {
+		t.Fatalf("mkdir city rig: %v", err)
+	}
+	gitCmd(t, cityRigDir, "init")
+	gitCmd(t, cityRigDir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+
+	otherRoot := t.TempDir()
+	otherRigDir := filepath.Join(otherRoot, "rig")
+	if err := os.MkdirAll(otherRigDir, 0o755); err != nil {
+		t.Fatalf("mkdir other rig: %v", err)
+	}
+	gitCmd(t, otherRigDir, "init")
+	gitCmd(t, otherRigDir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/master")
+	t.Chdir(otherRoot)
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	if err := cs.CreateRig(config.Rig{Name: "rig1", Path: "rig"}); err != nil {
+		t.Fatalf("CreateRig: %v", err)
+	}
+
+	got := cs.Config()
+	if got == nil || len(got.Rigs) != 1 {
+		t.Fatalf("Config() rigs = %+v, want one rig", got.Rigs)
+	}
+	if got.Rigs[0].DefaultBranch != "trunk" {
+		t.Fatalf("DefaultBranch = %q, want %q", got.Rigs[0].DefaultBranch, "trunk")
+	}
+}
+
+func TestDetectRigDefaultBranchSkipsEmptyPath(t *testing.T) {
+	got := detectRigDefaultBranch(t.TempDir(), config.Rig{Name: "rig1"})
+	if got.DefaultBranch != "" {
+		t.Fatalf("DefaultBranch = %q, want empty for empty rig path", got.DefaultBranch)
+	}
+}
+
 func TestControllerStateCreateRigInitializesStoreBeforePublishing(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -597,7 +597,7 @@ func buildPrimeContext(cityPath, cityName string, a *config.Agent, rigs []config
 	}
 
 	ctx.Branch = os.Getenv("GC_BRANCH")
-	ctx.DefaultBranch = defaultBranchFor(ctx.WorkDir)
+	ctx.DefaultBranch = defaultBranchForRig(ctx.RigName, rigs, ctx.WorkDir)
 	ctx.WorkQuery = expandAgentCommandTemplate(cityPath, cityName, a, rigs, "work_query", a.EffectiveWorkQuery(), stderr)
 	ctx.SlingQuery = expandAgentCommandTemplate(cityPath, cityName, a, rigs, "sling_query", a.EffectiveSlingQuery(), stderr)
 	return ctx

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -118,10 +118,11 @@ func newRigListCmd(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List registered rigs",
-		Long: `List all registered rigs with their paths, prefixes, and beads status.
+		Long: `List all registered rigs with their paths, prefixes, default branches, and beads status.
 
 Shows the HQ rig (the city itself) and all configured rigs. Each rig
-displays its bead ID prefix and whether its beads database is initialized.`,
+displays its bead ID prefix, recorded default branch when set, and whether
+its beads database is initialized.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdRigList(args, jsonFlag, stdout, stderr) != 0 {
@@ -286,6 +287,9 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			}
 		}
 	}
+	if reAdd && existingRig != nil && existingRig.EffectiveDefaultBranch() == "" && resolvedDefaultBranch != "" {
+		reAddNeedsConfigWrite = true
+	}
 
 	rootDefaultRigImports, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
 	if err != nil {
@@ -299,7 +303,12 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	if reAddNeedsConfigWrite {
 		next := *cfg
 		next.Rigs = append([]config.Rig{}, cfg.Rigs...)
-		next.Rigs[existingRigIdx].Path = rigPath
+		if strings.TrimSpace(next.Rigs[existingRigIdx].Path) == "" {
+			next.Rigs[existingRigIdx].Path = rigPath
+		}
+		if next.Rigs[existingRigIdx].EffectiveDefaultBranch() == "" && resolvedDefaultBranch != "" {
+			next.Rigs[existingRigIdx].DefaultBranch = resolvedDefaultBranch
+		}
 		nextCfg = &next
 	} else if !reAdd {
 		storedPrefix := ""
@@ -414,7 +423,9 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		if prefixOverride != "" && strings.ToLower(prefixOverride) != existingRig.EffectivePrefix() {
 			fmt.Fprintf(stderr, "gc rig add: warning: --prefix=%s ignored (existing: %s); edit city.toml to change\n", prefixOverride, existingRig.EffectivePrefix()) //nolint:errcheck // best-effort stderr
 		}
-		if defaultBranchOverride != "" && defaultBranchOverride != existingRig.EffectiveDefaultBranch() {
+		if defaultBranchOverride != "" &&
+			defaultBranchOverride != existingRig.EffectiveDefaultBranch() &&
+			(existingRig.EffectiveDefaultBranch() != "" || resolvedDefaultBranch != defaultBranchOverride) {
 			fmt.Fprintf(stderr, "gc rig add: warning: --default-branch=%s ignored (existing: %s); edit city.toml to change\n", defaultBranchOverride, existingRig.EffectiveDefaultBranch()) //nolint:errcheck // best-effort stderr
 		}
 	} else {
@@ -695,11 +706,12 @@ type RigListItem struct {
 	// Path is the absolute filesystem path to the rig directory, resolved from
 	// city.toml by resolveRigPaths. Always absolute in output, regardless of
 	// the relative form stored in city.toml.
-	Path      string `json:"path"`
-	Prefix    string `json:"prefix"`
-	HQ        bool   `json:"hq"`
-	Suspended bool   `json:"suspended"`
-	Beads     string `json:"beads"`
+	Path          string `json:"path"`
+	Prefix        string `json:"prefix"`
+	DefaultBranch string `json:"default_branch,omitempty"`
+	HQ            bool   `json:"hq"`
+	Suspended     bool   `json:"suspended"`
+	Beads         string `json:"beads"`
 }
 
 // doRigList is the pure logic for "gc rig list". It reads rigs from city.toml
@@ -735,11 +747,12 @@ func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.W
 		})
 		for i := range cfg.Rigs {
 			result.Rigs = append(result.Rigs, RigListItem{
-				Name:      cfg.Rigs[i].Name,
-				Path:      cfg.Rigs[i].Path,
-				Prefix:    cfg.Rigs[i].EffectivePrefix(),
-				Suspended: cfg.Rigs[i].Suspended,
-				Beads:     rigBeadsStatus(fs, cfg.Rigs[i].Path),
+				Name:          cfg.Rigs[i].Name,
+				Path:          cfg.Rigs[i].Path,
+				Prefix:        cfg.Rigs[i].EffectivePrefix(),
+				DefaultBranch: cfg.Rigs[i].EffectiveDefaultBranch(),
+				Suspended:     cfg.Rigs[i].Suspended,
+				Beads:         rigBeadsStatus(fs, cfg.Rigs[i].Path),
 			})
 		}
 		enc := json.NewEncoder(stdout)
@@ -775,6 +788,9 @@ func doRigList(fs fsys.FS, cityPath string, jsonOutput bool, stdout, stderr io.W
 		w(fmt.Sprintf("  %s:", header))
 		w(fmt.Sprintf("    Path:   %s", cfg.Rigs[i].Path))
 		w(fmt.Sprintf("    Prefix: %s", prefix))
+		if branch := cfg.Rigs[i].EffectiveDefaultBranch(); branch != "" {
+			w(fmt.Sprintf("    Default branch: %s", branch))
+		}
 		w(fmt.Sprintf("    Beads:  %s", beads))
 	}
 	return 0

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/git"
 	"github.com/gastownhall/gascity/internal/hooks"
 	"github.com/spf13/cobra"
 )
@@ -62,6 +63,7 @@ func newRigAddCmd(stdout, stderr io.Writer) *cobra.Command {
 	var startSuspended bool
 	var nameFlag string
 	var prefixFlag string
+	var defaultBranchFlag string
 	var adoptFlag bool
 	cmd := &cobra.Command{
 		Use:   "add <path>",
@@ -76,6 +78,10 @@ repeat the flag to compose multiple packs for one rig.
 
 Use --name to set the rig name explicitly (default: directory basename).
 Use --prefix to set the bead ID prefix explicitly (default: derived from name).
+Use --default-branch to set the rig's mainline branch explicitly. By default,
+gc rig add probes the repo's origin/HEAD (and falls back to the currently
+checked-out branch) and stores the result in city.toml so polecats and the
+refinery target the right branch without manual metadata patching.
 Use --start-suspended to add the rig in a suspended state (dormant-by-default).
 The rig's agents won't spawn until explicitly resumed with "gc rig resume".
 
@@ -85,13 +91,14 @@ Skips beads init; the git repo check remains informational.`,
 		Example: `  gc rig add /path/to/project
   gc rig add /path/to/project --name myrig
   gc rig add /path/to/project --prefix r1
+  gc rig add /path/to/master-repo --default-branch master
   gc rig add ./my-project --include packs/gastown
   gc rig add ./my-project --include packs/planner --include packs/architect
   gc rig add ./my-project --include packs/gastown --start-suspended
   gc rig add /path/to/existing --adopt`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdRigAdd(args, includes, nameFlag, prefixFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
+			if cmdRigAdd(args, includes, nameFlag, prefixFlag, defaultBranchFlag, startSuspended, adoptFlag, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -100,6 +107,7 @@ Skips beads init; the git repo check remains informational.`,
 	cmd.Flags().StringArrayVar(&includes, "include", nil, "pack directory for rig agents (repeatable)")
 	cmd.Flags().StringVar(&nameFlag, "name", "", "rig name (default: directory basename)")
 	cmd.Flags().StringVar(&prefixFlag, "prefix", "", "bead ID prefix (default: derived from name)")
+	cmd.Flags().StringVar(&defaultBranchFlag, "default-branch", "", "mainline branch (default: auto-detect from origin/HEAD or current branch)")
 	cmd.Flags().BoolVar(&startSuspended, "start-suspended", false, "add rig in suspended state (dormant-by-default)")
 	cmd.Flags().BoolVar(&adoptFlag, "adopt", false, "adopt existing .beads/ directory (skip init)")
 	return cmd
@@ -127,7 +135,7 @@ displays its bead ID prefix and whether its beads database is initialized.`,
 }
 
 // cmdRigAdd registers an external project directory as a rig in the city.
-func cmdRigAdd(args []string, includes []string, nameOverride, prefixOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
+func cmdRigAdd(args []string, includes []string, nameOverride, prefixOverride, defaultBranchOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
 		fmt.Fprintln(stderr, "gc rig add: missing path") //nolint:errcheck // best-effort stderr
 		return 1
@@ -144,7 +152,7 @@ func cmdRigAdd(args []string, includes []string, nameOverride, prefixOverride st
 		fmt.Fprintf(stderr, "gc rig add: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	return doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameOverride, prefixOverride, startSuspended, adopt, stdout, stderr)
+	return doRigAdd(fsys.OSFS{}, cityPath, rigPath, includes, nameOverride, prefixOverride, defaultBranchOverride, startSuspended, adopt, stdout, stderr)
 }
 
 func resolveRigAddPath(cityPath, rigArg string) (string, error) {
@@ -169,7 +177,7 @@ func resolveRigAddPath(cityPath, rigArg string) (string, error) {
 // city.toml is written last — if any earlier step fails, config is unchanged.
 // This prevents partial-state bugs where city.toml lists a rig but the rig's
 // infrastructure (beads, routes) was never created.
-func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverride, prefixOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
+func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverride, prefixOverride, defaultBranchOverride string, startSuspended, adopt bool, stdout, stderr io.Writer) int {
 	// Validate prefix format: hyphens break beadPrefix() which splits on
 	// the first '-' to extract the rig prefix from a bead ID.
 	if prefixOverride != "" && strings.Contains(prefixOverride, "-") {
@@ -208,6 +216,14 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	name := nameOverride
 	if name == "" {
 		name = filepath.Base(rigPath)
+	}
+
+	_, gitErr := fs.Stat(filepath.Join(rigPath, ".git"))
+	hasGit := gitErr == nil
+	defaultBranchOverride = strings.TrimSpace(defaultBranchOverride)
+	resolvedDefaultBranch := defaultBranchOverride
+	if resolvedDefaultBranch == "" && hasGit {
+		resolvedDefaultBranch = git.New(rigPath).ProbeDefaultBranch()
 	}
 
 	tomlPath := filepath.Join(cityPath, "city.toml")
@@ -291,10 +307,11 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 			storedPrefix = strings.ToLower(prefixOverride)
 		}
 		rig := config.Rig{
-			Name:      name,
-			Path:      rigPath,
-			Prefix:    storedPrefix,
-			Suspended: startSuspended,
+			Name:          name,
+			Path:          rigPath,
+			Prefix:        storedPrefix,
+			DefaultBranch: resolvedDefaultBranch,
+			Suspended:     startSuspended,
 		}
 		switch {
 		case len(includes) > 0:
@@ -383,9 +400,6 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		}
 	}
 
-	_, gitErr := fs.Stat(filepath.Join(rigPath, ".git"))
-	hasGit := gitErr == nil
-
 	// --- Phase 1: Infrastructure (all fallible, before touching city.toml) ---
 
 	w := func(s string) { fmt.Fprintln(stdout, s) } //nolint:errcheck // best-effort stdout
@@ -400,6 +414,9 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		if prefixOverride != "" && strings.ToLower(prefixOverride) != existingRig.EffectivePrefix() {
 			fmt.Fprintf(stderr, "gc rig add: warning: --prefix=%s ignored (existing: %s); edit city.toml to change\n", prefixOverride, existingRig.EffectivePrefix()) //nolint:errcheck // best-effort stderr
 		}
+		if defaultBranchOverride != "" && defaultBranchOverride != existingRig.EffectiveDefaultBranch() {
+			fmt.Fprintf(stderr, "gc rig add: warning: --default-branch=%s ignored (existing: %s); edit city.toml to change\n", defaultBranchOverride, existingRig.EffectiveDefaultBranch()) //nolint:errcheck // best-effort stderr
+		}
 	} else {
 		w(fmt.Sprintf("Adding rig '%s'...", name))
 	}
@@ -407,6 +424,9 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		w(fmt.Sprintf("  Detected git repo at %s", rigPath))
 	}
 	w(fmt.Sprintf("  Prefix: %s", prefix))
+	if !reAdd && resolvedDefaultBranch != "" {
+		w(fmt.Sprintf("  Default branch: %s", resolvedDefaultBranch))
+	}
 	if !reAdd {
 		switch {
 		case len(includes) > 0:

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -169,6 +170,35 @@ func TestDoRigAdd_DefaultBranchFlagOverridesProbe(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `default_branch = "develop"`) {
 		t.Errorf("city.toml should record flag-supplied default_branch=develop:\n%s", data)
+	}
+}
+
+func TestDoRigAdd_BackfillsExistingRigDefaultBranch(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rigPath := makeMasterRig(t)
+	cityToml := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"master-rig\"\npath = %q\n", rigPath)
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `default_branch = "master"`) {
+		t.Errorf("city.toml should backfill default_branch=master on re-add:\n%s", data)
 	}
 }
 
@@ -830,7 +860,7 @@ func TestDoRigList_WithRigs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\nprefix = \"fe\"\n"
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\nprefix = \"fe\"\ndefault_branch = \"develop\"\n"
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -857,9 +887,50 @@ func TestDoRigList_WithRigs(t *testing.T) {
 	if !strings.Contains(output, "Prefix: fe") {
 		t.Errorf("output missing rig prefix: %s", output)
 	}
+	if !strings.Contains(output, "Default branch: develop") {
+		t.Errorf("output missing rig default branch: %s", output)
+	}
 	if !strings.Contains(output, "not initialized") {
 		t.Errorf("output missing rig beads status: %s", output)
 	}
+}
+
+func TestDoRigListJSONShowsDefaultBranch(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(t.TempDir(), "my-frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\ndefault_branch = \"develop\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigList(fsys.OSFS{}, cityPath, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigList returned %d, stderr: %s", code, stderr.String())
+	}
+
+	var got struct {
+		Rigs []struct {
+			Name          string `json:"name"`
+			DefaultBranch string `json:"default_branch"`
+		} `json:"rigs"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode rig list JSON: %v\n%s", err, stdout.String())
+	}
+	for _, rig := range got.Rigs {
+		if rig.Name == "my-frontend" {
+			if rig.DefaultBranch != "develop" {
+				t.Fatalf("default_branch = %q, want develop\n%s", rig.DefaultBranch, stdout.String())
+			}
+			return
+		}
+	}
+	t.Fatalf("rig my-frontend not found in JSON:\n%s", stdout.String())
 }
 
 func TestDoRigList_Empty(t *testing.T) {

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -48,7 +49,7 @@ func TestDoRigAdd_Basic(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -71,6 +72,140 @@ func TestDoRigAdd_Basic(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "my-frontend") {
 		t.Errorf("city.toml should contain rig name:\n%s", data)
+	}
+}
+
+func runGitInTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func makeMasterRig(t *testing.T) string {
+	t.Helper()
+	bare := t.TempDir()
+	runGitInTest(t, bare, "init", "--bare")
+
+	rigPath := filepath.Join(t.TempDir(), "master-rig")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitInTest(t, rigPath, "init")
+	runGitInTest(t, rigPath, "config", "user.email", "test@test.com")
+	runGitInTest(t, rigPath, "config", "user.name", "Test")
+	runGitInTest(t, rigPath, "checkout", "-b", "master")
+	runGitInTest(t, rigPath, "commit", "--allow-empty", "-m", "init")
+	runGitInTest(t, rigPath, "remote", "add", "origin", bare)
+	runGitInTest(t, rigPath, "push", "-u", "origin", "master")
+	runGitInTest(t, bare, "symbolic-ref", "HEAD", "refs/heads/master")
+	runGitInTest(t, rigPath, "remote", "set-head", "origin", "master")
+	return rigPath
+}
+
+func TestDoRigAdd_DetectsDefaultBranchFromOriginHEAD(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := makeMasterRig(t)
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "Default branch: master") {
+		t.Errorf("output should report detected default branch master:\n%s", stdout.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `default_branch = "master"`) {
+		t.Errorf("city.toml should record default_branch=master:\n%s", data)
+	}
+}
+
+func TestDoRigAdd_DefaultBranchFlagOverridesProbe(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := makeMasterRig(t)
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "develop", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "Default branch: develop") {
+		t.Errorf("output should report flag-supplied default branch develop:\n%s", stdout.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `default_branch = "develop"`) {
+		t.Errorf("city.toml should record flag-supplied default_branch=develop:\n%s", data)
+	}
+}
+
+func TestDoRigAdd_NonGitDirOmitsDefaultBranch(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "no-git")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), "Default branch:") {
+		t.Errorf("output should not report a default branch for non-git dir:\n%s", stdout.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "default_branch") {
+		t.Errorf("city.toml should not record default_branch when probe finds nothing:\n%s", data)
 	}
 }
 
@@ -137,7 +272,7 @@ func TestDoRigAddWritesSiteBindingInsteadOfPath(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -195,7 +330,7 @@ func TestDoRigAddRouteFailureRollsBackConfig(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("doRigAdd = %d, want 1; stderr=%s", code, stderr.String())
 	}
@@ -237,7 +372,7 @@ func TestDoRigAdd_DuplicateNameDifferentPath(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("doRigAdd should fail for duplicate with different path, got code %d", code)
 	}
@@ -277,7 +412,7 @@ func TestDoRigAdd_IdempotentSameNameSamePath(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed for same name+path, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -337,7 +472,7 @@ func TestDoRigAdd_DoesNotWritePortFileForFileBackedExternalRig(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -369,7 +504,7 @@ func TestDoRigAdd_ReAddUsesExistingPrefix(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -404,7 +539,7 @@ func TestDoRigAdd_ReAddMissingPathUsesCandidateConfig(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -436,7 +571,7 @@ func TestDoRigAdd_ReAddWarnsDifferingFlags(t *testing.T) {
 
 	// Re-add with --start-suspended=true (differs from existing).
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/new"}, "", "", true, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/new"}, "", "", "", true, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -475,7 +610,7 @@ func TestDoRigAdd_ReAddNoSpuriousWarning(t *testing.T) {
 
 	// Re-add with default flags (no --start-suspended, no --include).
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -500,7 +635,7 @@ func TestDoRigAdd_NotADirectory(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, filePath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, filePath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for non-directory, got code %d", code)
 	}
@@ -525,7 +660,7 @@ func TestDoRigAdd_RoutesGenerated(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -563,7 +698,7 @@ func TestDoRigAdd_ConfigUnchangedOnInfraFailure(t *testing.T) {
 	f.Errors[filepath.Join("/fake-rig", ".beads")] = os.ErrPermission
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(f, cityPath, "/fake-rig", nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(f, cityPath, "/fake-rig", nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure, got code %d", code)
 	}
@@ -593,7 +728,7 @@ func TestDoRigAdd_RootPackDefaultRigImportsErrorDoesNotMutateRig(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(f, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(f, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -625,7 +760,7 @@ func TestDoRigAdd_CandidateValidationErrorDoesNotCreateMissingRig(t *testing.T) 
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected validation failure, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -660,7 +795,7 @@ func TestDoRigAdd_CreateMissingRigDirectoryError(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(f, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(f, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected mkdir failure, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -949,7 +1084,7 @@ func TestDoRigAdd_WithPack(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/gastown"}, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/gastown"}, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -995,7 +1130,7 @@ func TestDoRigAdd_WithMultiplePacks(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/planner", "packs/architect"}, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/planner", "packs/architect"}, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1059,7 +1194,7 @@ func TestDoRigAdd_WithoutPack(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1102,7 +1237,7 @@ func TestDoRigAdd_DefaultRigIncludes(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	// No --include flag → should fall back to default_rig_includes.
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1156,7 +1291,7 @@ source = "packs/a-pack"
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1211,7 +1346,7 @@ func TestDoRigAdd_ExplicitIncludeOverridesDefault(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	// Explicit --include should override default_rig_includes.
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/custom"}, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, []string{"packs/custom"}, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1258,7 +1393,7 @@ func TestDoRigAdd_PrefixCollision(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("doRigAdd should fail for prefix collision, got code %d", code)
 	}
@@ -1284,7 +1419,7 @@ func TestDoRigAdd_HQPrefixCollisionDoesNotMutateRig(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("doRigAdd should fail for HQ prefix collision, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -1339,7 +1474,7 @@ func TestDoRigAdd_ExplicitPrefixResolvesCollision(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "mfoo", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "mfoo", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1392,7 +1527,7 @@ func TestDoRigAdd_ExplicitPrefixConflictsWithExistingBeads(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "xx", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "xx", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for conflicting prefix, got code %d", code)
 	}
@@ -1427,7 +1562,7 @@ func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for conflicting derived prefix, got code %d", code)
 	}
@@ -1467,7 +1602,7 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for pre-existing .beads/ without --adopt, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -1495,7 +1630,7 @@ func TestDoRigAdd_ExistingBeadsStatErrorFailsClosed(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(f, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(f, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for .beads stat error, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -1581,7 +1716,7 @@ func TestDoRigAdd_ReAddWarnsDifferingPrefix(t *testing.T) {
 
 	// Re-add with differing --prefix should warn.
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "xx", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "xx", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -1611,7 +1746,7 @@ func TestDoRigAdd_PrefixCanonicalizedToLowercase(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "AB", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "AB", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed, got code %d, stderr: %s", code, stderr.String())
 	}
@@ -1639,7 +1774,7 @@ func TestDoRigAdd_PrefixCanonicalizedToLowercase(t *testing.T) {
 
 	// Verify re-add succeeds (no false-positive conflict with .beads).
 	var stdout2, stderr2 bytes.Buffer
-	code2 := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout2, &stderr2)
+	code2 := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout2, &stderr2)
 	if code2 != 0 {
 		t.Errorf("re-add should succeed, got code %d, stderr: %s", code2, stderr2.String())
 	}
@@ -1660,7 +1795,7 @@ func TestDoRigAdd_PrefixRejectsHyphens(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "my-app", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "my-app", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for hyphenated prefix, got code %d", code)
 	}
@@ -1775,7 +1910,7 @@ name = "inline-agent"
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -1822,7 +1957,7 @@ func TestDoRigAdd_AdoptExistingBeads(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ar", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ar", "", false, true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd --adopt returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1855,7 +1990,7 @@ func TestDoRigAdd_AdoptRequiresMetadataJSON(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, true, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure when .beads/metadata.json missing, got code %d", code)
 	}
@@ -1880,7 +2015,7 @@ func TestDoRigAdd_AdoptRequiresExistingDir(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, true, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for non-existent dir with --adopt, got code %d", code)
 	}
@@ -1917,7 +2052,7 @@ func TestDoRigAdd_AdoptNonGitDirSucceeds(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ng", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ng", "", false, true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd --adopt on non-git dir returned %d, stderr: %s", code, stderr.String())
 	}
@@ -1955,7 +2090,7 @@ func TestDoRigAdd_AdoptRequiresConfigYaml(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "nc", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "nc", "", false, true, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure when .beads/config.yaml missing, got code %d", code)
 	}
@@ -1992,7 +2127,7 @@ func TestDoRigAdd_AdoptRejectsEmptyConfigYaml(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ec", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "ec", "", false, true, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure when config.yaml lacks issue_prefix, got code %d", code)
 	}
@@ -2031,7 +2166,7 @@ func TestDoRigAdd_AdoptWithoutPrefixMismatch(t *testing.T) {
 
 	// No --prefix: derived prefix from basename "mismatch-rig" won't match "xr".
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, true, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, true, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected prefix mismatch failure, got code %d, stdout: %s", code, stdout.String())
 	}

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -995,9 +995,36 @@ func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 // slingFormulaSearchPaths returns the formula search paths for the current
 // sling context. Uses the target agent's rig to select rig-specific layers,
 // falling back to city-level layers via FormulaLayers.SearchPaths.
+//
+// slingFormulaTargetBranch resolves the branch used as base_branch /
+// target_branch in formula vars. Resolution order:
+//  1. metadata.target on the work bead (or convoy ancestor)
+//  2. DefaultBranch recorded on the bead's rig in city.toml
+//  3. DefaultBranch recorded on the agent's rig in city.toml
+//  4. Live probe of the rig repo (git symbolic-ref origin/HEAD)
 func slingFormulaTargetBranch(beadID string, deps slingDeps, a config.Agent) string {
 	if target := beadMetadataTarget(deps.Store, beadID); target != "" {
 		return target
+	}
+	if deps.Cfg != nil {
+		if beadID != "" {
+			if bp := sling.BeadPrefix(beadID); bp != "" {
+				if rig, ok := sling.FindRigByPrefix(deps.Cfg, bp); ok {
+					if branch := rig.EffectiveDefaultBranch(); branch != "" {
+						return branch
+					}
+				}
+			}
+		}
+		if a.Dir != "" {
+			for _, r := range deps.Cfg.Rigs {
+				if r.Name == a.Dir {
+					if branch := r.EffectiveDefaultBranch(); branch != "" {
+						return branch
+					}
+				}
+			}
+		}
 	}
 	return defaultBranchFor(slingFormulaRepoDir(beadID, deps, a))
 }

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1003,61 +1003,10 @@ func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 //  3. DefaultBranch recorded on the agent's rig in city.toml
 //  4. Live probe of the rig repo (git symbolic-ref origin/HEAD)
 func slingFormulaTargetBranch(beadID string, deps slingDeps, a config.Agent) string {
-	if target := beadMetadataTarget(deps.Store, beadID); target != "" {
-		return target
+	if deps.Branches == nil {
+		deps.Branches = cliBranchResolver{}
 	}
-	if deps.Cfg != nil {
-		if beadID != "" {
-			if bp := sling.BeadPrefix(beadID); bp != "" {
-				if rig, ok := sling.FindRigByPrefix(deps.Cfg, bp); ok {
-					if branch := rig.EffectiveDefaultBranch(); branch != "" {
-						return branch
-					}
-				}
-			}
-		}
-		if a.Dir != "" {
-			for _, r := range deps.Cfg.Rigs {
-				if r.Name == a.Dir {
-					if branch := r.EffectiveDefaultBranch(); branch != "" {
-						return branch
-					}
-				}
-			}
-		}
-	}
-	return defaultBranchFor(slingFormulaRepoDir(beadID, deps, a))
-}
-
-func beadMetadataTarget(store beads.Store, beadID string) string {
-	if store == nil || beadID == "" {
-		return ""
-	}
-
-	seen := make(map[string]struct{}, 8)
-	rootID := beadID
-	for beadID != "" {
-		if _, ok := seen[beadID]; ok {
-			return ""
-		}
-		seen[beadID] = struct{}{}
-
-		b, err := store.Get(beadID)
-		if err != nil {
-			return ""
-		}
-		if target := strings.TrimSpace(b.Metadata["target"]); target != "" {
-			if beadID == rootID || b.Type == "convoy" {
-				return target
-			}
-		}
-		beadID = strings.TrimSpace(b.ParentID)
-	}
-	return ""
-}
-
-func slingFormulaRepoDir(beadID string, deps slingDeps, a config.Agent) string {
-	return resolveSlingStoreRoot(deps.Cfg, deps.CityPath, beadID, a)
+	return sling.SlingFormulaTargetBranch(beadID, deps, a)
 }
 
 func slingFormulaUsesBaseBranch(formula string) bool {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -4074,10 +4074,10 @@ func TestSlingFormulaRepoDirUsesCanonicalRigRoot(t *testing.T) {
 		},
 	}
 
-	got := slingFormulaRepoDir("plain text", deps, config.Agent{Dir: "alpha"})
+	got := sling.SlingFormulaRepoDir("plain text", deps, config.Agent{Dir: "alpha"})
 	want := filepath.Join(cityPath, "rigs", "alpha")
 	if got != want {
-		t.Fatalf("slingFormulaRepoDir() = %q, want %q", got, want)
+		t.Fatalf("SlingFormulaRepoDir() = %q, want %q", got, want)
 	}
 }
 
@@ -6668,6 +6668,46 @@ func TestBuildSlingFormulaVarsPrefersStoredRigDefaultBranchForPolecatFormula(t *
 	}
 }
 
+func TestBuildSlingFormulaVarsPrefersStoredRigDefaultBranchForHyphenatedPrefix(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "agent-diagnostics", Path: "/agent-diagnostics", Prefix: "agent-diagnostics", DefaultBranch: "master"},
+		},
+	}
+	store := &recordingStore{
+		Store: beads.NewMemStore(),
+		beadsByID: map[string]beads.Bead{
+			"agent-diagnostics-hnn": {ID: "agent-diagnostics-hnn"},
+		},
+	}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Store = store
+
+	vars := buildSlingFormulaVars("mol-polecat-work", "agent-diagnostics-hnn", nil, config.Agent{Name: "polecat"}, deps)
+
+	if got, ok := findVarValue(vars, "base_branch"); !ok || got != "master" {
+		t.Fatalf("base_branch var = %q, %v; want master, true (from hyphenated rig prefix DefaultBranch)", got, ok)
+	}
+}
+
+func TestBuildSlingFormulaVarsPrefersStoredRigDefaultBranchForAgentPath(t *testing.T) {
+	rigPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: rigPath, Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+
+	vars := buildSlingFormulaVars("mol-refinery-patrol", "", nil, config.Agent{Name: "refinery", Dir: rigPath}, deps)
+
+	if got, ok := findVarValue(vars, "target_branch"); !ok || got != "master" {
+		t.Fatalf("target_branch var = %q, %v; want master, true (from path-scoped agent DefaultBranch)", got, ok)
+	}
+}
+
 func TestBuildSlingFormulaVarsPrefersStoredRigDefaultBranchForRefineryFormula(t *testing.T) {
 	// The refinery's mol-refinery-patrol uses target_branch instead of
 	// base_branch, but the resolution path is identical.
@@ -6951,8 +6991,8 @@ func TestBeadMetadataTargetStopsOnParentCycle(t *testing.T) {
 		},
 	}
 
-	if got := beadMetadataTarget(store, "A"); got != "" {
-		t.Fatalf("beadMetadataTarget = %q, want empty string", got)
+	if got := sling.BeadMetadataTarget(store, "A"); got != "" {
+		t.Fatalf("BeadMetadataTarget = %q, want empty string", got)
 	}
 }
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -6643,6 +6643,49 @@ func TestDefaultFormulaDryRun(t *testing.T) {
 	}
 }
 
+func TestBuildSlingFormulaVarsPrefersStoredRigDefaultBranchForPolecatFormula(t *testing.T) {
+	// Storing default_branch in city.toml must override the live probe so
+	// rigs whose origin/HEAD is unset still get the right base_branch.
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	store := &recordingStore{
+		Store: beads.NewMemStore(),
+		beadsByID: map[string]beads.Bead{
+			"SC-1": {ID: "SC-1"}, // no metadata.target — must fall through to rig default
+		},
+	}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+	deps.Store = store
+
+	vars := buildSlingFormulaVars("mol-polecat-work", "SC-1", nil, config.Agent{Name: "polecat", Dir: "scamper"}, deps)
+
+	if got, ok := findVarValue(vars, "base_branch"); !ok || got != "master" {
+		t.Fatalf("base_branch var = %q, %v; want master, true (from rig DefaultBranch)", got, ok)
+	}
+}
+
+func TestBuildSlingFormulaVarsPrefersStoredRigDefaultBranchForRefineryFormula(t *testing.T) {
+	// The refinery's mol-refinery-patrol uses target_branch instead of
+	// base_branch, but the resolution path is identical.
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+
+	vars := buildSlingFormulaVars("mol-refinery-patrol", "", nil, config.Agent{Name: "refinery", Dir: "scamper"}, deps)
+
+	if got, ok := findVarValue(vars, "target_branch"); !ok || got != "master" {
+		t.Fatalf("target_branch var = %q, %v; want master, true (from rig DefaultBranch)", got, ok)
+	}
+}
+
 func TestBuildSlingFormulaVarsUsesBeadTargetForPolecatFormula(t *testing.T) {
 	cfg := &config.City{Workspace: config.Workspace{Name: "test-city"}}
 	store := &recordingStore{

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -3522,6 +3522,8 @@ export interface components {
             status: string;
         };
         RigCreateInputBody: {
+            /** @description Mainline branch (e.g. main, master). Auto-detected when omitted. */
+            default_branch?: string;
             /** @description Rig name. */
             name: string;
             /** @description Filesystem path. */
@@ -3539,12 +3541,15 @@ export interface components {
             status: string;
         };
         RigPatch: {
+            DefaultBranch: string | null;
             Name: string;
             Path: string | null;
             Prefix: string | null;
             Suspended: boolean | null;
         };
         RigPatchSetInputBody: {
+            /** @description Override mainline branch. */
+            default_branch?: string;
             /** @description Rig name. */
             name?: string;
             /** @description Override filesystem path. */
@@ -3557,6 +3562,7 @@ export interface components {
         RigResponse: {
             /** Format: int64 */
             agent_count: number;
+            default_branch?: string;
             git?: components["schemas"]["GitStatus"];
             /** Format: date-time */
             last_activity?: string;
@@ -3568,6 +3574,8 @@ export interface components {
             suspended: boolean;
         };
         RigUpdateInputBody: {
+            /** @description Mainline branch (e.g. main, master). */
+            default_branch?: string;
             /** @description Filesystem path. */
             path?: string;
             /** @description Session name prefix. */

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -2146,6 +2146,10 @@ export type RigActionBody = {
 
 export type RigCreateInputBody = {
     /**
+     * Mainline branch (e.g. main, master). Auto-detected when omitted.
+     */
+    default_branch?: string;
+    /**
      * Rig name.
      */
     name: string;
@@ -2171,6 +2175,7 @@ export type RigCreatedOutputBody = {
 };
 
 export type RigPatch = {
+    DefaultBranch: string | null;
     Name: string;
     Path: string | null;
     Prefix: string | null;
@@ -2178,6 +2183,10 @@ export type RigPatch = {
 };
 
 export type RigPatchSetInputBody = {
+    /**
+     * Override mainline branch.
+     */
+    default_branch?: string;
     /**
      * Rig name.
      */
@@ -2198,6 +2207,7 @@ export type RigPatchSetInputBody = {
 
 export type RigResponse = {
     agent_count: number;
+    default_branch?: string;
     git?: GitStatus;
     last_activity?: string;
     name: string;
@@ -2208,6 +2218,10 @@ export type RigResponse = {
 };
 
 export type RigUpdateInputBody = {
+    /**
+     * Mainline branch (e.g. main, master).
+     */
+    default_branch?: string;
     /**
      * Filesystem path.
      */

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -680,7 +680,7 @@ func TestDoRigAddCreatesDirIfMissing(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -700,7 +700,7 @@ func TestDoRigAddMkdirRigPathFails(t *testing.T) {
 	f.Errors["/projects/myapp"] = fmt.Errorf("permission denied")
 
 	var stderr bytes.Buffer
-	code := doRigAdd(f, "/city", "/projects/myapp", nil, "", "", false, false, &bytes.Buffer{}, &stderr)
+	code := doRigAdd(f, "/city", "/projects/myapp", nil, "", "", "", false, false, &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doRigAdd = %d, want 1", code)
 	}
@@ -714,7 +714,7 @@ func TestDoRigAddNotADirectory(t *testing.T) {
 	f.Files["/projects/myapp"] = []byte("not a dir") // file, not directory
 
 	var stderr bytes.Buffer
-	code := doRigAdd(f, "/city", "/projects/myapp", nil, "", "", false, false, &bytes.Buffer{}, &stderr)
+	code := doRigAdd(f, "/city", "/projects/myapp", nil, "", "", "", false, false, &bytes.Buffer{}, &stderr)
 	if code != 1 {
 		t.Errorf("doRigAdd = %d, want 1", code)
 	}
@@ -744,7 +744,7 @@ func TestDoRigAddWithGit(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -774,7 +774,7 @@ func TestDoRigAddWithoutGit(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -299,6 +299,24 @@ func defaultBranchFor(dir string) string {
 	return branch
 }
 
+// defaultBranchForRig returns the rig's recorded DefaultBranch when set,
+// falling back to a runtime probe of dir. Use this in prompt/template
+// rendering so polecats and the refinery target the rig's true mainline
+// even when origin/HEAD is unset on the local clone.
+func defaultBranchForRig(rigName string, rigs []config.Rig, dir string) string {
+	if rigName != "" {
+		for i := range rigs {
+			if rigs[i].Name == rigName {
+				if branch := rigs[i].EffectiveDefaultBranch(); branch != "" {
+					return branch
+				}
+				break
+			}
+		}
+	}
+	return defaultBranchFor(dir)
+}
+
 // promptFuncMap returns template functions available in prompt templates.
 // sessionTemplate is the custom session naming template (empty = default).
 // store is used by the "session" function to look up bead-derived session

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -298,6 +298,35 @@ func TestRenderPromptDefaultBranch(t *testing.T) {
 	}
 }
 
+func TestDefaultBranchForRig_PrefersStoredValue(t *testing.T) {
+	rigs := []config.Rig{
+		{Name: "scamper", Path: "/scamper", DefaultBranch: "master"},
+		{Name: "other", Path: "/other"},
+	}
+	got := defaultBranchForRig("scamper", rigs, "/nonexistent/path")
+	if got != "master" {
+		t.Errorf("defaultBranchForRig(scamper) = %q, want %q (stored value)", got, "master")
+	}
+}
+
+func TestDefaultBranchForRig_FallsBackToProbeWhenUnset(t *testing.T) {
+	rigs := []config.Rig{
+		{Name: "other", Path: "/other"}, // no DefaultBranch
+	}
+	// No matching rig — fall back to defaultBranchFor("") which returns "main".
+	got := defaultBranchForRig("missing", rigs, "")
+	if got != "main" {
+		t.Errorf("defaultBranchForRig(missing) = %q, want %q (probe fallback)", got, "main")
+	}
+}
+
+func TestDefaultBranchForRig_EmptyRigName(t *testing.T) {
+	got := defaultBranchForRig("", nil, "")
+	if got != "main" {
+		t.Errorf("defaultBranchForRig() with empty rig = %q, want %q", got, "main")
+	}
+}
+
 func TestRenderPromptEnvOverridePriority(t *testing.T) {
 	f := fsys.NewFake()
 	f.Files["/city/prompts/test.md.tmpl"] = []byte("Root: {{ .CityRoot }}")

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -549,7 +549,7 @@ func TestRigAnywhere_RigAddName(t *testing.T) {
 		}
 
 		var stdout, stderr bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "custom-name", "", false, false, &stdout, &stderr)
+		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "custom-name", "", "", false, false, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("doRigAdd = %d, stderr: %s", code, stderr.String())
 		}
@@ -584,7 +584,7 @@ func TestRigAnywhere_RigAddName(t *testing.T) {
 		}
 
 		var stdout, stderr bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", false, false, &stdout, &stderr)
+		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", "", false, false, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("doRigAdd = %d, stderr: %s", code, stderr.String())
 		}
@@ -612,7 +612,7 @@ func TestRigAnywhere_RigAddName(t *testing.T) {
 
 		// First add succeeds.
 		var stdout1, stderr1 bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, city1, rigDir1, nil, "shared-name", "", false, false, &stdout1, &stderr1)
+		code := doRigAdd(fsys.OSFS{}, city1, rigDir1, nil, "shared-name", "", "", false, false, &stdout1, &stderr1)
 		if code != 0 {
 			t.Fatalf("first doRigAdd = %d, stderr: %s", code, stderr1.String())
 		}
@@ -627,7 +627,7 @@ func TestRigAnywhere_RigAddName(t *testing.T) {
 			t.Fatal(err)
 		}
 		var stdout2, stderr2 bytes.Buffer
-		code = doRigAdd(fsys.OSFS{}, city2, rigDir2, nil, "shared-name", "", false, false, &stdout2, &stderr2)
+		code = doRigAdd(fsys.OSFS{}, city2, rigDir2, nil, "shared-name", "", "", false, false, &stdout2, &stderr2)
 		if code != 0 {
 			t.Fatalf("second doRigAdd = %d, stderr: %s", code, stderr2.String())
 		}
@@ -656,7 +656,7 @@ func TestRigAnywhere_RigAddSiteBindingSync(t *testing.T) {
 		}
 
 		var stdout, stderr bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", false, false, &stdout, &stderr)
+		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", "", false, false, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("doRigAdd = %d, stderr: %s", code, stderr.String())
 		}
@@ -692,14 +692,14 @@ func TestRigAnywhere_RigAddSiteBindingSync(t *testing.T) {
 		writeRigAnywhereCityToml(t, cityPath, toml)
 
 		var stdout1, stderr1 bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", false, false, &stdout1, &stderr1)
+		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", "", false, false, &stdout1, &stderr1)
 		if code != 0 {
 			t.Fatalf("first doRigAdd = %d, stderr: %s", code, stderr1.String())
 		}
 
 		// Re-add should succeed without duplicates.
 		var stdout2, stderr2 bytes.Buffer
-		code = doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", false, false, &stdout2, &stderr2)
+		code = doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", "", false, false, &stdout2, &stderr2)
 		if code != 0 {
 			t.Fatalf("re-add doRigAdd = %d, stderr: %s", code, stderr2.String())
 		}
@@ -738,7 +738,7 @@ func TestRigAnywhere_RigAddBeadsEnv(t *testing.T) {
 		}
 
 		var stdout, stderr bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", false, false, &stdout, &stderr)
+		code := doRigAdd(fsys.OSFS{}, cityPath, rigDir, nil, "", "", "", false, false, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("doRigAdd = %d, stderr: %s", code, stderr.String())
 		}
@@ -768,7 +768,7 @@ func TestRigAnywhere_RigAddBeadsEnv(t *testing.T) {
 
 		// First add with city1.
 		var stdout1, stderr1 bytes.Buffer
-		code := doRigAdd(fsys.OSFS{}, city1, rigDir, nil, "", "", false, false, &stdout1, &stderr1)
+		code := doRigAdd(fsys.OSFS{}, city1, rigDir, nil, "", "", "", false, false, &stdout1, &stderr1)
 		if code != 0 {
 			t.Fatalf("first doRigAdd = %d, stderr: %s", code, stderr1.String())
 		}
@@ -787,7 +787,7 @@ func TestRigAnywhere_RigAddBeadsEnv(t *testing.T) {
 		writeRigAnywhereCityToml(t, city2, toml2)
 
 		var stdout2, stderr2 bytes.Buffer
-		code = doRigAdd(fsys.OSFS{}, city2, rigDir, nil, "", "", false, false, &stdout2, &stderr2)
+		code = doRigAdd(fsys.OSFS{}, city2, rigDir, nil, "", "", "", false, false, &stdout2, &stderr2)
 		if code != 0 {
 			t.Fatalf("second doRigAdd = %d, stderr: %s", code, stderr2.String())
 		}

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -291,7 +291,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		RigRoot:       rigRoot,
 		WorkDir:       workDir,
 		IssuePrefix:   findRigPrefix(rigName, p.rigs),
-		DefaultBranch: defaultBranchFor(workDir),
+		DefaultBranch: defaultBranchForRig(rigName, p.rigs, workDir),
 		WorkQuery:     expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQuery(), p.stderr),
 		SlingQuery:    expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
 		Env:           cfgAgent.Env,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1921,10 +1921,11 @@ gc rig add /path/to/project
 
 ## gc rig list
 
-List all registered rigs with their paths, prefixes, and beads status.
+List all registered rigs with their paths, prefixes, default branches, and beads status.
 
 Shows the HQ rig (the city itself) and all configured rigs. Each rig
-displays its bead ID prefix and whether its beads database is initialized.
+displays its bead ID prefix, recorded default branch when set, and whether
+its beads database is initialized.
 
 ```
 gc rig list [flags]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1882,6 +1882,10 @@ repeat the flag to compose multiple packs for one rig.
 
 Use --name to set the rig name explicitly (default: directory basename).
 Use --prefix to set the bead ID prefix explicitly (default: derived from name).
+Use --default-branch to set the rig's mainline branch explicitly. By default,
+gc rig add probes the repo's origin/HEAD (and falls back to the currently
+checked-out branch) and stores the result in city.toml so polecats and the
+refinery target the right branch without manual metadata patching.
 Use --start-suspended to add the rig in a suspended state (dormant-by-default).
 The rig's agents won't spawn until explicitly resumed with "gc rig resume".
 
@@ -1899,6 +1903,7 @@ gc rig add <path> [flags]
 gc rig add /path/to/project
   gc rig add /path/to/project --name myrig
   gc rig add /path/to/project --prefix r1
+  gc rig add /path/to/master-repo --default-branch master
   gc rig add ./my-project --include packs/gastown
   gc rig add ./my-project --include packs/planner --include packs/architect
   gc rig add ./my-project --include packs/gastown --start-suspended
@@ -1908,6 +1913,7 @@ gc rig add /path/to/project
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--adopt` | bool |  | adopt existing .beads/ directory (skip init) |
+| `--default-branch` | string |  | mainline branch (default: auto-detect from origin/HEAD or current branch) |
 | `--include` | stringArray |  | pack directory for rig agents (repeatable) |
 | `--name` | string |  | rig name (default: directory basename) |
 | `--prefix` | string |  | bead ID prefix (default: derived from name) |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -520,6 +520,7 @@ Rig defines an external project registered in the city.
 | `name` | string | **yes** |  | Name is the unique identifier for this rig. |
 | `path` | string |  |  | Path is the absolute filesystem path to the rig's repository. |
 | `prefix` | string |  |  | Prefix overrides the auto-derived bead ID prefix for this rig. |
+| `default_branch` | string |  |  | DefaultBranch is the rig repository's mainline branch (e.g. "main", "master", "develop"). When set, polecats and the refinery use this as the default merge target instead of probing origin/HEAD at sling time. Captured by `gc rig add` from the rig's git config; set manually for rigs whose mainline isn't reachable via origin/HEAD. |
 | `suspended` | boolean |  |  | Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume. |
 | `formulas_dir` | string |  |  | FormulasDir is a rig-local formula directory (Layer 4). Overrides pack formulas for this rig by filename. Relative paths resolve against the city directory. |
 | `includes` | []string |  |  | Includes lists pack directories or URLs for this rig (V1 mechanism). Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
@@ -541,6 +542,7 @@ RigPatch modifies an existing rig identified by Name.
 | `name` | string | **yes** |  | Name is the targeting key (required). Must match an existing rig's name. |
 | `path` | string |  |  | Path overrides the rig's filesystem path. |
 | `prefix` | string |  |  | Prefix overrides the bead ID prefix. |
+| `default_branch` | string |  |  | DefaultBranch overrides the rig's recorded mainline branch. |
 | `suspended` | boolean |  |  | Suspended overrides the rig's suspended state. |
 
 ## Service

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1840,6 +1840,10 @@
           "type": "string",
           "description": "Prefix overrides the auto-derived bead ID prefix for this rig."
         },
+        "default_branch": {
+          "type": "string",
+          "description": "DefaultBranch is the rig repository's mainline branch (e.g. \"main\",\n\"master\", \"develop\"). When set, polecats and the refinery use this\nas the default merge target instead of probing origin/HEAD at sling\ntime. Captured by `gc rig add` from the rig's git config; set\nmanually for rigs whose mainline isn't reachable via origin/HEAD."
+        },
         "suspended": {
           "type": "boolean",
           "description": "Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume."
@@ -1917,6 +1921,10 @@
         "prefix": {
           "type": "string",
           "description": "Prefix overrides the bead ID prefix."
+        },
+        "default_branch": {
+          "type": "string",
+          "description": "DefaultBranch overrides the rig's recorded mainline branch."
         },
         "suspended": {
           "type": "boolean",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1840,6 +1840,10 @@
           "type": "string",
           "description": "Prefix overrides the auto-derived bead ID prefix for this rig."
         },
+        "default_branch": {
+          "type": "string",
+          "description": "DefaultBranch is the rig repository's mainline branch (e.g. \"main\",\n\"master\", \"develop\"). When set, polecats and the refinery use this\nas the default merge target instead of probing origin/HEAD at sling\ntime. Captured by `gc rig add` from the rig's git config; set\nmanually for rigs whose mainline isn't reachable via origin/HEAD."
+        },
         "suspended": {
           "type": "boolean",
           "description": "Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume."
@@ -1917,6 +1921,10 @@
         "prefix": {
           "type": "string",
           "description": "Prefix overrides the bead ID prefix."
+        },
+        "default_branch": {
+          "type": "string",
+          "description": "DefaultBranch overrides the rig's recorded mainline branch."
         },
         "suspended": {
           "type": "boolean",

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -5293,6 +5293,10 @@
       "RigCreateInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Mainline branch (e.g. main, master). Auto-detected when omitted.",
+            "type": "string"
+          },
           "name": {
             "description": "Rig name.",
             "minLength": 1,
@@ -5338,6 +5342,12 @@
       "RigPatch": {
         "additionalProperties": false,
         "properties": {
+          "DefaultBranch": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "Name": {
             "type": "string"
           },
@@ -5364,6 +5374,7 @@
           "Name",
           "Path",
           "Prefix",
+          "DefaultBranch",
           "Suspended"
         ],
         "type": "object"
@@ -5396,6 +5407,9 @@
           "agent_count": {
             "format": "int64",
             "type": "integer"
+          },
+          "default_branch": {
+            "type": "string"
           },
           "git": {
             "$ref": "#/components/schemas/GitStatus"
@@ -5433,6 +5447,10 @@
       "RigUpdateInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Mainline branch (e.g. main, master).",
+            "type": "string"
+          },
           "path": {
             "description": "Filesystem path.",
             "type": "string"

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -5382,6 +5382,10 @@
       "RigPatchSetInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Override mainline branch.",
+            "type": "string"
+          },
           "name": {
             "description": "Rig name.",
             "type": "string"

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -5293,6 +5293,10 @@
       "RigCreateInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Mainline branch (e.g. main, master). Auto-detected when omitted.",
+            "type": "string"
+          },
           "name": {
             "description": "Rig name.",
             "minLength": 1,
@@ -5338,6 +5342,12 @@
       "RigPatch": {
         "additionalProperties": false,
         "properties": {
+          "DefaultBranch": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "Name": {
             "type": "string"
           },
@@ -5364,6 +5374,7 @@
           "Name",
           "Path",
           "Prefix",
+          "DefaultBranch",
           "Suspended"
         ],
         "type": "object"
@@ -5396,6 +5407,9 @@
           "agent_count": {
             "format": "int64",
             "type": "integer"
+          },
+          "default_branch": {
+            "type": "string"
           },
           "git": {
             "$ref": "#/components/schemas/GitStatus"
@@ -5433,6 +5447,10 @@
       "RigUpdateInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Mainline branch (e.g. main, master).",
+            "type": "string"
+          },
           "path": {
             "description": "Filesystem path.",
             "type": "string"

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -5382,6 +5382,10 @@
       "RigPatchSetInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Override mainline branch.",
+            "type": "string"
+          },
           "name": {
             "description": "Rig name.",
             "type": "string"

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -255,6 +255,9 @@ func (f *fakeMutatorState) UpdateRig(name string, patch RigUpdate) error {
 			if patch.Prefix != "" {
 				f.cfg.Rigs[i].Prefix = patch.Prefix
 			}
+			if patch.DefaultBranch != "" {
+				f.cfg.Rigs[i].DefaultBranch = patch.DefaultBranch
+			}
 			if patch.Suspended != nil {
 				f.cfg.Rigs[i].Suspended = *patch.Suspended
 			}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2083,6 +2083,9 @@ type RigActionBody struct {
 
 // RigCreateInputBody defines model for RigCreateInputBody.
 type RigCreateInputBody struct {
+	// DefaultBranch Mainline branch (e.g. main, master). Auto-detected when omitted.
+	DefaultBranch *string `json:"default_branch,omitempty"`
+
 	// Name Rig name.
 	Name string `json:"name"`
 
@@ -2104,10 +2107,11 @@ type RigCreatedOutputBody struct {
 
 // RigPatch defines model for RigPatch.
 type RigPatch struct {
-	Name      string  `json:"Name"`
-	Path      *string `json:"Path"`
-	Prefix    *string `json:"Prefix"`
-	Suspended *bool   `json:"Suspended"`
+	DefaultBranch *string `json:"DefaultBranch"`
+	Name          string  `json:"Name"`
+	Path          *string `json:"Path"`
+	Prefix        *string `json:"Prefix"`
+	Suspended     *bool   `json:"Suspended"`
 }
 
 // RigPatchSetInputBody defines model for RigPatchSetInputBody.
@@ -2127,18 +2131,22 @@ type RigPatchSetInputBody struct {
 
 // RigResponse defines model for RigResponse.
 type RigResponse struct {
-	AgentCount   int64      `json:"agent_count"`
-	Git          *GitStatus `json:"git,omitempty"`
-	LastActivity *time.Time `json:"last_activity,omitempty"`
-	Name         string     `json:"name"`
-	Path         string     `json:"path"`
-	Prefix       *string    `json:"prefix,omitempty"`
-	RunningCount int64      `json:"running_count"`
-	Suspended    bool       `json:"suspended"`
+	AgentCount    int64      `json:"agent_count"`
+	DefaultBranch *string    `json:"default_branch,omitempty"`
+	Git           *GitStatus `json:"git,omitempty"`
+	LastActivity  *time.Time `json:"last_activity,omitempty"`
+	Name          string     `json:"name"`
+	Path          string     `json:"path"`
+	Prefix        *string    `json:"prefix,omitempty"`
+	RunningCount  int64      `json:"running_count"`
+	Suspended     bool       `json:"suspended"`
 }
 
 // RigUpdateInputBody defines model for RigUpdateInputBody.
 type RigUpdateInputBody struct {
+	// DefaultBranch Mainline branch (e.g. main, master).
+	DefaultBranch *string `json:"default_branch,omitempty"`
+
 	// Path Filesystem path.
 	Path *string `json:"path,omitempty"`
 

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2116,6 +2116,9 @@ type RigPatch struct {
 
 // RigPatchSetInputBody defines model for RigPatchSetInputBody.
 type RigPatchSetInputBody struct {
+	// DefaultBranch Override mainline branch.
+	DefaultBranch *string `json:"default_branch,omitempty"`
+
 	// Name Rig name.
 	Name *string `json:"name,omitempty"`
 

--- a/internal/api/handler_patches_test.go
+++ b/internal/api/handler_patches_test.go
@@ -186,7 +186,7 @@ func TestHandleRigPatchSet(t *testing.T) {
 	fs := newFakeMutatorState(t)
 	h := newTestCityHandler(t, fs)
 
-	body := `{"name":"myrig","suspended":true}`
+	body := `{"name":"myrig","default_branch":"develop","suspended":true}`
 	req := httptest.NewRequest("PUT", cityURL(fs, "/patches/rigs"), strings.NewReader(body))
 	req.Header.Set("X-GC-Request", "true")
 	w := httptest.NewRecorder()
@@ -198,6 +198,9 @@ func TestHandleRigPatchSet(t *testing.T) {
 
 	if len(fs.cfg.Patches.Rigs) != 1 {
 		t.Fatalf("patches.rigs count = %d, want 1", len(fs.cfg.Patches.Rigs))
+	}
+	if fs.cfg.Patches.Rigs[0].DefaultBranch == nil || *fs.cfg.Patches.Rigs[0].DefaultBranch != "develop" {
+		t.Fatalf("DefaultBranch = %v, want develop", fs.cfg.Patches.Rigs[0].DefaultBranch)
 	}
 }
 

--- a/internal/api/handler_rigs.go
+++ b/internal/api/handler_rigs.go
@@ -13,14 +13,15 @@ import (
 )
 
 type rigResponse struct {
-	Name         string     `json:"name"`
-	Path         string     `json:"path"`
-	Suspended    bool       `json:"suspended"`
-	Prefix       string     `json:"prefix,omitempty"`
-	AgentCount   int        `json:"agent_count"`
-	RunningCount int        `json:"running_count"`
-	LastActivity *time.Time `json:"last_activity,omitempty"`
-	Git          *gitStatus `json:"git,omitempty"`
+	Name          string     `json:"name"`
+	Path          string     `json:"path"`
+	Suspended     bool       `json:"suspended"`
+	Prefix        string     `json:"prefix,omitempty"`
+	DefaultBranch string     `json:"default_branch,omitempty"`
+	AgentCount    int        `json:"agent_count"`
+	RunningCount  int        `json:"running_count"`
+	LastActivity  *time.Time `json:"last_activity,omitempty"`
+	Git           *gitStatus `json:"git,omitempty"`
 }
 
 type gitStatus struct {
@@ -56,12 +57,13 @@ func (s *Server) buildRigResponse(cfg *config.City, rig config.Rig, sp runtime.P
 	}
 
 	resp := rigResponse{
-		Name:         rig.Name,
-		Path:         rig.Path,
-		Suspended:    s.rigSuspended(cfg, rig, sp, cityName, cityPath),
-		Prefix:       rig.Prefix,
-		AgentCount:   agentCount,
-		RunningCount: runningCount,
+		Name:          rig.Name,
+		Path:          rig.Path,
+		Suspended:     s.rigSuspended(cfg, rig, sp, cityName, cityPath),
+		Prefix:        rig.Prefix,
+		DefaultBranch: rig.DefaultBranch,
+		AgentCount:    agentCount,
+		RunningCount:  runningCount,
 	}
 	if !maxActivity.IsZero() {
 		resp.LastActivity = &maxActivity

--- a/internal/api/huma_handlers_patches.go
+++ b/internal/api/huma_handlers_patches.go
@@ -146,10 +146,11 @@ func (s *Server) humaHandleRigPatchSet(_ context.Context, input *RigPatchSetInpu
 	}
 
 	patch := config.RigPatch{
-		Name:      input.Body.Name,
-		Path:      input.Body.Path,
-		Prefix:    input.Body.Prefix,
-		Suspended: input.Body.Suspended,
+		Name:          input.Body.Name,
+		Path:          input.Body.Path,
+		Prefix:        input.Body.Prefix,
+		DefaultBranch: input.Body.DefaultBranch,
+		Suspended:     input.Body.Suspended,
 	}
 
 	if patch.Name == "" {

--- a/internal/api/huma_handlers_rigs.go
+++ b/internal/api/huma_handlers_rigs.go
@@ -66,9 +66,10 @@ func (s *Server) humaHandleRigCreate(_ context.Context, input *RigCreateInput) (
 	}
 
 	rig := config.Rig{
-		Name:   input.Body.Name,
-		Path:   input.Body.Path,
-		Prefix: input.Body.Prefix,
+		Name:          input.Body.Name,
+		Path:          input.Body.Path,
+		Prefix:        input.Body.Prefix,
+		DefaultBranch: input.Body.DefaultBranch,
 	}
 
 	if err := sm.CreateRig(rig); err != nil {
@@ -88,9 +89,10 @@ func (s *Server) humaHandleRigUpdate(_ context.Context, input *RigUpdateInput) (
 	}
 
 	patch := RigUpdate{
-		Path:      input.Body.Path,
-		Prefix:    input.Body.Prefix,
-		Suspended: input.Body.Suspended,
+		Path:          input.Body.Path,
+		Prefix:        input.Body.Prefix,
+		DefaultBranch: input.Body.DefaultBranch,
+		Suspended:     input.Body.Suspended,
 	}
 
 	if err := sm.UpdateRig(input.Name, patch); err != nil {

--- a/internal/api/huma_types_patches.go
+++ b/internal/api/huma_types_patches.go
@@ -79,10 +79,11 @@ type RigPatchGetInput struct {
 type RigPatchSetInput struct {
 	CityScope
 	Body struct {
-		Name      string  `json:"name,omitempty" doc:"Rig name."`
-		Path      *string `json:"path,omitempty" doc:"Override filesystem path."`
-		Prefix    *string `json:"prefix,omitempty" doc:"Override bead ID prefix."`
-		Suspended *bool   `json:"suspended,omitempty" doc:"Override suspended state."`
+		Name          string  `json:"name,omitempty" doc:"Rig name."`
+		Path          *string `json:"path,omitempty" doc:"Override filesystem path."`
+		Prefix        *string `json:"prefix,omitempty" doc:"Override bead ID prefix."`
+		DefaultBranch *string `json:"default_branch,omitempty" doc:"Override mainline branch."`
+		Suspended     *bool   `json:"suspended,omitempty" doc:"Override suspended state."`
 	}
 }
 

--- a/internal/api/huma_types_rigs.go
+++ b/internal/api/huma_types_rigs.go
@@ -24,9 +24,10 @@ type RigGetInput struct {
 type RigCreateInput struct {
 	CityScope
 	Body struct {
-		Name   string `json:"name" doc:"Rig name." minLength:"1"`
-		Path   string `json:"path" doc:"Filesystem path." minLength:"1"`
-		Prefix string `json:"prefix,omitempty" doc:"Session name prefix."`
+		Name          string `json:"name" doc:"Rig name." minLength:"1"`
+		Path          string `json:"path" doc:"Filesystem path." minLength:"1"`
+		Prefix        string `json:"prefix,omitempty" doc:"Session name prefix."`
+		DefaultBranch string `json:"default_branch,omitempty" doc:"Mainline branch (e.g. main, master). Auto-detected when omitted."`
 	}
 }
 
@@ -35,9 +36,10 @@ type RigUpdateInput struct {
 	CityScope
 	Name string `path:"name" doc:"Rig name."`
 	Body struct {
-		Path      string `json:"path,omitempty" doc:"Filesystem path."`
-		Prefix    string `json:"prefix,omitempty" doc:"Session name prefix."`
-		Suspended *bool  `json:"suspended,omitempty" doc:"Whether rig is suspended."`
+		Path          string `json:"path,omitempty" doc:"Filesystem path."`
+		Prefix        string `json:"prefix,omitempty" doc:"Session name prefix."`
+		DefaultBranch string `json:"default_branch,omitempty" doc:"Mainline branch (e.g. main, master)."`
+		Suspended     *bool  `json:"suspended,omitempty" doc:"Whether rig is suspended."`
 	}
 }
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -5293,6 +5293,10 @@
       "RigCreateInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Mainline branch (e.g. main, master). Auto-detected when omitted.",
+            "type": "string"
+          },
           "name": {
             "description": "Rig name.",
             "minLength": 1,
@@ -5338,6 +5342,12 @@
       "RigPatch": {
         "additionalProperties": false,
         "properties": {
+          "DefaultBranch": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "Name": {
             "type": "string"
           },
@@ -5364,6 +5374,7 @@
           "Name",
           "Path",
           "Prefix",
+          "DefaultBranch",
           "Suspended"
         ],
         "type": "object"
@@ -5396,6 +5407,9 @@
           "agent_count": {
             "format": "int64",
             "type": "integer"
+          },
+          "default_branch": {
+            "type": "string"
           },
           "git": {
             "$ref": "#/components/schemas/GitStatus"
@@ -5433,6 +5447,10 @@
       "RigUpdateInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Mainline branch (e.g. main, master).",
+            "type": "string"
+          },
           "path": {
             "description": "Filesystem path.",
             "type": "string"

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -5382,6 +5382,10 @@
       "RigPatchSetInputBody": {
         "additionalProperties": false,
         "properties": {
+          "default_branch": {
+            "description": "Override mainline branch.",
+            "type": "string"
+          },
           "name": {
             "description": "Rig name.",
             "type": "string"

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -104,9 +104,10 @@ type AgentUpdate struct {
 // RigUpdate holds optional fields for a partial rig update. Pointer fields
 // distinguish "not set" from "set to zero value."
 type RigUpdate struct {
-	Path      string
-	Prefix    string
-	Suspended *bool
+	Path          string
+	Prefix        string
+	DefaultBranch string
+	Suspended     *bool
 }
 
 // ProviderUpdate holds optional fields for a partial provider update.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -456,6 +456,12 @@ type Rig struct {
 	Path string `toml:"path,omitempty"`
 	// Prefix overrides the auto-derived bead ID prefix for this rig.
 	Prefix string `toml:"prefix,omitempty"`
+	// DefaultBranch is the rig repository's mainline branch (e.g. "main",
+	// "master", "develop"). When set, polecats and the refinery use this
+	// as the default merge target instead of probing origin/HEAD at sling
+	// time. Captured by `gc rig add` from the rig's git config; set
+	// manually for rigs whose mainline isn't reachable via origin/HEAD.
+	DefaultBranch string `toml:"default_branch,omitempty"`
 	// Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume.
 	Suspended bool `toml:"suspended,omitempty"`
 	// FormulasDir is a rig-local formula directory (Layer 4). Overrides
@@ -750,6 +756,13 @@ func (r *Rig) EffectivePrefix() string {
 		return r.Prefix
 	}
 	return DeriveBeadsPrefix(r.Name)
+}
+
+// EffectiveDefaultBranch returns the rig's recorded default branch, or the
+// empty string if none is set. Callers should fall back to a runtime probe
+// (e.g., git symbolic-ref) when this returns "".
+func (r *Rig) EffectiveDefaultBranch() string {
+	return strings.TrimSpace(r.DefaultBranch)
 }
 
 // EffectiveHQPrefix returns the bead ID prefix for the city's HQ store.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,6 +116,38 @@ start_command = "claude --dangerously-skip-permissions"
 	}
 }
 
+func TestParseRigDefaultBranch(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "lights"
+
+[[rigs]]
+name = "scamper"
+path = "/scamper"
+default_branch = "master"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(cfg.Rigs) != 1 {
+		t.Fatalf("len(Rigs) = %d, want 1", len(cfg.Rigs))
+	}
+	if got := cfg.Rigs[0].DefaultBranch; got != "master" {
+		t.Errorf("DefaultBranch = %q, want %q", got, "master")
+	}
+	if got := cfg.Rigs[0].EffectiveDefaultBranch(); got != "master" {
+		t.Errorf("EffectiveDefaultBranch = %q, want %q", got, "master")
+	}
+}
+
+func TestEffectiveDefaultBranch_EmptyWhenUnset(t *testing.T) {
+	r := Rig{Name: "rig"}
+	if got := r.EffectiveDefaultBranch(); got != "" {
+		t.Errorf("EffectiveDefaultBranch() = %q, want empty", got)
+	}
+}
+
 func TestParseAgentSkillsAndMCP(t *testing.T) {
 	data := []byte(`
 [workspace]

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -160,6 +160,8 @@ type RigPatch struct {
 	Path *string `toml:"path,omitempty"`
 	// Prefix overrides the bead ID prefix.
 	Prefix *string `toml:"prefix,omitempty"`
+	// DefaultBranch overrides the rig's recorded mainline branch.
+	DefaultBranch *string `toml:"default_branch,omitempty"`
 	// Suspended overrides the rig's suspended state.
 	Suspended *bool `toml:"suspended,omitempty"`
 }
@@ -423,6 +425,9 @@ func applyRigPatch(cfg *City, patch *RigPatch) error {
 			}
 			if patch.Prefix != nil {
 				r.Prefix = *patch.Prefix
+			}
+			if patch.DefaultBranch != nil {
+				r.DefaultBranch = *patch.DefaultBranch
 			}
 			if patch.Suspended != nil {
 				r.Suspended = *patch.Suspended

--- a/internal/config/patch_test.go
+++ b/internal/config/patch_test.go
@@ -221,6 +221,23 @@ func TestApplyPatches_RigPath(t *testing.T) {
 	}
 }
 
+func TestApplyPatches_RigDefaultBranch(t *testing.T) {
+	cfg := &City{
+		Rigs: []Rig{{Name: "scamper", Path: "/scamper", DefaultBranch: "master"}},
+	}
+	err := ApplyPatches(cfg, Patches{
+		Rigs: []RigPatch{
+			{Name: "scamper", DefaultBranch: ptrStr("develop")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyPatches: %v", err)
+	}
+	if cfg.Rigs[0].DefaultBranch != "develop" {
+		t.Errorf("DefaultBranch = %q, want %q", cfg.Rigs[0].DefaultBranch, "develop")
+	}
+}
+
 func TestApplyPatches_RigSuspend(t *testing.T) {
 	cfg := &City{
 		Rigs: []Rig{{Name: "hw", Path: "/path"}},

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -645,9 +645,10 @@ func (e *Editor) CreateRig(r config.Rig) error {
 // distinguish "not set" from "set to zero value" to avoid the PATCH
 // zero-value trap (e.g., omitting suspended must not reset it to false).
 type RigUpdate struct {
-	Path      string
-	Prefix    string
-	Suspended *bool
+	Path          string
+	Prefix        string
+	DefaultBranch string
+	Suspended     *bool
 }
 
 // UpdateRig partially updates an existing rig. Only non-nil/non-empty
@@ -661,6 +662,9 @@ func (e *Editor) UpdateRig(name string, patch RigUpdate) error {
 				}
 				if patch.Prefix != "" {
 					cfg.Rigs[i].Prefix = patch.Prefix
+				}
+				if patch.DefaultBranch != "" {
+					cfg.Rigs[i].DefaultBranch = patch.DefaultBranch
 				}
 				if patch.Suspended != nil {
 					cfg.Rigs[i].Suspended = *patch.Suspended

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -66,6 +66,31 @@ func (g *Git) DefaultBranch() (string, error) {
 	return strings.TrimPrefix(ref, "refs/remotes/origin/"), nil
 }
 
+// ProbeDefaultBranch returns the repo's mainline branch name with a richer
+// fallback chain than DefaultBranch:
+//  1. refs/remotes/origin/HEAD symref (the configured default)
+//  2. the currently checked-out branch (when origin/HEAD is unset, the
+//     first branch is usually the mainline)
+//  3. empty string (caller decides)
+//
+// Use this at registration time (gc rig add) where we want to record the
+// repo's actual mainline rather than a generic "main" placeholder.
+func (g *Git) ProbeDefaultBranch() string {
+	if out, err := g.run("symbolic-ref", "refs/remotes/origin/HEAD"); err == nil {
+		ref := strings.TrimSpace(out)
+		if branch := strings.TrimPrefix(ref, "refs/remotes/origin/"); branch != "" {
+			return branch
+		}
+	}
+	if branch, err := g.CurrentBranch(); err == nil {
+		branch = strings.TrimSpace(branch)
+		if branch != "" && branch != "HEAD" {
+			return branch
+		}
+	}
+	return ""
+}
+
 // WorktreeRemove removes a worktree. If force is true, removes even with
 // uncommitted changes.
 func (g *Git) WorktreeRemove(path string, force bool) error {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -125,6 +125,49 @@ func TestDefaultBranch_FromOriginHEAD(t *testing.T) {
 	}
 }
 
+func TestProbeDefaultBranch_FromOriginHEAD(t *testing.T) {
+	bare := t.TempDir()
+	runGit(t, bare, "init", "--bare")
+
+	clone := t.TempDir()
+	runGit(t, clone, "clone", bare, ".")
+	runGit(t, clone, "config", "user.email", "test@test.com")
+	runGit(t, clone, "config", "user.name", "Test")
+	runGit(t, clone, "commit", "--allow-empty", "-m", "init")
+
+	target := "refs/remotes/origin/master"
+	runGit(t, clone, "update-ref", target, "HEAD")
+	runGit(t, clone, "symbolic-ref", "refs/remotes/origin/HEAD", target)
+
+	g := New(clone)
+	got := g.ProbeDefaultBranch()
+	if got != "master" {
+		t.Errorf("ProbeDefaultBranch() = %q, want %q", got, "master")
+	}
+}
+
+func TestProbeDefaultBranch_FallsBackToCurrentBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	// Force a known branch name; the test repo's default may be "main"
+	// or "master" depending on the host's git init.defaultBranch.
+	runGit(t, repo, "checkout", "-b", "develop")
+	g := New(repo)
+	got := g.ProbeDefaultBranch()
+	if got != "develop" {
+		t.Errorf("ProbeDefaultBranch() = %q, want %q (current branch fallback)", got, "develop")
+	}
+}
+
+func TestProbeDefaultBranch_NoRepo(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(dir))
+	g := New(dir)
+	got := g.ProbeDefaultBranch()
+	if got != "" {
+		t.Errorf("ProbeDefaultBranch() = %q, want empty (no repo)", got)
+	}
+}
+
 func TestWorktreeRemove(t *testing.T) {
 	repo := initTestRepo(t)
 	g := New(repo)

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -341,13 +341,14 @@ func RigDirForBead(cfg *config.City, beadID string) string {
 }
 
 // RigDirForAgent returns the rig directory for an agent by matching its Dir
-// field to a rig Name.
+// field to a rig name or configured rig path.
 func RigDirForAgent(cfg *config.City, a config.Agent) string {
-	if a.Dir == "" {
+	rigName := rigNameForAgent(cfg, a)
+	if rigName == "" {
 		return ""
 	}
 	for _, r := range cfg.Rigs {
-		if r.Name == a.Dir {
+		if r.Name == rigName {
 			return r.Path
 		}
 	}
@@ -835,13 +836,24 @@ func SlingFormulaUsesTargetBranch(formulaName string) bool {
 func SlingFormulaRepoDir(beadID string, deps SlingDeps, a config.Agent) string {
 	if deps.Cfg != nil {
 		if dir := RigDirForBead(deps.Cfg, beadID); dir != "" {
-			return dir
+			return resolveScopeRoot(deps.CityPath, dir)
 		}
 		if dir := RigDirForAgent(deps.Cfg, a); dir != "" {
-			return dir
+			return resolveScopeRoot(deps.CityPath, dir)
 		}
 	}
-	return deps.CityPath
+	return resolveScopeRoot(deps.CityPath, deps.CityPath)
+}
+
+func resolveScopeRoot(cityPath, storePath string) string {
+	scopeRoot := strings.TrimSpace(storePath)
+	if scopeRoot == "" {
+		scopeRoot = cityPath
+	}
+	if !filepath.IsAbs(scopeRoot) {
+		scopeRoot = filepath.Join(cityPath, scopeRoot)
+	}
+	return filepath.Clean(scopeRoot)
 }
 
 // SlingFormulaTargetBranch resolves the target branch for formula variables.
@@ -872,7 +884,7 @@ func rigStoredDefaultBranch(cfg *config.City, beadID string, a config.Agent) str
 		return ""
 	}
 	if beadID != "" {
-		if bp := BeadPrefix(beadID); bp != "" {
+		if bp := BeadPrefixForCity(cfg, beadID); bp != "" && !IsHQPrefix(cfg, bp) {
 			if rig, ok := FindRigByPrefix(cfg, bp); ok {
 				if branch := rig.EffectiveDefaultBranch(); branch != "" {
 					return branch
@@ -880,9 +892,9 @@ func rigStoredDefaultBranch(cfg *config.City, beadID string, a config.Agent) str
 			}
 		}
 	}
-	if a.Dir != "" {
+	if rigName := rigNameForAgent(cfg, a); rigName != "" {
 		for _, r := range cfg.Rigs {
-			if r.Name == a.Dir {
+			if r.Name == rigName {
 				if branch := r.EffectiveDefaultBranch(); branch != "" {
 					return branch
 				}

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -845,12 +845,49 @@ func SlingFormulaRepoDir(beadID string, deps SlingDeps, a config.Agent) string {
 }
 
 // SlingFormulaTargetBranch resolves the target branch for formula variables.
+// Resolution order:
+//  1. metadata.target on the work bead (per-bead override)
+//  2. DefaultBranch recorded on the bead's rig in city.toml (set by gc rig add)
+//  3. DefaultBranch recorded on the agent's rig in city.toml
+//  4. Live probe via deps.Branches.DefaultBranch (git symbolic-ref origin/HEAD)
 func SlingFormulaTargetBranch(beadID string, deps SlingDeps, a config.Agent) string {
 	if target := BeadMetadataTarget(deps.Store, beadID); target != "" {
 		return target
 	}
+	if branch := rigStoredDefaultBranch(deps.Cfg, beadID, a); branch != "" {
+		return branch
+	}
 	if deps.Branches != nil {
 		return deps.Branches.DefaultBranch(SlingFormulaRepoDir(beadID, deps, a))
+	}
+	return ""
+}
+
+// rigStoredDefaultBranch returns the DefaultBranch recorded on the rig the
+// bead/agent belongs to, or empty string if no match has a stored value.
+// Bead lookup wins over agent lookup so cross-rig sling targets still pick
+// the right rig.
+func rigStoredDefaultBranch(cfg *config.City, beadID string, a config.Agent) string {
+	if cfg == nil {
+		return ""
+	}
+	if beadID != "" {
+		if bp := BeadPrefix(beadID); bp != "" {
+			if rig, ok := FindRigByPrefix(cfg, bp); ok {
+				if branch := rig.EffectiveDefaultBranch(); branch != "" {
+					return branch
+				}
+			}
+		}
+	}
+	if a.Dir != "" {
+		for _, r := range cfg.Rigs {
+			if r.Name == a.Dir {
+				if branch := r.EffectiveDefaultBranch(); branch != "" {
+					return branch
+				}
+			}
+		}
 	}
 	return ""
 }

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -3146,6 +3146,26 @@ func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByBead(t *testing.T) {
 	}
 }
 
+func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByHyphenatedBeadPrefix(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "agent-diagnostics", Path: "/agent-diagnostics", Prefix: "agent-diagnostics", DefaultBranch: "master"},
+		},
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "polecat"} // no Dir - bead-prefix lookup must handle hyphenated prefixes
+
+	got := SlingFormulaTargetBranch("agent-diagnostics-hnn", deps, a)
+	if got != "master" {
+		t.Errorf("SlingFormulaTargetBranch = %q, want %q (hyphenated rig prefix stored default)", got, "master")
+	}
+}
+
 func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByAgent(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test"},
@@ -3164,6 +3184,27 @@ func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByAgent(t *testing.T) {
 	got := SlingFormulaTargetBranch("", deps, a)
 	if got != "master" {
 		t.Errorf("SlingFormulaTargetBranch = %q, want %q (rig stored default by agent.Dir)", got, "master")
+	}
+}
+
+func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByAgentPath(t *testing.T) {
+	rigPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: rigPath, Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "refinery", Dir: rigPath}
+
+	got := SlingFormulaTargetBranch("", deps, a)
+	if got != "master" {
+		t.Errorf("SlingFormulaTargetBranch = %q, want %q (rig stored default by agent path)", got, "master")
 	}
 }
 

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -3095,3 +3095,94 @@ func TestSlingFormulaSearchPaths_UnknownDir(t *testing.T) {
 		t.Fatalf("SlingFormulaSearchPaths(unknown dir) = %v, want %v", got, want)
 	}
 }
+
+// fixedBranchResolver returns a constant branch regardless of dir.
+type fixedBranchResolver struct{ branch string }
+
+func (r fixedBranchResolver) DefaultBranch(string) string { return r.branch }
+
+func TestSlingFormulaTargetBranch_PrefersBeadMetadata(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{Metadata: map[string]string{"target": "release/v2"}})
+	if err != nil {
+		t.Fatalf("seeding bead: %v", err)
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    store,
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "polecat", Dir: "scamper"}
+
+	got := SlingFormulaTargetBranch(bead.ID, deps, a)
+	if got != "release/v2" {
+		t.Errorf("SlingFormulaTargetBranch = %q, want %q (bead metadata wins)", got, "release/v2")
+	}
+}
+
+func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByBead(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "polecat"} // no Dir — bead-prefix lookup must win
+
+	got := SlingFormulaTargetBranch("SC-1", deps, a)
+	if got != "master" {
+		t.Errorf("SlingFormulaTargetBranch = %q, want %q (rig stored default by bead prefix)", got, "master")
+	}
+}
+
+func TestSlingFormulaTargetBranch_UsesRigDefaultBranchByAgent(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC", DefaultBranch: "master"},
+		},
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		Branches: fixedBranchResolver{branch: "main"},
+	}
+	a := config.Agent{Name: "refinery", Dir: "scamper"}
+
+	// No bead ID — agent.Dir lookup must find the rig.
+	got := SlingFormulaTargetBranch("", deps, a)
+	if got != "master" {
+		t.Errorf("SlingFormulaTargetBranch = %q, want %q (rig stored default by agent.Dir)", got, "master")
+	}
+}
+
+func TestSlingFormulaTargetBranch_FallsBackToProbeWhenUnset(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test"},
+		Rigs: []config.Rig{
+			{Name: "scamper", Path: "/scamper", Prefix: "SC"}, // no DefaultBranch
+		},
+	}
+	deps := SlingDeps{
+		Cfg:      cfg,
+		Store:    beads.NewMemStore(),
+		Branches: fixedBranchResolver{branch: "trunk"},
+	}
+	a := config.Agent{Name: "refinery", Dir: "scamper"}
+
+	got := SlingFormulaTargetBranch("SC-1", deps, a)
+	if got != "trunk" {
+		t.Errorf("SlingFormulaTargetBranch = %q, want %q (fallback to live probe)", got, "trunk")
+	}
+}


### PR DESCRIPTION
## Summary

`gc rig add` now auto-detects the rig's default branch instead of leaving formulas to bake in `main` and reject loop on `master`-default repos.

- Adds `Rig.DefaultBranch` field stored in `city.toml`
- `gc rig add` probes `origin/HEAD` with current-branch fallback; new `--default-branch` flag for explicit override
- Sling formula resolution (`base_branch` / `target_branch`) and `PromptContext.DefaultBranch` prefer the stored value over a live probe
- `RigPatch` parity; API surfaces `default_branch` on `rigResponse` and POST/PATCH `/v0/rigs`
- Tests cover probe, override, fallback, and formula var resolution

## Why

Concrete failure observed in the `scamper` rig (mainline `master`):
- Polecats and refinery defaulted `metadata.target=main`
- Refinery ran `git rebase origin/main` → `fatal: invalid upstream 'origin/main'`
- Bead bounced between polecat pool and refinery in a rejection loop
- Mayor's only workaround was hand-setting `--set-metadata target=master` on every new bead

Affects ANY rig added via `gc rig add` whose origin uses `master`, `develop`, `trunk`, or any non-`main` default.

## Acceptance

- `gc rig add /path/to/master-repo` writes `default_branch = "master"` into `city.toml`
- Polecats and refinery on that rig automatically use `master` as their target without manual metadata override
- Existing `main`-default rigs are unaffected
- `gc rig add --default-branch <name>` works for explicit override

## Related

- Issue #1512 (routing-target canonicalization) — different layer, overlapping code paths

Fixes ga-962