### PR TITLE
Adopt PR #1553: require canonical routed_to labels

### DIFF
--- a/examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh
+++ b/examples/hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 cd "$GC_DIR"
 
 AGENT_SHORT=$(basename "$GC_AGENT")
-POOL_LABEL="${GC_TEMPLATE:-worker}"
+POOL_LABEL="${GC_TEMPLATE:?GC_TEMPLATE must be set to canonical pool route target}"
 echo "[$AGENT_SHORT] Starting up"
 
 # Jitter to avoid 100 workers racing on the same bead.

--- a/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
@@ -5,9 +5,10 @@
 # file, commits on the branch, then hands off to the refinery for merge.
 #
 # Required env vars (set by gc start):
-#   GC_AGENT — this agent's name (e.g., "demo-repo/polecat-1")
-#   GC_CITY  — path to the city directory
-#   GC_DIR   — working directory (rig repo path)
+#   GC_AGENT    — this agent's session name
+#   GC_TEMPLATE — canonical pool route target (e.g., "demo-repo/lifecycle.polecat")
+#   GC_CITY     — path to the city directory
+#   GC_DIR      — working directory (rig repo path)
 
 set -euo pipefail
 
@@ -35,13 +36,7 @@ git config --global user.name 2>/dev/null || git config --global user.name "gc-a
 git pull --ff-only origin main 2>/dev/null || true
 
 AGENT_SHORT=$(basename "$GC_AGENT")
-
-# Pool label is the agent name without the instance suffix (-1, -2, etc.).
-# For pool max=1 the name has no suffix, so we only strip if it ends in -N.
-POOL_LABEL="$GC_AGENT"
-if [[ "$POOL_LABEL" =~ -[0-9]+$ ]]; then
-    POOL_LABEL="${POOL_LABEL%-*}"
-fi
+POOL_LABEL="${GC_TEMPLATE:?GC_TEMPLATE must be set to canonical pool route target}"
 
 echo "[$AGENT_SHORT] Starting up in rig dir: $GC_DIR"
 # Jitter startup to avoid pool members racing on the same bead.
@@ -158,7 +153,7 @@ echo "[$AGENT_SHORT] Worktree cleaned up. Branch $BRANCH persists."
 # ── Step 7: Hand off to refinery ──────────────────────────────────────────
 
 # Set branch metadata and reassign to the refinery for merge.
-REFINERY="${GC_AGENT%/*}/refinery"
+REFINERY="${GC_TEMPLATE%polecat}refinery"
 bd update "$BEAD_ID" --metadata "{\"branch\":\"$BRANCH\"}" --assignee="$REFINERY" 2>/dev/null || true
 
 gc mail send --all "READY FOR MERGE: $BRANCH ($BEAD_TITLE) → $REFINERY" 2>/dev/null || true

--- a/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh
@@ -38,6 +38,22 @@ git pull --ff-only origin main 2>/dev/null || true
 AGENT_SHORT=$(basename "$GC_AGENT")
 POOL_LABEL="${GC_TEMPLATE:?GC_TEMPLATE must be set to canonical pool route target}"
 
+derive_refinery_target() {
+    case "${GC_TEMPLATE:-}" in
+        *polecat)
+            printf '%s\n' "${GC_TEMPLATE%polecat}refinery"
+            ;;
+        "")
+            echo "GC_TEMPLATE must be set to canonical pool route target" >&2
+            return 1
+            ;;
+        *)
+            echo "GC_TEMPLATE=$GC_TEMPLATE does not end in 'polecat'; cannot derive refinery target" >&2
+            return 1
+            ;;
+    esac
+}
+
 echo "[$AGENT_SHORT] Starting up in rig dir: $GC_DIR"
 # Jitter startup to avoid pool members racing on the same bead.
 JITTER=$(( RANDOM % 3 ))
