### PR TITLE
fix(rig): fall back to cwd-walked city site binding for unregistered rigs (ga-9fb5)

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -629,7 +629,7 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 
 	// Fallback: a city declared locally but not yet handed to the
 	// supervisor (cities.toml does not list it) is invisible to the
-	// registry walks above. Honour --rig/$GC_RIG by checking the
+	// registry walks above. Honor --rig/$GC_RIG by checking the
 	// cwd-walked city for a site-bound rig of this name. Site binding
 	// is required: legacy city.toml-only paths remain rejected so the
 	// existing legacy_city_toml_path_is_not_registered_binding test

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -605,7 +605,7 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	var allStale []staleRegisteredCity
 	defer func() { emitStaleRegisteredCityWarnings(os.Stderr, allStale) }()
 
-	matches, stale, err := registeredRigBindingsByName(nameOrPath, true)
+	matches, stale, err := registeredRigBindingsByName(nameOrPath, false)
 	allStale = append(allStale, stale...)
 	if err != nil {
 		return resolvedContext{}, err
@@ -618,7 +618,7 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	if err != nil {
 		return resolvedContext{}, fmt.Errorf("rig %q: %w", nameOrPath, err)
 	}
-	matches, stale, err = registeredRigBindingsByPath(abs, true)
+	matches, stale, err = registeredRigBindingsByPath(abs, false)
 	allStale = append(allStale, stale...)
 	if err != nil {
 		return resolvedContext{}, err
@@ -633,7 +633,9 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	// the resolved city for a site-bound rig of this name. Site binding is
 	// required: legacy city.toml-only paths remain rejected so the existing
 	// legacy_city_toml_path_is_not_registered_binding test continues to pass.
-	if ctx, ok := lookupRigFromLocalCity(nameOrPath); ok {
+	if ctx, ok, err := lookupRigFromLocalCity(nameOrPath); err != nil {
+		return resolvedContext{}, err
+	} else if ok {
 		return ctx, nil
 	}
 	return resolvedContext{}, fmt.Errorf("rig %q is not registered in any city", nameOrPath)
@@ -646,48 +648,123 @@ func resolveLocalCityForRigFallback() (string, error) {
 	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
 		return gcCity, nil
 	}
-	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
-		return gcDirCity, nil
+	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" {
+		gcDirCity, err := findCity(gcDir)
+		if err != nil {
+			if !isCityDiscoveryNotFound(err) {
+				return "", err
+			}
+		} else {
+			return gcDirCity, nil
+		}
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
-	return findCity(cwd)
+	cityPath, err := findCity(cwd)
+	if err != nil {
+		if isCityDiscoveryNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return cityPath, nil
+}
+
+func isCityDiscoveryNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not in a city directory")
 }
 
 // lookupRigFromLocalCity resolves the local city without consulting --rig or
-// GC_RIG, then loads the city's .gc/site.toml binding and looks for a rig
-// whose name (or bound path) matches nameOrPath. Returns the resolved context
-// only when a site binding produced a non-empty rig.Path — legacy
-// city.toml-only paths are still rejected so this fallback preserves the
-// invariant pinned by legacy_city_toml_path_is_not_registered_binding.
-func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool) {
+// GC_RIG, then builds declared rig candidates from city.toml plus
+// .gc/site.toml, matching the registered resolver's binding semantics.
+// Legacy city.toml-only paths are still rejected so this fallback preserves
+// the invariant pinned by legacy_city_toml_path_is_not_registered_binding.
+func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool, error) {
 	cityPath, err := resolveLocalCityForRigFallback()
 	if err != nil {
-		return resolvedContext{}, false
+		return resolvedContext{}, false, err
+	}
+	if cityPath == "" {
+		return resolvedContext{}, false, nil
+	}
+	bindings, err := localCityRigBindings(cityPath)
+	if err != nil {
+		return resolvedContext{}, false, err
+	}
+
+	var nameMatches []registeredRigBinding
+	for _, binding := range bindings {
+		if binding.Rig.Name == nameOrPath {
+			nameMatches = append(nameMatches, binding)
+		}
+	}
+	if len(nameMatches) > 0 {
+		ctx, err := resolveRigBindingMatches(nameOrPath, nameMatches)
+		return ctx, true, err
+	}
+
+	requestPath := normalizePathForCompare(nameOrPath)
+	var pathMatches []registeredRigBinding
+	for _, binding := range bindings {
+		if pathWithinScope(requestPath, normalizePathForCompare(binding.Path)) {
+			pathMatches = append(pathMatches, binding)
+		}
+	}
+	pathMatches = keepDeepestRigBindings(pathMatches)
+	if len(pathMatches) > 0 {
+		ctx, err := resolveRigBindingMatches(requestPath, pathMatches)
+		return ctx, true, err
+	}
+
+	return resolvedContext{}, false, nil
+}
+
+func localCityRigBindings(cityPath string) ([]registeredRigBinding, error) {
+	cfg, err := loadCityConfigSuppressDeprecatedOrderWarnings(cityPath, io.Discard)
+	if err != nil {
+		if _, ok := missingRootCityTOML(err, cityPath); ok {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading local city rig bindings: %s: %w", cityPath, err)
 	}
 	siteBinding, err := config.LoadSiteBinding(fsys.OSFS{}, cityPath)
-	if err != nil || siteBinding == nil {
-		return resolvedContext{}, false
+	if err != nil {
+		return nil, fmt.Errorf("loading local city rig bindings: %s: %w", cityPath, err)
 	}
+	city := supervisor.CityEntry{Path: cityPath, Name: cfg.ResolvedWorkspaceName}
+	return siteBoundRigBindings(city, cfg, siteBinding), nil
+}
+
+func siteBoundRigBindings(city supervisor.CityEntry, cfg *config.City, siteBinding *config.SiteBinding) []registeredRigBinding {
+	siteRigPaths := make(map[string]string, len(siteBinding.Rigs))
 	for _, rig := range siteBinding.Rigs {
 		name := strings.TrimSpace(rig.Name)
 		path := strings.TrimSpace(rig.Path)
 		if name == "" || path == "" {
 			continue
 		}
-		if name == nameOrPath {
-			return resolvedContext{CityPath: cityPath, RigName: name}, true
-		}
-		// Path-form: also accept when nameOrPath is a directory equal
-		// to (or under) the bound rig path. Mirror the comparison used
-		// by registeredRigBindingsByPath so cwd-walk parity holds.
-		if pathWithinScope(normalizePathForCompare(nameOrPath), normalizePathForCompare(path)) {
-			return resolvedContext{CityPath: cityPath, RigName: name}, true
-		}
+		siteRigPaths[name] = path
 	}
-	return resolvedContext{}, false
+
+	var bindings []registeredRigBinding
+	for _, rig := range cfg.Rigs {
+		if strings.TrimSpace(rig.Name) == "" {
+			continue
+		}
+		sitePath := strings.TrimSpace(siteRigPaths[rig.Name])
+		if sitePath == "" {
+			continue
+		}
+		rig.Path = sitePath
+		bindings = append(bindings, registeredRigBinding{
+			City: city,
+			Rig:  rig,
+			Path: resolveStoreScopeRoot(city.Path, sitePath),
+		})
+	}
+	return bindings
 }
 
 // resolveRigPathToContext resolves an explicit path argument to a registered
@@ -821,29 +898,7 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 			loadErrors = append(loadErrors, fmt.Sprintf("%s: %v", registeredCityLabel(c), err))
 			continue
 		}
-		siteRigPaths := make(map[string]string, len(siteBinding.Rigs))
-		for _, siteRig := range siteBinding.Rigs {
-			name := strings.TrimSpace(siteRig.Name)
-			path := strings.TrimSpace(siteRig.Path)
-			if name == "" || path == "" {
-				continue
-			}
-			siteRigPaths[name] = path
-		}
-		for _, rig := range cfg.Rigs {
-			if strings.TrimSpace(rig.Name) == "" {
-				continue
-			}
-			sitePath := strings.TrimSpace(siteRigPaths[rig.Name])
-			if sitePath == "" {
-				continue
-			}
-			rig.Path = sitePath
-			binding := registeredRigBinding{
-				City: c,
-				Rig:  rig,
-				Path: resolveStoreScopeRoot(c.Path, sitePath),
-			}
+		for _, binding := range siteBoundRigBindings(c, cfg, siteBinding) {
 			if match(binding) {
 				matched = append(matched, binding)
 			}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -627,7 +627,56 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 		return resolveRigBindingMatches(abs, matches)
 	}
 
+	// Fallback: a city declared locally but not yet handed to the
+	// supervisor (cities.toml does not list it) is invisible to the
+	// registry walks above. Honour --rig/$GC_RIG by checking the
+	// cwd-walked city for a site-bound rig of this name. Site binding
+	// is required: legacy city.toml-only paths remain rejected so the
+	// existing legacy_city_toml_path_is_not_registered_binding test
+	// continues to pass.
+	if ctx, ok := lookupRigFromLocalCity(nameOrPath); ok {
+		return ctx, nil
+	}
 	return resolvedContext{}, fmt.Errorf("rig %q is not registered in any city", nameOrPath)
+}
+
+// lookupRigFromLocalCity walks up from cwd to find a city.toml. If
+// found, it loads the city's .gc/site.toml binding and looks for a rig
+// whose name (or bound path) matches nameOrPath. Returns the resolved
+// context only when a site binding produced a non-empty rig.Path —
+// legacy city.toml-only paths are still rejected so this fallback
+// preserves the invariant pinned by
+// legacy_city_toml_path_is_not_registered_binding.
+func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return resolvedContext{}, false
+	}
+	cityPath, err := findCity(cwd)
+	if err != nil {
+		return resolvedContext{}, false
+	}
+	siteBinding, err := config.LoadSiteBinding(fsys.OSFS{}, cityPath)
+	if err != nil || siteBinding == nil {
+		return resolvedContext{}, false
+	}
+	for _, rig := range siteBinding.Rigs {
+		name := strings.TrimSpace(rig.Name)
+		path := strings.TrimSpace(rig.Path)
+		if name == "" || path == "" {
+			continue
+		}
+		if name == nameOrPath {
+			return resolvedContext{CityPath: cityPath, RigName: name}, true
+		}
+		// Path-form: also accept when nameOrPath is a directory equal
+		// to (or under) the bound rig path. Mirror the comparison used
+		// by registeredRigBindingsByPath so cwd-walk parity holds.
+		if pathWithinScope(normalizePathForCompare(nameOrPath), normalizePathForCompare(path)) {
+			return resolvedContext{CityPath: cityPath, RigName: name}, true
+		}
+	}
+	return resolvedContext{}, false
 }
 
 // resolveRigPathToContext resolves an explicit path argument to a registered

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -629,30 +629,41 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 
 	// Fallback: a city declared locally but not yet handed to the
 	// supervisor (cities.toml does not list it) is invisible to the
