### PR TITLE
fix(orders): surface rig-scope mismatch in [[orders.overrides]] errors + add rig = "*" wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `[[orders.overrides]]` rig matching is stricter and clearer. A rigless
+  override (`rig` unset) still matches **only** city-level orders; if the
+  named order exists only as per-rig instances, the error now names every
+  matching rig so it's obvious what to type. `rig = "*"` is a new wildcard
+  that targets every instance of the named order (city-level + per-rig).
+  The literal `"*"` is reserved and rejected as a real rig name by config
+  validation.
 - Managed Dolt config now emits listener backlog and connection-timeout keys.
   Existing managed cities may see a `dolt-config` doctor warning until
   `gc dolt restart` or the next managed server start regenerates

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -370,7 +370,7 @@ OrderOverride modifies a scanned order's scheduling fields.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | **yes** |  | Name is the order name to target (required). |
-| `rig` | string |  |  | Rig scopes the override to a specific rig's order. Empty matches city-level orders. |
+| `rig` | string |  |  | Rig scopes the override to a specific rig's order. Empty matches ONLY city-level orders (those with no rig); it does NOT match per-rig instances of the same name — those expand at scan time and require an explicit rig. Use rig = "*" as a wildcard to match every instance of the named order (city-level + every rig-scoped copy). The literal "*" is reserved and rejected as a real rig name by config validation. |
 | `enabled` | boolean |  |  | Enabled overrides whether the order is active. |
 | `trigger` | string |  |  | Trigger overrides the trigger type. |
 | `gate` | string |  |  | Gate is a deprecated alias for Trigger accepted during the gate-&gt;trigger migration. Parsed inputs are normalized to Trigger. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1321,7 +1321,7 @@
         },
         "rig": {
           "type": "string",
-          "description": "Rig scopes the override to a specific rig's order.\nEmpty matches city-level orders."
+          "description": "Rig scopes the override to a specific rig's order. Empty matches\nONLY city-level orders (those with no rig); it does NOT match\nper-rig instances of the same name — those expand at scan time\nand require an explicit rig. Use rig = \"*\" as a wildcard to match\nevery instance of the named order (city-level + every rig-scoped\ncopy). The literal \"*\" is reserved and rejected as a real rig\nname by config validation."
         },
         "enabled": {
           "type": "boolean",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1321,7 +1321,7 @@
         },
         "rig": {
           "type": "string",
-          "description": "Rig scopes the override to a specific rig's order.\nEmpty matches city-level orders."
+          "description": "Rig scopes the override to a specific rig's order. Empty matches\nONLY city-level orders (those with no rig); it does NOT match\nper-rig instances of the same name — those expand at scan time\nand require an explicit rig. Use rig = \"*\" as a wildcard to match\nevery instance of the named order (city-level + every rig-scoped\ncopy). The literal \"*\" is reserved and rejected as a real rig\nname by config validation."
         },
         "enabled": {
           "type": "boolean",

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -327,8 +327,10 @@ schedule = "0 6 * * *"
 ```
 
 Overrides can change `enabled`, `trigger`, `interval`, `schedule`, `check`, `on`,
-`pool`, and `timeout`. The override matches by order name — if no order with
-that name exists, it's an error (fail-fast, not silent).
+`pool`, and `timeout`. The override matches by order name. An override that
+targets a nonexistent order produces an error rather than silently no-opping
+— `gc order` CLI commands fail; `gc start` logs the error and continues
+running with the unmatched override skipped.
 
 ### Rig scoping
 

--- a/docs/tutorials/07-orders.md
+++ b/docs/tutorials/07-orders.md
@@ -330,6 +330,36 @@ Overrides can change `enabled`, `trigger`, `interval`, `schedule`, `check`, `on`
 `pool`, and `timeout`. The override matches by order name — if no order with
 that name exists, it's an error (fail-fast, not silent).
 
+### Rig scoping
+
+Many orders expand at scan time into one instance per rig (anything in a
+rig's `orders/` directory or a pack imported into a rig). When the same
+order appears city-wide AND per-rig, an override must say which:
+
+```toml
+# Targets ONLY the city-level instance. Per-rig copies are unaffected.
+[[orders.overrides]]
+name = "patrol"
+enabled = false
+
+# Targets ONLY the demo-repo rig's copy.
+[[orders.overrides]]
+name = "patrol"
+rig = "demo-repo"
+enabled = false
+
+# Wildcard: targets every instance — city-level + all rig copies.
+[[orders.overrides]]
+name = "patrol"
+rig = "*"
+enabled = false
+```
+
+A rigless override against a name that exists ONLY as per-rig copies is an
+error; the message names the rigs so you know what to type. The literal
+`"*"` is reserved as the wildcard token and may not be used as a real rig
+name.
+
 ## Order history
 
 Every time an order fires, Gas City creates a tracking bead labeled with the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/orders"
 )
 
 // validAgentName matches names safe for use in session identifiers.
@@ -1088,8 +1089,13 @@ type OrdersConfig struct {
 type OrderOverride struct {
 	// Name is the order name to target (required).
 	Name string `toml:"name" jsonschema:"required"`
-	// Rig scopes the override to a specific rig's order.
-	// Empty matches city-level orders.
+	// Rig scopes the override to a specific rig's order. Empty matches
+	// ONLY city-level orders (those with no rig); it does NOT match
+	// per-rig instances of the same name — those expand at scan time
+	// and require an explicit rig. Use rig = "*" as a wildcard to match
+	// every instance of the named order (city-level + every rig-scoped
+	// copy). The literal "*" is reserved and rejected as a real rig
+	// name by config validation.
 	Rig string `toml:"rig,omitempty"`
 	// Enabled overrides whether the order is active.
 	Enabled *bool `toml:"enabled,omitempty"`
@@ -2716,6 +2722,11 @@ func ValidateRigs(rigs []Rig, hqPrefix string) error {
 	for i, r := range rigs {
 		if r.Name == "" {
 			return fmt.Errorf("rig[%d]: name is required", i)
+		}
+		// orders.RigWildcard is reserved as the [[orders.overrides]]
+		// token; a real rig with that name would be silently shadowed.
+		if r.Name == orders.RigWildcard {
+			return fmt.Errorf("rig[%d]: name %q is reserved as the [[orders.overrides]] wildcard", i, r.Name)
 		}
 		if r.Path == "" {
 			return fmt.Errorf("rig %q: path is required", r.Name)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2549,6 +2549,17 @@ func TestValidateRigs_MissingPath(t *testing.T) {
 	}
 }
 
+func TestValidateRigs_WildcardNameRejected(t *testing.T) {
+	rigs := []Rig{{Name: "*", Path: "/a"}}
+	err := ValidateRigs(rigs, "ci")
+	if err == nil {
+		t.Fatal(`expected error for rig name "*"`)
+	}
+	if !strings.Contains(err.Error(), "wildcard") {
+		t.Errorf("error = %q, want 'wildcard'", err)
+	}
+}
+
 func TestValidateRigs_DuplicateName(t *testing.T) {
 	rigs := []Rig{
 		{Name: "frontend", Path: "/a"},

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -1,6 +1,17 @@
 package orders
 
-import "fmt"
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// RigWildcard, when used as Override.Rig, matches every order with the
+// override's name regardless of rig scope (city-level + every rig-scoped
+// instance). It is reserved as a config-time literal: real rig names
+// equal to "*" are rejected by config validation.
+const RigWildcard = "*"
 
 // Override modifies a scanned order's scheduling fields.
 // Uses pointer fields to distinguish "not set" from "set to zero value."
@@ -20,9 +31,18 @@ type Override struct {
 }
 
 // ApplyOverrides applies each override to the matching order in aa.
-// Matching is by name, optionally scoped by rig. Returns an error if an
-// override targets a nonexistent order (following the agent override
-// pattern where unmatched targets are errors, not silent no-ops).
+//
+// Matching rules:
+//   - ov.Rig == "":  matches only city-level orders (those with no rig).
+//     If no city-level order with the name exists but rig-scoped instances
+//     do, returns an error suggesting the explicit rig = "<name>" syntax.
+//   - ov.Rig == "*": wildcard — matches every order with the name,
+//     regardless of rig.
+//   - otherwise:     matches only the order with that exact rig.
+//
+// Returns an error if an override targets a nonexistent order (following
+// the agent override pattern where unmatched targets are errors, not
+// silent no-ops).
 func ApplyOverrides(aa []Order, overrides []Override) error {
 	for i, ov := range overrides {
 		if ov.Name == "" {
@@ -33,23 +53,74 @@ func ApplyOverrides(aa []Order, overrides []Override) error {
 			if aa[j].Name != ov.Name {
 				continue
 			}
-			// Scope matching: when ov.Rig is set, only match that rig.
-			// When ov.Rig is empty, only match city-level orders
-			// (those with no rig), not rig-scoped ones.
-			if aa[j].Rig != ov.Rig {
+			if !rigMatches(ov.Rig, aa[j].Rig) {
 				continue
 			}
 			applyOverride(&aa[j], &ov)
 			found = true
 		}
 		if !found {
-			if ov.Rig != "" {
-				return fmt.Errorf("orders.overrides[%d]: order %q (rig %q) not found", i, ov.Name, ov.Rig)
-			}
-			return fmt.Errorf("orders.overrides[%d]: order %q not found", i, ov.Name)
+			return notFoundError(i, ov, aa)
 		}
 	}
 	return nil
+}
+
+func rigMatches(ovRig, orderRig string) bool {
+	if ovRig == RigWildcard {
+		return true
+	}
+	return ovRig == orderRig
+}
+
+// notFoundError builds the unmatched-override error. When the override is
+// rigless ("") but the slice contains rig-scoped orders with the same
+// name, the error names every such rig so the user knows exactly what to
+// type — this is the gotcha that the previous error message hid.
+func notFoundError(idx int, ov Override, aa []Order) error {
+	switch {
+	case ov.Rig == "":
+		rigs := rigsForName(aa, ov.Name)
+		if len(rigs) > 0 {
+			return fmt.Errorf(
+				"orders.overrides[%d]: order %q not found at city scope (%s rig-scoped); "+
+					"set %s to target a per-rig instance, "+
+					`or use rig = "*" to target all instances`,
+				idx, ov.Name, pluralizeRigCount(len(rigs)), formatRigSuggestions(rigs),
+			)
+		}
+		return fmt.Errorf("orders.overrides[%d]: order %q not found", idx, ov.Name)
+	case ov.Rig == RigWildcard:
+		return fmt.Errorf("orders.overrides[%d]: order %q not found (rig %q matches no instances)", idx, ov.Name, RigWildcard)
+	default:
+		return fmt.Errorf("orders.overrides[%d]: order %q (rig %q) not found", idx, ov.Name, ov.Rig)
+	}
+}
+
+func rigsForName(aa []Order, name string) []string {
+	seen := map[string]struct{}{}
+	for _, a := range aa {
+		if a.Name != name || a.Rig == "" {
+			continue
+		}
+		seen[a.Rig] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(seen))
+}
+
+func formatRigSuggestions(rigs []string) string {
+	parts := make([]string, len(rigs))
+	for i, r := range rigs {
+		parts[i] = fmt.Sprintf("rig = %q", r)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func pluralizeRigCount(n int) string {
+	if n == 1 {
+		return "1 instance"
+	}
+	return fmt.Sprintf("%d instances", n)
 }
 
 func applyOverride(a *Order, ov *Override) {

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// RigWildcard, when used as Override.Rig, matches every order with the
+// RigWildcard is the Override.Rig value that matches every order with the
 // override's name regardless of rig scope (city-level + every rig-scoped
 // instance). It is reserved as a config-time literal: real rig names
 // equal to "*" are rejected by config validation.
@@ -78,8 +78,8 @@ func rigMatches(ovRig, orderRig string) bool {
 // name, the error names every such rig so the user knows exactly what to
 // type — this is the gotcha that the previous error message hid.
 func notFoundError(idx int, ov Override, aa []Order) error {
-	switch {
-	case ov.Rig == "":
+	switch ov.Rig {
+	case "":
 		rigs := rigsForName(aa, ov.Name)
 		if len(rigs) > 0 {
 			return fmt.Errorf(
@@ -90,7 +90,7 @@ func notFoundError(idx int, ov Override, aa []Order) error {
 			)
 		}
 		return fmt.Errorf("orders.overrides[%d]: order %q not found", idx, ov.Name)
-	case ov.Rig == RigWildcard:
+	case RigWildcard:
 		return fmt.Errorf("orders.overrides[%d]: order %q not found (rig %q matches no instances)", idx, ov.Name, RigWildcard)
 	default:
 		return fmt.Errorf("orders.overrides[%d]: order %q (rig %q) not found", idx, ov.Name, ov.Rig)

--- a/internal/orders/override.go
+++ b/internal/orders/override.go
@@ -85,8 +85,8 @@ func notFoundError(idx int, ov Override, aa []Order) error {
 			return fmt.Errorf(
 				"orders.overrides[%d]: order %q not found at city scope (%s rig-scoped); "+
 					"set %s to target a per-rig instance, "+
-					`or use rig = "*" to target all instances`,
-				idx, ov.Name, pluralizeRigCount(len(rigs)), formatRigSuggestions(rigs),
+					"or use rig = %q to target all instances",
+				idx, ov.Name, pluralizeRigCount(len(rigs)), formatRigSuggestions(rigs), RigWildcard,
 			)
 		}
 		return fmt.Errorf("orders.overrides[%d]: order %q not found", idx, ov.Name)

--- a/internal/orders/override_test.go
+++ b/internal/orders/override_test.go
@@ -1,0 +1,254 @@
+package orders
+
+import (
+	"strings"
+	"testing"
+)
+
+// boolPtr / strPtr are local helpers so tests stay self-contained.
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }
+
+func TestApplyOverrides(t *testing.T) {
+	t.Parallel()
+
+	disabled := boolPtr(false)
+	tenSec := strPtr("10s")
+	thirtySec := strPtr("30s")
+
+	tests := []struct {
+		name      string
+		orders    []Order
+		overrides []Override
+		// wantErrSubstrs: all of these substrings must appear in the
+		// returned error. Empty means the call must succeed.
+		wantErrSubstrs []string
+		// check inspects the post-apply orders slice when no error.
+		check func(t *testing.T, aa []Order)
+	}{
+		{
+			name: "city level override matches city order",
+			orders: []Order{
+				{Name: "patrol", Rig: ""},
+			},
+			overrides: []Override{
+				{Name: "patrol", Rig: "", Enabled: disabled},
+			},
+			check: func(t *testing.T, aa []Order) {
+				t.Helper()
+				if aa[0].Enabled == nil || *aa[0].Enabled {
+					t.Errorf("city-level patrol not disabled: %+v", aa[0].Enabled)
+				}
+			},
+		},
+		{
+			name: "rig scoped override matches only that rig",
+			orders: []Order{
+				{Name: "patrol", Rig: "demo"},
+				{Name: "patrol", Rig: "prod"},
+			},
+			overrides: []Override{
+				{Name: "patrol", Rig: "demo", Interval: tenSec},
+			},
+			check: func(t *testing.T, aa []Order) {
+				t.Helper()
+				if aa[0].Interval != "10s" {
+					t.Errorf("demo patrol interval = %q, want 10s", aa[0].Interval)
+				}
+				if aa[1].Interval != "" {
+					t.Errorf("prod patrol interval should be unchanged, got %q", aa[1].Interval)
+				}
+			},
+		},
+		{
+			name: "rigless override does not match rig-scoped orders, error suggests rig syntax",
+			orders: []Order{
+				{Name: "patrol", Rig: "demo"},
+				{Name: "patrol", Rig: "prod"},
+				{Name: "other", Rig: ""},
+			},
+			overrides: []Override{
+				{Name: "patrol", Rig: "", Enabled: disabled},
+			},
+			wantErrSubstrs: []string{
+				"orders.overrides[0]",
+				`"patrol"`,
+				"not found",
+				// regression-grade: the enriched error must mention the
+				// rig-scope mismatch and the actual rig names that exist,
+				// so users see exactly what to type.
+				`rig = "demo"`,
+				`rig = "prod"`,
+			},
+		},
+		{
+			name: "rig scoped override with no matching rig instance returns error naming the rig",
+			orders: []Order{
+				{Name: "patrol", Rig: "demo"},
+			},
+			overrides: []Override{
+				{Name: "patrol", Rig: "missing", Interval: tenSec},
+			},
+			wantErrSubstrs: []string{
+				"orders.overrides[0]",
+				`"patrol"`,
+				`"missing"`,
+				"not found",
+			},
+		},
+		{
+			name: "wildcard rig matches every instance with that name",
+			orders: []Order{
+				{Name: "patrol", Rig: ""},
+				{Name: "patrol", Rig: "demo"},
+				{Name: "patrol", Rig: "prod"},
+				{Name: "other", Rig: "demo"},
+			},
+			overrides: []Override{
+				{Name: "patrol", Rig: RigWildcard, Enabled: disabled, Interval: thirtySec},
+			},
+			check: func(t *testing.T, aa []Order) {
+				t.Helper()
+				for i, a := range aa {
+					if a.Name != "patrol" {
+						if a.Enabled != nil {
+							t.Errorf("aa[%d] %q: unrelated order should not be touched", i, a.Name)
+						}
+						continue
+					}
+					if a.Enabled == nil || *a.Enabled {
+						t.Errorf("aa[%d] (rig=%q): expected disabled", i, a.Rig)
+					}
+					if a.Interval != "30s" {
+						t.Errorf("aa[%d] (rig=%q): interval=%q, want 30s", i, a.Rig, a.Interval)
+					}
+				}
+			},
+		},
+		{
+			name: "wildcard rig with no matching name still errors",
+			orders: []Order{
+				{Name: "patrol", Rig: "demo"},
+			},
+			overrides: []Override{
+				{Name: "ghost", Rig: RigWildcard, Enabled: disabled},
+			},
+			wantErrSubstrs: []string{
+				"orders.overrides[0]",
+				`"ghost"`,
+				"not found",
+			},
+		},
+		{
+			name: "empty name returns error",
+			orders: []Order{
+				{Name: "patrol", Rig: ""},
+			},
+			overrides: []Override{
+				{Name: "", Rig: "", Enabled: disabled},
+			},
+			wantErrSubstrs: []string{
+				"orders.overrides[0]",
+				"name is required",
+			},
+		},
+		{
+			name: "name not found anywhere returns plain not-found error",
+			orders: []Order{
+				{Name: "patrol", Rig: "demo"},
+			},
+			overrides: []Override{
+				{Name: "ghost", Rig: "", Enabled: disabled},
+			},
+			wantErrSubstrs: []string{
+				"orders.overrides[0]",
+				`"ghost"`,
+				"not found",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Copy orders so test cases don't bleed.
+			aa := make([]Order, len(tt.orders))
+			copy(aa, tt.orders)
+
+			err := ApplyOverrides(aa, tt.overrides)
+			if len(tt.wantErrSubstrs) == 0 {
+				if err != nil {
+					t.Fatalf("ApplyOverrides returned error: %v", err)
+				}
+				if tt.check != nil {
+					tt.check(t, aa)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ApplyOverrides succeeded; want error containing %v", tt.wantErrSubstrs)
+			}
+			msg := err.Error()
+			for _, sub := range tt.wantErrSubstrs {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error %q missing substring %q", msg, sub)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyOverrides_RiglessHintExcludesUnrelatedOrders ensures that the
+// rig-suggestion hint listing only reports rigs that have an order with the
+// override's name, not arbitrary rigs in the slice.
+func TestApplyOverrides_RiglessHintExcludesUnrelatedOrders(t *testing.T) {
+	t.Parallel()
+
+	aa := []Order{
+		{Name: "patrol", Rig: "demo"},
+		{Name: "elsewhere", Rig: "unrelated-rig"},
+	}
+	err := ApplyOverrides(aa, []Override{{Name: "patrol", Rig: ""}})
+	if err == nil {
+		t.Fatal("expected error for rigless override against rig-scoped patrol")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `rig = "demo"`) {
+		t.Errorf("error should suggest rig = %q; got %q", "demo", msg)
+	}
+	if strings.Contains(msg, "unrelated-rig") {
+		t.Errorf("error should NOT mention unrelated-rig; got %q", msg)
+	}
+}
+
+// TestApplyOverrides_PreservesNotFoundSubstring is a regression guard for
+// cmd/gc/order_dispatch_test.go's TestBuildOrderDispatcherOverrideNotFoundNonFatal,
+// which asserts strings.Contains(stderr, "not found"). If we change the
+// error wording in the future, this test fails first and forces an update
+// to the dispatcher test in the same change.
+func TestApplyOverrides_PreservesNotFoundSubstring(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		orders []Order
+		ov     Override
+	}{
+		{"missing name", []Order{{Name: "patrol"}}, Override{Name: "ghost"}},
+		{"missing rig", []Order{{Name: "patrol", Rig: "demo"}}, Override{Name: "patrol", Rig: "missing"}},
+		{"rigless against rig-scoped", []Order{{Name: "patrol", Rig: "demo"}}, Override{Name: "patrol"}},
+		{"wildcard against missing name", []Order{{Name: "patrol", Rig: "demo"}}, Override{Name: "ghost", Rig: RigWildcard}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ApplyOverrides(tc.orders, []Override{tc.ov})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "not found") {
+				t.Errorf("error %q must contain literal substring %q", err.Error(), "not found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`[[orders.overrides]]` with empty `rig` silently no-ops against per-rig orders today. The matching rule in `internal/orders/override.go` skips rig-scoped instances when `ov.Rig == ""`, then `ApplyOverrides` returns an `"order not found"` error. Two of three callers log-and-continue (`cmd/gc/order_dispatch.go:97`, `cmd/gc/api_state.go:700`), so the user sees no signal.

Production impact (caught downstream): a `[[orders.overrides]]` block with `enabled = false` and no `rig` was in place against `patrol-project-leads`, but all 13 rig-scoped instances + the city-level instance fired on schedule for an extended period — the override matched the (nonexistent) city-level instance, errored once at startup, and was logged-but-ignored.

This PR keeps the existing "warn but don't fail at startup" behavior and instead makes the warning **informative**, plus adds a wildcard for "all instances" intent.

## What changed

- **`internal/orders/override.go`** — when a rigless override misses but rig-scoped same-name orders exist, the error now lists the rigs so users see exactly what to type:
  > `orders.overrides[0]: order "patrol-project-leads" not found at city scope (13 instances rig-scoped); set rig = "demo-repo", rig = "live-docs", … to target a per-rig instance, or use rig = "*" to target all instances`
- **`rig = "*"` wildcard** — matches every instance of the named order (city-level + every rig-scoped copy). Added as `orders.RigWildcard` const.
- **`internal/config/config.go`** — `ValidateRigs` rejects `name = "*"` as a rig name (reservation overlap with the new wildcard). Updated `OrderOverride.Rig` godoc to spell out the three matching modes.
- **`docs/tutorials/07-orders.md`** — new "Rig scoping" subsection with all three modes + example for each.
- **`docs/schema/city-schema.{json,txt}`, `docs/reference/config.md`** — auto-regenerated via `make generate`.
- **`CHANGELOG.md`** — entry under `## [Unreleased]`.

## Deferred — flagged for maintainer review

These are deliberately out of scope; both warrant their own discussion:

1. **Making `ApplyOverrides` errors fatal at startup.** The existing `TestBuildOrderDispatcherOverrideNotFoundNonFatal` (`cmd/gc/order_dispatch_test.go:3203`) enshrines the current log-and-continue behavior intentionally — flipping it is a behavior change, not a bug fix. Worth a separate decision on whether mismatched overrides should fail-fast at `gc start`.

2. **Surfacing the same enriched error from the read path** at `cmd/gc/api_state.go:700` (currently `//nolint:errcheck` best-effort). A bounded-rate event-bus log keyed by config revision would close the dashboard-side blind spot without 500-ing every `/orders` request. Out of scope here.

## Test plan

- [x] New `internal/orders/override_test.go`: table-driven coverage for all matching modes (city / rig-scoped / wildcard / rigless-against-rig-scoped error / wildcard-no-match error / empty-name error / name-not-found error)
- [x] `TestApplyOverrides_RiglessHintExcludesUnrelatedOrders`: pins that the rig hint never lists rigs that don't have a matching order
- [x] `TestApplyOverrides_PreservesNotFoundSubstring`: regression guard for the cross-test contract with `cmd/gc/order_dispatch_test.go` (asserts `strings.Contains(stderr, "not found")`)
- [x] `TestValidateRigs_WildcardNameRejected`: hard-error path for the rig-name reservation
- [x] Existing `TestBuildOrderDispatcherOverrideNotFoundNonFatal` still passes unchanged (substring contract preserved)
- [x] `go vet ./...` clean
- [x] `make generate` produces zero working-tree drift after commit
- [x] `make test-fast-parallel` passes except for `internal/api.TestHandleSessionMessageQueuesSuspendedSessionMessage` — pre-existing race that reproduces on clean `origin/main`@732b330d, unrelated to this change

## Pre-push pipeline (gascity-ship)

- Stage 1 simplify: 3 fixes applied (`slices.Sorted`/`maps.Keys`, dropped trivial helper godocs, grammar fix via `pluralizeRigCount`, RigWildcard constant in tests, moved `"*"` reservation from soft warning to hard error in `ValidateRigs`)
- Stage 2a self-check: 7 Copilot-pattern audit clean
- Stage 2b multi-model `/review`: Claude × 3 (clean after simplify); Codex (gpt-5.4) caught my "avoids cycle" rationale was wrong — applied fix (use `orders.RigWildcard` const since `internal/config/pack.go` already imports orders); Copilot (gpt-5.3-codex) all VERIFIED
- Stage 3 gascity-checker (29-rule audit): 0 findings — B23 fix-scope completeness, B25 constant grep radius, B26 doc/code drift, B31 hard-fail examples audit all pass

## Bd

`gc-a3s` (P2, `pr-ready-with-design-questions`, `upstream-draft`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->