### PR TITLE
fix: route fanout fragment controls

### DIFF
--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
@@ -188,30 +189,51 @@ func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Be
 	}
 	routeCfg := loadAttemptRouteConfig(opts.CityPath)
 	for i := range fragment.Steps {
-		if fragment.Steps[i].Metadata["gc.kind"] == "spec" {
+		step := &fragment.Steps[i]
+		if step.Metadata["gc.kind"] == "spec" {
 			continue
 		}
-		target := strings.TrimSpace(fragment.Steps[i].Metadata["gc.run_target"])
-		if target == "" {
-			target = strings.TrimSpace(fragment.Steps[i].Metadata["gc.routed_to"])
-		}
-		if target == "" {
-			target = strings.TrimSpace(fragment.Steps[i].Assignee)
-		}
-		if target == "" {
-			target = executionRoute
-		} else {
-			target = qualifyAttemptTargetWithSourceRoute(target, executionRoute, routeCfg)
-		}
-		if isAttemptControlKind(fragment.Steps[i].Metadata["gc.kind"]) {
-			applyAttemptControlStepRoute(&fragment.Steps[i], target, routeCfg, store)
+		if isAttemptControlKind(step.Metadata["gc.kind"]) {
+			target := strings.TrimSpace(step.Metadata["gc.execution_routed_to"])
+			if target == "" {
+				target = fanoutFragmentStepTarget(*step, executionRoute, routeCfg)
+			}
+			applyAttemptControlStepRoute(step, target, routeCfg, store)
 			continue
 		}
+		if fanoutFragmentStepHasRoute(*step) {
+			continue
+		}
+		target := fanoutFragmentStepTarget(*step, executionRoute, routeCfg)
 		if target == "" {
 			continue
 		}
-		applyAttemptStepRoute(&fragment.Steps[i], target, routeCfg, store)
+		applyAttemptStepRoute(step, target, routeCfg, store)
 	}
+}
+
+func fanoutFragmentStepTarget(step formula.RecipeStep, executionRoute string, routeCfg *config.City) string {
+	target := strings.TrimSpace(step.Metadata["gc.run_target"])
+	if target == "" {
+		target = strings.TrimSpace(step.Metadata["gc.routed_to"])
+	}
+	if target == "" {
+		target = strings.TrimSpace(step.Assignee)
+	}
+	if target == "" {
+		return executionRoute
+	}
+	return qualifyAttemptTargetWithSourceRoute(target, executionRoute, routeCfg)
+}
+
+func fanoutFragmentStepHasRoute(step formula.RecipeStep) bool {
+	if strings.TrimSpace(step.Metadata["gc.execution_routed_to"]) != "" {
+		return true
+	}
+	if strings.TrimSpace(step.Metadata["gc.routed_to"]) != "" {
+		return true
+	}
+	return strings.TrimSpace(step.Assignee) != ""
 }
 
 func resolveExistingFragmentInstanceFromBeads(store beads.Store, all []beads.Bead, _ string, fragment *formula.FragmentRecipe, externalDeps []molecule.ExternalDep) (map[string]string, error) {

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -135,6 +135,7 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 				return ControlResult{}, fmt.Errorf("%s: preparing fragment %d: %w", bead.ID, index+1, err)
 			}
 		}
+		routeFanoutFragmentSteps(fragment, bead, opts, store)
 		externalDeps := expectedFragmentExternalDeps(fragment, mode, previousSinkIDs)
 		existingMapping, err := resolveExistingFragmentInstanceFromBeads(store, workflowBeads, rootID, fragment, externalDeps)
 		if err != nil {
@@ -175,6 +176,42 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		return ControlResult{}, fmt.Errorf("%s: recording fanout state: %w", bead.ID, err)
 	}
 	return ControlResult{Processed: true, Action: "fanout-spawn", Created: totalCreated}, nil
