### PR TITLE
Restrict Blacksmith CI to approved PR authors

### DIFF
--- a/.github/blacksmith-allowlist.txt
+++ b/.github/blacksmith-allowlist.txt
@@ -1,25 +1,9 @@
 # GitHub logins allowed to run sponsored Blacksmith CI automatically.
 # One login per line. Blank lines and # comments are ignored.
 #
-# Seeded from the current top repository contributors; maintainers can
-# add or remove names as the sponsored fast-path policy changes.
+# Blacksmith is limited to pull requests from these users. Pushes,
+# schedules, manual runs, and other contributors use GitHub-hosted runners.
 julianknutsen
-sjarmak
-GraemeF
-rileywhite
 csells
-thejosephstevens
-osamu2001
-tesdal
+sjarmak
 quad341
-alexsiri7
-boylec
-donbox
-stuartparmenter
-stebbins
-Rome-1
-wynged
-EmmittJ
-quietlathe2048
-rainydan
-myster-t

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,85 +42,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          event_name = os.environ["EVENT_NAME"]
-          author = os.environ.get("PR_AUTHOR", "").strip()
-          association = os.environ.get("PR_ASSOCIATION", "").strip().upper()
-          try:
-              labels_payload = json.loads(os.environ.get("PR_LABELS_JSON", "[]") or "[]")
-          except json.JSONDecodeError:
-              labels_payload = []
-          if labels_payload is None:
-              labels_payload = []
-          labels = {str(label).strip() for label in labels_payload if str(label).strip()}
-
-          allowlist_path = Path(".github/blacksmith-allowlist.txt")
-          allowlist = set()
-          if allowlist_path.exists():
-              for raw_line in allowlist_path.read_text(encoding="utf-8").splitlines():
-                  line = raw_line.split("#", 1)[0].strip()
-                  if line:
-                      allowlist.add(line.lower())
-
-          use_blacksmith = False
-          reason = ""
-          if event_name != "pull_request":
-              use_blacksmith = True
-              reason = f"{event_name} event"
-          elif "ok-to-blacksmith" in labels:
-              use_blacksmith = True
-              reason = "ok-to-blacksmith label"
-          elif association in {"OWNER", "MEMBER", "COLLABORATOR"}:
-              use_blacksmith = True
-              reason = f"trusted author association: {association}"
-          elif author.lower() in allowlist:
-              use_blacksmith = True
-              reason = "author is in .github/blacksmith-allowlist.txt"
-          else:
-              reason = (
-                  f"author {author or '<unknown>'} is not on the Blacksmith allowlist; "
-                  "using GitHub-hosted runners"
-              )
-
-          if use_blacksmith:
-              runners = {
-                  "runner_2vcpu": "blacksmith-2vcpu-ubuntu-2404",
-                  "runner_8vcpu": "blacksmith-8vcpu-ubuntu-2404",
-                  "runner_16vcpu": "blacksmith-16vcpu-ubuntu-2404",
-                  "runner_32vcpu": "blacksmith-32vcpu-ubuntu-2404",
-              }
-              backend = "Blacksmith"
-          else:
-              runners = {
-                  "runner_2vcpu": "ubuntu-latest",
-                  "runner_8vcpu": "ubuntu-latest",
-                  "runner_16vcpu": "ubuntu-latest",
-                  "runner_32vcpu": "ubuntu-latest",
-              }
-              backend = "GitHub-hosted"
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"use_blacksmith={str(use_blacksmith).lower()}\n")
-              out.write(f"reason={reason}\n")
-              for name, runner in runners.items():
-                  out.write(f"{name}={runner}\n")
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("## Runner policy\n\n")
-              summary.write(f"- backend: `{backend}`\n")
-              summary.write(f"- use_blacksmith: `{str(use_blacksmith).lower()}`\n")
-              summary.write(f"- reason: {reason}\n")
-              if event_name == "pull_request":
-                  summary.write(f"- author: `{author}`\n")
-                  summary.write(f"- association: `{association or '<empty>'}`\n")
-          PY
+          python3 .github/workflows/scripts/runner_policy.py
 
   # Detect which paths changed to gate conditional jobs.
   changes:
@@ -193,49 +116,38 @@ jobs:
               - 'internal/**'
               - 'examples/gastown/packs/**'
 
-  preflight-lint:
-    name: Preflight / lint
+  preflight-smoke:
+    name: Preflight / lint and smoke
     needs: runner-policy
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
+    env:
+      DOLT_VERSION: "1.86.6"
+      BD_VERSION: "v1.0.3"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: ./.github/actions/setup-gascity-ubuntu
         with:
-          go-version-file: go.mod
+          dolt-version: ${{ env.DOLT_VERSION }}
+          bd-version: ${{ env.BD_VERSION }}
+          install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
       - name: Lint
         run: make lint
