### PR TITLE
bd: drop redundant slow config set in gc-beads-bd op_init + lint guard

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3875,7 +3875,10 @@ esac
 		"3307",
 		filepath.Join(rigDir, ".beads"),
 	}, "|")
-	for _, name := range []string{"config.env", "migrate.env"} {
+	// config.env is no longer asserted: bd config set was removed in ga-5mym
+	// (replaced by ensure_bd_runtime_config_value direct SQL writes). migrate
+	// is still invoked via backfill_project_id_if_missing and pins env identically.
+	for _, name := range []string{"init.env", "migrate.env"} {
 		data, err := os.ReadFile(filepath.Join(captureDir, name))
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
@@ -4385,19 +4388,21 @@ esac
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
 	}
 
-	for _, name := range []string{"config-db.log", "migrate-db.log"} {
-		data, err := os.ReadFile(filepath.Join(captureDir, name))
-		if err != nil {
-			t.Fatalf("ReadFile(%s): %v", name, err)
-		}
-		lines := strings.Fields(string(data))
-		if len(lines) == 0 {
-			t.Fatalf("%s empty", name)
-		}
-		for _, line := range lines {
-			if line != "gascity" {
-				t.Fatalf("%s line = %q, want gascity", name, line)
-			}
+	// Only migrate-db.log is asserted: bd config set was removed in ga-5mym
+	// (replaced by ensure_bd_runtime_config_value direct SQL writes).
+	// The migrate path still proves normalization runs before downstream
+	// bd subcommands.
+	data, err := os.ReadFile(filepath.Join(captureDir, "migrate-db.log"))
+	if err != nil {
+		t.Fatalf("ReadFile(migrate-db.log): %v", err)
+	}
+	lines := strings.Fields(string(data))
+	if len(lines) == 0 {
+		t.Fatalf("migrate-db.log empty")
+	}
+	for _, line := range lines {
+		if line != "gascity" {
+			t.Fatalf("migrate-db.log line = %q, want gascity", line)
 		}
 	}
 	metaData, err := os.ReadFile(filepath.Join(cityPath, ".beads", "metadata.json"))
@@ -4529,19 +4534,20 @@ esac
 		t.Fatalf("gc-beads-bd init failed: %v\n%s", err, out)
 	}
 
-	for _, name := range []string{"config-db.log", "migrate-db.log"} {
-		data, err := os.ReadFile(filepath.Join(captureDir, name))
-		if err != nil {
-			t.Fatalf("ReadFile(%s): %v", name, err)
-		}
-		lines := strings.Fields(string(data))
-		if len(lines) == 0 {
-			t.Fatalf("%s empty", name)
-		}
-		for _, line := range lines {
-			if line != strings.ToUpper(managedDoltProbeDatabase) {
-				t.Fatalf("%s line = %q, want %s", name, line, strings.ToUpper(managedDoltProbeDatabase))
-			}
+	// Only migrate-db.log is asserted: bd config set was removed in ga-5mym
+	// (replaced by ensure_bd_runtime_config_value direct SQL writes).
+	want := strings.ToUpper(managedDoltProbeDatabase)
+	data, err := os.ReadFile(filepath.Join(captureDir, "migrate-db.log"))
+	if err != nil {
+		t.Fatalf("ReadFile(migrate-db.log): %v", err)
+	}
+	lines := strings.Fields(string(data))
+	if len(lines) == 0 {
+		t.Fatalf("migrate-db.log empty")
+	}
+	for _, line := range lines {
+		if line != want {
+			t.Fatalf("migrate-db.log line = %q, want %s", line, want)
 		}
 	}
 

--- a/cmd/gc/gc_beads_bd_lint_test.go
+++ b/cmd/gc/gc_beads_bd_lint_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestGcBeadsBdNoBdConfigSet enforces the perf-fix from ga-5mym: the
+// gc-beads-bd init script must never invoke `bd config set` (directly or
+// through the run_bd_* wrappers). bd >= 1.0.3 makes that call cost 18-50s
+// per invocation due to auto-migrate; combined cost overruns the 30s
+// providerOpTimeout and the supervisor wedges in starting_bead_store.
+//
+// The replacement path is ensure_bd_runtime_config_value (direct SQL into
+// the bd config table). Any future regression must use that helper, not
+// the slow bd CLI subcommand.
+func TestGcBeadsBdNoBdConfigSet(t *testing.T) {
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	f, err := os.Open(scriptPath)
+	if err != nil {
+		t.Fatalf("open script: %v", err)
+	}
+	defer f.Close()
+
+	// Match `bd <args> config set` and `run_bd_<wrapper> <args> config set`.
+	// The script invokes bd both directly and through helpers like
+	// run_bd_pinned, which always end up calling `bd config set` — both
+	// shapes hit the slow auto-migrate path.
+	pattern := regexp.MustCompile(`bd[a-zA-Z_]*[[:space:]]+.*config[[:space:]]+set`)
+	commentLine := regexp.MustCompile(`^[[:space:]]*#`)
+
+	var offenders []string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		if commentLine.MatchString(line) {
+			continue
+		}
+		if pattern.MatchString(line) {
+			offenders = append(offenders, formatOffender(scriptPath, lineNum, line))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan script: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("ERROR: bd config set re-introduced in gc-beads-bd.sh.\n"+
+			"See ga-5mym; use ensure_bd_runtime_config_value (direct SQL) instead.\n"+
+			"Offending lines:\n  %s", strings.Join(offenders, "\n  "))
+	}
+}
+
+func formatOffender(path string, line int, content string) string {
+	return path + ":" + strconv.Itoa(line) + ": " + strings.TrimSpace(content)
+}
+
+func repoRootForLint(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("abs cwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root")
+		}
+		dir = parent
+	}
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1908,7 +1908,9 @@ op_init() {
                 # and bd-specific bootstrap only.
                 ensure_beads_dir_permissions "$dir"
                 normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
-                run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+                # bd config set is slow under bd >= 1.0.3 (~50s for types.custom
+                # auto-migrate); ensure_bd_runtime_custom_types writes the same
+                # config table directly via SQL. See ga-5mym.
                 ensure_bd_runtime_custom_types "$dolt_database" "$custom_types"
                 ensure_bd_runtime_issue_prefix "$dolt_database" "$prefix"
                 backfill_project_id_if_missing "$dir"
@@ -1961,8 +1963,10 @@ op_init() {
         die "bd schema not visible for $dolt_database after init"
     fi
 
-    # Configure custom bead types (required since beads v0.46.0).
-    run_bd_pinned "$dir" config set types.custom "$custom_types" 2>/dev/null || true
+    # Configure custom bead types (required since beads v0.46.0). Write
+    # directly to bd's config table via SQL — `bd config set` costs ~50s
+    # per call under bd >= 1.0.3 (auto-migrate) and overruns the 30s
+    # provider op timeout. See ga-5mym.
     ensure_bd_runtime_custom_types "$dolt_database" "$custom_types"
 
     # Keep bd's runtime config in sync with GC's canonical prefix. This is

--- a/release-gates/ga-5mym-1-gate.md
+++ b/release-gates/ga-5mym-1-gate.md
@@ -1,0 +1,23 @@
+# Release Gate: ga-5mym.1 — drop slow bd config set in gc-beads-bd op_init + lint guard
+
+**Deploy bead:** ga-ss3v
+**Originating bead:** ga-5mym.1
+**Branch:** `builder/ga-5mym-1` (fork: `quad341/gascity`)
+**Commits:** 886874a2, db51865c
+**Verdict:** PASS
+
+## Criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `gascity/reviewer-1` PASS verdict in ga-ss3v notes; spec compliance, security, and shape-divergence justification all confirmed. |
+| 2 | Acceptance criteria met | PASS | TestGcBeadsBdNoBdConfigSet (untagged Go-level lint), TestGcBeadsBdInitFastPath, TestGcBeadsBdInitPinsManagedDoltEnvForBdSubcommands all pass. Three dependent fake-bd tests in beads_provider_lifecycle_test.go updated to drop config.env/config-db.log assertions. |
+| 3 | Tests pass | PASS | `go build ./...` clean, `go vet ./cmd/gc/...` clean, focused test suite PASS. |
+| 4 | No high-severity review findings open | PASS | Zero blockers. Reviewer noted shape divergence from original architect design as acceptable: main has SUPERSEDED the YAML-fallback approach with ensure_bd_runtime_config_value (writes directly via SQL), so the fix is just removing the redundant slow run_bd_pinned ... config set calls and adding the CI guard. |
+| 5 | Final branch is clean | PASS | `git status` clean (untracked `.gitkeep` only). |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree origin/main HEAD` writes merge tree without conflicts. Two commits ahead of origin/main. |
+
+## Pre-existing failures (NOT introduced)
+
+- TestDocDirCoverage (worktrees/ga-mol-bq54/ has markdown not in docTreeDirs) — unrelated, baseline-reproducible per builder.
+- TestInitBeadsForDirBdMaterializedScript* and TestGcBeadsBdInitRetriesRootStoreVerification — fail with 'connection refused' when no test dolt is running; environmental, unrelated.


### PR DESCRIPTION
## What this changes

`gc-beads-bd op_init` was calling `run_bd_pinned ... bd config set types.custom ...` twice — once for `init` and once for the migrate path. Each call invokes `bd` against the running Dolt server; in steady-state production this added ~50s per init under the 30s op timeout, occasionally tripping the timeout.

The redundancy was already invisible: a prior commit (99c98750) introduced `ensure_bd_runtime_config_value`, which writes the same `types.custom` value directly to bd's config table via SQL on the running Dolt server — strictly better than `bd config set` because it writes where bd reads first. The two `run_bd_pinned ... config set` calls had been left behind.

This PR:

1. Drops the two redundant `run_bd_pinned ... config set types.custom` calls from `op_init` in `examples/bd/assets/scripts/gc-beads-bd.sh`. The immediately-following `ensure_bd_runtime_custom_types` calls already cover the side effect.
2. Adds `TestGcBeadsBdNoBdConfigSet` — a Go-level lint test (untagged, runs in `go test ./...`) that fails CI if `bd config set` (or any `run_bd_<wrapper> ... config set` form) reappears in `gc-beads-bd.sh` outside comments. The pattern is `bd[a-zA-Z_]*\s+.*config\s+set` on non-comment lines.
3. Updates three dependent fake-bd tests in `beads_provider_lifecycle_test.go` to drop `config.env` / `config-db.log` assertions while keeping the `init.env` / `migrate.env` / `migrate-db.log` assertions intact.

## Review notes

- **Shape divergence from the architect brief.** The architect (ga-5mym) targeted promoting commit 4ef8ee5e from `local/integration-2026-04-26`, which used `ensure_types_custom_in_yaml` writing to `.beads/config.yaml` as bd's `GetCustomTypesFromYAML` fallback. Main has since SUPERSEDED that approach with the SQL writer; the perf fix here is the smaller, post-supersession diff.
- The lint test reads a static repo path with a bounded regex; no shell exec, no untrusted input.
- The replacement path (`ensure_bd_runtime_config_value`) validates db/key/value via `valid_sql_name` + `valid_custom_types_value` before INSERT.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./cmd/gc/...` clean.
- [x] `go test ./cmd/gc/ -run 'TestGcBeadsBdNoBdConfigSet|TestGcBeadsBdInitFastPath|TestGcBeadsBdInitPinsManagedDoltEnvForBdSubcommands'` PASS.
- [x] Inspect `examples/bd/assets/scripts/gc-beads-bd.sh` lines around the dropped block — comments anchor why `bd config set` is forbidden post-99c98750.
- [x] Release gate: [`release-gates/ga-5mym-1-gate.md`](release-gates/ga-5mym-1-gate.md)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->