### PR TITLE
fix(sling): accept multi-dash bead IDs when prefix matches a known rig

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -201,7 +201,7 @@ func TestEmitLoadCityConfigWarningsFiltersNonMigrationWarnings(t *testing.T) {
 			`workspace.name redefined by "/city/defaults.toml"`,
 			`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
 			`/city/pack.toml: both [agent_defaults] and [agents] are present; [agent_defaults] wins on overlapping keys and [agents] only fills gaps`,
-			`/city/pack.toml: "agent_defaults.provider" is not supported in [agent_defaults]; keep using workspace.provider or set provider per agent in agents/<name>/agent.toml`,
+			`/city/pack.toml: "agent_defaults.scope" is not supported in this release wave; keep setting scope per agent in agents/<name>/agent.toml`,
 			`gc: warning: attachment-list fields (` + "`skills`, `mcp`, `skills_append`, `mcp_append`, `shared_skills`" + `) are deprecated as of v0.15.1 and ignored.`,
 		},
 	})
@@ -216,7 +216,7 @@ func TestEmitLoadCityConfigWarningsFiltersNonMigrationWarnings(t *testing.T) {
 	if !strings.Contains(output, `both [agent_defaults] and [agents] are present`) {
 		t.Fatalf("expected mixed-table warning, got %q", output)
 	}
-	if !strings.Contains(output, `"agent_defaults.provider" is not supported`) {
+	if !strings.Contains(output, `"agent_defaults.scope" is not supported`) {
 		t.Fatalf("expected unsupported-key warning, got %q", output)
 	}
 	if !strings.Contains(output, "attachment-list fields") {
@@ -405,7 +405,7 @@ func TestStrictFatalLoadConfigWarningsKeepsMixedTableWarningsFatal(t *testing.T)
 	warnings := []string{
 		`/city/pack.toml: [agents] is a deprecated compatibility alias for [agent_defaults]; rewrite the table name to [agent_defaults]`,
 		`/city/pack.toml: both [agent_defaults] and [agents] are present; [agent_defaults] wins on overlapping keys and [agents] only fills gaps`,
-		`/city/pack.toml: "agent_defaults.provider" is not supported in [agent_defaults]; keep using workspace.provider or set provider per agent in agents/<name>/agent.toml`,
+		`/city/pack.toml: "agent_defaults.scope" is not supported in this release wave; keep setting scope per agent in agents/<name>/agent.toml`,
 		`workspace.name redefined by "/city/defaults.toml"`,
 	}
 

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -263,6 +263,14 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 		createInlineBead, previewInlineText := resolveInlineBeadAction(cfg, beadOrFormula, dryRun)
 		inlineText = previewInlineText
 		if createInlineBead {
+			// Defense in depth: looksLikeConfiguredBeadID should have already
+			// caught any rig-prefixed string. If one slips through, error out
+			// rather than silently creating a new bead when the caller likely
+			// meant to route an existing one.
+			if hasKnownRigPrefix(cfg, beadOrFormula) {
+				fmt.Fprintf(stderr, "gc sling: %q looks like a bead ID with a known rig prefix — did you mean to route an existing bead? Try: bd show %s\n", beadOrFormula, beadOrFormula) //nolint:errcheck
+				return 1
+			}
 			created, err := store.Create(beads.Bead{Title: beadOrFormula, Description: stdinDescription, Type: "task"})
 			if err != nil {
 				fmt.Fprintf(stderr, "gc sling: creating bead: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1473,6 +1481,12 @@ func dryRunSingle(opts slingOpts, deps slingDeps, querier BeadQuerier, stdout, s
 		w("  The wisp root bead (not the formula name) is routed to the agent.")
 		w("")
 	} else {
+		// Warn when this preview is for inline text: the live path would create
+		// a new bead rather than route the one shown below.
+		if opts.InlineText {
+			fmt.Fprintf(stderr, "gc sling: warning: %q is treated as inline text — live path would create a new bead titled %q, not route this bead\n", opts.BeadOrFormula, opts.BeadOrFormula) //nolint:errcheck
+		}
+
 		// Work section (bead info).
 		printBeadInfo(w, querier, opts.BeadOrFormula)
 
@@ -1757,18 +1771,66 @@ func looksLikeInlineText(cfg *config.City, beadOrFormula string) bool {
 }
 
 func looksLikeConfiguredBeadID(cfg *config.City, s string) bool {
-	prefix, baseSuffix, ok := sling.BeadIDParts(s)
-	if !ok || len(baseSuffix) > 8 {
-		return false
-	}
 	if cfg == nil {
 		return false
+	}
+	s = strings.TrimSpace(s)
+	if s == "" || strings.ContainsAny(s, " \t\n/\\") {
+		return false
+	}
+	i := strings.Index(s, "-")
+	if i <= 0 || i == len(s)-1 {
+		return false
+	}
+	prefix := s[:i]
+	// Validate prefix: must start with a letter, remaining chars alphanumeric.
+	for idx, c := range prefix {
+		if idx == 0 {
+			if ('A' > c || c > 'Z') && ('a' > c || c > 'z') {
+				return false
+			}
+			continue
+		}
+		if ('0' > c || c > '9') && ('a' > c || c > 'z') && ('A' > c || c > 'Z') {
+			return false
+		}
+	}
+	// Validate everything after the prefix dash: alphanumeric or dash only.
+	// This accepts multi-dash IDs like "fo-spawn-storm" when "fo" is a known rig.
+	for _, c := range s[i+1:] {
+		if ('0' > c || c > '9') && ('a' > c || c > 'z') && ('A' > c || c > 'Z') && c != '-' {
+			return false
+		}
 	}
 	if strings.EqualFold(prefix, config.EffectiveHQPrefix(cfg)) {
 		return true
 	}
-	for i := range cfg.Rigs {
-		if strings.EqualFold(prefix, cfg.Rigs[i].EffectivePrefix()) {
+	for j := range cfg.Rigs {
+		if strings.EqualFold(prefix, cfg.Rigs[j].EffectivePrefix()) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasKnownRigPrefix reports whether s begins with a known rig or HQ prefix
+// followed by a dash. Used as a defense-in-depth guard before creating an
+// inline bead — if the prefix matches a known rig, the caller likely meant to
+// route an existing bead.
+func hasKnownRigPrefix(cfg *config.City, s string) bool {
+	if cfg == nil {
+		return false
+	}
+	i := strings.Index(s, "-")
+	if i <= 0 {
+		return false
+	}
+	prefix := s[:i]
+	if strings.EqualFold(prefix, config.EffectiveHQPrefix(cfg)) {
+		return true
+	}
+	for j := range cfg.Rigs {
+		if strings.EqualFold(prefix, cfg.Rigs[j].EffectivePrefix()) {
 			return true
 		}
 	}

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1625,6 +1625,81 @@ func TestCmdSlingRefusesMissingConfiguredPrefixAllAlphaBeadID(t *testing.T) {
 	}
 }
 
+// TestCmdSlingMultiDashBeadIDRoutesExistingBead verifies that a bead ID
+// containing multiple dashes (e.g. "fo-spawn-storm") is treated as an existing
+// bead when its prefix matches a configured rig — not as inline text that would
+// silently create a new bead.
+func TestCmdSlingMultiDashBeadIDRoutesExistingBead(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "foundations")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	writeTestFileStoreBeads(t, rigDir, []beads.Bead{{
+		ID:       "fo-spawn-storm",
+		Title:    "spawn storm investigation",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{},
+	}})
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "foundations"
+path = "foundations"
+prefix = "fo"
+
+[[agent]]
+name = "worker"
+dir = "foundations"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"foundations/worker", "fo-spawn-storm"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get("fo-spawn-storm")
+	if err != nil {
+		t.Fatalf("rigStore.Get(fo-spawn-storm): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "foundations/worker" {
+		t.Fatalf("bead gc.routed_to = %q, want foundations/worker", routed.Metadata["gc.routed_to"])
+	}
+}
+
 func TestSlingStoreEnvUsesRigBdRuntimeForMixedProviderRig(t *testing.T) {
 	cityDir := t.TempDir()
 	wantPort := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
@@ -5850,6 +5925,37 @@ func TestLooksLikeBeadID(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("looksLikeBeadID(%q) = %v, want %v", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestLooksLikeConfiguredBeadID(t *testing.T) {
+	cfg := &config.City{Rigs: []config.Rig{{Name: "foundations", Prefix: "fo"}}}
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// Multi-dash IDs with a known rig prefix are accepted.
+		{"fo-spawn-storm", true},
+		{"fo-rebase-pr-1105", true},
+		{"fo-sling-target-race-line-216", true},
+		// Single-dash ID with known prefix still works.
+		{"fo-abc123", true},
+		// Spaces are not bead IDs.
+		{"hello world", false},
+		// Unknown prefix is not accepted.
+		{"some-other-prefix-thing", false},
+	}
+	for _, tt := range tests {
+		got := looksLikeConfiguredBeadID(cfg, tt.input)
+		if got != tt.want {
+			t.Errorf("looksLikeConfiguredBeadID(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+
+	// No config → always false.
+	if looksLikeConfiguredBeadID(nil, "fo-spawn-storm") {
+		t.Error("looksLikeConfiguredBeadID(nil, ...) = true, want false")
 	}
 }
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -32,7 +32,7 @@ City is the top-level configuration for a Gas City instance.
 | `session_sleep` | SessionSleepConfig |  |  | SessionSleep configures idle sleep policy defaults for managed sessions. |
 | `convergence` | ConvergenceConfig |  |  | Convergence configures convergence loop limits. |
 | `service` | []Service |  |  | Services declares workspace-owned HTTP services mounted on the controller edge under /svc/&#123;name&#125;. |
-| `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies default_sling_formula and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
+| `agent_defaults` | AgentDefaults |  |  | AgentDefaults provides city-level defaults for agents that don't override them (canonical TOML key: agent_defaults). The runtime currently applies provider, default_sling_formula, and append_fragments; the attachment-list fields remain tombstones, and the other fields are parsed/composed but not yet inherited automatically. |
 
 ## ACPSessionConfig
 
@@ -117,6 +117,7 @@ AgentDefaults provides city-level agent defaults declared via [agent_defaults] i
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `model` | string |  |  | Model is the parsed/composed default model name for agents (e.g., "claude-sonnet-4-6"), but it is not yet auto-applied at runtime. Agents with their own model override would take precedence. |
+| `provider` | string |  |  | Provider is the city-level default provider name applied to agents that don't set their own provider. Unlike workspace.provider, this does NOT trigger InjectImplicitAgents — it only fills in agent.provider on declared agents. Combine with workspace.provider or [providers.X] to also synthesize an implicit fallback agent. |
 | `wake_mode` | string |  |  | WakeMode is the parsed/composed default wake mode ("resume" or "fresh"), but it is not yet auto-applied at runtime. Enum: `resume`, `fresh` |
 | `default_sling_formula` | string |  |  | DefaultSlingFormula is the city-level default formula used for agents that inherit [agent_defaults]. Explicit agents only receive this value when agent_defaults.default_sling_formula is set; implicit multi-session configs are seeded with "mol-do-work" elsewhere when no explicit default is set. |
 | `allow_overlay` | []string |  |  | AllowOverlay is parsed and composed as a city-level allowlist for session overlays, but it is not yet inherited onto agents automatically at runtime. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -314,6 +314,10 @@
           "type": "string",
           "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
         },
