### PR TITLE
fix(dispatch): use read-only control work queries

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -72,33 +72,24 @@ func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix
 }
 
 func controlBdCommandRunnerForCity(cityPath string) beads.CommandRunner {
-	return sandboxBDCommandRunner(bdCommandRunnerWithManagedRetry(cityPath, func(dir string) map[string]string {
+	return bdCommandRunnerWithManagedRetry(cityPath, func(dir string) map[string]string {
 		env := bdRuntimeEnv(cityPath)
 		env["BEADS_DIR"] = filepath.Join(dir, ".beads")
 		applyControlBdEnv(env)
 		return env
-	}))
+	})
 }
 
 func controlBdCommandRunnerForRig(cityPath string, cfg *config.City, rigDir string) beads.CommandRunner {
-	return sandboxBDCommandRunner(bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
+	return bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
 		env := bdRuntimeEnvForRig(cityPath, cfg, rigDir)
 		applyControlBdEnv(env)
 		return env
-	}))
+	})
 }
 
 func applyControlBdEnv(env map[string]string) {
 	env["BD_EXPORT_AUTO"] = "false"
-}
-
-func sandboxBDCommandRunner(base beads.CommandRunner) beads.CommandRunner {
-	return func(dir, name string, args ...string) ([]byte, error) {
-		if name == "bd" {
-			args = append([]string{"--sandbox"}, args...)
-		}
-		return base(dir, name, args...)
-	}
 }
 
 func issuePrefixForScope(scopeRoot, cityPath string, cfg *config.City) string {

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -54,6 +54,53 @@ func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...str
 	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
 }
 
