### PR TITLE
fix(dolt): cleanup --force routes through running server (#1549)

### DIFF
--- a/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
+++ b/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
@@ -12,9 +12,10 @@
 #   6. sync.sh external-rig route discovery (parallel registry path to cleanup.sh)
 #   7. Server-reachability gate (#1549): --force without --server-down-ok refuses when
 #      dolt is unreachable, instead of corrupting NBS state via rm -rf.
-#   8. Identifier safety (#1549): orphans whose name contains characters outside
-#      [A-Za-z0-9_] are refused before any deletion attempt, so an attacker-controlled
-#      metadata.json cannot break out of the backtick-quoted SQL identifier.
+#   8. Identifier safety (#1549): orphans whose name does not match the allowlist
+#      (first char [A-Za-z0-9_], subsequent chars [A-Za-z0-9_-]) are refused before
+#      any deletion attempt, so an attacker-controlled metadata.json cannot break
+#      out of the backtick-quoted SQL identifier.
 #
 # Each scenario uses a separate city initialized from a pre-written TOML template.
 # The pack's cleanup.sh and sync.sh are staged once under $WORK/shared/ and each
@@ -689,16 +690,28 @@ fi
 
 # Mirrors the production server-reachability check (#1549). The fixture's
 # stub runtime.sh does not export GC_DOLT_PORT or the helper functions, so
-# tcp_reachable stays false; --force without --server-down-ok refuses,
-# --force --server-down-ok takes the rm path. The fixture has no live dolt
-# server, so the SQL-DROP branch is exercised by integration tests.
+# probe_available is determined by host nc/python3, and tcp_reachable stays
+# false. With nc OR python3 present + --server-down-ok the rm path runs;
+# without either, the script refuses regardless of --server-down-ok.
 host="${GC_DOLT_HOST:-127.0.0.1}"
 : "${GC_DOLT_USER:=root}"
-sql_args="--host $host --port ${GC_DOLT_PORT:-} --user $GC_DOLT_USER --no-tls"
 export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
 
+dolt_sql_q() {
+  _dolt_sql_q_timeout="$1"; shift
+  run_bounded "$_dolt_sql_q_timeout" \
+    dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
+    sql -q "$1"
+}
+
+probe_available=false
+if command -v nc >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1; then
+  probe_available=true
+fi
+
 tcp_reachable=false
-if [ -n "$GC_DOLT_PORT" ] \
+if [ "$probe_available" = true ] \
+  && [ -n "$GC_DOLT_PORT" ] \
   && command -v managed_runtime_tcp_reachable >/dev/null 2>&1 \
   && managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
   tcp_reachable=true
@@ -708,7 +721,7 @@ sql_works=false
 if [ "$tcp_reachable" = true ] \
   && command -v dolt >/dev/null 2>&1 \
   && command -v run_bounded >/dev/null 2>&1 \
-  && run_bounded 5 dolt $sql_args sql -q "SELECT 1" >/dev/null 2>&1; then
+  && dolt_sql_q 5 "SELECT 1" >/dev/null 2>&1; then
   sql_works=true
 fi
 
@@ -718,6 +731,10 @@ if [ "$sql_works" = true ]; then
 elif [ "$tcp_reachable" = true ]; then
   echo "gc dolt cleanup: dolt is listening on port $GC_DOLT_PORT but 'SELECT 1' failed;" >&2
   echo "  refusing to rm against a potentially-live server (#1549). Fix SQL access or stop dolt and retry." >&2
+  exit 1
+elif [ "$probe_available" = false ]; then
+  echo "gc dolt cleanup: cannot probe TCP reachability (neither nc nor python3 available);" >&2
+  echo "  refusing rm fallback regardless of --server-down-ok — cannot establish 'server is stopped' (#1549)." >&2
   exit 1
 elif [ "$server_down_ok" = true ]; then
   delete_via=rm
@@ -760,11 +777,11 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
       ;;
   esac
   if [ "$delete_via" = sql ]; then
-    if run_bounded 30 dolt $sql_args sql -q "DROP DATABASE IF EXISTS \`$db_name\`" >/dev/null 2>&1; then
+    if drop_output=$(dolt_sql_q 30 "DROP DATABASE IF EXISTS \`$db_name\`" 2>&1); then
       echo "removed" >> "$removed_tmp"
       echo "  Dropped $db_name"
     else
-      echo "  Failed to drop $db_name via SQL" >&2
+      echo "  Failed to drop $db_name via SQL: ${drop_output:-(no output)}" >&2
     fi
   else
     if rm -rf "$path"; then

--- a/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
+++ b/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
@@ -1,12 +1,20 @@
-# dolt cleanup + sync: external-rig discovery and allowlist guard (#706, #711)
+# dolt cleanup + sync: external-rig discovery and allowlist guard (#706, #711, #1549)
 #
-# Covers six scenarios:
+# Covers eight scenarios:
 #   1. External rig database is NOT listed as orphan (registry via gc rig list --json)
-#   2. --force removes genuine orphan at default data-dir (HQ-rooted; guard must not fire)
+#   2. --force removes genuine orphan at default data-dir (HQ-rooted; guard must not fire).
+#      Fixtures run without a live dolt server, so --server-down-ok is required to permit
+#      the filesystem rm fallback (#1549).
 #   3. Local rig database discovered via gc rig list --json (complements scenario 1)
-#   4. Allowlist refusal: orphan whose path overlaps a registered rig path is refused
+#   4. Allowlist refusal: orphan whose path overlaps a registered rig path is refused.
+#      Uses --server-down-ok so the server probe doesn't refuse first.
 #   5. Path-prefix boundary: rig at /a/b does NOT protect a database at /a/bc
 #   6. sync.sh external-rig route discovery (parallel registry path to cleanup.sh)
+#   7. Server-reachability gate (#1549): --force without --server-down-ok refuses when
+#      dolt is unreachable, instead of corrupting NBS state via rm -rf.
+#   8. Identifier safety (#1549): orphans whose name contains characters outside
+#      [A-Za-z0-9_] are refused before any deletion attempt, so an attacker-controlled
+#      metadata.json cannot break out of the backtick-quoted SQL identifier.
 #
 # Each scenario uses a separate city initialized from a pre-written TOML template.
 # The pack's cleanup.sh and sync.sh are staged once under $WORK/shared/ and each
@@ -49,7 +57,9 @@ stdout 'orphan_db'
 # Tests that --force removes genuine orphan at default data-dir (HQ-rooted).
 # The allowlist guard must not fire for HQ-managed storage: select(.hq != true)
 # excludes HQ from the rig-path overlap check, so orphan_db is correctly removed.
-exec gc dolt cleanup --force
+# --server-down-ok acknowledges that the test environment has no live dolt server
+# and permits the filesystem rm fallback (#1549).
+exec gc dolt cleanup --force --server-down-ok
 stdout 'Removed orphan_db'
 ! exists $WORK/city1/.beads/dolt/orphan_db
 exists $WORK/city1/.beads/dolt/ext_db
@@ -100,7 +110,9 @@ env CITY3_RIG_PATH=$WORK/city3-rig
 
 cp $WORK/shared/cleanup.sh $WORK/city3/packs/dolt/commands/cleanup.sh
 chmod 755 $WORK/city3/packs/dolt/commands/cleanup.sh
-! exec gc dolt cleanup --force
+# --server-down-ok lets the script proceed past the server-reachability gate
+# so the allowlist-overlap refusal (the actual subject of this scenario) fires.
+! exec gc dolt cleanup --force --server-down-ok
 stderr 'refusing to remove'
 
 # ==========================================================================
@@ -157,6 +169,50 @@ exec gc dolt sync --gc --dry-run
 stdout 'city5/\.beads/routes\.jsonl'
 stdout 'external-rig-5/\.beads/routes\.jsonl'
 stdout 'city5_db: skipped'
+
+# ==========================================================================
+# Scenario 7: Server-reachability gate (#1549)
+# ==========================================================================
+# city7 has one orphan_db. With no live dolt server and no --server-down-ok,
+# `gc dolt cleanup --force` MUST refuse rather than rm -rf — running rm
+# against per-database directories that the dolt server has open corrupts
+# NBS state and crash-loops the journal. The orphan must remain on disk.
+
+exec gc init --file $WORK/city7-cfg.toml $WORK/city7
+stdout 'Welcome to Gas City'
+
+cd $WORK/city7
+
+cp $WORK/shared/cleanup.sh $WORK/city7/packs/dolt/commands/cleanup.sh
+chmod 755 $WORK/city7/packs/dolt/commands/cleanup.sh
+
+! exec gc dolt cleanup --force
+stderr 'dolt server unreachable'
+stderr '--server-down-ok'
+exists $WORK/city7/.beads/dolt/orphan_db
+
+# ==========================================================================
+# Scenario 8: Identifier safety (#1549)
+# ==========================================================================
+# city8 has two orphans:
+#   safe_orphan       — passes the [A-Za-z0-9_] charset check
+#   bad-name-orphan   — contains a hyphen, would inject if interpolated into
+#                       backtick-quoted SQL. Must be refused before any
+#                       deletion attempt and must remain on disk.
+
+exec gc init --file $WORK/city8-cfg.toml $WORK/city8
+stdout 'Welcome to Gas City'
+
+cd $WORK/city8
+
+cp $WORK/shared/cleanup.sh $WORK/city8/packs/dolt/commands/cleanup.sh
+chmod 755 $WORK/city8/packs/dolt/commands/cleanup.sh
+
+exec gc dolt cleanup --force --server-down-ok
+stdout 'Removed safe_orphan'
+stderr 'name contains forbidden characters'
+! exists $WORK/city8/.beads/dolt/safe_orphan
+exists $WORK/city8/.beads/dolt/bad-name-orphan
 
 # ===========================================================================
 # Shared fixture: external-rig (used by city1 and city3)
@@ -383,6 +439,85 @@ GC_BEADS_BD_SCRIPT="${GC_BEADS_BD_SCRIPT:-/bin/true}"
 -- city5/packs/dolt/commands/.keep --
 
 # ===========================================================================
+# city7 fixtures (Scenario 7: server-reachability gate, #1549)
+# ===========================================================================
+
+-- city7-cfg.toml --
+[workspace]
+name = "city7"
+includes = ["packs/dolt"]
+
+-- city7/.beads/metadata.json --
+{"dolt_database": "city7_db", "issue_prefix": "c7"}
+
+-- city7/.beads/dolt/city7_db/.dolt/.keep --
+-- city7/.beads/dolt/orphan_db/.dolt/.keep --
+
+-- city7/packs/dolt/pack.toml --
+[pack]
+name = "dolt"
+schema = 1
+
+[[commands]]
+name = "cleanup"
+description = "Find and remove orphaned Dolt databases"
+script = "commands/cleanup.sh"
+
+-- city7/packs/dolt/scripts/runtime.sh --
+#!/bin/sh
+: "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
+CITY_RUNTIME_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}"
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_RUNTIME_DIR/packs/dolt}"
+DOLT_BEADS_DATA_DIR="$GC_CITY_PATH/.beads/dolt"
+if [ -d "$DOLT_BEADS_DATA_DIR" ]; then
+  DOLT_DATA_DIR="$DOLT_BEADS_DATA_DIR"
+else
+  DOLT_DATA_DIR="$PACK_STATE_DIR/dolt-data"
+fi
+
+-- city7/packs/dolt/commands/.keep --
+
+# ===========================================================================
+# city8 fixtures (Scenario 8: identifier safety, #1549)
+# ===========================================================================
+
+-- city8-cfg.toml --
+[workspace]
+name = "city8"
+includes = ["packs/dolt"]
+
+-- city8/.beads/metadata.json --
+{"dolt_database": "city8_db", "issue_prefix": "c8"}
+
+-- city8/.beads/dolt/city8_db/.dolt/.keep --
+-- city8/.beads/dolt/safe_orphan/.dolt/.keep --
+-- city8/.beads/dolt/bad-name-orphan/.dolt/.keep --
+
+-- city8/packs/dolt/pack.toml --
+[pack]
+name = "dolt"
+schema = 1
+
+[[commands]]
+name = "cleanup"
+description = "Find and remove orphaned Dolt databases"
+script = "commands/cleanup.sh"
+
+-- city8/packs/dolt/scripts/runtime.sh --
+#!/bin/sh
+: "${GC_CITY_PATH:?GC_CITY_PATH must be set}"
+CITY_RUNTIME_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}"
+PACK_STATE_DIR="${GC_PACK_STATE_DIR:-$CITY_RUNTIME_DIR/packs/dolt}"
+DOLT_BEADS_DATA_DIR="$GC_CITY_PATH/.beads/dolt"
+if [ -d "$DOLT_BEADS_DATA_DIR" ]; then
+  DOLT_DATA_DIR="$DOLT_BEADS_DATA_DIR"
+else
+  DOLT_DATA_DIR="$PACK_STATE_DIR/dolt-data"
+fi
+
+-- city8/packs/dolt/commands/.keep --
+
+# ===========================================================================
 # Shared cleanup.sh fixture — staged into each city's packs/dolt/commands/
 # by the exec cp calls above. Mirrors the logic of
 # examples/dolt/commands/cleanup/run.sh; the only adaptation is sourcing
