### PR TITLE
fix(api): server-side wait for sling-target visibility on POST /agents

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -784,12 +784,10 @@ func (cs *controllerState) CreateAgent(a config.Agent) error {
 }
 
 // WaitForAgentVisibility blocks until findAgent in the controller's hot-reloaded
-// config snapshot resolves the given qualified agent name. After CreateAgent,
-// mutateAndPoke has already refreshed cs.cfg from disk, so the first check
-// virtually always succeeds; the wait exists as a safety net for the runtime
-// race where a stale config-reload tick clobbers cs.cfg between our refresh
-// and a subsequent reader. The next runtime tick reads the latest disk content
-// and restores the agent.
+// config snapshot resolves the given qualified agent name. CreateAgent already
+// refreshes cs.cfg from disk, so the first check normally succeeds; the wait
+// preserves the HTTP contract that a successful POST /agents response can be
+// followed immediately by POST /sling against the same target.
 func (cs *controllerState) WaitForAgentVisibility(ctx context.Context, qualifiedName string) error {
 	return api.WaitForAgentVisibilityIn(ctx, cs.Config, qualifiedName)
 }

--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -783,6 +783,17 @@ func (cs *controllerState) CreateAgent(a config.Agent) error {
 	})
 }
 
+// WaitForAgentVisibility blocks until findAgent in the controller's hot-reloaded
+// config snapshot resolves the given qualified agent name. After CreateAgent,
+// mutateAndPoke has already refreshed cs.cfg from disk, so the first check
+// virtually always succeeds; the wait exists as a safety net for the runtime
+// race where a stale config-reload tick clobbers cs.cfg between our refresh
+// and a subsequent reader. The next runtime tick reads the latest disk content
+// and restores the agent.
+func (cs *controllerState) WaitForAgentVisibility(ctx context.Context, qualifiedName string) error {
+	return api.WaitForAgentVisibilityIn(ctx, cs.Config, qualifiedName)
+}
+
 // UpdateAgent partially updates an existing agent definition in city.toml.
 func (cs *controllerState) UpdateAgent(name string, patch api.AgentUpdate) error {
 	return cs.mutateAndPoke(func() error {

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/beads"
@@ -213,6 +214,52 @@ func TestControllerStateRuntimeUpdateDoesNotDropPendingMutationAgents(t *testing
 	}
 	if cs.configMutationPending.Load() {
 		t.Fatal("pending mutation marker not cleared after matching runtime update")
+	}
+}
+
+func TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "alpha")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	current := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Rigs:      []config.Rig{{Name: "alpha", Path: rigDir}},
+		Agents:    []config.Agent{{Name: "worker", Dir: "alpha", Provider: "bash"}},
+	}
+	content, err := current.Marshal()
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), content, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), current, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	if err := cs.CreateAgent(config.Agent{Name: "helper", Dir: "alpha", Provider: "bash"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	stale := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Rigs:      []config.Rig{{Name: "alpha", Path: rigDir}},
+		Agents:    []config.Agent{{Name: "worker", Dir: "alpha", Provider: "bash"}},
+	}
+	cs.updateFromRuntime(stale, runtime.NewFake(), "stale-rev")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := cs.WaitForAgentVisibility(ctx, "alpha/helper"); err != nil {
+		t.Fatalf("WaitForAgentVisibility after stale runtime update: %v", err)
+	}
+	got := cs.Config()
+	if len(got.Agents) != 2 || got.Agents[1].QualifiedName() != "alpha/helper" {
+		t.Fatalf("agents after stale runtime update = %+v, want alpha/helper still visible", got.Agents)
 	}
 }
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -258,9 +258,21 @@ func TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving(t *test
 		t.Fatalf("WaitForAgentVisibility after stale runtime update: %v", err)
 	}
 	got := cs.Config()
