### PR TITLE
fix(session): release named-session alias on terminal-ish state (ga-ue1r)

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -219,7 +219,38 @@ func preserveConfiguredNamedSessionBead(b beads.Bead, cfg *config.City, cityName
 	if !ok {
 		return false
 	}
-	return strings.TrimSpace(b.Metadata["session_name"]) == spec.SessionName
+	if strings.TrimSpace(b.Metadata["session_name"]) != spec.SessionName {
+		return false
+	}
+	// Identity match. Gate on terminal-ish state so a dead bead releases its
+	// alias instead of holding it forever (ga-ue1r / gm-0fl34g5 incident).
+	state := strings.TrimSpace(b.Metadata["state"])
+	switch state {
+	case "stopped":
+		// Deliberate sleep markers (city-stop, idle-timeout, drained,
+		// user-hold, wait-hold, context-churn, quarantine, no-wake-reason,
+		// config-drift) all signal "the runtime is gone but we plan to
+		// resume this bead" — hold the alias.
+		if strings.TrimSpace(b.Metadata["sleep_reason"]) != "" {
+			return true
+		}
+		// Race guard: preWakeCommit writes last_woke_at atomically before
+		// the runtime confirms started; state stays "stopped" until
+		// ConfirmStartedPatch. Mirror the precedent at city_runtime.go.
+		if lastWoke, ok := parseRFC3339Metadata(b.Metadata["last_woke_at"]); ok {
+			if time.Since(lastWoke) < staleCreatingStateTimeout {
+				return true
+			}
+		}
+		return false
+	case "failed-create":
+		// rollbackPendingCreate sets state="failed-create" only with
+		// Status=closed atomically. A Status=open + state="failed-create"
+		// combination means a write failed mid-rollback — release the
+		// alias so the next spawn can recover.
+		return false
+	}
+	return true
 }
 
 func reopenClosedConfiguredNamedSessionBead(

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1577,6 +1577,64 @@ func TestCloseSessionBeadIfRuntimeStoppedAndUnassigned_StopLeavesRunningKeepsBea
 }
 
 func TestSyncSessionBeads_PreservesConfiguredNamedSessionWithoutDesiredEntry(t *testing.T) {
+	// A configured named session with state=stopped + non-empty sleep_reason
+	// (deliberate sleep marker) must remain Status=open so gc start /
+	// next-wake reuses the same bead. See ga-ue1r policy Q1.
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "refinery", StartCommand: "true", MaxActiveSessions: intPtr(2)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "refinery", Mode: "on_demand"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "refinery")
+	bead, err := store.Create(beads.Bead{
+		Title:  "refinery",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "refinery",
+			"template":                   "refinery",
+			"state":                      "stopped",
+			"sleep_reason":               "city-stop",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "refinery",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create canonical bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, nil, sp, map[string]bool{sessionName: true}, cfg, clk, &stderr, false)
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", bead.ID, err)
+	}
+	if got.Status != "open" {
+		t.Fatalf("status = %q, want open", got.Status)
+	}
+	if got.Metadata["close_reason"] != "" {
+		t.Fatalf("close_reason = %q, want empty", got.Metadata["close_reason"])
+	}
+}
+
+// TestSyncSessionBeads_ReleasesStoppedNamedBeadWithoutSleepReason covers the
+// converse of the test above: a stopped bead with no sleep_reason and no
+// fresh last_woke_at is dead, not deliberately asleep. Its alias must be
+// released (close the bead) so the next spawn can claim the identity. The
+// existing close→reopen path (TestSyncSessionBeads_ReopensClosedConfiguredNamedSession)
+// preserves continuity by reusing the same bead ID on next demand. See
+// ga-ue1r policy Q2.
+func TestSyncSessionBeads_ReleasesStoppedNamedBeadWithoutSleepReason(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)}
 	sp := runtime.NewFake()
@@ -1615,11 +1673,8 @@ func TestSyncSessionBeads_PreservesConfiguredNamedSessionWithoutDesiredEntry(t *
 	if err != nil {
 		t.Fatalf("Get(%s): %v", bead.ID, err)
 	}
-	if got.Status != "open" {
-		t.Fatalf("status = %q, want open", got.Status)
-	}
-	if got.Metadata["close_reason"] != "" {
-		t.Fatalf("close_reason = %q, want empty", got.Metadata["close_reason"])
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed (alias released for re-claim)", got.Status)
 	}
 }
 