@@ -153,7 +169,7 @@ echo "[$AGENT_SHORT] Worktree cleaned up. Branch $BRANCH persists."
 # ── Step 7: Hand off to refinery ──────────────────────────────────────────
 
 # Set branch metadata and reassign to the refinery for merge.
-REFINERY="${GC_TEMPLATE%polecat}refinery"
+REFINERY="$(derive_refinery_target)"
 bd update "$BEAD_ID" --metadata "{\"branch\":\"$BRANCH\"}" --assignee="$REFINERY" 2>/dev/null || true
 
 gc mail send --all "READY FOR MERGE: $BRANCH ($BEAD_TITLE) → $REFINERY" 2>/dev/null || true

--- a/examples/lifecycle/packs/lifecycle/assets/scripts/mock-refinery.sh
+++ b/examples/lifecycle/packs/lifecycle/assets/scripts/mock-refinery.sh
@@ -6,7 +6,8 @@
 # closes the bead.
 #
 # Required env vars (set by gc start):
-#   GC_AGENT — this agent's name (e.g., "demo-repo/refinery")
+#   GC_AGENT — this agent's session name
+#   GC_ALIAS — canonical agent alias (e.g., "demo-repo/lifecycle.refinery")
 #   GC_CITY  — path to the city directory
 #   GC_DIR   — working directory (rig repo path)
 
@@ -21,6 +22,7 @@ export GIT_TERMINAL_PROMPT=0
 git pull --ff-only origin main 2>/dev/null || true
 
 AGENT_SHORT=$(basename "$GC_AGENT")
+MERGE_ASSIGNEE="${GC_ALIAS:?GC_ALIAS must be set to canonical refinery route target}"
 POLL_INTERVAL="${GC_REFINERY_POLL:-3}"
 
 echo "[$AGENT_SHORT] Starting merge agent in rig dir: $GC_DIR"
@@ -35,8 +37,8 @@ while true; do
     # separate pods; local: branches exist locally, fetch is a no-op).
     git fetch origin 2>/dev/null || true
 
-    # Scan for beads assigned to us (polecats reassign after pushing their branch).
-    MERGE_BEADS=$(bd list --assignee="$GC_AGENT" --status=in_progress --json 2>/dev/null || echo "[]")
+    # Scan for beads assigned to the canonical alias polecats hand off to.
+    MERGE_BEADS=$(bd list --assignee="$MERGE_ASSIGNEE" --status=in_progress --json 2>/dev/null || echo "[]")
 
     if echo "$MERGE_BEADS" | jq -e 'length > 0' >/dev/null 2>&1; then
         # Process each bead that has branch metadata.

