### PR TITLE
perf(dispatch): reduce control dispatcher store scans

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1359,7 +1359,7 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 	})
 
 	cdAgent := config.Agent{Name: config.ControlDispatcherAgentName}
-	wantQuery := workflowServeWorkQuery(cdAgent)
+	wantQuery := workflowServeControlReadyQuery(cdAgent, "control-dispatcher")
 	var gotQueries []string
 	var gotDirs []string
 	var gotEnv []map[string]string
@@ -1415,6 +1415,60 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 	}
 }
 
+func TestRunWorkflowServeDrainsReadyBatchBeforeRequery(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	var controlled []string
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		switch calls {
+		case 1:
+			return []hookBead{
+				{ID: "gc-ctrl-1", Metadata: map[string]string{"gc.kind": "scope-check"}},
+				{ID: "gc-ctrl-2", Metadata: map[string]string{"gc.kind": "workflow-finalize"}},
+			}, nil
+		default:
+			return nil, nil
+		}
+	}
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
+		controlled = append(controlled, beadID)
+		return nil
+	}
+
+	if err := runWorkflowServe("", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+
+	if !slices.Equal(controlled, []string{"gc-ctrl-1", "gc-ctrl-2"}) {
+		t.Fatalf("controlled beads = %#v, want ready batch drained in order", controlled)
+	}
+	if calls != 2 {
+		t.Fatalf("workflowServeList calls = %d, want first ready batch plus idle check", calls)
+	}
+}
+
 func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName})
 	if strings.Contains(query, "GC_SESSION_ORIGIN") {
@@ -1462,6 +1516,79 @@ esac
 `)
 	if got, want := strings.TrimSpace(out), `[{"id":"ga-ready"}]`; got != want {
 		t.Fatalf("control query output = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowServeControlReadyQueryUsesConfiguredRuntimeNameWhenEnvIsManualSession(t *testing.T) {
+	query := workflowServeControlReadyQuery(
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		"gascity--control-dispatcher",
+	)
+	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
+		"GC_SESSION_ID":     "mc-manual",
+		"GC_SESSION_NAME":   "s-mc-manual",
+		"GC_AGENT":          "s-mc-manual",
+		"GC_SESSION_ORIGIN": "manual",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  "ready --assignee=gascity--control-dispatcher --json --limit=20")
+    printf '[{"id":"ga-control-ready"}]'
+    ;;
+  *)
+    echo "unexpected first control query: $*" >&2
+    exit 42
+    ;;
+esac
+`)
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-control-ready"}]`; got != want {
+		t.Fatalf("control query output = %q, want %q", got, want)
+	}
+}
+
+func TestWorkflowServeControlReadyQueryPrioritizesConfiguredRuntimeName(t *testing.T) {
+	query := workflowServeControlReadyQuery(
+		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "gascity"},
+		"gascity--control-dispatcher",
+	)
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "bd.log")
+	bdPath := filepath.Join(tmp, "bd")
+	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$BD_LOG"
+case "$*" in
+  "ready --assignee=gascity--control-dispatcher --json --limit=20")
+    printf '[{"id":"ga-control-ready"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	out, err := shellWorkQueryWithEnv(query, t.TempDir(), []string{
+		"PATH=" + tmp + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"BD_LOG=" + logPath,
+		"GC_SESSION_ID=mc-manual",
+		"GC_SESSION_NAME=s-mc-manual",
+		"GC_AGENT=s-mc-manual",
+		"GC_SESSION_ORIGIN=manual",
+	})
+	if err != nil {
+		t.Fatalf("run workflow serve query: %v", err)
+	}
+	if got, want := strings.TrimSpace(out), `[{"id":"ga-control-ready"}]`; got != want {
+		t.Fatalf("control query output = %q, want %q", got, want)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	firstCall, _, _ := strings.Cut(strings.TrimSpace(string(logData)), "\n")
+	if want := "ready --assignee=gascity--control-dispatcher --json --limit=20"; firstCall != want {
+		t.Fatalf("first bd call = %q, want %q; all calls:\n%s", firstCall, want, string(logData))
 	}
 }
 

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -187,10 +187,14 @@ func runWorkflowServe(agentName string, follow bool, _ io.Writer, stderr io.Writ
 	}
 	workDir := agentCommandDir(cityPath, &agentCfg, cfg.Rigs)
 	workEnv := controllerWorkQueryEnv(cityPath, cfg, &agentCfg)
