### PR TITLE
fix(events): match nested payload keys via dotted path (#1613)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -75,7 +75,7 @@ func controlBdCommandRunnerForCity(cityPath string) beads.CommandRunner {
 	return bdCommandRunnerWithManagedRetry(cityPath, func(dir string) map[string]string {
 		env := bdRuntimeEnv(cityPath)
 		env["BEADS_DIR"] = filepath.Join(dir, ".beads")
-		applyControlBdEnv(env)
+		applyControllerBdEnv(env)
 		return env
 	})
 }
@@ -83,13 +83,20 @@ func controlBdCommandRunnerForCity(cityPath string) beads.CommandRunner {
 func controlBdCommandRunnerForRig(cityPath string, cfg *config.City, rigDir string) beads.CommandRunner {
 	return bdCommandRunnerWithManagedRetry(cityPath, func(_ string) map[string]string {
 		env := bdRuntimeEnvForRig(cityPath, cfg, rigDir)
-		applyControlBdEnv(env)
+		applyControllerBdEnv(env)
 		return env
 	})
 }
 
 func applyControlBdEnv(env map[string]string) {
 	env["BD_EXPORT_AUTO"] = "false"
+}
+
+func applyControllerBdEnv(env map[string]string) {
+	applyControlBdEnv(env)
+	if strings.TrimSpace(os.Getenv("BEADS_ACTOR")) == "" {
+		env["BEADS_ACTOR"] = "controller"
+	}
 }
 
 func issuePrefixForScope(scopeRoot, cityPath string, cfg *config.City) string {
@@ -524,16 +531,6 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 	// dolt.auto-start:false config (beads resolveAutoStart priority bug) and
 	// starts rogue servers from the agent's cwd with the wrong data_dir.
 	env["BEADS_DOLT_AUTO_START"] = "0"
-	// Default actor for bd shell-outs that originate from the controller
-	// process or any gc subprocess lacking an explicit identity. Without
-	// this, bd falls through its own resolution chain (BEADS_ACTOR →
-	// BD_ACTOR → git config user.name → $USER) and audit-logs supervisor
-	// activity as the OS user. Conditional so session contexts that already
-	// set BEADS_ACTOR (template_resolve.go) and order subprocesses that
-	// inherit BEADS_ACTOR via orderExecEnv pass through unchanged.
-	if os.Getenv("BEADS_ACTOR") == "" {
-		env["BEADS_ACTOR"] = "controller"
-	}
 	if !cityUsesBdStoreContract(cityPath) {
 		return env
 	}

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -524,6 +524,16 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 	// dolt.auto-start:false config (beads resolveAutoStart priority bug) and
 	// starts rogue servers from the agent's cwd with the wrong data_dir.
 	env["BEADS_DOLT_AUTO_START"] = "0"
+	// Default actor for bd shell-outs that originate from the controller
+	// process or any gc subprocess lacking an explicit identity. Without
+	// this, bd falls through its own resolution chain (BEADS_ACTOR →
+	// BD_ACTOR → git config user.name → $USER) and audit-logs supervisor
+	// activity as the OS user. Conditional so session contexts that already
+	// set BEADS_ACTOR (template_resolve.go) and order subprocesses that
+	// inherit BEADS_ACTOR via orderExecEnv pass through unchanged.
+	if os.Getenv("BEADS_ACTOR") == "" {
+		env["BEADS_ACTOR"] = "controller"
+	}
 	if !cityUsesBdStoreContract(cityPath) {
 		return env
 	}

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2653,12 +2653,7 @@ dolt.port: 3307
 	}
 }
 