+func controlBdStoreForCity(dir, cityPath string, cfg *config.City) *beads.BdStore {
+	return beads.NewBdStoreWithPrefix(dir, controlBdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
+}
+
+func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...string) *beads.BdStore {
+	prefix := issuePrefixForScope(rigDir, cityPath, cfg)
+	if prefix == "" {
+		for _, candidate := range knownPrefix {
+			if strings.TrimSpace(candidate) != "" {
+				prefix = candidate
+				break
+			}
+		}
+	}
+	return beads.NewBdStoreWithPrefix(rigDir, controlBdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+}
+
+func controlBdCommandRunnerForCity(cityPath string) beads.CommandRunner {
+	return sandboxBDCommandRunner(bdCommandRunnerWithManagedRetry(cityPath, func(dir string) map[string]string {
+		env := bdRuntimeEnv(cityPath)
+		env["BEADS_DIR"] = filepath.Join(dir, ".beads")
+		applyControlBdEnv(env)
+		return env
+	}))
+}
+
+func controlBdCommandRunnerForRig(cityPath string, cfg *config.City, rigDir string) beads.CommandRunner {
+	return sandboxBDCommandRunner(bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
+		env := bdRuntimeEnvForRig(cityPath, cfg, rigDir)
+		applyControlBdEnv(env)
+		return env
+	}))
+}
+
+func applyControlBdEnv(env map[string]string) {
+	env["BD_EXPORT_AUTO"] = "false"
+}
+
+func sandboxBDCommandRunner(base beads.CommandRunner) beads.CommandRunner {
+	return func(dir, name string, args ...string) ([]byte, error) {
+		if name == "bd" {
+			args = append([]string{"--sandbox"}, args...)
+		}
+		return base(dir, name, args...)
+	}
+}
+
 func issuePrefixForScope(scopeRoot, cityPath string, cfg *config.City) string {
 	if prefix := readScopeIssuePrefix(scopeRoot); prefix != "" {
 		return prefix

--- a/cmd/gc/cmd_bd_store_bridge.go
+++ b/cmd/gc/cmd_bd_store_bridge.go
@@ -310,6 +310,7 @@ func bdStoreBridgeEnv(dir, host, port, user, password string) map[string]string 
 		"BEADS_DOLT_SERVER_HOST",
 		"BEADS_DOLT_SERVER_PORT",
 		"BEADS_DOLT_SERVER_USER",
+		"BD_EXPORT_AUTO",
 		"GC_BEADS",
 		"GC_BEADS_PREFIX",
 		"GC_DOLT_DATABASE",
@@ -330,6 +331,7 @@ func bdStoreBridgeEnv(dir, host, port, user, password string) map[string]string 
 	env["GC_DOLT_PASSWORD"] = password
 	env["BEADS_DOLT_PASSWORD"] = password
 	env["BEADS_DOLT_AUTO_START"] = "0"
+	env["BD_EXPORT_AUTO"] = "false"
 	return env
 }
 

--- a/cmd/gc/cmd_bd_store_bridge_test.go
+++ b/cmd/gc/cmd_bd_store_bridge_test.go
@@ -48,10 +48,12 @@ BEADS_DOLT_SERVER_DATABASE=%s
 BEADS_CREDENTIALS_FILE=%s
 GC_BEADS=%s
 GC_BEADS_PREFIX=%s
+BD_EXPORT_AUTO=%s
 ' \
   "${BEADS_DIR:-}" "${GC_DOLT_HOST:-}" "${GC_DOLT_PORT:-}" "${GC_DOLT_USER:-}" "${GC_DOLT_PASSWORD:-}" \
   "${BEADS_DOLT_SERVER_HOST:-}" "${BEADS_DOLT_SERVER_PORT:-}" "${BEADS_DOLT_SERVER_USER:-}" "${BEADS_DOLT_PASSWORD:-}" \
-  "${BEADS_DOLT_SERVER_DATABASE:-}" "${BEADS_CREDENTIALS_FILE:-}" "${GC_BEADS:-}" "${GC_BEADS_PREFIX:-}" > "` + envFile + `"
+  "${BEADS_DOLT_SERVER_DATABASE:-}" "${BEADS_CREDENTIALS_FILE:-}" "${GC_BEADS:-}" "${GC_BEADS_PREFIX:-}" \
+  "${BD_EXPORT_AUTO:-}" > "` + envFile + `"
 printf '%s
 ' "$*" > "` + argsFile + `"
 case "${1:-}" in
@@ -152,6 +154,9 @@ func TestBdStoreBridgeCreateCmdProjectsCanonicalEnvAndClearsAmbientAuthority(t *
 	}
 	if got := envMap["GC_BEADS_PREFIX"]; got != "" {
 		t.Fatalf("GC_BEADS_PREFIX = %q, want empty after sanitization\n%s", got, string(envText))
+	}
+	if got := envMap["BD_EXPORT_AUTO"]; got != "false" {
+		t.Fatalf("BD_EXPORT_AUTO = %q, want false to suppress bridge auto-export\n%s", got, string(envText))
 	}
 
 	argsText, err := os.ReadFile(argsFile)

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -350,7 +350,9 @@ func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (be
 			}
 		}
 	}
-	return openStoreAtForCity(storePath, cityPath)
+	// A bd-backed scope can outlive its rig entry in city.toml. Control paths
+	// still need write-capable bd commands with auto-export suppressed.
+	return controlBdStoreForRig(scopeRoot, cityPath, cfg), nil
 }
 
 // findBeadAcrossStores tries the city store first, then all rig stores,

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -346,9 +346,6 @@ func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (be
 				rigPath = filepath.Join(cityPath, rigPath)
 			}
 			if samePath(rigPath, scopeRoot) {
-				if !scopeUsesManagedBdStoreContract(cityPath, scopeRoot) {
-					return openStoreAtForCity(storePath, cityPath)
-				}
 				return controlBdStoreForRig(scopeRoot, cityPath, cfg), nil
 			}
 		}

