### PR TITLE
fix(session): target stored log transcript lookup

### DIFF
--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 	"github.com/gastownhall/gascity/internal/worker"
+	workertranscript "github.com/gastownhall/gascity/internal/worker/transcript"
 	"github.com/spf13/cobra"
 )
 
@@ -120,14 +122,33 @@ func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store bead
 			}
 		}
 	}
-	path := resolveSessionLogPath(searchPaths, logCtx)
-	if path == "" && canFallbackStoredSessionLogByWorkDir(store, logCtx) {
+	path := ""
+	fallbackAllowed := canFallbackStoredSessionLogByWorkDir(store, logCtx)
+	if strings.TrimSpace(logCtx.sessionKey) != "" {
+		path = resolveSessionKeyedLogPath(searchPaths, logCtx)
+		if path == "" && fallbackAllowed {
+			path = resolveSessionLogPath(searchPaths, logCtx)
+		}
+	} else if fallbackAllowed {
+		path = resolveSessionLogPath(searchPaths, logCtx)
+	}
+	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
+		path = ""
+	}
+	if path == "" && fallbackAllowed {
 		factory, err := worker.NewFactory(worker.FactoryConfig{SearchPaths: searchPaths})
 		if err == nil {
 			path = factory.DiscoverWorkDirTranscript(logCtx.provider, logCtx.workDir)
 		}
 	}
+	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
+		path = ""
+	}
 	return path, logCtx.provider, true
