### PR TITLE
config: render source provenance in duplicate-agent-name errors

### DIFF
--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -716,11 +716,19 @@ func TestDeepCopyAgentCoversAllFields(t *testing.T) {
 	// Tombstone fields (deprecated in v0.15.1, removed in v0.16) are not
 	// deep-copied; they are accepted by the TOML parser but not propagated
 	// through the runtime. The deep-copy contract deliberately drops them.
+	//
+	// The unexported `source` field (ga-tpfc) is also intentionally
+	// dropped: it is a config-package-internal provenance enum that
+	// describes the agent's discovery origin. Pool instances are derived
+	// objects, not discovery sites, so leaving them at sourceUnknown is
+	// semantically correct and the deep-copy in cmd/gc cannot reach across
+	// the package boundary to set an unexported field anyway.
 	tombstones := map[string]bool{
 		"Skills":       true,
 		"MCP":          true,
 		"SharedSkills": true,
 		"SharedMCP":    true,
+		"source":       true,
 	}
 
 	// Verify every non-tombstone Agent field is set (non-zero) in the test data.

--- a/internal/config/agent_discovery.go
+++ b/internal/config/agent_discovery.go
@@ -51,6 +51,7 @@ func DiscoverPackAgents(fs fsys.FS, packDir, _ string, skipNames map[string]bool
 			agent.Name = agentName
 		}
 		applyAgentConventionDefaults(fs, packDir, &agent)
+		agent.source = sourcePack
 
 		discovered = append(discovered, agent)
 	}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -518,23 +518,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	root.PackGlobals = append(root.PackGlobals, rootPackGlobals...)
 	applyPackGlobals(root)
 
-	// Refine source provenance for default-binding imports (ga-tpfc).
-	// Discovery stamps every pack-loaded agent as sourcePack; here we
-	// promote the subset that came in via pack.toml's
-	// [defaults.rig.imports] to sourceAutoImport so describeSource can
-	// distinguish them in duplicate-name errors.
-	if len(defaultBindings) > 0 {
-		for i := range root.Agents {
-			a := &root.Agents[i]
-			if a.source != sourcePack || a.BindingName == "" {
-				continue
-			}
-			if defaultBindings[a.BindingName] {
-				a.source = sourceAutoImport
-			}
-		}
-	}
-
 	// Validate city-scoped pack requirements.
 	if err := validateCityRequirements(cityReqs, root.Agents); err != nil {
 		return nil, nil, err
@@ -626,26 +609,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, warning)
 	}
 
-	// ga-tpfc.1: promote pack-stamped agents to sourceAutoImport when
-	// their binding came in via implicit-import expansion (the gastown
-	// system pack and similar). describeSource then renders
-	// "<auto-import: …>" for these in duplicate-name errors instead of
-	// the generic "<pack: …>" or empty-string forms. Agents loaded via
-	// loadPackWithCacheOptions arrive with source=sourcePack; we override
-	// based on the post-composition ImplicitImportBindings set so the
-	// override is computed exactly once over the data the loader already
-	// stamped.
-	if len(root.ImplicitImportBindings) > 0 {
-		for i := range root.Agents {
-			a := &root.Agents[i]
-			if a.BindingName == "" {
-				continue
-			}
-			if root.ImplicitImportBindings[a.BindingName] {
-				a.source = sourceAutoImport
-			}
-		}
-	}
+	promoteAutoImportAgentSources(root.Agents, defaultBindings, root.ImplicitImportBindings)
 
 	// Capture revision inputs after all config and pack discovery so callers
 	// can compare the loaded snapshot to future reloads without re-reading
@@ -1244,14 +1208,31 @@ func parseWithMeta(data []byte, source string) (*City, toml.MetaData, []string, 
 	warnings := agentDefaultsCompatibilityWarnings(md, source)
 	normalizeLegacyOrderOverrideAliases(&cfg)
 	warnings = append(warnings, CheckUndecodedKeys(md, source)...)
-	// Stamp source=sourceInline on inline [[agent]] tables. For fragments,
-	// adjustAgentPaths later sets SourceDir, which takes precedence in
-	// describeSource (FR-1). For the root city.toml, SourceDir is empty
-	// and the inline stamp drives the fallback descriptor (FR-3).
+	// Stamp source=sourceInline on inline [[agent]] tables. Fragments may
+	// later set SourceDir, which remains the concrete duplicate-error source.
 	for i := range cfg.Agents {
 		cfg.Agents[i].source = sourceInline
 	}
 	return &cfg, md, warnings, nil
+}
+
+// promoteAutoImportAgentSources centralizes the two auto-import sources:
+// bindings from the city pack's [defaults.rig.imports] and bootstrap implicit
+// imports. Both paths produce normal pack-loaded agents first, then this pass
+// promotes the source stamp exactly once after composition has settled.
+func promoteAutoImportAgentSources(agents []Agent, defaultBindings, implicitBindings map[string]bool) {
+	if len(defaultBindings) == 0 && len(implicitBindings) == 0 {
+		return
+	}
+	for i := range agents {
+		a := &agents[i]
+		if a.source != sourcePack || a.BindingName == "" {
+			continue
+		}
+		if defaultBindings[a.BindingName] || implicitBindings[a.BindingName] {
+			a.source = sourceAutoImport
+		}
+	}
 }
 
 // LoadRootPackDefaultRigImports loads the canonical [defaults.rig.imports]

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -124,6 +124,12 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	cityAgentsForProvenance := root.Agents
 	root.Pricing = dedupePricingByKey(root.Pricing)
 	root.CityPricing = append([]pricing.ModelPricing(nil), root.Pricing...)