--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -331,17 +331,25 @@ func sourceWorkflowLockScopeForStoreRef(cityPath string, cfg *config.City, defau
 }
 
 func openControlStoreAtForCity(storePath, cityPath string, cfg *config.City) (beads.Store, error) {
+	scopeRoot := resolveStoreScopeRoot(cityPath, storePath)
+	provider := rawBeadsProviderForScope(scopeRoot, cityPath)
+	if provider == "file" || strings.HasPrefix(provider, "exec:") {
+		return openStoreAtForCity(storePath, cityPath)
+	}
+	if samePath(scopeRoot, cityPath) {
+		return controlBdStoreForCity(scopeRoot, cityPath, cfg), nil
+	}
 	if cfg != nil {
 		for _, rig := range cfg.Rigs {
 			rigPath := rig.Path
 			if !filepath.IsAbs(rigPath) {
 				rigPath = filepath.Join(cityPath, rigPath)
 			}
-			if samePath(rigPath, storePath) {
-				if !scopeUsesManagedBdStoreContract(cityPath, storePath) {
+			if samePath(rigPath, scopeRoot) {
+				if !scopeUsesManagedBdStoreContract(cityPath, scopeRoot) {
 					return openStoreAtForCity(storePath, cityPath)
 				}
-				return bdStoreForRig(storePath, cityPath, cfg), nil
+				return controlBdStoreForRig(scopeRoot, cityPath, cfg), nil
 			}
 		}
 	}

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1477,10 +1477,13 @@ func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 	if strings.Contains(query, "bd list --status in_progress") {
 		t.Fatalf("workflowServeControlReadyQuery should not return in-progress control beads: %q", query)
 	}
+	if !strings.Contains(query, "BD_EXPORT_AUTO=false") {
+		t.Fatalf("workflowServeControlReadyQuery should disable bd auto-export: %q", query)
+	}
 	for _, want := range []string{
-		`bd --readonly ready --assignee="$cand"`,
-		`bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned`,
-		`bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned`,
+		`bd --readonly --sandbox ready --assignee="$cand"`,
+		`bd --readonly --sandbox ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned`,
+		`bd --readonly --sandbox ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned`,
 	} {
 		if !strings.Contains(query, want) {
 			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
@@ -1503,10 +1506,10 @@ case "$*" in
   "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-in-progress"}]'
     ;;
-  "--readonly ready --assignee=gascity--control-dispatcher --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-ready"}]'
     ;;
-  "--readonly ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=20")
     printf '[{"id":"ga-routed"}]'
     ;;
   *)
@@ -1532,7 +1535,7 @@ func TestWorkflowServeControlReadyQueryUsesConfiguredRuntimeNameWhenEnvIsManualS
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "ready --assignee=gascity--control-dispatcher --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-control-ready"}]'
     ;;
   *)
@@ -1556,9 +1559,13 @@ func TestWorkflowServeControlReadyQueryPrioritizesConfiguredRuntimeName(t *testi
 	bdPath := filepath.Join(tmp, "bd")
 	if err := os.WriteFile(bdPath, []byte(`#!/bin/sh
 set -eu
+[ "${BD_EXPORT_AUTO:-}" = "false" ] || {
+  echo "BD_EXPORT_AUTO=${BD_EXPORT_AUTO:-}" >&2
+  exit 43
+}
 printf '%s\n' "$*" >> "$BD_LOG"
 case "$*" in
-  "ready --assignee=gascity--control-dispatcher --json --limit=20")
+  "--readonly --sandbox ready --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-control-ready"}]'
     ;;
   *)
@@ -1587,7 +1594,7 @@ esac
 		t.Fatalf("read bd log: %v", err)
 	}
 	firstCall, _, _ := strings.Cut(strings.TrimSpace(string(logData)), "\n")
-	if want := "ready --assignee=gascity--control-dispatcher --json --limit=20"; firstCall != want {
+	if want := "--readonly --sandbox ready --assignee=gascity--control-dispatcher --json --limit=20"; firstCall != want {
 		t.Fatalf("first bd call = %q, want %q; all calls:\n%s", firstCall, want, string(logData))
 	}
 }
@@ -1596,8 +1603,8 @@ func TestWorkflowServeControlReadyQueryQuotesMetadataFallbackTarget(t *testing.T
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "my rig"})
 	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{}, `#!/bin/sh
 set -eu
-case "$1|$2|$3|$4|$5|$6|$7" in
-  "--readonly|ready|--metadata-field|gc.routed_to=my rig/control-dispatcher|--unassigned|--json|--limit=20")
+case "$1|$2|$3|$4|$5|$6|$7|$8|${9-}" in
+  "--readonly|--sandbox|ready|--metadata-field|gc.routed_to=my rig/control-dispatcher|--unassigned|--json|--limit=20|")
     printf '[{"id":"ga-routed"}]'
     ;;
   *)
