### PR TITLE
fix(convoy): reject epic/container as direct convoy child

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/convoy"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/spf13/cobra"
@@ -176,6 +177,37 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 		return 1
 	}
 
+	// Pre-validate every child before mutating any state. This resolves the
+	// per-child store (cross-rig support) once and rejects epic/container
+	// children up front so a half-built convoy can't be left behind. See
+	// gc-867q for the failure mode this prevents.
+	type convoyChild struct {
+		id    string
+		store beads.Store
+		bead  beads.Bead
+	}
+	children := make([]convoyChild, 0, len(issueIDs))
+	for _, id := range issueIDs {
+		childStore := store
+		if cfg != nil {
+			if rd := rigDirForBead(cfg, id); rd != "" {
+				if rs, err := openStoreAtForCity(rd, cityPath); err == nil {
+					childStore = rs
+				}
+			}
+		}
+		bead, err := childStore.Get(id)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc convoy create: issue %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if rejectErr := convoy.RejectNonLeafChild(bead); rejectErr != nil {
+			fmt.Fprintf(stderr, "gc convoy create: %v\n", rejectErr) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		children = append(children, convoyChild{id: id, store: childStore, bead: bead})
+	}
+
 	b := beads.Bead{Title: name, Type: "convoy"}
 	if opts.Owned {
 		b.Labels = []string{"owned"}
@@ -196,25 +228,10 @@ func doConvoyCreateWithOptions(store beads.Store, cfg *config.City, cityPath str
 		// Non-fatal: convoy already created and event will be emitted.
 	}
 
-	for _, id := range issueIDs {
-		// Resolve the correct store for this child bead. Children may
-		// live in a rig store (different from the city root store where
-		// the convoy was created).
-		childStore := store
-		if cfg != nil {
-			if rd := rigDirForBead(cfg, id); rd != "" {
-				if rs, err := openStoreAtForCity(rd, cityPath); err == nil {
-					childStore = rs
-				}
-			}
-		}
-		if _, err := childStore.Get(id); err != nil {
-			fmt.Fprintf(stderr, "gc convoy create: issue %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
+	for _, c := range children {
 		parentID := convoy.ID
-		if err := childStore.Update(id, beads.UpdateOpts{ParentID: &parentID}); err != nil {
-			fmt.Fprintf(stderr, "gc convoy create: setting parent on %s: %v\n", id, err) //nolint:errcheck // best-effort stderr
+		if err := c.store.Update(c.id, beads.UpdateOpts{ParentID: &parentID}); err != nil {
+			fmt.Fprintf(stderr, "gc convoy create: setting parent on %s: %v\n", c.id, err) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
@@ -694,18 +711,23 @@ func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int
 	convoyID := args[0]
 	issueID := args[1]
 
-	convoy, err := store.Get(convoyID)
+	convoyBead, err := store.Get(convoyID)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy add: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if convoy.Type != "convoy" {
+	if convoyBead.Type != "convoy" {
 		fmt.Fprintf(stderr, "gc convoy add: bead %s is not a convoy\n", convoyID) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
-	if _, err := store.Get(issueID); err != nil {
+	issue, err := store.Get(issueID)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc convoy add: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if rejectErr := convoy.RejectNonLeafChild(issue); rejectErr != nil {
+		fmt.Fprintf(stderr, "gc convoy add: %v\n", rejectErr) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
@@ -717,6 +739,7 @@ func doConvoyAdd(store beads.Store, args []string, stdout, stderr io.Writer) int
 	fmt.Fprintf(stdout, "Added %s to convoy %s\n", issueID, convoyID) //nolint:errcheck // best-effort stdout
 	return 0
 }
+
 
 func newConvoyCloseCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{

--- a/cmd/gc/cmd_convoy_test.go
+++ b/cmd/gc/cmd_convoy_test.go
@@ -94,6 +94,95 @@ func TestConvoyCreateBadIssueID(t *testing.T) {
 	}
 }
 
+// TestConvoyCreateRejectsEpicChild asserts that 'gc convoy create <name> <epic-id>'
+// refuses to make an epic the direct child of a convoy. Pattern A (convoy → epic
+// → tasks) breaks 'gc sling' expansion: sling expands one level, hits the epic,
+// then errors. The fix shape is to catch this at convoy-create time with a
+// helpful message pointing to Pattern B (epic → convoy → tasks). See gc-867q.
+func TestConvoyCreateRejectsEpicChild(t *testing.T) {
+	store := beads.NewMemStore()
+	epic, _ := store.Create(beads.Bead{Title: "i18n epic", Type: "epic"})
+
+	var stderr bytes.Buffer
+	code := doConvoyCreate(store, events.Discard, []string{"i18n", epic.ID}, &bytes.Buffer{}, &stderr)
+	if code != 1 {
+		t.Errorf("doConvoyCreate = %d, want 1", code)
+	}
+	msg := stderr.String()
+	if !strings.Contains(msg, "epic") {
+		t.Errorf("stderr = %q, want mention of 'epic'", msg)
+	}
+	if !strings.Contains(msg, "Pattern B") {
+		t.Errorf("stderr = %q, want guidance referencing 'Pattern B'", msg)
+	}
+
+	// Epic should be untouched — no parent assigned, no convoy attempted.
+	got, err := store.Get(epic.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty (epic must not be reparented)", got.ParentID)
+	}
+}
+
+// TestConvoyCreateRejectsConvoyChild asserts that 'gc convoy create <name> <convoy-id>'
+// refuses to nest a convoy inside another convoy. Same family as the epic-child
+// rejection — convoys are container beads, not work units. See gc-867q.
+func TestConvoyCreateRejectsConvoyChild(t *testing.T) {
+	store := beads.NewMemStore()
+	inner, _ := store.Create(beads.Bead{Title: "inner convoy", Type: "convoy"})
+
+	var stderr bytes.Buffer
+	code := doConvoyCreate(store, events.Discard, []string{"outer", inner.ID}, &bytes.Buffer{}, &stderr)
+	if code != 1 {
+		t.Errorf("doConvoyCreate = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "convoy") {
+		t.Errorf("stderr = %q, want mention of 'convoy'", stderr.String())
+	}
+
+	got, err := store.Get(inner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ParentID != "" {
+		t.Errorf("inner convoy ParentID = %q, want empty", got.ParentID)
+	}
+}
+
+// TestConvoyCreateRejectsBeforeAnyChildMutation asserts that the convoy-create
+// rejection is "all-or-nothing": when one child is an epic, no other child
+// gets reparented. This prevents the half-applied state where some tasks are
+// under the new convoy and others aren't. See gc-867q.
+func TestConvoyCreateRejectsBeforeAnyChildMutation(t *testing.T) {
+	store := beads.NewMemStore()
+	task, _ := store.Create(beads.Bead{Title: "real task"})
+	epic, _ := store.Create(beads.Bead{Title: "narrative epic", Type: "epic"})
+
+	var stderr bytes.Buffer
+	code := doConvoyCreate(store, events.Discard, []string{"mixed", task.ID, epic.ID}, &bytes.Buffer{}, &stderr)
+	if code != 1 {
+		t.Errorf("doConvoyCreate = %d, want 1", code)
+	}
+
+	// The plain task must not have been reparented either.
+	gotTask, err := store.Get(task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotTask.ParentID != "" {
+		t.Errorf("task ParentID = %q, want empty (no partial application)", gotTask.ParentID)
+	}
+	gotEpic, err := store.Get(epic.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotEpic.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty", gotEpic.ParentID)
+	}
+}
+
 func TestConvoyCreateMultiRig(t *testing.T) {
 	// Simulate cross-rig convoy: convoy in city store, children in rig store.
 	cityStore := beads.NewMemStore()
@@ -569,6 +658,61 @@ func TestConvoyAddMissingArgs(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "usage:") {
 		t.Errorf("stderr = %q, want usage message", stderr.String())
+	}
+}
+
+// TestConvoyAddRejectsEpicChild asserts that 'gc convoy add <convoy> <epic-id>'
+// refuses to make an epic a child of a convoy. Same rationale as
+// TestConvoyCreateRejectsEpicChild — Pattern A is broken. See gc-867q.
+func TestConvoyAddRejectsEpicChild(t *testing.T) {
+	store := beads.NewMemStore()
+	convoy, _ := store.Create(beads.Bead{Title: "deploy", Type: "convoy"})
+	epic, _ := store.Create(beads.Bead{Title: "narrative epic", Type: "epic"})
+
+	var stderr bytes.Buffer
+	code := doConvoyAdd(store, []string{convoy.ID, epic.ID}, &bytes.Buffer{}, &stderr)
+	if code != 1 {
+		t.Errorf("doConvoyAdd = %d, want 1", code)
+	}
+	msg := stderr.String()
+	if !strings.Contains(msg, "epic") {
+		t.Errorf("stderr = %q, want mention of 'epic'", msg)
+	}
+	if !strings.Contains(msg, "Pattern B") {
+		t.Errorf("stderr = %q, want guidance referencing 'Pattern B'", msg)
+	}
+
+	got, err := store.Get(epic.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty", got.ParentID)
+	}
+}
+
+// TestConvoyAddRejectsConvoyChild asserts that 'gc convoy add <convoy> <convoy-id>'
+// refuses to nest one convoy inside another. See gc-867q.
+func TestConvoyAddRejectsConvoyChild(t *testing.T) {
+	store := beads.NewMemStore()
+	outer, _ := store.Create(beads.Bead{Title: "outer", Type: "convoy"})
+	inner, _ := store.Create(beads.Bead{Title: "inner", Type: "convoy"})
+
+	var stderr bytes.Buffer
+	code := doConvoyAdd(store, []string{outer.ID, inner.ID}, &bytes.Buffer{}, &stderr)
+	if code != 1 {
+		t.Errorf("doConvoyAdd = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "convoy") {
+		t.Errorf("stderr = %q, want mention of 'convoy'", stderr.String())
+	}
+
+	got, err := store.Get(inner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ParentID != "" {
+		t.Errorf("inner convoy ParentID = %q, want empty", got.ParentID)
 	}
 }
 

--- a/internal/api/handler_convoys_test.go
+++ b/internal/api/handler_convoys_test.go
@@ -59,6 +59,69 @@ func TestConvoyCreateInvalidItem(t *testing.T) {
 	}
 }
 
+// TestConvoyCreateRejectsEpicItem asserts the HTTP API refuses to attach an
+// epic as a direct child of a convoy and does NOT leave a half-built convoy
+// behind. Mirrors the CLI guard so the dashboard cannot reproduce the gc-867q
+// bug surface that bit qcore/qc-rz96.
+func TestConvoyCreateRejectsEpicItem(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	epic, _ := store.Create(beads.Bead{Title: "narrative", Type: "epic"})
+
+	body := `{"rig":"myrig","title":"deploy","items":["` + epic.ID + `"]}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/convoys"), strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Pattern B") {
+		t.Errorf("body = %q, want guidance referencing 'Pattern B'", rec.Body.String())
+	}
+
+	// The epic must not have been reparented and no convoy bead should exist.
+	gotEpic, _ := store.Get(epic.ID)
+	if gotEpic.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty", gotEpic.ParentID)
+	}
+	convoys, err := store.List(beads.ListQuery{Type: "convoy", IncludeClosed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(convoys) != 0 {
+		t.Errorf("found %d convoy beads, want 0 (rejection must not leave a half-built convoy)", len(convoys))
+	}
+}
+
+// TestConvoyAddRejectsEpicItem asserts that POST /convoy/{id}/add refuses to
+// attach an epic as a direct child of a convoy.
+func TestConvoyAddRejectsEpicItem(t *testing.T) {
+	state := newFakeMutatorState(t)
+	h := newTestCityHandler(t, state)
+
+	store := state.stores["myrig"]
+	convoy, _ := store.Create(beads.Bead{Title: "deploy", Type: "convoy"})
+	epic, _ := store.Create(beads.Bead{Title: "narrative", Type: "epic"})
+
+	body := `{"items":["` + epic.ID + `"]}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newPostRequest(cityURL(state, "/convoy/")+convoy.ID+"/add", strings.NewReader(body)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Pattern B") {
+		t.Errorf("body = %q, want guidance referencing 'Pattern B'", rec.Body.String())
+	}
+
+	gotEpic, _ := store.Get(epic.ID)
+	if gotEpic.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty", gotEpic.ParentID)
+	}
+}
+
 func TestConvoyAddItems(t *testing.T) {
 	state := newFakeMutatorState(t)
 	h := newTestCityHandler(t, state)

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/convoy"
 )
 
 // convoyProgress is the shared {total, closed} progress shape used by
@@ -202,19 +203,24 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 		return nil, huma.Error400BadRequest("rig is required when multiple rigs are configured")
 	}
 
-	// Pre-validate all items exist AND capture their current parent so
-	// a mid-link failure can roll each one back, not just delete the
-	// new convoy and leave items pointing at a deleted ID.
+	// Pre-validate all items exist, capture their current parent (so a
+	// mid-link failure can roll each one back), and reject epic/container
+	// types up front. Without the type check, a single epic in the items
+	// list would otherwise leave a half-built convoy bead behind and
+	// trigger the gc-867q bug surface.
 	prevParent := make(map[string]string, len(input.Body.Items))
 	for _, itemID := range input.Body.Items {
 		item, err := store.Get(itemID)
 		if err != nil {
 			return nil, storeError(err)
 		}
+		if rejectErr := convoy.RejectNonLeafChild(item); rejectErr != nil {
+			return nil, huma.Error400BadRequest(rejectErr.Error())
+		}
 		prevParent[itemID] = item.ParentID
 	}
 
-	convoy, err := store.Create(beads.Bead{
+	created, err := store.Create(beads.Bead{
 		Title: input.Body.Title,
 		Type:  "convoy",
 	})
@@ -230,11 +236,11 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 	// convoy ID — a worse state than half-populated.
 	applied := make([]string, 0, len(input.Body.Items))
 	for _, itemID := range input.Body.Items {
-		pid := convoy.ID
+		pid := created.ID
 		if err := store.Update(itemID, beads.UpdateOpts{ParentID: &pid}); err != nil {
 			rollbackConvoyMembership(store, applied, prevParent, "convoy.create")
-			if delErr := store.Delete(convoy.ID); delErr != nil {
-				log.Printf("gc api: convoy create rollback: delete %s after link failure: %v", convoy.ID, delErr)
+			if delErr := store.Delete(created.ID); delErr != nil {
+				log.Printf("gc api: convoy create rollback: delete %s after link failure: %v", created.ID, delErr)
 			}
 			return nil, huma.Error500InternalServerError("failed to link item " + itemID + ": " + err.Error())
 		}
@@ -243,7 +249,7 @@ func (s *Server) humaHandleConvoyCreate(_ context.Context, input *ConvoyCreateIn
 
 	return &IndexOutput[beads.Bead]{
 		Index: s.latestIndex(),
-		Body:  convoy,
+		Body:  created,
 	}, nil
 }
 
@@ -265,13 +271,18 @@ func (s *Server) humaHandleConvoyAdd(_ context.Context, input *ConvoyAddInput) (
 		if b.Type != "convoy" {
 			return nil, huma.Error400BadRequest("bead " + id + " is not a convoy")
 		}
-		// Pre-validate all items exist and capture their previous parent
-		// so rollback can restore it if one of the Updates later fails.
+		// Pre-validate all items exist, capture their previous parent (so
+		// rollback can restore it if one of the Updates later fails), and
+		// reject epic/container types so 'gc convoy add' can't reproduce
+		// the gc-867q bug surface that 'gc convoy create' already guards.
 		prevParent := make(map[string]string, len(input.Body.Items))
 		for _, itemID := range input.Body.Items {
 			item, err := store.Get(itemID)
 			if err != nil {
 				return nil, storeError(err)
+			}
+			if rejectErr := convoy.RejectNonLeafChild(item); rejectErr != nil {
+				return nil, huma.Error400BadRequest(rejectErr.Error())
 			}
 			prevParent[itemID] = item.ParentID
 		}

--- a/internal/convoy/convoy.go
+++ b/internal/convoy/convoy.go
@@ -38,9 +38,38 @@ type ConvoyProgressResult struct {
 	Complete bool
 }
 
+// RejectNonLeafChild reports an error when bead is an epic or a container
+// type, both of which break sling expansion if placed as a direct child of a
+// convoy. The shared rule keeps Pattern A (convoy → epic → tasks) out of every
+// code path that links items into a convoy: CLI ('gc convoy create',
+// 'gc convoy add'), the HTTP API, and the convoy package itself. See gc-867q
+// and the prep-convoy skill for the failure mode this prevents.
+func RejectNonLeafChild(bead beads.Bead) error {
+	if bead.Type == "epic" {
+		return fmt.Errorf("bead %s is an epic; epics must wrap convoys, not the other way around (Pattern B). Create the convoy first, then run 'gc bd update <convoy-id> --parent %s' to put the convoy under the epic", bead.ID, bead.ID)
+	}
+	if beads.IsContainerType(bead.Type) {
+		return fmt.Errorf("bead %s is a %s; convoys cannot contain other %s beads", bead.ID, bead.Type, bead.Type)
+	}
+	return nil
+}
+
 // ConvoyCreate creates a convoy bead, applies metadata, links child items,
 // and emits a ConvoyCreated event.
 func ConvoyCreate(deps ConvoyDeps, store beads.Store, input ConvoyCreateInput) (ConvoyCreateResult, error) {
+	// Pre-validate every item's type before creating the convoy. Without
+	// this, a single epic in the items list would leave a half-built
+	// convoy bead behind once the linking loop hit the offending item.
+	for _, itemID := range input.Items {
+		item, err := store.Get(itemID)
+		if err != nil {
+			return ConvoyCreateResult{}, fmt.Errorf("getting item %s: %w", itemID, err)
+		}
+		if rejectErr := RejectNonLeafChild(item); rejectErr != nil {
+			return ConvoyCreateResult{}, rejectErr
+		}
+	}
+
 	b := beads.Bead{
 		Title:  input.Title,
 		Type:   "convoy",
@@ -116,6 +145,19 @@ func ConvoyAddItems(_ ConvoyDeps, store beads.Store, convoyID string, items []st
 	}
 	if b.Type != "convoy" {
 		return fmt.Errorf("bead %s is not a convoy (type: %s)", convoyID, b.Type)
+	}
+
+	// Pre-validate every item's type before mutating any state, mirroring
+	// ConvoyCreate. A mid-loop rejection would otherwise leave earlier
+	// items already reparented.
+	for _, itemID := range items {
+		item, err := store.Get(itemID)
+		if err != nil {
+			return fmt.Errorf("getting item %s: %w", itemID, err)
+		}
+		if rejectErr := RejectNonLeafChild(item); rejectErr != nil {
+			return rejectErr
+		}
 	}
 
 	for _, itemID := range items {

--- a/internal/convoy/convoy_test.go
+++ b/internal/convoy/convoy_test.go
@@ -1,6 +1,7 @@
 package convoy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -145,6 +146,108 @@ func TestConvoyAddItemsOps(t *testing.T) {
 	child, _ := store.Get(b1.ID)
 	if child.ParentID != convoy.ID {
 		t.Errorf("parent = %q, want %q", child.ParentID, convoy.ID)
+	}
+}
+
+// TestRejectNonLeafChildAcceptsLeafTypes asserts that ordinary work bead types
+// (task, bug, chore, etc.) are accepted as direct children of a convoy.
+func TestRejectNonLeafChildAcceptsLeafTypes(t *testing.T) {
+	for _, typ := range []string{"task", "bug", "chore", "feature", ""} {
+		t.Run("type="+typ, func(t *testing.T) {
+			if err := RejectNonLeafChild(beads.Bead{ID: "gc-1", Type: typ}); err != nil {
+				t.Errorf("RejectNonLeafChild(type=%q) = %v, want nil", typ, err)
+			}
+		})
+	}
+}
+
+// TestRejectNonLeafChildRejectsEpic asserts that an epic cannot be a direct
+// child of a convoy. The error must mention 'epic' and 'Pattern B' so the
+// user is pointed to the correct fix. See gc-867q.
+func TestRejectNonLeafChildRejectsEpic(t *testing.T) {
+	err := RejectNonLeafChild(beads.Bead{ID: "qc-pwnu", Type: "epic"})
+	if err == nil {
+		t.Fatal("RejectNonLeafChild(epic) = nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "epic") {
+		t.Errorf("err = %q, want mention of 'epic'", msg)
+	}
+	if !strings.Contains(msg, "Pattern B") {
+		t.Errorf("err = %q, want guidance referencing 'Pattern B'", msg)
+	}
+	if !strings.Contains(msg, "qc-pwnu") {
+		t.Errorf("err = %q, want bead ID", msg)
+	}
+}
+
+// TestRejectNonLeafChildRejectsConvoy asserts that a convoy cannot be nested
+// inside another convoy.
+func TestRejectNonLeafChildRejectsConvoy(t *testing.T) {
+	err := RejectNonLeafChild(beads.Bead{ID: "qc-rz96", Type: "convoy"})
+	if err == nil {
+		t.Fatal("RejectNonLeafChild(convoy) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "convoy") {
+		t.Errorf("err = %q, want mention of 'convoy'", err.Error())
+	}
+}
+
+// TestConvoyCreateRejectsEpicItem asserts that ConvoyCreate refuses an epic in
+// the items list and does NOT create a convoy bead. Without this guard,
+// 'gc convoy create <name> <epic-id>' would leave a half-built convoy that
+// later breaks sling expansion. See gc-867q.
+func TestConvoyCreateRejectsEpicItem(t *testing.T) {
+	store := beads.NewMemStore()
+	deps := testConvoyDeps(store)
+	epic, _ := store.Create(beads.Bead{Title: "narrative", Type: "epic"})
+
+	result, err := ConvoyCreate(deps, store, ConvoyCreateInput{
+		Title: "deploy",
+		Items: []string{epic.ID},
+	})
+	if err == nil {
+		t.Fatal("ConvoyCreate with epic item = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "Pattern B") {
+		t.Errorf("err = %q, want guidance referencing 'Pattern B'", err.Error())
+	}
+	if result.Convoy.ID != "" {
+		t.Errorf("convoy was created (ID=%q) despite epic rejection — want no convoy bead", result.Convoy.ID)
+	}
+
+	// Epic must not have been reparented.
+	got, _ := store.Get(epic.ID)
+	if got.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty", got.ParentID)
+	}
+}
+
+// TestConvoyAddItemsRejectsEpicItem asserts that ConvoyAddItems refuses an epic
+// in the items list and does NOT reparent any earlier-listed item. See gc-867q.
+func TestConvoyAddItemsRejectsEpicItem(t *testing.T) {
+	store := beads.NewMemStore()
+	deps := testConvoyDeps(store)
+	convoy, _ := store.Create(beads.Bead{Title: "deploy", Type: "convoy"})
+	task, _ := store.Create(beads.Bead{Title: "real task"})
+	epic, _ := store.Create(beads.Bead{Title: "narrative", Type: "epic"})
+
+	err := ConvoyAddItems(deps, store, convoy.ID, []string{task.ID, epic.ID})
+	if err == nil {
+		t.Fatal("ConvoyAddItems with epic = nil error, want rejection")
+	}
+	if !strings.Contains(err.Error(), "Pattern B") {
+		t.Errorf("err = %q, want guidance referencing 'Pattern B'", err.Error())
+	}
+
+	// Task must not have been reparented (validation is all-or-nothing).
+	gotTask, _ := store.Get(task.ID)
+	if gotTask.ParentID != "" {
+		t.Errorf("task ParentID = %q, want empty (no partial application)", gotTask.ParentID)
+	}
+	gotEpic, _ := store.Get(epic.ID)
+	if gotEpic.ParentID != "" {
+		t.Errorf("epic ParentID = %q, want empty", gotEpic.ParentID)
 	}
 }
 


### PR DESCRIPTION
## Problem

Pattern A (convoy → epic → tasks) silently breaks \`gc sling <convoy>\`: the slinger expands one level, hits the epic, and errors:

> bead \<epic-id\> is an epic; first-class support is for convoys only

Tasks under the epic become unreachable; \`gc convoy status\` reports 0/1; refinery dispatches against the wrong base branch and has to rescue the run with merge-request mode. The qcore i18n convoy (qc-rz96 wrapping qc-pwnu) hit this on Apr 28, leaving 32 task beads invisible to dispatch — see gc-867q for the full incident write-up and reference to PR #1581.

The trigger is straightforward: nothing on the convoy-link path checks the child's type. \`gc convoy create deploy <epic-id>\` happily reparents the epic under the new convoy, and \`gc convoy add\` does the same. The same surfaces exist on the HTTP API (\`POST /v0/convoys\` and \`POST /v0/convoy/{id}/add\`), so the dashboard SPA can produce the bug class too.

## Fix

New shared rule, \`internal/convoy.RejectNonLeafChild\`: a bead with \`Type == \"epic\"\` or any \`beads.IsContainerType\` (currently \`\"convoy\"\`) cannot be a direct child of a convoy. The error names the offending bead, references Pattern B (epic → convoy → tasks), and gives the exact \`gc bd update\` invocation to put the epic on top after the convoy is created.

Every convoy-link path consults the shared rule:

| Caller | Path |
|---|---|
| CLI | \`cmd/gc/cmd_convoy.go\` — \`doConvoyCreateWithOptions\`, \`doConvoyAdd\` |
| Internal API | \`internal/convoy/convoy.go\` — \`ConvoyCreate\`, \`ConvoyAddItems\` |
| HTTP API | \`internal/api/huma_handlers_convoys.go\` — \`humaHandleConvoyCreate\`, \`humaHandleConvoyAdd\` |

\`gc convoy create\` now pre-validates every item in the request before creating the convoy bead. Without this, a single epic in the items list would otherwise leave a half-built convoy bead behind once the linking loop reached the offending item. \`ConvoyCreate\` and \`ConvoyAddItems\` follow the same all-or-nothing pattern; the API handlers integrate the type check into the existing pre-validation loop that already captured prior parents for rollback.

## Why this aligns with project philosophy

- **Layered architecture / SRP.** The validation is a domain rule, so it lives in \`internal/convoy\` (the convoy domain layer). CLI, API, and internal callers all consume the single rule rather than re-implementing it.
- **ZFC.** The check is pure transport — \"this type cannot be a direct child of a convoy.\" No judgment lives in Go; the agent prompt or operator decides what to do (use Pattern B, abandon the epic, etc.). The error message points to the documented procedure.
- **Bitter Lesson.** A future model writing a more elaborate convoy-creation flow gets the same guard for free; the rule does not encode any taxonomy beyond the existing \`beads.IsContainerType\` primitive plus the literal \`\"epic\"\` (used identically in \`internal/sling/sling_core.go\`).

## Tests

- **\`internal/convoy/convoy_test.go\`** — 6 sub-tests on \`RejectNonLeafChild\` (accepts task / bug / chore / feature / unset; rejects epic with Pattern B guidance; rejects convoy) plus integration tests asserting \`ConvoyCreate\` refuses to create a convoy when an item is an epic and \`ConvoyAddItems\` applies no partial state when one of several items is invalid.
- **\`cmd/gc/cmd_convoy_test.go\`** — 5 tests on \`doConvoyCreate\` / \`doConvoyAdd\` covering the epic case, the convoy-as-child case, and the all-or-nothing guarantee when one of several items is invalid.
- **\`internal/api/handler_convoys_test.go\`** — 2 handler tests asserting \`POST /v0/convoys\` and \`POST /v0/convoy/{id}/add\` return 400 with Pattern B guidance and leave the store unchanged.

Total runtime ~0.5s.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/convoy/... -run 'RejectNonLeaf|ConvoyCreateRejects|ConvoyAddItemsRejects'\` passes
- [x] \`go test ./cmd/gc/ -run 'TestConvoy(Create|Add)Rejects'\` passes (5/5)
- [x] \`go test ./internal/api/... -run 'ConvoyCreateRejects|ConvoyAddRejects'\` passes (2/2)

## Notes

- Pre-existing failure \`TestConvoyStoreCandidatesKeepFileProviderCityScoped\` reproduces on clean upstream/main; not a regression from this PR.
- Reported by \`gastown.mayor\` as gc-867q. Mayor's incident note documents the qcore i18n convoy that surfaced the failure mode.
- Follow-up fix shapes from gc-867q are out of scope here:
  - \`gc bd dep cycles\` should detect parent-child cycles (lives in beads CLI)
  - \`gc convoy status\` should reflect what \`gc sling\` will expand
  - Parent walker for \`metadata.target\` should prefer parents that have the metadata set
  Each is independent of this guard and warrants its own bead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->