### PR TITLE
perf(session): derive start concurrency from wake budget

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -69,7 +69,7 @@ type CityRuntime struct {
 
 	// Bead-driven reconciler state (Phase 2f).
 	sessionDrains     *drainTracker // in-memory drain tracker; nil when bead reconciler disabled
-	asyncStartLimiter chan struct{}
+	asyncStartLimiter *asyncStartLimiter
 	asyncStarts       asyncStartTracker
 	demandSnapshot    *runtimeDemandSnapshot
 
@@ -206,7 +206,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		poolSessions:            p.PoolSessions,
 		poolDeathHandlers:       p.PoolDeathHandlers,
 		suspendedNames:          suspendedNames,
-		asyncStartLimiter:       make(chan struct{}, maxParallelStartsPerTick(p.Cfg)),
+		asyncStartLimiter:       newAsyncStartLimiter(maxParallelStartsPerTick(p.Cfg)),
 		convergenceReqCh:        p.ConvergenceReqCh,
 		reloadReqCh: func() chan reloadRequest {
 			if p.ReloadReqCh != nil {
@@ -1420,10 +1420,12 @@ func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {
 	}
 }
 
-func (cr *CityRuntime) ensureAsyncStartLimiter() chan struct{} {
+func (cr *CityRuntime) ensureAsyncStartLimiter() *asyncStartLimiter {
 	capacity := maxParallelStartsPerTick(cr.cfg)
-	if cr.asyncStartLimiter == nil || cap(cr.asyncStartLimiter) != capacity {
-		cr.asyncStartLimiter = make(chan struct{}, capacity)
+	if cr.asyncStartLimiter == nil {
+		cr.asyncStartLimiter = newAsyncStartLimiter(capacity)
+	} else {
+		cr.asyncStartLimiter.resize(capacity)
 	}
 	return cr.asyncStartLimiter
 }

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -206,7 +206,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		poolSessions:            p.PoolSessions,
 		poolDeathHandlers:       p.PoolDeathHandlers,
 		suspendedNames:          suspendedNames,
-		asyncStartLimiter:       make(chan struct{}, defaultMaxParallelStartsPerWave),
+		asyncStartLimiter:       make(chan struct{}, maxParallelStartsPerTick(p.Cfg)),
 		convergenceReqCh:        p.ConvergenceReqCh,
 		reloadReqCh: func() chan reloadRequest {
 			if p.ReloadReqCh != nil {
@@ -1421,8 +1421,9 @@ func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {
 }
 
 func (cr *CityRuntime) ensureAsyncStartLimiter() chan struct{} {
-	if cr.asyncStartLimiter == nil {
-		cr.asyncStartLimiter = make(chan struct{}, defaultMaxParallelStartsPerWave)
+	capacity := maxParallelStartsPerTick(cr.cfg)
+	if cr.asyncStartLimiter == nil || cap(cr.asyncStartLimiter) != capacity {
+		cr.asyncStartLimiter = make(chan struct{}, capacity)
 	}
 	return cr.asyncStartLimiter
 }

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -253,6 +253,21 @@ func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeAsyncStartLimiterUsesMaxWakesPerTick(t *testing.T) {
+	maxWakes := 7
+	cfg := &config.City{Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes}}
+	cr := &CityRuntime{cfg: cfg}
+
+	if got := cap(cr.ensureAsyncStartLimiter()); got != maxWakes {
+		t.Fatalf("limiter cap = %d, want %d", got, maxWakes)
+	}
+
+	maxWakes = 2
+	if got := cap(cr.ensureAsyncStartLimiter()); got != maxWakes {
+		t.Fatalf("limiter cap after config change = %d, want %d", got, maxWakes)
+	}
+}
+
 type recordingOrderDispatcher struct {
 	called     atomic.Bool
 	calls      atomic.Int32

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -258,14 +258,54 @@ func TestCityRuntimeAsyncStartLimiterUsesMaxWakesPerTick(t *testing.T) {
 	cfg := &config.City{Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes}}
 	cr := &CityRuntime{cfg: cfg}
 
-	if got := cap(cr.ensureAsyncStartLimiter()); got != maxWakes {
+	if got := cr.ensureAsyncStartLimiter().capacity(); got != maxWakes {
 		t.Fatalf("limiter cap = %d, want %d", got, maxWakes)
 	}
 
 	maxWakes = 2
-	if got := cap(cr.ensureAsyncStartLimiter()); got != maxWakes {
+	if got := cr.ensureAsyncStartLimiter().capacity(); got != maxWakes {
 		t.Fatalf("limiter cap after config change = %d, want %d", got, maxWakes)
 	}
+}
+
+func TestCityRuntimeAsyncStartLimiterResizePreservesInFlightBudget(t *testing.T) {
+	maxWakes := 3
+	cfg := &config.City{Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes}}
+	cr := &CityRuntime{cfg: cfg}
+	limiter := cr.ensureAsyncStartLimiter()
+
+	var releases []func()
+	for i := 0; i < maxWakes; i++ {
+		release, reserved, outcome := reserveAsyncStartSlot(context.Background(), limiter)
+		if !reserved {
+			t.Fatalf("reserve initial slot = %s, want success", outcome)
+		}
+		releases = append(releases, release)
+	}
+
+	maxWakes = 2
+	resized := cr.ensureAsyncStartLimiter()
+	if resized != limiter {
+		t.Fatal("resized limiter should preserve the same in-flight reservation counter")
+	}
+	if got := resized.capacity(); got != maxWakes {
+		t.Fatalf("resized cap = %d, want %d", got, maxWakes)
+	}
+	if _, reserved, outcome := reserveAsyncStartSlot(context.Background(), resized); reserved || outcome != "deferred_by_async_start_limit" {
+		t.Fatalf("reserve while old slots exceed resized cap = reserved %v outcome %q, want deferred", reserved, outcome)
+	}
+
+	releases[0]()
+	if _, reserved, outcome := reserveAsyncStartSlot(context.Background(), resized); reserved || outcome != "deferred_by_async_start_limit" {
+		t.Fatalf("reserve at resized cap = reserved %v outcome %q, want deferred", reserved, outcome)
+	}
+	releases[1]()
+	release, reserved, outcome := reserveAsyncStartSlot(context.Background(), resized)
+	if !reserved {
+		t.Fatalf("reserve below resized cap = %s, want success", outcome)
+	}
+	release()
+	releases[2]()
 }
 
 type recordingOrderDispatcher struct {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -24,15 +24,21 @@ import (
 )
 
 const (
-	defaultMaxParallelStartsPerWave = 3
-	defaultMaxParallelStopsPerWave  = 3
-	defaultMaxParallelInterrupts    = 16
+	defaultMaxParallelStopsPerWave = 3
+	defaultMaxParallelInterrupts   = 16
 
 	// staleKeyDetectDelay is how long to wait after starting a session
 	// before checking if it died immediately (stale resume key detection).
 	// Matches the same constant in internal/session/chat.go.
 	staleKeyDetectDelay = 2 * time.Second
 )
+
+func maxParallelStartsPerTick(cfg *config.City) int {
+	if cfg == nil {
+		return config.DefaultMaxWakesPerTick
+	}
+	return cfg.Daemon.MaxWakesPerTickOrDefault()
+}
 
 type startCandidate struct {
 	session *beads.Bead
@@ -1381,10 +1387,10 @@ func executePlannedStartsTraced(
 		}
 	}
 	asyncLimiter := startOpts.asyncLimiter
+	maxWakes := maxParallelStartsPerTick(cfg)
 	if startOpts.async && asyncLimiter == nil {
-		asyncLimiter = make(chan struct{}, defaultMaxParallelStartsPerWave)
+		asyncLimiter = make(chan struct{}, maxWakes)
 	}
-	maxWakes := cfg.Daemon.MaxWakesPerTickOrDefault()
 	waveByCandidate, ok := candidateWaveOrder(candidates, cfg, desiredState, sp, cityName, store, clk)
 	if !ok {
 		fmt.Fprintln(stderr, "session reconciler: dependency graph fallback to serial start order") //nolint:errcheck
@@ -1429,7 +1435,7 @@ func executePlannedStartsTraced(
 				}
 				break
 			}
-			batchSize := min(defaultMaxParallelStartsPerWave, maxWakes-wakeCount)
+			batchSize := maxWakes - wakeCount
 			end := min(offset+batchSize, len(ready))
 			var prepared []preparedStart
 			var asyncPrepared []asyncPreparedStart
@@ -1480,7 +1486,7 @@ func executePlannedStartsTraced(
 			if startOpts.async {
 				results = enqueuePreparedStartWaveForCity(ctx, asyncPrepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr, trace, startOpts.asyncFollowUp)
 			} else {
-				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, defaultMaxParallelStartsPerWave)
+				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, maxWakes)
 			}
 			for _, result := range results {
 				if trace != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -24,6 +24,12 @@ import (
 )
 
 const (
+	// Starts spend the configurable MaxWakesPerTick budget across ticks, but
+	// preparation stays chunked so flapping dependencies are observed between batches.
+	defaultStartDependencyRecheckBatchSize = 3
+
+	// Stops and interrupts are teardown paths, so their parallelism is not
+	// derived from the wake budget used for starts.
 	defaultMaxParallelStopsPerWave = 3
 	defaultMaxParallelInterrupts   = 16
 
@@ -33,11 +39,86 @@ const (
 	staleKeyDetectDelay = 2 * time.Second
 )
 
+type asyncStartLimiter struct {
+	mu       sync.Mutex
+	limit    int
+	inFlight int
+}
+
+func newAsyncStartLimiter(capacity int) *asyncStartLimiter {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &asyncStartLimiter{limit: capacity}
+}
+
+func (l *asyncStartLimiter) resize(capacity int) {
+	if l == nil {
+		return
+	}
+	if capacity <= 0 {
+		capacity = 1
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.limit = capacity
+}
+
+func (l *asyncStartLimiter) capacity() int {
+	if l == nil {
+		return 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.limit
+}
+
+func (l *asyncStartLimiter) reserve(ctx context.Context) (func(), bool, string) {
+	if l == nil {
+		return func() {}, true, ""
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, false, "context_canceled"
+		default:
+		}
+	}
+	l.mu.Lock()
+	if l.inFlight >= l.limit {
+		l.mu.Unlock()
+		return nil, false, "deferred_by_async_start_limit"
+	}
+	l.inFlight++
+	l.mu.Unlock()
+	return func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if l.inFlight > 0 {
+			l.inFlight--
+		}
+	}, true, ""
+}
+
 func maxParallelStartsPerTick(cfg *config.City) int {
 	if cfg == nil {
 		return config.DefaultMaxWakesPerTick
 	}
 	return cfg.Daemon.MaxWakesPerTickOrDefault()
+}
+
+func startCandidateHasTemplateDependencies(candidate startCandidate, cfg *config.City) bool {
+	cfgAgent := findAgentByTemplate(cfg, candidate.logicalTemplate(cfg))
+	return cfgAgent != nil && len(cfgAgent.DependsOn) > 0
+}
+
+func asyncStartBatchNeedsFollowUp(candidates []startCandidate, cfg *config.City) bool {
+	for _, candidate := range candidates {
+		if startCandidateHasTemplateDependencies(candidate, cfg) {
+			return true
+		}
+	}
+	return false
 }
 
 type startCandidate struct {
@@ -77,7 +158,7 @@ type startResult struct {
 type startExecutionOptions struct {
 	async         bool
 	asyncFollowUp func()
-	asyncLimiter  chan struct{}
+	asyncLimiter  *asyncStartLimiter
 	asyncTracker  *asyncStartTracker
 }
 
@@ -95,7 +176,7 @@ func withAsyncStartFollowUp(fn func()) startExecutionOption {
 	}
 }
 
-func withAsyncStartLimiter(limiter chan struct{}) startExecutionOption {
+func withAsyncStartLimiter(limiter *asyncStartLimiter) startExecutionOption {
 	return func(opts *startExecutionOptions) {
 		opts.asyncLimiter = limiter
 	}
@@ -836,23 +917,8 @@ func enqueuePreparedStartWaveForCity(
 	return results
 }
 
-func reserveAsyncStartSlot(ctx context.Context, limiter chan struct{}) (func(), bool, string) {
-	if limiter == nil {
-		return func() {}, true, ""
-	}
-	if ctx != nil {
-		select {
-		case <-ctx.Done():
-			return nil, false, "context_canceled"
-		default:
-		}
-	}
-	select {
-	case limiter <- struct{}{}:
-		return func() { <-limiter }, true, ""
-	default:
-		return nil, false, "deferred_by_async_start_limit"
-	}
+func reserveAsyncStartSlot(ctx context.Context, limiter *asyncStartLimiter) (func(), bool, string) {
+	return limiter.reserve(ctx)
 }
 
 func commitAsyncStartResultWithContext(
@@ -1389,7 +1455,7 @@ func executePlannedStartsTraced(
 	asyncLimiter := startOpts.asyncLimiter
 	maxWakes := maxParallelStartsPerTick(cfg)
 	if startOpts.async && asyncLimiter == nil {
-		asyncLimiter = make(chan struct{}, maxWakes)
+		asyncLimiter = newAsyncStartLimiter(maxWakes)
 	}
 	waveByCandidate, ok := candidateWaveOrder(candidates, cfg, desiredState, sp, cityName, store, clk)
 	if !ok {
@@ -1404,7 +1470,7 @@ func executePlannedStartsTraced(
 	wakeCount := 0
 	for wave := 0; wave <= maxWave; wave++ {
 		waveStarted := time.Now()
-		asyncBatchEnqueued := false
+		asyncFollowUpRequired := false
 		var waveCandidates []startCandidate
 		for idx, candidate := range candidates {
 			if waveByCandidate[idx] == wave {
@@ -1435,11 +1501,12 @@ func executePlannedStartsTraced(
 				}
 				break
 			}
-			batchSize := maxWakes - wakeCount
+			batchSize := min(defaultStartDependencyRecheckBatchSize, maxWakes-wakeCount)
 			end := min(offset+batchSize, len(ready))
+			batchCandidates := ready[offset:end]
 			var prepared []preparedStart
 			var asyncPrepared []asyncPreparedStart
-			for _, candidate := range ready[offset:end] {
+			for _, candidate := range batchCandidates {
 				if !allDependenciesAliveForTemplateWithClock(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store, clk) {
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
 					continue
@@ -1485,8 +1552,11 @@ func executePlannedStartsTraced(
 			var results []startResult
 			if startOpts.async {
 				results = enqueuePreparedStartWaveForCity(ctx, asyncPrepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr, trace, startOpts.asyncFollowUp)
+				if len(results) > 0 && asyncStartBatchNeedsFollowUp(batchCandidates, cfg) {
+					asyncFollowUpRequired = true
+				}
 			} else {
-				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, maxWakes)
+				results = executePreparedStartWaveForCity(ctx, prepared, cityPath, sp, store, cfg, startupTimeout, batchSize)
 			}
 			for _, result := range results {
 				if trace != nil {
@@ -1498,7 +1568,6 @@ func executePlannedStartsTraced(
 				if result.outcome == "start_enqueued" {
 					logLifecycleOutcome(stderr, "start", wave, result.prepared.candidate.name(), result.prepared.candidate.logicalTemplate(cfg), result.outcome, result.started, result.finished, nil)
 					wakeCount++
-					asyncBatchEnqueued = true
 					continue
 				}
 				if result.err == nil && result.outcome != "session_initializing" {
@@ -1508,15 +1577,14 @@ func executePlannedStartsTraced(
 					wakeCount++
 				}
 			}
-			if startOpts.async && asyncBatchEnqueued {
+			if startOpts.async && asyncFollowUpRequired {
 				break
 			}
 		}
 		logLifecycleWave(stderr, "start", wave, waveStarted, len(waveCandidates))
-		if startOpts.async && asyncBatchEnqueued {
-			// Async starts intentionally enqueue one bounded batch per tick.
-			// Completion pokes the controller so the next batch observes
-			// committed dependency and pending-create state first.
+		if startOpts.async && asyncFollowUpRequired {
+			// Dependency-sensitive async batches yield after enqueueing so the
+			// next batch observes committed dependency and pending-create state.
 			return wakeCount
 		}
 	}

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -417,6 +417,24 @@ func (p *dropDependencyAfterNStartsProvider) Start(ctx context.Context, name str
 	return nil
 }
 
+func (p *dropDependencyAfterNStartsProvider) waitForStarts(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		p.mu.Lock()
+		got := p.starts
+		p.mu.Unlock()
+		if got >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d starts, got %d", want, got)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 type panicStartProvider struct {
 	*runtime.Fake
 }
@@ -948,10 +966,11 @@ func TestPrepareStartCandidate_NoneModeInitialMessageStaysInNudge(t *testing.T) 
 }
 
 func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testing.T) {
-	maxWakes := 3
+	maxWakes := 8
+	dropAfter := 3
 	sp := &dropDependencyAfterNStartsProvider{
 		Fake:      runtime.NewFake(),
-		dropAfter: maxWakes,
+		dropAfter: dropAfter,
 		depName:   "db",
 	}
 	if err := sp.Start(context.Background(), "db", runtime.Config{}); err != nil {
@@ -993,14 +1012,15 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 	}
 
 	poolDesired := map[string]int{"app-1": 1, "app-2": 1, "app-3": 1, "app-4": 1}
+	var stderr bytes.Buffer
 	woken := reconcileSessionBeads(
 		context.Background(), sessions, desired, configuredSessionNames(cfg, "", store),
 		cfg, sp, store, nil, nil, nil, newDrainTracker(), poolDesired, false, nil, "",
-		nil, clk, events.Discard, 5*time.Second, 0, ioDiscard{}, ioDiscard{},
+		nil, clk, events.Discard, 5*time.Second, 0, ioDiscard{}, &stderr,
 	)
 
-	if woken != maxWakes {
-		t.Fatalf("woken = %d, want %d", woken, maxWakes)
+	if woken != dropAfter {
+		t.Fatalf("woken = %d, want %d", woken, dropAfter)
 	}
 	for _, name := range []string{"app-1", "app-2", "app-3"} {
 		if !sp.IsRunning(name) {
@@ -1009,6 +1029,125 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 	}
 	if sp.IsRunning("app-4") {
 		t.Fatal("app-4 should be blocked after db dies between wave batches")
+	}
+	gotLog := stderr.String()
+	if !strings.Contains(gotLog, "session=app-4") || !strings.Contains(gotLog, "outcome=blocked_on_dependencies") {
+		t.Fatalf("app-4 log = %q, want blocked_on_dependencies", gotLog)
+	}
+	if strings.Contains(gotLog, "session=app-4 template=app-4 outcome=deferred_by_wake_budget") {
+		t.Fatalf("app-4 was deferred by wake budget instead of dependency recheck: %q", gotLog)
+	}
+}
+
+func TestExecutePlannedStartsTraced_AsyncRevalidatesDependenciesBetweenBatches(t *testing.T) {
+	maxWakes := 8
+	dropAfter := 3
+	sp := &dropDependencyAfterNStartsProvider{
+		Fake:      runtime.NewFake(),
+		dropAfter: dropAfter,
+		depName:   "db",
+	}
+	if err := sp.Start(context.Background(), "db", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes},
+		Agents: []config.Agent{
+			{Name: "app-1", DependsOn: []string{"db"}},
+			{Name: "app-2", DependsOn: []string{"db"}},
+			{Name: "app-3", DependsOn: []string{"db"}},
+			{Name: "app-4", DependsOn: []string{"db"}},
+			{Name: "db", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)}
+	desired := map[string]TemplateParams{}
+	candidates := make([]startCandidate, 0, 4)
+	for _, name := range []string{"app-1", "app-2", "app-3", "app-4"} {
+		tp := TemplateParams{Command: name, SessionName: name, TemplateName: name}
+		desired[name] = tp
+		created, err := store.Create(beads.Bead{
+			ID:     name + "-id",
+			Title:  name,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: creatingMeta(map[string]string{
+				"session_name":         name,
+				"template":             name,
+				"generation":           "1",
+				"continuation_epoch":   "1",
+				"instance_token":       "tok-" + name,
+				"pending_create_claim": "true",
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		candidate := created
+		candidates = append(candidates, startCandidate{session: &candidate, tp: tp})
+	}
+
+	woken := executePlannedStartsTraced(
+		context.Background(),
+		candidates,
+		cfg,
+		desired,
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		5*time.Second,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+	)
+	if woken != defaultStartDependencyRecheckBatchSize {
+		t.Fatalf("first async woken = %d, want dependency-recheck batch size %d", woken, defaultStartDependencyRecheckBatchSize)
+	}
+	sp.waitForStarts(t, 1+defaultStartDependencyRecheckBatchSize)
+	for _, name := range []string{"app-1", "app-2", "app-3"} {
+		if !sp.IsRunning(name) {
+			t.Fatalf("%s should have started before dependency loss was observed", name)
+		}
+	}
+	if sp.IsRunning("db") {
+		t.Fatal("db should have stopped after the dependency provider drop point")
+	}
+	if sp.IsRunning("app-4") {
+		t.Fatal("app-4 should not be enqueued in the async batch after db dies")
+	}
+
+	var secondStderr bytes.Buffer
+	woken = executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{candidates[3]},
+		cfg,
+		desired,
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		5*time.Second,
+		ioDiscard{},
+		&secondStderr,
+		nil,
+		withAsyncStartExecution(),
+	)
+	if woken != 0 {
+		t.Fatalf("second async woken = %d, want 0 after dependency loss", woken)
+	}
+	if sp.IsRunning("app-4") {
+		t.Fatal("app-4 should remain blocked after dependency loss")
+	}
+	gotLog := secondStderr.String()
+	if !strings.Contains(gotLog, "session=app-4") || !strings.Contains(gotLog, "outcome=blocked_on_dependencies") {
+		t.Fatalf("app-4 log = %q, want blocked_on_dependencies", gotLog)
 	}
 }
 
@@ -1155,13 +1294,14 @@ func TestExecutePlannedStartsTraced_AsyncLimitsEnqueuedStartsPerTick(t *testing.
 		nil,
 		withAsyncStartExecution(),
 	)
-	if woken != maxWakes {
-		t.Fatalf("woken = %d, want one bounded async batch of %d", woken, maxWakes)
+	wantWoken := maxWakes
+	if woken != wantWoken {
+		t.Fatalf("woken = %d, want configured wake budget %d", woken, wantWoken)
 	}
-	sp.waitForStarts(t, maxWakes)
+	sp.waitForStarts(t, wantWoken)
 	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
-	if sp.maxInFlight > maxWakes {
-		t.Fatalf("max in-flight starts = %d, want <= %d", sp.maxInFlight, maxWakes)
+	if sp.maxInFlight > wantWoken {
+		t.Fatalf("max in-flight starts = %d, want <= %d", sp.maxInFlight, wantWoken)
 	}
 }
 
@@ -1196,7 +1336,7 @@ func TestExecutePlannedStartsTraced_AsyncLimiterSharedAcrossTicks(t *testing.T) 
 		desired[name] = tp
 		return startCandidate{session: &session, tp: tp}
 	}
-	limiter := make(chan struct{}, 1)
+	limiter := newAsyncStartLimiter(1)
 	first := makeCandidate("worker-1")
 	second := makeCandidate("worker-2")
 
@@ -1315,8 +1455,11 @@ func TestExecutePlannedStartsTraced_AsyncLimiterDeferredStartDoesNotRunAfterCanc
 	t.Cleanup(func() { sp.release("worker") })
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
 	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
-	limiter := make(chan struct{}, 1)
-	limiter <- struct{}{}
+	limiter := newAsyncStartLimiter(1)
+	releaseLimiter, reserved, outcome := reserveAsyncStartSlot(context.Background(), limiter)
+	if !reserved {
+		t.Fatalf("reserve limiter = %s, want success", outcome)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if got := executePlannedStartsTraced(
@@ -1340,7 +1483,7 @@ func TestExecutePlannedStartsTraced_AsyncLimiterDeferredStartDoesNotRunAfterCanc
 		t.Fatalf("woken = %d, want 0 while async limiter is full", got)
 	}
 	cancel()
-	<-limiter
+	releaseLimiter()
 	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
 	updated, err := store.Get(session.ID)
 	if err != nil {
@@ -1349,6 +1492,19 @@ func TestExecutePlannedStartsTraced_AsyncLimiterDeferredStartDoesNotRunAfterCanc
 	if got := updated.Metadata["last_woke_at"]; got != "" {
 		t.Fatalf("last_woke_at = %q, want empty because no async start was queued", got)
 	}
+}
+
+func TestAsyncStartLimiterNilReceiverMethodsAreNoops(t *testing.T) {
+	var limiter *asyncStartLimiter
+	limiter.resize(5)
+	if got := limiter.capacity(); got != 0 {
+		t.Fatalf("nil limiter capacity = %d, want 0", got)
+	}
+	release, reserved, outcome := reserveAsyncStartSlot(context.Background(), limiter)
+	if !reserved || outcome != "" {
+		t.Fatalf("nil limiter reserve = reserved %v outcome %q, want success", reserved, outcome)
+	}
+	release()
 }
 
 func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *testing.T) {
@@ -1382,7 +1538,7 @@ func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *test
 		sp:                  sp,
 		rec:                 events.Discard,
 		standaloneCityStore: store,
-		asyncStartLimiter:   make(chan struct{}, maxParallelStartsPerTick(cfg)),
+		asyncStartLimiter:   newAsyncStartLimiter(maxParallelStartsPerTick(cfg)),
 		logPrefix:           "gc test",
 		stdout:              ioDiscard{},
 		stderr:              ioDiscard{},
@@ -2844,10 +3000,11 @@ func TestCommitStartResult_AtomicBatchLandsStateAndClaimClearTogether(t *testing
 }
 
 func TestExecutePlannedStarts_UsesLogicalTemplateForDependencyRechecks(t *testing.T) {
-	maxWakes := 3
+	maxWakes := 8
+	dropAfter := 3
 	sp := &dropDependencyAfterNStartsProvider{
 		Fake:      runtime.NewFake(),
-		dropAfter: maxWakes,
+		dropAfter: dropAfter,
 		depName:   "db",
 	}
 	if err := sp.Start(context.Background(), "db", runtime.Config{}); err != nil {
@@ -2895,13 +3052,14 @@ func TestExecutePlannedStarts_UsesLogicalTemplateForDependencyRechecks(t *testin
 		})
 	}
 
+	var stderr bytes.Buffer
 	woken := executePlannedStarts(
 		context.Background(), candidates, cfg, desired, sp, store, "",
-		clk, events.Discard, 5*time.Second, ioDiscard{}, ioDiscard{},
+		clk, events.Discard, 5*time.Second, ioDiscard{}, &stderr,
 	)
 
-	if woken != maxWakes {
-		t.Fatalf("woken = %d, want %d", woken, maxWakes)
+	if woken != dropAfter {
+		t.Fatalf("woken = %d, want %d", woken, dropAfter)
 	}
 	for _, name := range []string{"app-1", "app-2", "app-3"} {
 		if !sp.IsRunning(name) {
@@ -2910,6 +3068,13 @@ func TestExecutePlannedStarts_UsesLogicalTemplateForDependencyRechecks(t *testin
 	}
 	if sp.IsRunning("app-4") {
 		t.Fatal("app-4 should be blocked after db dies between batches even when bead template is stale")
+	}
+	gotLog := stderr.String()
+	if !strings.Contains(gotLog, "session=app-4") || !strings.Contains(gotLog, "template=app-4") || !strings.Contains(gotLog, "outcome=blocked_on_dependencies") {
+		t.Fatalf("app-4 log = %q, want logical template dependency block", gotLog)
+	}
+	if strings.Contains(gotLog, "session=app-4 template=app-4 outcome=deferred_by_wake_budget") {
+		t.Fatalf("app-4 was deferred by wake budget instead of dependency recheck: %q", gotLog)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -948,15 +948,17 @@ func TestPrepareStartCandidate_NoneModeInitialMessageStaysInNudge(t *testing.T) 
 }
 
 func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testing.T) {
+	maxWakes := 3
 	sp := &dropDependencyAfterNStartsProvider{
 		Fake:      runtime.NewFake(),
-		dropAfter: defaultMaxParallelStartsPerWave,
+		dropAfter: maxWakes,
 		depName:   "db",
 	}
 	if err := sp.Start(context.Background(), "db", runtime.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.City{
+		Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes},
 		Agents: []config.Agent{
 			{Name: "app-1", DependsOn: []string{"db"}},
 			{Name: "app-2", DependsOn: []string{"db"}},
@@ -997,8 +999,8 @@ func TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches(t *testi
 		nil, clk, events.Discard, 5*time.Second, 0, ioDiscard{}, ioDiscard{},
 	)
 
-	if woken != defaultMaxParallelStartsPerWave {
-		t.Fatalf("woken = %d, want %d", woken, defaultMaxParallelStartsPerWave)
+	if woken != maxWakes {
+		t.Fatalf("woken = %d, want %d", woken, maxWakes)
 	}
 	for _, name := range []string{"app-1", "app-2", "app-3"} {
 		if !sp.IsRunning(name) {
@@ -1107,10 +1109,11 @@ func TestExecutePlannedStartsTraced_AsyncLimitsEnqueuedStartsPerTick(t *testing.
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 0, 0, time.UTC)}
 	sp := newGatedStartProvider()
-	cfg := &config.City{}
+	maxWakes := 4
+	cfg := &config.City{Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes}}
 	desired := map[string]TemplateParams{}
 	var candidates []startCandidate
-	for _, name := range []string{"worker-1", "worker-2", "worker-3", "worker-4"} {
+	for _, name := range []string{"worker-1", "worker-2", "worker-3", "worker-4", "worker-5"} {
 		session, err := store.Create(beads.Bead{
 			ID:     "gc-" + name,
 			Title:  name,
@@ -1152,13 +1155,13 @@ func TestExecutePlannedStartsTraced_AsyncLimitsEnqueuedStartsPerTick(t *testing.
 		nil,
 		withAsyncStartExecution(),
 	)
-	if woken != defaultMaxParallelStartsPerWave {
-		t.Fatalf("woken = %d, want one bounded async batch of %d", woken, defaultMaxParallelStartsPerWave)
+	if woken != maxWakes {
+		t.Fatalf("woken = %d, want one bounded async batch of %d", woken, maxWakes)
 	}
-	sp.waitForStarts(t, defaultMaxParallelStartsPerWave)
+	sp.waitForStarts(t, maxWakes)
 	sp.ensureNoFurtherStart(t, 100*time.Millisecond)
-	if sp.maxInFlight > defaultMaxParallelStartsPerWave {
-		t.Fatalf("max in-flight starts = %d, want <= %d", sp.maxInFlight, defaultMaxParallelStartsPerWave)
+	if sp.maxInFlight > maxWakes {
+		t.Fatalf("max in-flight starts = %d, want <= %d", sp.maxInFlight, maxWakes)
 	}
 }
 
@@ -1379,7 +1382,7 @@ func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *test
 		sp:                  sp,
 		rec:                 events.Discard,
 		standaloneCityStore: store,
-		asyncStartLimiter:   make(chan struct{}, defaultMaxParallelStartsPerWave),
+		asyncStartLimiter:   make(chan struct{}, maxParallelStartsPerTick(cfg)),
 		logPrefix:           "gc test",
 		stdout:              ioDiscard{},
 		stderr:              ioDiscard{},
@@ -2841,15 +2844,17 @@ func TestCommitStartResult_AtomicBatchLandsStateAndClaimClearTogether(t *testing
 }
 
 func TestExecutePlannedStarts_UsesLogicalTemplateForDependencyRechecks(t *testing.T) {
+	maxWakes := 3
 	sp := &dropDependencyAfterNStartsProvider{
 		Fake:      runtime.NewFake(),
-		dropAfter: defaultMaxParallelStartsPerWave,
+		dropAfter: maxWakes,
 		depName:   "db",
 	}
 	if err := sp.Start(context.Background(), "db", runtime.Config{}); err != nil {
 		t.Fatal(err)
 	}
 	cfg := &config.City{
+		Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes},
 		Agents: []config.Agent{
 			{Name: "app-1", DependsOn: []string{"db"}},
 			{Name: "app-2", DependsOn: []string{"db"}},
@@ -2895,8 +2900,8 @@ func TestExecutePlannedStarts_UsesLogicalTemplateForDependencyRechecks(t *testin
 		clk, events.Discard, 5*time.Second, ioDiscard{}, ioDiscard{},
 	)
 
-	if woken != defaultMaxParallelStartsPerWave {
-		t.Fatalf("woken = %d, want %d", woken, defaultMaxParallelStartsPerWave)
+	if woken != maxWakes {
+		t.Fatalf("woken = %d, want %d", woken, maxWakes)
 	}
 	for _, name := range []string{"app-1", "app-2", "app-3"} {
 		if !sp.IsRunning(name) {


### PR DESCRIPTION
## Summary
- remove the hardcoded async start batch cap and derive start concurrency from `daemon.max_wakes_per_tick`
- resize the city runtime async start limiter when the configured wake budget changes
- update start scheduling tests so configured wake budgets drive batch size and dependency rechecks

## Tests
- go test ./cmd/gc -run 'TestCityRuntimeAsyncStartLimiterUsesMaxWakesPerTick|TestExecutePlannedStartsTraced_AsyncLimitsEnqueuedStartsPerTick|TestExecutePlannedStarts_RevalidatesDependenciesBetweenWaveBatches|TestExecutePlannedStarts_UsesLogicalTemplateForDependencyRechecks|TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot'\n- pre-commit hook: docs/schema generation, golangci-lint, go vet, GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->