### PR TITLE
fix: advance event cursors for exec orders

### DIFF
--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -422,6 +422,18 @@ func cmdOrderRun(name, rig string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if a.IsExec() {
+		if a.Trigger == "event" {
+			store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
+			if store == nil {
+				return storeCode
+			}
+			ep, epCode := openCityEventsProvider(stderr, "gc order run")
+			if ep == nil {
+				return epCode
+			}
+			defer ep.Close() //nolint:errcheck // best-effort
+			return doOrderRunExecTracked(a, cityPath, cfg, store, ep, stdout, stderr)
+		}
 		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
 	}
 	store, storeCode := openOrderStoreForOrder(cityPath, cfg, a, stderr, "gc order run")
@@ -454,13 +466,19 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 			fmt.Fprintf(stderr, "gc order run: %v\n", cfgErr) //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
+		return doOrderRunExecTracked(a, cityPath, cfg, store, ep, stdout, stderr)
 	}
 
-	// Capture event head before wisp creation (race-free cursor).
+	// Capture event head before wisp creation (race-free cursor). Event runs
+	// fail closed when the cursor cannot be read.
 	var headSeq uint64
 	if a.Trigger == "event" && ep != nil {
-		headSeq, _ = ep.LatestSeq()
+		var err error
+		headSeq, err = ep.LatestSeq()
+		if err != nil {
+			fmt.Fprintf(stderr, "gc order run: reading event cursor for %s: %v\n", a.ScopedName(), err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	scoped := a.ScopedName()
@@ -539,6 +557,46 @@ func doOrderRun(aa []orders.Order, name, rig, cityPath string, store beads.Store
 	}
 	fmt.Fprintln(stdout) //nolint:errcheck
 	return 0
+}
+
+func doOrderRunExecTracked(a orders.Order, cityPath string, cfg *config.City, store beads.Store, ep events.Provider, stdout, stderr io.Writer) int {
+	if a.Trigger != "event" || ep == nil {
+		return doOrderRunExec(a, cityPath, cfg, stdout, stderr)
+	}
+
+	scoped := a.ScopedName()
+	headSeq, err := ep.LatestSeq()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order run: reading event cursor for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	tracking, err := store.Create(beads.Bead{
+		Title:  "order:" + scoped,
+		Labels: []string{"order-run:" + scoped, labelOrderTracking},
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order run: creating exec tracking bead for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	defer store.Close(tracking.ID) //nolint:errcheck // best-effort close
+
+	// Persist the event cursor before running the command so manual event execs
+	// do not leave the controller cursor stale after the side effect.
+	if err := store.Update(tracking.ID, beads.UpdateOpts{Labels: eventCursorLabels(scoped, headSeq)}); err != nil {
+		fmt.Fprintf(stderr, "gc order run: labeling exec event cursor for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+
+	code := doOrderRunExec(a, cityPath, cfg, stdout, stderr)
+	labels := []string{"exec"}
+	if code != 0 {
+		labels = []string{"exec-failed"}
+	}
+	if err := store.Update(tracking.ID, beads.UpdateOpts{Labels: labels}); err != nil {
+		fmt.Fprintf(stderr, "gc order run: labeling exec tracking bead for %s: %v\n", scoped, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	return code
 }
 
 // doOrderRunExec runs an exec order directly via shell.

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -721,6 +721,133 @@ func TestOrderRun(t *testing.T) {
 	}
 }
 
+func TestOrderRunEventExecAdvancesCursor(t *testing.T) {
+	cityDir := t.TempDir()
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+`)
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+	aa := []orders.Order{{
+		Name:    "release-exec",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "printf ok",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "release-exec", "", cityDir, store, eventLog, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	results, err := store.ListByLabel("order-run:release-exec", 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq), "exec"} {
+		if !slicesContain(results[0].Labels, want) {
+			t.Fatalf("tracking bead labels = %v, want %s", results[0].Labels, want)
+		}
+	}
+}
+
+func TestCmdOrderRunEventExecAdvancesCursor(t *testing.T) {
+	cityDir := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_EVENTS", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_CITY_ROOT", cityDir)
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	t.Chdir(cityDir)
+
+	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
+name = "test-city"
+`)
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, "orders", "release-exec.toml"), `[order]
+exec = "printf ok"
+trigger = "event"
+on = "bead.closed"
+`)
+	var eventStderr bytes.Buffer
+	eventLog, err := events.NewFileRecorder(filepath.Join(cityDir, ".gc", "events.jsonl"), &eventStderr)
+	if err != nil {
+		t.Fatalf("NewFileRecorder(): %v", err)
+	}
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+	if err := eventLog.Close(); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdOrderRun("release-exec", "", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("cmdOrderRun = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	store, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(): %v", err)
+	}
+	results, err := store.ListByLabel("order-run:release-exec", 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("store.ListByLabel() len = %d, want 1 (%#v)", len(results), results)
+	}
+	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq), "exec"} {
+		if !slicesContain(results[0].Labels, want) {
+			t.Fatalf("tracking bead labels = %v, want %s", results[0].Labels, want)
+		}
+	}
+}
+
+func TestOrderRunEventFormulaLatestSeqErrorDoesNotInstantiate(t *testing.T) {
+	aa := []orders.Order{{
+		Name:         "release-watch",
+		Trigger:      "event",
+		On:           events.BeadClosed,
+		Formula:      "test-formula",
+		FormulaLayer: sharedTestFormulaDir,
+	}}
+	store := beads.NewMemStore()
+
+	var stdout, stderr bytes.Buffer
+	code := doOrderRun(aa, "release-watch", "", "/city", store, events.NewFailFake(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("doOrderRun = %d, want 1 when event cursor cannot be read; stdout: %s", code, stdout.String())
+	}
+	results, err := store.ListByLabel("order-run:release-watch", 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("store.ListByLabel(): %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("store.ListByLabel() len = %d, want 0 (%#v)", len(results), results)
+	}
+	if !strings.Contains(stderr.String(), "reading event cursor for release-watch") {
+		t.Fatalf("stderr = %q, want event cursor read failure", stderr.String())
+	}
+}
+
 func TestOrderRunResolvesPackBindingForPool(t *testing.T) {
 	aa := []orders.Order{
 		{Name: "digest", Formula: "mol-digest", Trigger: "cooldown", Interval: "24h", Pool: "dog", FormulaLayer: sharedTestFormulaDir},

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -407,6 +407,16 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.Store, target execStoreTarget, a orders.Order, cityPath, trackingID string) {
 	scoped := a.ScopedName()
 	labels := []string{"exec"}
+	var headSeq uint64
+	if a.Trigger == "event" && m.ep != nil {
+		headSeq, _ = m.ep.LatestSeq()
+		if headSeq > 0 {
+			labels = append(labels,
+				fmt.Sprintf("order:%s", scoped),
+				fmt.Sprintf("seq:%d", headSeq),
+			)
+		}
+	}
 
 	env := orderExecEnv(cityPath, m.cfg, target, a)
 	output, err := m.execRun(ctx, a.Exec, target.ScopeRoot, env)

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -376,6 +376,13 @@ func orderTriggerUsesLastRun(a orders.Order) bool {
 	return a.Trigger == "cooldown" || a.Trigger == "cron"
 }
 
+func eventCursorLabels(scoped string, headSeq uint64) []string {
+	return []string{
+		fmt.Sprintf("order:%s", scoped),
+		fmt.Sprintf("seq:%d", headSeq),
+	}
+}
+
 // dispatchOne runs a single order dispatch in its own goroutine.
 // For exec orders, runs the script directly. For formula orders,
 // instantiates a wisp. Emits events and updates the tracking bead.
@@ -408,42 +415,90 @@ func (m *memoryOrderDispatcher) dispatchExec(ctx context.Context, store beads.St
 	scoped := a.ScopedName()
 	labels := []string{"exec"}
 	var headSeq uint64
+	var hasEventCursor bool
 	if a.Trigger == "event" && m.ep != nil {
-		headSeq, _ = m.ep.LatestSeq()
-		if headSeq > 0 {
-			labels = append(labels,
-				fmt.Sprintf("order:%s", scoped),
-				fmt.Sprintf("seq:%d", headSeq),
-			)
+		var err error
+		headSeq, err = m.ep.LatestSeq()
+		if err != nil {
+			errMsg := fmt.Sprintf("reading event cursor: %v", err)
+			labels = []string{"exec-failed"}
+			logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", scoped, err)
+			if updateErr := store.Update(trackingID, beads.UpdateOpts{Labels: labels}); updateErr != nil {
+				logDispatchError(m.stderr, "gc: order %s: failed to label exec tracking bead %s: %v", scoped, trackingID, updateErr)
+			}
+			m.rec.Record(events.Event{
+				Type:    events.OrderFailed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: errMsg,
+			})
+			return
+		}
+		hasEventCursor = true
+		// Event-triggered exec orders persist the cursor before the command
+		// runs; otherwise a crash after the side effect can replay the event.
+		if err := store.Update(trackingID, beads.UpdateOpts{Labels: eventCursorLabels(scoped, headSeq)}); err != nil {
+			logDispatchError(m.stderr, "gc: order %s: failed to label exec event cursor on tracking bead %s: %v", scoped, trackingID, err)
+			labels = []string{"exec-failed"}
+			if updateErr := store.Update(trackingID, beads.UpdateOpts{Labels: labels}); updateErr != nil {
+				logDispatchError(m.stderr, "gc: order %s: failed to label exec tracking bead %s: %v", scoped, trackingID, updateErr)
+			}
+			m.rec.Record(events.Event{
+				Type:    events.OrderFailed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: fmt.Sprintf("exec tracking bead %s event cursor label failed for seq=%d: %v", trackingID, headSeq, err),
+			})
+			return
 		}
 	}
 
 	env := orderExecEnv(cityPath, m.cfg, target, a)
 	output, err := m.execRun(ctx, a.Exec, target.ScopeRoot, env)
+	var execErrMsg string
 	if err != nil {
 		redactionEnv := append(os.Environ(), env...)
-		errMsg := execenv.RedactText(err.Error(), redactionEnv)
-		labels = append(labels, "exec-failed")
-		logDispatchError(m.stderr, "gc: order exec %s failed: %s", scoped, errMsg)
+		execErrMsg = execenv.RedactText(err.Error(), redactionEnv)
+		labels = []string{"exec-failed"}
+		logDispatchError(m.stderr, "gc: order exec %s failed: %s", scoped, execErrMsg)
 		if len(output) > 0 {
 			logDispatchError(m.stderr, "gc: order exec %s output: %s", scoped, execenv.RedactText(string(output), redactionEnv))
+		}
+	}
+
+	// Label tracking bead with outcome via store (not CLI). For event execs,
+	// cursor labels were already persisted before the command ran.
+	if err := store.Update(trackingID, beads.UpdateOpts{Labels: labels}); err != nil {
+		logDispatchError(m.stderr, "gc: order %s: failed to label exec tracking bead %s: %v", scoped, trackingID, err)
+		msg := fmt.Sprintf("exec tracking bead %s label failed: %v", trackingID, err)
+		if hasEventCursor {
+			msg = fmt.Sprintf("seq=%d: %s", headSeq, msg)
 		}
 		m.rec.Record(events.Event{
 			Type:    events.OrderFailed,
 			Actor:   "controller",
 			Subject: scoped,
-			Message: errMsg,
+			Message: msg,
 		})
-	} else {
+		return
+	}
+	if execErrMsg != "" {
+		if hasEventCursor {
+			execErrMsg = fmt.Sprintf("seq=%d: %s", headSeq, execErrMsg)
+		}
 		m.rec.Record(events.Event{
-			Type:    events.OrderCompleted,
+			Type:    events.OrderFailed,
 			Actor:   "controller",
 			Subject: scoped,
+			Message: execErrMsg,
 		})
+		return
 	}
-
-	// Label tracking bead with outcome via store (not CLI).
-	store.Update(trackingID, beads.UpdateOpts{Labels: labels}) //nolint:errcheck // best-effort
+	m.rec.Record(events.Event{
+		Type:    events.OrderCompleted,
+		Actor:   "controller",
+		Subject: scoped,
+	})
 }
 
 // dispatchWisp instantiates a wisp from the order's formula.
@@ -461,10 +516,24 @@ func (m *memoryOrderDispatcher) dispatchWisp(ctx context.Context, store beads.St
 		return
 	}
 
-	// Capture event head before wisp creation for event triggers.
+	// Capture event head before wisp creation for event triggers. Event runs
+	// fail closed when the cursor cannot be read.
 	var headSeq uint64
 	if a.Trigger == "event" && m.ep != nil {
-		headSeq, _ = m.ep.LatestSeq()
+		var err error
+		headSeq, err = m.ep.LatestSeq()
+		if err != nil {
+			errMsg := fmt.Sprintf("reading event cursor: %v", err)
+			logDispatchError(m.stderr, "gc: order dispatch: reading event cursor for %s: %v", scoped, err)
+			m.rec.Record(events.Event{
+				Type:    events.OrderFailed,
+				Actor:   "controller",
+				Subject: scoped,
+				Message: errMsg,
+			})
+			m.markTrackingFailure(store, trackingID, scoped, a, 0)
+			return
+		}
 	}
 
 	var searchPaths []string
@@ -589,10 +658,7 @@ func (m *memoryOrderDispatcher) orderRigSuspended(a orders.Order) bool {
 func (m *memoryOrderDispatcher) markTrackingFailure(store beads.Store, trackingID, scoped string, a orders.Order, headSeq uint64) {
 	labels := []string{"wisp", "wisp-failed"}
 	if a.Trigger == "event" && headSeq > 0 {
-		labels = append(labels,
-			fmt.Sprintf("order:%s", scoped),
-			fmt.Sprintf("seq:%d", headSeq),
-		)
+		labels = append(labels, eventCursorLabels(scoped, headSeq)...)
 	}
 	if err := store.Update(trackingID, beads.UpdateOpts{Labels: labels}); err != nil {
 		logDispatchError(m.stderr, "gc: order %s: failed to mark tracking bead %s as failed: %v", scoped, trackingID, err)

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -429,6 +429,60 @@ func TestOrderDispatchRejectsAmbiguousEventPoolOncePerEvent(t *testing.T) {
 	}
 }
 
+func TestOrderDispatchEventExecAdvancesCursor(t *testing.T) {
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+
+	var calls int
+	execRun := func(context.Context, string, string, []string) ([]byte, error) {
+		calls++
+		return []byte("ok"), nil
+	}
+
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:    "release-exec",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "scripts/release.sh",
+	}}, store, eventLog, execRun, events.Discard)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	all := trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after first dispatch = %d, want 1", len(all))
+	}
+	if !slicesContain(all[0].Labels, "order:release-exec") {
+		t.Fatalf("tracking bead labels = %v, want order cursor label", all[0].Labels)
+	}
+	if !slicesContain(all[0].Labels, fmt.Sprintf("seq:%d", headSeq)) {
+		t.Fatalf("tracking bead labels = %v, want seq:%d", all[0].Labels, headSeq)
+	}
+	if calls != 1 {
+		t.Fatalf("exec calls after first dispatch = %d, want 1", calls)
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(10*time.Second))
+	ad.drain(context.Background())
+
+	all = trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after second dispatch = %d, want 1", len(all))
+	}
+	if calls != 1 {
+		t.Fatalf("exec calls after second dispatch = %d, want 1", calls)
+	}
+}
+
 func TestOrderDispatchResolvesImportedPackPoolAgainstCityShadow(t *testing.T) {
 	cityDir := t.TempDir()
 	writeImportedDogOrderFixture(t, cityDir, true)

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -47,6 +47,18 @@ type selectiveUpdateFailStore struct {
 	beads.Store
 }
 
+type execLabelUpdateFailStore struct {
+	beads.Store
+}
+
+type eventCursorUpdateFailStore struct {
+	beads.Store
+}
+
+type latestSeqFailProvider struct {
+	events.Provider
+}
+
 type countingListStore struct {
 	beads.Store
 
@@ -66,6 +78,28 @@ func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error
 		}
 	}
 	return s.Store.Update(id, opts)
+}
+
+func (s execLabelUpdateFailStore) Update(id string, opts beads.UpdateOpts) error {
+	for _, label := range opts.Labels {
+		if label == "exec" {
+			return fmt.Errorf("exec label failed")
+		}
+	}
+	return s.Store.Update(id, opts)
+}
+
+func (s eventCursorUpdateFailStore) Update(id string, opts beads.UpdateOpts) error {
+	for _, label := range opts.Labels {
+		if strings.HasPrefix(label, "order:") {
+			return fmt.Errorf("event cursor label failed")
+		}
+	}
+	return s.Store.Update(id, opts)
+}
+
+func (p latestSeqFailProvider) LatestSeq() (uint64, error) {
+	return 0, fmt.Errorf("latest seq failed")
 }
 
 func (s *countingListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
@@ -480,6 +514,291 @@ func TestOrderDispatchEventExecAdvancesCursor(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("exec calls after second dispatch = %d, want 1", calls)
+	}
+}
+
+func TestOrderDispatchEventExecFailureAdvancesCursor(t *testing.T) {
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+
+	var calls int
+	execRun := func(context.Context, string, string, []string) ([]byte, error) {
+		calls++
+		return []byte("failed"), fmt.Errorf("exit status 1")
+	}
+
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:    "release-exec",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "scripts/release.sh",
+	}}, store, eventLog, execRun, events.Discard)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	all := trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after first dispatch = %d, want 1", len(all))
+	}
+	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq), "exec-failed"} {
+		if !slicesContain(all[0].Labels, want) {
+			t.Fatalf("tracking bead labels = %v, want %s", all[0].Labels, want)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("exec calls after first dispatch = %d, want 1", calls)
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now())
+	ad.drain(context.Background())
+
+	all = trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after second dispatch = %d, want 1", len(all))
+	}
+	if calls != 1 {
+		t.Fatalf("exec calls after second dispatch = %d, want 1", calls)
+	}
+}
+
+func TestOrderDispatchEventExecLatestSeqErrorDoesNotRunExec(t *testing.T) {
+	store := beads.NewMemStore()
+	tracking, err := store.Create(beads.Bead{
+		Title:  "order:release-exec",
+		Labels: []string{"order-run:release-exec", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls int
+	execRun := func(context.Context, string, string, []string) ([]byte, error) {
+		calls++
+		return []byte("ok"), nil
+	}
+	var rec memRecorder
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:    "release-exec",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "scripts/release.sh",
+	}}, store, events.NewFailFake(), execRun, &rec)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	mad := ad.(*memoryOrderDispatcher)
+	mad.stderr = &stderr
+
+	logs := captureCmdOrderLogs(t, func() {
+		mad.dispatchExec(context.Background(), store, execStoreTarget{ScopeRoot: t.TempDir()}, mad.aa[0], t.TempDir(), tracking.ID)
+	})
+
+	if calls != 0 {
+		t.Fatalf("exec calls = %d, want 0", calls)
+	}
+	all := trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads = %d, want 1", len(all))
+	}
+	if !slicesContain(all[0].Labels, "exec-failed") {
+		t.Fatalf("tracking bead labels = %v, want exec-failed", all[0].Labels)
+	}
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event")
+	}
+	combined := logs + "\n" + stderr.String()
+	if !strings.Contains(combined, "reading event cursor for release-exec") {
+		t.Fatalf("logs = %q, want event cursor read failure", combined)
+	}
+
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	mad.ep = eventLog
+	mad.dispatchExec(context.Background(), store, execStoreTarget{ScopeRoot: t.TempDir()}, mad.aa[0], t.TempDir(), tracking.ID)
+
+	if calls != 1 {
+		t.Fatalf("exec calls after cursor read recovers = %d, want 1", calls)
+	}
+	all = trackingBeads(t, store, "order-run:release-exec")
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq), "exec"} {
+		if !slicesContain(all[0].Labels, want) {
+			t.Fatalf("tracking bead labels after retry = %v, want %s", all[0].Labels, want)
+		}
+	}
+}
+
+func TestOrderDispatchEventExecLabelFailureRecordsOrderFailure(t *testing.T) {
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+	headSeq, err := eventLog.LatestSeq()
+	if err != nil {
+		t.Fatalf("LatestSeq(): %v", err)
+	}
+
+	var calls int
+	execRun := func(context.Context, string, string, []string) ([]byte, error) {
+		calls++
+		return []byte("ok"), nil
+	}
+	var rec memRecorder
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:    "release-exec",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "scripts/release.sh",
+	}}, execLabelUpdateFailStore{Store: store}, eventLog, execRun, &rec)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	mad := ad.(*memoryOrderDispatcher)
+	mad.stderr = &stderr
+
+	logs := captureCmdOrderLogs(t, func() {
+		ad.dispatch(context.Background(), t.TempDir(), time.Now())
+		ad.drain(context.Background())
+	})
+
+	if calls != 1 {
+		t.Fatalf("exec calls = %d, want 1", calls)
+	}
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event")
+	}
+	if rec.hasType(events.OrderCompleted) {
+		t.Fatal("unexpected order.completed event")
+	}
+	all := trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after first dispatch = %d, want 1", len(all))
+	}
+	for _, want := range []string{"order:release-exec", fmt.Sprintf("seq:%d", headSeq)} {
+		if !slicesContain(all[0].Labels, want) {
+			t.Fatalf("tracking bead labels = %v, want %s", all[0].Labels, want)
+		}
+	}
+
+	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(10*time.Second))
+	ad.drain(context.Background())
+
+	all = trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label after second dispatch = %d, want 1", len(all))
+	}
+	if calls != 1 {
+		t.Fatalf("exec calls after second dispatch = %d, want 1", calls)
+	}
+	combined := logs + "\n" + stderr.String()
+	if !strings.Contains(combined, "failed to label exec tracking bead") {
+		t.Fatalf("logs = %q, want tracking label failure", combined)
+	}
+}
+
+func TestOrderDispatchEventExecCursorLabelFailureMarksExecFailed(t *testing.T) {
+	store := beads.NewMemStore()
+	eventLog := events.NewFake()
+	eventLog.Record(events.Event{Type: events.BeadClosed, Actor: "test"})
+
+	var calls int
+	execRun := func(context.Context, string, string, []string) ([]byte, error) {
+		calls++
+		return []byte("ok"), nil
+	}
+	var rec memRecorder
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:    "release-exec",
+		Trigger: "event",
+		On:      events.BeadClosed,
+		Exec:    "scripts/release.sh",
+	}}, eventCursorUpdateFailStore{Store: store}, eventLog, execRun, &rec)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	mad := ad.(*memoryOrderDispatcher)
+	mad.stderr = &stderr
+
+	logs := captureCmdOrderLogs(t, func() {
+		ad.dispatch(context.Background(), t.TempDir(), time.Now())
+		ad.drain(context.Background())
+	})
+
+	if calls != 0 {
+		t.Fatalf("exec calls = %d, want 0", calls)
+	}
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event")
+	}
+	if rec.hasType(events.OrderCompleted) {
+		t.Fatal("unexpected order.completed event")
+	}
+	all := trackingBeads(t, store, "order-run:release-exec")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label = %d, want 1", len(all))
+	}
+	if !slicesContain(all[0].Labels, "exec-failed") {
+		t.Fatalf("tracking bead labels = %v, want exec-failed", all[0].Labels)
+	}
+	combined := logs + "\n" + stderr.String()
+	if !strings.Contains(combined, "failed to label exec event cursor") {
+		t.Fatalf("logs = %q, want cursor label failure", combined)
+	}
+}
+
+func TestOrderDispatchEventWispLatestSeqErrorDoesNotInstantiate(t *testing.T) {
+	store := beads.NewMemStore()
+	tracking, err := store.Create(beads.Bead{
+		Title:  "order:release-watch",
+		Labels: []string{"order-run:release-watch", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rec memRecorder
+	var stderr bytes.Buffer
+	ad := buildOrderDispatcherFromListExec([]orders.Order{{
+		Name:         "release-watch",
+		Trigger:      "event",
+		On:           events.BeadClosed,
+		Formula:      "test-formula",
+		FormulaLayer: sharedTestFormulaDir,
+	}}, store, latestSeqFailProvider{Provider: events.NewFake()}, successfulExec, &rec)
+	if ad == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	mad := ad.(*memoryOrderDispatcher)
+	mad.stderr = &stderr
+
+	mad.dispatchWisp(context.Background(), store, mad.aa[0], t.TempDir(), tracking.ID)
+
+	all := trackingBeads(t, store, "order-run:release-watch")
+	if len(all) != 1 {
+		t.Fatalf("tracking beads with order-run label = %d, want only tracking bead", len(all))
+	}
+	if !slicesContain(all[0].Labels, "wisp-failed") {
+		t.Fatalf("tracking bead labels = %v, want wisp-failed", all[0].Labels)
+	}
+	if !rec.hasType(events.OrderFailed) {
+		t.Fatal("missing order.failed event")
+	}
+	if !strings.Contains(stderr.String(), "reading event cursor for release-watch") {
+		t.Fatalf("stderr = %q, want event cursor read failure", stderr.String())
 	}
 }
 

--- a/engdocs/architecture/orders.md
+++ b/engdocs/architecture/orders.md
@@ -247,8 +247,10 @@ Violations indicate bugs.
 
 - **Event trigger uses cursor-based deduplication**: Event orders track
   the highest processed event sequence number via `seq:<N>` labels on
-  wisp beads. Subsequent trigger checks use `AfterSeq` filtering to avoid
-  reprocessing already-handled events.
+  order-run beads. Formula orders stamp the wisp root or failure tracking
+  bead; exec orders stamp the tracking bead before the command runs. Subsequent
+  trigger checks use `AfterSeq` filtering to avoid reprocessing
+  already-handled events.
 
 - **Dispatch goroutines are drained on controller exit**: Each due
   order launches a goroutine whose completion is tracked by an
@@ -383,10 +385,14 @@ boundaries.
   `sh -c <check>` synchronously during trigger evaluation. A slow check
   command blocks evaluation of subsequent orders on that tick.
 
-- **Event trigger cursor is per-wisp, not per-dispatch**: The cursor
-  position is computed from `seq:<N>` labels on existing wisp beads via
-  `MaxSeqFromLabels()`. If wisp creation fails, the cursor is not
-  advanced, which may cause duplicate event processing on retry.
+- **Event trigger cursor is per-run, not per-dispatch**: The cursor
+  position is computed from `seq:<N>` labels on existing order-run beads via
+  `MaxSeqFromLabels()`. The controller and `gc order run` fail closed when the
+  current event head cannot be read. For side-effecting exec orders, the cursor
+  is persisted before the command runs so a crash after execution does not
+  replay the same event. Trade-off: a controller crash after the cursor stamp
+  and before exec start drops that event for idempotent exec orders; for
+  non-idempotent exec orders this is the safer failure mode.
 
 - **No hot-add of orders**: Order discovery runs on controller
   start and config reload (via fsnotify). Adding a new


### PR DESCRIPTION
## Summary
- stamp order:<name> and seq:<n> labels on event-triggered exec order tracking beads
- add a regression test proving an event-triggered exec order does not re-fire for the same event

## Tests
- go test ./cmd/gc -run TestOrderDispatchEventExecAdvancesCursor -count=1
- go test ./cmd/gc -run 'TestOrderDispatch(Event|RejectsAmbiguousEvent|Cooldown|Exec)' -count=1\n- go test ./cmd/gc -count=1\n- make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->