### PR TITLE
fix(tmux): drop if-shell guard from bind-key.sh; per-city socket makes it dead code

### DIFF
--- a/examples/gastown/bind_key_script_test.go
+++ b/examples/gastown/bind_key_script_test.go
@@ -1,0 +1,240 @@
+package gastown_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBindKeyScriptDirectBind exercises bind-key.sh against a stubbed
+// tmux that controls list-keys output and logs bind-key invocations.
+//
+// The script under test installs a tmux prefix binding directly,
+// without if-shell wrapping or fallback parsing. Per-city tmux socket
+// isolation (GC_TMUX_SOCKET, set by the controller) guarantees every
+// session on the socket is a GC session, so there is no non-GC
+// fallback path to preserve.
+//
+// The test cases verify:
+//
+//  1. No existing binding: bind-key is called with the command directly
+//     (no if-shell wrapper, no fallback).
+//  2. Existing default tmux binding ("next-window"): bind-key called
+//     with the GC command, overwriting cleanly. (Regression: the prior
+//     shape would wrap the existing binding inside if-shell, leading
+//     to recursive accumulation across re-runs.)
+//  3. Already-bound to the same GC command: bind-key NOT called
+//     (idempotency optimization — the command is already there).
+//  4. Already-bound to a different GC command: bind-key called with
+//     the new command (overwrite).
+//
+// Cases 2 + 3 between them rule out the recursive-wrapping bug: there
+// is no way for the script to install if-shell, so re-runs cannot
+// nest layers.
+func TestBindKeyScriptDirectBind(t *testing.T) {
+	bindKey := filepath.Join(exampleDir(), "packs", "gastown", "assets", "scripts", "bind-key.sh")
+	if _, err := os.Stat(bindKey); err != nil {
+		t.Fatalf("bind-key.sh not found at %s: %v", bindKey, err)
+	}
+
+	tests := []struct {
+		name           string
+		key            string
+		command        string
+		listKeysOutput string // simulated tmux list-keys output
+		// wantBindKeyCalled = true means we expect bind-key to be invoked.
+		// wantBindKeyArgs is checked as a substring of the logged invocation.
+		wantBindKeyCalled bool
+		wantBindKeyArgs   string
+		// Also assert what we did NOT see (regression checks).
+		wantNotInLog []string
+	}{
+		{
+			name:              "no existing binding installs command directly",
+			key:               "n",
+			command:           "run-shell '/path/to/cycle.sh next #{session_name} #{client_tty}'",
+			listKeysOutput:    "",
+			wantBindKeyCalled: true,
+			wantBindKeyArgs:   "bind-key -T prefix n",
+			wantNotInLog:      []string{"if-shell", "show-environment"},
+		},
+		{
+			name:              "default tmux binding overwritten without if-shell wrap",
+			key:               "n",
+			command:           "run-shell '/path/to/cycle.sh next #{session_name} #{client_tty}'",
+			listKeysOutput:    "bind-key -T prefix n next-window\n",
+			wantBindKeyCalled: true,
+			wantBindKeyArgs:   "bind-key -T prefix n",
+			// Regression: the prior shape would have wrapped "next-window"
+			// inside if-shell as the fallback. We want no if-shell at all.
+			wantNotInLog: []string{"if-shell", "next-window"},
+		},
+		{
+			name:              "idempotent: same command already bound is a no-op",
+			key:               "n",
+			command:           "run-shell '/path/to/cycle.sh next #{session_name} #{client_tty}'",
+			listKeysOutput:    "bind-key -T prefix n run-shell '/path/to/cycle.sh next #{session_name} #{client_tty}'\n",
+			wantBindKeyCalled: false,
+		},
+		{
+			name:              "different command in same key triggers re-bind",
+			key:               "n",
+			command:           "run-shell '/new/cycle.sh next #{session_name} #{client_tty}'",
+			listKeysOutput:    "bind-key -T prefix n run-shell '/old/cycle.sh next #{session_name} #{client_tty}'\n",
+			wantBindKeyCalled: true,
+			wantBindKeyArgs:   "bind-key -T prefix n",
+			wantNotInLog:      []string{"if-shell"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			bindLog := filepath.Join(t.TempDir(), "tmux-bind.log")
+			listKeysFile := filepath.Join(t.TempDir(), "list-keys-output.txt")
+			if err := os.WriteFile(listKeysFile, []byte(tt.listKeysOutput), 0o644); err != nil {
+				t.Fatalf("WriteFile listKeys: %v", err)
+			}
+
+			// Stub tmux:
+			//   list-keys: emit controlled output from $LIST_KEYS_FILE
+			//   bind-key:  log full argv to $TMUX_BIND_LOG
+			//   else:      no-op
+			writeExecutable(t, filepath.Join(binDir, "tmux"), `#!/bin/sh
+# Drop a leading "-L <socket>" pair if present (cycle.sh-style guard).
+if [ "$1" = "-L" ]; then
+    shift 2
+fi
+case "$1" in
+  list-keys)
+    cat "$LIST_KEYS_FILE" 2>/dev/null
+    ;;
+  bind-key)
+    printf '%s\n' "$*" >> "$TMUX_BIND_LOG"
+    ;;
+esac
+exit 0
+`)
+
+			env := map[string]string{
+				"PATH":           binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+				"TMUX_BIND_LOG":  bindLog,
+				"LIST_KEYS_FILE": listKeysFile,
+				"GC_TMUX_SOCKET": "", // disable -L flag so stub sees clean argv
+			}
+
+			cmd := exec.Command(bindKey, tt.key, tt.command)
+			cmd.Env = mergeTestEnv(env)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bind-key.sh failed: %v\n%s", err, out)
+			}
+
+			logBytes, _ := os.ReadFile(bindLog)
+			log := string(logBytes)
+
+			if !tt.wantBindKeyCalled {
+				if log != "" {
+					t.Fatalf("expected no bind-key call, got log: %q", log)
+				}
+				return
+			}
+
+			if !strings.Contains(log, tt.wantBindKeyArgs) {
+				t.Fatalf("expected bind-key log to contain %q, got: %q", tt.wantBindKeyArgs, log)
+			}
+			for _, forbidden := range tt.wantNotInLog {
+				if strings.Contains(log, forbidden) {
+					t.Fatalf("expected bind-key log NOT to contain %q (regression), got: %q",
+						forbidden, log)
+				}
+			}
+		})
+	}
+}
+
+// TestBindKeyScriptNoRecursiveWrapping asserts the structural property
+// that ruled the original bug: no matter how many times bind-key.sh is
+// invoked with the same args, the resulting binding is a single direct
+// command, not a stack of wrapped if-shell layers. This is the property
+// that hq-5vw7 (recursive wrapping) and hq-w1qlv ("command too long")
+// both manifest under the prior shape.
+func TestBindKeyScriptNoRecursiveWrapping(t *testing.T) {
+	bindKey := filepath.Join(exampleDir(), "packs", "gastown", "assets", "scripts", "bind-key.sh")
+	if _, err := os.Stat(bindKey); err != nil {
+		t.Fatalf("bind-key.sh not found: %v", err)
+	}
+
+	binDir := t.TempDir()
+	bindLog := filepath.Join(t.TempDir(), "tmux-bind.log")
+	listKeysFile := filepath.Join(t.TempDir(), "list-keys-output.txt")
+
+	// Stub tmux: each bind-key call updates the list-keys output so the
+	// next bind-key.sh invocation "sees" the prior binding (simulating
+	// what would happen across pack reinstalls / session_live re-fires).
+	writeExecutable(t, filepath.Join(binDir, "tmux"), `#!/bin/sh
+if [ "$1" = "-L" ]; then
+    shift 2
+fi
+case "$1" in
+  list-keys)
+    cat "$LIST_KEYS_FILE" 2>/dev/null
+    ;;
+  bind-key)
+    printf '%s\n' "$*" >> "$TMUX_BIND_LOG"
+    # Update list-keys output to reflect the new binding.
+    shift # drop "bind-key"
+    if [ "$1" = "-T" ]; then
+      table="$2"; key="$3"; shift 3
+      printf 'bind-key -T %s %s %s\n' "$table" "$key" "$*" > "$LIST_KEYS_FILE"
+    fi
+    ;;
+esac
+exit 0
+`)
+
+	env := map[string]string{
+		"PATH":           binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TMUX_BIND_LOG":  bindLog,
+		"LIST_KEYS_FILE": listKeysFile,
+		"GC_TMUX_SOCKET": "",
+	}
+
+	command := "run-shell '/path/to/cycle.sh next #{session_name} #{client_tty}'"
+
+	// Invoke bind-key.sh five times with the same args.
+	for i := 0; i < 5; i++ {
+		cmd := exec.Command(bindKey, "n", command)
+		cmd.Env = mergeTestEnv(env)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bind-key.sh iteration %d failed: %v\n%s", i, err, out)
+		}
+	}
+
+	logBytes, _ := os.ReadFile(bindLog)
+	log := string(logBytes)
+
+	// First call binds, subsequent four are no-ops (idempotent).
+	bindCount := strings.Count(log, "bind-key -T prefix n")
+	if bindCount != 1 {
+		t.Fatalf("expected exactly 1 bind-key invocation across 5 calls (idempotency); got %d:\n%s",
+			bindCount, log)
+	}
+	if strings.Contains(log, "if-shell") {
+		t.Fatalf("regression: bind-key log contains 'if-shell'; per-city socket isolation makes the wrap unnecessary:\n%s",
+			log)
+	}
+
+	// Final list-keys file should show the direct binding, not a wrapped one.
+	finalKeys, _ := os.ReadFile(listKeysFile)
+	finalStr := string(finalKeys)
+	if strings.Contains(finalStr, "if-shell") {
+		t.Fatalf("regression: final binding contains 'if-shell':\n%s", finalStr)
+	}
+	if !strings.Contains(finalStr, command) {
+		t.Fatalf("final binding does not contain expected command:\nbinding: %q\nwant substring: %q",
+			finalStr, command)
+	}
+}

