### PR TITLE
fix(workspacesvc): GC_SERVICE_URL_PREFIX includes /v0/city/<name> segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `proxy_process` services now receive a `GC_SERVICE_URL_PREFIX` that the
+  supervisor's public listener actually routes. Previously the prefix was
+  the per-city-relative `/svc/<name>`, so any service that composed
+  `CallbackURL = $GC_API_BASE_URL + $GC_SERVICE_URL_PREFIX` (the documented
+  shape for adapter self-registration) would 404 on inbound calls. The
+  prefix is now the full `/v0/city/<cityName>/svc/<svcName>` path. The
+  per-city router contract (`config.Service.MountPathOrDefault`) is
+  unchanged.
+
 ### Changed
 
 - Managed Dolt config now emits listener backlog and connection-timeout keys.

--- a/internal/citylayout/runtime.go
+++ b/internal/citylayout/runtime.go
@@ -91,3 +91,18 @@ func PackRuntimeEnvMap(cityRoot, packName string) map[string]string {
 	}
 	return env
 }
+
+// PublicServiceMountPath returns the supervisor-routable public path for a
+// workspace service: /v0/city/<cityName>/svc/<serviceName>. This is the
+// path the supervisor's public listener actually mounts;
+// internal/api/supervisor.go strips the /v0/city/<cityName> prefix before
+// forwarding the remaining /svc/... segment to the per-city router.
+//
+// Use this when composing a URL that an external service or out-of-process
+// adapter will hit inbound (e.g. as a registered CallbackURL). For paths
+// inside the per-city router (where the /v0/city/<name> prefix is already
+// stripped), use the per-city-relative form returned by
+// config.Service.MountPathOrDefault instead.
+func PublicServiceMountPath(cityName, serviceName string) string {
+	return "/v0/city/" + cityName + "/svc/" + serviceName
+}

--- a/internal/citylayout/runtime_test.go
+++ b/internal/citylayout/runtime_test.go
@@ -53,3 +53,34 @@ func TestSessionNameLocksDir(t *testing.T) {
 		t.Fatalf("SessionNameLocksDir = %q, want %q", got, "/city/.gc/session-name-locks")
 	}
 }
