### PR TITLE
refactor(reconciler): share pool-demand predicate with work_query Tier 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Default bead-backed pool-demand counts now use the same routed target
+  resolution as worker claim queries and exclude epic-routed beads, matching
+  the default worker `work_query` behavior. Custom `scale_check` overrides are
+  unchanged.
 - Empty JSON result collections for `gc mail thread`, `gc trace status`, and
   `gc trace show` now encode as `[]` instead of `null`; `gc trace show` also
   reports a concise no-records message in the default text mode.

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -102,10 +102,16 @@ type scaleParams struct {
 }
 
 // scaleParamsFor extracts scaling parameters from an Agent's fields.
+//
+// Check is the count-form pool-demand query (EffectivePoolDemandQuery).
+// It shares the bd ready predicate with EffectiveWorkQuery's Tier 3 via
+// bdReadyPoolDemandShell, keeping reconciler spawn decisions and worker
+// claim decisions structurally symmetric. See engdocs/architecture/dispatch.md
+// "scale_check ↔ work_query correspondence".
 func scaleParamsFor(a *config.Agent) scaleParams {
 	sp := scaleParams{
 		Min:   a.EffectiveMinActiveSessions(),
-		Check: a.EffectiveScaleCheck(),
+		Check: a.EffectivePoolDemandQuery(),
 	}
 	if m := a.EffectiveMaxActiveSessions(); m != nil {
 		sp.Max = *m

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -2,7 +2,7 @@
 title: "Dispatch (Sling)"
 ---
 
-> Last verified against code: 2026-04-25
+> Last verified against code: 2026-05-06
 
 ## Summary
 
@@ -140,6 +140,44 @@ CLI layer (cmd/gc/cmd_sling.go)
   `SlingQuery` field and `EffectiveSlingQuery()` method that determines
   how beads are routed to this agent.
 
+## scale_check ↔ work_query correspondence
+
+Dispatch has two read sides that must stay symmetric:
+
+- **Reconciler (spawn side)**: when deciding whether a pool template
+  needs another session, the controller invokes
+  `Agent.EffectivePoolDemandQuery` (a thin pass-through that
+  `EffectiveScaleCheck` also returns) and parses the count.
+- **Worker (claim side)**: when an ephemeral session boots, `gc hook`
+  invokes `Agent.EffectiveWorkQuery`, whose Tier 3 fires for unassigned
+  routed work after the assignee tiers fall through.
+
+Both forms answer the same question — "is there ready, unassigned,
+non-epic work routed to this template?" — and must therefore observe
+the bead store through the same filter. They share the predicate via
+the package-level helper `bdReadyPoolDemandShell(target) → "bd ready
+--metadata-field gc.routed_to=<target> --unassigned --exclude-type=epic
+--json"`. The count form pipes through `jq 'length'`; the work-query
+form appends `--limit=1` and prints the first match. Targets resolve to
+`Agent.PoolName` when set and `Agent.QualifiedName()` otherwise, so
+pool instances and pool templates land on the same routed queue.
+
+Diverging the two — for example, by adding a state filter to the
+work-query without updating the count form — re-introduces the
+protocol-mismatch class. Pre-PR #1516 symptom: the reconciler counted
+molecule-typed beads as demand while the worker's `bd ready` skipped
+them, so spawned sessions exited immediately and the reconciler
+re-spawned, producing spawn storms.
+
+PR #1516 retired the divergent molecule tier from both paths
+simultaneously, leaving "ready unassigned non-epic routed_to" as the
+single predicate shape. This refactor made that equivalence
+**structural** by routing both paths through `bdReadyPoolDemandShell`.
+Adding new tiers or filters in the future is a single-helper change; tests
+`TestPoolDemandPredicateSharedWithWorkQuery` (structural) and
+`TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics` (behavioral)
+guard against regressions.
+
 ## Invariants
 
 1. **Sling query placeholder is always `{}`.** The `buildSlingCommand`
@@ -183,6 +221,25 @@ CLI layer (cmd/gc/cmd_sling.go)
     `bd update {} --label=pool:<name>`. Custom `sling_query` overrides
     the default entirely.
 
+11. **scale_check ↔ work_query correspondence.** The reconciler's
+    pool-demand-detection path (`Agent.EffectivePoolDemandQuery`, count
+    form) and the worker's claim path (`Agent.EffectiveWorkQuery`, Tier
+    3 first-row form) MUST derive their `bd ready --metadata-field
+    gc.routed_to=<target> --unassigned --exclude-type=epic --json`
+    predicate from the same `bdReadyPoolDemandShell` helper in
+    `internal/config/config.go`. Any tier-shape change to one (added
+    filter, modified target resolution, new state) MUST be reflected in
+    the other. Diverging the two
+    re-introduces the protocol-mismatch class — the reconciler spawning
+    sessions for work the worker can't claim, or the worker idle while
+    new demand sits unspawned. Enforced by
+    `TestPoolDemandPredicateSharedWithWorkQuery` and
+    `TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics` in
+    `internal/config/config_test.go`. Historical context: PR #1516
+    symmetrically simplified both predicates to just "ready unassigned
+    non-epic routed_to" (removing molecule-tier counting from each); this
+    refactor made that equivalence structural rather than coincidental.
+
 ## Interactions
 
 | Depends on | How |
@@ -212,7 +269,7 @@ CLI layer (cmd/gc/cmd_sling.go)
 | `cmd/gc/system_formulas.go` | `MaterializeSystemFormulas`, `ListEmbeddedSystemFormulas`, stale file cleanup |
 | `cmd/gc/system_formulas_test.go` | Tests for materialization: empty FS, write, overwrite, stale cleanup, idempotency, orders |
 | `cmd/gc/pool.go` | `evaluatePool` (scale check), `poolAgents` (instance expansion), `expandSessionSetup` (template context) |
-| `internal/config/config.go` | `Agent.SlingQuery`, `Agent.EffectiveSlingQuery()`, `Agent.EffectiveWorkQuery()`, `Agent.IsPool()` |
+| `internal/config/config.go` | `Agent.SlingQuery`, `Agent.EffectiveSlingQuery()`, `Agent.EffectiveWorkQuery()`, `Agent.EffectivePoolDemandQuery()`, `Agent.EffectiveScaleCheck()`, `bdReadyPoolDemandShell()`, `Agent.IsPool()` |
 | `internal/beads/beads.go` | `IsContainerType`, `Store.MolCook`, `Store.Children`, `Store.SetMetadata` |
 | `internal/beads/bdstore.go` | `BdStore.MolCook` and `BdStore.MolCookOn` -- formula-backed wisp instantiation via `bd mol wisp` / `bd mol bond` |
 | `internal/telemetry/recorder.go` | `RecordSling` -- metrics counter + structured log event for each dispatch |

--- a/engdocs/architecture/dispatch.md
+++ b/engdocs/architecture/dispatch.md
@@ -2,7 +2,7 @@
 title: "Dispatch (Sling)"
 ---
 
-> Last verified against code: 2026-05-06
+> Last verified against code: 2026-05-21
 
 ## Summary
 
@@ -153,14 +153,21 @@ Dispatch has two read sides that must stay symmetric:
   routed work after the assignee tiers fall through.
 
 Both forms answer the same question — "is there ready, unassigned,
-non-epic work routed to this template?" — and must therefore observe
-the bead store through the same filter. They share the predicate via
-the package-level helper `bdReadyPoolDemandShell(target) → "bd ready
---metadata-field gc.routed_to=<target> --unassigned --exclude-type=epic
---json"`. The count form pipes through `jq 'length'`; the work-query
-form appends `--limit=1` and prints the first match. Targets resolve to
+non-epic work routed to this pool-demand target?" — and must therefore
+observe the bead store through the same filter. They share target
+resolution and the predicate: `bdReadyPoolDemandShell(target)` returns
+`bd ready --metadata-field gc.routed_to=<target> --unassigned
+--exclude-type=epic --json`. The count form pipes through `jq 'length'`;
+the work-query form appends
+`--limit=1` and prints the first match. Targets resolve to
 `Agent.PoolName` when set and `Agent.QualifiedName()` otherwise, so
 pool instances and pool templates land on the same routed queue.
+
+The shared predicate is the agreement substrate. Failure envelopes
+intentionally differ: the worker path suppresses `bd ready` stderr and
+returns `[]` so a session exits cleanly, while the count form propagates
+the failure to `evaluatePool`, which records telemetry and falls back to
+the pool minimum.
 
 Diverging the two — for example, by adding a state filter to the
 work-query without updating the count form — re-introduces the
@@ -169,14 +176,15 @@ molecule-typed beads as demand while the worker's `bd ready` skipped
 them, so spawned sessions exited immediately and the reconciler
 re-spawned, producing spawn storms.
 
-PR #1516 retired the divergent molecule tier from both paths
-simultaneously, leaving "ready unassigned non-epic routed_to" as the
-single predicate shape. This refactor made that equivalence
-**structural** by routing both paths through `bdReadyPoolDemandShell`.
-Adding new tiers or filters in the future is a single-helper change; tests
-`TestPoolDemandPredicateSharedWithWorkQuery` (structural) and
-`TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics` (behavioral)
-guard against regressions.
+PR #1516 retired the old molecule-counting tier from the count form. A
+later gc-udx change added `--exclude-type=epic` to the worker claim
+path, leaving the default count form one filter behind. This refactor
+does two things: routes both paths through `bdReadyPoolDemandShell` and
+adds `--exclude-type=epic` to the default count form. Custom
+`scale_check` overrides are unchanged. Future predicate changes should
+be single-helper changes; tests `TestPoolDemandPredicateSharedWithWorkQuery`
+(structural) and `TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics`
+(behavioral) guard against regressions.
 
 ## Invariants
 
@@ -226,19 +234,22 @@ guard against regressions.
     form) and the worker's claim path (`Agent.EffectiveWorkQuery`, Tier
     3 first-row form) MUST derive their `bd ready --metadata-field
     gc.routed_to=<target> --unassigned --exclude-type=epic --json`
