### PR TITLE
fix: stabilize copyfile fingerprints

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1521,14 +1521,13 @@ func configDriftTracePayload(storedHash, currentHash string, driftedFields []str
 	if fields == nil {
 		fields = []string{}
 	}
-	payload := traceRecordPayload{
-		"stored_hash":    storedHash,
-		"current_hash":   currentHash,
-		"drifted_fields": fields,
-	}
+	payload := traceRecordPayload{}
 	for k, v := range extra {
 		payload[k] = v
 	}
+	payload["stored_hash"] = storedHash
+	payload["current_hash"] = currentHash
+	payload["drifted_fields"] = fields
 	return payload
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -787,6 +787,7 @@ func reconcileSessionBeadsTraced(
 						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
 							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
 						}
+						driftedFields := runtime.CoreFingerprintDriftFields(storedBreakdown, agentCfg)
 						runtime.LogCoreFingerprintDrift(stderr, name, storedBreakdown, agentCfg)
 						restartedInPlace := false
 						// Attached sessions never get config-drift restarts.
@@ -806,22 +807,18 @@ func reconcileSessionBeadsTraced(
 							}
 							drainCancelled := cancelSessionConfigDriftDrain(*session, sp, dt)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredAttached), traceRecordPayload{
-									"stored_hash":    storedHash,
-									"current_hash":   currentHash,
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredAttached), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 									"active_reason":  "attached",
 									"drain_canceled": drainCancelled,
-								}, nil, "")
+								}), nil, "")
 							}
 							continue
 						}
 						if recentlyDeferredSessionAttachedConfigDrift(*session, clk, driftKey) {
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredAttached), traceRecordPayload{
-									"stored_hash":   storedHash,
-									"current_hash":  currentHash,
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredAttached), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 									"active_reason": "attached_recently",
-								}, nil, "")
+								}), nil, "")
 							}
 							continue
 						}
@@ -837,20 +834,15 @@ func reconcileSessionBeadsTraced(
 							}
 							if active {
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredActive), traceRecordPayload{
-										"stored_hash":   storedHash,
-										"current_hash":  currentHash,
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredActive), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 										"active_reason": activeReason,
-									}, nil, "")
+									}), nil, "")
 								}
 								continue
 							}
 							resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, alive, "creating", stderr)
 							if trace != nil {
-								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", traceRecordPayload{
-									"stored_hash":  storedHash,
-									"current_hash": currentHash,
-								}, nil, "")
+								trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "restart_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 							}
 							rec.Record(events.Event{
 								Type:    events.SessionDraining,
@@ -871,11 +863,9 @@ func reconcileSessionBeadsTraced(
 									drainCancelled = cancelSessionDrainForPending(*session, sp, dt)
 								}
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "pending", "deferred_pending", traceRecordPayload{
-										"stored_hash":    storedHash,
-										"current_hash":   currentHash,
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "pending", "deferred_pending", configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
 										"drain_canceled": drainCancelled,
-									}, nil, "")
+									}), nil, "")
 								}
 								continue
 							}