+
+func TestPublicServiceMountPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		cityName    string
+		serviceName string
+		want        string
+	}{
+		{
+			name:        "happy path",
+			cityName:    "test-city",
+			serviceName: "slack",
+			want:        "/v0/city/test-city/svc/slack",
+		},
+		{
+			name:        "city with hyphens",
+			cityName:    "demo-app",
+			serviceName: "bridge",
+			want:        "/v0/city/demo-app/svc/bridge",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PublicServiceMountPath(tt.cityName, tt.serviceName); got != tt.want {
+				t.Errorf("PublicServiceMountPath(%q, %q) = %q, want %q",
+					tt.cityName, tt.serviceName, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workspacesvc/proxy_process.go
+++ b/internal/workspacesvc/proxy_process.go
@@ -204,7 +204,7 @@ func (p *proxyProcessInstance) start(now time.Time) error {
 		"GC_SERVICE_STATE_ROOT="+p.absStateRoot,
 		"GC_SERVICE_RUN_ROOT="+filepath.Join(p.absStateRoot, "run"),
 		"GC_SERVICE_SOCKET="+p.socketPath,
-		"GC_SERVICE_URL_PREFIX="+p.svc.MountPathOrDefault(),
+		"GC_SERVICE_URL_PREFIX="+citylayout.PublicServiceMountPath(p.rt.CityName(), p.svc.Name),
 		"GC_SERVICE_PUBLIC_URL="+p.publication.URL,
 		"GC_SERVICE_VISIBILITY="+p.publication.Visibility,
 		"GC_PUBLISHED_SERVICES_DIR="+citylayout.PublishedServicesDir(p.rt.CityPath()),

--- a/internal/workspacesvc/proxy_process_test.go
+++ b/internal/workspacesvc/proxy_process_test.go
@@ -177,6 +177,7 @@ func TestProxyProcessHelper(t *testing.T) {
 			"GC_CITY_RUNTIME_DIR":       os.Getenv("GC_CITY_RUNTIME_DIR"),
 			"GC_SERVICE_NAME":           os.Getenv("GC_SERVICE_NAME"),
 			"GC_SERVICE_STATE_ROOT":     os.Getenv("GC_SERVICE_STATE_ROOT"),
+			"GC_SERVICE_URL_PREFIX":     os.Getenv("GC_SERVICE_URL_PREFIX"),
 			"GC_SERVICE_PUBLIC_URL":     os.Getenv("GC_SERVICE_PUBLIC_URL"),
 			"GC_SERVICE_VISIBILITY":     os.Getenv("GC_SERVICE_VISIBILITY"),
 			"GC_PUBLISHED_SERVICES_DIR": os.Getenv("GC_PUBLISHED_SERVICES_DIR"),
@@ -280,6 +281,11 @@ func TestProxyProcessPublishesServiceEnv(t *testing.T) {
 	}
 	if env["GC_PUBLISHED_SERVICES_DIR"] != citylayout.PublishedServicesDir(rt.cityPath) {
 		t.Fatalf("GC_PUBLISHED_SERVICES_DIR = %q, want %q", env["GC_PUBLISHED_SERVICES_DIR"], citylayout.PublishedServicesDir(rt.cityPath))
+	}
+	// Must be supervisor-routable; the per-city /svc/<name> form 404s on inbound.
+	wantPrefix := citylayout.PublicServiceMountPath(rt.cityName, "bridge")
+	if env["GC_SERVICE_URL_PREFIX"] != wantPrefix {
+		t.Fatalf("GC_SERVICE_URL_PREFIX = %q, want %q", env["GC_SERVICE_URL_PREFIX"], wantPrefix)
 	}
 }
 


### PR DESCRIPTION
## Summary

`proxy_process` services received `GC_SERVICE_URL_PREFIX = /svc/<name>` from `config.Service.MountPathOrDefault`. The supervisor's public listener (`:8372`) only mounts `/v0/city/{cityName}/svc/{name}/*` (`internal/api/supervisor.go:161`); anything else 404s. Services that compose `CallbackURL = $GC_API_BASE_URL + $GC_SERVICE_URL_PREFIX` — the documented self-registration shape — therefore registered unroutable URLs, and `gc` couldn't call them inbound.

This was latent until exercised by an out-of-tree adapter (slack); first symptom is every inbound `/extmsg/outbound` returning `FailureKind=not_found` in <5ms with `404`s logged on the supervisor.

## What changed

The two roles of "service mount path" are now separate:

- **`internal/config/service.go::MountPathOrDefault` is unchanged** — still returns the per-city-relative `/svc/<name>`. This is the route registered at `internal/api/server.go:159` and forwarded through `internal/api/supervisor.go:177-179` after the `/v0/city/<name>` prefix is stripped. Touching it would break the per-city mount, the `Status.MountPath` JSON wire field, and `manager.go:447-467` subpath logic.
- **New `internal/citylayout.PublicServiceMountPath(cityName, serviceName)`** returns the supervisor-routable public form `/v0/city/<cityName>/svc/<serviceName>`. It lives in `citylayout` next to existing canonical layout helpers (`PublishedServicesDir`, `ServiceStateDir`, `CityRuntimeEnv`).
- **`internal/workspacesvc/proxy_process.go:207`** now injects the public form, using `p.rt.CityName()`. `CityName()` is set once at runtime construction (`cmd/gc/city_runtime.go:196`, `cmd/gc/service_runtime.go:21`) and reload paths reject identity changes — no zero-window during reload.
- **`CHANGELOG.md`** entry under `## [Unreleased]` `### Fixed`.

## Tests

- `TestPublicServiceMountPath` in `internal/citylayout/runtime_test.go` — table-driven over the documented inputs.
- `TestProxyProcessPublishesServiceEnv` in `internal/workspacesvc/proxy_process_test.go` extended to round-trip `GC_SERVICE_URL_PREFIX` through the spawned subprocess and assert `/v0/city/test-city/svc/bridge`. The helper map at line 173 now echoes the env so any regression here gets caught.

`go vet ./...` clean. `go test ./internal/citylayout/... ./internal/workspacesvc/... -count=1 -race` clean.

No openapi or dashboard schema regen — `Status.MountPath` remains the per-city-relative `/svc/<name>` form on the wire.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `internal/citylayout` and `internal/workspacesvc` tests with `-race`
- [x] Repo-wide grep confirms `proxy_process.go:207` is the **only** producer of `GC_SERVICE_URL_PREFIX` and no in-`gc` code consumes it
- [x] No `examples/`, `docs/`, `engdocs/`, or `.txtar` fixture references the env var → no doc drift
- [x] `MountPathOrDefault` callers (`internal/api/server.go:159`, `internal/api/handler_services.go:29-37`, `internal/workspacesvc/manager.go:447-467,478`, `cmd/gc/cmd_service.go:251`) all still want the relative form — none break

## Pre-push pipeline (gascity-ship)

- Stage 1 simplify: 3 fixes applied (param rename `svcName` → `serviceName`, removed empty-input test cases that pinned malformed-URL behavior, trimmed branch-leakage comment in `proxy_process_test.go`)
- Stage 2a self-check: 7 Copilot-pattern audit clean
- Stage 2b multi-model `/review`: Codex (gpt-5.4) 7/7 VERIFIED, Copilot (gpt-5.3-codex) 7/7 VERIFIED — both confirmed the design split (new helper rather than changing `MountPathOrDefault`) and validated `CityName()` immutability for the controller's lifetime
- Stage 3 gascity-checker (29-rule audit): 0 findings — B23 fix-scope, B25 constant grep, B26 doc drift, B31 hard-fail examples audit all pass

## Bd

`gc-cdf` (P1, OPEN, labels: `proxy_process workspacesvc upstream-draft`). Unblocks gc-5rz Phase A slack adapter cutover.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->