### PR TITLE
fix: recover stale order tracking dispatches

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -66,6 +66,8 @@ type CityRuntime struct {
 	retiredOrderDispatchers []orderDispatcher
 	trace                   *sessionReconcilerTraceManager
 
+	orderSweepWatchdogLast time.Time
+
 	rec events.Recorder
 	cs  *controllerState // nil when controller-managed bead stores are unavailable
 	svc *workspacesvc.Manager
@@ -788,8 +790,35 @@ func (cr *CityRuntime) dispatchOrders(ctx context.Context, cityRoot string) {
 	if ctx.Err() != nil {
 		return
 	}
+	now := time.Now()
+	cr.runOrderTrackingSweepWatchdog(now)
 	if cr.od != nil {
-		cr.od.dispatch(ctx, cityRoot, time.Now())
+		cr.od.dispatch(ctx, cityRoot, now)
+	}
+}
+
+func (cr *CityRuntime) runOrderTrackingSweepWatchdog(now time.Time) {
+	if !cr.orderSweepWatchdogLast.IsZero() && now.Sub(cr.orderSweepWatchdogLast) < orderTrackingSweepWatchdogInterval {
+		return
+	}
+	cr.orderSweepWatchdogLast = now
+
+	store := cr.cityBeadStore()
+	if store == nil {
+		return
+	}
+	onlyOrders := map[string]struct{}{
+		orderTrackingSweepOrder: {},
+	}
+	n, err := sweepStaleOrderTracking(store, now, orderTrackingSweepWatchdogStaleAfter, onlyOrders, orderTrackingWatchdogMetadataInitiator)
+	if err != nil {
+		if cr.stderr != nil {
+			fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog: %v\n", cr.logPrefix, err) //nolint:errcheck // best-effort stderr
+		}
+		return
+	}
+	if n > 0 && cr.stderr != nil {
+		fmt.Fprintf(cr.stderr, "%s: order tracking sweep watchdog closed %d stale tracking bead(s)\n", cr.logPrefix, n) //nolint:errcheck // best-effort stderr
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -531,6 +531,49 @@ func TestCityRuntimeRunStartupOrderDispatchPanicIsRecovered(t *testing.T) {
 	}
 }
 
+func TestOrderTrackingSweepWatchdogOnlyClosesSweepOrderTracking(t *testing.T) {
+	store := beads.NewMemStore()
+	sweepTracking, err := store.Create(beads.Bead{
+		Title:  "order:" + orderTrackingSweepOrder,
+		Labels: []string{"order-run:" + orderTrackingSweepOrder, labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(sweep): %v", err)
+	}
+	mergeTracking, err := store.Create(beads.Bead{
+		Title:  "order:pr-merge-queue",
+		Labels: []string{"order-run:pr-merge-queue", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(merge): %v", err)
+	}
+
+	cr := &CityRuntime{
+		cityName:            "test-city",
+		cfg:                 &config.City{Workspace: config.Workspace{Name: "test-city"}},
+		standaloneCityStore: store,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+		logPrefix:           "gc test",
+	}
+	cr.runOrderTrackingSweepWatchdog(time.Now().Add(orderTrackingSweepWatchdogStaleAfter + time.Second))
+
+	gotSweep, err := store.Get(sweepTracking.ID)
+	if err != nil {
+		t.Fatalf("Get(sweep): %v", err)
+	}
+	if gotSweep.Status != "closed" {
+		t.Fatalf("sweep tracking status = %s, want closed", gotSweep.Status)
+	}
+	gotMerge, err := store.Get(mergeTracking.ID)
+	if err != nil {
+		t.Fatalf("Get(merge): %v", err)
+	}
+	if gotMerge.Status != "open" {
+		t.Fatalf("merge tracking status = %s, want open", gotMerge.Status)
+	}
+}
+
 func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/cmd/gc/cmd_order.go
+++ b/cmd/gc/cmd_order.go
@@ -32,7 +32,7 @@ tick and dispatches work when a trigger opens.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				fmt.Fprintln(stderr, "gc order: missing subcommand (list, show, run, check, history)") //nolint:errcheck // best-effort stderr
+				fmt.Fprintln(stderr, "gc order: missing subcommand (list, show, run, check, history, sweep-tracking)") //nolint:errcheck // best-effort stderr
 			} else {
 				fmt.Fprintf(stderr, "gc order: unknown subcommand %q\n", args[0]) //nolint:errcheck // best-effort stderr
 			}
@@ -45,6 +45,7 @@ tick and dispatches work when a trigger opens.`,
 		newOrderRunCmd(stdout, stderr),
 		newOrderCheckCmd(stdout, stderr),
 		newOrderHistoryCmd(stdout, stderr),
+		newOrderSweepTrackingCmd(stdout, stderr),
 	)
 	return cmd
 }
@@ -158,6 +159,29 @@ name. Use --rig to filter by rig.`,
 	}
 	cmd.Flags().StringVar(&rig, "rig", "", "rig name to filter order history")
 	_ = cmd.RegisterFlagCompletionFunc("rig", completeRigFlagNames)
+	return cmd
+}
+
+func newOrderSweepTrackingCmd(stdout, stderr io.Writer) *cobra.Command {
+	staleAfter := defaultOrderTrackingSweepStaleAfter
+	quiet := false
+	cmd := &cobra.Command{
+		Use:   "sweep-tracking",
+		Short: "Close stale order-tracking beads",
+		Long: `Close stale open order-tracking beads.
+
+This is intended for maintenance exec orders. It only closes tracking beads
+older than --stale-after so a fresh in-flight order is not interrupted.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if cmdOrderSweepTracking(staleAfter, quiet, stdout, stderr) != 0 {
+				return errExit
+			}
+			return nil
+		},
+	}
+	cmd.Flags().DurationVar(&staleAfter, "stale-after", defaultOrderTrackingSweepStaleAfter, "minimum age for an open tracking bead to be closed")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress success output")
 	return cmd
 }
 
@@ -910,6 +934,34 @@ func doOrderHistoryWithStoresResolver(name, rig string, aa []orders.Order, resol
 		for _, e := range entries {
 			fmt.Fprintf(stdout, "%-20s %-15s %s\n", e.order, e.id, e.createdAt.Format(time.RFC3339)) //nolint:errcheck
 		}
+	}
+	return 0
+}
+
+// --- gc order sweep-tracking ---
+
+func cmdOrderSweepTracking(staleAfter time.Duration, quiet bool, stdout, stderr io.Writer) int {
+	if staleAfter <= 0 {
+		fmt.Fprintln(stderr, "gc order sweep-tracking: --stale-after must be positive") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	store, err := openStoreAtForCity(cityPath, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	closed, err := sweepStaleOrderTracking(store, time.Now(), staleAfter, nil, orderTrackingSweepMetadataInitiator)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc order sweep-tracking: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if !quiet {
+		fmt.Fprintf(stdout, "closed %d stale order-tracking bead(s)\n", closed) //nolint:errcheck // best-effort stdout
 	}
 	return 0
 }

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -21,7 +21,17 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 )
 
-const labelOrderTracking = "order-tracking"
+const (
+	labelOrderTracking = "order-tracking"
+
+	orderTrackingSweepOrder                = "order-tracking-sweep"
+	defaultOrderTrackingSweepStaleAfter    = 10 * time.Minute
+	orderTrackingSweepWatchdogInterval     = 30 * time.Second
+	orderTrackingSweepWatchdogStaleAfter   = 2 * time.Minute
+	orderTrackingSweepMetadataReason       = "stale-order-tracking"
+	orderTrackingSweepMetadataInitiator    = "order-tracking-sweep"
+	orderTrackingWatchdogMetadataInitiator = "controller-watchdog"
+)
 
 // orderDispatcher evaluates order trigger conditions and dispatches due
 // orders as wisps or exec scripts. Follows the nil-guard tracker pattern:
@@ -733,6 +743,63 @@ func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
 		return n, fmt.Errorf("closing orphaned order-tracking beads: %w", err)
 	}
 	return n, nil
+}
+
+// sweepStaleOrderTracking closes open order-tracking beads whose creation
+// timestamp is older than staleAfter. When onlyOrders is non-empty, it only
+// closes tracking beads for those scoped order names.
+func sweepStaleOrderTracking(store beads.Store, now time.Time, staleAfter time.Duration, onlyOrders map[string]struct{}, initiator string) (int, error) {
+	if staleAfter <= 0 {
+		return 0, fmt.Errorf("stale-after must be positive")
+	}
+	all, err := store.ListByLabel(labelOrderTracking, 0)
+	if err != nil {
+		return 0, fmt.Errorf("listing order-tracking beads: %w", err)
+	}
+
+	cutoff := now.Add(-staleAfter)
+	var ids []string
+	for _, b := range all {
+		if len(onlyOrders) > 0 {
+			name, ok := orderNameFromTrackingBead(b)
+			if !ok {
+				continue
+			}
+			if _, ok := onlyOrders[name]; !ok {
+				continue
+			}
+		}
+		if b.CreatedAt.IsZero() || b.CreatedAt.After(cutoff) {
+			continue
+		}
+		ids = append(ids, b.ID)
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	metadata := map[string]string{
+		"order_tracking_sweep": orderTrackingSweepMetadataReason,
+	}
+	if initiator != "" {
+		metadata["order_tracking_sweep_by"] = initiator
+	}
+	n, err := store.CloseAll(ids, metadata)
+	if err != nil {
+		return n, fmt.Errorf("closing stale order-tracking beads: %w", err)
+	}
+	return n, nil
+}
+
+func orderNameFromTrackingBead(b beads.Bead) (string, bool) {
+	for _, label := range b.Labels {
+		if name, ok := strings.CutPrefix(label, "order-run:"); ok && name != "" {
+			return name, true
+		}
+	}
+	if name, ok := strings.CutPrefix(b.Title, "order:"); ok && name != "" {
+		return name, true
+	}
+	return "", false
 }
 
 // sweepOrphanedOrderTrackingRetry calls sweepOrphanedOrderTracking with

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2380,6 +2380,65 @@ func TestSweepOrphanedOrderTracking_OnlyClosedBeads(t *testing.T) {
 	}
 }
 
+func TestSweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads(t *testing.T) {
+	store := beads.NewMemStore()
+
+	old, err := store.Create(beads.Bead{
+		Title:  "order:old-sweep",
+		Labels: []string{"order-run:old-sweep", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(old): %v", err)
+	}
+	oldWork, err := store.Create(beads.Bead{
+		Title:  "real work",
+		Labels: []string{"order-run:old-sweep"},
+	})
+	if err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	fresh, err := store.Create(beads.Bead{
+		Title:  "order:fresh-sweep",
+		Labels: []string{"order-run:fresh-sweep", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create(fresh): %v", err)
+	}
+
+	closed, err := sweepStaleOrderTracking(store, time.Now(), 100*time.Millisecond, nil, orderTrackingSweepMetadataInitiator)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTracking: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	gotOld, err := store.Get(old.ID)
+	if err != nil {
+		t.Fatalf("Get(old): %v", err)
+	}
+	if gotOld.Status != "closed" {
+		t.Fatalf("old tracking status = %s, want closed", gotOld.Status)
+	}
+	gotFresh, err := store.Get(fresh.ID)
+	if err != nil {
+		t.Fatalf("Get(fresh): %v", err)
+	}
+	if gotFresh.Status != "open" {
+		t.Fatalf("fresh tracking status = %s, want open", gotFresh.Status)
+	}
+	gotWork, err := store.Get(oldWork.ID)
+	if err != nil {
+		t.Fatalf("Get(work): %v", err)
+	}
+	if gotWork.Status != "open" {
+		t.Fatalf("non-tracking work status = %s, want open", gotWork.Status)
+	}
+}
+
 func TestStartupSweepThenBuildDispatcher(t *testing.T) {
 	store := beads.NewMemStore()
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1549,6 +1549,7 @@ gc order
 | [gc order list](#gc-order-list) | List available orders |
 | [gc order run](#gc-order-run) | Execute an order manually |
 | [gc order show](#gc-order-show) | Show details of an order |
+| [gc order sweep-tracking](#gc-order-sweep-tracking) | Close stale order-tracking beads |
 
 ## gc order check
 
@@ -1619,6 +1620,22 @@ gc order show <name> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--rig` | string |  | rig name to disambiguate same-name orders |
+
+## gc order sweep-tracking
+
+Close stale open order-tracking beads.
+
+This is intended for maintenance exec orders. It only closes tracking beads
+older than --stale-after so a fresh in-flight order is not interrupted.
+
+```
+gc order sweep-tracking [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--quiet` | bool |  | suppress success output |
+| `--stale-after` | duration | `10m0s` | minimum age for an open tracking bead to be closed |
 
 ## gc pack
 

--- a/examples/gastown/packs/maintenance/orders/order-tracking-sweep.toml
+++ b/examples/gastown/packs/maintenance/orders/order-tracking-sweep.toml
@@ -1,0 +1,8 @@
+# Closes stale order tracking beads left behind by crashed or resource-starved
+# exec dispatches. Fresh tracking beads are left alone so in-flight orders keep
+# their normal single-flight protection.
+[order]
+description = "Close stale order-tracking beads so blocked orders can retry"
+trigger = "cooldown"
+interval = "1m"
+exec = "gc order sweep-tracking --stale-after 10m --quiet"


### PR DESCRIPTION
## Summary
- add a maintenance exec order that sweeps stale order-tracking beads
- add `gc order sweep-tracking` for stale-only cleanup
- add a controller watchdog that only unblocks the tracking sweep order itself

## Tests
- go test ./cmd/gc -run 'Test(SweepStaleOrderTracking_ClosesOnlyOldOpenTrackingBeads|OrderTrackingSweepWatchdogOnlyClosesSweepOrderTracking)$'\n- pre-commit hook: gofmt, docs generation, golangci-lint, go vet, go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->