--- a/examples/gastown/packs/gastown/assets/scripts/bind-key.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/bind-key.sh
@@ -1,65 +1,32 @@
 #!/bin/sh
-# bind-key.sh — idempotent tmux keybinding with fallback preservation.
-# Usage: bind-key.sh <key> <gc-command> [guard-pattern]
+# bind-key.sh — install a tmux prefix keybinding directly.
+# Usage: bind-key.sh <key> <command>
 #
-# If the key already has a GC binding (if-shell + gc), does nothing.
-# Otherwise captures the existing binding as fallback, then installs
-# an if-shell binding that runs <gc-command> in GC sessions and the
-# original binding in non-GC sessions.
+# Per-city tmux socket isolation (GC_TMUX_SOCKET, set by the controller
+# in internal/runtime/tmux/adapter.go) makes every session on the socket
+# a GC session. There is no non-GC fallback path to preserve, so the
+# binding installs <command> directly without if-shell wrapping.
 #
-# With per-city socket isolation, all sessions on the socket are GC
-# sessions. The guard checks for the GC_AGENT env var (set by the
-# controller on every agent session) as a reliable indicator.
+# tmux's bind-key naturally overwrites existing bindings; calling this
+# script twice with the same args is a no-op at the tmux level. The
+# early-exit on already-matching binding is an optimization to skip the
+# tmux call.
 set -e