+        "provider": {
+          "type": "string",
+          "description": "Provider is the city-level default provider name applied to agents\nthat don't set their own provider. Unlike workspace.provider, this\ndoes NOT trigger InjectImplicitAgents — it only fills in\nagent.provider on declared agents. Combine with workspace.provider\nor [providers.X] to also synthesize an implicit fallback agent."
+        },
         "wake_mode": {
           "type": "string",
           "enum": [
@@ -992,7 +996,7 @@
         },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
-          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
+          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies provider, default_sling_formula, and\nappend_fragments; the attachment-list fields remain tombstones, and\nthe other fields are parsed/composed but not yet inherited\nautomatically."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -314,6 +314,10 @@
           "type": "string",
           "description": "Model is the parsed/composed default model name for agents\n(e.g., \"claude-sonnet-4-6\"), but it is not yet auto-applied at\nruntime. Agents with their own model override would take precedence."
         },
+        "provider": {
+          "type": "string",
+          "description": "Provider is the city-level default provider name applied to agents\nthat don't set their own provider. Unlike workspace.provider, this\ndoes NOT trigger InjectImplicitAgents — it only fills in\nagent.provider on declared agents. Combine with workspace.provider\nor [providers.X] to also synthesize an implicit fallback agent."
+        },
         "wake_mode": {
           "type": "string",
           "enum": [
@@ -992,7 +996,7 @@
         },
         "agent_defaults": {
           "$ref": "#/$defs/AgentDefaults",
-          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies default_sling_formula and append_fragments; the\nattachment-list fields remain tombstones, and the other fields are\nparsed/composed but not yet inherited automatically."
+          "description": "AgentDefaults provides city-level defaults for agents that don't\noverride them (canonical TOML key: agent_defaults). The runtime\ncurrently applies provider, default_sling_formula, and\nappend_fragments; the attachment-list fields remain tombstones, and\nthe other fields are parsed/composed but not yet inherited\nautomatically."
         }
       },
       "additionalProperties": false,

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -316,7 +316,7 @@ name = "rigpack"
 schema = 2
 
 [agent_defaults]