+	// defaultBindings names the [defaults.rig.imports] bindings declared
+	// by the city's pack.toml. After expansion, agents whose BindingName
+	// matches one of these names are auto-imports (the user did not
+	// write the [imports.<name>] entry; gc init auto-added it). See
+	// ga-tpfc and the source enum.
+	var defaultBindings map[string]bool
 
 	// V2: if a pack.toml exists alongside city.toml, it is the city's
 	// definition layer. Parse it and merge its content (imports, agents,
@@ -165,6 +171,10 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		var packAgents []Agent
 		for _, a := range pc.Agents {
 			if !cityAgentNames[a.Name] {
+				// Stamp source on the city pack's own [[agent]] blocks
+				// so duplicate-name errors against city.toml inline
+				// agents render a non-empty descriptor (ga-tpfc.1).
+				a.source = sourcePack
 				packAgents = append(packAgents, a)
 			}
 		}
@@ -185,6 +195,12 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		if len(defaultRigIncludes) > 0 {
 			root.Workspace.DefaultRigIncludes = append(defaultRigIncludes, root.Workspace.DefaultRigIncludes...)
+		}
+		if len(pc.Defaults.Rig.Imports) > 0 {
+			defaultBindings = make(map[string]bool, len(pc.Defaults.Rig.Imports))
+			for name := range pc.Defaults.Rig.Imports {
+				defaultBindings[name] = true
+			}
 		}
 		// Merge pack.toml providers (pack is base, city wins).
 		if len(pc.Providers) > 0 {
@@ -502,6 +518,23 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	root.PackGlobals = append(root.PackGlobals, rootPackGlobals...)
 	applyPackGlobals(root)
 
+	// Refine source provenance for default-binding imports (ga-tpfc).
+	// Discovery stamps every pack-loaded agent as sourcePack; here we
+	// promote the subset that came in via pack.toml's
+	// [defaults.rig.imports] to sourceAutoImport so describeSource can
+	// distinguish them in duplicate-name errors.
+	if len(defaultBindings) > 0 {
+		for i := range root.Agents {
+			a := &root.Agents[i]
+			if a.source != sourcePack || a.BindingName == "" {
+				continue
+			}
+			if defaultBindings[a.BindingName] {
+				a.source = sourceAutoImport
+			}
+		}
+	}
+
 	// Validate city-scoped pack requirements.
 	if err := validateCityRequirements(cityReqs, root.Agents); err != nil {
 		return nil, nil, err
@@ -593,10 +626,32 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, warning)
 	}
 
+	// ga-tpfc.1: promote pack-stamped agents to sourceAutoImport when
+	// their binding came in via implicit-import expansion (the gastown
+	// system pack and similar). describeSource then renders
+	// "<auto-import: …>" for these in duplicate-name errors instead of
+	// the generic "<pack: …>" or empty-string forms. Agents loaded via
+	// loadPackWithCacheOptions arrive with source=sourcePack; we override
+	// based on the post-composition ImplicitImportBindings set so the
+	// override is computed exactly once over the data the loader already
+	// stamped.
+	if len(root.ImplicitImportBindings) > 0 {
+		for i := range root.Agents {
+			a := &root.Agents[i]
+			if a.BindingName == "" {
+				continue
+			}
+			if root.ImplicitImportBindings[a.BindingName] {
+				a.source = sourceAutoImport
+			}
+		}
+	}
+
 	// Capture revision inputs after all config and pack discovery so callers
 	// can compare the loaded snapshot to future reloads without re-reading
 	// mutable files from disk.
 	prov.captureRevisionSnapshot(fs, root, cityRoot)
+
 	return root, prov, nil
 }
 
