### PR TITLE
fix(gastown): use gc handoff --auto in PreCompact hooks

### DIFF
--- a/examples/gastown/packs/gastown/overlay/.claude/settings.json
+++ b/examples/gastown/packs/gastown/overlay/.claude/settings.json
@@ -21,7 +21,7 @@
           },
           {
             "type": "command",
-            "command": "gc handoff \"context cycle\""
+            "command": "gc handoff --auto \"context cycle\""
           }
         ]
       }

--- a/examples/gastown/precompact_hook_test.go
+++ b/examples/gastown/precompact_hook_test.go
@@ -1,0 +1,67 @@
+package gastown_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPreCompactHookUsesAutoHandoff guards the PreCompact hook in the gastown
+// pack overlay against the destructive-eviction regression documented in
+// gc-flp1.
+//
+// `gc handoff` (bare) sends mail AND requests a controller restart, which kills
+// the running session. For PreCompact — which fires automatically on every
+// Claude context-cycle inside any session running this overlay — restart-mode
+// turns every compaction into a session kill. When a human is mid-conversation
+// in a crew session (Mayor, Navani, Syl, etc.), this destroys their state.
+//
+// `gc handoff --auto` is the documented mode for this scenario: send mail,
+// skip restart, return immediately. The internal SDK hook config
+// (internal/hooks/config/claude.json) was switched to --auto in commit
+// 7b3b913a ("fix: add auto handoff for precompact"); the gastown pack overlay
+// must match.
+func TestPreCompactHookUsesAutoHandoff(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "overlay", ".claude", "settings.json")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading overlay settings: %v", err)
+	}
+
+	var cfg struct {
+		Hooks struct {
+			PreCompact []struct {
+				Hooks []struct {
+					Type    string `json:"type"`
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"PreCompact"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing overlay settings as JSON: %v", err)
+	}
+	if len(cfg.Hooks.PreCompact) == 0 {
+		t.Fatalf("expected PreCompact hooks in overlay settings; got none")
+	}
+
+	var sawHandoff bool
+	for _, group := range cfg.Hooks.PreCompact {
+		for _, h := range group.Hooks {
+			if !strings.Contains(h.Command, "gc handoff") {
+				continue
+			}
+			sawHandoff = true
+			if !strings.Contains(h.Command, "--auto") {
+				t.Errorf("PreCompact hook invokes 'gc handoff' without --auto; bare gc handoff requests a restart and kills the session on every compaction (gc-flp1).\n  command: %q\n  fix: insert --auto, e.g. 'gc handoff --auto \"context cycle\"'", h.Command)
+			}
+		}
+	}
+	if !sawHandoff {
+		t.Errorf("PreCompact hook does not call 'gc handoff' at all; expected 'gc handoff --auto \"context cycle\"'")
+	}
+}

--- a/examples/gastown/precompact_hook_test.go
+++ b/examples/gastown/precompact_hook_test.go
@@ -2,66 +2,150 @@ package gastown_test
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
 
-// TestPreCompactHookUsesAutoHandoff guards the PreCompact hook in the gastown
-// pack overlay against the destructive-eviction regression documented in
-// gc-flp1.
+// TestPreCompactHandoffHooksUseAuto guards shipped PreCompact hooks against
+// the destructive-eviction regression documented in gc-flp1.
 //
 // `gc handoff` (bare) sends mail AND requests a controller restart, which kills
-// the running session. For PreCompact — which fires automatically on every
-// Claude context-cycle inside any session running this overlay — restart-mode
-// turns every compaction into a session kill. When a human is mid-conversation
-// in a crew session (Mayor, Navani, Syl, etc.), this destroys their state.
+// the running session. For PreCompact — which fires automatically on provider
+// context cycles inside sessions running these overlays — restart-mode turns
+// every compaction into a session kill.
 //
 // `gc handoff --auto` is the documented mode for this scenario: send mail,
 // skip restart, return immediately. The internal SDK hook config
 // (internal/hooks/config/claude.json) was switched to --auto in commit
 // 7b3b913a ("fix: add auto handoff for precompact"); the gastown pack overlay
 // must match.
-func TestPreCompactHookUsesAutoHandoff(t *testing.T) {
-	dir := exampleDir()
-	path := filepath.Join(dir, "packs", "gastown", "overlay", ".claude", "settings.json")
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading overlay settings: %v", err)
-	}
-
-	var cfg struct {
-		Hooks struct {
-			PreCompact []struct {
-				Hooks []struct {
-					Type    string `json:"type"`
-					Command string `json:"command"`
-				} `json:"hooks"`
-			} `json:"PreCompact"`
-		} `json:"hooks"`
-	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parsing overlay settings as JSON: %v", err)
-	}
-	if len(cfg.Hooks.PreCompact) == 0 {
-		t.Fatalf("expected PreCompact hooks in overlay settings; got none")
+func TestPreCompactHandoffHooksUseAuto(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join(exampleDir(), "..", ".."))
+	paths := preCompactHookConfigPaths(t, repoRoot)
+	if len(paths) == 0 {
+		t.Fatalf("expected shipped PreCompact hook configs; got none")
 	}
 
 	var sawHandoff bool
-	for _, group := range cfg.Hooks.PreCompact {
-		for _, h := range group.Hooks {
-			if !strings.Contains(h.Command, "gc handoff") {
-				continue
+	for _, path := range paths {
+		path := path
+		t.Run(relPath(t, repoRoot, path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("reading hook config: %v", err)
 			}
-			sawHandoff = true
-			if !strings.Contains(h.Command, "--auto") {
-				t.Errorf("PreCompact hook invokes 'gc handoff' without --auto; bare gc handoff requests a restart and kills the session on every compaction (gc-flp1).\n  command: %q\n  fix: insert --auto, e.g. 'gc handoff --auto \"context cycle\"'", h.Command)
+
+			var cfg map[string]any
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				t.Fatalf("parsing hook config as JSON: %v", err)
 			}
-		}
+
+			for _, command := range preCompactCommands(cfg) {
+				if !containsGCHandoff(command) {
+					continue
+				}
+				sawHandoff = true
+				if !hasAutoFlag(command) {
+					t.Errorf("PreCompact hook invokes 'gc handoff' without --auto; bare gc handoff requests a restart and kills the session on every compaction (gc-flp1).\n  command: %q\n  fix: insert --auto, e.g. 'gc handoff --auto \"context cycle\"'", command)
+				}
+			}
+		})
 	}
 	if !sawHandoff {
-		t.Errorf("PreCompact hook does not call 'gc handoff' at all; expected 'gc handoff --auto \"context cycle\"'")
+		t.Errorf("shipped PreCompact hooks do not call 'gc handoff' at all; expected 'gc handoff --auto \"context cycle\"'")
 	}
+}
+
+func preCompactHookConfigPaths(t *testing.T, repoRoot string) []string {
+	t.Helper()
+
+	var paths []string
+	for _, root := range []string{"examples", "internal/bootstrap/packs"} {
+		err := filepath.WalkDir(filepath.Join(repoRoot, root), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+
+			dir := filepath.Base(filepath.Dir(path))
+			name := filepath.Base(path)
+			if (dir == ".claude" && name == "settings.json") || (dir == ".cursor" && name == "hooks.json") {
+				paths = append(paths, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func preCompactCommands(cfg map[string]any) []string {
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var commands []string
+	for _, key := range []string{"PreCompact", "preCompact"} {
+		commands = append(commands, hookCommands(hooks[key])...)
+	}
+	return commands
+}
+
+func hookCommands(raw any) []string {
+	var commands []string
+	items, ok := raw.([]any)
+	if !ok {
+		return commands
+	}
+
+	for _, item := range items {
+		hook, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if command, ok := hook["command"].(string); ok {
+			commands = append(commands, command)
+		}
+		commands = append(commands, hookCommands(hook["hooks"])...)
+	}
+	return commands
+}
+
+func containsGCHandoff(command string) bool {
+	fields := strings.Fields(command)
+	for i := 0; i < len(fields)-1; i++ {
+		if fields[i] == "gc" && fields[i+1] == "handoff" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAutoFlag(command string) bool {
+	for _, field := range strings.Fields(command) {
+		if field == "--auto" {
+			return true
+		}
+	}
+	return false
+}
+
+func relPath(t *testing.T, base, path string) string {
+	t.Helper()
+
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return path
+	}
+	return rel
 }

--- a/internal/bootstrap/packs/core/overlay/per-provider/cursor/.cursor/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/cursor/.cursor/hooks.json
@@ -8,7 +8,7 @@
     ],
     "preCompact": [
       {
-        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff \"context cycle\""
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto \"context cycle\""
       }
     ],
     "beforeSubmitPrompt": [


### PR DESCRIPTION
Follow-up for https://github.com/gastownhall/gascity/pull/1620.

Original PR: https://github.com/gastownhall/gascity/pull/1620
Original title: fix(gastown): use 'gc handoff --auto' in PreCompact to stop killing crew sessions
Original state: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up carries forward the original contributor change and the reviewed maintainer fixups because the workflow could not safely update the original fork branch directly. The attempted push to quickserve-ai/gascity:fix/precompact-auto-handoff failed with a GitHub 403 for the current maintainer token, so the workflow switched to the follow-up PR path.

Change set:
- Updates the Gas Town Claude PreCompact hook to call gc handoff --auto.
- Adds the same non-destructive PreCompact handoff behavior for the shipped Cursor provider overlay.
- Adds regression coverage that scans shipped PreCompact hook configs and fails bare gc handoff invocations without --auto.

Review summary:
The workflow review reached approval on attempt 2 after one maintainer fix iteration. The remaining notes were non-gating: the regression currently scans the two shipped hook file shapes, and existing Cursor workdirs may need separate lifecycle handling to pick up the corrected hook config.

Validation:
- Approval guard passed for PR #1620 after refreshing onto latest main.
- Base refresh preserved the adopted patch-id on main at 67de5b41e56a2fd6768832385e74de5059af1223.
- CI readiness was green for the reviewed original PR basis before this follow-up branch was opened.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->