@@ -391,11 +526,13 @@ GC_BEADS_BD_SCRIPT="${GC_BEADS_BD_SCRIPT:-/bin/true}"
 
 -- shared/cleanup.sh --
 #!/bin/sh
-# gc dolt cleanup — test fixture mirroring examples/dolt/commands/cleanup/run.sh (#706, #711).
+# gc dolt cleanup — test fixture mirroring examples/dolt/commands/cleanup/run.sh
+# (#706, #711, #1549).
 set -e
 
 force=false
 max_orphans=50
+server_down_ok=false
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/scripts/runtime.sh"
 data_dir="$DOLT_DATA_DIR"
@@ -404,7 +541,8 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --force) force=true; shift ;;
     --max)   max_orphans="$2"; shift 2 ;;
-    -h|--help) echo "Usage: gc dolt cleanup [--force] [--max N]"; exit 0 ;;
+    --server-down-ok) server_down_ok=true; shift ;;
+    -h|--help) echo "Usage: gc dolt cleanup [--force] [--max N] [--server-down-ok]"; exit 0 ;;
     *) echo "gc dolt cleanup: unknown flag: $1" >&2; exit 1 ;;
   esac
 done
@@ -533,6 +671,47 @@ if [ "$force" != true ]; then
   exit 0
 fi
 
