### PR TITLE
feat(session): prefer canonical tmux name for aliased non-pool sessions

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
@@ -409,7 +410,20 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 
 		sessName := explicitName
 		if sessName == "" {
-			sessName = sessionNameFor(b.ID)
+			// For aliased sessions (e.g. `gc session new --alias <rig>`),
+			// prefer the canonical template-derived tmux name so the session
+			// appears in tmux as e.g. "crew-<rig>" rather than the
+			// opaque "s-<beadID>" fallback. Pool slots and unaliased
+			// ephemerals retain s-<id> because they need per-instance
+			// uniqueness.
+			if alias != "" && extraMeta["pool_slot"] == "" {
+				if canonical := agent.SessionNameFor("", template, ""); canonical != "" {
+					sessName = canonical
+				}
+			}
+			if sessName == "" {
+				sessName = sessionNameFor(b.ID)
+			}
 			if err := m.store.SetMetadata(b.ID, "session_name", sessName); err != nil {
 				_ = m.store.Close(b.ID)
 				return fmt.Errorf("storing session name: %w", err)
@@ -642,7 +656,20 @@ func (m *Manager) createAliasedBeadOnlyNamed(alias, explicitName, template, titl
 
 		sessName := explicitName
 		if sessName == "" {
-			sessName = sessionNameFor(b.ID)
+			// For aliased sessions (e.g. `gc session new --alias <rig>`),
+			// prefer the canonical template-derived tmux name so the session
+			// appears in tmux as e.g. "crew-<rig>" rather than the
+			// opaque "s-<beadID>" fallback. Pool slots and unaliased
+			// ephemerals retain s-<id> because they need per-instance
+			// uniqueness.
+			if alias != "" && extraMeta["pool_slot"] == "" {
+				if canonical := agent.SessionNameFor("", template, ""); canonical != "" {
+					sessName = canonical
+				}
+			}
+			if sessName == "" {
+				sessName = sessionNameFor(b.ID)
+			}
 			if err := m.store.SetMetadata(b.ID, "session_name", sessName); err != nil {
 				_ = m.store.Close(b.ID)
 				return fmt.Errorf("storing session name: %w", err)


### PR DESCRIPTION
## Summary

Aliased sessions created via `gc session new --alias <name>` currently end up with an opaque `s-<beadID>` tmux session name, even though non-pool aliased sessions have a stable, predictable canonical form (`agent.SessionNameFor("", template, "")`). Operators using `tmux ls` or `Ctrl+B s` to switch sessions then have to cross-reference `gc session list` to know which `s-ga-XXXX` is which session.

## Change

Make `Manager.createAliasedNamedWithTransport` and `Manager.createAliasedBeadOnlyNamed` prefer the canonical name when:

- the caller passed `--alias` (`alias != ""`), and
- the session is not a pool slot (`extraMeta["pool_slot"] == ""`).

Pool slots and unaliased ephemerals retain `s-<id>` because they need per-instance uniqueness — only aliased sessions get the readable name. If canonical name resolution returns empty (e.g. unknown template), the code falls back to the existing `s-<beadID>` derivation, so behavior is unchanged for any path the canonical lookup cannot serve.

## Migration

Existing aliased sessions created before this change keep their `s-<beadID>` name until they are closed and re-created (`gc session close <alias>` then re-spawn).

## Test plan

- [x] `go build ./...` — builds clean
- [ ] Manual: close an existing aliased session, re-create with `gc session new <template> --alias <alias> --no-attach`, verify the new session appears in `tmux ls` under its canonical name instead of `s-ga-XXXX`.
- [ ] Verify pool-slot sessions still get `s-<beadID>` (no regression).
- [ ] Verify unaliased ephemeral sessions still get `s-<beadID>` (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)