### PR TITLE
feat: drain-without-work circuit-breaker for pool spawn storms

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -80,7 +80,8 @@ type CityRuntime struct {
 	standaloneRigStores map[string]beads.Store
 
 	// Bead-driven reconciler state (Phase 2f).
-	sessionDrains     *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
+	sessionDrains     *drainTracker     // in-memory drain tracker; nil when bead reconciler disabled
+	poolDrainBackoff  *poolDrainBackoff // drain-without-work spawn-storm circuit-breaker
 	asyncStartLimiter *asyncStartLimiter
 	asyncStarts       asyncStartTracker
 	demandSnapshot    *runtimeDemandSnapshot
@@ -312,6 +313,8 @@ func (cr *CityRuntime) run(ctx context.Context) {
 	// Initialize bead-driven drain tracker when bead store is available.
 	if cr.cityBeadStore() != nil && cr.tomlPath != "" {
 		cr.sessionDrains = newDrainTracker()
+		cr.poolDrainBackoff = newPoolDrainBackoff(clock.Real{})
+		cr.installPoolDrainObserver()
 	}
 	if ctx.Err() != nil {
 		return
@@ -1155,6 +1158,10 @@ func (cr *CityRuntime) reloadConfigTraced(
 	if cr.cityBeadStore() != nil && cr.tomlPath != "" && cr.sessionDrains == nil {
 		cr.sessionDrains = newDrainTracker()
 	}
+	if cr.cityBeadStore() != nil && cr.tomlPath != "" && cr.poolDrainBackoff == nil {
+		cr.poolDrainBackoff = newPoolDrainBackoff(clock.Real{})
+		cr.installPoolDrainObserver()
+	}
 	cr.configRev = result.Revision
 	cr.watchTargets = config.WatchTargets(result.Prov, nextCfg, cityRoot)
 	cr.restartConfigWatcher()
@@ -1848,6 +1855,12 @@ func (cr *CityRuntime) loadDemandSnapshot(
 		if sessionBeads != nil {
 			openSessionBeads = sessionBeads.Open()
 		}
+		// Drain-without-work circuit-breaker: zero out scale_check demand for
+		// pools that have hit the spawn-storm pathology threshold and have
+		// no successful claims to suppress the trigger. Operates on the
+		// scale_check map only — assigned-work resume requests still flow
+		// through, so a backoff cannot starve in-flight claimed work.
+		applyPoolDrainBackoff(cr.poolDrainBackoff, cr.cityBeadStore(), result.ScaleCheckCounts)
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
 		result.PoolDesiredCounts = retainScaleCheckPartialPoolDesired(
 			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
@@ -2046,6 +2059,22 @@ func (cr *CityRuntime) recordPreservedShutdownTrace() {
 		"city_name": cr.cityName,
 		"reason":    "supervisor_shutdown_preserve_mode",
 	})
+}
+
+// installPoolDrainObserver wires the drain-without-work detector to the
+// drainTracker's onComplete hook so each terminated drain feeds the
+// circuit-breaker. Reads cr.cfg and the city store at observation time —
+// safe across config reloads because the closure resolves fields lazily.
+func (cr *CityRuntime) installPoolDrainObserver() {
+	if cr == nil || cr.sessionDrains == nil || cr.poolDrainBackoff == nil {
+		return
+	}
+	detector := cr.poolDrainBackoff
+	cr.sessionDrains.mu.Lock()
+	cr.sessionDrains.onComplete = func(session beads.Bead) {
+		recordPoolDrainAck(detector, cr.cityBeadStore(), cr.cfg, session)
+	}
+	cr.sessionDrains.mu.Unlock()
 }
 
 // shutdown performs graceful two-pass agent shutdown for this city.

--- a/cmd/gc/pool_drain_backoff.go
+++ b/cmd/gc/pool_drain_backoff.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/clock"
+)
+
+// Drain-without-work circuit-breaker.
+//
+// This detector measures the spawn-storm pathology directly: count
+// drain-acked sessions that exited without claiming any work, per pool,
+// per rolling window. If that count crosses a threshold AND no claims
+// happened pool-wide in the same window (the Q6 rate-condition),
+// suppress new spawns with exponential backoff.
+//
+// It is a supplement to per-bead positive-signal detection: both share
+// cooldown surface, but this one is robust across worker-pool model
+// changes because it observes worker outcomes (drained without claiming),
+// not supervisor model preconditions.
+//
+// State is in-memory only; lost on controller restart, by design.
+const (
+	drainBackoffWindow    = 5 * time.Minute
+	drainBackoffThreshold = 3
+	drainBackoffBase      = 30 * time.Second
+	// drainBackoffMaxStreak guards against int64 overflow on the bit
+	// shift in backoffDurationForStreak; the schedule effectively caps
+	// at drainBackoffCap long before this clamp matters.
+	drainBackoffMaxStreak = 30
+	drainBackoffCap       = 5 * time.Minute
+)
+
+// poolBackoffStats tracks zero-claim drain-acks and active backoff state
+// for a single pool (agent template).
+type poolBackoffStats struct {
+	zeroClaimDrains []time.Time // sliding window of zero-claim drain-ack timestamps
+	backoffStreak   int         // consecutive backoff escalations (0 = inactive or just reset)
+	backoffUntil    time.Time   // backoff active when now < backoffUntil
+}
+
+// poolDrainBackoff is the long-lived detector state, one instance per
+// reconciler. Add it to CityRuntime alongside sessionDrains.
+type poolDrainBackoff struct {
+	mu      sync.Mutex
+	perPool map[string]*poolBackoffStats
+	clk     clock.Clock
+}
+
+func newPoolDrainBackoff(clk clock.Clock) *poolDrainBackoff {
+	if clk == nil {
+		clk = clock.Real{}
+	}
+	return &poolDrainBackoff{
+		perPool: make(map[string]*poolBackoffStats),
+		clk:     clk,
+	}
+}
+
+// RecordDrainAck records a drain-ack observation for a pool template.
+// hadClaims=true means the session claimed at least one work bead during
+// its lifetime; hadClaims=false is the zero-claim drain-ack the detector
+// is watching for.
+//
+// Stale entries outside the window are pruned eagerly here so the per-pool
+// slice stays bounded by threshold + churn during a single window.
+func (p *poolDrainBackoff) RecordDrainAck(template string, hadClaims bool) {
+	if p == nil || template == "" || hadClaims {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	stats := p.statsLocked(template)
+	now := p.clk.Now()
+	stats.zeroClaimDrains = pruneStale(stats.zeroClaimDrains, now.Add(-drainBackoffWindow))
+	stats.zeroClaimDrains = append(stats.zeroClaimDrains, now)
+}
+
+// NoteClaim records that a claim was observed for this pool. Successful
+// claims reset the backoff streak — the pool is healthy enough to make
+// progress, so the detector should not stack escalations.
+func (p *poolDrainBackoff) NoteClaim(template string) {
+	if p == nil || template == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	stats := p.statsLocked(template)
+	stats.backoffStreak = 0
+	stats.backoffUntil = time.Time{}
+	stats.zeroClaimDrains = nil
+}
+
+// Evaluate returns whether new spawns should be suppressed for this
+// template right now, and the time at which suppression ends.
+//
+// hasRecentPoolClaim is the Q6 rate-condition: when true, the pool had at
+// least one claim in the recent window pool-wide, so the detector treats
+// the zero-claim drain-acks as race-loser noise and does not fire. Callers
+// must compute this from the bead store at evaluation time.
+func (p *poolDrainBackoff) Evaluate(template string, hasRecentPoolClaim bool) (suppress bool, until time.Time) {
+	if p == nil || template == "" {
+		return false, time.Time{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	stats := p.statsLocked(template)
+	now := p.clk.Now()
+
+	// If a claim happened pool-wide, reset state — the pool is healthy.
+	if hasRecentPoolClaim {
+		stats.backoffStreak = 0
+		stats.backoffUntil = time.Time{}
+		stats.zeroClaimDrains = nil
+		return false, time.Time{}
+	}
+
+	stats.zeroClaimDrains = pruneStale(stats.zeroClaimDrains, now.Add(-drainBackoffWindow))
+
+	// Already in active backoff window.
+	if !stats.backoffUntil.IsZero() && now.Before(stats.backoffUntil) {
+		return true, stats.backoffUntil
+	}
+
+	// Threshold check: enough zero-claim drain-acks in window to escalate?
+	if len(stats.zeroClaimDrains) < drainBackoffThreshold {
+		return false, time.Time{}
+	}
+
+	// Escalate: increment streak, set new backoffUntil.
+	stats.backoffStreak++
+	stats.backoffUntil = now.Add(backoffDurationForStreak(stats.backoffStreak))
+	return true, stats.backoffUntil
+}
+
+// statsLocked returns the per-template stats, allocating on first use.
+// Caller must hold p.mu.
+func (p *poolDrainBackoff) statsLocked(template string) *poolBackoffStats {
+	stats := p.perPool[template]
+	if stats == nil {
+		stats = &poolBackoffStats{}
+		p.perPool[template] = stats
+	}
+	return stats
+}
+
+// backoffDurationForStreak returns the backoff window for the given
+// escalation streak. Streak 1 = base, streak 2 = 2*base, ... capped at
+// drainBackoffCap. Mirrors the per-bead detector's exponential schedule
+// so the two share a familiar shape.
+func backoffDurationForStreak(streak int) time.Duration {
+	if streak <= 0 {
+		return 0
+	}
+	if streak > drainBackoffMaxStreak {
+		streak = drainBackoffMaxStreak
+	}
+	d := drainBackoffBase << (streak - 1)
+	if d <= 0 || d > drainBackoffCap {
+		return drainBackoffCap
+	}
+	return d
+}
+
+// pruneStale drops timestamps strictly older than threshold, returning the
+// retained suffix without copying when no pruning is needed.
+func pruneStale(ts []time.Time, threshold time.Time) []time.Time {
+	cut := 0
+	for cut < len(ts) && ts[cut].Before(threshold) {
+		cut++
+	}
+	if cut == 0 {
+		return ts
+	}
+	return ts[cut:]
+}

--- a/cmd/gc/pool_drain_backoff_test.go
+++ b/cmd/gc/pool_drain_backoff_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/clock"
+)
+
+func TestPoolDrainBackoff_AccumulatesZeroClaimDrainsAndFires(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)}
+	p := newPoolDrainBackoff(clk)
+	template := "foundations/worker"
+
+	for i := 0; i < drainBackoffThreshold-1; i++ {
+		p.RecordDrainAck(template, false)
+	}
+	if suppress, _ := p.Evaluate(template, false); suppress {
+		t.Fatalf("Evaluate after %d zero-claim drains: got suppress=true, want false (below threshold)", drainBackoffThreshold-1)
+	}
+
+	p.RecordDrainAck(template, false) // now at threshold
+	suppress, until := p.Evaluate(template, false)
+	if !suppress {
+		t.Fatalf("Evaluate at threshold: got suppress=false, want true")
+	}
+	expectedUntil := clk.Now().Add(drainBackoffBase)
+	if !until.Equal(expectedUntil) {
+		t.Fatalf("Evaluate at threshold: got until=%v, want %v (now+base)", until, expectedUntil)
+	}
+}
+
+func TestPoolDrainBackoff_Q6RateConditionSuppressesRaceLosers(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)}
+	p := newPoolDrainBackoff(clk)
+	template := "foundations/worker"
+
+	// Simulate a claim race: one worker won, four lost. Race losers all
+	// drain-ack with claim_count=0; the winner consumed the work.
+	for i := 0; i < drainBackoffThreshold+1; i++ {
+		p.RecordDrainAck(template, false)
+	}
+
+	// Q6 fires: pool-wide there WAS a claim in the window. Detector must
+	// not suppress, and state should reset so it doesn't stay armed.
+	suppress, _ := p.Evaluate(template, true)
+	if suppress {
+		t.Fatalf("Evaluate with hasRecentPoolClaim=true: got suppress=true, want false (Q6 rate condition)")
+	}
+
+	// State reset: a fresh threshold's worth of zero-claim drains must be
+	// required to fire again.
+	for i := 0; i < drainBackoffThreshold-1; i++ {
+		p.RecordDrainAck(template, false)
+	}
+	if suppress, _ := p.Evaluate(template, false); suppress {
+		t.Fatalf("Evaluate after reset + below-threshold drains: got suppress=true, want false")
+	}
+}
+
+func TestPoolDrainBackoff_ExponentialSchedule(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)}
+	p := newPoolDrainBackoff(clk)
+	template := "foundations/worker"
+
+	want := []time.Duration{
+		drainBackoffBase,                   // streak 1: 30s
+		drainBackoffBase * 2,               // streak 2: 60s
+		drainBackoffBase * 4,               // streak 3: 120s
+		drainBackoffBase * 8,               // streak 4: 240s
+		drainBackoffCap,                    // streak >=5: capped at 5min
+	}
+
+	for i, expectedBackoff := range want {
+		// Drive enough zero-claim drains to (re-)cross threshold.
+		for j := 0; j < drainBackoffThreshold; j++ {
+			p.RecordDrainAck(template, false)
+		}
+		suppress, until := p.Evaluate(template, false)
+		if !suppress {
+			t.Fatalf("escalation #%d: got suppress=false, want true", i+1)
+		}
+		got := until.Sub(clk.Now())
+		if got != expectedBackoff {
+			t.Fatalf("escalation #%d: got backoff=%v, want %v", i+1, got, expectedBackoff)
+		}
+		// Skip past this backoff so the next iteration can escalate again.
+		clk.Advance(expectedBackoff + time.Second)
+	}
+}
+
+func TestPoolDrainBackoff_StaleDrainsAreDropped(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)}
+	p := newPoolDrainBackoff(clk)
+	template := "foundations/worker"
+
+	// Drain-acks just outside the window must not count toward threshold.
+	for i := 0; i < drainBackoffThreshold; i++ {
+		p.RecordDrainAck(template, false)
+	}
+	clk.Advance(drainBackoffWindow + time.Second)
+	if suppress, _ := p.Evaluate(template, false); suppress {
+		t.Fatalf("Evaluate after window expiry: got suppress=true, want false (stale drain-acks should not fire)")
+	}
+}
+
+func TestPoolDrainBackoff_HadClaimsIsIgnored(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)}
+	p := newPoolDrainBackoff(clk)
+	template := "foundations/worker"
+
+	// hadClaims=true means the session did productive work — never count.
+	for i := 0; i < drainBackoffThreshold*3; i++ {
+		p.RecordDrainAck(template, true)
+	}
+	if suppress, _ := p.Evaluate(template, false); suppress {
+		t.Fatalf("Evaluate after only hadClaims=true drains: got suppress=true, want false")
+	}
+}
+
+func TestPoolDrainBackoff_NoteClaimResetsBackoff(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)}
+	p := newPoolDrainBackoff(clk)
+	template := "foundations/worker"
+
+	for i := 0; i < drainBackoffThreshold; i++ {
+		p.RecordDrainAck(template, false)
+	}
+	if suppress, _ := p.Evaluate(template, false); !suppress {
+		t.Fatal("setup: expected suppression after threshold drains")
+	}
+
+	// Observed claim resets state.
+	p.NoteClaim(template)
+
+	// Even with hasRecentPoolClaim=false at evaluate time, NoteClaim has
+	// already cleared the streak/until/window — so we're back to idle.
+	if suppress, until := p.Evaluate(template, false); suppress {
+		t.Fatalf("Evaluate after NoteClaim: got suppress=true (until=%v), want false", until)
+	}
+}
+
+func TestPoolDrainBackoff_NilSafe(t *testing.T) {
+	var p *poolDrainBackoff
+	p.RecordDrainAck("x", false)
+	p.NoteClaim("x")
+	if suppress, _ := p.Evaluate("x", false); suppress {
+		t.Fatal("nil receiver: Evaluate should return suppress=false")
+	}
+}