@@ -4492,5 +4547,77 @@ func TestSyncSessionBeadsWithSnapshotAndRigStoresLeavesOrphanedSessionBeadOpenWh
 	}
 	if got.Status != "open" {
 		t.Fatalf("session bead status = %q, want open because rig-store work still owns it", got.Status)
+	}
+}
+
+// TestPreserveConfiguredNamedSessionBead_StateGate covers ga-ue1r: a named
+// bead in a terminal-ish state (state="stopped" with no sleep_reason and no
+// fresh last_woke_at, or state="failed-create") must release its alias so the
+// next spawn can claim the identity.
+func TestPreserveConfiguredNamedSessionBead_StateGate(t *testing.T) {
+	cityName := "test-city"
+	workspace := config.Workspace{Name: cityName}
+	cfg := &config.City{
+		Workspace: workspace,
+		Agents: []config.Agent{
+			{Name: "mayor", StartCommand: "true"},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cityName, workspace, "mayor")
+	freshWoke := time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339Nano)
+	staleWoke := time.Now().UTC().Add(-2 * time.Minute).Format(time.RFC3339Nano)
+
+	cases := []struct {
+		name        string
+		state       string
+		sleepReason string
+		lastWokeAt  string
+		want        bool
+	}{
+		{name: "active live bead", state: "active", want: true},
+		{name: "asleep with idle-timeout reason", state: "asleep", sleepReason: "idle-timeout", want: true},
+		{name: "stopped with city-stop reason holds", state: "stopped", sleepReason: "city-stop", want: true},
+		{name: "stopped with idle-timeout reason holds", state: "stopped", sleepReason: "idle-timeout", lastWokeAt: freshWoke, want: true},
+		{name: "stopped fresh wake holds (race guard)", state: "stopped", lastWokeAt: freshWoke, want: true},
+		{name: "stopped stale wake releases", state: "stopped", lastWokeAt: staleWoke, want: false},
+		{name: "stopped never woke releases", state: "stopped", want: false},
+		{name: "failed-create always releases", state: "failed-create", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := map[string]string{
+				"session_name":               sessionName,
+				"alias":                      "mayor",
+				"template":                   "mayor",
+				"agent_name":                 "mayor",
+				"state":                      tc.state,
+				namedSessionMetadataKey:      "true",
+				namedSessionIdentityMetadata: "mayor",
+				namedSessionModeMetadata:     "always",
+			}
+			if tc.sleepReason != "" {
+				meta["sleep_reason"] = tc.sleepReason
+			}
+			if tc.lastWokeAt != "" {
+				meta["last_woke_at"] = tc.lastWokeAt
+			}
+			b := beads.Bead{
+				ID:       "gm-test-" + tc.name,
+				Title:    "mayor",
+				Type:     sessionBeadType,
+				Status:   "open",
+				Labels:   []string{sessionBeadLabel, "agent:mayor"},
+				Metadata: meta,
+			}
+			got := preserveConfiguredNamedSessionBead(b, cfg, cityName)
+			if got != tc.want {
+				t.Fatalf("preserveConfiguredNamedSessionBead(state=%q sleep_reason=%q last_woke_at=%q) = %v, want %v",
+					tc.state, tc.sleepReason, tc.lastWokeAt, got, tc.want)
+			}
+		})
 	}
 }

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -145,6 +145,7 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 		"provider": "contract-agent",
 	}, http.StatusCreated)
 	targetAgent := rigName + "/worker"
