### PR TITLE
perf(reload): surface slow ticks, slow reload phases, and reload accept queue waits

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -568,6 +568,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 // Trigger identifies which tick site fired so operators can correlate
 // the log with the cause.
 func (cr *CityRuntime) safeTick(fn func(), trigger string) (panicked bool) {
+	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
 			panicked = true
@@ -578,10 +579,23 @@ func (cr *CityRuntime) safeTick(fn func(), trigger string) (panicked bool) {
 			fmt.Fprintf(cr.stderr, "%s: reconciler tick panicked (trigger=%s): %v (type=%T)\n%s\n", //nolint:errcheck // best-effort stderr
 				cr.logPrefix, trigger, r, r, debug.Stack())
 		}
+		// Slow ticks block reloadReqCh draining and produce "controller is
+		// busy" rejections. Surface them so operators can correlate slow
+		// reloads with the trigger that ate the budget.
+		if elapsed := time.Since(start); elapsed >= tickSlowThreshold {
+			fmt.Fprintf(cr.stderr, "%s: slow tick (trigger=%s) took %s (>= %s threshold)\n", //nolint:errcheck // best-effort stderr
+				cr.logPrefix, trigger, elapsed.Round(time.Millisecond), tickSlowThreshold)
+		}
 	}()
 	fn()
 	return false
 }
