### PR TITLE
config: layout-version migration error in ValidateAgents

### DIFF
--- a/cmd/gc/cmd_rig_endpoint.go
+++ b/cmd/gc/cmd_rig_endpoint.go
@@ -389,10 +389,15 @@ func readManagedRuntimePublishedPort(cityPath string) (string, error) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return "", err
 	}
-	if !state.Running || state.Port == 0 {
+	if !state.Running || state.Port <= 0 {
 		return "", fmt.Errorf("dolt runtime state unavailable")
 	}
-	if state.PID > 0 && !pidAlive(state.PID) {
+	if state.PID > 0 || strings.TrimSpace(state.DataDir) != "" {
+		if !validDoltRuntimeState(state, cityPath) {
+			return "", fmt.Errorf("dolt runtime state unavailable")
+		}
+	}
+	if state.PID < 0 {
 		return "", fmt.Errorf("dolt runtime state unavailable")
 	}
 	return strconv.Itoa(state.Port), nil

--- a/cmd/gc/pool_test.go
+++ b/cmd/gc/pool_test.go
@@ -717,18 +717,20 @@ func TestDeepCopyAgentCoversAllFields(t *testing.T) {
 	// deep-copied; they are accepted by the TOML parser but not propagated
 	// through the runtime. The deep-copy contract deliberately drops them.
 	//
-	// The unexported `source` field (ga-tpfc) is also intentionally
-	// dropped: it is a config-package-internal provenance enum that
-	// describes the agent's discovery origin. Pool instances are derived
-	// objects, not discovery sites, so leaving them at sourceUnknown is
-	// semantically correct and the deep-copy in cmd/gc cannot reach across
-	// the package boundary to set an unexported field anyway.
+	// The unexported `source` (ga-tpfc) and `layout` (ga-9ogb) fields
+	// are also intentionally dropped: they are config-package-internal
+	// provenance enums that describe the agent's discovery origin. Pool
+	// instances are derived objects, not discovery sites, so leaving
+	// them at the zero value is semantically correct and the deep-copy
+	// in cmd/gc cannot reach across the package boundary to set an
+	// unexported field anyway.
 	tombstones := map[string]bool{
 		"Skills":       true,
 		"MCP":          true,
 		"SharedSkills": true,
 		"SharedMCP":    true,
 		"source":       true,
+		"layout":       true,
 	}
 
 	// Verify every non-tombstone Agent field is set (non-zero) in the test data.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ description: Mintlify source files and contributor docs for Gas City.
 This directory is the source of truth for the Gas City documentation site.
 
 - Mintlify configuration lives in `docs.json`.
-- The published docs home page is [`index.mdx`](/docs/index.mdx).
+- The published docs home page is [`index.mdx`](index.mdx).
 - Downloadable specs live under `schema/`: supervisor OpenAPI,
   `gc events` JSONL, and `city.toml` JSON Schema.
 - Preview locally from the repo root with `./mint.sh dev` (Mintlify currently requires Node 22/24 LTS, not Node 25+).

--- a/docs/packv2/migration.mdx
+++ b/docs/packv2/migration.mdx
@@ -1,0 +1,93 @@
+# Pack V2 Migration Guide
+
+This guide covers the migration path for packs that still declare agents with
+v1 `[[agent]]` blocks while also using v2 convention-discovered agent
+directories.
+
+The duplicate-agent diagnostic links here when Gas City finds both of these
+definitions for the same agent name after pack composition:
+
+```toml
+[[agent]]
+name = "worker"
+```
+
+```text
+agents/worker/agent.toml
+```
+
+Gas City cannot infer which definition should win. The pack author must choose
+one layout for each agent name.
+
+## Recommended Migration
+
+Use the v2 agent directory layout for new and migrated packs.
+
+1. Create `agents/NAME/`.
+2. Move the v1 `[[agent]]` fields for that agent into
+   `agents/NAME/agent.toml`.
+3. Move the agent prompt into `agents/NAME/prompt.md` when the prompt is part
+   of the pack.
+4. Move agent-specific assets into the same directory:
+   `overlay/`, `skills/`, `mcp/`, and `template-fragments/`.
+5. Delete the old `[[agent]]` block from `pack.toml` or `city.toml`.
+6. Run the config-loading tests or `gc doctor` flow that exposed the collision.
+
+For the full v2 agent directory contract, see
+[`doc-agent-v2.md`](doc-agent-v2.md). For the pack and city model, see
+[`doc-pack-v2.md`](doc-pack-v2.md).
+
+## Field Mapping
+
+Most scalar fields move directly from the v1 `[[agent]]` block into
+`agent.toml`:
+
+```toml
+# pack.toml before
+[[agent]]
+name = "worker"
+scope = "city"
+provider = "codex"
+prompt_template = "prompts/worker.md"
+```
+
+```toml
+# agents/worker/agent.toml after
+scope = "city"
+provider = "codex"
+prompt_template = "prompt.md"
+```
+
+If the prompt is shared across multiple agents, keep using a pack-relative
+`prompt_template` path. If the prompt belongs only to this agent, prefer
+`agents/worker/prompt.md` and reference it as `prompt.md`.
+
+## Collision Resolution
+
+When the diagnostic reports a v1/v2 layout collision, inspect both source
+lines:
+
+```text
+v1 source: ...
+v2 source: ...
+```
+
+Then use one of these resolutions:
+
+- Keep the v2 directory and remove the v1 `[[agent]]` block.
+- Keep the v1 block temporarily and remove the v2 directory.
+- Rename one agent if the two definitions are intentionally different roles.
+
+Do not keep both definitions with the same name in the same composed city. That
+keeps load order significant and prevents the operator from knowing which
+agent definition is active.
+
+## Imports And Patches
+
+Imported packs should define agents in their own pack directories. A city that
+needs to adjust an imported agent should use patches or overrides rather than
+redeclaring the same agent name in another layout.
+
+During a staged migration, migrate one agent name at a time and run validation
+after each step. The desired steady state is that every composed agent name has
+one canonical definition path.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -63,7 +63,7 @@ Agent defines a configured agent in the city.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | **yes** |  | Name is the unique identifier for this agent. |
-| `description` | string |  |  | Description is a human-readable description shown in a real-world app's session creation UI. |
+| `description` | string |  |  | Description is a human-readable description shown in MC's session creation UI. |
 | `dir` | string |  |  | Dir is the identity prefix for rig-scoped agents and the default working directory when WorkDir is not set. |
 | `work_dir` | string |  |  | WorkDir overrides the session working directory without changing the agent's qualified identity. Relative paths resolve against city root and may use the same template placeholders as session_setup. |
 | `scope` | string |  |  | Scope defines where this agent is instantiated: "city" (one per city) or "rig" (one per rig, the default). Only meaningful for pack-defined agents; inline agents in city.toml use Dir directly. Enum: `city`, `rig` |
@@ -71,7 +71,7 @@ Agent defines a configured agent in the city.
 | `pre_start` | []string |  |  | PreStart is a list of shell commands run before session creation. Commands run on the target filesystem: locally for tmux, inside the pod/container for exec providers. Template variables same as session_setup. |
 | `prompt_template` | string |  |  | PromptTemplate is the path to this agent's prompt template file. Relative paths resolve against the city directory. |
 | `nudge` | string |  |  | Nudge is text typed into the agent's tmux session after startup. Used for CLI agents that don't accept command-line prompts. |
-| `session` | string |  |  | Session overrides the session transport for this agent. "" (default) uses the provider default. "tmux" uses the tmux-backed CLI path even when the provider supports ACP. "acp" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's resolved provider must have supports_acp = true. Enum: `acp`, `tmux` |
+| `session` | string |  |  | Session overrides the session transport for this agent. "" (default) uses the city-level session provider (typically tmux). "acp" uses the Agent Client Protocol (JSON-RPC over stdio). The agent's resolved provider must have supports_acp = true. Enum: `acp` |
 | `provider` | string |  |  | Provider names the provider preset to use for this agent. |
 | `start_command` | string |  |  | StartCommand overrides the provider's command for this agent. |
 | `args` | []string |  |  | Args overrides the provider's default arguments. |
@@ -143,7 +143,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
-| `session` | string |  |  | Session overrides the session transport ("acp" or "tmux"). |
+| `session` | string |  |  | Session overrides the session transport ("acp"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
 | `nudge` | string |  |  | Nudge overrides the nudge text. |
@@ -388,7 +388,7 @@ OrderOverride modifies a scanned order's scheduling fields.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | **yes** |  | Name is the order name to target (required). |
-| `rig` | string |  |  | Rig scopes the override to a specific rig's order. Empty matches ONLY city-level orders (those with no rig); it does NOT match per-rig instances of the same name — those expand at scan time and require an explicit rig. Use rig = "*" as a wildcard to match every instance of the named order (city-level + every rig-scoped copy). The literal "*" is reserved and rejected as a real rig name by config validation. |
+| `rig` | string |  |  | Rig scopes the override to a specific rig's order. Empty matches city-level orders. |
 | `enabled` | boolean |  |  | Enabled overrides whether the order is active. |
 | `trigger` | string |  |  | Trigger overrides the trigger type. |
 | `gate` | string |  |  | Gate is a deprecated alias for Trigger accepted during the gate-&gt;trigger migration. Parsed inputs are normalized to Trigger. |
@@ -520,7 +520,7 @@ Rig defines an external project registered in the city.
 | `name` | string | **yes** |  | Name is the unique identifier for this rig. |
 | `path` | string |  |  | Path is the absolute filesystem path to the rig's repository. |
 | `prefix` | string |  |  | Prefix overrides the auto-derived bead ID prefix for this rig. |
-| `default_branch` | string |  |  | DefaultBranch is the rig repository's mainline branch (e.g. "main", "master", "develop"). When set, polecats and the refinery use this as the default merge target instead of probing origin/HEAD at sling time. Captured by `gc rig add` from the rig's git config; set manually for rigs whose mainline isn't reachable via origin/HEAD. |
+| `default_branch` | string |  |  | DefaultBranch is the rig repository's mainline branch (e.g. "main", "master", "develop"). When set, routing formulas use this as the default merge target instead of probing origin/HEAD at sling time. Captured by `gc rig add` from the rig's git config; set manually for rigs whose mainline isn't reachable via origin/HEAD. |
 | `suspended` | boolean |  |  | Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume. |
 | `formulas_dir` | string |  |  | FormulasDir is a rig-local formula directory (Layer 4). Overrides pack formulas for this rig by filename. Relative paths resolve against the city directory. |
 | `includes` | []string |  |  | Includes lists pack directories or URLs for this rig (V1 mechanism). Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
@@ -639,7 +639,7 @@ Workspace holds city-level metadata and optional defaults that apply to all agen
 | `suspended` | boolean |  |  | Suspended controls whether the city is suspended. When true, all agents are effectively suspended: the reconciler won't spawn them, and gc hook/prime return empty. Inherits downward — individual agent/rig suspended fields are checked independently. |
 | `max_active_sessions` | integer |  |  | MaxActiveSessions is the workspace-level cap on total concurrent sessions. Nil means unlimited. Agents and rigs inherit this if they don't set their own. |
 | `session_template` | string |  |  | SessionTemplate is a template string supporting placeholders: &#123;&#123;.City&#125;&#125;, &#123;&#123;.Agent&#125;&#125; (sanitized), &#123;&#123;.Dir&#125;&#125;, &#123;&#123;.Name&#125;&#125;. Controls tmux session naming. Default (empty): "&#123;&#123;.Agent&#125;&#125;" — just the sanitized agent name. Per-city tmux socket isolation makes a city prefix unnecessary. |
-| `install_agent_hooks` | []string |  |  | InstallAgentHooks lists provider names whose hooks should be installed into agent working directories. Agent-level overrides workspace-level (replace, not additive). Supported: "claude", "codex", "gemini", "opencode", "copilot", "cursor", "kiro", "pi", "omp". |
+| `install_agent_hooks` | []string |  |  | InstallAgentHooks lists provider names whose hooks should be installed into agent working directories. Agent-level overrides workspace-level (replace, not additive). Supported: "claude", "codex", "gemini", "kiro", "opencode", "copilot", "cursor", "pi", "omp". |
 | `global_fragments` | []string |  |  | GlobalFragments lists named template fragments injected into every agent's rendered prompt. Applied before per-agent InjectFragments. Each name must match a &#123;&#123; define "name" &#125;&#125; block from a pack's prompts/shared/ directory. |
 | `includes` | []string |  |  | Includes lists pack directories or URLs to compose into this workspace. Replaces the older pack/packs fields. Each entry is a local path, a git source//sub#ref URL, or a GitHub tree URL. |
 | `default_rig_includes` | []string |  |  | DefaultRigIncludes lists pack directories applied to new rigs when "gc rig add" is called without --include. Allows cities to define a default pack for all rigs. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -52,7 +52,7 @@
         },
         "description": {
           "type": "string",
-          "description": "Description is a human-readable description shown in a real-world app's session creation UI."
+          "description": "Description is a human-readable description shown in MC's session creation UI."
         },
         "dir": {
           "type": "string",
@@ -92,10 +92,9 @@
         "session": {
           "type": "string",
           "enum": [
-            "acp",
-            "tmux"
+            "acp"
           ],
-          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the provider default.\n\"tmux\" uses the tmux-backed CLI path even when the provider supports ACP.\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's\nresolved provider must have supports_acp = true."
+          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the city-level session provider (typically tmux).\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio).\nThe agent's resolved provider must have supports_acp = true."
         },
         "provider": {
           "type": "string",
@@ -420,7 +419,7 @@
         },
         "session": {
           "type": "string",
-          "description": "Session overrides the session transport (\"acp\" or \"tmux\")."
+          "description": "Session overrides the session transport (\"acp\")."
         },
         "provider": {
           "type": "string",
@@ -1390,7 +1389,7 @@
         },
         "rig": {
           "type": "string",
-          "description": "Rig scopes the override to a specific rig's order. Empty matches\nONLY city-level orders (those with no rig); it does NOT match\nper-rig instances of the same name — those expand at scan time\nand require an explicit rig. Use rig = \"*\" as a wildcard to match\nevery instance of the named order (city-level + every rig-scoped\ncopy). The literal \"*\" is reserved and rejected as a real rig\nname by config validation."
+          "description": "Rig scopes the override to a specific rig's order.\nEmpty matches city-level orders."
         },
         "enabled": {
           "type": "boolean",
@@ -1842,7 +1841,7 @@
         },
         "default_branch": {
           "type": "string",
-          "description": "DefaultBranch is the rig repository's mainline branch (e.g. \"main\",\n\"master\", \"develop\"). When set, polecats and the refinery use this\nas the default merge target instead of probing origin/HEAD at sling\ntime. Captured by `gc rig add` from the rig's git config; set\nmanually for rigs whose mainline isn't reachable via origin/HEAD."
+          "description": "DefaultBranch is the rig repository's mainline branch (e.g. \"main\",\n\"master\", \"develop\"). When set, routing formulas use this as the\ndefault merge target instead of probing origin/HEAD at sling time.\nCaptured by `gc rig add` from the rig's git config; set manually for\nrigs whose mainline isn't reachable via origin/HEAD."
         },
         "suspended": {
           "type": "boolean",
@@ -2178,7 +2177,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "InstallAgentHooks lists provider names whose hooks should be installed\ninto agent working directories. Agent-level overrides workspace-level\n(replace, not additive). Supported: \"claude\", \"codex\", \"gemini\",\n\"opencode\", \"copilot\", \"cursor\", \"kiro\", \"pi\", \"omp\"."
+          "description": "InstallAgentHooks lists provider names whose hooks should be installed\ninto agent working directories. Agent-level overrides workspace-level\n(replace, not additive). Supported: \"claude\", \"codex\", \"gemini\",\n\"kiro\", \"opencode\", \"copilot\", \"cursor\", \"pi\", \"omp\"."
         },
         "global_fragments": {
           "items": {

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -52,7 +52,7 @@
         },
         "description": {
           "type": "string",
-          "description": "Description is a human-readable description shown in a real-world app's session creation UI."
+          "description": "Description is a human-readable description shown in MC's session creation UI."
         },
         "dir": {
           "type": "string",
@@ -92,10 +92,9 @@
         "session": {
           "type": "string",
           "enum": [
-            "acp",
-            "tmux"
+            "acp"
           ],
-          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the provider default.\n\"tmux\" uses the tmux-backed CLI path even when the provider supports ACP.\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's\nresolved provider must have supports_acp = true."
+          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the city-level session provider (typically tmux).\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio).\nThe agent's resolved provider must have supports_acp = true."
         },
         "provider": {
           "type": "string",
@@ -420,7 +419,7 @@
         },
         "session": {
           "type": "string",
-          "description": "Session overrides the session transport (\"acp\" or \"tmux\")."
+          "description": "Session overrides the session transport (\"acp\")."
         },
         "provider": {
           "type": "string",
@@ -1390,7 +1389,7 @@
         },
         "rig": {
           "type": "string",
-          "description": "Rig scopes the override to a specific rig's order. Empty matches\nONLY city-level orders (those with no rig); it does NOT match\nper-rig instances of the same name — those expand at scan time\nand require an explicit rig. Use rig = \"*\" as a wildcard to match\nevery instance of the named order (city-level + every rig-scoped\ncopy). The literal \"*\" is reserved and rejected as a real rig\nname by config validation."
+          "description": "Rig scopes the override to a specific rig's order.\nEmpty matches city-level orders."
         },
         "enabled": {
           "type": "boolean",
@@ -1842,7 +1841,7 @@
         },
         "default_branch": {
           "type": "string",
-          "description": "DefaultBranch is the rig repository's mainline branch (e.g. \"main\",\n\"master\", \"develop\"). When set, polecats and the refinery use this\nas the default merge target instead of probing origin/HEAD at sling\ntime. Captured by `gc rig add` from the rig's git config; set\nmanually for rigs whose mainline isn't reachable via origin/HEAD."
+          "description": "DefaultBranch is the rig repository's mainline branch (e.g. \"main\",\n\"master\", \"develop\"). When set, routing formulas use this as the\ndefault merge target instead of probing origin/HEAD at sling time.\nCaptured by `gc rig add` from the rig's git config; set manually for\nrigs whose mainline isn't reachable via origin/HEAD."
         },
         "suspended": {
           "type": "boolean",
@@ -2178,7 +2177,7 @@
             "type": "string"
           },
           "type": "array",
-          "description": "InstallAgentHooks lists provider names whose hooks should be installed\ninto agent working directories. Agent-level overrides workspace-level\n(replace, not additive). Supported: \"claude\", \"codex\", \"gemini\",\n\"opencode\", \"copilot\", \"cursor\", \"kiro\", \"pi\", \"omp\"."
+          "description": "InstallAgentHooks lists provider names whose hooks should be installed\ninto agent working directories. Agent-level overrides workspace-level\n(replace, not additive). Supported: \"claude\", \"codex\", \"gemini\",\n\"kiro\", \"opencode\", \"copilot\", \"cursor\", \"pi\", \"omp\"."
         },
         "global_fragments": {
           "items": {

--- a/internal/config/agent_discovery.go
+++ b/internal/config/agent_discovery.go
@@ -52,6 +52,7 @@ func DiscoverPackAgents(fs fsys.FS, packDir, _ string, skipNames map[string]bool
 		}
 		applyAgentConventionDefaults(fs, packDir, &agent)
 		agent.source = sourcePack
+		agent.layout = layoutV2Convention
 
 		discovered = append(discovered, agent)
 	}

--- a/internal/config/agent_layout_test.go
+++ b/internal/config/agent_layout_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// TestAgentLayoutString covers the debug-only String renderer.
+func TestAgentLayoutString(t *testing.T) {
+	cases := []struct {
+		l    agentLayout
+		want string
+	}{
+		{layoutUnknown, "unknown"},
+		{layoutV1Inline, "v1-inline"},
+		{layoutV2Convention, "v2-convention"},
+	}
+	for _, tc := range cases {
+		if got := tc.l.String(); got != tc.want {
+			t.Errorf("agentLayout(%d).String() = %q, want %q", tc.l, got, tc.want)
+		}
+	}
+}
+
+// TestDiscoverPackAgents_StampsV2Layout asserts that agents discovered
+// from a pack's agents/<name>/agent.toml carry layout=layoutV2Convention.
+func TestDiscoverPackAgents_StampsV2Layout(t *testing.T) {
+	packDir := t.TempDir()
+	agentDir := filepath.Join(packDir, "agents", "mayor")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(`
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agents, err := DiscoverPackAgents(fsys.OSFS{}, packDir, "test-pack", nil)
+	if err != nil {
+		t.Fatalf("DiscoverPackAgents: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0].layout != layoutV2Convention {
+		t.Errorf("agent.layout = %v, want layoutV2Convention", agents[0].layout)
+	}
+}
+
+// TestLoadPack_StampsV1Layout asserts that agents declared as
+// [[agent]] blocks in a pack's pack.toml carry layout=layoutV1Inline.
+func TestLoadPack_StampsV1Layout(t *testing.T) {
+	packDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(`
+[pack]
+name = "test-pack"
+schema = 1
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agents, _, _, _, _, _, _, err := loadPack(
+		fsys.OSFS{},
+		filepath.Join(packDir, "pack.toml"),
+		packDir,
+		packDir,
+		"test-rig",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("loadPack: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0].Name != "mayor" {
+		t.Fatalf("agent name = %q, want mayor", agents[0].Name)
+	}
+	if agents[0].layout != layoutV1Inline {
+		t.Errorf("agent.layout = %v, want layoutV1Inline", agents[0].layout)
+	}
+}
+
+// TestLoadPack_PreservesV2LayoutOnMixedPack asserts that when a pack
+// has both v1 [[agent]] blocks and v2 agents/<name>/ entries, each
+// agent retains its discovery-time layout stamp.
+func TestLoadPack_PreservesV2LayoutOnMixedPack(t *testing.T) {
+	packDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(`
+[pack]
+name = "test-pack"
+schema = 1
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	v2Dir := filepath.Join(packDir, "agents", "polecat")
+	if err := os.MkdirAll(v2Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(v2Dir, "agent.toml"), []byte(`
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agents, _, _, _, _, _, _, err := loadPack(
+		fsys.OSFS{},
+		filepath.Join(packDir, "pack.toml"),
+		packDir,
+		packDir,
+		"test-rig",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("loadPack: %v", err)
+	}
+
+	var mayor, polecat *Agent
+	for i := range agents {
+		switch agents[i].Name {
+		case "mayor":
+			mayor = &agents[i]
+		case "polecat":
+			polecat = &agents[i]
+		}
+	}
+	if mayor == nil || polecat == nil {
+		t.Fatalf("expected both mayor and polecat, got %d agents", len(agents))
+	}
+	if mayor.layout != layoutV1Inline {
+		t.Errorf("mayor.layout = %v, want layoutV1Inline", mayor.layout)
+	}
+	if polecat.layout != layoutV2Convention {
+		t.Errorf("polecat.layout = %v, want layoutV2Convention", polecat.layout)
+	}
+}
+
+// TestLoadWithIncludes_CityInlineHasUnknownLayout asserts that agents
+// declared via inline [[agent]] in city.toml carry
+// layout=layoutUnknown — they are a third category, not v1.
+func TestLoadWithIncludes_CityInlineHasUnknownLayout(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test-city"
+
+[[agent]]
+name = "mayor"
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	var mayor *Agent
+	for i := range cfg.Agents {
+		if cfg.Agents[i].Name == "mayor" && cfg.Agents[i].Dir == "" {
+			mayor = &cfg.Agents[i]
+			break
+		}
+	}
+	if mayor == nil {
+		t.Fatalf("mayor not found in cfg.Agents")
+	}
+	if mayor.layout != layoutUnknown {
+		t.Errorf("mayor.layout = %v, want layoutUnknown for city-inline agent", mayor.layout)
+	}
+}
+
+// TestApplyAgentPatch_PreservesLayout asserts the layout stamp survives
+// a patch application — same propagation invariant as ga-tpfc's
+// `source` field.
+func TestApplyAgentPatch_PreservesLayout(t *testing.T) {
+	strVal := func(s string) *string { return &s }
+	agent := Agent{Name: "mayor", layout: layoutV2Convention}
+	patch := AgentPatch{Name: "mayor", PromptTemplate: strVal("prompts/new.md")}
+	applyAgentPatchFields(&agent, &patch)
+	if agent.layout != layoutV2Convention {
+		t.Errorf("agent.layout after patch = %v, want layoutV2Convention (preserved)", agent.layout)
+	}
+}
+
+// TestApplyAgentOverride_PreservesLayout asserts the layout stamp
+// survives an override application.
+func TestApplyAgentOverride_PreservesLayout(t *testing.T) {
+	strVal := func(s string) *string { return &s }
+	agent := Agent{Name: "polecat", layout: layoutV1Inline}
+	override := AgentOverride{Agent: "polecat", PromptTemplate: strVal("prompts/p.md")}
+	applyAgentOverride(&agent, &override)
+	if agent.layout != layoutV1Inline {
+		t.Errorf("agent.layout after override = %v, want layoutV1Inline (preserved)", agent.layout)
+	}
+}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -10,7 +10,61 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/pricing"
 )
+
+// mergePricingByKey merges base and override pricing slices keyed by
+// (provider, model). When the same key appears in both, the override entry
+// wins. Duplicate keys within either input are collapsed to their last
+// occurrence. The returned slice preserves surviving base order followed by
+// surviving override-only entries in their original order. Used to compose
+// pack->city pricing layers during config load.
+func mergePricingByKey(base, override []pricing.ModelPricing) []pricing.ModelPricing {
+	base = dedupePricingByKey(base)
+	override = dedupePricingByKey(override)
+	if len(base) == 0 {
+		out := make([]pricing.ModelPricing, len(override))
+		copy(out, override)
+		return out
+	}
+	overrideIdx := make(map[string]int, len(override))
+	for i, p := range override {
+		overrideIdx[pricing.Key(p.Provider, p.Model)] = i
+	}
+	out := make([]pricing.ModelPricing, 0, len(base)+len(override))
+	usedOverride := make(map[int]bool, len(override))
+	for _, b := range base {
+		if i, ok := overrideIdx[pricing.Key(b.Provider, b.Model)]; ok {
+			out = append(out, override[i])
+			usedOverride[i] = true
+			continue
+		}
+		out = append(out, b)
+	}
+	for i, o := range override {
+		if !usedOverride[i] {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func dedupePricingByKey(in []pricing.ModelPricing) []pricing.ModelPricing {
+	if len(in) == 0 {
+		return nil
+	}
+	lastIdx := make(map[string]int, len(in))
+	for i, p := range in {
+		lastIdx[pricing.Key(p.Provider, p.Model)] = i
+	}
+	out := make([]pricing.ModelPricing, 0, len(lastIdx))
+	for i, p := range in {
+		if lastIdx[pricing.Key(p.Provider, p.Model)] == i {
+			out = append(out, p)
+		}
+	}
+	return out
+}
 
 // Provenance tracks where each configuration element originated during
 // composition. Built into the merge API from the start — retrofitting
@@ -31,6 +85,9 @@ type Provenance struct {
 	Workspace map[string]string
 	// Warnings collects non-fatal collision warnings from composition.
 	Warnings []string
+
+	sourceContents   map[string][]byte
+	revisionSnapshot *revisionSnapshot
 }
 
 // LoadOptions controls optional config-loading behavior.
@@ -62,8 +119,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 	cityRoot := filepath.Dir(path)
 	prov := newProvenance(path)
+	prov.recordSource(path, data)
 	prov.Warnings = append(prov.Warnings, rootWarnings...)
 	cityAgentsForProvenance := root.Agents
+	root.Pricing = dedupePricingByKey(root.Pricing)
+	root.CityPricing = append([]pricing.ModelPricing(nil), root.Pricing...)
 	// defaultBindings names the [defaults.rig.imports] bindings declared
 	// by the city's pack.toml. After expansion, agents whose BindingName
 	// matches one of these names are auto-imports (the user did not
@@ -154,6 +214,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
+		// Merge pack.toml pricing (pack is base, city wins by (provider, model) key).
+		if len(pc.Pricing) > 0 {
+			root.PackPricing = mergePricingByKey(root.PackPricing, pc.Pricing)
+			root.Pricing = mergePricingByKey(pc.Pricing, root.Pricing)
+		}
 		// Merge named sessions.
 		root.NamedSessions = append(pc.NamedSessions, root.NamedSessions...)
 		// Merge root-pack services as the portable base layer. city.toml
@@ -193,6 +258,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Track pack.toml agents in provenance.
 		trackAgents(prov, pc.Agents, packPath)
 		prov.Sources = append(prov.Sources, packPath)
+		prov.recordSource(packPath, packData)
 
 		packCommands, err := DiscoverPackCommands(fs, cityRoot, pc.Pack.Name)
 		if err != nil {
@@ -311,6 +377,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Merge fragment into root.
 		mergeFragment(root, frag, fragMeta, fragPath, prov)
 		prov.Sources = append(prov.Sources, fragPath)
+		prov.recordSource(fragPath, fragData)
 	}
 
 	// Inject system pack includes into Workspace.Includes. These are
@@ -335,7 +402,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Resolve named pack references to cache paths before any expansion.
 	resolveNamedPacks(root, cityRoot)
 
-	implicitImports, implicitPath, implicitErr := ReadImplicitImports()
+	implicitImports, implicitPath, implicitData, implicitErr := readImplicitImportsWithData()
 	if implicitErr != nil {
 		return nil, nil, implicitErr
 	}
@@ -387,6 +454,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		if addedImplicit && implicitPath != "" {
 			prov.Sources = append(prov.Sources, implicitPath)
+			if implicitData != nil {
+				prov.recordSource(implicitPath, implicitData)
+			}
 		}
 	}
 
@@ -578,6 +648,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 			}
 		}
 	}
+
+	// Capture revision inputs after all config and pack discovery so callers
+	// can compare the loaded snapshot to future reloads without re-reading
+	// mutable files from disk.
+	prov.captureRevisionSnapshot(fs, root, cityRoot)
 
 	return root, prov, nil
 }
@@ -788,6 +863,12 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 
 	// Packs: additive merge.
 	mergePacks(base, fragment, fragPath, prov)
+
+	// Pricing: city fragments are city-layer overrides.
+	if len(fragment.Pricing) > 0 {
+		base.CityPricing = mergePricingByKey(base.CityPricing, fragment.Pricing)
+		base.Pricing = mergePricingByKey(base.Pricing, fragment.Pricing)
+	}
 
 	// Patches: accumulate from fragments (applied after all merges).
 	base.Patches.Agents = append(base.Patches.Agents, fragment.Patches.Agents...)
@@ -1264,6 +1345,15 @@ func newProvenance(rootPath string) *Provenance {
 		Rigs:      make(map[string]string),
 		Workspace: make(map[string]string),
 	}
+}
+
+func (p *Provenance) recordSource(path string, data []byte) {
+	if p.sourceContents == nil {
+		p.sourceContents = make(map[string][]byte)
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	p.sourceContents[path] = cp
 }
 
 func trackAgents(prov *Provenance, agents []Agent, source string) {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -10,61 +10,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
-	"github.com/gastownhall/gascity/internal/pricing"
 )
-
-// mergePricingByKey merges base and override pricing slices keyed by
-// (provider, model). When the same key appears in both, the override entry
-// wins. Duplicate keys within either input are collapsed to their last
-// occurrence. The returned slice preserves surviving base order followed by
-// surviving override-only entries in their original order. Used to compose
-// pack→city pricing layers during config load.
-func mergePricingByKey(base, override []pricing.ModelPricing) []pricing.ModelPricing {
-	base = dedupePricingByKey(base)
-	override = dedupePricingByKey(override)
-	if len(base) == 0 {
-		out := make([]pricing.ModelPricing, len(override))
-		copy(out, override)
-		return out
-	}
-	overrideIdx := make(map[string]int, len(override))
-	for i, p := range override {
-		overrideIdx[pricing.Key(p.Provider, p.Model)] = i
-	}
-	out := make([]pricing.ModelPricing, 0, len(base)+len(override))
-	usedOverride := make(map[int]bool, len(override))
-	for _, b := range base {
-		if i, ok := overrideIdx[pricing.Key(b.Provider, b.Model)]; ok {
-			out = append(out, override[i])
-			usedOverride[i] = true
-			continue
-		}
-		out = append(out, b)
-	}
-	for i, o := range override {
-		if !usedOverride[i] {
-			out = append(out, o)
-		}
-	}
-	return out
-}
-
-func dedupePricingByKey(in []pricing.ModelPricing) []pricing.ModelPricing {
-	if len(in) == 0 {
-		return nil
-	}
-	lastIdx := make(map[string]int, len(in))
-	for i, p := range in {
-		lastIdx[pricing.Key(p.Provider, p.Model)] = i
-	}
-	out := make([]pricing.ModelPricing, 0, len(lastIdx))
-	for i, p := range in {
-		if lastIdx[pricing.Key(p.Provider, p.Model)] == i {
-			out = append(out, p)
-		}
-	}
-	return out
-}
 
 // Provenance tracks where each configuration element originated during
 // composition. Built into the merge API from the start — retrofitting
@@ -85,9 +31,6 @@ type Provenance struct {
 	Workspace map[string]string
 	// Warnings collects non-fatal collision warnings from composition.
 	Warnings []string
-
-	sourceContents   map[string][]byte
-	revisionSnapshot *revisionSnapshot
 }
 
 // LoadOptions controls optional config-loading behavior.
@@ -119,11 +62,8 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 	cityRoot := filepath.Dir(path)
 	prov := newProvenance(path)
-	prov.recordSource(path, data)
 	prov.Warnings = append(prov.Warnings, rootWarnings...)
 	cityAgentsForProvenance := root.Agents
-	root.Pricing = dedupePricingByKey(root.Pricing)
-	root.CityPricing = append([]pricing.ModelPricing(nil), root.Pricing...)
 	// defaultBindings names the [defaults.rig.imports] bindings declared
 	// by the city's pack.toml. After expansion, agents whose BindingName
 	// matches one of these names are auto-imports (the user did not
@@ -213,11 +153,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
-		// Merge pack.toml pricing (pack is base, city wins by (provider, model) key).
-		if len(pc.Pricing) > 0 {
-			root.PackPricing = mergePricingByKey(root.PackPricing, pc.Pricing)
-			root.Pricing = mergePricingByKey(pc.Pricing, root.Pricing)
-		}
 		// Merge named sessions.
 		root.NamedSessions = append(pc.NamedSessions, root.NamedSessions...)
 		// Merge root-pack services as the portable base layer. city.toml
@@ -257,7 +192,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Track pack.toml agents in provenance.
 		trackAgents(prov, pc.Agents, packPath)
 		prov.Sources = append(prov.Sources, packPath)
-		prov.recordSource(packPath, packData)
 
 		packCommands, err := DiscoverPackCommands(fs, cityRoot, pc.Pack.Name)
 		if err != nil {
@@ -376,7 +310,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Merge fragment into root.
 		mergeFragment(root, frag, fragMeta, fragPath, prov)
 		prov.Sources = append(prov.Sources, fragPath)
-		prov.recordSource(fragPath, fragData)
 	}
 
 	// Inject system pack includes into Workspace.Includes. These are
@@ -401,7 +334,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Resolve named pack references to cache paths before any expansion.
 	resolveNamedPacks(root, cityRoot)
 
-	implicitImports, implicitPath, implicitData, implicitErr := readImplicitImportsWithData()
+	implicitImports, implicitPath, implicitErr := ReadImplicitImports()
 	if implicitErr != nil {
 		return nil, nil, implicitErr
 	}
@@ -453,9 +386,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		if addedImplicit && implicitPath != "" {
 			prov.Sources = append(prov.Sources, implicitPath)
-			if implicitData != nil {
-				prov.recordSource(implicitPath, implicitData)
-			}
 		}
 	}
 
@@ -517,6 +447,23 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Apply [global] sections from packs to agents in scope.
 	root.PackGlobals = append(root.PackGlobals, rootPackGlobals...)
 	applyPackGlobals(root)
+
+	// Refine source provenance for default-binding imports (ga-tpfc).
+	// Discovery stamps every pack-loaded agent as sourcePack; here we
+	// promote the subset that came in via pack.toml's
+	// [defaults.rig.imports] to sourceAutoImport so describeSource can
+	// distinguish them in duplicate-name errors.
+	if len(defaultBindings) > 0 {
+		for i := range root.Agents {
+			a := &root.Agents[i]
+			if a.source != sourcePack || a.BindingName == "" {
+				continue
+			}
+			if defaultBindings[a.BindingName] {
+				a.source = sourceAutoImport
+			}
+		}
+	}
 
 	// Validate city-scoped pack requirements.
 	if err := validateCityRequirements(cityReqs, root.Agents); err != nil {
@@ -581,16 +528,6 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		return nil, nil, fmt.Errorf("%s: provider cache build failed: %w", path, err)
 	}
 
-	// v0.15.1: enrich every agent with its convention-discovered
-	// agent-local asset paths (agents/<name>/skills/, agents/<name>/mcp/).
-	// DiscoverPackAgents only does this for agents it creates — it skips
-	// names already present in pack.toml [[agent]] or city.toml
-	// [[agent]] entries, so those agents leave the discovery pass with
-	// empty SkillsDir/MCPDir even when agents/<name>/skills/ exists on
-	// disk. The materializer and collision validator both key off
-	// SkillsDir, so that gap silently loses agent-local skills for every
-	// explicitly-declared agent. Populate the fields here so the
-	// convention works uniformly.
 	populateAgentLocalAssetDirs(fs, root, cityRoot)
 
 	// Load namepool files for pool agents.
@@ -609,12 +546,37 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, warning)
 	}
 
-	promoteAutoImportAgentSources(root.Agents, defaultBindings, root.ImplicitImportBindings)
+	// v0.15.1: enrich every agent with its convention-discovered
+	// agent-local asset paths (agents/<name>/skills/, agents/<name>/mcp/).
+	// DiscoverPackAgents only does this for agents it creates — it skips
+	// names already present in pack.toml [[agent]] or city.toml
+	// [[agent]] entries, so those agents leave the discovery pass with
+	// empty SkillsDir/MCPDir even when agents/<name>/skills/ exists on
+	// disk. The materializer and collision validator both key off
+	// SkillsDir, so that gap silently loses agent-local skills for every
+	// explicitly-declared agent. Populate the fields here so the
+	// convention works uniformly.
 
-	// Capture revision inputs after all config and pack discovery so callers
-	// can compare the loaded snapshot to future reloads without re-reading
-	// mutable files from disk.
-	prov.captureRevisionSnapshot(fs, root, cityRoot)
+	// ga-tpfc.1: promote pack-stamped agents to sourceAutoImport when
+	// their binding came in via implicit-import expansion (the gastown
+	// system pack and similar). describeSource then renders
+	// "<auto-import: …>" for these in duplicate-name errors instead of
+	// the generic "<pack: …>" or empty-string forms. Agents loaded via
+	// loadPackWithCacheOptions arrive with source=sourcePack; we override
+	// based on the post-composition ImplicitImportBindings set so the
+	// override is computed exactly once over the data the loader already
+	// stamped.
+	if len(root.ImplicitImportBindings) > 0 {
+		for i := range root.Agents {
+			a := &root.Agents[i]
+			if a.BindingName == "" {
+				continue
+			}
+			if root.ImplicitImportBindings[a.BindingName] {
+				a.source = sourceAutoImport
+			}
+		}
+	}
 
 	return root, prov, nil
 }
