### PR TITLE
fix(session): skip terminal named-session reopen candidates

### DIFF
--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -322,6 +322,9 @@ func FindClosedNamedSessionBeadForSessionName(store beads.Store, identity, sessi
 		if b.Status != "closed" {
 			continue
 		}
+		if !closedNamedSessionReopenEligible(b) {
+			continue
+		}
 		if sessionName != "" {
 			if strings.TrimSpace(b.Metadata["session_name"]) == sessionName {
 				return b, true, nil
@@ -340,6 +343,21 @@ func FindClosedNamedSessionBeadForSessionName(store beads.Store, identity, sessi
 		return fallback, true, nil
 	}
 	return beads.Bead{}, false, nil
+}
+
+func closedNamedSessionReopenEligible(b beads.Bead) bool {
+	if strings.TrimSpace(b.Metadata["continuity_eligible"]) == "false" {
+		return false
+	}
+	switch strings.TrimSpace(b.Metadata["close_reason"]) {
+	case "duplicate", "duplicate-repair", "gc_swept", "orphaned", "reconfigured", "stale-session":
+		return false
+	}
+	switch strings.TrimSpace(b.Metadata["state"]) {
+	case "duplicate", "duplicate-repair", "gc_swept", "orphaned", "reconfigured", "stale-session":
+		return false
+	}
+	return true
 }
 
 // FindCanonicalNamedSessionBead finds the active bead that owns a configured named session.

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -165,6 +165,35 @@ func TestFindClosedNamedSessionBeadForSessionName_PrefersMatchingCanonicalCandid
 	}
 }
 
+func TestFindClosedNamedSessionBeadForSessionName_SkipsTerminalRetiredCandidate(t *testing.T) {
+	store := beads.NewMemStore()
+	orphaned, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name":               "test-city--mayor",
+			"close_reason":               "orphaned",
+			"state":                      "orphaned",
+			NamedSessionMetadataKey:      "true",
+			NamedSessionIdentityMetadata: "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(orphaned): %v", err)
+	}
+	if err := store.Close(orphaned.ID); err != nil {
+		t.Fatalf("Close(orphaned): %v", err)
+	}
+
+	found, ok, err := FindClosedNamedSessionBeadForSessionName(store, "mayor", "test-city--mayor")
+	if err != nil {
+		t.Fatalf("FindClosedNamedSessionBeadForSessionName: %v", err)
+	}
+	if ok {
+		t.Fatalf("FindClosedNamedSessionBeadForSessionName returned %q, want no reusable bead", found.ID)
+	}
+}
+
 func TestFindClosedNamedSessionBead_PrefersNewestClosedCanonical(t *testing.T) {
 	store := beads.NewMemStore()
 	older, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary
- prevent closed named-session beads with terminal retirement reasons from being reopened as configured session continuity
- add a regression test for stale/terminal candidates shadowing a valid older reopen candidate

## Verification
- go test ./internal/session -run TestFindClosedNamedSessionBead -count=1
- go test ./internal/session -count=1
- pre-commit hook: golangci-lint, go vet, observable go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->