+
+// tickSlowThreshold is the budget above which safeTick emits a stderr
+// warning. Reload accept timeouts (controllerReloadAcceptTimeout, 60s) fire
+// when a tick holds the main goroutine longer than this; surfacing the
+// trigger lets operators identify the responsible reconciler phase.
+const tickSlowThreshold = 2 * time.Second
 
 func convergenceStartupComplete(cr *CityRuntime) bool {
 	return cr.convHandler == nil ||

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -168,7 +168,13 @@ func sendReloadControlRequest(cityPath string, req reloadControlRequest) (reload
 	if err != nil {
 		return reloadControlReply{}, fmt.Errorf("marshaling request: %w", err)
 	}
-	readTimeout := 15 * time.Second
+	// The client must wait at least as long as the server's accept window
+	// (controllerReloadAcceptTimeout). Otherwise an --async request whose
+	// tick-bound controller cannot drain reloadReqCh in 15s ends up timing
+	// out client-side ("controller is running but not responding: i/o
+	// timeout") before the server has had a chance to write its busy/timeout
+	// reply, hiding the real reason from the operator.
+	readTimeout := controllerReloadAcceptTimeout + 10*time.Second
 	if req.Wait && req.Timeout != "" {
 		timeout, err := time.ParseDuration(req.Timeout)
 		if err != nil {

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -295,9 +295,19 @@ func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest)
 	}
 	timer := time.NewTimer(acceptTimeout)
 	defer timer.Stop()
+	queueStart := time.Now()
 	select {
 	case ch <- req:
+		// Surface unusually long queue waits so operators can correlate them
+		// with the slow tick that held the main goroutine. Reloads should
+		// normally accept in a handful of milliseconds.
+		if waited := time.Since(queueStart); waited >= reloadQueueWaitThreshold {
+			fmt.Fprintf(os.Stderr, "gc reload: waited %s in reload accept queue (controller main goroutine was busy; check `slow tick` warnings for the responsible trigger)\n", //nolint:errcheck // best-effort stderr
+				waited.Round(time.Millisecond))
+		}
 	case <-timer.C:
+		fmt.Fprintf(os.Stderr, "gc reload: accept queue timed out after %s (controller never freed the main goroutine; check `slow tick` warnings)\n", //nolint:errcheck // best-effort stderr
+			acceptTimeout.Round(time.Millisecond))
 		writeJSONLine(conn, reloadControlReply{
 			Outcome: reloadOutcomeBusy,
 			Message: "Reload request could not be accepted because the controller is busy.",
@@ -769,14 +779,29 @@ func reloadWarningsFromError(err error) []string {
 // canonical/compat default tables stay strict-fatal unless --no-strict
 // disables the gate.
 func tryReloadConfig(tomlPath, lockedWorkspaceName, cityRoot string) (*reloadResult, error) {
+	// Per-phase timing so a slow reload can be diagnosed from logs alone:
+	// healthy reloads should complete in well under a second; if a phase
+	// exceeds reloadPhaseSlowThreshold we surface it on stderr immediately.
+	phaseStart := time.Now()
+	logSlow := func(phase string) {
+		elapsed := time.Since(phaseStart)
+		if elapsed >= reloadPhaseSlowThreshold {
+			fmt.Fprintf(os.Stderr, "gc reload: phase %q took %s (>= %s threshold)\n", //nolint:errcheck // best-effort stderr
+				phase, elapsed.Round(time.Millisecond), reloadPhaseSlowThreshold)
+		}
+		phaseStart = time.Now()
+	}
+
 	if err := ensureLegacyNamedPacksCached(cityRoot); err != nil {
 		return nil, fmt.Errorf("fetching packs: %w", err)
 	}
+	logSlow("fetch-packs")
 
 	newCfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath, extraConfigFiles...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing city.toml: %w", err)
 	}
+	logSlow("parse-config")
 	applyFeatureFlags(newCfg)
 	reloadWarnings := append([]string(nil), prov.Warnings...)
 	resultWithWarnings := func(warnings []string) *reloadResult {
@@ -813,13 +838,27 @@ func tryReloadConfig(tomlPath, lockedWorkspaceName, cityRoot string) (*reloadRes
 	if err := workspacesvc.ValidateRuntimeSupport(newCfg.Services); err != nil {
 		return failWithWarnings(fmt.Errorf("validating services: %w", err))
 	}
+	logSlow("validate")
 	newName := loadedCityName(newCfg, filepath.Dir(tomlPath))
 	if newName != lockedWorkspaceName {
 		return failWithWarnings(fmt.Errorf("workspace.name changed from %q to %q (restart controller to apply)", lockedWorkspaceName, newName))
 	}
 	rev := config.Revision(fsys.OSFS{}, prov, newCfg, cityRoot)
+	logSlow("compute-revision")
 	return &reloadResult{Cfg: newCfg, Prov: prov, Revision: rev, Warnings: reloadWarnings}, nil
 }
+
+// reloadPhaseSlowThreshold is the per-phase budget above which tryReloadConfig
+// emits a stderr warning. Healthy reloads should finish each phase in well
+// under this; a phase exceeding it points at the bottleneck (e.g. dolt
+// metadata enumeration during compute-revision, or a slow remote pack fetch).
+const reloadPhaseSlowThreshold = 500 * time.Millisecond
+
+// reloadQueueWaitThreshold is the budget above which the reload accept handler
+// emits a stderr warning about how long the request waited in
+// reloadReqCh. Reloads should normally be drained within a few milliseconds;
+// long waits indicate a slow tick on the main goroutine.
+const reloadQueueWaitThreshold = 1 * time.Second
 
 // gracefulStopAll performs two-pass graceful shutdown:
 //  1. Send Interrupt (Ctrl-C) to all sessions


### PR DESCRIPTION
Tracks: `gcy-32i3`

## Summary

Operators see chronic `Reload request could not be accepted because the controller is busy.` rejections plus client-side `gc reload` failures with `controller is running but not responding: i/o timeout`, but `supervisor.log` gives no actionable signal — just the busy/timeout messages with no indication of which reconciler phase ate the budget. In one observed session, an operation that should complete in well under 2 seconds was taking over a minute.

This PR adds diagnostic instrumentation across the slow-reload pipeline (no behavior change beyond logging) plus one client-side timeout alignment so the real reason reaches the operator.

## Changes

1. **`cmd/gc/city_runtime.go` — `safeTick`.** Time each reconciler tick and emit a stderr warning when elapsed crosses `tickSlowThreshold` (2 s). The warning includes the trigger name so operators can correlate slow ticks with the cause (mail, snapshot, convergence, etc.).

2. **`cmd/gc/controller.go` — `handleReloadSocketCmd`.** Time the wait in `reloadReqCh` and emit a stderr warning when it crosses `reloadQueueWaitThreshold` (1 s). Reloads should normally drain within a handful of milliseconds; long waits point at a slow tick on the main goroutine. On accept timeout, also log the reason explicitly.

3. **`cmd/gc/controller.go` — `tryReloadConfig`.** Per-phase timing for `fetch-packs`, `parse-config`, `validate`, `compute-revision`. Each phase emits a stderr warning when it exceeds `reloadPhaseSlowThreshold` (500 ms). Healthy reloads finish each phase well under this; a phase exceeding it points at the bottleneck (e.g. dolt metadata enumeration during `compute-revision`, or a slow remote pack fetch).

4. **`cmd/gc/cmd_reload.go` — `sendReloadControlRequest`.** Align client `readTimeout` to `controllerReloadAcceptTimeout + 10 s` instead of a hardcoded 15 s. Otherwise an `--async` request whose tick-bound controller cannot drain `reloadReqCh` in 15 s ends up timing out client-side before the server has had a chance to write its busy/timeout reply, hiding the real reason.

## Constants introduced

- `tickSlowThreshold = 2 * time.Second` (city_runtime.go)
- `reloadQueueWaitThreshold = 1 * time.Second` (controller.go)
- `reloadPhaseSlowThreshold = 500 * time.Millisecond` (controller.go)

## Out of scope

The actual perf fixes — whatever phase turns out to be the culprit — are follow-up work, gated on the data this instrumentation surfaces.

## Test plan

- [x] `go build ./...` — builds clean
- [ ] Run controller, trigger a known-slow reload (e.g. while a long convergence tick is running), confirm `slow tick` and `gc reload: waited Xs` warnings appear in supervisor.log with the right trigger and timing.
- [ ] Verify `--async` client timeout is now \~70 s instead of 15 s by simulating a busy controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- mpr:issue-refs v1 -->
---
🔗 **Maintainer cross-reference** — added by the gascity maintainers, no action needed from you:
- Related to #2604 — adds per-tick timing with a slow-tick warning (tagged by trigger) plus reload queue-wait and per-phase reload timing, surfacing which reconciler phase starves control operations when a tick runs long; diagnostic instrumentation only, the perf fix is follow-up.

<sub>Linked for triage visibility — not auto-closing. If this looks off, just delete this block.</sub>
<!-- /mpr:issue-refs -->
