### PR TITLE
fix(events): tail event log on recorder startup

### DIFF
--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -599,6 +599,40 @@ func TestReadLatestSeqEmpty(t *testing.T) {
 	}
 }
 
+func TestReadLatestSeqUsesTailOfAppendOnlyLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	hugeMalformed := append(bytes.Repeat([]byte("x"), 2*1024*1024), '\n')
+	validTail := []byte(`{"seq":42,"type":"bead.updated","ts":"2026-01-01T00:00:00Z","actor":"test"}` + "\n")
+	if err := os.WriteFile(path, append(hugeMalformed, validTail...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	seq, err := ReadLatestSeq(path)
+	if err != nil {
+		t.Fatalf("ReadLatestSeq: %v", err)
+	}
+	if seq != 42 {
+		t.Fatalf("ReadLatestSeq = %d, want 42", seq)
+	}
+
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatalf("NewFileRecorder: %v", err)
+	}
+	rec.Record(Event{Type: BeadClosed, Actor: "test"})
+	rec.Close() //nolint:errcheck // test cleanup
+
+	seq, err = ReadLatestSeq(path)
+	if err != nil {
+		t.Fatalf("ReadLatestSeq(after record): %v", err)
+	}
+	if seq != 43 {
+		t.Fatalf("ReadLatestSeq(after record) = %d, want 43", seq)
+	}
+}
+
 func TestReadFrom(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
@@ -800,6 +834,59 @@ func TestFileRecorderWatch(t *testing.T) {
 	}
 	if e.Type != BeadClosed {
 		t.Errorf("Type = %q, want %q", e.Type, BeadClosed)
+	}
+}
+
+func TestFileRecorderWatchAfterLatestStartsAtEOF(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "gc-1"})
+	rec.Record(Event{Type: BeadUpdated, Actor: "human", Subject: "gc-1"})
+	seq, err := rec.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	w, err := rec.Watch(ctx, seq)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer w.Close() //nolint:errcheck // test cleanup
+
+	fw, ok := w.(*fileWatcher)
+	if !ok {
+		t.Fatalf("Watch returned %T, want *fileWatcher", w)
+	}
+	if fw.offset != info.Size() {
+		t.Fatalf("watch offset = %d, want EOF %d", fw.offset, info.Size())
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "gc-1"})
+	}()
+	e, err := w.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if e.Seq != seq+1 {
+		t.Fatalf("Seq = %d, want %d", e.Seq, seq+1)
+	}
+	if e.Type != BeadClosed {
+		t.Fatalf("Type = %q, want %q", e.Type, BeadClosed)
 	}
 }
 

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -73,8 +74,10 @@ func ReadFiltered(path string, filter Filter) ([]Event, error) {
 	return result, nil
 }
 
