### PR TITLE
perf(controller): use cached demand read model

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -70,6 +70,13 @@ type poolEvalWork struct {
 	newDemand bool
 }
 
+type defaultScaleCheckTarget struct {
+	template string
+	storeKey string
+	store    beads.Store
+	err      error
+}
+
 func evaluatePendingPools(
 	cfg *config.City,
 	pendingPools []poolEvalWork,
@@ -174,6 +181,9 @@ func evaluatePendingPoolsMap(
 // ACP route registration, and session bead auto-creation. These are safe
 // to repeat because hooks are installed to stable filesystem paths,
 // ACP routing is idempotent, and bead creation is deduplicated by template.
+// Rig-scoped agents with an implicit default scale_check require rigStores;
+// when rigStores is missing, they report zero new demand plus a diagnostic
+// rather than counting work from the wrong store.
 func buildDesiredState(
 	cityName, cityPath string,
 	beaconTime time.Time,
@@ -220,6 +230,7 @@ func buildDesiredStateWithSessionBeads(
 
 	desired := make(map[string]TemplateParams)
 	var pendingPools []poolEvalWork
+	var defaultScaleTargets []defaultScaleCheckTarget
 
 	for i := range cfg.Agents {
 		if cfg.Agents[i].Suspended {
@@ -247,9 +258,15 @@ func buildDesiredStateWithSessionBeads(
 				continue
 			}
 			// Named-session materialization is handled in the named-session pass,
-			// but generic scale_check/min demand for the backing template still
-			// creates ephemeral capacity through the pool pipeline.
+			// but explicit scale_check/min demand for the backing template still
+			// creates ephemeral capacity through the pool pipeline. The default
+			// routed-work scale_check is skipped here so routed metadata alone
+			// does not create a parallel generic worker for the same backing
+			// template.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+			if store != nil && strings.TrimSpace(cfg.Agents[i].ScaleCheck) == "" {
+				continue
+			}
 			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
 			continue
 		}
@@ -262,12 +279,12 @@ func buildDesiredStateWithSessionBeads(
 		// them as desired counts; bead-backed mode uses them as authoritative
 		// new unassigned demand while assigned work drives resume requests.
 		poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
+		if store != nil && strings.TrimSpace(cfg.Agents[i].ScaleCheck) == "" {
+			defaultScaleTargets = append(defaultScaleTargets, defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores))
+			continue
+		}
 		pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, env: controllerQueryRuntimeEnv(cityPath, cfg, &cfg.Agents[i]), newDemand: store != nil})
 	}
-
-	// scale_check runs in parallel for all pool agents — the authoritative
-	// demand signal for new sessions. Computed once, returned in result.
-	scaleCheckCounts := evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 
 	// Collect work beads with assignees — used for both pool demand and
 	// named session on_demand wake. Hoisted out of the store block so
@@ -276,6 +293,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkStores []beads.Store
 	var assignedWorkStoreRefs []string
 	var storePartial bool
+	var scaleCheckCounts map[string]int
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
 		if storePartial {
@@ -288,6 +306,16 @@ func buildDesiredStateWithSessionBeads(
 			}
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
+		}
+		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		if len(defaultScaleTargets) > 0 {
+			defaultCounts, errs := defaultScaleCheckCounts(defaultScaleTargets)
+			for _, err := range errs {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", err) //nolint:errcheck
+			}
+			for template, count := range defaultCounts {
+				scaleCheckCounts[template] = count
+			}
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
@@ -304,6 +332,7 @@ func buildDesiredStateWithSessionBeads(
 		}
 	} else {
 		// No store — use scale_check counts directly.
+		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		for _, pw := range pendingPools {
 			desiredCount := scaleCheckCounts[cfg.Agents[pw.agentIdx].QualifiedName()]
 			for slot := 1; slot <= desiredCount; slot++ {
@@ -578,7 +607,7 @@ func collectAssignedWorkBeadsWithStores(
 			seen := make(map[string]struct{})
 			// In-progress beads with an assignee (active work), plus stranded
 			// unassigned pool work that needs to be reopened.
-			if inProgress, err := source.store.List(beads.ListQuery{Status: "in_progress", Live: true}); err == nil {
+			if inProgress, err := listForControllerDemand(source.store, beads.ListQuery{Status: "in_progress"}); err == nil {
 				appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
@@ -587,9 +616,8 @@ func collectAssignedWorkBeadsWithStores(
 				}
 			}
 			// Ready beads with an assignee (queued direct handoff work that is
-			// actually runnable, not merely open). This is a lifecycle gate, so
-			// bypass the cache when a CachingStore wrapper is present.
-			if ready, err := beads.ReadyLive(source.store); err == nil {
+			// actually runnable, not merely open).
+			if ready, err := readyForControllerDemand(source.store); err == nil {
 				appendAssignedUnique(&result, &resultStores, &resultStoreRefs, ready, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("Ready(): %w", err))
@@ -616,6 +644,119 @@ func collectAssignedWorkBeadsWithStores(
 		}
 	}
 	return result, resultStores, resultStoreRefs, partial
+}
+
+func defaultScaleCheckTargetForAgent(
+	cityPath string,
+	cfg *config.City,
+	agentCfg *config.Agent,
+	cityStore beads.Store,
+	rigStores map[string]beads.Store,
+) defaultScaleCheckTarget {
+	target := defaultScaleCheckTarget{
+		template: agentCfg.QualifiedName(),
+		storeKey: "city",
+		store:    cityStore,
+	}
+	rigName := configuredRigName(cityPath, agentCfg, cfg.Rigs)
+	if rigName == "" {
+		return target
+	}
+	target.storeKey = "rig:" + rigName
+	if rigStores != nil {
+		if rigStore := rigStores[rigName]; rigStore != nil {
+			target.store = rigStore
+			return target
+		}
+	}
+	target.store = nil
+	target.err = fmt.Errorf("default scale_check %s: rig store %q unavailable", target.template, rigName)
+	return target
+}
+
+func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int, []error) {
+	counts := make(map[string]int, len(targets))
+	if len(targets) == 0 {
+		return counts, nil
+	}
+
+	type scaleStoreGroup struct {
+		store     beads.Store
+		templates map[string]struct{}
+	}
+	groups := make(map[string]*scaleStoreGroup)
+	var errs []error
+	for _, target := range targets {
+		template := strings.TrimSpace(target.template)
+		if template == "" {
+			continue
+		}
+		counts[template] = 0
+		if target.err != nil {
+			errs = append(errs, target.err)
+		}
+		if target.store == nil {
+			if target.err == nil {
+				errs = append(errs, fmt.Errorf("default scale_check %s: store unavailable", template))
+			}
+			continue
+		}
+		key := strings.TrimSpace(target.storeKey)
+		if key == "" {
+			key = fmt.Sprintf("%p", target.store)
+		}
+		group := groups[key]
+		if group == nil {
+			group = &scaleStoreGroup{store: target.store, templates: make(map[string]struct{})}
+			groups[key] = group
+		}
+		group.templates[template] = struct{}{}
+	}
+
+	for key, group := range groups {
+		ready, err := readyForControllerDemand(group.store)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s: Ready(): %w", key, err))
+			continue
+		}
+		for _, b := range ready {
+			if strings.TrimSpace(b.Assignee) != "" {
+				continue
+			}
+			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			if _, ok := group.templates[template]; ok {
+				counts[template]++
+			}
+		}
+	}
+	return counts, errs
+}
+
+func listForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {
+	if _, ok := store.(interface {
+		CachedList(beads.ListQuery) ([]beads.Bead, bool)
+	}); ok {
+		cacheQuery := query
+		cacheQuery.Live = false
+		return store.List(cacheQuery)
+	}
+	liveQuery := query
+	liveQuery.Live = true
+	return store.List(liveQuery)
+}
+
+func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
+	// Controller demand reads are intentionally cache-tolerant, not
+	// authoritative lifecycle gates; CachedReady falls back whenever the cache
+	// has dirty or unknown dependency coverage.
+	if cached, ok := store.(interface {
+		CachedReady() ([]beads.Bead, bool)
+	}); ok {
+		if ready, ok := cached.CachedReady(); ok {
+			return ready, nil
+		}
+	}
+	return beads.ReadyLive(store)
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -28,6 +28,66 @@ func (s listFailStore) List(_ beads.ListQuery) ([]beads.Bead, error) {
 	return nil, errors.New("list failed")
 }
 
+type readyFailStore struct {
+	beads.Store
+	readyCalls int
+}
+
+func (s *readyFailStore) Ready() ([]beads.Bead, error) {
+	s.readyCalls++
+	return nil, errors.New("backing ready should not be used")
+}
+
+type readyStaticStore struct {
+	beads.Store
+	ready      []beads.Bead
+	readyCalls int
+}
+
+func (s *readyStaticStore) Ready() ([]beads.Bead, error) {
+	s.readyCalls++
+	out := make([]beads.Bead, len(s.ready))
+	copy(out, s.ready)
+	return out, nil
+}
+
+type demandListCountingStore struct {
+	beads.Store
+	liveInProgressLists int
+	liveOpenMolecules   int
+}
+
+func (s *demandListCountingStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Live && query.Status == "in_progress" {
+		s.liveInProgressLists++
+	}
+	if query.Live && query.Status == "open" && query.Type == "molecule" {
+		s.liveOpenMolecules++
+	}
+	return s.Store.List(query)
+}
+
+type demandRefreshFailStore struct {
+	beads.Store
+	failNextGet         bool
+	liveInProgressLists int
+}
+
+func (s *demandRefreshFailStore) Get(id string) (beads.Bead, error) {
+	if s.failNextGet {
+		s.failNextGet = false
+		return beads.Bead{}, errors.New("transient get failure")
+	}
+	return s.Store.Get(id)
+}
+
+func (s *demandRefreshFailStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Live && query.Status == "in_progress" {
+		s.liveInProgressLists++
+	}
+	return s.Store.List(query)
+}
+
 type partialAssignedWorkStore struct {
 	*beads.MemStore
 	partialInProgress bool
@@ -95,6 +155,96 @@ func TestCollectAssignedWorkBeads_IncludesReadyOpenAssignedHandoff(t *testing.T)
 	}
 }
 
+func TestCollectAssignedWorkBeadsUsesCachedReadyReadModel(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	handoff, err := backing.Create(beads.Bead{
+		Title:    "merge me",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create handoff bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+	if len(got) != 1 || got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want [%s]", got, handoff.ID)
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	}
+}
+
+func TestCollectAssignedWorkBeadsUsesCachedInProgressReadModel(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	work, err := backing.Create(beads.Bead{
+		Title:    "active handoff",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("create active bead: %v", err)
+	}
+	if err := backing.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("set active bead in_progress: %v", err)
+	}
+	work, err = backing.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload active bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want [%s]", got, work.ID)
+	}
+	if backing.liveInProgressLists != 0 {
+		t.Fatalf("live in_progress list calls = %d, want cached demand read", backing.liveInProgressLists)
+	}
+}
+
+func TestCollectAssignedWorkBeadsFallsBackLiveWhenCachedInProgressDirty(t *testing.T) {
+	backing := &demandRefreshFailStore{Store: beads.NewMemStore()}
+	work, err := backing.Create(beads.Bead{
+		Title: "handoff becomes active",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("create active bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	status := "in_progress"
+	assignee := "repo/refinery"
+	backing.failNextGet = true
+	if err := cache.Update(work.ID, beads.UpdateOpts{Status: &status, Assignee: &assignee}); err != nil {
+		t.Fatalf("Update(active): %v", err)
+	}
+
+	got, partial := collectAssignedWorkBeads(&config.City{}, cache)
+	if partial {
+		t.Fatal("collectAssignedWorkBeads reported partial with successful live fallback")
+	}
+	if len(got) != 1 || got[0].ID != work.ID || got[0].Status != "in_progress" || got[0].Assignee != "repo/refinery" {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want live in-progress %s", got, work.ID)
+	}
+	if backing.liveInProgressLists != 1 {
+		t.Fatalf("live in_progress list calls = %d, want dirty cache fallback", backing.liveInProgressLists)
+	}
+}
+
 func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.T) {
 	store := beads.NewMemStore()
 	blocker, err := store.Create(beads.Bead{
@@ -121,6 +271,227 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 	got, _ := collectAssignedWorkBeads(&config.City{}, store)
 	if len(got) != 0 {
 		t.Fatalf("collectAssignedWorkBeads returned %d beads, want 0: %#v", len(got), got)
+	}
+}
+
+func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "queued routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 1", got)
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	}
+}
+
+func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
+	backing := &demandListCountingStore{Store: beads.NewMemStore()}
+	if _, err := backing.Create(beads.Bead{
+		Title:  "workflow root",
+		Type:   "molecule",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-min",
+		},
+	}); err != nil {
+		t.Fatalf("create molecule bead: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-min",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-min"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want molecule container ignored", got)
+	}
+	if backing.liveOpenMolecules != 0 {
+		t.Fatalf("live open molecule list calls = %d, want no molecule demand query", backing.liveOpenMolecules)
+	}
+}
+
+func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.T) {
+	backing := &readyFailStore{Store: beads.NewMemStore()}
+	blocker, err := backing.Create(beads.Bead{
+		Title:  "blocked earlier step",
+		Type:   "task",
+		Status: "open",
+	})
+	if err != nil {
+		t.Fatalf("create blocker: %v", err)
+	}
+	blocked, err := backing.Create(beads.Bead{
+		Title:  "future routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-max",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create blocked: %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := cache.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-max",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-max"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want blocked future work excluded", got)
+	}
+	if backing.readyCalls != 0 {
+		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+	}
+}
+
+func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T) {
+	backing := &readyStaticStore{
+		Store: beads.NewMemStore(),
+		ready: []beads.Bead{{
+			ID:     "gc-ready",
+			Title:  "ready routed work",
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": "gascity/workflows.codex-max",
+			},
+		}},
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-blocked","status":"open","metadata":{"gc.routed_to":"gascity/workflows.codex-max"}}`))
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-max",
+		storeKey: "rig:gascity",
+		store:    cache,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v", errs)
+	}
+	if got := counts["gascity/workflows.codex-max"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want live ready fallback count only", got)
+	}
+	if backing.readyCalls != 1 {
+		t.Fatalf("backing Ready calls = %d, want one live ready fallback", backing.readyCalls)
+	}
+}
+
+func TestDefaultScaleCheckCountsReportsMissingRigStore(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Rigs: []config.Rig{{
+			Name: "repo",
+			Path: filepath.Join(cityPath, "repos", "repo"),
+		}},
+	}
+	agent := &config.Agent{Name: "worker", Dir: filepath.Join("repos", "repo")}
+	cityStore := beads.NewMemStore()
+	if _, err := cityStore.Create(beads.Bead{
+		Title:  "wrong-store routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "repos/repo/worker",
+		},
+	}); err != nil {
+		t.Fatalf("create city routed bead: %v", err)
+	}
+	target := defaultScaleCheckTargetForAgent(cityPath, cfg, agent, cityStore, nil)
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{target})
+	if got := counts["repos/repo/worker"]; got != 0 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want 0", got)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v, want one missing rig-store diagnostic", errs)
+	}
+	if !strings.Contains(errs[0].Error(), `rig store "repo" unavailable`) {
+		t.Fatalf("defaultScaleCheckCounts err = %v, want missing rig-store diagnostic", errs[0])
+	}
+}
+
+func TestBuildDesiredStateDefaultScaleCheckMissingRigStoreReportsZeroDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "rig-owned routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "repos/repo/worker",
+		},
+	}); err != nil {
+		t.Fatalf("create city routed bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs: []config.Rig{{
+			Name: "repo",
+			Path: filepath.Join(cityPath, "repos", "repo"),
+		}},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               filepath.Join("repos", "repo"),
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(1),
+		}},
+	}
+
+	var stderr strings.Builder
+	got := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, &stderr)
+	if demand := got.ScaleCheckCounts["repos/repo/worker"]; demand != 0 {
+		t.Fatalf("ScaleCheckCounts[repos/repo/worker] = %d, want 0 without rig store", demand)
+	}
+	if len(got.State) != 0 {
+		t.Fatalf("desired sessions = %d, want none without rig store demand", len(got.State))
+	}
+	if !strings.Contains(stderr.String(), `rig store "repo" unavailable`) {
+		t.Fatalf("stderr = %q, want missing rig-store diagnostic", stderr.String())
 	}
 }
 

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
-func TestCollectAssignedWorkBeads_UsesLiveReadyForAssignedOpenHandoff(t *testing.T) {
+func TestCollectAssignedWorkBeads_UsesCachedReadyEventStateForAssignedOpenHandoff(t *testing.T) {
 	t.Parallel()
 
 	backing := beads.NewMemStore()
@@ -46,11 +47,101 @@ func TestCollectAssignedWorkBeads_UsesLiveReadyForAssignedOpenHandoff(t *testing
 	if err := backing.Update(blocker.ID, beads.UpdateOpts{Status: &closed}); err != nil {
 		t.Fatalf("Update(%s, closed): %v", blocker.ID, err)
 	}
+	closedBlocker, err := backing.Get(blocker.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", blocker.ID, err)
+	}
+	payload, err := json.Marshal(closedBlocker)
+	if err != nil {
+		t.Fatalf("Marshal(%s): %v", blocker.ID, err)
+	}
+	cache.ApplyEvent("bead.updated", payload)
 
 	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
 	if len(got) != 1 || got[0].ID != handoff.ID {
-		t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] from live ready state", got, handoff.ID)
+		t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] from cached ready event state", got, handoff.ID)
 	}
+}
+
+func TestCollectAssignedWorkBeads_FallsBackLiveWhenSparseDepHookInvalidatesCachedReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dep add", func(t *testing.T) {
+		t.Parallel()
+
+		backing := beads.NewMemStore()
+		blocker, err := backing.Create(beads.Bead{
+			Title:  "blocker",
+			Type:   "task",
+			Status: "open",
+		})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		handoff, err := backing.Create(beads.Bead{
+			Title:    "handoff",
+			Type:     "task",
+			Status:   "open",
+			Assignee: "worker",
+		})
+		if err != nil {
+			t.Fatalf("Create(handoff): %v", err)
+		}
+		cache := beads.NewCachingStoreForTest(backing, nil)
+		if err := cache.PrimeActive(); err != nil {
+			t.Fatalf("PrimeActive: %v", err)
+		}
+
+		if err := backing.DepAdd(handoff.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("backing DepAdd(%s <- %s): %v", handoff.ID, blocker.ID, err)
+		}
+		cache.ApplyEvent("bead.updated", []byte(`{"id":"`+handoff.ID+`","title":"handoff","status":"open","issue_type":"task","assignee":"worker","created_at":"2026-01-01T00:00:00Z"}`))
+
+		got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+		if len(got) != 0 {
+			t.Fatalf("collectAssignedWorkBeads() = %#v, want sparse dep-add event to force live blocked result", got)
+		}
+	})
+
+	t.Run("dep remove", func(t *testing.T) {
+		t.Parallel()
+
+		backing := beads.NewMemStore()
+		blocker, err := backing.Create(beads.Bead{
+			Title:  "blocker",
+			Type:   "task",
+			Status: "open",
+		})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		handoff, err := backing.Create(beads.Bead{
+			Title:    "handoff",
+			Type:     "task",
+			Status:   "open",
+			Assignee: "worker",
+		})
+		if err != nil {
+			t.Fatalf("Create(handoff): %v", err)
+		}
+		if err := backing.DepAdd(handoff.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("backing DepAdd(%s <- %s): %v", handoff.ID, blocker.ID, err)
+		}
+		cache := beads.NewCachingStoreForTest(backing, nil)
+		if err := cache.PrimeActive(); err != nil {
+			t.Fatalf("PrimeActive: %v", err)
+		}
+
+		if err := backing.DepRemove(handoff.ID, blocker.ID); err != nil {
+			t.Fatalf("backing DepRemove(%s <- %s): %v", handoff.ID, blocker.ID, err)
+		}
+		cache.ApplyEvent("bead.updated", []byte(`{"id":"`+handoff.ID+`","title":"handoff","status":"open","issue_type":"task","assignee":"worker","created_at":"2026-01-01T00:00:00Z"}`))
+
+		got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+		if len(got) != 1 || got[0].ID != handoff.ID {
+			t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] after sparse dep-remove event forced live ready result", got, handoff.ID)
+		}
+	})
 }
 
 func TestSessionHasOpenAssignedWorkInStore_UsesLiveOpenOwnership(t *testing.T) {

--- a/internal/api/handler_events_test.go
+++ b/internal/api/handler_events_test.go
@@ -156,6 +156,33 @@ func TestEventStream(t *testing.T) {
 	}
 }
 
