### PR TITLE
fix(bd): route city source bead lookups from rig cwd

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -207,6 +207,19 @@ func resolveBdScopeTarget(cfg *config.City, cityPath, rigName string, args []str
 		return bdRigScopeTarget(cityPath, rig), nil
 	}
 
+	cityTarget := bdCityScopeTarget(cityPath, cfg)
+	cityPrefix := config.EffectiveHQPrefix(cfg)
+	if cityPrefix != "" {
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "-") || beadPrefix(cfg, arg) != cityPrefix {
+				continue
+			}
+			if bdBeadExists(cityPath, cityTarget, arg) {
+				return cityTarget, nil
+			}
+		}
+	}
+
 	// Auto-detect from bead IDs in args, but only accept candidates that
 	// actually exist in the resolved rig store. This keeps hyphenated flag
 	// values and other non-ID args from silently retargeting the command.
@@ -234,11 +247,7 @@ func resolveBdScopeTarget(cfg *config.City, cityPath, rigName string, args []str
 		return bdRigScopeTarget(cityPath, rig), nil
 	}
 
-	return execStoreTarget{
-		ScopeRoot: resolveStoreScopeRoot(cityPath, cityPath),
-		ScopeKind: "city",
-		Prefix:    config.EffectiveHQPrefix(cfg),
-	}, nil
+	return cityTarget, nil
 }
 
 func bdRigForArg(cfg *config.City, arg string) (config.Rig, bool) {
@@ -262,5 +271,13 @@ func bdRigScopeTarget(cityPath string, rig config.Rig) execStoreTarget {
 		ScopeKind: "rig",
 		Prefix:    rig.EffectivePrefix(),
 		RigName:   rig.Name,
+	}
+}
+
+func bdCityScopeTarget(cityPath string, cfg *config.City) execStoreTarget {
+	return execStoreTarget{
+		ScopeRoot: resolveStoreScopeRoot(cityPath, cityPath),
+		ScopeKind: "city",
+		Prefix:    config.EffectiveHQPrefix(cfg),
 	}
 }

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -1338,6 +1338,38 @@ func TestResolveBdScopeTargetUsesEnclosingRig(t *testing.T) {
 	}
 }
 
+func TestResolveBdScopeTargetRoutesExistingCityBeadFromRigCwd(t *testing.T) {
+	origProbe := bdBeadExists
+	defer func() { bdBeadExists = origProbe }()
+	bdBeadExists = func(_ string, target execStoreTarget, beadID string) bool {
+		return target.ScopeKind == "city" && beadID == "mc-city1"
+	}
+
+	cityDir := filepath.Join(t.TempDir(), "city")
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(rigDir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "maintainer-city", Prefix: "mc"},
+		Rigs:      []config.Rig{{Name: "frontend", Path: "frontend", Prefix: "fr"}},
+	}
+	setCwd(t, filepath.Join(rigDir, "nested"))
+
+	got, err := resolveBdScopeTarget(cfg, cityDir, "", []string{"show", "mc-city1"})
+	if err != nil {
+		t.Fatalf("resolveBdScopeTarget() error = %v", err)
+	}
+	want := execStoreTarget{
+		ScopeRoot: cityDir,
+		ScopeKind: "city",
+		Prefix:    "mc",
+	}
+	if got != want {
+		t.Fatalf("resolveBdScopeTarget() = %#v, want %#v", got, want)
+	}
+}
+
 func TestGcBdRespectsRawCityFlag(t *testing.T) {
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag


### PR DESCRIPTION
## Summary
- prefer an existing city-scope bead ID when `gc bd` is invoked from inside a rig/worktree
- keep rig cwd fallback for non-city IDs and non-ID commands
- add regression coverage for `mc-*` source bead lookup from rig cwd

## Verification
- `go test ./cmd/gc -run 'TestResolveBdScopeTarget(RoutesExistingCityBeadFromRigCwd|UsesEnclosingRig)|TestGcBdRespectsRawCityFlag|TestGcBdUsesEnclosingRigWhenNoFlag' -count=1`\n- pre-commit hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->