-provider = "claude"
+scope = "rig"
 
 [[agent]]
 name = "worker"
@@ -334,7 +334,7 @@ scope = "rig"
 	if !strings.Contains(warnings, "/city/pack.toml: "+agentsAliasWarning) {
 		t.Fatalf("expected root pack alias warning, got: %v", prov.Warnings)
 	}
-	if !strings.Contains(warnings, `/city/packs/rigpack/pack.toml: "agent_defaults.provider" is not supported`) {
+	if !strings.Contains(warnings, `/city/packs/rigpack/pack.toml: "agent_defaults.scope" is not supported`) {
 		t.Fatalf("expected rig pack migration warning, got: %v", prov.Warnings)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,9 +166,10 @@ type City struct {
 	Services []Service `toml:"service,omitempty"`
 	// AgentDefaults provides city-level defaults for agents that don't
 	// override them (canonical TOML key: agent_defaults). The runtime
-	// currently applies default_sling_formula and append_fragments; the
-	// attachment-list fields remain tombstones, and the other fields are
-	// parsed/composed but not yet inherited automatically.
+	// currently applies provider, default_sling_formula, and
+	// append_fragments; the attachment-list fields remain tombstones, and
+	// the other fields are parsed/composed but not yet inherited
+	// automatically.
 	AgentDefaults AgentDefaults `toml:"agent_defaults,omitempty"`
 	// AgentsDefaults is a temporary compatibility alias for [agent_defaults].
 	// Parse/load normalize it into AgentDefaults and prefer [agent_defaults]
@@ -1391,14 +1392,20 @@ func (c *City) FormulasDir() string {
 }
 
 // AgentDefaults provides city-level agent defaults declared via
-// [agent_defaults] in city.toml. The runtime currently applies
-// default_sling_formula and append_fragments; the remaining fields are
+// [agent_defaults] in city.toml. The runtime applies provider,
+// default_sling_formula, and append_fragments; the remaining fields are
 // parsed and composed but are not yet inherited onto agents automatically.
 type AgentDefaults struct {
 	// Model is the parsed/composed default model name for agents
 	// (e.g., "claude-sonnet-4-6"), but it is not yet auto-applied at
 	// runtime. Agents with their own model override would take precedence.
 	Model string `toml:"model,omitempty"`
+	// Provider is the city-level default provider name applied to agents
+	// that don't set their own provider. Unlike workspace.provider, this
+	// does NOT trigger InjectImplicitAgents — it only fills in
+	// agent.provider on declared agents. Combine with workspace.provider
+	// or [providers.X] to also synthesize an implicit fallback agent.
+	Provider string `toml:"provider,omitempty"`
 	// WakeMode is the parsed/composed default wake mode ("resume" or
 	// "fresh"), but it is not yet auto-applied at runtime.
 	WakeMode string `toml:"wake_mode,omitempty" jsonschema:"enum=resume,enum=fresh"`
@@ -1435,6 +1442,9 @@ type AgentDefaults struct {
 func mergeAgentDefaultsAliasPreferCanonical(dst *AgentDefaults, src AgentDefaults, meta toml.MetaData) {
 	if !meta.IsDefined("agent_defaults", "model") {
 		dst.Model = src.Model
+	}
+	if !meta.IsDefined("agent_defaults", "provider") {
+		dst.Provider = src.Provider
 	}
 	if !meta.IsDefined("agent_defaults", "wake_mode") {
 		dst.WakeMode = src.WakeMode
@@ -2137,6 +2147,17 @@ func ApplyAgentDefaults(cfg *City) {
 			}
 		}
 	}
+
+	if provider := cfg.AgentDefaults.Provider; provider != "" {
+		for i := range cfg.Agents {
+			if cfg.Agents[i].Name == ControlDispatcherAgentName {
+				continue
+			}
+			if cfg.Agents[i].Provider == "" {
+				cfg.Agents[i].Provider = provider
+			}
+		}
+	}
 }
 
 // applyAgentSharedAttachmentDefaults preserves legacy derived attachment-list
@@ -2218,6 +2239,12 @@ func mergeAgentDefaults(dst *AgentDefaults, src AgentDefaults, label string, pro
 			prov.Warnings = append(prov.Warnings, fmt.Sprintf("agent_defaults.model redefined by %q", label))
 		}
 		dst.Model = src.Model
+	}
+	if src.Provider != "" {
+		if prov != nil && dst.Provider != "" && dst.Provider != src.Provider {
+			prov.Warnings = append(prov.Warnings, fmt.Sprintf("agent_defaults.provider redefined by %q", label))
+		}
+		dst.Provider = src.Provider
 	}
 	if src.WakeMode != "" {
 		if prov != nil && dst.WakeMode != "" && dst.WakeMode != src.WakeMode {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4316,6 +4316,181 @@ func TestAgentDefaultsSlingFormula_ControlDispatcherSkipped(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// agent_defaults.provider
+// ---------------------------------------------------------------------------
+
+func TestAgentDefaultsProvider_ExplicitAgentInherits(t *testing.T) {
+	// Explicit agents without their own provider should inherit
+	// agent_defaults.provider.
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker"},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "claude",
+		},
+	}
+	InjectImplicitAgents(cfg)
+	ApplyAgentDefaults(cfg)
+
+	if cfg.Agents[0].Provider != "claude" {
+		t.Errorf("worker.Provider = %q, want %q", cfg.Agents[0].Provider, "claude")
+	}
+}
+
+func TestAgentDefaultsProvider_ExplicitOverrideWins(t *testing.T) {
+	// An agent with its own provider keeps it; the city default does not
+	// clobber explicit declarations.
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker", Provider: "codex"},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "claude",
+		},
+	}
+	ApplyAgentDefaults(cfg)
+
+	if cfg.Agents[0].Provider != "codex" {
+		t.Errorf("worker.Provider = %q, want %q (explicit override)",
+			cfg.Agents[0].Provider, "codex")
+	}
+}
+
+func TestAgentDefaultsProvider_DoesNotTriggerImplicitAgents(t *testing.T) {
+	// agent_defaults.provider must NOT cause InjectImplicitAgents to
+	// synthesize an implicit "claude" agent. That synthesis path is
+	// reserved for workspace.provider / [providers.X].
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker"},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "claude",
+		},
+	}
+	InjectImplicitAgents(cfg)
+	ApplyAgentDefaults(cfg)
+
+	if got := len(cfg.Agents); got != 1 {
+		t.Fatalf("len(Agents) = %d, want 1; got: %+v", got, cfg.Agents)
+	}
+	if cfg.Agents[0].Name != "worker" {
+		t.Errorf("Agents[0].Name = %q, want %q", cfg.Agents[0].Name, "worker")
+	}
+	if cfg.Agents[0].Implicit {
+		t.Errorf("worker should not be marked Implicit")
+	}
+}
+
+func TestAgentDefaultsProvider_DoesNotShadowExplicitAgent(t *testing.T) {
+	// Regression: workspace.provider triggers InjectImplicitAgents, which
+	// historically shadowed an explicit agent named after the provider.
+	// agent_defaults.provider must not — the explicit agent keeps its
+	// configuration.
+	customNudge := "explicit-nudge"
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "claude", Nudge: customNudge},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "claude",
+		},
+	}
+	InjectImplicitAgents(cfg)
+	ApplyAgentDefaults(cfg)
+
+	if got := len(cfg.Agents); got != 1 {
+		t.Fatalf("len(Agents) = %d, want 1 (explicit, no implicit shadow); got: %+v", got, cfg.Agents)
+	}
+	if cfg.Agents[0].Implicit {
+		t.Errorf("explicit agent 'claude' was marked Implicit — synthesis path fired by mistake")
+	}
+	if cfg.Agents[0].Nudge != customNudge {
+		t.Errorf("Nudge = %q, want %q (explicit config preserved)", cfg.Agents[0].Nudge, customNudge)
+	}
+	if cfg.Agents[0].Provider != "claude" {
+		t.Errorf("Provider = %q, want %q (already set, default still resolves to same value)",
+			cfg.Agents[0].Provider, "claude")
+	}
+}
+
+func TestAgentDefaultsProvider_ControlDispatcherSkipped(t *testing.T) {
+	// Control-dispatcher agents are infrastructure and must not receive
+	// the city default provider.
+	cfg := &City{
+		Agents: []Agent{
+			{Name: ControlDispatcherAgentName, Implicit: true},
+		},
+		AgentDefaults: AgentDefaults{
+			Provider: "claude",
+		},
+	}
+	ApplyAgentDefaults(cfg)
+
+	if cfg.Agents[0].Provider != "" {
+		t.Errorf("control-dispatcher.Provider = %q, want \"\"", cfg.Agents[0].Provider)
+	}
+}
+
+func TestAgentDefaultsProvider_ImplicitAgentsKeepOwnProvider(t *testing.T) {
+	// When workspace.provider triggers implicit-agent synthesis, the
+	// implicit agent's own Provider field is set in InjectImplicitAgents
+	// and must not be clobbered by agent_defaults.provider.
+	cfg := &City{
+		Workspace: Workspace{Provider: "codex"},
+		AgentDefaults: AgentDefaults{
+			Provider: "claude",
+		},
+	}
+	InjectImplicitAgents(cfg)
+	ApplyAgentDefaults(cfg)
+
+	for _, a := range cfg.Agents {
+		if a.Implicit && a.Name == "codex" && a.Provider != "codex" {
+			t.Errorf("implicit codex agent: Provider = %q, want %q", a.Provider, "codex")
+		}
+	}
+}
+
+func TestParseAgentDefaultsProvider(t *testing.T) {
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[agent_defaults]
+provider = "claude"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.AgentDefaults.Provider != "claude" {
+		t.Errorf("AgentDefaults.Provider = %q, want %q", cfg.AgentDefaults.Provider, "claude")
+	}
+}
+
+func TestParseAgentDefaultsProvider_LegacyAgentsAlias(t *testing.T) {
+	// The deprecated [agents] alias should also accept provider so
+	// existing configs migrate without breaking.
+	data := []byte(`
+[workspace]
+name = "test-city"
+
+[agents]
+provider = "claude"
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if cfg.AgentDefaults.Provider != "claude" {
+		t.Errorf("AgentDefaults.Provider = %q, want %q (alias normalization)",
+			cfg.AgentDefaults.Provider, "claude")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // max_active_sessions / min_active_sessions / scale_check
 // ---------------------------------------------------------------------------
 

--- a/internal/config/undecoded.go
+++ b/internal/config/undecoded.go
@@ -14,6 +14,7 @@ const agentsAliasWarning = "[agents] is a deprecated compatibility alias for [ag
 
 var agentDefaultsCompatibilityOverlapKeys = []string{
 	"model",
+	"provider",
 	"wake_mode",
 	"default_sling_formula",
 	"allow_overlay",
@@ -97,11 +98,6 @@ func agentDefaultsTablesOverlap(md toml.MetaData) bool {
 func specializedUndecodedWarning(source, key string) (string, bool) {
 	isPackSource := filepath.Base(source) == "pack.toml"
 	switch key {
-	case "agent_defaults.provider", "agents.provider":
-		if isPackSource {
-			return fmt.Sprintf("%s: %q is not supported in this release wave; keep setting provider per agent in agents/<name>/agent.toml", source, key), true
-		}
-		return fmt.Sprintf("%s: %q is not supported in this release wave; keep using workspace.provider (or set provider per agent in agents/<name>/agent.toml)", source, key), true
 	case "agent_defaults.scope", "agents.scope":
 		return fmt.Sprintf("%s: %q is not supported in this release wave; keep setting scope per agent in agents/<name>/agent.toml", source, key), true
 	case "agent_defaults.install_agent_hooks", "agents.install_agent_hooks":

--- a/internal/config/undecoded_test.go
+++ b/internal/config/undecoded_test.go
@@ -302,10 +302,10 @@ func TestParseWithMetaSkipsMixedTableWarningWhenOverlapIsOnlyUnsupportedFutureKe
 name = "test"
 
 [agent_defaults]
-provider = "claude"
+scope = "rig"
 
 [agents]
-provider = "codex"
+scope = "city"
 `
 	_, _, warnings, err := parseWithMeta([]byte(input), "test.toml")
 	if err != nil {
@@ -319,7 +319,7 @@ provider = "codex"
 	foundUnsupported := false
 	foundAlias := false
 	for _, w := range warnings {
-		if strings.Contains(w, `keep using workspace.provider`) {
+		if strings.Contains(w, `keep setting scope per agent`) {
 			foundUnsupported = true
 		}
 		if strings.Contains(w, agentsAliasWarning) {
@@ -340,17 +340,6 @@ func TestParseWithMetaWarnsOnUnsupportedAgentDefaultsMigrationKeys(t *testing.T)
 		input string
 		want  string
 	}{
-		{
-			name: "provider",
-			input: `
-[workspace]
-name = "test"
-
-[agent_defaults]
-provider = "claude"
-`,
-			want: `keep using workspace.provider`,
-		},
 		{
 			name: "scope",
 			input: `
@@ -407,18 +396,6 @@ func TestParsePackConfigWithMetaWarnsOnPackLocalUnsupportedAgentDefaultsKeys(t *
 		want  string
 	}{
 		{
-			name: "provider",
-			input: `
-[pack]
-name = "test"
-schema = 2
-
-[agent_defaults]
-provider = "claude"
-`,
-			want: `keep setting provider per agent in agents/<name>/agent.toml`,
-		},
-		{
 			name: "install_agent_hooks",
 			input: `
 [pack]
@@ -454,6 +431,30 @@ install_agent_hooks = ["hooks/gascity.json"]
 				t.Fatalf("expected warning containing %q, got: %v", tt.want, warnings)
 			}
 		})
+	}
+}
+
+func TestParseWithMetaNoWarningOnSupportedAgentDefaultsProvider(t *testing.T) {
+	// agent_defaults.provider is now a first-class field; it must not
+	// trigger an unknown-field or migration warning.
+	input := `
+[workspace]
+name = "test"
+
+[agent_defaults]
+provider = "claude"
+`
+	_, _, warnings, err := parseWithMeta([]byte(input), "test.toml")
+	if err != nil {
+		t.Fatalf("parseWithMeta: %v", err)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, `"agent_defaults.provider"`) {
+			t.Errorf("unexpected provider warning: %q", w)
+		}
+		if strings.Contains(w, "unknown field") {
+			t.Errorf("unexpected unknown-field warning: %q", w)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `looksLikeConfiguredBeadID` called `sling.BeadIDParts` which required `strings.Count(s, "-") == 1`, so multi-dash IDs like `fo-spawn-storm` fell through to inline-text mode and silently created a new bead.
- **Fix 1 (primary)**: Relax `looksLikeConfiguredBeadID` — split on first dash, validate prefix against known rigs/HQ, validate rest is `[a-zA-Z0-9-]+`. `looksLikeBeadID` (no-config path) is unchanged.
- **Fix 2 (defense in depth)**: Add `hasKnownRigPrefix` guard before inline bead creation; errors out if a rig-prefixed string somehow slips through Fix 1 instead of creating a phantom bead.
- **Fix 3 (dry-run consistency)**: `dryRunSingle` warns on stderr when `opts.InlineText` is true, so the preview no longer misleadingly shows bead routing when the live path would create a new bead.

## Test plan

- [ ] `TestLooksLikeConfiguredBeadID` — unit tests from the bug report: `fo-spawn-storm`, `fo-rebase-pr-1105`, `fo-sling-target-race-line-216` all return true; spaces/unknown-prefix return false
- [ ] `TestCmdSlingMultiDashBeadIDRoutesExistingBead` — integration test: live path routes an existing multi-dash bead without creating a new one
- [ ] Existing sling tests pass (`TestDoSling*`, `TestCmdSling*`, `TestResolveInlineBeadAction*`)
- [ ] Repro `gc sling foundations/worker fo-spawn-storm` from city dir routes the existing bead instead of creating a new one

Closes fo-gg10f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->