-	// registry walks above. Honor --rig/$GC_RIG by checking the
-	// cwd-walked city for a site-bound rig of this name. Site binding
-	// is required: legacy city.toml-only paths remain rejected so the
-	// existing legacy_city_toml_path_is_not_registered_binding test
-	// continues to pass.
+	// registry walks above. Honor explicit local city resolution by checking
+	// the resolved city for a site-bound rig of this name. Site binding is
+	// required: legacy city.toml-only paths remain rejected so the existing
+	// legacy_city_toml_path_is_not_registered_binding test continues to pass.
 	if ctx, ok := lookupRigFromLocalCity(nameOrPath); ok {
 		return ctx, nil
 	}
 	return resolvedContext{}, fmt.Errorf("rig %q is not registered in any city", nameOrPath)
 }
 
-// lookupRigFromLocalCity walks up from cwd to find a city.toml. If
-// found, it loads the city's .gc/site.toml binding and looks for a rig
-// whose name (or bound path) matches nameOrPath. Returns the resolved
-// context only when a site binding produced a non-empty rig.Path —
-// legacy city.toml-only paths are still rejected so this fallback
-// preserves the invariant pinned by
-// legacy_city_toml_path_is_not_registered_binding.
-func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool) {
+func resolveLocalCityForRigFallback() (string, error) {
+	if cityFlag != "" {
+		return validateCityPath(cityFlag)
+	}
+	if gcCity, ok := resolveExplicitCityPathEnv(); ok {
+		return gcCity, nil
+	}
+	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
+		return gcDirCity, nil
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return resolvedContext{}, false
+		return "", err
 	}
-	cityPath, err := findCity(cwd)
+	return findCity(cwd)
+}
+
+// lookupRigFromLocalCity resolves the local city without consulting --rig or
+// GC_RIG, then loads the city's .gc/site.toml binding and looks for a rig
+// whose name (or bound path) matches nameOrPath. Returns the resolved context
+// only when a site binding produced a non-empty rig.Path — legacy
+// city.toml-only paths are still rejected so this fallback preserves the
+// invariant pinned by legacy_city_toml_path_is_not_registered_binding.
+func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool) {
+	cityPath, err := resolveLocalCityForRigFallback()
 	if err != nil {
 		return resolvedContext{}, false
 	}

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -605,7 +605,8 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	var allStale []staleRegisteredCity
 	defer func() { emitStaleRegisteredCityWarnings(os.Stderr, allStale) }()
 
-	matches, stale, err := registeredRigBindingsByName(nameOrPath, false)
+	var deferredRegisteredLoadErr error
+	matches, stale, err, loadErr := registeredRigBindingsByNameWithDeferredLoadError(nameOrPath, false)
 	allStale = append(allStale, stale...)
 	if err != nil {
 		return resolvedContext{}, err
@@ -613,18 +614,22 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 	if len(matches) > 0 {
 		return resolveRigBindingMatches(nameOrPath, matches)
 	}
+	deferredRegisteredLoadErr = loadErr
 
 	abs, err := filepath.Abs(nameOrPath)
 	if err != nil {
 		return resolvedContext{}, fmt.Errorf("rig %q: %w", nameOrPath, err)
 	}
-	matches, stale, err = registeredRigBindingsByPath(abs, false)
+	matches, stale, err, loadErr = registeredRigBindingsByPathWithDeferredLoadError(abs, false)
 	allStale = append(allStale, stale...)
 	if err != nil {
 		return resolvedContext{}, err
 	}
 	if len(matches) > 0 {
 		return resolveRigBindingMatches(abs, matches)
+	}
+	if deferredRegisteredLoadErr == nil {
+		deferredRegisteredLoadErr = loadErr
 	}
 
 	// Fallback: a city declared locally but not yet handed to the
@@ -637,6 +642,9 @@ func resolveRigToContext(nameOrPath string) (resolvedContext, error) {
 		return resolvedContext{}, err
 	} else if ok {
 		return ctx, nil
+	}
+	if deferredRegisteredLoadErr != nil {
+		return resolvedContext{}, deferredRegisteredLoadErr
 	}
 	return resolvedContext{}, fmt.Errorf("rig %q is not registered in any city", nameOrPath)
 }
@@ -827,21 +835,31 @@ type registeredRigBinding struct {
 }
 
 func registeredRigBindingsByName(name string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
+	matches, stale, err, _ = registeredRigBindingsByNameWithDeferredLoadError(name, failOnLoadError)
+	return matches, stale, err
+}
+
+func registeredRigBindingsByNameWithDeferredLoadError(name string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
 	return registeredRigBindings(failOnLoadError, func(binding registeredRigBinding) bool {
 		return binding.Rig.Name == name
 	})
 }
 
 func registeredRigBindingsByPath(dir string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error) {
+	matches, stale, err, _ = registeredRigBindingsByPathWithDeferredLoadError(dir, failOnLoadError)
+	return matches, stale, err
+}
+
+func registeredRigBindingsByPathWithDeferredLoadError(dir string, failOnLoadError bool) (matches []registeredRigBinding, stale []staleRegisteredCity, err error, deferredLoadErr error) {
 	dir = normalizePathForCompare(dir)
-	matches, stale, err = registeredRigBindings(failOnLoadError, func(binding registeredRigBinding) bool {
+	matches, stale, err, deferredLoadErr = registeredRigBindings(failOnLoadError, func(binding registeredRigBinding) bool {
 		rigPath := normalizePathForCompare(binding.Path)
 		return pathWithinScope(dir, rigPath)
 	})
 	if err != nil {
-		return nil, stale, err
+		return nil, stale, err, nil
 	}
-	return keepDeepestRigBindings(matches), stale, nil
+	return keepDeepestRigBindings(matches), stale, nil, deferredLoadErr
 }
 
 // staleRegisteredCity identifies a registered city whose city.toml is
@@ -872,11 +890,11 @@ func emitStaleRegisteredCityWarnings(w io.Writer, stale []staleRegisteredCity) {
 	}
 }
 
-func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding) bool) (_ []registeredRigBinding, stale []staleRegisteredCity, _ error) {
+func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding) bool) (_ []registeredRigBinding, stale []staleRegisteredCity, _ error, deferredLoadErr error) {
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
 	cities, err := reg.List()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, err, nil
 	}
 	var matched []registeredRigBinding
 	var loadErrors []string
