### PR TITLE
fix(reconcile): surface bd stdout error detail + raise reload accept timeout (#1560)

### DIFF
--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -176,13 +176,9 @@ func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reload
 	if err != nil {
 		return reloadControlReply{}, fmt.Errorf("marshaling request: %w", err)
 	}
-	readTimeout := 15 * time.Second
-	if req.Wait && req.Timeout != "" {
-		timeout, err := time.ParseDuration(req.Timeout)
-		if err != nil {
-			return reloadControlReply{}, fmt.Errorf("parsing request timeout: %w", err)
-		}
-		readTimeout = controllerReloadAcceptTimeout + timeout + 10*time.Second
+	readTimeout, err := reloadControlReadTimeout(req)
+	if err != nil {
+		return reloadControlReply{}, err
 	}
 	resp, err := sendControllerCommandWithReadTimeout(cityPath, "reload:"+string(data), readTimeout)
 	if err != nil {
@@ -193,6 +189,18 @@ func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reload
 		return reloadControlReply{}, fmt.Errorf("parsing response: %w", err)
 	}
 	return reply, nil
+}
+
+func reloadControlReadTimeout(req reloadControlRequest) (time.Duration, error) {
+	readTimeout := 2*controllerReloadAcceptTimeout + 10*time.Second
+	if req.Wait && req.Timeout != "" {
+		timeout, err := time.ParseDuration(req.Timeout)
+		if err != nil {
+			return 0, fmt.Errorf("parsing request timeout: %w", err)
+		}
+		readTimeout += timeout
+	}
+	return readTimeout, nil
 }
 
 func reloadUnavailableMessage(cityPath string) string {

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -31,7 +31,15 @@ const (
 )
 
 var (
-	controllerReloadAcceptTimeout = 5 * time.Second
+	// controllerReloadAcceptTimeout is how long a reload request waits for
+	// the controller's main goroutine to drain it from reloadReqCh. The
+	// main goroutine is blocked while a reconcile tick runs, and ticks can
+	// take 30s–90s+ under bead-store churn (see issue #1560). 5s was
+	// dramatically too short and produced "controller is busy" rejections
+	// for many minutes at a time. 60s gives the controller enough headroom
+	// to finish a tick before the reload is rejected, while still bounding
+	// the wait for genuinely deadlocked controllers.
+	controllerReloadAcceptTimeout = 60 * time.Second
 	sendReloadControlRequestHook  = sendReloadControlRequest
 	reloadUnavailableMessageHook  = reloadUnavailableMessage
 	supervisorAPIBaseURLHook      = supervisorAPIBaseURL

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -375,6 +375,40 @@ func TestHandleReloadSocketCmdWaitsForAcceptedAfterHandoff(t *testing.T) {
 	}
 }
 
+func TestControllerReloadAcceptTimeoutDefault(t *testing.T) {
+	if controllerReloadAcceptTimeout != 60*time.Second {
+		t.Fatalf("controllerReloadAcceptTimeout = %s, want 60s", controllerReloadAcceptTimeout)
+	}
+}
+
+func TestReloadControlReadTimeoutAsyncOutlastsAcceptAndAckWindow(t *testing.T) {
+	readTimeout, err := reloadControlReadTimeout(reloadControlRequest{Wait: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readTimeout <= 15*time.Second {
+		t.Fatalf("async read timeout = %s, want above old 15s client deadline", readTimeout)
+	}
+	if wantMin := 2*controllerReloadAcceptTimeout + 5*time.Second; readTimeout <= wantMin {
+		t.Fatalf("async read timeout = %s, want above controller window %s", readTimeout, wantMin)
+	}
+}
+
+func TestReloadControlReadTimeoutWaitIncludesRequestedTimeout(t *testing.T) {
+	oldAccept := controllerReloadAcceptTimeout
+	controllerReloadAcceptTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { controllerReloadAcceptTimeout = oldAccept })
+
+	readTimeout, err := reloadControlReadTimeout(reloadControlRequest{Wait: true, Timeout: "40ms"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 2*controllerReloadAcceptTimeout + 40*time.Millisecond + 10*time.Second
+	if readTimeout != want {
+		t.Fatalf("read timeout = %s, want %s", readTimeout, want)
+	}
+}
+
 func TestSendReloadControlRequestNoChange(t *testing.T) {
 	sp := runtime.NewFake()
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -77,13 +77,42 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 			}
 			return out, timeoutErr
 		}
-		if err != nil && stderr.Len() > 0 {
-			trace("error", err)
-			return out, fmt.Errorf("%w: %s", err, stderr.String())
+		if err != nil {
+			// bd writes structured errors to stdout (JSON envelope) when
+			// invoked with --json, while stderr is often empty. Surface
+			// whichever stream has content so supervisor logs become
+			// actionable instead of bare "exit status 1".
+			detail := strings.TrimSpace(stderr.String())
+			if detail == "" && name == "bd" {
+				detail = bdStdoutErrorDetail(out)
+			}
+			if detail != "" {
+				trace("error", err)
+				return out, fmt.Errorf("%w: %s", err, detail)
+			}
 		}
 		trace("done", err)
 		return out, err
 	}
+}
+
+// bdStdoutErrorDetail extracts a human-readable error description from
+// bd's JSON error envelope on stdout. bd writes structured errors as
+// {"error": "...", "schema_version": N} on stdout when invoked with
+// --json, while stderr is often empty. Returns "" when the output does
+// not look like a bd error envelope so callers can fall through.
+func bdStdoutErrorDetail(out []byte) string {
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return ""
+	}
+	var env struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(trimmed, &env); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(env.Error)
 }
 
 // PurgeRunnerFunc executes a bd purge command with custom dir and env.

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -102,7 +102,7 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 // --json, while stderr is often empty. Returns "" when the output does
 // not look like a bd error envelope so callers can fall through.
 func bdStdoutErrorDetail(out []byte) string {
-	trimmed := bytes.TrimSpace(out)
+	trimmed := bytes.TrimSpace(extractJSON(out))
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return ""
 	}

--- a/internal/beads/bdstore_internal_test.go
+++ b/internal/beads/bdstore_internal_test.go
@@ -1,0 +1,60 @@
+package beads
+
+import "testing"
+
+func TestBdStdoutErrorDetail(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "empty",
+			out:  "",
+			want: "",
+		},
+		{
+			name: "non json",
+			out:  "bd failed",
+			want: "",
+		},
+		{
+			name: "malformed json",
+			out:  `{"error":`,
+			want: "",
+		},
+		{
+			name: "missing error",
+			out:  `{"schema_version":1}`,
+			want: "",
+		},
+		{
+			name: "null error",
+			out:  `{"error":null,"schema_version":1}`,
+			want: "",
+		},
+		{
+			name: "blank error",
+			out:  `{"error":"   ","schema_version":1}`,
+			want: "",
+		},
+		{
+			name: "error envelope",
+			out:  `{"error":" no issue found bd-42 ","schema_version":1}`,
+			want: "no issue found bd-42",
+		},
+		{
+			name: "preamble before envelope",
+			out:  "bd warning before json\n{\"error\":\"resolving dependency: no issue found bd-42\",\"schema_version\":1}",
+			want: "resolving dependency: no issue found bd-42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bdStdoutErrorDetail([]byte(tt.out)); got != tt.want {
+				t.Fatalf("bdStdoutErrorDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1789,6 +1789,35 @@ func TestExecCommandRunnerWithEnvOverridesInheritedValues(t *testing.T) {
 	}
 }
 
+func TestExecCommandRunnerWithEnvSurfacesBdJSONErrorFromStdout(t *testing.T) {
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+printf '%s\n' 'bd warning before json'
+printf '%s\n' '{"error":"resolving dependency: no issue found bd-missing","schema_version":1}'
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	runner := beads.ExecCommandRunnerWithEnv(map[string]string{
+		"GC_CITY_PATH": "/city",
+	})
+
+	out, err := runner(t.TempDir(), "bd", "dep", "list", "bd-missing", "--json")
+	if err == nil {
+		t.Fatal("runner error = nil, want bd exit error")
+	}
+	if !strings.Contains(err.Error(), "resolving dependency: no issue found bd-missing") {
+		t.Fatalf("runner error = %q, want stdout JSON error detail", err.Error())
+	}
+	if !strings.Contains(string(out), `"schema_version":1`) {
+		t.Fatalf("runner stdout = %q, want original bd stdout preserved", string(out))
+	}
+}
+
 func TestBdStoreApplyGraphPlan(t *testing.T) {
 	dir := t.TempDir()
 	var capturedPlan beads.GraphApplyPlan


### PR DESCRIPTION
Fixes #1560.

## Summary

Two related fixes restore reconcile resilience under bead-store churn, especially when ephemeral `*-wisp-*` patrol-molecule beads appear in `bd list` output but `bd dep list <id>` cannot resolve them.

1. **`internal/beads/bdstore.go`** — `ExecCommandRunnerWithEnv` now extracts bd's JSON error envelope from stdout when stderr is empty. That turns opaque `exit status 1` failures into actionable errors such as `resolving <id>: no issue found ...`, which then feed the existing `isBdNotFound` handling in `DepList`. The active BdStore cache path already performs lazy per-ID dependency reads through `DepList`, so stale ephemeral IDs are treated as empty dependency lists instead of poisoning the cache refresh. `DepListBatch` is also kept aligned with `DepList` for defensive consistency, but the production cache path does not depend on a new `DepListBatch` per-ID fallback.

2. **`cmd/gc/cmd_reload.go`** — `controllerReloadAcceptTimeout` is raised from 5s to 60s with an explanatory comment. Reconcile ticks routinely run 30-90s+ under load, so the previous 5s accept timeout caused repeated `Reload request could not be accepted because the controller is busy.` rejections. The client read timeout now outlasts the controller-side socket deadline, including wait-mode timeout.

3. **Tests** — Added focused coverage for bd stdout error-envelope extraction, not-found-to-empty dependency semantics, and the reload read-timeout contract.

## Companion change

A companion PR on the beads repo (`fix(dep): tolerate unresolved IDs in batch dep list`) makes `bd dep list` itself resilient. The Gas City fix here does not rely on that batch fallback for the live cache path; it improves the subprocess error detail so the existing per-ID lazy dependency path can classify stale IDs correctly.

## Test plan

- [x] `make test` — passes
- [x] `go test ./internal/beads/` — passes
- [x] `go test ./cmd/gc/ -run Reload` — passes
- [x] `go build ./...` — builds clean
- [x] Manual: rebuilt `gc`, smoke-tested. Existing supervisor `~/.gc/supervisor.log` chronic `batch dep list: exit status 1` no longer cascades into stale-cache lifecycle bugs (sessions in `creating` reach `active` cleanly without the previous `state: reconfigured` auto-close).

## ZFC notes

The fix keeps Go on transport mechanics: preserve and expose bd's structured error detail, then let the existing typed store behavior handle not-found dependency reads as empty. No role behavior, thresholds, or orchestration judgment is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->