-	if len(got.Agents) != 2 || got.Agents[1].QualifiedName() != "alpha/helper" {
+	if !configHasAgent(got, "alpha/helper") {
 		t.Fatalf("agents after stale runtime update = %+v, want alpha/helper still visible", got.Agents)
 	}
+}
+
+func configHasAgent(cfg *config.City, qualifiedName string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, agent := range cfg.Agents {
+		if agent.QualifiedName() == qualifiedName {
+			return true
+		}
+	}
+	return false
 }
 
 func TestControllerStateRuntimeUpdateIgnoresEmptyRevisionDuringPendingMutation(t *testing.T) {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3203,7 +3203,11 @@ case "$cmd" in
     exit 0
     ;;
   --host)
-    exit 0
+    count=0
+    if [ -f "$attempts_file" ]; then
+      count=$(cat "$attempts_file")
+    fi
+    [ "$count" -ge 2 ]
     ;;
   sql-server)
     config_file=""
@@ -3242,9 +3246,12 @@ esac
 	}
 	fakeNC := filepath.Join(binDir, "nc")
 	fakeNCScript := fmt.Sprintf(`#!/bin/sh
-set -eu
 attempts_file=%q
-if [ -f "$attempts_file" ] && [ "$(cat "$attempts_file")" -ge 2 ]; then
+count=0
+if [ -f "$attempts_file" ]; then
+  count=$(cat "$attempts_file")
+fi
+if [ "$count" -ge 2 ]; then
   exit 0
 fi
 exit 1

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3241,7 +3241,15 @@ esac
 		t.Fatal(err)
 	}
 	fakeNC := filepath.Join(binDir, "nc")
-	if err := os.WriteFile(fakeNC, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	fakeNCScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+attempts_file=%q
+if [ -f "$attempts_file" ] && [ "$(cat "$attempts_file")" -ge 2 ]; then
+  exit 0
+fi
+exit 1
+`, attemptsFile)
+	if err := os.WriteFile(fakeNC, []byte(fakeNCScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/api/handler_agent_crud_test.go
+++ b/internal/api/handler_agent_crud_test.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestHandleAgentCreate(t *testing.T) {
@@ -41,15 +45,38 @@ func TestHandleAgentCreate(t *testing.T) {
 // exercised without spinning up the real controller.
 type agentVisibilityFakeState struct {
 	*fakeMutatorState
-	waitCalled atomic.Bool
-	waitName   atomic.Value // string
-	waitErr    error
+	waitCalled             atomic.Bool
+	waitName               atomic.Value // string
+	waitErr                error
+	waitUntilContextDone   bool
+	publishAgentDuringWait bool
+	pendingAgent           *config.Agent
 }
 
-func (s *agentVisibilityFakeState) WaitForAgentVisibility(_ context.Context, qualifiedName string) error {
+func (s *agentVisibilityFakeState) CreateAgent(a config.Agent) error {
+	if !s.publishAgentDuringWait {
+		return s.fakeMutatorState.CreateAgent(a)
+	}
+	pending := a
+	s.pendingAgent = &pending
+	return nil
+}
+
+func (s *agentVisibilityFakeState) WaitForAgentVisibility(ctx context.Context, qualifiedName string) error {
 	s.waitCalled.Store(true)
 	s.waitName.Store(qualifiedName)
-	return s.waitErr
+	if s.waitUntilContextDone {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if s.waitErr != nil {
+		return s.waitErr
+	}
+	if s.publishAgentDuringWait && s.pendingAgent != nil {
+		s.cfg.Agents = append(s.cfg.Agents, *s.pendingAgent)
+		s.pendingAgent = nil
+	}
+	return nil
 }
 
 // TestHandleAgentCreate_InvokesVisibilityWaiter verifies that POST /agents
@@ -76,9 +103,97 @@ func TestHandleAgentCreate_InvokesVisibilityWaiter(t *testing.T) {
 	}
 }
 
+// TestHandleAgentCreate_MakesImmediateSlingTargetVisible proves the handler
+// sequence that regressed in the live contract: once POST /agents returns 201,
+// a POST /sling against the same freshly-created target resolves through the
+// handler's current Config snapshot.
+func TestHandleAgentCreate_MakesImmediateSlingTargetVisible(t *testing.T) {
+	fs := &agentVisibilityFakeState{
+		fakeMutatorState:       newFakeMutatorState(t),
+		publishAgentDuringWait: true,
+	}
+	fs.cfg.Rigs[0].Prefix = "gc"
+	srv := New(fs)
+	srv.SlingRunnerFunc = func(_ string, _ string, _ map[string]string) (string, error) {
+		return "", nil
+	}
+	h := newTestCityHandlerWith(t, fs, srv)
+
+	b, err := fs.stores["myrig"].Create(beads.Bead{Title: "route me", Type: "task"})
+	if err != nil {
+		t.Fatalf("create bead: %v", err)
+	}
+
+	createReq := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(
+		`{"name":"coder","dir":"myrig","provider":"test-agent"}`,
+	))
+	createRec := httptest.NewRecorder()
+	h.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d; body = %s", createRec.Code, http.StatusCreated, createRec.Body.String())
+	}
+
+	slingBody := `{"target":"myrig/coder","bead":"` + b.ID + `"}`
+	slingRec := httptest.NewRecorder()
+	h.ServeHTTP(slingRec, newPostRequest(cityURL(fs, "/sling"), strings.NewReader(slingBody)))
+	if slingRec.Code != http.StatusOK {
+		t.Fatalf("sling status = %d, want %d; body = %s", slingRec.Code, http.StatusOK, slingRec.Body.String())
+	}
+}
+
+func TestHandleAgentCreate_VisibilityWaiterTimeoutIsBounded(t *testing.T) {
+	oldTimeout := agentVisibilityWaitTimeout
+	agentVisibilityWaitTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { agentVisibilityWaitTimeout = oldTimeout })
+
+	fs := &agentVisibilityFakeState{
+		fakeMutatorState:     newFakeMutatorState(t),
+		waitUntilContextDone: true,
+	}
+	h := newTestCityHandler(t, fs)
+
+	req := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(
+		`{"name":"coder","dir":"myrig","provider":"test-agent"}`,
+	))
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	h.ServeHTTP(rec, req)
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("handler returned after %s, want bounded visibility timeout", elapsed)
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("response leaked raw context error: %s", rec.Body.String())
+	}
+}
+
+func TestHandleAgentCreate_VisibilityWaiterCancelIsServiceUnavailable(t *testing.T) {
+	fs := &agentVisibilityFakeState{
+		fakeMutatorState: newFakeMutatorState(t),
+		waitErr:          context.Canceled,
+	}
+	h := newTestCityHandler(t, fs)
+
+	req := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(
+		`{"name":"coder","dir":"myrig","provider":"test-agent"}`,
+	))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), context.Canceled.Error()) {
+		t.Fatalf("response leaked raw context error: %s", rec.Body.String())
+	}
+}
+
 // TestHandleAgentCreate_VisibilityWaiterErrorSurfacesAs500 ensures that a