@@ -905,9 +923,12 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 		}
 	}
 	if len(loadErrors) > 0 && (failOnLoadError || len(matched) > 0) {
-		return nil, stale, fmt.Errorf("loading registered city rig bindings: %s", strings.Join(loadErrors, "; "))
+		return nil, stale, fmt.Errorf("loading registered city rig bindings: %s", strings.Join(loadErrors, "; ")), nil
 	}
-	return matched, stale, nil
+	if len(loadErrors) > 0 {
+		return matched, stale, nil, fmt.Errorf("loading registered city rig bindings: %s", strings.Join(loadErrors, "; "))
+	}
+	return matched, stale, nil, nil
 }
 
 func missingRootCityTOML(err error, cityPath string) (string, bool) {

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1291,6 +1291,7 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 	// registry, so `gc mcp list --rig X` reported the rig as unregistered
 	// even though it was perfectly visible to the user.
 	t.Run("local_unregistered_city_with_site_binding_resolves", func(t *testing.T) {
+		resetFlags(t)
 		gcHome := t.TempDir()
 		t.Setenv("GC_HOME", gcHome)
 
@@ -1316,6 +1317,210 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 		if ctx.RigName != "local-rig" {
 			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-rig")
+		}
+	})
+
+	t.Run("local_unregistered_city_ignores_unrelated_registered_load_error_by_name", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", "")
+		t.Setenv("GC_CITY_ROOT", "")
+		t.Setenv("GC_DIR", "")
+
+		badCity := setupCity(t, "broken-registered-city")
+		if err := os.WriteFile(config.SiteBindingPath(badCity), []byte("[[rig]\nname = \"broken\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		registerCityForRigResolution(t, gcHome, badCity, "broken-registered-city")
+
+		cityPath := setupCity(t, "local-load-error-city")
+		rigDir := filepath.Join(t.TempDir(), "local-load-error-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-load-error-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-load-error-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, cityPath)
+
+		ctx, err := resolveRigToContext("local-load-error-rig")
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-load-error-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-load-error-rig")
+		}
+	})
+
+	t.Run("local_unregistered_city_ignores_unrelated_registered_load_error_by_path", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", "")
+		t.Setenv("GC_CITY_ROOT", "")
+		t.Setenv("GC_DIR", "")
+
+		badCity := setupCity(t, "broken-registered-path-city")
+		if err := os.WriteFile(config.SiteBindingPath(badCity), []byte("[[rig]\nname = \"broken\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		registerCityForRigResolution(t, gcHome, badCity, "broken-registered-path-city")
+
+		cityPath := setupCity(t, "local-load-error-path-city")
+		rigDir := filepath.Join(t.TempDir(), "local-load-error-path-rig")
+		nestedDir := filepath.Join(rigDir, "nested")
+		if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-load-error-path-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-load-error-path-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, cityPath)
+
+		ctx, err := resolveRigToContext(nestedDir)
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-load-error-path-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-load-error-path-rig")
+		}
+	})
+
+	t.Run("local_unregistered_city_resolves_by_rig_path", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-path-city")
+		rigDir := filepath.Join(t.TempDir(), "local-path-rig")
+		nestedDir := filepath.Join(rigDir, "nested")
+		if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-path-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-path-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, t.TempDir())
+		cityFlag = cityPath
+
+		ctx, err := resolveRigToContext(nestedDir)
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-path-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-path-rig")
+		}
+	})
+
+	t.Run("local_unregistered_city_picks_deepest_rig_path", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-nested-city")
+		shallowDir := filepath.Join(t.TempDir(), "workspace")
+		deepDir := filepath.Join(shallowDir, "nested")
+		targetDir := filepath.Join(deepDir, "child")
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-nested-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"a-shallow\"\npath = %q\n\n[[rigs]]\nname = \"b-deep\"\npath = %q\n", shallowDir, deepDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, t.TempDir())
+		cityFlag = cityPath
+
+		ctx, err := resolveRigToContext(targetDir)
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "b-deep" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "b-deep")
+		}
+	})
+
+	t.Run("local_unregistered_city_resolves_relative_site_path", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-relative-city")
+		rigDir := filepath.Join(cityPath, "rigs", "relative-rig")
+		targetDir := filepath.Join(rigDir, "child")
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := "[workspace]\nname = \"local-relative-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"relative-rig\"\npath = \"rigs/relative-rig\"\n"
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, cityPath)
+		cityFlag = cityPath
+
+		ctx, err := resolveRigToContext(filepath.Join("rigs", "relative-rig", "child"))
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "relative-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "relative-rig")
+		}
+	})
+
+	t.Run("local_unregistered_city_rejects_stale_site_only_binding", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-stale-city")
+		staleDir := filepath.Join(t.TempDir(), "stale-rig")
+		if err := os.MkdirAll(staleDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := config.PersistRigSiteBindings(fsys.OSFS{}, cityPath, []config.Rig{{Name: "stale-rig", Path: staleDir}}); err != nil {
+			t.Fatalf("PersistRigSiteBindings: %v", err)
+		}
+		setCwd(t, t.TempDir())
+		cityFlag = cityPath
+
+		_, err := resolveRigToContext("stale-rig")
+		if err == nil {
+			t.Fatal("resolveRigToContext should reject site-only rig bindings not declared in city.toml")
+		}
+		if !strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("error = %q, want not registered", err)
+		}
+	})
+
+	t.Run("local_unregistered_city_malformed_site_binding_errors", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-malformed-city")
+		if err := os.WriteFile(config.SiteBindingPath(cityPath), []byte("[[rig]\nname = \"broken\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		setCwd(t, t.TempDir())
+		cityFlag = cityPath
+
+		_, err := resolveRigToContext("broken")
+		if err == nil {
+			t.Fatal("resolveRigToContext should surface malformed local site binding")
+		}
+		if !strings.Contains(err.Error(), "parsing site binding") {
+			t.Fatalf("error = %q, want parsing site binding", err)
 		}
 	})
 
@@ -1346,12 +1551,94 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 	})
 
