### PR TITLE
ci: dispatch label-requested PR suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
-      - unlabeled
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,8 +10,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
-      - unlabeled
   schedule:
     - cron: "24 4 * * 1"
   workflow_dispatch:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -26,8 +26,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
-      - unlabeled
     paths:
       - ".dockerignore"
       - ".trivyignore.yaml"

--- a/.github/workflows/dispatch-labeled-pr-suite.yml
+++ b/.github/workflows/dispatch-labeled-pr-suite.yml
@@ -1,0 +1,105 @@
+name: Dispatch labeled PR suite
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  dispatch-suite:
+    name: Dispatch requested suite
+    if: >-
+      github.event.label.name == 'needs-mac' ||
+      github.event.label.name == 'needs-review-formulas'
+    runs-on: ubuntu-latest
+    steps:
+      # This workflow never checks out or runs pull request code. It reads the
+      # trusted base allowlist, then dispatches a dedicated workflow with the
+      # PR head repository and SHA as explicit inputs.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Dispatch suite for trusted PR author
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.parse
+          import urllib.request
+          from pathlib import Path
+
+          label = os.environ["LABEL_NAME"]
+          draft = os.environ.get("PR_DRAFT", "").lower() == "true"
+          author = os.environ.get("PR_AUTHOR", "").strip()
+          association = os.environ.get("PR_ASSOCIATION", "").strip().upper()
+
+          if draft:
+              print("PR is draft; not dispatching a label-requested suite")
+              raise SystemExit(0)
+
+          allowlist = set()
+          for raw_line in Path(".github/blacksmith-allowlist.txt").read_text(encoding="utf-8").splitlines():
+              line = raw_line.split("#", 1)[0].strip()
+              if line:
+                  allowlist.add(line.lower())
+
+          trusted = association in {"OWNER", "MEMBER", "COLLABORATOR"} or author.lower() in allowlist
+          if not trusted:
+              print(f"PR author {author or '<unknown>'} is not trusted for label-dispatched suites")
+              raise SystemExit(0)
+
+          workflows = {
+              "needs-mac": ("mac-regression.yml", {"suite": "needs-mac"}),
+              "needs-review-formulas": ("review-formulas.yml", {}),
+          }
+          workflow, extra_inputs = workflows[label]
+          inputs = {
+              **extra_inputs,
+              "pr_number": os.environ["PR_NUMBER"],
+              "head_repo": os.environ["PR_HEAD_REPO"],
+              "head_ref": os.environ["PR_HEAD_REF"],
+              "head_sha": os.environ["PR_HEAD_SHA"],
+          }
+          payload = json.dumps({
+              "ref": os.environ["BASE_REF"],
+              "inputs": inputs,
+          }).encode("utf-8")
+
+          workflow_id = urllib.parse.quote(workflow, safe="")
+          url = f"https://api.github.com/repos/{os.environ['REPOSITORY']}/actions/workflows/{workflow_id}/dispatches"
+          request = urllib.request.Request(
+              url,
+              data=payload,
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2026-03-10",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              if response.status != 204:
+                  raise RuntimeError(f"unexpected dispatch status {response.status}")
+
+          print(f"Dispatched {workflow} for PR #{inputs['pr_number']} at {inputs['head_repo']}@{inputs['head_sha']}")
+          PY

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -10,7 +10,24 @@ on:
         options:
           - smoke
           - full
+          - needs-mac
         default: smoke
+      pr_number:
+        description: Pull request number for label-dispatched runs
+        required: false
+        type: string
+      head_repo:
+        description: Pull request head repository for label-dispatched runs
+        required: false
+        type: string
+      head_sha:
+        description: Pull request head SHA for label-dispatched runs
+        required: false
+        type: string
+      head_ref:
+        description: Pull request head ref for label-dispatched runs
+        required: false
+        type: string
   schedule:
     - cron: "17 3 * * *"
   pull_request:
@@ -20,13 +37,12 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
 
 permissions:
   contents: read
 
 concurrency:
-  group: mac-regression-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: mac-regression-${{ inputs.pr_number || github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
@@ -166,6 +182,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -199,6 +219,10 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -224,6 +248,10 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -244,10 +272,13 @@ jobs:
   mac-cover:
     name: Mac / test-cover
     needs: runner-policy
-    # Heavy job: schedule/full-dispatch/PR(needs-mac). Smoke dispatch skips.
+    # Heavy job: schedule/full-dispatch/needs-mac-dispatch/PR(needs-mac). Smoke dispatch skips.
     if: >-
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
+      ) ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -260,6 +291,10 @@ jobs:
       outcome: ${{ steps.cover.outcome }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -287,7 +322,10 @@ jobs:
     needs: runner-policy
     if: >-
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
+      ) ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -337,6 +375,10 @@ jobs:
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -353,7 +395,10 @@ jobs:
     needs: runner-policy
     if: >-
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
+      ) ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -375,6 +420,10 @@ jobs:
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -392,7 +441,10 @@ jobs:
     needs: runner-policy
     if: >-
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.suite == 'full') ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        (inputs.suite == 'full' || inputs.suite == 'needs-mac')
+      ) ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
@@ -436,6 +488,10 @@ jobs:
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -469,6 +525,10 @@ jobs:
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-macos
         with:
           dolt-version: ${{ env.DOLT_VERSION }}

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -11,14 +11,30 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number for label-dispatched runs
+        required: false
+        type: string
+      head_repo:
+        description: Pull request head repository for label-dispatched runs
+        required: false
+        type: string
+      head_sha:
+        description: Pull request head SHA for label-dispatched runs
+        required: false
+        type: string
+      head_ref:
+        description: Pull request head ref for label-dispatched runs
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: review-formulas-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: review-formulas-${{ github.event_name }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -135,16 +151,16 @@ jobs:
   gate:
     name: review-formulas routing
     needs: runner-policy
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.action != 'labeled' ||
-      (github.event.label.name == 'needs-review-formulas' || github.event.label.name == 'ok-to-blacksmith')
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     outputs:
       run_shard: ${{ steps.gate.outputs.run_shard }}
       reason: ${{ steps.gate.outputs.reason }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
@@ -169,8 +185,6 @@ jobs:
         id: gate
         env:
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-          LABELED_NAME: ${{ github.event.label.name }}
           PR_DRAFT: ${{ github.event.pull_request.draft }}
           PATH_HIT: ${{ steps.filter.outputs.review_formulas }}
           NEEDS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'needs-review-formulas') }}