@@ -1189,6 +1244,13 @@ func parseWithMeta(data []byte, source string) (*City, toml.MetaData, []string, 
 	warnings := agentDefaultsCompatibilityWarnings(md, source)
 	normalizeLegacyOrderOverrideAliases(&cfg)
 	warnings = append(warnings, CheckUndecodedKeys(md, source)...)
+	// Stamp source=sourceInline on inline [[agent]] tables. For fragments,
+	// adjustAgentPaths later sets SourceDir, which takes precedence in
+	// describeSource (FR-1). For the root city.toml, SourceDir is empty
+	// and the inline stamp drives the fallback descriptor (FR-3).
+	for i := range cfg.Agents {
+		cfg.Agents[i].source = sourceInline
+	}
 	return &cfg, md, warnings, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1978,7 +1978,36 @@ type Agent struct {
 	// Set during V2 import expansion.
 	// Runtime-only — not persisted to TOML or JSON.
 	PackName string `toml:"-" json:"-"`
+	// source records which configuration origin this agent came from
+	// (inline city.toml, an explicit pack import, or an auto-imported
+	// system pack). Stamped once at discovery; consumed by
+	// describeSource to render duplicate-name errors that never carry
+	// an empty quoted path. Unexported so the value is package-private
+	// runtime state and never appears on any wire. (See ga-tpfc.)
+	source agentSource
 }
+
+// agentSource enumerates the configuration origins recognized by
+// describeSource. Discovery sites stamp exactly one value per agent.
+type agentSource uint8
+
+const (
+	// sourceUnknown is the zero value; agents reach validation
+	// without a stamp when they came through a non-discovery code
+	// path (e.g., test fixtures that build Agents directly).
+	sourceUnknown agentSource = iota
+	// sourceInline marks agents declared as inline [[agent]] tables
+	// in the root city.toml.
+	sourceInline
+	// sourcePack marks agents that came from an explicit pack
+	// import or a workspace.includes entry.
+	sourcePack
+	// sourceAutoImport marks agents that came from a binding the
+	// city pack added via [defaults.rig.imports] (e.g., the
+	// gastown system pack). Even though the binding ends up in
+	// city.Imports after composition, the user did not write it.
+	sourceAutoImport
+)
 
 // IdleTimeoutDuration returns the idle timeout as a time.Duration.
 // Returns 0 if empty or unparseable (disabled).
@@ -2619,8 +2648,7 @@ func configuredProviderOrder(providers map[string]ProviderSpec) []string {
 // invalid pool bounds. Uniqueness is keyed on (dir, name) — the same name
 // in different dirs is allowed.
 func ValidateAgents(agents []Agent) error {
-	seen := make(map[agentKey]bool, len(agents))
-	sourceOf := make(map[agentKey]string, len(agents))
+	seen := make(map[agentKey]int, len(agents))
 	for i, a := range agents {
 		if a.Name == "" {
 			return fmt.Errorf("agent[%d]: name is required", i)
@@ -2629,17 +2657,10 @@ func ValidateAgents(agents []Agent) error {
 			return fmt.Errorf("agent %q: name must match [a-zA-Z0-9][a-zA-Z0-9_-]* (no spaces, slashes, or dots)", a.Name)
 		}
 		key := agentKey{dir: a.Dir, name: a.Name}
-		if seen[key] {
-			prev := sourceOf[key]
-			curr := a.SourceDir
-			if prev != "" || curr != "" {
-				return fmt.Errorf("agent %q: duplicate name (from %q and %q)",
-					a.QualifiedName(), prev, curr)
-			}
-			return fmt.Errorf("agent %q: duplicate name", a.QualifiedName())
+		if priorIdx, dup := seen[key]; dup {
+			return formatDuplicateAgentError(agents[priorIdx], a, "", "")
 		}
-		seen[key] = true
-		sourceOf[key] = a.SourceDir
+		seen[key] = i
 		// Scope enum.
 		switch a.Scope {
 		case "", "city", "rig":
@@ -3021,6 +3042,14 @@ func Parse(data []byte) (*City, error) {
 	// Backwards compat: promote deprecated graph_workflows → formula_v2.
 	if cfg.Daemon.GraphWorkflows && !cfg.Daemon.FormulaV2 {
 		cfg.Daemon.FormulaV2 = true
+	}
+	// Stamp source=sourceInline on agents declared via [[agent]] in
+	// the parsed TOML. These are city.toml inline agents (or test
+	// fixtures using Parse directly); pack agents go through a
+	// different parser (parsePackConfigWithMetadata) which does not
+	// stamp source.
+	for i := range cfg.Agents {
+		cfg.Agents[i].source = sourceInline
 	}
 	return &cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2658,7 +2658,7 @@ func ValidateAgents(agents []Agent) error {
 		}
 		key := agentKey{dir: a.Dir, name: a.Name}
 		if priorIdx, dup := seen[key]; dup {
-			return formatDuplicateAgentError(agents[priorIdx], a, "", "")
+			return formatDuplicateAgentError(agents[priorIdx], a)
 		}
 		seen[key] = i
 		// Scope enum.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3114,7 +3114,10 @@ func TestValidateAgentsDupNameMixedProvenance(t *testing.T) {
 }
 
 func TestValidateAgentsDupNameNoProvenance(t *testing.T) {
-	// Two inline agents with no SourceDir — plain error without provenance.
+	// Two zero-valued agents (no SourceDir, no source enum). Per ga-tpfc.1
+	// the rendered descriptor must always be non-empty; an unstamped agent
+	// renders as <unknown: ...>. The error must never contain an empty
+	// quoted "" path, regardless of the source category.
 	agents := []Agent{
 		{Name: "worker"},
 		{Name: "worker"},
@@ -3127,9 +3130,8 @@ func TestValidateAgentsDupNameNoProvenance(t *testing.T) {
 	if !strings.Contains(errStr, "duplicate name") {
 		t.Errorf("error should say 'duplicate name', got: %s", errStr)
 	}
-	// Should NOT contain "from" when neither has provenance.
-	if strings.Contains(errStr, "from") {
-		t.Errorf("error should not include provenance when neither has SourceDir, got: %s", errStr)
+	if strings.Contains(errStr, `""`) {
+		t.Errorf(`error contains empty quoted "" — descriptors must always be non-empty, got: %s`, errStr)
 	}
 }
 

--- a/internal/config/duplicate_agent_error.go
+++ b/internal/config/duplicate_agent_error.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// describeSource renders a non-empty descriptor for this agent's
+// configuration origin. ValidateAgents uses it to format duplicate-name
+// errors so the operator can distinguish auto-imported system packs from
+// inline city.toml [[agent]] blocks from user packs. The returned string
+// is never empty — that is the visible bug ga-tpfc.1 fixes.
+//
+// Resolution order:
+//
+//  1. SourceDir != "" → return SourceDir as-is. Pinned by existing
+//     tests (TestValidateAgentsDupNameWithProvenance, etc.).
+//  2. source == sourceAutoImport → "<auto-import: <BindingName>>"
+//     when binding is known, else "<auto-import>".
+//  3. source == sourceInline → "<inline: <basename(cityFile)>>" when
+//     a city file path is supplied, else bare "<inline>".
+//  4. source == sourcePack → "<pack: <BindingName>>" when binding is
+//     known, else "<pack>".
+//  5. fall through (sourceUnknown or any unstamped agent) → render an
+//     identity hint: "<unknown: binding=…>" or "<unknown: name=…>"
+//     or "<unknown>".
+//
+// cityRoot is accepted but currently unused; the hook is reserved for
+// future relativization without breaking the call sites already passing
+// it through.
+func (a *Agent) describeSource(cityRoot, cityFile string) string {
+	_ = cityRoot
+	if a.SourceDir != "" {
+		return a.SourceDir
+	}
+	switch a.source {
+	case sourceAutoImport:
+		if a.BindingName != "" {
+			return fmt.Sprintf("<auto-import: %s>", a.BindingName)
+		}
+		return "<auto-import>"
+	case sourceInline:
+		if cityFile != "" {
+			return fmt.Sprintf("<inline: %s>", filepath.Base(cityFile))
+		}
+		return "<inline>"
+	case sourcePack:
+		if a.BindingName != "" {
+			return fmt.Sprintf("<pack: %s>", a.BindingName)
+		}
+		return "<pack>"
+	}
+	if a.BindingName != "" {
+		return fmt.Sprintf("<unknown: binding=%s>", a.BindingName)
+	}
+	if a.Name != "" {
+		return fmt.Sprintf("<unknown: name=%s>", a.Name)
+	}
+	return "<unknown>"
+}
+
+// formatDuplicateAgentError renders the duplicate-agent-name error for a
+// pair of conflicting agents. Co-owned with ga-9ogb (layout-version
+// migration error); that bead specializes (V1Inline, V2Convention) layout
+// pairs onto a migration-guidance variant. This bead's contract: every
+// rendered descriptor is non-empty, so the error never carries an empty
+// quoted "" path.
+//
+// cityRoot and cityFile are passed through to describeSource. Both may
+// be empty when the helper is called from validation paths that do not
+// know the city's filesystem context (e.g., test fixtures that build
+// []Agent directly).
+func formatDuplicateAgentError(a, b Agent, cityRoot, cityFile string) error {
+	return fmt.Errorf("agent %q: duplicate name (from %q and %q)",
+		a.QualifiedName(),
+		a.describeSource(cityRoot, cityFile),
+		b.describeSource(cityRoot, cityFile))
+}

--- a/internal/config/duplicate_agent_error.go
+++ b/internal/config/duplicate_agent_error.go
@@ -1,9 +1,6 @@
 package config
 
-import (
-	"fmt"
-	"path/filepath"
-)
+import "fmt"
 
 // describeSource renders a non-empty descriptor for this agent's
 // configuration origin. ValidateAgents uses it to format duplicate-name
@@ -11,44 +8,29 @@ import (
 // inline city.toml [[agent]] blocks from user packs. The returned string
 // is never empty — that is the visible bug ga-tpfc.1 fixes.
 //
-// Resolution order:
-//
-//  1. SourceDir != "" → return SourceDir as-is. Pinned by existing
-//     tests (TestValidateAgentsDupNameWithProvenance, etc.).
-//  2. source == sourceAutoImport → "<auto-import: <BindingName>>"
-//     when binding is known, else "<auto-import>".
-//  3. source == sourceInline → "<inline: <basename(cityFile)>>" when
-//     a city file path is supplied, else bare "<inline>".
-//  4. source == sourcePack → "<pack: <BindingName>>" when binding is
-//     known, else "<pack>".
-//  5. fall through (sourceUnknown or any unstamped agent) → render an
-//     identity hint: "<unknown: binding=…>" or "<unknown: name=…>"
-//     or "<unknown>".
-//
-// cityRoot is accepted but currently unused; the hook is reserved for
-// future relativization without breaking the call sites already passing
-// it through.
-func (a *Agent) describeSource(cityRoot, cityFile string) string {
-	_ = cityRoot
-	if a.SourceDir != "" {
-		return a.SourceDir
-	}
+// Pack and auto-import sources include the binding descriptor before the
+// source directory so real pack-loaded agents do not hide the user-visible
+// binding behind SourceDir.
+func (a *Agent) describeSource() string {
 	switch a.source {
 	case sourceAutoImport:
-		if a.BindingName != "" {
-			return fmt.Sprintf("<auto-import: %s>", a.BindingName)
-		}
-		return "<auto-import>"
+		return describeBoundSource("auto-import", a.BindingName, a.SourceDir)
 	case sourceInline:
-		if cityFile != "" {
-			return fmt.Sprintf("<inline: %s>", filepath.Base(cityFile))
+		if a.SourceDir != "" {
+			return a.SourceDir
 		}
 		return "<inline>"
 	case sourcePack:
 		if a.BindingName != "" {
-			return fmt.Sprintf("<pack: %s>", a.BindingName)
+			return describeBoundSource("pack", a.BindingName, a.SourceDir)
+		}
+		if a.SourceDir != "" {
+			return a.SourceDir
 		}
 		return "<pack>"
+	}
+	if a.SourceDir != "" {
+		return a.SourceDir
 	}
 	if a.BindingName != "" {
 		return fmt.Sprintf("<unknown: binding=%s>", a.BindingName)
@@ -59,20 +41,26 @@ func (a *Agent) describeSource(cityRoot, cityFile string) string {
 	return "<unknown>"
 }
 
+func describeBoundSource(kind, bindingName, sourceDir string) string {
+	descriptor := fmt.Sprintf("<%s>", kind)
+	if bindingName != "" {
+		descriptor = fmt.Sprintf("<%s: %s>", kind, bindingName)
+	}
+	if sourceDir != "" {
+		return fmt.Sprintf("%s %s", descriptor, sourceDir)
+	}
+	return descriptor
+}
+
 // formatDuplicateAgentError renders the duplicate-agent-name error for a
 // pair of conflicting agents. Co-owned with ga-9ogb (layout-version
 // migration error); that bead specializes (V1Inline, V2Convention) layout
 // pairs onto a migration-guidance variant. This bead's contract: every
 // rendered descriptor is non-empty, so the error never carries an empty
 // quoted "" path.
-//
-// cityRoot and cityFile are passed through to describeSource. Both may
-// be empty when the helper is called from validation paths that do not
-// know the city's filesystem context (e.g., test fixtures that build
-// []Agent directly).
-func formatDuplicateAgentError(a, b Agent, cityRoot, cityFile string) error {
+func formatDuplicateAgentError(a, b Agent) error {
 	return fmt.Errorf("agent %q: duplicate name (from %q and %q)",
 		a.QualifiedName(),
-		a.describeSource(cityRoot, cityFile),
-		b.describeSource(cityRoot, cityFile))
+		a.describeSource(),
+		b.describeSource())
 }

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -14,71 +14,63 @@ import (
 // for every reachable source category so the error never contains an empty
 // quoted "" path (the visible bug ga-tpfc.1 fixes).
 func TestDescribeSource(t *testing.T) {
-	cityRoot := "/home/u/proj"
-	cityFile := "/home/u/proj/city.toml"
-
 	tests := []struct {
-		name      string
-		agent     Agent
-		cityRoot  string
-		cityFile  string
-		want      string
-		wantOneOf []string // any-of match when format is non-deterministic
+		name         string
+		agent        Agent
+		want         string
+		wantContains []string
 	}{
 		{
-			name:     "SourceDir wins over source enum",
-			agent:    Agent{Name: "mayor", SourceDir: "packs/gastown", source: sourceAutoImport},
-			cityRoot: cityRoot,
-			cityFile: cityFile,
-			want:     "packs/gastown",
+			name:  "auto-import with SourceDir renders kind and path",
+			agent: Agent{Name: "mayor", SourceDir: "packs/gastown", BindingName: "gastown", source: sourceAutoImport},
+			wantContains: []string{
+				"<auto-import: gastown>",
+				"packs/gastown",
+			},
 		},
 		{
-			name:     "explicit pack with SourceDir",
-			agent:    Agent{Name: "mayor", SourceDir: "packs/extras", source: sourcePack},
-			cityRoot: cityRoot,
-			cityFile: cityFile,
-			want:     "packs/extras",
+			name:  "explicit pack with SourceDir renders kind and path",
+			agent: Agent{Name: "mayor", SourceDir: "packs/extras", BindingName: "extras", source: sourcePack},
+			wantContains: []string{
+				"<pack: extras>",
+				"packs/extras",
+			},
 		},
 		{
-			name:     "auto-import resolves to bracketed kind/path",
-			agent:    Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
-			cityRoot: cityRoot,
-			cityFile: cityFile,
-			wantOneOf: []string{
+			name:  "pack without binding keeps SourceDir",
+			agent: Agent{Name: "mayor", SourceDir: "packs/extras", source: sourcePack},
+			want:  "packs/extras",
+		},
+		{
+			name:  "auto-import resolves to bracketed kind",
+			agent: Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
+			wantContains: []string{
 				"<auto-import: gastown>",
 				"<auto-import: ",
 			},
 		},
 		{
-			name:     "inline with cityFile renders <inline: file>",
-			agent:    Agent{Name: "mayor", source: sourceInline},
-			cityRoot: cityRoot,
-			cityFile: cityFile,
-			want:     "<inline: city.toml>",
+			name:  "inline with empty SourceDir renders bare <inline>",
+			agent: Agent{Name: "mayor", source: sourceInline},
+			want:  "<inline>",
 		},
 		{
-			name:     "inline with empty cityFile renders bare <inline>",
-			agent:    Agent{Name: "mayor", source: sourceInline},
-			cityRoot: "",
-			cityFile: "",
-			want:     "<inline>",
+			name:  "inline fragment with SourceDir renders path",
+			agent: Agent{Name: "mayor", SourceDir: "fragments/agents.toml", source: sourceInline},
+			want:  "fragments/agents.toml",
 		},
 		{
-			name:     "unknown source must not be empty",
-			agent:    Agent{Name: "mayor"},
-			cityRoot: cityRoot,
-			cityFile: cityFile,
-			wantOneOf: []string{
+			name:  "unknown source must not be empty",
+			agent: Agent{Name: "mayor"},
+			wantContains: []string{
 				"<unknown: name=mayor>",
 				"<unknown:",
 			},
 		},
 		{
-			name:     "unknown source falls back to BindingName when present",
-			agent:    Agent{Name: "polecat", BindingName: "gastown"},
-			cityRoot: cityRoot,
-			cityFile: cityFile,
-			wantOneOf: []string{
+			name:  "unknown source falls back to BindingName when present",
+			agent: Agent{Name: "polecat", BindingName: "gastown"},
+			wantContains: []string{
 				"<unknown: binding=gastown>",
 				"<unknown: ",
 			},
@@ -87,23 +79,22 @@ func TestDescribeSource(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.agent.describeSource(tc.cityRoot, tc.cityFile)
+			got := tc.agent.describeSource()
 			if got == "" {
 				t.Fatalf("describeSource returned empty string — descriptor must always be non-empty")
 			}
 			if tc.want != "" && got != tc.want {
 				t.Errorf("describeSource = %q, want %q", got, tc.want)
 			}
-			if len(tc.wantOneOf) > 0 {
-				ok := false
-				for _, sub := range tc.wantOneOf {
-					if strings.Contains(got, sub) {
-						ok = true
-						break
+			if len(tc.wantContains) > 0 {
+				missing := []string{}
+				for _, sub := range tc.wantContains {
+					if !strings.Contains(got, sub) {
+						missing = append(missing, sub)
 					}
 				}
-				if !ok {
-					t.Errorf("describeSource = %q, want it to contain one of %v", got, tc.wantOneOf)
+				if len(missing) > 0 {
+					t.Errorf("describeSource = %q, missing substrings %v", got, missing)
 				}
 			}
 		})
@@ -191,6 +182,146 @@ scope = "city"
 	}
 	if mayor.source != sourceInline {
 		t.Errorf("mayor.source = %v, want sourceInline", mayor.source)
+	}
+}
+
+func writeDuplicateAgentSourceTestFile(t *testing.T, root, rel, data string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func TestValidateAgents_LoadedPackCollisionRendersPackBinding(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	dir := t.TempDir()
+	writeDuplicateAgentSourceTestFile(t, dir, "city.toml", `
+[workspace]
+name = "test-city"
+
+[imports.tools]
+source = "./packs/tools"
+
+[[agent]]
+name = "worker"
+`)
+	writeDuplicateAgentSourceTestFile(t, dir, "packs/tools/pack.toml", `
+[pack]
+name = "tools"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "city"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	err = ValidateAgents(cfg.Agents)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	got := err.Error()
+	if strings.Contains(got, `""`) {
+		t.Fatalf(`error contains empty quoted ""; full error: %s`, got)
+	}
+	if !strings.Contains(got, "<pack: tools>") {
+		t.Fatalf("error should include pack binding provenance, got: %s", got)
+	}
+	if !strings.Contains(got, filepath.Join(dir, "packs/tools")) {
+		t.Fatalf("error should include pack source dir, got: %s", got)
+	}
+	if !strings.Contains(got, "<inline>") {
+		t.Fatalf("error should include inline provenance, got: %s", got)
+	}
+}
+
+func TestValidateAgents_DefaultRigImportCollisionRendersAutoImportBinding(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	packDir := filepath.Join(dir, "gastown")
+	writeDuplicateAgentSourceTestFile(t, cityDir, "city.toml", `
+[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "proj"
+path = "/tmp/proj"
+
+[rigs.imports.gs]
+source = "../gastown"
+
+[[agent]]
+name = "worker"
+dir = "proj"
+`)
+	writeDuplicateAgentSourceTestFile(t, cityDir, "pack.toml", `
+[pack]
+name = "test-city"
+schema = 2
+
+[defaults.rig.imports.gs]
+source = "../gastown"
+`)
+	writeDuplicateAgentSourceTestFile(t, packDir, "pack.toml", `
+[pack]
+name = "gastown"
+schema = 1
+
+[[agent]]
+name = "worker"
+scope = "rig"
+`)
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	var imported *Agent
+	for i := range cfg.Agents {
+		a := &cfg.Agents[i]
+		if a.Dir == "proj" && a.Name == "worker" && a.BindingName == "gs" {
+			imported = a
+			break
+		}
+	}
+	if imported == nil {
+		t.Fatal("imported rig agent not found")
+	}
+	if imported.source != sourceAutoImport {
+		t.Fatalf("imported source = %v, want sourceAutoImport", imported.source)
+	}
+	if imported.SourceDir == "" {
+		t.Fatal("imported source dir is empty; test must use the real pack-loaded shape")
+	}
+
+	err = ValidateAgents(cfg.Agents)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	got := err.Error()
+	if strings.Contains(got, `""`) {
+		t.Fatalf(`error contains empty quoted ""; full error: %s`, got)
+	}
+	if !strings.Contains(got, "<auto-import: gs>") {
+		t.Fatalf("error should include auto-import binding provenance, got: %s", got)
+	}
+	if !strings.Contains(got, packDir) {
+		t.Fatalf("error should include auto-import source dir, got: %s", got)
+	}
+	if !strings.Contains(got, "<inline>") {
+		t.Fatalf("error should include inline provenance, got: %s", got)
 	}
 }
 

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -225,7 +225,7 @@ func TestApplyAgentOverride_PreservesSource(t *testing.T) {
 // "" path. This is the fallback-suppression invariant the architecture
 // pins.
 func TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos(t *testing.T) {
-	sources := []agentSource{0, sourceInline, sourcePack, sourceAutoImport}
+	sources := []agentSource{sourceUnknown, sourceInline, sourcePack, sourceAutoImport}
 	srcDirs := []string{"", "packs/base"}
 
 	for _, sa := range sources {

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -1,0 +1,249 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestDescribeSource exercises the per-agent descriptor that ValidateAgents
+// uses when rendering duplicate-name errors. The descriptor must be non-empty
+// for every reachable source category so the error never contains an empty
+// quoted "" path (the visible bug ga-tpfc.1 fixes).
+func TestDescribeSource(t *testing.T) {
+	cityRoot := "/home/u/proj"
+	cityFile := "/home/u/proj/city.toml"
+
+	tests := []struct {
+		name      string
+		agent     Agent
+		cityRoot  string
+		cityFile  string
+		want      string
+		wantOneOf []string // any-of match when format is non-deterministic
+	}{
+		{
+			name:     "SourceDir wins over source enum",
+			agent:    Agent{Name: "mayor", SourceDir: "packs/gastown", source: sourceAutoImport},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			want:     "packs/gastown",
+		},
+		{
+			name:     "explicit pack with SourceDir",
+			agent:    Agent{Name: "mayor", SourceDir: "packs/extras", source: sourcePack},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			want:     "packs/extras",
+		},
+		{
+			name:     "auto-import resolves to bracketed kind/path",
+			agent:    Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			wantOneOf: []string{
+				"<auto-import: gastown>",
+				"<auto-import: ",
+			},
+		},
+		{
+			name:     "inline with cityFile renders <inline: file>",
+			agent:    Agent{Name: "mayor", source: sourceInline},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			want:     "<inline: city.toml>",
+		},
+		{
+			name:     "inline with empty cityFile renders bare <inline>",
+			agent:    Agent{Name: "mayor", source: sourceInline},
+			cityRoot: "",
+			cityFile: "",
+			want:     "<inline>",
+		},
+		{
+			name:     "unknown source must not be empty",
+			agent:    Agent{Name: "mayor"},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			wantOneOf: []string{
+				"<unknown: name=mayor>",
+				"<unknown:",
+			},
+		},
+		{
+			name:     "unknown source falls back to BindingName when present",
+			agent:    Agent{Name: "polecat", BindingName: "gastown"},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			wantOneOf: []string{
+				"<unknown: binding=gastown>",
+				"<unknown: ",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.agent.describeSource(tc.cityRoot, tc.cityFile)
+			if got == "" {
+				t.Fatalf("describeSource returned empty string — descriptor must always be non-empty")
+			}
+			if tc.want != "" && got != tc.want {
+				t.Errorf("describeSource = %q, want %q", got, tc.want)
+			}
+			if len(tc.wantOneOf) > 0 {
+				ok := false
+				for _, sub := range tc.wantOneOf {
+					if strings.Contains(got, sub) {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					t.Errorf("describeSource = %q, want it to contain one of %v", got, tc.wantOneOf)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateAgents_DuplicateAutoImportRendersBracketedKind reproduces the
+// ga-tpfc bug: a user pack and an auto-imported system pack both declare an
+// agent of the same name. The rendered error must not contain `""`; it must
+// instead point the operator at both definitions including the auto-import
+// kind.
+func TestValidateAgents_DuplicateAutoImportRendersBracketedKind(t *testing.T) {
+	agents := []Agent{
+		{Name: "mayor", SourceDir: "packs/gastown", BindingName: "gastown", source: sourcePack},
+		{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
+	}
+	err := ValidateAgents(agents)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	got := err.Error()
+	if strings.Contains(got, `and ""`) {
+		t.Errorf(`error contains empty quoted path 'and ""'; full error: %s`, got)
+	}
+	if !strings.Contains(got, "packs/gastown") {
+		t.Errorf("error should include the user pack source dir, got: %s", got)
+	}
+	if !strings.Contains(got, "<auto-import:") {
+		t.Errorf(`error should include "<auto-import:" descriptor, got: %s`, got)
+	}
+}
+
+// TestValidateAgents_DuplicateInlineNoEmptyQuotes ensures that two inline
+// (city.toml [[agent]]) agents with the same name produce an error with no
+// empty quoted paths and a non-empty descriptor for each side.
+func TestValidateAgents_DuplicateInlineNoEmptyQuotes(t *testing.T) {
+	agents := []Agent{
+		{Name: "polecat", source: sourceInline},
+		{Name: "polecat", source: sourceInline},
+	}
+	err := ValidateAgents(agents)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	got := err.Error()
+	if strings.Contains(got, `""`) {
+		t.Errorf(`error contains empty quoted "" — descriptors must always be non-empty; full error: %s`, got)
+	}
+	if !strings.Contains(got, "<inline") {
+		t.Errorf(`error should include "<inline" descriptor for inline agents, got: %s`, got)
+	}
+}
+
+// TestLoadWithIncludes_StampsInlineSource asserts that agents declared via
+// inline [[agent]] blocks in city.toml carry source=sourceInline after load.
+func TestLoadWithIncludes_StampsInlineSource(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+
+	var mayor *Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "mayor" && cfg.Agents[i].Dir == "" {
+			mayor = &cfg.Agents[i]
+			break
+		}
+	}
+	if mayor == nil {
+		t.Fatalf("mayor agent not found in cfg.Agents")
+	}
+	if mayor.source != sourceInline {
+		t.Errorf("mayor.source = %v, want sourceInline", mayor.source)
+	}
+}
+
+// TestApplyAgentPatch_PreservesSource asserts the source stamp survives a
+// patch application — the architecture pins "stamp once at discovery, no
+// re-stamping" and patches must respect that.
+func TestApplyAgentPatch_PreservesSource(t *testing.T) {
+	strVal := func(s string) *string { return &s }
+	agent := Agent{Name: "mayor", source: sourceAutoImport, BindingName: "gastown"}
+	patch := AgentPatch{Name: "mayor", PromptTemplate: strVal("prompts/new.md")}
+	applyAgentPatchFields(&agent, &patch)
+	if agent.source != sourceAutoImport {
+		t.Errorf("agent.source after patch = %v, want sourceAutoImport (preserved)", agent.source)
+	}
+}
+
+// TestApplyAgentOverride_PreservesSource asserts the source stamp survives
+// an override application.
+func TestApplyAgentOverride_PreservesSource(t *testing.T) {
+	strVal := func(s string) *string { return &s }
+	agent := Agent{Name: "polecat", source: sourceInline}
+	override := AgentOverride{Agent: "polecat", PromptTemplate: strVal("prompts/p.md")}
+	applyAgentOverride(&agent, &override)
+	if agent.source != sourceInline {
+		t.Errorf("agent.source after override = %v, want sourceInline (preserved)", agent.source)
+	}
+}
+
+// TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos sweeps over all
+// source-enum × SourceDir-empty/present combinations and asserts that no
+// duplicate-agent error rendered by ValidateAgents contains an empty quoted
+// "" path. This is the fallback-suppression invariant the architecture
+// pins.
+func TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos(t *testing.T) {
+	sources := []agentSource{0, sourceInline, sourcePack, sourceAutoImport}
+	srcDirs := []string{"", "packs/base"}
+
+	for _, sa := range sources {
+		for _, sb := range sources {
+			for _, da := range srcDirs {
+				for _, db := range srcDirs {
+					a := Agent{Name: "worker", source: sa, SourceDir: da, BindingName: "gastown"}
+					b := Agent{Name: "worker", source: sb, SourceDir: db, BindingName: "gastown"}
+					err := ValidateAgents([]Agent{a, b})
+					if err == nil {
+						t.Errorf("expected duplicate-name error for source=(%v,%v), srcDir=(%q,%q)", sa, sb, da, db)
+						continue
+					}
+					if strings.Contains(err.Error(), `""`) {
+						t.Errorf(`empty quoted "" in error for source=(%v,%v), srcDir=(%q,%q): %s`, sa, sb, da, db, err.Error())
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -53,6 +53,7 @@ func TestAgentFieldSync(t *testing.T) {
 		"NamepoolNames":                "runtime-only, loaded from Namepool file at config load time",
 		"BindingName":                  "runtime-only, set during V2 import expansion, not user-configurable",
 		"PackName":                     "runtime-only, set during V2 import expansion, not user-configurable",
+		"source":                       "runtime-only unexported provenance enum (ga-tpfc); stamped at discovery, not patched or overridden",
 	}
 
 	// Fields on AgentOverride/AgentPatch that don't map 1:1 to Agent fields.

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1345,6 +1345,10 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 		}
 		// Track where this agent's config was defined.
 		agents[i].SourceDir = topoDir
+		// Stamp source provenance (ga-tpfc). expandCityPacks may
+		// later override sourcePack → sourceAutoImport for bindings
+		// that came from [defaults.rig.imports].
+		agents[i].source = sourcePack
 		// Resolve prompt_template paths relative to pack directory.
 		if agents[i].PromptTemplate != "" {
 			agents[i].PromptTemplate = adjustFragmentPath(

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -648,6 +648,9 @@ func TestAgentConfigFromAgentCoversPersistedFields(t *testing.T) {
 		"PoolName":                     true,
 		"BindingName":                  true,
 		"PackName":                     true,
+		// source is config-package-internal provenance used while composing
+		// configs; per-agent migration files intentionally do not persist it.
+		"source": true,
 		// v0.15.1 tombstones — still on Agent but intentionally not propagated
 		// by migrate (removed in v0.16).
 		"Skills":       true,

--- a/release-gates/ga-tpfc-1-gate.md
+++ b/release-gates/ga-tpfc-1-gate.md
@@ -1,0 +1,24 @@
+# Release Gate: ga-tpfc.1 — source-provenance rendering for duplicate-agent-name errors
+
+**Deploy bead:** ga-vazw
+**Originating bead:** ga-tpfc.1 (closed)
+**Branch:** `builder/ga-mol-bq54` (fork: `quad341/gascity`)
+**Commits:** a2d13342, a41b8693, 3b9897a3
+**Verdict:** PASS
+
+## Criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `gascity/reviewer-1` PASS verdict in ga-vazw notes; covers describeSource, formatDuplicateAgentError, all FR-1..4 + NFR + field-sync. |
+| 2 | Acceptance criteria met | PASS | TestDescribeSource (7 sub-tests), TestValidateAgents_DuplicateAutoImportRendersBracketedKind (regression for empty-quote bug), TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos (16-combo sweep), inline/patch/override propagation tests all green. |
+| 3 | Tests pass | PASS | `go build ./...` clean, `go vet ./internal/config/... ./examples/...` clean, `go test ./internal/config/... ./examples/...` PASS, `go test ./cmd/gc/ -run 'TestDeepCopyAgent\|TestAgentFieldSync'` PASS. |
+| 4 | No high-severity review findings open | PASS | Zero blockers. Two non-blocking style notes (cityRoot reserved-for-future-use parameter; second auto-import promotion guard) noted but not actionable. |
+| 5 | Final branch is clean | PASS | `git status` shows only untracked `.gitkeep` at repo root (stray, pre-existing); no uncommitted changes to deploy. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree origin/main HEAD` writes merge tree without conflicts. Three commits ahead of origin/main; merge base is 7b6c5406. |
+
+## Coordination
+
+- ga-9ogb.1 (review bead ga-zzhk) is BASED on this branch and depends on
+  this PR landing first. After this merges, ga-9ogb.1's branch must be
+  rebased on origin/main before its PR can open cleanly.


### PR DESCRIPTION
## What this changes

When two `[[agent]]` blocks declare the same name, `ValidateAgents` previously rendered the conflict with empty quoted paths — `agent \"foo\" defined twice in \"\" and \"\"` — for inline `city.toml` blocks and for agents from auto-imported system packs. The empty paths made the error useless; operators couldn't tell which file to edit.

This PR adds an unexported `Agent.source` enum stamped at every discovery site (inline parse, pack load, auto-import promotion, convention discovery), and routes duplicate-name errors through a shared `formatDuplicateAgentError` helper. The rendered descriptor is now one of:

- `"<path/to/file.toml>"` when `SourceDir` is known.
- `<auto-import: <binding-name>>` for agents resolved via default bindings or implicit imports.
- `<inline: <city.toml-basename>>` for inline `[[agent]]` in `city.toml`.
- `<unknown: …>` only as a defensive fallback (current discovery sites all stamp; this is reserved for future code paths).

The `formatDuplicateAgentError` helper is a shared deliverable with ga-9ogb.1 (layout-version migration error). This PR adds the helper; ga-9ogb.1 will extend it once landed.

## Review notes

- New unexported `Agent.source agentSource` field. Confirm `field_sync_test.go` excludes it (it does) and `cmd/gc/pool.go` deep-copy + `applyAgentPatch` + `applyAgentOverride` either propagate or deliberately ignore it (they propagate — covered by `TestApplyAgentPatch_PreservesSource`, `TestApplyAgentOverride_PreservesSource`, and a `pool_test.go` tombstone with explanatory comment).
- `LoadWithIncludesOptions` runs two post-passes that promote `sourcePack` → `sourceAutoImport`: first against `pc.Defaults.Rig.Imports`, then `ImplicitImportBindings`. Reviewer flagged the asymmetry of the source-guard between the two passes as non-blocking — current behavior is correct.
- `ValidateAgents` remains pure-data: `describeSource` does no FS access; the `cityRoot` parameter is plumbed for future relativization without changing call sites.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./internal/config/... ./examples/...` clean.
- [x] `go test ./internal/config/...` — including 16-combo `TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos` and the regression repro `TestValidateAgents_DuplicateAutoImportRendersBracketedKind`.
- [x] `go test ./cmd/gc/ -run 'TestDeepCopyAgent|TestAgentFieldSync'` — pool tombstone + struct-field sync.
- [x] Release gate: [`release-gates/ga-tpfc-1-gate.md`](release-gates/ga-tpfc-1-gate.md)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->