+}
+
+func resolveSessionKeyedLogPath(searchPaths []string, logCtx sessionLogContext) string {
+	return workertranscript.DiscoverKeyedPath(searchPaths, logCtx.provider, logCtx.workDir, logCtx.sessionKey)
 }
 
 type sessionLogContext struct {
@@ -135,6 +156,7 @@ type sessionLogContext struct {
 	workDir    string
 	sessionKey string
 	provider   string
+	createdAt  time.Time
 }
 
 func resolveSessionLogContext(cityPath string, cfg *config.City, store beads.Store, identifier string) (sessionLogContext, bool) {
@@ -162,19 +184,44 @@ func resolveSessionLogContext(cityPath string, cfg *config.City, store beads.Sto
 		workDir:    workDir,
 		sessionKey: strings.TrimSpace(b.Metadata["session_key"]),
 		provider:   provider,
+		createdAt:  b.CreatedAt,
 	}, true
+}
+
+func sessionLogPathFreshEnough(path string, sessionCreatedAt time.Time) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	if sessionCreatedAt.IsZero() {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.ModTime().Before(sessionCreatedAt.Add(-2 * time.Second))
 }
 
 func canFallbackStoredSessionLogByWorkDir(store beads.Store, logCtx sessionLogContext) bool {
 	if store == nil || strings.TrimSpace(logCtx.sessionID) == "" || strings.TrimSpace(logCtx.workDir) == "" {
 		return false
 	}
-	all, err := store.ListByLabel(sessionpkg.LabelSession, 0)
+	all, err := sessionLogFallbackCandidates(store, logCtx.workDir, logCtx.provider)
 	if err != nil {
 		return false
 	}
+	targetLive := false
+	for _, b := range all {
+		if b.ID == logCtx.sessionID {
+			targetLive = sessionLogFallbackCandidateLive(b)
+			break
+		}
+	}
 	matches := 0
 	for _, b := range all {
+		if !sessionpkg.IsSessionBeadOrRepairable(b) {
+			continue
+		}
 		if strings.TrimSpace(b.Metadata["work_dir"]) != logCtx.workDir {
 			continue
 		}
@@ -185,12 +232,58 @@ func canFallbackStoredSessionLogByWorkDir(store beads.Store, logCtx sessionLogCo
 		if logCtx.provider != "" && provider != "" && provider != logCtx.provider {
 			continue
 		}
+		if targetLive && b.ID != logCtx.sessionID && !sessionLogFallbackCandidateLive(b) {
+			continue
+		}
 		matches++
 		if matches > 1 {
 			return false
 		}
 	}
 	return matches == 1
+}
+
+func sessionLogFallbackCandidates(store beads.Store, workDir, provider string) ([]beads.Bead, error) {
+	candidates := make(map[string]beads.Bead)
+	add := func(filters map[string]string) error {
+		found, err := store.ListByMetadata(filters, 0)
+		if err != nil {
+			return err
+		}
+		for _, b := range found {
+			candidates[b.ID] = b
+		}
+		return nil
+	}
+	if strings.TrimSpace(provider) == "" {
+		if err := add(map[string]string{"work_dir": workDir}); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := add(map[string]string{"work_dir": workDir, "provider": provider}); err != nil {
+			return nil, err
+		}
+		if err := add(map[string]string{"work_dir": workDir, "provider_kind": provider}); err != nil {
+			return nil, err
+		}
+	}
+	out := make([]beads.Bead, 0, len(candidates))
+	for _, b := range candidates {
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+func sessionLogFallbackCandidateLive(b beads.Bead) bool {
+	if b.Status == "closed" {
+		return false
+	}
+	switch sessionpkg.State(strings.TrimSpace(b.Metadata["state"])) {
+	case sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateCreating, sessionpkg.StateDraining:
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, identifier string) (string, bool) {
@@ -364,7 +457,7 @@ func printLogEntry(w io.Writer, e *worker.TranscriptEntry) {
 
 	mc := resolveMessage(e.Message)
 	if mc == nil {
-		// Unparseable message — print raw truncated.
+		// Unparseable message; print raw truncated.
 		if len(e.Message) > 0 {
 			raw := string(e.Message)
 			if len(raw) > 200 {

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -47,6 +47,14 @@ func writeNamedTestSession(t *testing.T, searchBase, workDir, fileName string, l
 	return path
 }
 
+type noLabelScanSessionLogStore struct {
+	*beads.MemStore
+}
+
+func (s *noLabelScanSessionLogStore) ListByLabel(label string, _ int, _ ...beads.QueryOpt) ([]beads.Bead, error) {
+	return nil, fmt.Errorf("unexpected label scan for %q", label)
+}
+
 func TestDoSessionLogsBasic(t *testing.T) {
 	searchBase := t.TempDir()
 	workDir := t.TempDir()
@@ -123,7 +131,7 @@ func TestDoSessionLogsTailReturnsLastNEntries(t *testing.T) {
 		t.Errorf("tail=2 should include the last entry 'reply-3', got: %s", out)
 	}
 	// Everything before the last 2 must be absent. In particular, the FIRST
-	// entry must not leak through — that was the bug the user reported.
+	// entry must not leak through; that was the bug the user reported.
 	forbidden := []string{"first", "reply-1", "second", "reply-2"}
 	for _, s := range forbidden {
 		if strings.Contains(out, s) {
@@ -380,6 +388,67 @@ func TestResolveStoredSessionLogSource_DoesNotCrossAmbiguousWorkDir(t *testing.T
 	}
 	if got != "" {
 		t.Fatalf("resolveStoredSessionLogSource() path = %q, want empty for ambiguous same-workdir transcript", got)
+	}
+}
+
+func TestCanFallbackStoredSessionLogByWorkDirUsesTargetedLookup(t *testing.T) {
+	store := &noLabelScanSessionLogStore{MemStore: beads.NewMemStore()}
+	workDir := t.TempDir()
+	b, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"provider":     "codex",
+			"session_name": "worker",
+			"state":        "awake",
+			"work_dir":     workDir,
+		},
+	})
+
+	ok := canFallbackStoredSessionLogByWorkDir(store, sessionLogContext{
+		sessionID: b.ID,
+		workDir:   workDir,
+		provider:  "codex",
+	})
+	if !ok {
+		t.Fatal("canFallbackStoredSessionLogByWorkDir() = false, want true")
+	}
+}
+
+func TestCanFallbackStoredSessionLogByWorkDirIgnoresAsleepPeersForLiveTarget(t *testing.T) {
+	store := beads.NewMemStore()
+	workDir := t.TempDir()
+	target, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "worker",
+			"provider":     "codex",
+			"session_name": "worker",
+			"state":        "awake",
+			"work_dir":     workDir,
+		},
+	})
+	_, _ = store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":        "old-worker",
+			"provider":     "codex",
+			"session_name": "old-worker",
+			"state":        "asleep",
+			"work_dir":     workDir,
+		},
+	})
+
+	ok := canFallbackStoredSessionLogByWorkDir(store, sessionLogContext{
+		sessionID: target.ID,
+		workDir:   workDir,
+		provider:  "codex",
+	})
+	if !ok {
+		t.Fatal("canFallbackStoredSessionLogByWorkDir() = false, want true")
 	}
 }
 


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1520.

Original PR title: fix(session): target stored log transcript lookup
Original PR state at finalization: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This branch contains the reviewed/adopted tip from the PR-review workflow. The original PR has maintainer edits disabled, so this follow-up preserves contributor authorship while allowing the maintainer-owned branch to run CI and merge.

Review synthesis:
- Latest attempt: 7
- Decision: approve
- Score: 905 / 1000, threshold 850
- Required changes: none
- Final diff: cmd/gc/cmd_session_logs.go and cmd/gc/cmd_session_logs_test.go, 167 insertions and 5 deletions

Validated in the final review:
- Wrapped custom providers use `builtin_ancestor > provider_kind > provider` precedence for transcript discovery.
- Keyed, provider-fallback, and workdir fallback transcript paths are guarded by transcript freshness checks.
- Closed-target fallback ambiguity rejects ambiguous same-workdir peers.
- Workdir fallback uses metadata lookup instead of a broad session-label scan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->