-// wait failure (e.g., context deadline) does not silently 201 — the caller
-// must know the agent isn't yet reachable through findAgent.
+// projection failure does not silently 201 — the caller must know the agent
+// isn't yet reachable through findAgent.
 func TestHandleAgentCreate_VisibilityWaiterErrorSurfacesAs500(t *testing.T) {
 	fs := &agentVisibilityFakeState{
 		fakeMutatorState: newFakeMutatorState(t),
@@ -93,6 +208,9 @@ func TestHandleAgentCreate_VisibilityWaiterErrorSurfacesAs500(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusInternalServerError, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "simulated visibility wait failure") {
+		t.Fatalf("response leaked raw waiter error: %s", w.Body.String())
 	}
 }
 

--- a/internal/api/handler_agent_crud_test.go
+++ b/internal/api/handler_agent_crud_test.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -30,6 +33,66 @@ func TestHandleAgentCreate(t *testing.T) {
 	}
 	if !found {
 		t.Error("agent 'coder' not found in config after create")
+	}
+}
+
+// agentVisibilityFakeState wraps fakeMutatorState with an
+// AgentVisibilityWaiter implementation so the handler-side wiring can be
+// exercised without spinning up the real controller.
+type agentVisibilityFakeState struct {
+	*fakeMutatorState
+	waitCalled atomic.Bool
+	waitName   atomic.Value // string
+	waitErr    error
+}
+
+func (s *agentVisibilityFakeState) WaitForAgentVisibility(_ context.Context, qualifiedName string) error {
+	s.waitCalled.Store(true)
+	s.waitName.Store(qualifiedName)
+	return s.waitErr
+}
+
+// TestHandleAgentCreate_InvokesVisibilityWaiter verifies that POST /agents
+// calls WaitForAgentVisibility with the qualified name on success. This is
+// the read-after-write guarantee that prevents a follow-up POST /sling from
+// 404ing on the freshly created target.
+func TestHandleAgentCreate_InvokesVisibilityWaiter(t *testing.T) {
+	fs := &agentVisibilityFakeState{fakeMutatorState: newFakeMutatorState(t)}
+	h := newTestCityHandler(t, fs)
+
+	body := `{"name":"coder","dir":"myrig","provider":"claude"}`
+	req := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	if !fs.waitCalled.Load() {
+		t.Fatal("WaitForAgentVisibility was not called")
+	}
+	if got, _ := fs.waitName.Load().(string); got != "myrig/coder" {
+		t.Errorf("WaitForAgentVisibility called with %q, want %q", got, "myrig/coder")
+	}
+}
+
+// TestHandleAgentCreate_VisibilityWaiterErrorSurfacesAs500 ensures that a
+// wait failure (e.g., context deadline) does not silently 201 — the caller
+// must know the agent isn't yet reachable through findAgent.
+func TestHandleAgentCreate_VisibilityWaiterErrorSurfacesAs500(t *testing.T) {
+	fs := &agentVisibilityFakeState{
+		fakeMutatorState: newFakeMutatorState(t),
+		waitErr:          errors.New("simulated visibility wait failure"),
+	}
+	h := newTestCityHandler(t, fs)
+
+	body := `{"name":"coder","dir":"myrig","provider":"claude"}`
+	req := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusInternalServerError, w.Body.String())
 	}
 }
 

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -23,6 +23,11 @@ const lookPathCacheTTL = 30 * time.Second
 // from blocking the caller for a perceptible time on the happy path.
 const agentVisibilityPollInterval = 50 * time.Millisecond
 