-
-  preflight-format:
-    name: Preflight / format
-    needs: runner-policy
-    runs-on: ${{ needs.runner-policy.outputs.runner_8vcpu }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
-      - name: Install tools
-        run: make install-tools
       - name: Format
         run: make fmt-check
-
-  preflight-vet:
-    name: Preflight / vet
-    needs: runner-policy
-    runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
       - name: Vet
         run: make vet
+      - name: Docs
+        run: make check-docs
+      - name: Smoke unit tests
+        run: make test
 
   preflight-unit-cover:
     name: Preflight / unit cover
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - preflight-smoke
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "1.86.6"
@@ -258,21 +170,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-  preflight-docs:
-    name: Preflight / docs
-    needs: runner-policy
-    runs-on: ${{ needs.runner-policy.outputs.runner_8vcpu }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
-      - name: Docs
-        run: make check-docs
-
   preflight-acceptance:
     name: Preflight / acceptance A
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - preflight-smoke
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     env:
       DOLT_VERSION: "1.86.6"
@@ -287,24 +189,11 @@ jobs:
       - name: Acceptance tests (Tier A)
         run: make test-acceptance
 
-  preflight-dashboard:
-    name: Preflight / dashboard drift
-    needs: runner-policy
-    runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "22"
-      - name: Dashboard bundle drift check
-        run: make dashboard-ci
-
-  preflight-spec:
-    name: Preflight / spec drift
-    needs: runner-policy
+  preflight-generated:
+    name: Preflight / generated artifacts
+    needs:
+      - runner-policy
+      - preflight-smoke
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
       # Make TestGeneratedClientInSync fatal on missing oapi-codegen so the
@@ -315,6 +204,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - name: Dashboard bundle drift check
+        run: make dashboard-ci
       - name: OpenAPI spec + client drift check
         run: make spec-ci
 
@@ -324,14 +218,10 @@ jobs:
     name: Check
     needs:
       - runner-policy
-      - preflight-lint
-      - preflight-format
-      - preflight-vet
+      - preflight-smoke
       - preflight-unit-cover
-      - preflight-docs
       - preflight-acceptance
-      - preflight-dashboard
-      - preflight-spec
+      - preflight-generated
     if: ${{ always() }}
     runs-on: ${{ needs.runner-policy.outputs.runner_2vcpu }}
     env:
@@ -376,17 +266,24 @@ jobs:
           args: check
 
   cmd-gc-process:
-    name: cmd/gc process / ${{ matrix.shard_index }} of 6
+    name: cmd/gc process / shards ${{ matrix.shard_group }}
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.cmd_gc_process == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
-    timeout-minutes: 20
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [1, 2, 3, 4, 5, 6]
+        include:
+          - shard_group: 1-2 of 6
+            shards: 1 2
+          - shard_group: 3-4 of 6
+            shards: 3 4
+          - shard_group: 5-6 of 6
+            shards: 5 6
     env:
       DOLT_VERSION: "1.86.6"
       BD_VERSION: "v1.0.3"
@@ -400,104 +297,79 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Run cmd/gc process suite
-        run: make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD=${{ matrix.shard_index }} CMD_GC_PROCESS_TOTAL=6
+        run: |
+          for shard in ${{ matrix.shards }}; do
+            make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD="$shard" CMD_GC_PROCESS_TOTAL=6
+          done
 
   integration-shards:
     name: Integration / ${{ matrix.shard_name }}
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - preflight-smoke
     runs-on: ${{ needs.runner-policy.outputs.runner_32vcpu }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - shard_name: packages-core-1-of-4
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-core-1-of-4
-          - shard_name: packages-core-2-of-4
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-core-2-of-4
-          - shard_name: packages-core-3-of-4
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-core-3-of-4
-          - shard_name: packages-core-4-of-4
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-core-4-of-4
-          - shard_name: packages-cmd-gc-1-of-6
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-cmd-gc-1-of-6
-          - shard_name: packages-cmd-gc-2-of-6
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-cmd-gc-2-of-6
-          - shard_name: packages-cmd-gc-3-of-6
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-cmd-gc-3-of-6
-          - shard_name: packages-cmd-gc-4-of-6
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-cmd-gc-4-of-6
-          - shard_name: packages-cmd-gc-5-of-6
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-cmd-gc-5-of-6
-          - shard_name: packages-cmd-gc-6-of-6
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-cmd-gc-6-of-6
-          - shard_name: packages-runtime-tmux-1-of-3
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-runtime-tmux-1-of-3
-          - shard_name: packages-runtime-tmux-2-of-3
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-runtime-tmux-2-of-3
-          - shard_name: packages-runtime-tmux-3-of-3
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard packages-runtime-tmux-3-of-3
-          - shard_name: review-formulas-basic-1-of-2
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard review-formulas-basic-1-of-2
-          - shard_name: review-formulas-basic-2-of-2
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard review-formulas-basic-2-of-2
-          - shard_name: review-formulas-retries-1-of-2
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard review-formulas-retries-1-of-2
-          - shard_name: review-formulas-retries-2-of-2
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard review-formulas-retries-2-of-2
+          - shard_name: packages-core
+            timeout_minutes: 35
+            command: |
+              ./scripts/test-integration-shard packages-core-1-of-4
+              ./scripts/test-integration-shard packages-core-2-of-4
+              ./scripts/test-integration-shard packages-core-3-of-4
+              ./scripts/test-integration-shard packages-core-4-of-4
+          - shard_name: packages-cmd-gc
+            timeout_minutes: 45
+            command: |
+              ./scripts/test-integration-shard packages-cmd-gc-1-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-2-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-3-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-4-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-5-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-6-of-6
+          - shard_name: packages-runtime-tmux
+            timeout_minutes: 30
+            command: |
+              ./scripts/test-integration-shard packages-runtime-tmux-1-of-3
+              ./scripts/test-integration-shard packages-runtime-tmux-2-of-3
+              ./scripts/test-integration-shard packages-runtime-tmux-3-of-3
+          - shard_name: review-formulas-basic
+            timeout_minutes: 30
+            command: make test-integration-review-formulas-basic
+          - shard_name: review-formulas-retries
+            timeout_minutes: 30
+            command: make test-integration-review-formulas-retries
           - shard_name: review-formulas-recovery
             timeout_minutes: 25
             command: make test-integration-review-formulas-recovery
           - shard_name: bdstore
             timeout_minutes: 15
             command: make test-integration-bdstore
-          - shard_name: rest-smoke-1-of-2
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-smoke-1-of-2
-          - shard_name: rest-smoke-2-of-2
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-smoke-2-of-2
-          - shard_name: rest-full-1-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-1-of-8
-          - shard_name: rest-full-2-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-2-of-8
-          - shard_name: rest-full-3-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-3-of-8
-          - shard_name: rest-full-4-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-4-of-8
-          - shard_name: rest-full-5-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-5-of-8
-          - shard_name: rest-full-6-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-6-of-8
-          - shard_name: rest-full-7-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-7-of-8
-          - shard_name: rest-full-8-of-8
-            timeout_minutes: 20
-            command: ./scripts/test-integration-shard rest-full-8-of-8
+          - shard_name: rest-smoke
+            timeout_minutes: 25
+            command: make test-integration-rest-smoke
+          - shard_name: rest-full-1-2-of-8
+            timeout_minutes: 35
+            command: |
+              ./scripts/test-integration-shard rest-full-1-of-8
+              ./scripts/test-integration-shard rest-full-2-of-8
+          - shard_name: rest-full-3-4-of-8
+            timeout_minutes: 35
+            command: |
+              ./scripts/test-integration-shard rest-full-3-of-8
+              ./scripts/test-integration-shard rest-full-4-of-8
+          - shard_name: rest-full-5-6-of-8
+            timeout_minutes: 35
+            command: |
+              ./scripts/test-integration-shard rest-full-5-of-8
+              ./scripts/test-integration-shard rest-full-6-of-8
+          - shard_name: rest-full-7-8-of-8
+            timeout_minutes: 35
+            command: |
+              ./scripts/test-integration-shard rest-full-7-of-8
+              ./scripts/test-integration-shard rest-full-8-of-8
     env:
       DOLT_VERSION: "1.86.6"
       BD_VERSION: "v1.0.3"
@@ -518,6 +390,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.worker == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
@@ -552,6 +425,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.worker == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
@@ -586,6 +460,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.worker == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
@@ -620,6 +495,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
       - worker-core-claude
       - worker-core-codex
       - worker-core-gemini
@@ -729,6 +605,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.worker_phase2 == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
@@ -767,6 +644,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.worker_phase2 == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
@@ -805,6 +683,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.worker_phase2 == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     env:
@@ -979,7 +858,9 @@ jobs:
   # load-bearing discipline step.
   dashboard:
     name: Dashboard SPA
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - preflight-smoke
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1016,6 +897,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.mail == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_8vcpu }}
     continue-on-error: true  # upstream mcp_agent_mail API may drift
@@ -1045,6 +927,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.docker == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_16vcpu }}
     steps:
