### PR TITLE
Adopt PR #1454: harden hook inject behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session bead reconciliation now stops suspended and orphaned runtimes before
   closing their beads; resuming one of those sessions starts a fresh lifecycle
   instead of continuing the previous runtime process.
+- `gc hook --inject` is now silent legacy compatibility for already-installed
+  Stop/session-end hooks. Fresh managed hook configs no longer install it;
+  routed work pickup should happen through the SessionStart claim protocol or
+  an explicit non-inject `gc hook` call.
 
 ## [1.0.0] - 2026-04-21
 

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -136,9 +136,8 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	// names; named-session context preserves the runtime-supplied owner
 	// env while selecting the backing config through GC_TEMPLATE.
 	resolvedAgentName := a.QualifiedName()
-	resolvedSessionName := cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
 	agentForQuery := resolvedAgentName
-	sessionForQuery := resolvedSessionName
+	sessionForQuery := ""
 	if sessionTemplateContext {
 		agentForQuery = os.Getenv("GC_ALIAS")
 		if agentForQuery == "" {
@@ -148,6 +147,8 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 			agentForQuery = os.Getenv("GC_AGENT")
 		}
 		sessionForQuery = os.Getenv("GC_SESSION_NAME")
+	} else {
+		sessionForQuery = cliSessionName(cityPath, cityName, resolvedAgentName, cfg.Workspace.SessionTemplate)
 	}
 	overrides := hookQueryEnv(cityPath, cfg, &a)
 	overrides["GC_AGENT"] = agentForQuery
@@ -240,10 +241,8 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	hasWork := workQueryHasReadyWork(normalized)
 
 	if inject {
-		if hasWork {
-			content := formatHookInjectReminder(normalized)
-			_ = writeProviderHookContextForEvent(stdout, hookFormat, "Stop", content)
-		}
+		_ = hasWork
+		_ = hookFormat
 		return 0 // --inject always exits 0
 	}
 
@@ -256,23 +255,6 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	}
 	fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
 	return 0