@@ -825,12 +787,6 @@ func mergeFragment(base, fragment *City, fragMeta toml.MetaData, fragPath string
 
 	// Packs: additive merge.
 	mergePacks(base, fragment, fragPath, prov)
-
-	// Pricing: city fragments are city-layer overrides.
-	if len(fragment.Pricing) > 0 {
-		base.CityPricing = mergePricingByKey(base.CityPricing, fragment.Pricing)
-		base.Pricing = mergePricingByKey(base.Pricing, fragment.Pricing)
-	}
 
 	// Patches: accumulate from fragments (applied after all merges).
 	base.Patches.Agents = append(base.Patches.Agents, fragment.Patches.Agents...)
@@ -1208,31 +1164,14 @@ func parseWithMeta(data []byte, source string) (*City, toml.MetaData, []string, 
 	warnings := agentDefaultsCompatibilityWarnings(md, source)
 	normalizeLegacyOrderOverrideAliases(&cfg)
 	warnings = append(warnings, CheckUndecodedKeys(md, source)...)
-	// Stamp source=sourceInline on inline [[agent]] tables. Fragments may
-	// later set SourceDir, which remains the concrete duplicate-error source.
+	// Stamp source=sourceInline on inline [[agent]] tables. For fragments,
+	// adjustAgentPaths later sets SourceDir, which takes precedence in
+	// describeSource (FR-1). For the root city.toml, SourceDir is empty
+	// and the inline stamp drives the fallback descriptor (FR-3).
 	for i := range cfg.Agents {
 		cfg.Agents[i].source = sourceInline
 	}
 	return &cfg, md, warnings, nil
-}
-
-// promoteAutoImportAgentSources centralizes the two auto-import sources:
-// bindings from the city pack's [defaults.rig.imports] and bootstrap implicit
-// imports. Both paths produce normal pack-loaded agents first, then this pass
-// promotes the source stamp exactly once after composition has settled.
-func promoteAutoImportAgentSources(agents []Agent, defaultBindings, implicitBindings map[string]bool) {
-	if len(defaultBindings) == 0 && len(implicitBindings) == 0 {
-		return
-	}
-	for i := range agents {
-		a := &agents[i]
-		if a.source != sourcePack || a.BindingName == "" {
-			continue
-		}
-		if defaultBindings[a.BindingName] || implicitBindings[a.BindingName] {
-			a.source = sourceAutoImport
-		}
-	}
 }
 
 // LoadRootPackDefaultRigImports loads the canonical [defaults.rig.imports]
@@ -1324,15 +1263,6 @@ func newProvenance(rootPath string) *Provenance {
 		Rigs:      make(map[string]string),
 		Workspace: make(map[string]string),
 	}
-}
-
-func (p *Provenance) recordSource(path string, data []byte) {
-	if p.sourceContents == nil {
-		p.sourceContents = make(map[string][]byte)
-	}
-	cp := make([]byte, len(data))
-	copy(cp, data)
-	p.sourceContents[path] = cp
 }
 
 func trackAgents(prov *Provenance, agents []Agent, source string) {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -111,10 +111,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		var packAgents []Agent
 		for _, a := range pc.Agents {
 			if !cityAgentNames[a.Name] {
-				// Stamp source on the city pack's own [[agent]] blocks
-				// so duplicate-name errors against city.toml inline
-				// agents render a non-empty descriptor (ga-tpfc.1).
+				// Stamp provenance on the city pack's own [[agent]]
+				// blocks; these are v1 inline pack agents, distinct
+				// from v2 convention-discovered agents.
 				a.source = sourcePack
+				a.layout = layoutV1Inline
 				packAgents = append(packAgents, a)
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -15,8 +14,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
-	"github.com/gastownhall/gascity/internal/orders"
-	"github.com/gastownhall/gascity/internal/pricing"
 )
 
 // validAgentName matches names safe for use in session identifiers.
@@ -33,50 +30,17 @@ const (
 	// ControlDispatcherAgentName is the built-in deterministic control lane for
 	// graph.v2 workflow control beads.
 	ControlDispatcherAgentName = "control-dispatcher"
-	// controlDispatcherDefaultTracePathExpr is the watcher-safe default trace
-	// target for the control-dispatcher. The controller ignores the hidden .gc
-	// subtree recursively, so defaults must stay under it to avoid self-triggered
-	// config-watch churn. The trace intentionally stays a flat, well-known file
-	// under .gc/runtime because operators and tests tail a single canonical path.
-	//
-	// Per-dispatcher distinction (closes #1650) is layered on top in
-	// cmd/gc/template_resolve.go at session-spawn time: agentEnv there
-	// overrides GC_CONTROL_DISPATCHER_TRACE_DEFAULT with a per-name absolute
-	// path, which the ${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-...} expression
-	// below consumes. The shell template stays uniform so the trust decision
-	// lives in Go.
-	controlDispatcherDefaultTracePathExpr = `${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-${GC_CITY}/` + citylayout.RuntimeDataRoot + `/control-dispatcher-trace.log}`
-	// controlDispatcherTraceInit exports the resolved trace path. Explicit
-	// GC_WORKFLOW_TRACE overrides win first; otherwise the runtime injects a
-	// precomputed watcher-safe default trace path for the current city/session.
-	controlDispatcherTraceInit = `export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-` + controlDispatcherDefaultTracePathExpr + `}"`
-	// controlDispatcherTraceDirInit creates the parent directory for the
-	// resolved trace path. This preserves explicit GC_WORKFLOW_TRACE overrides
-	// instead of unconditionally depending on the default runtime root.
-	controlDispatcherTraceDirInit = `trace_dir="${GC_WORKFLOW_TRACE%/*}"; if [ "$trace_dir" = "$GC_WORKFLOW_TRACE" ]; then trace_dir="."; elif [ -z "$trace_dir" ]; then trace_dir="/"; fi; mkdir -p "$trace_dir"`
 	// ControlDispatcherStartCommand runs the built-in control-dispatcher worker.
 	// Wrapped in `sh -c` so any appended prompt suffix is ignored as $0.
 	// The control lane is kept resident and blocks on workflow-relevant city
 	// events instead of exiting after each one-shot drain.
-	//
-	// The trace log default is under .gc/runtime/ so it sits inside the
-	// controller's fsnotify exclusion (cmd/gc/controller.go shouldIgnoreConfigWatchEvent
-	// excludes the .gc and .beads path segments). Placing it at city root
-	// caused every append to fire markDirty() through the watcher debouncer,
-	// which kept the patrol loop in continuous reconciliation and blew patrol
-	// cycle duration well past the configured patrol_interval. See
-	// engdocs/design/session-reconciler-tracing.md for the canonical
-	// .gc/runtime/ convention for trace data.
-	ControlDispatcherStartCommand = `sh -c '` + controlDispatcherTraceInit + `; ` + controlDispatcherTraceDirInit + `; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + ControlDispatcherAgentName + `'`
+	ControlDispatcherStartCommand = `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + ControlDispatcherAgentName + `'`
 )
 
 // ControlDispatcherStartCommandFor returns the start command for a
-// control-dispatcher agent with the given qualified name. The shell-level
-// trace default is uniform across dispatchers; per-dispatcher distinction
-// (closes #1650) is injected via agentEnv in cmd/gc/template_resolve.go at
-// session-spawn time so the trust decision happens in Go.
+// control-dispatcher agent with the given qualified name.
 func ControlDispatcherStartCommandFor(qualifiedName string) string {
-	return `sh -c '` + controlDispatcherTraceInit + `; ` + controlDispatcherTraceDirInit + `; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
+	return `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
 }
 
 // BindingQualifiedName returns the binding-qualified agent identity without a
@@ -207,9 +171,6 @@ type City struct {
 	SessionSleep SessionSleepConfig `toml:"session_sleep,omitempty"`
 	// Convergence configures convergence loop limits.
 	Convergence ConvergenceConfig `toml:"convergence,omitempty"`
-	// Doctor configures gc doctor thresholds and policy toggles
-	// (worktree size warnings, nested-worktree auto-prune).
-	Doctor DoctorConfig `toml:"doctor,omitempty"`
 	// Services declares workspace-owned HTTP services mounted on the
 	// controller edge under /svc/{name}.
 	Services []Service `toml:"service,omitempty"`
@@ -334,17 +295,6 @@ type City struct {
 	// ResolvedProviders is the eager-resolution cache populated by
 	// BuildResolvedProviderCache after compose + patch. Runtime-only.
 	ResolvedProviders map[string]ResolvedProvider `toml:"-" json:"-"`
-	// Pricing holds per-model cost rate overrides keyed by (provider, model).
-	// City-level entries override pack-level entries which override the
-	// defaults shipped with the pricing package. See internal/pricing for the
-	// estimation seam introduced by issue #1255 (1d).
-	Pricing []pricing.ModelPricing `toml:"pricing,omitempty"`
-	// PackPricing preserves the pack-level pricing layer before Pricing is
-	// flattened for legacy callers. Runtime-only.
-	PackPricing []pricing.ModelPricing `toml:"-" json:"-"`
-	// CityPricing preserves the city-level pricing layer before Pricing is
-	// flattened for legacy callers. Runtime-only.
-	CityPricing []pricing.ModelPricing `toml:"-" json:"-"`
 }
 
 // NamedSession defines a canonical persistent session backed by an agent
@@ -463,12 +413,6 @@ type Rig struct {
 	Path string `toml:"path,omitempty"`
 	// Prefix overrides the auto-derived bead ID prefix for this rig.
 	Prefix string `toml:"prefix,omitempty"`
-	// DefaultBranch is the rig repository's mainline branch (e.g. "main",
-	// "master", "develop"). When set, polecats and the refinery use this
-	// as the default merge target instead of probing origin/HEAD at sling
-	// time. Captured by `gc rig add` from the rig's git config; set
-	// manually for rigs whose mainline isn't reachable via origin/HEAD.
-	DefaultBranch string `toml:"default_branch,omitempty"`
 	// Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume.
 	Suspended bool `toml:"suspended,omitempty"`
 	// FormulasDir is a rig-local formula directory (Layer 4). Overrides
@@ -535,7 +479,7 @@ type AgentOverride struct {
 	// PromptTemplate overrides the prompt template path.
 	// Relative paths resolve against the city directory.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
-	// Session overrides the session transport ("acp" or "tmux").
+	// Session overrides the session transport ("acp").
 	Session *string `toml:"session,omitempty"`
 	// Provider overrides the provider name.
 	Provider *string `toml:"provider,omitempty"`
@@ -765,13 +709,6 @@ func (r *Rig) EffectivePrefix() string {
 	return DeriveBeadsPrefix(r.Name)
 }
 
-// EffectiveDefaultBranch returns the rig's recorded default branch, or the
-// empty string if none is set. Callers should fall back to a runtime probe
-// (e.g., git symbolic-ref) when this returns "".
-func (r *Rig) EffectiveDefaultBranch() string {
-	return strings.TrimSpace(r.DefaultBranch)
-}
-
 // EffectiveHQPrefix returns the bead ID prefix for the city's HQ store.
 // Uses the effective site-bound prefix first, then the declared workspace
 // Prefix, then derives one from the effective city name.
@@ -879,7 +816,7 @@ type Workspace struct {
 	// InstallAgentHooks lists provider names whose hooks should be installed
 	// into agent working directories. Agent-level overrides workspace-level
 	// (replace, not additive). Supported: "claude", "codex", "gemini",
-	// "opencode", "copilot", "cursor", "kiro", "pi", "omp".
+	// "opencode", "copilot", "cursor", "pi", "omp".
 	InstallAgentHooks []string `toml:"install_agent_hooks,omitempty"`
 	// GlobalFragments lists named template fragments injected into every
 	// agent's rendered prompt. Applied before per-agent InjectFragments.
@@ -1121,11 +1058,6 @@ type DoltConfig struct {
 	Port int `toml:"port,omitempty" jsonschema:"default=0"`
 	// Host is the dolt server hostname. Defaults to localhost.
 	Host string `toml:"host,omitempty" jsonschema:"default=localhost"`
-	// ArchiveLevel controls Dolt's auto_gc archive aggressiveness.
-	// 0 disables archive compaction (lower CPU on startup).
-	// 1 enables archive compaction (higher CPU on startup).
-	// nil (omitted) defaults to 0.
-	ArchiveLevel *int `toml:"archive_level,omitempty" jsonschema:"default=0"`
 }
 
 // FormulasConfig holds formula directory settings.
@@ -1152,13 +1084,8 @@ type OrdersConfig struct {
 type OrderOverride struct {
 	// Name is the order name to target (required).
 	Name string `toml:"name" jsonschema:"required"`
-	// Rig scopes the override to a specific rig's order. Empty matches
-	// ONLY city-level orders (those with no rig); it does NOT match
-	// per-rig instances of the same name — those expand at scan time
-	// and require an explicit rig. Use rig = "*" as a wildcard to match
-	// every instance of the named order (city-level + every rig-scoped
-	// copy). The literal "*" is reserved and rejected as a real rig
-	// name by config validation.
+	// Rig scopes the override to a specific rig's order.
+	// Empty matches city-level orders.
 	Rig string `toml:"rig,omitempty"`
 	// Enabled overrides whether the order is active.
 	Enabled *bool `toml:"enabled,omitempty"`
@@ -1264,95 +1191,6 @@ func (c ChatSessionsConfig) IdleTimeoutDuration() time.Duration {
 	return d
 }
 
-// DoctorConfig holds settings for the gc doctor surface. Operator-tunable
-// thresholds and policy toggles live here; mechanical structural checks
-// (broken-worktree pointers, missing files) remain hardcoded since they
-// cannot be operator-tuned in any meaningful sense.
-type DoctorConfig struct {
-	// WorktreeRigWarnSize is the per-rig warning threshold for the total
-	// disk footprint under .gc/worktrees/<rig>/. Reported by the
-	// worktree-disk-size check. Go-style human size string ("10GB", "500MB").
-	// Empty or unparseable falls back to the default (10 GB).
-	WorktreeRigWarnSize string `toml:"worktree_rig_warn_size,omitempty" jsonschema:"default=10GB"`
-
-	// WorktreeRigErrorSize is the per-rig error threshold. When any rig
-	// exceeds this, the worktree-disk-size check reports an error rather
-	// than a warning. Empty or unparseable falls back to the default
-	// (50 GB).
-	WorktreeRigErrorSize string `toml:"worktree_rig_error_size,omitempty" jsonschema:"default=50GB"`
-
-	// NestedWorktreePrune escalates the nested-worktree-prune check
-	// from warning to error severity when safely-prunable nested
-	// worktrees are present, so CI / scripted doctor runs fail until
-	// the operator runs `gc doctor --fix`. Actual removal still
-	// requires --fix; this flag does not auto-prune. Safety is
-	// enforced by mechanical checks (no uncommitted changes, no
-	// unpushed commits, no stashes) — never by role identity.
-	NestedWorktreePrune bool `toml:"nested_worktree_prune,omitempty" jsonschema:"default=false"`
-}
-
-const (
-	defaultWorktreeRigWarnBytes  = int64(10) * 1024 * 1024 * 1024 // 10 GB
-	defaultWorktreeRigErrorBytes = int64(50) * 1024 * 1024 * 1024 // 50 GB
-)
-
-// WorktreeRigWarnBytes returns the warning threshold in bytes. Falls
-// back to defaultWorktreeRigWarnBytes when unset, unparseable, or
-// non-positive.
-func (c DoctorConfig) WorktreeRigWarnBytes() int64 {
-	if n, ok := parseHumanSize(c.WorktreeRigWarnSize); ok && n > 0 {
-		return n
-	}
-	return defaultWorktreeRigWarnBytes
-}
-
-// WorktreeRigErrorBytes returns the error threshold in bytes. Falls
-// back to defaultWorktreeRigErrorBytes when unset, unparseable, or
-// non-positive. The error threshold is clamped to at least the warn
-// threshold to keep the two-tier semantics monotonic; if the operator
-// configures error < warn, the warn value wins.
-func (c DoctorConfig) WorktreeRigErrorBytes() int64 {
-	warn := c.WorktreeRigWarnBytes()
-	n, ok := parseHumanSize(c.WorktreeRigErrorSize)
-	if !ok || n <= 0 {
-		n = defaultWorktreeRigErrorBytes
-	}
-	if n < warn {
-		return warn
-	}
-	return n
-}
-
-// parseHumanSize parses sizes like "10GB", "500 MB", "1024" (bytes
-// implied) into a byte count. Whitespace tolerant, case-insensitive.
-// Returns ok=false when the string is empty or unparseable so callers
-// can apply their own default.
-func parseHumanSize(s string) (int64, bool) {
-	s = strings.TrimSpace(strings.ToUpper(s))
-	if s == "" {
-		return 0, false
-	}
-	var unit int64 = 1
-	switch {
-	case strings.HasSuffix(s, "GB"):
-		unit = 1024 * 1024 * 1024
-		s = strings.TrimSpace(strings.TrimSuffix(s, "GB"))
-	case strings.HasSuffix(s, "MB"):
-		unit = 1024 * 1024
-		s = strings.TrimSpace(strings.TrimSuffix(s, "MB"))
-	case strings.HasSuffix(s, "KB"):
-		unit = 1024
-		s = strings.TrimSpace(strings.TrimSuffix(s, "KB"))
-	case strings.HasSuffix(s, "B"):
-		s = strings.TrimSpace(strings.TrimSuffix(s, "B"))
-	}
-	n, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	return n * unit, true
-}
-
 // ConvergenceConfig holds convergence loop limits.
 type ConvergenceConfig struct {
 	// MaxPerAgent is the maximum number of active convergence loops per agent.
@@ -1399,20 +1237,6 @@ type DaemonConfig struct {
 	// RestartWindow is the sliding time window for counting restarts.
 	// Duration string (e.g., "30s", "5m", "1h"). Defaults to "1h".
 	RestartWindow string `toml:"restart_window,omitempty" jsonschema:"default=1h"`
-	// SessionCircuitBreaker enables the named-session respawn circuit breaker.
-	// When enabled, the controller suppresses no-progress named-session respawns
-	// after the configured restart threshold is exceeded.
-	SessionCircuitBreaker bool `toml:"session_circuit_breaker,omitempty"`
-	// SessionCircuitBreakerMaxRestarts overrides MaxRestarts for the
-	// named-session respawn circuit breaker. Nil reuses MaxRestartsOrDefault.
-	// 0 disables the circuit breaker even when SessionCircuitBreaker is true.
-	SessionCircuitBreakerMaxRestarts *int `toml:"session_circuit_breaker_max_restarts,omitempty" jsonschema:"default=5"`
-	// SessionCircuitBreakerWindow overrides RestartWindow for the named-session
-	// respawn circuit breaker. Empty reuses RestartWindowDuration.
-	SessionCircuitBreakerWindow string `toml:"session_circuit_breaker_window,omitempty" jsonschema:"default=1h"`
-	// SessionCircuitBreakerResetAfter is the cooldown before an open named-session
-	// breaker resets automatically. Empty defaults to 2 * SessionCircuitBreakerWindowDuration.
-	SessionCircuitBreakerResetAfter string `toml:"session_circuit_breaker_reset_after,omitempty"`
 	// ShutdownTimeout is the time to wait after sending Ctrl-C before force-killing
 	// agents during shutdown. Duration string (e.g., "5s", "30s"). Set to "0s"
 	// for immediate kill. Defaults to "5s".
@@ -1443,13 +1267,6 @@ type DaemonConfig struct {
 	// single tick. Nil (unset) defaults to 5. Values <= 0 are treated as the
 	// default — set a positive integer to override.
 	MaxWakesPerTick *int `toml:"max_wakes_per_tick,omitempty" jsonschema:"default=5"`
-	// NudgeDispatcher selects how queued nudges get delivered to running
-	// sessions. "legacy" (default) auto-spawns a per-session `gc nudge poll`
-	// process that polls the file-backed queue every 2s. "supervisor" runs
-	// the delivery loop inside the city runtime instead, with a unix-socket
-	// wake fast path triggered by enqueue, eliminating the per-session bd
-	// shellout storm.
-	NudgeDispatcher string `toml:"nudge_dispatcher,omitempty" jsonschema:"default=legacy,enum=legacy,enum=supervisor"`
 }
 
 // PatrolIntervalDuration returns the patrol interval as a time.Duration.
@@ -1463,18 +1280,6 @@ func (d *DaemonConfig) PatrolIntervalDuration() time.Duration {
 		return 30 * time.Second
 	}
 	return dur
-}
-
-// NudgeDispatcherMode returns the nudge dispatcher mode, defaulting to
-// "legacy". Unknown values are treated as "legacy" so a malformed config
-// does not silently disable the per-session pollers.
-func (d *DaemonConfig) NudgeDispatcherMode() string {
-	switch d.NudgeDispatcher {
-	case "supervisor":
-		return "supervisor"
-	default:
-		return "legacy"
-	}
 }
 
 // MaxRestartsOrDefault returns the max restarts threshold. Nil (unset) defaults
@@ -1495,42 +1300,6 @@ func (d *DaemonConfig) RestartWindowDuration() time.Duration {
 	dur, err := time.ParseDuration(d.RestartWindow)
 	if err != nil {
 		return time.Hour
-	}
-	return dur
-}
-
-// SessionCircuitBreakerMaxRestartsOrDefault returns the named-session respawn
-// circuit-breaker threshold. Nil reuses MaxRestartsOrDefault; zero disables it.
-func (d *DaemonConfig) SessionCircuitBreakerMaxRestartsOrDefault() int {
-	if d.SessionCircuitBreakerMaxRestarts == nil {
-		return d.MaxRestartsOrDefault()
-	}
-	return *d.SessionCircuitBreakerMaxRestarts
-}
-
-// SessionCircuitBreakerWindowDuration returns the named-session respawn
-// circuit-breaker rolling window. Empty reuses RestartWindowDuration.
-func (d *DaemonConfig) SessionCircuitBreakerWindowDuration() time.Duration {
-	if d.SessionCircuitBreakerWindow == "" {
-		return d.RestartWindowDuration()
-	}
-	dur, err := time.ParseDuration(d.SessionCircuitBreakerWindow)
-	if err != nil {
-		return d.RestartWindowDuration()
-	}
-	return dur
-}
-
-// SessionCircuitBreakerResetAfterDuration returns the named-session respawn
-// circuit-breaker cooldown. Empty or invalid values default to 2 * window.
-func (d *DaemonConfig) SessionCircuitBreakerResetAfterDuration() time.Duration {
-	window := d.SessionCircuitBreakerWindowDuration()
-	if d.SessionCircuitBreakerResetAfter == "" {
-		return 2 * window
-	}
-	dur, err := time.ParseDuration(d.SessionCircuitBreakerResetAfter)
-	if err != nil {
-		return 2 * window
 	}
 	return dur
 }
@@ -1719,7 +1488,7 @@ func normalizeAgentDefaultsAlias(cfg *City, meta toml.MetaData) {
 type Agent struct {
 	// Name is the unique identifier for this agent.
 	Name string `toml:"name" jsonschema:"required"`
-	// Description is a human-readable description shown in a real-world app's session creation UI.
+	// Description is a human-readable description shown in MC's session creation UI.
 	Description string `toml:"description,omitempty"`
 	// Dir is the identity prefix for rig-scoped agents and the default
 	// working directory when WorkDir is not set.
@@ -1745,11 +1514,10 @@ type Agent struct {
 	// Used for CLI agents that don't accept command-line prompts.
 	Nudge string `toml:"nudge,omitempty"`
 	// Session overrides the session transport for this agent.
-	// "" (default) uses the provider default.
-	// "tmux" uses the tmux-backed CLI path even when the provider supports ACP.
-	// "acp" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's
-	// resolved provider must have supports_acp = true.
-	Session string `toml:"session,omitempty" jsonschema:"enum=acp,enum=tmux"`
+	// "" (default) uses the city-level session provider (typically tmux).
+	// "acp" uses the Agent Client Protocol (JSON-RPC over stdio).
+	// The agent's resolved provider must have supports_acp = true.
+	Session string `toml:"session,omitempty" jsonschema:"enum=acp"`
 	// Provider names the provider preset to use for this agent.
 	Provider string `toml:"provider,omitempty"`
 	// StartCommand overrides the provider's command for this agent.
@@ -2046,8 +1814,6 @@ func (a *Agent) AttachEnabled() bool {
 //
 // State priority: in_progress+assigned (crash recovery) >
 // ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
-// Formula roots that are themselves executable must be represented as ready()
-// work (for example type=wisp); molecule containers are not routable demand.
 //
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
@@ -2084,7 +1850,10 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-			`printf "[]"'`
+			// Tier 4: open routed molecule roots. scale_check already counts
+			// these, so startup must be able to see them too.
+			`bd list --metadata-field gc.routed_to=` + target +
+			` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null'`
 	}
 	return `sh -c '` +
 		// Tier 1: in_progress assigned to any of my identifiers (crash recovery).
@@ -2183,7 +1952,8 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 
 // EffectiveScaleCheck returns the scale check command for this agent.
 // If ScaleCheck is set, returns it. Otherwise returns a default that
-// counts new unassigned work routed to this agent's template via ready().
+// counts new unassigned work routed to this agent's template, including
+// standalone formula-dispatched molecule beads (which bd ready excludes).
 // Assigned in-progress work is resumed from session beads, so it must not
 // create additional generic pool demand here.
 func (a *Agent) EffectiveScaleCheck() string {
@@ -2191,8 +1961,11 @@ func (a *Agent) EffectiveScaleCheck() string {
 		return a.ScaleCheck
 	}
 	template := a.QualifiedName()
-	return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
-		` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
+	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
+		`molecules=$(bd list --metadata-field gc.routed_to=` + template +
+		` --status=open --type=molecule --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
+		`echo "$(( ${ready:-0} + ${molecules:-0} ))" || echo 0`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.
@@ -2570,13 +2343,6 @@ func injectControlDispatcherAgents(cfg *City, existing map[agentKey]bool) {
 }
 
 // newControlDispatcherAgent creates a control-dispatcher agent for the given scope.
-//
-// Per-dispatcher GC_CONTROL_DISPATCHER_TRACE_DEFAULT injection (closes #1650)
-// happens in cmd/gc/template_resolve.go at session-spawn time, where
-// agentEnv has the right priority in mergeEnv to override the uniform
-// city-level default seeded by cityRuntimeEnvMapForCity. See
-// citylayout.ControlDispatcherTraceDefaultPathFor for the path computation.
-// Operators retain GC_WORKFLOW_TRACE as the topmost override.
 func newControlDispatcherAgent(dir string) Agent {
 	qualifiedName := ControlDispatcherAgentName
 	if dir != "" {
@@ -2658,7 +2424,7 @@ func ValidateAgents(agents []Agent) error {
 		}
 		key := agentKey{dir: a.Dir, name: a.Name}
 		if priorIdx, dup := seen[key]; dup {
-			return formatDuplicateAgentError(agents[priorIdx], a)
+			return formatDuplicateAgentError(agents[priorIdx], a, "", "")
 		}
 		seen[key] = i
 		// Scope enum.
@@ -2883,11 +2649,6 @@ func ValidateRigs(rigs []Rig, hqPrefix string) error {
 		if r.Name == "" {
 			return fmt.Errorf("rig[%d]: name is required", i)
 		}
-		// orders.RigWildcard is reserved as the [[orders.overrides]]
-		// token; a real rig with that name would be silently shadowed.
-		if r.Name == orders.RigWildcard {
-			return fmt.Errorf("rig[%d]: name %q is reserved as the [[orders.overrides]] wildcard", i, r.Name)
-		}
 		if r.Path == "" {
 			return fmt.Errorf("rig %q: path is required", r.Name)
 		}
@@ -2917,8 +2678,8 @@ func DefaultCity(name string) City {
 
 func defaultInstallAgentHooksForProvider(provider string) []string {
 	switch strings.TrimSpace(provider) {
-	case "opencode", "kiro":
-		return []string{strings.TrimSpace(provider)}
+	case "opencode":
+		return []string{"opencode"}
 	default:
 		return nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -14,6 +15,8 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/orders"
+	"github.com/gastownhall/gascity/internal/pricing"
 )
 
 // validAgentName matches names safe for use in session identifiers.
@@ -30,17 +33,50 @@ const (
 	// ControlDispatcherAgentName is the built-in deterministic control lane for
 	// graph.v2 workflow control beads.
 	ControlDispatcherAgentName = "control-dispatcher"
+	// controlDispatcherDefaultTracePathExpr is the watcher-safe default trace
+	// target for the control-dispatcher. The controller ignores the hidden .gc
+	// subtree recursively, so defaults must stay under it to avoid self-triggered
+	// config-watch churn. The trace intentionally stays a flat, well-known file
+	// under .gc/runtime because operators and tests tail a single canonical path.
+	//
+	// Per-dispatcher distinction (closes #1650) is layered on top in
+	// cmd/gc/template_resolve.go at session-spawn time: agentEnv there
+	// overrides GC_CONTROL_DISPATCHER_TRACE_DEFAULT with a per-name absolute
+	// path, which the ${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-...} expression
+	// below consumes. The shell template stays uniform so the trust decision
+	// lives in Go.
+	controlDispatcherDefaultTracePathExpr = `${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-${GC_CITY}/` + citylayout.RuntimeDataRoot + `/control-dispatcher-trace.log}`
+	// controlDispatcherTraceInit exports the resolved trace path. Explicit
+	// GC_WORKFLOW_TRACE overrides win first; otherwise the runtime injects a
+	// precomputed watcher-safe default trace path for the current city/session.
+	controlDispatcherTraceInit = `export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-` + controlDispatcherDefaultTracePathExpr + `}"`
+	// controlDispatcherTraceDirInit creates the parent directory for the
+	// resolved trace path. This preserves explicit GC_WORKFLOW_TRACE overrides
+	// instead of unconditionally depending on the default runtime root.
+	controlDispatcherTraceDirInit = `trace_dir="${GC_WORKFLOW_TRACE%/*}"; if [ "$trace_dir" = "$GC_WORKFLOW_TRACE" ]; then trace_dir="."; elif [ -z "$trace_dir" ]; then trace_dir="/"; fi; mkdir -p "$trace_dir"`
 	// ControlDispatcherStartCommand runs the built-in control-dispatcher worker.
 	// Wrapped in `sh -c` so any appended prompt suffix is ignored as $0.
 	// The control lane is kept resident and blocks on workflow-relevant city
 	// events instead of exiting after each one-shot drain.
-	ControlDispatcherStartCommand = `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + ControlDispatcherAgentName + `'`
+	//
+	// The trace log default is under .gc/runtime/ so it sits inside the
+	// controller's fsnotify exclusion (cmd/gc/controller.go shouldIgnoreConfigWatchEvent
+	// excludes the .gc and .beads path segments). Placing it at city root
+	// caused every append to fire markDirty() through the watcher debouncer,
+	// which kept the patrol loop in continuous reconciliation and blew patrol
+	// cycle duration well past the configured patrol_interval. See
+	// engdocs/design/session-reconciler-tracing.md for the canonical
+	// .gc/runtime/ convention for trace data.
+	ControlDispatcherStartCommand = `sh -c '` + controlDispatcherTraceInit + `; ` + controlDispatcherTraceDirInit + `; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + ControlDispatcherAgentName + `'`
 )
 
 // ControlDispatcherStartCommandFor returns the start command for a
-// control-dispatcher agent with the given qualified name.
+// control-dispatcher agent with the given qualified name. The shell-level
+// trace default is uniform across dispatchers; per-dispatcher distinction
+// (closes #1650) is injected via agentEnv in cmd/gc/template_resolve.go at
+// session-spawn time so the trust decision happens in Go.
 func ControlDispatcherStartCommandFor(qualifiedName string) string {
-	return `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
+	return `sh -c '` + controlDispatcherTraceInit + `; ` + controlDispatcherTraceDirInit + `; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
 }
 
 // BindingQualifiedName returns the binding-qualified agent identity without a
@@ -171,6 +207,9 @@ type City struct {
 	SessionSleep SessionSleepConfig `toml:"session_sleep,omitempty"`
 	// Convergence configures convergence loop limits.
 	Convergence ConvergenceConfig `toml:"convergence,omitempty"`
+	// Doctor configures gc doctor thresholds and policy toggles
+	// (worktree size warnings, nested-worktree auto-prune).
+	Doctor DoctorConfig `toml:"doctor,omitempty"`
 	// Services declares workspace-owned HTTP services mounted on the
 	// controller edge under /svc/{name}.
 	Services []Service `toml:"service,omitempty"`
@@ -295,6 +334,17 @@ type City struct {
 	// ResolvedProviders is the eager-resolution cache populated by
 	// BuildResolvedProviderCache after compose + patch. Runtime-only.
 	ResolvedProviders map[string]ResolvedProvider `toml:"-" json:"-"`
+	// Pricing holds per-model cost rate overrides keyed by (provider, model).
+	// City-level entries override pack-level entries which override the
+	// defaults shipped with the pricing package. See internal/pricing for the
+	// estimation seam introduced by issue #1255 (1d).
+	Pricing []pricing.ModelPricing `toml:"pricing,omitempty"`
+	// PackPricing preserves the pack-level pricing layer before Pricing is
+	// flattened for legacy callers. Runtime-only.
+	PackPricing []pricing.ModelPricing `toml:"-" json:"-"`
+	// CityPricing preserves the city-level pricing layer before Pricing is
+	// flattened for legacy callers. Runtime-only.
+	CityPricing []pricing.ModelPricing `toml:"-" json:"-"`
 }
 
 // NamedSession defines a canonical persistent session backed by an agent
@@ -413,6 +463,12 @@ type Rig struct {
 	Path string `toml:"path,omitempty"`
 	// Prefix overrides the auto-derived bead ID prefix for this rig.
 	Prefix string `toml:"prefix,omitempty"`
+	// DefaultBranch is the rig repository's mainline branch (e.g. "main",
+	// "master", "develop"). When set, routing formulas use this as the
+	// default merge target instead of probing origin/HEAD at sling time.
+	// Captured by `gc rig add` from the rig's git config; set manually for
+	// rigs whose mainline isn't reachable via origin/HEAD.
+	DefaultBranch string `toml:"default_branch,omitempty"`
 	// Suspended prevents the reconciler from spawning agents in this rig. Toggle with gc rig suspend/resume.
 	Suspended bool `toml:"suspended,omitempty"`
 	// FormulasDir is a rig-local formula directory (Layer 4). Overrides
@@ -709,6 +765,13 @@ func (r *Rig) EffectivePrefix() string {
 	return DeriveBeadsPrefix(r.Name)
 }
 
+// EffectiveDefaultBranch returns the rig's recorded default branch, or the
+// empty string if none is set. Callers should fall back to a runtime probe
+// (e.g., git symbolic-ref) when this returns "".
+func (r *Rig) EffectiveDefaultBranch() string {
+	return strings.TrimSpace(r.DefaultBranch)
+}
+
 // EffectiveHQPrefix returns the bead ID prefix for the city's HQ store.
 // Uses the effective site-bound prefix first, then the declared workspace
 // Prefix, then derives one from the effective city name.
@@ -816,7 +879,7 @@ type Workspace struct {
 	// InstallAgentHooks lists provider names whose hooks should be installed
 	// into agent working directories. Agent-level overrides workspace-level
 	// (replace, not additive). Supported: "claude", "codex", "gemini",
-	// "opencode", "copilot", "cursor", "pi", "omp".
+	// "kiro", "opencode", "copilot", "cursor", "pi", "omp".
 	InstallAgentHooks []string `toml:"install_agent_hooks,omitempty"`
 	// GlobalFragments lists named template fragments injected into every
 	// agent's rendered prompt. Applied before per-agent InjectFragments.
@@ -1058,6 +1121,11 @@ type DoltConfig struct {
 	Port int `toml:"port,omitempty" jsonschema:"default=0"`
 	// Host is the dolt server hostname. Defaults to localhost.
 	Host string `toml:"host,omitempty" jsonschema:"default=localhost"`
+	// ArchiveLevel controls Dolt's auto_gc archive aggressiveness.
+	// 0 disables archive compaction (lower CPU on startup).
+	// 1 enables archive compaction (higher CPU on startup).
+	// nil (omitted) defaults to 0.
+	ArchiveLevel *int `toml:"archive_level,omitempty" jsonschema:"default=0"`
 }
 
 // FormulasConfig holds formula directory settings.
@@ -1191,6 +1259,95 @@ func (c ChatSessionsConfig) IdleTimeoutDuration() time.Duration {
 	return d
 }
 
+// DoctorConfig holds settings for the gc doctor surface. Operator-tunable
+// thresholds and policy toggles live here; mechanical structural checks
+// (broken-worktree pointers, missing files) remain hardcoded since they
+// cannot be operator-tuned in any meaningful sense.
+type DoctorConfig struct {
+	// WorktreeRigWarnSize is the per-rig warning threshold for the total
+	// disk footprint under .gc/worktrees/<rig>/. Reported by the
+	// worktree-disk-size check. Go-style human size string ("10GB", "500MB").
+	// Empty or unparseable falls back to the default (10 GB).
+	WorktreeRigWarnSize string `toml:"worktree_rig_warn_size,omitempty" jsonschema:"default=10GB"`
+
+	// WorktreeRigErrorSize is the per-rig error threshold. When any rig
+	// exceeds this, the worktree-disk-size check reports an error rather
+	// than a warning. Empty or unparseable falls back to the default
+	// (50 GB).
+	WorktreeRigErrorSize string `toml:"worktree_rig_error_size,omitempty" jsonschema:"default=50GB"`
+
+	// NestedWorktreePrune escalates the nested-worktree-prune check
+	// from warning to error severity when safely-prunable nested
+	// worktrees are present, so CI / scripted doctor runs fail until
+	// the operator runs `gc doctor --fix`. Actual removal still
+	// requires --fix; this flag does not auto-prune. Safety is
+	// enforced by mechanical checks (no uncommitted changes, no
+	// unpushed commits, no stashes) — never by role identity.
+	NestedWorktreePrune bool `toml:"nested_worktree_prune,omitempty" jsonschema:"default=false"`
+}
+
+const (
+	defaultWorktreeRigWarnBytes  = int64(10) * 1024 * 1024 * 1024 // 10 GB
+	defaultWorktreeRigErrorBytes = int64(50) * 1024 * 1024 * 1024 // 50 GB
+)
+
+// WorktreeRigWarnBytes returns the warning threshold in bytes. Falls
+// back to defaultWorktreeRigWarnBytes when unset, unparseable, or
+// non-positive.
+func (c DoctorConfig) WorktreeRigWarnBytes() int64 {
+	if n, ok := parseHumanSize(c.WorktreeRigWarnSize); ok && n > 0 {
+		return n
+	}
+	return defaultWorktreeRigWarnBytes
+}
+
+// WorktreeRigErrorBytes returns the error threshold in bytes. Falls
+// back to defaultWorktreeRigErrorBytes when unset, unparseable, or
+// non-positive. The error threshold is clamped to at least the warn
+// threshold to keep the two-tier semantics monotonic; if the operator
+// configures error < warn, the warn value wins.
+func (c DoctorConfig) WorktreeRigErrorBytes() int64 {
+	warn := c.WorktreeRigWarnBytes()
+	n, ok := parseHumanSize(c.WorktreeRigErrorSize)
+	if !ok || n <= 0 {
+		n = defaultWorktreeRigErrorBytes
+	}
+	if n < warn {
+		return warn
+	}
+	return n
+}
+
+// parseHumanSize parses sizes like "10GB", "500 MB", "1024" (bytes
+// implied) into a byte count. Whitespace tolerant, case-insensitive.
+// Returns ok=false when the string is empty or unparseable so callers
+// can apply their own default.
+func parseHumanSize(s string) (int64, bool) {
+	s = strings.TrimSpace(strings.ToUpper(s))
+	if s == "" {
+		return 0, false
+	}
+	var unit int64 = 1
+	switch {
+	case strings.HasSuffix(s, "GB"):
+		unit = 1024 * 1024 * 1024
+		s = strings.TrimSpace(strings.TrimSuffix(s, "GB"))
+	case strings.HasSuffix(s, "MB"):
+		unit = 1024 * 1024
+		s = strings.TrimSpace(strings.TrimSuffix(s, "MB"))
+	case strings.HasSuffix(s, "KB"):
+		unit = 1024
+		s = strings.TrimSpace(strings.TrimSuffix(s, "KB"))
+	case strings.HasSuffix(s, "B"):
+		s = strings.TrimSpace(strings.TrimSuffix(s, "B"))
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n * unit, true
+}
+
 // ConvergenceConfig holds convergence loop limits.
 type ConvergenceConfig struct {
 	// MaxPerAgent is the maximum number of active convergence loops per agent.
@@ -1237,6 +1394,20 @@ type DaemonConfig struct {
 	// RestartWindow is the sliding time window for counting restarts.
 	// Duration string (e.g., "30s", "5m", "1h"). Defaults to "1h".
 	RestartWindow string `toml:"restart_window,omitempty" jsonschema:"default=1h"`
+	// SessionCircuitBreaker enables the named-session respawn circuit breaker.
+	// When enabled, the controller suppresses no-progress named-session respawns
+	// after the configured restart threshold is exceeded.
+	SessionCircuitBreaker bool `toml:"session_circuit_breaker,omitempty"`
+	// SessionCircuitBreakerMaxRestarts overrides MaxRestarts for the
+	// named-session respawn circuit breaker. Nil reuses MaxRestartsOrDefault.
+	// 0 disables the circuit breaker even when SessionCircuitBreaker is true.
+	SessionCircuitBreakerMaxRestarts *int `toml:"session_circuit_breaker_max_restarts,omitempty" jsonschema:"default=5"`
+	// SessionCircuitBreakerWindow overrides RestartWindow for the named-session
+	// respawn circuit breaker. Empty reuses RestartWindowDuration.
+	SessionCircuitBreakerWindow string `toml:"session_circuit_breaker_window,omitempty" jsonschema:"default=1h"`
+	// SessionCircuitBreakerResetAfter is the cooldown before an open named-session
+	// breaker resets automatically. Empty defaults to 2 * SessionCircuitBreakerWindowDuration.
+	SessionCircuitBreakerResetAfter string `toml:"session_circuit_breaker_reset_after,omitempty"`
 	// ShutdownTimeout is the time to wait after sending Ctrl-C before force-killing
 	// agents during shutdown. Duration string (e.g., "5s", "30s"). Set to "0s"
 	// for immediate kill. Defaults to "5s".
@@ -1267,6 +1438,13 @@ type DaemonConfig struct {
 	// single tick. Nil (unset) defaults to 5. Values <= 0 are treated as the
 	// default — set a positive integer to override.
 	MaxWakesPerTick *int `toml:"max_wakes_per_tick,omitempty" jsonschema:"default=5"`
+	// NudgeDispatcher selects how queued nudges get delivered to running
+	// sessions. "legacy" (default) auto-spawns a per-session `gc nudge poll`
+	// process that polls the file-backed queue every 2s. "supervisor" runs
+	// the delivery loop inside the city runtime instead, with a unix-socket
+	// wake fast path triggered by enqueue, eliminating the per-session bd
+	// shellout storm.
+	NudgeDispatcher string `toml:"nudge_dispatcher,omitempty" jsonschema:"default=legacy,enum=legacy,enum=supervisor"`
 }
 
 // PatrolIntervalDuration returns the patrol interval as a time.Duration.
@@ -1302,6 +1480,54 @@ func (d *DaemonConfig) RestartWindowDuration() time.Duration {
 		return time.Hour
 	}
 	return dur
+}
+
+// SessionCircuitBreakerMaxRestartsOrDefault returns the named-session respawn
+// circuit-breaker threshold. Nil reuses MaxRestartsOrDefault; zero disables it.
+func (d *DaemonConfig) SessionCircuitBreakerMaxRestartsOrDefault() int {
+	if d.SessionCircuitBreakerMaxRestarts == nil {
+		return d.MaxRestartsOrDefault()
+	}
+	return *d.SessionCircuitBreakerMaxRestarts
+}
+
+// SessionCircuitBreakerWindowDuration returns the named-session respawn
+// circuit-breaker rolling window. Empty reuses RestartWindowDuration.
+func (d *DaemonConfig) SessionCircuitBreakerWindowDuration() time.Duration {
+	if d.SessionCircuitBreakerWindow == "" {
+		return d.RestartWindowDuration()
+	}
+	dur, err := time.ParseDuration(d.SessionCircuitBreakerWindow)
+	if err != nil {
+		return d.RestartWindowDuration()
+	}
+	return dur
+}
+
+// SessionCircuitBreakerResetAfterDuration returns the named-session respawn
+// circuit-breaker cooldown. Empty or invalid values default to 2 * window.
+func (d *DaemonConfig) SessionCircuitBreakerResetAfterDuration() time.Duration {
+	window := d.SessionCircuitBreakerWindowDuration()
+	if d.SessionCircuitBreakerResetAfter == "" {
+		return 2 * window
+	}
+	dur, err := time.ParseDuration(d.SessionCircuitBreakerResetAfter)
+	if err != nil {
+		return 2 * window
+	}
+	return dur
+}
+
+// NudgeDispatcherMode returns the nudge dispatcher mode, defaulting to
+// "legacy". Unknown values are treated as "legacy" so a malformed config
+// does not silently disable the per-session pollers.
+func (d *DaemonConfig) NudgeDispatcherMode() string {
+	switch d.NudgeDispatcher {
+	case "supervisor":
+		return "supervisor"
+	default:
+		return "legacy"
+	}
 }
 
 // ShutdownTimeoutDuration returns the shutdown timeout as a time.Duration.
@@ -1854,6 +2080,8 @@ func (a *Agent) AttachEnabled() bool {
 //
 // State priority: in_progress+assigned (crash recovery) >
 // ready+assigned (pre-assigned) > ready+unassigned+routed_to (pool).
+// Formula roots that are themselves executable must be represented as ready()
+// work (for example type=wisp); molecule containers are not routable demand.
 //
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
@@ -1890,10 +2118,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
 			` --unassigned --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-			// Tier 4: open routed molecule roots. scale_check already counts
-			// these, so startup must be able to see them too.
-			`bd list --metadata-field gc.routed_to=` + target +
-			` --status=open --type=molecule --no-assignee --json --limit=1 2>/dev/null'`
+			`printf "[]"'`
 	}
 	return `sh -c '` +
 		// Tier 1: in_progress assigned to any of my identifiers (crash recovery).
@@ -1992,8 +2217,7 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 
 // EffectiveScaleCheck returns the scale check command for this agent.
 // If ScaleCheck is set, returns it. Otherwise returns a default that
-// counts new unassigned work routed to this agent's template, including
-// standalone formula-dispatched molecule beads (which bd ready excludes).
+// counts new unassigned work routed to this agent's template via ready().
 // Assigned in-progress work is resumed from session beads, so it must not
 // create additional generic pool demand here.
 func (a *Agent) EffectiveScaleCheck() string {
@@ -2001,11 +2225,8 @@ func (a *Agent) EffectiveScaleCheck() string {
 		return a.ScaleCheck
 	}
 	template := a.QualifiedName()
-	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
-		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`molecules=$(bd list --metadata-field gc.routed_to=` + template +
-		` --status=open --type=molecule --no-assignee --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`echo "$(( ${ready:-0} + ${molecules:-0} ))" || echo 0`
+	return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.
@@ -2689,6 +2910,11 @@ func ValidateRigs(rigs []Rig, hqPrefix string) error {
 		if r.Name == "" {
 			return fmt.Errorf("rig[%d]: name is required", i)
 		}
+		// orders.RigWildcard is reserved as the [[orders.overrides]]
+		// token; a real rig with that name would be silently shadowed.
+		if r.Name == orders.RigWildcard {
+			return fmt.Errorf("rig[%d]: name %q is reserved as the [[orders.overrides]] wildcard", i, r.Name)
+		}
 		if r.Path == "" {
 			return fmt.Errorf("rig %q: path is required", r.Name)
 		}
@@ -2718,8 +2944,8 @@ func DefaultCity(name string) City {
 
 func defaultInstallAgentHooksForProvider(provider string) []string {
 	switch strings.TrimSpace(provider) {
-	case "opencode":
-		return []string{"opencode"}
+	case "kiro", "opencode":
+		return []string{strings.TrimSpace(provider)}
 	default:
 		return nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1753,6 +1753,13 @@ type Agent struct {
 	// an empty quoted path. Unexported so the value is package-private
 	// runtime state and never appears on any wire. (See ga-tpfc.)
 	source agentSource
+	// layout records which pack layout (v1 inline [[agent]] block in
+	// pack.toml vs. v2 agents/<name>/agent.toml convention) produced
+	// this agent. Stamped once at discovery; consumed by
+	// formatDuplicateAgentError to specialize the (V1Inline,
+	// V2Convention) collision into a migration-guidance variant.
+	// Unexported, runtime-only, never on any wire. (See ga-9ogb.)
+	layout agentLayout
 }
 
 // agentSource enumerates the configuration origins recognized by
@@ -1776,6 +1783,39 @@ const (
 	// city.Imports after composition, the user did not write it.
 	sourceAutoImport
 )
+
+// agentLayout enumerates the pack-layout origin of an agent: which
+// on-disk shape produced it. Exactly one value is stamped at
+// discovery time. Used by formatDuplicateAgentError to detect a v1↔v2
+// migration collision and emit a migration-guidance error. Unexported
+// so the type is package-private runtime state and never appears on
+// any wire.
+type agentLayout uint8
+
+const (
+	// layoutUnknown is the zero value. Agents reach validation
+	// without a layout stamp when they came through a non-discovery
+	// path (test fixtures, city.toml inline [[agent]] blocks — those
+	// last are a third category, not v1).
+	layoutUnknown agentLayout = iota
+	// layoutV1Inline marks agents declared as inline [[agent]] blocks
+	// in a pack's pack.toml.
+	layoutV1Inline
+	// layoutV2Convention marks agents discovered from a pack's
+	// agents/<name>/agent.toml file.
+	layoutV2Convention
+)
+
+// String renders an agentLayout for debug logs only.
+func (l agentLayout) String() string {
+	switch l {
+	case layoutV1Inline:
+		return "v1-inline"
+	case layoutV2Convention:
+		return "v2-convention"
+	}
+	return "unknown"
+}
 
 // IdleTimeoutDuration returns the idle timeout as a time.Duration.
 // Returns 0 if empty or unparseable (disabled).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2464,7 +2464,7 @@ func ValidateAgents(agents []Agent) error {
 		}
 		key := agentKey{dir: a.Dir, name: a.Name}
 		if priorIdx, dup := seen[key]; dup {
-			return formatDuplicateAgentError(agents[priorIdx], a, "", "")
+			return formatDuplicateAgentError(agents[priorIdx], a)
 		}
 		seen[key] = i
 		// Scope enum.

--- a/internal/config/duplicate_agent_error.go
+++ b/internal/config/duplicate_agent_error.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 // describeSource renders a non-empty descriptor for this agent's
 // configuration origin. ValidateAgents uses it to format duplicate-name
@@ -8,29 +11,44 @@ import "fmt"
 // inline city.toml [[agent]] blocks from user packs. The returned string
 // is never empty — that is the visible bug ga-tpfc.1 fixes.
 //
-// Pack and auto-import sources include the binding descriptor before the
-// source directory so real pack-loaded agents do not hide the user-visible
-// binding behind SourceDir.
-func (a *Agent) describeSource() string {
+// Resolution order:
+//
+//  1. SourceDir != "" → return SourceDir as-is. Pinned by existing
+//     tests (TestValidateAgentsDupNameWithProvenance, etc.).
+//  2. source == sourceAutoImport → "<auto-import: <BindingName>>"
+//     when binding is known, else "<auto-import>".
+//  3. source == sourceInline → "<inline: <basename(cityFile)>>" when
+//     a city file path is supplied, else bare "<inline>".
+//  4. source == sourcePack → "<pack: <BindingName>>" when binding is
+//     known, else "<pack>".
+//  5. fall through (sourceUnknown or any unstamped agent) → render an
+//     identity hint: "<unknown: binding=…>" or "<unknown: name=…>"
+//     or "<unknown>".
+//
+// cityRoot is accepted but currently unused; the hook is reserved for
+// future relativization without breaking the call sites already passing
+// it through.
+func (a *Agent) describeSource(cityRoot, cityFile string) string {
+	_ = cityRoot
+	if a.SourceDir != "" {
+		return a.SourceDir
+	}
 	switch a.source {
 	case sourceAutoImport:
-		return describeBoundSource("auto-import", a.BindingName, a.SourceDir)
+		if a.BindingName != "" {
+			return fmt.Sprintf("<auto-import: %s>", a.BindingName)
+		}
+		return "<auto-import>"
 	case sourceInline:
-		if a.SourceDir != "" {
-			return a.SourceDir
+		if cityFile != "" {
+			return fmt.Sprintf("<inline: %s>", filepath.Base(cityFile))
 		}
 		return "<inline>"
 	case sourcePack:
 		if a.BindingName != "" {
-			return describeBoundSource("pack", a.BindingName, a.SourceDir)
-		}
-		if a.SourceDir != "" {
-			return a.SourceDir
+			return fmt.Sprintf("<pack: %s>", a.BindingName)
 		}
 		return "<pack>"
-	}
-	if a.SourceDir != "" {
-		return a.SourceDir
 	}
 	if a.BindingName != "" {
 		return fmt.Sprintf("<unknown: binding=%s>", a.BindingName)
@@ -41,26 +59,20 @@ func (a *Agent) describeSource() string {
 	return "<unknown>"
 }
 
-func describeBoundSource(kind, bindingName, sourceDir string) string {
-	descriptor := fmt.Sprintf("<%s>", kind)
-	if bindingName != "" {
-		descriptor = fmt.Sprintf("<%s: %s>", kind, bindingName)
-	}
-	if sourceDir != "" {
-		return fmt.Sprintf("%s %s", descriptor, sourceDir)
-	}
-	return descriptor
-}
-
 // formatDuplicateAgentError renders the duplicate-agent-name error for a
 // pair of conflicting agents. Co-owned with ga-9ogb (layout-version
 // migration error); that bead specializes (V1Inline, V2Convention) layout
 // pairs onto a migration-guidance variant. This bead's contract: every
 // rendered descriptor is non-empty, so the error never carries an empty
 // quoted "" path.
-func formatDuplicateAgentError(a, b Agent) error {
+//
+// cityRoot and cityFile are passed through to describeSource. Both may
+// be empty when the helper is called from validation paths that do not
+// know the city's filesystem context (e.g., test fixtures that build
+// []Agent directly).
+func formatDuplicateAgentError(a, b Agent, cityRoot, cityFile string) error {
 	return fmt.Errorf("agent %q: duplicate name (from %q and %q)",
 		a.QualifiedName(),
-		a.describeSource(),
-		b.describeSource())
+		a.describeSource(cityRoot, cityFile),
+		b.describeSource(cityRoot, cityFile))
 }

--- a/internal/config/duplicate_agent_error.go
+++ b/internal/config/duplicate_agent_error.go
@@ -61,18 +61,62 @@ func (a *Agent) describeSource(cityRoot, cityFile string) string {
 
 // formatDuplicateAgentError renders the duplicate-agent-name error for a
 // pair of conflicting agents. Co-owned with ga-9ogb (layout-version
-// migration error); that bead specializes (V1Inline, V2Convention) layout
-// pairs onto a migration-guidance variant. This bead's contract: every
-// rendered descriptor is non-empty, so the error never carries an empty
-// quoted "" path.
+// migration error); when the pair is exactly (layoutV1Inline,
+// layoutV2Convention) — in either order — the helper emits a
+// migration-guidance variant including both source descriptors and the
+// migration-guide doc path. Otherwise it falls through to the generic
+// "duplicate name (from … and …)" format.
+//
+// Every rendered descriptor is non-empty (the contract ga-tpfc.1 fixed),
+// so the error never carries an empty quoted "" path.
 //
 // cityRoot and cityFile are passed through to describeSource. Both may
 // be empty when the helper is called from validation paths that do not
 // know the city's filesystem context (e.g., test fixtures that build
 // []Agent directly).
 func formatDuplicateAgentError(a, b Agent, cityRoot, cityFile string) error {
+	if v1, v2, ok := orderV1V2(a, b); ok {
+		return formatV1V2MigrationError(v1, v2, cityRoot, cityFile)
+	}
 	return fmt.Errorf("agent %q: duplicate name (from %q and %q)",
 		a.QualifiedName(),
 		a.describeSource(cityRoot, cityFile),
 		b.describeSource(cityRoot, cityFile))
+}
+
+// orderV1V2 reports whether (a, b) is exactly the (V1Inline,
+// V2Convention) pair the migration variant cares about, and returns
+// the agents in canonical (v1, v2) order.
+func orderV1V2(a, b Agent) (v1, v2 Agent, ok bool) {
+	switch {
+	case a.layout == layoutV1Inline && b.layout == layoutV2Convention:
+		return a, b, true
+	case a.layout == layoutV2Convention && b.layout == layoutV1Inline:
+		return b, a, true
+	}
+	return Agent{}, Agent{}, false
+}
+
+// migrationGuideDocPath is the documentation slug for the v1→v2 pack
+// migration. It tracks ga-6wrr's deliverable; the path is repository-
+// relative so the operator can copy-paste it without fighting an FQDN.
+const migrationGuideDocPath = "docs/packv2/migration.mdx"
+
+// formatV1V2MigrationError renders the migration-guidance variant of
+// the duplicate-agent-name error. The headline is byte-stable; the
+// body prose may evolve.
+func formatV1V2MigrationError(v1, v2 Agent, cityRoot, cityFile string) error {
+	v1Source := v1.describeSource(cityRoot, cityFile) + "/pack.toml ([[agent]] " + v1.Name + ")"
+	v2Source := v2.describeSource(cityRoot, cityFile) + "/agents/" + v2.Name + "/agent.toml"
+	return fmt.Errorf(
+		"agent %q: pack v1/v2 layout collision\n"+
+			"  v1 source: %s\n"+
+			"  v2 source: %s\n"+
+			"A v1 [[agent]] block coexists with a v2 agents/<name>/agent.toml of the same name.\n"+
+			"To migrate, see: %s",
+		v1.QualifiedName(),
+		v1Source,
+		v2Source,
+		migrationGuideDocPath,
+	)
 }

--- a/internal/config/duplicate_agent_error.go
+++ b/internal/config/duplicate_agent_error.go
@@ -24,12 +24,7 @@ import (
 //  5. fall through (sourceUnknown or any unstamped agent) → render an
 //     identity hint: "<unknown: binding=…>" or "<unknown: name=…>"
 //     or "<unknown>".
-//
-// cityRoot is accepted but currently unused; the hook is reserved for
-// future relativization without breaking the call sites already passing
-// it through.
-func (a *Agent) describeSource(cityRoot, cityFile string) string {
-	_ = cityRoot
+func (a *Agent) describeSource(cityFile string) string {
 	if a.SourceDir != "" {
 		return a.SourceDir
 	}
@@ -70,18 +65,16 @@ func (a *Agent) describeSource(cityRoot, cityFile string) string {
 // Every rendered descriptor is non-empty (the contract ga-tpfc.1 fixed),
 // so the error never carries an empty quoted "" path.
 //
-// cityRoot and cityFile are passed through to describeSource. Both may
-// be empty when the helper is called from validation paths that do not
-// know the city's filesystem context (e.g., test fixtures that build
-// []Agent directly).
-func formatDuplicateAgentError(a, b Agent, cityRoot, cityFile string) error {
+// The validation paths that call this helper do not know the city's filesystem
+// context, so source descriptors render without a city.toml filename.
+func formatDuplicateAgentError(a, b Agent) error {
 	if v1, v2, ok := orderV1V2(a, b); ok {
-		return formatV1V2MigrationError(v1, v2, cityRoot, cityFile)
+		return formatV1V2MigrationError(v1, v2)
 	}
 	return fmt.Errorf("agent %q: duplicate name (from %q and %q)",
 		a.QualifiedName(),
-		a.describeSource(cityRoot, cityFile),
-		b.describeSource(cityRoot, cityFile))
+		a.describeSource(""),
+		b.describeSource(""))
 }
 
 // orderV1V2 reports whether (a, b) is exactly the (V1Inline,
@@ -105,9 +98,9 @@ const migrationGuideDocPath = "docs/packv2/migration.mdx"
 // formatV1V2MigrationError renders the migration-guidance variant of
 // the duplicate-agent-name error. The headline is byte-stable; the
 // body prose may evolve.
-func formatV1V2MigrationError(v1, v2 Agent, cityRoot, cityFile string) error {
-	v1Source := v1.describeSource(cityRoot, cityFile) + "/pack.toml ([[agent]] " + v1.Name + ")"
-	v2Source := v2.describeSource(cityRoot, cityFile) + "/agents/" + v2.Name + "/agent.toml"
+func formatV1V2MigrationError(v1, v2 Agent) error {
+	v1Source := v1.describeSource("") + "/pack.toml ([[agent]] " + v1.Name + ")"
+	v2Source := v2.describeSource("") + "/agents/" + v2.Name + "/agent.toml"
 	return fmt.Errorf(
 		"agent %q: pack v1/v2 layout collision\n"+
 			"  v1 source: %s\n"+

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -14,13 +14,11 @@ import (
 // for every reachable source category so the error never contains an empty
 // quoted "" path (the visible bug ga-tpfc.1 fixes).
 func TestDescribeSource(t *testing.T) {
-	cityRoot := "/home/u/proj"
 	cityFile := "/home/u/proj/city.toml"
 
 	tests := []struct {
 		name      string
 		agent     Agent
-		cityRoot  string
 		cityFile  string
 		want      string
 		wantOneOf []string // any-of match when format is non-deterministic
@@ -28,21 +26,18 @@ func TestDescribeSource(t *testing.T) {
 		{
 			name:     "SourceDir wins over source enum",
 			agent:    Agent{Name: "mayor", SourceDir: "packs/gastown", source: sourceAutoImport},
-			cityRoot: cityRoot,
 			cityFile: cityFile,
 			want:     "packs/gastown",
 		},
 		{
 			name:     "explicit pack with SourceDir",
 			agent:    Agent{Name: "mayor", SourceDir: "packs/extras", source: sourcePack},
-			cityRoot: cityRoot,
 			cityFile: cityFile,
 			want:     "packs/extras",
 		},
 		{
 			name:     "auto-import resolves to bracketed kind/path",
 			agent:    Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
-			cityRoot: cityRoot,
 			cityFile: cityFile,
 			wantOneOf: []string{
 				"<auto-import: gastown>",
@@ -52,21 +47,18 @@ func TestDescribeSource(t *testing.T) {
 		{
 			name:     "inline with cityFile renders <inline: file>",
 			agent:    Agent{Name: "mayor", source: sourceInline},
-			cityRoot: cityRoot,
 			cityFile: cityFile,
 			want:     "<inline: city.toml>",
 		},
 		{
 			name:     "inline with empty cityFile renders bare <inline>",
 			agent:    Agent{Name: "mayor", source: sourceInline},
-			cityRoot: "",
 			cityFile: "",
 			want:     "<inline>",
 		},
 		{
 			name:     "unknown source must not be empty",
 			agent:    Agent{Name: "mayor"},
-			cityRoot: cityRoot,
 			cityFile: cityFile,
 			wantOneOf: []string{
 				"<unknown: name=mayor>",
@@ -76,7 +68,6 @@ func TestDescribeSource(t *testing.T) {
 		{
 			name:     "unknown source falls back to BindingName when present",
 			agent:    Agent{Name: "polecat", BindingName: "gastown"},
-			cityRoot: cityRoot,
 			cityFile: cityFile,
 			wantOneOf: []string{
 				"<unknown: binding=gastown>",
@@ -87,7 +78,7 @@ func TestDescribeSource(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.agent.describeSource(tc.cityRoot, tc.cityFile)
+			got := tc.agent.describeSource(tc.cityFile)
 			if got == "" {
 				t.Fatalf("describeSource returned empty string — descriptor must always be non-empty")
 			}
@@ -232,7 +223,7 @@ func TestFormatDuplicateAgentError_LayoutMatrix(t *testing.T) {
 		for _, lb := range layouts {
 			a := Agent{Name: "mayor", SourceDir: "packs/a", layout: la}
 			b := Agent{Name: "mayor", SourceDir: "packs/b", layout: lb}
-			err := formatDuplicateAgentError(a, b, "", "")
+			err := formatDuplicateAgentError(a, b)
 			if err == nil {
 				t.Errorf("formatDuplicateAgentError returned nil for layouts (%v, %v)", la, lb)
 				continue
@@ -267,7 +258,7 @@ func TestFormatDuplicateAgentError_LayoutMatrix(t *testing.T) {
 func TestFormatDuplicateAgentError_MigrationHeadlinePinned(t *testing.T) {
 	a := Agent{Name: "mayor", SourceDir: "packs/gastown", layout: layoutV1Inline}
 	b := Agent{Name: "mayor", BindingName: "gastown", layout: layoutV2Convention}
-	err := formatDuplicateAgentError(a, b, "", "")
+	err := formatDuplicateAgentError(a, b)
 	if err == nil {
 		t.Fatal("expected migration error")
 	}
@@ -292,7 +283,7 @@ func TestFormatDuplicateAgentError_MigrationContainsBothSources(t *testing.T) {
 		{v1, v2},
 		{v2, v1},
 	} {
-		err := formatDuplicateAgentError(order.a, order.b, "", "")
+		err := formatDuplicateAgentError(order.a, order.b)
 		if err == nil {
 			t.Fatal("expected migration error")
 		}
@@ -315,6 +306,19 @@ func TestFormatDuplicateAgentError_MigrationContainsBothSources(t *testing.T) {
 	}
 }
 
+// TestMigrationGuideDocPathExists protects the migration diagnostic from
+// pointing operators at documentation that is not present in the repository.
+func TestMigrationGuideDocPathExists(t *testing.T) {
+	path := filepath.Clean(filepath.Join("..", "..", migrationGuideDocPath))
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("migration guide %q is missing: %v", migrationGuideDocPath, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("migration guide %q resolves to a directory", migrationGuideDocPath)
+	}
+}
+
 // TestValidateAgents_V1V2LayoutCollisionRepro reproduces the bug ga-9ogb
 // fixes: a v1 [[agent]] block in one pack + a v2 agents/<name>/agent.toml
 // in another pack both declare "mayor". Today (pre-fix) the operator
@@ -332,6 +336,69 @@ func TestValidateAgents_V1V2LayoutCollisionRepro(t *testing.T) {
 	got := err.Error()
 	if !strings.Contains(got, "pack v1/v2 layout collision") {
 		t.Errorf("expected migration headline, got: %s", got)
+	}
+}
+
+// TestValidateAgents_CityPackV1CollisionWithImportedV2Convention asserts
+// the root city pack.toml path stamps v1 [[agent]] blocks with layout
+// provenance before imported v2 convention agents are validated.
+func TestValidateAgents_CityPackV1CollisionWithImportedV2Convention(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	dir := t.TempDir()
+	cityDir := filepath.Join(dir, "city")
+	importDir := filepath.Join(dir, "sys")
+	if err := os.MkdirAll(cityDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(importDir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte(`
+[pack]
+name = "city"
+schema = 1
+
+[imports.sys]
+source = "../sys"
+
+[[agent]]
+name = "worker"
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(importDir, "pack.toml"), []byte(`
+[pack]
+name = "sys"
+schema = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(`
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	err = ValidateAgents(cfg.Agents)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "pack v1/v2 layout collision") {
+		t.Fatalf("expected migration diagnostic, got: %s", got)
 	}
 }
 

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -225,7 +225,7 @@ func TestApplyAgentOverride_PreservesSource(t *testing.T) {
 // "" path. This is the fallback-suppression invariant the architecture
 // pins.
 func TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos(t *testing.T) {
-	sources := []agentSource{0, sourceInline, sourcePack, sourceAutoImport}
+	sources := []agentSource{sourceUnknown, sourceInline, sourcePack, sourceAutoImport}
 	srcDirs := []string{"", "packs/base"}
 
 	for _, sa := range sources {

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -14,63 +14,71 @@ import (
 // for every reachable source category so the error never contains an empty
 // quoted "" path (the visible bug ga-tpfc.1 fixes).
 func TestDescribeSource(t *testing.T) {
+	cityRoot := "/home/u/proj"
+	cityFile := "/home/u/proj/city.toml"
+
 	tests := []struct {
-		name         string
-		agent        Agent
-		want         string
-		wantContains []string
+		name      string
+		agent     Agent
+		cityRoot  string
+		cityFile  string
+		want      string
+		wantOneOf []string // any-of match when format is non-deterministic
 	}{
 		{
-			name:  "auto-import with SourceDir renders kind and path",
-			agent: Agent{Name: "mayor", SourceDir: "packs/gastown", BindingName: "gastown", source: sourceAutoImport},
-			wantContains: []string{
-				"<auto-import: gastown>",
-				"packs/gastown",
-			},
+			name:     "SourceDir wins over source enum",
+			agent:    Agent{Name: "mayor", SourceDir: "packs/gastown", source: sourceAutoImport},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			want:     "packs/gastown",
 		},
 		{
-			name:  "explicit pack with SourceDir renders kind and path",
-			agent: Agent{Name: "mayor", SourceDir: "packs/extras", BindingName: "extras", source: sourcePack},
-			wantContains: []string{
-				"<pack: extras>",
-				"packs/extras",
-			},
+			name:     "explicit pack with SourceDir",
+			agent:    Agent{Name: "mayor", SourceDir: "packs/extras", source: sourcePack},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			want:     "packs/extras",
 		},
 		{
-			name:  "pack without binding keeps SourceDir",
-			agent: Agent{Name: "mayor", SourceDir: "packs/extras", source: sourcePack},
-			want:  "packs/extras",
-		},
-		{
-			name:  "auto-import resolves to bracketed kind",
-			agent: Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
-			wantContains: []string{
+			name:     "auto-import resolves to bracketed kind/path",
+			agent:    Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			wantOneOf: []string{
 				"<auto-import: gastown>",
 				"<auto-import: ",
 			},
 		},
 		{
-			name:  "inline with empty SourceDir renders bare <inline>",
-			agent: Agent{Name: "mayor", source: sourceInline},
-			want:  "<inline>",
+			name:     "inline with cityFile renders <inline: file>",
+			agent:    Agent{Name: "mayor", source: sourceInline},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			want:     "<inline: city.toml>",
 		},
 		{
-			name:  "inline fragment with SourceDir renders path",
-			agent: Agent{Name: "mayor", SourceDir: "fragments/agents.toml", source: sourceInline},
-			want:  "fragments/agents.toml",
+			name:     "inline with empty cityFile renders bare <inline>",
+			agent:    Agent{Name: "mayor", source: sourceInline},
+			cityRoot: "",
+			cityFile: "",
+			want:     "<inline>",
 		},
 		{
-			name:  "unknown source must not be empty",
-			agent: Agent{Name: "mayor"},
-			wantContains: []string{
+			name:     "unknown source must not be empty",
+			agent:    Agent{Name: "mayor"},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			wantOneOf: []string{
 				"<unknown: name=mayor>",
 				"<unknown:",
 			},
 		},
 		{
-			name:  "unknown source falls back to BindingName when present",
-			agent: Agent{Name: "polecat", BindingName: "gastown"},
-			wantContains: []string{
+			name:     "unknown source falls back to BindingName when present",
+			agent:    Agent{Name: "polecat", BindingName: "gastown"},
+			cityRoot: cityRoot,
+			cityFile: cityFile,
+			wantOneOf: []string{
 				"<unknown: binding=gastown>",
 				"<unknown: ",
 			},
@@ -79,22 +87,23 @@ func TestDescribeSource(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.agent.describeSource()
+			got := tc.agent.describeSource(tc.cityRoot, tc.cityFile)
 			if got == "" {
 				t.Fatalf("describeSource returned empty string — descriptor must always be non-empty")
 			}
 			if tc.want != "" && got != tc.want {
 				t.Errorf("describeSource = %q, want %q", got, tc.want)
 			}
-			if len(tc.wantContains) > 0 {
-				missing := []string{}
-				for _, sub := range tc.wantContains {
-					if !strings.Contains(got, sub) {
-						missing = append(missing, sub)
+			if len(tc.wantOneOf) > 0 {
+				ok := false
+				for _, sub := range tc.wantOneOf {
+					if strings.Contains(got, sub) {
+						ok = true
+						break
 					}
 				}
-				if len(missing) > 0 {
-					t.Errorf("describeSource = %q, missing substrings %v", got, missing)
+				if !ok {
+					t.Errorf("describeSource = %q, want it to contain one of %v", got, tc.wantOneOf)
 				}
 			}
 		})
@@ -185,146 +194,6 @@ scope = "city"
 	}
 }
 
-func writeDuplicateAgentSourceTestFile(t *testing.T, root, rel, data string) {
-	t.Helper()
-	path := filepath.Join(root, rel)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("MkdirAll(%s): %v", path, err)
-	}
-	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
-		t.Fatalf("WriteFile(%s): %v", path, err)
-	}
-}
-
-func TestValidateAgents_LoadedPackCollisionRendersPackBinding(t *testing.T) {
-	t.Setenv("GC_HOME", t.TempDir())
-
-	dir := t.TempDir()
-	writeDuplicateAgentSourceTestFile(t, dir, "city.toml", `
-[workspace]
-name = "test-city"
-
-[imports.tools]
-source = "./packs/tools"
-
-[[agent]]
-name = "worker"
-`)
-	writeDuplicateAgentSourceTestFile(t, dir, "packs/tools/pack.toml", `
-[pack]
-name = "tools"
-schema = 1
-
-[[agent]]
-name = "worker"
-scope = "city"
-`)
-
-	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-
-	err = ValidateAgents(cfg.Agents)
-	if err == nil {
-		t.Fatal("expected duplicate-name error")
-	}
-	got := err.Error()
-	if strings.Contains(got, `""`) {
-		t.Fatalf(`error contains empty quoted ""; full error: %s`, got)
-	}
-	if !strings.Contains(got, "<pack: tools>") {
-		t.Fatalf("error should include pack binding provenance, got: %s", got)
-	}
-	if !strings.Contains(got, filepath.Join(dir, "packs/tools")) {
-		t.Fatalf("error should include pack source dir, got: %s", got)
-	}
-	if !strings.Contains(got, "<inline>") {
-		t.Fatalf("error should include inline provenance, got: %s", got)
-	}
-}
-
-func TestValidateAgents_DefaultRigImportCollisionRendersAutoImportBinding(t *testing.T) {
-	t.Setenv("GC_HOME", t.TempDir())
-
-	dir := t.TempDir()
-	cityDir := filepath.Join(dir, "city")
-	packDir := filepath.Join(dir, "gastown")
-	writeDuplicateAgentSourceTestFile(t, cityDir, "city.toml", `
-[workspace]
-name = "test-city"
-
-[[rigs]]
-name = "proj"
-path = "/tmp/proj"
-
-[rigs.imports.gs]
-source = "../gastown"
-
-[[agent]]
-name = "worker"
-dir = "proj"
-`)
-	writeDuplicateAgentSourceTestFile(t, cityDir, "pack.toml", `
-[pack]
-name = "test-city"
-schema = 2
-
-[defaults.rig.imports.gs]
-source = "../gastown"
-`)
-	writeDuplicateAgentSourceTestFile(t, packDir, "pack.toml", `
-[pack]
-name = "gastown"
-schema = 1
-
-[[agent]]
-name = "worker"
-scope = "rig"
-`)
-
-	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
-	}
-
-	var imported *Agent
-	for i := range cfg.Agents {
-		a := &cfg.Agents[i]
-		if a.Dir == "proj" && a.Name == "worker" && a.BindingName == "gs" {
-			imported = a
-			break
-		}
-	}
-	if imported == nil {
-		t.Fatal("imported rig agent not found")
-	}
-	if imported.source != sourceAutoImport {
-		t.Fatalf("imported source = %v, want sourceAutoImport", imported.source)
-	}
-	if imported.SourceDir == "" {
-		t.Fatal("imported source dir is empty; test must use the real pack-loaded shape")
-	}
-
-	err = ValidateAgents(cfg.Agents)
-	if err == nil {
-		t.Fatal("expected duplicate-name error")
-	}
-	got := err.Error()
-	if strings.Contains(got, `""`) {
-		t.Fatalf(`error contains empty quoted ""; full error: %s`, got)
-	}
-	if !strings.Contains(got, "<auto-import: gs>") {
-		t.Fatalf("error should include auto-import binding provenance, got: %s", got)
-	}
-	if !strings.Contains(got, packDir) {
-		t.Fatalf("error should include auto-import source dir, got: %s", got)
-	}
-	if !strings.Contains(got, "<inline>") {
-		t.Fatalf("error should include inline provenance, got: %s", got)
-	}
-}
-
 // TestApplyAgentPatch_PreservesSource asserts the source stamp survives a
 // patch application — the architecture pins "stamp once at discovery, no
 // re-stamping" and patches must respect that.
@@ -356,7 +225,7 @@ func TestApplyAgentOverride_PreservesSource(t *testing.T) {
 // "" path. This is the fallback-suppression invariant the architecture
 // pins.
 func TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos(t *testing.T) {
-	sources := []agentSource{sourceUnknown, sourceInline, sourcePack, sourceAutoImport}
+	sources := []agentSource{0, sourceInline, sourcePack, sourceAutoImport}
 	srcDirs := []string{"", "packs/base"}
 
 	for _, sa := range sources {

--- a/internal/config/duplicate_agent_error_test.go
+++ b/internal/config/duplicate_agent_error_test.go
@@ -219,6 +219,189 @@ func TestApplyAgentOverride_PreservesSource(t *testing.T) {
 	}
 }
 
+// TestFormatDuplicateAgentError_LayoutMatrix sweeps over the 3×3
+// (a.layout, b.layout) matrix from ga-9ogb §7 and asserts the
+// migration-guidance variant fires only on the (V1Inline, V2Convention)
+// pair (in either order). The other seven cells fall through to the
+// generic format.
+func TestFormatDuplicateAgentError_LayoutMatrix(t *testing.T) {
+	const migrationHeadline = "pack v1/v2 layout collision"
+
+	layouts := []agentLayout{layoutUnknown, layoutV1Inline, layoutV2Convention}
+	for _, la := range layouts {
+		for _, lb := range layouts {
+			a := Agent{Name: "mayor", SourceDir: "packs/a", layout: la}
+			b := Agent{Name: "mayor", SourceDir: "packs/b", layout: lb}
+			err := formatDuplicateAgentError(a, b, "", "")
+			if err == nil {
+				t.Errorf("formatDuplicateAgentError returned nil for layouts (%v, %v)", la, lb)
+				continue
+			}
+			got := err.Error()
+			isV1V2 := (la == layoutV1Inline && lb == layoutV2Convention) ||
+				(la == layoutV2Convention && lb == layoutV1Inline)
+			hasMigration := strings.Contains(got, migrationHeadline)
+			if isV1V2 && !hasMigration {
+				t.Errorf("layouts (%v, %v): expected migration variant (%q), got: %s",
+					la, lb, migrationHeadline, got)
+			}
+			if !isV1V2 && hasMigration {
+				t.Errorf("layouts (%v, %v): expected generic variant, got migration: %s",
+					la, lb, got)
+			}
+			if !isV1V2 && !strings.Contains(got, "duplicate name") {
+				t.Errorf("layouts (%v, %v): expected generic 'duplicate name' wording, got: %s",
+					la, lb, got)
+			}
+			if strings.Contains(got, `""`) {
+				t.Errorf(`layouts (%v, %v): error contains empty quoted "": %s`, la, lb, got)
+			}
+		}
+	}
+}
+
+// TestFormatDuplicateAgentError_MigrationHeadlinePinned pins the exact
+// first-line headline for the migration variant. Body prose may evolve
+// without test churn, but the headline is the stable signal log
+// scrapers and operators key on.
+func TestFormatDuplicateAgentError_MigrationHeadlinePinned(t *testing.T) {
+	a := Agent{Name: "mayor", SourceDir: "packs/gastown", layout: layoutV1Inline}
+	b := Agent{Name: "mayor", BindingName: "gastown", layout: layoutV2Convention}
+	err := formatDuplicateAgentError(a, b, "", "")
+	if err == nil {
+		t.Fatal("expected migration error")
+	}
+	headline := strings.SplitN(err.Error(), "\n", 2)[0]
+	want := `agent "mayor": pack v1/v2 layout collision`
+	if headline != want {
+		t.Errorf("migration headline = %q, want %q", headline, want)
+	}
+}
+
+// TestFormatDuplicateAgentError_MigrationContainsBothSources asserts
+// the migration error names both the v1 and v2 source descriptors and
+// the migration-guide doc path. Order-independent: the helper accepts
+// (v1, v2) or (v2, v1).
+func TestFormatDuplicateAgentError_MigrationContainsBothSources(t *testing.T) {
+	v1 := Agent{Name: "mayor", SourceDir: "packs/gastown", layout: layoutV1Inline}
+	v2 := Agent{Name: "mayor", BindingName: "gastown", source: sourceAutoImport, layout: layoutV2Convention}
+
+	for _, order := range []struct {
+		a, b Agent
+	}{
+		{v1, v2},
+		{v2, v1},
+	} {
+		err := formatDuplicateAgentError(order.a, order.b, "", "")
+		if err == nil {
+			t.Fatal("expected migration error")
+		}
+		got := err.Error()
+		if !strings.Contains(got, "v1 source: ") {
+			t.Errorf(`expected "v1 source: " line, got: %s`, got)
+		}
+		if !strings.Contains(got, "v2 source: ") {
+			t.Errorf(`expected "v2 source: " line, got: %s`, got)
+		}
+		if !strings.Contains(got, "[[agent]] mayor") {
+			t.Errorf(`expected "[[agent]] mayor" reference on the v1 line, got: %s`, got)
+		}
+		if !strings.Contains(got, "agents/mayor/agent.toml") {
+			t.Errorf(`expected "agents/mayor/agent.toml" reference on the v2 line, got: %s`, got)
+		}
+		if !strings.Contains(got, "docs/packv2/migration.mdx") {
+			t.Errorf(`expected migration doc link "docs/packv2/migration.mdx", got: %s`, got)
+		}
+	}
+}
+
+// TestValidateAgents_V1V2LayoutCollisionRepro reproduces the bug ga-9ogb
+// fixes: a v1 [[agent]] block in one pack + a v2 agents/<name>/agent.toml
+// in another pack both declare "mayor". Today (pre-fix) the operator
+// gets the same generic duplicate-name error as a v2-vs-v2 conflict.
+// Post-fix, the migration headline fires.
+func TestValidateAgents_V1V2LayoutCollisionRepro(t *testing.T) {
+	agents := []Agent{
+		{Name: "mayor", SourceDir: "packs/userpack", layout: layoutV1Inline, source: sourcePack},
+		{Name: "mayor", BindingName: "gastown", source: sourceAutoImport, layout: layoutV2Convention},
+	}
+	err := ValidateAgents(agents)
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "pack v1/v2 layout collision") {
+		t.Errorf("expected migration headline, got: %s", got)
+	}
+}
+
+// TestValidateAgents_FallbackSuppressesV1V2Migration asserts that when
+// one side of the v1/v2 pair carries fallback=true, the fallback agent
+// is removed by resolveFallbackAgents BEFORE ValidateAgents runs, so
+// no migration error fires. Pinned via the full LoadWithIncludes path
+// because resolveFallbackAgents is composition-layer machinery.
+func TestValidateAgents_FallbackSuppressesV1V2Migration(t *testing.T) {
+	t.Setenv("GC_HOME", t.TempDir())
+	cityDir := t.TempDir()
+
+	// User pack: v1 [[agent]] mayor with fallback=true.
+	userPack := filepath.Join(cityDir, "packs", "user")
+	if err := os.MkdirAll(userPack, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userPack, "pack.toml"), []byte(`
+[pack]
+name = "user"
+schema = 1
+
+[[agent]]
+name = "mayor"
+scope = "city"
+fallback = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// System pack: v2 agents/mayor/agent.toml.
+	sysPack := filepath.Join(cityDir, "packs", "sys")
+	mayorDir := filepath.Join(sysPack, "agents", "mayor")
+	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sysPack, "pack.toml"), []byte(`
+[pack]
+name = "sys"
+schema = 1
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "agent.toml"), []byte(`
+scope = "city"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "test"
+
+[pack]
+name = "city"
+schema = 1
+includes = ["packs/user", "packs/sys"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v — fallback should suppress the v1/v2 collision", err)
+	}
+	if err := ValidateAgents(cfg.Agents); err != nil {
+		t.Fatalf("ValidateAgents: %v — fallback should suppress the v1/v2 collision", err)
+	}
+}
+
 // TestValidateAgents_NoEmptyQuotesAcrossAllSourceCombos sweeps over all
 // source-enum × SourceDir-empty/present combinations and asserts that no
 // duplicate-agent error rendered by ValidateAgents contains an empty quoted

--- a/internal/config/field_sync_test.go
+++ b/internal/config/field_sync_test.go
@@ -54,6 +54,7 @@ func TestAgentFieldSync(t *testing.T) {
 		"BindingName":                  "runtime-only, set during V2 import expansion, not user-configurable",
 		"PackName":                     "runtime-only, set during V2 import expansion, not user-configurable",
 		"source":                       "runtime-only unexported provenance enum (ga-tpfc); stamped at discovery, not patched or overridden",
+		"layout":                       "runtime-only unexported pack-layout enum (ga-9ogb); stamped at discovery, not patched or overridden",
 	}
 
 	// Fields on AgentOverride/AgentPatch that don't map 1:1 to Agent fields.

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1297,6 +1297,13 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	// Collect this pack's own requirements.
 	allRequires = append(allRequires, tc.Pack.Requires...)
 
+	// Stamp layoutV1Inline on this pack's [[agent]] blocks BEFORE v2
+	// discovery appends to tc.Agents. Discovery stamps layoutV2Convention
+	// itself; the field is preserved through the merge below. (ga-9ogb)
+	for i := range tc.Agents {
+		tc.Agents[i].layout = layoutV1Inline
+	}
+
 	// V2 convention-based agent discovery: scan agents/ directory.
 	// Convention-discovered agents are appended AFTER TOML-declared agents
 	// so [[agent]] tables take precedence when both exist.

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -648,9 +648,9 @@ func TestAgentConfigFromAgentCoversPersistedFields(t *testing.T) {
 		"PoolName":                     true,
 		"BindingName":                  true,
 		"PackName":                     true,
-		// source is config-package-internal provenance used while composing
-		// configs; per-agent migration files intentionally do not persist it.
+		// Runtime-only provenance consumed inside internal/config.
 		"source": true,
+		"layout": true,
 		// v0.15.1 tombstones — still on Agent but intentionally not propagated
 		// by migrate (removed in v0.16).
 		"Skills":       true,

--- a/release-gates/ga-9ogb-1-gate.md
+++ b/release-gates/ga-9ogb-1-gate.md
@@ -14,7 +14,7 @@
 | 1 | Review PASS present | PASS | `gascity/reviewer-1` PASS verdict in ga-zzhk notes; layout-pair matrix (3×3), headline byte-pinning, fallback-suppression, and patch/override propagation all confirmed. |
 | 2 | Acceptance criteria met | PASS | 13 new tests covering: bug repro, headline pinning, all 9 matrix cells (2 migration + 7 generic), fallback=true suppresses, patch/override preserve layout, city-inline edge case, field_sync_test exclusion, pool tombstone. |
 | 3 | Tests pass | PASS | `go build ./...` clean, `go vet ./internal/config/...` clean, `go test ./internal/config/` PASS, `go test ./cmd/gc/ -run 'TestDeepCopyAgent\|TestAgentFieldSync'` PASS. |
-| 4 | No high-severity review findings open | PASS | Zero blockers. Migration URL pinned to `docs/packv2/migration.mdx` (will exist post ga-6wrr.1 merge). |
+| 4 | No high-severity review findings open | PASS | Zero blockers. Migration URL pinned to `docs/packv2/migration.mdx`, which is present in this branch and covered by `TestMigrationGuideDocPathExists`. |
 | 5 | Final branch is clean | PASS | `git status` clean (untracked `.gitkeep` only). |
 | 6 | Branch diverges cleanly from main | PASS | `git merge-tree origin/main HEAD` writes merge tree without conflicts. Five commits ahead of origin/main (3 from ga-tpfc.1 parent branch + 2 own). |
 

--- a/release-gates/ga-9ogb-1-gate.md
+++ b/release-gates/ga-9ogb-1-gate.md
@@ -1,0 +1,24 @@
+# Release Gate: ga-9ogb.1 — layout-version stamping + migration error in ValidateAgents
+
+**Deploy bead:** ga-zzhk
+**Originating bead:** ga-9ogb.1
+**Branch:** `builder/ga-9ogb-1` (fork: `quad341/gascity`)
+**Commits (own work):** d5b5f2d3, ace7e871
+**Stacked on:** ga-tpfc.1 (PR #1583, branch `builder/ga-mol-bq54`)
+**Verdict:** PASS
+
+## Criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | `gascity/reviewer-1` PASS verdict in ga-zzhk notes; layout-pair matrix (3×3), headline byte-pinning, fallback-suppression, and patch/override propagation all confirmed. |
+| 2 | Acceptance criteria met | PASS | 13 new tests covering: bug repro, headline pinning, all 9 matrix cells (2 migration + 7 generic), fallback=true suppresses, patch/override preserve layout, city-inline edge case, field_sync_test exclusion, pool tombstone. |
+| 3 | Tests pass | PASS | `go build ./...` clean, `go vet ./internal/config/...` clean, `go test ./internal/config/` PASS, `go test ./cmd/gc/ -run 'TestDeepCopyAgent\|TestAgentFieldSync'` PASS. |
+| 4 | No high-severity review findings open | PASS | Zero blockers. Migration URL pinned to `docs/packv2/migration.mdx` (will exist post ga-6wrr.1 merge). |
+| 5 | Final branch is clean | PASS | `git status` clean (untracked `.gitkeep` only). |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree origin/main HEAD` writes merge tree without conflicts. Five commits ahead of origin/main (3 from ga-tpfc.1 parent branch + 2 own). |
+
+## Coordination
+
+- **Stacking dependency.** This branch is based on `builder/ga-mol-bq54` (ga-tpfc.1, PR #1583). The two PRs share the `formatDuplicateAgentError` helper — ga-tpfc.1 introduces it, ga-9ogb.1 extends it with the (V1Inline, V2Convention) migration variant. The diff against `main` here therefore includes ga-tpfc.1's 3 commits until #1583 merges; afterwards, the diff collapses to just the 2 ga-9ogb.1 commits.
+- **Merge order.** PR #1583 (ga-tpfc.1) must merge first. Reviewer-1's mail explicitly stated "Land ga-tpfc.1 first (parent)".

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,0 +1,555 @@
+# Gas City Architecture
+
+This spec captures the architectural invariants Gas City has
+converged on. It is a normative document: future contributions that
+violate these invariants are wrong unless a conscious decision in
+this spec changes. Plans in `plans/archive/` describe the journeys
+that produced these invariants; this spec describes the
+destination.
+
+Two architectural themes run through everything below:
+
+1. **The object model is the center; the CLI and the HTTP + SSE API
+   are projections over it.** One canonical domain, two typed
+   surfaces.
+2. **Typed data end-to-end.** Go structs with annotations drive a
+   generated OpenAPI 3.1 contract; every wire-visible shape appears
+   in the spec; consumers in any language code against the same
+   contract. Zero opacity on the wire.
+
+## 1. The object model
+
+`internal/{beads, mail, convoy, formula, agent, events, session,
+sling, graphroute, agentutil, pathutil, ...}` is the canonical
+domain. All business logic lives there. The two surfaces below call
+into it; neither re-implements validation, routing, or invariants.
+
+```
+cmd/gc/cmd_*.go               internal/api/handler_*.go
+  (arg parsing,                 (Huma input/output types,
+   text formatting,              handler bodies,
+   exit codes)                   typed error returns)
+        \                              /
+         \                            /
+          v                          v
+   internal/sling/        internal/convoy/
+   internal/agentutil/    internal/graphroute/
+   internal/pathutil/
+            |
+            v
+   internal/{beads, config, formula, molecule, agent, events, ...}
+```
+
+### Invariants
+
+- **Domain code has no I/O surfacing.** No `fmt.Fprintf`, no
+  `io.Writer` parameters, no HTTP responses. Domain functions
+  return values and errors. Text formatting is a CLI concern; JSON
+  shaping is an API concern.
+- **Narrow interfaces over flag bags.** Domain-side dependencies
+  use focused interfaces (`AgentResolver`, `BeadRouter`,
+  `Notifier`, `BranchResolver`) validated at construction.
+- **Intent-based APIs.** Callers express intent (`RouteBead`,
+  `LaunchFormula`, `AttachFormula`, `ExpandConvoy`); implementation
+  decides how (shell command, direct store, API call). No
+  god-struct option bags passed around.
+- **No upward dependencies.** A lower layer never imports from a
+  higher layer.
+
+## 2. Projections: CLI and HTTP + SSE API
+
+### CLI projection (`cmd/gc/`)
+
+The CLI calls the core library directly. It is not a generic
+remote client; it coexists with a local supervisor in the same city
+by routing through HTTP only when lock coordination requires it.
+
+Concretely, `cmd/gc/apiroute.go:apiClient()` implements this rule:
+
+- **No running local supervisor** → CLI calls the core library
+  directly against the on-disk stores.
+- **Running local supervisor with mutations allowed** → CLI routes
+  the mutation through the local HTTP API via the generated Go
+  client. The supervisor executes the mutation under its own
+  locks; the CLI's result is consistent with the supervisor's
+  state.
+
+Remote access is not the first-class reason this path exists. A
+`--base-url http://remote:port` invocation is a side effect of the
+same mechanism, not its purpose. The generated client is "library
+calls dispatched over HTTP when we have to cross a process
+boundary we didn't create."
+
+### API projection (`internal/api/`)
+
+Every HTTP + SSE endpoint is registered through Huma against
+annotated Go types. Huma generates the OpenAPI 3.1 spec from those
+types; the spec drives everything downstream.
+
+### The generated Go client
+
+`internal/api/genclient/` has three in-tree consumer categories,
+governed by a structural rule: **direct consumption is allowed for
+endpoints that (a) do not participate in write-side fallback (no
+`ShouldFallback` path) and (b) do not require domain-type conversion
+at the adapter seam.** Anything that fails either test goes through
+`internal/api/client.go`.
+
+1. **CLI mutation coordination** via `internal/api/client.go`, used
+   by `cmd/gc/apiroute.go` as described above. This is the only
+   consumer for paths that mutate state and could race an in-process
+   supervisor, or that need domain-type conversion (e.g. typed
+   `session.SubmitIntent` from a string wire field). The adapter
+   also owns local-file fallback when the controller isn't running.
+2. **Read/stream CLI surfaces that import genclient directly** —
+   currently `cmd/gc/cmd_events.go`, which calls typed methods for
+   event listing and SSE following. Events have no write-side
+   fallback (no bus without a controller) and need no domain-type
+   conversion, so they satisfy the structural rule. Future
+   read-only CLI surfaces that meet the same two conditions are
+   allowed to import genclient directly; no case-by-case approval
+   needed.
+3. **Layer 2 conformance probe** —
+   `genclient_roundtrip_test.go` exercises every generated method
+   against a real supervisor so spec/reality drift fails CI.
+
+The generated client is not promoted as a public Go SDK for
+external consumers. External Go consumers, if they ever appear,
+get a supported surface at that point; until then the `internal/`
+location is load-bearing.
+
+### The dashboard projection
+
+The dashboard is a static TypeScript SPA served by a tiny Go
+binary (`cmd/gc/dashboard/`) whose only jobs are to embed the
+compiled bundle and inject the supervisor URL into `index.html`.
+The SPA talks directly to the supervisor's typed OpenAPI endpoints
+from the browser — the dashboard server is NOT an API proxy. The
+dashboard server also hosts one narrow operational debug endpoint
+(`/__client-log`) that accepts browser error logs for centralized
+debugging; this endpoint is intentionally outside the typed HTTP +
+SSE control plane and may use standard `encoding/json` for body
+decoding.
+
+## 3. The typed-wire principle
+
+The invariants below apply to every operation under `internal/api/`
+except the `/svc/*` workspace-service proxy (see §5).
+
+### 3.1 Annotations drive the live implementation
+
+Each endpoint is a Go function whose signature (typed input struct,
+typed output struct) plus a `huma.Operation` value IS the endpoint
+definition. Huma binds it, validates it, routes it, serializes it,
+schema-describes it. There is no second description of the endpoint
+anywhere — not in a router table, not in an OpenAPI YAML, not in a
+client stub.
+
+### 3.2 Spec is generated, never hand-written
+
+`internal/api/openapi.json` and `docs/schema/openapi.json` are
+outputs of `cmd/genspec`, which reads the live Huma registration
+from a `SupervisorMux`. The pre-commit hook regenerates both on
+every Go-file commit. `TestOpenAPISpecInSync` fails CI if the
+committed spec drifts from what the supervisor serves.
+
+### 3.3 The routes we register ARE the routes we expose
+
+Per-city operations live at `/v0/city/{cityName}/...`.
+Supervisor-scope operations live at their top-level paths. No
+shadow mapping. No `prefix-strip-and-forward`. No client-side
+path-rewrite helpers. The existence of such a helper is direct
+evidence the spec disagrees with reality and is a bug to fix.
+
+### 3.4 No hand-constructed JSON for domain data
+
+Every wire byte that represents a domain value comes from encoding
+a typed Go struct (schema-registered with Huma) through the
+standard JSON encoder, directly or via Huma's own serialization
+machinery. This principle forbids three anti-patterns specifically:
+
+- `json.Marshal(map[string]any{...})` — untyped input.
+- `fmt.Sprintf`-built JSON strings — hand-constructed shape.
+- `json.Marshal(anyInterfaceValue)` where the interface carries
+  values whose types are not schema-registered — hides the shape
+  from the spec.
+
+The test a reviewer applies: *is there any line in your code that
+produces JSON-shaped output from non-typed or map-typed input?* If
+yes, violation. If every JSON byte comes from `encoder.Encode` of a
+typed, schema-registered struct, the principle holds.
+
+Protocol framing around domain data — HTTP status codes, HTTP
+response headers, SSE `id:` / `event:` / `data:` / retry line
+separators, chunked-encoding bytes — is not domain data and is not
+in scope for this principle. The carve-out is direction-symmetric
+and covers two specific files: `internal/api/sse.go` (emitter)
+hand-writes the SSE protocol-text lines around a typed
+`encoder.Encode(data)` call on a registered struct, and
+`cmd/gc/cmd_events.go:sseDecoder` (consumer) hand-parses the same
+SSE protocol-text lines and `json.Unmarshal`s the `data:` payload
+into typed `genclient.*` structs. In both directions the domain
+payload IS framework-encoded/decoded; the surrounding protocol
+literals are not JSON at all.
+
+New SSE endpoints must register through `registerSSE` /
+`registerSSEStringID`; ad-hoc SSE handlers outside those helpers
+are not covered by this carve-out.
+
+Edge cases that are NOT wire and therefore exempt:
+
+- SQL/BLOB (de)serialization in storage packages.
+- Hashing request bodies for idempotency keys.
+- Parsing stored JSONL transcript/log files from disk.
+- Parsing external-tool output we don't own (provider CLI stdout,
+  provider auth files like `~/.codex/auth.json`).
+- Internal event-bus `[]byte` payloads between in-process emitters
+  and consumers (these become typed at the wire via the registry —
+  see §4).
+
+Custom `MarshalJSON` / `UnmarshalJSON` on wire types are forbidden
+with two narrow, documented exceptions:
+
+- **`SessionRawMessageFrame`** (`internal/api/session_frame_types.go`)
+  — the raw-frame pass-through for provider-native session
+  transcripts; forwards arbitrary JSON the provider wrote. See §3.6.
+- **`EventPayloadUnion`** (`internal/api/convoy_event_stream.go`)
+  — the wire wrapper around `events.Payload` that emits the typed
+  payload as a named `oneOf` component. Its `MarshalJSON` emits
+  the concrete variant directly (so the wire sees `{"rig":...}`
+  rather than a wrapper object); its Schema method registers and
+  refs the named component. Required to get a single named
+  `EventPayload` component schema that Go and TS clients can both
+  consume.
+
+### 3.5 Typed structs for every shape knowable at compile time
+
+Every response field, every SSE event payload, every input body is
+a named Go struct with real fields and Huma tags. No
+`json.RawMessage` or `map[string]any` in the typed control plane,
+with exactly one class of exception (§3.6).
+
+"Heterogeneous", "opaque", "clients render it generically", "we'll
+figure out the union later", and "it's just internal" are not
+qualifying exceptions. If our code constructs the map, we know the
+keys. Make it a struct.
+
+### 3.5.1 No hidden inputs — every accepted parameter appears in the spec
+
+Every input a handler reads MUST be a typed field on its Huma
+input struct (`path:`, `query:`, `header:`, or `Body`). The
+generated OpenAPI spec is the complete and exhaustive description
+of the inputs an endpoint accepts. Running a request through a
+handler must not produce a different outcome than running the same
+request through the spec.
+
+Three anti-patterns are specifically forbidden:
+
+- **Dynamic or wildcard query parameters.** Any scheme where a
+  handler accepts query keys matching a pattern (`var.*`, `meta_*`,
+  `x-*`) rather than declared names. OpenAPI 3.1 cannot express
+  wildcard query keys; accepting them creates a hidden contract
+  the spec cannot describe. When a handler needs an open-ended
+  string-to-string dictionary as input, move the input into a
+  typed request body field (`Vars map[string]string` on a POST
+  body). Dictionary bodies have a schema; dictionary query
+  parameters do not.
+- **Resolvers that read raw URL query or header values that
+  aren't declared input fields.** `huma.Resolver` implementations
+  may validate or normalize values the struct already declares,
+  but may not read keys off `ctx.URL().Query()` or `ctx.Header()`
+  that aren't present on the input struct. If a resolver needs a
+  value, that value is a declared field — no exceptions.
+- **Presence-vs-empty semantics not expressible in JSONSchema.**
+  If a handler behaves differently for "parameter absent" vs
+  "parameter present with empty value", the input field must be a
+  pointer type (`*string`) so the distinction appears on the wire
+  contract. Resolver-based presence flags hide the semantics.
+
+The test a reviewer applies: does running an undeclared query
+parameter or an undeclared body field through the handler change
+its behavior? If yes, violation. The spec is the contract; the
+handler does not get a second, private contract the spec doesn't
+know about.
+
+Huma does not reject undeclared query parameters by default
+(they are silently ignored). That is not permission to rely on
+them — silent acceptance of undeclared parameters is a property
+of the framework, not a blessing of hidden contract. Callers that
+send undeclared parameters are sending noise; handlers that read
+them are violating this principle.
+
+### 3.6 Raw pass-through for provider-native session frames
+
+Session transcript streaming and query endpoints forward
+provider-native frames with full fidelity. Each response/envelope
+identifies the producing provider via a `provider` field whose
+value is one of the known provider keys (`claude`, `codex`,
+`gemini`, `open-code`, etc.); each frame's JSON is emitted verbatim
+as the provider wrote it, with no GC-side interpretation.
+Consumers parse frames using provider-specific logic on their side,
+keyed by the provider identifier on the envelope.
+
+The single JSON-pass-through wire type is `SessionRawMessageFrame`
+(`internal/api/session_frame_types.go`). Its Schema method emits
+an "any JSON value" schema because Gas City does not own the
+shape of provider frames. Publishing typed wire schemas for
+provider frames would claim a contract we don't own: a provider
+could change its frame shape tomorrow and the spec would silently
+lie until regenerated. Honest opacity with a provider discriminator
+is the right design.
+
+Passing through externally-authored shapes is not a license to
+also opacify our own shapes that happen to be nested near them.
+Every GC-owned field on the same envelope as the raw frames
+(envelope metadata, provider identifier, session info) stays
+typed.
+
+### 3.7 Every event type has a typed wire payload
+
+See §4.
+
+### 3.8 Error responses are typed too
+
+Every error returned by a Huma handler is a
+`huma.StatusError`-producing call with a real problem-details
+body. No `apiError{}` shortcuts. No hand-written `writeError`.
+
+For the outermost panic-recovery middleware (which must run before
+Huma enters the stack), error bodies are pre-serialized
+`application/problem+json` byte constants — one `var` declaration
+per well-known error, no runtime `json.Marshal`. The constants
+live in `internal/api/middleware.go` as `problemBody` values.
+
+### 3.9 `/svc/*` is the only exclusion
+
+`/svc/*` is a raw pass-through to external service processes that
+own their own contracts. It is explicitly not a typed API
+surface. This is the single carved-out path inside `internal/api/`.
+If `/svc/*` ever becomes typed, it gets its own migration.
+
+## 4. Event typing (the registry)
+
+Events are a first-class part of the typed wire contract. Both the
+SSE streams (`/v0/events/stream`,
+`/v0/city/{cityName}/events/stream`) and the list endpoints
+(`GET /v0/events`, `GET /v0/city/{cityName}/events`) describe their
+`payload` field as a named `oneOf` union covering every registered
+`events.Payload` shape. There is no opaque `payload: {}` anywhere
+on the wire.
+
+### Mechanism
+
+- **Bus layer (`internal/events`)** stores payloads as `[]byte` so
+  it stays domain-agnostic. `events.Event` and `events.TaggedEvent`
+  are bus-internal types only; they are never returned directly
+  from an HTTP handler.
+- **Registry (`internal/events/payload.go`)** holds the event-type
+  → Go-type mapping. `events.RegisterPayload(typeConst, sample)`
+  associates a constant with a sample value of a type implementing
+  the sealed `events.Payload` interface. `events.DecodePayload`
+  turns bus bytes back into the registered typed value.
+- **Emitters** take values of `events.Payload` rather than
+  `map[string]any`. The sealed interface keeps ad-hoc shapes out
+  of emission sites at compile time.
+- **Wire projection** — the API-layer `WireEvent` /
+  `WireTaggedEvent` types (list) and `eventStreamEnvelope` /
+  `taggedEventStreamEnvelope` (SSE) carry a typed `Payload` field
+  wrapped in `EventPayloadUnion`. `EventPayloadUnion.Schema`
+  registers a named `EventPayload` component whose schema is a
+  `oneOf` of every registered payload type.
+
+### Registry coverage
+
+Every constant in `events.KnownEventTypes` MUST have a registered
+payload. Events that carry no structured data register
+`events.NoPayload` — a typed empty struct that still produces a
+named schema variant so the wire stays uniform across event types.
+
+`TestEveryKnownEventTypeHasRegisteredPayload` fails CI if a new
+constant is added without registration; that's how the registry
+discipline stays load-bearing rather than best-effort.
+
+**Decode-failure policy (uniform across list and stream).** Decode
+failures and unregistered event types are omitted from list and
+stream output and logged via `log.Printf`; the wire never carries
+a degraded envelope with nil payload. A malformed event is a CI
+bug (the registry-coverage test above catches it before prod);
+emitting a typed envelope with `payload: null` would train
+consumers to tolerate broken payloads, defeating the point of
+§3.4. Clean omission plus a loud log is the contract.
+
+### Discrimination design
+
+The envelope carries a plain `type: string` field; the `payload`
+field is the discriminated `oneOf` union. Consumers switch on
+`type` and narrow `payload` explicitly:
+
+```typescript
+if (event.type === "mail.sent") {
+  use(event.payload as MailEventPayload);
+}
+```
+
+Envelope-level discrimination — each event-type constant pinned
+as a `type` const in its own envelope variant, with OpenAPI 3.1
+discriminators giving consumers automatic narrowing — would be
+nicer. It is not the design because no current Go OpenAPI client
+generator produces a workable Go type from envelope-level
+`oneOf`:
+
+- **oapi-codegen** collapses the envelope to a `json.RawMessage`
+  wrapper that loses all field access — `cmd/gc/cmd_events.go`'s
+  field-based construction breaks.
+- **ogen** drops `text/event-stream` operations entirely —
+  the events streams disappear from the generated client.
+
+The payload-field-union design is the current ceiling. Every
+payload variant is still fully typed on the wire; consumers narrow
+explicitly rather than getting automatic discriminator narrowing.
+See §6 for the full tooling note.
+
+## 5. Developer workflow
+
+The invariants above exist so the developer's contribution to the
+HTTP + SSE surface is Go code only. Tooling produces everything
+else.
+
+### Adding or changing a REST operation
+
+1. Edit or add input/output struct types with Huma tags
+   (`json:"..."`, `minLength:"1"`, `required:"true"`, etc.).
+2. Write the handler function; register via `huma.Register` (or
+   the `cityGet` / `cityPost` / `cityPatch` / etc. helpers in
+   `internal/api/city_scope.go` for per-city scoped operations).
+3. Commit. Pre-commit regenerates `internal/api/openapi.json`,
+   `docs/schema/openapi.json`, `internal/api/genclient/`, and the
+   TS types under `cmd/gc/dashboard/web/src/generated/`. Mintlify
+   publishes the spec on the next docs build.
+
+### Adding or changing an event type
+
+1. Add the constant to `internal/events/events.go` and append it
+   to `events.KnownEventTypes`.
+2. Define a typed payload struct implementing `events.Payload` (a
+   trivial `IsEventPayload()` method), or use `events.NoPayload`
+   for events whose envelope fields alone capture the semantics.
+3. Call `events.RegisterPayload(constant, sample)` from an
+   `init()` in the domain package that owns the event (e.g.
+   `internal/api/event_payloads.go` for mail/bead;
+   `internal/extmsg/events.go` for extmsg).
+4. Commit. Pre-commit regenerates the discriminated-union wire
+   schema; generated clients gain the new typed variant
+   automatically.
+
+### CI guards
+
+Skipping any step lands on a CI failure, not a production bug:
+
+| Miss | Caught by |
+|---|---|
+| Spec not regenerated after Go-type change | `TestOpenAPISpecInSync` |
+| Generated Go client out of sync with spec | `TestGeneratedClientInSync` |
+| Handler response field undeclared in spec | Layer 1 response-validation tests |
+| Spec/client method-shape drift | Layer 2 round-trip tests (`genclient_roundtrip_test.go`) |
+| End-to-end binary wire regression | Layer 3 integration tests (`//go:build integration`) |
+| New event-type constant without registered payload | `TestEveryKnownEventTypeHasRegisteredPayload` |
+| Hard-coded SPA `/v0/...` path outside typed client | TypeScript build (`satisfies SpecPath` in `api.ts`) |
+
+## 6. Tooling landscape
+
+Principle 7's "payload-field-level discrimination rather than
+envelope-level" is a Go-tooling constraint, not a principled
+preference. The TypeScript and Go ecosystems differ on what they
+support; this section records what we evaluated and what we use
+per language.
+
+### Go (server-side Huma, client via oapi-codegen)
+
+- **Huma v2** — server framework. Generates OpenAPI 3.1 from
+  annotated Go types; we use it for every typed endpoint. Emits a
+  3.0 downgrade on request for consumers that still need 3.0.
+- **oapi-codegen** — our current Go client generator. Supports
+  OpenAPI 3.0 (we feed it the downgrade from Huma). When given
+  envelope-level `oneOf`, it generates `struct { union
+  json.RawMessage }` with `AsX`/`FromX`/`MergeX` accessor methods.
+  That shape breaks field-based construction in
+  `cmd/gc/cmd_events.go`. It does generate typed request methods
+  for SSE endpoints, but does not parse SSE frames — the caller
+  handles framing.
+- **ogen** — evaluated via spike. Refuses `text/event-stream`
+  content type entirely; every SSE endpoint is dropped from the
+  generated client. With `ignore_not_implemented: all`, ogen
+  produces clean REST types but drops SSE operations Gas City is
+  built on. Not viable.
+- **openapi-generator** (Java-based) — breaks the pure-Go toolchain
+  and generates less-idiomatic Go.
+- **Commercial SDK generators** (Speakeasy, Fern, Stainless) —
+  generate typed Go SSE clients including envelope-level `oneOf`
+  handling. Not open source; paid plans start at ~$250/mo.
+
+The payload-field-union `EventPayload` design (Principle 7) is the
+current ceiling under open-source Go tooling. Revisit if
+oapi-codegen's experimental 3.1/3.2-aware branch stabilizes or if
+another open-source Go generator ships envelope-level `oneOf` plus
+SSE that works with our shape.
+
+### TypeScript (dashboard SPA)
+
+- **`openapi-fetch`** — typed `fetch` wrapper, the tool the
+  dashboard uses for every REST call site. Typed path/body/response
+  against `openapi-typescript`-generated `schema.d.ts`. Minimal
+  runtime, well-documented, keeps REST call-site code short. Does
+  not handle SSE — that's what drives the dual-tool design below.
+- **`@hey-api/openapi-ts`** — open-source generator the dashboard
+  uses exclusively for SSE. Generates typed stream functions using
+  `fetch()` + `ReadableStream` (not `EventSource`), which means
+  custom auth headers work, retry with exponential backoff is
+  built in, and each stream has typed discriminated-union response
+  types keyed by the SSE `event` name. `sse.ts` is a thin callback
+  bridge over the generated `streamSupervisorEvents`,
+  `streamEvents`, and `streamSession` functions; the per-frame
+  JSON parsing, line buffering, and retry are all framework code.
+- **`openapi-typescript-codegen`** — unmaintained.
+- **OpenAPI Generator** (Java) — same pure-toolchain concern as Go.
+
+The dual-tool design is pragmatic, not aspirational: each library
+handles what it's good at. `openapi-fetch` is the minimal typed
+surface for REST consumers (kept because it has zero impact on
+call-site code and the ecosystem has shifted to hey-api slowly
+enough that we'd gain nothing by churning every REST call today).
+`@hey-api/openapi-ts` is the only open-source TS tool that
+generates typed SSE stream clients, and it handles every aspect of
+the SSE wire that used to be hand-rolled in `sse.ts`.
+
+The Go-side `oneOf` ceiling described above does not apply to
+TypeScript consumers. SSE frames come typed and discriminated
+through the generated stream functions; consumers get automatic
+`switch (frame.event)` narrowing with no hand-written parser or
+type guard in the SPA.
+
+## 7. What is out of scope
+
+- **`/svc/*` proxy.** See §3.9.
+- **Outbound HTTP** (`internal/extmsg/http_adapter.go`,
+  `internal/workspacesvc/proxy_process.go`). Not typed API
+  endpoints; we consume someone else's contract.
+- **Storage-layer (de)serialization** (SQL BLOBs, JSONL log files,
+  external-tool auth files). Not on our wire.
+- **Generated Go client as a Go SDK surface.** Stays in
+  `internal/` until external consumers show up.
+- **WebSocket transport.** HTTP + SSE only. OpenAPI 3.1 + Huma
+  covers SSE end-to-end, so AsyncAPI / Modelina are not in play.
+
+## 8. Maintenance rule
+
+Every file-path citation in this spec is load-bearing. If you
+rename or remove a cited symbol (`events.KnownEventTypes`,
+`EventPayloadUnion`, `TestEveryKnownEventTypeHasRegisteredPayload`,
+`cmd/gc/apiroute.go:apiClient()`, etc.), **update this spec in the
+same commit**. A stale spec is worse than no spec — it misleads
+future agents about what invariants hold.
+
+Line numbers are deliberately omitted so the spec survives
+refactors. Package names, type names, and test names are stable
+anchors.

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -30,16 +30,12 @@ var markdownLinkRE = regexp.MustCompile(`\[[^][]+\]\(([^)]+)\)`)
 // and should be link-checked. Update this list when adding or removing doc
 // directories. TestDocDirCoverage will fail if a new directory with markdown
 // appears that is not accounted for here or in docTreeIgnored.
-var docTreeDirs = []string{"contrib", "docs", "engdocs", "release-gates"}
+var docTreeDirs = []string{"contrib", "docs", "engdocs", "release-gates", "specs"}
 
 // docTreeIgnored lists directories that contain markdown but are not
 // documentation trees (e.g., embedded prompt templates, test fixtures,
 // gitignored scratch space for local work).
-var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "release-gates", "scripts", "test", "tmp"}
-
-var markdownFileNameIgnored = map[string]bool{
-	"README.md": true,
-}
+var docTreeIgnored = []string{"cmd", "examples", "internal", "plans", "scripts", "test", "tmp"}
 
 // knownBrokenLinks lists links to docs that do not exist yet. These are
 // excluded from TestLocalMarkdownLinks failures but still logged. Remove
@@ -62,9 +58,6 @@ func allDocsMarkdownFiles(root string) ([]string, error) {
 		if e.IsDir() {
 			continue
 		}
-		if markdownFileNameIgnored[e.Name()] {
-			continue
-		}
 		ext := filepath.Ext(e.Name())
 		if ext == ".md" || ext == ".mdx" {
 			files = append(files, filepath.Join(root, e.Name()))
@@ -81,9 +74,6 @@ func allDocsMarkdownFiles(root string) ([]string, error) {
 			if d.IsDir() {
 				return nil
 			}
-			if markdownFileNameIgnored[d.Name()] {
-				return nil
-			}
 			ext := filepath.Ext(path)
 			if ext == ".md" || ext == ".mdx" {
 				files = append(files, path)
@@ -97,24 +87,6 @@ func allDocsMarkdownFiles(root string) ([]string, error) {
 
 	sort.Strings(files)
 	return files, nil
-}
-
-func TestAllDocsMarkdownFilesExcludesREADMEs(t *testing.T) {
-	root := repoRoot()
-	files, err := allDocsMarkdownFiles(root)
-	if err != nil {
-		t.Fatalf("collecting markdown files: %v", err)
-	}
-
-	excluded := map[string]bool{
-		filepath.Join(root, "README.md"):         true,
-		filepath.Join(root, "docs", "README.md"): true,
-	}
-	for _, path := range files {
-		if excluded[path] {
-			t.Fatalf("%s should not be included in docs link checks", path)
-		}
-	}
 }
 
 func publicSurfaceMarkdownFiles(root string) ([]string, error) {
@@ -598,7 +570,7 @@ func TestNoKnownStaleDocReferences(t *testing.T) {
 		"agent.NewFake",
 		"session.Fake",
 		"agent.Fake",
-		"internal/dolt/",
+		"internal/dolt",
 	}
 
 	var hits []string

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -570,7 +570,7 @@ func TestNoKnownStaleDocReferences(t *testing.T) {
 		"agent.NewFake",
 		"session.Fake",
 		"agent.Fake",
-		"internal/dolt",
+		"internal/dolt/",
 	}
 
 	var hits []string


### PR DESCRIPTION
## What this changes

When a pack defines an agent in BOTH the legacy v1 inline form (`[[agent]]` blocks under the pack root) AND the v2 convention form (`agents/<name>/` directories), `ValidateAgents` previously rendered the same generic duplicate-name message used for any other collision. Operators migrating packs from v1 to v2 had to diff their pack manually to discover the layout collision.

This PR makes the migration case self-explanatory:

1. Adds an unexported `Agent.layout agentLayout` enum stamped at every discovery site:
   - `loadPack` stamps `layoutV1Inline` on `tc.Agents` BEFORE v2 discovery appends.
   - `DiscoverPackAgents` stamps `layoutV2Convention` on convention-discovered agents.
   - Both stamps survive the merge so the helper sees the original layouts.
2. Extends the shared `formatDuplicateAgentError` helper (introduced in #1583 / ga-tpfc.1) with a `(V1Inline, V2Convention)` pair detector. When that exact pair is seen (in either order), the helper emits a migration-aware headline `agent %q: pack v1/v2 layout collision` with a pointer to `docs/packv2/migration.mdx` (delivered by ga-6wrr.1). The other 7 matrix cells stay generic.
3. Suppresses the migration variant when `Agent.fallback=true` — fallbacks are intentional dual-stamps in the migration path.

## Why one PR / stacking note

This branch is stacked on `builder/ga-mol-bq54` (#1583, ga-tpfc.1). The two share the `formatDuplicateAgentError` helper — ga-tpfc.1 introduces it; this PR extends it. Until #1583 merges, the diff here shows 5 commits (3 from #1583 + 2 own); after #1583 merges the diff collapses to just the 2 ga-9ogb.1 commits.

**#1583 must merge first.**

## Review notes

- New unexported `Agent.layout agentLayout` field. Same field-sync pattern as `source` from #1583: `field_sync_test.go` excludes it; `cmd/gc/pool.go` deep-copy tombstone updated with the same documented cross-package gap.
- Migration headline `agent %q: pack v1/v2 layout collision` is byte-pinned by `TestFormatDuplicateAgentError_MigrationHeadlinePinned` so any future drift in error wording fails the test.
- Migration URL points to `docs/packv2/migration.mdx`. That file is the deliverable of ga-6wrr.1; the URL is pinned to the path that will exist post-merge, not the current main.
- `ValidateAgents` remains pure-data: layout-pair detection is a string-formatting branch in the helper, no FS access.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./internal/config/...` clean.
- [x] `go test ./internal/config/` — 13 new tests covering 3×3 layout matrix, headline pinning, bug repro, fallback suppression, patch/override propagation, city-inline edge case.
- [x] `go test ./cmd/gc/ -run 'TestDeepCopyAgent|TestAgentFieldSync'` — pool tombstone + struct-field sync.
- [x] Existing same-version duplicate tests stay green (no regression on the 7 generic matrix cells).
- [x] Release gate: [`release-gates/ga-9ogb-1-gate.md`](release-gates/ga-9ogb-1-gate.md)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->