+}
+
+func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Bead, opts ProcessOptions, store beads.Store) {
+	if fragment == nil {
+		return
+	}
+	executionRoute := strings.TrimSpace(control.Metadata["gc.execution_routed_to"])
+	if executionRoute == "" {
+		executionRoute = strings.TrimSpace(control.Metadata["gc.routed_to"])
+	}
+	routeCfg := loadAttemptRouteConfig(opts.CityPath)
+	for i := range fragment.Steps {
+		if fragment.Steps[i].Metadata["gc.kind"] == "spec" {
+			continue
+		}
+		target := strings.TrimSpace(fragment.Steps[i].Metadata["gc.run_target"])
+		if target == "" {
+			target = strings.TrimSpace(fragment.Steps[i].Metadata["gc.routed_to"])
+		}
+		if target == "" {
+			target = strings.TrimSpace(fragment.Steps[i].Assignee)
+		}
+		if target == "" {
+			target = executionRoute
+		} else {
+			target = qualifyAttemptTargetWithSourceRoute(target, executionRoute, routeCfg)
+		}
+		if isAttemptControlKind(fragment.Steps[i].Metadata["gc.kind"]) {
+			applyAttemptControlStepRoute(&fragment.Steps[i], target, routeCfg, store)
+			continue
+		}
+		if target == "" {
+			continue
+		}
+		applyAttemptStepRoute(&fragment.Steps[i], target, routeCfg, store)
+	}
 }
 
 func resolveExistingFragmentInstanceFromBeads(store beads.Store, all []beads.Bead, _ string, fragment *formula.FragmentRecipe, externalDeps []molecule.ExternalDep) (map[string]string, error) {

--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -422,6 +422,9 @@ func (s scopeSnapshot) hasOpenScopeMembers(ignoreIDs ...string) bool {
 		if _, skip := ignored[member.ID]; skip {
 			continue
 		}
+		if member.Metadata["gc.kind"] == "spec" {
+			continue
+		}
 		switch member.Metadata["gc.scope_role"] {
 		case "body", "teardown":
 			continue
@@ -500,6 +503,9 @@ func (s scopeSnapshot) skipOpenScopeMembers(store beads.Store, skipControlID str
 	pending := make(map[string]beads.Bead)
 	for _, member := range s.members {
 		if member.ID == skipControlID || member.Status != "open" {
+			continue
+		}
+		if member.Metadata["gc.kind"] == "spec" {
 			continue
 		}
 		switch member.Metadata["gc.scope_role"] {

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3388,6 +3388,152 @@ on_exhausted = "hard_fail"
 	}
 }
 
+func TestProcessFanoutPreservesPreparedControlExecutionRoutes(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`
+[workspace]
+name = "maintainer-city"
+
+[[rig]]
+name = "gascity"
+path = "/tmp/gascity"
+
+[[agent]]
+name = "reviewer"
+dir = "gascity"
+
+[[agent]]
+name = "control-dispatcher"
+dir = "gascity"
+max_active_sessions = 1
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+metadata = { "gc.run_target" = "{reviewer}", "gc.scope_ref" = "body", "gc.scope_role" = "member" }
+
+[template.retry]
+max_attempts = 3
+on_exhausted = "hard_fail"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "survey",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.survey",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"gascity/reviewer"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for survey",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "fanout",
+			"gc.root_bead_id":        workflow.ID,
+			"gc.control_for":         "demo.survey",
+			"gc.execution_routed_to": "gascity/reviewer",
+			"gc.for_each":            "output.items",
+			"gc.bond":                "expansion-review",
+			"gc.bond_vars":           `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":         "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{
+		CityPath:           dir,
+		FormulaSearchPaths: []string{dir},
+		PrepareFragment: func(fragment *formula.FragmentRecipe, _ beads.Bead) error {
+			for i := range fragment.Steps {
+				if fragment.Steps[i].Metadata == nil {
+					fragment.Steps[i].Metadata = make(map[string]string)
+				}
+				fragment.Steps[i].Metadata["gc.dynamic_fragment"] = "true"
+			}
+			formula.ApplyFragmentRecipeGraphControls(fragment)
+			for i := range fragment.Steps {
+				step := &fragment.Steps[i]
+				switch step.Metadata["gc.kind"] {
+				case "workflow", "scope", "ralph", "retry", "spec":
+					continue
+				case "scope-check", "workflow-finalize", "fanout", "check", "retry-eval":
+					step.Metadata["gc.execution_routed_to"] = "gascity/reviewer"
+					delete(step.Metadata, "gc.routed_to")
+					step.Assignee = "gascity--control-dispatcher"
+				default:
+					step.Metadata["gc.routed_to"] = "gascity/reviewer"
+					delete(step.Metadata, "gc.execution_routed_to")
+					step.Assignee = "gascity--reviewer"
+				}
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("result = %+v, want processed fanout-spawn", result)
+	}
+
+	retryControl := findAttemptByRef(t, store, workflow.ID, "expansion-review.demo.survey.item.1.review")
+	if retryControl.ID == "" {
+		t.Fatal("retry control not created")
+	}
+	if retryControl.Metadata["gc.kind"] != "retry" {
+		t.Fatalf("retry control gc.kind = %q, want retry", retryControl.Metadata["gc.kind"])
+	}
+	if got := retryControl.Assignee; got != "gascity--control-dispatcher" {
+		t.Fatalf("retry control assignee = %q, want gascity--control-dispatcher", got)
+	}
+	if got := retryControl.Metadata["gc.execution_routed_to"]; got != "gascity/reviewer" {
+		t.Fatalf("retry control gc.execution_routed_to = %q, want gascity/reviewer", got)
+	}
+
+	scopeCheck := findAttemptByRef(t, store, workflow.ID, "expansion-review.demo.survey.item.1.review-scope-check")
+	if scopeCheck.ID == "" {
+		t.Fatal("scope-check control not created")
+	}
+	if scopeCheck.Metadata["gc.kind"] != "scope-check" {
+		t.Fatalf("scope-check gc.kind = %q, want scope-check", scopeCheck.Metadata["gc.kind"])
+	}
+	if got := scopeCheck.Assignee; got != "gascity--control-dispatcher" {
+		t.Fatalf("scope-check assignee = %q, want gascity--control-dispatcher", got)
+	}
+	if got := scopeCheck.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("scope-check gc.routed_to = %q, want empty direct dispatcher assignee", got)
+	}
+	if got := scopeCheck.Metadata["gc.execution_routed_to"]; got != "gascity/reviewer" {
+		t.Fatalf("scope-check gc.execution_routed_to = %q, want gascity/reviewer", got)
+	}
+}
+
 func TestProcessFanoutResumesExistingFragmentsWithoutDuplicates(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -5281,6 +5281,77 @@ func TestFullMetadataPropagationChain(t *testing.T) {
 	}
 }
 
+func TestProcessScopeCheckIgnoresOpenSpecBeadsWhenCompletingScope(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "iteration 1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "review-loop.iteration.1",
+		},
+	})
+	mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Step spec for apply",
+		Type:  "spec",
+		Metadata: map[string]string{
+			"gc.kind":         "spec",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "review-loop.iteration.1",
+			"gc.scope_role":   "member",
+			"gc.step_ref":     "review-loop.iteration.1.apply.spec",
+		},
+	})
+	member := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "apply",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "review-loop.iteration.1",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "pass",
+		},
+	})
+	scopeCheck := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize apply",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "review-loop.iteration.1",
+			"gc.scope_role":   "control",
+		},
+	})
+	mustDepAdd(t, store, scopeCheck.ID, member.ID, "blocks")
+	mustDepAdd(t, store, body.ID, scopeCheck.ID, "blocks")
+
+	result, err := ProcessControl(store, mustGetBead(t, store, scopeCheck.ID), ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(scope-check): %v", err)
+	}
+	if result.Action != "scope-pass" {
+		t.Fatalf("scope-check action = %q, want scope-pass", result.Action)
+	}
+
+	bodyAfter := mustGetBead(t, store, body.ID)
+	if bodyAfter.Status != "closed" || bodyAfter.Metadata["gc.outcome"] != "pass" {
+		t.Fatalf("scope body = status %q outcome %q, want closed/pass", bodyAfter.Status, bodyAfter.Metadata["gc.outcome"])
+	}
+}
+
 // TestProcessControlEmitsSkipReasonWhenNotOpen is the regression guard for
 // the 20-minute silent stall on ga-ttn5z. When a rogue worker had flipped
 // a retry-control bead (ga-fw2fm) to status=in_progress, ProcessControl

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3281,6 +3281,113 @@ needs = ["{target}.review"]
 	}
 }
 
