### PR TITLE
fix(runtime): keep request-restart blocked via signal channel instead of bare select

### DIFF
--- a/cmd/gc/cmd_runtime_drain.go
+++ b/cmd/gc/cmd_runtime_drain.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/events"
@@ -458,8 +461,16 @@ func doRuntimeRequestRestart(dops drainOps, persistRestart func() error, rec eve
 	})
 	fmt.Fprintln(stdout, "Restart requested. Blocking until controller kills this session...") //nolint:errcheck // best-effort stdout
 
-	// Block forever. The controller will kill the entire process tree.
-	select {}
+	// Block until the controller kills the process tree. A bare select{}
+	// would trip Go's runtime deadlock detector (a single goroutine asleep
+	// with no live channel triggers "all goroutines are asleep — deadlock!").
+	// Subscribing to OS signals keeps the runtime alive: the signal-handling
+	// goroutine counts as runnable, and the kill the controller sends will
+	// arrive here as SIGTERM.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	<-sigCh
+	return 0
 }
 
 // doRuntimeDrainAck sets the drain-ack flag on the session. The controller


### PR DESCRIPTION
## Summary

`doRuntimeRequestRestart` ended with a bare `select {}`. Go's runtime deadlock detector trips when a single goroutine is asleep with no live channel, so the call panicked with `fatal error: all goroutines are asleep - deadlock!` and exited with code 2 instead of blocking until the controller killed the session.

```
Restart requested. Blocking until controller kills this session...
fatal error: all goroutines are asleep - deadlock!
goroutine 1 [select (no cases)]:
main.doRuntimeRequestRestart cmd/gc/cmd_runtime_drain.go:462 +0x160
```

## Impact

Every agent that calls `gc runtime request-restart` on context exhaustion crashed out of the call instead of waiting for the controller. The `GC_RESTART_REQUESTED` metadata may have been set before the panic — the print happens before the select — but the agent could not rely on the call to block, so the controller's reconcile and the agent's exit raced.

## Fix

Replace `select {}` with `signal.Notify` + a blocking receive on a signal channel:

```go
sigCh := make(chan os.Signal, 1)
signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
<-sigCh
return 0
```

The signal-handling goroutine counts as runnable, so Go's deadlock detector stays quiet, and the kill the controller sends arrives here as SIGTERM and unblocks the receive.

## Test plan

- [x] `go build ./...` — builds clean
- [ ] Manual: rebuild `gc`, call `gc runtime request-restart` on a controller-managed session, verify the call blocks until the controller kills the session (no Go runtime panic, no exit code 2).
- [ ] Confirm `GC_RESTART_REQUESTED` metadata persists and the controller reconciles the restart on its next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)