### PR TITLE
fix(session): derive canonical name for singleton in 'gc session new'

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -11,6 +11,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
@@ -180,7 +181,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	if alias != "" && found.SupportsMultipleSessions() {
 		alias = workdirutil.SessionQualifiedName(cityPath, found, cfg.Rigs, requestedAlias, "")
 	}
-	explicitName, err := sessionExplicitNameForNewSession(&found, alias)
+	explicitName, err := sessionExplicitNameForNewSession(&found, alias, cfg.EffectiveCityName(), cfg.Workspace.SessionTemplate)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc session new: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1644,11 +1645,35 @@ func resolveWorkDirForQualifiedName(cityPath string, cfg *config.City, agent *co
 	return resolveConfiguredWorkDir(cityPath, cityName, qualifiedName, agent, rigs)
 }
 
-func sessionExplicitNameForNewSession(agent *config.Agent, alias string) (string, error) {
-	if agent == nil || !agent.SupportsMultipleSessions() || strings.TrimSpace(alias) != "" {
+// sessionExplicitNameForNewSession returns the explicit session_name to stamp
+// on a new session bead from `gc session new` (and the equivalent template
+// materialization path).
+//
+// The shape mirrors how the rig reconciler names canonical sessions: derive
+// from agent.SessionNameFor over the qualified-name primitive ("/"→"--",
+// "."→"__"). Three branches:
+//
+//  1. An alias was given → return "" so the manager uses the alias-driven
+//     path (alias becomes the runtime session name).
+//  2. The template supports multiple concurrent sessions and no alias was
+//     given → generate "<base>-adhoc-<hex>" so each ad-hoc materialization
+//     gets a unique tmux-safe identity.
+//  3. Singleton template (max_active_sessions=1, no namepool) → derive the
+//     canonical primitive name (e.g. "qcore/syl" → "qcore--syl",
+//     "gastown.mayor" → "gastown__mayor"). This matches what `gc rig restart`
+//     produces via providers.go, so manual `gc session new <rig>/<agent>` and
+//     reconciler-driven materialization agree on the runtime tmux name.
+//     Without this branch, singletons fall through the manager's empty-name
+//     path and end up with the legacy "s-<beadID>" form, which is unfindable
+//     by canonical name.
+func sessionExplicitNameForNewSession(agentCfg *config.Agent, alias, cityName, sessionTemplate string) (string, error) {
+	if agentCfg == nil || strings.TrimSpace(alias) != "" {
 		return "", nil
 	}
-	return session.GenerateAdhocExplicitName(agent.Name)
+	if !agentCfg.SupportsMultipleSessions() {
+		return agent.SessionNameFor(cityName, agentCfg.QualifiedName(), sessionTemplate), nil
+	}
+	return session.GenerateAdhocExplicitName(agentCfg.Name)
 }
 
 func shouldAttachNewSession(noAttach bool, transport string) bool {

--- a/cmd/gc/cmd_session_explicit_name_test.go
+++ b/cmd/gc/cmd_session_explicit_name_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestSessionExplicitNameForNewSession_SingletonReturnsCanonicalName verifies
+// that gc session new on a singleton agent (max_active_sessions=1) derives the
+// explicit session name from the session-name primitive ("/"→"--", "."→"__")
+// instead of leaving it empty (which previously caused the manager to fall
+// back to "s-<beadID>"). This matches the canonical names produced by the rig
+// reconciler in cmd/gc/providers.go (agent.SessionNameFor + QualifiedName).
+func TestSessionExplicitNameForNewSession_SingletonReturnsCanonicalName(t *testing.T) {
+	tests := []struct {
+		name       string
+		agent      *config.Agent
+		alias      string
+		cityName   string
+		sessionTpl string
+		want       string
+	}{
+		{
+			name: "rig-scoped singleton uses primitive -- separator",
+			agent: &config.Agent{
+				Dir:               "qcore",
+				Name:              "syl",
+				MaxActiveSessions: intPtr(1),
+			},
+			want: "qcore--syl",
+		},
+		{
+			name: "binding-scoped singleton uses primitive __ separator",
+			agent: &config.Agent{
+				BindingName:       "gastown",
+				Name:              "mayor",
+				MaxActiveSessions: intPtr(1),
+			},
+			want: "gastown__mayor",
+		},
+		{
+			name: "rig+binding singleton encodes both separators",
+			agent: &config.Agent{
+				Dir:               "town",
+				BindingName:       "gastown",
+				Name:              "polecat",
+				MaxActiveSessions: intPtr(1),
+			},
+			want: "town--gastown__polecat",
+		},
+		{
+			name: "bare singleton returns bare name unchanged",
+			agent: &config.Agent{
+				Name:              "helper",
+				MaxActiveSessions: intPtr(1),
+			},
+			want: "helper",
+		},
+		{
+			name: "explicit alias short-circuits to empty (manager handles aliased path)",
+			agent: &config.Agent{
+				Dir:               "qcore",
+				Name:              "syl",
+				MaxActiveSessions: intPtr(1),
+			},
+			alias: "syl-debug",
+			want:  "",
+		},
+		{
+			name:  "nil agent returns empty",
+			agent: nil,
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sessionExplicitNameForNewSession(tt.agent, tt.alias, tt.cityName, tt.sessionTpl)
+			if err != nil {
+				t.Fatalf("sessionExplicitNameForNewSession: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("sessionExplicitNameForNewSession(...) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSessionExplicitNameForNewSession_MultiSessionGeneratesAdhoc verifies the
+// pre-existing multi-session behavior is unchanged: when an agent supports
+// multiple concurrent sessions and no alias is given, an "<base>-adhoc-<hex>"
+// name is generated.
+func TestSessionExplicitNameForNewSession_MultiSessionGeneratesAdhoc(t *testing.T) {
+	agent := &config.Agent{Name: "worker"} // nil MaxActiveSessions → unlimited
+	got, err := sessionExplicitNameForNewSession(agent, "", "", "")
+	if err != nil {
+		t.Fatalf("sessionExplicitNameForNewSession: %v", err)
+	}
+	if !strings.HasPrefix(got, "worker-adhoc-") {
+		t.Errorf("multi-session name = %q, want prefix %q", got, "worker-adhoc-")
+	}
+}
+
+// TestSessionExplicitNameForNewSession_HonorsCustomSessionTemplate verifies
+// that when a city configures a non-default session_template, singleton names
+// are rendered through it (matching agent.SessionNameFor's contract).
+func TestSessionExplicitNameForNewSession_HonorsCustomSessionTemplate(t *testing.T) {
+	agent := &config.Agent{
+		Dir:               "qcore",
+		Name:              "syl",
+		MaxActiveSessions: intPtr(1),
+	}
+	// Per agent.SessionNameFor: when session_template is set, City and Agent
+	// template variables are interpolated.
+	got, err := sessionExplicitNameForNewSession(agent, "", "myCity", "{{.City}}-{{.Agent}}")
+	if err != nil {
+		t.Fatalf("sessionExplicitNameForNewSession: %v", err)
+	}
+	want := "myCity-qcore--syl"
+	if got != want {
+		t.Errorf("custom session_template name = %q, want %q", got, want)
+	}
+}

--- a/cmd/gc/session_template_start.go
+++ b/cmd/gc/session_template_start.go
@@ -285,7 +285,7 @@ func materializeSessionForAgentConfig(cityPath string, cfg *config.City, store b
 	if err != nil {
 		return "", err
 	}
-	explicitName, err := sessionExplicitNameForNewSession(agentCfg, "")
+	explicitName, err := sessionExplicitNameForNewSession(agentCfg, "", cfg.EffectiveCityName(), cfg.Workspace.SessionTemplate)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Problem

`gc session new <agent-qualified-name>` for a singleton template (e.g. `gc session new qcore/syl`, where the template has `max_active_sessions=1` and no namepool) produces a tmux session named `s-<beadID>` (e.g. `s-hq-ad6x`) instead of the canonical `<rig>--<agent>` name (e.g. `qcore--syl`).

The rig reconciler in `cmd/gc/providers.go` already produces canonical names by calling `agent.SessionNameFor(cityName, a.QualifiedName(), template)`. `gc session new` diverged: `sessionExplicitNameForNewSession` generated explicit names only for multi-session templates and returned empty for singletons. The session manager's empty-name fallback then derived `s-<beadID>` via `sessionNameFor(b.ID)`.

### Repro

```sh
gc rig resume qcore                       # rig with all crew stopped
gc session new qcore/syl --no-attach      # creates session bead hq-ad6x
gc rig restart qcore                      # spawns witness/refinery/dispatcher with canonical names
tmux -L <socket> ls
# Before:
#   qcore--control-dispatcher
#   qcore--refinery
#   qcore--witness
#   s-hq-ad6x          <- syl, unfindable by canonical name
# After:
#   qcore--syl
```

### Effect

- Agent unfindable by canonical name in tmux. `gc nudge`, `tmux attach -t qcore--syl`, and human muscle memory all expect `<rig>--<agent>`.
- Bites every time someone spawns a single crew member manually instead of via `gc rig restart`.
- Inconsistent with the agent-qualified-name primitive that #1571 (cycle scoping) and #1573 (bind-key dispatch) both extend.

## Fix

In `sessionExplicitNameForNewSession`, when the template is a singleton (`!SupportsMultipleSessions()`), derive the explicit name from the session-name primitive — the same path the reconciler uses:

```go
return agent.SessionNameFor(cityName, agentCfg.QualifiedName(), sessionTemplate), nil
```

Both spawn paths (`gc session new` and `cmd/gc/providers.go` reconciler) now agree on the runtime tmux name. Multi-session templates retain the existing `<base>-adhoc-<hex>` behavior; explicit `--alias` short-circuits to empty so the manager handles aliased path unchanged.

## Why this aligns with project philosophy

Same architectural family as #1571 (`cycle.sh`) and #1573 (`bind-key.sh`): code paths producing or consuming session names should consume the canonical primitive (`/`→`--`, `.`→`__`) defined in `internal/agent/session_name.go`, rather than re-deriving identity from bead IDs or hardcoded role names.

The `SanitizeQualifiedNameForSession` mapping IS the contract that distinguishes rig-scope from city/imported scope at the session-name level. Every Go consumer of session names operates on that contract — `gc session new` was the outlier producing bead-derived ad-hoc names for the singleton case.

## Tests

Adds `cmd/gc/cmd_session_explicit_name_test.go` with 8 sub-tests covering:

- **Rig-scoped singleton** (`qcore/syl` → `qcore--syl`)
- **Binding-scoped singleton** (`gastown.mayor` → `gastown__mayor`)
- **Rig + binding singleton** (`qcore.dev/syl` → `qcore--syl` with binding override)
- **Bare singleton** (`mayor` → `mayor`, no scoping prefix)
- **Explicit `--alias`** short-circuits to empty (manager handles aliased path)
- **Multi-session template** still generates `<base>-adhoc-<hex>` (no regression)
- **Custom `session_template`** renders through `agent.SessionNameFor`
- **Singleton with explicit `--alias`** still short-circuits

Total runtime ~25ms.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/gc/ -run TestSessionExplicitNameForNewSession` passes (8/8 sub-tests)
- [x] Manual: `gc session new qcore/syl --no-attach` → `tmux -L <socket> ls` shows `qcore--syl`, not `s-hq-<beadID>`
- [x] Manual: `gc session new mayor` (bare singleton) → unchanged behavior
- [x] Manual: `gc session new <multi-session-template>` → still produces `<base>-adhoc-<hex>`

## Notes

- Pre-existing failure `TestCmdSessionNudgeQueueResolvesSessionName` reproduces on clean upstream/main; not a regression from this PR.
- Reported by `gastown.mayor` as `gc-ntr7`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->