### PR TITLE
fix: make async event results reliable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,5 +373,3 @@ These apply to all code in this project — frontend and server:
   static checking (linting, compilers, etc) is that they surface issues at
   build-time so that they can be fixed now instead of lead to errors at runtime.
   Take advantage of that feedback to fix those errors!
-- **Use Centralized Semantic Constant Values** using enums and constants instead
-  of spreading magic numbers through-out the code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,3 +373,5 @@ These apply to all code in this project — frontend and server:
   static checking (linting, compilers, etc) is that they surface issues at
   build-time so that they can be fixed now instead of lead to errors at runtime.
   Take advantage of that feedback to fix those errors!
+- **Use Centralized Semantic Constant Values** using enums and constants instead
+  of spreading magic numbers through-out the code.

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gastownhall/gascity/internal/mail"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
@@ -1070,6 +1071,45 @@ func (cs *controllerState) Poke() {
 	select {
 	case cs.pokeCh <- struct{}{}:
 	default: // poke already pending
+	}
+}
+
+// WaitForSessionCommandable waits until the controller has reconciled an async
+// session create into a lifecycle state that can accept normal commands.
+func (cs *controllerState) WaitForSessionCommandable(ctx context.Context, sessionID string) (session.Info, error) {
+	store := cs.CityBeadStore()
+	if store == nil {
+		return session.Info{}, errors.New("city bead store is unavailable")
+	}
+	catalog, err := workerSessionCatalogWithConfig(cs.CityPath(), store, cs.SessionProvider(), cs.Config())
+	if err != nil {
+		return session.Info{}, err
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		info, err := catalog.Get(sessionID)
+		if err != nil {
+			return session.Info{}, err
+		}
+		if info.Closed {
+			return session.Info{}, fmt.Errorf("session is closed: %s", sessionID)
+		}
+		switch info.State {
+		case session.StateActive, session.StateAwake, session.StateAsleep, session.StateSuspended, session.StateQuarantined:
+			return info, nil
+		case session.StateCreating, "":
+		default:
+			return session.Info{}, fmt.Errorf("session %s reached non-commandable state %q", sessionID, info.State)
+		}
+
+		select {
+		case <-ctx.Done():
+			return session.Info{}, fmt.Errorf("session %s did not become commandable: %w", sessionID, ctx.Err())
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -2087,7 +2087,7 @@ export interface components {
             ready_delay_ms?: number;
         };
         AsyncAcceptedBody: {
-            /** @description City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. */
+            /** @description City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty. */
             event_cursor: string;
             /** @description Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id. */
             request_id: string;
@@ -2098,7 +2098,7 @@ export interface components {
             status: string;
         };
         AsyncAcceptedResponse: {
-            /** @description Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. */
+            /** @description Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty. */
             event_cursor: string;
             /** @description Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id. */
             request_id: string;

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -575,7 +575,7 @@ export interface paths {
         };
         /**
          * Stream city events in real time
-         * @description Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param.
+         * @description Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param; omitting both starts at the current city event head.
          */
         get: operations["stream-events"];
         put?: never;
@@ -1859,7 +1859,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Stream tagged events from all running cities. */
+        /**
+         * Stream tagged events from all running cities.
+         * @description Server-Sent Events stream of supervisor-tagged events. Supports reconnection via Last-Event-ID header or after_cursor query param; omitting both starts at the current supervisor event head.
+         */
         get: operations["stream-supervisor-events"];
         put?: never;
         post?: never;
@@ -2084,6 +2087,8 @@ export interface components {
             ready_delay_ms?: number;
         };
         AsyncAcceptedBody: {
+            /** @description City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. */
+            event_cursor: string;
             /** @description Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id. */
             request_id: string;
             /**
@@ -2093,6 +2098,8 @@ export interface components {
             status: string;
         };
         AsyncAcceptedResponse: {
+            /** @description Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. */
+            event_cursor: string;
             /** @description Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id. */
             request_id: string;
         };
@@ -3636,7 +3643,7 @@ export interface components {
         SessionCreateSucceededPayload: {
             /** @description Correlation ID from the 202 response. */
             request_id: string;
-            /** @description Full session state as returned by GET /session/{id}. */
+            /** @description Full session state as returned by GET /session/{id}. For session.create, this result is emitted only after the session has left creating and can accept normal metadata and lifecycle commands. */
             session: components["schemas"]["SessionResponse"];
         };
         SessionInfo: {
@@ -7588,11 +7595,11 @@ export interface operations {
     "stream-events": {
         parameters: {
             query?: {
-                /** @description Reconnect position: only deliver events after this sequence number. */
+                /** @description Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head. */
                 after_seq?: string;
             };
             header?: {
-                /** @description SSE reconnect position from the last received event ID. */
+                /** @description SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head. */
                 "Last-Event-ID"?: string;
             };
             path: {
@@ -11526,11 +11533,11 @@ export interface operations {
     "stream-supervisor-events": {
         parameters: {
             query?: {
-                /** @description Alternative to Last-Event-ID for browsers that can't set custom headers. */
+                /** @description Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head. */
                 after_cursor?: string;
             };
             header?: {
-                /** @description Reconnect cursor (composite per-city cursor). */
+                /** @description Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head. */
                 "Last-Event-ID"?: string;
             };
             path?: never;

--- a/cmd/gc/dashboard/web/src/generated/sdk.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/sdk.gen.ts
@@ -336,7 +336,7 @@ export const emitEvent = <ThrowOnError extends boolean = false>(options: Options
 /**
  * Stream city events in real time
  *
- * Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param.
+ * Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param; omitting both starts at the current city event head.
  */
 export const streamEvents = <ThrowOnError extends boolean = false>(options: Options<StreamEventsData, ThrowOnError, StreamEventsResponse>) => (options.client ?? client).sse.get<StreamEventsResponses, StreamEventsErrors, ThrowOnError>({ url: '/v0/city/{cityName}/events/stream', ...options });
 
@@ -1008,6 +1008,8 @@ export const getV0Events = <ThrowOnError extends boolean = false>(options?: Opti
 
 /**
  * Stream tagged events from all running cities.
+ *
+ * Server-Sent Events stream of supervisor-tagged events. Supports reconnection via Last-Event-ID header or after_cursor query param; omitting both starts at the current supervisor event head.
  */
 export const streamSupervisorEvents = <ThrowOnError extends boolean = false>(options?: Options<StreamSupervisorEventsData, ThrowOnError, StreamSupervisorEventsResponse>) => (options?.client ?? client).sse.get<StreamSupervisorEventsResponses, StreamSupervisorEventsErrors, ThrowOnError>({ url: '/v0/events/stream', ...options });
 

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -220,7 +220,7 @@ export type AnnotatedProviderResponse = {
 
 export type AsyncAcceptedBody = {
     /**
-     * City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.
+     * City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty.
      */
     event_cursor: string;
     /**
@@ -235,7 +235,7 @@ export type AsyncAcceptedBody = {
 
 export type AsyncAcceptedResponse = {
     /**
-     * Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.
+     * Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.
      */
     event_cursor: string;
     /**

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -220,6 +220,10 @@ export type AnnotatedProviderResponse = {
 
 export type AsyncAcceptedBody = {
     /**
+     * City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.
+     */
+    event_cursor: string;
+    /**
      * Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id.
      */
     request_id: string;
@@ -230,6 +234,10 @@ export type AsyncAcceptedBody = {
 };
 
 export type AsyncAcceptedResponse = {
+    /**
+     * Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.
+     */
+    event_cursor: string;
     /**
      * Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.
      */
@@ -2310,7 +2318,7 @@ export type SessionCreateSucceededPayload = {
      */
     request_id: string;
     /**
-     * Full session state as returned by GET /session/{id}.
+     * Full session state as returned by GET /session/{id}. For session.create, this result is emitted only after the session has left creating and can accept normal metadata and lifecycle commands.
      */
     session: SessionResponse;
 };
@@ -6233,7 +6241,7 @@ export type StreamEventsData = {
     body?: never;
     headers?: {
         /**
-         * SSE reconnect position from the last received event ID.
+         * SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.
          */
         'Last-Event-ID'?: string;
     };
@@ -6245,7 +6253,7 @@ export type StreamEventsData = {
     };
     query?: {
         /**
-         * Reconnect position: only deliver events after this sequence number.
+         * Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.
          */
         after_seq?: string;
     };
@@ -10087,14 +10095,14 @@ export type StreamSupervisorEventsData = {
     body?: never;
     headers?: {
         /**
-         * Reconnect cursor (composite per-city cursor).
+         * Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.
          */
         'Last-Event-ID'?: string;
     };
     path?: never;
     query?: {
         /**
-         * Alternative to Last-Event-ID for browsers that can't set custom headers.
+         * Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.
          */
         after_cursor?: string;
     };

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -146,7 +146,15 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 		template = session.Metadata["template"]
 	}
 	agent := findAgentByTemplate(cfg, template)
-	return agent != nil && !agent.Suspended
+	if agent != nil {
+		return !agent.Suspended
+	}
+	// API config mutations and session creation can arrive in adjacent
+	// reconciler ticks. Preserve a fresh pending-create bead while the runtime
+	// config snapshot catches up so it is not falsely closed as orphaned.
+	return strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
+		strings.TrimSpace(session.Metadata["state"]) == "creating" &&
+		!staleCreatingState(session, clk)
 }
 
 func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1802,6 +1802,30 @@ func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.
 	}
 }
 
+func TestReconcileSessionBeads_FreshPendingCreateSurvivesStaleConfigSnapshot(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("s-gc-late", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "creating",
+		"pending_create_claim": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 without desired-state membership", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("fresh pending-create session was closed as orphan: %+v", got)
+	}
+	if got.Metadata["state"] == "orphaned" || got.Metadata["close_reason"] == "orphaned" {
+		t.Fatalf("fresh pending-create session was marked orphaned: %+v", got.Metadata)
+	}
+}
+
 func TestReconcileSessionBeads_DependencyOrdering_DepDeadBlocksWake(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -100,6 +100,11 @@ the per-operation `responses.200.content.text/event-stream` entry.
 Clients should follow the standard SSE reconnection protocol
 (`Last-Event-ID` header) where the server supports it; the event bus
 stream (`/v0/events/stream`) replays from the last received index.
+When no cursor is supplied, event streams start at the current event
+head and deliver future events only. Async `202 Accepted` responses
+include an `event_cursor` captured before the operation starts; pass
+that value as `after_cursor` or `after_seq` to wait for the operation's
+request-result event without replaying unrelated historical backlog.
 
 Fatal setup errors are returned as normal Problem Details responses
 *before* the stream's 200 headers commit, never as a 200 stream that
@@ -121,12 +126,13 @@ is nothing to poll.
 
 ```json
 {
-  "request_id": "req-..."
+  "request_id": "req-...",
+  "event_cursor": "__supervisor__:42,my-city:17"
 }
 ```
 
-Use the returned `request_id` to correlate the completion event on
-the supervisor event stream.
+Use `request_id` to correlate the completion event. Use `event_cursor`
+as the `after_cursor` value on the supervisor event stream.
 
 ### Completion events
 
@@ -149,10 +155,8 @@ returned `request_id`; no polling of `GET /v0/cities` or
 
 Either order works. The recommended flow is:
 
-1. `POST /v0/city` and wait for `202 {request_id}`.
-2. `GET /v0/events/stream?after_cursor=0` — request replay from
-   the start so `city.created` and the terminal request event are
-   delivered even if they fired before subscribe.
+1. `POST /v0/city` and wait for `202 {request_id, event_cursor}`.
+2. `GET /v0/events/stream?after_cursor=<event_cursor>`.
 3. Read frames until `payload.request_id == response.request_id` and
    `type ∈ {"request.result.city.create", "request.failed"}`.
 
@@ -193,9 +197,13 @@ simple `gc register`.
 
 ```json
 {
-  "request_id": "req-..."
+  "request_id": "req-...",
+  "event_cursor": "__supervisor__:43,my-city:21"
 }
 ```
+
+Pass `event_cursor` as `after_cursor` on `/v0/events/stream` and wait
+for the terminal event whose payload contains the returned `request_id`.
 
 ### Completion events
 
@@ -244,7 +252,8 @@ behavior, heartbeat suppression, and the `--seq` plain-text cursor format, see
   terminal `request.result.session.*` or `request.failed` events by
   `payload.request_id`.
 - Resume:
-  - `Last-Event-ID` or `after_seq`
+  - `Last-Event-ID` or `after_seq`; omit both to start from the
+    current city event head.
 - `gc events` in city scope outputs one `TypedEventStreamEnvelope` JSON
   object per line.
 - `gc events --watch` and `gc events --follow` in city scope output one
@@ -263,7 +272,8 @@ behavior, heartbeat suppression, and the `--seq` plain-text cursor format, see
   on this stream. Match terminal `request.result.city.*` or
   `request.failed` events by `payload.request_id`.
 - Resume:
-  - `Last-Event-ID` or `after_cursor`
+  - `Last-Event-ID` or `after_cursor`; omit both to start from the
+    current supervisor event head.
 - `gc events` in supervisor scope outputs one `TypedTaggedEventStreamEnvelope`
   JSON object per line.
 - `gc events --watch` and `gc events --follow` in supervisor scope

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -86,6 +86,9 @@ stdout, but the line schema is different from list mode.
   stdout.
 - If `--watch` times out without a match, stdout is empty and the command exits
   successfully.
+- API streams without `after_seq`, `after_cursor`, or `Last-Event-ID` start
+  at the current event head. Pass the `event_cursor` returned by async POST
+  responses when waiting for request-result events after the POST returns.
 
 #### City Scope
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -728,7 +728,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty.",
             "type": "string"
           },
           "request_id": {
@@ -754,7 +754,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.",
             "type": "string"
           },
           "request_id": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -727,6 +727,10 @@
       "AsyncAcceptedBody": {
         "additionalProperties": false,
         "properties": {
+          "event_cursor": {
+            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "type": "string"
+          },
           "request_id": {
             "description": "Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id.",
             "type": "string"
@@ -741,20 +745,26 @@
         },
         "required": [
           "status",
-          "request_id"
+          "request_id",
+          "event_cursor"
         ],
         "type": "object"
       },
       "AsyncAcceptedResponse": {
         "additionalProperties": false,
         "properties": {
+          "event_cursor": {
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "type": "string"
+          },
           "request_id": {
             "description": "Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.",
             "type": "string"
           }
         },
         "required": [
-          "request_id"
+          "request_id",
+          "event_cursor"
         ],
         "type": "object"
       },
@@ -5632,7 +5642,7 @@
           },
           "session": {
             "$ref": "#/components/schemas/SessionResponse",
-            "description": "Full session state as returned by GET /session/{id}."
+            "description": "Full session state as returned by GET /session/{id}. For session.create, this result is emitted only after the session has left creating and can accept normal metadata and lifecycle commands."
           }
         },
         "required": [
@@ -15150,7 +15160,7 @@
     },
     "/v0/city/{cityName}/events/stream": {
       "get": {
-        "description": "Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param.",
+        "description": "Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param; omitting both starts at the current city event head.",
         "operationId": "stream-events",
         "parameters": [
           {
@@ -15166,21 +15176,21 @@
             }
           },
           {
-            "description": "Reconnect position: only deliver events after this sequence number.",
+            "description": "Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.",
             "explode": false,
             "in": "query",
             "name": "after_seq",
             "schema": {
-              "description": "Reconnect position: only deliver events after this sequence number.",
+              "description": "Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.",
               "type": "string"
             }
           },
           {
-            "description": "SSE reconnect position from the last received event ID.",
+            "description": "SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.",
             "in": "header",
             "name": "Last-Event-ID",
             "schema": {
-              "description": "SSE reconnect position from the last received event ID.",
+              "description": "SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.",
               "type": "string"
             }
           }
@@ -22745,24 +22755,25 @@
     },
     "/v0/events/stream": {
       "get": {
+        "description": "Server-Sent Events stream of supervisor-tagged events. Supports reconnection via Last-Event-ID header or after_cursor query param; omitting both starts at the current supervisor event head.",
         "operationId": "stream-supervisor-events",
         "parameters": [
           {
-            "description": "Reconnect cursor (composite per-city cursor).",
+            "description": "Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.",
             "in": "header",
             "name": "Last-Event-ID",
             "schema": {
-              "description": "Reconnect cursor (composite per-city cursor).",
+              "description": "Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.",
               "type": "string"
             }
           },
           {
-            "description": "Alternative to Last-Event-ID for browsers that can't set custom headers.",
+            "description": "Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.",
             "explode": false,
             "in": "query",
             "name": "after_cursor",
             "schema": {
-              "description": "Alternative to Last-Event-ID for browsers that can't set custom headers.",
+              "description": "Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.",
               "type": "string"
             }
           }

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -728,7 +728,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty.",
             "type": "string"
           },
           "request_id": {
@@ -754,7 +754,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.",
             "type": "string"
           },
           "request_id": {

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -727,6 +727,10 @@
       "AsyncAcceptedBody": {
         "additionalProperties": false,
         "properties": {
+          "event_cursor": {
+            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "type": "string"
+          },
           "request_id": {
             "description": "Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id.",
             "type": "string"
@@ -741,20 +745,26 @@
         },
         "required": [
           "status",
-          "request_id"
+          "request_id",
+          "event_cursor"
         ],
         "type": "object"
       },
       "AsyncAcceptedResponse": {
         "additionalProperties": false,
         "properties": {
+          "event_cursor": {
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "type": "string"
+          },
           "request_id": {
             "description": "Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.",
             "type": "string"
           }
         },
         "required": [
-          "request_id"
+          "request_id",
+          "event_cursor"
         ],
         "type": "object"
       },
@@ -5632,7 +5642,7 @@
           },
           "session": {
             "$ref": "#/components/schemas/SessionResponse",
-            "description": "Full session state as returned by GET /session/{id}."
+            "description": "Full session state as returned by GET /session/{id}. For session.create, this result is emitted only after the session has left creating and can accept normal metadata and lifecycle commands."
           }
         },
         "required": [
@@ -15150,7 +15160,7 @@
     },
     "/v0/city/{cityName}/events/stream": {
       "get": {
-        "description": "Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param.",
+        "description": "Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param; omitting both starts at the current city event head.",
         "operationId": "stream-events",
         "parameters": [
           {
@@ -15166,21 +15176,21 @@
             }
           },
           {
-            "description": "Reconnect position: only deliver events after this sequence number.",
+            "description": "Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.",
             "explode": false,
             "in": "query",
             "name": "after_seq",
             "schema": {
-              "description": "Reconnect position: only deliver events after this sequence number.",
+              "description": "Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.",
               "type": "string"
             }
           },
           {
-            "description": "SSE reconnect position from the last received event ID.",
+            "description": "SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.",
             "in": "header",
             "name": "Last-Event-ID",
             "schema": {
-              "description": "SSE reconnect position from the last received event ID.",
+              "description": "SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.",
               "type": "string"
             }
           }
@@ -22745,24 +22755,25 @@
     },
     "/v0/events/stream": {
       "get": {
+        "description": "Server-Sent Events stream of supervisor-tagged events. Supports reconnection via Last-Event-ID header or after_cursor query param; omitting both starts at the current supervisor event head.",
         "operationId": "stream-supervisor-events",
         "parameters": [
           {
-            "description": "Reconnect cursor (composite per-city cursor).",
+            "description": "Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.",
             "in": "header",
             "name": "Last-Event-ID",
             "schema": {
-              "description": "Reconnect cursor (composite per-city cursor).",
+              "description": "Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.",
               "type": "string"
             }
           },
           {
-            "description": "Alternative to Last-Event-ID for browsers that can't set custom headers.",
+            "description": "Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.",
             "explode": false,
             "in": "query",
             "name": "after_cursor",
             "schema": {
-              "description": "Alternative to Last-Event-ID for browsers that can't set custom headers.",
+              "description": "Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.",
               "type": "string"
             }
           }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"time"
@@ -120,12 +121,19 @@ type sseEnvelope struct {
 // until it finds an event matching the given request_id (in success or
 // failure payloads), and returns the envelope. The caller decodes the
 // typed payload.
-func (c *Client) waitForEvent(ctx context.Context, requestID string, successType, failOp string) (*sseEnvelope, error) {
+func (c *Client) waitForEvent(ctx context.Context, requestID string, successType, failOp, eventCursor string) (*sseEnvelope, error) {
 	streamURL := c.baseURL + "/v0/events/stream"
+	cursor := strings.TrimSpace(eventCursor)
 	if c.cityName != "" {
-		streamURL = c.baseURL + "/v0/city/" + c.cityName + "/events/stream?after_seq=0"
+		if cursor == "" {
+			cursor = "0"
+		}
+		streamURL = c.baseURL + "/v0/city/" + c.cityName + "/events/stream?after_seq=" + url.QueryEscape(cursor)
 	} else {
-		streamURL += "?after_cursor=0"
+		if cursor == "" {
+			cursor = "0"
+		}
+		streamURL += "?after_cursor=" + url.QueryEscape(cursor)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
 	if err != nil {
@@ -468,7 +476,7 @@ func (c *Client) SendSessionMessage(id, message string) error {
 	}
 	requestID := resp.JSON202.RequestId
 
-	env, err := c.waitForEvent(ctx, requestID, events.RequestResultSessionMessage, RequestOperationSessionMessage)
+	env, err := c.waitForEvent(ctx, requestID, events.RequestResultSessionMessage, RequestOperationSessionMessage, resp.JSON202.EventCursor)
 	if err != nil {
 		return err
 	}
@@ -511,7 +519,7 @@ func (c *Client) SubmitSession(id, message string, intent session.SubmitIntent) 
 
 	ctx, cancel := context.WithTimeout(context.Background(), sessionMessageTimeout)
 	defer cancel()
-	env, err := c.waitForEvent(ctx, requestID, events.RequestResultSessionSubmit, RequestOperationSessionSubmit)
+	env, err := c.waitForEvent(ctx, requestID, events.RequestResultSessionSubmit, RequestOperationSessionSubmit, resp.JSON202.EventCursor)
 	if err != nil {
 		return SessionSubmitResponse{}, err
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -76,7 +76,7 @@ func TestClientWaitForEventRequestsReplayCursorForCityStream(t *testing.T) {
 	defer ts.Close()
 
 	c := NewCityScopedClient(ts.URL, "alpha")
-	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.session.message", RequestOperationSessionMessage)
+	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.session.message", RequestOperationSessionMessage, "")
 
 	query := <-seen
 	if got := query.Get("after_seq"); got != "0" {
@@ -96,11 +96,51 @@ func TestClientWaitForEventRequestsReplayCursorForSupervisorStream(t *testing.T)
 	defer ts.Close()
 
 	c := NewClient(ts.URL)
-	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate)
+	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "")
 
 	query := <-seen
 	if got := query.Get("after_cursor"); got != "0" {
 		t.Fatalf("after_cursor = %q, want 0", got)
+	}
+}
+
+func TestClientWaitForEventUsesAcceptedCursorForCityStream(t *testing.T) {
+	seen := make(chan url.Values, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/city/alpha/events/stream" {
+			t.Fatalf("path = %q, want /v0/city/alpha/events/stream", r.URL.Path)
+		}
+		seen <- r.URL.Query()
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer ts.Close()
+
+	c := NewCityScopedClient(ts.URL, "alpha")
+	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.session.message", RequestOperationSessionMessage, "42")
+
+	query := <-seen
+	if got := query.Get("after_seq"); got != "42" {
+		t.Fatalf("after_seq = %q, want 42", got)
+	}
+}
+
+func TestClientWaitForEventUsesAcceptedCursorForSupervisorStream(t *testing.T) {
+	seen := make(chan url.Values, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/events/stream" {
+			t.Fatalf("path = %q, want /v0/events/stream", r.URL.Path)
+		}
+		seen <- r.URL.Query()
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer ts.Close()
+
+	c := NewClient(ts.URL)
+	_, _ = c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "alpha:7,__supervisor__:9")
+
+	query := <-seen
+	if got := query.Get("after_cursor"); got != "alpha:7,__supervisor__:9" {
+		t.Fatalf("after_cursor = %q, want alpha:7,__supervisor__:9", got)
 	}
 }
 
@@ -111,7 +151,7 @@ func TestClientWaitForEventReportsNonOKSSEStatus(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(ts.URL)
-	_, err := c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate)
+	_, err := c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "")
 	if err == nil {
 		t.Fatal("waitForEvent succeeded for non-OK SSE response")
 	}
@@ -129,7 +169,7 @@ func TestClientWaitForEventReportsScannerError(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(ts.URL)
-	_, err := c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate)
+	_, err := c.waitForEvent(t.Context(), "req-never", "request.result.city.create", RequestOperationCityCreate, "")
 	if err == nil {
 		t.Fatal("waitForEvent succeeded after scanner failure")
 	}
@@ -149,7 +189,7 @@ func TestClientWaitForEventHandlesMultiLineDataFrames(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(ts.URL)
-	env, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage)
+	env, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage, "")
 	if err != nil {
 		t.Fatalf("waitForEvent: %v", err)
 	}
@@ -168,7 +208,7 @@ func TestClientWaitForEventHandlesEventFieldWithoutSpace(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(ts.URL)
-	env, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage)
+	env, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage, "")
 	if err != nil {
 		t.Fatalf("waitForEvent: %v", err)
 	}
@@ -186,7 +226,7 @@ func TestClientWaitForEventReportsMalformedMatchingSuccessPayload(t *testing.T) 
 	defer ts.Close()
 
 	c := NewCityScopedClient(ts.URL, "alpha")
-	_, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage)
+	_, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage, "")
 	if err == nil {
 		t.Fatal("waitForEvent succeeded with malformed matching success payload")
 	}
@@ -204,7 +244,7 @@ func TestClientWaitForEventReportsMalformedRequestFailedPayload(t *testing.T) {
 	defer ts.Close()
 
 	c := NewCityScopedClient(ts.URL, "alpha")
-	_, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage)
+	_, err := c.waitForEvent(t.Context(), "req-1", "request.result.session.message", RequestOperationSessionMessage, "")
 	if err == nil {
 		t.Fatal("waitForEvent succeeded with malformed request.failed payload")
 	}
@@ -223,7 +263,7 @@ func TestClientWaitForEventHonorsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	c := NewClient(ts.URL)
-	_, err := c.waitForEvent(ctx, "req-never", "request.result.city.create", RequestOperationCityCreate)
+	_, err := c.waitForEvent(ctx, "req-never", "request.result.city.create", RequestOperationCityCreate, "")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v, want context.Canceled", err)
 	}
@@ -629,13 +669,13 @@ func TestClientSendSessionMessageWaitsForResultEvent(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-msg"}) //nolint:errcheck
+			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-msg", "event_cursor": "17"}) //nolint:errcheck
 		case r.Method == http.MethodGet && r.URL.Path == "/v0/city/alpha/events/stream":
 			if !sawPost {
 				t.Fatal("event stream opened before message POST")
 			}
-			if got := r.URL.Query().Get("after_seq"); got != "0" {
-				t.Fatalf("after_seq = %q, want 0", got)
+			if got := r.URL.Query().Get("after_seq"); got != "17" {
+				t.Fatalf("after_seq = %q, want 17", got)
 			}
 			writeSSEEnvelope(t, w, events.RequestResultSessionMessage, SessionMessageSucceededPayload{
 				RequestID: "req-msg",
@@ -665,7 +705,7 @@ func TestClientSendSessionMessageReportsAsyncFailure(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/v0/city/alpha/session/sess-123/messages":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-msg"}) //nolint:errcheck
+			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-msg", "event_cursor": "18"}) //nolint:errcheck
 		case r.Method == http.MethodGet && r.URL.Path == "/v0/city/alpha/events/stream":
 			writeSSEEnvelope(t, w, events.RequestFailed, RequestFailedPayload{
 				RequestID:    "req-msg",
@@ -704,13 +744,13 @@ func TestClientSubmitSessionWaitsForResultEvent(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-submit"}) //nolint:errcheck
+			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-submit", "event_cursor": "21"}) //nolint:errcheck
 		case r.Method == http.MethodGet && r.URL.Path == "/v0/city/alpha/events/stream":
 			if !sawPost {
 				t.Fatal("event stream opened before submit POST")
 			}
-			if got := r.URL.Query().Get("after_seq"); got != "0" {
-				t.Fatalf("after_seq = %q, want 0", got)
+			if got := r.URL.Query().Get("after_seq"); got != "21" {
+				t.Fatalf("after_seq = %q, want 21", got)
 			}
 			writeSSEEnvelope(t, w, events.RequestResultSessionSubmit, SessionSubmitSucceededPayload{
 				RequestID: "req-submit",
@@ -746,7 +786,7 @@ func TestClientSubmitSessionReportsAsyncFailure(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/v0/city/alpha/session/sess-123/submit":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-submit"}) //nolint:errcheck
+			json.NewEncoder(w).Encode(map[string]string{"request_id": "req-submit", "event_cursor": "22"}) //nolint:errcheck
 		case r.Method == http.MethodGet && r.URL.Path == "/v0/city/alpha/events/stream":
 			writeSSEEnvelope(t, w, events.RequestFailed, RequestFailedPayload{
 				RequestID:    "req-submit",

--- a/internal/api/event_payloads.go
+++ b/internal/api/event_payloads.go
@@ -67,7 +67,7 @@ func (CityUnregisterSucceededPayload) IsEventPayload() {}
 // SessionCreateSucceededPayload is emitted on request.result.session.create.
 type SessionCreateSucceededPayload struct {
 	RequestID string          `json:"request_id" doc:"Correlation ID from the 202 response."`
-	Session   sessionResponse `json:"session" doc:"Full session state as returned by GET /session/{id}."`
+	Session   sessionResponse `json:"session" doc:"Full session state as returned by GET /session/{id}. For session.create, this result is emitted only after the session has left creating and can accept normal metadata and lifecycle commands."`
 }
 
 // IsEventPayload marks SessionCreateSucceededPayload as an events.Payload variant.

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -415,7 +415,7 @@ type AnnotatedProviderResponse struct {
 
 // AsyncAcceptedBody defines model for AsyncAcceptedBody.
 type AsyncAcceptedBody struct {
-	// EventCursor City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.
+	// EventCursor City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty.
 	EventCursor string `json:"event_cursor"`
 
 	// RequestId Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id.
@@ -427,7 +427,7 @@ type AsyncAcceptedBody struct {
 
 // AsyncAcceptedResponse defines model for AsyncAcceptedResponse.
 type AsyncAcceptedResponse struct {
-	// EventCursor Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.
+	// EventCursor Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.
 	EventCursor string `json:"event_cursor"`
 
 	// RequestId Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -415,6 +415,9 @@ type AnnotatedProviderResponse struct {
 
 // AsyncAcceptedBody defines model for AsyncAcceptedBody.
 type AsyncAcceptedBody struct {
+	// EventCursor City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.
+	EventCursor string `json:"event_cursor"`
+
 	// RequestId Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id.
 	RequestId string `json:"request_id"`
 
@@ -424,6 +427,9 @@ type AsyncAcceptedBody struct {
 
 // AsyncAcceptedResponse defines model for AsyncAcceptedResponse.
 type AsyncAcceptedResponse struct {
+	// EventCursor Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.
+	EventCursor string `json:"event_cursor"`
+
 	// RequestId Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.
 	RequestId string `json:"request_id"`
 }
@@ -4164,10 +4170,10 @@ type EmitEventParams struct {
 
 // StreamEventsParams defines parameters for StreamEvents.
 type StreamEventsParams struct {
-	// AfterSeq Reconnect position: only deliver events after this sequence number.
+	// AfterSeq Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.
 	AfterSeq *string `form:"after_seq,omitempty" json:"after_seq,omitempty"`
 
-	// LastEventID SSE reconnect position from the last received event ID.
+	// LastEventID SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.
 	LastEventID *string `json:"Last-Event-ID,omitempty"`
 }
 
@@ -4788,10 +4794,10 @@ type GetV0EventsParams struct {
 
 // StreamSupervisorEventsParams defines parameters for StreamSupervisorEvents.
 type StreamSupervisorEventsParams struct {
-	// AfterCursor Alternative to Last-Event-ID for browsers that can't set custom headers.
+	// AfterCursor Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.
 	AfterCursor *string `form:"after_cursor,omitempty" json:"after_cursor,omitempty"`
 
-	// LastEventID Reconnect cursor (composite per-city cursor).
+	// LastEventID Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.
 	LastEventID *string `json:"Last-Event-ID,omitempty"`
 }
 

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -899,6 +899,150 @@ func TestBeadUpdateSetsAndClearsParent(t *testing.T) {
 	}
 }
 
+func TestBeadParentRestoreGraphAndFilteredListWithRig(t *testing.T) {
+	state := newFakeState(t)
+	backing := beads.NewMemStore()
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	state.stores["alpha"] = cache
+	state.cfg.Rigs = append(state.cfg.Rigs, config.Rig{Name: "alpha", Path: "/tmp/alpha"})
+	h := newTestCityHandler(t, state)
+
+	createBead := func(body string) beads.Bead {
+		t.Helper()
+		req := newPostRequest(cityURL(state, "/beads"), bytes.NewBufferString(body))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("create status = %d, want %d; body: %s", rec.Code, http.StatusCreated, rec.Body.String())
+		}
+		var created beads.Bead
+		if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+			t.Fatalf("decode created bead: %v", err)
+		}
+		return created
+	}
+	postOK := func(path, body string) {
+		t.Helper()
+		req := newPostRequest(cityURL(state, path), bytes.NewBufferString(body))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST %s status = %d, want %d; body: %s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+	}
+	containsID := func(items []beads.Bead, id string) bool {
+		for _, item := range items {
+			if item.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	root := createBead(`{
+		"rig":"alpha",
+		"title":"MC live contract root",
+		"type":"feature",
+		"priority":2,
+		"labels":["mc-live-contract","root"],
+		"metadata":{"mc.contract.run_id":"run-1"}
+	}`)
+	postOK("/bead/"+root.ID+"/update", `{"status":"in_progress","metadata":{"mc.contract.updated":"true"}}`)
+	postOK("/bead/"+root.ID+"/close", ``)
+	postOK("/bead/"+root.ID+"/reopen", ``)
+
+	child := createBead(`{
+		"rig":"alpha",
+		"title":"MC live contract child",
+		"type":"task",
+		"priority":1,
+		"parent":"` + root.ID + `",
+		"labels":["mc-live-contract","child","needs-update"],
+		"metadata":{"mc.contract.run_id":"run-1"}
+	}`)
+	sibling := createBead(`{
+		"rig":"alpha",
+		"title":"MC live contract sibling",
+		"type":"bug",
+		"priority":3,
+		"parent":"` + root.ID + `",
+		"labels":["mc-live-contract","sibling"],
+		"metadata":{"mc.contract.run_id":"run-1"}
+	}`)
+
+	postOK("/bead/"+child.ID+"/update", `{
+		"parent":"",
+		"status":"in_progress",
+		"labels":["verified"],
+		"remove_labels":["needs-update"],
+		"metadata":{"mc.contract.updated":"true"},
+		"type":"bug",
+		"priority":4
+	}`)
+	postOK("/bead/"+child.ID+"/update", `{
+		"parent":"`+root.ID+`",
+		"metadata":{"mc.contract.parent_restored":"true"}
+	}`)
+
+	getBead := httptest.NewRecorder()
+	h.ServeHTTP(getBead, httptest.NewRequest("GET", cityURL(state, "/bead/")+child.ID, nil))
+	if getBead.Code != http.StatusOK {
+		t.Fatalf("get child status = %d, want %d; body: %s", getBead.Code, http.StatusOK, getBead.Body.String())
+	}
+	var restored beads.Bead
+	if err := json.NewDecoder(getBead.Body).Decode(&restored); err != nil {
+		t.Fatalf("decode restored child: %v", err)
+	}
+	if restored.ParentID != root.ID {
+		t.Fatalf("restored child parent = %q, want %q", restored.ParentID, root.ID)
+	}
+
+	depsRec := httptest.NewRecorder()
+	h.ServeHTTP(depsRec, httptest.NewRequest("GET", cityURL(state, "/bead/")+root.ID+"/deps", nil))
+	if depsRec.Code != http.StatusOK {
+		t.Fatalf("deps status = %d, want %d; body: %s", depsRec.Code, http.StatusOK, depsRec.Body.String())
+	}
+	var deps BeadDepsResponse
+	if err := json.NewDecoder(depsRec.Body).Decode(&deps); err != nil {
+		t.Fatalf("decode deps: %v", err)
+	}
+	if !containsID(deps.Children, child.ID) {
+		t.Fatalf("deps children = %#v, want child %s", deps.Children, child.ID)
+	}
+
+	graphRec := httptest.NewRecorder()
+	h.ServeHTTP(graphRec, httptest.NewRequest("GET", cityURL(state, "/beads/graph/")+root.ID, nil))
+	if graphRec.Code != http.StatusOK {
+		t.Fatalf("graph status = %d, want %d; body: %s", graphRec.Code, http.StatusOK, graphRec.Body.String())
+	}
+	var graph BeadGraphResponse
+	if err := json.NewDecoder(graphRec.Body).Decode(&graph); err != nil {
+		t.Fatalf("decode graph: %v", err)
+	}
+	if !containsID(graph.Beads, child.ID) || !containsID(graph.Beads, sibling.ID) {
+		t.Fatalf("graph beads = %#v, want child %s and sibling %s", graph.Beads, child.ID, sibling.ID)
+	}
+
+	listRec := httptest.NewRecorder()
+	h.ServeHTTP(listRec, httptest.NewRequest("GET", cityURL(state, "/beads?label=mc-live-contract&limit=50&rig=alpha"), nil))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d; body: %s", listRec.Code, http.StatusOK, listRec.Body.String())
+	}
+	var list struct {
+		Items []beads.Bead `json:"items"`
+		Total int          `json:"total"`
+	}
+	if err := json.NewDecoder(listRec.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if list.Total < 3 || !containsID(list.Items, root.ID) || !containsID(list.Items, sibling.ID) {
+		t.Fatalf("filtered beads = %+v, want root %s and sibling %s", list, root.ID, sibling.ID)
+	}
+}
+
 func TestBeadDepsUsesRoutePrefixStore(t *testing.T) {
 	state, alphaStore, betaStore := configureBeadRouteState(t)
 	parent, err := betaStore.Create(beads.Bead{Title: "Parent"})

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -378,6 +378,14 @@ func (p *blockingNudgeProvider) Nudge(name string, content []runtime.ContentBloc
 	return p.Fake.Nudge(name, content)
 }
 
+type pendingSessionMissingProvider struct {
+	*runtime.Fake
+}
+
+func (p *pendingSessionMissingProvider) Pending(_ string) (*runtime.PendingInteraction, error) {
+	return nil, fmt.Errorf("capturing pane: %w", runtime.ErrSessionNotFound)
+}
+
 type stateWithSessionProvider struct {
 	*fakeState
 	provider runtime.Provider
@@ -2096,6 +2104,44 @@ func TestHandleSessionCreateAsync(t *testing.T) {
 	}
 	if fs.pokeCount != 1 {
 		t.Fatalf("pokeCount = %d, want 1", fs.pokeCount)
+	}
+}
+
+func TestHandleSessionCreateAsyncResultIsCommandable(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	body := `{"kind":"agent","name":"myrig/worker","alias":"commandable","async":true}`
+	req := newPostRequest(cityURL(fs, "/sessions"), strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("create status = %d, want %d; body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	accepted := decodeAsyncAccepted(t, rec.Body)
+	success, failure := waitForSessionCreateResult(t, fs.eventProv, accepted.RequestID)
+	if success == nil {
+		t.Fatalf("session create failed: %s: %s", failure.ErrorCode, failure.ErrorMessage)
+	}
+	if success.Session.State == string(session.StateCreating) {
+		t.Fatalf("session create result state = %q, want commandable state", success.Session.State)
+	}
+
+	suspendReq := newPostRequest(cityURL(fs, "/session/")+success.Session.ID+"/suspend", nil)
+	suspendRec := httptest.NewRecorder()
+	h.ServeHTTP(suspendRec, suspendReq)
+
+	if suspendRec.Code != http.StatusOK {
+		t.Fatalf("suspend status = %d, want %d; body: %s", suspendRec.Code, http.StatusOK, suspendRec.Body.String())
+	}
+	bead, err := fs.cityBeadStore.Get(success.Session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", success.Session.ID, err)
+	}
+	if got := bead.Metadata["state"]; got != string(session.StateSuspended) {
+		t.Fatalf("state after suspend = %q, want %q", got, session.StateSuspended)
 	}
 }
 
@@ -4244,6 +4290,46 @@ func TestHandleSessionPendingAndRespond(t *testing.T) {
 	}
 	if got := fs.sp.Responses[info.SessionName]; len(got) != 1 || got[0].Action != "approve" {
 		t.Fatalf("responses = %#v, want single approve", got)
+	}
+}
+
+func TestHandleSessionPendingReturnsEmptyWhenRuntimeSessionMissing(t *testing.T) {
+	fs := newSessionFakeState(t)
+	info := createTestSession(t, fs.cityBeadStore, fs.sp, "Interactive")
+	state := &stateWithSessionProvider{
+		fakeState: fs,
+		provider:  &pendingSessionMissingProvider{Fake: fs.sp},
+	}
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID+"/pending", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pending status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var pendingResp sessionPendingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&pendingResp); err != nil {
+		t.Fatalf("decode pending: %v", err)
+	}
+	if !pendingResp.Supported {
+		t.Fatalf("Supported = false, want true for interaction-capable provider")
+	}
+	if pendingResp.Pending != nil {
+		t.Fatalf("Pending = %#v, want nil when runtime session is gone", pendingResp.Pending)
+	}
+
+	respondReq := newPostRequest(cityURL(fs, "/session/")+info.ID+"/respond", strings.NewReader(`{"action":"approve"}`))
+	respondRec := httptest.NewRecorder()
+	h.ServeHTTP(respondRec, respondReq)
+
+	if respondRec.Code != http.StatusConflict {
+		t.Fatalf("respond status = %d, want %d; body: %s", respondRec.Code, http.StatusConflict, respondRec.Body.String())
+	}
+	if !strings.Contains(respondRec.Body.String(), "no_pending") {
+		t.Fatalf("respond body = %q, want no_pending problem", respondRec.Body.String())
 	}
 }
 

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -2145,10 +2145,14 @@ func TestHandleSessionCreateAsyncResultIsCommandable(t *testing.T) {
 	}
 }
 
-func TestHandleSessionCreateAsyncEmitsBeforeMetadataPersistenceCompletes(t *testing.T) {
+func TestHandleSessionCreateAsyncEmitsBeforeOptionalMetadataPersistenceCompletes(t *testing.T) {
 	fs := newSessionFakeState(t)
 	blocking := &blockingSetMetadataBatchStore{
-		Store:   fs.cityBeadStore,
+		Store: fs.cityBeadStore,
+		shouldBlock: func(kvs map[string]string) bool {
+			return kvs["real_world_app_session_kind"] == "agent" &&
+				kvs["real_world_app_project_id"] == "myrig"
+		},
 		entered: make(chan struct{}),
 		release: make(chan struct{}),
 	}
@@ -2190,14 +2194,17 @@ func TestHandleSessionCreateAsyncEmitsBeforeMetadataPersistenceCompletes(t *test
 
 type blockingSetMetadataBatchStore struct {
 	beads.Store
-	entered chan struct{}
-	release chan struct{}
-	once    sync.Once
+	shouldBlock func(map[string]string) bool
+	entered     chan struct{}
+	release     chan struct{}
+	once        sync.Once
 }
 
 func (s *blockingSetMetadataBatchStore) SetMetadataBatch(id string, kvs map[string]string) error {
-	s.once.Do(func() { close(s.entered) })
-	<-s.release
+	if s.shouldBlock != nil && s.shouldBlock(kvs) {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
 	return s.Store.SetMetadataBatch(id, kvs)
 }
 

--- a/internal/api/huma_handlers_events.go
+++ b/internal/api/huma_handlers_events.go
@@ -138,6 +138,14 @@ func (s *Server) streamEvents(hctx huma.Context, input *EventStreamInput, send s
 	ctx := hctx.Context()
 	ep := s.state.EventProvider()
 	afterSeq := input.resolveAfterSeq()
+	if strings.TrimSpace(input.LastEventID) == "" && strings.TrimSpace(input.AfterSeq) == "" {
+		seq, err := ep.LatestSeq()
+		if err != nil {
+			log.Printf("api: events-stream: latest seq failed: %v", err)
+		} else {
+			afterSeq = seq
+		}
+	}
 	watcher, err := ep.Watch(ctx, afterSeq)
 	if err != nil {
 		log.Printf("api: events-stream: Watch failed after_seq=%d: %v", afterSeq, err)

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -25,7 +25,14 @@ import (
 // respond, suspend, close, wake, rename). Split out of huma_handlers_sessions.go
 // to isolate mutation logic from reads and streaming.
 
-var sessionMessageAsyncTimeout = sessionMessageTimeout
+var (
+	sessionMessageAsyncTimeout      = sessionMessageTimeout
+	sessionCreateCommandableTimeout = 120 * time.Second
+)
+
+type sessionCommandableWaiter interface {
+	WaitForSessionCommandable(context.Context, string) (session.Info, error)
+}
 
 func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCreateInput) (*SessionCreateOutput, error) {
 	store := s.state.CityBeadStore()
@@ -119,7 +126,10 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
-	eventCursor := s.currentCityEventCursor()
+	eventCursor, cursorErr := s.currentCityEventCursor()
+	if cursorErr != nil {
+		return nil, huma.Error500InternalServerError(cursorErr.Error())
+	}
 
 	go func() {
 		defer s.recoverAsRequestFailed(reqID, RequestOperationSessionCreate)
@@ -153,6 +163,11 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 			return
 		}
 		var info session.Info
+		createMode := worker.CreateModeStarted
+		waiter, waitForCommandable := s.state.(sessionCommandableWaiter)
+		if waitForCommandable {
+			createMode = worker.CreateModeDeferred
+		}
 		reservationIDs := []string{alias, explicitName}
 		reserveConcreteIdentity := agentCfg.SupportsMultipleSessions() && strings.TrimSpace(workDirQualifiedName) != ""
 		if reserveConcreteIdentity {
@@ -171,19 +186,31 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 				return nameErr
 			}
 			var err error
-			info, err = handle.Create(context.Background(), worker.CreateModeStarted)
+			info, err = handle.Create(context.Background(), createMode)
 			return err
 		})
 		if createErr != nil {
 			s.emitSessionCreateFailed(reqID, "create_failed", createErr.Error())
 			return
 		}
+		if waitForCommandable {
+			s.state.Poke()
+			waitCtx, cancel := context.WithTimeout(context.Background(), sessionCreateCommandableTimeout)
+			info, createErr = waiter.WaitForSessionCommandable(waitCtx, info.ID)
+			cancel()
+			if createErr != nil {
+				s.emitSessionCreateFailed(reqID, "create_failed", createErr.Error())
+				return
+			}
+		}
 
 		resp := sessionToResponse(info, s.state.Config())
 		resp.Kind = "agent"
 		s.emitSessionCreateSucceeded(reqID, resp)
 		s.persistSessionMeta(store, info.ID, "agent", body.ProjectID, nil)
-		s.state.Poke()
+		if !waitForCommandable {
+			s.state.Poke()
+		}
 
 		titleProvider := s.resolveTitleProvider()
 		MaybeGenerateTitleAsync(store, info.ID, body.Title, body.Message, titleProvider, info.WorkDir, func(format string, args ...any) {
@@ -286,7 +313,10 @@ func (s *Server) humaCreateProviderSession(_ context.Context, store beads.Store,
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
-	eventCursor := s.currentCityEventCursor()
+	eventCursor, cursorErr := s.currentCityEventCursor()
+	if cursorErr != nil {
+		return nil, huma.Error500InternalServerError(cursorErr.Error())
+	}
 	go func() {
 		defer s.recoverAsRequestFailed(reqID, RequestOperationSessionCreate)
 		resolvedCfg, cfgErr := resolvedSessionConfigForProvider(alias, "", template, title, transport, extraMeta, resolved, command, workDir, mcpServers)
@@ -443,7 +473,10 @@ func (s *Server) humaHandleSessionSubmit(_ context.Context, input *SessionSubmit
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
-	eventCursor := s.currentCityEventCursor()
+	eventCursor, cursorErr := s.currentCityEventCursor()
+	if cursorErr != nil {
+		return nil, huma.Error500InternalServerError(cursorErr.Error())
+	}
 	message := input.Body.Message
 	sessionTarget := input.ID
 	go func() {
@@ -482,7 +515,10 @@ func (s *Server) humaHandleSessionMessage(_ context.Context, input *SessionMessa
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
-	eventCursor := s.currentCityEventCursor()
+	eventCursor, cursorErr := s.currentCityEventCursor()
+	if cursorErr != nil {
+		return nil, huma.Error500InternalServerError(cursorErr.Error())
+	}
 	message := input.Body.Message
 	sessionTarget := input.ID
 	go func() {

--- a/internal/api/huma_handlers_sessions_command.go
+++ b/internal/api/huma_handlers_sessions_command.go
@@ -119,6 +119,7 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
+	eventCursor := s.currentCityEventCursor()
 
 	go func() {
 		defer s.recoverAsRequestFailed(reqID, RequestOperationSessionCreate)
@@ -170,7 +171,7 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 				return nameErr
 			}
 			var err error
-			info, err = handle.Create(context.Background(), worker.CreateModeDeferred)
+			info, err = handle.Create(context.Background(), worker.CreateModeStarted)
 			return err
 		})
 		if createErr != nil {
@@ -193,6 +194,7 @@ func (s *Server) humaHandleSessionCreate(ctx context.Context, input *SessionCrea
 	out := &SessionCreateOutput{Status: http.StatusAccepted}
 	out.Body.Status = "accepted"
 	out.Body.RequestID = reqID
+	out.Body.EventCursor = eventCursor
 	return out, nil
 }
 
@@ -284,6 +286,7 @@ func (s *Server) humaCreateProviderSession(_ context.Context, store beads.Store,
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
+	eventCursor := s.currentCityEventCursor()
 	go func() {
 		defer s.recoverAsRequestFailed(reqID, RequestOperationSessionCreate)
 		resolvedCfg, cfgErr := resolvedSessionConfigForProvider(alias, "", template, title, transport, extraMeta, resolved, command, workDir, mcpServers)
@@ -333,6 +336,7 @@ func (s *Server) humaCreateProviderSession(_ context.Context, store beads.Store,
 	out := &SessionCreateOutput{Status: http.StatusAccepted}
 	out.Body.Status = "accepted"
 	out.Body.RequestID = reqID
+	out.Body.EventCursor = eventCursor
 	return out, nil
 }
 
@@ -439,6 +443,7 @@ func (s *Server) humaHandleSessionSubmit(_ context.Context, input *SessionSubmit
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
+	eventCursor := s.currentCityEventCursor()
 	message := input.Body.Message
 	sessionTarget := input.ID
 	go func() {
@@ -459,6 +464,7 @@ func (s *Server) humaHandleSessionSubmit(_ context.Context, input *SessionSubmit
 	out := &SessionSubmitOutput{}
 	out.Body.Status = "accepted"
 	out.Body.RequestID = reqID
+	out.Body.EventCursor = eventCursor
 	return out, nil
 }
 
@@ -476,6 +482,7 @@ func (s *Server) humaHandleSessionMessage(_ context.Context, input *SessionMessa
 	if reqIDErr != nil {
 		return nil, huma.Error500InternalServerError(reqIDErr.Error())
 	}
+	eventCursor := s.currentCityEventCursor()
 	message := input.Body.Message
 	sessionTarget := input.ID
 	go func() {
@@ -555,6 +562,7 @@ func (s *Server) humaHandleSessionMessage(_ context.Context, input *SessionMessa
 	out := &SessionMessageOutput{}
 	out.Body.Status = "accepted"
 	out.Body.RequestID = reqID
+	out.Body.EventCursor = eventCursor
 	return out, nil
 }
 

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -86,7 +86,7 @@ type cityCreateRequest struct {
 // request_id. Polling is unnecessary.
 type asyncAcceptedResponse struct {
 	RequestID   string `json:"request_id" doc:"Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id."`
-	EventCursor string `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog."`
+	EventCursor string `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty."`
 }
 
 // SupervisorCityCreateInput is the input for POST /v0/city.
@@ -354,7 +354,10 @@ func (sm *SupervisorMux) humaHandleCityCreate(ctx context.Context, input *Superv
 	if err != nil {
 		return nil, huma.Error500InternalServerError(fmt.Sprintf("generating request ID: %v", err))
 	}
-	eventCursor := sm.currentSupervisorEventCursor()
+	eventCursor, cursorErr := sm.currentSupervisorEventCursor()
+	if cursorErr != nil {
+		return nil, huma.Error500InternalServerError(cursorErr.Error())
+	}
 	pendingStored := false
 	if store, ok := sm.resolver.(PendingRequestStore); ok {
 		if err := store.StorePendingRequestID(dir, reqID); err != nil {
@@ -510,7 +513,10 @@ func (sm *SupervisorMux) humaHandleCityUnregister(ctx context.Context, input *Su
 	if err != nil {
 		return nil, huma.Error500InternalServerError(fmt.Sprintf("generating request ID: %v", err))
 	}
-	eventCursor := sm.currentSupervisorEventCursor()
+	eventCursor, cursorErr := sm.currentSupervisorEventCursor()
+	if cursorErr != nil {
+		return nil, huma.Error500InternalServerError(cursorErr.Error())
+	}
 
 	// Store the pending request_id BEFORE Unregister triggers a
 	// reconciler reload, so the reconciler can correlate the
@@ -648,6 +654,10 @@ func (sm *SupervisorMux) currentSupervisorEventTotal() int {
 	if err != nil {
 		log.Printf("api: supervisor events total: %v", err)
 	}
+	// This optimized unfiltered total treats LatestSeq as an event count because
+	// event logs are append-only, gap-free, and unpruned today. Any future
+	// retention/pruning/compaction must replace this path with an explicit count
+	// API.
 	const maxInt = int(^uint(0) >> 1)
 	total := 0
 	for _, seq := range cursors {
@@ -659,16 +669,20 @@ func (sm *SupervisorMux) currentSupervisorEventTotal() int {
 	return total
 }
 
-func (sm *SupervisorMux) currentSupervisorEventCursor() string {
+func (sm *SupervisorMux) currentSupervisorEventCursor() (string, error) {
 	mux := sm.buildMultiplexer()
 	cursors, err := mux.LatestCursor()
 	if err != nil {
-		log.Printf("api: supervisor events cursor: %v", err)
+		// Async supervisor writes need a complete pre-acceptance cursor for all
+		// cities. List and stream paths may degrade with partial cursors, but
+		// this path fails before accepting the request so clients never wait from
+		// an ambiguous cursor.
+		return "", fmt.Errorf("capturing supervisor event cursor: %w", err)
 	}
 	if cursor := events.FormatCursor(cursors); cursor != "" {
-		return cursor
+		return cursor, nil
 	}
-	return "0"
+	return "0", nil
 }
 
 // --- Supervisor global events stream (Fix 3g final wiring) ---

--- a/internal/api/huma_handlers_supervisor.go
+++ b/internal/api/huma_handlers_supervisor.go
@@ -85,7 +85,8 @@ type cityCreateRequest struct {
 // request.result.city.create or request.failed with the returned
 // request_id. Polling is unnecessary.
 type asyncAcceptedResponse struct {
-	RequestID string `json:"request_id" doc:"Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id."`
+	RequestID   string `json:"request_id" doc:"Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id."`
+	EventCursor string `json:"event_cursor" doc:"Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog."`
 }
 
 // SupervisorCityCreateInput is the input for POST /v0/city.
@@ -141,8 +142,8 @@ type SupervisorEventListOutput struct {
 
 // SupervisorEventStreamInput is the input for GET /v0/events/stream (supervisor scope).
 type SupervisorEventStreamInput struct {
-	LastEventID string `header:"Last-Event-ID" required:"false" doc:"Reconnect cursor (composite per-city cursor)."`
-	AfterCursor string `query:"after_cursor" required:"false" doc:"Alternative to Last-Event-ID for browsers that can't set custom headers."`
+	LastEventID string `header:"Last-Event-ID" required:"false" doc:"Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head."`
+	AfterCursor string `query:"after_cursor" required:"false" doc:"Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head."`
 }
 
 // --- Huma API setup ---
@@ -219,6 +220,7 @@ func (sm *SupervisorMux) registerSupervisorRoutes() {
 		Method:      http.MethodGet,
 		Path:        "/v0/events/stream",
 		Summary:     "Stream tagged events from all running cities.",
+		Description: "Server-Sent Events stream of supervisor-tagged events. Supports reconnection via Last-Event-ID header or after_cursor query param; omitting both starts at the current supervisor event head.",
 	}, map[string]any{
 		"tagged_event": sseEventContract{
 			runtimeSample: &taggedEventStreamEnvelope{},
@@ -352,6 +354,7 @@ func (sm *SupervisorMux) humaHandleCityCreate(ctx context.Context, input *Superv
 	if err != nil {
 		return nil, huma.Error500InternalServerError(fmt.Sprintf("generating request ID: %v", err))
 	}
+	eventCursor := sm.currentSupervisorEventCursor()
 	pendingStored := false
 	if store, ok := sm.resolver.(PendingRequestStore); ok {
 		if err := store.StorePendingRequestID(dir, reqID); err != nil {
@@ -399,7 +402,7 @@ func (sm *SupervisorMux) humaHandleCityCreate(ctx context.Context, input *Superv
 	out := &SupervisorCityCreateOutput{
 		Status: http.StatusAccepted,
 	}
-	out.Body = asyncAcceptedResponse{RequestID: reqID}
+	out.Body = asyncAcceptedResponse{RequestID: reqID, EventCursor: eventCursor}
 	return out, nil
 }
 
@@ -507,6 +510,7 @@ func (sm *SupervisorMux) humaHandleCityUnregister(ctx context.Context, input *Su
 	if err != nil {
 		return nil, huma.Error500InternalServerError(fmt.Sprintf("generating request ID: %v", err))
 	}
+	eventCursor := sm.currentSupervisorEventCursor()
 
 	// Store the pending request_id BEFORE Unregister triggers a
 	// reconciler reload, so the reconciler can correlate the
@@ -549,7 +553,7 @@ func (sm *SupervisorMux) humaHandleCityUnregister(ctx context.Context, input *Su
 	}
 
 	out := &SupervisorCityUnregisterOutput{Status: http.StatusAccepted}
-	out.Body = cityUnregisterResponse{RequestID: reqID}
+	out.Body = cityUnregisterResponse{RequestID: reqID, EventCursor: eventCursor}
 	return out, nil
 }
 
@@ -598,7 +602,14 @@ func (sm *SupervisorMux) humaHandleEventList(_ context.Context, input *Superviso
 	} else if ok {
 		filter.Since = time.Now().Add(-d)
 	}
-	evts, err := mux.ListAll(filter)
+	var evts []events.TaggedEvent
+	var err error
+	optimizedTail := input.Limit > 0 && supervisorEventListFilterIsEmpty(filter)
+	if optimizedTail {
+		evts, err = mux.ListTail(filter, input.Limit)
+	} else {
+		evts, err = mux.ListAll(filter)
+	}
 	if err != nil {
 		return nil, huma.Error500InternalServerError("internal: " + err.Error())
 	}
@@ -614,14 +625,50 @@ func (sm *SupervisorMux) humaHandleEventList(_ context.Context, input *Superviso
 	// Total is the full match count so clients can distinguish "limit
 	// truncated" from "the server only had N events."
 	out.Body.Total = len(wires)
+	if optimizedTail {
+		out.Body.Total = sm.currentSupervisorEventTotal()
+	}
 	// Limit clamp: take the N most recent events (wires is already
 	// chronologically ordered). Critical for `gc events --seq` which
 	// computes the head cursor from the last event only.
-	if input.Limit > 0 && input.Limit < len(wires) {
+	if !optimizedTail && input.Limit > 0 && input.Limit < len(wires) {
 		wires = wires[len(wires)-input.Limit:]
 	}
 	out.Body.Items = wires
 	return out, nil
+}
+
+func supervisorEventListFilterIsEmpty(filter events.Filter) bool {
+	return filter.Type == "" && filter.Actor == "" && filter.Since.IsZero() && filter.AfterSeq == 0
+}
+
+func (sm *SupervisorMux) currentSupervisorEventTotal() int {
+	mux := sm.buildMultiplexer()
+	cursors, err := mux.LatestCursor()
+	if err != nil {
+		log.Printf("api: supervisor events total: %v", err)
+	}
+	const maxInt = int(^uint(0) >> 1)
+	total := 0
+	for _, seq := range cursors {
+		if seq > uint64(maxInt-total) {
+			return maxInt
+		}
+		total += int(seq)
+	}
+	return total
+}
+
+func (sm *SupervisorMux) currentSupervisorEventCursor() string {
+	mux := sm.buildMultiplexer()
+	cursors, err := mux.LatestCursor()
+	if err != nil {
+		log.Printf("api: supervisor events cursor: %v", err)
+	}
+	if cursor := events.FormatCursor(cursors); cursor != "" {
+		return cursor
+	}
+	return "0"
 }
 
 // --- Supervisor global events stream (Fix 3g final wiring) ---
@@ -667,12 +714,21 @@ func (sm *SupervisorMux) streamGlobalEvents(hctx huma.Context, input *Supervisor
 	if cursor == "" {
 		cursor = strings.TrimSpace(input.AfterCursor)
 	}
-	cursors := events.ParseCursor(cursor)
+
+	mux := sm.buildMultiplexer()
+	var cursors map[string]uint64
+	if cursor == "" {
+		var err error
+		cursors, err = mux.LatestCursor()
+		if err != nil {
+			log.Printf("api: supervisor events-stream: latest cursor failed: %v", err)
+		}
+	} else {
+		cursors = events.ParseCursor(cursor)
+	}
 	if cursors == nil {
 		cursors = make(map[string]uint64)
 	}
-
-	mux := sm.buildMultiplexer()
 	mw, err := mux.Watch(hctx.Context(), cursors)
 	if err != nil {
 		log.Printf("api: supervisor events-stream: Watch failed cursors=%v: %v", cursors, err)

--- a/internal/api/huma_handlers_supervisor_test.go
+++ b/internal/api/huma_handlers_supervisor_test.go
@@ -231,6 +231,41 @@ func TestSupervisorCityCreateReturnsRequestID(t *testing.T) {
 	}
 }
 
+func TestSupervisorCityCreateReturnsCurrentEventCursor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cityPath := filepath.Join(home, "mc-city")
+	recorder := events.NewFake()
+	recorder.Record(events.Event{Type: events.SessionWoke, Actor: "seed"})
+	resolver := &fakeCityResolver{
+		cities:             map[string]*fakeState{},
+		supervisorRecorder: recorder,
+	}
+	init := &fakeInitializer{
+		scaffoldResult: &cityinit.InitResult{
+			CityName:     "mc-city",
+			CityPath:     cityPath,
+			ProviderUsed: "codex",
+		},
+	}
+	sm := NewSupervisorMux(resolver, init, false, "test", time.Now())
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/city", strings.NewReader(`{"dir":"mc-city","provider":"codex"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "test")
+	rec := httptest.NewRecorder()
+
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	accepted := decodeAsyncAccepted(t, rec.Body)
+	if accepted.EventCursor != "__supervisor__:1" {
+		t.Fatalf("event_cursor = %q, want __supervisor__:1", accepted.EventCursor)
+	}
+}
+
 func TestSupervisorCityCreateStoresPendingRequestForReconciler(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -523,6 +558,35 @@ func TestSupervisorCityUnregisterUsesInitializer(t *testing.T) {
 	}
 	if body := rec.Body.String(); !strings.Contains(body, `"request_id"`) {
 		t.Fatalf("body = %s, want request_id", body)
+	}
+}
+
+func TestSupervisorCityUnregisterReturnsCurrentEventCursor(t *testing.T) {
+	recorder := events.NewFake()
+	recorder.Record(events.Event{Type: events.SessionWoke, Actor: "seed"})
+	resolver := &fakeCityResolver{
+		cities:             map[string]*fakeState{},
+		supervisorRecorder: recorder,
+	}
+	init := &fakeInitializer{
+		unregisterResult: &cityinit.UnregisterResult{
+			CityName: "mc-city",
+			CityPath: "/tmp/mc-city",
+		},
+	}
+	sm := NewSupervisorMux(resolver, init, false, "test", time.Now())
+	req := httptest.NewRequest(http.MethodPost, "/v0/city/mc-city/unregister", nil)
+	req.Header.Set("X-GC-Request", "test")
+	rec := httptest.NewRecorder()
+
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	accepted := decodeAsyncAccepted(t, rec.Body)
+	if accepted.EventCursor != "__supervisor__:1" {
+		t.Fatalf("event_cursor = %q, want __supervisor__:1", accepted.EventCursor)
 	}
 }
 

--- a/internal/api/huma_types_events.go
+++ b/internal/api/huma_types_events.go
@@ -44,8 +44,8 @@ type EventEmitOutput struct {
 // EventStreamInput is the Huma input for GET /v0/city/{cityName}/events/stream.
 type EventStreamInput struct {
 	CityScope
-	AfterSeq    string `query:"after_seq" required:"false" doc:"Reconnect position: only deliver events after this sequence number."`
-	LastEventID string `header:"Last-Event-ID" required:"false" doc:"SSE reconnect position from the last received event ID."`
+	AfterSeq    string `query:"after_seq" required:"false" doc:"Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head."`
+	LastEventID string `header:"Last-Event-ID" required:"false" doc:"SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head."`
 }
 
 // HeartbeatEvent is an empty event emitted periodically on SSE streams to keep

--- a/internal/api/huma_types_sessions.go
+++ b/internal/api/huma_types_sessions.go
@@ -62,7 +62,7 @@ type SessionCreateInput struct {
 type asyncAcceptedBody struct {
 	Status      string `json:"status" doc:"Async request status." example:"accepted"`
 	RequestID   string `json:"request_id" doc:"Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id."`
-	EventCursor string `json:"event_cursor" doc:"City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog."`
+	EventCursor string `json:"event_cursor" doc:"City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty."`
 }
 
 // SessionCreateOutput is the Huma output for POST /v0/sessions.

--- a/internal/api/huma_types_sessions.go
+++ b/internal/api/huma_types_sessions.go
@@ -60,8 +60,9 @@ type SessionCreateInput struct {
 
 // asyncAcceptedBody is the response body for all async session 202 responses.
 type asyncAcceptedBody struct {
-	Status    string `json:"status" doc:"Async request status." example:"accepted"`
-	RequestID string `json:"request_id" doc:"Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id."`
+	Status      string `json:"status" doc:"Async request status." example:"accepted"`
+	RequestID   string `json:"request_id" doc:"Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id."`
+	EventCursor string `json:"event_cursor" doc:"City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog."`
 }
 
 // SessionCreateOutput is the Huma output for POST /v0/sessions.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -728,7 +728,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or the event log is empty.",
             "type": "string"
           },
           "request_id": {
@@ -754,7 +754,7 @@
         "additionalProperties": false,
         "properties": {
           "event_cursor": {
-            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog. A value of 0 can also mean no event provider is configured or every event log is empty.",
             "type": "string"
           },
           "request_id": {

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -727,6 +727,10 @@
       "AsyncAcceptedBody": {
         "additionalProperties": false,
         "properties": {
+          "event_cursor": {
+            "description": "City event-stream sequence captured before the async request was accepted. Pass this value as after_seq to /v0/city/{cityName}/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "type": "string"
+          },
           "request_id": {
             "description": "Correlation ID. Watch the city event stream for request.result.session.create, request.result.session.message, request.result.session.submit, or request.failed with this request_id.",
             "type": "string"
@@ -741,20 +745,26 @@
         },
         "required": [
           "status",
-          "request_id"
+          "request_id",
+          "event_cursor"
         ],
         "type": "object"
       },
       "AsyncAcceptedResponse": {
         "additionalProperties": false,
         "properties": {
+          "event_cursor": {
+            "description": "Supervisor event-stream cursor captured before the async request was accepted. Pass this value as after_cursor to /v0/events/stream to receive the request result without replaying unrelated historical backlog.",
+            "type": "string"
+          },
           "request_id": {
             "description": "Correlation ID. Watch /v0/events/stream for request.result.city.create, request.result.city.unregister, or request.failed with this request_id.",
             "type": "string"
           }
         },
         "required": [
-          "request_id"
+          "request_id",
+          "event_cursor"
         ],
         "type": "object"
       },
@@ -5632,7 +5642,7 @@
           },
           "session": {
             "$ref": "#/components/schemas/SessionResponse",
-            "description": "Full session state as returned by GET /session/{id}."
+            "description": "Full session state as returned by GET /session/{id}. For session.create, this result is emitted only after the session has left creating and can accept normal metadata and lifecycle commands."
           }
         },
         "required": [
@@ -15150,7 +15160,7 @@
     },
     "/v0/city/{cityName}/events/stream": {
       "get": {
-        "description": "Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param.",
+        "description": "Server-Sent Events stream of city events with optional workflow projections. Supports reconnection via Last-Event-ID header or after_seq query param; omitting both starts at the current city event head.",
         "operationId": "stream-events",
         "parameters": [
           {
@@ -15166,21 +15176,21 @@
             }
           },
           {
-            "description": "Reconnect position: only deliver events after this sequence number.",
+            "description": "Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.",
             "explode": false,
             "in": "query",
             "name": "after_seq",
             "schema": {
-              "description": "Reconnect position: only deliver events after this sequence number.",
+              "description": "Reconnect position: only deliver events after this sequence number. Omit after_seq and Last-Event-ID to start at the current city event head.",
               "type": "string"
             }
           },
           {
-            "description": "SSE reconnect position from the last received event ID.",
+            "description": "SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.",
             "in": "header",
             "name": "Last-Event-ID",
             "schema": {
-              "description": "SSE reconnect position from the last received event ID.",
+              "description": "SSE reconnect position from the last received event ID. Omit Last-Event-ID and after_seq to start at the current city event head.",
               "type": "string"
             }
           }
@@ -22745,24 +22755,25 @@
     },
     "/v0/events/stream": {
       "get": {
+        "description": "Server-Sent Events stream of supervisor-tagged events. Supports reconnection via Last-Event-ID header or after_cursor query param; omitting both starts at the current supervisor event head.",
         "operationId": "stream-supervisor-events",
         "parameters": [
           {
-            "description": "Reconnect cursor (composite per-city cursor).",
+            "description": "Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.",
             "in": "header",
             "name": "Last-Event-ID",
             "schema": {
-              "description": "Reconnect cursor (composite per-city cursor).",
+              "description": "Reconnect cursor (composite per-city cursor). Omit Last-Event-ID and after_cursor to start at the current supervisor event head.",
               "type": "string"
             }
           },
           {
-            "description": "Alternative to Last-Event-ID for browsers that can't set custom headers.",
+            "description": "Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.",
             "explode": false,
             "in": "query",
             "name": "after_cursor",
             "schema": {
-              "description": "Alternative to Last-Event-ID for browsers that can't set custom headers.",
+              "description": "Alternative to Last-Event-ID for browsers that can't set custom headers. Omit after_cursor and Last-Event-ID to start at the current supervisor event head.",
               "type": "string"
             }
           }

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -166,6 +166,21 @@ func TestAsyncAcceptedRequestIDDescriptionsNameTypedResultEvents(t *testing.T) {
 	assertDescription("AsyncAcceptedBody", "request.result.session.submit")
 	assertDescription("AsyncAcceptedResponse", "request.result.city.create")
 	assertDescription("AsyncAcceptedResponse", "request.result.city.unregister")
+
+	assertCursorDescription := func(schema, want string) {
+		t.Helper()
+		got := openAPI.Components.Schemas[schema].Properties["event_cursor"].Description
+		if !bytes.Contains([]byte(got), []byte(want)) {
+			t.Fatalf("%s event_cursor description = %q, want to mention %q", schema, got, want)
+		}
+	}
+	assertCursorDescription("AsyncAcceptedBody", "after_seq")
+	assertCursorDescription("AsyncAcceptedResponse", "after_cursor")
+
+	got := openAPI.Components.Schemas["SessionCreateSucceededPayload"].Properties["session"].Description
+	if !bytes.Contains([]byte(got), []byte("lifecycle commands")) {
+		t.Fatalf("SessionCreateSucceededPayload session description = %q, want to mention lifecycle commands", got)
+	}
 }
 
 func TestOrderResponseSchemaKeepsMigrationFieldsOptional(t *testing.T) {

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -176,6 +176,8 @@ func TestAsyncAcceptedRequestIDDescriptionsNameTypedResultEvents(t *testing.T) {
 	}
 	assertCursorDescription("AsyncAcceptedBody", "after_seq")
 	assertCursorDescription("AsyncAcceptedResponse", "after_cursor")
+	assertCursorDescription("AsyncAcceptedBody", "no event provider")
+	assertCursorDescription("AsyncAcceptedResponse", "no event provider")
 
 	got := openAPI.Components.Schemas["SessionCreateSucceededPayload"].Properties["session"].Description
 	if !bytes.Contains([]byte(got), []byte("lifecycle commands")) {

--- a/internal/api/request_id.go
+++ b/internal/api/request_id.go
@@ -19,17 +19,16 @@ func newRequestID() (string, error) {
 	return "req-" + hex.EncodeToString(b), nil
 }
 
-func (s *Server) currentCityEventCursor() string {
+func (s *Server) currentCityEventCursor() (string, error) {
 	ep := s.state.EventProvider()
 	if ep == nil {
-		return "0"
+		return "0", nil
 	}
 	seq, err := ep.LatestSeq()
 	if err != nil {
-		log.Printf("api: city events cursor: %v", err)
-		return "0"
+		return "", fmt.Errorf("capturing city event cursor: %w", err)
 	}
-	return strconv.FormatUint(seq, 10)
+	return strconv.FormatUint(seq, 10), nil
 }
 
 // EmitTypedEvent records a typed async result event to the given recorder.

--- a/internal/api/request_id.go
+++ b/internal/api/request_id.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/gastownhall/gascity/internal/events"
 )
@@ -16,6 +17,19 @@ func newRequestID() (string, error) {
 		return "", fmt.Errorf("generating request ID: %w", err)
 	}
 	return "req-" + hex.EncodeToString(b), nil
+}
+
+func (s *Server) currentCityEventCursor() string {
+	ep := s.state.EventProvider()
+	if ep == nil {
+		return "0"
+	}
+	seq, err := ep.LatestSeq()
+	if err != nil {
+		log.Printf("api: city events cursor: %v", err)
+		return "0"
+	}
+	return strconv.FormatUint(seq, 10)
 }
 
 // EmitTypedEvent records a typed async result event to the given recorder.

--- a/internal/api/request_id_test.go
+++ b/internal/api/request_id_test.go
@@ -74,6 +74,37 @@ func TestRequestIDFromPayloadCoversAsyncPayloads(t *testing.T) {
 	}
 }
 
+func TestCurrentCityEventCursor(t *testing.T) {
+	t.Run("no provider", func(t *testing.T) {
+		fs := newFakeState(t)
+		fs.eventProv = nil
+		srv := &Server{state: fs}
+		if got := srv.currentCityEventCursor(); got != "0" {
+			t.Fatalf("currentCityEventCursor() = %q, want 0", got)
+		}
+	})
+
+	t.Run("latest seq", func(t *testing.T) {
+		fs := newFakeState(t)
+		ep := fs.eventProv.(*events.Fake)
+		ep.Record(events.Event{Type: events.SessionWoke, Actor: "test"})
+		ep.Record(events.Event{Type: events.SessionStopped, Actor: "test"})
+		srv := &Server{state: fs}
+		if got := srv.currentCityEventCursor(); got != "2" {
+			t.Fatalf("currentCityEventCursor() = %q, want 2", got)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		fs := newFakeState(t)
+		fs.eventProv = events.NewFailFake()
+		srv := &Server{state: fs}
+		if got := srv.currentCityEventCursor(); got != "0" {
+			t.Fatalf("currentCityEventCursor() = %q, want 0", got)
+		}
+	})
+}
+
 func TestEmitRequestFailedRecordsTypedPayload(t *testing.T) {
 	rec := events.NewFake()
 

--- a/internal/api/request_id_test.go
+++ b/internal/api/request_id_test.go
@@ -79,7 +79,11 @@ func TestCurrentCityEventCursor(t *testing.T) {
 		fs := newFakeState(t)
 		fs.eventProv = nil
 		srv := &Server{state: fs}
-		if got := srv.currentCityEventCursor(); got != "0" {
+		got, err := srv.currentCityEventCursor()
+		if err != nil {
+			t.Fatalf("currentCityEventCursor() error = %v", err)
+		}
+		if got != "0" {
 			t.Fatalf("currentCityEventCursor() = %q, want 0", got)
 		}
 	})
@@ -90,7 +94,11 @@ func TestCurrentCityEventCursor(t *testing.T) {
 		ep.Record(events.Event{Type: events.SessionWoke, Actor: "test"})
 		ep.Record(events.Event{Type: events.SessionStopped, Actor: "test"})
 		srv := &Server{state: fs}
-		if got := srv.currentCityEventCursor(); got != "2" {
+		got, err := srv.currentCityEventCursor()
+		if err != nil {
+			t.Fatalf("currentCityEventCursor() error = %v", err)
+		}
+		if got != "2" {
 			t.Fatalf("currentCityEventCursor() = %q, want 2", got)
 		}
 	})
@@ -99,8 +107,8 @@ func TestCurrentCityEventCursor(t *testing.T) {
 		fs := newFakeState(t)
 		fs.eventProv = events.NewFailFake()
 		srv := &Server{state: fs}
-		if got := srv.currentCityEventCursor(); got != "0" {
-			t.Fatalf("currentCityEventCursor() = %q, want 0", got)
+		if got, err := srv.currentCityEventCursor(); err == nil {
+			t.Fatalf("currentCityEventCursor() = %q, nil error; want provider error", got)
 		}
 	})
 }

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -310,7 +310,7 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		Path:        cityScopePrefix + "/events/stream",
 		Summary:     "Stream city events in real time",
 		Description: "Server-Sent Events stream of city events with optional workflow projections. " +
-			"Supports reconnection via Last-Event-ID header or after_seq query param.",
+			"Supports reconnection via Last-Event-ID header or after_seq query param; omitting both starts at the current city event head.",
 	}, map[string]any{
 		"event": sseEventContract{
 			runtimeSample: eventStreamEnvelope{},

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -1072,6 +1072,49 @@ func TestSupervisorGlobalEventStreamAfterCursorReplaysFromCursor(t *testing.T) {
 	}
 }
 
+func TestCurrentSupervisorEventCursorReturnsProviderErrors(t *testing.T) {
+	s := newFakeState(t)
+	s.cityName = "alpha"
+	s.eventProv = events.NewFailFake()
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"alpha": s,
+	})
+
+	if got, err := sm.currentSupervisorEventCursor(); err == nil {
+		t.Fatalf("currentSupervisorEventCursor() = %q, nil error; want provider error", got)
+	}
+}
+
+func TestCurrentSupervisorEventCursorIsStrictOnPartialProviderFailure(t *testing.T) {
+	healthy := newFakeState(t)
+	healthy.cityName = "alpha"
+	healthy.eventProv.(*events.Fake).Record(events.Event{
+		Type:    events.SessionWoke,
+		Actor:   "tester",
+		Subject: "healthy",
+	})
+	broken := newFakeState(t)
+	broken.cityName = "bravo"
+	broken.eventProv = events.NewFailFake()
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"alpha": healthy,
+		"bravo": broken,
+	})
+
+	got, err := sm.currentSupervisorEventCursor()
+	if err == nil {
+		t.Fatalf("currentSupervisorEventCursor() = %q, nil error; want strict partial-provider failure", got)
+	}
+	if got != "" {
+		t.Fatalf("currentSupervisorEventCursor() returned partial cursor %q with error; want empty cursor", got)
+	}
+	if !strings.Contains(err.Error(), "bravo") {
+		t.Fatalf("currentSupervisorEventCursor() error = %v, want broken city name", err)
+	}
+}
+
 func TestSupervisorGlobalEventStreamProjectsWorkflowMetadata(t *testing.T) {
 	s1 := newFakeState(t)
 	s1.cityName = "alpha"

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -491,6 +491,28 @@ func TestSupervisorPerCityEventStreamEmitsNoPayloadObject(t *testing.T) {
 	}
 }
 
+func TestSupervisorPerCityEventStreamWithoutCursorStartsAtHead(t *testing.T) {
+	s := newFakeState(t)
+	s.cityName = "gc-work"
+	ep := s.eventProv.(*events.Fake)
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "tester", Subject: "old"})
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"gc-work": s,
+	})
+
+	frame := firstSSEFrameAfterRecord(t, sm, "/v0/city/gc-work/events/stream", "event", func() {
+		ep.Record(events.Event{Type: events.SessionWoke, Actor: "tester", Subject: "new"})
+	})
+	if frame.ID != "2" {
+		t.Fatalf("SSE id = %q, want 2; body=%s", frame.ID, frame.Data)
+	}
+	data := decodeSSETestData(t, frame)
+	if data["subject"] != "new" {
+		t.Fatalf("data.subject = %v, want new; data=%v", data["subject"], data)
+	}
+}
+
 func TestSupervisorGlobalEventList(t *testing.T) {
 	s1 := newFakeState(t)
 	s1.cityName = "alpha"
@@ -664,6 +686,42 @@ func TestSupervisorGlobalEventListWithFilter(t *testing.T) {
 	}
 	if resp.Items[0].Type != events.SessionWoke {
 		t.Errorf("type = %q, want %q", resp.Items[0].Type, events.SessionWoke)
+	}
+}
+
+func TestSupervisorGlobalEventListLimitReturnsTail(t *testing.T) {
+	s1 := newFakeState(t)
+	s1.cityName = "alpha"
+	ep := s1.eventProv.(*events.Fake)
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "a1", Subject: "old"})
+	ep.Record(events.Event{Type: events.SessionStopped, Actor: "a1", Subject: "middle"})
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "a1", Subject: "new"})
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{"alpha": s1})
+
+	req := httptest.NewRequest("GET", "/v0/events?limit=1", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []events.TaggedEvent `json:"items"`
+		Total int                  `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Fatalf("total = %d, want 3", resp.Total)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(resp.Items))
+	}
+	if resp.Items[0].Subject != "new" {
+		t.Fatalf("subject = %q, want new", resp.Items[0].Subject)
 	}
 }
 
@@ -888,6 +946,28 @@ func TestSupervisorGlobalEventStreamEmitsNoPayloadObject(t *testing.T) {
 	payloadObject := assertJSONPayloadObject(t, data["payload"])
 	if len(payloadObject) != 0 {
 		t.Fatalf("data.payload = %v, want empty object for NoPayload", payloadObject)
+	}
+}
+
+func TestSupervisorGlobalEventStreamWithoutCursorStartsAtHead(t *testing.T) {
+	s := newFakeState(t)
+	s.cityName = "alpha"
+	ep := s.eventProv.(*events.Fake)
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "tester", Subject: "old"})
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"alpha": s,
+	})
+
+	frame := firstSSEFrameAfterRecord(t, sm, "/v0/events/stream", "tagged_event", func() {
+		ep.Record(events.Event{Type: events.SessionWoke, Actor: "tester", Subject: "new"})
+	})
+	if frame.ID != "alpha:2" {
+		t.Fatalf("SSE id = %q, want alpha:2; body=%s", frame.ID, frame.Data)
+	}
+	data := decodeSSETestData(t, frame)
+	if data["subject"] != "new" {
+		t.Fatalf("data.subject = %v, want new; data=%v", data["subject"], data)
 	}
 }
 

--- a/internal/api/supervisor_test.go
+++ b/internal/api/supervisor_test.go
@@ -725,6 +725,87 @@ func TestSupervisorGlobalEventListLimitReturnsTail(t *testing.T) {
 	}
 }
 
+func TestSupervisorGlobalEventListLimitReturnsTailAcrossCitiesWithHeadTotal(t *testing.T) {
+	s1 := newFakeState(t)
+	s1.cityName = "alpha"
+	alpha := s1.eventProv.(*events.Fake)
+	alpha.Record(events.Event{Type: events.SessionWoke, Actor: "a1", Subject: "alpha-old", Ts: time.Unix(1, 0)})
+	alpha.Record(events.Event{Type: events.SessionWoke, Actor: "a1", Subject: "alpha-new", Ts: time.Unix(4, 0)})
+
+	s2 := newFakeState(t)
+	s2.cityName = "beta"
+	beta := s2.eventProv.(*events.Fake)
+	beta.Record(events.Event{Type: events.SessionWoke, Actor: "b1", Subject: "beta-old", Ts: time.Unix(2, 0)})
+	beta.Record(events.Event{Type: events.SessionStopped, Actor: "b1", Subject: "beta-middle", Ts: time.Unix(3, 0)})
+	beta.Record(events.Event{Type: events.SessionWoke, Actor: "b1", Subject: "beta-new", Ts: time.Unix(5, 0)})
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"alpha": s1,
+		"beta":  s2,
+	})
+
+	req := httptest.NewRequest("GET", "/v0/events?limit=2", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []events.TaggedEvent `json:"items"`
+		Total int                  `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 5 {
+		t.Fatalf("total = %d, want 5", resp.Total)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(resp.Items))
+	}
+	if resp.Items[0].Subject != "alpha-new" || resp.Items[1].Subject != "beta-new" {
+		t.Fatalf("subjects = [%s %s], want [alpha-new beta-new]", resp.Items[0].Subject, resp.Items[1].Subject)
+	}
+}
+
+func TestSupervisorGlobalEventListLimitWithFilterReportsFilteredTotal(t *testing.T) {
+	s1 := newFakeState(t)
+	s1.cityName = "alpha"
+	ep := s1.eventProv.(*events.Fake)
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "a1", Subject: "old", Ts: time.Unix(1, 0)})
+	ep.Record(events.Event{Type: events.SessionStopped, Actor: "a1", Subject: "ignored", Ts: time.Unix(2, 0)})
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "a1", Subject: "new", Ts: time.Unix(3, 0)})
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{"alpha": s1})
+
+	req := httptest.NewRequest("GET", "/v0/events?type=session.woke&limit=1", nil)
+	rec := httptest.NewRecorder()
+	sm.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Items []events.TaggedEvent `json:"items"`
+		Total int                  `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Fatalf("total = %d, want 2 filtered matches", resp.Total)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(resp.Items))
+	}
+	if resp.Items[0].Subject != "new" {
+		t.Fatalf("subject = %q, want new", resp.Items[0].Subject)
+	}
+}
+
 func TestSupervisorGlobalEventListRejectsInvalidSince(t *testing.T) {
 	sm := newTestSupervisorMux(t, map[string]*fakeState{})
 
@@ -968,6 +1049,26 @@ func TestSupervisorGlobalEventStreamWithoutCursorStartsAtHead(t *testing.T) {
 	data := decodeSSETestData(t, frame)
 	if data["subject"] != "new" {
 		t.Fatalf("data.subject = %v, want new; data=%v", data["subject"], data)
+	}
+}
+
+func TestSupervisorGlobalEventStreamAfterCursorReplaysFromCursor(t *testing.T) {
+	s := newFakeState(t)
+	s.cityName = "alpha"
+	ep := s.eventProv.(*events.Fake)
+	ep.Record(events.Event{Type: events.SessionWoke, Actor: "tester", Subject: "old"})
+
+	sm := newTestSupervisorMux(t, map[string]*fakeState{
+		"alpha": s,
+	})
+
+	frame := firstSSEFrameAfterRecord(t, sm, "/v0/events/stream?after_cursor=alpha:0", "tagged_event", func() {})
+	if frame.ID != "alpha:1" {
+		t.Fatalf("SSE id = %q, want alpha:1; body=%s", frame.ID, frame.Data)
+	}
+	data := decodeSSETestData(t, frame)
+	if data["subject"] != "old" {
+		t.Fatalf("data.subject = %v, want old; data=%v", data["subject"], data)
 	}
 }
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -135,6 +135,12 @@ type Provider interface {
 	Close() error
 }
 
+// TailProvider is an optional extension for providers that can return the
+// trailing matching events without scanning or materializing the whole history.
+type TailProvider interface {
+	ListTail(filter Filter, limit int) ([]Event, error)
+}
+
 // Watcher yields events one at a time. Created by [Provider.Watch].
 // Callers must call Close() when done watching.
 type Watcher interface {

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -354,6 +354,38 @@ func TestFakeList(t *testing.T) {
 	}
 }
 
+func TestFakeListTailFiltersLimitModesAndErrors(t *testing.T) {
+	f := NewFake()
+	f.Record(Event{Type: BeadCreated, Actor: "human", Subject: "old"})
+	f.Record(Event{Type: BeadClosed, Actor: "human", Subject: "ignored"})
+	f.Record(Event{Type: BeadCreated, Actor: "human", Subject: "middle"})
+	f.Record(Event{Type: BeadCreated, Actor: "gc", Subject: "wrong-actor"})
+	f.Record(Event{Type: BeadCreated, Actor: "human", Subject: "new"})
+
+	tail, err := f.ListTail(Filter{Type: BeadCreated, Actor: "human"}, 2)
+	if err != nil {
+		t.Fatalf("ListTail(limit): %v", err)
+	}
+	if len(tail) != 2 {
+		t.Fatalf("ListTail(limit) got %d events, want 2", len(tail))
+	}
+	if tail[0].Subject != "middle" || tail[1].Subject != "new" {
+		t.Fatalf("tail subjects = [%s %s], want [middle new]", tail[0].Subject, tail[1].Subject)
+	}
+
+	all, err := f.ListTail(Filter{Type: BeadCreated, Actor: "human"}, 0)
+	if err != nil {
+		t.Fatalf("ListTail(limit=0): %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("ListTail(limit=0) got %d events, want 3", len(all))
+	}
+
+	if _, err := NewFailFake().ListTail(Filter{}, 1); err == nil {
+		t.Fatal("ListTail on broken fake returned nil error")
+	}
+}
+
 func TestFakeLatestSeq(t *testing.T) {
 	f := NewFake()
 	seq, err := f.LatestSeq()
@@ -613,6 +645,86 @@ func TestReadFilteredTail(t *testing.T) {
 	}
 }
 
+func TestReadFilteredTailScansBackwardsAcrossChunks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	base := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	appendEvent := func(e Event, ending string) {
+		t.Helper()
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(raw)
+		buf.WriteString(ending)
+	}
+
+	appendEvent(Event{Seq: 1, Type: SessionWoke, Actor: "api", Subject: "too-low-seq", Ts: base.Add(9 * time.Second)}, "\n")
+	appendEvent(Event{
+		Seq:     2,
+		Type:    SessionWoke,
+		Actor:   "api",
+		Subject: "cross-chunk",
+		Ts:      base.Add(10 * time.Second),
+		Message: string(bytes.Repeat([]byte("x"), 70*1024)),
+	}, "\n")
+	appendEvent(Event{Seq: 3, Type: SessionStopped, Actor: "api", Subject: "wrong-type", Ts: base.Add(11 * time.Second)}, "\n")
+	appendEvent(Event{Seq: 4, Type: SessionWoke, Actor: "worker", Subject: "wrong-actor", Ts: base.Add(12 * time.Second)}, "\n")
+	appendEvent(Event{Seq: 5, Type: SessionWoke, Actor: "api", Subject: "too-old", Ts: base.Add(-time.Second)}, "\n")
+	buf.WriteString("\nnot-json\n")
+	appendEvent(Event{Seq: 6, Type: SessionWoke, Actor: "api", Subject: "tail-match", Ts: base.Add(20 * time.Second)}, "\r\n")
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFilteredTail(path, Filter{
+		AfterSeq: 1,
+		Type:     SessionWoke,
+		Actor:    "api",
+		Since:    base,
+	}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2: %+v", len(got), got)
+	}
+	if got[0].Subject != "cross-chunk" || got[1].Subject != "tail-match" {
+		t.Fatalf("subjects = [%s %s], want [cross-chunk tail-match]", got[0].Subject, got[1].Subject)
+	}
+}
+
+func TestReadFilteredTailLimitModesAndMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "created"})
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "closed"})
+	rec.Close() //nolint:errcheck // test cleanup
+
+	got, err := ReadFilteredTail(path, Filter{Actor: "human"}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit=0 got %d events, want 2", len(got))
+	}
+
+	missing, err := ReadFilteredTail(filepath.Join(dir, "missing.jsonl"), Filter{}, 1)
+	if err != nil {
+		t.Fatalf("missing file error: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("missing file got %+v, want nil", missing)
+	}
+}
+
 func TestReadLatestSeq(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")
@@ -820,6 +932,32 @@ func TestFileRecorderList(t *testing.T) {
 	}
 	if created[0].Subject != "gc-1" {
 		t.Errorf("Subject = %q, want %q", created[0].Subject, "gc-1")
+	}
+}
+
+func TestFileRecorderListTail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rec.Close() //nolint:errcheck // test cleanup
+
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "old"})
+	rec.Record(Event{Type: BeadClosed, Actor: "human", Subject: "ignored"})
+	rec.Record(Event{Type: BeadCreated, Actor: "human", Subject: "new"})
+
+	got, err := rec.ListTail(Filter{Type: BeadCreated}, 1)
+	if err != nil {
+		t.Fatalf("ListTail: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListTail got %d events, want 1", len(got))
+	}
+	if got[0].Subject != "new" {
+		t.Fatalf("subject = %q, want new", got[0].Subject)
 	}
 }
 

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -586,6 +586,33 @@ func TestReadFilteredAfterSeqCombined(t *testing.T) {
 	}
 }
 
+func TestReadFilteredTail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	var stderr bytes.Buffer
+	rec, err := NewFileRecorder(path, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Record(Event{Type: BeadCreated, Actor: "human"}) // seq 1
+	rec.Record(Event{Type: BeadClosed, Actor: "human"})  // seq 2
+	rec.Record(Event{Type: BeadCreated, Actor: "human"}) // seq 3
+	rec.Record(Event{Type: BeadClosed, Actor: "human"})  // seq 4
+	rec.Record(Event{Type: BeadCreated, Actor: "human"}) // seq 5
+	rec.Close()                                          //nolint:errcheck // test cleanup
+
+	got, err := ReadFilteredTail(path, Filter{Type: BeadCreated}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].Seq != 3 || got[1].Seq != 5 {
+		t.Fatalf("tail seqs = [%d %d], want [3 5]", got[0].Seq, got[1].Seq)
+	}
+}
+
 func TestReadLatestSeq(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.jsonl")

--- a/internal/events/fake.go
+++ b/internal/events/fake.go
@@ -56,21 +56,40 @@ func (f *Fake) List(filter Filter) ([]Event, error) {
 	}
 	var result []Event
 	for _, e := range f.Events {
-		if filter.AfterSeq > 0 && e.Seq <= filter.AfterSeq {
-			continue
+		if eventMatchesFilter(e, filter) {
+			result = append(result, e)
 		}
-		if filter.Type != "" && e.Type != filter.Type {
-			continue
-		}
-		if filter.Actor != "" && e.Actor != filter.Actor {
-			continue
-		}
-		if !filter.Since.IsZero() && e.Ts.Before(filter.Since) {
-			continue
-		}
-		result = append(result, e)
 	}
 	return result, nil
+}
+
+// ListTail returns the trailing matching events from the in-memory store.
+func (f *Fake) ListTail(filter Filter, limit int) ([]Event, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.broken {
+		return nil, fmt.Errorf("events provider unavailable")
+	}
+	if limit <= 0 {
+		var result []Event
+		for _, e := range f.Events {
+			if eventMatchesFilter(e, filter) {
+				result = append(result, e)
+			}
+		}
+		return result, nil
+	}
+	reversed := make([]Event, 0, limit)
+	for i := len(f.Events) - 1; i >= 0 && len(reversed) < limit; i-- {
+		e := f.Events[i]
+		if eventMatchesFilter(e, filter) {
+			reversed = append(reversed, e)
+		}
+	}
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+	return reversed, nil
 }
 
 // LatestSeq returns the highest sequence number, or 0 if empty.

--- a/internal/events/multiplexer.go
+++ b/internal/events/multiplexer.go
@@ -112,6 +112,7 @@ func (m *Multiplexer) ListTail(filter Filter, limit int) ([]TaggedEvent, error) 
 			}
 		}
 		if err != nil {
+			log.Printf("events: list tail failed for city %q: %v", city, err)
 			continue // best-effort: skip cities with errors
 		}
 		for _, e := range evts {
@@ -132,15 +133,17 @@ func (m *Multiplexer) ListTail(filter Filter, limit int) ([]TaggedEvent, error) 
 func (m *Multiplexer) LatestCursor() (map[string]uint64, error) {
 	providers := m.snapshot()
 	cursors := make(map[string]uint64, len(providers))
+	var errs []error
 	for city, p := range providers {
 		seq, err := p.LatestSeq()
 		if err != nil {
 			log.Printf("events: latest cursor failed for city %q: %v", city, err)
+			errs = append(errs, fmt.Errorf("%s: %w", city, err))
 			continue
 		}
 		cursors[city] = seq
 	}
-	return cursors, nil
+	return cursors, errors.Join(errs...)
 }
 
 // Watch returns a Watcher that merges events from all currently registered

--- a/internal/events/multiplexer.go
+++ b/internal/events/multiplexer.go
@@ -91,6 +91,58 @@ func (m *Multiplexer) ListAll(filter Filter) ([]TaggedEvent, error) {
 	return all, nil
 }
 
+// ListTail returns the trailing matching events across all cities. It asks
+// tail-capable providers for only their local tail, then trims the merged
+// result to the requested global limit.
+func (m *Multiplexer) ListTail(filter Filter, limit int) ([]TaggedEvent, error) {
+	if limit <= 0 {
+		return m.ListAll(filter)
+	}
+	providers := m.snapshot()
+	var all []TaggedEvent
+	for city, p := range providers {
+		var evts []Event
+		var err error
+		if tail, ok := p.(TailProvider); ok {
+			evts, err = tail.ListTail(filter, limit)
+		} else {
+			evts, err = p.List(filter)
+			if limit < len(evts) {
+				evts = evts[len(evts)-limit:]
+			}
+		}
+		if err != nil {
+			continue // best-effort: skip cities with errors
+		}
+		for _, e := range evts {
+			all = append(all, TaggedEvent{Event: e, City: city})
+		}
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Ts.Before(all[j].Ts)
+	})
+	if limit < len(all) {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
+}
+
+// LatestCursor returns the current highest sequence number for each provider.
+// Providers that fail are skipped, matching ListAll's best-effort aggregation.
+func (m *Multiplexer) LatestCursor() (map[string]uint64, error) {
+	providers := m.snapshot()
+	cursors := make(map[string]uint64, len(providers))
+	for city, p := range providers {
+		seq, err := p.LatestSeq()
+		if err != nil {
+			log.Printf("events: latest cursor failed for city %q: %v", city, err)
+			continue
+		}
+		cursors[city] = seq
+	}
+	return cursors, nil
+}
+
 // Watch returns a Watcher that merges events from all currently registered
 // city providers. Events are yielded in approximate time order. The cursor
 // is a map of city→seq positions (use ParseCursor/FormatCursor to persist).

--- a/internal/events/multiplexer_test.go
+++ b/internal/events/multiplexer_test.go
@@ -53,6 +53,32 @@ func TestMultiplexerListAllWithFilter(t *testing.T) {
 	}
 }
 
+func TestMultiplexerListTailLimitsAcrossCities(t *testing.T) {
+	m := NewMultiplexer()
+
+	f1 := NewFake()
+	f1.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "old-a", Ts: time.Unix(1, 0)})
+	f1.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "new-a", Ts: time.Unix(3, 0)})
+
+	f2 := NewFake()
+	f2.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "old-b", Ts: time.Unix(2, 0)})
+	f2.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "new-b", Ts: time.Unix(4, 0)})
+
+	m.Add("city-a", f1)
+	m.Add("city-b", f2)
+
+	evts, err := m.ListTail(Filter{}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 2 {
+		t.Fatalf("got %d events, want 2", len(evts))
+	}
+	if evts[0].Subject != "new-a" || evts[1].Subject != "new-b" {
+		t.Fatalf("subjects = [%s %s], want [new-a new-b]", evts[0].Subject, evts[1].Subject)
+	}
+}
+
 func TestMultiplexerWatch(t *testing.T) {
 	m := NewMultiplexer()
 

--- a/internal/events/multiplexer_test.go
+++ b/internal/events/multiplexer_test.go
@@ -145,8 +145,8 @@ func TestMultiplexerLatestCursorSkipsBrokenProviders(t *testing.T) {
 	m.Add("broken", NewFailFake())
 
 	cursors, err := m.LatestCursor()
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("LatestCursor() error = nil, want broken provider error")
 	}
 	if len(cursors) != 2 {
 		t.Fatalf("cursor count = %d, want 2: %v", len(cursors), cursors)

--- a/internal/events/multiplexer_test.go
+++ b/internal/events/multiplexer_test.go
@@ -79,6 +79,86 @@ func TestMultiplexerListTailLimitsAcrossCities(t *testing.T) {
 	}
 }
 
+func TestMultiplexerListTailUsesFallbackAndSkipsErrors(t *testing.T) {
+	m := NewMultiplexer()
+
+	listOnly := NewFake()
+	listOnly.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "list-old", Ts: time.Unix(1, 0)})
+	listOnly.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "list-middle", Ts: time.Unix(4, 0)})
+	listOnly.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "list-new", Ts: time.Unix(6, 0)})
+
+	tailCapable := NewFake()
+	tailCapable.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "tail-old", Ts: time.Unix(2, 0)})
+	tailCapable.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "tail-middle", Ts: time.Unix(3, 0)})
+	tailCapable.Record(Event{Type: SessionWoke, Actor: "b1", Subject: "tail-new", Ts: time.Unix(5, 0)})
+
+	m.Add("list-only", &providerWithoutTail{fake: listOnly})
+	m.Add("tail-capable", tailCapable)
+	m.Add("broken", NewFailFake())
+
+	evts, err := m.ListTail(Filter{Type: SessionWoke}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 3 {
+		t.Fatalf("got %d events, want 3", len(evts))
+	}
+	got := []string{evts[0].Subject, evts[1].Subject, evts[2].Subject}
+	want := []string{"list-middle", "tail-new", "list-new"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("subjects = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestMultiplexerListTailLimitZeroDelegatesToListAll(t *testing.T) {
+	m := NewMultiplexer()
+	f := NewFake()
+	f.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "old", Ts: time.Unix(1, 0)})
+	f.Record(Event{Type: SessionStopped, Actor: "a1", Subject: "ignored", Ts: time.Unix(2, 0)})
+	f.Record(Event{Type: SessionWoke, Actor: "a1", Subject: "new", Ts: time.Unix(3, 0)})
+	m.Add("city-a", f)
+
+	evts, err := m.ListTail(Filter{Type: SessionWoke}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evts) != 2 {
+		t.Fatalf("got %d events, want 2", len(evts))
+	}
+	if evts[0].Subject != "old" || evts[1].Subject != "new" {
+		t.Fatalf("subjects = [%s %s], want [old new]", evts[0].Subject, evts[1].Subject)
+	}
+}
+
+func TestMultiplexerLatestCursorSkipsBrokenProviders(t *testing.T) {
+	m := NewMultiplexer()
+	alpha := NewFake()
+	alpha.Record(Event{Type: SessionWoke, Actor: "a1"})
+	alpha.Record(Event{Type: SessionWoke, Actor: "a1"})
+	beta := NewFake()
+	beta.Record(Event{Type: SessionWoke, Actor: "b1"})
+
+	m.Add("alpha", alpha)
+	m.Add("beta", beta)
+	m.Add("broken", NewFailFake())
+
+	cursors, err := m.LatestCursor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cursors) != 2 {
+		t.Fatalf("cursor count = %d, want 2: %v", len(cursors), cursors)
+	}
+	if cursors["alpha"] != 2 || cursors["beta"] != 1 {
+		t.Fatalf("cursors = %v, want alpha:2 beta:1", cursors)
+	}
+	if _, ok := cursors["broken"]; ok {
+		t.Fatalf("broken provider included in cursor map: %v", cursors)
+	}
+}
+
 func TestMultiplexerWatch(t *testing.T) {
 	m := NewMultiplexer()
 
@@ -235,4 +315,28 @@ func TestMultiplexerSkipsBrokenProvider(t *testing.T) {
 	if len(evts) != 1 {
 		t.Fatalf("got %d events, want 1", len(evts))
 	}
+}
+
+type providerWithoutTail struct {
+	fake *Fake
+}
+
+func (p *providerWithoutTail) Record(e Event) {
+	p.fake.Record(e)
+}
+
+func (p *providerWithoutTail) List(filter Filter) ([]Event, error) {
+	return p.fake.List(filter)
+}
+
+func (p *providerWithoutTail) LatestSeq() (uint64, error) {
+	return p.fake.LatestSeq()
+}
+
+func (p *providerWithoutTail) Watch(ctx context.Context, afterSeq uint64) (Watcher, error) {
+	return p.fake.Watch(ctx, afterSeq)
+}
+
+func (p *providerWithoutTail) Close() error {
+	return p.fake.Close()
 }

--- a/internal/events/reader.go
+++ b/internal/events/reader.go
@@ -57,21 +57,100 @@ func ReadFiltered(path string, filter Filter) ([]Event, error) {
 
 	var result []Event
 	for _, e := range all {
-		if filter.AfterSeq > 0 && e.Seq <= filter.AfterSeq {
-			continue
+		if eventMatchesFilter(e, filter) {
+			result = append(result, e)
 		}
-		if filter.Type != "" && e.Type != filter.Type {
-			continue
-		}
-		if filter.Actor != "" && e.Actor != filter.Actor {
-			continue
-		}
-		if !filter.Since.IsZero() && e.Ts.Before(filter.Since) {
-			continue
-		}
-		result = append(result, e)
 	}
 	return result, nil
+}
+
+// ReadFilteredTail reads the trailing matching events from path. A positive
+// limit returns at most that many events in chronological order; limit <= 0
+// falls back to ReadFiltered.
+func ReadFilteredTail(path string, filter Filter, limit int) ([]Event, error) {
+	if limit <= 0 {
+		return ReadFiltered(path, filter)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading events tail: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat events tail: %w", err)
+	}
+	return readFilteredTailFromFile(f, info.Size(), filter, limit)
+}
+
+func readFilteredTailFromFile(f *os.File, size int64, filter Filter, limit int) ([]Event, error) {
+	if size <= 0 {
+		return nil, nil
+	}
+	const chunkSize int64 = 64 * 1024
+	var reversed []Event
+	var pending []byte
+	end := size
+	for end > 0 && len(reversed) < limit {
+		n := chunkSize
+		if end < n {
+			n = end
+		}
+		start := end - n
+		chunk := make([]byte, n)
+		if _, err := f.ReadAt(chunk, start); err != nil && err != io.EOF {
+			return nil, fmt.Errorf("reading events tail: %w", err)
+		}
+		data := make([]byte, 0, len(chunk)+len(pending))
+		data = append(data, chunk...)
+		data = append(data, pending...)
+		parts := bytes.Split(data, []byte{'\n'})
+		firstComplete := 0
+		if start > 0 {
+			pending = append(pending[:0], parts[0]...)
+			firstComplete = 1
+		} else {
+			pending = nil
+		}
+		for i := len(parts) - 1; i >= firstComplete && len(reversed) < limit; i-- {
+			line := bytes.TrimSuffix(parts[i], []byte{'\r'})
+			if len(bytes.TrimSpace(line)) == 0 {
+				continue
+			}
+			var e Event
+			if err := json.Unmarshal(line, &e); err != nil {
+				continue
+			}
+			if eventMatchesFilter(e, filter) {
+				reversed = append(reversed, e)
+			}
+		}
+		end = start
+	}
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+	return reversed, nil
+}
+
+func eventMatchesFilter(e Event, filter Filter) bool {
+	if filter.AfterSeq > 0 && e.Seq <= filter.AfterSeq {
+		return false
+	}
+	if filter.Type != "" && e.Type != filter.Type {
+		return false
+	}
+	if filter.Actor != "" && e.Actor != filter.Actor {
+		return false
+	}
+	if !filter.Since.IsZero() && e.Ts.Before(filter.Since) {
+		return false
+	}
+	return true
 }
 
 // ReadLatestSeq returns the latest complete event Seq in the events file, or

--- a/internal/events/recorder.go
+++ b/internal/events/recorder.go
@@ -98,6 +98,11 @@ func (r *FileRecorder) List(filter Filter) ([]Event, error) {
 	return ReadFiltered(r.path, filter)
 }
 
+// ListTail returns trailing matching events from the underlying file.
+func (r *FileRecorder) ListTail(filter Filter, limit int) ([]Event, error) {
+	return ReadFilteredTail(r.path, filter, limit)
+}
+
 // LatestSeq returns the highest sequence number in the event log.
 func (r *FileRecorder) LatestSeq() (uint64, error) {
 	r.mu.Lock()

--- a/internal/runtime/tmux/interaction.go
+++ b/internal/runtime/tmux/interaction.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -178,6 +179,9 @@ func (t *Tmux) Pending(name string) (*runtime.PendingInteraction, error) {
 	if err != nil {
 		// Pane might not exist (session not started yet or already stopped).
 		// Check for known "can't find" errors vs unexpected failures.
+		if errors.Is(err, ErrSessionNotFound) {
+			return nil, fmt.Errorf("capturing pane: %w: %w", runtime.ErrSessionNotFound, err)
+		}
 		if strings.Contains(err.Error(), "can't find") || strings.Contains(err.Error(), "no server") {
 			return nil, nil
 		}
@@ -227,6 +231,9 @@ func (t *Tmux) Respond(name string, response runtime.InteractionResponse) error 
 	// Verify the expected approval is still present before sending keys.
 	paneText, err := t.CapturePane(name, 40)
 	if err != nil {
+		if errors.Is(err, ErrSessionNotFound) {
+			return fmt.Errorf("pre-verify capture failed: %w: %w", runtime.ErrSessionNotFound, err)
+		}
 		return fmt.Errorf("pre-verify capture failed: %w", err)
 	}
 	current := parseApprovalPrompt(paneText)
@@ -260,6 +267,9 @@ func (t *Tmux) Respond(name string, response runtime.InteractionResponse) error 
 
 	// Send the keystroke once.
 	if _, err := t.run("send-keys", "-t", name, "-l", key); err != nil {
+		if errors.Is(err, ErrSessionNotFound) {
+			return fmt.Errorf("send-keys failed: %w: %w", runtime.ErrSessionNotFound, err)
+		}
 		return fmt.Errorf("send-keys failed: %w", err)
 	}
 

--- a/internal/runtime/tmux/interaction_test.go
+++ b/internal/runtime/tmux/interaction_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -189,6 +190,35 @@ func TestPhase2ProviderPendingInteractionSeam(t *testing.T) {
 
 	pending, err := provider.Pending(session)
 	reporter.Require(t, pendingInteractionSeamResult(session, pending, err, fe.calls))
+}
+
+func TestProviderPendingMapsTmuxSessionNotFoundToRuntimeSentinel(t *testing.T) {
+	provider := &Provider{
+		tm: &Tmux{
+			exec: &fakeExecutor{err: ErrSessionNotFound},
+		},
+	}
+
+	pending, err := provider.Pending("missing")
+	if pending != nil {
+		t.Fatalf("Pending = %#v, want nil", pending)
+	}
+	if !errors.Is(err, runtime.ErrSessionNotFound) {
+		t.Fatalf("Pending error = %v, want runtime.ErrSessionNotFound", err)
+	}
+}
+
+func TestProviderRespondMapsTmuxSessionNotFoundToRuntimeSentinel(t *testing.T) {
+	provider := &Provider{
+		tm: &Tmux{
+			exec: &fakeExecutor{err: ErrSessionNotFound},
+		},
+	}
+
+	err := provider.Respond("missing", runtime.InteractionResponse{Action: "approve"})
+	if !errors.Is(err, runtime.ErrSessionNotFound) {
+		t.Fatalf("Respond error = %v, want runtime.ErrSessionNotFound", err)
+	}
 }
 
 func TestPhase2ProviderRespondRejectsMismatchedRequest(t *testing.T) {

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -743,6 +743,9 @@ func (m *Manager) Pending(id string) (*runtime.PendingInteraction, bool, error) 
 		if errors.Is(err, runtime.ErrInteractionUnsupported) {
 			return nil, false, nil
 		}
+		if runtime.IsSessionGone(err) {
+			return nil, true, nil
+		}
 		return nil, true, fmt.Errorf("getting pending interaction: %w", err)
 	}
 	return pending, true, nil
@@ -763,6 +766,9 @@ func (m *Manager) Respond(id string, response runtime.InteractionResponse) error
 		if err != nil {
 			if errors.Is(err, runtime.ErrInteractionUnsupported) {
 				return ErrInteractionUnsupported
+			}
+			if runtime.IsSessionGone(err) {
+				return ErrNoPendingInteraction
 			}
 			return fmt.Errorf("getting pending interaction: %w", err)
 		}

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -743,7 +744,8 @@ func (m *Manager) Pending(id string) (*runtime.PendingInteraction, bool, error) 
 		if errors.Is(err, runtime.ErrInteractionUnsupported) {
 			return nil, false, nil
 		}
-		if runtime.IsSessionGone(err) {
+		if errors.Is(err, runtime.ErrSessionNotFound) {
+			log.Printf("session: pending interaction runtime session gone for %q: %v", sessName, err)
 			return nil, true, nil
 		}
 		return nil, true, fmt.Errorf("getting pending interaction: %w", err)
@@ -767,7 +769,8 @@ func (m *Manager) Respond(id string, response runtime.InteractionResponse) error
 			if errors.Is(err, runtime.ErrInteractionUnsupported) {
 				return ErrInteractionUnsupported
 			}
-			if runtime.IsSessionGone(err) {
+			if errors.Is(err, runtime.ErrSessionNotFound) {
+				log.Printf("session: respond pending probe runtime session gone for %q: %v", sessName, err)
 				return ErrNoPendingInteraction
 			}
 			return fmt.Errorf("getting pending interaction: %w", err)
@@ -787,6 +790,10 @@ func (m *Manager) Respond(id string, response runtime.InteractionResponse) error
 		if err := ip.Respond(sessName, response); err != nil {
 			if errors.Is(err, runtime.ErrInteractionUnsupported) {
 				return ErrInteractionUnsupported
+			}
+			if errors.Is(err, runtime.ErrSessionNotFound) {
+				log.Printf("session: respond runtime session gone for %q: %v", sessName, err)
+				return ErrNoPendingInteraction
 			}
 			return fmt.Errorf("responding to pending interaction: %w", err)
 		}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -480,6 +480,9 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 		// Start the runtime session.
 		if err := m.sp.Start(ctx, sessName, cfg); err != nil {
 			if runtimeSessionMatchesBead(m.sp, sessName, b.ID, meta["instance_token"]) {
+				if metaErr := m.confirmStartedRuntimeMetadata(b.ID, &b); metaErr != nil {
+					return metaErr
+				}
 				info = m.infoFromBead(b)
 				return nil
 			}
@@ -494,6 +497,15 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 			}
 			return fmt.Errorf("starting session: %w", err)
 		}
+		if metaErr := m.confirmStartedRuntimeMetadata(b.ID, &b); metaErr != nil {
+			if stopErr := m.sp.Stop(sessName); stopErr != nil {
+				metaErr = errors.Join(metaErr, fmt.Errorf("stopping runtime after metadata failure: %w", stopErr))
+			}
+			if rbErr := rollbackFailedCreate(); rbErr != nil {
+				return errors.Join(metaErr, rbErr)
+			}
+			return metaErr
+		}
 
 		info = m.infoFromBead(b)
 		return nil
@@ -502,6 +514,22 @@ func (m *Manager) createAliasedNamedWithTransport(ctx context.Context, alias, ex
 		return Info{}, err
 	}
 	return info, nil
+}
+
+func (m *Manager) confirmStartedRuntimeMetadata(id string, b *beads.Bead) error {
+	metadata := ConfirmStartedPatch(time.Now().UTC())
+	if err := m.store.SetMetadataBatch(id, metadata); err != nil {
+		return fmt.Errorf("storing started runtime metadata: %w", err)
+	}
+	if b != nil {
+		if b.Metadata == nil {
+			b.Metadata = make(map[string]string, len(metadata))
+		}
+		for k, v := range metadata {
+			b.Metadata[k] = v
+		}
+	}
+	return nil
 }
 
 // CreateNamedWithTransport creates a new chat session bead with an optional

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2685,6 +2685,41 @@ func TestPendingAndRespond(t *testing.T) {
 	}
 }
 
+type pendingSessionGoneProvider struct {
+	*runtime.Fake
+}
+
+func (p *pendingSessionGoneProvider) Pending(_ string) (*runtime.PendingInteraction, error) {
+	return nil, fmt.Errorf("capturing pane: %w", runtime.ErrSessionNotFound)
+}
+
+func TestPendingAndRespondTreatMissingRuntimeSessionAsNoPending(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &pendingSessionGoneProvider{Fake: runtime.NewFake()}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	pending, supported, err := mgr.Pending(info.ID)
+	if err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	if !supported {
+		t.Fatal("Pending should report supported when the provider supports interactions")
+	}
+	if pending != nil {
+		t.Fatalf("Pending = %#v, want nil for missing runtime session", pending)
+	}
+
+	err = mgr.Respond(info.ID, runtime.InteractionResponse{Action: "approve"})
+	if !errors.Is(err, ErrNoPendingInteraction) {
+		t.Fatalf("Respond error = %v, want ErrNoPendingInteraction", err)
+	}
+}
+
 func TestSendRejectsPendingInteraction(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -249,6 +249,51 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreateConfirmsStartedStateWithoutControllerDriftHash(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(
+		context.Background(),
+		"helper",
+		"my chat",
+		"claude",
+		"/tmp",
+		"claude",
+		map[string]string{"BEADS_DIR": "/tmp/beads"},
+		ProviderResume{},
+		runtime.Config{
+			Env:              map[string]string{"GC_CITY": "test-city"},
+			FingerprintExtra: map[string]string{"depends_on": "db"},
+			SessionLive:      []string{"echo live"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := b.Metadata["started_config_hash"]; got != "" {
+		t.Fatalf("started_config_hash = %q, want empty so controller owns drift hashes", got)
+	}
+	if got := b.Metadata["started_live_hash"]; got != "" {
+		t.Fatalf("started_live_hash = %q, want empty so controller owns drift hashes", got)
+	}
+	if got := b.Metadata["live_hash"]; got != "" {
+		t.Fatalf("live_hash = %q, want empty so controller owns drift hashes", got)
+	}
+	if got := b.Metadata["state_reason"]; got != "creation_complete" {
+		t.Fatalf("state_reason = %q, want creation_complete", got)
+	}
+	if got := b.Metadata["creation_complete_at"]; got == "" {
+		t.Fatal("creation_complete_at is empty")
+	}
+}
+
 func TestCreateDefaultsTitleToTemplate(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()
@@ -2693,6 +2738,31 @@ func (p *pendingSessionGoneProvider) Pending(_ string) (*runtime.PendingInteract
 	return nil, fmt.Errorf("capturing pane: %w", runtime.ErrSessionNotFound)
 }
 
+type pendingSessionErrorProvider struct {
+	*runtime.Fake
+	err error
+}
+
+func (p *pendingSessionErrorProvider) Pending(_ string) (*runtime.PendingInteraction, error) {
+	return nil, p.err
+}
+
+type respondSessionGoneProvider struct {
+	*runtime.Fake
+}
+
+func (p *respondSessionGoneProvider) Pending(_ string) (*runtime.PendingInteraction, error) {
+	return &runtime.PendingInteraction{
+		RequestID: "req-1",
+		Kind:      "approval",
+		Prompt:    "approve?",
+	}, nil
+}
+
+func (p *respondSessionGoneProvider) Respond(_ string, _ runtime.InteractionResponse) error {
+	return fmt.Errorf("send-keys failed: %w", runtime.ErrSessionNotFound)
+}
+
 func TestPendingAndRespondTreatMissingRuntimeSessionAsNoPending(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := &pendingSessionGoneProvider{Fake: runtime.NewFake()}
@@ -2717,6 +2787,61 @@ func TestPendingAndRespondTreatMissingRuntimeSessionAsNoPending(t *testing.T) {
 	err = mgr.Respond(info.ID, runtime.InteractionResponse{Action: "approve"})
 	if !errors.Is(err, ErrNoPendingInteraction) {
 		t.Fatalf("Respond error = %v, want ErrNoPendingInteraction", err)
+	}
+}
+
+func TestRespondTreatsRuntimeSessionGoneDuringResponseAsNoPending(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &respondSessionGoneProvider{Fake: runtime.NewFake()}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	err = mgr.Respond(info.ID, runtime.InteractionResponse{Action: "approve"})
+	if !errors.Is(err, ErrNoPendingInteraction) {
+		t.Fatalf("Respond error = %v, want ErrNoPendingInteraction", err)
+	}
+}
+
+func TestPendingAndRespondDoNotSwallowUnrelatedNotFoundErrors(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &pendingSessionErrorProvider{
+		Fake: runtime.NewFake(),
+		err:  fmt.Errorf("loading config file: not found"),
+	}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	pending, supported, err := mgr.Pending(info.ID)
+	if err == nil {
+		t.Fatalf("Pending err = nil, want unrelated provider error")
+	}
+	if !supported {
+		t.Fatal("Pending should report supported when provider returned a non-session-gone error")
+	}
+	if pending != nil {
+		t.Fatalf("Pending = %#v, want nil on provider error", pending)
+	}
+	if !strings.Contains(err.Error(), "loading config file: not found") {
+		t.Fatalf("Pending err = %v, want original provider error", err)
+	}
+
+	err = mgr.Respond(info.ID, runtime.InteractionResponse{Action: "approve"})
+	if err == nil {
+		t.Fatalf("Respond err = nil, want unrelated provider error")
+	}
+	if errors.Is(err, ErrNoPendingInteraction) {
+		t.Fatalf("Respond err = %v, must not downgrade unrelated provider errors to ErrNoPendingInteraction", err)
+	}
+	if !strings.Contains(err.Error(), "loading config file: not found") {
+		t.Fatalf("Respond err = %v, want original provider error", err)
 	}
 }
 

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -81,7 +81,8 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 	cityName := "real-world-app-contract-" + strconv.FormatInt(time.Now().UnixNano(), 36)
 	cityDir := filepath.Join(root, "cities", cityName)
 	createCity := liveContractJSON[struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}](t, baseURL, validator, http.MethodPost, "/v0/city", map[string]string{
 		"dir":           cityDir,
 		"start_command": "bash " + agentScript("stuck-agent.sh"),
@@ -89,13 +90,16 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 	if createCity.RequestID == "" {
 		t.Fatalf("city create response missing request_id")
 	}
+	if createCity.EventCursor == "" {
+		t.Fatalf("city create response missing event_cursor")
+	}
 
 	cityBase := "/v0/city/" + url.PathEscape(cityName)
 	waitForLiveContractRequestID[struct {
 		RequestID string `json:"request_id"`
 		Name      string `json:"name"`
 		Path      string `json:"path"`
-	}](t, baseURL, validator, "/v0/events", createCity.RequestID, "request.result.city.create", 120*time.Second)
+	}](t, baseURL, validator, "/v0/events", createCity.RequestID, "request.result.city.create", 120*time.Second, createCity.EventCursor)
 	liveContractJSON[struct {
 		Status string `json:"status"`
 	}](t, baseURL, validator, http.MethodGet, cityBase+"/health", nil, http.StatusOK)
@@ -501,11 +505,20 @@ description = "Read and complete {{issue}}."
 	}](t, baseURL, validator, http.MethodDelete, cityBase+"/rig/"+url.PathEscape(rigName), nil, http.StatusOK)
 
 	unregister := liveContractJSON[struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}](t, baseURL, validator, http.MethodPost, cityBase+"/unregister", nil, http.StatusAccepted)
 	if unregister.RequestID == "" {
 		t.Fatalf("unregister response missing request_id")
 	}
+	if unregister.EventCursor == "" {
+		t.Fatalf("unregister response missing event_cursor")
+	}
+	waitForLiveContractRequestID[struct {
+		RequestID string `json:"request_id"`
+		Name      string `json:"name"`
+		Path      string `json:"path"`
+	}](t, baseURL, validator, "/v0/events", unregister.RequestID, "request.result.city.unregister", 120*time.Second, unregister.EventCursor)
 	waitForCityAbsent(t, baseURL, validator, cityName, 45*time.Second)
 }
 
@@ -616,8 +629,9 @@ type contractGraphDep struct {
 func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, targetAgent, rigName, label string) string {
 	t.Helper()
 	create := liveContractJSON[struct {
-		RequestID string `json:"request_id"`
-		Status    string `json:"status"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
+		Status      string `json:"status"`
 	}](t, baseURL, v, http.MethodPost, cityBase+"/sessions", map[string]any{
 		"alias":      "rw-" + label,
 		"async":      true,
@@ -629,6 +643,9 @@ func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalid
 	if create.RequestID == "" {
 		t.Fatalf("%s session create response missing request_id", label)
 	}
+	if create.EventCursor == "" {
+		t.Fatalf("%s session create response missing event_cursor", label)
+	}
 	result := waitForLiveContractRequestID[struct {
 		RequestID string `json:"request_id"`
 		Session   struct {
@@ -636,10 +653,14 @@ func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalid
 			Title string `json:"title"`
 			Alias string `json:"alias"`
 			Rig   string `json:"rig"`
+			State string `json:"state"`
 		} `json:"session"`
-	}](t, baseURL, v, "/v0/events", create.RequestID, "request.result.session.create", 120*time.Second)
+	}](t, baseURL, v, cityBase+"/events", create.RequestID, "request.result.session.create", 120*time.Second, create.EventCursor)
 	if result.Session.ID == "" {
 		t.Fatalf("%s session create result missing session.id", label)
+	}
+	if result.Session.State == "creating" {
+		t.Fatalf("%s session create result state = %q, want commandable state", label, result.Session.State)
 	}
 	if result.Session.Title != "real-world app contract "+label {
 		t.Fatalf("%s session title = %q", label, result.Session.Title)
@@ -650,6 +671,7 @@ func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalid
 	if result.Session.Alias == "" {
 		t.Fatalf("%s session missing controller-managed alias", label)
 	}
+	liveContractJSON[map[string]any](t, baseURL, v, http.MethodGet, cityBase+"/session/"+url.PathEscape(result.Session.ID)+"/pending", nil, http.StatusOK)
 	return result.Session.ID
 }
 
@@ -697,16 +719,20 @@ func exerciseLiveContractSessionLifecycle(t *testing.T, baseURL string, v openap
 	}
 
 	msg := liveContractJSON[struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}](t, baseURL, v, http.MethodPost, sessionPath+"/messages", map[string]string{
 		"message": "real-world app contract message " + runID,
 	}, http.StatusAccepted)
 	if msg.RequestID == "" || msg.RequestID == id {
 		t.Fatalf("message response = %+v, want request_id distinct from session id %q", msg, id)
 	}
+	if msg.EventCursor == "" {
+		t.Fatalf("message response missing event_cursor")
+	}
 	waitForLiveContractRequestID[struct {
 		RequestID string `json:"request_id"`
-	}](t, baseURL, v, "/v0/events", msg.RequestID, "request.result.session.message", 120*time.Second)
+	}](t, baseURL, v, cityBase+"/events", msg.RequestID, "request.result.session.message", 120*time.Second, msg.EventCursor)
 
 	liveContractJSON[map[string]any](t, baseURL, v, http.MethodGet, sessionPath+"/pending", nil, http.StatusOK)
 	liveContractRequestOneOf(t, baseURL, v, http.MethodPost, sessionPath+"/respond", map[string]string{
@@ -756,6 +782,9 @@ func exerciseLiveContractSessionLifecycle(t *testing.T, baseURL string, v openap
 	if killed.ID != killID {
 		t.Fatalf("kill id = %q, want %q", killed.ID, killID)
 	}
+	liveContractJSON[struct {
+		Status string `json:"status"`
+	}](t, baseURL, v, http.MethodPost, cityBase+"/session/"+url.PathEscape(killID)+"/close?delete=true", nil, http.StatusOK)
 }
 
 func waitForLiveContractSessionState(t *testing.T, baseURL string, v openapivalidator.Validator, sessionPath, want string, timeout time.Duration) {
@@ -771,6 +800,31 @@ func waitForLiveContractSessionState(t *testing.T, baseURL string, v openapivali
 		time.Sleep(250 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %s state at %s", want, sessionPath)
+}
+
+func waitForLiveContractSessionCommandable(t *testing.T, baseURL string, v openapivalidator.Validator, sessionPath string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastState string
+	for time.Now().Before(deadline) {
+		session := liveContractJSON[struct {
+			State string `json:"state"`
+		}](t, baseURL, v, http.MethodGet, sessionPath, nil, http.StatusOK)
+		lastState = session.State
+		switch session.State {
+		case "creating":
+			time.Sleep(250 * time.Millisecond)
+			continue
+		case "crashed", "closed":
+			t.Fatalf("session at %s reached state %q before command lifecycle checks", sessionPath, session.State)
+		default:
+			if session.State != "" {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for session at %s to leave creating state; last state=%q", sessionPath, lastState)
 }
 
 func exerciseLiveContractFormulasAndWorkflows(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, formulaName, targetAgent, rigName, rootBeadID, runID string) {
@@ -1044,9 +1098,9 @@ func validateLiveContractResponse(t *testing.T, v openapivalidator.Validator, re
 	t.Fatalf("%s %s response does not match OpenAPI schema:\n%sbody: %s", req.Method, req.URL.Path, details.String(), string(raw))
 }
 
-func waitForLiveContractRequestID[T any](t *testing.T, baseURL string, v openapivalidator.Validator, path, requestID, successType string, timeout time.Duration) T {
+func waitForLiveContractRequestID[T any](t *testing.T, baseURL string, v openapivalidator.Validator, path, requestID, successType string, timeout time.Duration, eventCursor ...string) T {
 	t.Helper()
-	env := waitForLiveContractRequestEvent(t, baseURL, path, requestID, successType, timeout)
+	env := waitForLiveContractRequestEvent(t, baseURL, path, requestID, successType, timeout, eventCursor...)
 	var payload T
 	if err := json.Unmarshal(env.Payload, &payload); err != nil {
 		t.Fatalf("%s payload for request_id=%s did not decode: %v\npayload: %s", successType, requestID, err, string(env.Payload))
@@ -1054,19 +1108,38 @@ func waitForLiveContractRequestID[T any](t *testing.T, baseURL string, v openapi
 	return payload
 }
 
-func waitForLiveContractRequestEvent(t *testing.T, baseURL, path, requestID, successType string, timeout time.Duration) contractEvent {
+func waitForLiveContractRequestEvent(t *testing.T, baseURL, path, requestID, successType string, timeout time.Duration, eventCursor ...string) contractEvent {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	cursor := ""
+	if len(eventCursor) > 0 {
+		cursor = strings.TrimSpace(eventCursor[0])
+	}
 	streamPath := path
-	if strings.HasSuffix(streamPath, "/events") {
-		streamPath += "/stream?after_seq=0"
+	if strings.HasSuffix(streamPath, "/events") && streamPath != "/v0/events" {
+		streamPath += "/stream"
+		if cursor != "" {
+			streamPath += "?after_seq=" + url.QueryEscape(cursor)
+		} else {
+			streamPath += "?after_seq=0"
+		}
 	} else {
-		streamPath = strings.TrimSuffix(streamPath, "/") + "/stream?after_cursor=0"
+		streamPath = strings.TrimSuffix(streamPath, "/") + "/stream"
+		if cursor != "" {
+			streamPath += "?after_cursor=" + url.QueryEscape(cursor)
+		} else {
+			streamPath += "?after_cursor=0"
+		}
 	}
 	if path == "/v0/events" {
-		streamPath = "/v0/events/stream?after_cursor=0"
+		streamPath = "/v0/events/stream"
+		if cursor != "" {
+			streamPath += "?after_cursor=" + url.QueryEscape(cursor)
+		} else {
+			streamPath += "?after_cursor=0"
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+streamPath, nil)

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -470,6 +470,9 @@ description = "Read and complete {{issue}}."
 	liveContractJSON[struct {
 		Status string `json:"status"`
 	}](t, baseURL, validator, http.MethodDelete, mailPath+mailRigQuery, nil, http.StatusOK)
+	liveContractJSON[struct {
+		Status string `json:"status"`
+	}](t, baseURL, validator, http.MethodPost, cityBase+"/session/"+url.PathEscape(sessionID)+"/close?delete=true", nil, http.StatusOK)
 
 	exerciseLiveContractSessionLifecycle(t, baseURL, validator, cityBase, targetAgent, rigName, runID)
 
@@ -497,6 +500,7 @@ description = "Read and complete {{issue}}."
 	liveContractJSON[struct {
 		Status string `json:"status"`
 	}](t, baseURL, validator, http.MethodPatch, cityBase, map[string]bool{"suspended": true}, http.StatusOK)
+	closeLiveContractRigSessions(t, baseURL, validator, cityBase, rigName)
 	liveContractJSON[struct {
 		Status string `json:"status"`
 	}](t, baseURL, validator, http.MethodPatch, cityBase, map[string]bool{"suspended": false}, http.StatusOK)
@@ -673,6 +677,42 @@ func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalid
 	}
 	liveContractJSON[map[string]any](t, baseURL, v, http.MethodGet, cityBase+"/session/"+url.PathEscape(result.Session.ID)+"/pending", nil, http.StatusOK)
 	return result.Session.ID
+}
+
+func closeLiveContractRigSessions(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, rigName string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		sessions := liveContractJSON[struct {
+			Items []struct {
+				ID       string `json:"id"`
+				Rig      string `json:"rig"`
+				Template string `json:"template"`
+				State    string `json:"state"`
+			} `json:"items"`
+		}](t, baseURL, v, http.MethodGet, cityBase+"/sessions?limit=100", nil, http.StatusOK)
+
+		remaining := 0
+		for _, sess := range sessions.Items {
+			if sess.ID == "" || sess.State == "closed" {
+				continue
+			}
+			if sess.Rig != rigName && !strings.HasPrefix(sess.Template, rigName+"/") {
+				continue
+			}
+			remaining++
+			liveContractJSON[struct {
+				Status string `json:"status"`
+			}](t, baseURL, v, http.MethodPost, cityBase+"/session/"+url.PathEscape(sess.ID)+"/close?delete=true", nil, http.StatusOK)
+		}
+		if remaining == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out closing %d live contract rig session(s)", remaining)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 func exerciseLiveContractSessionLifecycle(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, targetAgent, rigName, runID string) {
@@ -1098,9 +1138,9 @@ func validateLiveContractResponse(t *testing.T, v openapivalidator.Validator, re
 	t.Fatalf("%s %s response does not match OpenAPI schema:\n%sbody: %s", req.Method, req.URL.Path, details.String(), string(raw))
 }
 
-func waitForLiveContractRequestID[T any](t *testing.T, baseURL string, v openapivalidator.Validator, path, requestID, successType string, timeout time.Duration, eventCursor ...string) T {
+func waitForLiveContractRequestID[T any](t *testing.T, baseURL string, v openapivalidator.Validator, path, requestID, successType string, timeout time.Duration, eventCursor string) T {
 	t.Helper()
-	env := waitForLiveContractRequestEvent(t, baseURL, path, requestID, successType, timeout, eventCursor...)
+	env := waitForLiveContractRequestEvent(t, baseURL, path, requestID, successType, timeout, eventCursor)
 	var payload T
 	if err := json.Unmarshal(env.Payload, &payload); err != nil {
 		t.Fatalf("%s payload for request_id=%s did not decode: %v\npayload: %s", successType, requestID, err, string(env.Payload))
@@ -1108,15 +1148,12 @@ func waitForLiveContractRequestID[T any](t *testing.T, baseURL string, v openapi
 	return payload
 }
 
-func waitForLiveContractRequestEvent(t *testing.T, baseURL, path, requestID, successType string, timeout time.Duration, eventCursor ...string) contractEvent {
+func waitForLiveContractRequestEvent(t *testing.T, baseURL, path, requestID, successType string, timeout time.Duration, eventCursor string) contractEvent {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cursor := ""
-	if len(eventCursor) > 0 {
-		cursor = strings.TrimSpace(eventCursor[0])
-	}
+	cursor := strings.TrimSpace(eventCursor)
 	streamPath := path
 	if strings.HasSuffix(streamPath, "/events") && streamPath != "/v0/events" {
 		streamPath += "/stream"

--- a/test/integration/huma_binary_test.go
+++ b/test/integration/huma_binary_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -374,13 +375,17 @@ func TestHumaBinary_CityCreateAsync(t *testing.T) {
 		t.Errorf("POST /v0/city took %s, want fast scaffold response (<20s); async contract is broken", postDur)
 	}
 	var createResp struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	if err := json.Unmarshal(postBody, &createResp); err != nil {
 		t.Fatalf("decode create response: %v; body: %s", err, string(postBody))
 	}
 	if createResp.RequestID == "" {
 		t.Fatalf("empty request_id in response; body: %s", string(postBody))
+	}
+	if createResp.EventCursor == "" {
+		t.Fatalf("empty event_cursor in response; body: %s", string(postBody))
 	}
 	// The city name is the basename of cityDir.
 	cityName := filepath.Base(cityDir)
@@ -390,12 +395,12 @@ func TestHumaBinary_CityCreateAsync(t *testing.T) {
 	// the city to cities.toml synchronously before POST returns, and
 	// TransientCityEventProviders reads cities.toml directly, so the
 	// mux contains this city's event provider by the time the client
-	// receives 202. after_cursor=0 requests replay from the start
-	// so the client doesn't miss completion if it fires between POST
-	// return and subscribe.
+	// receives 202. event_cursor is the supervisor head captured before
+	// acceptance, so the client catches this request's result without
+	// replaying unrelated historical backlog.
 	streamCtx, streamCancel := context.WithTimeout(context.Background(), 90*time.Second)
 	t.Cleanup(streamCancel)
-	streamReq, err := http.NewRequestWithContext(streamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor=0", nil)
+	streamReq, err := http.NewRequestWithContext(streamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor="+url.QueryEscape(createResp.EventCursor), nil)
 	if err != nil {
 		t.Fatalf("build stream request: %v", err)
 	}
@@ -536,10 +541,14 @@ func TestHumaBinary_CityUnregisterAsync(t *testing.T) {
 		t.Fatalf("POST /v0/city status = %d, want 202; body: %s", postResp.StatusCode, string(postBody))
 	}
 	var createResp struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	if err := json.Unmarshal(postBody, &createResp); err != nil {
 		t.Fatalf("decode create response: %v; body: %s", err, string(postBody))
+	}
+	if createResp.EventCursor == "" {
+		t.Fatalf("empty city create event_cursor in response; body: %s", string(postBody))
 	}
 	// The city name is the basename of cityDir.
 	cityName := filepath.Base(cityDir)
@@ -550,7 +559,7 @@ func TestHumaBinary_CityUnregisterAsync(t *testing.T) {
 	// running set).
 	streamCtx, streamCancel := context.WithTimeout(context.Background(), 180*time.Second)
 	t.Cleanup(streamCancel)
-	streamReq, err := http.NewRequestWithContext(streamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor=0", nil)
+	streamReq, err := http.NewRequestWithContext(streamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor="+url.QueryEscape(createResp.EventCursor), nil)
 	if err != nil {
 		t.Fatalf("build stream request: %v", err)
 	}
@@ -618,7 +627,8 @@ ready:
 		t.Errorf("POST unregister took %s, want fast response (<20s)", unregDur)
 	}
 	var unregBodyDecoded struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	if err := json.Unmarshal(unregBody, &unregBodyDecoded); err != nil {
 		t.Fatalf("decode unregister response: %v; body: %s", err, string(unregBody))
@@ -626,16 +636,39 @@ ready:
 	if unregBodyDecoded.RequestID == "" {
 		t.Errorf("unregister response missing request_id; body: %s", string(unregBody))
 	}
+	if unregBodyDecoded.EventCursor == "" {
+		t.Fatalf("unregister response missing event_cursor; body: %s", string(unregBody))
+	}
 	t.Logf("POST unregister returned 202 in %s (request_id=%s)", unregDur.Round(time.Millisecond), unregBodyDecoded.RequestID)
 
 	// 4. Wait for request.result.city.unregister (or request.failed
-	// with operation=city.unregister) on the SSE stream.
+	// with operation=city.unregister) on a stream opened after the POST
+	// from the returned event cursor.
+	unregStreamCtx, unregStreamCancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(unregStreamCancel)
+	unregStreamReq, err := http.NewRequestWithContext(unregStreamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor="+url.QueryEscape(unregBodyDecoded.EventCursor), nil)
+	if err != nil {
+		t.Fatalf("build unregister stream request: %v", err)
+	}
+	unregStreamReq.Header.Set("Accept", "text/event-stream")
+	unregStreamResp, err := http.DefaultClient.Do(unregStreamReq)
+	if err != nil {
+		t.Fatalf("GET /v0/events/stream for unregister: %v", err)
+	}
+	defer unregStreamResp.Body.Close() //nolint:errcheck
+	if unregStreamResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(unregStreamResp.Body)
+		t.Fatalf("GET /v0/events/stream for unregister status = %d, want 200; body: %s", unregStreamResp.StatusCode, string(b))
+	}
+	unregEventLines := make(chan string, 256)
+	go readSSEFrames(unregStreamResp.Body, unregEventLines)
+
 	unregDeadline := time.After(120 * time.Second)
 	for {
 		select {
 		case <-unregDeadline:
 			t.Fatalf("timed out waiting for request.result.city.unregister for %q", cityName)
-		case line, ok := <-eventLines:
+		case line, ok := <-unregEventLines:
 			if !ok {
 				t.Fatalf("SSE stream closed before request.result.city.unregister for %q arrived", cityName)
 			}
@@ -766,16 +799,23 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 		t.Fatalf("POST /v0/city status = %d, want 202; body: %s", postResp.StatusCode, string(postBody))
 	}
 	var createResp struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	json.Unmarshal(postBody, &createResp) //nolint:errcheck
+	if createResp.RequestID == "" {
+		t.Fatalf("empty city create request_id in response; body: %s", string(postBody))
+	}
+	if createResp.EventCursor == "" {
+		t.Fatalf("empty city create event_cursor in response; body: %s", string(postBody))
+	}
 	cityName := filepath.Base(cityDir)
 	cityBase := baseURL + "/v0/city/" + cityName
 
 	// 2. Subscribe to events and wait for city ready.
 	streamCtx, streamCancel := context.WithTimeout(context.Background(), 120*time.Second)
 	t.Cleanup(streamCancel)
-	streamReq, _ := http.NewRequestWithContext(streamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor=0", nil)
+	streamReq, _ := http.NewRequestWithContext(streamCtx, http.MethodGet, baseURL+"/v0/events/stream?after_cursor="+url.QueryEscape(createResp.EventCursor), nil)
 	streamReq.Header.Set("Accept", "text/event-stream")
 	streamResp, err := http.DefaultClient.Do(streamReq)
 	if err != nil {
@@ -804,11 +844,15 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 		t.Fatalf("POST /sessions status = %d, want 202; body: %s", sessResp.StatusCode, string(sessRespBody))
 	}
 	var sessAccepted struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	json.Unmarshal(sessRespBody, &sessAccepted) //nolint:errcheck
 	if sessAccepted.RequestID == "" {
 		t.Fatalf("empty session create request_id in response; body: %s", string(sessRespBody))
+	}
+	if sessAccepted.EventCursor == "" {
+		t.Fatalf("empty session create event_cursor in response; body: %s", string(sessRespBody))
 	}
 	var sessResult struct {
 		RequestID string `json:"request_id"`
@@ -816,7 +860,7 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"session"`
 	}
-	if payload := waitForRequestResultOnStream(t, eventLines, sessAccepted.RequestID, "request.result.session.create", 120*time.Second); payload != nil {
+	if payload := waitForRequestResultFromStreamURL(t, cityBase+"/events/stream?after_seq="+url.QueryEscape(sessAccepted.EventCursor), sessAccepted.RequestID, "request.result.session.create", 120*time.Second); payload != nil {
 		if err := json.Unmarshal(payload, &sessResult); err != nil {
 			t.Fatalf("decode session create result payload: %v; payload=%s", err, string(payload))
 		}
@@ -857,11 +901,15 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 		t.Fatalf("POST /messages status = %d, want 202; body: %s", msgResp.StatusCode, string(msgRespBody))
 	}
 	var msgAccepted struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	json.Unmarshal(msgRespBody, &msgAccepted) //nolint:errcheck
 	if msgAccepted.RequestID == "" {
 		t.Fatalf("empty message request_id in response; body: %s", string(msgRespBody))
+	}
+	if msgAccepted.EventCursor == "" {
+		t.Fatalf("empty message event_cursor in response; body: %s", string(msgRespBody))
 	}
 	if msgDur > 5*time.Second {
 		t.Errorf("POST /messages took %s, want fast async response (<5s)", msgDur)
@@ -869,7 +917,7 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 	t.Logf("POST /messages returned 202 in %s", msgDur.Round(time.Millisecond))
 
 	// 6. Wait for request.result.session.message on the event stream.
-	waitForRequestResultOnStream(t, eventLines, msgAccepted.RequestID, "request.result.session.message", 120*time.Second)
+	waitForRequestResultFromStreamURL(t, cityBase+"/events/stream?after_seq="+url.QueryEscape(msgAccepted.EventCursor), msgAccepted.RequestID, "request.result.session.message", 120*time.Second)
 	t.Logf("request.result.session.message received for %q", sessionID)
 
 	// 7. Submit a follow-up message and wait for the async result.
@@ -887,14 +935,41 @@ func TestHumaBinary_SessionMessageAsync(t *testing.T) {
 		t.Fatalf("POST /submit status = %d, want 202; body: %s", submitResp.StatusCode, string(submitRespBody))
 	}
 	var submitAccepted struct {
-		RequestID string `json:"request_id"`
+		RequestID   string `json:"request_id"`
+		EventCursor string `json:"event_cursor"`
 	}
 	json.Unmarshal(submitRespBody, &submitAccepted) //nolint:errcheck
 	if submitAccepted.RequestID == "" {
 		t.Fatalf("empty submit request_id in response; body: %s", string(submitRespBody))
 	}
-	waitForRequestResultOnStream(t, eventLines, submitAccepted.RequestID, "request.result.session.submit", 120*time.Second)
+	if submitAccepted.EventCursor == "" {
+		t.Fatalf("empty submit event_cursor in response; body: %s", string(submitRespBody))
+	}
+	waitForRequestResultFromStreamURL(t, cityBase+"/events/stream?after_seq="+url.QueryEscape(submitAccepted.EventCursor), submitAccepted.RequestID, "request.result.session.submit", 120*time.Second)
 	t.Logf("request.result.session.submit received for %q", sessionID)
+}
+
+func waitForRequestResultFromStreamURL(t *testing.T, streamURL, requestID, successType string, timeout time.Duration) json.RawMessage {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
+	if err != nil {
+		t.Fatalf("build event stream request: %v", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", streamURL, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		t.Fatalf("GET %s status = %d, want 200; body: %s", streamURL, resp.StatusCode, string(body))
+	}
+	lines := make(chan string, 256)
+	go readSSEFrames(resp.Body, lines)
+	return waitForRequestResultOnStream(t, lines, requestID, successType, timeout)
 }
 
 // waitForRequestResultOnStream waits for a typed success event


### PR DESCRIPTION
## Summary

- Add async `event_cursor` responses for supervisor/city operations and document cursor semantics in OpenAPI.
- Make event streams start at the live head unless an explicit cursor is supplied, avoiding unbounded historical replay for async result waits.
- Emit `request.result.session.create` only after the session has left `creating` and is commandable.
- Return typed no-pending behavior when pending runtime lookup reports the runtime session is gone instead of surfacing a 500.
- Expand GC live contract coverage for city/session/bead async result flows.

## Validation

- PASS: `.githooks/pre-commit` with observable logs at `/tmp/gascity-precommit.log`
- PASS: `make lint`, `make vet`, `make test`, `make check-docs`, dashboard generation/build/typecheck/smoke via pre-commit
- PASS: MC live contract before commit: `GC_API_URL=http://127.0.0.1:8372 GC_LIVE_SPEC_SOURCE=live GC_LIVE_CONTRACT=1 npm run test:gc-live` -> 70 passed, 2 skipped, 0 failed

## Notes

`bd dolt push` could not run from this checkout because no active beads workspace/database was present (`bd where` reports no active beads workspace).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->