### PR TITLE
fix: preserve partial bead outage semantics

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -564,6 +564,9 @@ func collectAssignedWorkBeadsWithStores(
 				appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
+				if beads.IsPartialResult(err) && len(inProgress) > 0 {
+					appendInProgressWorkUnique(cfg, &result, &resultStores, inProgress, seen, s)
+				}
 			}
 			// Ready beads with an assignee (queued direct handoff work that is
 			// actually runnable, not merely open). This is a lifecycle gate, so
@@ -572,6 +575,9 @@ func collectAssignedWorkBeadsWithStores(
 				appendAssignedUnique(&result, &resultStores, ready, seen, s)
 			} else {
 				errs = append(errs, fmt.Errorf("Ready(): %w", err))
+				if beads.IsPartialResult(err) && len(ready) > 0 {
+					appendAssignedUnique(&result, &resultStores, ready, seen, s)
+				}
 			}
 			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, errs: errs}
 		}()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -28,6 +28,34 @@ func (s listFailStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
 	return nil, errors.New("list failed")
 }
 
+type partialAssignedWorkStore struct {
+	*beads.MemStore
+	partialInProgress bool
+	partialReady      bool
+}
+
+func (s *partialAssignedWorkStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	rows, err := s.MemStore.List(query)
+	if err != nil {
+		return nil, err
+	}
+	if s.partialInProgress && query.Status == "in_progress" && query.Live {
+		return rows, &beads.PartialResultError{Op: "bd list", Err: errors.New("skipped corrupt in-progress bead")}
+	}
+	return rows, nil
+}
+
+func (s *partialAssignedWorkStore) Ready() ([]beads.Bead, error) {
+	rows, err := s.MemStore.Ready()
+	if err != nil {
+		return nil, err
+	}
+	if s.partialReady {
+		return rows, &beads.PartialResultError{Op: "bd ready", Err: errors.New("skipped corrupt ready bead")}
+	}
+	return rows, nil
+}
+
 func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T) {
 	store := beads.NewMemStore()
 	handoff, err := store.Create(beads.Bead{
@@ -150,6 +178,69 @@ func TestCollectAssignedWorkBeads_ExcludesSessionBeads(t *testing.T) {
 	}
 	if got[0].ID != task.ID {
 		t.Fatalf("expected task %q, got %q", task.ID, got[0].ID)
+	}
+}
+
+func TestCollectAssignedWorkBeads_PreservesPartialInProgressSurvivors(t *testing.T) {
+	t.Parallel()
+
+	store := &partialAssignedWorkStore{
+		MemStore:          beads.NewMemStore(),
+		partialInProgress: true,
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "assigned active work",
+		Type:     "task",
+		Assignee: "worker-1",
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set work in_progress: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload work bead: %v", err)
+	}
+
+	got, stores, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
+	if !partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeadsWithStores returned %#v, want partial survivor %s", got, work.ID)
+	}
+	if len(stores) != 1 || stores[0] != store {
+		t.Fatalf("stores = %#v, want source store for partial survivor", stores)
+	}
+}
+
+func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
+	t.Parallel()
+
+	store := &partialAssignedWorkStore{
+		MemStore:     beads.NewMemStore(),
+		partialReady: true,
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "assigned ready work",
+		Type:     "task",
+		Assignee: "worker-1",
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	got, stores, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
+	if !partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeadsWithStores returned %#v, want partial ready survivor %s", got, work.ID)
+	}
+	if len(stores) != 1 || stores[0] != store {
+		t.Fatalf("stores = %#v, want source store for partial survivor", stores)
 	}
 }
 

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -3841,6 +3841,10 @@ export interface components {
             mail: components["schemas"]["StatusMailCounts"];
             /** @description City name. */
             name: string;
+            /** @description True when one or more status backing reads returned incomplete data. */
+            partial?: boolean;
+            /** @description Human-readable errors from incomplete status backing reads. */
+            partial_errors?: string[] | null;
             /** @description City directory path. */
             path: string;
             /**

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -2578,6 +2578,14 @@ export type StatusBody = {
      */
     name: string;
     /**
+     * True when one or more status backing reads returned incomplete data.
+     */
+    partial?: boolean;
+    /**
+     * Human-readable errors from incomplete status backing reads.
+     */
+    partial_errors?: Array<string> | null;
+    /**
      * City directory path.
      */
     path: string;

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -6201,6 +6201,20 @@
             "description": "City name.",
             "type": "string"
           },
+          "partial": {
+            "description": "True when one or more status backing reads returned incomplete data.",
+            "type": "boolean"
+          },
+          "partial_errors": {
+            "description": "Human-readable errors from incomplete status backing reads.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "path": {
             "description": "City directory path.",
             "type": "string"

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -6201,6 +6201,20 @@
             "description": "City name.",
             "type": "string"
           },
+          "partial": {
+            "description": "True when one or more status backing reads returned incomplete data.",
+            "type": "boolean"
+          },
+          "partial_errors": {
+            "description": "Human-readable errors from incomplete status backing reads.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "path": {
             "description": "City directory path.",
             "type": "string"

--- a/internal/api/cache_read_model.go
+++ b/internal/api/cache_read_model.go
@@ -21,3 +21,14 @@ func listSessionBeadsForReadModel(store beads.Store) ([]beads.Bead, error) {
 	}
 	return store.List(query)
 }