--- a/examples/routing_namespace_test.go
+++ b/examples/routing_namespace_test.go
@@ -42,3 +42,56 @@ func TestShippedExamplesDoNotHardcodeShortRoutedToPools(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestExamplePoolScriptsUseCanonicalGCTemplateRoutes(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	root := filepath.Dir(filename)
+
+	checks := []struct {
+		rel      string
+		required []string
+		banned   []string
+	}{
+		{
+			rel: "hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh",
+			required: []string{
+				`POOL_LABEL="${GC_TEMPLATE:?`,
+				`gc.routed_to=$POOL_LABEL`,
+			},
+			banned: []string{
+				`POOL_LABEL="${GC_TEMPLATE:-worker}"`,
+			},
+		},
+		{
+			rel: "lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh",
+			required: []string{
+				`POOL_LABEL="${GC_TEMPLATE:?`,
+				`REFINERY="${GC_TEMPLATE%polecat}refinery"`,
+				`gc.routed_to=$POOL_LABEL`,
+			},
+			banned: []string{
+				`POOL_LABEL="$GC_AGENT"`,
+				`REFINERY="${GC_AGENT%/*}/refinery"`,
+			},
+		},
+	}
+
+	for _, check := range checks {
+		path := filepath.Join(root, check.rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", check.rel, err)
+		}
+		body := string(data)
+		for _, required := range check.required {
+			if !strings.Contains(body, required) {
+				t.Errorf("%s missing canonical route pattern %q", check.rel, required)
+			}
+		}
+		for _, banned := range check.banned {
+			if strings.Contains(body, banned) {
+				t.Errorf("%s still contains short-form route pattern %q", check.rel, banned)
+			}
+		}
+	}
+}

--- a/examples/routing_namespace_test.go
+++ b/examples/routing_namespace_test.go
@@ -2,6 +2,7 @@ package examples_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -44,54 +45,182 @@ func TestShippedExamplesDoNotHardcodeShortRoutedToPools(t *testing.T) {
 }
 
 func TestExamplePoolScriptsUseCanonicalGCTemplateRoutes(t *testing.T) {
-	_, filename, _, _ := runtime.Caller(0)
-	root := filepath.Dir(filename)
+	root := examplesRoot(t)
 
-	checks := []struct {
+	tests := []struct {
+		name     string
 		rel      string
-		required []string
-		banned   []string
+		template string
+		want     string
 	}{
 		{
-			rel: "hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh",
-			required: []string{
-				`POOL_LABEL="${GC_TEMPLATE:?`,
-				`gc.routed_to=$POOL_LABEL`,
-			},
-			banned: []string{
-				`POOL_LABEL="${GC_TEMPLATE:-worker}"`,
-			},
+			name:     "hyperscale worker",
+			rel:      "hyperscale/packs/hyperscale/assets/scripts/mock-worker.sh",
+			template: "demo/hyperscale.worker",
+			want:     "demo/hyperscale.worker",
 		},
 		{
-			rel: "lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh",
-			required: []string{
-				`POOL_LABEL="${GC_TEMPLATE:?`,
-				`REFINERY="${GC_TEMPLATE%polecat}refinery"`,
-				`gc.routed_to=$POOL_LABEL`,
-			},
-			banned: []string{
-				`POOL_LABEL="$GC_AGENT"`,
-				`REFINERY="${GC_AGENT%/*}/refinery"`,
-			},
+			name:     "lifecycle polecat",
+			rel:      "lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh",
+			template: "demo/lifecycle.polecat",
+			want:     "demo/lifecycle.polecat",
 		},
 	}
 
-	for _, check := range checks {
-		path := filepath.Join(root, check.rel)
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("reading %s: %v", check.rel, err)
-		}
-		body := string(data)
-		for _, required := range check.required {
-			if !strings.Contains(body, required) {
-				t.Errorf("%s missing canonical route pattern %q", check.rel, required)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(root, tt.rel)
+			assignment := shellLineContaining(t, path, "POOL_LABEL=")
+			got := runShell(t, []string{"GC_TEMPLATE=" + tt.template}, assignment+`
+printf '%s' "$POOL_LABEL"
+`)
+			if got != tt.want {
+				t.Fatalf("POOL_LABEL = %q, want %q", got, tt.want)
 			}
-		}
-		for _, banned := range check.banned {
-			if strings.Contains(body, banned) {
-				t.Errorf("%s still contains short-form route pattern %q", check.rel, banned)
+
+			cmd := shellCommand(t, nil, assignment)
+			if err := cmd.Run(); err == nil {
+				t.Fatalf("POOL_LABEL assignment succeeded without GC_TEMPLATE")
 			}
+		})
+	}
+}
+
+func TestLifecyclePolecatDerivesRefineryTargetFromCanonicalTemplate(t *testing.T) {
+	root := examplesRoot(t)
+	path := filepath.Join(root, "lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh")
+	function := shellFunction(t, path, "derive_refinery_target")
+
+	tests := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{
+			name:     "v1 template",
+			template: "demo/polecat",
+			want:     "demo/refinery",
+		},
+		{
+			name:     "binding qualified template",
+			template: "demo/lifecycle.polecat",
+			want:     "demo/lifecycle.refinery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runShell(t, []string{"GC_TEMPLATE=" + tt.template}, function+`
+derive_refinery_target
+`)
+			if got != tt.want {
+				t.Fatalf("derive_refinery_target() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	cmd := shellCommand(t, []string{"GC_TEMPLATE=demo/lifecycle.worker"}, function+`
+derive_refinery_target
+`)
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("derive_refinery_target succeeded for a non-polecat template")
+	}
+}
+
+func TestLifecycleRefineryConsumesPolecatHandoffAlias(t *testing.T) {
+	root := examplesRoot(t)
+	polecatPath := filepath.Join(root, "lifecycle/packs/lifecycle/assets/scripts/mock-polecat.sh")
+	refineryPath := filepath.Join(root, "lifecycle/packs/lifecycle/assets/scripts/mock-refinery.sh")
+
+	polecatTarget := runShell(t, []string{"GC_TEMPLATE=demo/lifecycle.polecat"}, shellFunction(t, polecatPath, "derive_refinery_target")+`
+derive_refinery_target
+`)
+	refineryAssignment := shellLineContaining(t, refineryPath, "MERGE_ASSIGNEE=")
+	refineryAssignee := runShell(t, []string{
+		"GC_ALIAS=" + polecatTarget,
+		"GC_AGENT=demo--lifecycle__refinery",
+	}, refineryAssignment+`
+printf '%s' "$MERGE_ASSIGNEE"
+`)
+
+	if refineryAssignee != polecatTarget {
+		t.Fatalf("refinery consumes assignee %q, want polecat handoff target %q", refineryAssignee, polecatTarget)
+	}
+	if refineryAssignee == "demo--lifecycle__refinery" {
+		t.Fatalf("refinery still consumes sanitized GC_AGENT instead of canonical GC_ALIAS")
+	}
+}
+
+func examplesRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}
+
+func shellLineContaining(t *testing.T, path, needle string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, needle) {
+			return line
 		}
 	}
+	t.Fatalf("%s missing shell line containing %q", path, needle)
+	return ""
+}
+
+func shellFunction(t *testing.T, path, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if line == name+"() {" {
+			for j := i + 1; j < len(lines); j++ {
+				if lines[j] == "}" {
+					return strings.Join(lines[i:j+1], "\n")
+				}
+			}
+			t.Fatalf("%s shell function %q has no closing brace", path, name)
+		}
+	}
+	t.Fatalf("%s missing shell function %q", path, name)
+	return ""
+}
+
+func runShell(t *testing.T, env []string, body string) string {
+	t.Helper()
+	cmd := shellCommand(t, env, body)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("shell command failed: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func shellCommand(t *testing.T, env []string, body string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("bash", "-e", "-u", "-o", "pipefail", "-c", body)
+	cmd.Env = append(scrubEnv(os.Environ(), "GC_TEMPLATE", "GC_ALIAS", "GC_AGENT"), env...)
+	return cmd
+}
+
+func scrubEnv(env []string, names ...string) []string {
+	blocked := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		blocked[name] = struct{}{}
+	}
+	kept := env[:0]
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if _, ok := blocked[name]; !ok {
+			kept = append(kept, entry)
+		}
+	}
+	return kept
 }


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1553 because the original PR reports `maintainerCanModify=false` and the reviewed result includes a maintainer fixup commit.

Original PR title: `fix: require canonical routed_to labels in example pools`
Original PR state at finalization: `OPEN`
Configured base branch: `main`
Original GitHub base branch: `main`
Base mismatch: none

This follow-up branch is based on the recorded upstream base `7b6c5406313a9d7e6a992c6e20e70891481c0e51` and includes the reviewed original contribution plus the approved fix iteration:

- `1bb6a3667` `fix: require canonical routed_to labels in example pools`
- `5dbd838ce` `fix: align lifecycle refinery handoff routing`

Review summary:

PR #1553 reached approval after 1 fix iteration. Latest attempt 2 is `approve` with score 950 / 1000 against threshold 850, with no remaining required changes.

CI will be observed on this follow-up PR before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->