-	// Companion to the previous test: the local-city fallback only fires
-	// when a real .gc/site.toml binding exists. A legacy city.toml with
+	t.Run("local_unregistered_city_preserves_explicit_city_error", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+		setCwd(t, t.TempDir())
+		cityFlag = filepath.Join(t.TempDir(), "not-a-city")
+
+		_, err := resolveRigToContext("missing-rig")
+		if err == nil {
+			t.Fatal("resolveRigToContext should surface explicit local city errors")
+		}
+		if !strings.Contains(err.Error(), "not a city directory") {
+			t.Fatalf("error = %q, want not a city directory", err)
+		}
+		if strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("error = %q, should preserve city error instead of falling back to not registered", err)
+		}
+	})
+
+	t.Run("local_unregistered_city_uses_GC_CITY_PATH_env", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-env-city")
+		rigDir := filepath.Join(t.TempDir(), "local-env-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-env-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-env-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, t.TempDir())
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", cityPath)
+		t.Setenv("GC_CITY_ROOT", "")
+		t.Setenv("GC_DIR", "")
+
+		ctx, err := resolveRigToContext("local-env-rig")
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-env-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-env-rig")
+		}
+	})
+
+	t.Run("local_unregistered_city_uses_GC_DIR_env", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-gc-dir-city")
+		rigDir := filepath.Join(cityPath, "rigs", "local-gc-dir-rig")
+		nestedDir := filepath.Join(rigDir, "nested")
+		if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-gc-dir-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-gc-dir-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, t.TempDir())
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", "")
+		t.Setenv("GC_CITY_ROOT", "")
+		t.Setenv("GC_DIR", nestedDir)
+
+		ctx, err := resolveRigToContext("local-gc-dir-rig")
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-gc-dir-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-gc-dir-rig")
+		}
+	})
+
+	// Companion to local_unregistered_city_uses_explicit_city_flag: the
+	// local-city fallback only fires when a real .gc/site.toml binding exists.
+	// A legacy city.toml with
 	// an inline `path = ...` (no site binding) must still be rejected so
 	// the legacy_city_toml_path_is_not_registered_binding invariant
 	// continues to apply at the cwd-walk level too.
 	t.Run("local_unregistered_city_legacy_path_still_rejected", func(t *testing.T) {
+		resetFlags(t)
 		gcHome := t.TempDir()
 		t.Setenv("GC_HOME", gcHome)
 

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1283,6 +1283,74 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 	})
 