+	waitForLiveContractAgent(t, baseURL, validator, cityBase, targetAgent, 30*time.Second)
 
 	publicProviders := liveContractJSON[struct {
 		Items []struct {
@@ -157,13 +158,10 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 	liveContractJSON[map[string]any](t, baseURL, validator, http.MethodGet, cityBase+"/readiness?fresh=false", nil, http.StatusOK)
 	liveContractJSON[map[string]any](t, baseURL, validator, http.MethodGet, cityBase+"/provider-readiness?fresh=false", nil, http.StatusOK)
 	cfg := liveContractJSON[struct {
-		Agents []struct {
-			Name string `json:"name"`
-			Dir  string `json:"dir"`
-		} `json:"agents"`
+		Agents []contractConfigAgent `json:"agents"`
 	}](t, baseURL, validator, http.MethodGet, cityBase+"/config", nil, http.StatusOK)
-	if len(cfg.Agents) == 0 {
-		t.Fatal("GET config returned no agents after creating test agent")
+	if !liveContractConfigHasAgent(cfg.Agents, "worker", rigName) {
+		t.Fatalf("GET config missing created agent %q; agents=%+v", targetAgent, cfg.Agents)
 	}
 
 	runID := strconv.FormatInt(time.Now().UnixNano(), 36)
@@ -208,6 +206,7 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 		t.Fatalf("decode idempotent bead: %v", err)
 	}
 
+	waitForLiveContractAgent(t, baseURL, validator, cityBase, targetAgent, 30*time.Second)
 	liveContractJSON[struct {
 		Status string `json:"status"`
 		Target string `json:"target"`
@@ -611,6 +610,20 @@ type contractGraphDep struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 	Kind string `json:"kind"`
+}
+
+type contractConfigAgent struct {
+	Name string `json:"name"`
+	Dir  string `json:"dir"`
+}
+
+func liveContractConfigHasAgent(agents []contractConfigAgent, name, dir string) bool {
+	for _, agent := range agents {
+		if agent.Name == name && agent.Dir == dir {
+			return true
+		}
+	}
+	return false
 }
 
 func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, targetAgent, rigName, label string) string {
@@ -1290,6 +1303,47 @@ func liveContractRigList(baseURL string, v openapivalidator.Validator, cityBase 
 		return rigs, err
 	}
 	return rigs, nil
+}
+
+func waitForLiveContractAgent(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, targetAgent string, timeout time.Duration) {
+	t.Helper()
+	dir, base, ok := strings.Cut(targetAgent, "/")
+	if !ok || dir == "" || base == "" {
+		t.Fatalf("target agent %q is not a qualified rig agent", targetAgent)
+	}
+	path := cityBase + "/agent/" + url.PathEscape(dir) + "/" + url.PathEscape(base)
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		req, err := liveContractHTTPRequest(baseURL, http.MethodGet, path, nil)
+		if err != nil {
+			t.Fatalf("GET %s build request: %v", path, err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		raw, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			if v != nil {
+				resp.Body = io.NopCloser(bytes.NewReader(raw))
+				validateLiveContractResponse(t, v, req, resp, raw)
+				_ = resp.Body.Close()
+			}
+			return
+		}
+		lastErr = fmt.Errorf("GET %s status %d: %s", path, resp.StatusCode, string(raw))
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for agent %q at %s; last error: %v", targetAgent, path, lastErr)
 }
 
 func runLiveContractReadSweep(t *testing.T, baseURL string, v openapivalidator.Validator, specBytes []byte, cityName, rigName string) {


### PR DESCRIPTION
## Summary

`preserveConfiguredNamedSessionBead` returned `true` for any `Status=open` named bead with a configured `[[agent]]` match — regardless of `Metadata["state"]`. A bead in `state="stopped"` (no live runtime) or `state="failed-create"` kept `Status=open`, held its alias, and rejected every new spawn under that alias with:

```
session beads: alias "<X>" for <X> unavailable: session alias already exists conflicts with concrete session identity on <bead-id>
```

Live symptom: `gm-0fl34g5` blocked the `gascity/builder-1` alias for ~24h on a real city. Clearing `agent_name` metadata manually unblocked spawns immediately, confirming the alias-resolver path was the only thing wedged.

Architecture filed in `ga-ue1r`; builder spec in `ga-qfgu`. RCA done by gascity-investigator; three policy decisions made by deep-investigator subbing for gascity/architect (which couldn't hydrate due to ga-mf1).

## Approach

Gate `preserveConfiguredNamedSessionBead` on terminal-ish state instead of treating identity-match as authoritative for "alias bound":

- **`state="stopped"` + non-empty `sleep_reason` → HOLD.** Deliberate sleep markers (`city-stop`, `idle-timeout`, `drained`, `user-hold`, `wait-hold`, `context-churn`, `quarantine`, `no-wake-reason`, `config-drift`) all signal "the runtime is gone but we plan to resume this bead" — `gc start`/`gc session wake` reuses the same bead.
- **`state="stopped"` + fresh `last_woke_at` (within `staleCreatingStateTimeout`, 60s) → HOLD.** Race guard against `preWakeCommit`, which writes `last_woke_at` atomically before `ConfirmStartedPatch` lands `state="active"`. Mirrors the precedent at `cmd/gc/city_runtime.go`.
- **`state="stopped"` + empty `sleep_reason` + stale-or-empty `last_woke_at` → RELEASE.** Continuity preserved through the existing close→reopen contract: `closeBead`'s `session.ClosePatch` keeps `session_name` and identity metadata, `ensureSessionAliasAvailable` skips closed beads (`internal/session/names.go`), and `reopenClosedConfiguredNamedSessionBead` reuses the same bead ID on next demand. The exact same mechanism that already handles `gc session close`.
- **`state="failed-create"` → RELEASE always.** `rollbackPendingCreate` sets `failed-create` only with `Status=closed` atomically; a `Status=open` + `failed-create` combination means a write failed mid-rollback — releasing lets the next spawn recover.

## Policy decisions (recorded inline)

- **Q1 (city-stop continuity):** HOLD via the `sleep_reason` non-empty branch. `cmd_stop.go` writes `sleep_reason="city-stop"` precisely so `gc start` can resume the same bead.
- **Q2 (supervisor-restart continuity):** RELEASE. Continuity is preserved through close→reopen; same bead ID gets reused. Removes the asymmetry where `gc session close` already released but `state="stopped"` didn't.
- **Q3 (race guard):** `last_woke_at` + `staleCreatingStateTimeout` (60s). Same age-guard pattern already in `city_runtime.go:1526-1533`. `creation_complete_at` is post-confirm and irrelevant for the wake window. `state_changed_at` is unreliable because `state="stopped"` is synthesized by `syncSessionCachedState`, not written through a transition.

## Tests

- **New `TestPreserveConfiguredNamedSessionBead_StateGate`** covers all 8 rows in the policy table:
  - active live bead → preserve
  - asleep with idle-timeout reason → preserve
  - stopped with city-stop reason → preserve
  - stopped with idle-timeout reason → preserve
  - stopped fresh wake (race guard) → preserve
  - stopped stale wake → release
  - stopped never woke → release
  - failed-create → release
- **`TestSyncSessionBeads_PreservesConfiguredNamedSessionWithoutDesiredEntry`** updated. The old version asserted preserve for `state="stopped"` with no `sleep_reason` — the exact behavior this PR is changing. Updated to assert preserve for `state="stopped"` + `sleep_reason="city-stop"` (the HOLD branch).
- **New `TestSyncSessionBeads_ReleasesStoppedNamedBeadWithoutSleepReason`** covers the converse: a stopped bead with no `sleep_reason` and no fresh `last_woke_at` transitions to `Status="closed"` so the alias frees.
- Continuity (close→reopen reuses the same bead ID) is already covered by the existing `TestSyncSessionBeads_ReopensClosedConfiguredNamedSession`.

## Out of scope

- **Bug ga-mf1** (pool-spawn beads never transition `creating → active`) — separate root cause, separate bead. The mayor flagged a live repro on `gm-hj03m`; worth a follow-up investigation after this lands.
- **PRs #1531/#1532/#1533** (sister fixes on the `pending_create_claim` path) — they target a strictly different state bucket. No conflict; this fix doesn't depend on them and they don't depend on this.

## Test plan

- [x] `go test ./cmd/gc/ -run "TestPreserveConfiguredNamedSessionBead_StateGate|TestSyncSessionBeads_PreservesConfigured|TestSyncSessionBeads_ReleasesStopped|TestSyncSessionBeads_ReopensClosed"` passes.
- [x] `go test ./internal/session/ ./internal/sling/` passes.
- [ ] Live verification: `gc sling gascity/builder-1 <bead>` succeeds against a stopped predecessor bead instead of failing with "alias already belongs to".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->