+# Mirrors the production server-reachability check (#1549). The fixture's
+# stub runtime.sh does not export GC_DOLT_PORT or the helper functions, so
+# tcp_reachable stays false; --force without --server-down-ok refuses,
+# --force --server-down-ok takes the rm path. The fixture has no live dolt
+# server, so the SQL-DROP branch is exercised by integration tests.
+host="${GC_DOLT_HOST:-127.0.0.1}"
+: "${GC_DOLT_USER:=root}"
+sql_args="--host $host --port ${GC_DOLT_PORT:-} --user $GC_DOLT_USER --no-tls"
+export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
+
+tcp_reachable=false
+if [ -n "$GC_DOLT_PORT" ] \
+  && command -v managed_runtime_tcp_reachable >/dev/null 2>&1 \
+  && managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
+  tcp_reachable=true
+fi
+
+sql_works=false
+if [ "$tcp_reachable" = true ] \
+  && command -v dolt >/dev/null 2>&1 \
+  && command -v run_bounded >/dev/null 2>&1 \
+  && run_bounded 5 dolt $sql_args sql -q "SELECT 1" >/dev/null 2>&1; then
+  sql_works=true
+fi
+
+delete_via=""
+if [ "$sql_works" = true ]; then
+  delete_via=sql
+elif [ "$tcp_reachable" = true ]; then
+  echo "gc dolt cleanup: dolt is listening on port $GC_DOLT_PORT but 'SELECT 1' failed;" >&2
+  echo "  refusing to rm against a potentially-live server (#1549). Fix SQL access or stop dolt and retry." >&2
+  exit 1
+elif [ "$server_down_ok" = true ]; then
+  delete_via=rm
+else
+  echo "gc dolt cleanup: dolt server unreachable on port ${GC_DOLT_PORT:-unset};" >&2
+  echo "  rm -rf against per-database dirs while the server is up corrupts NBS state (#1549)." >&2
+  echo "  Either start dolt and re-run, or pass --server-down-ok if the server is intentionally stopped." >&2
+  exit 1
+fi
+
 refused_tmp=$(mktemp)
 removed_tmp=$(mktemp)
 echo "$orphans" | while IFS='|' read -r db_name size path; do
@@ -543,11 +722,27 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
     echo "refused" >> "$refused_tmp"
     continue
   fi
-  if rm -rf "$path"; then
-    echo "removed" >> "$removed_tmp"
-    echo "  Removed $db_name"
+  case "$db_name" in
+    ''|*[!A-Za-z0-9_]*)
+      echo "refusing to remove '$db_name': name contains forbidden characters (allowed: A-Z, a-z, 0-9, _)" >&2
+      echo "refused" >> "$refused_tmp"
+      continue
+      ;;
+  esac
+  if [ "$delete_via" = sql ]; then
+    if run_bounded 30 dolt $sql_args sql -q "DROP DATABASE IF EXISTS \`$db_name\`" >/dev/null 2>&1; then
+      echo "removed" >> "$removed_tmp"
+      echo "  Dropped $db_name"
+    else
+      echo "  Failed to drop $db_name via SQL" >&2
+    fi
   else
-    echo "  Failed to remove $db_name" >&2
+    if rm -rf "$path"; then
+      echo "removed" >> "$removed_tmp"
+      echo "  Removed $db_name"
+    else
+      echo "  Failed to remove $db_name" >&2
+    fi
   fi
 done
 

--- a/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
+++ b/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
@@ -197,7 +197,7 @@ exists $WORK/city7/.beads/dolt/orphan_db
 # city8 has three orphans:
 #   safe_orphan         — pure [A-Za-z0-9_]; allowed
 #   ok-hyphen-orphan    — internal hyphen; allowed (matches health/gc-nudge)
-#   _leading_unsafe     — staged on disk under a non-conforming directory name
+#   -leading-unsafe     — staged on disk under a non-conforming directory name
 #                         that fails the leading-charset check. Must be refused
 #                         before any deletion attempt and must remain on disk.
 # Because at least one orphan was refused as unsafe, the script must exit
@@ -654,7 +654,7 @@ overlapping_rig_path() {
 }
 
 allowlist_file=$(mktemp)
-trap 'rm -f "$allowlist_file" "${refused_tmp:-}" "${removed_tmp:-}"' EXIT
+trap 'rm -f "$allowlist_file" "${refused_tmp:-}" "${removed_tmp:-}" "${unsafe_tmp:-}"' EXIT
 allowlist_ready=true
 if ! compute_allowlist_file "$allowlist_file"; then
   allowlist_ready=false

--- a/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
+++ b/cmd/gc/testdata/dolt-cleanup-external-rig.txtar
@@ -194,11 +194,20 @@ exists $WORK/city7/.beads/dolt/orphan_db
 # ==========================================================================
 # Scenario 8: Identifier safety (#1549)
 # ==========================================================================