-// TestBdRuntimeEnvDefaultsBeadsActorToControllerWhenUnset verifies that the
-// supervisor (and any gc context lacking an explicit identity) gets a
-// non-OS-user actor for bd shell-outs. Without this default, bd's actor
-// resolution falls through to git config user.name and supervisor activity
-// is audit-logged as if the human typed it.
-func TestBdRuntimeEnvDefaultsBeadsActorToControllerWhenUnset(t *testing.T) {
+func TestBdRuntimeEnvDoesNotDefaultBeadsActorWhenUnset(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
 	_ = os.Unsetenv("BEADS_ACTOR")
@@ -2666,16 +2661,16 @@ func TestBdRuntimeEnvDefaultsBeadsActorToControllerWhenUnset(t *testing.T) {
 	cityPath := t.TempDir()
 	env := bdRuntimeEnv(cityPath)
 
-	if got := env["BEADS_ACTOR"]; got != "controller" {
-		t.Fatalf("BEADS_ACTOR = %q, want %q (supervisor should default to controller)", got, "controller")
+	if _, present := env["BEADS_ACTOR"]; present {
+		t.Fatalf("BEADS_ACTOR = %q, want absent for neutral bd runtime env", env["BEADS_ACTOR"])
 	}
 }
 
 // TestBdRuntimeEnvPreservesInheritedBeadsActor verifies that session
 // contexts (template_resolve.go sets BEADS_ACTOR=<sessname>) and exec
 // orders (orderExecEnv sets BEADS_ACTOR=order:<name>) are not clobbered by
-// the controller default. The override is conditional precisely so the
-// inherited value passes through mergeEnv unchanged.
+// the neutral bd runtime env. The key is omitted so the inherited value
+// passes through mergeEnv unchanged.
 func TestBdRuntimeEnvPreservesInheritedBeadsActor(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
@@ -2686,5 +2681,38 @@ func TestBdRuntimeEnvPreservesInheritedBeadsActor(t *testing.T) {
 
 	if _, present := env["BEADS_ACTOR"]; present {
 		t.Fatalf("env[BEADS_ACTOR] = %q, expected key absent so parent value passes through", env["BEADS_ACTOR"])
+	}
+}
+
+func TestControlBdCommandRunnerDefaultsBeadsActorToControllerWhenUnset(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	origRunner := beadsExecCommandRunnerWithEnv
+	t.Cleanup(func() { beadsExecCommandRunnerWithEnv = origRunner })
+
+	var captured map[string]string
+	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+		captured = map[string]string{}
+		for key, value := range env {
+			captured[key] = value
+		}
+		return func(_ string, _ string, _ ...string) ([]byte, error) {
+			return []byte("ok"), nil
+		}
+	}
+
+	cityPath := t.TempDir()
+	runner := controlBdCommandRunnerForCity(cityPath)
+	if _, err := runner(cityPath, "bd", "list", "--json"); err != nil {
+		t.Fatalf("control runner error = %v, want nil", err)
+	}
+
+	if got := captured["BEADS_ACTOR"]; got != "controller" {
+		t.Fatalf("BEADS_ACTOR = %q, want controller for controller-owned bd runner", got)
+	}
+	if got := captured["BD_EXPORT_AUTO"]; got != "false" {
+		t.Fatalf("BD_EXPORT_AUTO = %q, want false", got)
 	}
 }

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2652,3 +2652,39 @@ dolt.port: 3307
 		t.Fatalf("recoverCalls = %d, want 0", recoverCalls)
 	}
 }
+
+// TestBdRuntimeEnvDefaultsBeadsActorToControllerWhenUnset verifies that the
+// supervisor (and any gc context lacking an explicit identity) gets a
+// non-OS-user actor for bd shell-outs. Without this default, bd's actor
+// resolution falls through to git config user.name and supervisor activity
+// is audit-logged as if the human typed it.
+func TestBdRuntimeEnvDefaultsBeadsActorToControllerWhenUnset(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	cityPath := t.TempDir()
+	env := bdRuntimeEnv(cityPath)
+
+	if got := env["BEADS_ACTOR"]; got != "controller" {
+		t.Fatalf("BEADS_ACTOR = %q, want %q (supervisor should default to controller)", got, "controller")
+	}
+}
+
+// TestBdRuntimeEnvPreservesInheritedBeadsActor verifies that session
+// contexts (template_resolve.go sets BEADS_ACTOR=<sessname>) and exec
+// orders (orderExecEnv sets BEADS_ACTOR=order:<name>) are not clobbered by
+// the controller default. The override is conditional precisely so the
+// inherited value passes through mergeEnv unchanged.
+func TestBdRuntimeEnvPreservesInheritedBeadsActor(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("BEADS_ACTOR", "mayor")
+
+	cityPath := t.TempDir()
+	env := bdRuntimeEnv(cityPath)
+
+	if _, present := env["BEADS_ACTOR"]; present {
+		t.Fatalf("env[BEADS_ACTOR] = %q, expected key absent so parent value passes through", env["BEADS_ACTOR"])
+	}
+}

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -300,6 +300,10 @@ func TestResolveBdScopeTargetErrorsOnForeignRedirect(t *testing.T) {
 }
 
 func TestBdCommandEnvUsesCanonicalRigTarget(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
 	cityDir := t.TempDir()
 	wantPort := strconv.Itoa(writeReachableManagedDoltState(t, cityDir))
 	rigDir := filepath.Join(t.TempDir(), "repo")
@@ -340,6 +344,39 @@ dolt.auto-start: false
 	}
 	if got := env["GC_BEADS_PREFIX"]; got != "repo" {
 		t.Fatalf("GC_BEADS_PREFIX = %q, want %q", got, "repo")
+	}
+	if _, present := env["BEADS_ACTOR"]; present {
+		t.Fatalf("BEADS_ACTOR = %q, want absent for direct gc bd env without explicit actor", env["BEADS_ACTOR"])
+	}
+}
+
+func TestBdCommandRunnerForCityDoesNotDefaultBeadsActorWhenUnset(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	origRunner := beadsExecCommandRunnerWithEnv
+	t.Cleanup(func() { beadsExecCommandRunnerWithEnv = origRunner })
+
+	var captured map[string]string
+	beadsExecCommandRunnerWithEnv = func(env map[string]string) beads.CommandRunner {
+		captured = map[string]string{}
+		for key, value := range env {
+			captured[key] = value
+		}
+		return func(_ string, _ string, _ ...string) ([]byte, error) {
+			return []byte("ok"), nil
+		}
+	}
+
+	cityPath := t.TempDir()
+	runner := bdCommandRunnerForCity(cityPath)
+	if _, err := runner(cityPath, "bd", "list", "--json"); err != nil {
+		t.Fatalf("bd runner error = %v, want nil", err)
+	}
+
+	if _, present := captured["BEADS_ACTOR"]; present {
+		t.Fatalf("BEADS_ACTOR = %q, want absent for normal bd runner without explicit actor", captured["BEADS_ACTOR"])
 	}
 }
 

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -177,7 +177,7 @@ DTO or SSE envelope.`,
 	cmd.Flags().StringVar(&timeoutFlag, "timeout", "30s", "Max wait duration for --watch (e.g. 30s, 5m)")
 	cmd.Flags().Uint64Var(&afterFlag, "after", 0, "Resume from this city event sequence number (city scope only)")
 	cmd.Flags().StringVar(&afterCursor, "after-cursor", "", "Resume from this supervisor event cursor (supervisor scope only)")
-	cmd.Flags().StringArrayVar(&payloadMatch, "payload-match", nil, "Filter by payload field (key=value, repeatable)")
+	cmd.Flags().StringArrayVar(&payloadMatch, "payload-match", nil, "Filter by payload field (key=value or key.subkey=value, repeatable)")
 	cmd.Flags().BoolVar(&jsonFlagDeprecated, "json", false, "Deprecated: output is always JSONL. Accepted for back-compat.")
 	_ = cmd.Flags().MarkDeprecated("json", "output is always JSONL; the flag is now a no-op and will be removed in a future release")
 	return cmd
@@ -1447,28 +1447,40 @@ func matchPayloadObject(obj map[string]any, payloadMatch map[string][]string) bo
 //
 // This allows --payload-match to filter nested event payloads such as
 // bead.closed (where the actually-filterable fields live under
-// payload.bead.*) while remaining backward-compatible with existing
-// flat-key callers.
+// payload.bead.*). At each object level, an exact match for the remaining
+// key wins before walking another segment, so literal dotted keys such as
+// "gc.root_bead_id" under bead.metadata remain filterable.
 //
 // Returns (value, true) if the path resolves; (nil, false) if any segment
 // is missing or an intermediate value is not an object.
 func lookupPayloadKey(obj map[string]any, key string) (any, bool) {
+	if value, ok := obj[key]; ok {
+		return value, true
+	}
 	if !strings.Contains(key, ".") {
-		v, ok := obj[key]
-		return v, ok
+		return nil, false
 	}
-	var current any = obj
-	for _, part := range strings.Split(key, ".") {
-		m, ok := current.(map[string]any)
+	parts := strings.Split(key, ".")
+	current := obj
+	for i, part := range parts {
+		remaining := strings.Join(parts[i:], ".")
+		if value, ok := current[remaining]; ok {
+			return value, true
+		}
+		value, ok := current[part]
 		if !ok {
 			return nil, false
 		}
-		current, ok = m[part]
+		if i == len(parts)-1 {
+			return value, true
+		}
+		next, ok := value.(map[string]any)
 		if !ok {
 			return nil, false
 		}
+		current = next
 	}
-	return current, true
+	return nil, false
 }
 
 func payloadValueString(value any) string {

--- a/cmd/gc/cmd_events.go
+++ b/cmd/gc/cmd_events.go
@@ -1422,7 +1422,7 @@ func matchPayload(payload any, payloadMatch map[string][]string) bool {
 
 func matchPayloadObject(obj map[string]any, payloadMatch map[string][]string) bool {
 	for key, wants := range payloadMatch {
-		value, ok := obj[key]
+		value, ok := lookupPayloadKey(obj, key)
 		if !ok {
 			return false
 		}
@@ -1439,6 +1439,36 @@ func matchPayloadObject(obj map[string]any, payloadMatch map[string][]string) bo
 		}
 	}
 	return true
+}
+
+// lookupPayloadKey resolves a key against a payload object, supporting
+// dotted paths into nested map[string]any values. A flat key like "type"
+// looks up at the top level; "bead.issue_type" walks obj["bead"]["issue_type"].
+//
+// This allows --payload-match to filter nested event payloads such as
+// bead.closed (where the actually-filterable fields live under
+// payload.bead.*) while remaining backward-compatible with existing
+// flat-key callers.
+//
+// Returns (value, true) if the path resolves; (nil, false) if any segment
+// is missing or an intermediate value is not an object.
+func lookupPayloadKey(obj map[string]any, key string) (any, bool) {
+	if !strings.Contains(key, ".") {
+		v, ok := obj[key]
+		return v, ok
+	}
+	var current any = obj
+	for _, part := range strings.Split(key, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
 }
 
 func payloadValueString(value any) string {

--- a/cmd/gc/cmd_events_test.go
+++ b/cmd/gc/cmd_events_test.go
@@ -855,6 +855,55 @@ func TestMatchPayload(t *testing.T) {
 			t.Fatal("expected nested key OR-list to match task")
 		}
 	})
+
+	t.Run("matches literal dotted key below nested map", func(t *testing.T) {
+		payload := map[string]any{
+			"bead": map[string]any{
+				"metadata": map[string]any{
+					"gc.root_bead_id": "ga-root",
+				},
+			},
+		}
+		if !matchPayload(payload, map[string][]string{"bead.metadata.gc.root_bead_id": {"ga-root"}}) {
+			t.Fatal("expected dotted path to match literal metadata key gc.root_bead_id")
+		}
+	})
+
+	t.Run("matches deeper nested payload via dotted path", func(t *testing.T) {
+		payload := map[string]any{
+			"request": map[string]any{
+				"result": map[string]any{
+					"status": "ok",
+				},
+			},
+		}
+		if !matchPayload(payload, map[string][]string{"request.result.status": {"ok"}}) {
+			t.Fatal("expected 3-segment nested key to match")
+		}
+	})
+
+	t.Run("matches flat and nested filters together", func(t *testing.T) {
+		payload := map[string]any{
+			"type": "bead.closed",
+			"bead": map[string]any{"issue_type": "task"},
+		}
+		filter := map[string][]string{
+			"type":            {"bead.closed"},
+			"bead.issue_type": {"task"},
+		}
+		if !matchPayload(payload, filter) {
+			t.Fatal("expected combined flat and nested filters to match")
+		}
+	})
+
+	t.Run("matches nested numeric payload value", func(t *testing.T) {
+		payload := map[string]any{
+			"bead": map[string]any{"priority": 2.0},
+		}
+		if !matchPayload(payload, map[string][]string{"bead.priority": {"2"}}) {
+			t.Fatal("expected nested numeric value to match string form")
+		}
+	})
 }
 
 func TestParsePayloadMatch(t *testing.T) {

--- a/cmd/gc/cmd_events_test.go
+++ b/cmd/gc/cmd_events_test.go
@@ -783,6 +783,78 @@ func TestMatchPayload(t *testing.T) {
 			t.Fatal("expected OR payload match to succeed")
 		}
 	})
+
+	t.Run("matches nested payload via dotted path", func(t *testing.T) {
+		// bead.closed events have shape {"payload":{"bead":{"issue_type":"...",...}}}
+		// where the filterable fields live nested under "bead". A dotted-key
+		// filter must walk into the nested map.
+		payload := map[string]any{
+			"bead": map[string]any{
+				"id":         "pc-wisp-foo",
+				"issue_type": "molecule",
+				"status":     "closed",
+			},
+		}
+		if !matchPayload(payload, map[string][]string{"bead.issue_type": {"molecule"}}) {
+			t.Fatal("expected nested key bead.issue_type to match molecule")
+		}
+		if !matchPayload(payload, map[string][]string{"bead.status": {"closed"}}) {
+			t.Fatal("expected nested key bead.status to match closed")
+		}
+	})
+
+	t.Run("nested key value mismatch returns false", func(t *testing.T) {
+		payload := map[string]any{
+			"bead": map[string]any{"issue_type": "molecule"},
+		}
+		if matchPayload(payload, map[string][]string{"bead.issue_type": {"task"}}) {
+			t.Fatal("expected nested value mismatch to fail")
+		}
+	})
+
+	t.Run("missing intermediate path returns false", func(t *testing.T) {
+		payload := map[string]any{"foo": "bar"}
+		if matchPayload(payload, map[string][]string{"bead.issue_type": {"molecule"}}) {
+			t.Fatal("expected missing intermediate map to fail closed")
+		}
+	})
+
+	t.Run("intermediate non-object returns false", func(t *testing.T) {
+		// "bead" is a string here, not a map — walking should fail without panic.
+		payload := map[string]any{"bead": "not-an-object"}
+		if matchPayload(payload, map[string][]string{"bead.issue_type": {"molecule"}}) {
+			t.Fatal("expected non-object intermediate to fail closed")
+		}
+	})
+
+	t.Run("flat key still matches at top level (backward-compat)", func(t *testing.T) {
+		payload := map[string]any{"type": "merge-request"}
+		if !matchPayload(payload, map[string][]string{"type": {"merge-request"}}) {
+			t.Fatal("flat top-level key must still match")
+		}
+	})
+
+	t.Run("flat key with no dot does not silently traverse", func(t *testing.T) {
+		// Guard against future refactors where lookupPayloadKey accidentally
+		// walks even when there's no dot. A flat key "type" must not match
+		// a nested {"bead":{"type":"..."}} value.
+		payload := map[string]any{
+			"bead": map[string]any{"type": "merge-request"},
+		}
+		if matchPayload(payload, map[string][]string{"type": {"merge-request"}}) {
+			t.Fatal("flat key must not match nested value at the same name")
+		}
+	})
+
+	t.Run("nested OR works across siblings", func(t *testing.T) {
+		payload := map[string]any{
+			"bead": map[string]any{"issue_type": "task"},
+		}
+		filter := map[string][]string{"bead.issue_type": {"bug", "task", "molecule"}}
+		if !matchPayload(payload, filter) {
+			t.Fatal("expected nested key OR-list to match task")
+		}
+	})
 }
 
 func TestParsePayloadMatch(t *testing.T) {

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -742,7 +742,11 @@ func openCityRecorderAt(cityPath string, stderr io.Writer) events.Recorder {
 
 // eventActor returns the public actor identity for events.
 // Prefer the session alias when present, but preserve GC_AGENT fallback for
-// managed-session hooks and older event-emitting contexts.
+// managed-session hooks and older event-emitting contexts. BEADS_ACTOR is
+// the cross-process identity signal shared with bd; falling through to it
+// before "human" lets supervisor-spawned hooks (e.g., bd on_close →
+// `gc event emit`) be attributed correctly to the controller or the order
+// that triggered the close.
 func eventActor() string {
 	if alias := strings.TrimSpace(os.Getenv("GC_ALIAS")); alias != "" {
 		return alias
@@ -752,6 +756,9 @@ func eventActor() string {
 	}
 	if sessionID := strings.TrimSpace(os.Getenv("GC_SESSION_ID")); sessionID != "" {
 		return sessionID
+	}
+	if beadsActor := strings.TrimSpace(os.Getenv("BEADS_ACTOR")); beadsActor != "" {
+		return beadsActor
 	}
 	return "human"
 }

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4486,6 +4486,58 @@ func TestLockedWriterSerializesConcurrentWrites(t *testing.T) {
 	}
 }
 
+// TestOrderExecEnvSetsBeadsActorToOrderName verifies that exec orders
+// spawned by the controller carry an order-scoped BEADS_ACTOR into their
+// subprocess env, so any bd shell-out from inside the order's command
+// (e.g., `gc order sweep-tracking` → `bd close`) is audit-logged as
+// "order:<name>" rather than the controller default. This is what gives
+// the dashboard fine-grained attribution per order.
+func TestOrderExecEnvSetsBeadsActorToOrderName(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	cityDir := t.TempDir()
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	a := orders.Order{Name: "order-tracking-sweep", Trigger: "cooldown", Interval: "1m", Exec: "true"}
+
+	envSlice := orderExecEnv(cityDir, nil, target, a)
+
+	want := "BEADS_ACTOR=order:order-tracking-sweep"
+	found := false
+	for _, entry := range envSlice {
+		if entry == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("orderExecEnv missing %q; env=%v", want, envSlice)
+	}
+}
+
+// TestOrderExecEnvSkipsBeadsActorForUnnamedOrder guards against accidentally
+// emitting "BEADS_ACTOR=order:" (empty suffix) when an order has no name.
+// The conditional in orderExecEnv prevents that — verified here so future
+// edits don't regress.
+func TestOrderExecEnvSkipsBeadsActorForUnnamedOrder(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("BEADS_ACTOR")
+
+	cityDir := t.TempDir()
+	target := execStoreTarget{ScopeRoot: cityDir, ScopeKind: "city", Prefix: "pc"}
+	a := orders.Order{Trigger: "cooldown", Interval: "1m", Exec: "true"} // no Name
+
+	envSlice := orderExecEnv(cityDir, nil, target, a)
+
+	for _, entry := range envSlice {
+		if entry == "BEADS_ACTOR=order:" {
+			t.Fatalf("orderExecEnv emitted bare order: prefix for unnamed order; env=%v", envSlice)
+		}
+	}
+}
+
 func TestLockedStderrPreservesNil(t *testing.T) {
 	if got := lockedStderr(nil); got != nil {
 		t.Fatalf("lockedStderr(nil): got %v, want nil", got)

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4490,7 +4490,7 @@ func TestLockedWriterSerializesConcurrentWrites(t *testing.T) {
 // spawned by the controller carry an order-scoped BEADS_ACTOR into their
 // subprocess env, so any bd shell-out from inside the order's command
 // (e.g., `gc order sweep-tracking` → `bd close`) is audit-logged as
-// "order:<name>" rather than the controller default. This is what gives
+// "order:<name>" rather than an ambient identity. This is what gives
 // the dashboard fine-grained attribution per order.
 func TestOrderExecEnvSetsBeadsActorToOrderName(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -98,6 +98,13 @@ func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a o
 	env["GC_STORE_ROOT"] = target.ScopeRoot
 	env["GC_STORE_SCOPE"] = target.ScopeKind
 	env["GC_BEADS_PREFIX"] = target.Prefix
+	// Tag every bd interaction this exec order produces with the order's
+	// name so audit logs and the dashboard can attribute housekeeping
+	// activity to the responsible order rather than to the controller's
+	// default identity. Overrides bdRuntimeEnv's "controller" default.
+	if name := strings.TrimSpace(a.Name); name != "" {
+		env["BEADS_ACTOR"] = "order:" + name
+	}
 	if target.ScopeKind == "rig" {
 		env["GC_RIG"] = target.RigName
 		env["GC_RIG_ROOT"] = target.ScopeRoot

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -100,8 +100,7 @@ func orderExecEnv(cityPath string, cfg *config.City, target execStoreTarget, a o
 	env["GC_BEADS_PREFIX"] = target.Prefix
 	// Tag every bd interaction this exec order produces with the order's
 	// name so audit logs and the dashboard can attribute housekeeping
-	// activity to the responsible order rather than to the controller's
-	// default identity. Overrides bdRuntimeEnv's "controller" default.
+	// activity to the responsible order rather than an ambient identity.
 	if name := strings.TrimSpace(a.Name); name != "" {
 		env["BEADS_ACTOR"] = "order:" + name
 	}

--- a/cmd/gc/session_target_test.go
+++ b/cmd/gc/session_target_test.go
@@ -89,3 +89,44 @@ func TestEventActorPrefersAliasThenSessionID(t *testing.T) {
 		t.Fatalf("eventActor() without alias = %q, want gc-42", got)
 	}
 }
+
+// TestEventActorFallsBackToBeadsActorBeforeHuman covers the supervisor and
+// order-subprocess paths. bd shell hooks (on_close, on_update, on_create)
+// fan out to `gc event emit ...` without --actor; that subprocess inherits
+// no GC_ALIAS/GC_AGENT/GC_SESSION_ID from the controller. Without this
+// fallback, every supervisor-initiated bead change shows up in the
+// dashboard as "human". With BEADS_ACTOR set (by bdRuntimeEnv to
+// "controller", or by orderExecEnv to "order:<name>"), the fallback
+// recovers the right identity.
+func TestEventActorFallsBackToBeadsActorBeforeHuman(t *testing.T) {
+	t.Setenv("GC_ALIAS", "")
+	t.Setenv("GC_AGENT", "")
+	t.Setenv("GC_SESSION_ID", "")
+	t.Setenv("BEADS_ACTOR", "controller")
+	if got := eventActor(); got != "controller" {
+		t.Fatalf("eventActor() with only BEADS_ACTOR=controller = %q, want controller", got)
+	}
+
+	t.Setenv("BEADS_ACTOR", "order:order-tracking-sweep")
+	if got := eventActor(); got != "order:order-tracking-sweep" {
+		t.Fatalf("eventActor() with BEADS_ACTOR=order:... = %q, want order:order-tracking-sweep", got)
+	}
+
+	t.Setenv("BEADS_ACTOR", "")
+	if got := eventActor(); got != "human" {
+		t.Fatalf("eventActor() with no identity = %q, want human (final fallback)", got)
+	}
+}
+
+// TestEventActorBeadsActorRanksBelowGCAlias verifies the priority order:
+// session contexts that set both GC_ALIAS and BEADS_ACTOR (template
+// resolve sets both to the same name, but the ranking matters if they
+// ever diverge) keep using GC_ALIAS so the existing session-attribution
+// behavior is preserved.
+func TestEventActorBeadsActorRanksBelowGCAlias(t *testing.T) {
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("BEADS_ACTOR", "controller")
+	if got := eventActor(); got != "mayor" {
+		t.Fatalf("eventActor() with GC_ALIAS=mayor and BEADS_ACTOR=controller = %q, want mayor (alias wins)", got)
+	}
+}

--- a/cmd/gc/session_target_test.go
+++ b/cmd/gc/session_target_test.go
@@ -95,8 +95,8 @@ func TestEventActorPrefersAliasThenSessionID(t *testing.T) {
 // fan out to `gc event emit ...` without --actor; that subprocess inherits
 // no GC_ALIAS/GC_AGENT/GC_SESSION_ID from the controller. Without this
 // fallback, every supervisor-initiated bead change shows up in the
-// dashboard as "human". With BEADS_ACTOR set (by bdRuntimeEnv to
-// "controller", or by orderExecEnv to "order:<name>"), the fallback
+// dashboard as "human". With BEADS_ACTOR set by controller bd wrappers
+// or by orderExecEnv to "order:<name>", the fallback
 // recovers the right identity.
 func TestEventActorFallsBackToBeadsActorBeforeHuman(t *testing.T) {
 	t.Setenv("GC_ALIAS", "")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1029,7 +1029,7 @@ gc events
 | `--after-cursor` | string |  | Resume from this supervisor event cursor (supervisor scope only) |
 | `--api` | string |  | GC API server URL override (auto-discovered by default) |
 | `--follow` | bool |  | Continuously stream events as they arrive |
-| `--payload-match` | stringArray |  | Filter by payload field (key=value, repeatable) |
+| `--payload-match` | stringArray |  | Filter by payload field (key=value or key.subkey=value, repeatable) |
 | `--seq` | bool |  | Print the current head cursor and exit |
 | `--since` | string |  | Show events since duration ago (e.g. 1h, 30m) |
 | `--timeout` | string | `30s` | Max wait duration for --watch (e.g. 30s, 5m) |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -150,6 +150,10 @@ the JSON shape:
 
 The same rule applies to both list mode and stream mode.
 
+`--payload-match` accepts top-level fields and dotted paths into nested
+payload objects. For example, use
+`--payload-match bead.issue_type=task` to match bead events by issue type.
+
 ## Machine-Readable Schema
 
 The downloadable <a href="/schema/events.txt" download="events.json">events.json</a>


### PR DESCRIPTION
Fixes #1613.

## Summary

`gc events --payload-match key=value` was documented as a generic payload filter but `matchPayloadObject` only walked the top-level keys of the unmarshalled payload. The `bead.*` event family (`bead.created`, `bead.updated`, `bead.closed`) all emit payloads of shape `{"bead":{"issue_type":"...","status":"...",...}}`, so the filterable fields live nested under `bead` and the user-facing filter silently returned zero matches in the common case.

This PR adds dotted-path support: a key without `.` looks up at the top level (existing behavior, fully backward-compatible); a key with `.` walks each segment through `map[string]any` values.

## Examples after this change

```bash
# bead.closed events for a specific issue type
gc events --type=bead.closed --payload-match bead.issue_type=task