+func TestProcessFanoutRoutesFragmentRetryControlsToControlDispatcher(t *testing.T) {
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`
+[workspace]
+name = "maintainer-city"
+
+[[rig]]
+name = "gascity"
+path = "/tmp/gascity"
+
+[[agent]]
+name = "reviewer"
+dir = "gascity"
+
+[[agent]]
+name = "control-dispatcher"
+dir = "gascity"
+max_active_sessions = 1
+`), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+metadata = { "gc.run_target" = "{reviewer}", "gc.scope_ref" = "body", "gc.scope_role" = "member" }
+
+[template.retry]
+max_attempts = 3
+on_exhausted = "hard_fail"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "survey",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "demo.survey",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"gascity/reviewer"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for survey",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":                "fanout",
+			"gc.root_bead_id":        workflow.ID,
+			"gc.control_for":         "demo.survey",
+			"gc.execution_routed_to": "gascity/reviewer",
+			"gc.for_each":            "output.items",
+			"gc.bond":                "expansion-review",
+			"gc.bond_vars":           `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":         "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{
+		CityPath:           dir,
+		FormulaSearchPaths: []string{dir},
+	})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("result = %+v, want processed fanout-spawn", result)
+	}
+
+	logical := findAttemptByRef(t, store, workflow.ID, "expansion-review.demo.survey.item.1.review")
+	if logical.ID == "" {
+		t.Fatal("logical retry control not created")
+	}
+	if logical.Metadata["gc.kind"] != "retry" {
+		t.Fatalf("logical gc.kind = %q, want retry", logical.Metadata["gc.kind"])
+	}
+	if got := logical.Assignee; got != "gascity--control-dispatcher" {
+		t.Fatalf("logical retry assignee = %q, want gascity--control-dispatcher", got)
+	}
+	if got := logical.Metadata["gc.routed_to"]; got != "" {
+		t.Fatalf("logical retry gc.routed_to = %q, want empty direct dispatcher assignee", got)
+	}
+	if got := logical.Metadata["gc.execution_routed_to"]; got != "gascity/reviewer" {
+		t.Fatalf("logical retry gc.execution_routed_to = %q, want gascity/reviewer", got)
+	}
+}
+
 func TestProcessFanoutResumesExistingFragmentsWithoutDuplicates(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 


### PR DESCRIPTION
## Summary
- route dynamically materialized fanout fragment control beads through the control-dispatcher lane
- add a regression covering retry controls emitted from runtime fanout fragments

## Verification
- go test ./internal/dispatch -count=1
- pre-commit hook ran observable fast unit loop during commit
- go install ./cmd/gc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->