+
+key="$1"
+command="$2"
+
+[ -z "$key" ] || [ -z "$command" ] && exit 1
 
 # Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
 gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
 
-key="$1"
-gc_command="$2"
-guard_pattern="${3:-GC_AGENT}"
-
-[ -z "$key" ] || [ -z "$gc_command" ] && exit 1
-
-# Check if already a GC binding (idempotent).
+# Skip the bind-key call if the binding already contains the requested
+# command. Fixed-string substring match is robust against tmux's quoting
+# variations across versions.
 existing=$(gcmux list-keys -T prefix "$key" 2>/dev/null || true)
-if printf '%s' "$existing" | grep -q 'if-shell' && printf '%s' "$existing" | grep -q 'gc '; then
+if printf '%s' "$existing" | grep -qF "$command"; then
     exit 0
 fi
 
-# Parse existing binding command as fallback.
-# tmux list-keys format: bind-key [-r] -T <table> <key> <command> [args...]
-fallback=""
-if [ -n "$existing" ]; then
-    # Skip past "-T prefix <key>" to get the command portion.
-    # Handle optional -r flag.
-    fallback=$(printf '%s' "$existing" | head -1 | awk '
-    {
-        i = 1
-        # skip "bind-key"
-        if ($i == "bind-key") i++
-        # skip optional -r
-        if ($i == "-r") i++
-        # skip -T <table> <key>
-        if ($i == "-T") i += 3
-        # rest is the command
-        cmd = ""
-        for (; i <= NF; i++) cmd = cmd (cmd ? " " : "") $i
-        print cmd
-    }')
-fi
-
-# Default fallbacks for common keys.
-if [ -z "$fallback" ]; then
-    case "$key" in
-        n) fallback="next-window" ;;
-        p) fallback="previous-window" ;;
-        *) fallback="command-prompt" ;;
-    esac
-fi
-
-# Install the if-shell binding.
-# Guard checks for GC_AGENT env var in the session environment,
-# which the controller sets on every agent session at startup.
-guard="tmux ${GC_TMUX_SOCKET:+-L $GC_TMUX_SOCKET} show-environment -t '#{session_name}' ${guard_pattern} >/dev/null 2>&1"
-gcmux bind-key -T prefix "$key" if-shell "$guard" "$gc_command" "$fallback"
+gcmux bind-key -T prefix "$key" "$command"

