### PR TITLE
test(reconciler): pin post-churn re-wake invariant for named-always sessions (#1493)

### DIFF
--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -80,3 +80,80 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 		t.Fatalf("decision = %+v, want pending wake", got)
 	}
 }
+
+// TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes pins issue
+// #1493: a mode=always named session that hit checkChurn below the
+// quarantine threshold must be re-woken on the next reconciler tick.
+//
+// The metadata shape below is the exact post-churn snapshot reported on the
+// issue: state=asleep, sleep_reason="" (recordChurn does not set
+// sleep_reason below defaultMaxChurnCycles), state_reason="creation_complete"
+// (carried over from the prior wake, untouched by checkChurn/recordChurn),
+// last_woke_at="" (cleared by checkChurn:644 to make the trigger
+// edge-triggered), wake_attempts=0, churn_count=1.
+//
+// The test drives the full bead → AwakeInput → ComputeAwakeSet path so any
+// regression in the lifecycle projection, the bridge, or ComputeAwakeSet
+// fails it. Without the fix, the session sits asleep indefinitely despite
+// mode=always and only `gc session pin` unsticks it.
+func TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "refinery"}},
+		NamedSessions: []config.NamedSession{
+			{Name: "refinery", Template: "refinery", Mode: "always"},
+		},
+	}
+	postChurnBead := beads.Bead{
+		ID:     "mc-session-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":                      "asleep",
+			"sleep_reason":               "",
+			"state_reason":               "creation_complete",
+			"last_woke_at":               "",
+			"wake_attempts":              "0",
+			"churn_count":                "1",
+			"session_key":                "",
+			"continuation_reset_pending": "",
+			"pending_create_claim":       "",
+			"pin_awake":                  "",
+			"session_name":               "refinery",
+			"template":                   "refinery",
+			"configured_named_identity":  "refinery",
+			"configured_named_mode":      "always",
+		},
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		[]beads.Bead{postChurnBead},
+		nil, nil, nil, nil, nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	if len(input.SessionBeads) != 1 {
+		t.Fatalf("SessionBeads length = %d, want 1", len(input.SessionBeads))
+	}
+	bead := input.SessionBeads[0]
+	if bead.NamedIdentity != "refinery" {
+		t.Errorf("projected NamedIdentity = %q, want refinery (configured_named_identity should survive churn)", bead.NamedIdentity)
+	}
+	if bead.State != "asleep" {
+		t.Errorf("projected State = %q, want asleep", bead.State)
+	}
+
+	decisions := ComputeAwakeSet(input)
+	got, ok := decisions["refinery"]
+	if !ok {
+		t.Fatal("decision for 'refinery' missing from awake set")
+	}
+	if !got.ShouldWake {
+		t.Fatalf("post-churn named-always session should wake; got decision = %+v", got)
+	}
+	if got.Reason != "named-always" {
+		t.Errorf("wake reason = %q, want named-always", got.Reason)
+	}
+}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -81,27 +81,15 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 	}
 }
 
-// TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes pins issue
-// #1493: a mode=always named session that hit checkChurn below the
-// quarantine threshold must be re-woken on the next reconciler tick.
-//
-// The metadata shape below is the exact post-churn snapshot reported on the
-// issue: state=asleep, sleep_reason="" (recordChurn does not set
-// sleep_reason below defaultMaxChurnCycles), state_reason="creation_complete"
-// (carried over from the prior wake, untouched by checkChurn/recordChurn),
-// last_woke_at="" (cleared by checkChurn:644 to make the trigger
-// edge-triggered), wake_attempts=0, churn_count=1.
-//
-// The test drives the full bead → AwakeInput → ComputeAwakeSet path so any
-// regression in the lifecycle projection, the bridge, or ComputeAwakeSet
-// fails it. Without the fix, the session sits asleep indefinitely despite
-// mode=always and only `gc session pin` unsticks it.
-func TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes(t *testing.T) {
+// TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes pins the
+// contract for a mode=always named session that was put to sleep after churn:
+// if named-session metadata survives, the next awake-set pass must re-wake it.
+func TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "refinery"}},
+		Agents: []config.Agent{{Name: "worker"}},
 		NamedSessions: []config.NamedSession{
-			{Name: "refinery", Template: "refinery", Mode: "always"},
+			{Name: "worker", Template: "worker", Mode: "always"},
 		},
 	}
 	postChurnBead := beads.Bead{
@@ -119,9 +107,9 @@ func TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes(t *testing.T)
 			"continuation_reset_pending": "",
 			"pending_create_claim":       "",
 			"pin_awake":                  "",
-			"session_name":               "refinery",
-			"template":                   "refinery",
-			"configured_named_identity":  "refinery",
+			"session_name":               "worker",
+			"template":                   "worker",
+			"configured_named_identity":  "worker",
 			"configured_named_mode":      "always",
 		},
 	}
@@ -138,17 +126,17 @@ func TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes(t *testing.T)
 		t.Fatalf("SessionBeads length = %d, want 1", len(input.SessionBeads))
 	}
 	bead := input.SessionBeads[0]
-	if bead.NamedIdentity != "refinery" {
-		t.Errorf("projected NamedIdentity = %q, want refinery (configured_named_identity should survive churn)", bead.NamedIdentity)
+	if bead.NamedIdentity != "worker" {
+		t.Errorf("projected NamedIdentity = %q, want worker (configured_named_identity should survive churn)", bead.NamedIdentity)
 	}
 	if bead.State != "asleep" {
 		t.Errorf("projected State = %q, want asleep", bead.State)
 	}
 
 	decisions := ComputeAwakeSet(input)
-	got, ok := decisions["refinery"]
+	got, ok := decisions["worker"]
 	if !ok {
-		t.Fatal("decision for 'refinery' missing from awake set")
+		t.Fatal("decision for 'worker' missing from awake set")
 	}
 	if !got.ShouldWake {
 		t.Fatalf("post-churn named-always session should wake; got decision = %+v", got)

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1490,56 +1490,6 @@ func TestNamedAlways_SuspensionPropagation(t *testing.T) {
 	}
 }
 
-// TestNamedAlways_PostChurnRewakes pins the wake-after-churn invariant from
-// issue #1493. After checkChurn fires for a non-quarantining churn cycle on
-// a mode=always named session, the projected AwakeSessionBead has
-// State=asleep, SleepReason="" (recordChurn does not set sleep_reason below
-// the quarantine threshold), QuarantinedUntil=zero, and the named identity
-// metadata still present. The reconciler must re-wake it on the next tick;
-// otherwise the session sits asleep indefinitely despite mode=always.
-func TestNamedAlways_PostChurnRewakes(t *testing.T) {
-	result := ComputeAwakeSet(AwakeInput{
-		Agents:        []AwakeAgent{{QualifiedName: "refinery"}},
-		NamedSessions: []AwakeNamedSession{{Identity: "refinery", Template: "refinery", Mode: "always"}},
-		SessionBeads: []AwakeSessionBead{{
-			ID:            "mc-1",
-			SessionName:   "refinery",
-			Template:      "refinery",
-			State:         "asleep",
-			SleepReason:   "", // recordChurn leaves this empty below the quarantine threshold
-			NamedIdentity: "refinery",
-			// QuarantinedUntil zero, HeldUntil zero, WaitHold false,
-			// DependencyOnly false, Drained false, Pinned false: the exact
-			// shape produced by recordChurn when churn_count < defaultMaxChurnCycles.
-		}},
-		Now: now,
-	})
-	assertAwake(t, result, "refinery")
-	assertReason(t, result, "refinery", "named-always")
-}
-
-// TestNamedAlways_QuarantinedAfterChurnDoesNotWake pins the negative half of
-// the invariant: when churn pushes the session into quarantine
-// (QuarantinedUntil in the future), the session must stay asleep until the
-// quarantine elapses. Sibling test to TestNamedAlways_PostChurnRewakes.
-func TestNamedAlways_QuarantinedAfterChurnDoesNotWake(t *testing.T) {
-	result := ComputeAwakeSet(AwakeInput{
-		Agents:        []AwakeAgent{{QualifiedName: "refinery"}},
-		NamedSessions: []AwakeNamedSession{{Identity: "refinery", Template: "refinery", Mode: "always"}},
-		SessionBeads: []AwakeSessionBead{{
-			ID:               "mc-1",
-			SessionName:      "refinery",
-			Template:         "refinery",
-			State:            "asleep",
-			SleepReason:      "context-churn",
-			NamedIdentity:    "refinery",
-			QuarantinedUntil: now.Add(15 * time.Minute),
-		}},
-		Now: now,
-	})
-	assertAsleep(t, result, "refinery")
-}
-
 func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	// Pool with scale=0 and running session. Override must NOT
 	// keep pool sessions alive — scale-down must work.

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1490,6 +1490,56 @@ func TestNamedAlways_SuspensionPropagation(t *testing.T) {
 	}
 }
 