-# city8 has two orphans:
-#   safe_orphan       — passes the [A-Za-z0-9_] charset check
-#   bad-name-orphan   — contains a hyphen, would inject if interpolated into
-#                       backtick-quoted SQL. Must be refused before any
-#                       deletion attempt and must remain on disk.
+# city8 has three orphans:
+#   safe_orphan         — pure [A-Za-z0-9_]; allowed
+#   ok-hyphen-orphan    — internal hyphen; allowed (matches health/gc-nudge)
+#   _leading_unsafe     — staged on disk under a non-conforming directory name
+#                         that fails the leading-charset check. Must be refused
+#                         before any deletion attempt and must remain on disk.
+# Because at least one orphan was refused as unsafe, the script must exit
+# non-zero even though the safe orphans were removed — identifier-safety
+# refusals signal "DB in an impossible state" (manual fs mucking, corrupted
+# metadata, attempted injection) and demand operator attention.
+#
+# The leading-unsafe orphan's directory name uses a leading hyphen, which the
+# new regex rejects via the `[A-Za-z0-9_]*` first-char gate. The directory is
+# staged inside the test environment via a separate metadata.json fragment.
 
 exec gc init --file $WORK/city8-cfg.toml $WORK/city8
 stdout 'Welcome to Gas City'
@@ -208,11 +217,18 @@ cd $WORK/city8
 cp $WORK/shared/cleanup.sh $WORK/city8/packs/dolt/commands/cleanup.sh
 chmod 755 $WORK/city8/packs/dolt/commands/cleanup.sh
 
-exec gc dolt cleanup --force --server-down-ok
+# Stage the leading-hyphen orphan dir at runtime (txtar -- markers can't carry
+# leading-hyphen path segments without ambiguity).
+mkdir $WORK/city8/.beads/dolt/-leading-unsafe
+mkdir $WORK/city8/.beads/dolt/-leading-unsafe/.dolt
+
+! exec gc dolt cleanup --force --server-down-ok
 stdout 'Removed safe_orphan'
-stderr 'name contains forbidden characters'
+stdout 'Removed ok-hyphen-orphan'
+stderr 'name must start with'
 ! exists $WORK/city8/.beads/dolt/safe_orphan
-exists $WORK/city8/.beads/dolt/bad-name-orphan
+! exists $WORK/city8/.beads/dolt/ok-hyphen-orphan
+exists $WORK/city8/.beads/dolt/-leading-unsafe
 
 # ===========================================================================
 # Shared fixture: external-rig (used by city1 and city3)
@@ -491,7 +507,7 @@ includes = ["packs/dolt"]
 
 -- city8/.beads/dolt/city8_db/.dolt/.keep --
 -- city8/.beads/dolt/safe_orphan/.dolt/.keep --
--- city8/.beads/dolt/bad-name-orphan/.dolt/.keep --
+-- city8/.beads/dolt/ok-hyphen-orphan/.dolt/.keep --
 
 -- city8/packs/dolt/pack.toml --
 [pack]
@@ -696,7 +712,7 @@ if [ "$tcp_reachable" = true ] \
   sql_works=true
 fi
 
-delete_via=""
+unset delete_via
 if [ "$sql_works" = true ]; then
   delete_via=sql
 elif [ "$tcp_reachable" = true ]; then
@@ -711,9 +727,14 @@ else
   echo "  Either start dolt and re-run, or pass --server-down-ok if the server is intentionally stopped." >&2
   exit 1
 fi
+case "${delete_via:-}" in
+  sql|rm) ;;
+  *) echo "gc dolt cleanup: internal error — delete_via not set" >&2; exit 1 ;;
+esac
 
 refused_tmp=$(mktemp)
 removed_tmp=$(mktemp)
+unsafe_tmp=$(mktemp)
 echo "$orphans" | while IFS='|' read -r db_name size path; do
   [ -z "$db_name" ] && continue
   overlap=$(overlapping_rig_path "$path")
@@ -723,9 +744,18 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
     continue
   fi
   case "$db_name" in
-    ''|*[!A-Za-z0-9_]*)
-      echo "refusing to remove '$db_name': name contains forbidden characters (allowed: A-Z, a-z, 0-9, _)" >&2
-      echo "refused" >> "$refused_tmp"
+    [A-Za-z0-9_]*)
+      case "$db_name" in
+        *[!A-Za-z0-9_-]*)
+          echo "refusing to remove '$db_name': name contains forbidden characters (allowed: A-Z, a-z, 0-9, _, -)" >&2
+          echo "unsafe" >> "$unsafe_tmp"
+          continue
+          ;;
+      esac
+      ;;
+    *)
+      echo "refusing to remove '$db_name': name must start with [A-Za-z0-9_]" >&2
+      echo "unsafe" >> "$unsafe_tmp"
       continue
       ;;
   esac
@@ -748,10 +778,12 @@ done
 
 removed=$(wc -l < "$removed_tmp" | tr -d ' ')
 refused_count=$(wc -l < "$refused_tmp" | tr -d ' ')
+unsafe_count=$(wc -l < "$unsafe_tmp" | tr -d ' ')
 echo ""
 echo "Removed $removed of $orphan_count orphaned database(s)."
 
-if [ "$removed" -lt "$((orphan_count - refused_count))" ] \
+if [ "$unsafe_count" -gt 0 ] \
+  || [ "$removed" -lt "$((orphan_count - refused_count - unsafe_count))" ] \
   || { [ "$refused_count" -gt 0 ] && [ "$removed" -eq 0 ]; }; then
   exit 1
 fi

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -239,7 +239,7 @@ if [ "$tcp_reachable" = true ] \
   sql_works=true
 fi
 
-delete_via=""
+unset delete_via
 if [ "$sql_works" = true ]; then
   delete_via=sql
 elif [ "$tcp_reachable" = true ]; then
@@ -254,12 +254,26 @@ else
   echo "  Either start dolt and re-run, or pass --server-down-ok if the server is intentionally stopped." >&2
   exit 1
 fi
+# Belt-and-suspenders: a future edit that opens a fall-through path here would
+# silently route to the rm branch below, re-introducing the corruption #1549
+# fixes. Crash loudly instead.
+case "${delete_via:-}" in
+  sql|rm) ;;
+  *) echo "gc dolt cleanup: internal error — delete_via not set" >&2; exit 1 ;;
+esac
 
 # Remove each orphan. Track refusals and successful removals via tmpfiles so