--- a/examples/gastown/packs/gastown/assets/scripts/tmux-keybindings.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/tmux-keybindings.sh
@@ -13,22 +13,10 @@ gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
 
 # ── Mail click binding (root table: left-click on status-right) ───────
 # Shows unread mail preview in a popup when clicking the status-right area.
-guard="tmux ${GC_TMUX_SOCKET:+-L $GC_TMUX_SOCKET} show-environment -t '#{session_name}' GC_AGENT >/dev/null 2>&1"
+# Per-city socket isolation makes every session on this socket a GC
+# session, so we install the popup directly without an if-shell guard.
+mail_popup="display-popup -E -w 60 -h 15 'gc mail peek || echo No unread mail'"
 existing=$(gcmux list-keys -T root MouseDown1StatusRight 2>/dev/null || true)
-if ! printf '%s' "$existing" | grep -q 'gc mail'; then
-    fallback=""
-    if [ -n "$existing" ]; then
-        fallback=$(printf '%s' "$existing" | head -1 | awk '
-        {
-            i = 1; if ($i == "bind-key") i++; if ($i == "-r") i++
-            if ($i == "-T") i += 3
-            cmd = ""; for (; i <= NF; i++) cmd = cmd (cmd ? " " : "") $i
-            print cmd
-        }')
-    fi
-    [ -z "$fallback" ] && fallback=":"
-    gcmux bind-key -T root MouseDown1StatusRight \
-        if-shell "$guard" \
-        "display-popup -E -w 60 -h 15 'gc mail peek || echo No unread mail'" \
-        "$fallback"
+if ! printf '%s' "$existing" | grep -qF "$mail_popup"; then
+    gcmux bind-key -T root MouseDown1StatusRight "$mail_popup"
 fi


### PR DESCRIPTION
## Problem

`bind-key.sh` has wrapped every binding in `if-shell` since pre-Pack-V2: the GC command on one branch, the prior binding preserved as a "non-GC fallback". The script's own header comment admits this is dead code:

> With per-city socket isolation, all sessions on the socket are GC sessions.

Per-city socket isolation is a hard SDK primitive — the controller sets `GC_TMUX_SOCKET` to a per-city socket name in [`internal/runtime/tmux/adapter.go:632-636`](internal/runtime/tmux/adapter.go), and every `gcmux()` invocation in pack scripts goes through it. **There are no non-GC sessions on this socket to fall back to.** The wrap is dead code.

The dead wrap causes two real bugs that aren't theoretical:

### 1. Recursive accumulation across re-runs

The idempotency check (`grep -q if-shell` AND `grep -q gc`) matches both the existing wrapped binding AND a freshly wrapped one, but the script also has a path that captures the existing binding as the new "fallback" branch. Across `N` session_live re-fires the binding nests `N` `if-shell` layers deep. Eventually trips tmux's command-line length limit (`"command too long"` on inspection).

### 2. Multi-kilobyte binding stored per key

Observed in the wild on an 8-session deployment: the `prefix-g` binding had grown into multi-KB of escaped fallback soup, breaking introspection of the binding.

The same dead-guard pattern is inlined in `tmux-keybindings.sh` for the `MouseDown1StatusRight` (mail click) binding — same socket primitive, same fix opportunity.

## Fix

Install the binding directly. No `if-shell`, no fallback parsing.

- `bind-key.sh` becomes ~30 lines: take key + command, skip if the existing binding already contains the command (substring match), otherwise `bind-key -T prefix <key> <command>`.
- `tmux-keybindings.sh` mail-click block drops the guard string, the awk fallback parser, and the if-shell wrap. Just `bind-key -T root MouseDown1StatusRight <command>` if not already bound.

`tmux`'s `bind-key` naturally overwrites; calling either path twice with the same args is a no-op at the tmux level. The substring-based early-exit is an optimization, not a correctness requirement.

Net diff: **−45 lines**. The awk fallback block, the default-fallback case statement (`n→next-window`, `p→previous-window`, `*→command-prompt`), the `show-environment` guard string, and the `[3]` `guard_pattern` arg all go away.

## Why this aligns with project philosophy

This PR doesn't introduce a new convention — it removes code that predates an SDK primitive that obsoletes it.

**Per-city socket isolation IS a primitive.** The controller in `internal/runtime/tmux/adapter.go` sets `GC_TMUX_SOCKET` to a city-specific socket name on every agent session. Every `gcmux()` invocation in pack scripts uses `tmux -L $GC_TMUX_SOCKET`, so all sessions on the socket are managed agent sessions by construction. There is no "user happens to attach to this socket and want non-GC bindings" path — that user would attach to a different socket.

**The script's header comment already states this fact** but the body still implements the obsolete wrap. The PR aligns the code with the comment.

This also resolves the script-layer instances of the same shape we addressed for `cycle.sh` in #1571: shell scripts in pack assets should consume SDK primitives instead of re-implementing assumptions that the SDK has already supplanted.

## Behavior preservation

- **First-time bind on default tmux**: existing `next-window` binding is replaced by the GC command. Same behavior as before (the prior shape would wrap `next-window` inside `if-shell` as the fallback; now it's just gone, which is the correct behavior on a per-city socket).
- **Repeat binds with same args**: no-op at the tmux level (overwrite-with-same), and an early-exit optimization avoids the spurious `bind-key` call. Same observable behavior.
- **Repeat binds with different commands**: overwrite cleanly. Same as before.
- **Mail click**: same popup, same behavior, no guard wrap.

## Tests

Adds `examples/gastown/bind_key_script_test.go` mirroring the existing `maintenance_scripts_test.go` pattern (stub binary on PATH, exec script, assert on logged calls). Two test functions:

**`TestBindKeyScriptDirectBind`** — 4 sub-tests:
- No existing binding → `bind-key` called with command, no `if-shell`.
- Default tmux binding (`next-window`) overwritten cleanly, no `if-shell`, no `next-window` preserved as fallback.
- Same command already bound → `bind-key` NOT called (idempotency).
- Different command in same key → re-bind, no `if-shell`.

**`TestBindKeyScriptNoRecursiveWrapping`** — structural property test:
- Invokes `bind-key.sh` 5 times with the same args.
- Asserts exactly 1 `bind-key` invocation across 5 calls (idempotency).
- Asserts the resulting binding contains no `if-shell`.
- This is the property that ruled the original `hq-5vw7` (recursive wrapping) and `hq-w1qlv` ("command too long") bugs locally.

Total runtime ~1.7s.

## Test plan

- [x] `make check` passes locally
- [x] `go test ./examples/gastown/ -run TestBindKey` passes (5 sub-tests)
- [x] `sh -n bind-key.sh && sh -n tmux-keybindings.sh` clean
- [x] Manual: re-run pack `session_live` hooks 5×, inspect `tmux list-keys -T prefix n` — single direct binding, no `if-shell` nesting
- [x] Manual: click status-right area — mail popup appears (no regression on mouse binding)

## Related

- #1571 (cycle.sh primitive-based grouping) — same architectural lesson applied to a different script in the same directory. Independent; no merge dependency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->