### PR TITLE
feat(formula): polecat self-review runs affected tests when rig provides one

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -7,6 +7,7 @@ package gastown_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,15 +17,25 @@ import (
 	"text/template"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
 func exampleDir() string {
 	_, filename, _, _ := runtime.Caller(0)
 	return filepath.Dir(filename)
+}
+
+func gastownFormulaSearchPaths() []string {
+	dir := exampleDir()
+	return []string{
+		filepath.Join(dir, "packs", "gastown", "formulas"),
+		filepath.Clean(filepath.Join(dir, "..", "..", "internal", "bootstrap", "packs", "core", "formulas")),
+	}
 }
 
 func runCmd(t *testing.T, dir, name string, args ...string) string {
@@ -410,6 +421,59 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 			t.Fatalf("polecat formula must preserve refinery handoff diagnostics and pass a nudge message; found %q", bad)
 		}
 	}
+}
+
+func TestPolecatFormulaSelfReviewRendersAffectedTestModes(t *testing.T) {
+	fallback := cookPolecatSelfReviewDescription(t, map[string]string{
+		"issue":        "HW-42",
+		"test_command": "make test",
+	})
+	if strings.Contains(fallback, "{{affected_tests_command}}") {
+		t.Fatalf("fallback self-review retained affected_tests_command placeholder:\n%s", fallback)
+	}
+	assertContainsInOrder(t, fallback,
+		`if [ -n "" ]; then`,
+		`else`,
+		`make test`,
+	)
+
+	configured := cookPolecatSelfReviewDescription(t, map[string]string{
+		"issue":                  "HW-42",
+		"test_command":           "make test",
+		"affected_tests_command": "scripts/affected-tests.sh",
+	})
+	if strings.Contains(configured, "{{affected_tests_command}}") {
+		t.Fatalf("configured self-review retained affected_tests_command placeholder:\n%s", configured)
+	}
+	assertContainsInOrder(t, configured,
+		`if [ -n "scripts/affected-tests.sh" ]; then`,
+		`scripts/affected-tests.sh`,
+		`else`,
+		`make test`,
+	)
+}
+
+func cookPolecatSelfReviewDescription(t *testing.T, vars map[string]string) string {
+	t.Helper()
+
+	store := beads.NewMemStore()
+	result, err := molecule.Cook(context.Background(), store, "mol-polecat-work", gastownFormulaSearchPaths(), molecule.Options{
+		Title: "HW-42",
+		Vars:  vars,
+	})
+	if err != nil {
+		t.Fatalf("Cook mol-polecat-work: %v", err)
+	}
+
+	selfReviewID := result.IDMapping["mol-polecat-work.self-review"]
+	if selfReviewID == "" {
+		t.Fatalf("cooked formula missing self-review step: %#v", result.IDMapping)
+	}
+	selfReview, err := store.Get(selfReviewID)
+	if err != nil {
+		t.Fatalf("get self-review bead: %v", err)
+	}
+	return selfReview.Description
 }
 
 func TestPolecatPromptDoneSequenceSignalsRefinery(t *testing.T) {

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -85,6 +85,12 @@ The formula step descriptions are your instructions — work through them in ord
 The formula handles everything: load context -> branch setup -> preflight ->
 implement -> self-review + tests -> submit and exit.
 
+**Affected-test gate before push.** The self-review step runs only the tests
+your diff touches when the rig configures `affected_tests_command` (mirrors
+the rig CI's affected-package logic — same script, run locally). Falls back
+to the full `test_command` for rigs without one. Either way, push is gated
+on local pass — don't ship a PR with locally-failing tests.
+
 {{ template "following-mol" . }}
 
 Your formula: `mol-polecat-work`

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -37,7 +37,7 @@ refinery. Resume the existing branch — don't redo all the work.
 | Unsure what to do | Mail Witness, don't guess |"""
 formula = "mol-polecat-work"
 extends = ["mol-polecat-base"]
-version = 9
+version = 10
 
 [vars]
 [vars.binding_prefix]
@@ -177,6 +177,80 @@ Empty setup_command → skip.
 **Exit criteria:** In your worktree, on a clean feature branch, rebased
 on latest {{base_branch}}, deps installed, worktree and branch recorded
 on the bead."""
+
+[[steps]]
+id = "self-review"
+title = "Self-review and run tests (affected-aware)"
+needs = ["implement"]
+description = """
+Review your changes and verify they work. Override of mol-polecat-base
+`self-review` to support affected-test detection — when the rig configures
+`affected_tests_command`, only the tests touched by your diff run, instead
+of the full suite. Saves polecat time and reduces CI clog from PRs whose
+locally-runnable failures should have been caught before push.
+
+**Config: setup_command = {{setup_command}}**
+**Config: typecheck_command = {{typecheck_command}}**
+**Config: lint_command = {{lint_command}}**
+**Config: build_command = {{build_command}}**
+**Config: test_command = {{test_command}}**
+**Config: affected_tests_command = {{affected_tests_command}}**
+
+**1. Review the diff:**
+```bash
+git diff origin/{{base_branch}}...HEAD
+git log --oneline origin/{{base_branch}}..HEAD
+git diff --stat origin/{{base_branch}}...HEAD
+```
+
+Check for: bugs, security issues, style violations, missing error handling,
+debug cruft, unintended file changes. Fix anything you find.
+
+**2. Run quality checks (skip empty commands):**
+```bash
+{{setup_command}}
+{{typecheck_command}}
+{{lint_command}}
+{{build_command}}
+```
+
+**3. Run tests — affected subset if rig provides one, full suite otherwise:**
+```bash
+if [ -n "{{affected_tests_command}}" ]; then
+    # Rig has an affected-tests detector. Run only the tests our diff
+    # touches — same logic the rig's CI uses to dispatch test workflows.
+    # The command must read `git diff --name-only origin/{{base_branch}}...HEAD`
+    # internally and execute the relevant test subset.
+    {{affected_tests_command}}
+else
+    # No affected detector — run the full suite (legacy behavior).
+    {{test_command}}
+fi
+```
+
+**ALL CHECKS MUST PASS.** If your change caused the failure, fix it.
+If pre-existing, file a bead.
+
+Refusing to push on local failure is a feature: the rig's CI will run the
+same affected subset (and more), and a PR that already fails locally will
+fail in CI too — wasting reviewer attention and CI minutes. Fix before
+submitting.
+
+**4. Ensure everything is committed:**
+```bash
+git status                  # Must be clean
+git log origin/{{base_branch}}..HEAD --oneline  # Must show your commits
+```
+
+If uncommitted changes exist:
+```bash
+git add -A && git commit -m "<type>: <description> ({{issue}})"
+```
+
+NEVER discard implementation changes with `git checkout -- .`
+
+**Exit criteria:** All checks pass (affected subset OR full suite), all
+changes committed, working tree clean."""
 
 [[steps]]
 id = "submit-and-exit"

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -23,6 +23,13 @@ only the refinery verifies merges and closes beads.
 `{{base_branch}}` may come from the work bead's own `metadata.target` or
 be inherited from a parent convoy with `metadata.target` set.
 
+## Variables
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| binding_prefix | import binding | Agent identity prefix for bound Gas Town imports. |
+| affected_tests_command | rig `formula_vars` | Shell-safe command that reads `git diff --name-only origin/{{base_branch}}...HEAD` and runs the matching test subset. Empty = run full `test_command`. |
+
 **Rejection-aware.** If the work bead has `metadata.branch` and
 `metadata.rejection_reason`, a previous attempt was rejected by the
 refinery. Resume the existing branch — don't redo all the work.
@@ -42,6 +49,10 @@ version = 10
 [vars]
 [vars.binding_prefix]
 description = "Import binding prefix for gastown agent identities, including trailing dot when bound."
+default = ""
+
+[vars.affected_tests_command]
+description = "Shell-safe affected-tests command. Must read `git diff --name-only origin/{{base_branch}}...HEAD` and run the matching test subset. From rig `formula_vars` or empty to run full test_command."
 default = ""
 
 [[steps]]


### PR DESCRIPTION
## Summary

Override `mol-polecat-work` self-review step (which extends `mol-polecat-base`) to honor a new `{{affected_tests_command}}` template variable. When the rig sets it, the polecat runs only the tests its diff touches — same logic the rig's CI uses to dispatch test workflows — instead of the full `{{test_command}}`. Falls back to the existing `test_command` for rigs without an affected detector, so behavior is unchanged for them.

**Why:** Stop polecats from clogging CI with PRs whose locally-runnable tests would have failed before push. Lots of partser-tightening fallout commits (`fix(ci): skip ...`) recently — those tests would have been caught locally if the polecat ran the affected subset before pushing.

## Files

- `examples/gastown/packs/gastown/formulas/mol-polecat-work.toml` — adds `self-review` step override (currently only `workspace-setup` and `submit-and-exit` are overridden); bumps formula version 8 → 9
- `examples/gastown/packs/gastown/agents/polecat/prompt.template.md` — one-paragraph note about the affected-test gate so polecats know the contract

## Per-rig wiring (out of scope here)

Per-rig packs need to set `affected_tests_command = "scripts/run-affected-tests.sh"` (or equivalent) in their polecat agent config. partcl is doing this in pa-gsvjx — a script that mirrors the dorny/paths-filter DAG in `partcl/.github/workflows/affected.yml`.

## Test plan

- [ ] Polecat in a rig WITHOUT `affected_tests_command` set: runs full `{{test_command}}` in self-review (legacy behavior, unchanged)
- [ ] Polecat in a rig WITH `affected_tests_command = "false"` set: refuses to push (test that the gate works)
- [ ] Polecat in a rig WITH a real `affected_tests_command`: runs only the affected subset; full suite is NOT run by self-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->