+	cityName := loadedCityName(cfg, cityPath)
 	// Expand {{.Rig}}/{{.AgentBase}} once so the long-poll drain reuses the
 	// rig-scoped command instead of passing the literal template to the shell
 	// on every iteration. #793.
-	workQuery := expandAgentCommandTemplate(cityPath, loadedCityName(cfg, cityPath), &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
+	workQuery := expandAgentCommandTemplate(cityPath, cityName, &agentCfg, cfg.Rigs, "work_query", agentCfg.EffectiveWorkQuery(), stderr)
+	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
+		workQuery = workflowServeControlReadyQuery(agentCfg, config.NamedSessionRuntimeName(cityName, cfg.Workspace, agentCfg.QualifiedName()))
+	}
 	workflowTracef("serve start agent=%s city=%s dir=%s", agentCfg.QualifiedName(), cityPath, workDir)
 	if !follow {
 		_, err := drainWorkflowServeWork(agentCfg, cityPath, workDir, workQuery, workEnv, stderr)
@@ -265,7 +269,6 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 			workflowTracef("serve processed bead=%s kind=%s", beadID, kind)
 			result.processedAny = true
 			processedThisCycle = true
-			break
 		}
 		if processedThisCycle {
 			continue
@@ -420,13 +423,13 @@ func workflowServeQuery(workQuery string) string {
 }
 
 func workflowServeWorkQuery(agentCfg config.Agent, expandedWorkQuery ...string) string {
+	if len(expandedWorkQuery) > 0 {
+		return workflowServeQuery(expandedWorkQuery[0])
+	}
 	if agentCfg.WorkQuery == "" && isWorkflowServeControlDispatcherAgent(agentCfg) {
 		return workflowServeControlReadyQuery(agentCfg)
 	}
 	workQuery := agentCfg.EffectiveWorkQuery()
-	if len(expandedWorkQuery) > 0 {
-		workQuery = expandedWorkQuery[0]
-	}
 	return workflowServeQuery(workQuery)
 }
 
@@ -436,18 +439,26 @@ func isWorkflowServeControlDispatcherAgent(agentCfg config.Agent) bool {
 		strings.HasSuffix(qualified, "/"+config.ControlDispatcherAgentName)
 }
 
-func workflowServeControlReadyQuery(agentCfg config.Agent) string {
+func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames ...string) string {
 	target := strings.TrimSpace(agentCfg.QualifiedName())
 	if target == "" {
 		target = config.ControlDispatcherAgentName
 	}
 	limit := fmt.Sprintf("%d", workflowServeScanLimit)
 	queryPrefix := `GC_CONTROL_TARGET=` + shellquote.Quote(target)
+	for _, name := range controlSessionNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		queryPrefix += ` GC_CONTROL_SESSION_NAME=` + shellquote.Quote(name)
+		break
+	}
 	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
 		queryPrefix += ` GC_CONTROL_LEGACY_TARGET=` + shellquote.Quote(legacy)
 	}
 	query := queryPrefix + ` sh -c '` +
-		`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS" "$GC_CONTROL_TARGET"; do ` +
+		`for id in "$GC_CONTROL_SESSION_NAME" "$GC_SESSION_NAME" "$GC_ALIAS" "$GC_CONTROL_TARGET" "$GC_SESSION_ID"; do ` +
 		`[ -z "$id" ] && continue; ` +
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -165,19 +165,15 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 	if scopeRef == "" {
 		return ControlResult{}, fmt.Errorf("%s: missing gc.scope_ref", bead.ID)
 	}