@@ -1073,6 +956,7 @@ jobs:
     needs:
       - runner-policy
       - changes
+      - preflight-smoke
     if: needs.changes.outputs.k8s == 'true'
     runs-on: ${{ needs.runner-policy.outputs.runner_8vcpu }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,11 +359,12 @@ jobs:
             command: |
               ./scripts/test-integration-shard rest-full-5-of-8
               ./scripts/test-integration-shard rest-full-6-of-8
-          - shard_name: rest-full-7-8-of-8
+          - shard_name: rest-full-7-of-8
             timeout_minutes: 35
-            command: |
-              ./scripts/test-integration-shard rest-full-7-of-8
-              ./scripts/test-integration-shard rest-full-8-of-8
+            command: ./scripts/test-integration-shard rest-full-7-of-8
+          - shard_name: rest-full-8-of-8
+            timeout_minutes: 35
+            command: ./scripts/test-integration-shard rest-full-8-of-8
     env:
       DOLT_VERSION: "1.86.6"
       BD_VERSION: "v1.0.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   runner-policy:
     name: Runner policy
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     outputs:
       use_blacksmith: ${{ steps.policy.outputs.use_blacksmith }}
       reason: ${{ steps.policy.outputs.reason }}
@@ -30,13 +30,7 @@ jobs:
       runner_16vcpu: ${{ steps.policy.outputs.runner_16vcpu }}
       runner_32vcpu: ${{ steps.policy.outputs.runner_32vcpu }}
     steps:
-      # Read the allowlist from the trusted base revision, not from PR code.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name != 'pull_request' }}
       - name: Select runner backend
         id: policy
         env:

--- a/.github/workflows/close-stale-needs.yml
+++ b/.github/workflows/close-stale-needs.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   close-needs-info:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,87 +44,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          event_name = os.environ["EVENT_NAME"]
-          author = os.environ.get("PR_AUTHOR", "").strip()
-          association = os.environ.get("PR_ASSOCIATION", "").strip().upper()
-          try:
-              labels_payload = json.loads(os.environ.get("PR_LABELS_JSON", "[]") or "[]")
-          except json.JSONDecodeError:
-              labels_payload = []
-          if labels_payload is None:
-              labels_payload = []
-          labels = {str(label).strip() for label in labels_payload if str(label).strip()}
-
-          allowlist_path = Path(".github/blacksmith-allowlist.txt")
-          allowlist = set()
-          if allowlist_path.exists():
-              for raw_line in allowlist_path.read_text(encoding="utf-8").splitlines():
-                  line = raw_line.split("#", 1)[0].strip()
-                  if line:
-                      allowlist.add(line.lower())
-
-          use_blacksmith = False
-          reason = ""
-          if event_name != "pull_request":
-              use_blacksmith = True
-              reason = f"{event_name} event"
-          elif "ok-to-blacksmith" in labels:
-              use_blacksmith = True
-              reason = "ok-to-blacksmith label"
-          elif association in {"OWNER", "MEMBER", "COLLABORATOR"}:
-              use_blacksmith = True
-              reason = f"trusted author association: {association}"
-          elif author.lower() in allowlist:
-              use_blacksmith = True
-              reason = "author is in .github/blacksmith-allowlist.txt"
-          else:
-              reason = (
-                  f"author {author or '<unknown>'} is not on the Blacksmith allowlist; "
-                  "using GitHub-hosted runners"
-              )
-
-          if use_blacksmith:
-              runners = {
-                  "runner_2vcpu": "blacksmith-2vcpu-ubuntu-2404",
-                  "runner_8vcpu": "blacksmith-8vcpu-ubuntu-2404",
-                  "runner_16vcpu": "blacksmith-16vcpu-ubuntu-2404",
-                  "runner_32vcpu": "blacksmith-32vcpu-ubuntu-2404",
-                  "runner_macos": "blacksmith-12vcpu-macos-15",
-              }
-              backend = "Blacksmith"
-          else:
-              runners = {
-                  "runner_2vcpu": "ubuntu-latest",
-                  "runner_8vcpu": "ubuntu-latest",
-                  "runner_16vcpu": "ubuntu-latest",
-                  "runner_32vcpu": "ubuntu-latest",
-                  "runner_macos": "macos-15",
-              }
-              backend = "GitHub-hosted"
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"use_blacksmith={str(use_blacksmith).lower()}\n")
-              out.write(f"reason={reason}\n")
-              for name, runner in runners.items():
-                  out.write(f"{name}={runner}\n")
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("## Runner policy\n\n")
-              summary.write(f"- backend: `{backend}`\n")
-              summary.write(f"- use_blacksmith: `{str(use_blacksmith).lower()}`\n")
-              summary.write(f"- reason: {reason}\n")
-              if event_name == "pull_request":
-                  summary.write(f"- author: `{author}`\n")
-                  summary.write(f"- association: `{association or '<empty>'}`\n")
-          PY
+          python3 .github/workflows/scripts/runner_policy.py
 
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   runner-policy:
     name: Runner policy
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     outputs:
       use_blacksmith: ${{ steps.policy.outputs.use_blacksmith }}
       reason: ${{ steps.policy.outputs.reason }}