+// agentVisibilityWaitTimeout bounds the POST /agents read-after-write wait.
+// The controller should converge much faster; this timeout prevents a broken
+// projection from tying up the handler after the config mutation succeeded.
+var agentVisibilityWaitTimeout = 3 * time.Second
+
 type agentResponse struct {
 	Name        string       `json:"name"`
 	Description string       `json:"description,omitempty"`

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,6 +14,14 @@ import (
 )
 
 const lookPathCacheTTL = 30 * time.Second
+
+// agentVisibilityPollInterval is how often WaitForAgentVisibilityIn re-reads
+// the cfg snapshot while waiting for a freshly created agent to become
+// resolvable through findAgent. Kept short because the typical race window
+// (a runtime config-reload tick that started before the mutation but applies
+// after it) is sub-second; the fast cadence keeps the POST /agents response
+// from blocking the caller for a perceptible time on the happy path.
+const agentVisibilityPollInterval = 50 * time.Millisecond
 
 type agentResponse struct {
 	Name        string       `json:"name"`
@@ -149,6 +158,44 @@ func discoverUnlimitedPool(a config.Agent, poolName, cityName, sessTmpl string, 
 // using the canonical naming contract from agent.SessionNameFor.
 func agentSessionName(cityName, qualifiedName, sessionTemplate string) string {
 	return agent.SessionNameFor(cityName, qualifiedName, sessionTemplate)
+}
+
+// WaitForAgentVisibilityIn polls cfgSnapshot() until findAgent resolves the
+// given qualified agent name, or returns an error if ctx is done. It is the
+// shared building block for AgentVisibilityWaiter implementations.
+//
+// Callers pass cs.Config (or any other snapshot accessor that returns the
+// hot-reloaded *config.City) so the polling reads the live snapshot, not a
+// stale capture. The first check happens before the first sleep so the
+// happy path returns immediately when no runtime race occurred.
+func WaitForAgentVisibilityIn(ctx context.Context, cfgSnapshot func() *config.City, qualifiedName string) error {
+	return waitForAgentVisibilityIn(ctx, cfgSnapshot, qualifiedName, agentVisibilityPollInterval)
+}
+
+func waitForAgentVisibilityIn(ctx context.Context, cfgSnapshot func() *config.City, qualifiedName string, interval time.Duration) error {
+	check := func() bool {
+		cfg := cfgSnapshot()
+		if cfg == nil {
+			return false
+		}
+		_, ok := findAgent(cfg, qualifiedName)
+		return ok
+	}
+	if check() {
+		return nil
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for agent %q to become visible: %w", qualifiedName, ctx.Err())
+		case <-ticker.C:
+		}
+		if check() {
+			return nil
+		}
+	}
 }
 
 // findAgent looks up an agent by qualified name in the config.

--- a/internal/api/handler_agents_test.go
+++ b/internal/api/handler_agents_test.go
@@ -1023,3 +1023,68 @@ func TestProviderPathCheck_FallsBackToRawWhenNoCache(t *testing.T) {
 		t.Errorf("providerPathCheck = %q, want custom-cli", got)
 	}
 }
+
+// TestWaitForAgentVisibilityIn_ReturnsImmediatelyOnHit covers the happy
+// path: the freshly created agent is already visible in the snapshot
+// and the wait returns without sleeping.
+func TestWaitForAgentVisibilityIn_ReturnsImmediatelyOnHit(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker", Dir: "alpha"}},
+	}
+	calls := 0
+	snapshot := func() *config.City {
+		calls++
+		return cfg
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := WaitForAgentVisibilityIn(ctx, snapshot, "alpha/worker"); err != nil {
+		t.Fatalf("WaitForAgentVisibilityIn: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("snapshot calls = %d, want 1 (no polling on hit)", calls)
+	}
+}
+
+// TestWaitForAgentVisibilityIn_PollsUntilVisible covers the race recovery
+// path: a stale runtime tick clobbers the snapshot after CreateAgent, the
+// next runtime tick restores it, and the wait succeeds once the agent
+// reappears.
+func TestWaitForAgentVisibilityIn_PollsUntilVisible(t *testing.T) {
+	stale := &config.City{}
+	fresh := &config.City{
+		Agents: []config.Agent{{Name: "worker", Dir: "alpha"}},
+	}
+	calls := 0
+	snapshot := func() *config.City {
+		calls++
+		if calls < 3 {
+			return stale
+		}
+		return fresh
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := waitForAgentVisibilityIn(ctx, snapshot, "alpha/worker", time.Millisecond); err != nil {
+		t.Fatalf("waitForAgentVisibilityIn: %v", err)
+	}
+	if calls < 3 {
+		t.Errorf("snapshot calls = %d, want >= 3 (polled past stale snapshots)", calls)
+	}
+}
+
+// TestWaitForAgentVisibilityIn_RespectsContext covers the bounded-failure
+// case: the agent never appears and the wait surfaces ctx.Err() instead of
+// blocking indefinitely.
+func TestWaitForAgentVisibilityIn_RespectsContext(t *testing.T) {
+	snapshot := func() *config.City { return &config.City{} }
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := waitForAgentVisibilityIn(ctx, snapshot, "alpha/worker", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want wrapped DeadlineExceeded", err)
+	}
+}

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"errors"
+	"log"
 	"strings"
 	"time"
 
@@ -255,18 +257,33 @@ func (s *Server) humaHandleAgentCreate(ctx context.Context, input *AgentCreateIn
 	// Block until the new agent is reachable through findAgent, so the
 	// 201 response is a strict read-after-write signal: a follow-up
 	// POST /sling against the same target will not race a stale runtime
-	// config snapshot. See beads.ParentProjectionWaiter for the matching
-	// pattern in POST /bead/{id}/update.
+	// config snapshot. This is intentionally scoped to agents because sling
+	// target resolution reads the agent projection immediately after create.
 	qualifiedName := a.QualifiedName()
 	if waiter, ok := s.state.(AgentVisibilityWaiter); ok {
-		if err := waiter.WaitForAgentVisibility(ctx, qualifiedName); err != nil {
-			return nil, huma.Error500InternalServerError(err.Error())
+		waitCtx, cancel := context.WithTimeout(ctx, agentVisibilityWaitTimeout)
+		err := waiter.WaitForAgentVisibility(waitCtx, qualifiedName)
+		cancel()
+		if err != nil {
+			log.Printf("api: agent %s visibility confirmation failed after create: %v", qualifiedName, err)
+			return nil, agentVisibilityWaitHTTPError(err)
 		}
 	}
 	resp := &AgentCreatedOutput{}
 	resp.Body.Status = "created"
 	resp.Body.Agent = qualifiedName
 	return resp, nil
+}
+
+func agentVisibilityWaitHTTPError(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return huma.Error503ServiceUnavailable("agent was created, but visibility confirmation was canceled")
+	case errors.Is(err, context.DeadlineExceeded):
+		return huma.Error504GatewayTimeout("agent was created, but visibility was not confirmed before timeout")
+	default:
+		return huma.Error500InternalServerError("agent was created, but visibility confirmation failed")
+	}
 }
 
 // humaHandleAgentUpdate is the Huma-typed handler for

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -236,7 +236,7 @@ func (s *Server) agentByName(name string) (*IndexOutput[agentResponse], error) {
 // humaHandleAgentCreate is the Huma-typed handler for POST /v0/agents.
 // Body validation (Name and Provider required with minLength:"1") is
 // enforced by the framework from AgentCreateInput's struct tags.
-func (s *Server) humaHandleAgentCreate(_ context.Context, input *AgentCreateInput) (*AgentCreatedOutput, error) {
+func (s *Server) humaHandleAgentCreate(ctx context.Context, input *AgentCreateInput) (*AgentCreatedOutput, error) {
 	sm, ok := s.state.(StateMutator)
 	if !ok {
 		return nil, errMutationsNotSupported
@@ -252,9 +252,20 @@ func (s *Server) humaHandleAgentCreate(_ context.Context, input *AgentCreateInpu
 	if err := sm.CreateAgent(a); err != nil {
 		return nil, mutationError(err)
 	}
+	// Block until the new agent is reachable through findAgent, so the
+	// 201 response is a strict read-after-write signal: a follow-up
+	// POST /sling against the same target will not race a stale runtime
+	// config snapshot. See beads.ParentProjectionWaiter for the matching
+	// pattern in POST /bead/{id}/update.
+	qualifiedName := a.QualifiedName()
+	if waiter, ok := s.state.(AgentVisibilityWaiter); ok {
+		if err := waiter.WaitForAgentVisibility(ctx, qualifiedName); err != nil {
+			return nil, huma.Error500InternalServerError(err.Error())
+		}
+	}
 	resp := &AgentCreatedOutput{}
 	resp.Body.Status = "created"
-	resp.Body.Agent = a.QualifiedName()
+	resp.Body.Agent = qualifiedName
 	return resp, nil
 }
 

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -6,6 +6,7 @@
 package api
 
 import (
+	"context"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -138,6 +139,19 @@ type ProviderUpdate struct {
 // /v0/config/explain endpoint to distinguish inline vs pack-derived agents.
 type RawConfigProvider interface {
 	RawConfig() *config.City
+}
+
+// AgentVisibilityWaiter is an optional capability for states whose Config()
+// snapshot may briefly lag a successful agent mutation under concurrent
+// runtime reloads. Callers that need strict read-after-write semantics for
+// agent target resolution can type-assert this interface after CreateAgent
+// to ensure the new agent is visible through findAgent before returning a
+// success response. Mirrors the beads.ParentProjectionWaiter pattern.
+type AgentVisibilityWaiter interface {
+	// WaitForAgentVisibility blocks until findAgent in the current Config()
+	// resolves the given qualified agent name, or returns an error if the
+	// projection does not converge before ctx is done.
+	WaitForAgentVisibility(ctx context.Context, qualifiedName string) error
 }
 
 // StateMutator extends State with write operations for mutation endpoints.

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -142,11 +142,13 @@ type RawConfigProvider interface {
 }
 
 // AgentVisibilityWaiter is an optional capability for states whose Config()
-// snapshot may briefly lag a successful agent mutation under concurrent
-// runtime reloads. Callers that need strict read-after-write semantics for
-// agent target resolution can type-assert this interface after CreateAgent
-// to ensure the new agent is visible through findAgent before returning a
-// success response. Mirrors the beads.ParentProjectionWaiter pattern.
+// snapshot may briefly lag a successful agent mutation. Callers that need
+// strict read-after-write semantics for agent target resolution can type-assert
+// this interface after CreateAgent to ensure the new agent is visible through
+// findAgent before returning a success response. The interface is deliberately
+// agent-scoped because POST /sling resolves targets through the agent
+// projection immediately after create; rig and provider create endpoints do not
+// currently expose the same follow-up target-resolution contract.
 type AgentVisibilityWaiter interface {
 	// WaitForAgentVisibility blocks until findAgent in the current Config()
 	// resolves the given qualified agent name, or returns an error if the


### PR DESCRIPTION
## Summary

Closes the same-shape race PR #1236 fixes for the deps query at `gc_live_contract_test.go:237`, but for the sling-target lookup at line 216.

`POST /v0/agents` returned 201 as soon as the controller's editor wrote `city.toml` and `refreshConfigSnapshot` updated `cs.cfg`. A concurrent runtime reload tick that started before the mutation but applied after it could clobber `cs.cfg` with a snapshot that lacked the new agent. A client immediately POSTing `/sling` against the freshly created target then observed a transient 404 — `findAgent` reads `s.state.Config()`, and that view had momentarily regressed despite GET /config seeing the agent moments earlier.

This is the failure currently blocking PR #1055 on every CI run.

## Fix shape (matches PR #1236 / `beads.ParentProjectionWaiter`)

- **`AgentVisibilityWaiter`** (`internal/api/state.go`) — optional capability that callers needing strict read-after-write semantics for agent target resolution type-assert.
- **`WaitForAgentVisibilityIn`** (`internal/api/handler_agents.go`) — shared building block that polls `cfgSnapshot()` until `findAgent` resolves the qualified name, or surfaces `ctx.Err()` on cancellation. First check happens before the first sleep so the happy path returns immediately.
- **`controllerState.WaitForAgentVisibility`** (`cmd/gc/api_state.go`) — delegates to the helper using `cs.Config` so polling reads the live hot-reloaded snapshot.
- **`humaHandleAgentCreate`** calls `WaitForAgentVisibility` after a successful `CreateAgent`, surfacing wait failures as 500 so the caller knows the agent isn't yet reachable through `findAgent`.

## Why a sibling PR

cwalv's push access on `gastownhall/gascity` is read-only, so this lands as a sibling rather than a follow-up commit on `fix-gc-live-contract-flake`. Same test, same shape, different operation.

## Test plan

- [x] `go test ./internal/api/` — full package green
- [x] `TestHandleAgentCreate_InvokesVisibilityWaiter` verifies the handler calls `WaitForAgentVisibility` with the correct qualified name
- [x] `TestHandleAgentCreate_VisibilityWaiterErrorSurfacesAs500` verifies wait failures don't silently 201
- [x] `TestWaitForAgentVisibilityIn_{ReturnsImmediatelyOnHit,PollsUntilVisible,RespectsContext}` cover the helper's three branches
- [x] `go run ./cmd/genspec` — no OpenAPI / generated client drift (500 already covered by `default` response)
- [x] `go vet ./internal/api/ ./cmd/gc/` clean
- [ ] CI — `TestGCLiveContract_BeadsAndEvents` no longer races at line 216 across `-count=20` runs (verifying via this PR's CI; the failure is not reproducible locally on a 192-CPU host per worker analysis)

## Related

- PR #1236 — co-located precedent, same test, same shape, deps-query operation at line 237
- PR #1055 (fo-ship-dolt-probe) — blocked on this flake on every CI run; should unblock once this lands

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->