-
-	snapshot, err := tracePhase(opts, bead.ID, "load-snapshot", func() (scopeSnapshot, error) {
-		return loadScopeSnapshot(store, rootID, scopeRef)
+	body, err := tracePhase(opts, bead.ID, "resolve-body", func() (beads.Bead, error) {
+		return resolveScopeBody(store, rootID, scopeRef)
 	})
 	if err != nil {
 		if errors.Is(err, errScopeBodyMissing) {
 			return ControlResult{}, ErrControlPending
 		}
-		return ControlResult{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", bead.ID, scopeRef, err)
+		return ControlResult{}, fmt.Errorf("%s: loading scope body for %s: %w", bead.ID, scopeRef, err)
 	}
-	opts.tracef("scope-check bead=%s snapshot root=%s scope=%s all=%d members=%d body=%s subject=%s outcome=%s",
-		bead.ID, rootID, scopeRef, len(snapshot.all), len(snapshot.members), snapshot.body.ID, subject.ID, subject.Metadata["gc.outcome"])
-	body := snapshot.body
 
 	if isRetryAttemptSubject(subject) {
 		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
@@ -185,9 +181,18 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		}); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: completing retry-attempt control bead: %w", bead.ID, err)
 		}
-		remainingOpen := snapshot.hasOpenScopeMembers(bead.ID)
+		remainingOpen, err := tracePhase(opts, bead.ID, "check-open-members", func() (bool, error) {
+			return hasOpenScopeMembers(store, rootID, scopeRef, bead.ID)
+		})
+		if err != nil {
+			return ControlResult{}, fmt.Errorf("%s: checking scope completion: %w", bead.ID, err)
+		}
 		opts.tracef("scope-check bead=%s phase=check-remaining-open remaining_open=%t ignore=%s", bead.ID, remainingOpen, bead.ID)
 		if !remainingOpen {
+			snapshot, err := loadScopeSnapshotForControl(store, rootID, scopeRef, body, subject, bead.ID, opts)
+			if err != nil {
+				return ControlResult{}, err
+			}
 			outputJSON, err := tracePhase(opts, bead.ID, "resolve-output", func() (string, error) {
 				return snapshot.resolveScopeOutputJSON(subject)
 			})
@@ -229,6 +234,10 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 	}
 
 	if subject.Metadata["gc.outcome"] == "fail" {
+		snapshot, err := loadScopeSnapshotForControl(store, rootID, scopeRef, body, subject, bead.ID, opts)
+		if err != nil {
+			return ControlResult{}, err
+		}
 		skipped, err := tracePhase(opts, bead.ID, "skip-open-members", func() (int, error) {
 			return snapshot.skipOpenScopeMembers(store, bead.ID)
 		})
@@ -256,9 +265,18 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		return ControlResult{}, fmt.Errorf("%s: completing control bead: %w", bead.ID, err)
 	}
 
-	remainingOpen := snapshot.hasOpenScopeMembers(bead.ID)
+	remainingOpen, err := tracePhase(opts, bead.ID, "check-open-members", func() (bool, error) {
+		return hasOpenScopeMembers(store, rootID, scopeRef, bead.ID)
+	})
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: checking scope completion: %w", bead.ID, err)
+	}
 	opts.tracef("scope-check bead=%s phase=check-remaining-open remaining_open=%t ignore=%s", bead.ID, remainingOpen, bead.ID)
 	if !remainingOpen {
+		snapshot, err := loadScopeSnapshotForControl(store, rootID, scopeRef, body, subject, bead.ID, opts)
+		if err != nil {
+			return ControlResult{}, err
+		}
 		// Propagate non-gc metadata from scope members to the scope body.
 		// This enables compositional metadata bubbling: attempt → retry →
 		// scope → ralph → parent scope, etc.
@@ -299,41 +317,91 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 	return ControlResult{Processed: true, Action: "continue"}, nil
 }
 
