### PR TITLE
fix: block nudge poller test binary recursion

### DIFF
--- a/internal/session/submit.go
+++ b/internal/session/submit.go
@@ -458,7 +458,10 @@ func deferredSubmitAgentKey(b beads.Bead) string {
 	return b.Title
 }
 
-var startSessionSubmitPoller = ensureSessionSubmitPoller
+var (
+	startSessionSubmitPoller      = ensureSessionSubmitPoller
+	sessionSubmitPollerExecutable = os.Executable
+)
 
 func ensureSessionSubmitPoller(cityPath, agentName, sessionName string) error {
 	pidPath := sessionSubmitPollerPIDPath(cityPath, sessionName)
@@ -466,9 +469,12 @@ func ensureSessionSubmitPoller(cityPath, agentName, sessionName string) error {
 		if running, _ := existingSessionSubmitPollerPID(pidPath); running {
 			return nil
 		}
-		exe, err := os.Executable()
+		exe, err := sessionSubmitPollerExecutable()
 		if err != nil {
 			return err
+		}
+		if isGoTestExecutable(exe) {
+			return fmt.Errorf("refusing to start nudge poller with Go test binary %q", exe)
 		}
 		cmd := exec.Command(exe, "nudge", "poll", "--city", cityPath, "--session", sessionName, agentName)
 		cmd.Env = os.Environ()
@@ -490,6 +496,10 @@ func ensureSessionSubmitPoller(cityPath, agentName, sessionName string) error {
 		}
 		return cmd.Process.Release()
 	})
+}
+
+func isGoTestExecutable(path string) bool {
+	return strings.HasSuffix(filepath.Base(path), ".test")
 }
 
 func sessionSubmitPollerPIDPath(cityPath, sessionName string) string {

--- a/internal/session/submit_test.go
+++ b/internal/session/submit_test.go
@@ -2,7 +2,11 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -393,6 +397,31 @@ func TestSubmitFollowUpQueuesDeferredMessageAndStartsCodexPoller(t *testing.T) {
 	}
 	if pollerCalls != 1 {
 		t.Fatalf("pollerCalls = %d, want 1", pollerCalls)
+	}
+}
+
+func TestEnsureSessionSubmitPollerRejectsGoTestExecutable(t *testing.T) {
+	cityPath := t.TempDir()
+	exe := filepath.Join(t.TempDir(), "session.test")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(test executable): %v", err)
+	}
+
+	origExecutable := sessionSubmitPollerExecutable
+	sessionSubmitPollerExecutable = func() (string, error) {
+		return exe, nil
+	}
+	defer func() { sessionSubmitPollerExecutable = origExecutable }()
+
+	err := ensureSessionSubmitPoller(cityPath, "agent", "s-test")
+	if err == nil || !strings.Contains(err.Error(), "Go test binary") {
+		t.Fatalf("ensureSessionSubmitPoller error = %v, want Go test binary refusal", err)
+	}
+	if _, statErr := os.Stat(sessionSubmitPollerPIDPath(cityPath, "s-test")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("poller pid file stat error = %v, want not exist", statErr)
+	}
+	if _, statErr := os.Stat(sessionSubmitPollerLogPath(cityPath, "s-test")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("poller log file stat error = %v, want not exist", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- refuse to start detached nudge pollers when the resolved executable is a Go test binary
- add a regression test that injects a `session.test` executable and verifies no pid/log is written

## Tests
- go test ./internal/session -run 'TestEnsureSessionSubmitPollerRejectsGoTestExecutable|TestSubmitFollowUpQueuesDeferredMessageForPoolManagedSession|TestSubmitDefaultQueuesWhenWakeAlreadyRequested' -count=1\n- go test ./internal/session -count=1\n- go test ./cmd/gc -run 'TestDispatchReadyWaitNudges|Test.*Nudge.*Poller|Test.*Submit' -count=1\n- pre-commit hook: go test ./..., golangci-lint, go vet, generated-doc checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->