### PR TITLE
test: cover stale local test gaps

### DIFF
--- a/internal/api/title_generate_test.go
+++ b/internal/api/title_generate_test.go
@@ -166,7 +166,7 @@ func TestTitleModelFlagArgs(t *testing.T) {
 			{
 				Key: "model",
 				Choices: []config.OptionChoice{
-					{Value: "opus", FlagArgs: []string{"--model", "claude-opus-4-6"}},
+					{Value: "opus", FlagArgs: []string{"--model", "claude-opus-4-7"}},
 					{Value: "haiku", FlagArgs: []string{"--model", "claude-haiku-4-5-20251001"}},
 				},
 			},

--- a/internal/session/chat_test.go
+++ b/internal/session/chat_test.go
@@ -56,10 +56,10 @@ func TestStripResumeFlag(t *testing.T) {
 	}{
 		{
 			name:       "removes resume flag and key",
-			cmd:        "claude --model claude-opus-4-6 --resume abc-123",
+			cmd:        "claude --model claude-opus-4-7 --resume abc-123",
 			resumeFlag: "--resume",
 			sessionKey: "abc-123",
-			want:       "claude --model claude-opus-4-6",
+			want:       "claude --model claude-opus-4-7",
 		},
 		{
 			name:       "resume flag at end",

--- a/test/acceptance/init_lifecycle_test.go
+++ b/test/acceptance/init_lifecycle_test.go
@@ -143,8 +143,9 @@ source = ".gc/system/packs/gastown"
 		t.Fatalf("gc init resume failed with missing packs — Bug 4 regression:\n%s", out)
 	}
 	t.Cleanup(func() {
-		helpers.RunGC(c.Env, c.Dir, "stop", c.Dir)       //nolint:errcheck
-		helpers.RunGC(c.Env, c.Dir, "unregister", c.Dir) //nolint:errcheck
+		helpers.RunGC(c.Env, c.Dir, "stop", c.Dir)               //nolint:errcheck
+		helpers.RunGC(c.Env, c.Dir, "unregister", c.Dir)         //nolint:errcheck
+		helpers.RunGC(c.Env, "", "supervisor", "stop", "--wait") //nolint:errcheck
 	})
 	// Positive assertion: packs must have been materialized.
 	if !c.HasFile(".gc/system/packs/gastown/pack.toml") {


### PR DESCRIPTION
## Summary
- update stale local test fixtures to match current origin/main behavior
- stop acceptance init lifecycle cleanup through the supervisor before city cleanup

## Verification
- go test ./internal/api ./internal/session
- pre-commit hook, including make test, passed during commit

Part of the local gap analysis: these were the remaining test-only local diffs not already covered by origin/main or an existing user-owned PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->