### PR TITLE
tut02 grammar: fix missing word "know"

### DIFF
--- a/docs/tutorials/02-agents.md
+++ b/docs/tutorials/02-agents.md
@@ -60,7 +60,7 @@ and execute it.
 4. Check for more work. Repeat until the queue is empty.
 ```
 
-The `gc prime` command let's an agent running in GC how to behave, specially how
+The `gc prime` command let's an agent running in GC know how to behave, specifically how
 to look for work that's been assigned to it. In [tutorial
 01](/tutorials/01-cities-and-rigs), we learned that slinging work to an agent created a
 bead. Looking here at the default prompt, it should be clear how the agent can


### PR DESCRIPTION
## Summary

- Have read this tut several times and my brain keeps tripping on this sentence

## Testing

No testing, the missing word is obvious from the diff

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->