@@ -32,13 +32,7 @@ jobs:
       runner_32vcpu: ${{ steps.policy.outputs.runner_32vcpu }}
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
     steps:
-      # Read the allowlist from the trusted base revision, not from PR code.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name != 'pull_request' }}
       - name: Select runner backend
         id: policy
         env:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -77,87 +77,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          event_name = os.environ["EVENT_NAME"]
-          author = os.environ.get("PR_AUTHOR", "").strip()
-          association = os.environ.get("PR_ASSOCIATION", "").strip().upper()
-          try:
-              labels_payload = json.loads(os.environ.get("PR_LABELS_JSON", "[]") or "[]")
-          except json.JSONDecodeError:
-              labels_payload = []
-          if labels_payload is None:
-              labels_payload = []
-          labels = {str(label).strip() for label in labels_payload if str(label).strip()}
-
-          allowlist_path = Path(".github/blacksmith-allowlist.txt")
-          allowlist = set()
-          if allowlist_path.exists():
-              for raw_line in allowlist_path.read_text(encoding="utf-8").splitlines():
-                  line = raw_line.split("#", 1)[0].strip()
-                  if line:
-                      allowlist.add(line.lower())
-
-          use_blacksmith = False
-          reason = ""
-          if event_name != "pull_request":
-              use_blacksmith = True
-              reason = f"{event_name} event"
-          elif "ok-to-blacksmith" in labels:
-              use_blacksmith = True
-              reason = "ok-to-blacksmith label"
-          elif association in {"OWNER", "MEMBER", "COLLABORATOR"}:
-              use_blacksmith = True
-              reason = f"trusted author association: {association}"
-          elif author.lower() in allowlist:
-              use_blacksmith = True
-              reason = "author is in .github/blacksmith-allowlist.txt"
-          else:
-              reason = (
-                  f"author {author or '<unknown>'} is not on the Blacksmith allowlist; "
-                  "using GitHub-hosted runners"
-              )
-
-          if use_blacksmith:
-              runners = {
-                  "runner_2vcpu": "blacksmith-2vcpu-ubuntu-2404",
-                  "runner_8vcpu": "blacksmith-8vcpu-ubuntu-2404",
-                  "runner_16vcpu": "blacksmith-16vcpu-ubuntu-2404",
-                  "runner_32vcpu": "blacksmith-32vcpu-ubuntu-2404",
-                  "runner_macos": "blacksmith-12vcpu-macos-15",
-              }
-              backend = "Blacksmith"
-          else:
-              runners = {
-                  "runner_2vcpu": "ubuntu-latest",
-                  "runner_8vcpu": "ubuntu-latest",
-                  "runner_16vcpu": "ubuntu-latest",
-                  "runner_32vcpu": "ubuntu-latest",
-                  "runner_macos": "macos-15",
-              }
-              backend = "GitHub-hosted"
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"use_blacksmith={str(use_blacksmith).lower()}\n")
-              out.write(f"reason={reason}\n")
-              for name, runner in runners.items():
-                  out.write(f"{name}={runner}\n")
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("## Runner policy\n\n")
-              summary.write(f"- backend: `{backend}`\n")
-              summary.write(f"- use_blacksmith: `{str(use_blacksmith).lower()}`\n")
-              summary.write(f"- reason: {reason}\n")
-              if event_name == "pull_request":
-                  summary.write(f"- author: `{author}`\n")
-                  summary.write(f"- association: `{association or '<empty>'}`\n")
-          PY
+          python3 .github/workflows/scripts/runner_policy.py
 
   dockerfile-config:
     name: Dockerfile config

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   runner-policy:
     name: Runner policy
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     outputs:
       use_blacksmith: ${{ steps.policy.outputs.use_blacksmith }}
       reason: ${{ steps.policy.outputs.reason }}
@@ -65,13 +65,7 @@ jobs:
       runner_32vcpu: ${{ steps.policy.outputs.runner_32vcpu }}
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
     steps:
-      # Read the allowlist from the trusted base revision, not from PR code.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name != 'pull_request' }}
       - name: Select runner backend
         id: policy
         env:

--- a/.github/workflows/homebrew-tap-smoke.yml
+++ b/.github/workflows/homebrew-tap-smoke.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tap-smoke:
     name: Tap install smoke
-    runs-on: blacksmith-12vcpu-macos-15
+    runs-on: macos-15
     timeout-minutes: 30
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -82,87 +82,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          event_name = os.environ["EVENT_NAME"]
-          author = os.environ.get("PR_AUTHOR", "").strip()
-          association = os.environ.get("PR_ASSOCIATION", "").strip().upper()
-          try:
-              labels_payload = json.loads(os.environ.get("PR_LABELS_JSON", "[]") or "[]")
-          except json.JSONDecodeError:
-              labels_payload = []
-          if labels_payload is None:
-              labels_payload = []
-          labels = {str(label).strip() for label in labels_payload if str(label).strip()}
-
-          allowlist_path = Path(".github/blacksmith-allowlist.txt")
-          allowlist = set()
-          if allowlist_path.exists():
-              for raw_line in allowlist_path.read_text(encoding="utf-8").splitlines():
-                  line = raw_line.split("#", 1)[0].strip()
-                  if line:
-                      allowlist.add(line.lower())
-
-          use_blacksmith = False
-          reason = ""
-          if event_name != "pull_request":
-              use_blacksmith = True
-              reason = f"{event_name} event"
-          elif "ok-to-blacksmith" in labels:
-              use_blacksmith = True
-              reason = "ok-to-blacksmith label"
-          elif association in {"OWNER", "MEMBER", "COLLABORATOR"}:
-              use_blacksmith = True
-              reason = f"trusted author association: {association}"
-          elif author.lower() in allowlist:
-              use_blacksmith = True
-              reason = "author is in .github/blacksmith-allowlist.txt"
-          else:
-              reason = (
-                  f"author {author or '<unknown>'} is not on the Blacksmith allowlist; "
-                  "using GitHub-hosted runners"
-              )
-
-          if use_blacksmith:
-              runners = {
-                  "runner_2vcpu": "blacksmith-2vcpu-ubuntu-2404",
-                  "runner_8vcpu": "blacksmith-8vcpu-ubuntu-2404",
-                  "runner_16vcpu": "blacksmith-16vcpu-ubuntu-2404",
-                  "runner_32vcpu": "blacksmith-32vcpu-ubuntu-2404",
-                  "runner_macos": "blacksmith-12vcpu-macos-15",
-              }
-              backend = "Blacksmith"
-          else:
-              runners = {
-                  "runner_2vcpu": "ubuntu-latest",
-                  "runner_8vcpu": "ubuntu-latest",
-                  "runner_16vcpu": "ubuntu-latest",
-                  "runner_32vcpu": "ubuntu-latest",
-                  "runner_macos": "macos-15",
-              }
-              backend = "GitHub-hosted"
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"use_blacksmith={str(use_blacksmith).lower()}\n")
-              out.write(f"reason={reason}\n")
-              for name, runner in runners.items():
-                  out.write(f"{name}={runner}\n")
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("## Runner policy\n\n")
-              summary.write(f"- backend: `{backend}`\n")
-              summary.write(f"- use_blacksmith: `{str(use_blacksmith).lower()}`\n")
-              summary.write(f"- reason: {reason}\n")
-              if event_name == "pull_request":
-                  summary.write(f"- author: `{author}`\n")
-                  summary.write(f"- association: `{association or '<empty>'}`\n")
-          PY
+          python3 .github/workflows/scripts/runner_policy.py
 
   # Fast quality gates that Linux runs on every PR. Keep these cheap so a
   # Mac-parity loop stays interactive.