+func loadScopeSnapshotForControl(store beads.Store, rootID, scopeRef string, body, subject beads.Bead, controlID string, opts ProcessOptions) (scopeSnapshot, error) {
+	snapshot, err := tracePhase(opts, controlID, "load-snapshot", func() (scopeSnapshot, error) {
+		return loadScopeSnapshotWithBody(store, rootID, scopeRef, body)
+	})
+	if err != nil {
+		if errors.Is(err, errScopeBodyMissing) {
+			return scopeSnapshot{}, ErrControlPending
+		}
+		return scopeSnapshot{}, fmt.Errorf("%s: loading scope snapshot for %s: %w", controlID, scopeRef, err)
+	}
+	opts.tracef("scope-check bead=%s snapshot root=%s scope=%s all=%d members=%d body=%s subject=%s outcome=%s",
+		controlID, rootID, scopeRef, len(snapshot.all), len(snapshot.members), snapshot.body.ID, subject.ID, subject.Metadata["gc.outcome"])
+	return snapshot, nil
+}
+
 type scopeSnapshot struct {
-	rootID   string
-	scopeRef string
-	all      []beads.Bead
-	members  []beads.Bead
-	body     beads.Bead
+	rootID      string
+	scopeRef    string
+	all         []beads.Bead
+	allComplete bool
+	members     []beads.Bead
+	body        beads.Bead
 }
 
 func loadScopeSnapshot(store beads.Store, rootID, scopeRef string) (scopeSnapshot, error) {
-	all, err := listByWorkflowRoot(store, rootID)
+	body, err := resolveScopeBody(store, rootID, scopeRef)
+	if err != nil {
+		return scopeSnapshot{}, err
+	}
+	return loadScopeSnapshotWithBody(store, rootID, scopeRef, body)
+}
+
+func loadScopeSnapshotWithBody(store beads.Store, rootID, scopeRef string, body beads.Bead) (scopeSnapshot, error) {
+	members, err := listByWorkflowRootAndScope(store, rootID, scopeRef)
 	if err != nil {
 		return scopeSnapshot{}, err
 	}
 	snapshot := scopeSnapshot{
 		rootID:   rootID,
 		scopeRef: scopeRef,
-		all:      all,
+		members:  members,
+		body:     body,
 	}
-	bodyFound := false
-	for _, bead := range all {
-		if bead.Metadata["gc.root_bead_id"] != rootID {
+	snapshot.all = mergeScopeSnapshotBeads(snapshot.members, snapshot.body)
+	return snapshot, nil
+}
+
+func listByWorkflowRootAndScope(store beads.Store, rootID, scopeRef string) ([]beads.Bead, error) {
+	return store.List(beads.ListQuery{
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+			"gc.scope_ref":    scopeRef,
+		},
+		IncludeClosed: true,
+	})
+}
+
+func listActiveByWorkflowRootAndScope(store beads.Store, rootID, scopeRef string) ([]beads.Bead, error) {
+	return store.List(beads.ListQuery{
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+			"gc.scope_ref":    scopeRef,
+		},
+	})
+}
+
+func mergeScopeSnapshotBeads(members []beads.Bead, body beads.Bead) []beads.Bead {
+	out := make([]beads.Bead, 0, len(members)+1)
+	seen := make(map[string]struct{}, len(members)+1)
+	for _, bead := range members {
+		if bead.ID == "" {
 			continue
 		}
-		if bead.Metadata["gc.scope_ref"] == scopeRef {
-			snapshot.members = append(snapshot.members, bead)
+		if _, ok := seen[bead.ID]; ok {
+			continue
 		}
-		if !bodyFound && bead.Metadata["gc.kind"] == "scope" && matchesScopeRef(bead, scopeRef) {
-			snapshot.body = bead
-			bodyFound = true
+		out = append(out, bead)
+		seen[bead.ID] = struct{}{}
+	}
+	if body.ID != "" {
+		if _, ok := seen[body.ID]; !ok {
+			out = append(out, body)
 		}
 	}
-	if !bodyFound {
-		return scopeSnapshot{}, fmt.Errorf("%w: scope %q not found under root %s", errScopeBodyMissing, scopeRef, rootID)
-	}
-	return snapshot, nil
+	return out
 }
 
 func (s scopeSnapshot) hasOpenScopeMembers(ignoreIDs ...string) bool {
@@ -362,6 +430,14 @@ func (s scopeSnapshot) hasOpenScopeMembers(ignoreIDs ...string) bool {
 		}
 	}
 	return false
+}
+
+func hasOpenScopeMembers(store beads.Store, rootID, scopeRef string, ignoreIDs ...string) (bool, error) {
+	members, err := listActiveByWorkflowRootAndScope(store, rootID, scopeRef)
+	if err != nil {
+		return false, err
+	}
+	return scopeSnapshot{members: members}.hasOpenScopeMembers(ignoreIDs...), nil
 }
 
 func (s scopeSnapshot) propagateScopeMemberMetadata(store beads.Store, bodyID string) error {
@@ -413,6 +489,14 @@ func (s scopeSnapshot) resolveScopeOutputJSON(subject beads.Bead) (string, error
 }
 
 func (s scopeSnapshot) skipOpenScopeMembers(store beads.Store, skipControlID string) (int, error) {
+	all := s.all
+	if !s.allComplete {
+		loaded, err := listByWorkflowRoot(store, s.rootID)
+		if err != nil {
+			return 0, err
+		}
+		all = loaded
+	}
 	pending := make(map[string]beads.Bead)
 	for _, member := range s.members {
 		if member.ID == skipControlID || member.Status != "open" {
@@ -434,7 +518,7 @@ func (s scopeSnapshot) skipOpenScopeMembers(store beads.Store, skipControlID str
 		case "body", "teardown":
 			continue
 		}
-		for _, candidate := range s.all {
+		for _, candidate := range all {
 			if candidate.Status != "open" {
 				continue
 			}
@@ -947,6 +1031,16 @@ func resolveBlockingSubjectID(store beads.Store, beadID string) (string, error) 
 }
 
 func resolveScopeBody(store beads.Store, rootID, scopeRef string) (beads.Bead, error) {
+	if bead, ok, err := resolveScopeBodyByRole(store, rootID, scopeRef, false); err != nil {
+		return beads.Bead{}, err
+	} else if ok {
+		return bead, nil
+	}
+	if bead, ok, err := resolveScopeBodyByRole(store, rootID, scopeRef, true); err != nil {
+		return beads.Bead{}, err
+	} else if ok {
+		return bead, nil
+	}
 	all, err := listByWorkflowRoot(store, rootID)
 	if err != nil {
 		return beads.Bead{}, err
@@ -955,6 +1049,26 @@ func resolveScopeBody(store beads.Store, rootID, scopeRef string) (beads.Bead, e
 		return bead, nil
 	}
 	return beads.Bead{}, fmt.Errorf("%w: scope %q not found under root %s", errScopeBodyMissing, scopeRef, rootID)
+}
+
+func resolveScopeBodyByRole(store beads.Store, rootID, scopeRef string, includeClosed bool) (beads.Bead, bool, error) {
+	matches, err := store.List(beads.ListQuery{
+		Metadata: map[string]string{
+			"gc.root_bead_id": rootID,
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+		},
+		IncludeClosed: includeClosed,
+	})
+	if err != nil {
+		return beads.Bead{}, false, err
+	}
+	for _, bead := range matches {
+		if matchesScopeRef(bead, scopeRef) {
+			return bead, true, nil
+		}
+	}
+	return beads.Bead{}, false, nil
 }
 
 func skipOpenScopeMembers(store beads.Store, rootID, scopeRef, skipControlID string) (int, error) {
@@ -988,14 +1102,6 @@ func sortedPendingIDs(pending map[string]beads.Bead) []string {
 	}
 	sort.Strings(ids)
 	return ids
-}
-
-func hasOpenScopeMembers(store beads.Store, rootID, scopeRef string) (bool, error) {
-	snapshot, err := loadScopeSnapshot(store, rootID, scopeRef)
-	if err != nil {
-		return false, err
-	}
-	return snapshot.hasOpenScopeMembers(), nil
 }
 
 func listByWorkflowRoot(store beads.Store, rootID string) ([]beads.Bead, error) {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -116,6 +116,151 @@ func TestProcessScopeCheckClosesScopeOnSuccess(t *testing.T) {
 	}
 }
 
+func TestProcessScopeCheckSuccessUsesScopedSnapshotQueries(t *testing.T) {
+	t.Parallel()
+
+	base := beads.NewMemStore()
+	store := &scopeSnapshotQueryGuardStore{Store: base}
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "body",
+		},
+	})
+	step := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "implement",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "pass",
+		},
+	})
+	control := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for implement",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	control = mustGetBead(t, store, control.ID)
+
+	mustDepAdd(t, store, control.ID, step.ID, "blocks")
+	mustDepAdd(t, store, body.ID, control.ID, "blocks")
+
+	result, err := ProcessControl(store, control, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(scope-check): %v", err)
+	}
+	if !result.Processed || result.Action != "scope-pass" {
+		t.Fatalf("scope result = %+v, want processed scope-pass", result)
+	}
+	if store.broadRootQueries != 0 {
+		t.Fatalf("broad workflow-root queries = %d, want 0", store.broadRootQueries)
+	}
+	if store.scopedMemberQueries == 0 {
+		t.Fatal("expected scoped member query")
+	}
+	if store.scopeBodyQueries == 0 {
+		t.Fatal("expected scope body query")
+	}
+}
+
+func TestProcessScopeCheckPassWithRemainingOpenAvoidsClosedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	base := beads.NewMemStore()
+	store := &scopeSnapshotQueryGuardStore{Store: base}
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "body",
+		},
+	})
+	done := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "done",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "pass",
+		},
+	})
+	stillOpen := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "still open",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+		},
+	})
+	control := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for done",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+
+	mustDepAdd(t, store, control.ID, done.ID, "blocks")
+
+	result, err := ProcessControl(store, control, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(scope-check): %v", err)
+	}
+	if !result.Processed || result.Action != "continue" {
+		t.Fatalf("scope result = %+v, want processed continue", result)
+	}
+	if store.closedScopedQueries != 0 {
+		t.Fatalf("closed scoped snapshot queries = %d, want 0", store.closedScopedQueries)
+	}
+	if store.activeScopedQueries == 0 {
+		t.Fatal("expected active scoped completion query")
+	}
+	remaining, err := store.Get(stillOpen.ID)
+	if err != nil {
+		t.Fatalf("Get remaining member: %v", err)
+	}
+	if remaining.Status != "open" {
+		t.Fatalf("remaining member status = %q, want open", remaining.Status)
+	}
+}
+
 func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 	t.Parallel()
 
