### PR TITLE
fix(extmsg): wire-typed snake_case decode for adapter /publish receipts

### DIFF
--- a/internal/extmsg/http_adapter.go
+++ b/internal/extmsg/http_adapter.go
@@ -103,8 +103,8 @@ func (a *HTTPAdapter) Publish(ctx context.Context, req PublishRequest) (*Publish
 		}, nil
 	}
 
-	var receipt PublishReceipt
-	if err := json.Unmarshal(respBody, &receipt); err != nil {
+	var wire wirePublishReceipt
+	if err := json.Unmarshal(respBody, &wire); err != nil {
 		// Malformed 2xx body — cannot confirm delivery.
 		return &PublishReceipt{
 			Conversation: req.Conversation,
@@ -112,7 +112,38 @@ func (a *HTTPAdapter) Publish(ctx context.Context, req PublishRequest) (*Publish
 			FailureKind:  PublishFailureTransient,
 		}, nil
 	}
-	return &receipt, nil
+	return wire.toPublishReceipt(), nil
+}
+
+// wirePublishReceipt mirrors PublishReceipt with the snake_case json tags
+// adapters write on the /publish response body. PublishReceipt itself is
+// intentionally untagged — it is exposed via the Huma API as
+// OutboundResult.Receipt where PascalCase is the public contract — so we
+// use this intermediate type at the wire boundary instead of changing
+// PublishReceipt's serialization shape.
+//
+// Without this shim, json.Unmarshal into the untagged PublishReceipt
+// silently zeroes MessageID, FailureKind, RetryAfter, and Metadata,
+// because Go's case-insensitive field match does not bridge the
+// underscore boundary (e.g. "message_id" does not match "MessageID").
+type wirePublishReceipt struct {
+	MessageID    string             `json:"message_id,omitempty"`
+	Conversation ConversationRef    `json:"conversation"`
+	Delivered    bool               `json:"delivered"`
+	FailureKind  PublishFailureKind `json:"failure_kind,omitempty"`
+	RetryAfter   time.Duration      `json:"retry_after,omitempty"`
+	Metadata     map[string]string  `json:"metadata,omitempty"`
+}
+
+func (w wirePublishReceipt) toPublishReceipt() *PublishReceipt {
+	return &PublishReceipt{
+		MessageID:    w.MessageID,
+		Conversation: w.Conversation,
+		Delivered:    w.Delivered,
+		FailureKind:  w.FailureKind,
+		RetryAfter:   w.RetryAfter,
+		Metadata:     w.Metadata,
+	}
 }
 
 // EnsureChildConversation forwards a child conversation request to the

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -131,6 +131,14 @@ type ExternalOriginEnvelope struct {
 }
 
 // AdapterCapabilities describes what a transport adapter supports.
+//
+// Intentionally untagged: this struct does not cross the gc↔adapter HTTP
+// callback wire. It is passed by value at adapter construction (see
+// NewHTTPAdapter) and exposed via the Huma API at POST /extmsg/adapters,
+// which serializes it with PascalCase keys today. Adding json tags here
+// would silently change that public API contract; if a snake_case
+// migration is wanted, do it as a coordinated API change with
+// regenerated clients, not as a side-effect of this fix.
 type AdapterCapabilities struct {
 	SupportsChildConversations bool
 	SupportsAttachments        bool
@@ -138,12 +146,19 @@ type AdapterCapabilities struct {
 }
 
 // PublishRequest is a request to publish a message to an external conversation.
+//
+// JSON tags are required: this struct is serialized over the HTTP wire to
+// out-of-process adapters (gc → adapter `/publish`), and the adapter side
+// parses snake_case keys. Without tags, Go marshals fields as PascalCase,
+// and case-insensitive matching on the receiver does not bridge the
+// underscore difference (so `ReplyToMessageID` would not match the
+// adapter's `reply_to_message_id` tag and the field would silently zero).
 type PublishRequest struct {
-	Conversation     ConversationRef
-	Text             string
-	ReplyToMessageID string
-	IdempotencyKey   string
-	Metadata         map[string]string
+	Conversation     ConversationRef   `json:"conversation"`
+	Text             string            `json:"text"`
+	ReplyToMessageID string            `json:"reply_to_message_id,omitempty"`
+	IdempotencyKey   string            `json:"idempotency_key,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
 // PublishFailureKind classifies the reason a publish attempt failed.
@@ -165,6 +180,13 @@ const (
 )
 
 // PublishReceipt is the result of a publish attempt.
+//
+// Intentionally untagged: this struct is exposed via the Huma API as
+// OutboundResult.Receipt at POST /extmsg/outbound, where the public
+// contract is PascalCase. The gc↔adapter HTTP callback wire (which
+// uses snake_case) is bridged in HTTPAdapter.Publish via an explicit
+// wire-shaped intermediate type, so domain-type tagging is not needed
+// to fix the silent-drop bug.
 type PublishReceipt struct {
 	MessageID    string
 	Conversation ConversationRef

--- a/internal/extmsg/types_wire_test.go
+++ b/internal/extmsg/types_wire_test.go
@@ -1,0 +1,140 @@
+package extmsg
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestPublishRequestSnakeCaseWire pins the wire format of PublishRequest.
+// Without explicit json tags, Go marshals fields as PascalCase and the
+// adapter's snake_case decoder silently drops underscore-bearing fields
+// (Go's case-insensitive match does not bridge the underscore boundary).
+// This test fails loudly if the tags are removed or renamed.
+func TestPublishRequestSnakeCaseWire(t *testing.T) {
+	req := PublishRequest{
+		Conversation: ConversationRef{
+			Provider:       "slack",
+			ConversationID: "C123",
+			Kind:           ConversationRoom,
+		},
+		Text:             "hello",
+		ReplyToMessageID: "1700000000.000100",
+		IdempotencyKey:   "idem-xyz",
+		Metadata:         map[string]string{"thread_ts": "1700000000.000100"},
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal(PublishRequest): %v", err)
+	}
+
+	mustContain := []string{
+		`"conversation":`,
+		`"text":"hello"`,
+		`"reply_to_message_id":"1700000000.000100"`,
+		`"idempotency_key":"idem-xyz"`,
+		`"metadata":`,
+	}
+	for _, want := range mustContain {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("PublishRequest JSON missing %q\nfull body: %s", want, body)
+		}
+	}
+
+	mustNotContain := []string{
+		`"ReplyToMessageID"`,
+		`"IdempotencyKey"`,
+		`"Metadata"`,
+		`"Text"`,
+		`"Conversation"`,
+	}
+	for _, banned := range mustNotContain {
+		if bytes.Contains(body, []byte(banned)) {
+			t.Errorf("PublishRequest JSON contains PascalCase key %q (tags missing or wrong)\nfull body: %s", banned, body)
+		}
+	}
+}
+
+// TestWirePublishReceiptDecodesSnakeCase pins decode of an adapter
+// /publish response into the wire-shaped intermediate type. This is
+// the path HTTPAdapter.Publish takes — it must decode adapter
+// snake_case correctly so that MessageID, FailureKind, RetryAfter, and
+// Metadata round-trip with non-zero values. If the wire shim's tags
+// regress, this test fails because each field's want-value is
+// distinguishable from its zero value (the bug-mode the test is
+// guarding against).
+func TestWirePublishReceiptDecodesSnakeCase(t *testing.T) {
+	// Shape an adapter would write (snake_case, all fields populated).
+	adapterBody := []byte(`{
+		"conversation": {"provider":"slack","conversation_id":"C123","kind":"room"},
+		"message_id": "1700000000.000100",
+		"delivered": true,
+		"failure_kind": "rate_limited",
+		"retry_after": 5000000000,
+		"metadata": {"thread_ts":"1700000000.000100"}
+	}`)
+
+	var wire wirePublishReceipt
+	if err := json.Unmarshal(adapterBody, &wire); err != nil {
+		t.Fatalf("Unmarshal(wirePublishReceipt): %v", err)
+	}
+	receipt := wire.toPublishReceipt()
+
+	if got, want := receipt.MessageID, "1700000000.000100"; got != want {
+		t.Errorf("MessageID = %q, want %q (json tag missing — silent drop)", got, want)
+	}
+	if !receipt.Delivered {
+		t.Errorf("Delivered = false, want true")
+	}
+	if got, want := receipt.FailureKind, PublishFailureRateLimited; got != want {
+		t.Errorf("FailureKind = %q, want %q (json tag missing — silent drop)", got, want)
+	}
+	if got, want := receipt.RetryAfter, 5*time.Second; got != want {
+		t.Errorf("RetryAfter = %v, want %v (json tag missing — silent drop)", got, want)
+	}
+	if got, want := receipt.Conversation.ConversationID, "C123"; got != want {
+		t.Errorf("Conversation.ConversationID = %q, want %q", got, want)
+	}
+	if got, want := receipt.Metadata["thread_ts"], "1700000000.000100"; got != want {
+		t.Errorf("Metadata[thread_ts] = %q, want %q (json tag missing — silent drop)", got, want)
+	}
+}
+
+// TestPublishReceiptStaysPascalCaseOnAPISurface guards the Huma API
+// contract: PublishReceipt is exposed as OutboundResult.Receipt at
+// POST /extmsg/outbound, where the public schema (internal/api/openapi.json)
+// advertises PascalCase keys. If someone tags PublishReceipt's fields
+// in an attempt to "fix" the snake_case bug at the type level, this
+// test fails because Go's json.Marshal of an untagged struct uses the
+// field name verbatim.
+func TestPublishReceiptStaysPascalCaseOnAPISurface(t *testing.T) {
+	receipt := PublishReceipt{
+		MessageID: "M1",
+		Conversation: ConversationRef{
+			Provider:       "slack",
+			ConversationID: "C1",
+			Kind:           ConversationRoom,
+		},
+		Delivered:   true,
+		FailureKind: PublishFailureRateLimited,
+		RetryAfter:  5 * time.Second,
+		Metadata:    map[string]string{"k": "v"},
+	}
+	body, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatalf("Marshal(PublishReceipt): %v", err)
+	}
+	mustContain := []string{
+		`"MessageID":"M1"`,
+		`"FailureKind":"rate_limited"`,
+		`"RetryAfter":`,
+		`"Delivered":true`,
+	}
+	for _, want := range mustContain {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("PublishReceipt JSON missing %q (Huma API surface contract drift)\nfull body: %s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`internal/extmsg/types.go::PublishRequest` was missing JSON struct tags. When `HTTPAdapter.Publish` marshaled it to send to an out-of-process adapter, Go's `encoding/json` fell back to PascalCase. Adapters parse with explicit snake_case tags, and Go's case-insensitive matching does NOT bridge the underscore boundary, so `ReplyToMessageID`, `IdempotencyKey`, and `Metadata` were silently dropped on the wire.

A parallel sibling bug existed on the receipt path: `PublishReceipt` was also untagged, and `HTTPAdapter.Publish` decoded adapter responses into it directly. Adapter responses use snake_case keys, so `MessageID` and `FailureKind` were silently zeroed on receive — which broke threaded replies because gc had no provider message ID to chain on.

Discovered live during the Slack pack oversight-rig PL room reply-threading session: the supervisor sent `ReplyToMessageID:"…"`, the adapter received `reply_to_message_id:""`.

## Why a wire shim instead of just tagging the domain types

Initial pass tagged `PublishReceipt` and `AdapterCapabilities` directly. A second-opinion review caught that **both types are exposed via the Huma API**:
- `AdapterCapabilities` is the body of `POST /extmsg/adapters`
- `PublishReceipt` is `OutboundResult.Receipt`, returned by `POST /extmsg/outbound`

The checked-in `internal/api/openapi.json`, `docs/schema/openapi.json`, generated Go genclient (`internal/api/genclient/client_gen.go`), and dashboard TS types (`cmd/gc/dashboard/web/src/generated/{schema.d.ts,types.gen.ts}`) all advertise PascalCase keys for these types. Tagging the domain types would silently flip the live API contract.

This PR keeps the Huma API contract unchanged and bridges the gc↔adapter HTTP wire via an explicit shim — aligning with AGENTS.md's *"Keep Serialization/Deserialization At The Edges"*.

## What changed

- **`internal/extmsg/types.go`**
  - `PublishRequest`: tagged with snake_case (no Huma surface — verified, only test refs in `internal/api/handler_extmsg_test.go`).
  - `PublishReceipt`: kept untagged with an explanatory doc comment. The gc↔adapter wire crossing is bridged elsewhere.
  - `AdapterCapabilities`: kept untagged with an explanatory doc comment. Does not cross the adapter callback wire.
- **`internal/extmsg/http_adapter.go`**
  - New unexported `wirePublishReceipt` with explicit snake_case tags.
  - `Publish()` now decodes the adapter response into the wire type, then converts via `wire.toPublishReceipt()` to the domain type.
- **`internal/extmsg/types_wire_test.go`** (new)
  - `TestPublishRequestSnakeCaseWire` — pins outbound marshal of `PublishRequest`. Asserts each underscore-bearing key is present and bans PascalCase.
  - `TestWirePublishReceiptDecodesSnakeCase` — pins decode of an adapter response via the wire shim. Uses non-zero distinguishable values for every previously-silent-drop field (`message_id`, `failure_kind: "rate_limited"`, `retry_after: 5s`, `metadata`), so a regressed tag fails the test instead of silently round-tripping the same zero.
  - `TestPublishReceiptStaysPascalCaseOnAPISurface` — guards the Huma API contract: `json.Marshal(PublishReceipt{...})` must still produce `"MessageID"`, `"FailureKind"`, `"RetryAfter"`. Protects against a future *"fix the bug at the type level"* attempt that would silently break every API client.

## Sibling-type audit

| Type | Status |
|---|---|
| `PublishRequest`              | was BROKEN → FIXED with tags |
| `PublishReceipt`              | was BROKEN → FIXED via wire shim |
| `AdapterCapabilities`         | Huma-surfaced, intentionally untagged |
| `EnsureChildConversation`     | safe — uses explicit `map[string]any` with snake_case keys; decodes into already-tagged `ConversationRef` |
| `ExternalInboundMessage`      | already correctly tagged |

## Test plan

- [x] `go test ./internal/extmsg/... -race` clean
- [x] Stash-revert verification: tests build-fail without `wirePublishReceipt`, confirming the shim is load-bearing
- [x] `go vet ./...`, `make lint`, `go build ./...`, `make check`, `make check-docs` all clean
- [x] `make dashboard-check` clean — **no OpenAPI / TS client drift**, by design
- [x] `make generate` produces no working-tree drift

## Out of scope

- Migrating the Huma API surface from PascalCase to snake_case. That's a coordinated API change with regenerated clients, not a side effect of this fix.
