### PR TITLE
fix(session): clean dead runtime artifacts

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -413,7 +413,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			}
 		}()
 
-		cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sp, cr.stderr)
+		cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 		// Reap stale session beads from a previous run before building desired
 		// state, so desired state does not reference already-closed beads (#742).
 		if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
@@ -697,7 +697,7 @@ func (cr *CityRuntime) tick(
 	// the reconciler to read/write hashes during reconciliation.
 	// Reap open session beads whose tmux session is dead before loading demand
 	// so stale names cannot block desired-state computation (#742).
-	cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sp, cr.stderr)
+	cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sessionDrains, cr.sp, cr.stderr)
 	if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
 		sessionBeads = cr.loadSessionBeadSnapshot()
 	}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -413,6 +413,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			}
 		}()
 
+		cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sp, cr.stderr)
 		// Reap stale session beads from a previous run before building desired
 		// state, so desired state does not reference already-closed beads (#742).
 		if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
@@ -696,6 +697,7 @@ func (cr *CityRuntime) tick(
 	// the reconciler to read/write hashes during reconciliation.
 	// Reap open session beads whose tmux session is dead before loading demand
 	// so stale names cannot block desired-state computation (#742).
+	cleanupDeadRuntimeSessionCorpses(sessionBeads, cr.sp, cr.stderr)
 	if reapStaleSessionBeads(cr.cityBeadStore(), cr.sp, cr.sessionDrains, clock.Real{}, cr.stderr) > 0 {
 		sessionBeads = cr.loadSessionBeadSnapshot()
 	}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -239,9 +239,29 @@ func waitForStandaloneControllerStop(cityPath string, timeout time.Duration) err
 func doStop(sessionNames []string, sp runtime.Provider, cfg *config.City, store beads.Store, timeout time.Duration,
 	rec events.Recorder, stdout, stderr io.Writer,
 ) int {
+	visible := map[string]bool{}
+	if sp != nil {
+		names, err := sp.ListRunning("")
+		if err != nil {
+			names = nil
+		}
+		for _, name := range names {
+			if name = strings.TrimSpace(name); name != "" {
+				visible[name] = true
+			}
+		}
+	}
 	var running []string
 	for _, sn := range sessionNames {
+		sn = strings.TrimSpace(sn)
+		if sn == "" {
+			continue
+		}
 		if alive, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, sn); err == nil && alive {
+			running = append(running, sn)
+			continue
+		}
+		if visible[sn] {
 			running = append(running, sn)
 		}
 	}

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -242,8 +242,13 @@ func doStop(sessionNames []string, sp runtime.Provider, cfg *config.City, store 
 	visible := map[string]bool{}
 	if sp != nil {
 		names, err := sp.ListRunning("")
-		if err != nil {
+		partialList := runtime.IsPartialListError(err)
+		if err != nil && !partialList {
+			fmt.Fprintf(stderr, "gc stop: listing sessions: %v\n", err) //nolint:errcheck // best-effort stderr
 			names = nil
+		}
+		if partialList {
+			fmt.Fprintf(stderr, "gc stop: listing sessions partially failed: %v\n", err) //nolint:errcheck // best-effort stderr
 		}
 		for _, name := range names {
 			if name = strings.TrimSpace(name); name != "" {

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -893,6 +893,9 @@ func gracefulStopAll(
 			running, _ = workerSessionTargetRunningWithConfig("", nil, sp, nil, name)
 		}
 		if !running {
+			if err := sp.Stop(name); err != nil && !runtime.IsSessionGone(err) {
+				fmt.Fprintf(stderr, "cleaning exited agent '%s': %v\n", name, err) //nolint:errcheck // best-effort stderr
+			}
 			fmt.Fprintf(stdout, "Agent '%s' exited gracefully\n", name) //nolint:errcheck // best-effort stdout
 			subject := name
 			if target, ok := targetByName[name]; ok && target.subject != "" {

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1474,10 +1474,14 @@ func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr i
 	return true
 }
 
-// reapStaleSessionBeads closes session beads that are stuck in the creating
-// state past the startup grace period — sessions whose tmux process never
-// completed startup, so they are guaranteed not to hold work claims (claim
-// is the first thing a worker does after startup).
+// reapStaleSessionBeads closes beads whose runtime is gone while startup is
+// still incomplete. cleanupDeadRuntimeSessionCorpses handles the inverse
+// mismatch: open beads whose runtime artifact is visible but confirmed dead.
+//
+// This function only targets session beads stuck in the creating state past the
+// startup grace period — sessions whose tmux process never completed startup,
+// so they are guaranteed not to hold work claims (claim is the first thing a
+// worker does after startup).
 //
 // Sessions that completed startup (state=active, awake, etc.) are NEVER reaped
 // here even if their tmux session has died: they may hold in_progress claims,
@@ -1557,16 +1561,25 @@ func reapStaleSessionBeads(
 
 func cleanupDeadRuntimeSessionCorpses(
 	sessionBeads *sessionBeadSnapshot,
+	dt *drainTracker,
 	sp runtime.Provider,
 	stderr io.Writer,
 ) int {
 	if sessionBeads == nil || sp == nil {
 		return 0
 	}
+	deadChecker, ok := sp.(runtime.DeadRuntimeSessionChecker)
+	if !ok {
+		return 0
+	}
 	visible, err := sp.ListRunning("")
-	if err != nil {
+	partialList := runtime.IsPartialListError(err)
+	if err != nil && !partialList {
 		fmt.Fprintf(stderr, "session reconciler: listing runtime sessions for dead cleanup: %v\n", err) //nolint:errcheck
 		return 0
+	}
+	if partialList {
+		fmt.Fprintf(stderr, "session reconciler: listing runtime sessions partially failed for dead cleanup; checking %d visible session(s): %v\n", len(visible), err) //nolint:errcheck
 	}
 	if len(visible) == 0 {
 		return 0
@@ -1585,18 +1598,31 @@ func cleanupDeadRuntimeSessionCorpses(
 	cleaned := 0
 	seen := make(map[string]bool)
 	for _, b := range sessionBeads.Open() {
+		pendingCreate := strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true"
+		if pendingCreate || (dt != nil && dt.get(b.ID) != nil) || isNamedSessionBead(b) {
+			continue
+		}
 		name := strings.TrimSpace(b.Metadata["session_name"])
 		if name == "" || seen[name] || !visibleSet[name] {
 			continue
 		}
 		seen[name] = true
-		if sp.IsRunning(name) {
+		dead, err := deadChecker.IsDeadRuntimeSession(name)
+		if err != nil {
+			fmt.Fprintf(stderr, "session reconciler: confirming dead runtime session %s: %v\n", name, err) //nolint:errcheck
+			continue
+		}
+		if !dead {
 			continue
 		}
 		if err := sp.Stop(name); err != nil {
+			if runtime.IsSessionGone(err) {
+				continue
+			}
 			fmt.Fprintf(stderr, "session reconciler: cleaning dead runtime session %s: %v\n", name, err) //nolint:errcheck
 			continue
 		}
+		fmt.Fprintf(stderr, "session reconciler: cleaned dead runtime session %s\n", name) //nolint:errcheck
 		cleaned++
 	}
 	return cleaned

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1555,6 +1555,53 @@ func reapStaleSessionBeads(
 	return reaped
 }
 
+func cleanupDeadRuntimeSessionCorpses(
+	sessionBeads *sessionBeadSnapshot,
+	sp runtime.Provider,
+	stderr io.Writer,
+) int {
+	if sessionBeads == nil || sp == nil {
+		return 0
+	}
+	visible, err := sp.ListRunning("")
+	if err != nil {
+		fmt.Fprintf(stderr, "session reconciler: listing runtime sessions for dead cleanup: %v\n", err) //nolint:errcheck
+		return 0
+	}
+	if len(visible) == 0 {
+		return 0
+	}
+	visibleSet := make(map[string]bool, len(visible))
+	for _, name := range visible {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			visibleSet[name] = true
+		}
+	}
+	if len(visibleSet) == 0 {
+		return 0
+	}
+
+	cleaned := 0
+	seen := make(map[string]bool)
+	for _, b := range sessionBeads.Open() {
+		name := strings.TrimSpace(b.Metadata["session_name"])
+		if name == "" || seen[name] || !visibleSet[name] {
+			continue
+		}
+		seen[name] = true
+		if sp.IsRunning(name) {
+			continue
+		}
+		if err := sp.Stop(name); err != nil {
+			fmt.Fprintf(stderr, "session reconciler: cleaning dead runtime session %s: %v\n", name, err) //nolint:errcheck
+			continue
+		}
+		cleaned++
+	}
+	return cleaned
+}
+
 func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	store beads.Store,
 	rigStores map[string]beads.Store,

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -53,16 +53,25 @@ type stopHookProvider struct {
 
 type deadRuntimeArtifactProvider struct {
 	*runtime.Fake
-	visible map[string]bool
-	live    map[string]bool
-	stopped []string
+	visible   map[string]bool
+	live      map[string]bool
+	dead      map[string]bool
+	deadErrs  map[string]error
+	stopErrs  map[string]error
+	listErr   error
+	stopped   []string
+	stopCalls map[string]int
 }
 
 func newDeadRuntimeArtifactProvider() *deadRuntimeArtifactProvider {
 	return &deadRuntimeArtifactProvider{
-		Fake:    runtime.NewFake(),
-		visible: make(map[string]bool),
-		live:    make(map[string]bool),
+		Fake:      runtime.NewFake(),
+		visible:   make(map[string]bool),
+		live:      make(map[string]bool),
+		dead:      make(map[string]bool),
+		deadErrs:  make(map[string]error),
+		stopErrs:  make(map[string]error),
+		stopCalls: make(map[string]int),
 	}
 }
 
@@ -73,17 +82,29 @@ func (p *deadRuntimeArtifactProvider) ListRunning(prefix string) ([]string, erro
 			names = append(names, name)
 		}
 	}
-	return names, nil
+	return names, p.listErr
 }
 
 func (p *deadRuntimeArtifactProvider) IsRunning(name string) bool {
 	return p.live[name]
 }
 
+func (p *deadRuntimeArtifactProvider) IsDeadRuntimeSession(name string) (bool, error) {
+	if err := p.deadErrs[name]; err != nil {
+		return false, err
+	}
+	return p.dead[name], nil
+}
+
 func (p *deadRuntimeArtifactProvider) Stop(name string) error {
+	p.stopCalls[name]++
+	if err := p.stopErrs[name]; err != nil {
+		return err
+	}
 	p.stopped = append(p.stopped, name)
 	delete(p.visible, name)
 	delete(p.live, name)
+	delete(p.dead, name)
 	return nil
 }
 
@@ -4183,6 +4204,7 @@ func TestCleanupDeadRuntimeSessionCorpsesStopsVisibleDeadSessions(t *testing.T) 
 	sp.visible["live-worker"] = true
 	sp.visible["untracked-worker"] = true
 	sp.live["live-worker"] = true
+	sp.dead["dead-worker"] = true
 
 	snapshot := newSessionBeadSnapshot([]beads.Bead{
 		{
@@ -4212,7 +4234,7 @@ func TestCleanupDeadRuntimeSessionCorpsesStopsVisibleDeadSessions(t *testing.T) 
 	})
 
 	var stderr bytes.Buffer
-	got := cleanupDeadRuntimeSessionCorpses(snapshot, sp, &stderr)
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, nil, sp, &stderr)
 	if got != 1 {
 		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
 	}
@@ -4221,6 +4243,188 @@ func TestCleanupDeadRuntimeSessionCorpsesStopsVisibleDeadSessions(t *testing.T) 
 	}
 	if !sp.visible["live-worker"] || !sp.visible["untracked-worker"] {
 		t.Fatalf("cleanup stopped live or untracked session: visible=%v", sp.visible)
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesSkipsLivenessUncertainty(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["worker"] = true
+	sp.deadErrs["worker"] = errors.New("pane state unavailable")
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "s1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker",
+		},
+	}})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, nil, sp, &stderr)
+	if got != 0 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 0", got)
+	}
+	if sp.stopCalls["worker"] != 0 {
+		t.Fatalf("Stop called for liveness-uncertain session: calls=%d stderr=%q", sp.stopCalls["worker"], stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "confirming dead runtime session worker") {
+		t.Fatalf("stderr = %q, want dead-confirmation warning", stderr.String())
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesSkipsVisibleSessionWhenCheckerReportsLive(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["mixed-pane-worker"] = true
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "s1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "mixed-pane-worker",
+		},
+	}})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, nil, sp, &stderr)
+	if got != 0 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 0", got)
+	}
+	if sp.stopCalls["mixed-pane-worker"] != 0 {
+		t.Fatalf("Stop calls = %d, want 0 for checker-live session", sp.stopCalls["mixed-pane-worker"])
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesUsesPartialListResults(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["worker"] = true
+	sp.dead["worker"] = true
+	sp.listErr = &runtime.PartialListError{Err: errors.New("remote backend down")}
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "s1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker",
+		},
+	}})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, nil, sp, &stderr)
+	if got != 1 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+	if sp.stopCalls["worker"] != 1 {
+		t.Fatalf("Stop calls = %d, want 1", sp.stopCalls["worker"])
+	}
+	if !strings.Contains(stderr.String(), "listing runtime sessions partially failed") {
+		t.Fatalf("stderr = %q, want partial-list warning", stderr.String())
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesSkipsLifecycleOwnedBeads(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	for _, name := range []string{"pending-worker", "draining-worker", "named-worker", "ordinary-worker"} {
+		sp.visible[name] = true
+		sp.dead[name] = true
+	}
+
+	dt := newDrainTracker()
+	dt.set("draining", &drainState{reason: "user"})
+	snapshot := newSessionBeadSnapshot([]beads.Bead{
+		{
+			ID:     "pending",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name":         "pending-worker",
+				"pending_create_claim": "true",
+			},
+		},
+		{
+			ID:     "draining",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": "draining-worker",
+			},
+		},
+		{
+			ID:     "named",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name":                       "named-worker",
+				session.NamedSessionMetadataKey:      "true",
+				session.NamedSessionIdentityMetadata: "rig/worker",
+				session.NamedSessionModeMetadata:     "always",
+			},
+		},
+		{
+			ID:     "ordinary",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": "ordinary-worker",
+			},
+		},
+	})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, dt, sp, &stderr)
+	if got != 1 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+	if sp.stopCalls["ordinary-worker"] != 1 {
+		t.Fatalf("ordinary Stop calls = %d, want 1", sp.stopCalls["ordinary-worker"])
+	}
+	for _, name := range []string{"pending-worker", "draining-worker", "named-worker"} {
+		if sp.stopCalls[name] != 0 {
+			t.Fatalf("Stop(%s) calls = %d, want 0", name, sp.stopCalls[name])
+		}
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesSkipsBlankAndDeduplicatesNames(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["worker"] = true
+	sp.dead["worker"] = true
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{
+		{ID: "blank", Status: "open", Metadata: map[string]string{"session_name": "  "}},
+		{ID: "first", Status: "open", Metadata: map[string]string{"session_name": "worker"}},
+		{ID: "second", Status: "open", Metadata: map[string]string{"session_name": " worker "}},
+	})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, nil, sp, &stderr)
+	if got != 1 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+	if sp.stopCalls["worker"] != 1 {
+		t.Fatalf("Stop calls = %d, want 1", sp.stopCalls["worker"])
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesReportsStopErrors(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["worker"] = true
+	sp.dead["worker"] = true
+	sp.stopErrs["worker"] = errors.New("stop failed")
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "s1",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker",
+		},
+	}})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, nil, sp, &stderr)
+	if got != 0 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 0", got)
+	}
+	if sp.stopCalls["worker"] != 1 {
+		t.Fatalf("Stop calls = %d, want 1", sp.stopCalls["worker"])
+	}
+	if !strings.Contains(stderr.String(), "cleaning dead runtime session worker: stop failed") {
+		t.Fatalf("stderr = %q, want Stop error", stderr.String())
 	}
 }
 

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -51,6 +51,42 @@ type stopHookProvider struct {
 	beforeStop func(string)
 }
 