@@ -1619,7 +1626,7 @@ func TestWorkflowServeControlReadyQueryUsesLegacyRouteForNamedSessions(t *testin
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "--readonly ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=20")
+  "--readonly --sandbox ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=20")
     printf '[{"id":"ga-legacy-route"}]'
     ;;
   *)
@@ -1799,6 +1806,69 @@ path = %q
 	}
 	if gotBeadID != "gc-rig-control" {
 		t.Fatalf("control beadID = %q, want gc-rig-control", gotBeadID)
+	}
+}
+
+func TestOpenControlStoreUsesSandboxedBdRunner(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "myrig-repo")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "myrig", Path: rigDir}},
+	}
+	t.Setenv("GC_BEADS", "bd")
+
+	var calls [][]string
+	var envs []map[string]string
+	prevRunner := beadsExecCommandRunnerWithEnv
+	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+		envs = append(envs, maps.Clone(env))
+		return func(_ string, name string, args ...string) ([]byte, error) {
+			if name != "bd" {
+				return nil, fmt.Errorf("unexpected command %q", name)
+			}
+			calls = append(calls, append([]string(nil), args...))
+			return []byte(`[]`), nil
+		}
+	}
+	t.Cleanup(func() { beadsExecCommandRunnerWithEnv = prevRunner })
+
+	status := "closed"
+	cityStore, err := openControlStoreAtForCity(cityDir, cityDir, cfg)
+	if err != nil {
+		t.Fatalf("openControlStoreAtForCity(city): %v", err)
+	}
+	if err := cityStore.Update("ga-city-control", beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("city control update: %v", err)
+	}
+	rigStore, err := openControlStoreAtForCity(rigDir, cityDir, cfg)
+	if err != nil {
+		t.Fatalf("openControlStoreAtForCity(rig): %v", err)
+	}
+	if err := rigStore.Update("ga-rig-control", beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("rig control update: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("bd calls = %#v, want two update calls", calls)
+	}
+	if len(envs) != 2 {
+		t.Fatalf("bd envs = %#v, want two command environments", envs)
+	}
+	for i, call := range calls {
+		if len(call) < 2 || call[0] != "--sandbox" || call[1] != "update" {
+			t.Fatalf("bd call = %#v, want --sandbox update ...", call)
+		}
+		if got := envs[i]["BD_EXPORT_AUTO"]; got != "false" {
+			t.Fatalf("bd env %d BD_EXPORT_AUTO = %q, want false", i, got)
+		}
 	}
 }
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1601,19 +1601,38 @@ esac
 
 func TestWorkflowServeControlReadyQueryQuotesMetadataFallbackTarget(t *testing.T) {
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "my rig"})
-	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{}, `#!/bin/sh
+	tmp := t.TempDir()
+	argsPath := filepath.Join(tmp, "matched.args")
+	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{
+		"BD_MATCHED_ARGS": argsPath,
+	}, `#!/bin/sh
 set -eu