-# the subshell's counters survive (the pipe creates a subshell).
+# the subshell's counters survive (the pipe creates a subshell). Identifier-
+# safety refusals are tracked separately because they signal "DB in an
+# impossible state" (manual fs mucking, corrupted metadata, attempted
+# injection) and must surface as a non-zero exit even when other orphans were
+# removed successfully — overlap-allowlist refusals stay on the existing
+# partial-progress semantics ("did the batch make as much progress as it
+# could").
 refused_tmp=$(mktemp)
 removed_tmp=$(mktemp)
-trap 'rm -f "$allowlist_file" "$refused_tmp" "$removed_tmp"' EXIT
+unsafe_tmp=$(mktemp)
+trap 'rm -f "$allowlist_file" "$refused_tmp" "$removed_tmp" "$unsafe_tmp"' EXIT
 echo "$orphans" | while IFS='|' read -r db_name size path; do
   [ -z "$db_name" ] && continue
 
@@ -277,11 +291,22 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
   # Identifier safety: dolt_database flows from operator-controlled metadata.json
   # straight into a backtick-quoted SQL identifier. Reject anything outside the
   # safe charset before interpolating, so an embedded backtick or semicolon
-  # cannot break out of the quoted identifier into arbitrary SQL.
+  # cannot break out of the quoted identifier into arbitrary SQL. Charset
+  # matches `valid_database_name` in commands/gc-nudge/run.sh so a name probed
+  # by `gc dolt health` or nudged by `gc dolt gc-nudge` is also reachable here.
   case "$db_name" in
-    ''|*[!A-Za-z0-9_]*)
-      echo "refusing to remove '$db_name': name contains forbidden characters (allowed: A-Z, a-z, 0-9, _)" >&2
-      echo "refused" >> "$refused_tmp"
+    [A-Za-z0-9_]*)
+      case "$db_name" in
+        *[!A-Za-z0-9_-]*)
+          echo "refusing to remove '$db_name': name contains forbidden characters (allowed: A-Z, a-z, 0-9, _, -)" >&2
+          echo "unsafe" >> "$unsafe_tmp"
+          continue
+          ;;
+      esac
+      ;;
+    *)
+      echo "refusing to remove '$db_name': name must start with [A-Za-z0-9_]" >&2
+      echo "unsafe" >> "$unsafe_tmp"
       continue
       ;;
   esac
@@ -303,15 +328,23 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
   fi
 done
 
-# Count removed and refused (the removal loop runs in a subshell, so the
-# parent shell reads back through the tmpfiles).
+# Count removed, refused (allowlist), and unsafe (identifier-safety) (the
+# removal loop runs in a subshell, so the parent shell reads back through the
+# tmpfiles).
 removed=$(wc -l < "$removed_tmp" | tr -d ' ')
 refused_count=$(wc -l < "$refused_tmp" | tr -d ' ')
+unsafe_count=$(wc -l < "$unsafe_tmp" | tr -d ' ')
 echo ""
 echo "Removed $removed of $orphan_count orphaned database(s)."
 
-# Exit non-zero if any orphan was refused or failed to remove.
-if [ "$removed" -lt "$((orphan_count - refused_count))" ] \
+# Exit non-zero when:
+#   * any unsafe identifier was found — DB in an impossible state, demands
+#     operator attention even if other orphans were removed, OR
+#   * any orphan failed to remove (count math doesn't add up — silent failure
+#     in the loop), OR
+#   * the entire batch was refused (no progress made).
+if [ "$unsafe_count" -gt 0 ] \
+  || [ "$removed" -lt "$((orphan_count - refused_count - unsafe_count))" ] \
   || { [ "$refused_count" -gt 0 ] && [ "$removed" -eq 0 ]; }; then
   exit 1
 fi

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -212,20 +212,41 @@ if [ "$force" != true ]; then
   exit 0
 fi
 
-# Choose deletion strategy. Three ways the probe can land:
+# Choose deletion strategy. Four states the probe can land in (the
+# "cannot probe" state was missed initially — `managed_runtime_tcp_reachable`
+# returns false for both genuinely-unreachable AND no-probe-tool-available,
+# which would otherwise let --server-down-ok rm against a live server on
+# systems missing both nc and python3):
 #   * SELECT 1 succeeds → server is up and answering; SQL DROP is safe.
 #   * Port reachable but SELECT 1 fails → server may still hold open fds;
 #     refuse regardless of --server-down-ok (the flag advertises a STOPPED
 #     server, not an unhealthy one).
+#   * Cannot probe TCP (no nc, no python3) → cannot establish "stopped";
+#     refuse regardless of --server-down-ok.
 #   * Port unreachable → server is stopped; fall back to rm only when the
 #     operator has acknowledged via --server-down-ok.
 host="${GC_DOLT_HOST:-127.0.0.1}"
 : "${GC_DOLT_USER:=root}"
-sql_args="--host $host --port ${GC_DOLT_PORT:-} --user $GC_DOLT_USER --no-tls"
 export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
 
+# dolt_sql_q TIMEOUT QUERY  — invoke dolt CLI with each arg explicitly quoted
+# so neither host nor user (env-controlled) word-splits into adjacent flags
+# even on unexpected values. Stdout/stderr are captured by callers as needed.
+dolt_sql_q() {
+  _dolt_sql_q_timeout="$1"; shift
+  run_bounded "$_dolt_sql_q_timeout" \
+    dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
+    sql -q "$1"
+}
+
+probe_available=false
+if command -v nc >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1; then
+  probe_available=true
+fi
+
 tcp_reachable=false
-if [ -n "$GC_DOLT_PORT" ] \
+if [ "$probe_available" = true ] \
+  && [ -n "$GC_DOLT_PORT" ] \
   && command -v managed_runtime_tcp_reachable >/dev/null 2>&1 \
   && managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
   tcp_reachable=true
@@ -235,7 +256,7 @@ sql_works=false
 if [ "$tcp_reachable" = true ] \
   && command -v dolt >/dev/null 2>&1 \
   && command -v run_bounded >/dev/null 2>&1 \
-  && run_bounded 5 dolt $sql_args sql -q "SELECT 1" >/dev/null 2>&1; then
+  && dolt_sql_q 5 "SELECT 1" >/dev/null 2>&1; then
   sql_works=true
 fi
 
@@ -245,6 +266,11 @@ if [ "$sql_works" = true ]; then
 elif [ "$tcp_reachable" = true ]; then
   echo "gc dolt cleanup: dolt is listening on port $GC_DOLT_PORT but 'SELECT 1' failed;" >&2
   echo "  refusing to rm against a potentially-live server (#1549). Fix SQL access or stop dolt and retry." >&2
