### PR TITLE
fix(nudge): treat ambiguous bead IDs as missing; prune expired entries unconditionally

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1417,9 +1417,9 @@ func pruneExpiredQueuedNudges(state *nudgeQueueState, store beads.Store, now tim
 				item.LastError = "expired"
 			}
 			state.Dead = append(state.Dead, item)
-			if err := markQueuedNudgeTerminal(store, item, "expired", item.LastError, "", now); err != nil {
-				return err
-			}
+			// Best-effort: remove expired item from pending even if bead update fails.
+			// A failed bead update here would trap the item in pending forever.
+			_ = markQueuedNudgeTerminal(store, item, "expired", item.LastError, "", now)
 			continue
 		}
 		filtered = append(filtered, item)
@@ -1438,9 +1438,8 @@ func recoverExpiredInFlightNudges(state *nudgeQueueState, store beads.Store, now
 				item.LastError = "expired"
 			}
 			state.Dead = append(state.Dead, item)
-			if err := markQueuedNudgeTerminal(store, item, "expired", item.LastError, "", now); err != nil {
-				return err
-			}
+			// Best-effort: remove expired item from in-flight even if bead update fails.
+			_ = markQueuedNudgeTerminal(store, item, "expired", item.LastError, "", now)
 			continue
 		}
 		if item.LeaseUntil.IsZero() || !item.LeaseUntil.After(now) {

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -42,6 +42,25 @@ func (s *missingNudgeBeadStore) Close(id string) error {
 	return s.MemStore.Close(id)
 }
 
+type ambiguousNudgeBeadStore struct {
+	*beads.MemStore
+	ambiguousID string
+}
+
+func (s *ambiguousNudgeBeadStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.ambiguousID {
+		return fmt.Errorf("setting metadata on %q: exit status 1: Error resolving %s: ambiguous ID %q matches 86 issues: [gc-170 gc-171 gc-172 ...]\nUse more characters to disambiguate", id, id, id)
+	}
+	return s.MemStore.SetMetadataBatch(id, kvs)
+}
+
+func (s *ambiguousNudgeBeadStore) Close(id string) error {
+	if id == s.ambiguousID {
+		return fmt.Errorf("closing bead %q: exit status 1: Error resolving %s: ambiguous ID %q matches 86 issues: [gc-170 gc-171 gc-172 ...]\nUse more characters to disambiguate", id, id, id)
+	}
+	return s.MemStore.Close(id)
+}
+
 type unrelatedNotFoundNudgeBeadStore struct {
 	*beads.MemStore
 	errorID string
@@ -190,6 +209,75 @@ func TestPruneExpiredQueuedNudgesIgnoresMissingTerminalBead(t *testing.T) {
 	}
 	if state.Dead[0].LastError != "expired" {
 		t.Fatalf("dead[0].LastError = %q, want expired", state.Dead[0].LastError)
+	}
+}
+
+func TestMarkQueuedNudgeTerminalHandlesAmbiguousBeadID(t *testing.T) {
+	store := &ambiguousNudgeBeadStore{MemStore: beads.NewMemStore(), ambiguousID: "gc-17"}
+	item := queuedNudge{
+		ID:        "nudge-ambiguous",
+		Agent:     "wendy.wendy",
+		SessionID: "mc-ayq6xi",
+		Source:    "session",
+		Message:   "follow up",
+		BeadID:    "gc-17",
+		CreatedAt: time.Now().Add(-time.Minute).UTC(),
+	}
+	createdID, created, err := ensureQueuedNudgeBead(store, item)
+	if err != nil {
+		t.Fatalf("ensureQueuedNudgeBead: %v", err)
+	}
+	if !created {
+		t.Fatal("expected ensureQueuedNudgeBead to create a backing nudge bead")
+	}
+
+	now := time.Now().UTC()
+	item.LastError = "expired"
+	if err := markQueuedNudgeTerminal(store, item, "expired", "expired", "", now); err != nil {
+		t.Fatalf("markQueuedNudgeTerminal with ambiguous BeadID: %v", err)
+	}
+
+	bead, err := store.Get(createdID)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", createdID, err)
+	}
+	if bead.Status != "closed" {
+		t.Fatalf("bead.Status = %q, want closed", bead.Status)
+	}
+	if bead.Metadata["state"] != "expired" {
+		t.Fatalf("state = %q, want expired", bead.Metadata["state"])
+	}
+}
+
+func TestPruneExpiredQueuedNudgesWithAmbiguousBeadIDContinues(t *testing.T) {
+	// Regression: stale entries with short bead IDs (e.g. "gc-17") that match many
+	// beads in a large store used to abort the entire nudge processing loop.
+	store := &ambiguousNudgeBeadStore{MemStore: beads.NewMemStore(), ambiguousID: "gc-17"}
+	now := time.Now().UTC()
+	state := &nudgeQueueState{
+		Pending: []queuedNudge{
+			{
+				ID:           "nudge-ambiguous",
+				BeadID:       "gc-17",
+				Agent:        "gc-ub35o",
+				SessionID:    "gc-ub35o",
+				Source:       "session",
+				Message:      "Run gc hook",
+				CreatedAt:    now.Add(-8 * 24 * time.Hour),
+				DeliverAfter: now.Add(-8 * 24 * time.Hour),
+				ExpiresAt:    now.Add(-7 * 24 * time.Hour),
+			},
+		},
+	}
+
+	if err := pruneExpiredQueuedNudges(state, store, now); err != nil {
+		t.Fatalf("pruneExpiredQueuedNudges: %v", err)
+	}
+	if len(state.Pending) != 0 {
+		t.Fatalf("pending = %d, want 0 (stale entry must be pruned)", len(state.Pending))
+	}
+	if len(state.Dead) != 1 {
+		t.Fatalf("dead = %d, want 1", len(state.Dead))
 	}
 }
 

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -182,7 +182,9 @@ func isMissingQueuedNudgeBeadErr(err error, beadID string) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "no issue found matching "+strings.ToLower(strconv.Quote(beadID))) ||
-		strings.Contains(msg, "error resolving "+beadID+": no issue found")
+		strings.Contains(msg, "error resolving "+beadID+": no issue found") ||
+		strings.Contains(msg, "ambiguous id") ||
+		strings.Contains(msg, "use more characters to disambiguate")
 }
 
 func marshalNudgeReference(ref *nudgeReference) string {

--- a/internal/nudgequeue/waits.go
+++ b/internal/nudgequeue/waits.go
@@ -1,6 +1,7 @@
 package nudgequeue
 
 import (
+	"errors"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -95,9 +96,15 @@ func markTerminal(store beads.Store, nudgeID, now string) error {
 			"commit_boundary": "delivery-withdrawn",
 			"terminal_at":     now,
 		}); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
 			return err
 		}
 		if err := store.Close(item.ID); err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- `isMissingQueuedNudgeBeadErr` now recognises `bd`'s `"ambiguous ID"` / `"Use more characters to disambiguate"` errors as a not-found condition. In stores with 31k+ beads, a stale short bead ID (e.g. `gc-17`) substring-matches dozens of beads; the ambiguous error was not classified as ErrNotFound, so every subsequent nudge / `mail --notify` call aborted.