@@ -491,14 +636,37 @@ func TestProcessScopeCheckUsesSingleWorkflowSnapshotAndEmitsTrace(t *testing.T) 
 	if result.Action != "scope-pass" {
 		t.Fatalf("action = %q, want scope-pass", result.Action)
 	}
-	if store.listCalls != 1 {
-		t.Fatalf("List calls = %d, want 1 workflow snapshot", store.listCalls)
+	if store.listCalls != 3 {
+		t.Fatalf("List calls = %d, want 3 scoped completion/snapshot queries", store.listCalls)
 	}
-	if len(store.queries) != 1 {
-		t.Fatalf("queries = %d, want 1", len(store.queries))
+	if len(store.queries) != 3 {
+		t.Fatalf("queries = %d, want 3", len(store.queries))
 	}
-	if got := store.queries[0].Metadata["gc.root_bead_id"]; got != workflow.ID {
-		t.Fatalf("root metadata query = %q, want %q", got, workflow.ID)
+	for i, query := range store.queries {
+		if got := query.Metadata["gc.root_bead_id"]; got != workflow.ID {
+			t.Fatalf("query[%d] root metadata = %q, want %q", i, got, workflow.ID)
+		}
+	}
+	if got := store.queries[0].Metadata["gc.kind"]; got != "scope" {
+		t.Fatalf("query[0] gc.kind = %q, want scope", got)
+	}
+	if got := store.queries[0].Metadata["gc.scope_role"]; got != "body" {
+		t.Fatalf("query[0] gc.scope_role = %q, want body", got)
+	}
+	if store.queries[0].IncludeClosed {
+		t.Fatal("query[0] should be active-only body lookup")
+	}
+	if got := store.queries[1].Metadata["gc.scope_ref"]; got != "body" {
+		t.Fatalf("query[1] gc.scope_ref = %q, want body", got)
+	}
+	if store.queries[1].IncludeClosed {
+		t.Fatal("query[1] should be active-only completion check")
+	}
+	if got := store.queries[2].Metadata["gc.scope_ref"]; got != "body" {
+		t.Fatalf("query[2] gc.scope_ref = %q, want body", got)
+	}
+	if !store.queries[2].IncludeClosed {
+		t.Fatal("query[2] should load closed scope members for final snapshot")
 	}
 	traceText := trace.String()
 	for _, want := range []string{
@@ -528,6 +696,35 @@ func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	s.listCalls++
 	s.queries = append(s.queries, query)
 	return s.MemStore.List(query)
+}
+
+type scopeSnapshotQueryGuardStore struct {
+	beads.Store
+	broadRootQueries    int
+	scopedMemberQueries int
+	scopeBodyQueries    int
+	activeScopedQueries int
+	closedScopedQueries int
+}
+
+func (s *scopeSnapshotQueryGuardStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if root := strings.TrimSpace(query.Metadata["gc.root_bead_id"]); root != "" {
+		switch {
+		case len(query.Metadata) == 1:
+			s.broadRootQueries++
+			return nil, fmt.Errorf("unexpected broad workflow-root query for %s", root)
+		case query.Metadata["gc.scope_ref"] != "":
+			s.scopedMemberQueries++
+			if query.IncludeClosed {
+				s.closedScopedQueries++
+			} else {
+				s.activeScopedQueries++
+			}
+		case query.Metadata["gc.kind"] == "scope":
+			s.scopeBodyQueries++
+		}
+	}
+	return s.Store.List(query)
 }
 
 func newStrictCloseStore() *strictCloseStore {


### PR DESCRIPTION
## Summary
- resolve scope-check bodies and members with targeted metadata queries instead of broad workflow-root scans
- avoid loading closed scope snapshots when active members are still open
- drain all ready control-dispatcher beads from a batch before re-querying and prefer the configured dispatcher runtime name

## Tests
- go test ./internal/dispatch ./cmd/gc -run 'TestProcessScopeCheck|TestRunWorkflowServe|TestWorkflowServeControlReadyQuery'\n- pre-commit: golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->