-// ReadLatestSeq returns the highest Seq in the events file, or 0 if
-// the file is missing or empty.
+// ReadLatestSeq returns the latest complete event Seq in the events file, or
+// 0 if the file is missing or empty. Event logs are append-only and sequence
+// numbers are monotonic, so this reads backward from the tail instead of
+// parsing historical events on every recorder open.
 func ReadLatestSeq(path string) (uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -85,19 +88,89 @@ func ReadLatestSeq(path string) (uint64, error) {
 	}
 	defer f.Close() //nolint:errcheck // read-only file
 
-	var maxSeq uint64
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // handle lines up to 1MB
-	for scanner.Scan() {
-		var e Event
-		if json.Unmarshal(scanner.Bytes(), &e) == nil && e.Seq > maxSeq {
-			maxSeq = e.Seq
+	info, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat events: %w", err)
+	}
+	return readLatestSeqFromTail(f, info.Size())
+}
+
+func readLatestSeqFromTail(f *os.File, size int64) (uint64, error) {
+	if size <= 0 {
+		return 0, nil
+	}
+	const chunkSize int64 = 64 * 1024
+	var suffix []byte
+	end := size
+	first := true
+	for end > 0 {
+		n := chunkSize
+		if end < n {
+			n = end
+		}
+		start := end - n
+		chunk := make([]byte, n)
+		if _, err := f.ReadAt(chunk, start); err != nil && err != io.EOF {
+			return 0, fmt.Errorf("reading latest seq: %w", err)
+		}
+		data := make([]byte, 0, len(chunk)+len(suffix))
+		data = append(data, chunk...)
+		data = append(data, suffix...)
+		searchEnd := len(data)
+		if first && len(data) > 0 && data[len(data)-1] != '\n' {
+			idx := bytes.LastIndexByte(data, '\n')
+			if idx < 0 {
+				suffix = data
+				end = start
+				first = false
+				continue
+			}
+			searchEnd = idx
+		}
+		searchStart := 0
+		if start > 0 {
+			idx := bytes.IndexByte(data, '\n')
+			if idx < 0 {
+				suffix = data
+				end = start
+				first = false
+				continue
+			}
+			searchStart = idx + 1
+		}
+		if seq, ok := latestSeqInCompleteLines(data[searchStart:searchEnd]); ok {
+			return seq, nil
+		}
+		suffix = data
+		end = start
+		first = false
+	}
+	return 0, nil
+}
+
+func latestSeqInCompleteLines(data []byte) (uint64, bool) {
+	for len(data) > 0 {
+		idx := bytes.LastIndexByte(data, '\n')
+		var line []byte
+		if idx >= 0 {
+			line = data[idx+1:]
+			data = data[:idx]
+		} else {
+			line = data
+			data = nil
+		}
+		line = bytes.TrimSuffix(line, []byte{'\r'})
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var header struct {
+			Seq uint64 `json:"seq"`
+		}
+		if err := json.Unmarshal(line, &header); err == nil && header.Seq > 0 {
+			return header.Seq, true
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return maxSeq, fmt.Errorf("scanning events: %w", err)
-	}
-	return maxSeq, nil
+	return 0, false
 }
 
 // ReadFrom reads events starting at the given byte offset in the file.

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -26,30 +25,17 @@ type FileRecorder struct {
 	closed bool
 }
 
-// NewFileRecorder opens (or creates) the event log at path. It scans any
-// existing file to find the maximum sequence number so new events continue
+// NewFileRecorder opens (or creates) the event log at path. It reads the tail
+// sequence from any existing append-only log so new events continue
 // monotonically. Parent directories are created as needed.
 func NewFileRecorder(path string, stderr io.Writer) (*FileRecorder, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("creating event log directory: %w", err)
 	}
 
-	// Scan existing file for max seq before opening for append.
-	var maxSeq uint64
-	if f, err := os.Open(path); err == nil {
-		scanner := bufio.NewScanner(f)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // handle lines up to 1MB
-		for scanner.Scan() {
-			var e Event
-			if json.Unmarshal(scanner.Bytes(), &e) == nil && e.Seq > maxSeq {
-				maxSeq = e.Seq
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			f.Close() //nolint:errcheck // closing after scan error
-			return nil, fmt.Errorf("scanning event log: %w", err)
-		}
-		f.Close() //nolint:errcheck // read-only scan
+	maxSeq, err := ReadLatestSeq(path)
+	if err != nil {
+		return nil, err
 	}
 
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
@@ -107,11 +93,20 @@ func (r *FileRecorder) LatestSeq() (uint64, error) {
 
 // Watch returns a Watcher that polls the event file for new events.
 func (r *FileRecorder) Watch(ctx context.Context, afterSeq uint64) (Watcher, error) {
+	var offset int64
+	r.mu.Lock()
+	if afterSeq >= r.seq {
+		if info, err := r.file.Stat(); err == nil {
+			offset = info.Size()
+		}
+	}
+	r.mu.Unlock()
 	return &fileWatcher{
 		path:     r.path,
 		afterSeq: afterSeq,
 		ctx:      ctx,
 		poll:     250 * time.Millisecond,
+		offset:   offset,
 		done:     make(chan struct{}),
 	}, nil
 }


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1434 because the original PR has maintainer edits disabled.

Original PR: https://github.com/gastownhall/gascity/pull/1434
Original title: fix(events): tail event log on recorder startup
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none; configured base matches GitHub base.

This branch carries the reviewed adopted tip from the PR-review workflow. The single commit preserves Julian Knutsen as author.

Review status:
- Latest review attempt: 7
- Decision: approve
- Quality score: 960 / 1000, threshold 850
- Required changes: None

Validation evidence from the approved scorecard:
- `git diff --check refs/adopt-pr/ga-3hvc7/upstream-base..HEAD`
- `go test ./internal/events/... -count=1 -timeout=60s`
- `go vet ./internal/events/...`

Remaining non-gating review notes:
- Package-level mutable `watchTailSnapshotHook` is a race-prone test seam if future event tests use `t.Parallel()`.
- Tail-snapshot error coverage relies on a NUL path and direct unexported-field construction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->