- `pruneExpiredQueuedNudges` and `recoverExpiredInFlightNudges` now drop expired items even if the bead metadata update fails (best-effort). A failed update was re-inserting the item into Pending on the next tick, creating a self-perpetuating trap.
- `markTerminal` in `internal/nudgequeue/waits.go` now continues past `ErrNotFound` on individual bead updates so one missing bead does not abort the loop.

## Root cause

Stale expired entries in `.gc/nudges/state.json` can reference bead IDs that no longer exist in the city store. When any nudge fires, `markQueuedNudgeTerminal` iterates pending items and calls `store.SetMetadataBatch(item.BeadID, ...)`. If the bead is stale, `bd` falls back to partial/substring match; in a large store that match becomes ambiguous → `bd` errors with `"ambiguous ID \"%s\" matches N issues"`. That error was not classified as `ErrNotFound`, so it propagated all the way up through nudge / `mail --notify`.

## Test plan

- `TestMarkQueuedNudgeTerminalHandlesAmbiguousBeadID` — verifies `markQueuedNudgeTerminal` treats the ambiguous error as not-found and completes successfully
- `TestPruneExpiredQueuedNudgesWithAmbiguousBeadIDContinues` — verifies `pruneExpiredQueuedNudges` prunes the expired item even when `markQueuedNudgeTerminal` returns an ambiguous error
- All 6 directly related regression tests pass; broader nudge test suite shows only pre-existing environment-dependent failures (require live `bd update` / city infrastructure)

## References

- `cmd/gc/nudge_beads.go:172` — `isMissingQueuedNudgeBeadErr`
- `cmd/gc/cmd_nudge.go:1411,1432` — `pruneExpiredQueuedNudges`, `recoverExpiredInFlightNudges`
- `internal/nudgequeue/waits.go:80` — `markTerminal`
- Incident: city store with 31,116 beads; stale `state.json` with `gc-17` (substring-matches 86 beads)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->