### PR TITLE
test(bd): regression guard against slow bd config set in op_init (ga-5mym.1)

### DIFF
--- a/cmd/gc/gc_beads_bd_lint_test.go
+++ b/cmd/gc/gc_beads_bd_lint_test.go
@@ -26,7 +26,7 @@ func TestGcBeadsBdNoBdConfigSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open script: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() //nolint:errcheck // test cleanup
 
 	// Match `bd <args> config set` and `run_bd_<wrapper> <args> config set`.
 	// The script invokes bd both directly and through helpers like

--- a/cmd/gc/gc_beads_bd_lint_test.go
+++ b/cmd/gc/gc_beads_bd_lint_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestGcBeadsBdNoBdConfigSet enforces the perf-fix from ga-5mym: the
+// gc-beads-bd init script must never invoke `bd config set` (directly or
+// through the run_bd_* wrappers). bd >= 1.0.3 makes that call cost 18-50s
+// per invocation due to auto-migrate; combined cost overruns the 30s
+// providerOpTimeout and the supervisor wedges in starting_bead_store.
+//
+// The replacement path is ensure_bd_runtime_config_value (direct SQL into
+// the bd config table). Any future regression must use that helper, not
+// the slow bd CLI subcommand.
+func TestGcBeadsBdNoBdConfigSet(t *testing.T) {
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	f, err := os.Open(scriptPath)
+	if err != nil {
+		t.Fatalf("open script: %v", err)
+	}
+	defer f.Close()
+
+	// Match `bd <args> config set` and `run_bd_<wrapper> <args> config set`.
+	// The script invokes bd both directly and through helpers like
+	// run_bd_pinned, which always end up calling `bd config set` — both
+	// shapes hit the slow auto-migrate path.
+	pattern := regexp.MustCompile(`bd[a-zA-Z_]*[[:space:]]+.*config[[:space:]]+set`)
+	commentLine := regexp.MustCompile(`^[[:space:]]*#`)
+
+	var offenders []string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		if commentLine.MatchString(line) {
+			continue
+		}
+		if pattern.MatchString(line) {
+			offenders = append(offenders, formatOffender(scriptPath, lineNum, line))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan script: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("ERROR: bd config set re-introduced in gc-beads-bd.sh.\n"+
+			"See ga-5mym; use ensure_bd_runtime_config_value (direct SQL) instead.\n"+
+			"Offending lines:\n  %s", strings.Join(offenders, "\n  "))
+	}
+}
+
+func formatOffender(path string, line int, content string) string {
+	return path + ":" + strconv.Itoa(line) + ": " + strings.TrimSpace(content)
+}
+
+func repoRootForLint(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("abs cwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `TestGcBeadsBdNoBdConfigSet` (lint test) — scans `examples/bd/assets/scripts/gc-beads-bd.sh` and fails if any non-comment line invokes `bd config set` (directly or through `run_bd_*` wrappers).
- Why: `bd >= 1.0.3` makes that subcommand cost 18-50s per call due to auto-migrate. Two such calls in `op_init` combined to overrun the 30s `providerOpTimeout` and wedge the supervisor in `starting_bead_store`. PR #1264 already removed those calls and replaced them with `ensure_bd_runtime_config_value` (direct SQL into the bd config table); this test guards against re-introducing the slow CLI subcommand on a future edit.

## Context
Carrying forward only the regression-test portion of the originally-larger #1584. The fix portion of #1584 was made redundant by #1264 and #1584 was closed as superseded; this PR is the unique value-add — a tiny standalone lint guard. Per mayor's nudge on 2026-05-02.

## Test plan
- [x] `go test ./cmd/gc/ -run TestGcBeadsBdNoBdConfigSet -count=1` passes on current main.
- [ ] CI green.

## Refs
- ga-5mym.1 (the original bug bead, closed via #1264).
- ga-3kyh (asked to fix #1584 CI; the meaningful piece is here, the rest of #1584 is moot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->