-case "$1|$2|$3|$4|$5|$6|$7|$8|${9-}" in
-  "--readonly|--sandbox|ready|--metadata-field|gc.routed_to=my rig/control-dispatcher|--unassigned|--json|--limit=20|")
-    printf '[{"id":"ga-routed"}]'
-    ;;
-  *)
-    printf '[]'
-    ;;
-esac
+if [ "$#" -eq 8 ] &&
+   [ "$1" = "--readonly" ] &&
+   [ "$2" = "--sandbox" ] &&
+   [ "$3" = "ready" ] &&
+   [ "$4" = "--metadata-field" ] &&
+   [ "$5" = "gc.routed_to=my rig/control-dispatcher" ] &&
+   [ "$6" = "--unassigned" ] &&
+   [ "$7" = "--json" ] &&
+   [ "$8" = "--limit=20" ]; then
+  printf '%s\n' "$@" > "$BD_MATCHED_ARGS"
+  printf '[{"id":"ga-routed"}]'
+  exit 0
+fi
+printf '[]'
 `)
 	if got, want := strings.TrimSpace(out), `[{"id":"ga-routed"}]`; got != want {
 		t.Fatalf("control query output = %q, want %q", got, want)
+	}
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read matched args: %v", err)
+	}
+	gotArgs := strings.Split(strings.TrimSpace(string(argsData)), "\n")
+	wantArgs := []string{"--readonly", "--sandbox", "ready", "--metadata-field", "gc.routed_to=my rig/control-dispatcher", "--unassigned", "--json", "--limit=20"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("matched bd args = %#v, want %#v", gotArgs, wantArgs)
 	}
 }
 
@@ -1809,7 +1828,7 @@ path = %q
 	}
 }
 
-func TestOpenControlStoreUsesSandboxedBdRunner(t *testing.T) {
+func TestOpenControlStoreDisablesAutoExportWithoutSandboxingWrites(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
@@ -1863,13 +1882,71 @@ func TestOpenControlStoreUsesSandboxedBdRunner(t *testing.T) {
 		t.Fatalf("bd envs = %#v, want two command environments", envs)
 	}
 	for i, call := range calls {
-		if len(call) < 2 || call[0] != "--sandbox" || call[1] != "update" {
-			t.Fatalf("bd call = %#v, want --sandbox update ...", call)
+		if len(call) < 1 || call[0] != "update" {
+			t.Fatalf("bd call = %#v, want update ...", call)
+		}
+		if slices.Contains(call, "--sandbox") {
+			t.Fatalf("bd call = %#v, write-capable control stores must not use --sandbox", call)
 		}
 		if got := envs[i]["BD_EXPORT_AUTO"]; got != "false" {
 			t.Fatalf("bd env %d BD_EXPORT_AUTO = %q, want false", i, got)
 		}
 	}
+}
+
+func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecStoreCityConfig(t, cityDir, "metro-city", "ct", []config.Rig{{
+		Name:   "frontend",
+		Path:   "rigs/frontend",
+		Prefix: "fe",
+	}})
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "metro-city", Prefix: "ct"},
+		Rigs: []config.Rig{{
+			Name:   "frontend",
+			Path:   "rigs/frontend",
+			Prefix: "fe",
+		}},
+	}
+
+	t.Run("file", func(t *testing.T) {
+		t.Setenv("GC_BEADS", "file")
+		store, err := openControlStoreAtForCity(rigDir, cityDir, cfg)
+		if err != nil {
+			t.Fatalf("openControlStoreAtForCity(file): %v", err)
+		}
+		if _, ok := store.(*beads.FileStore); !ok {
+			t.Fatalf("control store = %T, want *beads.FileStore for file provider", store)
+		}
+	})
+
+	t.Run("exec", func(t *testing.T) {
+		captureDir := t.TempDir()
+		script := writeExecCaptureScript(t, captureDir)
+		provider := "exec:" + script
+		t.Setenv("GC_BEADS", provider)
+
+		store, err := openControlStoreAtForCity(rigDir, cityDir, cfg)
+		if err != nil {
+			t.Fatalf("openControlStoreAtForCity(exec): %v", err)
+		}
+		if _, err := store.Create(beads.Bead{Title: "rig"}); err != nil {
+			t.Fatalf("exec control Create: %v", err)
+		}
+		env := readExecCaptureEnv(t, filepath.Join(captureDir, "frontend.env"))
+		if got := env["GC_PROVIDER"]; got != provider {
+			t.Fatalf("exec GC_PROVIDER = %q, want %q", got, provider)
+		}
+		if got := env["GC_STORE_SCOPE"]; got != "rig" {
+			t.Fatalf("exec GC_STORE_SCOPE = %q, want rig", got)
+		}
+	})
 }
 
 func TestRunWorkflowServeUsesGCTemplateForSessionContext(t *testing.T) {

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1478,9 +1478,9 @@ func TestWorkflowServeControlReadyQueryUsesControlTiers(t *testing.T) {
 		t.Fatalf("workflowServeControlReadyQuery should not return in-progress control beads: %q", query)
 	}
 	for _, want := range []string{
-		`bd ready --assignee="$cand"`,
-		`bd ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned`,
-		`bd ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned`,
+		`bd --readonly ready --assignee="$cand"`,
+		`bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned`,
+		`bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned`,
 	} {
 		if !strings.Contains(query, want) {
 			t.Fatalf("workflowServeControlReadyQuery missing %q in %q", want, query)
@@ -1503,10 +1503,10 @@ case "$*" in
   "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-in-progress"}]'
     ;;
-  "ready --assignee=gascity--control-dispatcher --json --limit=20")
+  "--readonly ready --assignee=gascity--control-dispatcher --json --limit=20")
     printf '[{"id":"ga-ready"}]'
     ;;
-  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=20")
+  "--readonly ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=20")
     printf '[{"id":"ga-routed"}]'
     ;;
   *)
@@ -1596,8 +1596,8 @@ func TestWorkflowServeControlReadyQueryQuotesMetadataFallbackTarget(t *testing.T
 	query := workflowServeControlReadyQuery(config.Agent{Name: config.ControlDispatcherAgentName, Dir: "my rig"})
 	out := runWorkflowServeShellQueryForTest(t, query, map[string]string{}, `#!/bin/sh
 set -eu