@@ -319,7 +240,11 @@ jobs:
   # shard stays separate so it can gate on nightly / full-dispatch only.
   mac-integration-packages:
     name: Mac / integration packages / ${{ matrix.shard_name }}
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - mac-quality
+      - mac-unit
+      - mac-acceptance
     if: >-
       github.event_name == 'schedule' ||
       (
@@ -333,37 +258,33 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'needs-mac')
       )
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - shard_name: core-1-of-4
-            shard: packages-core-1-of-4
-          - shard_name: core-2-of-4
-            shard: packages-core-2-of-4
-          - shard_name: core-3-of-4
-            shard: packages-core-3-of-4
-          - shard_name: core-4-of-4
-            shard: packages-core-4-of-4
-          - shard_name: cmd-gc-1-of-6
-            shard: packages-cmd-gc-1-of-6
-          - shard_name: cmd-gc-2-of-6
-            shard: packages-cmd-gc-2-of-6
-          - shard_name: cmd-gc-3-of-6
-            shard: packages-cmd-gc-3-of-6
-          - shard_name: cmd-gc-4-of-6
-            shard: packages-cmd-gc-4-of-6
-          - shard_name: cmd-gc-5-of-6
-            shard: packages-cmd-gc-5-of-6
-          - shard_name: cmd-gc-6-of-6
-            shard: packages-cmd-gc-6-of-6
-          - shard_name: tmux-1-of-3
-            shard: packages-runtime-tmux-1-of-3
-          - shard_name: tmux-2-of-3
-            shard: packages-runtime-tmux-2-of-3
-          - shard_name: tmux-3-of-3
-            shard: packages-runtime-tmux-3-of-3
+          - shard_name: core
+            timeout_minutes: 60
+            command: |
+              ./scripts/test-integration-shard packages-core-1-of-4
+              ./scripts/test-integration-shard packages-core-2-of-4
+              ./scripts/test-integration-shard packages-core-3-of-4
+              ./scripts/test-integration-shard packages-core-4-of-4
+          - shard_name: cmd-gc
+            timeout_minutes: 75
+            command: |
+              ./scripts/test-integration-shard packages-cmd-gc-1-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-2-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-3-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-4-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-5-of-6
+              ./scripts/test-integration-shard packages-cmd-gc-6-of-6
+          - shard_name: tmux
+            timeout_minutes: 45
+            command: |
+              ./scripts/test-integration-shard packages-runtime-tmux-1-of-3
+              ./scripts/test-integration-shard packages-runtime-tmux-2-of-3
+              ./scripts/test-integration-shard packages-runtime-tmux-3-of-3
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -388,11 +309,15 @@ jobs:
         run: make install-tools
       - name: Run integration shard
         id: shard
-        run: ./scripts/test-integration-shard ${{ matrix.shard }}
+        run: ${{ matrix.command }}
 
   mac-integration-bdstore:
     name: Mac / integration (bdstore)
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - mac-quality
+      - mac-unit
+      - mac-acceptance
     if: >-
       github.event_name == 'schedule' ||
       (
@@ -438,7 +363,11 @@ jobs:
 
   mac-integration-rest:
     name: Mac / integration rest / ${{ matrix.shard_name }}
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - mac-quality
+      - mac-unit
+      - mac-acceptance
     if: >-
       github.event_name == 'schedule' ||
       (
@@ -452,31 +381,34 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'needs-mac')
       )
     runs-on: ${{ needs.runner-policy.outputs.runner_macos }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - shard_name: smoke-1-of-2
-            shard: rest-smoke-1-of-2
-          - shard_name: smoke-2-of-2
-            shard: rest-smoke-2-of-2
-          - shard_name: full-1-of-8
-            shard: rest-full-1-of-8
-          - shard_name: full-2-of-8
-            shard: rest-full-2-of-8
-          - shard_name: full-3-of-8
-            shard: rest-full-3-of-8
-          - shard_name: full-4-of-8
-            shard: rest-full-4-of-8
-          - shard_name: full-5-of-8
-            shard: rest-full-5-of-8
-          - shard_name: full-6-of-8
-            shard: rest-full-6-of-8
-          - shard_name: full-7-of-8
-            shard: rest-full-7-of-8
-          - shard_name: full-8-of-8
-            shard: rest-full-8-of-8
+          - shard_name: smoke
+            timeout_minutes: 45
+            command: make test-integration-rest-smoke
+          - shard_name: full-1-2-of-8
+            timeout_minutes: 45
+            command: |
+              ./scripts/test-integration-shard rest-full-1-of-8
+              ./scripts/test-integration-shard rest-full-2-of-8
+          - shard_name: full-3-4-of-8
+            timeout_minutes: 45
+            command: |
+              ./scripts/test-integration-shard rest-full-3-of-8
+              ./scripts/test-integration-shard rest-full-4-of-8
+          - shard_name: full-5-6-of-8
+            timeout_minutes: 45
+            command: |
+              ./scripts/test-integration-shard rest-full-5-of-8
+              ./scripts/test-integration-shard rest-full-6-of-8
+          - shard_name: full-7-8-of-8
+            timeout_minutes: 45
+            command: |
+              ./scripts/test-integration-shard rest-full-7-of-8
+              ./scripts/test-integration-shard rest-full-8-of-8
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -501,12 +433,16 @@ jobs:
         run: make install-tools
       - name: Run integration shard
         id: shard
-        run: ./scripts/test-integration-shard ${{ matrix.shard }}
+        run: ${{ matrix.command }}
 
   # Long-running review-formulas shard — nightly / full dispatch only.
   mac-integration-review-formulas:
     name: Mac / integration (review-formulas)
-    needs: runner-policy
+    needs:
+      - runner-policy
+      - mac-quality
+      - mac-unit
+      - mac-acceptance
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.suite == 'full')

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -398,11 +398,12 @@ jobs:
             command: |
               ./scripts/test-integration-shard rest-full-5-of-8
               ./scripts/test-integration-shard rest-full-6-of-8