# bead.updated events for status transitions
gc events --type=bead.updated --payload-match bead.status=in_progress
```

The flat-key form continues to work unchanged:

```bash
# merge-request events with explicit type — payload top-level key
gc events --payload-match type=merge-request
```

## Implementation

- New helper `lookupPayloadKey(obj, key)` resolves the key path. For flat keys (no `.`) it short-circuits to a single map lookup (no allocation for `strings.Split`); for dotted keys it walks each segment, returning `(nil, false)` if any intermediate segment is missing or not a `map[string]any`.
- `matchPayloadObject` swaps `obj[key]` for `lookupPayloadKey(obj, key)`; no other behavior changes.

`git diff --stat origin/main`: 2 files, +103 / -1.

## Tests

`TestMatchPayload` extended with seven sub-tests:

- nested dotted path matches
- nested key value mismatch returns false
- missing intermediate path returns false
- intermediate non-object returns false (no panic on type-assertion)
- flat top-level key still matches (backward-compat)
- flat key with no dot does NOT silently traverse into nested values with the same name (guards against future refactors)
- nested OR-list works (multiple wants for one nested key)

All existing `TestMatchPayload` and `TestParsePayloadMatch` cases remain unchanged and still pass.

```
$ go test ./cmd/gc/ -run "TestMatchPayload|TestParsePayloadMatch" -v
=== RUN   TestMatchPayload
=== RUN   TestMatchPayload/nil_filter_always_matches
=== RUN   TestMatchPayload/matches_map_payload
=== RUN   TestMatchPayload/repeated_keys_mean_OR
=== RUN   TestMatchPayload/matches_nested_payload_via_dotted_path
=== RUN   TestMatchPayload/nested_key_value_mismatch_returns_false
=== RUN   TestMatchPayload/missing_intermediate_path_returns_false
=== RUN   TestMatchPayload/intermediate_non-object_returns_false
=== RUN   TestMatchPayload/flat_key_still_matches_at_top_level_(backward-compat)
=== RUN   TestMatchPayload/flat_key_with_no_dot_does_not_silently_traverse
=== RUN   TestMatchPayload/nested_OR_works_across_siblings
--- PASS: TestMatchPayload (0.00s)
=== RUN   TestParsePayloadMatch
--- PASS: TestParsePayloadMatch (0.00s)
PASS
ok      github.com/gastownhall/gascity/cmd/gc   0.035s
```

## Discovery context

Hit by a multi-agent coordinator (Claude Code "deacon" pattern) trying to filter `bead.closed` events to ignore its own wisp molecule lifecycle. The `--payload-match issue_type=molecule` filter silently returned zero matches; we worked around with a `jq` post-filter on the event stream. With this fix, `--payload-match bead.issue_type=molecule` works as expected and the workaround is no longer needed.

## Checklist

- [x] Linked an issue (#1613) with reproducer and root cause analysis
- [x] Added tests for behavior changes (7 new sub-tests)
- [x] Backward-compatible — flat-key form unchanged; existing tests still pass
- [x] No breaking changes
- [x] No docs updates needed (`--help` text doesn't change; behavior matches existing description "Filter by payload field")

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->