@@ -185,9 +199,7 @@ jobs:
             run_shard=true
             reason="push to main safety net"
           elif [[ "$PR_DRAFT" != "true" ]]; then
-            if [[ "$EVENT_ACTION" == "labeled" && "$LABELED_NAME" != "needs-review-formulas" && "$LABELED_NAME" != "ok-to-blacksmith" ]]; then
-              reason="ignored unrelated label event"
-            elif [[ "$PATH_HIT" == "true" || "$NEEDS_LABEL" == "true" ]]; then
+            if [[ "$PATH_HIT" == "true" || "$NEEDS_LABEL" == "true" ]]; then
               run_shard=true
               reason="pull request path/label match"
             else
@@ -234,6 +246,10 @@ jobs:
             coverprofile: coverage.integration-review-formulas-recovery.txt
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ inputs.head_repo || github.repository }}
+          ref: ${{ inputs.head_sha || github.sha }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-gascity-ubuntu
         with:
           dolt-version: ${{ env.DOLT_VERSION }}
@@ -277,13 +293,7 @@ jobs:
       - runner-policy
       - gate
       - review-formulas-shard
-    if: >-
-      always() &&
-      (
-        github.event_name != 'pull_request' ||
-        github.event.action != 'labeled' ||
-        (github.event.label.name == 'needs-review-formulas' || github.event.label.name == 'ok-to-blacksmith')
-      )
+    if: always()
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     steps:
       - name: Finalize review-formulas result


### PR DESCRIPTION
## Summary
- remove label-only `pull_request` triggers from CI, CodeQL, Container Scan, Mac Regression, and review-formulas
- add a metadata-only `pull_request_target` router for label events
- dispatch Mac Regression when `needs-mac` is added by passing the PR head repo/SHA into `workflow_dispatch`
- dispatch the review-formulas shard when `needs-review-formulas` is added the same way
- keep `ok-to-blacksmith` as runner-policy configuration for the next/retried real run; it does not dispatch CI by itself

## Why
GitHub Actions supports `pull_request.labeled`, but not pre-filtering that event by label name. If a heavyweight workflow listens to `labeled`, every triage label still creates a workflow run record and fork-run approval can block before job-level `if:` gates run.

This keeps normal CI to one real run per PR code event while still allowing specific labels to request focused suites. The router never checks out or runs pull request code. It only reads `.github/blacksmith-allowlist.txt` from the trusted base revision, verifies the PR author is trusted by association or allowlist, then dispatches the requested workflow with explicit PR head inputs.

Mac label dispatch uses a `needs-mac` suite value so it matches the old PR label behavior: quality/unit/acceptance plus Mac cover/packages/bdstore/rest, while leaving the long Mac review-formulas shard to schedule/full dispatch.

## Validation
- `git diff --check origin/main...HEAD`
- verified no heavy workflow has literal `labeled`/`unlabeled` pull_request trigger
- PyYAML parse of `.github/workflows/*.yml` and `.github/workflows/*.yaml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml .github/workflows/*.yaml`