### PR TITLE
Support explicit tmux session transport

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -903,6 +903,11 @@ func ensureDependencyOnlyTemplate(
 	if cfgAgent == nil || !cfgAgent.SupportsGenericEphemeralSessions() || desiredHasTemplate(desired, cfgAgent.QualifiedName()) {
 		return
 	}
+	qualifiedName := cfgAgent.QualifiedName()
+	if err := validateAgentSessionTransportForBuild(bp, cfgAgent, qualifiedName); err != nil {
+		fmt.Fprintf(stderr, "buildDesiredState: dependency floor %q: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
+		return
+	}
 
 	if bp.beadStore == nil {
 		name := cfgAgent.Name
@@ -927,7 +932,6 @@ func ensureDependencyOnlyTemplate(
 	// Bead selection keys off the configured base template, not the pool-
 	// instance form, because normalizedSessionTemplate reads the bead's
 	// "template" metadata which is always the base.
-	qualifiedName := cfgAgent.QualifiedName()
 	sessionBead, err := selectOrCreateDependencyPoolSessionBead(bp, cfgAgent, qualifiedName)
 	if err != nil {
 		fmt.Fprintf(stderr, "buildDesiredState: dependency floor %q: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
@@ -997,6 +1001,10 @@ func realizePoolDesiredSessions(
 	stderr io.Writer,
 ) {
 	qualifiedName := cfgAgent.QualifiedName()
+	if err := validateAgentSessionTransportForBuild(bp, cfgAgent, qualifiedName); err != nil {
+		fmt.Fprintf(stderr, "buildDesiredState: pool %q: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
+		return
+	}
 	used := make(map[string]bool)
 	usedSlots := make(map[int]bool)
 	for _, request := range poolState.Requests {
@@ -1346,8 +1354,26 @@ func prepareTemplateResolution(bp *agentBuildParams, cfgAgent *config.Agent, qua
 }
 
 func resolveTemplatePrepared(bp *agentBuildParams, cfgAgent *config.Agent, qualifiedName string, fpExtra map[string]string) (TemplateParams, error) {
+	if err := validateAgentSessionTransportForBuild(bp, cfgAgent, qualifiedName); err != nil {
+		return TemplateParams{}, err
+	}
 	prepareTemplateResolution(bp, cfgAgent, qualifiedName, bp.stderr)
 	return resolveTemplate(bp, cfgAgent, qualifiedName, fpExtra)
+}
+
+func validateAgentSessionTransportForBuild(bp *agentBuildParams, cfgAgent *config.Agent, qualifiedName string) error {
+	if bp == nil || cfgAgent == nil {
+		return nil
+	}
+	resolved, err := config.ResolveProvider(cfgAgent, bp.workspace, bp.providers, bp.lookPath)
+	if err != nil {
+		return fmt.Errorf("agent %q: %w", qualifiedName, err)
+	}
+	transport := config.ResolveSessionCreateTransport(cfgAgent.Session, resolved)
+	if err := validateResolvedSessionTransport(resolved, transport, bp.sp); err != nil {
+		return fmt.Errorf("agent %q: %w", qualifiedName, err)
+	}
+	return nil
 }
 
 // installAgentSideEffects performs idempotent side effects for a resolved

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -34,6 +34,14 @@ type partialAssignedWorkStore struct {
 	partialReady      bool
 }
 
+type acpOnlyDesiredStateProvider struct {
+	*runtime.Fake
+}
+
+func (p *acpOnlyDesiredStateProvider) SupportsTransport(transport string) bool {
+	return transport == config.SessionTransportACP
+}
+
 func (s *partialAssignedWorkStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	rows, err := s.MemStore.List(query)
 	if err != nil {
@@ -387,6 +395,49 @@ func TestBuildDesiredState_UsesAgentHookOverride(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(cityPath, ".gemini", "settings.json")); !os.IsNotExist(err) {
 		t.Fatalf("workspace gemini hook should not be installed for agent override: %v", err)
+	}
+}
+
+func TestBuildDesiredStateRejectsExplicitTmuxAgentWhenSessionProviderCannotRouteTmux(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city", Provider: "opencode"},
+		Session:   config.SessionConfig{Provider: config.SessionTransportACP},
+		Providers: map[string]config.ProviderSpec{
+			"opencode": {
+				Command:     "echo",
+				Args:        []string{"provider"},
+				ACPCommand:  "echo",
+				ACPArgs:     []string{"acp"},
+				PromptMode:  "none",
+				SupportsACP: boolPtr(true),
+			},
+		},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Provider:          "opencode",
+			Session:           config.SessionTransportTmux,
+			MaxActiveSessions: intPtr(1),
+			ScaleCheck:        "printf 1",
+		}},
+	}
+	store := beads.NewMemStore()
+	sp := &acpOnlyDesiredStateProvider{Fake: runtime.NewFake()}
+	var stderr strings.Builder
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, sp, store, &stderr)
+	if len(dsResult.State) != 0 {
+		t.Fatalf("desired state size = %d, want 0: %#v", len(dsResult.State), dsResult.State)
+	}
+	beads, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel(%q): %v", sessionBeadLabel, err)
+	}
+	if len(beads) != 0 {
+		t.Fatalf("session bead count = %d, want 0: %#v", len(beads), beads)
+	}
+	if got := stderr.String(); !strings.Contains(got, "cannot route tmux sessions") {
+		t.Fatalf("stderr = %q, want tmux routing rejection", got)
 	}
 }
 

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -316,7 +316,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 			fmt.Fprintf(stdout, "Session %s created from template %q (reconciler will start it).\n", info.ID, canonicalTemplate) //nolint:errcheck // best-effort stdout
 
 			if !shouldAttachNewSession(noAttach, sessionTransport) {
-				if sessionTransport == "acp" && !noAttach {
+				if sessionTransport == config.SessionTransportACP && !noAttach {
 					fmt.Fprintln(stdout, "Session uses ACP transport; not attaching.") //nolint:errcheck // best-effort stdout
 				}
 				return 0
@@ -410,7 +410,7 @@ func cmdSessionNew(args []string, alias, title, titleHint string, noAttach bool,
 	fmt.Fprintf(stdout, "Session %s created from template %q.\n", info.ID, canonicalTemplate) //nolint:errcheck // best-effort stdout
 
 	if !shouldAttachNewSession(noAttach, sessionTransport) {
-		if sessionTransport == "acp" && !noAttach {
+		if sessionTransport == config.SessionTransportACP && !noAttach {
 			fmt.Fprintln(stdout, "Session uses ACP transport; not attaching.") //nolint:errcheck // best-effort stdout
 		}
 		return 0
@@ -430,7 +430,7 @@ func newSessionStoredMCPMetadata(
 	alias, template, provider, workDir, transport string,
 	metadata map[string]string,
 ) (map[string]string, error) {
-	if strings.TrimSpace(transport) != "acp" {
+	if strings.TrimSpace(transport) != config.SessionTransportACP {
 		return metadata, nil
 	}
 	mcpServers, err := resolvedRuntimeMCPServersWithConfig(
@@ -471,8 +471,17 @@ type acpRouteRegistrar interface {
 func validateResolvedSessionTransport(resolved *config.ResolvedProvider, transport string, sp runtime.Provider) error {
 	transport = strings.TrimSpace(transport)
 	switch transport {
-	case "", config.SessionTransportTmux:
+	case "":
 		return nil
+	case config.SessionTransportTmux:
+		if sessionProviderSupportsTmux(sp) {
+			return nil
+		}
+		providerName := transport
+		if resolved != nil && resolved.Name != "" {
+			providerName = resolved.Name
+		}
+		return fmt.Errorf("provider %q requires tmux transport but the session provider cannot route tmux sessions", providerName)
 	case config.SessionTransportACP:
 	default:
 		return fmt.Errorf("unknown session transport %q", transport)
@@ -501,12 +510,19 @@ func sessionProviderSupportsACP(sp runtime.Provider) bool {
 		return false
 	}
 	if provider, ok := sp.(runtime.TransportCapabilityProvider); ok {
-		return provider.SupportsTransport("acp")
+		return provider.SupportsTransport(config.SessionTransportACP)
 	}
 	if _, ok := sp.(acpRouteRegistrar); ok {
 		return true
 	}
 	return false
+}
+
+func sessionProviderSupportsTmux(sp runtime.Provider) bool {
+	if provider, ok := sp.(runtime.TransportCapabilityProvider); ok {
+		return provider.SupportsTransport(config.SessionTransportTmux)
+	}
+	return true
 }
 
 func resolvedSessionCommand(cityPath string, resolved *config.ResolvedProvider, optionOverrides map[string]string, transport string) (string, error) {
@@ -1664,7 +1680,7 @@ func sessionExplicitNameForNewSession(agent *config.Agent, alias string) (string
 }
 
 func shouldAttachNewSession(noAttach bool, transport string) bool {
-	return !noAttach && transport != "acp"
+	return !noAttach && transport != config.SessionTransportACP
 }
 
 // formatDuration formats a duration for human display.

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -470,8 +470,12 @@ type acpRouteRegistrar interface {
 
 func validateResolvedSessionTransport(resolved *config.ResolvedProvider, transport string, sp runtime.Provider) error {
 	transport = strings.TrimSpace(transport)
-	if transport != "acp" {
+	switch transport {
+	case "", config.SessionTransportTmux:
 		return nil
+	case config.SessionTransportACP:
+	default:
+		return fmt.Errorf("unknown session transport %q", transport)
 	}
 	providerName := ""
 	if resolved != nil {

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1697,6 +1697,23 @@ func TestValidateResolvedSessionTransportAcceptsRoutedACPProvider(t *testing.T) 
 	}
 }
 
+func TestValidateResolvedSessionTransportAcceptsTmuxTransport(t *testing.T) {
+	if err := validateResolvedSessionTransport(&config.ResolvedProvider{
+		Name: "opencode",
+	}, "tmux", runtime.NewFake()); err != nil {
+		t.Fatalf("validateResolvedSessionTransport() = %v, want nil", err)
+	}
+}
+
+func TestValidateResolvedSessionTransportRejectsUnknownTransport(t *testing.T) {
+	err := validateResolvedSessionTransport(&config.ResolvedProvider{
+		Name: "opencode",
+	}, "stdio", runtime.NewFake())
+	if err == nil || !strings.Contains(err.Error(), "unknown session transport") {
+		t.Fatalf("validateResolvedSessionTransport() error = %v, want unknown transport error", err)
+	}
+}
+
 func TestValidateResolvedSessionTransportRejectsRoutedProviderWhenTransportCapabilityDisablesACP(t *testing.T) {
 	err := validateResolvedSessionTransport(&config.ResolvedProvider{
 		Name:        "opencode",

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -533,6 +533,34 @@ args = ["{{.AgentName}}", "{{.WorkDir}}", "{{.TemplateName}}"]
 	}
 }
 
+func TestCmdSessionNewRejectsExplicitTmuxAgentWhenCitySessionProviderIsACP(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	oldBuild := buildSessionProviderByName
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+		if name == "acp" {
+			return &transportCapableSessionProvider{Fake: runtime.NewFake()}, nil
+		}
+		return oldBuild(name, sc, cityName, cityPath)
+	}
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writePoolACPCityExplicitTmuxAgentTOML(t, cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionNew([]string{"demo/ant"}, "", "", "", true, &stdout, &stderr); code == 0 {
+		t.Fatalf("cmdSessionNew(explicit tmux on ACP city) = %d, want failure", code)
+	}
+	if !strings.Contains(stderr.String(), "requires tmux transport") {
+		t.Fatalf("stderr = %q, want tmux transport error", stderr.String())
+	}
+	if got := sessionBeads(t, cityDir); len(got) != 0 {
+		t.Fatalf("session bead count = %d, want 0", len(got))
+	}
+}
+
 func TestCmdSessionNew_PoolTemplateRejectsAliasMatchingConcreteIdentity(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")
@@ -1432,6 +1460,42 @@ acp_args = ["acp"]
 	}
 }
 
+func writePoolACPCityExplicitTmuxAgentTOML(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.gc): %v", err)
+	}
+	rigRoot := filepath.Join(dir, "repos", "demo")
+	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig root): %v", err)
+	}
+	data := []byte(fmt.Sprintf(`[workspace]
+name = "test-city"
+
+[beads]
+provider = "file"
+
+[session]
+provider = "acp"
+
+[[rigs]]
+name = "demo"
+path = %q
+
+[[agent]]
+name = "ant"
+dir = "demo"
+provider = "codex"
+session = "tmux"
+work_dir = ".gc/worktrees/{{.Rig}}/ants/{{.AgentBase}}"
+min_active_sessions = 0
+max_active_sessions = 4
+`, rigRoot))
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+}
+
 func sessionBeads(t *testing.T, cityDir string) []beads.Bead {
 	t.Helper()
 	store, err := openCityStoreAt(cityDir)
@@ -1700,8 +1764,17 @@ func TestValidateResolvedSessionTransportAcceptsRoutedACPProvider(t *testing.T) 
 func TestValidateResolvedSessionTransportAcceptsTmuxTransport(t *testing.T) {
 	if err := validateResolvedSessionTransport(&config.ResolvedProvider{
 		Name: "opencode",
-	}, "tmux", runtime.NewFake()); err != nil {
+	}, config.SessionTransportTmux, runtime.NewFake()); err != nil {
 		t.Fatalf("validateResolvedSessionTransport() = %v, want nil", err)
+	}
+}
+
+func TestValidateResolvedSessionTransportRejectsTmuxWhenSessionProviderIsACPOnly(t *testing.T) {
+	err := validateResolvedSessionTransport(&config.ResolvedProvider{
+		Name: "opencode",
+	}, config.SessionTransportTmux, &transportCapableSessionProvider{Fake: runtime.NewFake()})
+	if err == nil || !strings.Contains(err.Error(), "requires tmux transport") {
+		t.Fatalf("validateResolvedSessionTransport() error = %v, want tmux routing error", err)
 	}
 }
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -131,8 +131,14 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	}
 	sessionTransport := config.ResolveSessionCreateTransport(cfgAgent.Session, resolved)
 	// Step 2: Validate session vs provider compatibility.
-	if sessionTransport == "acp" && !resolved.SupportsACP {
-		return TemplateParams{}, fmt.Errorf("agent %q: session = \"acp\" but provider %q does not support ACP (set supports_acp = true on the provider)", qualifiedName, resolved.Name)
+	switch sessionTransport {
+	case config.SessionTransportACP:
+		if !resolved.SupportsACP {
+			return TemplateParams{}, fmt.Errorf("agent %q: session = \"acp\" but provider %q does not support ACP (set supports_acp = true on the provider)", qualifiedName, resolved.Name)
+		}
+	case "", config.SessionTransportTmux:
+	default:
+		return TemplateParams{}, fmt.Errorf("agent %q: unknown session transport %q", qualifiedName, sessionTransport)
 	}
 
 	// Step 3: Expand dir template.
@@ -151,10 +157,13 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	// Step 5: Build copy_files and command with settings args + schema defaults.
 	var copyFiles []runtime.CopyEntry
 	var command string
-	if sessionTransport == "acp" {
+	switch sessionTransport {
+	case config.SessionTransportACP:
 		command = resolved.ACPCommandString()
-	} else {
+	case "", config.SessionTransportTmux:
 		command = resolved.CommandString()
+	default:
+		return TemplateParams{}, fmt.Errorf("agent %q: unknown session transport %q", qualifiedName, sessionTransport)
 	}
 	// Append schema-derived default args (e.g., --dangerously-skip-permissions
 	// from EffectiveDefaults["permission_mode"] = "unrestricted").
@@ -481,7 +490,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		}
 	}
 	var mcpServers []runtime.MCPServerConfig
-	if sessionTransport == "acp" {
+	if sessionTransport == config.SessionTransportACP {
 		mcpServers = materialize.RuntimeMCPServers(mcpCatalog.Servers)
 	}
 
@@ -518,7 +527,7 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		RigName:          rigName,
 		RigRoot:          rigRoot,
 		WakeMode:         cfgAgent.WakeMode,
-		IsACP:            sessionTransport == "acp",
+		IsACP:            sessionTransport == config.SessionTransportACP,
 		HookEnabled:      hasHooks,
 		MCPServers:       mcpServers,
 	}, nil

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -75,7 +75,7 @@ type TemplateParams struct {
 	RigRoot string
 	// WakeMode controls whether the next wake resumes or starts fresh conversation state.
 	WakeMode string
-	// IsACP is true if session = "acp".
+	// IsACP is true when the resolved session transport is SessionTransportACP.
 	IsACP bool
 	// HookEnabled reports whether provider hooks are installed for this agent.
 	// Hooks complement startup delivery but do not replace the initial

--- a/cmd/gc/template_resolve_prompt_test.go
+++ b/cmd/gc/template_resolve_prompt_test.go
@@ -348,6 +348,84 @@ func TestResolveTemplateNoneModeRetainsPromptForDeferredDelivery(t *testing.T) {
 	}
 }
 
+func TestResolveTemplateExplicitTmuxUsesProviderCommandForOpenCode(t *testing.T) {
+	cityPath := t.TempDir()
+	fs := fsys.NewFake()
+	fs.Files[cityPath+"/prompts/pool-worker.md"] = []byte("pool prompt body")
+
+	params := &agentBuildParams{
+		fs:        fs,
+		cityName:  "bright-lights",
+		cityPath:  cityPath,
+		workspace: &config.Workspace{Name: "bright-lights", Provider: "gemini"},
+		providers: map[string]config.ProviderSpec{
+			"gemini": {
+				Base:        stringPtr("builtin:opencode"),
+				Command:     "opencode",
+				PathCheck:   "opencode",
+				Args:        []string{"--model", "google/gemini-3.1-pro-preview"},
+				PromptMode:  "flag",
+				PromptFlag:  "--prompt",
+				SupportsACP: boolPtr(true),
+				ACPArgs:     []string{"acp"},
+			},
+		},
+		lookPath:        func(string) (string, error) { return "/usr/bin/opencode", nil },
+		beaconTime:      testBeaconTime,
+		sessionTemplate: "",
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+	}
+	agent := &config.Agent{
+		Name:           "gemini",
+		PromptTemplate: "prompts/pool-worker.md",
+		Provider:       "gemini",
+		Session:        "tmux",
+	}
+
+	tp, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+	if tp.IsACP {
+		t.Fatal("IsACP = true, want false for explicit tmux transport")
+	}
+	want := "opencode --model google/gemini-3.1-pro-preview"
+	if tp.Command != want {
+		t.Fatalf("Command = %q, want %q", tp.Command, want)
+	}
+}
+
+func TestResolveTemplateRejectsUnknownSessionTransport(t *testing.T) {
+	cityPath := t.TempDir()
+	fs := fsys.NewFake()
+	fs.Files[cityPath+"/prompts/pool-worker.md"] = []byte("pool prompt body")
+
+	params := &agentBuildParams{
+		fs:              fs,
+		cityName:        "bright-lights",
+		cityPath:        cityPath,
+		workspace:       &config.Workspace{Name: "bright-lights", Provider: "opencode"},
+		providers:       config.BuiltinProviders(),
+		lookPath:        func(string) (string, error) { return "/usr/bin/opencode", nil },
+		beaconTime:      testBeaconTime,
+		sessionTemplate: "",
+		beadNames:       make(map[string]string),
+		stderr:          io.Discard,
+	}
+	agent := &config.Agent{
+		Name:           "opencode",
+		PromptTemplate: "prompts/pool-worker.md",
+		Provider:       "opencode",
+		Session:        "stdio",
+	}
+
+	_, err := resolveTemplate(params, agent, agent.QualifiedName(), nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown session transport") {
+		t.Fatalf("resolveTemplate() error = %v, want unknown session transport", err)
+	}
+}
+
 func TestResolveTemplateHookEnabledOpencodeOmitsPrimeInstruction(t *testing.T) {
 	cityPath := t.TempDir()
 	fs := fsys.NewFake()

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -70,7 +70,7 @@ Agent defines a configured agent in the city.
 | `pre_start` | []string |  |  | PreStart is a list of shell commands run before session creation. Commands run on the target filesystem: locally for tmux, inside the pod/container for exec providers. Template variables same as session_setup. |
 | `prompt_template` | string |  |  | PromptTemplate is the path to this agent's prompt template file. Relative paths resolve against the city directory. |
 | `nudge` | string |  |  | Nudge is text typed into the agent's tmux session after startup. Used for CLI agents that don't accept command-line prompts. |
-| `session` | string |  |  | Session overrides the session transport for this agent. "" (default) uses the city-level session provider (typically tmux). "acp" uses the Agent Client Protocol (JSON-RPC over stdio). The agent's resolved provider must have supports_acp = true. Enum: `acp` |
+| `session` | string |  |  | Session overrides the session transport for this agent. "" (default) uses the provider default. "tmux" uses the tmux-backed CLI path even when the provider supports ACP. "acp" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's resolved provider must have supports_acp = true. Enum: `acp`, `tmux` |
 | `provider` | string |  |  | Provider names the provider preset to use for this agent. |
 | `start_command` | string |  |  | StartCommand overrides the provider's command for this agent. |
 | `args` | []string |  |  | Args overrides the provider's default arguments. |
@@ -142,7 +142,7 @@ AgentOverride modifies a pack-stamped agent for a specific rig.
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
-| `session` | string |  |  | Session overrides the session transport ("acp"). |
+| `session` | string |  |  | Session overrides the session transport ("acp" or "tmux"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
 | `nudge` | string |  |  | Nudge overrides the nudge text. |
@@ -192,7 +192,7 @@ AgentPatch modifies an existing agent identified by (Dir, Name).
 | `env_remove` | []string |  |  | EnvRemove lists env var keys to remove after merging. |
 | `pre_start` | []string |  |  | PreStart overrides the agent's pre_start commands. |
 | `prompt_template` | string |  |  | PromptTemplate overrides the prompt template path. Relative paths resolve against the city directory. |
-| `session` | string |  |  | Session overrides the session transport ("acp"). |
+| `session` | string |  |  | Session overrides the session transport ("acp" or "tmux"). |
 | `provider` | string |  |  | Provider overrides the provider name. |
 | `start_command` | string |  |  | StartCommand overrides the start command. |
 | `nudge` | string |  |  | Nudge overrides the nudge text. |

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -92,9 +92,10 @@
         "session": {
           "type": "string",
           "enum": [
-            "acp"
+            "acp",
+            "tmux"
           ],
-          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the city-level session provider (typically tmux).\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio).\nThe agent's resolved provider must have supports_acp = true."
+          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the provider default.\n\"tmux\" uses the tmux-backed CLI path even when the provider supports ACP.\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's\nresolved provider must have supports_acp = true."
         },
         "provider": {
           "type": "string",
@@ -419,7 +420,7 @@
         },
         "session": {
           "type": "string",
-          "description": "Session overrides the session transport (\"acp\")."
+          "description": "Session overrides the session transport (\"acp\" or \"tmux\")."
         },
         "provider": {
           "type": "string",
@@ -662,7 +663,7 @@
         },
         "session": {
           "type": "string",
-          "description": "Session overrides the session transport (\"acp\")."
+          "description": "Session overrides the session transport (\"acp\" or \"tmux\")."
         },
         "provider": {
           "type": "string",

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -92,9 +92,10 @@
         "session": {
           "type": "string",
           "enum": [
-            "acp"
+            "acp",
+            "tmux"
           ],
-          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the city-level session provider (typically tmux).\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio).\nThe agent's resolved provider must have supports_acp = true."
+          "description": "Session overrides the session transport for this agent.\n\"\" (default) uses the provider default.\n\"tmux\" uses the tmux-backed CLI path even when the provider supports ACP.\n\"acp\" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's\nresolved provider must have supports_acp = true."
         },
         "provider": {
           "type": "string",
@@ -419,7 +420,7 @@
         },
         "session": {
           "type": "string",
-          "description": "Session overrides the session transport (\"acp\")."
+          "description": "Session overrides the session transport (\"acp\" or \"tmux\")."
         },
         "provider": {
           "type": "string",
@@ -662,7 +663,7 @@
         },
         "session": {
           "type": "string",
-          "description": "Session overrides the session transport (\"acp\")."
+          "description": "Session overrides the session transport (\"acp\" or \"tmux\")."
         },
         "provider": {
           "type": "string",

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -1952,6 +1952,42 @@ func TestHandleSessionCreateRejectsACPAgentWithoutACPRouting(t *testing.T) {
 	}
 }
 
+func TestHandleSessionCreateRejectsExplicitTmuxAgentWhenCitySessionProviderIsACP(t *testing.T) {
+	fs := newSessionFakeState(t)
+	fs.cfg.Session.Provider = "acp"
+	fs.cfg.Agents[0].Provider = "opencode"
+	fs.cfg.Agents[0].Session = "tmux"
+	fs.cfg.Providers["opencode"] = config.ProviderSpec{
+		DisplayName: "OpenCode",
+		Command:     "/bin/echo",
+		PathCheck:   "true",
+	}
+	state := &stateWithSessionProvider{
+		fakeState: fs,
+		provider:  &transportCapableProvider{Fake: runtime.NewFake()},
+	}
+	srv := New(state)
+	h := newTestCityHandlerWith(t, state, srv)
+
+	req := newPostRequest(cityURL(fs, "/sessions"), strings.NewReader(`{"kind":"agent","name":"myrig/worker"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "requires tmux transport") {
+		t.Fatalf("body = %q, want tmux transport error", rec.Body.String())
+	}
+	items, err := fs.cityBeadStore.ListByLabel(session.LabelSession, 0)
+	if err != nil {
+		t.Fatalf("ListByLabel: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("session bead count = %d, want 0", len(items))
+	}
+}
+
 func TestHumaHandleSessionCreateRejectsACPAgentWithoutACPRouting(t *testing.T) {
 	supportsACP := true
 	fs := newSessionFakeState(t)

--- a/internal/api/session_transport.go
+++ b/internal/api/session_transport.go
@@ -14,8 +14,12 @@ type acpRoutingProvider interface {
 
 func validateSessionTransport(resolved *config.ResolvedProvider, transport string, sp runtime.Provider) (string, error) {
 	transport = strings.TrimSpace(transport)
-	if transport != "acp" {
+	switch transport {
+	case "", config.SessionTransportTmux:
 		return transport, nil
+	case config.SessionTransportACP:
+	default:
+		return "", fmt.Errorf("unknown session transport %q", transport)
 	}
 	providerName := ""
 	if resolved != nil {

--- a/internal/api/session_transport.go
+++ b/internal/api/session_transport.go
@@ -15,8 +15,17 @@ type acpRoutingProvider interface {
 func validateSessionTransport(resolved *config.ResolvedProvider, transport string, sp runtime.Provider) (string, error) {
 	transport = strings.TrimSpace(transport)
 	switch transport {
-	case "", config.SessionTransportTmux:
+	case "":
 		return transport, nil
+	case config.SessionTransportTmux:
+		if transportSupportsTmux(sp) {
+			return transport, nil
+		}
+		providerName := transport
+		if resolved != nil && resolved.Name != "" {
+			providerName = resolved.Name
+		}
+		return "", fmt.Errorf("provider %q requires tmux transport but the session provider cannot route tmux sessions", providerName)
 	case config.SessionTransportACP:
 	default:
 		return "", fmt.Errorf("unknown session transport %q", transport)
@@ -52,10 +61,17 @@ func transportSupportsACP(sp runtime.Provider) bool {
 		return false
 	}
 	if provider, ok := sp.(runtime.TransportCapabilityProvider); ok {
-		return provider.SupportsTransport("acp")
+		return provider.SupportsTransport(config.SessionTransportACP)
 	}
 	if _, ok := sp.(acpRoutingProvider); ok {
 		return true
 	}
 	return false
+}
+
+func transportSupportsTmux(sp runtime.Provider) bool {
+	if provider, ok := sp.(runtime.TransportCapabilityProvider); ok {
+		return provider.SupportsTransport(config.SessionTransportTmux)
+	}
+	return true
 }

--- a/internal/api/session_transport_test.go
+++ b/internal/api/session_transport_test.go
@@ -43,6 +43,27 @@ func TestProviderSessionTransportSupportsACPAloneStaysDefault(t *testing.T) {
 	}
 }
 
+func TestValidateSessionTransportAcceptsTmuxTransport(t *testing.T) {
+	transport, err := validateSessionTransport(&config.ResolvedProvider{
+		Name: "custom",
+	}, "tmux", runtime.NewFake())
+	if err != nil {
+		t.Fatalf("validateSessionTransport: %v", err)
+	}
+	if transport != "tmux" {
+		t.Fatalf("validateSessionTransport() = %q, want %q", transport, "tmux")
+	}
+}
+
+func TestValidateSessionTransportRejectsUnknownTransport(t *testing.T) {
+	_, err := validateSessionTransport(&config.ResolvedProvider{
+		Name: "custom",
+	}, "stdio", runtime.NewFake())
+	if err == nil {
+		t.Fatal("validateSessionTransport() error = nil, want unknown transport error")
+	}
+}
+
 func TestResolveSessionTemplateForCreateUsesProviderACPDefault(t *testing.T) {
 	fs := newSessionFakeState(t)
 	supportsACP := true

--- a/internal/api/session_transport_test.go
+++ b/internal/api/session_transport_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -46,12 +47,21 @@ func TestProviderSessionTransportSupportsACPAloneStaysDefault(t *testing.T) {
 func TestValidateSessionTransportAcceptsTmuxTransport(t *testing.T) {
 	transport, err := validateSessionTransport(&config.ResolvedProvider{
 		Name: "custom",
-	}, "tmux", runtime.NewFake())
+	}, config.SessionTransportTmux, runtime.NewFake())
 	if err != nil {
 		t.Fatalf("validateSessionTransport: %v", err)
 	}
-	if transport != "tmux" {
-		t.Fatalf("validateSessionTransport() = %q, want %q", transport, "tmux")
+	if transport != config.SessionTransportTmux {
+		t.Fatalf("validateSessionTransport() = %q, want %q", transport, config.SessionTransportTmux)
+	}
+}
+
+func TestValidateSessionTransportRejectsTmuxWhenSessionProviderIsACPOnly(t *testing.T) {
+	_, err := validateSessionTransport(&config.ResolvedProvider{
+		Name: "custom",
+	}, config.SessionTransportTmux, &createTransportCapableProvider{Fake: runtime.NewFake()})
+	if err == nil || !strings.Contains(err.Error(), "requires tmux transport") {
+		t.Fatalf("validateSessionTransport() error = %v, want tmux routing error", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -484,7 +484,7 @@ type AgentOverride struct {
 	// PromptTemplate overrides the prompt template path.
 	// Relative paths resolve against the city directory.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
-	// Session overrides the session transport ("acp").
+	// Session overrides the session transport ("acp" or "tmux").
 	Session *string `toml:"session,omitempty"`
 	// Provider overrides the provider name.
 	Provider *string `toml:"provider,omitempty"`
@@ -1663,10 +1663,11 @@ type Agent struct {
 	// Used for CLI agents that don't accept command-line prompts.
 	Nudge string `toml:"nudge,omitempty"`
 	// Session overrides the session transport for this agent.
-	// "" (default) uses the city-level session provider (typically tmux).
-	// "acp" uses the Agent Client Protocol (JSON-RPC over stdio).
-	// The agent's resolved provider must have supports_acp = true.
-	Session string `toml:"session,omitempty" jsonschema:"enum=acp"`
+	// "" (default) uses the provider default.
+	// "tmux" uses the tmux-backed CLI path even when the provider supports ACP.
+	// "acp" uses the Agent Client Protocol (JSON-RPC over stdio); the agent's
+	// resolved provider must have supports_acp = true.
+	Session string `toml:"session,omitempty" jsonschema:"enum=acp,enum=tmux"`
 	// Provider names the provider preset to use for this agent.
 	Provider string `toml:"provider,omitempty"`
 	// StartCommand overrides the provider's command for this agent.

--- a/internal/config/launch_command.go
+++ b/internal/config/launch_command.go
@@ -25,10 +25,13 @@ type ProviderLaunchCommand struct {
 //
 // When transport is "acp", the ACP-specific command (ACPCommand/ACPArgs) is
 // used as the base instead of the default Command/Args. Pass "" for the
-// default (tmux) transport.
+// provider default or "tmux" for the tmux-backed CLI transport.
 func BuildProviderLaunchCommand(cityPath string, resolved *ResolvedProvider, optionOverrides map[string]string, transport string) (ProviderLaunchCommand, error) {
 	if resolved == nil {
 		return ProviderLaunchCommand{}, fmt.Errorf("resolved provider is nil")
+	}
+	if !IsValidSessionTransport(transport) {
+		return ProviderLaunchCommand{}, fmt.Errorf("unknown session transport %q", strings.TrimSpace(transport))
 	}
 
 	command := providerLaunchBaseCommand(resolved, transport)
@@ -67,15 +70,21 @@ func BuildProviderLaunchCommandWithoutOptions(cityPath string, resolved *Resolve
 	if resolved == nil {
 		return ProviderLaunchCommand{}, fmt.Errorf("resolved provider is nil")
 	}
+	if !IsValidSessionTransport(transport) {
+		return ProviderLaunchCommand{}, fmt.Errorf("unknown session transport %q", strings.TrimSpace(transport))
+	}
 	return appendProviderSettings(cityPath, resolved.Name, providerLaunchBaseCommand(resolved, transport)), nil
 }
 
 func providerLaunchBaseCommand(resolved *ResolvedProvider, transport string) string {
-	command := resolved.CommandString()
-	if transport == "acp" {
-		command = resolved.ACPCommandString()
+	switch strings.TrimSpace(transport) {
+	case SessionTransportACP:
+		return resolved.ACPCommandString()
+	case "", SessionTransportTmux:
+		return resolved.CommandString()
+	default:
+		return resolved.CommandString()
 	}
-	return command
 }
 
 func appendProviderSettings(cityPath, providerName, command string) ProviderLaunchCommand {

--- a/internal/config/launch_command_test.go
+++ b/internal/config/launch_command_test.go
@@ -103,6 +103,24 @@ func TestBuildProviderLaunchCommandUsesACPCommand(t *testing.T) {
 			t.Fatalf("Command = %q, want %q", got.Command, want)
 		}
 	})
+
+	t.Run("tmux transport uses CommandString", func(t *testing.T) {
+		got, err := BuildProviderLaunchCommand("", rp, nil, "tmux")
+		if err != nil {
+			t.Fatalf("BuildProviderLaunchCommand: %v", err)
+		}
+		want := "custom-opencode"
+		if got.Command != want {
+			t.Fatalf("Command = %q, want %q", got.Command, want)
+		}
+	})
+
+	t.Run("unknown transport errors", func(t *testing.T) {
+		_, err := BuildProviderLaunchCommand("", rp, nil, "stdio")
+		if err == nil {
+			t.Fatal("BuildProviderLaunchCommand() error = nil, want unknown transport error")
+		}
+	})
 }
 
 func TestBuildProviderLaunchCommandWithoutOptionsSkipsDefaultsButKeepsSettings(t *testing.T) {

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -39,7 +39,7 @@ type AgentPatch struct {
 	// PromptTemplate overrides the prompt template path.
 	// Relative paths resolve against the city directory.
 	PromptTemplate *string `toml:"prompt_template,omitempty"`
-	// Session overrides the session transport ("acp").
+	// Session overrides the session transport ("acp" or "tmux").
 	Session *string `toml:"session,omitempty"`
 	// Provider overrides the provider name.
 	Provider *string `toml:"provider,omitempty"`

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -211,6 +211,24 @@ type ResolvedProvider struct {
 	EffectiveDefaults map[string]string
 }
 
+const (
+	// SessionTransportACP creates sessions through the Agent Client Protocol.
+	SessionTransportACP = "acp"
+	// SessionTransportTmux creates sessions through the tmux-backed CLI path.
+	SessionTransportTmux = "tmux"
+)
+
+// IsValidSessionTransport reports whether transport is a recognized explicit
+// session transport. The empty string is valid and means provider default.
+func IsValidSessionTransport(transport string) bool {
+	switch strings.TrimSpace(transport) {
+	case "", SessionTransportACP, SessionTransportTmux:
+		return true
+	default:
+		return false
+	}
+}
+
 // CommandString returns the full command line: command followed by args.
 func (rp *ResolvedProvider) CommandString() string {
 	if len(rp.Args) == 0 {
@@ -251,7 +269,7 @@ func (rp *ResolvedProvider) DefaultSessionTransport() string {
 		family = strings.TrimSpace(rp.Name)
 	}
 	if family == "opencode" {
-		return "acp"
+		return SessionTransportACP
 	}
 	return ""
 }
@@ -266,7 +284,7 @@ func (rp *ResolvedProvider) ProviderSessionCreateTransport() string {
 		return transport
 	}
 	if strings.TrimSpace(rp.ACPCommand) != "" || rp.ACPArgs != nil {
-		return "acp"
+		return SessionTransportACP
 	}
 	return ""
 }
@@ -275,13 +293,19 @@ func (rp *ResolvedProvider) ProviderSessionCreateTransport() string {
 // fresh session from an agent/template configuration.
 func ResolveSessionCreateTransport(agentSession string, resolved *ResolvedProvider) string {
 	agentSession = strings.TrimSpace(agentSession)
-	if agentSession != "" {
+	switch agentSession {
+	case SessionTransportACP:
+		return SessionTransportACP
+	case SessionTransportTmux:
+		return SessionTransportTmux
+	case "":
+		if resolved == nil {
+			return ""
+		}
+		return strings.TrimSpace(resolved.ProviderSessionCreateTransport())
+	default:
 		return agentSession
 	}
-	if resolved == nil {
-		return ""
-	}
-	return strings.TrimSpace(resolved.ProviderSessionCreateTransport())
 }
 
 // TitleModelFlagArgs resolves the TitleModel key against the "model"

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -457,6 +457,17 @@ func TestResolveSessionCreateTransportPrefersAgentSessionOverride(t *testing.T) 
 	}
 }
 
+func TestResolveSessionCreateTransportExplicitTmuxOverridesProviderACPDefault(t *testing.T) {
+	got := ResolveSessionCreateTransport("tmux", &ResolvedProvider{
+		Name:        "opencode",
+		SupportsACP: true,
+		ACPArgs:     []string{"acp"},
+	})
+	if got != "tmux" {
+		t.Fatalf("ResolveSessionCreateTransport() = %q, want %q", got, "tmux")
+	}
+}
+
 func TestResolveSessionCreateTransportFallsBackToProviderCreateTransport(t *testing.T) {
 	got := ResolveSessionCreateTransport("", &ResolvedProvider{
 		Name:        "custom-acp",

--- a/internal/config/validate_semantics.go
+++ b/internal/config/validate_semantics.go
@@ -45,9 +45,9 @@ func ValidateSemantics(cfg *City, source string) []string {
 
 	// Check agent session field.
 	for _, a := range cfg.Agents {
-		if a.Session != "" && a.Session != "acp" {
+		if !IsValidSessionTransport(a.Session) {
 			warnings = append(warnings, fmt.Sprintf(
-				"%s: agent %q: session %q is not a valid session transport (use \"acp\" or omit)",
+				"%s: agent %q: session %q is not a valid session transport (use \"acp\", \"tmux\", or omit)",
 				source, a.QualifiedName(), a.Session))
 		}
 	}

--- a/internal/config/validate_semantics_test.go
+++ b/internal/config/validate_semantics_test.go
@@ -77,6 +77,33 @@ func TestValidateSemanticsStartCommandSkipsProviderCheck(t *testing.T) {
 	}
 }
 
+func TestValidateSemanticsAgentSessionTransportAllowsTmux(t *testing.T) {
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker", Provider: "claude", Session: "tmux"},
+		},
+	}
+	warnings := ValidateSemantics(cfg, "city.toml")
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for tmux session transport, got: %v", warnings)
+	}
+}
+
+func TestValidateSemanticsAgentSessionTransportRejectsUnknown(t *testing.T) {
+	cfg := &City{
+		Agents: []Agent{
+			{Name: "worker", Provider: "claude", Session: "stdio"},
+		},
+	}
+	warnings := ValidateSemantics(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "stdio") || !strings.Contains(warnings[0], "tmux") {
+		t.Fatalf("warning should mention bad value and allowed transports: %s", warnings[0])
+	}
+}
+
 func TestValidateSemanticsProviderPromptModeBad(t *testing.T) {
 	cfg := &City{
 		Providers: map[string]ProviderSpec{


### PR DESCRIPTION
Summary:
- add first-class acp/tmux session transport constants and validation
- make tmux explicitly select provider CLI launch commands instead of ACP commands
- update config schema/docs and tests for tmux plus unknown transport rejection

Testing:
- make test
- go test ./internal/config -run 'TestValidateSemanticsAgentSessionTransport|TestResolveSessionCreateTransport|TestBuildProviderLaunchCommandUsesACPCommand'
- go test ./cmd/gc -run 'TestResolveTemplateExplicitTmuxUsesProviderCommandForOpenCode|TestResolveTemplateRejectsUnknownSessionTransport|TestValidateResolvedSessionTransport'
- go test ./internal/api -run 'TestProviderSessionTransport|TestValidateSessionTransport|TestResolveSessionTemplate'
- go test ./test/docsync -run TestSchemaFreshness
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->