+	// Regression for ga-gu3p / ga-9fb5: a city declared locally on disk
+	// (city.toml + .gc/site.toml) but not yet registered with the
+	// supervisor (cities.toml empty) must still resolve --rig from cwd.
+	// `gc rig list` already works in this state because it reads city.toml
+	// directly; resolveRigToContext used to only consult the supervisor
+	// registry, so `gc mcp list --rig X` reported the rig as unregistered
+	// even though it was perfectly visible to the user.
+	t.Run("local_unregistered_city_with_site_binding_resolves", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-city")
+		rigDir := filepath.Join(t.TempDir(), "local-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// writeRigAnywhereCityToml writes both city.toml AND .gc/site.toml
+		// (via PersistRigSiteBindings) — exactly the on-disk state that
+		// the user hits before `gc start` registers the city. Deliberately
+		// skip registerCityForRigResolution so cities.toml stays empty.
+		toml := fmt.Sprintf("[workspace]\nname = \"local-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, cityPath)
+
+		ctx, err := resolveRigToContext("local-rig")
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-rig")
+		}
+	})
+
+	// Companion to the previous test: the local-city fallback only fires
+	// when a real .gc/site.toml binding exists. A legacy city.toml with
+	// an inline `path = ...` (no site binding) must still be rejected so
+	// the legacy_city_toml_path_is_not_registered_binding invariant
+	// continues to apply at the cwd-walk level too.
+	t.Run("local_unregistered_city_legacy_path_still_rejected", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-legacy")
+		rigDir := filepath.Join(t.TempDir(), "local-legacy-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		legacy := fmt.Sprintf("[workspace]\nname = \"local-legacy\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-legacy-rig\"\npath = %q\n", rigDir)
+		if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(legacy), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(config.SiteBindingPath(cityPath)); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		setCwd(t, cityPath)
+
+		_, err := resolveRigToContext("local-legacy-rig")
+		if err == nil {
+			t.Fatal("resolveRigToContext should reject a legacy city.toml even via the local-city fallback")
+		}
+		if !strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("error = %q, want not registered", err)
+		}
+	})
+
 	t.Run("path_argument_fails_closed_on_binding_load_error", func(t *testing.T) {
 		gcHome := t.TempDir()
 		t.Setenv("GC_HOME", gcHome)

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1393,6 +1393,45 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 	})
 