-          - shard_name: full-7-8-of-8
+          - shard_name: full-7-of-8
             timeout_minutes: 45
-            command: |
-              ./scripts/test-integration-shard rest-full-7-of-8
-              ./scripts/test-integration-shard rest-full-8-of-8
+            command: ./scripts/test-integration-shard rest-full-7-of-8
+          - shard_name: full-8-of-8
+            timeout_minutes: 45
+            command: ./scripts/test-integration-shard rest-full-8-of-8
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.SYNTHETIC_API_KEY }}

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   runner-policy:
     name: Runner policy
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     outputs:
       use_blacksmith: ${{ steps.policy.outputs.use_blacksmith }}
       reason: ${{ steps.policy.outputs.reason }}
@@ -70,13 +70,7 @@ jobs:
       runner_32vcpu: ${{ steps.policy.outputs.runner_32vcpu }}
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
     steps:
-      # Read the allowlist from the trusted base revision, not from PR code.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name != 'pull_request' }}
       - name: Select runner backend
         id: policy
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   tier-b:
     name: Tier B acceptance tests
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
       ANTHROPIC_API_KEY: ${{ secrets.SYNTHETIC_API_KEY }}
@@ -56,7 +56,7 @@ jobs:
 
   mac-inference:
     name: Mac / Tier B+C inference tests
-    runs-on: blacksmith-12vcpu-macos-15
+    runs-on: macos-15
     timeout-minutes: 180
     env:
       ANTHROPIC_BASE_URL: https://api.synthetic.new/anthropic
@@ -94,7 +94,7 @@ jobs:
 
   worker-inference-claude:
     name: WorkerInference claude/tmux-cli
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       PROFILE: claude/tmux-cli
       WORKER_REPORT_DIR: ${{ github.workspace }}/.nightly-tmp/worker-inference-claude-reports
@@ -166,7 +166,7 @@ jobs:
 
   worker-inference-codex:
     name: WorkerInference codex/tmux-cli
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       PROFILE: codex/tmux-cli
       WORKER_REPORT_DIR: ${{ github.workspace }}/.nightly-tmp/worker-inference-codex-reports
@@ -220,7 +220,7 @@ jobs:
 
   worker-inference-gemini:
     name: WorkerInference gemini/tmux-cli
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       PROFILE: gemini/tmux-cli
       WORKER_REPORT_DIR: ${{ github.workspace }}/.nightly-tmp/worker-inference-gemini-reports
@@ -277,7 +277,7 @@ jobs:
 
   worker-inference-summary:
     name: Worker inference summary
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: ${{ always() }}
     needs:
       - worker-inference-claude