-case "$1|$2|$3|$4|$5|$6" in
-  "ready|--metadata-field|gc.routed_to=my rig/control-dispatcher|--unassigned|--json|--limit=20")
+case "$1|$2|$3|$4|$5|$6|$7" in
+  "--readonly|ready|--metadata-field|gc.routed_to=my rig/control-dispatcher|--unassigned|--json|--limit=20")
     printf '[{"id":"ga-routed"}]'
     ;;
   *)
@@ -1619,7 +1619,7 @@ func TestWorkflowServeControlReadyQueryUsesLegacyRouteForNamedSessions(t *testin
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=20")
+  "--readonly ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=20")
     printf '[{"id":"ga-legacy-route"}]'
     ;;
   *)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1917,6 +1917,7 @@ func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.
 
 	t.Run("file", func(t *testing.T) {
 		t.Setenv("GC_BEADS", "file")
+		t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 		store, err := openControlStoreAtForCity(rigDir, cityDir, cfg)
 		if err != nil {
 			t.Fatalf("openControlStoreAtForCity(file): %v", err)
@@ -1931,6 +1932,7 @@ func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.
 		script := writeExecCaptureScript(t, captureDir)
 		provider := "exec:" + script
 		t.Setenv("GC_BEADS", provider)
+		t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 		store, err := openControlStoreAtForCity(rigDir, cityDir, cfg)
 		if err != nil {
@@ -1947,6 +1949,69 @@ func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.
 			t.Fatalf("exec GC_STORE_SCOPE = %q, want rig", got)
 		}
 	})
+}
+
+func TestOpenControlStoreAtForCityUsesControlRunnerForStaleBdScope(t *testing.T) {
+	clearGCEnv(t)
+	cityDir := t.TempDir()
+	staleRigDir := filepath.Join(cityDir, "rigs", "removed")
+	if err := os.MkdirAll(filepath.Join(staleRigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleRigDir, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"removed"}`), 0o644); err != nil {
+		t.Fatalf("write stale rig metadata: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Rigs:      []config.Rig{{Name: "active", Path: "rigs/active"}},
+	}
+	t.Setenv("GC_BEADS", "bd")
+
+	var calls [][]string
+	var envs []map[string]string
+	prevRunner := beadsExecCommandRunnerWithEnv
+	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+		envs = append(envs, maps.Clone(env))
+		return func(_ string, name string, args ...string) ([]byte, error) {
+			if name != "bd" {
+				return nil, fmt.Errorf("unexpected command %q", name)
+			}
+			calls = append(calls, append([]string(nil), args...))
+			return []byte(`[]`), nil
+		}
+	}
+	t.Cleanup(func() { beadsExecCommandRunnerWithEnv = prevRunner })
+
+	status := "closed"
+	store, err := openControlStoreAtForCity(staleRigDir, cityDir, cfg)
+	if err != nil {
+		t.Fatalf("openControlStoreAtForCity(stale rig): %v", err)
+	}
+	if err := store.Update("ga-stale-control", beads.UpdateOpts{Status: &status}); err != nil {
+		t.Fatalf("stale rig control update: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("bd calls = %#v, want one update call", calls)
+	}
+	if len(envs) != 1 {
+		t.Fatalf("bd envs = %#v, want one command environment", envs)
+	}
+	if call := calls[0]; len(call) < 1 || call[0] != "update" {
+		t.Fatalf("bd call = %#v, want update ...", calls[0])
+	}
+	if slices.Contains(calls[0], "--sandbox") {
+		t.Fatalf("bd call = %#v, write-capable control stores must not use --sandbox", calls[0])
+	}
+	if got := envs[0]["BD_EXPORT_AUTO"]; got != "false" {
+		t.Fatalf("BD_EXPORT_AUTO = %q, want false", got)
+	}
+	if got := envs[0]["BEADS_DIR"]; got != filepath.Join(staleRigDir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want stale rig store", got)
+	}
+	if got := envs[0]["GC_RIG_ROOT"]; got != staleRigDir {
+		t.Fatalf("GC_RIG_ROOT = %q, want stale rig root", got)
+	}
 }
 
 func TestRunWorkflowServeUsesGCTemplateForSessionContext(t *testing.T) {

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -445,7 +445,7 @@ func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames .
 		target = config.ControlDispatcherAgentName
 	}
 	limit := fmt.Sprintf("%d", workflowServeScanLimit)
-	queryPrefix := `GC_CONTROL_TARGET=` + shellquote.Quote(target)
+	queryPrefix := `BD_EXPORT_AUTO=false GC_CONTROL_TARGET=` + shellquote.Quote(target)
 	for _, name := range controlSessionNames {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -463,14 +463,14 @@ func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames .
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd --readonly ready --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
+		`r=$(bd --readonly --sandbox ready --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
-		`r=$(bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null); ` +
+		`r=$(bd --readonly --sandbox ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `
 	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
-		query += `bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null'`
+		query += `bd --readonly --sandbox ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null'`
 	} else {
 		query += `printf "[]"` + `'`
 	}

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -463,14 +463,14 @@ func workflowServeControlReadyQuery(agentCfg config.Agent, controlSessionNames .
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd ready --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
+		`r=$(bd --readonly ready --assignee="$cand" --json --limit=` + limit + ` 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
-		`r=$(bd ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null); ` +
+		`r=$(bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; `
 	if legacy := workflowServeLegacyControlRoute(target); legacy != "" {
-		query += `bd ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null'`
+		query += `bd --readonly ready --metadata-field "gc.routed_to=$GC_CONTROL_LEGACY_TARGET" --unassigned --json --limit=` + limit + ` 2>/dev/null'`
 	} else {
 		query += `printf "[]"` + `'`
 	}


### PR DESCRIPTION
## Summary
- make control-dispatcher work discovery use bd --readonly ready so dirty worktrees cannot trigger auto-export during read-only polling
- update control serve query tests to lock in the read-only command shape

## Verification
- go test ./cmd/gc -run 'TestWorkflowServeControlReadyQuery' -count=1
- go test ./cmd/gc -run 'TestWorkflowServeControlReadyQuery|TestRunWorkflowServeProcessesReadyControlBeadsThenExits' -count=1
- pre-commit hook: golangci-lint, go vet, observable go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->