+type deadRuntimeArtifactProvider struct {
+	*runtime.Fake
+	visible map[string]bool
+	live    map[string]bool
+	stopped []string
+}
+
+func newDeadRuntimeArtifactProvider() *deadRuntimeArtifactProvider {
+	return &deadRuntimeArtifactProvider{
+		Fake:    runtime.NewFake(),
+		visible: make(map[string]bool),
+		live:    make(map[string]bool),
+	}
+}
+
+func (p *deadRuntimeArtifactProvider) ListRunning(prefix string) ([]string, error) {
+	var names []string
+	for name := range p.visible {
+		if strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+func (p *deadRuntimeArtifactProvider) IsRunning(name string) bool {
+	return p.live[name]
+}
+
+func (p *deadRuntimeArtifactProvider) Stop(name string) error {
+	p.stopped = append(p.stopped, name)
+	delete(p.visible, name)
+	delete(p.live, name)
+	return nil
+}
+
 func (s *failingCloseStore) Close(_ string) error {
 	return errors.New("close failed")
 }
@@ -4138,6 +4174,53 @@ func TestReapStaleSessionBeads_NilStoreAndProvider(t *testing.T) {
 	}
 	if got := reapStaleSessionBeads(nil, runtime.NewFake(), nil, clk, &stderr); got != 0 {
 		t.Errorf("nil store: got %d, want 0", got)
+	}
+}
+
+func TestCleanupDeadRuntimeSessionCorpsesStopsVisibleDeadSessions(t *testing.T) {
+	sp := newDeadRuntimeArtifactProvider()
+	sp.visible["dead-worker"] = true
+	sp.visible["live-worker"] = true
+	sp.visible["untracked-worker"] = true
+	sp.live["live-worker"] = true
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{
+		{
+			ID:     "s1",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": "dead-worker",
+				"template":     "worker",
+			},
+		},
+		{
+			ID:     "s2",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": "live-worker",
+				"template":     "worker",
+			},
+		},
+		{
+			ID:     "s3",
+			Status: "open",
+			Metadata: map[string]string{
+				"session_name": "absent-worker",
+				"template":     "worker",
+			},
+		},
+	})
+
+	var stderr bytes.Buffer
+	got := cleanupDeadRuntimeSessionCorpses(snapshot, sp, &stderr)
+	if got != 1 {
+		t.Fatalf("cleanupDeadRuntimeSessionCorpses() = %d, want 1; stderr=%q", got, stderr.String())
+	}
+	if len(sp.stopped) != 1 || sp.stopped[0] != "dead-worker" {
+		t.Fatalf("stopped = %v, want [dead-worker]", sp.stopped)
+	}
+	if !sp.visible["live-worker"] || !sp.visible["untracked-worker"] {
+		t.Fatalf("cleanup stopped live or untracked session: visible=%v", sp.visible)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -397,17 +397,20 @@ func (p *staleIsRunningAfterInterruptProvider) IsRunning(name string) bool {
 
 type exitedArtifactAfterInterruptProvider struct {
 	*runtime.Fake
-	mu         sync.Mutex
-	exited     map[string]bool
-	stopCalls  map[string]int
-	listExited bool
+	mu                     sync.Mutex
+	exited                 map[string]bool
+	stopCalls              map[string]int
+	keepRunningOnInterrupt map[string]bool
+	listExited             bool
+	listErr                error
 }
 
 func newExitedArtifactAfterInterruptProvider() *exitedArtifactAfterInterruptProvider {
 	return &exitedArtifactAfterInterruptProvider{
-		Fake:      runtime.NewFake(),
-		exited:    make(map[string]bool),
-		stopCalls: make(map[string]int),
+		Fake:                   runtime.NewFake(),
+		exited:                 make(map[string]bool),
+		stopCalls:              make(map[string]int),
+		keepRunningOnInterrupt: make(map[string]bool),
 	}
 }
 
@@ -420,6 +423,12 @@ func (p *exitedArtifactAfterInterruptProvider) markExited(name string) {
 func (p *exitedArtifactAfterInterruptProvider) Interrupt(name string) error {
 	if err := p.Fake.Interrupt(name); err != nil {
 		return err
+	}
+	p.mu.Lock()
+	keepRunning := p.keepRunningOnInterrupt[name]
+	p.mu.Unlock()
+	if keepRunning {
+		return nil
 	}
 	p.markExited(name)
 	return nil
@@ -447,7 +456,7 @@ func (p *exitedArtifactAfterInterruptProvider) ListRunning(prefix string) ([]str
 			filtered = append(filtered, name)
 		}
 	}
-	return filtered, nil
+	return filtered, p.listErr
 }
 
 func (p *exitedArtifactAfterInterruptProvider) Stop(name string) error {
@@ -3335,6 +3344,34 @@ func TestGracefulStopAll_CleansExitedRuntimeArtifact(t *testing.T) {
 	}
 }
 
+func TestGracefulStopAll_CleansExitedRuntimeArtifactAlongsideLiveSurvivor(t *testing.T) {
+	sp := newExitedArtifactAfterInterruptProvider()
+	for _, name := range []string{"corpse-worker", "live-worker"} {
+		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+			t.Fatalf("Start(%s): %v", name, err)
+		}
+	}
+	sp.keepRunningOnInterrupt["live-worker"] = true
+
+	rec := events.NewFake()
+	var stdout, stderr bytes.Buffer
+
+	gracefulStopAll([]string{"corpse-worker", "live-worker"}, sp, 20*time.Millisecond, rec, nil, nil, &stdout, &stderr)
+
+	if sp.stopCalls["corpse-worker"] == 0 {
+		t.Fatalf("expected cleanup Stop for exited runtime artifact, calls=%+v", sp.Calls)
+	}
+	if sp.stopCalls["live-worker"] == 0 {
+		t.Fatalf("expected forced Stop for live survivor, calls=%+v", sp.Calls)
+	}
+	if !strings.Contains(stdout.String(), "Agent 'corpse-worker' exited gracefully") {
+		t.Fatalf("stdout = %q, want corpse graceful-exit message", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Stopped agent 'live-worker'") {
+		t.Fatalf("stdout = %q, want live forced-stop message", stdout.String())
+	}
+}
+
 func TestDoStopCleansExitedRuntimeArtifact(t *testing.T) {
 	sp := newExitedArtifactAfterInterruptProvider()
 	if err := sp.Start(context.Background(), "custom-worker", runtime.Config{}); err != nil {
@@ -3349,6 +3386,38 @@ func TestDoStopCleansExitedRuntimeArtifact(t *testing.T) {
 
 	if sp.stopCalls["custom-worker"] == 0 {
 		t.Fatalf("expected doStop to cleanup exited runtime artifact, calls=%+v", sp.Calls)
+	}
+}
+
+func TestDoStopCleansVisibleExitedRuntimeArtifactWithPartialListError(t *testing.T) {
+	sp := newExitedArtifactAfterInterruptProvider()
+	if err := sp.Start(context.Background(), "custom-worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	sp.markExited("custom-worker")
+	sp.listExited = true
+	sp.listErr = &runtime.PartialListError{Err: errors.New("remote backend down")}
+
+	var stdout, stderr bytes.Buffer
+
+	doStop([]string{"custom-worker"}, sp, nil, nil, 20*time.Millisecond, events.Discard, &stdout, &stderr)
+
+	if sp.stopCalls["custom-worker"] == 0 {
+		t.Fatalf("expected doStop to cleanup exited runtime artifact despite partial list error, calls=%+v", sp.Calls)
+	}
+	if !strings.Contains(stderr.String(), "listing sessions partially failed") {
+		t.Fatalf("stderr = %q, want partial-list warning", stderr.String())
+	}
+}
+
+func TestDoStopSkipsExplicitNameThatIsNeitherAliveNorVisible(t *testing.T) {
+	sp := newExitedArtifactAfterInterruptProvider()
+	var stdout, stderr bytes.Buffer
+
+	doStop([]string{"absent-worker"}, sp, nil, nil, 20*time.Millisecond, events.Discard, &stdout, &stderr)
+
+	if sp.stopCalls["absent-worker"] != 0 {
+		t.Fatalf("Stop calls for absent-worker = %d, want 0", sp.stopCalls["absent-worker"])
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -395,6 +395,68 @@ func (p *staleIsRunningAfterInterruptProvider) IsRunning(name string) bool {
 	return p.Fake.IsRunning(name)
 }
 
+type exitedArtifactAfterInterruptProvider struct {
+	*runtime.Fake
+	mu         sync.Mutex
+	exited     map[string]bool
+	stopCalls  map[string]int
+	listExited bool
+}
+
+func newExitedArtifactAfterInterruptProvider() *exitedArtifactAfterInterruptProvider {
+	return &exitedArtifactAfterInterruptProvider{
+		Fake:      runtime.NewFake(),
+		exited:    make(map[string]bool),
+		stopCalls: make(map[string]int),
+	}
+}
+
+func (p *exitedArtifactAfterInterruptProvider) markExited(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.exited[name] = true
+}
+
+func (p *exitedArtifactAfterInterruptProvider) Interrupt(name string) error {
+	if err := p.Fake.Interrupt(name); err != nil {
+		return err
+	}
+	p.markExited(name)
+	return nil
+}
+
+func (p *exitedArtifactAfterInterruptProvider) IsRunning(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.exited[name] {
+		return false
+	}
+	return p.Fake.IsRunning(name)
+}
+
+func (p *exitedArtifactAfterInterruptProvider) ListRunning(prefix string) ([]string, error) {
+	names, err := p.Fake.ListRunning(prefix)
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	filtered := names[:0]
+	for _, name := range names {
+		if p.listExited || !p.exited[name] {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered, nil
+}
+
+func (p *exitedArtifactAfterInterruptProvider) Stop(name string) error {
+	p.mu.Lock()
+	p.stopCalls[name]++
+	p.mu.Unlock()
+	return p.Fake.Stop(name)
+}
+
 type dropDependencyAfterNStartsProvider struct {
 	*runtime.Fake
 	mu        sync.Mutex
@@ -3251,6 +3313,42 @@ func TestGracefulStopAll_UsesListRunningToStopLingeringSessions(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Stopped agent 'custom-worker'") {
 		t.Fatalf("stdout = %q, want forced stop message", stdout.String())
+	}
+}
+
+func TestGracefulStopAll_CleansExitedRuntimeArtifact(t *testing.T) {
+	sp := newExitedArtifactAfterInterruptProvider()
+	if err := sp.Start(context.Background(), "custom-worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := events.NewFake()
+	var stdout, stderr bytes.Buffer
+
+	gracefulStopAll([]string{"custom-worker"}, sp, 20*time.Millisecond, rec, nil, nil, &stdout, &stderr)
+
+	if sp.stopCalls["custom-worker"] == 0 {
+		t.Fatalf("expected gracefulStopAll to cleanup exited runtime artifact, calls=%+v", sp.Calls)
+	}
+	if !strings.Contains(stdout.String(), "Agent 'custom-worker' exited gracefully") {
+		t.Fatalf("stdout = %q, want graceful exit message", stdout.String())
+	}
+}
+
+func TestDoStopCleansExitedRuntimeArtifact(t *testing.T) {
+	sp := newExitedArtifactAfterInterruptProvider()
+	if err := sp.Start(context.Background(), "custom-worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	sp.markExited("custom-worker")
+	sp.listExited = true
+
+	var stdout, stderr bytes.Buffer
+
+	doStop([]string{"custom-worker"}, sp, nil, nil, 20*time.Millisecond, events.Discard, &stdout, &stderr)
+
+	if sp.stopCalls["custom-worker"] == 0 {
+		t.Fatalf("expected doStop to cleanup exited runtime artifact, calls=%+v", sp.Calls)
 	}
 }
 

--- a/internal/runtime/auto/auto.go
+++ b/internal/runtime/auto/auto.go
@@ -26,6 +26,7 @@ type Provider struct {
 
 var (
 	_ runtime.Provider                      = (*Provider)(nil)
+	_ runtime.DeadRuntimeSessionChecker     = (*Provider)(nil)
 	_ runtime.InteractionProvider           = (*Provider)(nil)
 	_ runtime.InterruptBoundaryWaitProvider = (*Provider)(nil)
 	_ runtime.InterruptedTurnResetProvider  = (*Provider)(nil)
@@ -173,6 +174,30 @@ func (p *Provider) IsRunning(name string) bool {
 		return p.defaultSP.IsRunning(name)
 	}
 	return p.acpSP.IsRunning(name)
+}
+
+// IsDeadRuntimeSession checks both backends for a positive dead-artifact
+// report because ListRunning is also merged across both backends.
+func (p *Provider) IsDeadRuntimeSession(name string) (bool, error) {
+	primary := p.route(name)
+	if dead, err := providerDeadRuntimeSession(primary, name); dead || err != nil {
+		return dead, err
+	}
+	p.mu.RLock()
+	isACP := p.routes[name]
+	p.mu.RUnlock()
+	if isACP {
+		return providerDeadRuntimeSession(p.defaultSP, name)
+	}
+	return providerDeadRuntimeSession(p.acpSP, name)
+}
+
+func providerDeadRuntimeSession(sp runtime.Provider, name string) (bool, error) {
+	checker, ok := sp.(runtime.DeadRuntimeSessionChecker)
+	if !ok {
+		return false, nil
+	}
+	return checker.IsDeadRuntimeSession(name)
 }
 
 // IsAttached delegates to the routed backend.

--- a/internal/runtime/auto/auto_test.go
+++ b/internal/runtime/auto/auto_test.go
@@ -22,6 +22,29 @@ func (p *falseNegativeStopProvider) Stop(string) error { return p.stopErr }
 
 func (p *falseNegativeStopProvider) IsRunning(string) bool { return false }
 
+type deadRuntimeCheckProvider struct {
+	*runtime.Fake
+	dead   map[string]bool
+	errs   map[string]error
+	checks []string
+}
+
+func newDeadRuntimeCheckProvider() *deadRuntimeCheckProvider {
+	return &deadRuntimeCheckProvider{
+		Fake: runtime.NewFake(),
+		dead: make(map[string]bool),
+		errs: make(map[string]error),
+	}
+}
+
+func (p *deadRuntimeCheckProvider) IsDeadRuntimeSession(name string) (bool, error) {
+	p.checks = append(p.checks, name)
+	if err := p.errs[name]; err != nil {
+		return false, err
+	}
+	return p.dead[name], nil
+}
+
 func TestRouteDefaultAndACP(t *testing.T) {
 	defaultSP := runtime.NewFake()
 	acpSP := runtime.NewFake()
@@ -343,6 +366,46 @@ func TestIsRunningFallsThrough(t *testing.T) {
 	_ = acpSP.Start(context.Background(), "lost-route", runtime.Config{})
 	if !p.IsRunning("lost-route") {
 		t.Fatal("IsRunning should fall through to ACP when default reports not running")
+	}
+}
+
+func TestIsDeadRuntimeSessionChecksUnroutedFallbackChecker(t *testing.T) {
+	defaultSP := runtime.NewFake()
+	acpSP := newDeadRuntimeCheckProvider()
+	acpSP.dead["lost-route"] = true
+	p := New(defaultSP, acpSP)
+
+	dead, err := p.IsDeadRuntimeSession("lost-route")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if !dead {
+		t.Fatal("IsDeadRuntimeSession = false, want true from fallback checker")
+	}
+	if got := acpSP.checks; len(got) != 1 || got[0] != "lost-route" {
+		t.Fatalf("fallback checks = %v, want [lost-route]", got)
+	}
+}
+
+func TestIsDeadRuntimeSessionFindsDefaultCorpseBehindStaleACPRoute(t *testing.T) {
+	defaultSP := newDeadRuntimeCheckProvider()
+	acpSP := newDeadRuntimeCheckProvider()
+	defaultSP.dead["agent"] = true
+	p := New(defaultSP, acpSP)
+	p.RouteACP("agent")
+
+	dead, err := p.IsDeadRuntimeSession("agent")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if !dead {
+		t.Fatal("IsDeadRuntimeSession = false, want true from default backend")
+	}
+	if got := acpSP.checks; len(got) != 1 || got[0] != "agent" {
+		t.Fatalf("primary checks = %v, want [agent]", got)
+	}
+	if got := defaultSP.checks; len(got) != 1 || got[0] != "agent" {
+		t.Fatalf("fallback checks = %v, want [agent]", got)
 	}
 }
 

--- a/internal/runtime/hybrid/hybrid.go
+++ b/internal/runtime/hybrid/hybrid.go
@@ -19,6 +19,7 @@ type Provider struct {
 
 var (
 	_ runtime.Provider                      = (*Provider)(nil)
+	_ runtime.DeadRuntimeSessionChecker     = (*Provider)(nil)
 	_ runtime.InteractionProvider           = (*Provider)(nil)
 	_ runtime.InterruptBoundaryWaitProvider = (*Provider)(nil)
 	_ runtime.InterruptedTurnResetProvider  = (*Provider)(nil)
@@ -55,6 +56,16 @@ func (p *Provider) Interrupt(name string) error {
 // IsRunning delegates to the routed backend.
 func (p *Provider) IsRunning(name string) bool {
 	return p.route(name).IsRunning(name)
+}
+
+// IsDeadRuntimeSession delegates to the routed backend when it can positively
+// distinguish live sessions from visible dead artifacts.
+func (p *Provider) IsDeadRuntimeSession(name string) (bool, error) {
+	checker, ok := p.route(name).(runtime.DeadRuntimeSessionChecker)
+	if !ok {
+		return false, nil
+	}
+	return checker.IsDeadRuntimeSession(name)
 }
 
 // IsAttached delegates to the routed backend.

--- a/internal/runtime/hybrid/hybrid_test.go
+++ b/internal/runtime/hybrid/hybrid_test.go
@@ -3,6 +3,7 @@ package hybrid
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -176,4 +177,84 @@ func TestPendingUnsupportedWhenBackendLacksInteractionSupport(t *testing.T) {
 
 type runtimeNoInteractionProvider struct {
 	runtime.Provider
+}
+
+type deadRuntimeCheckProvider struct {
+	*runtime.Fake
+	dead   map[string]bool
+	errs   map[string]error
+	checks []string
+}
+
+func newDeadRuntimeCheckProvider() *deadRuntimeCheckProvider {
+	return &deadRuntimeCheckProvider{
+		Fake: runtime.NewFake(),
+		dead: make(map[string]bool),
+		errs: make(map[string]error),
+	}
+}
+
+func (p *deadRuntimeCheckProvider) IsDeadRuntimeSession(name string) (bool, error) {
+	p.checks = append(p.checks, name)
+	if err := p.errs[name]; err != nil {
+		return false, err
+	}
+	return p.dead[name], nil
+}
+
+func TestIsDeadRuntimeSessionDelegatesToRoutedChecker(t *testing.T) {
+	local := newDeadRuntimeCheckProvider()
+	remote := newDeadRuntimeCheckProvider()
+	remote.dead["polecat-1"] = true
+	h := New(local, remote, isRemote)
+
+	dead, err := h.IsDeadRuntimeSession("polecat-1")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if !dead {
+		t.Fatal("IsDeadRuntimeSession = false, want true from routed remote checker")
+	}
+	if len(local.checks) != 0 {
+		t.Fatalf("local checks = %v, want none", local.checks)
+	}
+	if got := remote.checks; len(got) != 1 || got[0] != "polecat-1" {
+		t.Fatalf("remote checks = %v, want [polecat-1]", got)
+	}
+}
+
+func TestIsDeadRuntimeSessionReturnsFalseWhenRoutedBackendLacksChecker(t *testing.T) {
+	local := runtime.NewFake()
+	remote := newDeadRuntimeCheckProvider()
+	remote.dead["refinery"] = true
+	h := New(local, remote, isRemote)
+
+	dead, err := h.IsDeadRuntimeSession("refinery")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if dead {
+		t.Fatal("IsDeadRuntimeSession = true, want false for non-checker routed backend")
+	}
+	if len(remote.checks) != 0 {
+		t.Fatalf("remote checks = %v, want none for local-routed session", remote.checks)
+	}
+}
+
+func TestIsDeadRuntimeSessionReturnsRoutedCheckerError(t *testing.T) {
+	local := newDeadRuntimeCheckProvider()
+	remote := newDeadRuntimeCheckProvider()
+	remote.errs["polecat-1"] = fmt.Errorf("runtime unavailable")
+	h := New(local, remote, isRemote)
+
+	dead, err := h.IsDeadRuntimeSession("polecat-1")
+	if err == nil {
+		t.Fatal("IsDeadRuntimeSession error = nil, want routed checker error")
+	}
+	if dead {
+		t.Fatal("IsDeadRuntimeSession = true, want false on checker error")
+	}
+	if !strings.Contains(err.Error(), "runtime unavailable") {
+		t.Fatalf("IsDeadRuntimeSession error = %v, want runtime unavailable", err)
+	}
 }

--- a/internal/runtime/provider_core.go
+++ b/internal/runtime/provider_core.go
@@ -48,6 +48,15 @@ func IsPartialListError(err error) bool {
 	return errors.As(err, &target)
 }
 
+// DeadRuntimeSessionChecker is an optional provider capability for destructive
+// cleanup paths that need positive proof a visible runtime artifact is dead.
+// A false result means either the session is live, absent, or unsupported by
+// the backend; a non-nil error means liveness could not be confirmed.
+type DeadRuntimeSessionChecker interface {
+	// IsDeadRuntimeSession reports whether name is visible but confirmed dead.
+	IsDeadRuntimeSession(name string) (bool, error)
+}
+
 // MergeBackendListResults merges provider ListRunning results. On partial
 // backend failure it returns the best-effort merged names plus a
 // [PartialListError] so callers can continue with partial results while still

--- a/internal/runtime/tmux/adapter.go
+++ b/internal/runtime/tmux/adapter.go
@@ -33,6 +33,7 @@ var instanceTokenReader = rand.Reader
 // Compile-time check.
 var (
 	_ runtime.Provider                      = (*Provider)(nil)
+	_ runtime.DeadRuntimeSessionChecker     = (*Provider)(nil)
 	_ runtime.ImmediateNudgeProvider        = (*Provider)(nil)
 	_ runtime.InterruptBoundaryWaitProvider = (*Provider)(nil)
 	_ runtime.InterruptedTurnResetProvider  = (*Provider)(nil)
@@ -226,6 +227,23 @@ func (p *Provider) Interrupt(name string) error {
 // are correctly excluded — only sessions with live panes are "running".
 func (p *Provider) IsRunning(name string) bool {
 	return p.cache.IsRunning(name)
+}
+
+// IsDeadRuntimeSession reports whether a visible tmux session is a
+// remain-on-exit corpse with no live panes.
+func (p *Provider) IsDeadRuntimeSession(name string) (bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, nil
+	}
+	dead, err := p.tm.sessionPanesDead(name)
+	if err != nil {
+		if errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrNoServer) {
+			return false, nil
+		}
+		return false, err
+	}
+	return dead, nil
 }
 
 // IsAttached reports whether a user terminal is connected to the named session.

--- a/internal/runtime/tmux/executor_test.go
+++ b/internal/runtime/tmux/executor_test.go
@@ -271,6 +271,67 @@ func TestIsSessionRunningFallsBackToSessionExistsOnPaneQueryError(t *testing.T) 
 	}
 }
 
+func TestProviderIsDeadRuntimeSessionRequiresEveryPaneDead(t *testing.T) {
+	fe := &fakeExecutor{
+		out: "1\n0",
+	}
+	tm := &Tmux{cfg: Config{SocketName: "x"}, exec: fe}
+	p := &Provider{tm: tm}
+
+	dead, err := p.IsDeadRuntimeSession("runner")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if dead {
+		t.Fatal("IsDeadRuntimeSession = true, want false when any pane is live")
+	}
+
+	if len(fe.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fe.calls))
+	}
+	want := []string{"-u", "-L", "x", "list-panes", "-s", "-t", "=runner", "-F", "#{pane_dead}"}
+	if len(fe.calls[0]) != len(want) {
+		t.Fatalf("call = %v, want %v", fe.calls[0], want)
+	}
+	for i := range want {
+		if fe.calls[0][i] != want[i] {
+			t.Fatalf("call arg %d = %q, want %q; call=%v", i, fe.calls[0][i], want[i], fe.calls[0])
+		}
+	}
+}
+
+func TestProviderIsDeadRuntimeSessionTrueWhenAllPanesDead(t *testing.T) {
+	fe := &fakeExecutor{
+		out: "1\n1",
+	}
+	tm := &Tmux{cfg: Config{SocketName: "x"}, exec: fe}
+	p := &Provider{tm: tm}
+
+	dead, err := p.IsDeadRuntimeSession("runner")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if !dead {
+		t.Fatal("IsDeadRuntimeSession = false, want true when all panes are dead")
+	}
+}
+
+func TestProviderIsDeadRuntimeSessionTreatsAbsentSessionAsNotDead(t *testing.T) {
+	fe := &fakeExecutor{
+		err: ErrSessionNotFound,
+	}
+	tm := &Tmux{cfg: Config{SocketName: "x"}, exec: fe}
+	p := &Provider{tm: tm}
+
+	dead, err := p.IsDeadRuntimeSession("missing")
+	if err != nil {
+		t.Fatalf("IsDeadRuntimeSession: %v", err)
+	}
+	if dead {
+		t.Fatal("IsDeadRuntimeSession = true, want false for absent session")
+	}
+}
+
 func TestWaitForRuntimeReadyCapturesPromptAboveBlankFooter(t *testing.T) {
 	fe := &promptFooterExecutor{}
 	tm := &Tmux{cfg: DefaultConfig(), exec: fe}

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -1699,6 +1699,28 @@ func (t *Tmux) IsPaneDead(target string) (bool, error) {
 	}
 }
 
+func (t *Tmux) sessionPanesDead(session string) (bool, error) {
+	out, err := t.run("list-panes", "-s", "-t", "="+session, "-F", "#{pane_dead}")
+	if err != nil {
+		return false, err
+	}
+	values := strings.Fields(out)
+	if len(values) == 0 {
+		return false, fmt.Errorf("empty pane_dead list for session %s", session)
+	}
+	for _, value := range values {
+		switch value {
+		case "0":
+			return false, nil
+		case "1":
+			continue
+		default:
+			return false, fmt.Errorf("unexpected pane_dead value %q for session %s", value, session)
+		}
+	}
+	return true, nil
+}
+
 // IsSessionRunning reports whether the tmux session exists and its primary pane
 // still has a live process. Dead panes kept by remain-on-exit are treated as
 // not running.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -724,7 +724,15 @@ func (m *Manager) Suspend(id string) error {
 		// even when liveness already reports false; tmux remain-on-exit panes
 		// can be non-running but still need their session artifact removed.
 		if strings.TrimSpace(sessName) != "" {
-			if err := m.sp.Stop(sessName); err != nil {
+			running := m.sp.IsRunning(sessName)
+			err := m.sp.Stop(sessName)
+			if err != nil && !running {
+				// Preserve historical Suspend semantics for already-dead
+				// sessions: cleanup is best-effort when the runtime did not
+				// report a live process before Stop.
+				err = nil
+			}
+			if err != nil {
 				return fmt.Errorf("stopping runtime session: %w", err)
 			}
 		}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -720,8 +720,10 @@ func (m *Manager) Suspend(id string) error {
 			return err
 		}
 
-		// Kill the runtime session (skip if already dead).
-		if m.sp.IsRunning(sessName) {
+		// Kill the runtime session. Stop is provider-idempotent, so call it
+		// even when liveness already reports false; tmux remain-on-exit panes
+		// can be non-running but still need their session artifact removed.
+		if strings.TrimSpace(sessName) != "" {
 			if err := m.sp.Stop(sessName); err != nil {
 				return fmt.Errorf("stopping runtime session: %w", err)
 			}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -28,6 +28,7 @@ type noImmediateProvider struct {
 type nonRunningStopRecorder struct {
 	*runtime.Fake
 	stopCalls int
+	stopErr   error
 }
 
 func (p *nonRunningStopRecorder) IsRunning(string) bool {
@@ -36,6 +37,9 @@ func (p *nonRunningStopRecorder) IsRunning(string) bool {
 
 func (p *nonRunningStopRecorder) Stop(name string) error {
 	p.stopCalls++
+	if p.stopErr != nil {
+		return p.stopErr
+	}
 	return p.Fake.Stop(name)
 }
 
@@ -1289,6 +1293,31 @@ func TestSuspendCleansDeadRuntimeArtifact(t *testing.T) {
 
 	if sp.stopCalls != 1 {
 		t.Fatalf("Stop calls = %d, want 1 to clean dead runtime artifact", sp.stopCalls)
+	}
+}
+
+func TestSuspendKeepsNonRunningCleanupBestEffort(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &nonRunningStopRecorder{Fake: runtime.NewFake(), stopErr: errors.New("cleanup unavailable")}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+	if sp.stopCalls != 1 {
+		t.Fatalf("Stop calls = %d, want 1", sp.stopCalls)
+	}
+	got, err := mgr.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != StateSuspended {
+		t.Fatalf("State = %q, want %q", got.State, StateSuspended)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -25,6 +25,20 @@ type noImmediateProvider struct {
 	runtime.Provider
 }
 
+type nonRunningStopRecorder struct {
+	*runtime.Fake
+	stopCalls int
+}
+
+func (p *nonRunningStopRecorder) IsRunning(string) bool {
+	return false
+}
+
+func (p *nonRunningStopRecorder) Stop(name string) error {
+	p.stopCalls++
+	return p.Fake.Stop(name)
+}
+
 func (p *startOverrideProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
 	if p.startErr != nil {
 		return p.startErr
@@ -1256,6 +1270,25 @@ func TestSuspendCrashedSession(t *testing.T) {
 	}
 	if got.State != StateSuspended {
 		t.Errorf("State = %q, want %q", got.State, StateSuspended)
+	}
+}
+
+func TestSuspendCleansDeadRuntimeArtifact(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := &nonRunningStopRecorder{Fake: runtime.NewFake()}
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.Create(context.Background(), "helper", "", "claude", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	if sp.stopCalls != 1 {
+		t.Fatalf("Stop calls = %d, want 1 to clean dead runtime artifact", sp.stopCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- clean provider runtime artifacts even when session liveness already reports stopped
- sweep visible dead runtime session artifacts during controller startup and tick reconciliation
- keep `gc stop` from treating arbitrary missing names as stop targets while still cleaning runtime-listed artifacts

## Tests
- go test ./internal/session ./cmd/gc -run 'TestSuspendCleansDeadRuntimeArtifact|TestCleanupDeadRuntimeSessionCorpsesStopsVisibleDeadSessions|TestGracefulStopAll_CleansExitedRuntimeArtifact|TestDoStopCleansExitedRuntimeArtifact|TestDoStopAgentNotRunning'\n- go test ./internal/session ./cmd/gc\n- pre-commit hook: docs/schema generation, golangci-lint, go vet, GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->