-}
-
-func formatHookInjectReminder(normalizedWork string) string {
-	return fmt.Sprintf(`<system-reminder>
-You have pending work. Pick up the next item:
-
-<work-items>
-%s
-</work-items>
-
-Use the bead id from the work item:
-- If the item is not assigned to you yet, run `+"`bd update <id> --claim`"+`.
-- Do the requested work.
-- When done, run `+"`bd close <id>`"+`.
-Run `+"`gc hook`"+` to see the full queue.
-</system-reminder>
-`, normalizedWork)
 }
 
 func workQueryHasReadyWork(output string) bool {

--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -20,11 +20,11 @@ func newHookCmd(stdout, stderr io.Writer) *cobra.Command {
 	var hookFormat string
 	cmd := &cobra.Command{
 		Use:   "hook [agent]",
-		Short: "Check for available work (use --inject for Stop hook output)",
+		Short: "Check for available work",
 		Long: `Checks for available work using the agent's work_query config.
 
 Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
-With --inject: wraps output in <system-reminder> for hook injection, always exits 0.
+With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.`,
 		Args: cobra.MaximumNArgs(1),
@@ -35,8 +35,11 @@ With --inject: wraps output in <system-reminder> for hook injection, always exit
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&inject, "inject", false, "output <system-reminder> block for hook injection")
+	cmd.Flags().BoolVar(&inject, "inject", false, "silent legacy Stop-hook compatibility; skip work query and exit 0")
 	cmd.Flags().StringVar(&hookFormat, "hook-format", "", "format hook output for a provider")
+	if flag := cmd.Flags().Lookup("hook-format"); flag != nil {
+		flag.Hidden = true
+	}
 	return cmd
 }
 
@@ -48,6 +51,13 @@ func cmdHook(args []string, stdout, stderr io.Writer) int {
 }
 
 func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, stderr io.Writer) int {
+	if inject {
+		return 0
+	}
+	// Accepted for compatibility with installed hook commands; non-inject
+	// gc hook output is intentionally raw regardless of provider format.
+	_ = hookFormat
+
 	agentName := os.Getenv("GC_ALIAS")
 	if agentName == "" {
 		agentName = os.Getenv("GC_AGENT")
@@ -66,26 +76,17 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		agentName = args[0]
 	}
 	if agentName == "" {
-		if inject {
-			return 0 // --inject always exits 0
-		}
 		fmt.Fprintln(stderr, "gc hook: agent not specified (set $GC_AGENT or pass as argument)") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	cityPath, err := resolveCity()
 	if err != nil {
-		if inject {
-			return 0
-		}
 		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	cfg, err := loadCityConfig(cityPath, stderr)
 	if err != nil {
-		if inject {
-			return 0
-		}
 		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -96,26 +97,17 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	resolveRigPaths(cityPath, cfg.Rigs)
 
 	if citySuspended(cfg) {
-		if inject {
-			return 0
-		}
 		fmt.Fprintln(stderr, "gc hook: city is suspended") //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	a, ok := resolveAgentIdentity(cfg, agentName, currentRigContext(cfg))
 	if !ok {
-		if inject {
-			return 0
-		}
 		fmt.Fprintf(stderr, "gc hook: agent %q not found in config\n", agentName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	if isAgentEffectivelySuspended(cfg, &a) {
-		if inject {
-			return 0
-		}
 		fmt.Fprintf(stderr, "gc hook: agent %q is suspended\n", agentName) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -163,7 +155,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 	runner := func(command, dir string) (string, error) {
 		return shellWorkQueryWithEnv(command, dir, queryEnv)
 	}
-	return doHookWithFormat(workQuery, workDir, inject, hookFormat, runner, stdout, stderr)
+	return doHook(workQuery, workDir, inject, runner, stdout, stderr)
 }
 
 // hookQueryEnv returns the full work-query environment for a hook subprocess.
@@ -221,17 +213,14 @@ func workQueryEnvForDir(env []string, dir string) []string {
 
 // doHook is the pure logic for gc hook. Runs the work query and outputs
 // results based on mode. Without inject: prints raw output, returns 0 if
-// work, 1 if empty. With inject: wraps in <system-reminder>, always returns 0.
+// work, 1 if empty. With inject: skips the work query and returns 0.
 func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, stderr io.Writer) int {
-	return doHookWithFormat(workQuery, dir, inject, "", runner, stdout, stderr)
-}
+	if inject {
+		return 0
+	}
 
-func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, runner WorkQueryRunner, stdout, stderr io.Writer) int {
 	output, err := runner(workQuery, dir)
 	if err != nil {
-		if inject {
-			return 0 // --inject always exits 0
-		}
 		fmt.Fprintf(stderr, "gc hook: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
@@ -239,12 +228,6 @@ func doHookWithFormat(workQuery, dir string, inject bool, hookFormat string, run
 	trimmed := strings.TrimSpace(output)
 	normalized := normalizeWorkQueryOutput(trimmed)
 	hasWork := workQueryHasReadyWork(normalized)
-
-	if inject {
-		_ = hasWork
-		_ = hookFormat
-		return 0 // --inject always exits 0
-	}
 
 	// Non-inject mode: print raw output. Return 0 only when work exists.
 	if !hasWork {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -86,38 +85,19 @@ func TestHookInjectSuppressesNoReadyMessage(t *testing.T) {
 	}
 }
 
-func TestHookInjectFormatsOutput(t *testing.T) {
+func TestHookInjectIsNonIntrusiveWithWork(t *testing.T) {
 	runner := func(string, string) (string, error) { return "hw-1  open  Fix the bug\n", nil }
 	var stdout, stderr bytes.Buffer
 	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
 	if code != 0 {
 		t.Errorf("doHook(inject, work) = %d, want 0", code)
 	}
-	out := stdout.String()
-	if !strings.Contains(out, "<system-reminder>") {
-		t.Errorf("stdout missing <system-reminder>: %q", out)
-	}
-	if !strings.Contains(out, "</system-reminder>") {
-		t.Errorf("stdout missing </system-reminder>: %q", out)
-	}
-	if !strings.Contains(out, "<work-items>") {
-		t.Errorf("stdout missing <work-items>: %q", out)
-	}
-	if !strings.Contains(out, "hw-1") {
-		t.Errorf("stdout missing work item: %q", out)
-	}
-	if !strings.Contains(out, "gc hook") {
-		t.Errorf("stdout missing 'gc hook' hint: %q", out)
-	}
-	if !strings.Contains(out, "bd update <id> --claim") {
-		t.Errorf("stdout missing claim command: %q", out)
-	}
-	if !strings.Contains(out, "bd close <id>") {
-		t.Errorf("stdout missing close command: %q", out)
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty non-intrusive inject output", stdout.String())
 	}
 }
 
-func TestHookCommandCodexInjectEmitsSingleStopPayload(t *testing.T) {
+func TestHookCommandCodexInjectDoesNotBlockStop(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
@@ -141,19 +121,56 @@ work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("gc hook command failed: %v; stderr=%s", err, stderr.String())
 	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty non-blocking Stop hook output", stdout.String())
+	}
+}
 
-	var payload struct {
-		Decision string `json:"decision"`
-		Reason   string `json:"reason"`
+func TestCmdHookSessionTemplateContextDoesNotScanSessionsForName(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	fakeBin := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
-		t.Fatalf("stdout is not a single JSON payload: %v\n%s", err, stdout.String())
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if got, want := payload.Decision, "block"; got != want {
-		t.Fatalf("decision = %q, want %q", got, want)
+	fakeBD := filepath.Join(fakeBin, "bd")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nprintf '[]'\n", logPath)
+	if err := os.WriteFile(fakeBD, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(payload.Reason, "hw-1") {
-		t.Fatalf("reason = %q, want pending work", payload.Reason)
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_ALIAS", "worker-1")
+	t.Setenv("GC_SESSION_ID", "mc-session")
+	t.Setenv("GC_SESSION_NAME", "runtime-session")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdHookWithFormat(nil, true, "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdHookWithFormat() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", logPath, err)
+	}
+	logText := string(logData)
+	if strings.Contains(logText, "--label=gc:session") {
+		t.Fatalf("gc hook scanned all session beads before running work_query:\n%s", logText)
+	}
+	if !strings.Contains(logText, "--assignee=runtime-session") {
+		t.Fatalf("gc hook did not pass runtime session name into work_query; bd log:\n%s", logText)
 	}
 }
 

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -97,6 +97,28 @@ func TestHookInjectIsNonIntrusiveWithWork(t *testing.T) {
 	}
 }
 
+func TestHookInjectDoesNotRunWorkQuery(t *testing.T) {
+	called := false
+	runner := func(string, string) (string, error) {
+		called = true
+		return "hw-1  open  Fix the bug\n", nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", "", true, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("doHook(inject, work) = %d, want 0", code)
+	}
+	if called {
+		t.Fatal("inject mode ran the work query even though its output is ignored")
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty non-intrusive inject output", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestHookCommandCodexInjectDoesNotBlockStop(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
@@ -123,6 +145,84 @@ work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty non-blocking Stop hook output", stdout.String())
+	}
+}
+
+func TestHookCommandInjectSkipsConfiguredWorkQuery(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "work-query-ran")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+work_query = "printf ran > %q"
+`, marker)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newHookCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"worker", "--inject", "--hook-format", "codex"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc hook command failed: %v; stderr=%s", err, stderr.String())
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("inject mode ran configured work_query; marker stat err=%v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty non-blocking Stop hook output", stdout.String())
+	}
+}
+
+func TestHookCommandHookFormatIsIgnoredForNonInjectOutput(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "worker"
+work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	run := func(args ...string) (string, string, error) {
+		var stdout, stderr bytes.Buffer
+		cmd := newHookCmd(&stdout, &stderr)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		return stdout.String(), stderr.String(), err
+	}
+
+	rawOut, rawErr, err := run("worker")
+	if err != nil {
+		t.Fatalf("gc hook worker failed: %v; stderr=%s", err, rawErr)
+	}
+	formattedOut, formattedErr, err := run("worker", "--hook-format", "codex")
+	if err != nil {
+		t.Fatalf("gc hook worker --hook-format codex failed: %v; stderr=%s", err, formattedErr)
+	}
+	if formattedOut != rawOut {
+		t.Fatalf("hook-format changed non-inject output:\nraw:       %q\nformatted: %q", rawOut, formattedOut)
+	}
+	if formattedErr != rawErr {
+		t.Fatalf("hook-format changed non-inject stderr:\nraw:       %q\nformatted: %q", rawErr, formattedErr)
+	}
+	if strings.Contains(formattedOut, "system-reminder") {
+		t.Fatalf("non-inject hook output was provider-formatted: %q", formattedOut)
 	}
 }
 
@@ -157,9 +257,9 @@ name = "worker"
 	t.Setenv("GC_SESSION_NAME", "runtime-session")
 
 	var stdout, stderr bytes.Buffer
-	code := cmdHookWithFormat(nil, true, "", &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("cmdHookWithFormat() = %d, want 0; stderr=%s", code, stderr.String())
+	code := cmdHookWithFormat(nil, false, "", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("cmdHookWithFormat() = %d, want 1 for empty work; stderr=%s", code, stderr.String())
 	}
 	logData, err := os.ReadFile(logPath)
 	if err != nil {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -338,12 +338,14 @@ func TestMaterializeBuiltinPacksPiHookUsesCurrentExtensionAPI(t *testing.T) {
 		"module.exports = function gascityPiExtension(pi)",
 		`pi.on("session_start"`,
 		`pi.on("session_compact"`,
-		`pi.on("session_shutdown"`,
 		`pi.on("before_agent_start"`,
 	} {
 		if !strings.Contains(data, want) {
 			t.Errorf("materialized Pi hook missing current extension API marker %q:\n%s", want, data)
 		}
+	}
+	if strings.Contains(data, "gc hook --inject") {
+		t.Errorf("materialized Pi hook should not install no-op gc hook --inject:\n%s", data)
 	}
 	for _, legacy := range []string{
 		"module.exports = {",

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1813,7 +1813,7 @@ func TestDoInitSettingsIsValidJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("settings.json 'hooks' is not an object")
 	}
-	for _, event := range []string{"SessionStart", "PreCompact", "UserPromptSubmit", "Stop"} {
+	for _, event := range []string{"SessionStart", "PreCompact", "UserPromptSubmit"} {
 		if _, ok := hookMap[event]; !ok {
 			t.Errorf("settings.json missing hook event %q", event)
 		}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,7 +36,7 @@ gc [flags]
 | [gc graph](#gc-graph) | Show dependency graph for beads |
 | [gc handoff](#gc-handoff) | Send handoff mail and restart controller-managed sessions |
 | [gc help](#gc-help) | Help about any command |
-| [gc hook](#gc-hook) | Check for available work (use --inject for Stop hook output) |
+| [gc hook](#gc-hook) | Check for available work |
 | [gc import](#gc-import) | Manage pack imports |
 | [gc init](#gc-init) | Initialize a new city |
 | [gc mail](#gc-mail) | Send and receive messages between agents and humans |
@@ -1127,7 +1127,7 @@ gc help [command]
 Checks for available work using the agent's work_query config.
 
 Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
-With --inject: wraps output in &lt;system-reminder&gt; for hook injection, always exits 0.
+With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.
 
@@ -1137,8 +1137,7 @@ gc hook [agent] [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--hook-format` | string |  | format hook output for a provider |
-| `--inject` | bool |  | output &lt;system-reminder&gt; block for hook injection |
+| `--inject` | bool |  | silent legacy Stop-hook compatibility; skip work query and exit 0 |
 
 ## gc import
 

--- a/docs/tutorials/06-beads.md
+++ b/docs/tutorials/06-beads.md
@@ -381,18 +381,20 @@ Set target of convoy mc-zk1 to develop
 
 ## How agents find work
 
-This is where beads connect to the runtime. Agents discover work through _hooks_
-— shell commands that run between turns and check for available beads.
+This is where beads connect to the runtime. Routed agents discover work through
+the claim protocol rendered into their session startup prompt. The protocol asks
+`gc hook` for eligible work, claims one bead with `bd update --claim`, and then
+the agent runs exactly that bead. The legacy Stop-hook form, `gc hook --inject`,
+is silent compatibility behavior and no longer injects work into the agent.
 
 The typical flow:
 
 1. Work is created (via `bd create`, `gc sling`, formula cook, etc.)
 2. Work is routed to an agent (via assignee or `gc.routed_to` metadata)
-3. Agent's hook runs a _work query_ and looks for matching ready beads
-4. If work is found, the hook injects it into the agent's context as a system
-   reminder
-5. The agent sees the work and acts on it (GUPP: "if you find work on your hook,
-   you run it")
+3. Session startup runs the agent's _work query_ through `gc hook`
+4. The claim protocol atomically claims one ready bead
+5. The agent sees the claimed work and acts on it (GUPP: "if you find work on
+   your hook, you run it")
 
 For routed pool work, the query checks metadata instead of assignee:
 

--- a/engdocs/architecture/life-of-a-bead.md
+++ b/engdocs/architecture/life-of-a-bead.md
@@ -110,13 +110,15 @@ operation" (forward compatible).
 
 A bead exists, but no agent knows about it yet. Discovery is how agents
 find work. Gas City uses the **pull model**: agents poll for available
-work rather than being pushed assignments.
+work rather than being pushed assignments. Routed agents normally discover
+work through the claim protocol rendered into the session startup prompt:
+the protocol calls `gc hook`, claims exactly one returned bead with
+`bd update --claim`, and then the agent works that claimed bead.
 
 ### The hook mechanism (gc hook)
 
-Every agent has a `work_query` config field. When the agent's session
-provider fires a hook (e.g., Claude's Stop hook), it runs `gc hook`
-(`cmd/gc/cmd_hook.go`). The flow:
+Every agent has a `work_query` config field. `gc hook`
+(`cmd/gc/cmd_hook.go`) runs that query for plain hook discovery. The flow:
 
 1. `cmdHook()` resolves the agent from `$GC_AGENT` or a positional arg
 2. Loads city config, checks suspension status
@@ -134,9 +136,9 @@ the bd CLI filters by label server-side.
 
 ### The --inject mode
 
-With `--inject`, `gc hook` wraps output in a `<system-reminder>` XML block
-for LLM context injection. Hook-enabled agents discover work automatically
-between turns. If no work exists, `--inject` emits nothing and exits 0.
+`gc hook --inject` is legacy Stop-hook compatibility. It exits 0 without
+running the work query and emits no output. Routed discovery belongs in the
+session startup claim protocol or an explicit plain `gc hook` invocation.
 
 ### Ready() and GUPP
 

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -25,17 +25,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject --hook-format codex"
-          }
-        ]
-      }
     ]
   }
 }

--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/copilot-instructions.md
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/copilot-instructions.md
@@ -17,14 +17,21 @@ check for new messages from other agents or the controller.
 
 ## Work pickup
 
-When you finish your current task or have no active work, run
-`gc hook --inject` to check for and claim new work from the queue.
+Session startup should include the claim protocol for assigned work. When you
+finish your current task or have no active work mid-session, run `gc hook` to
+check for routed work, then claim exactly one returned bead with
+`bd update <id> --claim` before working it.
+
+`gc hook --inject` is legacy compatibility for older Stop/session-end hook
+files. It exits successfully without checking or claiming work, and fresh
+managed hook installs do not call it.
 
 ## Key commands
 
 - `gc prime` — load/reload agent context
 - `gc mail check --inject` — check for inter-agent messages
-- `gc hook --inject` — check for and claim available work
+- `gc hook` — check for available routed work
+- `bd update <id> --claim` — claim one bead before working it
 - `bd ready` — list ready beads (tasks)
 - `bd show <id>` — show bead details
 - `bd close <id>` — mark a bead as done

--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
@@ -19,13 +19,6 @@
         "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject",
         "timeoutSec": 10
       }
-    ],
-    "sessionEnd": [
-      {
-        "type": "command",
-        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject",
-        "timeoutSec": 10
-      }
     ]
   }
 }

--- a/internal/bootstrap/packs/core/overlay/per-provider/cursor/.cursor/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/cursor/.cursor/hooks.json
@@ -18,11 +18,6 @@
       {
         "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject"
       }
-    ],
-    "stop": [
-      {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject"
-      }
     ]
   }
 }

--- a/internal/bootstrap/packs/core/overlay/per-provider/gemini/.gemini/settings.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/gemini/.gemini/settings.json
@@ -38,21 +38,6 @@
           {
             "type": "command",
             "command": "gc mail check --inject --hook-format gemini"
-          },
-          {
-            "type": "command",
-            "command": "gc hook --inject --hook-format gemini"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gc hook --inject --hook-format gemini"
           }
         ]
       }

--- a/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
+++ b/internal/bootstrap/packs/core/overlay/per-provider/omp/.omp/hooks/gc-hook.ts
@@ -4,7 +4,6 @@
 // Events:
 //   session.created    → gc prime (load context)
 //   session.compacted  → gc prime (reload after compaction)
-//   session.deleted    → gc hook --inject (pick up work on exit)
 //   chat.system.transform → gc nudge drain --inject + gc mail check --inject
 
 import { execSync } from "child_process";
@@ -30,7 +29,6 @@ export default {
   events: {
     "session.created": () => run("gc prime --hook"),
     "session.compacted": () => run("gc prime --hook"),
-    "session.deleted": () => run("gc hook --inject"),
   },
 
   hooks: {

--- a/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/opencode/.opencode/plugins/gascity.js
@@ -8,7 +8,6 @@
 // Gas City uses:
 //   - session.created / session.compacted → gc prime --hook (side effects such
 //     as session-id persistence and poller bootstrap)
-//   - session.deleted → gc hook --inject (pick up newly queued work on exit)
 //   - experimental.chat.system.transform → inject gc prime --hook, queued
 //     nudges, and unread mail into the system prompt for each turn
 
@@ -60,9 +59,6 @@ export default async function gascityPlugin({ directory }) {
         case "session.created":
         case "session.compacted":
           await readPrime(true);
-          return;
-        case "session.deleted":
-          await run(directory, "hook", "--inject");
           return;
         default:
           return;

--- a/internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js
+++ b/internal/bootstrap/packs/core/overlay/per-provider/pi/.pi/extensions/gc-hooks.js
@@ -8,7 +8,6 @@
 // Events:
 //   session_start    → gc prime --hook (load context side effects)
 //   session_compact  → gc prime --hook (reload after compaction)
-//   session_shutdown → gc hook --inject on process quit
 //   before_agent_start → gc nudge drain --inject + gc mail check --inject
 
 const { execFileSync } = require("node:child_process");
@@ -43,12 +42,6 @@ module.exports = function gascityPiExtension(pi) {
 
   pi.on("session_compact", (_event, ctx) => {
     run(["prime", "--hook"], ctx.cwd);
-  });
-
-  pi.on("session_shutdown", (event, ctx) => {
-    if (event.reason === "quit") {
-      run(["hook", "--inject"], ctx.cwd);
-    }
   });
 
   pi.on("before_agent_start", (event, ctx) => {

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -38,17 +38,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc hook --inject"
-          }
-        ]
-      }
     ]
   }
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -127,6 +127,9 @@ func TestInstallClaude(t *testing.T) {
 	if !strings.Contains(s, "gc nudge drain --inject") {
 		t.Error("claude settings should contain gc nudge drain --inject")
 	}
+	if strings.Contains(s, "gc hook --inject") {
+		t.Error("fresh claude settings should not install no-op gc hook --inject")
+	}
 	if !strings.Contains(s, `"skipDangerousModePermissionPrompt": true`) {
 		t.Error("claude settings should contain skipDangerousModePermissionPrompt")
 	}
@@ -743,6 +746,19 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	if !strings.Contains(codexHooks, "--hook-format codex") {
 		t.Error("codex hooks should request Codex hook output format")
 	}
+	for _, rel := range []string{
+		"/work/.codex/hooks.json",
+		"/work/.gemini/settings.json",
+		"/work/.opencode/plugins/gascity.js",
+		"/work/.github/hooks/gascity.json",
+		"/work/.cursor/hooks.json",
+		"/work/.pi/extensions/gc-hooks.js",
+		"/work/.omp/hooks/gc-hook.ts",
+	} {
+		if strings.Contains(string(fs.Files[rel]), "gc hook --inject") {
+			t.Errorf("fresh overlay-managed provider file %s should not install no-op gc hook --inject", rel)
+		}
+	}
 }
 
 func TestInstallPiHookUsesCurrentExtensionAPI(t *testing.T) {
@@ -756,7 +772,6 @@ func TestInstallPiHookUsesCurrentExtensionAPI(t *testing.T) {
 		"module.exports = function gascityPiExtension(pi)",
 		`pi.on("session_start"`,
 		`pi.on("session_compact"`,
-		`pi.on("session_shutdown"`,
 		`pi.on("before_agent_start"`,
 	} {
 		if !strings.Contains(data, want) {

--- a/test/integration/e2e_hook_test.go
+++ b/test/integration/e2e_hook_test.go
@@ -3,6 +3,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -51,29 +53,38 @@ func TestE2E_Hook_WithWork(t *testing.T) {
 	}
 }
 
-// TestE2E_Hook_Inject verifies that gc hook --inject wraps output in
-// system-reminder tags and always exits 0.
+// TestE2E_Hook_Inject verifies that gc hook --inject is silent legacy
+// compatibility and does not run the configured work query.
 func TestE2E_Hook_Inject(t *testing.T) {
+	const markerName = "inject-work-query-ran"
 	city := e2eCity{
 		Agents: []e2eAgent{
 			{
 				Name:         "injectee",
 				StartCommand: e2eSleepScript(),
-				WorkQuery:    "echo 'inject hook work items'",
+				WorkQuery:    "touch .gc/" + markerName + " && echo 'inject hook work items'",
 			},
 		},
 	}
-	cityDir := setupE2ECity(t, nil, city)
+	cityDir := setupE2ECityNoStart(t, city)
+	markerPath := filepath.Join(cityDir, ".gc", markerName)
+	if _, err := os.Stat(markerPath); err == nil {
+		t.Fatalf("work_query marker exists before gc hook --inject: %s", markerPath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("checking pre-hook work_query marker: %v", err)
+	}
 
-	// Hook with --inject should wrap in system-reminder.
 	out, err := gc(cityDir, "hook", "--inject", "injectee")
 	if err != nil {
 		t.Fatalf("gc hook --inject should exit 0: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(out, "<system-reminder>") {
-		t.Errorf("expected <system-reminder> in inject output:\n%s", out)
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("gc hook --inject should be silent, got:\n%s", out)
 	}
-	if !strings.Contains(out, "inject hook work items") {
-		t.Errorf("expected work items in inject output:\n%s", out)
+
+	if _, err := os.Stat(markerPath); err == nil {
+		t.Fatalf("gc hook --inject ran work_query; marker exists at %s", markerPath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("checking work_query marker: %v", err)
 	}
 }


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1454.

Original PR: harden(hook): make inject mode non-intrusive
Original PR state at finalization: OPEN
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

This follow-up is required because the original PR reported `maintainerCanModify=false`, so the reviewed maintainer fixes cannot be pushed back to the original branch.

Changes included:
- Preserves the contributor's hook-inject hardening commit on the current `main` base.
- Adds the maintainer fix commit `5684f0c94` addressing review findings.
- Documents the silent legacy compatibility behavior for `gc hook --inject` and removes fresh managed Stop-hook inject installs.

Review status:
- Latest review attempt: 6
- Decision: approve
- Quality score: 950 / 1000, threshold 850
- Required changes: none

Review TL;DR:
PR #1454 `harden(hook): make inject mode non-intrusive` reached approval after 5 fix iteration(s). Latest attempt 6 is `approve` with score 950 / 1000 against threshold 850.