+	t.Run("local_unregistered_city_miss_preserves_registered_load_error", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+		t.Setenv("GC_CITY", "")
+		t.Setenv("GC_CITY_PATH", "")
+		t.Setenv("GC_CITY_ROOT", "")
+		t.Setenv("GC_DIR", "")
+
+		badCity := setupCity(t, "broken-registered-miss-city")
+		if err := os.WriteFile(config.SiteBindingPath(badCity), []byte("[[rig]\nname = \"broken\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		registerCityForRigResolution(t, gcHome, badCity, "broken-registered-miss-city")
+
+		cityPath := setupCity(t, "local-miss-city")
+		rigDir := filepath.Join(t.TempDir(), "local-other-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-miss-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-other-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, cityPath)
+
+		_, err := resolveRigToContext("missing-rig")
+		if err == nil {
+			t.Fatal("resolveRigToContext should preserve registered load errors when local fallback misses")
+		}
+		if !strings.Contains(err.Error(), "loading registered city rig bindings") {
+			t.Fatalf("error = %q, want registered city binding load error", err)
+		}
+		if !strings.Contains(err.Error(), "broken-registered-miss-city") {
+			t.Fatalf("error = %q, want bad city name", err)
+		}
+		if strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("error = %q, should preserve registered load error instead of not registered", err)
+		}
+	})
+
 	t.Run("local_unregistered_city_resolves_by_rig_path", func(t *testing.T) {
 		resetFlags(t)
 		gcHome := t.TempDir()

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1319,6 +1319,33 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		}
 	})
 