+func TestEventStreamCommitsHeadersBeforeFirstEvent(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+cityURL(state, "/events/stream"), nil)
+	if err != nil {
+		t.Fatalf("build stream request: %v", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET events stream before first event: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+}
+
 func TestEventStreamProjectsWorkflowMetadata(t *testing.T) {
 	state := newFakeState(t)
 	store := state.stores["myrig"]

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -326,7 +326,11 @@ func beginSSEStream(hctx huma.Context) (bw any, encoder *json.Encoder, flusher h
 	hctx.SetHeader("Cache-Control", "no-cache")
 	hctx.SetHeader("Connection", "keep-alive")
 	body := hctx.BodyWriter()
-	return body, json.NewEncoder(body), findFlusher(body)
+	flusher = findFlusher(body)
+	if flusher != nil {
+		flusher.Flush()
+	}
+	return body, json.NewEncoder(body), flusher
 }
 
 // writeSSEFrame emits one SSE frame (id/event/data/blank line) to bw and

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -194,6 +194,16 @@ func (c *CachingStore) PrimeActive() error {
 		all = append(all, beads...)
 	}
 
+	beadMap := make(map[string]Bead, len(all))
+	for _, b := range all {
+		beadMap[b.ID] = cloneBead(b)
+	}
+	depMap, depsComplete, depErr := c.fetchDepsForIDs(beadIDs(beadMap))
+	if depErr != nil {
+		partialErr = errors.Join(partialErr, depErr)
+		c.recordProblem("prime active dep cache", depErr)
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	now := time.Now()
@@ -210,6 +220,11 @@ func (c *CachingStore) PrimeActive() error {
 			continue
 		}
 		c.beads[b.ID] = cloneBead(b)
+		if depsComplete && depErr == nil {
+			c.deps[b.ID] = cloneDeps(depMap[b.ID])
+		} else {
+			c.deps[b.ID] = depsFromBeadFields(b)
+		}
 		delete(c.deletedSeq, b.ID)
 		if !recentLocalMutation(c.localBeadAt[b.ID], now) {
 			delete(c.beadSeq, b.ID)
@@ -271,7 +286,7 @@ func (c *CachingStore) Prime(_ context.Context) error {
 	defer c.mu.Unlock()
 	if c.mutationSeq == startSeq {
 		nextBeads := beadMap
-		nextDeps := depMap
+		nextDeps := depsFromBeads(beadMap, depMap, depsComplete && depErr == nil)
 		nextDirty := make(map[string]struct{})
 		nextBeadSeq := make(map[string]uint64)
 		nextLocalBeadAt := make(map[string]time.Time)
@@ -314,8 +329,10 @@ func (c *CachingStore) Prime(_ context.Context) error {
 			c.beads[id] = b
 			delete(c.deletedSeq, id)
 			delete(c.beadSeq, id)
-			if deps, ok := depMap[id]; ok {
-				c.deps[id] = deps
+			if depsComplete && depErr == nil {
+				c.deps[id] = cloneDeps(depMap[id])
+			} else {
+				c.deps[id] = depsFromBeadFields(b)
 			}
 		}
 		c.depsComplete = false
@@ -435,6 +452,44 @@ func (c *CachingStore) fetchDepsForIDs(ids []string) (map[string][]Dep, bool, er
 		depMap[id] = cloneDeps(deps)
 	}
 	return depMap, true, nil
+}
+
+func depsFromBeads(beadMap map[string]Bead, depMap map[string][]Dep, useDepMap bool) map[string][]Dep {
+	deps := make(map[string][]Dep, len(beadMap))
+	for id, b := range beadMap {
+		if useDepMap {
+			deps[id] = cloneDeps(depMap[id])
+			continue
+		}
+		deps[id] = depsFromBeadFields(b)
+	}
+	return deps
+}
+
+func depsFromBeadFields(b Bead) []Dep {
+	// Structured dependencies are the authoritative bead representation when
+	// present; Needs is the legacy shorthand used when no dependency objects
+	// were carried on the bead payload.
+	if len(b.Dependencies) > 0 {
+		return cloneDeps(b.Dependencies)
+	}
+	if len(b.Needs) == 0 {
+		return nil
+	}
+	deps := make([]Dep, 0, len(b.Needs))
+	for _, need := range b.Needs {
+		depType := "blocks"
+		dependsOnID := need
+		if strings.Contains(need, ":") {
+			parts := strings.SplitN(need, ":", 2)
+			if parts[0] != "" && parts[1] != "" {
+				depType = parts[0]
+				dependsOnID = parts[1]
+			}
+		}
+		deps = append(deps, Dep{IssueID: b.ID, DependsOnID: dependsOnID, Type: depType})
+	}
+	return deps
 }
 
 func cloneDeps(deps []Dep) []Dep {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -29,15 +29,24 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 
 	now := time.Now()
 	c.mu.RLock()
-	if c.state != cacheLive {
+	if c.state != cacheLive && c.state != cachePartial {
 		c.mu.RUnlock()
 		return
 	}
 	current, cached := c.beads[patch.ID]
+	currentDeps, depsKnown := c.deps[patch.ID]
+	if !depsKnown && c.depsComplete {
+		depsKnown = true
+	}
+	currentDeps = cloneDeps(currentDeps)
 	_, locallyMutated := c.beadSeq[patch.ID]
-	recentlyLocal := recentLocalMutation(c.localBeadAt[patch.ID], now)
+	localBeadAt := c.localBeadAt[patch.ID]
+	locallyChanged := !localBeadAt.IsZero()
+	recentlyLocal := recentLocalMutation(localBeadAt, now)
 	_, locallyDeleted := c.deletedSeq[patch.ID]
-	conflictsCached := cached && cacheEventConflictsCurrent(current, patch, fields)
+	fieldConflictCached := cached && cacheEventConflictsCurrent(current, patch, fields)
+	dependencyConflictCached := cached && cacheEventDependencyConflict(currentDeps, depsKnown, patch, fields)
+	conflictsCached := fieldConflictCached || dependencyConflictCached
 	var conflictBase Bead
 	if conflictsCached {
 		conflictBase = cloneBead(current)
@@ -62,7 +71,10 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		verifiedConflict = true
 		verifiedClosedBase = conflictBase
 	}
-	if conflictsCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
+	if fieldConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
+		return
+	}
+	if dependencyConflictCached && eventType != "bead.closed" && (locallyChanged || locallyMutated) && !verifiedConflict {
 		return
 	}
 	if conflictsCached && recentlyLocal && !verifiedConflict {
@@ -96,17 +108,26 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.state != cacheLive {
+	if c.state != cacheLive && c.state != cachePartial {
 		return
 	}
 	if current, ok := c.beads[patch.ID]; ok {
-		if cacheEventConflictsCurrent(current, patch, fields) {
+		currentDeps, depsKnown := c.deps[patch.ID]
+		if !depsKnown && c.depsComplete {
+			depsKnown = true
+		}
+		fieldConflict := cacheEventConflictsCurrent(current, patch, fields)
+		dependencyConflict := cacheEventDependencyConflict(currentDeps, depsKnown, patch, fields)
+		if fieldConflict || dependencyConflict {
 			if eventType == "bead.closed" {
 				if !verifiedConflict || beadChanged(current, verifiedClosedBase) {
 					return
 				}
 			} else {
-				if _, locallyMutated := c.beadSeq[patch.ID]; locallyMutated {
+				if _, locallyMutated := c.beadSeq[patch.ID]; fieldConflict && locallyMutated {
+					return
+				}
+				if _, locallyMutated := c.beadSeq[patch.ID]; dependencyConflict && locallyMutated {
 					return
 				}
 				if recentLocalMutation(c.localBeadAt[patch.ID], time.Now()) &&
@@ -124,6 +145,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		if _, exists := c.beads[b.ID]; !exists {
 			c.noteMutationLocked(b.ID)
 			c.beads[b.ID] = cloneBead(b)
+			c.updateEventDepsLocked(eventType, b, fields)
 			delete(c.dirty, b.ID)
 			delete(c.deletedSeq, b.ID)
 		}
@@ -132,6 +154,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	case "bead.updated":
 		c.noteMutationLocked(b.ID)
 		c.beads[b.ID] = cloneBead(b)
+		c.updateEventDepsLocked(eventType, b, fields)
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
@@ -141,6 +164,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			c.updateStatsLocked()
 		}
 		c.beads[b.ID] = cloneBead(b)
+		c.updateEventDepsLocked(eventType, b, fields)
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
@@ -153,12 +177,35 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	}
 }
 
+func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields map[string]json.RawMessage) {
+	if hasCacheEventField(fields, "dependencies") || hasCacheEventField(fields, "needs") {
+		c.deps[b.ID] = depsFromBeadFields(b)
+		return
+	}
+	if eventType == "bead.created" && cacheEventLooksComplete(fields) {
+		c.deps[b.ID] = depsFromBeadFields(b)
+		return
+	}
+	if eventType == "bead.updated" && cacheEventLooksComplete(fields) {
+		// bd dep add/remove update hooks can send complete bead fields without
+		// dependencies. Treat dependency coverage as unknown so demand reads
+		// fall back to live readiness until reconciliation refreshes the cache.
+		delete(c.deps, b.ID)
+		c.depsComplete = false
+		return
+	}
+	if _, ok := c.deps[b.ID]; ok {
+		return
+	}
+	c.depsComplete = false
+}
+
 // ApplyDepEvent updates the dep cache for a bead. Call after dep
 // mutations are detected via events or write-through.
 func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.state != cacheLive {
+	if c.state != cacheLive && c.state != cachePartial {
 		return
 	}
 	c.noteMutationLocked(beadID)
@@ -255,6 +302,17 @@ func cacheEventConflictsCurrent(current, patch Bead, fields map[string]json.RawM
 	return false
 }
 
+func cacheEventConflictsCached(current Bead, currentDeps []Dep, depsKnown bool, patch Bead, fields map[string]json.RawMessage) bool {
+	if cacheEventConflictsCurrent(current, patch, fields) {
+		return true
+	}
+	return cacheEventDependencyConflict(currentDeps, depsKnown, patch, fields)
+}
+
+func cacheEventDependencyConflict(currentDeps []Dep, depsKnown bool, patch Bead, fields map[string]json.RawMessage) bool {
+	return cacheEventHasDependencyField(fields) && depsKnown && depsChanged(currentDeps, depsFromBeadFields(patch))
+}
+
 func (c *CachingStore) cacheEventMatchesBacking(id string, patch Bead, fields map[string]json.RawMessage) (bool, error) {
 	fresh, err := c.backing.Get(id)
 	if err != nil {
@@ -272,7 +330,7 @@ func (c *CachingStore) cacheClosedEventMatchesBacking(id string) (bool, error) {
 }
 
 func cacheEventPatchMatchesBead(current, patch Bead, fields map[string]json.RawMessage) bool {
-	return !cacheEventConflictsCurrent(current, patch, fields)
+	return !cacheEventConflictsCached(current, depsFromBeadFields(current), true, patch, fields)
 }
 
 func recentLocalMutation(mutatedAt time.Time, now time.Time) bool {
@@ -308,6 +366,17 @@ func (c *CachingStore) carryRecentLocalMutationLocked(id string, nextDirty map[s
 func hasCacheEventField(fields map[string]json.RawMessage, name string) bool {
 	_, ok := fields[name]
 	return ok
+}
+
+func cacheEventHasDependencyField(fields map[string]json.RawMessage) bool {
+	return hasCacheEventField(fields, "dependencies") || hasCacheEventField(fields, "needs")
+}
+
+func cacheEventLooksComplete(fields map[string]json.RawMessage) bool {
+	return hasCacheEventField(fields, "title") &&
+		hasCacheEventField(fields, "status") &&
+		hasCacheEventField(fields, "created_at") &&
+		(hasCacheEventField(fields, "issue_type") || hasCacheEventField(fields, "type"))
 }
 
 func decodeCacheEvent(payload json.RawMessage) (Bead, map[string]json.RawMessage, error) {

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1581,6 +1581,92 @@ func TestCachingStoreBdPrimeAndReconcileSkipFullDepScan(t *testing.T) {
 	}
 }
 
+func TestCachingStoreBdPrimeActiveUsesListDependenciesForCachedReady(t *testing.T) {
+	t.Parallel()
+
+	var depListCalls int
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			t.Fatalf("command name = %q, want bd", name)
+		}
+		if len(args) > 0 && args[0] == "dep" {
+			depListCalls++
+			t.Fatalf("unexpected dep scan command: %v", args)
+		}
+		if len(args) > 0 && args[0] == "list" {
+			argLine := strings.Join(args, " ")
+			if strings.Contains(argLine, "--status=open") {
+				return []byte(`[
+					{"id":"bd-blocker","title":"blocker","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
+					{"id":"bd-blocked","title":"blocked","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:01Z","labels":["task"],"metadata":{},"dependencies":[{"issue_id":"bd-blocked","depends_on_id":"bd-blocker","type":"blocks"}]}
+				]`), nil
+			}
+			if strings.Contains(argLine, "--status=in_progress") {
+				return []byte(`[]`), nil
+			}
+		}
+		return []byte(`[]`), nil
+	}
+	cache := NewCachingStoreForTest(NewBdStore("/city", runner), nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	ids := map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if !ids["bd-blocker"] || ids["bd-blocked"] {
+		t.Fatalf("CachedReady ids = %v, want blocker ready and blocked excluded", ids)
+	}
+	if depListCalls != 0 {
+		t.Fatalf("dep list calls = %d, want 0", depListCalls)
+	}
+}
+
+func TestCachingStoreBdReconcileRefreshesListDependenciesForCachedReady(t *testing.T) {
+	t.Parallel()
+
+	runner := newCachingStoreBdDepRunner(t)
+	cache := NewCachingStore(NewBdStore("/city", runner.run), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	assertCachedReadyContains := func(wantReady bool) {
+		t.Helper()
+		ready, ok := cache.CachedReady()
+		if !ok {
+			t.Fatal("CachedReady reported cache unavailable")
+		}
+		readyByID := make(map[string]bool, len(ready))
+		for _, bead := range ready {
+			readyByID[bead.ID] = true
+		}
+		if readyByID["bd-1"] != wantReady {
+			t.Fatalf("CachedReady includes bd-1 = %v, want %v; ready=%v", readyByID["bd-1"], wantReady, readyByID)
+		}
+	}
+
+	assertCachedReadyContains(true)
+
+	runner.deps["bd-1"] = []Dep{{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"}}
+	cache.runReconciliation()
+	assertCachedReadyContains(false)
+
+	runner.deps["bd-1"] = nil
+	cache.runReconciliation()
+	assertCachedReadyContains(true)
+
+	if runner.depScanCalls != 0 {
+		t.Fatalf("dep scan calls = %d, want 0", runner.depScanCalls)
+	}
+}
+
 func TestCachingStoreBdIncompleteDepsUseBackingForDownDepList(t *testing.T) {
 	t.Parallel()
 
@@ -1693,12 +1779,7 @@ func (r *cachingStoreBdDepRunner) run(_, name string, args ...string) ([]byte, e
 	}
 	switch args[0] {
 	case "list":
-		return []byte(`[
-			{"id":"bd-1","title":"task","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
-			{"id":"bd-2","title":"dep 2","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
-			{"id":"bd-3","title":"dep 3","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}},
-			{"id":"bd-4","title":"dep 4","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}}
-		]`), nil
+		return r.listOutput(), nil
 	case "ready":
 		return []byte(`[]`), nil
 	case "dep":
@@ -1735,6 +1816,31 @@ func (r *cachingStoreBdDepRunner) runDep(args ...string) ([]byte, error) {
 	}
 	r.t.Fatalf("unexpected dep command: %v", args)
 	return nil, nil
+}
+
+func (r *cachingStoreBdDepRunner) listOutput() []byte {
+	var b strings.Builder
+	ids := []string{"bd-1", "bd-2", "bd-3", "bd-4"}
+	b.WriteByte('[')
+	for i, id := range ids {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%q,"title":%q,"status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","labels":["task"],"metadata":{}`, id, "dep "+strings.TrimPrefix(id, "bd-"))
+		if deps := r.deps[id]; len(deps) > 0 {
+			b.WriteString(`,"dependencies":[`)
+			for depIdx, dep := range deps {
+				if depIdx > 0 {
+					b.WriteByte(',')
+				}
+				fmt.Fprintf(&b, `{"issue_id":%q,"depends_on_id":%q,"type":%q}`, dep.IssueID, dep.DependsOnID, dep.Type)
+			}
+			b.WriteByte(']')
+		}
+		b.WriteByte('}')
+	}
+	b.WriteByte(']')
+	return []byte(b.String())
 }
 
 func (r *cachingStoreBdDepRunner) depListOutput(issueID string) []byte {

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -32,11 +32,11 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 		primePartialErr := c.primePartialErr
 		if len(c.dirty) > 0 {
 			c.mu.RUnlock()
-			return c.backing.List(query)
+			return c.backing.List(liveListQuery(query))
 		}
 		if primePartialErr != nil {
 			c.mu.RUnlock()
-			return c.backing.List(query)
+			return c.backing.List(liveListQuery(query))
 		}
 		// PrimeActive loads the full active set (open + in_progress), so
 		// active-only queries are complete even before the history prime finishes.
@@ -64,10 +64,10 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 		// The cache never has a complete closed-only or parent-history view, so
 		// preserve the old backing-store behavior for those query shapes.
 		if query.Status == "closed" || query.ParentID != "" {
-			return c.backing.List(query)
+			return c.backing.List(liveListQuery(query))
 		}
 
-		all, err := c.backing.List(query)
+		all, err := c.backing.List(liveListQuery(query))
 		if err != nil {
 			if !IsPartialResult(err) {
 				return finish(cached, nil)
@@ -88,7 +88,12 @@ func (c *CachingStore) List(query ListQuery) ([]Bead, error) {
 		return finish(cached, err)
 	}
 	c.mu.RUnlock()
-	return c.backing.List(query)
+	return c.backing.List(liveListQuery(query))
+}
+
+func liveListQuery(query ListQuery) ListQuery {
+	query.Live = true
+	return query
 }
 
 // CachedList returns query results from the in-memory cache only. The boolean
@@ -167,6 +172,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			}
 		}
 		c.beads[item.ID] = cloneBead(item)
+		c.deps[item.ID] = depsFromBeadFields(item)
 		delete(c.dirty, item.ID)
 		delete(c.deletedSeq, item.ID)
 		if !recentLocalMutation(c.localBeadAt[item.ID], now) {
@@ -185,6 +191,7 @@ func (c *CachingStore) refreshCachedBeads(query ListQuery, startSeq uint64, item
 			continue
 		}
 		c.beads[id] = bead
+		c.deps[id] = depsFromBeadFields(bead)
 		delete(c.dirty, id)
 		delete(c.deletedSeq, id)
 		if !recentLocalMutation(c.localBeadAt[id], now) {
@@ -294,6 +301,7 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 				return Bead{}, ErrNotFound
 			}
 			c.beads[id] = cloneBead(fresh)
+			c.deps[id] = depsFromBeadFields(fresh)
 			delete(c.dirty, id)
 			delete(c.deletedSeq, id)
 			delete(c.beadSeq, id)
@@ -362,6 +370,60 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 	}
 	c.mu.RUnlock()
 	return c.backing.Ready()
+}
+
+// CachedReady returns ready beads from the in-memory active read model.
+// The boolean reports whether the cache was initialized enough to answer
+// without touching the backing store. Unlike Ready, this can answer from a
+// partial active cache only when each open bead has known dependency coverage.
+func (c *CachingStore) CachedReady() ([]Bead, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.state != cacheLive && c.state != cachePartial {
+		return nil, false
+	}
+	if c.primePartialErr != nil || len(c.dirty) > 0 {
+		return nil, false
+	}
+
+	statusByID := make(map[string]string, len(c.beads))
+	openBeads := make([]Bead, 0, len(c.beads))
+	for _, b := range c.beads {
+		statusByID[b.ID] = b.Status
+		if b.Status == "open" && !IsReadyExcludedType(b.Type) {
+			openBeads = append(openBeads, cloneBead(b))
+		}
+	}
+
+	result := make([]Bead, 0, len(openBeads))
+	for _, b := range openBeads {
+		deps, ok := c.deps[b.ID]
+		switch {
+		case ok:
+		case c.depsComplete:
+			deps = nil
+		default:
+			return nil, false
+		}
+		if cachedBeadReady(statusByID, deps) {
+			result = append(result, cloneBead(b))
+		}
+	}
+	return result, true
+}
+
+func cachedBeadReady(statusByID map[string]string, deps []Dep) bool {
+	for _, dep := range deps {
+		switch dep.Type {
+		case "blocks", "waits-for", "conditional-blocks":
+		default:
+			continue
+		}
+		if status, ok := statusByID[dep.DependsOnID]; ok && status != "closed" {
+			return false
+		}
+	}
+	return true
 }
 
 // Children returns beads with the given parent ID.

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -108,6 +108,10 @@ func (c *CachingStore) runReconciliation() {
 			if _, keep := c.recentLocalBeadConflictLocked(id, freshBead, now); keep {
 				continue
 			}
+			freshDeps := depsFromBeadFields(freshBead)
+			if useFreshDeps {
+				freshDeps = depMap[id]
+			}
 
 			old, exists := c.beads[id]
 			switch {
@@ -123,7 +127,7 @@ func (c *CachingStore) runReconciliation() {
 					eventType: "bead.updated",
 					bead:      cloneBead(freshBead),
 				})
-			case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
+			case depsChanged(c.deps[id], freshDeps):
 				updates++
 				notifications = append(notifications, cacheNotification{
 					eventType: "bead.updated",
@@ -132,9 +136,7 @@ func (c *CachingStore) runReconciliation() {
 			}
 
 			c.beads[id] = cloneBead(freshBead)
-			if useFreshDeps {
-				c.deps[id] = cloneDeps(depMap[id])
-			}
+			c.deps[id] = cloneDeps(freshDeps)
 			delete(c.dirty, id)
 			delete(c.deletedSeq, id)
 			if !recentLocalMutation(c.localBeadAt[id], now) {
@@ -207,12 +209,12 @@ func (c *CachingStore) runReconciliation() {
 			beadForCache = current
 			preservedRecentLocal = true
 		}
-		nextBeads[id] = cloneBead(beadForCache)
+		freshDeps := depsFromBeadFields(freshBead)
 		if useFreshDeps {
-			nextDeps[id] = cloneDeps(depMap[id])
-		} else if deps, ok := c.deps[id]; ok {
-			nextDeps[id] = cloneDeps(deps)
+			freshDeps = depMap[id]
 		}
+		nextBeads[id] = cloneBead(beadForCache)
+		nextDeps[id] = cloneDeps(freshDeps)
 
 		old, exists := c.beads[id]
 		switch {
@@ -228,7 +230,7 @@ func (c *CachingStore) runReconciliation() {
 				eventType: "bead.updated",
 				bead:      cloneBead(freshBead),
 			})
-		case useFreshDeps && depsChanged(c.deps[id], depMap[id]):
+		case !preservedRecentLocal && depsChanged(c.deps[id], freshDeps):
 			updates++
 			notifications = append(notifications, cacheNotification{
 				eventType: "bead.updated",

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -1081,6 +1081,18 @@ func (s *dirtyGetRaceStore) Get(id string) (beads.Bead, error) {
 	}
 }
 
+type updateRefreshStore struct {
+	beads.Store
+	fresh map[string]beads.Bead
+}
+
+func (s *updateRefreshStore) Get(id string) (beads.Bead, error) {
+	if b, ok := s.fresh[id]; ok {
+		return b, nil
+	}
+	return s.Store.Get(id)
+}
+
 func TestCachingStoreGetFallsBackForClosedBeadsAfterPrime(t *testing.T) {
 	t.Parallel()
 	mem := beads.NewMemStore()
@@ -1170,6 +1182,309 @@ func TestCachingStoreReadyTreatsMissingDepTargetAsClosedWithoutBackingGet(t *tes
 	}
 	if gets := backing.getCount(); gets != 0 {
 		t.Fatalf("Ready() performed %d backing Get calls, want 0", gets)
+	}
+}
+
+func TestCachingStoreCachedReadyUsesPrimedDependencies(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	blocked, err := mem.Create(beads.Bead{Title: "Blocked"})
+	if err != nil {
+		t.Fatalf("Create(blocked): %v", err)
+	}
+	ready, err := mem.Create(beads.Bead{Title: "Ready"})
+	if err != nil {
+		t.Fatalf("Create(ready): %v", err)
+	}
+	if err := mem.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	got, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	ids := map[string]bool{}
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids[blocker.ID] || !ids[ready.ID] || ids[blocked.ID] {
+		t.Fatalf("CachedReady ids = %v, want blocker and ready only", ids)
+	}
+}
+
+func TestCachingStoreCachedReadyUsesWriteThroughDependencies(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	blocked, err := mem.Create(beads.Bead{Title: "Blocked"})
+	if err != nil {
+		t.Fatalf("Create(blocked): %v", err)
+	}
+
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+	if err := cache.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+		t.Fatalf("DepAdd: %v", err)
+	}
+
+	got, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	ids := map[string]bool{}
+	for _, b := range got {
+		ids[b.ID] = true
+	}
+	if !ids[blocker.ID] || ids[blocked.ID] {
+		t.Fatalf("CachedReady ids = %v, want blocker only", ids)
+	}
+}
+
+func TestCachingStoreCachedReadyIgnoresStaleDependencyEventsAfterLocalMutation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dep add", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		target, err := mem.Create(beads.Bead{Title: "Target"})
+		if err != nil {
+			t.Fatalf("Create(target): %v", err)
+		}
+		cache := beads.NewCachingStoreForTest(mem, nil)
+		if err := cache.PrimeActive(); err != nil {
+			t.Fatalf("PrimeActive: %v", err)
+		}
+		if err := cache.DepAdd(target.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd: %v", err)
+		}
+
+		cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Target","status":"open","issue_type":"task","dependencies":[]}`))
+
+		ready, ok := cache.CachedReady()
+		if !ok {
+			t.Fatal("CachedReady reported cache unavailable")
+		}
+		ids := map[string]bool{}
+		for _, b := range ready {
+			ids[b.ID] = true
+		}
+		if ids[target.ID] {
+			t.Fatalf("CachedReady ids = %v, want stale event to leave target blocked", ids)
+		}
+	})
+
+	t.Run("dep remove", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		target, err := mem.Create(beads.Bead{Title: "Target", Needs: []string{blocker.ID}})
+		if err != nil {
+			t.Fatalf("Create(target): %v", err)
+		}
+		cache := beads.NewCachingStoreForTest(mem, nil)
+		if err := cache.PrimeActive(); err != nil {
+			t.Fatalf("PrimeActive: %v", err)
+		}
+		if err := cache.DepRemove(target.ID, blocker.ID); err != nil {
+			t.Fatalf("DepRemove: %v", err)
+		}
+
+		cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Target","status":"open","issue_type":"task","needs":["`+blocker.ID+`"]}`))
+
+		ready, ok := cache.CachedReady()
+		if !ok {
+			t.Fatal("CachedReady reported cache unavailable")
+		}
+		ids := map[string]bool{}
+		for _, b := range ready {
+			ids[b.ID] = true
+		}
+		if !ids[target.ID] {
+			t.Fatalf("CachedReady ids = %v, want stale event to leave target ready", ids)
+		}
+	})
+}
+
+func TestCachingStoreCachedReadyIgnoresStaleDependencyEventsAfterEventMutation(t *testing.T) {
+	t.Parallel()
+
+	mem := beads.NewMemStore()
+	closedBlocker, err := mem.Create(beads.Bead{Title: "Closed blocker"})
+	if err != nil {
+		t.Fatalf("Create(closed blocker): %v", err)
+	}
+	closed := "closed"
+	if err := mem.Update(closedBlocker.ID, beads.UpdateOpts{Status: &closed}); err != nil {
+		t.Fatalf("Update(closed blocker): %v", err)
+	}
+	openBlocker, err := mem.Create(beads.Bead{Title: "Open blocker"})
+	if err != nil {
+		t.Fatalf("Create(open blocker): %v", err)
+	}
+	target, err := mem.Create(beads.Bead{Title: "Target"})
+	if err != nil {
+		t.Fatalf("Create(target): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Target","status":"open","issue_type":"task","dependencies":[{"issue_id":"`+target.ID+`","depends_on_id":"`+closedBlocker.ID+`","type":"blocks"},{"issue_id":"`+target.ID+`","depends_on_id":"`+openBlocker.ID+`","type":"blocks"}]}`))
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Target","status":"open","issue_type":"task","dependencies":[{"issue_id":"`+target.ID+`","depends_on_id":"`+closedBlocker.ID+`","type":"blocks"}]}`))
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	ids := map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if ids[target.ID] {
+		t.Fatalf("CachedReady ids = %v, want stale dependency event to leave target blocked by %s", ids, openBlocker.ID)
+	}
+}
+
+func TestCachingStoreCachedReadyUsesCompleteCreatedEventDependencies(t *testing.T) {
+	t.Parallel()
+	cache := beads.NewCachingStoreForTest(beads.NewMemStore(), nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-1","title":"Event task","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	if len(ready) != 1 || ready[0].ID != "gc-1" {
+		t.Fatalf("CachedReady = %#v, want event-created bead", ready)
+	}
+}
+
+func TestCachingStoreCachedReadyUnavailableForPartialEventDependencies(t *testing.T) {
+	t.Parallel()
+	cache := beads.NewCachingStoreForTest(beads.NewMemStore(), nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-1","status":"open"}`))
+
+	if ready, ok := cache.CachedReady(); ok {
+		t.Fatalf("CachedReady ok with unknown event dependency coverage, ready=%v", ready)
+	}
+}
+
+func TestCachingStoreCachedReadyRefreshesEventNeedsDependencies(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	target, err := mem.Create(beads.Bead{Title: "Event target"})
+	if err != nil {
+		t.Fatalf("Create(target): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","needs":["`+blocker.ID+`"]}`))
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after needs add")
+	}
+	ids := map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if ids[target.ID] {
+		t.Fatalf("CachedReady ids = %v, want target blocked by event needs", ids)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
+	if ready, ok = cache.CachedReady(); ok {
+		t.Fatalf("CachedReady available after dependency-omitting update, ready=%v", ready)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","needs":[]}`))
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after explicit needs clear")
+	}
+	ids = map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if !ids[target.ID] {
+		t.Fatalf("CachedReady ids = %v, want target ready after explicit needs clear", ids)
+	}
+}
+
+func TestCachingStoreUpdateClearsCachedDependenciesFromFreshBead(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	blocked, err := mem.Create(beads.Bead{Title: "Blocked", Needs: []string{blocker.ID}})
+	if err != nil {
+		t.Fatalf("Create(blocked): %v", err)
+	}
+	backing := &updateRefreshStore{
+		Store: beads.NewMemStoreFrom(2, []beads.Bead{blocker, blocked}, nil),
+		fresh: make(map[string]beads.Bead),
+	}
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	fresh := blocked
+	fresh.Title = "Cleared"
+	fresh.Needs = nil
+	fresh.Dependencies = nil
+	backing.fresh[blocked.ID] = fresh
+	title := "Cleared"
+	if err := cache.Update(blocked.ID, beads.UpdateOpts{Title: &title}); err != nil {
+		t.Fatalf("Update(blocked): %v", err)
+	}
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	ids := map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if !ids[blocked.ID] {
+		t.Fatalf("CachedReady ids = %v, want update refresh to clear stale deps", ids)
 	}
 }
 

--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -22,6 +22,7 @@ func (c *CachingStore) Create(b Bead) (Bead, error) {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(created.ID)
 	c.beads[created.ID] = cloneBead(created)
+	c.deps[created.ID] = depsFromBeadFields(created)
 	delete(c.dirty, created.ID)
 	delete(c.deletedSeq, created.ID)
 	c.markFreshLocked(time.Now())
@@ -52,6 +53,7 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(id)
 	c.beads[id] = cloneBead(fresh)
+	c.deps[id] = depsFromBeadFields(fresh)
 	delete(c.dirty, id)
 	delete(c.deletedSeq, id)
 	c.markFreshLocked(time.Now())
@@ -258,13 +260,14 @@ func (c *CachingStore) DepAdd(issueID, dependsOnID, depType string) error {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(issueID)
 	if !c.depsComplete {
-		delete(c.deps, issueID)
-		delete(c.dirty, issueID)
-		delete(c.deletedSeq, issueID)
-		c.markFreshLocked(time.Now())
-		c.updateStatsLocked()
-		c.mu.Unlock()
-		return nil
+		if _, known := c.deps[issueID]; !known {
+			delete(c.dirty, issueID)
+			delete(c.deletedSeq, issueID)
+			c.markFreshLocked(time.Now())
+			c.updateStatsLocked()
+			c.mu.Unlock()
+			return nil
+		}
 	}
 	deps := c.deps[issueID]
 	for i, d := range deps {
@@ -297,13 +300,14 @@ func (c *CachingStore) DepRemove(issueID, dependsOnID string) error {
 	c.mu.Lock()
 	c.noteLocalMutationLocked(issueID)
 	if !c.depsComplete {
-		delete(c.deps, issueID)
-		delete(c.dirty, issueID)
-		delete(c.deletedSeq, issueID)
-		c.markFreshLocked(time.Now())
-		c.updateStatsLocked()
-		c.mu.Unlock()
-		return nil
+		if _, known := c.deps[issueID]; !known {
+			delete(c.dirty, issueID)
+			delete(c.deletedSeq, issueID)
+			c.markFreshLocked(time.Now())
+			c.updateStatsLocked()
+			c.mu.Unlock()
+			return nil
+		}
 	}
 	deps := c.deps[issueID]
 	for i, d := range deps {

--- a/test/acceptance/session_test.go
+++ b/test/acceptance/session_test.go
@@ -9,9 +9,11 @@
 package acceptance_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/session"
 	helpers "github.com/gastownhall/gascity/test/acceptance/helpers"
 )
 
@@ -90,38 +92,52 @@ func TestSessionErrors(t *testing.T) {
 	})
 }
 
-func TestSessionEmptyCity(t *testing.T) {
+func TestSessionDefaultNamedSession(t *testing.T) {
 	c := helpers.NewCity(t, testEnv)
 	c.Init("claude")
 
-	t.Run("List_Empty", func(t *testing.T) {
+	t.Run("List_DefaultNamedSession", func(t *testing.T) {
 		out, err := c.GC("session", "list")
 		if err != nil {
 			t.Fatalf("gc session list: %v\n%s", err, out)
 		}
-		if !strings.Contains(out, "No sessions found") {
-			t.Errorf("expected 'No sessions found' on fresh city, got:\n%s", out)
+		if strings.Contains(out, "No sessions found") {
+			t.Errorf("expected default named session on fresh city, got:\n%s", out)
+		}
+		for _, want := range []string{"mayor", "creating"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in default named session list, got:\n%s", want, out)
+			}
 		}
 	})
 
-	t.Run("List_JSON", func(t *testing.T) {
+	t.Run("List_JSON_DefaultNamedSession", func(t *testing.T) {
 		out, err := c.GC("session", "list", "--json")
 		if err != nil {
 			t.Fatalf("gc session list --json: %v\n%s", err, out)
 		}
-		trimmed := strings.TrimSpace(out)
-		if trimmed != "[]" && trimmed != "null" && !strings.HasPrefix(trimmed, "[") {
-			t.Errorf("expected JSON array on fresh city, got:\n%s", out)
+		var got []session.Info
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("gc session list --json output is not a session array: %v\n%s", err, out)
+		}
+		if len(got) != 1 {
+			t.Fatalf("session count = %d, want 1 default named session\n%s", len(got), out)
+		}
+		if got[0].Template != "mayor" {
+			t.Errorf("template = %q, want mayor\n%s", got[0].Template, out)
+		}
+		if got[0].State != session.StateCreating {
+			t.Errorf("state = %q, want creating\n%s", got[0].State, out)
 		}
 	})
 
-	t.Run("Prune_Empty", func(t *testing.T) {
+	t.Run("Prune_NoClosedSessions", func(t *testing.T) {
 		out, err := c.GC("session", "prune")
 		if err != nil {
 			t.Fatalf("gc session prune: %v\n%s", err, out)
 		}
 		if !strings.Contains(out, "No sessions to prune") {
-			t.Errorf("expected 'No sessions to prune' on fresh city, got:\n%s", out)
+			t.Errorf("expected 'No sessions to prune' with only default named session, got:\n%s", out)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- use the active cache read model for controller in-progress and ready demand queries
- count default scale demand from cached routed ready work for store-backed reconciliation
- fall back to live ready checks when cached dependency coverage is incomplete

## Tests
- go test ./internal/beads ./cmd/gc
- pre-commit full fast gate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->