@@ -886,10 +876,7 @@ func reconcileSessionBeadsTraced(
 							if beginSessionDrain(*session, sp, dt, "config-drift", clk, ddt) {
 								fmt.Fprintf(stdout, "Draining session '%s': config-drift\n", name) //nolint:errcheck
 								if trace != nil {
-									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", traceRecordPayload{
-										"stored_hash":  storedHash,
-										"current_hash": currentHash,
-									}, nil, "")
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "drain", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 								}
 								rec.Record(events.Event{
 									Type:    events.SessionDraining,
@@ -952,12 +939,14 @@ func reconcileSessionBeadsTraced(
 					agentCfg := templateParamsToConfig(tp)
 					currentHash := runtime.CoreFingerprint(agentCfg)
 					if storedHash != currentHash {
+						var storedBreakdown map[string]string
+						if raw := session.Metadata["core_hash_breakdown"]; raw != "" {
+							_ = json.Unmarshal([]byte(raw), &storedBreakdown)
+						}
+						driftedFields := runtime.CoreFingerprintDriftFields(storedBreakdown, agentCfg)
 						resetConfiguredNamedSessionForConfigDrift(session, store, sp, name, false, "asleep", stderr)
 						if trace != nil {
-							trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "repair_in_place", traceRecordPayload{
-								"stored_hash":  storedHash,
-								"current_hash": currentHash,
-							}, nil, "")
+							trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", "repair_in_place", configDriftTracePayload(storedHash, currentHash, driftedFields, nil), nil, "")
 						}
 						continue
 					}
@@ -1525,6 +1514,22 @@ func sessionConfigDriftKey(session beads.Bead, cfg *config.City, tp TemplatePara
 		return ""
 	}
 	return storedHash + ":" + currentHash
+}
+
+func configDriftTracePayload(storedHash, currentHash string, driftedFields []string, extra traceRecordPayload) traceRecordPayload {
+	fields := append([]string(nil), driftedFields...)
+	if fields == nil {
+		fields = []string{}
+	}
+	payload := traceRecordPayload{
+		"stored_hash":    storedHash,
+		"current_hash":   currentHash,
+		"drifted_fields": fields,
+	}
+	for k, v := range extra {
+		payload[k] = v
+	}
+	return payload
 }
 
 func applyTemplateOverridesToConfig(agentCfg *runtime.Config, session beads.Bead, tp TemplateParams) {

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -72,6 +72,25 @@ func TestConfigDriftTracePayloadIncludesDriftedFields(t *testing.T) {
 	}
 }
 
+func TestConfigDriftTracePayloadReservedFieldsOverrideExtras(t *testing.T) {
+	payload := configDriftTracePayload("stored", "current", []string{"CopyFiles"}, traceRecordPayload{
+		"stored_hash":    "extra-stored",
+		"current_hash":   "extra-current",
+		"drifted_fields": []string{"Command"},
+	})
+
+	fields, ok := payload["drifted_fields"].([]string)
+	if !ok {
+		t.Fatalf("drifted_fields type = %T, want []string", payload["drifted_fields"])
+	}
+	if len(fields) != 1 || fields[0] != "CopyFiles" {
+		t.Fatalf("drifted_fields = %v, want [CopyFiles]", fields)
+	}
+	if payload["stored_hash"] != "stored" || payload["current_hash"] != "current" {
+		t.Fatalf("reserved hash fields should win over extras: %#v", payload)
+	}
+}
+
 func TestTraceArmStorePersistence(t *testing.T) {
 	cityDir := t.TempDir()
 	store := newSessionReconcilerTraceArmStore(cityDir)

--- a/cmd/gc/session_reconciler_trace_test.go
+++ b/cmd/gc/session_reconciler_trace_test.go
@@ -52,6 +52,26 @@ func TestNormalizeTraceOutcomeCodeAcceptsDeferredActive(t *testing.T) {
 	}
 }
 
+func TestConfigDriftTracePayloadIncludesDriftedFields(t *testing.T) {
+	payload := configDriftTracePayload("stored", "current", []string{"CopyFiles"}, traceRecordPayload{
+		"active_reason": "attached",
+	})
+
+	fields, ok := payload["drifted_fields"].([]string)
+	if !ok {
+		t.Fatalf("drifted_fields type = %T, want []string", payload["drifted_fields"])
+	}
+	if len(fields) != 1 || fields[0] != "CopyFiles" {
+		t.Fatalf("drifted_fields = %v, want [CopyFiles]", fields)
+	}
+	if payload["stored_hash"] != "stored" || payload["current_hash"] != "current" {
+		t.Fatalf("hash fields missing from payload: %#v", payload)
+	}
+	if payload["active_reason"] != "attached" {
+		t.Fatalf("extra field not preserved: %#v", payload)
+	}
+}
+
 func TestTraceArmStorePersistence(t *testing.T) {
 	cityDir := t.TempDir()
 	store := newSessionReconcilerTraceArmStore(cityDir)

--- a/internal/runtime/fingerprint.go
+++ b/internal/runtime/fingerprint.go
@@ -309,12 +309,16 @@ func CoreFingerprintBreakdown(cfg Config) map[string]string {
 	}
 }
 
-// LogCoreFingerprintDrift writes diagnostic output when config-drift is
-// detected, showing per-field hash breakdown and values for the current
-// config. Compare against stored breakdown (from session start metadata)
-// to identify which field changed.
-func LogCoreFingerprintDrift(w io.Writer, name string, storedBreakdown map[string]string, current Config) {
-	currentBreakdown := CoreFingerprintBreakdown(current)
+// CoreFingerprintDriftFields returns sorted core fingerprint field names whose
+// current hashes differ from the stored per-field breakdown.
+func CoreFingerprintDriftFields(storedBreakdown map[string]string, current Config) []string {
+	if len(storedBreakdown) == 0 {
+		return nil
+	}
+	return coreFingerprintDriftFields(storedBreakdown, CoreFingerprintBreakdown(current))
+}
+
+func coreFingerprintDriftFields(storedBreakdown, currentBreakdown map[string]string) []string {
 	var diffs []string
 	for field, ch := range currentBreakdown {
 		sh := storedBreakdown[field]
@@ -323,6 +327,16 @@ func LogCoreFingerprintDrift(w io.Writer, name string, storedBreakdown map[strin
 		}
 	}
 	sort.Strings(diffs)
+	return diffs
+}
+
+// LogCoreFingerprintDrift writes diagnostic output when config-drift is
+// detected, showing per-field hash breakdown and values for the current
+// config. Compare against stored breakdown (from session start metadata)
+// to identify which field changed.
+func LogCoreFingerprintDrift(w io.Writer, name string, storedBreakdown map[string]string, current Config) {
+	currentBreakdown := CoreFingerprintBreakdown(current)
+	diffs := coreFingerprintDriftFields(storedBreakdown, currentBreakdown)
 	if len(diffs) == 0 {
 		// No stored breakdown available or all fields match — log full breakdown.
 		if len(storedBreakdown) == 0 {

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -453,6 +453,41 @@ func TestHashPathContentDirectory(t *testing.T) {
 	}
 }
 
+func TestHashPathContentDirectoryIgnoresRuntimeGeneratedArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "scripts")
+	if err := os.MkdirAll(filepath.Join(sub, "__pycache__"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "check.py"), []byte("print('ok')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h1 := HashPathContent(sub)
+	if h1 == "" {
+		t.Fatal("expected non-empty hash for directory")
+	}
+
+	if err := os.WriteFile(filepath.Join(sub, "__pycache__", "check.cpython-312.pyc"), []byte("cache-a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "scratch.tmp"), []byte("temporary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h2 := HashPathContent(sub)
+	if h2 != h1 {
+		t.Fatalf("runtime-generated artifacts changed directory hash: %s vs %s", h1, h2)
+	}
+
+	if err := os.WriteFile(filepath.Join(sub, "check.py"), []byte("print('changed')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h3 := HashPathContent(sub)
+	if h3 == h1 {
+		t.Fatal("source file changes should change directory hash")
+	}
+}
+
 func TestHashPathContentMissingPath(t *testing.T) {
 	h := HashPathContent("/nonexistent/path/that/does/not/exist")
 	if h != "" {
@@ -505,5 +540,23 @@ func TestLogCoreFingerprintDriftCopyFiles(t *testing.T) {
 	}
 	if !bytes.Contains([]byte(out), []byte("RelDst")) {
 		t.Errorf("expected RelDst detail in CopyFiles drift output, got: %s", out)
+	}
+}
+
+func TestCoreFingerprintDriftFields(t *testing.T) {
+	current := Config{
+		Command:   "claude",
+		CopyFiles: []CopyEntry{{RelDst: "bar", Probed: true, ContentHash: "newhash"}},
+	}
+	stored := CoreFingerprintBreakdown(current)
+	stored["CopyFiles"] = "oldhash"
+
+	got := CoreFingerprintDriftFields(stored, current)
+	if len(got) != 1 || got[0] != "CopyFiles" {
+		t.Fatalf("CoreFingerprintDriftFields = %v, want [CopyFiles]", got)
+	}
+
+	if got := CoreFingerprintDriftFields(nil, current); len(got) != 0 {
+		t.Fatalf("CoreFingerprintDriftFields with missing breakdown = %v, want empty", got)
 	}
 }

--- a/internal/runtime/fingerprint_test.go
+++ b/internal/runtime/fingerprint_test.go
@@ -454,9 +454,173 @@ func TestHashPathContentDirectory(t *testing.T) {
 }
 
 func TestHashPathContentDirectoryIgnoresRuntimeGeneratedArtifacts(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(t *testing.T, dir string)
+	}{
+		{
+			name: "__pycache__",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				cacheDir := filepath.Join(dir, "__pycache__")
+				if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(cacheDir, "check.cpython-312.pyc"), []byte("cache-a"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: ".pytest_cache",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				cacheDir := filepath.Join(dir, ".pytest_cache", "v")
+				if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(cacheDir, "cache"), []byte("pytest"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: ".mypy_cache",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				cacheDir := filepath.Join(dir, ".mypy_cache", "3.12")
+				if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(cacheDir, "module.data.json"), []byte("mypy"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: ".ruff_cache",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				cacheDir := filepath.Join(dir, ".ruff_cache")
+				if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(cacheDir, "CACHEDIR.TAG"), []byte("ruff"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: ".pyc file",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "check.pyc"), []byte("cache-a"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: ".pyo file",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "check.pyo"), []byte("cache-a"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "editor backup suffix",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "check.py~"), []byte("backup"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "vim swap file",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, ".check.py.swp"), []byte("swap"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "vim swap extension file",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, ".check.py.swx"), []byte("swap"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			sub := filepath.Join(dir, "scripts")
+			if err := os.MkdirAll(sub, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(sub, "check.py"), []byte("print('ok')\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			h1 := HashPathContent(sub)
+			if h1 == "" {
+				t.Fatal("expected non-empty hash for directory")
+			}
+
+			tt.write(t, sub)
+			h2 := HashPathContent(sub)
+			if h2 != h1 {
+				t.Fatalf("%s changed directory hash: %s vs %s", tt.name, h1, h2)
+			}
+		})
+	}
+}
+
+func TestHashPathContentDirectoryFingerprintsUserAuthoredTempExtensionFiles(t *testing.T) {
+	tests := []string{
+		"payload.tmp",
+		"fixture.temp",
+		"notes.swp",
+		"notes.swx",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			sub := filepath.Join(dir, "scripts")
+			if err := os.MkdirAll(sub, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(sub, "check.py"), []byte("print('ok')\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			h1 := HashPathContent(sub)
+			if h1 == "" {
+				t.Fatal("expected non-empty hash for directory")
+			}
+
+			if err := os.WriteFile(filepath.Join(sub, name), []byte("user-authored"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			h2 := HashPathContent(sub)
+			if h2 == h1 {
+				t.Fatalf("user-authored %s should change directory hash", name)
+			}
+		})
+	}
+}
+
+func TestHashPathContentDirectoryFingerprintsSourceFileChanges(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "scripts")
-	if err := os.MkdirAll(filepath.Join(sub, "__pycache__"), 0o755); err != nil {
+	if err := os.MkdirAll(sub, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(sub, "check.py"), []byte("print('ok')\n"), 0o644); err != nil {
@@ -468,22 +632,11 @@ func TestHashPathContentDirectoryIgnoresRuntimeGeneratedArtifacts(t *testing.T) 
 		t.Fatal("expected non-empty hash for directory")
 	}
 
-	if err := os.WriteFile(filepath.Join(sub, "__pycache__", "check.cpython-312.pyc"), []byte("cache-a"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(sub, "scratch.tmp"), []byte("temporary"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	h2 := HashPathContent(sub)
-	if h2 != h1 {
-		t.Fatalf("runtime-generated artifacts changed directory hash: %s vs %s", h1, h2)
-	}
-
 	if err := os.WriteFile(filepath.Join(sub, "check.py"), []byte("print('changed')\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	h3 := HashPathContent(sub)
-	if h3 == h1 {
+	h2 := HashPathContent(sub)
+	if h2 == h1 {
 		t.Fatal("source file changes should change directory hash")
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -299,8 +299,9 @@ type CopyEntry struct {
 
 // HashPathContent returns a hex-encoded SHA-256 of the content at path.
 // For a regular file, hashes the file content. For a directory, hashes
-// a sorted manifest of relative paths and their contents. Returns empty
-// string on any error (caller should treat as "unknown").
+// a sorted manifest of relative paths and their contents while ignoring
+// runtime-generated cache/temp artifacts. Returns empty string on any error
+// (caller should treat as "unknown").
 func HashPathContent(path string) string {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -325,10 +326,19 @@ func HashPathContent(path string) string {
 			walkErr = true
 			return nil
 		}
+		rel, _ := filepath.Rel(path, p)
+		if rel == "." {
+			return nil
+		}
+		if hashPathContentSkipEntry(d) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		if d.IsDir() {
 			return nil
 		}
-		rel, _ := filepath.Rel(path, p)
 		entries = append(entries, rel)
 		return nil
 	})
@@ -347,6 +357,23 @@ func HashPathContent(path string) string {
 		h.Write([]byte{0}) //nolint:errcheck // hash.Write never errors
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func hashPathContentSkipEntry(d fs.DirEntry) bool {
+	base := d.Name()
+	if d.IsDir() {
+		switch base {
+		case "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache":
+			return true
+		default:
+			return false
+		}
+	}
+	switch filepath.Ext(base) {
+	case ".pyc", ".pyo", ".tmp", ".temp", ".swp", ".swx":
+		return true
+	}
+	return strings.HasSuffix(base, "~")
 }
 
 // Config holds the parameters for starting a new session.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -300,8 +300,8 @@ type CopyEntry struct {
 // HashPathContent returns a hex-encoded SHA-256 of the content at path.
 // For a regular file, hashes the file content. For a directory, hashes
 // a sorted manifest of relative paths and their contents while ignoring
-// runtime-generated cache/temp artifacts. Returns empty string on any error
-// (caller should treat as "unknown").
+// runtime-generated Python cache and editor backup artifacts. Returns empty
+// string on any error (caller should treat as "unknown").
 func HashPathContent(path string) string {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -370,8 +370,10 @@ func hashPathContentSkipEntry(d fs.DirEntry) bool {
 		}
 	}
 	switch filepath.Ext(base) {
-	case ".pyc", ".pyo", ".tmp", ".temp", ".swp", ".swx":
+	case ".pyc", ".pyo":
 		return true
+	case ".swp", ".swx":
+		return strings.HasPrefix(base, ".")
 	}
 	return strings.HasSuffix(base, "~")
 }


### PR DESCRIPTION
## Summary
- ignore runtime-generated cache/temp artifacts when hashing copied directory contents
- expose config-drift field breakdowns in reconciler trace payloads
- add regression coverage for stable copyfile hashes and drift-field payloads

## Tests
- go test ./internal/runtime -run 'TestHashPathContent|TestCoreFingerprintDriftFields|TestLogCoreFingerprintDriftCopyFiles' -count=1
- go test ./cmd/gc -run TestConfigDriftTracePayloadIncludesDriftedFields -count=1
- go test ./cmd/gc -run ConfigDrift -count=1
- go test ./internal/runtime -count=1
- go test ./cmd/gc -count=1
- make test
- pre-commit hook: generators, golangci-lint, go vet, GC_FAST_UNIT=1 go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->