--- a/.github/workflows/notify-image-build.yaml
+++ b/.github/workflows/notify-image-build.yaml
@@ -25,7 +25,7 @@ permissions: {}
 
 jobs:
   notify:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger runtime image rebuild
         env:

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -21,7 +21,7 @@ jobs:
 
   ubuntu_fast_tests:
     name: ubuntu / fast tests / ${{ matrix.label }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
@@ -67,7 +67,7 @@ jobs:
 
   ubuntu_make_check_docs:
     name: ubuntu / make check-docs
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -81,7 +81,7 @@ jobs:
 
   ubuntu_acceptance_a:
     name: ubuntu / acceptance A / ${{ matrix.label }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
@@ -142,7 +142,7 @@ jobs:
 
   ubuntu_acceptance_b:
     name: ubuntu / acceptance B / ${{ matrix.shard_index }} of 3
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
 
   ubuntu_acceptance_c:
     name: ubuntu / acceptance C / ${{ matrix.shard_index }} of 5
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -193,7 +193,7 @@ jobs:
 
   ubuntu_integration_shards:
     name: ubuntu / integration / ${{ matrix.shard_name }}
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
@@ -314,7 +314,7 @@ jobs:
 
   ubuntu_tutorial:
     name: ubuntu / tutorial goldens / ${{ matrix.shard_index }} of 6
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 110
     strategy:
       fail-fast: false
@@ -348,7 +348,7 @@ jobs:
 
   ubuntu_goreleaser_snapshot:
     name: ubuntu / goreleaser snapshot
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -373,7 +373,7 @@ jobs:
 
   macos_fast_tests:
     name: macOS / fast tests / ${{ matrix.label }}
-    runs-on: blacksmith-12vcpu-macos-15
+    runs-on: macos-15
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
@@ -421,7 +421,7 @@ jobs:
   rc_summary:
     name: RC summary
     if: ${{ always() }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs:
       - ci_parity
       - ubuntu_fast_tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     name: Release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
@@ -57,7 +57,7 @@ jobs:
     name: Attest release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     needs: release
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       attestations: write
       contents: write
@@ -110,7 +110,7 @@ jobs:
     name: Update Homebrew formula
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     needs: [release, attest-release]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/remove-needs-info.yml
+++ b/.github/workflows/remove-needs-info.yml
@@ -12,7 +12,7 @@ jobs:
   # pull_request_target is safe here because this job never checks out or runs
   # pull request code; it only removes labels from the issue/PR metadata.
   remove-label:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/remove-needs-triage.yml
+++ b/.github/workflows/remove-needs-triage.yml
@@ -12,7 +12,7 @@ jobs:
   # pull_request_target is safe here because this job never checks out or runs
   # pull request code; it only removes labels from the issue/PR metadata.
   remove-triage-label:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -66,87 +66,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          event_name = os.environ["EVENT_NAME"]
-          author = os.environ.get("PR_AUTHOR", "").strip()
-          association = os.environ.get("PR_ASSOCIATION", "").strip().upper()
-          try:
-              labels_payload = json.loads(os.environ.get("PR_LABELS_JSON", "[]") or "[]")
-          except json.JSONDecodeError:
-              labels_payload = []
-          if labels_payload is None:
-              labels_payload = []
-          labels = {str(label).strip() for label in labels_payload if str(label).strip()}
-
-          allowlist_path = Path(".github/blacksmith-allowlist.txt")
-          allowlist = set()
-          if allowlist_path.exists():
-              for raw_line in allowlist_path.read_text(encoding="utf-8").splitlines():
-                  line = raw_line.split("#", 1)[0].strip()
-                  if line:
-                      allowlist.add(line.lower())
-
-          use_blacksmith = False
-          reason = ""
-          if event_name != "pull_request":
-              use_blacksmith = True
-              reason = f"{event_name} event"
-          elif "ok-to-blacksmith" in labels:
-              use_blacksmith = True
-              reason = "ok-to-blacksmith label"
-          elif association in {"OWNER", "MEMBER", "COLLABORATOR"}:
-              use_blacksmith = True
-              reason = f"trusted author association: {association}"
-          elif author.lower() in allowlist:
-              use_blacksmith = True
-              reason = "author is in .github/blacksmith-allowlist.txt"
-          else:
-              reason = (
-                  f"author {author or '<unknown>'} is not on the Blacksmith allowlist; "
-                  "using GitHub-hosted runners"
-              )
-
-          if use_blacksmith:
-              runners = {
-                  "runner_2vcpu": "blacksmith-2vcpu-ubuntu-2404",
-                  "runner_8vcpu": "blacksmith-8vcpu-ubuntu-2404",
-                  "runner_16vcpu": "blacksmith-16vcpu-ubuntu-2404",
-                  "runner_32vcpu": "blacksmith-32vcpu-ubuntu-2404",
-                  "runner_macos": "blacksmith-12vcpu-macos-15",
-              }
-              backend = "Blacksmith"
-          else:
-              runners = {
-                  "runner_2vcpu": "ubuntu-latest",
-                  "runner_8vcpu": "ubuntu-latest",
-                  "runner_16vcpu": "ubuntu-latest",
-                  "runner_32vcpu": "ubuntu-latest",
-                  "runner_macos": "macos-15",
-              }
-              backend = "GitHub-hosted"
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
-              out.write(f"use_blacksmith={str(use_blacksmith).lower()}\n")
-              out.write(f"reason={reason}\n")
-              for name, runner in runners.items():
-                  out.write(f"{name}={runner}\n")
-
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("## Runner policy\n\n")
-              summary.write(f"- backend: `{backend}`\n")
-              summary.write(f"- use_blacksmith: `{str(use_blacksmith).lower()}`\n")
-              summary.write(f"- reason: {reason}\n")
-              if event_name == "pull_request":
-                  summary.write(f"- author: `{author}`\n")
-                  summary.write(f"- association: `{association or '<empty>'}`\n")
-          PY
+          python3 .github/workflows/scripts/runner_policy.py
 
   gate:
     name: review-formulas routing
@@ -229,20 +150,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: review-formulas-basic-1-of-2
-            label: basic-1-of-2
-            coverprofile: coverage.integration-review-formulas-basic-1.txt
-          - shard: review-formulas-basic-2-of-2
-            label: basic-2-of-2
-            coverprofile: coverage.integration-review-formulas-basic-2.txt
-          - shard: review-formulas-retries-1-of-2
-            label: retries-1-of-2
-            coverprofile: coverage.integration-review-formulas-retries-1.txt
-          - shard: review-formulas-retries-2-of-2
-            label: retries-2-of-2
-            coverprofile: coverage.integration-review-formulas-retries-2.txt
-          - shard: review-formulas-recovery
-            label: recovery
+          - label: basic
+            command: make test-integration-review-formulas-basic-cover
+            coverprofile: coverage.integration-review-formulas-basic.txt
+          - label: retries
+            command: make test-integration-review-formulas-retries-cover
+            coverprofile: coverage.integration-review-formulas-retries.txt
+          - label: recovery
+            command: make test-integration-review-formulas-recovery-cover
             coverprofile: coverage.integration-review-formulas-recovery.txt
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -259,7 +174,7 @@ jobs:
         run: make install-tools
       - name: Run review-formulas shard
         id: shard
-        run: GO_TEST_COVERPROFILE=${{ matrix.coverprofile }} ./scripts/test-integration-shard ${{ matrix.shard }}
+        run: ${{ matrix.command }}
       - name: Inspect shard coverage profile
         if: steps.shard.outcome == 'success'
         run: |

--- a/.github/workflows/review-formulas.yml
+++ b/.github/workflows/review-formulas.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   runner-policy:
     name: Runner policy
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && contains(fromJSON('["julianknutsen","csells","sjarmak","quad341"]'), github.event.pull_request.user.login) && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     outputs:
       use_blacksmith: ${{ steps.policy.outputs.use_blacksmith }}
       reason: ${{ steps.policy.outputs.reason }}
@@ -54,13 +54,7 @@ jobs:
       runner_32vcpu: ${{ steps.policy.outputs.runner_32vcpu }}
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
     steps:
-      # Read the allowlist from the trusted base revision, not from PR code.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: ${{ github.event_name != 'pull_request' }}
       - name: Select runner backend
         id: policy
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
     permissions:

--- a/.github/workflows/scripts/runner_policy.py
+++ b/.github/workflows/scripts/runner_policy.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Select GitHub Actions runners for Gas City workflows."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+ALLOWLIST_PATH = Path(".github/blacksmith-allowlist.txt")
+
+BLACKSMITH_RUNNERS = {
+    "runner_2vcpu": "blacksmith-2vcpu-ubuntu-2404",
+    "runner_8vcpu": "blacksmith-8vcpu-ubuntu-2404",
+    "runner_16vcpu": "blacksmith-16vcpu-ubuntu-2404",
+    "runner_32vcpu": "blacksmith-32vcpu-ubuntu-2404",
+    "runner_macos": "blacksmith-12vcpu-macos-15",
+}
+
+GITHUB_RUNNERS = {
+    "runner_2vcpu": "ubuntu-latest",
+    "runner_8vcpu": "ubuntu-latest",
+    "runner_16vcpu": "ubuntu-latest",
+    "runner_32vcpu": "ubuntu-latest",
+    "runner_macos": "macos-15",
+}
+
+
+def load_allowlist(path: Path = ALLOWLIST_PATH) -> set[str]:
+    """Load the Blacksmith pull request author allowlist."""
+    allowlist: set[str] = set()
+    if not path.exists():
+        return allowlist
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if line:
+            allowlist.add(line.lower())
+    return allowlist
+
+
+def select_runners(event_name: str, author: str, allowlist: set[str]) -> tuple[bool, str, dict[str, str]]:
+    """Return whether to use Blacksmith, the reason, and runner labels."""
+    normalized_event = event_name.strip()
+    normalized_author = author.strip()
+    if normalized_event == "pull_request" and normalized_author.lower() in allowlist:
+        return True, "pull request author is in .github/blacksmith-allowlist.txt", BLACKSMITH_RUNNERS
+    if normalized_event != "pull_request":
+        return (
+            False,
+            f"Blacksmith is limited to approved pull requests; using GitHub-hosted runners for {normalized_event or '<unknown>'}",
+            GITHUB_RUNNERS,
+        )
+    return (
+        False,
+        f"author {normalized_author or '<unknown>'} is not on the Blacksmith allowlist; using GitHub-hosted runners",
+        GITHUB_RUNNERS,
+    )
+
+
+def append_outputs(use_blacksmith: bool, reason: str, runners: dict[str, str]) -> None:
+    """Append selected policy fields to GITHUB_OUTPUT."""
+    output_path = os.environ["GITHUB_OUTPUT"]
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"use_blacksmith={str(use_blacksmith).lower()}\n")
+        output.write(f"reason={reason}\n")
+        for name, runner in runners.items():
+            output.write(f"{name}={runner}\n")
+
+
+def append_summary(use_blacksmith: bool, reason: str, event_name: str, author: str) -> None:
+    """Append a human-readable runner policy summary."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    backend = "Blacksmith" if use_blacksmith else "GitHub-hosted"
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write("## Runner policy\n\n")
+        summary.write(f"- backend: `{backend}`\n")
+        summary.write(f"- use_blacksmith: `{str(use_blacksmith).lower()}`\n")
+        summary.write(f"- reason: {reason}\n")
+        if event_name == "pull_request":
+            summary.write(f"- author: `{author or '<unknown>'}`\n")
+
+
+def main() -> None:
+    event_name = os.environ["EVENT_NAME"]
+    author = os.environ.get("PR_AUTHOR", "").strip()
+    use_blacksmith, reason, runners = select_runners(event_name, author, load_allowlist())
+    append_outputs(use_blacksmith, reason, runners)
+    append_summary(use_blacksmith, reason, event_name, author)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/test_runner_policy.py
+++ b/.github/workflows/scripts/test_runner_policy.py
@@ -1,0 +1,58 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import runner_policy
+
+
+class RunnerPolicyTests(unittest.TestCase):
+    def test_load_allowlist_ignores_comments_and_case_normalizes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "allowlist.txt"
+            path.write_text(
+                "julianknutsen\n"
+                "  Csells  # maintainer\n"
+                "\n"
+                "# comment\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(runner_policy.load_allowlist(path), {"julianknutsen", "csells"})
+
+    def test_pull_request_from_allowlisted_author_uses_blacksmith(self) -> None:
+        use_blacksmith, reason, runners = runner_policy.select_runners(
+            "pull_request",
+            "Quad341",
+            {"quad341"},
+        )
+
+        self.assertTrue(use_blacksmith)
+        self.assertIn("allowlist", reason)
+        self.assertEqual(runners["runner_32vcpu"], "blacksmith-32vcpu-ubuntu-2404")
+        self.assertEqual(runners["runner_macos"], "blacksmith-12vcpu-macos-15")
+
+    def test_push_uses_github_even_for_allowlisted_author(self) -> None:
+        use_blacksmith, reason, runners = runner_policy.select_runners(
+            "push",
+            "julianknutsen",
+            {"julianknutsen"},
+        )
+
+        self.assertFalse(use_blacksmith)
+        self.assertIn("approved pull requests", reason)
+        self.assertEqual(runners["runner_32vcpu"], "ubuntu-latest")
+
+    def test_unlisted_pull_request_author_uses_github(self) -> None:
+        use_blacksmith, reason, runners = runner_policy.select_runners(
+            "pull_request",
+            "external-contributor",
+            {"julianknutsen"},
+        )
+
+        self.assertFalse(use_blacksmith)
+        self.assertIn("not on the Blacksmith allowlist", reason)
+        self.assertEqual(runners["runner_macos"], "macos-15")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -12,7 +12,7 @@ jobs:
   # pull_request_target is safe here because this job never checks out or runs
   # pull request code; it only labels the issue/PR from event metadata.
   add-triage-label:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -2295,9 +2295,14 @@ while True:
 	for {
 		data, err := os.ReadFile(readyPath)
 		if err == nil {
-			port, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			trimmed := strings.TrimSpace(string(data))
+			if trimmed == "" {
+				time.Sleep(25 * time.Millisecond)
+				continue
+			}
+			port, parseErr := strconv.Atoi(trimmed)
 			if parseErr != nil {
-				t.Fatalf("parse listener port %q: %v", strings.TrimSpace(string(data)), parseErr)
+				t.Fatalf("parse listener port %q: %v", trimmed, parseErr)
 			}
 			conn, dialErr := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 200*time.Millisecond)
 			if dialErr == nil {

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -1098,7 +1098,7 @@ func liveContractHTTPRequest(baseURL, method, path string, body any) (*http.Requ
 
 func assertLiveContractStreamOpens(t *testing.T, baseURL, path string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- restrict Blacksmith runner selection to pull_request events from julianknutsen, csells, sjarmak, or quad341
- route main pushes, schedules, manual runs, releases, and other contributors to GitHub-hosted runners
- add a shared runner policy script and unit tests
- add a lint/docs/unit-smoke preflight before broad CI fanout and group small CI/Mac/review-formulas shards into fewer jobs

## Testing
- python3 -m unittest discover .github/workflows/scripts
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -config-file .github/actionlint.yaml
- git diff --check
- make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->