### PR TITLE
fix(gastown): use 'gc handoff --auto' in PreCompact to stop killing crew sessions

### DIFF
--- a/examples/gastown/packs/gastown/overlay/.claude/settings.json
+++ b/examples/gastown/packs/gastown/overlay/.claude/settings.json
@@ -21,7 +21,7 @@
           },
           {
             "type": "command",
-            "command": "gc handoff \"context cycle\""
+            "command": "gc handoff --auto \"context cycle\""
           }
         ]
       }

--- a/examples/gastown/precompact_hook_test.go
+++ b/examples/gastown/precompact_hook_test.go
@@ -1,0 +1,67 @@
+package gastown_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPreCompactHookUsesAutoHandoff guards the PreCompact hook in the gastown
+// pack overlay against the destructive-eviction regression documented in
+// gc-flp1.
+//
+// `gc handoff` (bare) sends mail AND requests a controller restart, which kills
+// the running session. For PreCompact — which fires automatically on every
+// Claude context-cycle inside any session running this overlay — restart-mode
+// turns every compaction into a session kill. When a human is mid-conversation
+// in a crew session (Mayor, Navani, Syl, etc.), this destroys their state.
+//
+// `gc handoff --auto` is the documented mode for this scenario: send mail,
+// skip restart, return immediately. The internal SDK hook config
+// (internal/hooks/config/claude.json) was switched to --auto in commit
+// 7b3b913a ("fix: add auto handoff for precompact"); the gastown pack overlay
+// must match.
+func TestPreCompactHookUsesAutoHandoff(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "overlay", ".claude", "settings.json")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading overlay settings: %v", err)
+	}
+
+	var cfg struct {
+		Hooks struct {
+			PreCompact []struct {
+				Hooks []struct {
+					Type    string `json:"type"`
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"PreCompact"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing overlay settings as JSON: %v", err)
+	}
+	if len(cfg.Hooks.PreCompact) == 0 {
+		t.Fatalf("expected PreCompact hooks in overlay settings; got none")
+	}
+
+	var sawHandoff bool
+	for _, group := range cfg.Hooks.PreCompact {
+		for _, h := range group.Hooks {
+			if !strings.Contains(h.Command, "gc handoff") {
+				continue
+			}
+			sawHandoff = true
+			if !strings.Contains(h.Command, "--auto") {
+				t.Errorf("PreCompact hook invokes 'gc handoff' without --auto; bare gc handoff requests a restart and kills the session on every compaction (gc-flp1).\n  command: %q\n  fix: insert --auto, e.g. 'gc handoff --auto \"context cycle\"'", h.Command)
+			}
+		}
+	}
+	if !sawHandoff {
+		t.Errorf("PreCompact hook does not call 'gc handoff' at all; expected 'gc handoff --auto \"context cycle\"'")
+	}
+}


### PR DESCRIPTION
## What

The PreCompact hook in the gastown pack overlay (`examples/gastown/packs/gastown/overlay/.claude/settings.json`) invoked bare `gc handoff "context cycle"`. Bare `gc handoff` sends mail AND requests a controller restart, killing the running session. PreCompact fires automatically on every Claude context-cycle inside any session running this overlay, so every compaction turned into a session kill — destroying conversation state with no audit log when a human was mid-session.

`gc handoff --auto` is the documented mode for exactly this scenario: send the mail, skip the restart, return immediately. The flag was added in #1567 (Julian Knutsen, "fix: add auto handoff for precompact", commit 7b3b913a), which switched the SDK's bundled hook config (`internal/hooks/config/claude.json`). The gastown pack overlay was not updated in that PR, so end-user sessions — which load the overlay, not the SDK config — never got the fix.

This PR brings the overlay in line. Sessions materialized via `gc init --from gastown` (every default deployment) immediately stop self-destructing on compaction.

## Architectural principle

Pack content should consume the SDK's documented contract (here, the `--auto` flag's non-destructive behavior) rather than carrying the legacy destructive shape. This is the same pattern Chris Sells flagged as needing system-wide treatment in the routing-normalization debate (issue cluster #1397 / #1486 / #855 / #1439) and that tprox called for: *"design a system for the packs, routing, and assignees that guarantees the same normalized label across all these locations."*

Sibling fixes from quickserve-ai/gascity that share this pattern (consume the canonical SDK primitive instead of re-deriving in pack/CLI surfaces):

- #1571 (cycle.sh) — drives grouping from session-name primitive separators (`/`→`--`, `.`→`__`) rather than hardcoded role names.
- #1573 (bind-key.sh) — drops if-shell guard; consumes the per-city tmux socket primitive (every session on the socket is a GC session, by construction).
- #1591 (`gc session new`) — derives canonical session name for singletons from the session-name primitive instead of falling back to `s-<beadID>`.
- #1604 (convoy reject epic-as-child) — single domain rule consumed by every convoy-link surface (CLI, internal API, HTTP).
- (this PR) — pack overlay consumes the `--auto` contract documented for the PreCompact lifecycle.

Each is small in isolation; the cluster is the concrete case for the unified pattern.

## Test

`examples/gastown/precompact_hook_test.go` — `TestPreCompactHookUsesAutoHandoff`. Reads the overlay JSON, walks PreCompact hooks, fails if any `gc handoff` invocation lacks `--auto`. Same shape as `bind_key_script_test.go` (#1573) and `cycle_script_test.go` (#1571).

## Scope

This closes the destructive trigger only. The quickserve-ai team has additional follow-up work tracked locally for the broader incident (audit-log gap on session-lifecycle events, idle_timeout treating crew sessions like polecats, missing crew/polecat distinction in `max_active_sessions=1` enforcement). Those are separate concerns and don't gate this small, well-tested patch.

## Watch list (quickserve-ai/gascity)

- [ ] CI green
- [ ] Review feedback addressed
- [ ] Merge upstream → drop our local pack divergence (`~/qlandia/packs/gastown/...`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->