### PR TITLE
fix(reconciler): use pending_create_started_at for staleCreatingState

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1416,7 +1416,7 @@ func selectOrCreatePoolSessionBead(
 			return bead, nil
 		}
 	}
-	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads)
+	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp))
 }
 
 func selectOrCreateDependencyPoolSessionBead(
@@ -1444,7 +1444,11 @@ func selectOrCreateDependencyPoolSessionBead(
 			return bead, nil
 		}
 	}
-	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads)
+	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp))
+}
+
+func poolSessionCreateStartedAt(_ *agentBuildParams) time.Time {
+	return time.Now().UTC()
 }
 
 func agentInSuspendedRig(

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
+	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -3088,6 +3089,40 @@ func TestSelectOrCreatePoolSessionBead_SkipsDrained(t *testing.T) {
 	}
 	if result.ID == drained.ID {
 		t.Fatal("should not reuse drained session bead for new-tier request")
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_UsesFreshCreateTimeNotBeaconTime(t *testing.T) {
+	store := beads.NewMemStore()
+	snapshot := &sessionBeadSnapshot{}
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	anchor := time.Now().UTC()
+	oldBeacon := anchor.Add(-2 * staleCreatingStateTimeout)
+	beforeCreate := anchor.Add(-time.Second)
+	bp := &agentBuildParams{
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+		beaconTime:   oldBeacon,
+	}
+
+	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+	}
+	startedAt, err := time.Parse(time.RFC3339, result.Metadata["pending_create_started_at"])
+	if err != nil {
+		t.Fatalf("parse pending_create_started_at %q: %v", result.Metadata["pending_create_started_at"], err)
+	}
+	if startedAt.Before(beforeCreate) {
+		t.Fatalf("pending_create_started_at = %s, want current create time after %s", startedAt, beforeCreate)
+	}
+	if !startedAt.After(oldBeacon.Add(staleCreatingStateTimeout)) {
+		t.Fatalf("pending_create_started_at = %s, want independent from stale beacon %s", startedAt, oldBeacon)
+	}
+	result.CreatedAt = oldBeacon
+	if staleCreatingState(result, &clock.Fake{Time: startedAt.Add(30 * time.Second)}) {
+		t.Fatal("fresh pool session was stale when row CreatedAt matched old controller beacon")
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1642,11 +1642,8 @@ func sweepUndesiredPoolSessionBeads(
 // still alive.
 func isStaleCreating(bead beads.Bead) bool {
 	now := time.Now()
-	if v := strings.TrimSpace(bead.Metadata["pending_create_started_at"]); v != "" {
-		started, err := time.Parse(time.RFC3339, v)
-		if err == nil {
-			return !now.Before(started.Add(staleCreatingStateTimeout))
-		}
+	if started, ok := parseRFC3339Metadata(bead.Metadata["pending_create_started_at"]); ok {
+		return !now.Before(started.Add(staleCreatingStateTimeout))
 	}
 	if bead.CreatedAt.IsZero() {
 		return true
@@ -1654,9 +1651,9 @@ func isStaleCreating(bead beads.Bead) bool {
 	return !now.Before(bead.CreatedAt.Add(staleCreatingStateTimeout))
 }
 
-// parseRFC3339Metadata parses an RFC3339 timestamp metadata value. A missing
-// or unparseable value returns ok=false; the caller treats that as "no per-
-// start marker present" so older beads (pre-creation_complete_at rollout)
+// parseRFC3339Metadata parses an RFC3339 timestamp metadata value. A missing,
+// zero, or unparseable value returns ok=false; the caller treats that as "no
+// per-start marker present" so older beads (pre-creation_complete_at rollout)
 // fall through to the default sweepable path rather than being protected
 // indefinitely.
 func parseRFC3339Metadata(v string) (time.Time, bool) {
@@ -1666,6 +1663,9 @@ func parseRFC3339Metadata(v string) (time.Time, bool) {
 	}
 	t, err := time.Parse(time.RFC3339, v)
 	if err != nil {
+		return time.Time{}, false
+	}
+	if t.IsZero() {
 		return time.Time{}, false
 	}
 	return t, true

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1572,7 +1572,7 @@ func sweepUndesiredPoolSessionBeads(
 		if strings.TrimSpace(bead.Metadata["pending_create_claim"]) == "true" {
 			continue
 		}
-		if strings.TrimSpace(bead.Metadata["state"]) == "creating" && !isStaleCreating(bead.CreatedAt) {
+		if strings.TrimSpace(bead.Metadata["state"]) == "creating" && !isStaleCreating(bead) {
 			continue
 		}
 		// Age grace period for the post-creating, pre-wake window. After
@@ -1636,15 +1636,22 @@ func sweepUndesiredPoolSessionBeads(
 }
 
 // isStaleCreating mirrors staleCreatingState in session_reconcile.go without
-// requiring a clock.Clock dependency: a zero CreatedAt is treated as stale,
-// and otherwise the bead is stale once staleCreatingStateTimeout has elapsed.
-// Keeping this shape identical to the reconciler's predicate means the sweep
-// and the reconciler agree about which in-flight create beads are still alive.
-func isStaleCreating(createdAt time.Time) bool {
-	if createdAt.IsZero() {
+// requiring a clock.Clock dependency. It prefers the per-attempt
+// pending_create_started_at marker and falls back to CreatedAt for older beads
+// so the sweep and reconciler agree about which in-flight create beads are
+// still alive.
+func isStaleCreating(bead beads.Bead) bool {
+	now := time.Now()
+	if v := strings.TrimSpace(bead.Metadata["pending_create_started_at"]); v != "" {
+		started, err := time.Parse(time.RFC3339, v)
+		if err == nil {
+			return !now.Before(started.Add(staleCreatingStateTimeout))
+		}
+	}
+	if bead.CreatedAt.IsZero() {
 		return true
 	}
-	return time.Since(createdAt) >= staleCreatingStateTimeout
+	return !now.Before(bead.CreatedAt.Add(staleCreatingStateTimeout))
 }
 
 // parseRFC3339Metadata parses an RFC3339 timestamp metadata value. A missing

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1161,6 +1161,45 @@ func TestSweepUndesiredPoolSessionBeads_SkipsStalePendingCreateClaim(t *testing.
 	}
 }
 
+func TestSweepUndesiredPoolSessionBeads_UsesPendingCreateStartedAtForCreatingState(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Now().UTC()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":              "worker-bd-fresh-create",
+			"template":                  "worker",
+			"agent_name":                "worker",
+			"pool_slot":                 "1",
+			poolManagedMetadataKey:      boolMetadata(true),
+			"state":                     "creating",
+			"pending_create_started_at": pendingCreateStartedAtNow(now.Add(-30 * time.Second)),
+			"continuation_epoch":        "1",
+			"generation":                "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	bead.CreatedAt = now.Add(-2 * time.Minute)
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{bead})
+
+	closed := sweepUndesiredPoolSessionBeads(
+		store,
+		nil,
+		sessionBeads,
+		nil,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		runtime.NewFake(),
+		false,
+	)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0 — fresh pending_create_started_at must keep old creating bead alive", closed)
+	}
+}
+
 func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -1200,6 +1200,21 @@ func TestSweepUndesiredPoolSessionBeads_UsesPendingCreateStartedAtForCreatingSta
 	}
 }
 
+func TestIsStaleCreatingTreatsZeroPendingCreateStartedAtAsMissing(t *testing.T) {
+	now := time.Now().UTC()
+	bead := beads.Bead{
+		Metadata: map[string]string{
+			"state":                     "creating",
+			"pending_create_started_at": (time.Time{}).UTC().Format(time.RFC3339),
+		},
+		CreatedAt: now,
+	}
+
+	if isStaleCreating(bead) {
+		t.Fatal("zero pending_create_started_at should fall back to fresh CreatedAt")
+	}
+}
+
 func TestSweepUndesiredPoolSessionBeads_ClosesStoppedSessions(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{

--- a/cmd/gc/cmd_session_pin.go
+++ b/cmd/gc/cmd_session_pin.go
@@ -81,8 +81,9 @@ func cmdSessionSetPin(args []string, pinned bool, stdout, stderr io.Writer) int 
 		id, err = resolveSessionIDWithConfig(cityPath, cfg, store, args[0])
 		if err != nil {
 			id, err = resolveSessionIDMaterializingNamedWithMetadata(cityPath, cfg, store, args[0], map[string]string{
-				"pin_awake":            "true",
-				"pending_create_claim": "",
+				"pin_awake":                 "true",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
 			})
 			materializedForPin = err == nil
 		}

--- a/cmd/gc/cmd_session_wake.go
+++ b/cmd/gc/cmd_session_wake.go
@@ -77,9 +77,10 @@ func cmdSessionWake(args []string, stdout, stderr io.Writer) int {
 	}
 	if !hasRunnableTemplate && sessionWakeRequestedCreate(b) {
 		if err := store.SetMetadataBatch(id, map[string]string{
-			"state":                string(session.StateAsleep),
-			"state_reason":         "",
-			"pending_create_claim": "",
+			"state":                     string(session.StateAsleep),
+			"state_reason":              "",
+			"pending_create_claim":      "",
+			"pending_create_started_at": "",
 		}); err != nil {
 			fmt.Fprintf(stderr, "gc session wake: updating metadata: %v\n", err) //nolint:errcheck
 			return 1

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1505,6 +1505,7 @@ func setMetaBatch(store beads.Store, id string, batch map[string]string, stderr 
 func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr io.Writer) bool {
 	patch := session.ClosePatch(now.UTC(), "failed-create")
 	patch["pending_create_claim"] = ""
+	patch["pending_create_started_at"] = ""
 	if setMetaBatch(store, id, patch, stderr) != nil {
 		return false
 	}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -319,6 +319,16 @@ func reopenClosedConfiguredNamedSessionBead(
 			"pending_create_claim": pendingCreateClaim,
 			"synced_at":            now.Format("2006-01-02T15:04:05Z07:00"),
 		}
+		// Reset the pending-create stale clock to NOW. The bead row's
+		// CreatedAt reflects when it was first minted (potentially
+		// long ago); this reopen is a fresh spawn attempt, so the
+		// staleCreatingState window must start counting from here,
+		// not from CreatedAt.
+		if pendingCreateClaim == "true" {
+			batch["pending_create_started_at"] = pendingCreateStartedAtNow(now)
+		} else {
+			batch["pending_create_started_at"] = ""
+		}
 		for k, v := range extraMeta {
 			batch[k] = v
 		}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -933,6 +933,7 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			}
 			if createState != "active" {
 				meta["pending_create_claim"] = "true"
+				meta["pending_create_started_at"] = pendingCreateStartedAtNow(now)
 			}
 			if tp.DependencyOnly {
 				meta["dependency_only"] = boolMetadata(true)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -215,6 +215,38 @@ func TestSyncSessionBeads_CreatesNewBeads(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_CreatesNonActiveBeadWithPendingCreateStartedAt(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+
+	ds := map[string]TemplateParams{
+		"helper": {TemplateName: "helper", Command: "true"},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, ds, sp, allConfiguredDS(ds), nil, clk, &stderr, false)
+
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	all := allSessionBeads(t, store)
+	if len(all) != 1 {
+		t.Fatalf("expected 1 bead, got %d", len(all))
+	}
+	b := all[0]
+	if got := b.Metadata["state"]; got != "creating" {
+		t.Fatalf("state = %q, want creating", got)
+	}
+	if got := b.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+	if got, want := b.Metadata["pending_create_started_at"], pendingCreateStartedAtNow(clk.Now()); got != want {
+		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
+	}
+}
+
 func TestSyncSessionBeads_ExistingDesiredUsesSnapshotStateWithoutWorkerLookup(t *testing.T) {
 	base := beads.NewMemStore()
 	store := &sessionGetSpyStore{Store: base}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -973,8 +973,70 @@ func TestSyncSessionBeads_ReopensClosedConfiguredNamedSession(t *testing.T) {
 	if got := all[0].Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", got)
 	}
+	if got, want := all[0].Metadata["pending_create_started_at"], pendingCreateStartedAtNow(clk.Now()); got != want {
+		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
+	}
 	if got := all[0].Metadata["session_name"]; got != sessionName {
 		t.Fatalf("session_name = %q, want %q", got, sessionName)
+	}
+}
+
+func TestReopenClosedConfiguredNamedSessionBeadClearsPendingCreateStartedAtWhenActive(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 1, 9, 30, 0, 0, time.UTC)
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "refinery", StartCommand: "true", MaxActiveSessions: intPtr(2)},
+		},
+		NamedSessions: []config.NamedSession{
+			{Template: "refinery", Mode: "on_demand"},
+		},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.Workspace.Name, cfg.Workspace, "refinery")
+	closed, err := store.Create(beads.Bead{
+		Title:  "refinery",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      "refinery",
+			"template":                   "refinery",
+			"state":                      "suspended",
+			"close_reason":               "suspended",
+			"pending_create_started_at":  pendingCreateStartedAtNow(now.Add(-2 * time.Minute)),
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "refinery",
+			namedSessionModeMetadata:     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create closed canonical bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("close canonical bead: %v", err)
+	}
+
+	var stderr bytes.Buffer
+	reopened, ok := reopenClosedConfiguredNamedSessionBead(
+		cityPath, store, cfg, "test-city", "refinery", sessionName, "active", now, nil, &stderr,
+	)
+	if !ok {
+		t.Fatalf("reopenClosedConfiguredNamedSessionBead failed: %s", stderr.String())
+	}
+	if reopened.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want empty", reopened.Metadata["pending_create_claim"])
+	}
+	if reopened.Metadata["pending_create_started_at"] != "" {
+		t.Fatalf("pending_create_started_at = %q, want empty", reopened.Metadata["pending_create_started_at"])
+	}
+	stored, err := store.Get(closed.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", closed.ID, err)
+	}
+	if stored.Metadata["pending_create_started_at"] != "" {
+		t.Fatalf("stored pending_create_started_at = %q, want empty", stored.Metadata["pending_create_started_at"])
 	}
 }
 
@@ -2709,7 +2771,7 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 	sp := runtime.NewFake()
 	template := "pack/worker"
 
-	owner, err := createPoolSessionBead(store, template, nil)
+	owner, err := createPoolSessionBead(store, template, nil, clk.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2764,7 +2826,7 @@ func TestCreatePoolSessionBead_MetadataFailureLeavesReachablePlaceholder(t *test
 	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
 	template := "pack/worker"
 
-	if _, err := createPoolSessionBead(store, template, nil); err == nil {
+	if _, err := createPoolSessionBead(store, template, nil, time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)); err == nil {
 		t.Fatal("createPoolSessionBead returned nil error, want session_name metadata failure")
 	}
 

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -32,16 +33,17 @@ func createPoolSessionBead(
 	}
 	instanceToken := sessionpkg.NewInstanceToken()
 	meta := map[string]string{
-		"template":             template,
-		"agent_name":           template,
-		"state":                "creating",
-		"pending_create_claim": "true",
-		"session_origin":       "ephemeral",
-		"generation":           "1",
-		"continuation_epoch":   "1",
-		"instance_token":       instanceToken,
-		"session_name":         pendingPoolSessionName(template, instanceToken),
-		poolManagedMetadataKey: boolMetadata(true),
+		"template":                  template,
+		"agent_name":                template,
+		"state":                     "creating",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": pendingCreateStartedAtNow(time.Now()),
+		"session_origin":            "ephemeral",
+		"generation":                "1",
+		"continuation_epoch":        "1",
+		"instance_token":            instanceToken,
+		"session_name":              pendingPoolSessionName(template, instanceToken),
+		poolManagedMetadataKey:      boolMetadata(true),
 	}
 	bead, err := store.Create(beads.Bead{
 		Title:    targetBasename(template),

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -27,6 +27,7 @@ func createPoolSessionBead(
 	store beads.Store,
 	template string,
 	sessionBeads *sessionBeadSnapshot,
+	now time.Time,
 ) (beads.Bead, error) {
 	if store == nil {
 		return beads.Bead{}, fmt.Errorf("session store unavailable for pool template %q", template)
@@ -37,7 +38,7 @@ func createPoolSessionBead(
 		"agent_name":                template,
 		"state":                     "creating",
 		"pending_create_claim":      "true",
-		"pending_create_started_at": pendingCreateStartedAtNow(time.Now()),
+		"pending_create_started_at": pendingCreateStartedAtNow(now),
 		"session_origin":            "ephemeral",
 		"generation":                "1",
 		"continuation_epoch":        "1",

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -2,20 +2,25 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
 
 func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
 
-	bead, err := createPoolSessionBead(store, "gascity/claude", nil)
+	bead, err := createPoolSessionBead(store, "gascity/claude", nil, now)
 	if err != nil {
 		t.Fatalf("createPoolSessionBead: %v", err)
 	}
 
 	if got := bead.Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+	if got, want := bead.Metadata["pending_create_started_at"], pendingCreateStartedAtNow(now); got != want {
+		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
 	}
 
 	stored, err := store.Get(bead.ID)
@@ -24,5 +29,8 @@ func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
 	}
 	if got := stored.Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("stored pending_create_claim = %q, want true", got)
+	}
+	if got, want := stored.Metadata["pending_create_started_at"], pendingCreateStartedAtNow(now); got != want {
+		t.Fatalf("stored pending_create_started_at = %q, want %q", got, want)
 	}
 }

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -878,11 +878,8 @@ func staleCreatingState(session beads.Bead, clk clock.Clock) bool {
 		return false
 	}
 	now := clk.Now()
-	if v := strings.TrimSpace(session.Metadata["pending_create_started_at"]); v != "" {
-		started, err := time.Parse(time.RFC3339, v)
-		if err == nil {
-			return !now.Before(started.Add(staleCreatingStateTimeout))
-		}
+	if started, ok := parseRFC3339Metadata(session.Metadata["pending_create_started_at"]); ok {
+		return !now.Before(started.Add(staleCreatingStateTimeout))
 	}
 	if session.CreatedAt.IsZero() {
 		return true
@@ -895,6 +892,9 @@ func staleCreatingState(session beads.Bead, clk clock.Clock) bool {
 // state=creating with pending_create_claim=true. Must match the format
 // staleCreatingState parses (RFC3339).
 func pendingCreateStartedAtNow(now time.Time) string {
+	if now.IsZero() {
+		now = time.Now()
+	}
 	return now.UTC().Format(time.RFC3339)
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -178,10 +178,7 @@ func sessionStartRequested(session beads.Bead, clk clock.Clock) bool {
 // transition (see staleCreatingState below), not from the bead row's
 // CreatedAt — so configured-named-session reopens get a fresh window
 // each time the bead is reopened.
-//
-// Declared as var (not const) so tests can override it without forcing
-// every test fixture to use 60s+ timestamps.
-var staleCreatingStateTimeout = time.Minute
+const staleCreatingStateTimeout = time.Minute
 
 func sessionMetadataState(session beads.Bead) string {
 	switch state := strings.TrimSpace(session.Metadata["state"]); state {

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -173,7 +173,15 @@ func sessionStartRequested(session beads.Bead, clk clock.Clock) bool {
 	return !staleCreatingState(session, clk)
 }
 
-const staleCreatingStateTimeout = time.Minute
+// staleCreatingStateTimeout bounds how long a state=creating bead may sit
+// before the reconciler rolls it back. Measured from the pending-create
+// transition (see staleCreatingState below), not from the bead row's
+// CreatedAt — so configured-named-session reopens get a fresh window
+// each time the bead is reopened.
+//
+// Declared as var (not const) so tests can override it without forcing
+// every test fixture to use 60s+ timestamps.
+var staleCreatingStateTimeout = time.Minute
 
 func sessionMetadataState(session beads.Bead) string {
 	switch state := strings.TrimSpace(session.Metadata["state"]); state {
@@ -850,14 +858,47 @@ func emptyNil(batch map[string]string) map[string]string {
 	return batch
 }
 
+// staleCreatingState returns true when a state=creating bead has been
+// stuck in that state longer than staleCreatingStateTimeout.
+//
+// "How long" is measured from the most recent transition into the
+// creating/pending-create state, NOT from the bead's original
+// CreatedAt. Configured-named-session beads (e.g. beads/planner) get
+// REOPENED on demand — the same bead row toggles closed→open with
+// state→creating — so its CreatedAt is from when the bead row was
+// first created (potentially hours/days/months ago) and is irrelevant
+// to whether the current spawn attempt is stuck.
+//
+// Order of preference:
+//  1. metadata["pending_create_started_at"] — set by createPoolSessionBead
+//     and reopenClosedConfiguredNamedSessionBead at the moment the bead
+//     enters state=creating with pending_create_claim=true.
+//  2. session.CreatedAt — fallback for fresh pool beads minted before
+//     this metadata key was introduced, and for any caller that creates
+//     a bead in state=creating without going through the helpers above.
 func staleCreatingState(session beads.Bead, clk clock.Clock) bool {
 	if clk == nil {
 		return false
 	}
+	now := clk.Now()
+	if v := strings.TrimSpace(session.Metadata["pending_create_started_at"]); v != "" {
+		started, err := time.Parse(time.RFC3339, v)
+		if err == nil {
+			return !now.Before(started.Add(staleCreatingStateTimeout))
+		}
+	}
 	if session.CreatedAt.IsZero() {
 		return true
 	}
-	return !clk.Now().Before(session.CreatedAt.Add(staleCreatingStateTimeout))
+	return !now.Before(session.CreatedAt.Add(staleCreatingStateTimeout))
+}
+
+// pendingCreateStartedAtNow returns the timestamp string to write into
+// metadata["pending_create_started_at"] when a bead transitions into
+// state=creating with pending_create_claim=true. Must match the format
+// staleCreatingState parses (RFC3339).
+func pendingCreateStartedAtNow(now time.Time) string {
+	return now.UTC().Format(time.RFC3339)
 }
 
 // topoOrder returns session beads in dependency order (dependencies first).

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -245,6 +245,7 @@ func TestWakeReasons_StaleCreatingWithoutPendingClaimDoesNotWakeCreate(t *testin
 		"session_name": "worker-b1",
 		"state":        "creating",
 	})
+	// Past staleCreatingStateTimeout (60s).
 	session.CreatedAt = now.Add(-2 * time.Minute)
 
 	reasons := wakeReasons(session, &config.City{}, nil, nil, nil, nil, clk)
@@ -280,6 +281,7 @@ func TestWakeReasons_PendingCreateClaimKeepsWakeCreateAfterCreatingGoesStale(t *
 		"state":                "creating",
 		"pending_create_claim": "true",
 	})
+	// Past staleCreatingStateTimeout (60s).
 	session.CreatedAt = now.Add(-2 * time.Minute)
 
 	reasons := wakeReasons(session, &config.City{}, nil, nil, nil, nil, clk)
@@ -1408,6 +1410,7 @@ func TestHealState_StaleCreatingWithoutPendingClaimHealsToAsleep(t *testing.T) {
 	session := makeBead("b1", map[string]string{
 		"state": "creating",
 	})
+	// Past staleCreatingStateTimeout (60s).
 	session.CreatedAt = clk.Now().Add(-2 * time.Minute)
 
 	healState(&session, false, store, clk)
@@ -1481,6 +1484,7 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 					"session_key":         "old-key",
 					"started_config_hash": "old-hash",
 				})
+				// Past staleCreatingStateTimeout (60s).
 				b.CreatedAt = now.Add(-2 * time.Minute)
 				return b
 			}(),

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -318,6 +318,12 @@ func TestStaleCreatingStateUsesPendingCreateStartedAtWhenPresent(t *testing.T) {
 			startedAt: "not-rfc3339",
 			wantStale: false,
 		},
+		{
+			name:      "zero pending create timestamp falls back to row creation",
+			createdAt: now.Add(-30 * time.Second),
+			startedAt: (time.Time{}).UTC().Format(time.RFC3339),
+			wantStale: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -332,6 +338,16 @@ func TestStaleCreatingStateUsesPendingCreateStartedAtWhenPresent(t *testing.T) {
 				t.Fatalf("staleCreatingState = %v, want %v", got, tt.wantStale)
 			}
 		})
+	}
+}
+
+func TestPendingCreateStartedAtNowSubstitutesCurrentTimeForZeroInput(t *testing.T) {
+	got := pendingCreateStartedAtNow(time.Time{})
+	if got == (time.Time{}).UTC().Format(time.RFC3339) {
+		t.Fatal("pendingCreateStartedAtNow wrote the zero timestamp")
+	}
+	if _, err := time.Parse(time.RFC3339, got); err != nil {
+		t.Fatalf("pendingCreateStartedAtNow returned invalid RFC3339 timestamp %q: %v", got, err)
 	}
 }
 

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -290,6 +290,51 @@ func TestWakeReasons_PendingCreateClaimKeepsWakeCreateAfterCreatingGoesStale(t *
 	}
 }
 
+func TestStaleCreatingStateUsesPendingCreateStartedAtWhenPresent(t *testing.T) {
+	now := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		startedAt string
+		wantStale bool
+	}{
+		{
+			name:      "fresh pending create timestamp keeps old bead fresh",
+			createdAt: now.Add(-2 * time.Minute),
+			startedAt: pendingCreateStartedAtNow(now.Add(-30 * time.Second)),
+			wantStale: false,
+		},
+		{
+			name:      "stale pending create timestamp wins over fresh row creation",
+			createdAt: now.Add(-30 * time.Second),
+			startedAt: pendingCreateStartedAtNow(now.Add(-2 * time.Minute)),
+			wantStale: true,
+		},
+		{
+			name:      "invalid pending create timestamp falls back to row creation",
+			createdAt: now.Add(-30 * time.Second),
+			startedAt: "not-rfc3339",
+			wantStale: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := makeBead("b1", map[string]string{
+				"state":                     "creating",
+				"pending_create_started_at": tt.startedAt,
+			})
+			session.CreatedAt = tt.createdAt
+
+			if got := staleCreatingState(session, clk); got != tt.wantStale {
+				t.Fatalf("staleCreatingState = %v, want %v", got, tt.wantStale)
+			}
+		})
+	}
+}
+
 func TestWakeReasons_DrainedSleepPoolSessionDoesNotGetWakeConfig(t *testing.T) {
 	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -394,6 +394,24 @@ func reconcileSessionBeadsTraced(
 	// remaining stale beads roll back on subsequent ticks.
 	const maxRollbacksPerTick = 5
 	rollbacksThisTick := 0
+	attemptRollbackPendingCreate := func(session *beads.Bead, templateName, name, action, detail string) {
+		if rollbacksThisTick >= maxRollbacksPerTick {
+			fmt.Fprintf(stderr, "session reconciler: deferring rollback of %s (%s): rollback budget exhausted this tick\n", name, detail) //nolint:errcheck
+			if trace != nil {
+				trace.recordDecision("reconciler.session.pending_create", templateName, name, action, "rollback_deferred", traceRecordPayload{
+					"rollbacks_this_tick":    rollbacksThisTick,
+					"max_rollbacks_per_tick": maxRollbacksPerTick,
+				}, nil, "")
+			}
+			return
+		}
+		rollbacksThisTick++
+		fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: %s\n", name, detail) //nolint:errcheck
+		if trace != nil {
+			trace.recordDecision("reconciler.session.pending_create", templateName, name, action, "rollback", nil, nil, "")
+		}
+		rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
+	}
 	for i := range ordered {
 		session := &ordered[i]
 
@@ -589,22 +607,7 @@ func reconcileSessionBeadsTraced(
 			}
 		}
 		if alive && shouldRollbackPendingCreate(session) && !runningSessionMatchesPendingCreate(session, name, sp) {
-			if rollbacksThisTick >= maxRollbacksPerTick {
-				fmt.Fprintf(stderr, "session reconciler: deferring rollback of %s (live-runtime mismatch): rollback budget exhausted this tick\n", name) //nolint:errcheck
-				if trace != nil {
-					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_rollback", "rollback_deferred", traceRecordPayload{
-						"rollbacks_this_tick":    rollbacksThisTick,
-						"max_rollbacks_per_tick": maxRollbacksPerTick,
-					}, nil, "")
-				}
-				continue
-			}
-			rollbacksThisTick++
-			fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: live runtime belongs to another session\n", name) //nolint:errcheck
-			if trace != nil {
-				trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_rollback", "rollback", nil, nil, "")
-			}
-			rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
+			attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_rollback", "live runtime belongs to another session")
 			continue
 		}
 		// Desired-branch counterpart to pendingCreateSessionStillLeased: a
@@ -620,11 +623,7 @@ func reconcileSessionBeadsTraced(
 				startupTimeout = cfg.Session.StartupTimeoutDuration()
 			}
 			if !pendingCreateStartInFlight(*session, clk, startupTimeout) && staleCreatingState(*session, clk) {
-				fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: lease expired and no live runtime\n", name) //nolint:errcheck
-				if trace != nil {
-					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_lease_expired", "rollback", nil, nil, "")
-				}
-				rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
+				attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_lease_expired", "lease expired and no live runtime")
 				continue
 			}
 		}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -591,6 +591,12 @@ func reconcileSessionBeadsTraced(
 		if alive && shouldRollbackPendingCreate(session) && !runningSessionMatchesPendingCreate(session, name, sp) {
 			if rollbacksThisTick >= maxRollbacksPerTick {
 				fmt.Fprintf(stderr, "session reconciler: deferring rollback of %s (live-runtime mismatch): rollback budget exhausted this tick\n", name) //nolint:errcheck
+				if trace != nil {
+					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_rollback", "rollback_deferred", traceRecordPayload{
+						"rollbacks_this_tick":    rollbacksThisTick,
+						"max_rollbacks_per_tick": maxRollbacksPerTick,
+					}, nil, "")
+				}
 				continue
 			}
 			rollbacksThisTick++
@@ -923,7 +929,7 @@ func reconcileSessionBeadsTraced(
 								}
 								continue
 							}
-							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, "creating", stderr)
+							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, "creating", clk.Now().UTC(), stderr)
 							if trace != nil {
 								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 							}
@@ -1027,7 +1033,7 @@ func reconcileSessionBeadsTraced(
 							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
 						}
 						driftedFields := runtime.CoreFingerprintDriftFields(storedBreakdown, agentCfg)
-						resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", stderr)
+						resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", clk.Now().UTC(), stderr)
 						if trace != nil {
 							trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "repair_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 						}
@@ -1700,6 +1706,7 @@ func resetConfiguredNamedSessionForConfigDrift(
 	sessionName string,
 	alive bool,
 	nextState string,
+	now time.Time,
 	stderr io.Writer,
 ) {
 	if session == nil || store == nil {
@@ -1717,7 +1724,7 @@ func resetConfiguredNamedSessionForConfigDrift(
 	if newKey, err := sessionpkg.GenerateSessionKey(); err == nil {
 		newSessionKey = newKey
 	}
-	batch := sessionpkg.ConfigDriftResetPatch(sessionpkg.State(nextState), newSessionKey)
+	batch := sessionpkg.ConfigDriftResetPatch(sessionpkg.State(nextState), newSessionKey, now)
 	batch[namedSessionConfigDriftDeferredAtMetadata] = ""
 	batch[namedSessionConfigDriftDeferredKeyMetadata] = ""
 	batch[sessionAttachedConfigDriftDeferredAtMetadata] = ""

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -385,6 +385,15 @@ func reconcileSessionBeadsTraced(
 	// Phase 1: Forward pass (topo order) — wake sessions, handle alive state.
 	var startCandidates []startCandidate
 	var wakeTargets []wakeTarget
+	// Rate-limit rollbacks per tick. Each rollbackPendingCreate fires three
+	// bd subprocess calls (~2s each at the bd dolt-commit cost), so an
+	// unbounded rollback storm easily blows the tick past
+	// staleCreatingStateTimeout (60s) and starves executePlannedStartsTraced
+	// — fresh pending-create beads age out before op=start fires. Capping
+	// rollbacks per tick lets the rest of the tick make forward progress;
+	// remaining stale beads roll back on subsequent ticks.
+	const maxRollbacksPerTick = 5
+	rollbacksThisTick := 0
 	for i := range ordered {
 		session := &ordered[i]
 
@@ -580,6 +589,11 @@ func reconcileSessionBeadsTraced(
 			}
 		}
 		if alive && shouldRollbackPendingCreate(session) && !runningSessionMatchesPendingCreate(session, name, sp) {
+			if rollbacksThisTick >= maxRollbacksPerTick {
+				fmt.Fprintf(stderr, "session reconciler: deferring rollback of %s (live-runtime mismatch): rollback budget exhausted this tick\n", name) //nolint:errcheck
+				continue
+			}
+			rollbacksThisTick++
 			fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: live runtime belongs to another session\n", name) //nolint:errcheck
 			if trace != nil {
 				trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_rollback", "rollback", nil, nil, "")

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3140,6 +3140,76 @@ func TestReconcileSessionBeads_RollbackBudgetDefersExcessMismatchesAndStillStart
 	}
 }
 
+func TestReconcileSessionBeads_RollbackBudgetDefersExcessStaleNoRuntimeCreatesAndStillStarts(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "helper"}}}
+
+	var sessions []beads.Bead
+	staleStartedAt := pendingCreateStartedAtNow(env.clk.Now().Add(-2 * time.Minute))
+	for i := 0; i < 6; i++ {
+		name := fmt.Sprintf("sky-%d", i)
+		env.addDesired(name, "helper", false)
+		session := env.createSessionBead(name, "helper")
+		env.markSessionCreating(&session)
+		session.CreatedAt = env.clk.Now().Add(-2 * time.Minute)
+		env.setSessionMetadata(&session, map[string]string{
+			"pending_create_claim":      "true",
+			"pending_create_started_at": staleStartedAt,
+			"session_name_explicit":     "true",
+			"instance_token":            fmt.Sprintf("token-%d", i),
+		})
+		sessions = append(sessions, session)
+	}
+
+	env.addDesired("starter", "helper", false)
+	starter := env.createSessionBead("starter", "helper")
+	env.markSessionCreating(&starter)
+	sessions = append(sessions, starter)
+
+	if woken := env.reconcile(sessions); woken != 1 {
+		t.Fatalf("woken = %d, want 1 planned start after rollback budget is exhausted", woken)
+	}
+	if got := strings.Count(env.stderr.String(), "deferring rollback of sky-"); got != 1 {
+		t.Fatalf("deferred rollback messages = %d, want 1; stderr:\n%s", got, env.stderr.String())
+	}
+	closedCreates := 0
+	deferredCreates := 0
+	for i := 0; i < 6; i++ {
+		name := fmt.Sprintf("sky-%d", i)
+		got, err := env.store.Get(sessions[i].ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", sessions[i].ID, err)
+		}
+		if got.Status == "closed" {
+			if got.Metadata["close_reason"] != "failed-create" {
+				t.Fatalf("%s close_reason = %q, want failed-create", name, got.Metadata["close_reason"])
+			}
+			closedCreates++
+			continue
+		}
+		if got.Metadata["pending_create_claim"] != "true" {
+			t.Fatalf("%s pending_create_claim = %q, want true on deferred stale create", name, got.Metadata["pending_create_claim"])
+		}
+		deferredCreates++
+	}
+	if closedCreates != 5 {
+		t.Fatalf("closed stale creates = %d, want 5", closedCreates)
+	}
+	if deferredCreates != 1 {
+		t.Fatalf("deferred stale creates = %d, want 1", deferredCreates)
+	}
+	started, err := env.store.Get(starter.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", starter.ID, err)
+	}
+	if started.Metadata["state"] != "active" {
+		t.Fatalf("starter state = %q, want active", started.Metadata["state"])
+	}
+	if !env.sp.IsRunning("starter") {
+		t.Fatal("starter runtime was not started after rollback budget was exhausted")
+	}
+}
+
 func TestReconcileSessionBeads_ConvergesPendingCreateOnLateSuccessStartError(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &lateSuccessStartProvider{

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3064,6 +3064,82 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenConflictingRuntimeAlrea
 	}
 }
 
+func TestReconcileSessionBeads_RollbackBudgetDefersExcessMismatchesAndStillStarts(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "helper"}}}
+
+	var sessions []beads.Bead
+	for i := 0; i < 6; i++ {
+		name := fmt.Sprintf("sky-%d", i)
+		env.addDesired(name, "helper", false)
+		session := env.createSessionBead(name, "helper")
+		env.markSessionCreating(&session)
+		env.setSessionMetadata(&session, map[string]string{
+			"pending_create_claim":  "true",
+			"session_name_explicit": "true",
+			"instance_token":        fmt.Sprintf("token-%d", i),
+		})
+		if err := env.sp.Start(context.Background(), name, runtime.Config{Command: "test-cmd"}); err != nil {
+			t.Fatalf("Start(%s): %v", name, err)
+		}
+		if err := env.sp.SetMeta(name, "GC_SESSION_ID", "different-"+session.ID); err != nil {
+			t.Fatalf("SetMeta(%s, GC_SESSION_ID): %v", name, err)
+		}
+		if err := env.sp.SetMeta(name, "GC_INSTANCE_TOKEN", "different-token"); err != nil {
+			t.Fatalf("SetMeta(%s, GC_INSTANCE_TOKEN): %v", name, err)
+		}
+		sessions = append(sessions, session)
+	}
+
+	env.addDesired("starter", "helper", false)
+	starter := env.createSessionBead("starter", "helper")
+	env.markSessionCreating(&starter)
+	sessions = append(sessions, starter)
+
+	if woken := env.reconcile(sessions); woken != 1 {
+		t.Fatalf("woken = %d, want 1 planned start after rollback budget is exhausted", woken)
+	}
+	if got := strings.Count(env.stderr.String(), "deferring rollback of sky-"); got != 1 {
+		t.Fatalf("deferred rollback messages = %d, want 1; stderr:\n%s", got, env.stderr.String())
+	}
+	closedMismatches := 0
+	deferredMismatches := 0
+	for i := 0; i < 6; i++ {
+		name := fmt.Sprintf("sky-%d", i)
+		got, err := env.store.Get(sessions[i].ID)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", sessions[i].ID, err)
+		}
+		if got.Status == "closed" {
+			if got.Metadata["close_reason"] != "failed-create" {
+				t.Fatalf("%s close_reason = %q, want failed-create", name, got.Metadata["close_reason"])
+			}
+			closedMismatches++
+			continue
+		}
+		if got.Metadata["pending_create_claim"] != "true" {
+			t.Fatalf("%s pending_create_claim = %q, want true on deferred mismatch", name, got.Metadata["pending_create_claim"])
+		}
+		deferredMismatches++
+	}
+	if closedMismatches != 5 {
+		t.Fatalf("closed mismatches = %d, want 5", closedMismatches)
+	}
+	if deferredMismatches != 1 {
+		t.Fatalf("deferred mismatches = %d, want 1", deferredMismatches)
+	}
+	started, err := env.store.Get(starter.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", starter.ID, err)
+	}
+	if started.Metadata["state"] != "active" {
+		t.Fatalf("starter state = %q, want active", started.Metadata["state"])
+	}
+	if !env.sp.IsRunning("starter") {
+		t.Fatal("starter runtime was not started after rollback budget was exhausted")
+	}
+}
+
 func TestReconcileSessionBeads_ConvergesPendingCreateOnLateSuccessStartError(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &lateSuccessStartProvider{

--- a/internal/api/handler_session_stream.go
+++ b/internal/api/handler_session_stream.go
@@ -87,13 +87,14 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 		writeSessionManagerError(w, err)
 		return
 	}
+	format := r.URL.Query().Get("format")
 	handle, err := s.workerHandleForSession(store, id)
 	if err != nil {
 		writeSessionManagerError(w, err)
 		return
 	}
 	historyReq := worker.HistoryRequest{}
-	if r.URL.Query().Get("format") == "raw" && !info.Closed {
+	if format == "raw" && !info.Closed {
 		historyReq.TailCompactions = 1
 	}
 	history, historyErr := handle.History(worker.WithoutOperationEvents(r.Context()), historyReq)
@@ -109,7 +110,7 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	running := workerPhaseHasLiveOutput(state.Phase)
-	if !hasHistory && !running {
+	if !hasHistory && !running && format != "raw" {
 		writeError(w, http.StatusNotFound, "not_found", "session "+id+" has no live output")
 		return
 	}
@@ -129,7 +130,6 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	format := r.URL.Query().Get("format")
 	if format == "raw" && !info.Closed {
 		data, _ := json.Marshal(SessionStreamRawMessageEvent{
 			ID:       info.ID,

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -4695,6 +4695,36 @@ func TestHandleSessionStreamStoppedWithoutOutputReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestHandleSessionStreamRawStoppedWithoutOutputReturnsEmptyStream(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+	srv.sessionLogSearchPaths = []string{t.TempDir()}
+
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	info, err := mgr.Create(context.Background(), "default", "No Output", "echo test", t.TempDir(), "test", nil, session.ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID+"/stream?format=raw", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if !strings.Contains(rec.Body.String(), `"format":"raw"`) || !strings.Contains(rec.Body.String(), `"messages":[]`) {
+		t.Fatalf("raw stream body missing empty raw frame: %s", rec.Body.String())
+	}
+}
+
 func TestHandleSessionStreamClosedSessionReturnsSnapshot(t *testing.T) {
 	fs := newSessionFakeState(t)
 	searchBase := t.TempDir()

--- a/internal/api/huma_handlers_sessions_stream.go
+++ b/internal/api/huma_handlers_sessions_stream.go
@@ -51,7 +51,7 @@ func (s *Server) resolveSessionStream(ctx context.Context, input *SessionStreamI
 		return nil, humaSessionManagerError(stateErr)
 	}
 	running := workerPhaseHasLiveOutput(state.Phase)
-	if !hasHistory && !running {
+	if !hasHistory && !running && input.Format != "raw" {
 		return nil, huma.Error404NotFound("session " + id + " has no live output")
 	}
 

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -406,6 +406,7 @@ func (m *Manager) confirmLiveSessionState(id string, b *beads.Bead) error {
 	}
 	if strings.TrimSpace(b.Metadata["pending_create_claim"]) != "" {
 		batch["pending_create_claim"] = ""
+		batch["pending_create_started_at"] = ""
 	}
 	if len(batch) == 0 {
 		return nil

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -503,14 +503,22 @@ func creatingStateIsStale(input LifecycleInput) bool {
 	if input.StaleCreatingAfter <= 0 {
 		return false
 	}
-	if input.CreatedAt.IsZero() {
-		return true
-	}
 	now := input.Now
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	return !now.Before(input.CreatedAt.Add(input.StaleCreatingAfter))
+	startedAt := input.CreatedAt
+	if input.Metadata != nil {
+		if v := strings.TrimSpace(input.Metadata["pending_create_started_at"]); v != "" {
+			if t, err := time.Parse(time.RFC3339, v); err == nil && !t.IsZero() {
+				startedAt = t
+			}
+		}
+	}
+	if startedAt.IsZero() {
+		return true
+	}
+	return !now.Before(startedAt.Add(input.StaleCreatingAfter))
 }
 
 func shouldResetContinuation(base BaseState, meta map[string]string, sleepReason string) bool {

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -159,6 +159,29 @@ func TestProjectLifecycleDesiredStateAndBlockers(t *testing.T) {
 	}
 }
 
+func TestProjectLifecycleCreatingStalenessUsesPendingCreateStartedAt(t *testing.T) {
+	now := time.Date(2026, 5, 3, 9, 0, 0, 0, time.UTC)
+	view := ProjectLifecycle(LifecycleInput{
+		Status: "open",
+		Metadata: map[string]string{
+			"state":                     string(StateCreating),
+			"session_name":              "s-worker",
+			"pending_create_started_at": now.Add(-30 * time.Second).UTC().Format(time.RFC3339),
+		},
+		Runtime:            RuntimeFacts{Observed: true, Alive: false},
+		CreatedAt:          now.Add(-2 * time.Minute),
+		StaleCreatingAfter: time.Minute,
+		Now:                now,
+	})
+
+	if view.RuntimeProjection != RuntimeProjectionFreshCreating {
+		t.Fatalf("RuntimeProjection = %q, want %q", view.RuntimeProjection, RuntimeProjectionFreshCreating)
+	}
+	if view.ReconciledState != StateCreating {
+		t.Fatalf("ReconciledState = %q, want %q", view.ReconciledState, StateCreating)
+	}
+}
+
 func TestProjectLifecycleNamedIdentityProjection(t *testing.T) {
 	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
 

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -48,19 +48,27 @@ func applyFreshWakeConversationReset(patch MetadataPatch) {
 	patch[startupDialogVerifiedKey] = ""
 }
 
+func pendingCreateStartedAt(now time.Time) string {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.UTC().Format(time.RFC3339)
+}
+
 // RequestWakePatch records a controller-owned one-shot create claim.
-func RequestWakePatch(reason string) MetadataPatch {
+func RequestWakePatch(reason string, now time.Time) MetadataPatch {
 	return MetadataPatch{
-		"state":                string(StateCreating),
-		"state_reason":         reason,
-		"pending_create_claim": "true",
-		"held_until":           "",
-		"quarantined_until":    "",
-		"sleep_reason":         "",
-		"wait_hold":            "",
-		"sleep_intent":         "",
-		"wake_attempts":        "0",
-		"churn_count":          "0",
+		"state":                     string(StateCreating),
+		"state_reason":              reason,
+		"pending_create_claim":      "true",
+		"pending_create_started_at": pendingCreateStartedAt(now),
+		"held_until":                "",
+		"quarantined_until":         "",
+		"sleep_reason":              "",
+		"wait_hold":                 "",
+		"sleep_intent":              "",
+		"wake_attempts":             "0",
+		"churn_count":               "0",
 	}
 }
 
@@ -152,11 +160,12 @@ func ClearExpiredQuarantinePatch(sleepReason string) MetadataPatch {
 // bead whose last_woke_at was later cleared by crash/churn recovery.
 func ConfirmStartedPatch(now time.Time) MetadataPatch {
 	return MetadataPatch{
-		"state":                string(StateActive),
-		"state_reason":         "creation_complete",
-		"creation_complete_at": now.UTC().Format(time.RFC3339),
-		"pending_create_claim": "",
-		"sleep_reason":         "",
+		"state":                     string(StateActive),
+		"state_reason":              "creation_complete",
+		"creation_complete_at":      now.UTC().Format(time.RFC3339),
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
+		"sleep_reason":              "",
 	}
 }
 
@@ -209,6 +218,7 @@ func CommitStartedPatch(input CommitStartedPatchInput) MetadataPatch {
 	}
 	if input.ClearPendingCreateClaim {
 		patch["pending_create_claim"] = ""
+		patch["pending_create_started_at"] = ""
 	}
 	return patch
 }
@@ -225,12 +235,13 @@ func BeginDrainPatch(now time.Time, reason string) MetadataPatch {
 // SleepPatch records a non-terminal sleep/drain result.
 func SleepPatch(now time.Time, reason string) MetadataPatch {
 	return MetadataPatch{
-		"state":                string(StateAsleep),
-		"sleep_reason":         reason,
-		"last_woke_at":         "",
-		"pending_create_claim": "",
-		"sleep_intent":         "",
-		"slept_at":             now.UTC().Format(time.RFC3339),
+		"state":                     string(StateAsleep),
+		"sleep_reason":              reason,
+		"last_woke_at":              "",
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
+		"sleep_intent":              "",
+		"slept_at":                  now.UTC().Format(time.RFC3339),
 	}
 }
 
@@ -239,9 +250,10 @@ func SleepPatch(now time.Time, reason string) MetadataPatch {
 // reselect it, but explicit attach or work can.
 func AcknowledgeDrainPatch(freshWake bool) MetadataPatch {
 	patch := MetadataPatch{
-		"state":                string(StateDrained),
-		"last_woke_at":         "",
-		"pending_create_claim": "",
+		"state":                     string(StateDrained),
+		"last_woke_at":              "",
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
 	}
 	if freshWake {
 		patch["session_key"] = ""
@@ -275,6 +287,7 @@ func RestartRequestPatch(sessionKey string) MetadataPatch {
 		"continuation_reset_pending": "true",
 		"last_woke_at":               "",
 		"pending_create_claim":       "",
+		"pending_create_started_at":  "",
 	}
 	if sessionKey != "" {
 		patch["session_key"] = sessionKey
@@ -285,17 +298,19 @@ func RestartRequestPatch(sessionKey string) MetadataPatch {
 // ConfigDriftResetPatch records an in-place named-session repair after core
 // config drift. Creating claims a new runtime start; asleep stays dormant
 // until the next normal wake reason.
-func ConfigDriftResetPatch(nextState State, sessionKey string) MetadataPatch {
+func ConfigDriftResetPatch(nextState State, sessionKey string, now time.Time) MetadataPatch {
 	patch := MetadataPatch{
 		"state":                      string(nextState),
 		"last_woke_at":               "",
 		"restart_requested":          "",
 		"continuation_reset_pending": "true",
 		"pending_create_claim":       "",
+		"pending_create_started_at":  "",
 	}
 	applyFreshWakeConversationReset(patch)
 	if nextState == StateCreating {
 		patch["pending_create_claim"] = "true"
+		patch["pending_create_started_at"] = pendingCreateStartedAt(now)
 	}
 	if sessionKey != "" {
 		patch["session_key"] = sessionKey
@@ -310,11 +325,12 @@ func ArchivePatch(now time.Time, reason string, continuityEligible bool) Metadat
 		continuity = "true"
 	}
 	return MetadataPatch{
-		"state":                string(StateArchived),
-		"state_reason":         reason,
-		"archived_at":          now.UTC().Format(time.RFC3339),
-		"continuity_eligible":  continuity,
-		"pending_create_claim": "",
+		"state":                     string(StateArchived),
+		"state_reason":              reason,
+		"archived_at":               now.UTC().Format(time.RFC3339),
+		"continuity_eligible":       continuity,
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
 	}
 }
 
@@ -368,12 +384,13 @@ func ReactivatePatch(continuityEligible bool) MetadataPatch {
 		continuity = "true"
 	}
 	return MetadataPatch{
-		"state":                string(StateAsleep),
-		"state_reason":         "reactivated",
-		"pending_create_claim": "",
-		"continuity_eligible":  continuity,
-		"quarantined_until":    "",
-		"crash_count":          "0",
-		"archived_at":          "",
+		"state":                     string(StateAsleep),
+		"state_reason":              "reactivated",
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
+		"continuity_eligible":       continuity,
+		"quarantined_until":         "",
+		"crash_count":               "0",
+		"archived_at":               "",
 	}
 }

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -17,18 +17,19 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 	}{
 		{
 			name:  "request wake",
-			patch: RequestWakePatch("explicit"),
+			patch: RequestWakePatch("explicit", now),
 			want: MetadataPatch{
-				"state":                string(StateCreating),
-				"state_reason":         "explicit",
-				"pending_create_claim": "true",
-				"held_until":           "",
-				"quarantined_until":    "",
-				"sleep_reason":         "",
-				"wait_hold":            "",
-				"sleep_intent":         "",
-				"wake_attempts":        "0",
-				"churn_count":          "0",
+				"state":                     string(StateCreating),
+				"state_reason":              "explicit",
+				"pending_create_claim":      "true",
+				"pending_create_started_at": now.UTC().Format(time.RFC3339),
+				"held_until":                "",
+				"quarantined_until":         "",
+				"sleep_reason":              "",
+				"wait_hold":                 "",
+				"sleep_intent":              "",
+				"wake_attempts":             "0",
+				"churn_count":               "0",
 			},
 		},
 		{
@@ -81,11 +82,12 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			name:  "confirm started",
 			patch: ConfirmStartedPatch(now),
 			want: MetadataPatch{
-				"state":                string(StateActive),
-				"state_reason":         "creation_complete",
-				"creation_complete_at": now.UTC().Format(time.RFC3339),
-				"pending_create_claim": "",
-				"sleep_reason":         "",
+				"state":                     string(StateActive),
+				"state_reason":              "creation_complete",
+				"creation_complete_at":      now.UTC().Format(time.RFC3339),
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
+				"sleep_reason":              "",
 			},
 		},
 		{
@@ -101,21 +103,23 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			name:  "sleep",
 			patch: SleepPatch(now, "idle-timeout"),
 			want: MetadataPatch{
-				"state":                string(StateAsleep),
-				"sleep_reason":         "idle-timeout",
-				"last_woke_at":         "",
-				"pending_create_claim": "",
-				"sleep_intent":         "",
-				"slept_at":             now.Format(time.RFC3339),
+				"state":                     string(StateAsleep),
+				"sleep_reason":              "idle-timeout",
+				"last_woke_at":              "",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
+				"sleep_intent":              "",
+				"slept_at":                  now.Format(time.RFC3339),
 			},
 		},
 		{
 			name:  "acknowledge drain resume mode",
 			patch: AcknowledgeDrainPatch(false),
 			want: MetadataPatch{
-				"state":                "drained",
-				"last_woke_at":         "",
-				"pending_create_claim": "",
+				"state":                     "drained",
+				"last_woke_at":              "",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
 			},
 		},
 		{
@@ -125,6 +129,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"state":                      "drained",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 				"session_key":                "",
 				"started_config_hash":        "",
 				"started_live_hash":          "",
@@ -141,6 +146,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"sleep_reason":               "idle",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 				"sleep_intent":               "",
 				"slept_at":                   now.Format(time.RFC3339),
 				"session_key":                "",
@@ -160,6 +166,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_reset_pending": "true",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 				"session_key":                "new-session-key",
 			},
 		},
@@ -172,11 +179,12 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"continuation_reset_pending": "true",
 				"last_woke_at":               "",
 				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 			},
 		},
 		{
 			name:  "config drift reset to creating",
-			patch: ConfigDriftResetPatch(StateCreating, "new-session-key"),
+			patch: ConfigDriftResetPatch(StateCreating, "new-session-key", now),
 			want: MetadataPatch{
 				"state":                      string(StateCreating),
 				"started_config_hash":        "",
@@ -187,12 +195,13 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"restart_requested":          "",
 				"continuation_reset_pending": "true",
 				"pending_create_claim":       "true",
+				"pending_create_started_at":  now.UTC().Format(time.RFC3339),
 				"session_key":                "new-session-key",
 			},
 		},
 		{
 			name:  "config drift reset to asleep",
-			patch: ConfigDriftResetPatch(StateAsleep, "new-session-key"),
+			patch: ConfigDriftResetPatch(StateAsleep, "new-session-key", now),
 			want: MetadataPatch{
 				"state":                      string(StateAsleep),
 				"started_config_hash":        "",
@@ -203,12 +212,13 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"restart_requested":          "",
 				"continuation_reset_pending": "true",
 				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 				"session_key":                "new-session-key",
 			},
 		},
 		{
 			name:  "config drift reset to asleep without rotated key",
-			patch: ConfigDriftResetPatch(StateAsleep, ""),
+			patch: ConfigDriftResetPatch(StateAsleep, "", now),
 			want: MetadataPatch{
 				"state":                      string(StateAsleep),
 				"started_config_hash":        "",
@@ -219,28 +229,31 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 				"restart_requested":          "",
 				"continuation_reset_pending": "true",
 				"pending_create_claim":       "",
+				"pending_create_started_at":  "",
 			},
 		},
 		{
 			name:  "archive continuity eligible",
 			patch: ArchivePatch(now, "drain_complete", true),
 			want: MetadataPatch{
-				"state":                string(StateArchived),
-				"state_reason":         "drain_complete",
-				"archived_at":          now.Format(time.RFC3339),
-				"continuity_eligible":  "true",
-				"pending_create_claim": "",
+				"state":                     string(StateArchived),
+				"state_reason":              "drain_complete",
+				"archived_at":               now.Format(time.RFC3339),
+				"continuity_eligible":       "true",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
 			},
 		},
 		{
 			name:  "archive historical only",
 			patch: ArchivePatch(now, "duplicate-repair", false),
 			want: MetadataPatch{
-				"state":                string(StateArchived),
-				"state_reason":         "duplicate-repair",
-				"archived_at":          now.Format(time.RFC3339),
-				"continuity_eligible":  "false",
-				"pending_create_claim": "",
+				"state":                     string(StateArchived),
+				"state_reason":              "duplicate-repair",
+				"archived_at":               now.Format(time.RFC3339),
+				"continuity_eligible":       "false",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
 			},
 		},
 		{
@@ -257,21 +270,22 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			name:  "retire named session",
 			patch: RetireNamedSessionPatch(now, "duplicate-repair", "worker"),
 			want: MetadataPatch{
-				"state":                  string(StateArchived),
-				"state_reason":           "duplicate-repair",
-				"archived_at":            now.Format(time.RFC3339),
-				"continuity_eligible":    "false",
-				"alias":                  "",
-				"session_name":           "",
-				"session_name_explicit":  "",
-				"pending_create_claim":   "",
-				"retired_named_identity": "worker",
-				"synced_at":              now.Format(time.RFC3339),
-				"held_until":             "",
-				"quarantined_until":      "",
-				"wait_hold":              "",
-				"sleep_intent":           "",
-				"sleep_reason":           "",
+				"state":                     string(StateArchived),
+				"state_reason":              "duplicate-repair",
+				"archived_at":               now.Format(time.RFC3339),
+				"continuity_eligible":       "false",
+				"alias":                     "",
+				"session_name":              "",
+				"session_name_explicit":     "",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
+				"retired_named_identity":    "worker",
+				"synced_at":                 now.Format(time.RFC3339),
+				"held_until":                "",
+				"quarantined_until":         "",
+				"wait_hold":                 "",
+				"sleep_intent":              "",
+				"sleep_reason":              "",
 			},
 		},
 		{
@@ -289,26 +303,28 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			name:  "reactivate continuity eligible",
 			patch: ReactivatePatch(true),
 			want: MetadataPatch{
-				"state":                string(StateAsleep),
-				"state_reason":         "reactivated",
-				"pending_create_claim": "",
-				"continuity_eligible":  "true",
-				"quarantined_until":    "",
-				"crash_count":          "0",
-				"archived_at":          "",
+				"state":                     string(StateAsleep),
+				"state_reason":              "reactivated",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
+				"continuity_eligible":       "true",
+				"quarantined_until":         "",
+				"crash_count":               "0",
+				"archived_at":               "",
 			},
 		},
 		{
 			name:  "reactivate historical only",
 			patch: ReactivatePatch(false),
 			want: MetadataPatch{
-				"state":                string(StateAsleep),
-				"state_reason":         "reactivated",
-				"pending_create_claim": "",
-				"continuity_eligible":  "false",
-				"quarantined_until":    "",
-				"crash_count":          "0",
-				"archived_at":          "",
+				"state":                     string(StateAsleep),
+				"state_reason":              "reactivated",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
+				"continuity_eligible":       "false",
+				"quarantined_until":         "",
+				"crash_count":               "0",
+				"archived_at":               "",
 			},
 		},
 		{
@@ -371,7 +387,7 @@ func TestMetadataPatchApplyReturnsMergedCopy(t *testing.T) {
 		"state":        string(StateAsleep),
 		"session_name": "s-worker",
 	}
-	patch := RequestWakePatch("pin")
+	patch := RequestWakePatch("pin", time.Date(2026, 4, 15, 13, 0, 0, 0, time.UTC))
 
 	merged := patch.Apply(original)
 	if merged["state"] != string(StateCreating) {
@@ -398,15 +414,16 @@ func TestCommitStartedPatchBuildsAtomicStartMetadata(t *testing.T) {
 	})
 
 	want := MetadataPatch{
-		"started_config_hash":  "core-hash",
-		"live_hash":            "live-hash",
-		"started_live_hash":    "live-hash",
-		"core_hash_breakdown":  `{"command":"core-hash"}`,
-		"state":                string(StateActive),
-		"state_reason":         "creation_complete",
-		"creation_complete_at": now.Format(time.RFC3339),
-		"sleep_reason":         "",
-		"pending_create_claim": "",
+		"started_config_hash":       "core-hash",
+		"live_hash":                 "live-hash",
+		"started_live_hash":         "live-hash",
+		"core_hash_breakdown":       `{"command":"core-hash"}`,
+		"state":                     string(StateActive),
+		"state_reason":              "creation_complete",
+		"creation_complete_at":      now.Format(time.RFC3339),
+		"sleep_reason":              "",
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
 	}
 	if !reflect.DeepEqual(patch, want) {
 		t.Fatalf("patch = %#v, want %#v", patch, want)
@@ -426,7 +443,7 @@ func TestCommitStartedPatchClearsPendingCreateClaimAtomicallyWithStateTransition
 		ClearPendingCreateClaim: true,
 		Now:                     now,
 	})
-	required := []string{"state", "state_reason", "creation_complete_at", "pending_create_claim"}
+	required := []string{"state", "state_reason", "creation_complete_at", "pending_create_claim", "pending_create_started_at"}
 	for _, key := range required {
 		if _, ok := patch[key]; !ok {
 			t.Fatalf("patch missing %q — sweep-visibility atomicity broken: %#v", key, patch)
@@ -434,6 +451,9 @@ func TestCommitStartedPatchClearsPendingCreateClaimAtomicallyWithStateTransition
 	}
 	if patch["pending_create_claim"] != "" {
 		t.Fatalf("pending_create_claim = %q, want cleared", patch["pending_create_claim"])
+	}
+	if patch["pending_create_started_at"] != "" {
+		t.Fatalf("pending_create_started_at = %q, want cleared", patch["pending_create_started_at"])
 	}
 }
 
@@ -532,7 +552,8 @@ func TestClearWakeBlockersPatchClearsOnlyWakeBlockerMetadata(t *testing.T) {
 }
 
 func TestRequestWakePatchClearsStaleWakeBlockers(t *testing.T) {
-	merged := RequestWakePatch("manual").Apply(map[string]string{
+	now := time.Date(2026, 4, 15, 13, 0, 0, 0, time.UTC)
+	merged := RequestWakePatch("manual", now).Apply(map[string]string{
 		"state":             string(StateAsleep),
 		"held_until":        "9999-12-31T23:59:59Z",
 		"quarantined_until": "9999-12-31T23:59:59Z",
@@ -553,6 +574,9 @@ func TestRequestWakePatchClearsStaleWakeBlockers(t *testing.T) {
 			t.Fatalf("%s = %q, want reset to 0", key, merged[key])
 		}
 	}
+	if got, want := merged["pending_create_started_at"], now.UTC().Format(time.RFC3339); got != want {
+		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
+	}
 }
 
 func TestArchivePatchClearsStaleCreateClaim(t *testing.T) {
@@ -567,6 +591,9 @@ func TestArchivePatchClearsStaleCreateClaim(t *testing.T) {
 	}
 	if merged["pending_create_claim"] != "" {
 		t.Fatalf("pending_create_claim = %q, want cleared", merged["pending_create_claim"])
+	}
+	if merged["pending_create_started_at"] != "" {
+		t.Fatalf("pending_create_started_at = %q, want cleared", merged["pending_create_started_at"])
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -644,6 +644,7 @@ func (m *Manager) createAliasedBeadOnlyNamed(alias, explicitName, template, titl
 			meta["session_key"] = sessionKey
 		}
 		meta["pending_create_claim"] = "true"
+		meta["pending_create_started_at"] = pendingCreateStartedAt(time.Now().UTC())
 		if explicitName != "" {
 			meta["session_name"] = explicitName
 			meta["session_name_explicit"] = "true"
@@ -860,6 +861,7 @@ func (m *Manager) retireConfiguredNamedSessionIdentifiers(id string, b beads.Bea
 	update.Metadata["session_name"] = ""
 	update.Metadata["session_name_explicit"] = ""
 	update.Metadata["pending_create_claim"] = ""
+	update.Metadata["pending_create_started_at"] = ""
 	if err := m.store.Update(id, update); err != nil {
 		return fmt.Errorf("retiring configured named session identifiers: %w", err)
 	}

--- a/internal/session/waits.go
+++ b/internal/session/waits.go
@@ -183,13 +183,13 @@ func WakeSession(store beads.Store, sessionBead beads.Bead, now time.Time) ([]st
 	state := State(strings.TrimSpace(sessionBead.Metadata["state"]))
 	batch := ClearWakeBlockersPatch(state, sessionBead.Metadata["sleep_reason"])
 	if state == StateSuspended || state == StateDrained {
-		for k, v := range RequestWakePatch(string(WakeCauseExplicit)) {
+		for k, v := range RequestWakePatch(string(WakeCauseExplicit), now) {
 			batch[k] = v
 		}
 	}
 	if view.BaseState == BaseStateArchived && view.ContinuityEligible {
 		// RequestWakePatch clears wake blockers before claiming the start.
-		batch = RequestWakePatch(string(WakeCauseExplicit))
+		batch = RequestWakePatch(string(WakeCauseExplicit), now)
 		batch["archived_at"] = ""
 		batch["continuity_eligible"] = "true"
 	}

--- a/internal/session/waits_test.go
+++ b/internal/session/waits_test.go
@@ -73,6 +73,7 @@ func TestCancelWaits_CancelsLegacyWaitBeadsWithoutLegacyTypeQuery(t *testing.T) 
 
 func TestWakeSessionRequestsStartForSuspendedBead(t *testing.T) {
 	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 3, 8, 30, 0, 0, time.UTC)
 	sessionBead, err := store.Create(beads.Bead{
 		Type:   BeadType,
 		Labels: []string{LabelSession},
@@ -88,7 +89,7 @@ func TestWakeSessionRequestsStartForSuspendedBead(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	if _, err := WakeSession(store, sessionBead, time.Now().UTC()); err != nil {
+	if _, err := WakeSession(store, sessionBead, now); err != nil {
 		t.Fatalf("WakeSession: %v", err)
 	}
 
@@ -104,6 +105,9 @@ func TestWakeSessionRequestsStartForSuspendedBead(t *testing.T) {
 	}
 	if got := updated.Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+	if got, want := updated.Metadata["pending_create_started_at"], now.UTC().Format(time.RFC3339); got != want {
+		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
 	}
 	for _, key := range []string{"held_until", "wait_hold", "sleep_reason"} {
 		if got := updated.Metadata[key]; got != "" {
@@ -160,6 +164,7 @@ func TestWakeSessionRejectsArchivedHistoricalBead(t *testing.T) {
 
 func TestWakeSessionRequestsStartForContinuityEligibleArchivedBead(t *testing.T) {
 	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 3, 8, 45, 0, 0, time.UTC)
 	sessionBead, err := store.Create(beads.Bead{
 		Type:   BeadType,
 		Labels: []string{LabelSession},
@@ -191,7 +196,7 @@ func TestWakeSessionRequestsStartForContinuityEligibleArchivedBead(t *testing.T)
 		t.Fatalf("create wait: %v", err)
 	}
 
-	if _, err := WakeSession(store, sessionBead, time.Now().UTC()); err != nil {
+	if _, err := WakeSession(store, sessionBead, now); err != nil {
 		t.Fatalf("WakeSession: %v", err)
 	}
 
@@ -207,6 +212,9 @@ func TestWakeSessionRequestsStartForContinuityEligibleArchivedBead(t *testing.T)
 	}
 	if got := updated.Metadata["pending_create_claim"]; got != "true" {
 		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+	if got, want := updated.Metadata["pending_create_started_at"], now.UTC().Format(time.RFC3339); got != want {
+		t.Fatalf("pending_create_started_at = %q, want %q", got, want)
 	}
 	for _, key := range []string{"held_until", "quarantined_until", "wait_hold", "sleep_intent", "sleep_reason", "archived_at"} {
 		if got := updated.Metadata[key]; got != "" {

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -231,13 +231,62 @@ func tailText(s string, maxLines int) string {
 func initBd(t *testing.T, dir string) string {
 	t.Helper()
 	prefix := uniqueCityName()
-	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "-q")
+	binary := realBDBinary
+	if strings.TrimSpace(binary) == "" {
+		binary = bdBinary
+	}
+	cmd := exec.Command(binary, "init", "-p", prefix, "--skip-hooks", "-q")
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = standaloneBdInitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init in %s failed: %v\noutput: %s", dir, err, out)
 	}
 	return prefix
+}
+
+func standaloneBdInitEnv() []string {
+	return filterEnvMany(os.Environ(),
+		"BEADS_DIR",
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_PASSWORD",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_CITY_ROOT",
+		"GC_CITY_RUNTIME_DIR",
+		"GC_DOLT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PASSWORD",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+	)
+}
+
+func TestInitBdIgnoresAmbientDoltEndpoint(t *testing.T) {
+	t.Setenv("BEADS_DIR", filepath.Join(t.TempDir(), "ambient", ".beads"))
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "127.0.0.1")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PORT", "0")
+
+	dir := t.TempDir()
+	prefix := initBd(t, dir)
+
+	out, err := bd(dir, "create", "ambient dolt endpoint ignored")
+	if err != nil {
+		t.Fatalf("bd create after initBd failed: %v\noutput: %s", err, out)
+	}
+	beadID := extractBeadID(t, out)
+	if !strings.HasPrefix(beadID, prefix) {
+		t.Fatalf("bead ID %q should start with prefix %q", beadID, prefix)
+	}
 }
 
 // createBead creates a bead and returns its ID.

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -245,7 +245,7 @@ func initBd(t *testing.T, dir string) string {
 }
 
 func standaloneBdEnv() []string {
-	return filterEnvMany(os.Environ(),
+	env := filterEnvMany(os.Environ(),
 		"BEADS_DIR",
 		"BEADS_DOLT_AUTO_START",
 		"BEADS_DOLT_PASSWORD",
@@ -266,6 +266,32 @@ func standaloneBdEnv() []string {
 		"GC_RIG",
 		"GC_RIG_ROOT",
 	)
+	return append(env, "GC_DOLT=skip")
+}
+
+func TestStandaloneBdEnvForcesNonDoltMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "127.0.0.1")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
+	t.Setenv("GC_DOLT", "server")
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PORT", "0")
+
+	got := parseEnvList(standaloneBdEnv())
+	if got["GC_DOLT"] != "skip" {
+		t.Fatalf("GC_DOLT = %q, want skip", got["GC_DOLT"])
+	}
+	for _, key := range []string{
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+	} {
+		if got[key] != "" {
+			t.Fatalf("%s should be scrubbed, got %q", key, got[key])
+		}
+	}
 }
 
 func TestInitBdIgnoresAmbientDoltEndpoint(t *testing.T) {

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -237,14 +237,14 @@ func initBd(t *testing.T, dir string) string {
 	}
 	cmd := exec.Command(binary, "init", "-p", prefix, "--skip-hooks", "-q")
 	cmd.Dir = dir
-	cmd.Env = standaloneBdInitEnv()
+	cmd.Env = standaloneBdEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init in %s failed: %v\noutput: %s", dir, err, out)
 	}
 	return prefix
 }
 
-func standaloneBdInitEnv() []string {
+func standaloneBdEnv() []string {
 	return filterEnvMany(os.Environ(),
 		"BEADS_DIR",
 		"BEADS_DOLT_AUTO_START",

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -659,6 +659,7 @@ func integrationEnvDolt() []string {
 
 func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env := filterEnv(os.Environ(), "GC_BEADS")
+	env = filterEnv(env, "BEADS_DIR")
 	env = filterEnv(env, "GC_DOLT")
 	env = filterEnv(env, "PATH")
 	env = filterEnv(env, "GC_HOME")
@@ -1081,6 +1082,7 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	integrationToolBinDir = filepath.Join(t.TempDir(), "bin")
 
 	t.Setenv("HOME", "/host/home")
+	t.Setenv("BEADS_DIR", "/host/beads")
 	t.Setenv("GC_DOLT_HOST", "ambient-host")
 	t.Setenv("GC_DOLT_PORT", "0")
 	t.Setenv("GC_DOLT_USER", "ambient-user")
@@ -1111,6 +1113,7 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 		t.Fatalf("BEADS_DOLT_AUTO_START = %q, want %q; tests must match bdRuntimeEnv and suppress bd's rogue auto-start", got["BEADS_DOLT_AUTO_START"], "0")
 	}
 	for _, key := range []string{
+		"BEADS_DIR",
 		"GC_DOLT_HOST",
 		"GC_DOLT_PORT",
 		"GC_DOLT_USER",

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -444,6 +444,9 @@ func bdDolt(dir string, args ...string) (string, error) {
 	}
 	if port, ok := ensureManagedDoltPortForTest(dir); ok {
 		env = appendManagedDoltEndpointEnv(env, port)
+		if delay := managedDoltRetryDelay(out); delay > 0 {
+			time.Sleep(delay)
+		}
 		return runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
 	}
 	return out, err
@@ -957,6 +960,8 @@ func ensureManagedDoltPortForTest(cityDir string) (string, bool) {
 func managedDoltTransportRetryable(out string) bool {
 	msg := strings.ToLower(out)
 	for _, marker := range []string{
+		"dolt circuit breaker is open",
+		"server appears down, failing fast",
 		"dolt server unreachable",
 		"dial tcp",
 		"connection refused",
@@ -969,6 +974,14 @@ func managedDoltTransportRetryable(out string) bool {
 		}
 	}
 	return false
+}
+
+func managedDoltRetryDelay(out string) time.Duration {
+	msg := strings.ToLower(out)
+	if strings.Contains(msg, "dolt circuit breaker is open") || strings.Contains(msg, "server appears down, failing fast") {
+		return 5 * time.Second
+	}
+	return 0
 }
 
 func testPortReachable(port string) bool {
@@ -1145,6 +1158,19 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 		if _, ok := got[key]; ok {
 			t.Fatalf("%s leaked into integration env: %v", key, got[key])
 		}
+	}
+}
+
+func TestManagedDoltTransportRetryableRecognizesCircuitBreaker(t *testing.T) {
+	output := `{"error":"failed to open database: dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)"}`
+	if !managedDoltTransportRetryable(output) {
+		t.Fatalf("managedDoltTransportRetryable(%q) = false, want true", output)
+	}
+	if got := managedDoltRetryDelay(output); got < 5*time.Second {
+		t.Fatalf("managedDoltRetryDelay(%q) = %s, want at least 5s", output, got)
+	}
+	if got := managedDoltRetryDelay("dial tcp 127.0.0.1:3306: connect: connection refused"); got != 0 {
+		t.Fatalf("managedDoltRetryDelay for plain transport error = %s, want 0", got)
 	}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -394,11 +394,30 @@ func gcDolt(dir string, args ...string) (string, error) {
 // bd runs the bd binary with the given args. If dir is non-empty, it sets
 // the working directory. Returns combined stdout+stderr and any error.
 func bd(dir string, args ...string) (string, error) {
+	if usesStandaloneBdStore(dir, args) {
+		return runCommand(dir, standaloneBdEnv(), integrationBDCommandTimeout, realBDBinary, args...)
+	}
 	out, err := runCommand(dir, commandEnvForDir(dir, false), integrationBDCommandTimeout, bdBinary, args...)
 	if err == nil || !shouldUseFileStoreBDFallback(dir, out, args) {
 		return out, err
 	}
 	return runFileStoreBD(dir, args...)
+}
+
+func usesStandaloneBdStore(dir string, args []string) bool {
+	if dir == "" || len(args) == 0 || args[0] == "init" {
+		return false
+	}
+	if strings.TrimSpace(realBDBinary) == "" {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".beads")); err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gc", "beads.json")); err == nil {
+		return false
+	}
+	return true
 }
 
 // bdDolt runs bd against a Dolt-backed city using the same isolated runtime


### PR DESCRIPTION
## Summary

`staleCreatingState` measured staleness from `bead.CreatedAt`, but configured-named-session beads (mayor, `beads/planner`, `beads/builder`, etc.) are reopened on demand — the same bead row toggles closed→open with state→creating, while `CreatedAt` still reflects when the row was first minted (potentially hours, days, or months ago). On every reopen the staleness check returned `true` immediately, the orphan-side rollback fired before `executePlannedStarts` could even run, the bead was closed as failed-create, and the next tick reopened it. **Repeat.** A configured-named-session that ever closed could never spawn again.

Concrete repro: `gm-z51f7` (`beads/planner`) sat in creating→reaped→creating for 25+ minutes with active demand from slung work; same pattern for `beads/architect`, `beads/validator`, `beads/builder`. The `op=start` command never got a chance to fire.

## Fix

A new `pending_create_started_at` (RFC3339) metadata field is set the moment a bead enters `state=creating` with `pending_create_claim=true`. `staleCreatingState` reads that field with `bead.CreatedAt` as fallback for callers that haven't been updated. Two write sites:

- `createPoolSessionBead` (`cmd/gc/session_name_lookup.go`) — fresh pool beads.
- `reopenClosedConfiguredNamedSessionBead` (`cmd/gc/session_beads.go`) — configured-named reopen path; clears the field when reopening without `pending_create_claim` so a stale value can't outlive a non-claim path.

`staleCreatingStateTimeout` becomes a `var` (still 60s) so tests can override without bumping every fixture timestamp into the multi-minute range. **No timeout change** — this PR explicitly does not paper over the fork-per-call cost issue with a longer window.

### Defensive companion: rate-limit rollbacks per tick (max 5)

Each `rollbackPendingCreate` fires three `bd` subprocess writes (~2s each under the current `bd` dolt-commit cost), so an unbounded rollback storm in a single tick easily blows the tick past `staleCreatingStateTimeout` (60s) and starves `executePlannedStarts` — fresh pending-create beads age out before `op=start` fires. Capping rollbacks at 5/tick lets the rest of the tick make forward progress; remaining stale beads roll back on subsequent ticks. The deeper fork-per-call cost is tracked separately for the architect.

The cap is applied at the existing live-runtime-mismatch rollback site only. The desired-branch `!alive` rollback site introduced by #1533 is not in `main` yet; if #1533 lands before this, a follow-up will extend the cap there.

## Verification

- `go test ./cmd/gc/...` passes (full suite, 76s).
- Live supervisor with this fix spawned 20+ active agents including every previously-broken named-session reopen: `beads/planner`, `beads/architect`, `beads/validator`, `beads/builder`. `beads/planner` completed end-to-end work on a slung PG-backing-store PRD and emitted seven architect-bound child beads.

## Test plan

- [x] `go test ./cmd/gc/...`
- [x] Verified spawn unblocked on a live supervisor with multiple stuck `beads/*` named sessions.
- [ ] Reviewer to sanity-check the field is written on every `state=creating` transition we care about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->