+
+func sessionReadModelRows(store beads.Store) ([]beads.Bead, []string, error) {
+	rows, err := listSessionBeadsForReadModel(store)
+	if err == nil {
+		return rows, nil, nil
+	}
+	if beads.IsPartialResult(err) && len(rows) > 0 {
+		return rows, []string{err.Error()}, nil
+	}
+	return nil, nil, err
+}

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2419,6 +2419,12 @@ type StatusBody struct {
 	// Name City name.
 	Name string `json:"name"`
 
+	// Partial True when one or more status backing reads returned incomplete data.
+	Partial *bool `json:"partial,omitempty"`
+
+	// PartialErrors Human-readable errors from incomplete status backing reads.
+	PartialErrors *[]string `json:"partial_errors,omitempty"`
+
 	// Path City directory path.
 	Path string `json:"path"`
 

--- a/internal/api/handler_beads_partial_test.go
+++ b/internal/api/handler_beads_partial_test.go
@@ -18,13 +18,18 @@ import (
 type failingBeadStore struct {
 	beads.Store
 	listErr        error
+	listResult     []beads.Bead
 	readyErr       error
+	readyResult    []beads.Bead
 	updateFailAt   map[string]error // item ID → error (fails Update for that ID)
 	updateCallback func(id string)  // optional: called on every Update before injecting failure
 }
 
 func (f *failingBeadStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 	if f.listErr != nil {
+		if f.listResult != nil {
+			return f.listResult, f.listErr
+		}
 		return nil, f.listErr
 	}
 	return f.Store.List(q)
@@ -32,6 +37,9 @@ func (f *failingBeadStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 
 func (f *failingBeadStore) Ready() ([]beads.Bead, error) {
 	if f.readyErr != nil {
+		if f.readyResult != nil {
+			return f.readyResult, f.readyErr
+		}
 		return nil, f.readyErr
 	}
 	return f.Store.Ready()
@@ -94,6 +102,49 @@ func TestBeadListSurfacesStoreErrorsAsPartial(t *testing.T) {
 	}
 }
 
+func TestBeadListPreservesPartialResultRows(t *testing.T) {
+	fs := newPartialListState(t, nil, nil)
+	bad := fs.stores["bad"]
+	survivors, err := bad.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("seed survivors: %v", err)
+	}
+	fs.stores["bad"] = &failingBeadStore{
+		Store:      bad,
+		listResult: survivors,
+		listErr: &beads.PartialResultError{
+			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		},
+	}
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Items         []beads.Bead `json:"items"`
+		Partial       bool         `json:"partial"`
+		PartialErrors []string     `json:"partial_errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	if !body.Partial {
+		t.Fatalf("Partial = false, want true")
+	}
+	if len(body.PartialErrors) == 0 {
+		t.Fatalf("PartialErrors empty")
+	}
+	if !containsBeadTitle(body.Items, "would-be-lost") {
+		t.Fatalf("Items = %+v, want surviving partial row from bad rig", body.Items)
+	}
+}
+
 // When EVERY rig store fails, returning 200 + empty + partial=true
 // conflates outage with "no data". The handler must return 503 so
 // clients can tell the difference.
@@ -110,6 +161,49 @@ func TestBeadListReturns503OnTotalOutage(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != 503 {
 		t.Errorf("status = %d, want 503 when every backend fails (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBeadReadyPreservesPartialResultRows(t *testing.T) {
+	fs := newPartialListState(t, nil, nil)
+	bad := fs.stores["bad"]
+	survivors, err := bad.Ready()
+	if err != nil {
+		t.Fatalf("seed ready survivors: %v", err)
+	}
+	fs.stores["bad"] = &failingBeadStore{
+		Store:       bad,
+		readyResult: survivors,
+		readyErr: &beads.PartialResultError{
+			Op:  "bd ready",
+			Err: errors.New("skipped 1 corrupt bead"),
+		},
+	}
+	h := newTestCityHandler(t, fs)
+
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads/ready"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Items         []beads.Bead `json:"items"`
+		Partial       bool         `json:"partial"`
+		PartialErrors []string     `json:"partial_errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	if !body.Partial {
+		t.Fatalf("Partial = false, want true")
+	}
+	if len(body.PartialErrors) == 0 {
+		t.Fatalf("PartialErrors empty")
+	}
+	if !containsBeadTitle(body.Items, "would-be-lost") {
+		t.Fatalf("Items = %+v, want surviving partial ready row from bad rig", body.Items)
 	}
 }
 
@@ -138,4 +232,13 @@ func TestBeadReadySurfacesStoreErrorsAsPartial(t *testing.T) {
 	if len(body.PartialErrors) == 0 {
 		t.Errorf("PartialErrors empty")
 	}
+}
+
+func containsBeadTitle(items []beads.Bead, title string) bool {
+	for _, item := range items {
+		if item.Title == title {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/handler_beads_partial_test.go
+++ b/internal/api/handler_beads_partial_test.go
@@ -164,6 +164,26 @@ func TestBeadListReturns503OnTotalOutage(t *testing.T) {
 	}
 }
 
+func TestBeadListReturns503OnEmptyPartialTotalOutage(t *testing.T) {
+	fs := newFakeState(t)
+	fs.stores["myrig"] = &failingBeadStore{
+		Store:      fs.stores["myrig"],
+		listResult: []beads.Bead{},
+		listErr: &beads.PartialResultError{
+			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Errorf("status = %d, want 503 when every backend has zero usable rows (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
 func TestBeadReadyPreservesPartialResultRows(t *testing.T) {
 	fs := newPartialListState(t, nil, nil)
 	bad := fs.stores["bad"]
@@ -231,6 +251,26 @@ func TestBeadReadySurfacesStoreErrorsAsPartial(t *testing.T) {
 	}
 	if len(body.PartialErrors) == 0 {
 		t.Errorf("PartialErrors empty")
+	}
+}
+
+func TestBeadReadyReturns503OnEmptyPartialTotalOutage(t *testing.T) {
+	fs := newFakeState(t)
+	fs.stores["myrig"] = &failingBeadStore{
+		Store:       fs.stores["myrig"],
+		readyResult: []beads.Bead{},
+		readyErr: &beads.PartialResultError{
+			Op:  "bd ready",
+			Err: errors.New("skipped 1 corrupt bead"),
+		},
+	}
+
+	h := newTestCityHandler(t, fs)
+	req := httptest.NewRequest("GET", cityURL(fs, "/beads/ready"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Errorf("status = %d, want 503 when every backend has zero usable ready rows (body=%q)", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/api/handler_sessions.go
+++ b/internal/api/handler_sessions.go
@@ -208,7 +208,7 @@ func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
 	templateFilter := q.Get("template")
 	wantPeek := q.Get("peek") == "true"
 
-	all, err := listSessionBeadsForReadModel(store)
+	all, partialErrors, err := sessionReadModelRows(store)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
@@ -234,14 +234,25 @@ func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
 		if pp.Limit < len(items) {
 			items = items[:pp.Limit]
 		}
-		writeJSON(w, http.StatusOK, listResponse{Items: items, Total: len(items)})
+		writeJSON(w, http.StatusOK, listResponse{
+			Items:         items,
+			Total:         len(items),
+			Partial:       len(partialErrors) > 0,
+			PartialErrors: partialErrors,
+		})
 		return
 	}
 	page, total, nextCursor := paginate(items, pp)
 	if page == nil {
 		page = []sessionResponse{}
 	}
-	writeJSON(w, http.StatusOK, listResponse{Items: page, Total: total, NextCursor: nextCursor})
+	writeJSON(w, http.StatusOK, listResponse{
+		Items:         page,
+		Total:         total,
+		NextCursor:    nextCursor,
+		Partial:       len(partialErrors) > 0,
+		PartialErrors: partialErrors,
+	})
 }
 
 func (s *Server) handleSessionGet(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -64,6 +64,110 @@ func (s *cachedOnlyListStoreForSessionTest) CachedList(query beads.ListQuery) ([
 	return rows, true
 }
 
+type partialPrimeSessionStore struct {
+	*beads.MemStore
+	partialRows    []beads.Bead
+	labelListCalls int
+}
+
+func (s *partialPrimeSessionStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	rows, err := s.MemStore.List(query)
+	if err != nil {
+		return nil, err
+	}
+	if query.AllowScan || query.Label == session.LabelSession {
+		if query.Label == session.LabelSession {
+			s.labelListCalls++
+		}
+		if s.partialRows != nil {
+			rows = append([]beads.Bead(nil), s.partialRows...)
+		}
+		return rows, &beads.PartialResultError{
+			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		}
+	}
+	return rows, nil
+}
+
+func TestListSessionBeadsForReadModelFallsBackAfterPartialCachePrime(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialPrimeSessionStore{MemStore: beads.NewMemStore()}
+	survivor, err := backing.Create(beads.Bead{
+		Title:  "session survivor",
+		Labels: []string{session.LabelSession},
+	})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "dropped session",
+		Labels: []string{session.LabelSession},
+	}); err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	backing.partialRows = []beads.Bead{survivor}
+
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	rows, err := listSessionBeadsForReadModel(cache)
+	var partial *beads.PartialResultError
+	if !errors.As(err, &partial) {
+		t.Fatalf("listSessionBeadsForReadModel error = %v, want *PartialResultError", err)
+	}
+	if backing.labelListCalls != 1 {
+		t.Fatalf("label List calls = %d, want 1 backing fallback after partial prime", backing.labelListCalls)
+	}
+	if len(rows) != 1 || rows[0].ID != survivor.ID {
+		t.Fatalf("rows = %+v, want partial survivor %s", rows, survivor.ID)
+	}
+}
+
+func TestHandleSessionListPreservesPartialRows(t *testing.T) {
+	fs := newSessionFakeState(t)
+	store := &partialPrimeSessionStore{MemStore: beads.NewMemStore()}
+	fs.cityBeadStore = store
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	info := createTestSession(t, store, fs.sp, "Session survivor")
+	survivor, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", info.ID, err)
+	}
+	store.partialRows = []beads.Bead{survivor}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/sessions"), nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Items         []sessionResponse `json:"items"`
+		Total         int               `json:"total"`
+		Partial       bool              `json:"partial"`
+		PartialErrors []string          `json:"partial_errors"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(body.PartialErrors) == 0 {
+		t.Fatal("partial_errors empty")
+	}
+	if body.Total != 1 || len(body.Items) != 1 || body.Items[0].ID != info.ID {
+		t.Fatalf("body = %+v, want surviving session %s", body, info.ID)
+	}
+}
+
 func writeGeminiHistoryFixtureForAPI(t *testing.T, path, sessionID string, messages ...string) {
 	t.Helper()
 

--- a/internal/api/handler_status.go
+++ b/internal/api/handler_status.go
@@ -56,6 +56,7 @@ func (s *Server) buildStatusBody() StatusBody {
 	cityName := s.state.CityName()
 	sessTmpl := cfg.Workspace.SessionTemplate
 	sessionSnapshot := s.statusSessionSnapshot()
+	partialErrors := append([]string(nil), sessionSnapshot.partialErrors...)
 
 	// Count agents by state.
 	var ac agentCounts
@@ -113,7 +114,10 @@ func (s *Server) buildStatusBody() StatusBody {
 		seenStores[key] = true
 		list, err := store.List(beads.ListQuery{AllowScan: true})
 		if err != nil {
-			continue
+			partialErrors = append(partialErrors, fmt.Sprintf("rig %s work: %v", rigName, err))
+			if !beads.IsPartialResult(err) || len(list) == 0 {
+				continue
+			}
 		}
 		for _, b := range list {
 			switch b.Type {
@@ -149,24 +153,27 @@ func (s *Server) buildStatusBody() StatusBody {
 	uptime := int(time.Since(s.state.StartedAt()).Seconds())
 
 	return StatusBody{
-		Name:       cityName,
-		Path:       s.state.CityPath(),
-		Version:    s.state.Version(),
-		UptimeSec:  uptime,
-		Suspended:  cfg.Workspace.Suspended,
-		AgentCount: ac.Total,
-		RigCount:   rc.Total,
-		Running:    rawRunning,
-		Agents:     ac,
-		Rigs:       rc,
-		Work:       wc,
-		Mail:       mc,
+		Name:          cityName,
+		Path:          s.state.CityPath(),
+		Version:       s.state.Version(),
+		UptimeSec:     uptime,
+		Suspended:     cfg.Workspace.Suspended,
+		AgentCount:    ac.Total,
+		RigCount:      rc.Total,
+		Running:       rawRunning,
+		Agents:        ac,
+		Rigs:          rc,
+		Work:          wc,
+		Mail:          mc,
+		Partial:       len(partialErrors) > 0,
+		PartialErrors: partialErrors,
 	}
 }
 
 type statusSessionSnapshot struct {
 	bySessionName map[string]statusSessionInfo
 	byTemplate    map[string][]statusSessionInfo
+	partialErrors []string
 }
 
 type statusSessionInfo struct {
@@ -190,9 +197,13 @@ func (s *Server) statusSessionSnapshot() statusSessionSnapshot {
 		return snapshot
 	}
 
-	rows, err := listSessionBeadsForReadModel(store)
+	rows, partialErrors, err := sessionReadModelRows(store)
 	if err != nil {
+		snapshot.partialErrors = []string{fmt.Sprintf("sessions: %v", err)}
 		return snapshot
+	}
+	for _, partialErr := range partialErrors {
+		snapshot.partialErrors = append(snapshot.partialErrors, fmt.Sprintf("sessions: %s", partialErr))
 	}
 
 	seenSessionName := make(map[string]bool, len(rows))

--- a/internal/api/handler_status_test.go
+++ b/internal/api/handler_status_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -82,6 +83,69 @@ func TestHandleStatusEnriched(t *testing.T) {
 	// Rig counts.
 	if resp.Rigs.Total != 1 {
 		t.Errorf("Rigs.Total = %d, want 1", resp.Rigs.Total)
+	}
+}
+
+func TestHandleStatusPreservesPartialWorkCountSurvivors(t *testing.T) {
+	state := newFakeState(t)
+	store := beads.NewMemStore()
+	open, err := store.Create(beads.Bead{Type: "task", Title: "open survivor", Status: "open"})
+	if err != nil {
+		t.Fatalf("Create(open): %v", err)
+	}
+	ready, err := store.Create(beads.Bead{Type: "task", Title: "ready survivor", Status: "ready"})
+	if err != nil {
+		t.Fatalf("Create(ready): %v", err)
+	}
+	readyStatus := "ready"
+	if err := store.Update(ready.ID, beads.UpdateOpts{Status: &readyStatus}); err != nil {
+		t.Fatalf("Update(ready): %v", err)
+	}
+	ready, err = store.Get(ready.ID)
+	if err != nil {
+		t.Fatalf("Get(ready): %v", err)
+	}
+	inProgress, err := store.Create(beads.Bead{Type: "task", Title: "claimed survivor", Status: "in_progress"})
+	if err != nil {
+		t.Fatalf("Create(in_progress): %v", err)
+	}
+	inProgressStatus := "in_progress"
+	if err := store.Update(inProgress.ID, beads.UpdateOpts{Status: &inProgressStatus}); err != nil {
+		t.Fatalf("Update(in_progress): %v", err)
+	}
+	inProgress, err = store.Get(inProgress.ID)
+	if err != nil {
+		t.Fatalf("Get(in_progress): %v", err)
+	}
+	state.stores["myrig"] = &failingBeadStore{
+		Store:      store,
+		listResult: []beads.Bead{open, ready, inProgress},
+		listErr: &beads.PartialResultError{
+			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		},
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Work.Open != 1 || resp.Work.Ready != 1 || resp.Work.InProgress != 1 {
+		t.Fatalf("Work = %+v, want partial survivors counted", resp.Work)
+	}
+	if !resp.Partial {
+		t.Fatalf("Partial = false, want true for partial work count")
+	}
+	if len(resp.PartialErrors) == 0 {
+		t.Fatalf("PartialErrors empty")
 	}
 }
 
@@ -177,6 +241,57 @@ func TestHandleStatusUsesCachedSessionStateForSuspendedAgents(t *testing.T) {
 	}
 	if resp.Running != 1 {
 		t.Fatalf("Running = %d, want raw liveness count 1", resp.Running)
+	}
+}
+
+func TestHandleStatusUsesPartialSessionRows(t *testing.T) {
+	state := newFakeState(t)
+	store := &partialPrimeSessionStore{MemStore: beads.NewMemStore()}
+	state.cityBeadStore = store
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Status: "open",
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"state":        string(session.StateSuspended),
+			"template":     "myrig/worker",
+			"session_name": "myrig--worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	store.partialRows = []beads.Bead{sessionBead}
+	if err := state.sp.Start(context.Background(), "myrig--worker", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	h := newTestCityHandler(t, state)
+
+	req := httptest.NewRequest("GET", cityURL(state, "/status"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp statusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Agents.Suspended != 1 {
+		t.Fatalf("Agents.Suspended = %d, want partial survivor to mark session suspended", resp.Agents.Suspended)
+	}
+	if resp.Agents.Running != 0 {
+		t.Fatalf("Agents.Running = %d, want 0 for suspended partial survivor", resp.Agents.Running)
+	}
+	if resp.Running != 1 {
+		t.Fatalf("Running = %d, want raw liveness count 1", resp.Running)
+	}
+	if !resp.Partial {
+		t.Fatalf("Partial = false, want true for partial session snapshot")
+	}
+	if len(resp.PartialErrors) == 0 {
+		t.Fatalf("PartialErrors empty")
 	}
 }
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -5,9 +5,11 @@ package api
 // fixtures) and by the agents-cache envelope. Huma handlers use
 // ListOutput[T] / ListBody[T] instead.
 type listResponse struct {
-	Items      any    `json:"items"`
-	Total      int    `json:"total"`
-	NextCursor string `json:"next_cursor,omitempty"`
+	Items         any      `json:"items"`
+	Total         int      `json:"total"`
+	NextCursor    string   `json:"next_cursor,omitempty"`
+	Partial       bool     `json:"partial,omitempty"`
+	PartialErrors []string `json:"partial_errors,omitempty"`
 }
 
 // latestIndex returns the latest event sequence, or 0 if unavailable.

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -58,7 +58,7 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 			pa.attempt()
 			list, err := store.List(query)
 			if err != nil {
-				if isBeadPartialResult(err) {
+				if beads.IsPartialResult(err) && len(list) > 0 {
 					pa.record("rig "+rigName, err)
 					pa.success()
 				} else {
@@ -136,7 +136,7 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 		pa.attempt()
 		ready, err := beads.ReadyLive(stores[rigName])
 		if err != nil {
-			if isBeadPartialResult(err) {
+			if beads.IsPartialResult(err) && len(ready) > 0 {
 				pa.record("rig "+rigName, err)
 				pa.success()
 			} else {
@@ -166,11 +166,6 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 			PartialErrors: pa.messages(),
 		},
 	}, nil
-}
-
-func isBeadPartialResult(err error) bool {
-	var partial *beads.PartialResultError
-	return errors.As(err, &partial)
 }
 
 // humaHandleBeadGraph is the Huma-typed handler for GET /v0/beads/graph/{rootID}.

--- a/internal/api/huma_handlers_beads.go
+++ b/internal/api/huma_handlers_beads.go
@@ -58,10 +58,16 @@ func (s *Server) humaHandleBeadList(ctx context.Context, input *BeadListInput) (
 			pa.attempt()
 			list, err := store.List(query)
 			if err != nil {
-				pa.record("rig "+rigName, err)
-				continue
+				if isBeadPartialResult(err) {
+					pa.record("rig "+rigName, err)
+					pa.success()
+				} else {
+					pa.record("rig "+rigName, err)
+					continue
+				}
+			} else {
+				pa.success()
 			}
-			pa.success()
 			for _, b := range list {
 				dedupeKey := rigName + "\x00" + b.ID
 				if dedupe && seen[dedupeKey] {
@@ -130,10 +136,16 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 		pa.attempt()
 		ready, err := beads.ReadyLive(stores[rigName])
 		if err != nil {
-			pa.record("rig "+rigName, err)
-			continue
+			if isBeadPartialResult(err) {
+				pa.record("rig "+rigName, err)
+				pa.success()
+			} else {
+				pa.record("rig "+rigName, err)
+				continue
+			}
+		} else {
+			pa.success()
 		}
-		pa.success()
 		all = append(all, ready...)
 	}
 	if pa.totalOutage() {
@@ -154,6 +166,11 @@ func (s *Server) humaHandleBeadReady(ctx context.Context, input *BeadReadyInput)
 			PartialErrors: pa.messages(),
 		},
 	}, nil
+}
+
+func isBeadPartialResult(err error) bool {
+	var partial *beads.PartialResultError
+	return errors.As(err, &partial)
 }
 
 // humaHandleBeadGraph is the Huma-typed handler for GET /v0/beads/graph/{rootID}.

--- a/internal/api/huma_handlers_sessions_query.go
+++ b/internal/api/huma_handlers_sessions_query.go
@@ -25,7 +25,7 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	mgr := s.sessionManager(store)
 	cfg := s.state.Config()
 
-	all, err := listSessionBeadsForReadModel(store)
+	all, partialErrors, err := sessionReadModelRows(store)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(err.Error())
 	}
@@ -70,7 +70,12 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 		}
 		return &ListOutput[sessionResponse]{
 			Index: s.latestIndex(),
-			Body:  ListBody[sessionResponse]{Items: items, Total: total},
+			Body: ListBody[sessionResponse]{
+				Items:         items,
+				Total:         total,
+				Partial:       len(partialErrors) > 0,
+				PartialErrors: partialErrors,
+			},
 		}, nil
 	}
 
@@ -80,7 +85,13 @@ func (s *Server) humaHandleSessionList(_ context.Context, input *SessionListInpu
 	}
 	return &ListOutput[sessionResponse]{
 		Index: s.latestIndex(),
-		Body:  ListBody[sessionResponse]{Items: page, Total: total, NextCursor: nextCursor},
+		Body: ListBody[sessionResponse]{
+			Items:         page,
+			Total:         total,
+			NextCursor:    nextCursor,
+			Partial:       len(partialErrors) > 0,
+			PartialErrors: partialErrors,
+		},
 	}, nil
 }
 

--- a/internal/api/huma_types_patches.go
+++ b/internal/api/huma_types_patches.go
@@ -149,18 +149,20 @@ type PatchDeletedResponse struct {
 
 // StatusBody is the response body for GET /v0/status.
 type StatusBody struct {
-	Name       string            `json:"name" doc:"City name."`
-	Path       string            `json:"path" doc:"City directory path."`
-	Version    string            `json:"version,omitempty" doc:"Server version."`
-	UptimeSec  int               `json:"uptime_sec" doc:"Server uptime in seconds."`
-	Suspended  bool              `json:"suspended" doc:"Whether the city is suspended."`
-	AgentCount int               `json:"agent_count" doc:"Total agent count (deprecated, use agents.total)."`
-	RigCount   int               `json:"rig_count" doc:"Total rig count (deprecated, use rigs.total)."`
-	Running    int               `json:"running" doc:"Number of running agent processes."`
-	Agents     StatusAgentCounts `json:"agents" doc:"Agent state counts."`
-	Rigs       StatusRigCounts   `json:"rigs" doc:"Rig state counts."`
-	Work       StatusWorkCounts  `json:"work" doc:"Work item counts."`
-	Mail       StatusMailCounts  `json:"mail" doc:"Mail counts."`
+	Name          string            `json:"name" doc:"City name."`
+	Path          string            `json:"path" doc:"City directory path."`
+	Version       string            `json:"version,omitempty" doc:"Server version."`
+	UptimeSec     int               `json:"uptime_sec" doc:"Server uptime in seconds."`
+	Suspended     bool              `json:"suspended" doc:"Whether the city is suspended."`
+	AgentCount    int               `json:"agent_count" doc:"Total agent count (deprecated, use agents.total)."`
+	RigCount      int               `json:"rig_count" doc:"Total rig count (deprecated, use rigs.total)."`
+	Running       int               `json:"running" doc:"Number of running agent processes."`
+	Agents        StatusAgentCounts `json:"agents" doc:"Agent state counts."`
+	Rigs          StatusRigCounts   `json:"rigs" doc:"Rig state counts."`
+	Work          StatusWorkCounts  `json:"work" doc:"Work item counts."`
+	Mail          StatusMailCounts  `json:"mail" doc:"Mail counts."`
+	Partial       bool              `json:"partial,omitempty" doc:"True when one or more status backing reads returned incomplete data."`
+	PartialErrors []string          `json:"partial_errors,omitempty" doc:"Human-readable errors from incomplete status backing reads."`
 }
 
 // Session types moved to huma_types_sessions.go.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -6201,6 +6201,20 @@
             "description": "City name.",
             "type": "string"
           },
+          "partial": {
+            "description": "True when one or more status backing reads returned incomplete data.",
+            "type": "boolean"
+          },
+          "partial_errors": {
+            "description": "Human-readable errors from incomplete status backing reads.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "path": {
             "description": "City directory path.",
             "type": "string"

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -360,6 +360,11 @@ func (e *PartialResultError) Unwrap() error {
 	return e.Err
 }
 
+func isPartialResultError(err error) bool {
+	var partial *PartialResultError
+	return errors.As(err, &partial)
+}
+
 // parseIssuesTolerant unmarshals a JSON array of bdIssue objects, skipping
 // any entries that fail to parse (e.g. corrupt metadata with non-string values).
 // This prevents a single bad bead from breaking all list operations.

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -329,12 +329,11 @@ type bdIssueDep struct {
 	DependencyType string `json:"dependency_type"`
 }
 
-// PartialResultError indicates that a list-style bd command succeeded for some
-// entries but its output included entries that failed to parse. The successful
-// entries are still returned alongside this error; callers that handle dropped
-// beads defensively (e.g. the cache reconciler verifying via Get) may proceed
-// with the partial result, while callers that require a complete picture
-// should treat this as a hard failure.
+// PartialResultError indicates that a list-style bd command returned at least
+// one usable entry but also included entries that failed to parse. The
+// successful entries are still returned alongside this error; callers that can
+// surface partial data may proceed with those rows, while callers that require
+// a complete picture should treat this as a hard failure.
 type PartialResultError struct {
 	// Op identifies the bd subcommand that produced the partial result
 	// (e.g. "bd list", "bd ready").
@@ -360,7 +359,8 @@ func (e *PartialResultError) Unwrap() error {
 	return e.Err
 }
 
-func isPartialResultError(err error) bool {
+// IsPartialResult reports whether err wraps a PartialResultError.
+func IsPartialResult(err error) bool {
 	var partial *PartialResultError
 	return errors.As(err, &partial)
 }
@@ -810,6 +810,9 @@ func (s *BdStore) List(query ListQuery) ([]Bead, error) {
 	}
 	filtered := applyListQuery(result, query)
 	if parseErr != nil {
+		if len(filtered) == 0 {
+			return nil, fmt.Errorf("bd list: %w", parseErr)
+		}
 		// Surface partial-parse outcomes so callers can distinguish a complete
 		// list from one that silently dropped entries. Treating a partial list
 		// as authoritative has driven a runaway cache-reconcile loop in the
@@ -890,6 +893,9 @@ func (s *BdStore) Ready() ([]Bead, error) {
 		result = append(result, bead)
 	}
 	if parseErr != nil {
+		if len(result) == 0 {
+			return nil, fmt.Errorf("bd ready: %w", parseErr)
+		}
 		return result, &PartialResultError{Op: "bd ready", Err: parseErr}
 	}
 	return result, nil

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -624,6 +624,51 @@ func TestBdStoreListReturnsPartialResultsOnCorruptEntries(t *testing.T) {
 	}
 }
 
+func TestBdStoreListReturnsHardErrorWithoutUsableSurvivors(t *testing.T) {
+	tests := []struct {
+		name string
+		out  []byte
+	}{
+		{
+			name: "malformed top-level json",
+			out:  []byte(`{not-json`),
+		},
+		{
+			name: "all entries corrupt",
+			out: []byte(`[
+				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time"}
+			]`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := fakeRunner(map[string]struct {
+				out []byte
+				err error
+			}{
+				`bd list --json --include-infra --include-gates --limit 0`: {out: tc.out},
+			})
+
+			s := beads.NewBdStore("/city", runner)
+			got, err := s.ListOpen()
+			if err == nil {
+				t.Fatal("ListOpen() error = nil, want hard parse error")
+			}
+			if len(got) != 0 {
+				t.Fatalf("ListOpen() returned %v, want no usable survivors", got)
+			}
+			var partial *beads.PartialResultError
+			if errors.As(err, &partial) {
+				t.Fatalf("ListOpen() error = %v, want hard parse error not *PartialResultError", err)
+			}
+			if !strings.Contains(err.Error(), "bd list") {
+				t.Fatalf("ListOpen() error = %q, want bd list context", err)
+			}
+		})
+	}
+}
+
 func TestBdStoreReadyReturnsPartialResultErrorOnCorruptEntries(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte
@@ -648,6 +693,35 @@ func TestBdStoreReadyReturnsPartialResultErrorOnCorruptEntries(t *testing.T) {
 	}
 	if partial.Op != "bd ready" {
 		t.Errorf("PartialResultError.Op = %q, want %q", partial.Op, "bd ready")
+	}
+}
+
+func TestBdStoreReadyReturnsHardErrorWithoutUsableSurvivors(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-bad","title":"bad","status":"open","issue_type":"task","created_at":"not-a-time"}
+			]`),
+		},
+	})
+
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready()
+	if err == nil {
+		t.Fatal("Ready() error = nil, want hard parse error")
+	}
+	if len(got) != 0 {
+		t.Fatalf("Ready() returned %v, want no usable survivors", got)
+	}
+	var partial *beads.PartialResultError
+	if errors.As(err, &partial) {
+		t.Fatalf("Ready() error = %v, want hard parse error not *PartialResultError", err)
+	}
+	if !strings.Contains(err.Error(), "bd ready") {
+		t.Fatalf("Ready() error = %q, want bd ready context", err)
 	}
 }
 

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -165,7 +165,10 @@ func (c *CachingStore) PrimeActive() error {
 	for _, status := range []string{"open", "in_progress"} {
 		beads, err := c.backing.List(ListQuery{Status: status})
 		if err != nil {
-			return fmt.Errorf("prime active (%s): %w", status, err)
+			if !isPartialResultError(err) {
+				return fmt.Errorf("prime active (%s): %w", status, err)
+			}
+			c.recordProblem(fmt.Sprintf("prime active (%s)", status), err)
 		}
 		all = append(all, beads...)
 	}
@@ -205,6 +208,11 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	for attempt := 1; attempt <= 3; attempt++ {
 		all, err = c.backing.List(ListQuery{AllowScan: true}) // active beads only (default)
 		if err == nil {
+			break
+		}
+		if isPartialResultError(err) {
+			c.recordProblem("prime cache: partial list", err)
+			err = nil
 			break
 		}
 		c.recordProblem(fmt.Sprintf("prime cache attempt %d/3", attempt), err)

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -27,16 +27,17 @@ type CachingStore struct {
 	backing  Store // runtime: always *BdStore; tests may use MemStore
 	idPrefix string
 
-	mu           sync.RWMutex
-	beads        map[string]Bead
-	deps         map[string][]Dep
-	depsComplete bool
-	dirty        map[string]struct{}
-	beadSeq      map[string]uint64
-	deletedSeq   map[string]uint64
-	state        cacheState
-	lastFreshAt  time.Time
-	mutationSeq  uint64
+	mu              sync.RWMutex
+	beads           map[string]Bead
+	deps            map[string][]Dep
+	depsComplete    bool
+	dirty           map[string]struct{}
+	beadSeq         map[string]uint64
+	deletedSeq      map[string]uint64
+	state           cacheState
+	lastFreshAt     time.Time
+	mutationSeq     uint64
+	primePartialErr error
 
 	reconciling  atomic.Bool
 	syncFailures int
@@ -162,12 +163,14 @@ func (c *CachingStore) PrimeActive() error {
 	c.mu.RUnlock()
 
 	var all []Bead
+	var partialErr error
 	for _, status := range []string{"open", "in_progress"} {
 		beads, err := c.backing.List(ListQuery{Status: status})
 		if err != nil {
-			if !isPartialResultError(err) {
+			if !IsPartialResult(err) {
 				return fmt.Errorf("prime active (%s): %w", status, err)
 			}
+			partialErr = errors.Join(partialErr, err)
 			c.recordProblem(fmt.Sprintf("prime active (%s)", status), err)
 		}
 		all = append(all, beads...)
@@ -190,6 +193,7 @@ func (c *CachingStore) PrimeActive() error {
 	if c.state == cacheUninitialized {
 		c.state = cachePartial
 	}
+	c.primePartialErr = partialErr
 	c.markFreshLocked(time.Now())
 	c.updateStatsLocked()
 	return nil
@@ -205,13 +209,15 @@ func (c *CachingStore) Prime(_ context.Context) error {
 
 	var all []Bead
 	var err error
+	var partialErr error
 	for attempt := 1; attempt <= 3; attempt++ {
 		all, err = c.backing.List(ListQuery{AllowScan: true}) // active beads only (default)
 		if err == nil {
 			break
 		}
-		if isPartialResultError(err) {
+		if IsPartialResult(err) {
 			c.recordProblem("prime cache: partial list", err)
+			partialErr = err
 			err = nil
 			break
 		}
@@ -264,6 +270,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	c.state = cacheLive
 	c.syncFailures = 0
 	c.stats.SyncFailures = 0
+	c.primePartialErr = partialErr
 	c.markFreshLocked(now)
 	c.updateStatsLocked()
 	return nil

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -427,12 +427,12 @@ func TestCachingStorePrimeActiveUsesPartialResultRows(t *testing.T) {
 		t.Fatalf("PrimeActive: %v", err)
 	}
 
-	items, ok := cache.CachedList(ListQuery{AllowScan: true})
-	if !ok {
-		t.Fatal("CachedList ok = false, want primed cache")
-	}
-	if !hasBead(items, open.ID) || !hasBead(items, inProgress.ID) {
-		t.Fatalf("CachedList = %+v, want partial open row and in-progress row", items)
+	cache.mu.RLock()
+	_, hasOpen := cache.beads[open.ID]
+	_, hasInProgress := cache.beads[inProgress.ID]
+	cache.mu.RUnlock()
+	if !hasOpen || !hasInProgress {
+		t.Fatalf("cache.beads has open=%v in_progress=%v, want both partial rows retained", hasOpen, hasInProgress)
 	}
 	stats := cache.Stats()
 	if stats.ProblemCount != 1 {
@@ -463,12 +463,11 @@ func TestCachingStorePrimeUsesPartialResultRows(t *testing.T) {
 		t.Fatalf("Prime: %v", err)
 	}
 
-	items, ok := cache.CachedList(ListQuery{AllowScan: true})
-	if !ok {
-		t.Fatal("CachedList ok = false, want primed cache")
-	}
-	if !hasBead(items, survivor.ID) {
-		t.Fatalf("CachedList = %+v, want partial survivor %s", items, survivor.ID)
+	cache.mu.RLock()
+	_, hasSurvivor := cache.beads[survivor.ID]
+	cache.mu.RUnlock()
+	if !hasSurvivor {
+		t.Fatalf("cache.beads missing partial survivor %s", survivor.ID)
 	}
 	stats := cache.Stats()
 	if stats.ProblemCount != 1 {
@@ -479,6 +478,130 @@ func TestCachingStorePrimeUsesPartialResultRows(t *testing.T) {
 	}
 	if cache.state != cacheLive {
 		t.Fatalf("state = %v, want cacheLive", cache.state)
+	}
+}
+
+func TestCachingStoreCachedListRejectsPartialPrime(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{
+		Store:            NewMemStore(),
+		partialAllowScan: true,
+	}
+	survivor, err := backing.Create(Bead{Title: "survives partial prime"})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	if _, err := backing.Create(Bead{Title: "dropped by bd parse"}); err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	backing.partialRows = []Bead{survivor}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	items, ok := cache.CachedList(ListQuery{AllowScan: true})
+	if ok {
+		t.Fatalf("CachedList ok = true with items %+v, want ok=false while primePartialErr is set", items)
+	}
+}
+
+func TestCachingStorePrimePartialDoesNotServeActiveListAsComplete(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{
+		Store:            NewMemStore(),
+		partialAllowScan: true,
+	}
+	survivor, err := backing.Create(Bead{Title: "survives partial prime"})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	dropped, err := backing.Create(Bead{Title: "dropped by bd parse"})
+	if err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	backing.partialRows = []Bead{survivor}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	items, err := cache.List(ListQuery{AllowScan: true})
+	var partial *PartialResultError
+	if !errors.As(err, &partial) {
+		t.Fatalf("List() error = %v, want *PartialResultError after partial prime", err)
+	}
+	if hasBead(items, dropped.ID) {
+		t.Fatalf("List() returned dropped bead %s despite backing partial rows: %+v", dropped.ID, items)
+	}
+	if !hasBead(items, survivor.ID) {
+		t.Fatalf("List() = %+v, want partial survivor %s", items, survivor.ID)
+	}
+}
+
+func TestCachingStorePrimeActivePartialFallsBackForActiveList(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{
+		Store:           NewMemStore(),
+		partialStatuses: map[string]bool{"open": true},
+	}
+	survivor, err := backing.Create(Bead{Title: "survives partial active prime"})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	dropped, err := backing.Create(Bead{Title: "dropped from primed status"})
+	if err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	backing.partialRows = []Bead{survivor}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	items, err := cache.List(ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("List() error = %v, want clean backing fallback", err)
+	}
+	if !hasBead(items, survivor.ID) || !hasBead(items, dropped.ID) {
+		t.Fatalf("List() = %+v, want backing fallback to return survivor %s and dropped %s", items, survivor.ID, dropped.ID)
+	}
+}
+
+func TestCachingStoreReadyFallsBackAfterPartialPrime(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{
+		Store:            NewMemStore(),
+		partialAllowScan: true,
+	}
+	survivor, err := backing.Create(Bead{Title: "survives partial prime"})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	dropped, err := backing.Create(Bead{Title: "dropped by bd parse"})
+	if err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	backing.partialRows = []Bead{survivor}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	items, err := cache.Ready()
+	if err != nil {
+		t.Fatalf("Ready() error = %v, want backing fallback success", err)
+	}
+	if !hasBead(items, survivor.ID) || !hasBead(items, dropped.ID) {
+		t.Fatalf("Ready() = %+v, want backing fallback to include survivor %s and dropped %s", items, survivor.ID, dropped.ID)
 	}
 }
 
@@ -503,8 +626,17 @@ func TestCachingStoreRunReconciliationDoesNotTreatPartialResultAsAuthoritative(t
 	}
 
 	backing.partialAllowScan = true
-	backing.partialRows = []Bead{survivor}
-	for i := 0; i < maxCacheSyncFailures; i++ {
+	claimedStatus := "in_progress"
+	if err := backing.Update(survivor.ID, UpdateOpts{Status: &claimedStatus}); err != nil {
+		t.Fatalf("Update(survivor): %v", err)
+	}
+	updatedSurvivor, err := backing.Get(survivor.ID)
+	if err != nil {
+		t.Fatalf("Get(updated survivor): %v", err)
+	}
+	backing.partialRows = []Bead{updatedSurvivor}
+	cache.runReconciliation()
+	for i := 1; i < maxCacheSyncFailures; i++ {
 		cache.runReconciliation()
 	}
 
@@ -512,14 +644,21 @@ func TestCachingStoreRunReconciliationDoesNotTreatPartialResultAsAuthoritative(t
 		if event == "bead.closed:"+dropped.ID {
 			t.Fatalf("partial reconcile emitted synthetic close for dropped row: %v", events)
 		}
+		if event == "bead.updated:"+survivor.ID {
+			t.Fatalf("partial reconcile emitted update for survivor row: %v", events)
+		}
 	}
 	cache.mu.RLock()
 	_, stillCached := cache.beads[dropped.ID]
+	cachedSurvivor := cache.beads[survivor.ID]
 	state := cache.state
 	syncFailures := cache.syncFailures
 	cache.mu.RUnlock()
 	if !stillCached {
 		t.Fatalf("dropped row %s was evicted from cache after partial reconcile", dropped.ID)
+	}
+	if cachedSurvivor.Status == claimedStatus {
+		t.Fatalf("survivor status = %q, want partial reconcile to leave cached status non-authoritative", cachedSurvivor.Status)
 	}
 	if state != cacheDegraded {
 		t.Fatalf("state = %v, want cacheDegraded after repeated partial list failures", state)
@@ -530,6 +669,85 @@ func TestCachingStoreRunReconciliationDoesNotTreatPartialResultAsAuthoritative(t
 	stats := cache.Stats()
 	if stats.ProblemCount != int64(maxCacheSyncFailures) {
 		t.Fatalf("ProblemCount = %d, want %d", stats.ProblemCount, maxCacheSyncFailures)
+	}
+}
+
+func TestCachingStoreRunReconciliationDegradesImmediatelyOnPartialResult(t *testing.T) {
+	t.Parallel()
+
+	backing := &readyCountingPartialListStore{
+		partialListErrorStore: &partialListErrorStore{
+			Store:           NewMemStore(),
+			partialStatuses: map[string]bool{"open": true},
+		},
+	}
+	survivor, err := backing.Create(Bead{Title: "survives partial list"})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	if _, err := backing.Create(Bead{Title: "dropped by bd parse"}); err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.partialAllowScan = true
+	backing.partialRows = []Bead{survivor}
+	cache.runReconciliation()
+
+	cache.mu.RLock()
+	state := cache.state
+	cache.mu.RUnlock()
+	if state != cacheDegraded {
+		t.Fatalf("state = %v, want cacheDegraded after one partial reconcile", state)
+	}
+	items, err := cache.List(ListQuery{Status: "open"})
+	if !IsPartialResult(err) {
+		t.Fatalf("List() error = %v, want PartialResultError", err)
+	}
+	if !hasBead(items, survivor.ID) {
+		t.Fatalf("List() = %+v, want survivor %s from backing fallback", items, survivor.ID)
+	}
+	if cached, ok := cache.CachedList(ListQuery{Status: "open"}); ok {
+		t.Fatalf("CachedList() = %+v, true; want unavailable after partial reconcile", cached)
+	}
+	readyCalls := backing.readyCalls
+	if _, err := cache.Ready(); err != nil {
+		t.Fatalf("Ready(): %v", err)
+	}
+	if backing.readyCalls == readyCalls {
+		t.Fatalf("Ready() did not fall back to backing store after partial reconcile")
+	}
+}
+
+func TestCachingStoreRunReconciliationDegradesPartialCache(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{Store: NewMemStore()}
+	if _, err := backing.Create(Bead{Title: "active bead"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	backing.partialAllowScan = true
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cache.runReconciliation()
+	}
+
+	cache.mu.RLock()
+	state := cache.state
+	syncFailures := cache.syncFailures
+	cache.mu.RUnlock()
+	if state != cacheDegraded {
+		t.Fatalf("state = %v, want cacheDegraded after repeated partial reconcile failures from cachePartial", state)
+	}
+	if syncFailures != maxCacheSyncFailures {
+		t.Fatalf("syncFailures = %d, want %d", syncFailures, maxCacheSyncFailures)
 	}
 }
 
@@ -798,7 +1016,7 @@ func (s *partialListErrorStore) List(query ListQuery) ([]Bead, error) {
 	if err != nil {
 		return nil, err
 	}
-	if s.partialStatuses[query.Status] || s.partialAllowScan && query.AllowScan {
+	if s.partialStatuses[query.Status] || (s.partialAllowScan && query.AllowScan) {
 		if s.partialRows != nil {
 			items = make([]Bead, len(s.partialRows))
 			for i := range s.partialRows {
@@ -811,6 +1029,16 @@ func (s *partialListErrorStore) List(query ListQuery) ([]Bead, error) {
 		}
 	}
 	return items, nil
+}
+
+type readyCountingPartialListStore struct {
+	*partialListErrorStore
+	readyCalls int
+}
+
+func (s *readyCountingPartialListStore) Ready() ([]Bead, error) {
+	s.readyCalls++
+	return s.partialListErrorStore.Ready()
 }
 
 func hasBead(items []Bead, id string) bool {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -402,6 +402,137 @@ func TestCachingStoreRunReconciliationRecordsProblemAndDegrades(t *testing.T) {
 	}
 }
 
+func TestCachingStorePrimeActiveUsesPartialResultRows(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{
+		Store:           NewMemStore(),
+		partialStatuses: map[string]bool{"open": true},
+	}
+	open, err := backing.Create(Bead{Title: "open survivor"})
+	if err != nil {
+		t.Fatalf("Create(open): %v", err)
+	}
+	inProgress, err := backing.Create(Bead{Title: "in progress survivor"})
+	if err != nil {
+		t.Fatalf("Create(in_progress): %v", err)
+	}
+	status := "in_progress"
+	if err := backing.Update(inProgress.ID, UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("Update(in_progress): %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	items, ok := cache.CachedList(ListQuery{AllowScan: true})
+	if !ok {
+		t.Fatal("CachedList ok = false, want primed cache")
+	}
+	if !hasBead(items, open.ID) || !hasBead(items, inProgress.ID) {
+		t.Fatalf("CachedList = %+v, want partial open row and in-progress row", items)
+	}
+	stats := cache.Stats()
+	if stats.ProblemCount != 1 {
+		t.Fatalf("ProblemCount = %d, want 1", stats.ProblemCount)
+	}
+	if !strings.Contains(stats.LastProblem, "prime active (open)") {
+		t.Fatalf("LastProblem = %q, want prime active context", stats.LastProblem)
+	}
+	if cache.state != cachePartial {
+		t.Fatalf("state = %v, want cachePartial", cache.state)
+	}
+}
+
+func TestCachingStorePrimeUsesPartialResultRows(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{
+		Store:            NewMemStore(),
+		partialAllowScan: true,
+	}
+	survivor, err := backing.Create(Bead{Title: "prime survivor"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	items, ok := cache.CachedList(ListQuery{AllowScan: true})
+	if !ok {
+		t.Fatal("CachedList ok = false, want primed cache")
+	}
+	if !hasBead(items, survivor.ID) {
+		t.Fatalf("CachedList = %+v, want partial survivor %s", items, survivor.ID)
+	}
+	stats := cache.Stats()
+	if stats.ProblemCount != 1 {
+		t.Fatalf("ProblemCount = %d, want 1", stats.ProblemCount)
+	}
+	if !strings.Contains(stats.LastProblem, "prime cache") {
+		t.Fatalf("LastProblem = %q, want prime cache context", stats.LastProblem)
+	}
+	if cache.state != cacheLive {
+		t.Fatalf("state = %v, want cacheLive", cache.state)
+	}
+}
+
+func TestCachingStoreRunReconciliationDoesNotTreatPartialResultAsAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	backing := &partialListErrorStore{Store: NewMemStore()}
+	survivor, err := backing.Create(Bead{Title: "survives partial list"})
+	if err != nil {
+		t.Fatalf("Create(survivor): %v", err)
+	}
+	dropped, err := backing.Create(Bead{Title: "dropped by bd parse"})
+	if err != nil {
+		t.Fatalf("Create(dropped): %v", err)
+	}
+	var events []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		events = append(events, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	backing.partialAllowScan = true
+	backing.partialRows = []Bead{survivor}
+	for i := 0; i < maxCacheSyncFailures; i++ {
+		cache.runReconciliation()
+	}
+
+	for _, event := range events {
+		if event == "bead.closed:"+dropped.ID {
+			t.Fatalf("partial reconcile emitted synthetic close for dropped row: %v", events)
+		}
+	}
+	cache.mu.RLock()
+	_, stillCached := cache.beads[dropped.ID]
+	state := cache.state
+	syncFailures := cache.syncFailures
+	cache.mu.RUnlock()
+	if !stillCached {
+		t.Fatalf("dropped row %s was evicted from cache after partial reconcile", dropped.ID)
+	}
+	if state != cacheDegraded {
+		t.Fatalf("state = %v, want cacheDegraded after repeated partial list failures", state)
+	}
+	if syncFailures != maxCacheSyncFailures {
+		t.Fatalf("syncFailures = %d, want %d", syncFailures, maxCacheSyncFailures)
+	}
+	stats := cache.Stats()
+	if stats.ProblemCount != int64(maxCacheSyncFailures) {
+		t.Fatalf("ProblemCount = %d, want %d", stats.ProblemCount, maxCacheSyncFailures)
+	}
+}
+
 func TestCachingStoreNextReconcileDelayUsesFreshnessWatchdog(t *testing.T) {
 	t.Parallel()
 
@@ -653,6 +784,42 @@ func (s *listFailingStore) List(query ListQuery) ([]Bead, error) {
 		return nil, errors.New("transient list failure")
 	}
 	return s.Store.List(query)
+}
+
+type partialListErrorStore struct {
+	Store
+	partialStatuses  map[string]bool
+	partialAllowScan bool
+	partialRows      []Bead
+}
+
+func (s *partialListErrorStore) List(query ListQuery) ([]Bead, error) {
+	items, err := s.Store.List(query)
+	if err != nil {
+		return nil, err
+	}
+	if s.partialStatuses[query.Status] || s.partialAllowScan && query.AllowScan {
+		if s.partialRows != nil {
+			items = make([]Bead, len(s.partialRows))
+			for i := range s.partialRows {
+				items[i] = cloneBead(s.partialRows[i])
+			}
+		}
+		return items, &PartialResultError{
+			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		}
+	}
+	return items, nil
+}
+
+func hasBead(items []Bead, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 type partialCloseAllStore struct {

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -8,8 +8,9 @@ import (
 
 // List returns beads matching the query. Active-bead queries are served from
 // cache when available. IncludeClosed queries merge cached active results with
-// backing-store history when possible so callers keep the old best-effort
-// behavior from ListByLabel/ListByMetadata during transient bd failures.
+// backing-store history when possible, preserving partial backing rows when bd
+// reports corrupt entries and retaining cache-only fallback for transient
+// non-partial bd failures.
 func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	if !query.HasFilter() && !query.AllowScan {
 		return nil, fmt.Errorf("listing beads: %w", ErrQueryRequiresScan)
@@ -43,16 +44,16 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 		}
 		c.mu.RUnlock()
 
-		finish := func(items []Bead) ([]Bead, error) {
+		finish := func(items []Bead, err error) ([]Bead, error) {
 			sortBeadsForQuery(items, query.Sort)
 			if query.Limit > 0 && len(items) > query.Limit {
 				items = items[:query.Limit]
 			}
-			return items, nil
+			return items, err
 		}
 
 		if !query.IncludesClosed() {
-			return finish(cached)
+			return finish(cached, nil)
 		}
 
 		// The cache never has a complete closed-only or parent-history view, so
@@ -63,7 +64,9 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 
 		all, err := c.backing.List(query)
 		if err != nil {
-			return finish(cached)
+			if !isPartialResultError(err) {
+				return finish(cached, nil)
+			}
 		}
 
 		seen := make(map[string]bool, len(cached))
@@ -77,7 +80,7 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 			cached = append(cached, b)
 			seen[b.ID] = true
 		}
-		return finish(cached)
+		return finish(cached, err)
 	}
 	c.mu.RUnlock()
 	return c.backing.List(query)

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -29,7 +29,12 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 	c.mu.RLock()
 	state := c.state
 	if state == cacheLive || state == cachePartial {
+		primePartialErr := c.primePartialErr
 		if len(c.dirty) > 0 {
+			c.mu.RUnlock()
+			return c.backing.List(query)
+		}
+		if primePartialErr != nil {
 			c.mu.RUnlock()
 			return c.backing.List(query)
 		}
@@ -64,7 +69,7 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 
 		all, err := c.backing.List(query)
 		if err != nil {
-			if !isPartialResultError(err) {
+			if !IsPartialResult(err) {
 				return finish(cached, nil)
 			}
 		}
@@ -95,6 +100,9 @@ func (c *CachingStore) CachedList(query ListQuery) ([]Bead, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.state != cacheLive && c.state != cachePartial {
+		return nil, false
+	}
+	if c.primePartialErr != nil {
 		return nil, false
 	}
 	cached := make([]Bead, 0, len(c.beads))
@@ -272,6 +280,10 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 	c.mu.RLock()
 	if c.state == cacheLive && c.depsComplete {
 		if len(c.dirty) > 0 {
+			c.mu.RUnlock()
+			return c.backing.Ready()
+		}
+		if c.primePartialErr != nil {
 			c.mu.RUnlock()
 			return c.backing.Ready()
 		}

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -71,7 +71,7 @@ func (c *CachingStore) runReconciliation() {
 	if err != nil {
 		c.mu.Lock()
 		c.syncFailures++
-		if c.syncFailures >= maxCacheSyncFailures && c.state == cacheLive {
+		if (IsPartialResult(err) || c.syncFailures >= maxCacheSyncFailures) && (c.state == cacheLive || c.state == cachePartial) {
 			c.state = cacheDegraded
 		}
 		c.recordProblemLocked("reconcile cache", err)
@@ -157,6 +157,7 @@ func (c *CachingStore) runReconciliation() {
 
 		c.syncFailures = 0
 		c.depsComplete = useFreshDeps
+		c.primePartialErr = nil
 		if c.state == cacheDegraded {
 			c.state = cacheLive
 		}
@@ -230,6 +231,7 @@ func (c *CachingStore) runReconciliation() {
 	c.beadSeq = make(map[string]uint64)
 	c.deletedSeq = make(map[string]uint64)
 	c.syncFailures = 0
+	c.primePartialErr = nil
 	if c.state == cacheDegraded {
 		c.state = cacheLive
 	}

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -1402,6 +1402,35 @@ func TestCachingStoreListIncludeClosedFallsBackToCachedMatches(t *testing.T) {
 	}
 }
 
+func TestCachingStoreListIncludeClosedPreservesPartialBackingRows(t *testing.T) {
+	t.Parallel()
+	backing := &partialIncludeClosedMetadataStore{MemStore: beads.NewMemStore()}
+	open, _ := backing.Create(beads.Bead{Title: "open workflow"})
+	_ = backing.SetMetadata(open.ID, "gc.kind", "workflow")
+	closed, _ := backing.Create(beads.Bead{Title: "closed workflow"})
+	_ = backing.SetMetadata(closed.ID, "gc.kind", "workflow")
+	if err := backing.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cs := beads.NewCachingStoreForTest(backing, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	results, err := cs.List(beads.ListQuery{
+		Metadata:      map[string]string{"gc.kind": "workflow"},
+		IncludeClosed: true,
+	})
+	var partial *beads.PartialResultError
+	if !errors.As(err, &partial) {
+		t.Fatalf("List(include closed) error = %v, want *PartialResultError", err)
+	}
+	if !containsBeadID(results, open.ID) || !containsBeadID(results, closed.ID) {
+		t.Fatalf("results = %+v, want cached active row and partial closed backing row", results)
+	}
+}
+
 type failingIncludeClosedMetadataStore struct {
 	*beads.MemStore
 }
@@ -1411,6 +1440,33 @@ func (s *failingIncludeClosedMetadataStore) List(query beads.ListQuery) ([]beads
 		return nil, errors.New("history unavailable")
 	}
 	return s.MemStore.List(query)
+}
+
+type partialIncludeClosedMetadataStore struct {
+	*beads.MemStore
+}
+
+func (s *partialIncludeClosedMetadataStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	items, err := s.MemStore.List(query)
+	if err != nil {
+		return nil, err
+	}
+	if query.IncludeClosed && len(query.Metadata) > 0 {
+		return items, &beads.PartialResultError{
+			Op:  "bd list",
+			Err: errors.New("skipped 1 corrupt bead"),
+		}
+	}
+	return items, nil
+}
+
+func containsBeadID(items []beads.Bead, id string) bool {
+	for _, item := range items {
+		if item.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func strPtr(s string) *string { return &s }


### PR DESCRIPTION
Follow-up to https://github.com/gastownhall/gascity/pull/1413 after the original PR was already merged.

Original PR title: fix(beads): surface PartialResultError from BdStore.List/Ready
Original PR state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none
Workflow launch bead: ga-rxw3dv
Review root: ga-0i0fnc

This follow-up carries only the maintainer fixups from the approved adopt-pr review branch:

- 6ecbb7979 fix: preserve partial bead results in callers
- 63b6c2e5a fix: preserve partial bead outage semantics

Review synthesis:
- Latest review attempt: 6
- Decision: approve
- Quality score: 899 / 1000, threshold 850
- Required changes: None
- Validated: BdStore List/Ready now surface typed partial results; cache prime/reconcile no longer treat partial scans as authoritative; API/status/session/controller consumers preserve usable survivor rows while surfacing partial state; regression coverage pins survivor behavior and outage semantics.

CI is required before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->