+// TestNamedAlways_PostChurnRewakes pins the wake-after-churn invariant from
+// issue #1493. After checkChurn fires for a non-quarantining churn cycle on
+// a mode=always named session, the projected AwakeSessionBead has
+// State=asleep, SleepReason="" (recordChurn does not set sleep_reason below
+// the quarantine threshold), QuarantinedUntil=zero, and the named identity
+// metadata still present. The reconciler must re-wake it on the next tick;
+// otherwise the session sits asleep indefinitely despite mode=always.
+func TestNamedAlways_PostChurnRewakes(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "refinery"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "refinery", Template: "refinery", Mode: "always"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:            "mc-1",
+			SessionName:   "refinery",
+			Template:      "refinery",
+			State:         "asleep",
+			SleepReason:   "", // recordChurn leaves this empty below the quarantine threshold
+			NamedIdentity: "refinery",
+			// QuarantinedUntil zero, HeldUntil zero, WaitHold false,
+			// DependencyOnly false, Drained false, Pinned false: the exact
+			// shape produced by recordChurn when churn_count < defaultMaxChurnCycles.
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "refinery")
+	assertReason(t, result, "refinery", "named-always")
+}
+
+// TestNamedAlways_QuarantinedAfterChurnDoesNotWake pins the negative half of
+// the invariant: when churn pushes the session into quarantine
+// (QuarantinedUntil in the future), the session must stay asleep until the
+// quarantine elapses. Sibling test to TestNamedAlways_PostChurnRewakes.
+func TestNamedAlways_QuarantinedAfterChurnDoesNotWake(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:        []AwakeAgent{{QualifiedName: "refinery"}},
+		NamedSessions: []AwakeNamedSession{{Identity: "refinery", Template: "refinery", Mode: "always"}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:               "mc-1",
+			SessionName:      "refinery",
+			Template:         "refinery",
+			State:            "asleep",
+			SleepReason:      "context-churn",
+			NamedIdentity:    "refinery",
+			QuarantinedUntil: now.Add(15 * time.Minute),
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "refinery")
+}
+
 func TestScaledPool_NotAffectedByRunningOverride(t *testing.T) {
 	// Pool with scale=0 and running session. Override must NOT
 	// keep pool sessions alive — scale-down must work.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1621,70 +1621,12 @@ func TestReconcileSessionBeads_AlwaysNamedSessionWakesFromDrainedCompatibilitySt
 	}
 }
 
-// TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep pins
-// issue #1493: a mode=always named session that hit checkChurn below the
-// quarantine threshold must be re-woken on the next reconciler tick.
-//
-// The metadata shape below is the exact post-churn snapshot reported on the
-// issue: state=asleep, sleep_reason="" (recordChurn does not set
-// sleep_reason below defaultMaxChurnCycles), state_reason="creation_complete"
-// (carried over from the prior wake, untouched by checkChurn/recordChurn),
-// last_woke_at="" (cleared by checkChurn:644 to make the trigger
-// edge-triggered), wake_attempts=0, churn_count=1.
-//
-// Without the fix the session sits asleep indefinitely despite mode=always,
-// and only `gc session pin` unsticks it (which would set pin_awake=true and
-// route through a different gate).
-func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep(t *testing.T) {
-	env := newReconcilerTestEnv()
-	env.cfg = &config.City{
-		Workspace:     config.Workspace{Name: "test-city"},
-		Agents:        []config.Agent{{Name: "worker", StartCommand: "true"}},
-		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
-	}
-	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
-	env.desiredState[sessionName] = TemplateParams{
-		Command:                 "true",
-		SessionName:             sessionName,
-		TemplateName:            "worker",
-		ConfiguredNamedIdentity: "worker",
-		ConfiguredNamedMode:     "always",
-	}
-	session := env.createSessionBead(sessionName, "worker")
-	env.setSessionMetadata(&session, map[string]string{
-		namedSessionMetadataKey:      "true",
-		namedSessionIdentityMetadata: "worker",
-		namedSessionModeMetadata:     "always",
-		"state":                      "asleep",
-		"sleep_reason":               "",
-		"state_reason":               "creation_complete",
-		"last_woke_at":               "",
-		"wake_attempts":              "0",
-		"churn_count":                "1",
-		"session_key":                "",
-		"continuation_reset_pending": "true",
-	})
-
-	woken := env.reconcile([]beads.Bead{session})
-
-	if woken != 1 {
-		t.Fatalf("woken = %d, want 1 (#1493: post-churn named-always session must re-wake)", woken)
-	}
-	if !env.sp.IsRunning(sessionName) {
-		t.Fatalf("always named session %q should have been restarted after post-churn sleep (#1493)", sessionName)
-	}
-}
-
 // TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence
-// pins issue #1493 by driving the full crash-then-recover sequence rather
-// than pre-staging the post-churn metadata. The first tick records a churn
-// event for a session that survived past stabilityThreshold but died before
-// churnProductivityThreshold; the second tick must wake it.
-//
-// This catches regressions that the pre-staged variant
-// (TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep)
-// would miss because it relies on metadata that healState or recordChurn
-// may write inconsistently with what a hand-staged test sets.
+// pins the expected post-churn contract by driving the full crash-then-recover
+// sequence instead of pre-staging post-churn metadata. This covers the contract
+// needed for issue #1493, but it is not proof that the reported production
+// trigger was reproduced or fixed; keep #1493 open until reporter confirmation
+// or a production-shaped integration shard reproduces the original symptom.
 func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -1701,7 +1643,7 @@ func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence(t *
 		ConfiguredNamedMode:     "always",
 	}
 	session := env.createSessionBead(sessionName, "worker")
-	// Mark the bead as having woken 90 seconds ago — past stabilityThreshold
+	// Mark the bead as having woken 90 seconds ago: past stabilityThreshold
 	// (30s) and before churnProductivityThreshold (5min). This is the churn
 	// band that recordChurn fires for. The session is NOT running in the
 	// fake provider, so the reconciler will see alive=false.
@@ -1754,8 +1696,7 @@ func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence(t *
 // TestReconcileSessionBeads_QuarantinedNamedSessionStaysAsleepAfterChurn pins
 // the negative half of the post-churn invariant: when churn pushes the
 // session into quarantine, the session must stay asleep until the
-// quarantine elapses, even for mode=always. Sibling test to
-// TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep.
+// quarantine elapses, even for mode=always.
 func TestReconcileSessionBeads_QuarantinedNamedSessionStaysAsleepAfterChurn(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1621,6 +1621,177 @@ func TestReconcileSessionBeads_AlwaysNamedSessionWakesFromDrainedCompatibilitySt
 	}
 }
 
+// TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep pins
+// issue #1493: a mode=always named session that hit checkChurn below the
+// quarantine threshold must be re-woken on the next reconciler tick.
+//
+// The metadata shape below is the exact post-churn snapshot reported on the
+// issue: state=asleep, sleep_reason="" (recordChurn does not set
+// sleep_reason below defaultMaxChurnCycles), state_reason="creation_complete"
+// (carried over from the prior wake, untouched by checkChurn/recordChurn),
+// last_woke_at="" (cleared by checkChurn:644 to make the trigger
+// edge-triggered), wake_attempts=0, churn_count=1.
+//
+// Without the fix the session sits asleep indefinitely despite mode=always,
+// and only `gc session pin` unsticks it (which would set pin_awake=true and
+// route through a different gate).
+func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "asleep",
+		"sleep_reason":               "",
+		"state_reason":               "creation_complete",
+		"last_woke_at":               "",
+		"wake_attempts":              "0",
+		"churn_count":                "1",
+		"session_key":                "",
+		"continuation_reset_pending": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1 (#1493: post-churn named-always session must re-wake)", woken)
+	}
+	if !env.sp.IsRunning(sessionName) {
+		t.Fatalf("always named session %q should have been restarted after post-churn sleep (#1493)", sessionName)
+	}
+}
+
+// TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence
+// pins issue #1493 by driving the full crash-then-recover sequence rather
+// than pre-staging the post-churn metadata. The first tick records a churn
+// event for a session that survived past stabilityThreshold but died before
+// churnProductivityThreshold; the second tick must wake it.
+//
+// This catches regressions that the pre-staged variant
+// (TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep)
+// would miss because it relies on metadata that healState or recordChurn
+// may write inconsistently with what a hand-staged test sets.
+func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	// Mark the bead as having woken 90 seconds ago — past stabilityThreshold
+	// (30s) and before churnProductivityThreshold (5min). This is the churn
+	// band that recordChurn fires for. The session is NOT running in the
+	// fake provider, so the reconciler will see alive=false.
+	wokeAt := env.clk.Now().Add(-90 * time.Second).UTC().Format(time.RFC3339)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"last_woke_at":               wokeAt,
+		"session_key":                "old-key",
+	})
+
+	// First tick: detect non-productive death, recordChurn fires, session
+	// transitions through to asleep state.
+	env.reconcile([]beads.Bead{session})
+
+	// Reload the bead from the store to capture every metadata change made
+	// by the reconciler tick (healState, checkChurn, recordChurn).
+	reloaded, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if reloaded.Metadata["churn_count"] != "1" {
+		t.Fatalf("after tick 1 churn_count = %q, want 1 (recordChurn must fire)", reloaded.Metadata["churn_count"])
+	}
+	if reloaded.Metadata["last_woke_at"] != "" {
+		t.Fatalf("after tick 1 last_woke_at = %q, want empty (checkChurn clears it)", reloaded.Metadata["last_woke_at"])
+	}
+
+	// Second tick: the post-churn shape is now in the store. The
+	// named-always session must be re-woken on this tick.
+	env.clk.Time = env.clk.Time.Add(30 * time.Second)
+	env.reconcile([]beads.Bead{reloaded})
+
+	if !env.sp.IsRunning(sessionName) {
+		final, _ := env.store.Get(session.ID)
+		t.Fatalf(
+			"always named session %q must restart on the tick after churn (#1493); state=%q sleep_reason=%q churn_count=%q wake_attempts=%q quarantined_until=%q",
+			sessionName,
+			final.Metadata["state"],
+			final.Metadata["sleep_reason"],
+			final.Metadata["churn_count"],
+			final.Metadata["wake_attempts"],
+			final.Metadata["quarantined_until"],
+		)
+	}
+}
+
+// TestReconcileSessionBeads_QuarantinedNamedSessionStaysAsleepAfterChurn pins
+// the negative half of the post-churn invariant: when churn pushes the
+// session into quarantine, the session must stay asleep until the
+// quarantine elapses, even for mode=always. Sibling test to
+// TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep.
+func TestReconcileSessionBeads_QuarantinedNamedSessionStaysAsleepAfterChurn(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "asleep",
+		"sleep_reason":               "context-churn",
+		"churn_count":                "3",
+		"quarantined_until":          env.clk.Now().Add(15 * time.Minute).UTC().Format(time.RFC3339),
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 (quarantined session must not wake during the quarantine window)", woken)
+	}
+	if env.sp.IsRunning(sessionName) {
+		t.Fatalf("quarantined named session %q must stay asleep until the quarantine elapses", sessionName)
+	}
+}
+
 func TestReconcileSessionBeads_OrdinaryDesiredStateDoesNotWakeDrainedCompatibilityState(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{


### PR DESCRIPTION
## Summary

Pins the wake-after-churn invariant from #1493 with five regression tests at three layers, plus a sibling negative test for the quarantine path.

- `cmd/gc/compute_awake_set_test.go` — `TestNamedAlways_PostChurnRewakes`, `TestNamedAlways_QuarantinedAfterChurnDoesNotWake` (pure `ComputeAwakeSet`)
- `cmd/gc/compute_awake_bridge_test.go` — `TestBuildAwakeInputFromReconciler_NamedAlwaysPostChurnRewakes` (lifecycle projection + bridge + ComputeAwakeSet)
- `cmd/gc/session_reconciler_test.go` — `TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterPostChurnSleep`, `TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence`, `TestReconcileSessionBeads_QuarantinedNamedSessionStaysAsleepAfterChurn` (full reconciler tick, including a live two-tick test where the first tick drives `checkChurn → recordChurn` through the actual reconciler and the second tick must re-wake)

## Reproduction status — important

The reported symptom (a `mode=always` named session sitting asleep indefinitely after `checkChurn` fires below the quarantine threshold) **does not reproduce on `origin/main`**. Every test in this PR — including the live churn sequence — correctly re-wakes the session.

Either:
- `main` has moved past the bug since 1.0.1 (e.g. via #1336/#1367 lifecycle hardening, async start commits, pending-create recovery, or pool ownership identifier fixes), or
- The production trigger has factors the unit-test harness doesn't replicate (real tmux, multi-rig pool layout, specific config layering, or metadata fields not included in the issue's snapshot — `detached_at`, `last_activity`, `sleep_policy_fingerprint`, `continuity_eligible`, `started_config_hash`).

Either way these tests document the expected post-churn re-wake contract end-to-end so any future regression that re-introduces the symptom is caught in CI rather than only in production.

The metadata shape under test mirrors the issue's snapshot exactly:

```
state: asleep
sleep_reason: ""
state_reason: "creation_complete"
last_woke_at: ""
wake_attempts: 0
churn_count: 1
configured_named_mode: "always"
session_key: ""
continuation_reset_pending: ""
```

## Ask for the reporter

@rileywhite — could you confirm whether the original symptom still reproduces on a current `main` build? If yes, please share `gc version` plus the full metadata batch (including `detached_at`, `last_activity`, `sleep_policy_fingerprint`, `continuity_eligible`, `started_config_hash`, and the agent's `sleep_after_idle` setting if any). That will let us narrow which production factor my unit harness is missing.

If no, this PR can land as forward-looking regression coverage and #1493 closes.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] `go test ./cmd/gc/ -count=1` — passes (86s, full package)
- [x] All 5 new tests + 2 existing related tests pass and pin the expected behavior
- [ ] Reporter confirms whether bug still reproduces on current main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->