### PR TITLE
test: stabilize phase0 continuity wake assertion

### DIFF
--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -403,6 +403,7 @@ func writeControllerNamedSessionCityTOML(t *testing.T, dir, cityName, mode, idle
 	var buf bytes.Buffer
 	buf.WriteString("[workspace]\nname = " + `"` + cityName + `"` + "\n\n")
 	buf.WriteString("[beads]\nprovider = \"file\"\n\n")
+	buf.WriteString("[daemon]\nshutdown_timeout = \"20ms\"\n\n")
 	buf.WriteString("[[agent]]\nname = \"mayor\"\nstart_command = \"echo hello\"\n")
 	if idleTimeout != "" {
 		buf.WriteString("idle_timeout = " + `"` + idleTimeout + `"` + "\n")

--- a/internal/api/session_model_phase0_lifecycle_spec_test.go
+++ b/internal/api/session_model_phase0_lifecycle_spec_test.go
@@ -352,11 +352,23 @@ func TestPhase0HandleSessionWake_ContinuityEligibleArchivedBeadRequestsStart(t *
 	if err != nil {
 		t.Fatalf("Get(%s): %v", id, err)
 	}
-	if got := updated.Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating", got)
+	switch got := updated.Metadata["state"]; got {
+	case "creating":
+		if got := updated.Metadata["pending_create_claim"]; got != "true" {
+			t.Fatalf("pending_create_claim = %q while creating, want true", got)
+		}
+	case "active":
+		if got := updated.Metadata["pending_create_claim"]; got != "" {
+			t.Fatalf("pending_create_claim = %q after active start, want cleared", got)
+		}
+	default:
+		t.Fatalf("state = %q, want creating or active", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true", got)
+	if got := updated.Metadata["archived_at"]; got != "" {
+		t.Fatalf("archived_at = %q, want cleared after continuity wake", got)
+	}
+	if got := updated.Metadata["continuity_eligible"]; got != "true" {
+		t.Fatalf("continuity_eligible = %q, want true", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stabilize the Phase 0 continuity wake test that failed in https://github.com/gastownhall/gascity/actions/runs/25288822215/job/74138141330.
- The wake handler requests a start, then the fake runtime can complete that async start before the test reads the bead back.
- Accept both valid post-wake states: `creating` with `pending_create_claim`, or already `active` with that claim cleared.

## Verification

- `go test ./internal/api -run TestPhase0HandleSessionWake_ContinuityEligibleArchivedBeadRequestsStart -count=500`
- `go test ./internal/api`
- `make test`
- pre-commit hook (fmt-check, lint, vet, generated docs checks, fast unit loop)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->