-    predicate from the same `bdReadyPoolDemandShell` helper in
-    `internal/config/config.go`. Any tier-shape change to one (added
-    filter, modified target resolution, new state) MUST be reflected in
-    the other. Diverging the two
+    predicate from the same target-resolution helper and
+    `bdReadyPoolDemandShell` helper in `internal/config/config.go`. Any
+    pool-demand predicate change to one (added filter, modified target
+    resolution, new state) MUST be reflected in the other. Diverging the two
     re-introduces the protocol-mismatch class — the reconciler spawning
     sessions for work the worker can't claim, or the worker idle while
-    new demand sits unspawned. Enforced by
+    new demand sits unspawned. The legacy `workflow-control` fallback is
+    worker-only for pre-rename `control-dispatcher` graphs and intentionally
+    lives outside the shared primary pool-demand predicate. Enforced by
     `TestPoolDemandPredicateSharedWithWorkQuery` and
     `TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics` in
     `internal/config/config_test.go`. Historical context: PR #1516
-    symmetrically simplified both predicates to just "ready unassigned
-    non-epic routed_to" (removing molecule-tier counting from each); this
-    refactor made that equivalence structural rather than coincidental.
+    removed the old molecule-counting tier from the count form; a later
+    gc-udx change added `--exclude-type=epic` to the worker path; this
+    refactor adds that filter to the default count form and makes the
+    equivalence structural rather than coincidental.
 
 ## Interactions
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2493,6 +2493,22 @@ func (a *Agent) AttachEnabled() bool {
 	return a.Attach == nil || *a.Attach
 }
 
