### PR TITLE
fix(beads): kill bd subprocess trees on timeout

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -22,6 +22,8 @@ import (
 // The dir argument sets the working directory; name and args specify the command.
 type CommandRunner func(dir, name string, args ...string) ([]byte, error)
 
+var bdCommandTimeout = 120 * time.Second
+
 // ExecCommandRunner returns a CommandRunner that uses os/exec to run commands.
 // Captures stdout for parsing and stderr for error diagnostics.
 // When the command is "bd", records telemetry (duration, status, output).
@@ -53,11 +55,15 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 				time.Now().UTC().Format(time.RFC3339Nano), status, time.Since(start), dir, name, args, msg)
 		}
 		trace("start", nil)
-		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), bdCommandTimeout)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, name, args...)
 		cmd.WaitDelay = 2 * time.Second
+		prepareCommandForTimeout(cmd)
 		cmd.Dir = dir
+		cmd.Cancel = func() error {
+			return killCommandTree(cmd)
+		}
 		if len(env) > 0 {
 			cmd.Env = mergeEnv(os.Environ(), env)
 		}
@@ -70,7 +76,7 @@ func ExecCommandRunnerWithEnv(env map[string]string) CommandRunner {
 				err, out, stderr.String())
 		}
 		if ctx.Err() == context.DeadlineExceeded {
-			timeoutErr := fmt.Errorf("timed out after 120s")
+			timeoutErr := fmt.Errorf("timed out after %s", bdCommandTimeout)
 			trace("timeout", timeoutErr)
 			if stderr.Len() > 0 {
 				return out, fmt.Errorf("%w: %s", timeoutErr, stderr.String())

--- a/internal/beads/bdstore_exec_internal_test.go
+++ b/internal/beads/bdstore_exec_internal_test.go
@@ -1,0 +1,66 @@
+package beads
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecCommandRunnerTimeoutKillsChildProcess(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh unavailable")
+	}
+
+	oldTimeout := bdCommandTimeout
+	bdCommandTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { bdCommandTimeout = oldTimeout })
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "child.pid")
+	script := filepath.Join(dir, "spawn-child.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+sleep 30 &
+echo "$!" > "$1"
+wait
+`), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	runner := ExecCommandRunner()
+	_, err := runner(dir, script, pidFile)
+	if err == nil {
+		t.Fatal("runner unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "timed out after") {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+
+	pidBytes, readErr := os.ReadFile(pidFile)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid := strings.TrimSpace(string(pidBytes))
+	if pid == "" {
+		t.Fatal("child pid was empty")
+	}
+
+	for i := 0; i < 20; i++ {
+		if err := exec.Command("kill", "-0", pid).Run(); err != nil {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	_ = exec.Command("kill", "-KILL", pid).Run()
+	t.Fatalf("child process %s survived command timeout", pid)
+}
+
+func TestKillCommandTreeHandlesNilCommand(t *testing.T) {
+	if err := killCommandTree(nil); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("killCommandTree(nil): %v", err)
+	}
+}

--- a/internal/beads/exec_timeout_unix.go
+++ b/internal/beads/exec_timeout_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package beads
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareCommandForTimeout(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killCommandTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err == nil {
+		if killErr := syscall.Kill(-pgid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return killErr
+		}
+		return nil
+	}
+	if killErr := cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+		return killErr
+	}
+	return nil
+}

--- a/internal/beads/exec_timeout_windows.go
+++ b/internal/beads/exec_timeout_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package beads
+
+import "os/exec"
+
+func prepareCommandForTimeout(_ *exec.Cmd) {}
+
+func killCommandTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}


### PR DESCRIPTION
## Summary
- make the bd command timeout configurable for tests
- put timed bd commands in their own process group on Unix
- kill the command tree on timeout so child processes do not survive the parent shell

## Test
- go test ./internal/beads

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->