--- a/cmd/gc/pool_drain_backoff_test.go
+++ b/cmd/gc/pool_drain_backoff_test.go
@@ -64,11 +64,11 @@ func TestPoolDrainBackoff_ExponentialSchedule(t *testing.T) {
 	template := "foundations/worker"
 
 	want := []time.Duration{
-		drainBackoffBase,                   // streak 1: 30s
-		drainBackoffBase * 2,               // streak 2: 60s
-		drainBackoffBase * 4,               // streak 3: 120s
-		drainBackoffBase * 8,               // streak 4: 240s
-		drainBackoffCap,                    // streak >=5: capped at 5min
+		drainBackoffBase,     // streak 1: 30s
+		drainBackoffBase * 2, // streak 2: 60s
+		drainBackoffBase * 4, // streak 3: 120s
+		drainBackoffBase * 8, // streak 4: 240s
+		drainBackoffCap,      // streak >=5: capped at 5min
 	}
 
 	for i, expectedBackoff := range want {

--- a/cmd/gc/pool_drain_backoff_wire.go
+++ b/cmd/gc/pool_drain_backoff_wire.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// sessionHadClaims reports whether any work bead is attributed to this
+// session — measured by Assignee matching the session's identity. Closed
+// beads count: if a session ever owned work, it is not a zero-claim drain
+// even if the work has since wrapped up.
+//
+// Returns true on store error to fail safe — the detector should not fire
+// on transient query failures.
+func sessionHadClaims(store beads.Store, session beads.Bead) bool {
+	if store == nil {
+		return true
+	}
+	candidates := sessionClaimIdentities(session)
+	if len(candidates) == 0 {
+		return true
+	}
+	for _, identity := range candidates {
+		beadList, err := store.List(beads.ListQuery{
+			Assignee:      identity,
+			IncludeClosed: true,
+		})
+		if err != nil {
+			return true
+		}
+		for _, b := range beadList {
+			if b.Type == sessionBeadType {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// sessionClaimIdentities returns the set of identity strings that may
+// appear in a work bead's Assignee field for this session. Workers may
+// claim using GC_SESSION_NAME, GC_AGENT, or a configured named identity;
+// returning all of them keeps the lookup robust to that variation.
+func sessionClaimIdentities(session beads.Bead) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	add(session.Metadata["session_name"])
+	add(session.Metadata["agent_name"])
+	add(session.Metadata["alias"])
+	add(session.Metadata["configured_named_identity"])
+	return out
+}
+
+// poolHasLiveClaim reports whether any work bead routed to this pool is
+// currently held by a worker — in_progress with non-empty Assignee. This
+// is the Q6 rate-condition input: while progress is in flight somewhere
+// in the pool, in-flight zero-claim drain-acks are treated as race-loser
+// noise and the circuit-breaker does not fire.
+//
+// We check live in-progress state rather than a recency window because
+// the bead model has no UpdatedAt. If the pool finished a burst and is
+// now idle, scale_check should return 0 demand anyway — when it doesn't,
+// the detector is correct to throttle.
+//
+// Returns true on store error to fail safe.
+func poolHasLiveClaim(store beads.Store, template string) bool {
+	if store == nil || template == "" {
+		return true
+	}
+	beadList, err := store.List(beads.ListQuery{
+		Status:   "in_progress",
+		Metadata: map[string]string{"gc.routed_to": template},
+	})
+	if err != nil {
+		return true
+	}
+	for _, b := range beadList {
+		if b.Type == sessionBeadType {
+			continue
+		}
+		if strings.TrimSpace(b.Assignee) == "" {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// recordPoolDrainAck wires a completed drain into the detector. It is the
+// onComplete callback installed on drainTracker. Only pool-managed
+// ephemeral sessions feed the detector — named/manual sessions have
+// different lifecycle semantics and are not part of the spawn-storm
+// pathology.
+func recordPoolDrainAck(detector *poolDrainBackoff, store beads.Store, cfg *config.City, session beads.Bead) {
+	if detector == nil {
+		return
+	}
+	if !isEphemeralSessionBead(session) || isManualSessionBead(session) || isNamedSessionBead(session) {
+		return
+	}
+	template := normalizedSessionTemplate(session, cfg)
+	if template == "" {
+		return
+	}
+	hadClaims := sessionHadClaims(store, session)
+	detector.RecordDrainAck(template, hadClaims)
+}
+
+// applyPoolDrainBackoff suppresses scale_check counts for pools that the
+// detector has flagged. Mutates scaleCheckCounts in place. The Q6
+// rate-condition (any in-progress pool-routed claim) is checked per pool
+// against the live store before suppression is applied.
+//
+// Called from the demand-snapshot path after scale_check runs and before
+// pool desired states are computed.
+func applyPoolDrainBackoff(
+	detector *poolDrainBackoff,
+	store beads.Store,
+	scaleCheckCounts map[string]int,
+) {
+	if detector == nil || len(scaleCheckCounts) == 0 {
+		return
+	}
+	for template, count := range scaleCheckCounts {
+		if count <= 0 {
+			continue
+		}
+		hasClaim := poolHasLiveClaim(store, template)
+		suppress, _ := detector.Evaluate(template, hasClaim)
+		if suppress {
+			scaleCheckCounts[template] = 0
+		}
+	}
+}

--- a/cmd/gc/session_types.go
+++ b/cmd/gc/session_types.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 )
 
@@ -75,6 +76,12 @@ type drainTracker struct {
 	drains          map[string]*drainState     // session bead ID -> drain state
 	idleProbes      map[string]*idleProbeState // session bead ID -> async idle probe
 	idleProbeCursor int
+	// onComplete, when set, is invoked once per session whose drain
+	// reaches the terminal completeDrain path. The reconciler uses this
+	// to feed the drain-without-work circuit-breaker without widening
+	// the advanceSessionDrains signature. Pure observation hook —
+	// must not block or mutate drain state.
+	onComplete func(session beads.Bead)
 }
 
 func newDrainTracker() *drainTracker {

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -454,6 +454,7 @@ func advanceSessionDrainsWithSessionsTraced(
 		if !running {
 			// Process exited — drain complete.
 			completeDrain(session, store, ds, clk)
+			notifyDrainObservers(dt, *session)
 			dt.clearIdleProbe(id)
 			dt.remove(id)
 			telemetry.RecordDrainTransition(context.Background(), name, ds.reason, "complete")
@@ -568,6 +569,7 @@ func advanceSessionDrainsWithSessionsTraced(
 			}
 			if !running {
 				completeDrain(session, store, ds, clk)
+				notifyDrainObservers(dt, *session)
 				dt.clearIdleProbe(id)
 				dt.remove(id)
 				telemetry.RecordDrainTransition(context.Background(), name, ds.reason, "timeout")
@@ -579,6 +581,22 @@ func advanceSessionDrainsWithSessionsTraced(
 		}
 		// Else: still draining, check again next tick.
 	}
+}
+
+// notifyDrainObservers fires the drainTracker's onComplete callback for a
+// session whose drain just terminated. Callback is best-effort: a nil
+// receiver, missing callback, or zero-value session is a silent no-op.
+func notifyDrainObservers(dt *drainTracker, session beads.Bead) {
+	if dt == nil {
+		return
+	}
+	dt.mu.Lock()
+	cb := dt.onComplete
+	dt.mu.Unlock()
+	if cb == nil {
+		return
+	}
+	cb(session)
 }
 
 // completeDrain writes drain-complete metadata to the bead.

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -247,6 +247,44 @@ System formulas are embedded in the `gc` binary and materialized to
 layer (Layer 0) in the formula resolution stack. Pack and city-level
 formulas override system formulas by name.
 
+## Spawn-Storm Defenses
+
+Pool agents have a feedback loop between `scale_check` (the demand
+oracle) and `work_query` (what a worker finds at the hook): when the two
+disagree about whether actionable work exists, the controller can
+spawn worker after worker that immediately drain-acks because no work
+is claimable. This is a "spawn storm" — visible as a sustained run of
+ephemeral pool sessions starting and exiting with `claim_count == 0`.
+
+Two complementary detectors guard against this:
+
+- **Per-bead positive-signal detector** (`spawn_storm.go`, sibling
+  defense layer): watches that pool work which scale_check says is
+  there actually does get claimed by spawned workers. When a specific
+  bead is repeatedly slung but never claimed, this detector trips and
+  applies exponential backoff before spawning more workers for it.
+
+- **Drain-without-work circuit breaker** (`pool_drain_backoff.go`):
+  observes the pathology directly — counts drain-acked sessions whose
+  lifetime claim count was zero, per pool, per rolling 5-minute window.
+  When that count crosses a threshold AND no in-progress claim exists
+  pool-wide (the rate-condition that suppresses race-loser noise),
+  scale_check demand for that pool is forced to 0 and held there with
+  exponential backoff (30s → 60s → 120s → 240s → 5min capped).
+
+Both detectors share cooldown surface — a successful claim observed
+pool-wide resets the drain-detector's streak immediately, the same
+healthy-progress signal the per-bead detector also responds to. The
+drain detector is robust across worker-pool model changes because it
+keys off worker outcomes (terminated without claiming) rather than
+supervisor model preconditions, so future changes to `work_query`
+semantics cannot silently disable it.
+
+State for the drain detector lives in memory on `CityRuntime` alongside
+`drainTracker`; it is intentionally lost on controller restart so a
+freshly restarted controller starts in the unsuppressed state and
+re-derives any active backoff from observed behavior.
+
 ## Testing
 
 Dispatch testing follows the philosophy in


### PR DESCRIPTION
## Summary

Implements the drain-without-work circuit-breaker designed in fo-ky6oh
(operator-confirmed, sign-off in close notes). Adds a second-source
detector that observes the spawn-storm pathology directly — counts
drain-acked sessions with zero lifetime claims per pool, per rolling
5-minute window. When the count crosses threshold AND no in-progress
claim exists pool-wide (Q6 rate-condition), zero out scale_check
demand for the template with exponential backoff (30s → 60s → 120s →
240s → 5min cap).

## Why a new detector

Per fo-ky6oh's operator-confirmed framing: this **supplements** the
per-bead positive-signal detector in PR #1064 — both share cooldown
surface, but this detector keys off worker outcomes (drained without
claiming) rather than supervisor model preconditions, so future
\`work_query\` semantic changes cannot silently disable it. The two
form complementary defense layers.

## How it wires in

- \`pool_drain_backoff.go\` — detector + state machine. In-memory state
  on CityRuntime alongside \`drainTracker\`; lost on controller restart
  by design.
- \`session_types.go\` — adds \`onComplete\` callback hook to
  \`drainTracker\`. The reconciler installs a closure that records the
  drain-ack with the session's lifetime claim count. Closure pattern
  avoids widening every \`advanceSessionDrains*\` signature.
- \`session_wake.go\` — calls \`notifyDrainObservers\` at both terminal
  drain paths (clean exit + force-stop timeout) so completeDrain feeds
  the detector exactly once per drain cycle.
- \`city_runtime.go\` — initialization next to \`sessionDrains\` (both at
  startup and on bead-store-becomes-available reload). Suppression is
  applied in \`loadDemandSnapshot\` after \`scale_check\` returns and
  before \`ComputePoolDesiredStates\` assembles SessionRequests.
  Assigned-work resume requests bypass the gate so backoff cannot
  starve in-flight claimed work.
- \`pool_drain_backoff_wire.go\` — bead-store query helpers
  (\`sessionHadClaims\`, \`poolHasLiveClaim\`) and the
  \`recordPoolDrainAck\` / \`applyPoolDrainBackoff\` glue. Both queries
  fail-safe (return true on store error) so transient store failures
  cannot make the detector fire.
- \`engdocs/architecture/dispatch.md\` — new \"Spawn-Storm Defenses\"
  section covering both detectors and their shared cooldown surface.

## Tests

Unit tests in \`pool_drain_backoff_test.go\` cover:

- **Zero-claim drain-ack accumulation** drives the detector to fire at
  threshold (and stays quiet below it)
- **Q6 rate-condition** suppresses the race-loser scenario: with a
  threshold's worth of zero-claim drain-acks AND a pool-wide claim,
  the detector does not fire, and the state resets so a fresh
  threshold is required to re-arm
- **Exponential backoff schedule** (30s → 60s → 120s → 240s → 5min
  cap) — five escalations validated in sequence
- Stale drain-acks outside the window are dropped
- \`hadClaims=true\` drain-acks (productive sessions) never count toward
  threshold
- Observed claim resets backoff state immediately
- Nil receiver is safe (parity with other reconciler helpers)

## Stacking

Base is \`fix/main-auto-port-bind-retry-20260501\` (PR #1582) so the
tempfile flake on \`Preflight / acceptance A\` doesn't keep failing
this PR's CI. GitHub auto-retargets to main when #1582 merges.

## Test plan

- [ ] CI green on \`Preflight\` and \`Test\`
- [ ] Reviewers confirm Q6 rate-condition matches the operator's
      design intent (in-progress claimed bead = pool is healthy)
- [ ] Reviewers confirm the choice to query \"any in-progress claim\"
      rather than a recency window — bead model has no UpdatedAt, and
      idle pools should report zero scale_check demand anyway

## Related

- fo-ky6oh (closed): design bead, full design notes including operator
  sign-off on Q1 (supplement vs replace) and Q4 (count race losers)
- fo-0aing: this implementation bead
- PR #1064 (draft): per-bead positive-signal detector — sibling
  defense layer
- gc-wisp-exch: operator post-mortem (origin of this idea)