### PR TITLE
fix(beads): guard stale hook events; harden auto-port retry test

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3245,7 +3245,15 @@ esac
 		t.Fatal(err)
 	}
 	fakeNC := filepath.Join(binDir, "nc")
-	if err := os.WriteFile(fakeNC, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	fakeNCScript := fmt.Sprintf(`#!/bin/sh
+attempts_file=%q
+count=0
+if [ -f "$attempts_file" ]; then
+  count=$(cat "$attempts_file")
+fi
+[ "$count" -ge 2 ]
+`, attemptsFile)
+	if err := os.WriteFile(fakeNC, []byte(fakeNCScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -42,6 +42,8 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	conflictsCached := cached && cacheEventConflictsCurrent(current, patch, fields)
 	verifiedConflict := false
 	var verifiedClosedBase Bead
+	verifiedRecentLocal := false
+	var verifiedRecentLocalBase Bead
 	if conflictsCached && eventType == "bead.closed" {
 		matchesBacking, verifyErr := c.cacheClosedEventMatchesBacking(patch.ID)
 		if verifyErr != nil {
@@ -60,6 +62,8 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		return
 	}
 	if conflictsCached && recentlyLocal && !verifiedConflict {
+		verifiedRecentLocal = true
+		verifiedRecentLocalBase = cloneBead(current)
 		matchesBacking, verifyErr := c.cacheEventMatchesBacking(patch.ID, patch, fields)
 		if verifyErr == nil && !matchesBacking {
 			return
@@ -97,8 +101,14 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 				if !verifiedConflict || beadChanged(current, verifiedClosedBase) {
 					return
 				}
-			} else if _, locallyMutated := c.beadSeq[patch.ID]; locallyMutated {
-				return
+			} else {
+				if _, locallyMutated := c.beadSeq[patch.ID]; locallyMutated {
+					return
+				}
+				if recentLocalMutation(c.localBeadAt[patch.ID], time.Now()) &&
+					(!verifiedRecentLocal || beadChanged(current, verifiedRecentLocalBase)) {
+					return
+				}
 			}
 		}
 		b = mergeCacheEventPatch(current, patch, fields)

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -37,9 +37,13 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	_, locallyMutated := c.beadSeq[patch.ID]
 	recentlyLocal := recentLocalMutation(c.localBeadAt[patch.ID], now)
 	_, locallyDeleted := c.deletedSeq[patch.ID]
+	conflictsCached := cached && cacheEventConflictsCurrent(current, patch, fields)
+	var conflictBase Bead
+	if conflictsCached {
+		conflictBase = cloneBead(current)
+	}
 	c.mu.RUnlock()
 
-	conflictsCached := cached && cacheEventConflictsCurrent(current, patch, fields)
 	verifiedConflict := false
 	var verifiedClosedBase Bead
 	verifiedRecentLocal := false
@@ -56,14 +60,14 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			return
 		}
 		verifiedConflict = true
-		verifiedClosedBase = cloneBead(current)
+		verifiedClosedBase = conflictBase
 	}
 	if conflictsCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
 		return
 	}
 	if conflictsCached && recentlyLocal && !verifiedConflict {
 		verifiedRecentLocal = true
-		verifiedRecentLocalBase = cloneBead(current)
+		verifiedRecentLocalBase = conflictBase
 		matchesBacking, verifyErr := c.cacheEventMatchesBacking(patch.ID, patch, fields)
 		if verifyErr == nil && !matchesBacking {
 			return

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -652,6 +652,79 @@ func TestCachingStoreApplyEventRechecksLocalMutationBeforeCommit(t *testing.T) {
 	}
 }
 
+func TestCachingStoreApplyEventRechecksRecentLocalAfterGetRefresh(t *testing.T) {
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "base"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	localTitle := "local"
+	if err := cache.Update(bead.ID, UpdateOpts{Title: &localTitle}); err != nil {
+		t.Fatalf("Update local title: %v", err)
+	}
+	cache.mu.Lock()
+	cache.dirty[bead.ID] = struct{}{}
+	cache.mu.Unlock()
+	if _, err := cache.Get(bead.ID); err != nil {
+		t.Fatalf("Get refresh after local update: %v", err)
+	}
+
+	cache.mu.RLock()
+	_, locallyMutated := cache.beadSeq[bead.ID]
+	recentlyLocal := recentLocalMutation(cache.localBeadAt[bead.ID], time.Now())
+	cache.mu.RUnlock()
+	if locallyMutated || !recentlyLocal {
+		t.Fatalf("markers after Get refresh: locallyMutated=%v recentlyLocal=%v, want false/true", locallyMutated, recentlyLocal)
+	}
+
+	externalTitle := "external"
+	if err := backing.Update(bead.ID, UpdateOpts{Title: &externalTitle}); err != nil {
+		t.Fatalf("Update backing external title: %v", err)
+	}
+	payload := json.RawMessage(fmt.Sprintf(`{"id":%q,"title":%q}`, bead.ID, externalTitle))
+
+	beforeCommit := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	cache.applyEventBeforeCommitForTest = func() {
+		close(beforeCommit)
+		<-releaseCommit
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cache.ApplyEvent("bead.updated", payload)
+		close(done)
+	}()
+
+	<-beforeCommit
+	newerTitle := "newer local cache"
+	if err := backing.Update(bead.ID, UpdateOpts{Title: &newerTitle}); err != nil {
+		t.Fatalf("Update backing newer title: %v", err)
+	}
+	cache.mu.Lock()
+	cache.dirty[bead.ID] = struct{}{}
+	cache.mu.Unlock()
+	if _, err := cache.Get(bead.ID); err != nil {
+		t.Fatalf("Get refresh before event commit: %v", err)
+	}
+	close(releaseCommit)
+	<-done
+
+	got, err := cache.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get after stale event race: %v", err)
+	}
+	if got.Title != newerTitle {
+		t.Fatalf("Title after stale event race = %q, want %q", got.Title, newerTitle)
+	}
+}
+
 func TestCachingStoreRunReconciliationRecordsProblemAndDegrades(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- harden `TestGcBeadsBdStartRetriesAutoPortBindConflict` so the fake `nc` probe only succeeds after the second sql-server attempt is recorded
- guard the beads cache against stale `bead.updated` hook events overwriting a newer recent-local refresh
- add regression coverage for the `Get` refresh path where `beadSeq` is cleared while `localBeadAt` remains recent

## Validation
- go test ./cmd/gc -run TestGcBeadsBdStartRetriesAutoPortBindConflict -count=5 -v
- go test ./cmd/gc -run TestGcBeadsBdStartRetriesAutoPortBindConflict -count=10 -v
- go test ./internal/beads -run 'TestCachingStoreApplyEventRechecks(LocalMutationBeforeCommit|RecentLocalAfterGetRefresh)' -count=1
- go test ./internal/beads -count=1
- ./scripts/test-integration-shard packages-cmd-gc-4-of-6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