+// bdReadyPoolDemandShell returns the bd ready predicate for unassigned,
+// non-epic pool demand routed to target. This is the one-source-of-truth for the
+// "is there work this template can claim?" question that both the worker
+// (via EffectiveWorkQuery Tier 3) and the reconciler (via
+// EffectivePoolDemandQuery, count-form) ask. Diverging the two
+// re-introduces the protocol-mismatch class — see the
+// "scale_check ↔ work_query correspondence" note in
+// engdocs/architecture/dispatch.md and the spawn-storm regression
+// addressed by PR #1516.
+//
+// Callers append their own bd flags (--limit=1 for first-row work_query;
+// piped to jq 'length' for the count-form) and shell handling.
+func bdReadyPoolDemandShell(target string) string {
+	return `bd ready --metadata-field gc.routed_to=` + target + ` --unassigned --exclude-type=epic --json`
+}
+
 // EffectiveWorkQuery returns the work query command for this agent.
 // If WorkQuery is set, returns it as-is. Otherwise returns the default
 // three-tier query with multi-identifier assignee resolution.
@@ -2517,6 +2533,10 @@ func (a *Agent) AttachEnabled() bool {
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
 // the routed_to tier fires to detect new demand.
+//
+// Tier 3's predicate is shared with EffectivePoolDemandQuery via
+// bdReadyPoolDemandShell so reconciler spawn decisions and worker claim
+// decisions stay symmetric.
 func (a *Agent) EffectiveWorkQuery() string {
 	if a.WorkQuery != "" {
 		return a.WorkQuery
@@ -2546,8 +2566,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`ephemeral|"") ;; ` +
 			`*) exit 0 ;; ` +
 			`esac; ` +
-			`r=$(bd ready --metadata-field gc.routed_to=` + target +
-			` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+			`r=$(` + bdReadyPoolDemandShell(target) + ` --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`printf "[]"'`
 	}
@@ -2581,11 +2600,9 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`ephemeral|"") ;; ` +
 		`*) exit 0 ;; ` +
 		`esac; ` +
-		`r=$(bd ready --metadata-field gc.routed_to=` + target +
-		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
+		`r=$(` + bdReadyPoolDemandShell(target) + ` --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
-		`bd ready --metadata-field gc.routed_to=` + legacyTarget +
-		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null'`
+		bdReadyPoolDemandShell(legacyTarget) + ` --limit=1 2>/dev/null'`
 }
 
 func legacyWorkflowControlQualifiedName(target string) string {
@@ -2646,18 +2663,38 @@ func (a *Agent) DrainTimeoutDuration() time.Duration {
 	return dur
 }
 
-// EffectiveScaleCheck returns the scale check command for this agent.
-// If ScaleCheck is set, returns it. Otherwise returns a default that
-// counts new unassigned work routed to this agent's template via ready().
-// Assigned in-progress work is resumed from session beads, so it must not
-// create additional generic pool demand here.
-func (a *Agent) EffectiveScaleCheck() string {
+// EffectivePoolDemandQuery returns the count-form pool-demand query the
+// reconciler runs to detect new unassigned routed work. It is the
+// reconciler-side counterpart to EffectiveWorkQuery's Tier 3 (the worker
+// claim path): both derive their predicate from bdReadyPoolDemandShell so
+// any future change to the pool-demand shape flows to both paths
+// simultaneously.
+//
+// If ScaleCheck is set (user override), it takes precedence and is
+// returned as-is. Otherwise the default count-form is returned.
+//
+// Assigned in-progress work is resumed from session beads, so it must
+// not create additional generic pool demand here.
+//
+// See engdocs/architecture/dispatch.md "scale_check ↔ work_query
+// correspondence" and the protocol-mismatch class regression addressed
+// by PR #1516.
+func (a *Agent) EffectivePoolDemandQuery() string {
 	if a.ScaleCheck != "" {
 		return a.ScaleCheck
 	}
 	template := a.QualifiedName()
-	return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
-		` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
+	return `ready_json=$(` + bdReadyPoolDemandShell(template) +
+		` --limit 0) && printf '%s\n' "$ready_json" | jq 'length'`
+}
+
+// EffectiveScaleCheck returns the scale check command for this agent.
+// Pass-through to EffectivePoolDemandQuery for back-compat with code and
+// configs that name the predicate "scale_check"; new call sites should
+// prefer EffectivePoolDemandQuery to make the dependency on the
+// work_query predicate explicit.
+func (a *Agent) EffectiveScaleCheck() string {
+	return a.EffectivePoolDemandQuery()
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2495,18 +2495,24 @@ func (a *Agent) AttachEnabled() bool {
 
 // bdReadyPoolDemandShell returns the bd ready predicate for unassigned,
 // non-epic pool demand routed to target. This is the one-source-of-truth for the
-// "is there work this template can claim?" question that both the worker
-// (via EffectiveWorkQuery Tier 3) and the reconciler (via
-// EffectivePoolDemandQuery, count-form) ask. Diverging the two
-// re-introduces the protocol-mismatch class — see the
-// "scale_check ↔ work_query correspondence" note in
-// engdocs/architecture/dispatch.md and the spawn-storm regression
-// addressed by PR #1516.
+// "is there work on this routed queue?" question that both the worker (via
+// EffectiveWorkQuery Tier 3) and the reconciler (via EffectivePoolDemandQuery,
+// count-form) ask. Diverging the two re-introduces the protocol-mismatch class;
+// see the "scale_check ↔ work_query correspondence" note in
+// engdocs/architecture/dispatch.md.
 //
 // Callers append their own bd flags (--limit=1 for first-row work_query;
 // piped to jq 'length' for the count-form) and shell handling.
 func bdReadyPoolDemandShell(target string) string {
 	return `bd ready --metadata-field gc.routed_to=` + target + ` --unassigned --exclude-type=epic --json`
+}
+
+func (a *Agent) poolDemandTarget() string {
+	target := a.QualifiedName()
+	if a.PoolName != "" {
+		target = a.PoolName
+	}
+	return target
 }
 
 // EffectiveWorkQuery returns the work query command for this agent.
@@ -2541,10 +2547,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 	if a.WorkQuery != "" {
 		return a.WorkQuery
 	}
-	target := a.QualifiedName()
-	if a.PoolName != "" {
-		target = a.PoolName
-	}
+	target := a.poolDemandTarget()
 	legacyTarget := legacyWorkflowControlQualifiedName(target)
 	if legacyTarget == "" {
 		return `sh -c '` +
@@ -2683,8 +2686,8 @@ func (a *Agent) EffectivePoolDemandQuery() string {
 	if a.ScaleCheck != "" {
 		return a.ScaleCheck
 	}
-	template := a.QualifiedName()
-	return `ready_json=$(` + bdReadyPoolDemandShell(template) +
+	target := a.poolDemandTarget()
+	return `ready_json=$(` + bdReadyPoolDemandShell(target) +
 		` --limit 0) && printf '%s\n' "$ready_json" | jq 'length'`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1747,8 +1747,8 @@ func TestDefaultPoolCheckUsesPoolName(t *testing.T) {
 		PoolName: "hello-world/dog",
 	}
 	check := a.EffectiveScaleCheck()
-	if !strings.Contains(check, "gc.routed_to=hello-world/dog-1") {
-		t.Errorf("EffectiveScaleCheck() = %q, want gc.routed_to=hello-world/dog-1", check)
+	if !strings.Contains(check, "gc.routed_to=hello-world/dog") {
+		t.Errorf("EffectiveScaleCheck() = %q, want gc.routed_to=hello-world/dog", check)
 	}
 }
 
@@ -1762,6 +1762,9 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("EffectiveScaleCheck() = %q, want bd ready for blocker-aware counting", check)
 	}
+	if !strings.Contains(check, "--exclude-type=epic") {
+		t.Errorf("EffectiveScaleCheck() = %q, want --exclude-type=epic for executable demand only", check)
+	}
 	if strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck() = %q, should not count molecule containers as demand", check)
 	}
@@ -1774,23 +1777,45 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 // test for the protocol-mismatch class addressed by PR #1516. The
 // reconciler's pool-demand path (EffectivePoolDemandQuery) and the
 // worker's claim path (EffectiveWorkQuery Tier 3) must derive their
-// "is there work this template can claim?" predicate from the same
+// "is there work on this routed queue?" predicate from the same
 // bdReadyPoolDemandShell helper. Adding a tier to one without updating
 // the other re-introduces the spawn-storm bug — this test ensures both
 // reference the identical predicate string for the same target.
 func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
-	a := Agent{Name: "worker", Dir: "foundations"}
-	target := "foundations/worker"
-	predicate := bdReadyPoolDemandShell(target)
-
-	wq := a.EffectiveWorkQuery()
-	if !strings.Contains(wq, predicate) {
-		t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", predicate, wq)
+	tests := []struct {
+		name   string
+		agent  Agent
+		target string
+	}{
+		{
+			name:   "template",
+			agent:  Agent{Name: "worker", Dir: "foundations"},
+			target: "foundations/worker",
+		},
+		{
+			name: "pool instance",
+			agent: Agent{
+				Name:     "worker-1",
+				Dir:      "foundations",
+				PoolName: "foundations/worker",
+			},
+			target: "foundations/worker",
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			predicate := bdReadyPoolDemandShell(tt.target)
 
-	demand := a.EffectivePoolDemandQuery()
-	if !strings.Contains(demand, predicate) {
-		t.Errorf("EffectivePoolDemandQuery() missing shared predicate %q in %q", predicate, demand)
+			wq := tt.agent.EffectiveWorkQuery()
+			if !strings.Contains(wq, predicate) {
+				t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", predicate, wq)
+			}
+
+			demand := tt.agent.EffectivePoolDemandQuery()
+			if !strings.Contains(demand, predicate) {
+				t.Errorf("EffectivePoolDemandQuery() missing shared predicate %q in %q", predicate, demand)
+			}
+		})
 	}
 }
 
@@ -1820,22 +1845,38 @@ func TestEffectivePoolDemandQueryRespectsOverride(t *testing.T) {
 // report no work. This is the
 // regression test for the spawn-storm class fo-spawn-storm describes.
 func TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics(t *testing.T) {
-	a := Agent{Name: "worker", Dir: "foundations"}
-
 	cases := []struct {
 		name           string
+		agent          Agent
+		target         string
 		bdReadyOutput  string
 		wantWorkQuery  string
 		wantDemandZero bool
 	}{
 		{
 			name:           "no routed work",
+			agent:          Agent{Name: "worker", Dir: "foundations"},
+			target:         "foundations/worker",
 			bdReadyOutput:  `[]`,
 			wantWorkQuery:  `[]`,
 			wantDemandZero: true,
 		},
 		{
 			name:           "one routed unassigned bead",
+			agent:          Agent{Name: "worker", Dir: "foundations"},
+			target:         "foundations/worker",
+			bdReadyOutput:  `[{"id":"fo-routed"}]`,
+			wantWorkQuery:  `[{"id":"fo-routed"}]`,
+			wantDemandZero: false,
+		},
+		{
+			name: "pool instance uses pool target",
+			agent: Agent{
+				Name:     "worker-1",
+				Dir:      "foundations",
+				PoolName: "foundations/worker",
+			},
+			target:         "foundations/worker",
 			bdReadyOutput:  `[{"id":"fo-routed"}]`,
 			wantWorkQuery:  `[{"id":"fo-routed"}]`,
 			wantDemandZero: false,
@@ -1845,7 +1886,7 @@ func TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			bdScript := `#!/bin/sh
 case "$*" in
-  *"ready --metadata-field gc.routed_to=foundations/worker --unassigned --exclude-type=epic"*)
+  *"ready --metadata-field gc.routed_to=` + tc.target + ` --unassigned --exclude-type=epic"*)
     printf '%s' '` + tc.bdReadyOutput + `'
     ;;
   *)
@@ -1853,11 +1894,11 @@ case "$*" in
     ;;
 esac
 `
-			wqOut := strings.TrimSpace(runEffectiveWorkQuery(t, a, nil, bdScript))
+			wqOut := strings.TrimSpace(runEffectiveWorkQuery(t, tc.agent, nil, bdScript))
 			if wqOut != tc.wantWorkQuery {
 				t.Errorf("EffectiveWorkQuery output = %q, want %q", wqOut, tc.wantWorkQuery)
 			}
-			demandOut := strings.TrimSpace(runShellWithFakeBd(t, a.EffectivePoolDemandQuery(), nil, bdScript))
+			demandOut := strings.TrimSpace(runShellWithFakeBd(t, tc.agent.EffectivePoolDemandQuery(), nil, bdScript))
 			if tc.wantDemandZero {
 				if demandOut != "0" {
 					t.Errorf("EffectivePoolDemandQuery output = %q, want 0", demandOut)
@@ -2047,6 +2088,9 @@ func TestEffectiveScaleCheckDefaults(t *testing.T) {
 	if !strings.Contains(check, "--unassigned") {
 		t.Errorf("EffectiveScaleCheck = %q, want --unassigned for new unassigned demand", check)
 	}
+	if !strings.Contains(check, "--exclude-type=epic") {
+		t.Errorf("EffectiveScaleCheck = %q, want --exclude-type=epic for executable demand only", check)
+	}
 	if strings.Contains(check, "--type=molecule") || strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("EffectiveScaleCheck = %q, should not count molecule containers as demand", check)
 	}
@@ -2069,6 +2113,9 @@ func TestEffectiveScaleCheckDefaultsQualified(t *testing.T) {
 	if !strings.Contains(check, "--unassigned") {
 		t.Errorf("EffectiveScaleCheck = %q, want --unassigned for new unassigned demand", check)
 	}
+	if !strings.Contains(check, "--exclude-type=epic") {
+		t.Errorf("EffectiveScaleCheck = %q, want --exclude-type=epic for executable demand only", check)
+	}
 	if strings.Contains(check, "--type=molecule") {
 		t.Errorf("EffectiveScaleCheck = %q, should not count molecule containers as demand", check)
 	}
@@ -2089,6 +2136,9 @@ func TestEffectiveScaleCheckUsesReadyOnly(t *testing.T) {
 
 	if !strings.Contains(check, "bd ready") {
 		t.Errorf("missing bd ready query for blocker-aware task counting")
+	}
+	if !strings.Contains(check, "--exclude-type=epic") {
+		t.Errorf("EffectiveScaleCheck = %q, want --exclude-type=epic for executable demand only", check)
 	}
 	if strings.Contains(check, "--status=open --type=molecule") {
 		t.Errorf("unexpected molecule query in scale check: %q", check)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1770,6 +1770,107 @@ func TestDefaultPoolCheckUsesBdReady(t *testing.T) {
 	}
 }
 
+// TestPoolDemandPredicateSharedWithWorkQuery is the structural regression
+// test for the protocol-mismatch class addressed by PR #1516. The
+// reconciler's pool-demand path (EffectivePoolDemandQuery) and the
+// worker's claim path (EffectiveWorkQuery Tier 3) must derive their
+// "is there work this template can claim?" predicate from the same
+// bdReadyPoolDemandShell helper. Adding a tier to one without updating
+// the other re-introduces the spawn-storm bug — this test ensures both
+// reference the identical predicate string for the same target.
+func TestPoolDemandPredicateSharedWithWorkQuery(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "foundations"}
+	target := "foundations/worker"
+	predicate := bdReadyPoolDemandShell(target)
+
+	wq := a.EffectiveWorkQuery()
+	if !strings.Contains(wq, predicate) {
+		t.Errorf("EffectiveWorkQuery() missing shared predicate %q in %q", predicate, wq)
+	}
+
+	demand := a.EffectivePoolDemandQuery()
+	if !strings.Contains(demand, predicate) {
+		t.Errorf("EffectivePoolDemandQuery() missing shared predicate %q in %q", predicate, demand)
+	}
+}
+
+// TestEffectivePoolDemandQueryRespectsOverride verifies the user-set
+// scale_check override flows through unchanged. Pass-through behavior
+// preserves config-side flexibility while keeping the default form
+// structurally tied to the work_query predicate.
+func TestEffectivePoolDemandQueryRespectsOverride(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "foundations", ScaleCheck: "echo 7"}
+	if got := a.EffectivePoolDemandQuery(); got != "echo 7" {
+		t.Errorf("EffectivePoolDemandQuery() = %q, want %q", got, "echo 7")
+	}
+	if got := a.EffectiveScaleCheck(); got != "echo 7" {
+		t.Errorf("EffectiveScaleCheck() = %q, want pass-through %q", got, "echo 7")
+	}
+}
+
+// TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics is the behavioral
+// counterpart to TestPoolDemandPredicateSharedWithWorkQuery. Given a
+// fake bd that returns the same routed-and-claimable signal to either
+// caller, EffectiveWorkQuery (worker side) and EffectivePoolDemandQuery
+// (reconciler side) must agree: both see work, or both see none.
+//
+// The "state worker can't claim" cases — the bead is assigned, blocked,
+// in_progress, or an epic — are filtered by `bd ready --unassigned
+// --exclude-type=epic`, so the fake returns [] for them and both paths
+// report no work. This is the
+// regression test for the spawn-storm class fo-spawn-storm describes.
+func TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "foundations"}
+
+	cases := []struct {
+		name           string
+		bdReadyOutput  string
+		wantWorkQuery  string
+		wantDemandZero bool
+	}{
+		{
+			name:           "no routed work",
+			bdReadyOutput:  `[]`,
+			wantWorkQuery:  `[]`,
+			wantDemandZero: true,
+		},
+		{
+			name:           "one routed unassigned bead",
+			bdReadyOutput:  `[{"id":"fo-routed"}]`,
+			wantWorkQuery:  `[{"id":"fo-routed"}]`,
+			wantDemandZero: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bdScript := `#!/bin/sh
+case "$*" in
+  *"ready --metadata-field gc.routed_to=foundations/worker --unassigned --exclude-type=epic"*)
+    printf '%s' '` + tc.bdReadyOutput + `'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`
+			wqOut := strings.TrimSpace(runEffectiveWorkQuery(t, a, nil, bdScript))
+			if wqOut != tc.wantWorkQuery {
+				t.Errorf("EffectiveWorkQuery output = %q, want %q", wqOut, tc.wantWorkQuery)
+			}
+			demandOut := strings.TrimSpace(runShellWithFakeBd(t, a.EffectivePoolDemandQuery(), nil, bdScript))
+			if tc.wantDemandZero {
+				if demandOut != "0" {
+					t.Errorf("EffectivePoolDemandQuery output = %q, want 0", demandOut)
+				}
+			} else {
+				if demandOut == "0" {
+					t.Errorf("EffectivePoolDemandQuery output = %q, want >0 when work_query reports work", demandOut)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateAgentsCustomQueries(t *testing.T) {
 	// Both set: OK
 	agents := []Agent{{
@@ -3892,6 +3993,14 @@ func TestEffectiveMethodsQualifyConsistently(t *testing.T) {
 
 func runEffectiveWorkQuery(t *testing.T, a Agent, env map[string]string, bdScript string) string {
 	t.Helper()
+	return runShellWithFakeBd(t, a.EffectiveWorkQuery(), env, bdScript)
+}
+
+// runShellWithFakeBd executes shellCmd with a fake `bd` script on PATH so
+// shared-predicate tests can exercise EffectiveWorkQuery and
+// EffectivePoolDemandQuery against the same simulated bd state.
+func runShellWithFakeBd(t *testing.T, shellCmd string, env map[string]string, bdScript string) string {
+	t.Helper()
 
 	tmp := t.TempDir()
 	bdPath := filepath.Join(tmp, "bd")
@@ -3899,14 +4008,14 @@ func runEffectiveWorkQuery(t *testing.T, a Agent, env map[string]string, bdScrip
 		t.Fatalf("write fake bd: %v", err)
 	}
 
-	cmd := exec.Command("sh", "-c", a.EffectiveWorkQuery())
+	cmd := exec.Command("sh", "-c", shellCmd)
 	cmd.Env = []string{"PATH=" + tmp + ":" + os.Getenv("PATH")}
 	for k, v := range env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("run work query: %v", err)
+		t.Fatalf("run shell with fake bd: %v", err)
 	}
 	return string(out)
 }


### PR DESCRIPTION
## Summary

Make the equivalence between the worker's claim path (`EffectiveWorkQuery` Tier 3) and the reconciler's spawn path (`EffectiveScaleCheck` / new `EffectivePoolDemandQuery`) **structural** rather than coincidental.

PR #1516 symmetrically simplified both predicates to "ready unassigned routed_to" by retiring the molecule tier from each side. Post-#1516 the two are textually equivalent — but they remained two separate code paths. A future PR adding a tier to one without the other would silently re-introduce the protocol-mismatch class addressed by fo-spawn-storm (the reconciler spawning sessions for work the worker can't claim, or vice versa).

This refactor closes the residual gap by extracting the shared predicate into a single helper:

```go
func bdReadyPoolDemandShell(target string) string {
    return `bd ready --metadata-field gc.routed_to=` + target + ` --unassigned --json`
}
```

Both `EffectiveWorkQuery` Tier 3 (with `--limit=1` appended, first-row form) and the new `EffectivePoolDemandQuery` (piped through `jq 'length'`, count form) derive from this helper. The reconciler's `scaleParamsFor` now calls `EffectivePoolDemandQuery` directly so the dependency on the work-query predicate is explicit at the call site. `EffectiveScaleCheck` remains as a thin pass-through for back-compat with code and configs that name the predicate "scale_check".

## Tests

- **Structural** — `TestPoolDemandPredicateSharedWithWorkQuery` asserts both methods reference the `bdReadyPoolDemandShell` output for the same target. Future divergence becomes a compile-touched test failure rather than a quiet behavior regression.
- **Behavioral** — `TestPoolDemandAndWorkQueryAgreeOnRoutedSemantics` runs both queries against the same fake `bd` and asserts they agree on \"routed work present\" / \"no routed work\". This is the behavioral counterpart called out in fo-glz1h: a state the worker can't claim must produce demand=0 from the reconciler.
- **Override pass-through** — `TestEffectivePoolDemandQueryRespectsOverride` confirms a user-set `scale_check` short-circuits both methods.

## Docs

`engdocs/architecture/dispatch.md` gets:
- A new \"scale_check ↔ work_query correspondence\" section explaining the two read sides and why they must stay symmetric, with the spawn-storm pre-#1516 symptom called out as the failure mode.
- A new invariant (#11) that any tier-shape change to one MUST flow through `bdReadyPoolDemandShell` to the other, with the regression tests named.
- The Code Map row for `internal/config/config.go` gains the new symbols.
- \"Last verified against code\" date bumped to 2026-05-01.

## Stack

Based on `fix/main-auto-port-bind-retry-20260501` (PR #1582) so the unrelated tempfile flake on `main` doesn't keep failing CI for this branch.

## Test plan

- [x] `go test ./internal/config/...` passes (existing + 3 new tests).
- [x] `go vet ./...` clean.
- [x] Targeted pool tests (`TestEvaluatePool*`, `TestScaleParams*`, `TestPool*`) pass.
- [ ] Full CI run on the PR (broader cmd/gc suite has pre-existing failures on `fix/main-auto-port-bind-retry-20260501` — TestCmdHookPoolInstanceUsesTemplatePoolLabel, TestDoPrimePoolAgentFallback, TestControllerStateCreateRigPokesReconciler, TestReconcileCitiesNameDriftStopsBeadsProvider — verified to fail on this base before any of these changes; not introduced by this PR).

## Related

- Closes fo-glz1h (surviving \"Keep\" item from the now-closed fo-78wj3, plus the dispatch.md updates flagged by gc-wisp-acvu).
- Follows up on PR #1516 (commit 6b5d9121) — the symmetric simplification this builds on.
- Closes the residual structural gap behind fo-spawn-storm (DEFERRED).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->