+  exit 1
+elif [ "$probe_available" = false ]; then
+  echo "gc dolt cleanup: cannot probe TCP reachability (neither nc nor python3 available);" >&2
+  echo "  refusing rm fallback regardless of --server-down-ok — cannot establish 'server is stopped' (#1549)." >&2
+  echo "  Install nc or python3, or stop dolt and use 'dolt sql -q \"DROP DATABASE\"' against another live instance." >&2
   exit 1
 elif [ "$server_down_ok" = true ]; then
   delete_via=rm
@@ -312,11 +338,13 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
   esac
 
   if [ "$delete_via" = sql ]; then
-    if run_bounded 30 dolt $sql_args sql -q "DROP DATABASE IF EXISTS \`$db_name\`" >/dev/null 2>&1; then
+    # Capture stdout+stderr so a DROP failure (auth, TLS, unknown-db, etc.)
+    # surfaces actionable detail to the operator instead of a generic message.
+    if drop_output=$(dolt_sql_q 30 "DROP DATABASE IF EXISTS \`$db_name\`" 2>&1); then
       echo "removed" >> "$removed_tmp"
       echo "  Dropped $db_name"
     else
-      echo "  Failed to drop $db_name via SQL" >&2
+      echo "  Failed to drop $db_name via SQL: ${drop_output:-(no output)}" >&2
     fi
   else
     if rm -rf "$path"; then

--- a/examples/dolt/commands/cleanup/run.sh
+++ b/examples/dolt/commands/cleanup/run.sh
@@ -6,11 +6,20 @@
 # databases (dry-run). Use --force to remove them.
 # Use --max to set a safety limit (refuses if more orphans than --max).
 #
-# Environment: GC_CITY_PATH
+# Removal strategy: when the dolt SQL server is reachable, --force issues
+# `DROP DATABASE IF EXISTS` through the running server (server-side NBS lock
+# serializes the close+remove safely). Falling back to filesystem `rm -rf`
+# while the server has the database open corrupts NBS state and crash-loops
+# the journal on next restart (#1549). The fallback is only taken when the
+# server is provably unreachable AND the operator passes --server-down-ok.
+#
+# Environment: GC_CITY_PATH (also GC_DOLT_PORT, GC_DOLT_HOST, GC_DOLT_USER,
+# GC_DOLT_PASSWORD when probing the running server)
 set -e
 
 force=false
 max_orphans=50
+server_down_ok=false
 PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
 . "$PACK_DIR/assets/scripts/runtime.sh"
 data_dir="$DOLT_DATA_DIR"
@@ -19,14 +28,20 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --force) force=true; shift ;;
     --max)   max_orphans="$2"; shift 2 ;;
+    --server-down-ok) server_down_ok=true; shift ;;
     -h|--help)
-      echo "Usage: gc dolt cleanup [--force] [--max N]"
+      echo "Usage: gc dolt cleanup [--force] [--max N] [--server-down-ok]"
       echo ""
       echo "Find Dolt databases not referenced by any registered rig."
       echo ""
       echo "Flags:"
-      echo "  --force    Actually remove orphaned databases"
-      echo "  --max N    Refuse if more than N orphans (default: 50)"
+      echo "  --force            Actually remove orphaned databases"
+      echo "  --max N            Refuse if more than N orphans (default: 50)"
+      echo "  --server-down-ok   Permit filesystem rm fallback when the dolt"
+      echo "                     server is provably stopped. Without this flag"
+      echo "                     --force refuses to run when dolt is unreachable,"
+      echo "                     because rm -rf against a live server's data"
+      echo "                     directory corrupts NBS state (#1549)."
       exit 0
       ;;
     *) echo "gc dolt cleanup: unknown flag: $1" >&2; exit 1 ;;
@@ -197,6 +212,49 @@ if [ "$force" != true ]; then
   exit 0
 fi
 
+# Choose deletion strategy. Three ways the probe can land:
+#   * SELECT 1 succeeds → server is up and answering; SQL DROP is safe.
+#   * Port reachable but SELECT 1 fails → server may still hold open fds;
+#     refuse regardless of --server-down-ok (the flag advertises a STOPPED
+#     server, not an unhealthy one).
+#   * Port unreachable → server is stopped; fall back to rm only when the
+#     operator has acknowledged via --server-down-ok.
+host="${GC_DOLT_HOST:-127.0.0.1}"
+: "${GC_DOLT_USER:=root}"
+sql_args="--host $host --port ${GC_DOLT_PORT:-} --user $GC_DOLT_USER --no-tls"
+export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
+
+tcp_reachable=false
+if [ -n "$GC_DOLT_PORT" ] \
+  && command -v managed_runtime_tcp_reachable >/dev/null 2>&1 \
+  && managed_runtime_tcp_reachable "$GC_DOLT_PORT"; then
+  tcp_reachable=true
+fi
+
+sql_works=false
+if [ "$tcp_reachable" = true ] \
+  && command -v dolt >/dev/null 2>&1 \
+  && command -v run_bounded >/dev/null 2>&1 \
+  && run_bounded 5 dolt $sql_args sql -q "SELECT 1" >/dev/null 2>&1; then
+  sql_works=true
+fi
+
+delete_via=""
+if [ "$sql_works" = true ]; then
+  delete_via=sql
+elif [ "$tcp_reachable" = true ]; then
+  echo "gc dolt cleanup: dolt is listening on port $GC_DOLT_PORT but 'SELECT 1' failed;" >&2
+  echo "  refusing to rm against a potentially-live server (#1549). Fix SQL access or stop dolt and retry." >&2
+  exit 1
+elif [ "$server_down_ok" = true ]; then
+  delete_via=rm
+else
+  echo "gc dolt cleanup: dolt server unreachable on port ${GC_DOLT_PORT:-unset};" >&2
+  echo "  rm -rf against per-database dirs while the server is up corrupts NBS state (#1549)." >&2
+  echo "  Either start dolt and re-run, or pass --server-down-ok if the server is intentionally stopped." >&2
+  exit 1
+fi
+
 # Remove each orphan. Track refusals and successful removals via tmpfiles so
 # the subshell's counters survive (the pipe creates a subshell).
 refused_tmp=$(mktemp)
@@ -216,11 +274,32 @@ echo "$orphans" | while IFS='|' read -r db_name size path; do
     continue
   fi
 
