### PR TITLE
fix(dispatch): propagate source-chain terminal metadata

### DIFF
--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -715,11 +715,14 @@ func walkSourceBeadChain(rootStore beads.Store, rootID string, opts ProcessOptio
 				stopWalk = true
 				return nil
 			}
-			if loaded.Status == "closed" {
-				opts.tracef("close-source-chain root=%s skip reason=already_closed source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
+			if !mutate {
 				return nil
 			}
-			if !mutate {
+			if err := propagateSourceBeadTerminalMetadata(nextStore, loaded.ID, current.Metadata); err != nil {
+				return fmt.Errorf("propagating source bead metadata %s in %s: %w", nextID, sourceChainStoreLabel(effectiveRef), err)
+			}
+			if loaded.Status == "closed" {
+				opts.tracef("close-source-chain root=%s skip reason=already_closed source=%s ref=%s", rootID, nextID, sourceChainStoreLabel(effectiveRef))
 				return nil
 			}
 			if err := closeSourceBeadPreservingOutcome(nextStore, loaded); err != nil {
@@ -922,6 +925,15 @@ func closeSourceBeadPreservingOutcome(store beads.Store, bead beads.Bead) error 
 		opts.Metadata = map[string]string{"gc.outcome": "pass"}
 	}
 	return store.Update(bead.ID, opts)
+}
+
+func propagateSourceBeadTerminalMetadata(store beads.Store, beadID string, metadata map[string]string) error {
+	batch := make(map[string]string)
+	copyNonGCMetadata(batch, metadata)
+	if len(batch) == 0 {
+		return nil
+	}
+	return store.SetMetadataBatch(beadID, batch)
 }
 
 func recordWorkflowFinalizeError(store beads.Store, finalizerID string, err error) error {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -834,8 +834,9 @@ func TestProcessWorkflowFinalizeClosesCrossStoreSourceBead(t *testing.T) {
 		Title: "Adopt PR: gastownhall/example#1",
 		Type:  "task",
 		Metadata: map[string]string{
-			"pr_review.pr_number": "1",
-			"pr_review.repo_slug": "gastownhall/example",
+			"pr_review.pr_number":       "1",
+			"pr_review.repo_slug":       "gastownhall/example",
+			"pr_review.workflow_status": "running",
 		},
 	})
 
@@ -843,8 +844,11 @@ func TestProcessWorkflowFinalizeClosesCrossStoreSourceBead(t *testing.T) {
 		Title: "Adopt PR workflow: gastownhall/example#1",
 		Type:  "task",
 		Metadata: map[string]string{
-			"gc.source_bead_id":   citySource.ID,
-			"gc.source_store_ref": "city:test",
+			"gc.source_bead_id":         citySource.ID,
+			"gc.source_store_ref":       "city:test",
+			"pr_review.final_pr_url":    "https://github.com/gastownhall/example/pull/1",
+			"pr_review.workflow_status": "completed",
+			"workflow_id":               "wf-1",
 		},
 	})
 
@@ -928,6 +932,15 @@ func TestProcessWorkflowFinalizeClosesCrossStoreSourceBead(t *testing.T) {
 	}
 	if got := citySourceAfter.Metadata["gc.outcome"]; got != "pass" {
 		t.Errorf("city source bead gc.outcome = %q, want %q", got, "pass")
+	}
+	if got := citySourceAfter.Metadata["pr_review.workflow_status"]; got != "completed" {
+		t.Errorf("city source bead pr_review.workflow_status = %q, want completed", got)
+	}
+	if got := citySourceAfter.Metadata["pr_review.final_pr_url"]; got != "https://github.com/gastownhall/example/pull/1" {
+		t.Errorf("city source bead final PR URL = %q, want propagated final PR URL", got)
+	}
+	if got := citySourceAfter.Metadata["workflow_id"]; got != "wf-1" {
+		t.Errorf("city source bead workflow_id = %q, want propagated workflow id", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- copy non-`gc.*` terminal metadata from child workflow source beads to parent source beads before source-chain closure
- preserve source workflow audit fields such as final PR URL and workflow status when graph finalization closes city source beads
- add regression coverage for cross-store PR-review source metadata

## Verification
- `go test ./internal/dispatch -run 'TestProcessWorkflowFinalize(ClosesCrossStoreSourceBead|LeavesCrossStoreSourceBeadOpenOnFailure)' -count=1`\n- pre-commit hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->