+	t.Run("local_unregistered_city_uses_explicit_city_flag", func(t *testing.T) {
+		resetFlags(t)
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		cityPath := setupCity(t, "local-flag-city")
+		rigDir := filepath.Join(t.TempDir(), "local-flag-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		toml := fmt.Sprintf("[workspace]\nname = \"local-flag-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"local-flag-rig\"\npath = %q\n", rigDir)
+		writeRigAnywhereCityToml(t, cityPath, toml)
+		setCwd(t, t.TempDir())
+		cityFlag = cityPath
+
+		ctx, err := resolveRigToContext("local-flag-rig")
+		if err != nil {
+			t.Fatalf("resolveRigToContext: %v", err)
+		}
+		if ctx.CityPath != cityPath {
+			t.Errorf("CityPath = %q, want %q", ctx.CityPath, cityPath)
+		}
+		if ctx.RigName != "local-flag-rig" {
+			t.Errorf("RigName = %q, want %q", ctx.RigName, "local-flag-rig")
+		}
+	})
+
 	// Companion to the previous test: the local-city fallback only fires
 	// when a real .gc/site.toml binding exists. A legacy city.toml with
 	// an inline `path = ...` (no site binding) must still be rejected so


### PR DESCRIPTION
## Summary
- `gc mcp list --rig X` reported \"rig not registered in any city\" while `gc rig list` (run from the same cwd) showed the rig fine. Reason: the two surfaces consulted different sources of truth.
- `resolveRigToContext` only walked the supervisor registry (cities.toml). A city declared on disk (city.toml + .gc/site.toml) but not yet handed to the supervisor was invisible.
- New helper `lookupRigFromLocalCity` walks up from cwd to find a city.toml, loads .gc/site.toml, and accepts the rig (by name or by path) when the binding has a non-empty Path. Wired as a final fallback after both registry walks miss.
- Site binding is required: legacy `city.toml` with bare `path = ...` and no `.gc/site.toml` is still rejected. The existing `legacy_city_toml_path_is_not_registered_binding` invariant is preserved, plus a new `local_unregistered_city_legacy_path_still_rejected` sub-test pins it for the cwd-walk branch.

## Test plan
- [x] `go test ./cmd/gc/ -run TestRigAnywhere_ResolveRigToContext -count=1` — all 14 sub-tests pass (including the 2 new ones and the existing legacy invariant).
- [x] `go vet ./...` clean.
- [x] Pre-existing baseline failures in `TestRigAnywhere_ResolveContext/{registered_rig_cwd_ambiguous_falls_through, gc_city_env_only_rig_from_cwd}` (different test function, unrelated infra-resolve issue) verified to fail identically on `origin/main` with this diff stashed.
- [ ] CI green.

## Reproducer
- `/tmp/mcp-bug-repro/` (kept by gascity/investigator) — minimal city with city.toml + .gc/site.toml, GC_HOME isolated to an empty registry.

## Refs
- ga-gu3p (parent bug bead, closed by investigator).
- ga-9fb5 (this fix's bead).
- Out of scope per spec: changing `gc rig list` to consult the registry, auto-registering local cities, error-message changes in the multi-city ambiguity path, and adding a fallback for legacy `city.toml` `path = ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->