-  if rm -rf "$path"; then
-    echo "removed" >> "$removed_tmp"
-    echo "  Removed $db_name"
+  # Identifier safety: dolt_database flows from operator-controlled metadata.json
+  # straight into a backtick-quoted SQL identifier. Reject anything outside the
+  # safe charset before interpolating, so an embedded backtick or semicolon
+  # cannot break out of the quoted identifier into arbitrary SQL.
+  case "$db_name" in
+    ''|*[!A-Za-z0-9_]*)
+      echo "refusing to remove '$db_name': name contains forbidden characters (allowed: A-Z, a-z, 0-9, _)" >&2
+      echo "refused" >> "$refused_tmp"
+      continue
+      ;;
+  esac
+
+  if [ "$delete_via" = sql ]; then
+    if run_bounded 30 dolt $sql_args sql -q "DROP DATABASE IF EXISTS \`$db_name\`" >/dev/null 2>&1; then
+      echo "removed" >> "$removed_tmp"
+      echo "  Dropped $db_name"
+    else
+      echo "  Failed to drop $db_name via SQL" >&2
+    fi
   else
-    echo "  Failed to remove $db_name" >&2
+    if rm -rf "$path"; then
+      echo "removed" >> "$removed_tmp"
+      echo "  Removed $db_name"
+    else
+      echo "  Failed to remove $db_name" >&2
+    fi
   fi
 done
 

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -105,14 +105,14 @@ the server's NBS lock):
 ```bash
 gc dolt cleanup --force --max <count>
 ```
-If `gc dolt cleanup` refuses with `dolt server unreachable`, the dolt server
-is stopped — do NOT pass `--server-down-ok` to bypass the refusal while it
-might still be running (rm -rf against a live data dir corrupts NBS state,
-#1549). Escalate instead so an operator can confirm the server is truly
-stopped before falling back:
+If `gc dolt cleanup` returns `dolt server unreachable`, STOP. Do NOT retry
+with `--server-down-ok` in this formula. Escalate immediately. Only a human
+operator may use `--server-down-ok` after independently verifying the dolt
+server process is stopped and the port is closed — running rm -rf against a
+live data dir corrupts NBS state and crash-loops the journal (#1549).
 ```bash
 gc mail send mayor/ -s "ESCALATION: <count> orphan databases detected, dolt unreachable [HIGH]" \\
-  -m "Too many orphans for inline SQL cleanup AND gc dolt cleanup refused (server unreachable). Operator must confirm dolt is stopped, then re-run with --server-down-ok."
+  -m "Too many orphans for inline SQL cleanup AND gc dolt cleanup refused (server unreachable). Operator must confirm dolt is stopped (process gone AND port closed), then re-run with --server-down-ok."
 ```
 
 **4. Record results:**

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -105,14 +105,15 @@ the server's NBS lock):
 ```bash
 gc dolt cleanup --force --max <count>
 ```
-If `gc dolt cleanup` returns `dolt server unreachable`, STOP. Do NOT retry
-with `--server-down-ok` from any agent context, including this formula. The
+If `gc dolt cleanup` returns ANY refusal (server unreachable, port reachable
+but `SELECT 1` failed, or cannot probe TCP), STOP. Do NOT retry with
+`--server-down-ok` from any agent context, including this formula. The
 flag is a TTY-only operator gesture; if you are an agent, you are not the
 operator, regardless of who scheduled you. Escalate immediately. Only a
-human operator may use `--server-down-ok` after independently verifying the
-dolt server process is stopped and the port is closed — running rm -rf
-against a live data dir corrupts NBS state and crash-loops the journal
-(#1549).
+human operator may use `--server-down-ok`, and only after independently
+verifying the dolt server process is stopped AND the port is closed —
+running rm -rf against a live data dir corrupts NBS state and crash-loops
+the journal (#1549).
 ```bash
 gc mail send mayor/ -s "ESCALATION: <count> orphan databases detected, dolt unreachable [HIGH]" \\
   -m "Too many orphans for inline SQL cleanup AND gc dolt cleanup refused (server unreachable). Operator must confirm dolt is stopped (process gone AND port closed), then re-run with --server-down-ok."

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -106,10 +106,13 @@ the server's NBS lock):
 gc dolt cleanup --force --max <count>
 ```
 If `gc dolt cleanup` returns `dolt server unreachable`, STOP. Do NOT retry
-with `--server-down-ok` in this formula. Escalate immediately. Only a human
-operator may use `--server-down-ok` after independently verifying the dolt
-server process is stopped and the port is closed — running rm -rf against a
-live data dir corrupts NBS state and crash-loops the journal (#1549).
+with `--server-down-ok` from any agent context, including this formula. The
+flag is a TTY-only operator gesture; if you are an agent, you are not the
+operator, regardless of who scheduled you. Escalate immediately. Only a
+human operator may use `--server-down-ok` after independently verifying the
+dolt server process is stopped and the port is closed — running rm -rf
+against a live data dir corrupts NBS state and crash-loops the journal
+(#1549).
 ```bash
 gc mail send mayor/ -s "ESCALATION: <count> orphan databases detected, dolt unreachable [HIGH]" \\
   -m "Too many orphans for inline SQL cleanup AND gc dolt cleanup refused (server unreachable). Operator must confirm dolt is stopped (process gone AND port closed), then re-run with --server-down-ok."

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -99,14 +99,20 @@ DROP DATABASE IF EXISTS `<orphan_name>`;
 ```
 
 **3. If orphan count > {{max_orphans_for_sql}}:**
-SQL cleanup would take too long. Use gc dolt cleanup instead:
+SQL cleanup would take too long via this loop. Delegate to gc dolt cleanup,
+which itself routes through the running server's `DROP DATABASE` (safe under
+the server's NBS lock):
 ```bash
 gc dolt cleanup --force --max <count>
 ```
-If even that fails, escalate:
+If `gc dolt cleanup` refuses with `dolt server unreachable`, the dolt server
+is stopped — do NOT pass `--server-down-ok` to bypass the refusal while it
+might still be running (rm -rf against a live data dir corrupts NBS state,
+#1549). Escalate instead so an operator can confirm the server is truly
+stopped before falling back:
 ```bash
-gc mail send mayor/ -s "ESCALATION: <count> orphan databases detected [HIGH]" \\
-  -m "Too many orphans for SQL cleanup. Recommend filesystem cleanup."
+gc mail send mayor/ -s "ESCALATION: <count> orphan databases detected, dolt unreachable [HIGH]" \\
+  -m "Too many orphans for inline SQL cleanup AND gc dolt cleanup refused (server unreachable). Operator must confirm dolt is stopped, then re-run with --server-down-ok."
 ```
 
 **4. Record results:**

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -115,7 +115,8 @@ gc nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 | Close completed work | `gc bd close <id> --reason "..."` |
 | Request target restart | `gc session kill <target>` |
 | List orphan databases | `gc dolt cleanup` |
-| Remove orphan databases | `gc dolt cleanup --force` |
+| Remove orphan databases | `gc dolt cleanup --force` (safe via SQL DROP when dolt is up) |
+| Remove orphan databases (dolt stopped) | `gc dolt cleanup --force --server-down-ok` |
 | Exit (return to pool) | `gc runtime drain-ack && exit` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -116,7 +116,7 @@ gc nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 | Request target restart | `gc session kill <target>` |
 | List orphan databases | `gc dolt cleanup` |
 | Remove orphan databases | `gc dolt cleanup --force` (safe via SQL DROP when dolt is up) |
-| Remove orphan databases (dolt stopped) | `gc dolt cleanup --force --server-down-ok` |
+| Remove orphan databases (dolt stopped) | `gc dolt cleanup --force --server-down-ok` (**operator/TTY-only**; do **not** use from autonomous/agent contexts — the rm fallback corrupts NBS state if dolt is actually running, #1549) |
 | Exit (return to pool) | `gc runtime drain-ack && exit` |
 
 Working directory: {{ .WorkDir }}


### PR DESCRIPTION
Closes #1549. Closes #1527 (duplicate, same author).

## Summary

`gc dolt cleanup --force` did `rm -rf` against per-database directories the dolt SQL server held open, panicking the server's NBS table persister on shutdown and crash-looping the journal on every restart. Two corruption events in 48h required JSONL snapshot restore. The fix routes deletion through the running server's `DROP DATABASE` (server-side NBS lock serializes safely) and only allows the rm fallback when the server is provably stopped AND the operator passes a new `--server-down-ok` flag.

## Changes

### `examples/dolt/commands/cleanup/run.sh`

Three-state deletion strategy decided up front, after the orphan list is built:

| Probe outcome | Behavior |
|---|---|
| TCP reachable + `SELECT 1` succeeds | `DROP DATABASE IF EXISTS \`<name>\`` via dolt CLI |
| TCP reachable + `SELECT 1` fails | **Refuse regardless of flags** — server may still hold open fds |
| TCP unreachable + `--server-down-ok` | rm -rf (operator has acknowledged stopped state) |
| TCP unreachable + no flag | Refuse with #1549 explanation |

Identifier-safety regex aligned with `examples/dolt/commands/gc-nudge/run.sh:196`'s `valid_database_name`: starts with `[A-Za-z0-9_]`, body allows hyphens. Refusals separated into `unsafe_count` so identifier-safety failures (DB in an impossible state — manual fs mucking, corrupted metadata, attempted injection) force a non-zero exit even when other orphans were removed.

### Prompt updates

* `examples/dolt/formulas/mol-dog-stale-db.toml`: agents must NOT pass `--server-down-ok` from any agent context. The flag is a TTY-only operator gesture.
* `examples/gastown/packs/maintenance/agents/dog/prompt.template.md`: cheat-sheet documents both `--force` (SQL when up) and `--force --server-down-ok` (rm only when stopped).

### Test fixture

`cmd/gc/testdata/dolt-cleanup-external-rig.txtar` mirrors the new branch logic. Two new scenarios:

* **Scenario 7** — server-reachability gate: `--force` without `--server-down-ok` and no live server refuses with the #1549 explanation; orphan stays on disk.
* **Scenario 8** — identifier safety: orphan with leading hyphen (`-leading-unsafe`) is refused; safe orphans (`safe_orphan`, `ok-hyphen-orphan`) are removed; run exits non-zero.

## Behavior change (release note)

`gc dolt cleanup --force` now refuses when the dolt server is unreachable unless `--server-down-ok` is passed. Downstream automation that wraps `gc dolt cleanup --force` in cron/systemd without a live dolt server will newly fail; either start dolt before running, or pass `--server-down-ok` after confirming the server is stopped.

## Related

* `examples/dolt/formulas/mol-dog-phantom-db.toml` was already migrated off rm to `mv -f` quarantine in #1537 (julianknutsen). Untouched here.
* PR #1548 (open, quad341) refactors the `mol-dog-stale-db` formula to call a future Go-side `gc dolt-cleanup` command. The two PRs will conflict on `examples/dolt/formulas/mol-dog-stale-db.toml`. Whichever lands second must carry the `--server-down-ok` policy paragraph forward into the new formula's apply step — when ga-921b adds the Go command, it must also implement the SQL-first/rm-only-when-server-down logic, or this bug class returns one layer up.

## Test plan

- [x] `make build` — clean
- [x] `go vet ./...` — clean
- [x] `make check` — clean (one flake on `TestGcBeadsBdStartRetriesAutoPortBindConflict` is a known port-bind race unrelated to this PR; passes on isolated re-run)
- [x] `make check-docs` — clean
- [x] `GC_FAST_UNIT=0 go test -run 'TestTutorial01/dolt-cleanup-external-rig' ./cmd/gc/` — all 8 scenarios pass
- [ ] Manual verification under live dolt: dispatch `mol-dog-stale-db` with orphans present, observe SQL-DROP path used and no NBS panic
- [ ] Manual verification with dolt stopped: `gc dolt cleanup --force` refuses with #1549 message; `--force --server-down-ok` falls back to rm

## Review pipeline

Multi-model review (Claude + Codex GPT-5.4) over two iterations. Iteration-1 findings (regex divergence with health/gc-nudge, counter-conflation exit-code, missing defensive guard, formula prompt strength) addressed in commit 241b4b60. Iteration-2 (fixture trap leak, prompt rationalization vector, comment doc-fix) addressed in 9a8f613e. Both models APPROVE; gascity-checker contributor audit READY with 3 non-blocking minors (SQL-DROP happy-path follow-up coverage, archive doc unlisted flag, this release note).

## Follow-ups (not in scope)

* SQL-DROP happy-path coverage requires a live dolt server in a testscript. Worth filing a follow-up bead.
* SQL arg construction is duplicated across 5+ commands in `examples/dolt/commands/*/run.sh`; extracting a `dolt_sql_args` helper into `examples/dolt/assets/scripts/runtime.sh` would let cleanup, health, recover, sync, gc-nudge, and sql call one helper.
* The N orphan → N dolt subprocess calls could be batched via `dolt sql < statements.txt`, established pattern in `recover/run.sh:41` and `health/run.sh:160`. Trade-off: per-orphan diagnostic granularity vs spawn cost. Out of scope for the correctness fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->