### PR TITLE
fix(controller): preserve cached demand correctness

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -231,6 +232,7 @@ func buildDesiredStateWithSessionBeads(
 	desired := make(map[string]TemplateParams)
 	var pendingPools []poolEvalWork
 	var defaultScaleTargets []defaultScaleCheckTarget
+	var defaultNamedScaleTargets []defaultScaleCheckTarget
 
 	for i := range cfg.Agents {
 		if cfg.Agents[i].Suspended {
@@ -259,12 +261,12 @@ func buildDesiredStateWithSessionBeads(
 			}
 			// Named-session materialization is handled in the named-session pass,
 			// but explicit scale_check/min demand for the backing template still
-			// creates ephemeral capacity through the pool pipeline. The default
-			// routed-work scale_check is skipped here so routed metadata alone
-			// does not create a parallel generic worker for the same backing
-			// template.
+			// creates ephemeral capacity through the pool pipeline. The implicit
+			// routed-work scale_check feeds named demand separately so it does
+			// not create a parallel generic worker for the same backing template.
 			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
 			if store != nil && strings.TrimSpace(cfg.Agents[i].ScaleCheck) == "" {
+				defaultNamedScaleTargets = append(defaultNamedScaleTargets, defaultScaleCheckTargetForAgent(cityPath, cfg, &cfg.Agents[i], store, rigStores))
 				continue
 			}
 			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
@@ -294,6 +296,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkStoreRefs []string
 	var storePartial bool
 	var scaleCheckCounts map[string]int
+	var namedDefaultDemand map[string]bool
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
 		if storePartial {
@@ -315,6 +318,13 @@ func buildDesiredStateWithSessionBeads(
 			}
 			for template, count := range defaultCounts {
 				scaleCheckCounts[template] = count
+			}
+		}
+		if len(defaultNamedScaleTargets) > 0 {
+			var namedErrs []error
+			namedDefaultDemand, namedErrs = defaultNamedSessionDemand(defaultNamedScaleTargets, cfg, cityName)
+			for _, err := range namedErrs {
+				fmt.Fprintf(stderr, "buildDesiredState: %v (using named demand=false)\n", err) //nolint:errcheck
 			}
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
@@ -373,6 +383,11 @@ func buildDesiredStateWithSessionBeads(
 		namedSpecs[identity] = spec
 	}
 	namedWorkReady := make(map[string]bool, len(namedSpecs))
+	for identity := range namedDefaultDemand {
+		if _, ok := namedSpecs[identity]; ok {
+			namedWorkReady[identity] = true
+		}
+	}
 	// Check assigned work beads: if any work bead's Assignee matches a named
 	// session's identity, that session has direct demand.
 	//
@@ -716,8 +731,10 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 	for key, group := range groups {
 		ready, err := readyForControllerDemand(group.store)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("default scale_check %s: Ready(): %w", key, err))
-			continue
+			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
+			if !beads.IsPartialResult(err) || len(ready) == 0 {
+				continue
+			}
 		}
 		for _, b := range ready {
 			if strings.TrimSpace(b.Assignee) != "" {
@@ -730,6 +747,104 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		}
 	}
 	return counts, errs
+}
+
+func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.City, cityName string) (map[string]bool, []error) {
+	demand := make(map[string]bool)
+	if len(targets) == 0 || cfg == nil {
+		return demand, nil
+	}
+
+	type scaleStoreGroup struct {
+		store     beads.Store
+		templates map[string]struct{}
+	}
+	groups := make(map[string]*scaleStoreGroup)
+	var errs []error
+	for _, target := range targets {
+		template := strings.TrimSpace(target.template)
+		if template == "" {
+			continue
+		}
+		if target.err != nil {
+			errs = append(errs, target.err)
+		}
+		if target.store == nil {
+			if target.err == nil {
+				errs = append(errs, fmt.Errorf("default scale_check %s: store unavailable", template))
+			}
+			continue
+		}
+		key := strings.TrimSpace(target.storeKey)
+		if key == "" {
+			key = fmt.Sprintf("%p", target.store)
+		}
+		group := groups[key]
+		if group == nil {
+			group = &scaleStoreGroup{store: target.store, templates: make(map[string]struct{})}
+			groups[key] = group
+		}
+		group.templates[template] = struct{}{}
+	}
+
+	namedByIdentity := make(map[string]namedSessionSpec)
+	identitiesByTemplate := make(map[string][]string)
+	for i := range cfg.NamedSessions {
+		identity := cfg.NamedSessions[i].QualifiedName()
+		spec, ok := findNamedSessionSpec(cfg, cityName, identity)
+		if !ok || spec.Mode == "always" {
+			continue
+		}
+		template := strings.TrimSpace(namedSessionBackingTemplate(spec))
+		if template == "" {
+			continue
+		}
+		namedByIdentity[spec.Identity] = spec
+		identitiesByTemplate[template] = append(identitiesByTemplate[template], spec.Identity)
+	}
+
+	for key, group := range groups {
+		ready, err := readyForControllerDemand(group.store)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
+			if !beads.IsPartialResult(err) || len(ready) == 0 {
+				continue
+			}
+		}
+		for _, b := range ready {
+			if strings.TrimSpace(b.Assignee) != "" {
+				continue
+			}
+			routedTo := strings.TrimSpace(b.Metadata["gc.routed_to"])
+			if routedTo == "" {
+				continue
+			}
+			if spec, ok := namedByIdentity[routedTo]; ok {
+				template := strings.TrimSpace(namedSessionBackingTemplate(spec))
+				if _, targetTemplate := group.templates[template]; targetTemplate {
+					demand[spec.Identity] = true
+				}
+				continue
+			}
+			if _, targetTemplate := group.templates[routedTo]; !targetTemplate {
+				continue
+			}
+			identities := identitiesByTemplate[routedTo]
+			if len(identities) == 1 {
+				demand[identities[0]] = true
+			}
+		}
+	}
+	return demand, errs
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func listForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.Bead, error) {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1318,6 +1318,130 @@ func TestBuildDesiredState_OnDemandNamedSession_DefaultRoutedWorkMaterializesNam
 	}
 }
 
+func TestBuildDesiredState_OnDemandNamedSession_DefaultRoutedTemplateMaterializesSingletonIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued worker work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	foundNamed := false
+	for _, tp := range dsResult.State {
+		if tp.TemplateName != "worker" {
+			continue
+		}
+		if tp.ConfiguredNamedIdentity == "primary" {
+			foundNamed = true
+			continue
+		}
+		t.Fatalf("routed singleton template created generic worker session: %+v", tp)
+	}
+	if !foundNamed {
+		t.Fatal("default routed work should materialize the singleton named identity for worker")
+	}
+	if !dsResult.NamedSessionDemand["primary"] {
+		t.Fatal("NamedSessionDemand should record singleton identity demand")
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_DefaultRoutedTemplateDoesNotPickAmbiguousIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued worker work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{
+			{Name: "primary", Template: "worker", Mode: "on_demand"},
+			{Name: "secondary", Template: "worker", Mode: "on_demand"},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if dsResult.NamedSessionDemand["primary"] || dsResult.NamedSessionDemand["secondary"] {
+		t.Fatalf("ambiguous template route recorded named demand: %v", dsResult.NamedSessionDemand)
+	}
+	for _, tp := range dsResult.State {
+		switch tp.ConfiguredNamedIdentity {
+		case "primary", "secondary":
+			t.Fatalf("ambiguous template route materialized named identity: %+v", tp)
+		}
+	}
+}
+
+func TestBuildDesiredState_OnDemandNamedSession_DefaultRoutedNoMatchDoesNotMaterialize(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued unmatched work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "missing",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if dsResult.NamedSessionDemand["primary"] {
+		t.Fatal("unmatched route should not record named-session demand")
+	}
+	if len(dsResult.State) != 0 {
+		t.Fatalf("unmatched route should not materialize sessions: %+v", dsResult.State)
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_DirectAssigneeMaterializes(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -421,6 +421,50 @@ func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T
 	}
 }
 
+func TestDefaultScaleCheckCountsUsesPartialReadyRows(t *testing.T) {
+	store := &partialAssignedWorkStore{MemStore: beads.NewMemStore(), partialReady: true}
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "gascity/workflows.codex-max",
+		},
+	}); err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+
+	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "gascity/workflows.codex-max",
+		storeKey: "rig:gascity",
+		store:    store,
+	}})
+	if got := counts["gascity/workflows.codex-max"]; got != 1 {
+		t.Fatalf("defaultScaleCheckCounts = %d, want survivor row counted", got)
+	}
+	if len(errs) != 1 || !beads.IsPartialResult(errs[0]) {
+		t.Fatalf("defaultScaleCheckCounts errs = %v, want partial-result diagnostic", errs)
+	}
+}
+
+func TestDefaultScaleCheckCountsReadyErrorNamesAffectedTemplates(t *testing.T) {
+	store := &readyFailStore{Store: beads.NewMemStore()}
+
+	_, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{
+		{template: "gascity/workflows.codex-min", storeKey: "rig:gascity", store: store},
+		{template: "gascity/workflows.codex-max", storeKey: "rig:gascity", store: store},
+	})
+	if len(errs) != 1 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v, want one grouped Ready diagnostic", errs)
+	}
+	msg := errs[0].Error()
+	for _, want := range []string{"rig:gascity", "gascity/workflows.codex-min", "gascity/workflows.codex-max"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("defaultScaleCheckCounts err = %q, want affected template %q", msg, want)
+		}
+	}
+}
+
 func TestDefaultScaleCheckCountsReportsMissingRigStore(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{
@@ -1224,7 +1268,7 @@ func TestBuildDesiredState_PoolInFlightSessionsPreservePartialScaleDemand(t *tes
 	}
 }
 
-func TestBuildDesiredState_OnDemandNamedSession_RoutedMetadataAloneDoesNotMaterialize(t *testing.T) {
+func TestBuildDesiredState_OnDemandNamedSession_DefaultRoutedWorkMaterializesNamedSession(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{
@@ -1252,10 +1296,25 @@ func TestBuildDesiredState_OnDemandNamedSession_RoutedMetadataAloneDoesNotMateri
 	}
 
 	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	foundNamed := false
+	foundGeneric := false
 	for _, tp := range dsResult.State {
 		if tp.TemplateName == "mayor" {
-			t.Fatalf("routed metadata alone should not materialize on-demand named session: %+v", tp)
+			if tp.ConfiguredNamedIdentity == "mayor" {
+				foundNamed = true
+				continue
+			}
+			foundGeneric = true
 		}
+	}
+	if !foundNamed {
+		t.Fatal("default routed work should materialize the on-demand named session")
+	}
+	if foundGeneric {
+		t.Fatal("default routed work should not create a parallel generic session for the named template")
+	}
+	if !dsResult.NamedSessionDemand["mayor"] {
+		t.Fatal("NamedSessionDemand should record default routed work for mayor")
 	}
 }
 
@@ -1481,6 +1540,12 @@ func TestBuildDesiredState_AlwaysNamedSession_MaterializesWithoutWorkBeads(t *te
 	found := false
 	for _, tp := range dsResult.State {
 		if tp.TemplateName == "mayor" {
+			if tp.ConfiguredNamedIdentity != "mayor" {
+				t.Fatalf("ConfiguredNamedIdentity = %q, want mayor", tp.ConfiguredNamedIdentity)
+			}
+			if tp.ConfiguredNamedMode != "always" {
+				t.Fatalf("ConfiguredNamedMode = %q, want always", tp.ConfiguredNamedMode)
+			}
 			found = true
 			break
 		}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -465,6 +465,49 @@ func TestDefaultScaleCheckCountsReadyErrorNamesAffectedTemplates(t *testing.T) {
 	}
 }
 
+func TestDefaultNamedSessionDemandUsesPartialReadyRows(t *testing.T) {
+	store := &partialAssignedWorkStore{MemStore: beads.NewMemStore(), partialReady: true}
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued worker work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "worker",
+		},
+	}); err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name: "worker",
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "worker",
+			Mode:     "on_demand",
+		}},
+	}
+
+	demand, errs := defaultNamedSessionDemand([]defaultScaleCheckTarget{{
+		template: "worker",
+		storeKey: "rig:gascity",
+		store:    store,
+	}}, cfg, "test-city")
+	if !demand["primary"] {
+		t.Fatalf("defaultNamedSessionDemand[primary] = false, want survivor row counted")
+	}
+	if len(errs) != 1 || !beads.IsPartialResult(errs[0]) {
+		t.Fatalf("defaultNamedSessionDemand errs = %v, want partial-result diagnostic", errs)
+	}
+	msg := errs[0].Error()
+	for _, want := range []string{"rig:gascity", "worker"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("defaultNamedSessionDemand err = %q, want affected template %q", msg, want)
+		}
+	}
+}
+
 func TestDefaultScaleCheckCountsReportsMissingRigStore(t *testing.T) {
 	cityPath := t.TempDir()
 	cfg := &config.City{

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1397,10 +1397,11 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	}
 
 	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cr.cfg, cr.cityPath, open, assignedWorkBeads, assignedWorkStoreRefs)
-	reconcileSessionBeadsTraced(
+	reconcileSessionBeadsTracedWithNamedDemand(
 		ctx, cr.cityPath, open, desiredState, cfgNames, cr.cfg, cr.sp, store,
 		cr.dops,
 		awakeAssignedWorkBeads, rigStores, readyWaitSet, cr.sessionDrains, poolDesired,
+		result.NamedSessionDemand,
 		result.snapshotQueryPartial(),
 		workSet, cityName,
 		cr.it, clock.Real{}, cr.rec, cr.cfg.Session.StartupTimeoutDuration(),
@@ -1718,7 +1719,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		poolDesired = make(map[string]int)
 	}
 	mergeNamedSessionDemand(poolDesired, wfcResult.NamedSessionDemand, filteredCfg)
-	reconcileSessionBeadsAtPath(
+	reconcileSessionBeadsAtPathWithNamedDemand(
 		ctx,
 		cr.cityPath,
 		open,
@@ -1733,6 +1734,7 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 		nil, // control-dispatcher ticks only need ownership continuity, not main-tick assigned/ready snapshots
 		cr.sessionDrains,
 		poolDesired,
+		wfcResult.NamedSessionDemand,
 		false, // storeQueryPartial: config-change path doesn't query work beads
 		nil,   // workSet: not computed for config-change reconcile
 		cr.cityName,

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -623,9 +623,10 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 	}
 	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
 	awakeAssignedWorkBeads := filterAssignedWorkBeadsForSessionWake(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
-	reconcileSessionBeadsAtPath(
+	reconcileSessionBeadsAtPathWithNamedDemand(
 		sigCtx, cityPath, open, ds, cfgNames, cfg, sp, oneShotStore,
 		nil, awakeAssignedWorkBeads, rigStores, nil, dt, poolDesired,
+		dsResult.NamedSessionDemand,
 		dsResult.snapshotQueryPartial(),
 		nil, cityName,
 		nil, clock.Real{}, recorder, cfg.Session.StartupTimeoutDuration(), 0,

--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -18,6 +18,7 @@ func buildAwakeInputFromReconciler(
 	cfg *config.City,
 	sessionBeads []beads.Bead,
 	poolDesired map[string]int,
+	namedSessionDemand map[string]bool,
 	workSet map[string]bool,
 	readyWaitSet map[string]bool,
 	assignedWorkBeads []beads.Bead,
@@ -26,14 +27,15 @@ func buildAwakeInputFromReconciler(
 	clk time.Time,
 ) AwakeInput {
 	input := AwakeInput{
-		ScaleCheckCounts: poolDesired,
-		WorkSet:          workSet,
-		ReadyWaitSet:     readyWaitSet,
-		RunningSessions:  make(map[string]bool),
-		AttachedSessions: make(map[string]bool),
-		PendingSessions:  make(map[string]bool),
-		ChatIdleTimeout:  cfg.ChatSessions.IdleTimeoutDuration(),
-		Now:              clk,
+		ScaleCheckCounts:   poolDesired,
+		NamedSessionDemand: cloneBoolMap(namedSessionDemand),
+		WorkSet:            workSet,
+		ReadyWaitSet:       readyWaitSet,
+		RunningSessions:    make(map[string]bool),
+		AttachedSessions:   make(map[string]bool),
+		PendingSessions:    make(map[string]bool),
+		ChatIdleTimeout:    cfg.ChatSessions.IdleTimeoutDuration(),
+		Now:                clk,
 	}
 
 	// Agents
@@ -149,7 +151,7 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 				reasons = []WakeReason{WakePin}
 			case "wait-ready":
 				reasons = []WakeReason{WakeWait}
-			case "assigned-work", "work-query":
+			case "assigned-work", "named-demand", "work-query":
 				reasons = []WakeReason{WakeWork}
 			default:
 				reasons = []WakeReason{WakeConfig}
@@ -161,6 +163,17 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 		}
 	}
 	return evals
+}
+
+func cloneBoolMap(source map[string]bool) map[string]bool {
+	if source == nil {
+		return nil
+	}
+	out := make(map[string]bool, len(source))
+	for key, value := range source {
+		out[key] = value
+	}
+	return out
 }
 
 func parseSleepDuration(s string) time.Duration {

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -29,6 +29,7 @@ func TestBuildAwakeInputFromReconcilerUsesLifecycleProjectionForCompatibilitySta
 		nil,
 		nil,
 		nil,
+		nil,
 		now,
 	)
 
@@ -66,6 +67,7 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 		nil,
 		nil,
 		nil,
+		nil,
 		[]wakeTarget{{session: &session, alive: true}},
 		sp,
 		now,
@@ -78,6 +80,50 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 	got := decisions["s-worker"]
 	if !got.ShouldWake || got.Reason != "pending" {
 		t.Fatalf("decision = %+v, want pending wake", got)
+	}
+}
+
+func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker"}},
+		NamedSessions: []config.NamedSession{
+			{Name: "primary", Template: "worker", Mode: "on_demand"},
+		},
+	}
+	sessionBead := beads.Bead{
+		ID:     "mc-session-1",
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"state":                     "asleep",
+			"session_name":              "primary",
+			"template":                  "worker",
+			"configured_named_identity": "primary",
+			"configured_named_mode":     "on_demand",
+		},
+	}
+
+	input := buildAwakeInputFromReconciler(
+		cfg,
+		[]beads.Bead{sessionBead},
+		map[string]int{"worker": 1},
+		map[string]bool{"primary": true},
+		nil,
+		nil,
+		nil,
+		nil,
+		runtime.NewFake(),
+		now,
+	)
+
+	if !input.NamedSessionDemand["primary"] {
+		t.Fatalf("NamedSessionDemand[primary] = false, want true")
+	}
+	decisions := ComputeAwakeSet(input)
+	got := decisions["primary"]
+	if !got.ShouldWake || got.Reason != "named-demand" {
+		t.Fatalf("decision = %+v, want named-demand wake", got)
 	}
 }
 
@@ -117,7 +163,7 @@ func TestBuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes(t *testing.T) 
 	input := buildAwakeInputFromReconciler(
 		cfg,
 		[]beads.Bead{postChurnBead},
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil,
 		runtime.NewFake(),
 		now,
 	)

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -16,18 +16,19 @@ const defaultOnDemandIdleTimeout = 5 * time.Minute
 // should be awake. All external I/O (shell commands, tmux checks, store
 // queries) happens before this function is called.
 type AwakeInput struct {
-	Agents           []AwakeAgent
-	NamedSessions    []AwakeNamedSession
-	SessionBeads     []AwakeSessionBead
-	WorkBeads        []AwakeWorkBead
-	ScaleCheckCounts map[string]int  // agent template → scale_check count
-	WorkSet          map[string]bool // agent template → work_query found pending work
-	RunningSessions  map[string]bool // session name → tmux exists
-	AttachedSessions map[string]bool // session name → user attached
-	PendingSessions  map[string]bool // session name → pending interaction
-	ReadyWaitSet     map[string]bool // session bead ID → durable wait is ready
-	ChatIdleTimeout  time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
-	Now              time.Time
+	Agents             []AwakeAgent
+	NamedSessions      []AwakeNamedSession
+	SessionBeads       []AwakeSessionBead
+	WorkBeads          []AwakeWorkBead
+	ScaleCheckCounts   map[string]int  // agent template → scale_check count
+	NamedSessionDemand map[string]bool // named-session identity → routed/assigned work demand
+	WorkSet            map[string]bool // agent template → work_query found pending work
+	RunningSessions    map[string]bool // session name → tmux exists
+	AttachedSessions   map[string]bool // session name → user attached
+	PendingSessions    map[string]bool // session name → pending interaction
+	ReadyWaitSet       map[string]bool // session bead ID → durable wait is ready
+	ChatIdleTimeout    time.Duration   // global idle timeout for manual/chat sessions (0 = disabled)
+	Now                time.Time
 }
 
 // AwakeAgent represents an [[agent]] config entry.
@@ -126,10 +127,22 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 				desired[ns.Identity] = "named-always"
 			}
 		case "on_demand":
-			// On-demand named sessions materialize from direct targeting,
-			// direct concrete ownership, dependencies, binding continuity,
-			// and pinning. Generic scale_check demand belongs to ephemeral
-			// capacity, not named identity materialization.
+			// On-demand named sessions wake only from named demand that was
+			// resolved by the desired-state pass, not generic template demand.
+			if !input.NamedSessionDemand[ns.Identity] {
+				continue
+			}
+			if agent, ok := agentsByName[ns.Template]; ok && agent.Suspended {
+				continue
+			}
+			if sn := findNamedSessionName(input.SessionBeads, ns.Identity); sn != "" {
+				bead := findBeadBySessionName(input.SessionBeads, sn)
+				if bead != nil && !bead.DependencyOnly && !bead.Drained && bead.State != "closed" {
+					desired[sn] = "named-demand"
+				}
+			} else {
+				desired[ns.Identity] = "named-demand"
+			}
 		}
 	}
 

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -181,6 +181,30 @@ func TestNamedOnDemand_ExactNamedIdentityAssigneeWakes(t *testing.T) {
 	assertReason(t, result, "hello-world--refinery", "assigned-work")
 }
 
+func TestNamedOnDemand_NamedSessionDemandWakesExistingIdentity(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:             []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions:      []AwakeNamedSession{{Identity: "hello-world/refinery", Template: "hello-world/refinery", Mode: "on_demand"}},
+		SessionBeads:       []AwakeSessionBead{{ID: "mc-1", SessionName: "hello-world--refinery", Template: "hello-world/refinery", State: "asleep", NamedIdentity: "hello-world/refinery"}},
+		NamedSessionDemand: map[string]bool{"hello-world/refinery": true},
+		Now:                now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "named-demand")
+}
+
+func TestNamedOnDemand_NamedSessionDemandWakesSingletonTemplateResolvedIdentity(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents:             []AwakeAgent{{QualifiedName: "worker"}},
+		NamedSessions:      []AwakeNamedSession{{Identity: "primary", Template: "worker", Mode: "on_demand"}},
+		SessionBeads:       []AwakeSessionBead{{ID: "mc-1", SessionName: "primary", Template: "worker", State: "asleep", NamedIdentity: "primary"}},
+		NamedSessionDemand: map[string]bool{"primary": true},
+		Now:                now,
+	})
+	assertAwake(t, result, "primary")
+	assertReason(t, result, "primary", "named-demand")
+}
+
 func TestNamedOnDemand_PendingCreateWakesWithoutDemand(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{{QualifiedName: "hello-world/refinery"}},

--- a/cmd/gc/lifecycle_live_query_test.go
+++ b/cmd/gc/lifecycle_live_query_test.go
@@ -63,7 +63,7 @@ func TestCollectAssignedWorkBeads_UsesCachedReadyEventStateForAssignedOpenHandof
 	}
 }
 
-func TestCollectAssignedWorkBeads_FallsBackLiveWhenSparseDepHookInvalidatesCachedReady(t *testing.T) {
+func TestCollectAssignedWorkBeads_UsesExplicitDepEventsForCachedReady(t *testing.T) {
 	t.Parallel()
 
 	t.Run("dep add", func(t *testing.T) {
@@ -95,11 +95,11 @@ func TestCollectAssignedWorkBeads_FallsBackLiveWhenSparseDepHookInvalidatesCache
 		if err := backing.DepAdd(handoff.ID, blocker.ID, "blocks"); err != nil {
 			t.Fatalf("backing DepAdd(%s <- %s): %v", handoff.ID, blocker.ID, err)
 		}
-		cache.ApplyEvent("bead.updated", []byte(`{"id":"`+handoff.ID+`","title":"handoff","status":"open","issue_type":"task","assignee":"worker","created_at":"2026-01-01T00:00:00Z"}`))
+		cache.ApplyDepEvent(handoff.ID, []beads.Dep{{IssueID: handoff.ID, DependsOnID: blocker.ID, Type: "blocks"}})
 
 		got, _ := collectAssignedWorkBeads(&config.City{}, cache)
 		if len(got) != 0 {
-			t.Fatalf("collectAssignedWorkBeads() = %#v, want sparse dep-add event to force live blocked result", got)
+			t.Fatalf("collectAssignedWorkBeads() = %#v, want explicit dep-add event to block handoff", got)
 		}
 	})
 
@@ -135,11 +135,11 @@ func TestCollectAssignedWorkBeads_FallsBackLiveWhenSparseDepHookInvalidatesCache
 		if err := backing.DepRemove(handoff.ID, blocker.ID); err != nil {
 			t.Fatalf("backing DepRemove(%s <- %s): %v", handoff.ID, blocker.ID, err)
 		}
-		cache.ApplyEvent("bead.updated", []byte(`{"id":"`+handoff.ID+`","title":"handoff","status":"open","issue_type":"task","assignee":"worker","created_at":"2026-01-01T00:00:00Z"}`))
+		cache.ApplyDepEvent(handoff.ID, nil)
 
 		got, _ := collectAssignedWorkBeads(&config.City{}, cache)
 		if len(got) != 1 || got[0].ID != handoff.ID {
-			t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] after sparse dep-remove event forced live ready result", got, handoff.ID)
+			t.Fatalf("collectAssignedWorkBeads() = %#v, want [%s] after explicit dep-remove event", got, handoff.ID)
 		}
 	})
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -302,6 +302,8 @@ func reconcileSessionBeads(
 // work that lives outside the primary store. Pass nil when no rig
 // stores are attached; the reconciler will fall back to primary-store-
 // only queries.
+//
+//nolint:unparam // compatibility wrapper keeps the established test/helper signature.
 func reconcileSessionBeadsAtPath(
 	ctx context.Context,
 	cityPath string,
@@ -327,9 +329,41 @@ func reconcileSessionBeadsAtPath(
 	driftDrainTimeout time.Duration,
 	stdout, stderr io.Writer,
 ) int {
-	return reconcileSessionBeadsTraced(
+	return reconcileSessionBeadsAtPathWithNamedDemand(
 		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
-		poolDesired, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
+		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr,
+	)
+}
+
+func reconcileSessionBeadsAtPathWithNamedDemand(
+	ctx context.Context,
+	cityPath string,
+	sessions []beads.Bead,
+	desiredState map[string]TemplateParams,
+	configuredNames map[string]bool,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	dops drainOps,
+	assignedWorkBeads []beads.Bead,
+	rigStores map[string]beads.Store,
+	readyWaitSet map[string]bool,
+	dt *drainTracker,
+	poolDesired map[string]int,
+	namedSessionDemand map[string]bool,
+	storeQueryPartial bool,
+	workSet map[string]bool,
+	cityName string,
+	it idleTracker,
+	clk clock.Clock,
+	rec events.Recorder,
+	startupTimeout time.Duration,
+	driftDrainTimeout time.Duration,
+	stdout, stderr io.Writer,
+) int {
+	return reconcileSessionBeadsTracedWithNamedDemand(
+		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
+		poolDesired, namedSessionDemand, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, nil,
 	)
 }
 
@@ -348,6 +382,41 @@ func reconcileSessionBeadsTraced(
 	readyWaitSet map[string]bool,
 	dt *drainTracker,
 	poolDesired map[string]int,
+	storeQueryPartial bool,
+	workSet map[string]bool,
+	cityName string,
+	it idleTracker,
+	clk clock.Clock,
+	rec events.Recorder,
+	startupTimeout time.Duration,
+	driftDrainTimeout time.Duration,
+	stdout, stderr io.Writer,
+	trace *sessionReconcilerTraceCycle,
+	startOptions ...startExecutionOption,
+) int {
+	return reconcileSessionBeadsTracedWithNamedDemand(
+		ctx, cityPath, sessions, desiredState, configuredNames, cfg, sp, store, dops, assignedWorkBeads, rigStores, readyWaitSet, dt,
+		poolDesired, nil, storeQueryPartial, workSet, cityName, it, clk, rec, startupTimeout, driftDrainTimeout, stdout, stderr, trace,
+		startOptions...,
+	)
+}
+
+func reconcileSessionBeadsTracedWithNamedDemand(
+	ctx context.Context,
+	cityPath string,
+	sessions []beads.Bead,
+	desiredState map[string]TemplateParams,
+	configuredNames map[string]bool,
+	cfg *config.City,
+	sp runtime.Provider,
+	store beads.Store,
+	dops drainOps,
+	assignedWorkBeads []beads.Bead,
+	rigStores map[string]beads.Store,
+	readyWaitSet map[string]bool,
+	dt *drainTracker,
+	poolDesired map[string]int,
+	namedSessionDemand map[string]bool,
 	storeQueryPartial bool,
 	workSet map[string]bool,
 	cityName string,
@@ -1209,7 +1278,7 @@ func reconcileSessionBeadsTraced(
 
 	// Use ComputeAwakeSet for the wake/sleep decision.
 	awakeInput := buildAwakeInputFromReconciler(
-		cfg, ordered, poolDesired, workSet, readyWaitSet,
+		cfg, ordered, poolDesired, namedSessionDemand, workSet, readyWaitSet,
 		assignedWorkBeads, wakeTargets, sp, clk.Now(),
 	)
 	awakeDecisions := ComputeAwakeSet(awakeInput)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1846,6 +1846,111 @@ func TestReconcileSessionBeads_OnDemandNamedSessionDoesNotWakeFromDesiredStatePr
 	}
 }
 
+func TestReconcileSessionBeads_OnDemandNamedSessionWakesFromRoutedIdentityDemand(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "mayor",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{Template: "mayor", Mode: "on_demand"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, "mayor")
+
+	woken, running := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, sessionName, "mayor", "mayor")
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+	if !running {
+		t.Fatalf("on-demand named session %q was not started from routed identity demand", sessionName)
+	}
+}
+
+func TestReconcileSessionBeads_OnDemandNamedSessionWakesFromRoutedSingletonTemplateDemand(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+			WorkQuery:         "printf ''",
+		}},
+		NamedSessions: []config.NamedSession{{Name: "primary", Template: "worker", Mode: "on_demand"}},
+	}
+
+	woken, running := reconcileExistingAsleepNamedSessionWithRoutedWork(t, cfg, "primary", "primary", "worker")
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+	if !running {
+		t.Fatal("on-demand named session primary was not started from routed singleton-template demand")
+	}
+}
+
+func reconcileExistingAsleepNamedSessionWithRoutedWork(t *testing.T, cfg *config.City, sessionName, identity, routedTo string) (int, bool) {
+	t.Helper()
+
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued named work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": routedTo,
+		},
+	}); err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  sessionName,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      identity,
+			"template":                   cfg.NamedSessions[0].Template,
+			"state":                      "asleep",
+			"generation":                 "1",
+			"instance_token":             "canonical-token",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: identity,
+			namedSessionModeMetadata:     "on_demand",
+		},
+	}); err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	dsResult := buildDesiredState(cfg.EffectiveCityName(), cityPath, clk.Now().UTC(), cfg, sp, store, &stderr)
+	if !dsResult.NamedSessionDemand[identity] {
+		t.Fatalf("NamedSessionDemand[%s] = false for routed_to=%s; stderr:\n%s", identity, routedTo, stderr.String())
+	}
+	cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
+	syncSessionBeads(cityPath, store, dsResult.State, sp, cfgNames, cfg, clk, &stderr, true)
+	sessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessions, dsResult.ScaleCheckCounts))
+	if poolDesired == nil {
+		poolDesired = make(map[string]int)
+	}
+	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+
+	woken := reconcileSessionBeadsAtPathWithNamedDemand(
+		context.Background(), cityPath, sessions, dsResult.State, cfgNames, cfg, sp,
+		store, nil, dsResult.AssignedWorkBeads, nil, nil, newDrainTracker(), poolDesired,
+		dsResult.NamedSessionDemand, dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+	return woken, sp.IsRunning(sessionName)
+}
+
 func TestReconcileSessionBeads_SyncsGCDirWithWorkDirOverride(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}

--- a/engdocs/design/named-configured-sessions.md
+++ b/engdocs/design/named-configured-sessions.md
@@ -423,6 +423,11 @@ Named sessions add a second desired-state source:
   - the template has pending work, or
   - dependency wake requires the named-session identity
 
+An `always` named session is visible on a fresh city as a canonical session
+bead in `creating` state before the runtime process is confirmed. This is the
+same controller-owned creation intent used for any desired session; it is not a
+separate operator action.
+
 Dependency wake is evaluated over the validated graph of fully qualified
 template identities after pack expansion, not over ambiguous bare
 template strings. Each configured named session maps 1:1 to one

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -89,9 +89,11 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	}
 
 	b := patch
+	refreshedFromBacking := false
 	if !cached {
 		if fresh, err := c.backing.Get(patch.ID); err == nil {
 			b = fresh
+			refreshedFromBacking = true
 		} else if errors.Is(err, ErrNotFound) {
 			if eventType != "bead.created" && locallyDeleted {
 				return
@@ -144,7 +146,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 		if _, exists := c.beads[b.ID]; !exists {
 			c.noteMutationLocked(b.ID)
 			c.beads[b.ID] = cloneBead(b)
-			c.updateEventDepsLocked(eventType, b, fields)
+			c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
 			delete(c.dirty, b.ID)
 			delete(c.deletedSeq, b.ID)
 		}
@@ -153,7 +155,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	case "bead.updated":
 		c.noteMutationLocked(b.ID)
 		c.beads[b.ID] = cloneBead(b)
-		c.updateEventDepsLocked(eventType, b, fields)
+		c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
@@ -163,7 +165,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 			c.updateStatsLocked()
 		}
 		c.beads[b.ID] = cloneBead(b)
-		c.updateEventDepsLocked(eventType, b, fields)
+		c.updateEventDepsLocked(eventType, b, fields, refreshedFromBacking)
 		delete(c.dirty, b.ID)
 		delete(c.deletedSeq, b.ID)
 		mutated = true
@@ -176,7 +178,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	}
 }
 
-func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields map[string]json.RawMessage) {
+func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields map[string]json.RawMessage, refreshedFromBacking bool) {
 	if hasCacheEventField(fields, "dependencies") || hasCacheEventField(fields, "needs") {
 		c.deps[b.ID] = depsFromBeadFields(b)
 		return
@@ -186,11 +188,16 @@ func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields ma
 		return
 	}
 	if eventType == "bead.updated" && cacheEventLooksComplete(fields) {
-		// A complete field update without dependency fields is ordinarily a
-		// bead-field change, not a dependency mutation. Preserve known dep
-		// coverage so unrelated status/title updates do not force store-wide
-		// live-ready fallback. Real dependency changes arrive via explicit dep
-		// events or write-through mutation paths.
+		if refreshedFromBacking {
+			c.deps[b.ID] = depsFromBeadFields(b)
+			return
+		}
+		// bd dependency mutations arrive through the same on_update hook as
+		// field changes, and the hook payload omits dependencies after removals.
+		// Treat the bead's dependency coverage as unknown until the backing
+		// store or reconciliation supplies an explicit dependency snapshot.
+		delete(c.deps, b.ID)
+		c.depsComplete = false
 		return
 	}
 	if _, ok := c.deps[b.ID]; ok {

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -41,7 +41,6 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	currentDeps = cloneDeps(currentDeps)
 	_, locallyMutated := c.beadSeq[patch.ID]
 	localBeadAt := c.localBeadAt[patch.ID]
-	locallyChanged := !localBeadAt.IsZero()
 	recentlyLocal := recentLocalMutation(localBeadAt, now)
 	_, locallyDeleted := c.deletedSeq[patch.ID]
 	fieldConflictCached := cached && cacheEventConflictsCurrent(current, patch, fields)
@@ -74,7 +73,7 @@ func (c *CachingStore) ApplyEvent(eventType string, payload json.RawMessage) {
 	if fieldConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
 		return
 	}
-	if dependencyConflictCached && eventType != "bead.closed" && (locallyChanged || locallyMutated) && !verifiedConflict {
+	if dependencyConflictCached && eventType != "bead.closed" && locallyMutated && !verifiedConflict {
 		return
 	}
 	if conflictsCached && recentlyLocal && !verifiedConflict {
@@ -187,14 +186,17 @@ func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields ma
 		return
 	}
 	if eventType == "bead.updated" && cacheEventLooksComplete(fields) {
-		// bd dep add/remove update hooks can send complete bead fields without
-		// dependencies. Treat dependency coverage as unknown so demand reads
-		// fall back to live readiness until reconciliation refreshes the cache.
-		delete(c.deps, b.ID)
-		c.depsComplete = false
+		// A complete field update without dependency fields is ordinarily a
+		// bead-field change, not a dependency mutation. Preserve known dep
+		// coverage so unrelated status/title updates do not force store-wide
+		// live-ready fallback. Real dependency changes arrive via explicit dep
+		// events or write-through mutation paths.
 		return
 	}
 	if _, ok := c.deps[b.ID]; ok {
+		return
+	}
+	if eventType == "bead.updated" && c.depsComplete {
 		return
 	}
 	c.depsComplete = false

--- a/internal/beads/caching_store_events.go
+++ b/internal/beads/caching_store_events.go
@@ -204,13 +204,16 @@ func (c *CachingStore) updateEventDepsLocked(eventType string, b Bead, fields ma
 		return
 	}
 	if eventType == "bead.updated" && c.depsComplete {
+		c.depsComplete = false
+		c.recordProblemLocked("apply bead.updated event", fmt.Errorf("dependency cache marked complete but missing deps for %s", b.ID))
 		return
 	}
 	c.depsComplete = false
 }
 
-// ApplyDepEvent updates the dep cache for a bead. Call after dep
-// mutations are detected via events or write-through.
+// ApplyDepEvent updates the dep cache for callers that have an authoritative
+// dependency snapshot. bd hook payloads that omit dependency fields still flow
+// through ApplyEvent and fall back to reconciliation.
 func (c *CachingStore) ApplyDepEvent(beadID string, deps []Dep) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1660,10 +1660,36 @@ func TestCachingStoreBdReconcileRefreshesListDependenciesForCachedReady(t *testi
 
 	runner.deps["bd-1"] = nil
 	cache.runReconciliation()
-	assertCachedReadyContains(true)
+	assertCachedReadyContains(false)
 
 	if runner.depScanCalls != 0 {
 		t.Fatalf("dep scan calls = %d, want 0", runner.depScanCalls)
+	}
+}
+
+func TestCachingStoreBdReconcilePreservesCachedDepsWhenListOmitsDependencies(t *testing.T) {
+	t.Parallel()
+
+	runner := newCachingStoreBdDepRunner(t)
+	runner.deps["bd-1"] = []Dep{{IssueID: "bd-1", DependsOnID: "bd-2", Type: "blocks"}}
+	cache := NewCachingStore(NewBdStore("/city", runner.run), nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	runner.deps["bd-1"] = nil
+	cache.runReconciliation()
+
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable")
+	}
+	readyByID := make(map[string]bool, len(ready))
+	for _, bead := range ready {
+		readyByID[bead.ID] = true
+	}
+	if readyByID["bd-1"] {
+		t.Fatalf("CachedReady includes bd-1 after omitted deps, ready=%v", readyByID)
 	}
 }
 

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1660,14 +1660,14 @@ func TestCachingStoreBdReconcileRefreshesListDependenciesForCachedReady(t *testi
 
 	runner.deps["bd-1"] = nil
 	cache.runReconciliation()
-	assertCachedReadyContains(false)
+	assertCachedReadyContains(true)
 
 	if runner.depScanCalls != 0 {
 		t.Fatalf("dep scan calls = %d, want 0", runner.depScanCalls)
 	}
 }
 
-func TestCachingStoreBdReconcilePreservesCachedDepsWhenListOmitsDependencies(t *testing.T) {
+func TestCachingStoreBdReconcileClearsCachedDepsWhenListOmitsDependencies(t *testing.T) {
 	t.Parallel()
 
 	runner := newCachingStoreBdDepRunner(t)
@@ -1688,8 +1688,8 @@ func TestCachingStoreBdReconcilePreservesCachedDepsWhenListOmitsDependencies(t *
 	for _, bead := range ready {
 		readyByID[bead.ID] = true
 	}
-	if readyByID["bd-1"] {
-		t.Fatalf("CachedReady includes bd-1 after omitted deps, ready=%v", readyByID)
+	if !readyByID["bd-1"] {
+		t.Fatalf("CachedReady excludes bd-1 after omitted deps, ready=%v", readyByID)
 	}
 }
 

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -583,6 +583,41 @@ func TestCachingStoreApplyEventRecordsProblemOnMalformedPayload(t *testing.T) {
 	}
 }
 
+func TestCachingStoreSparseUpdatedEventFallsBackWhenCompleteCoverageIsMissingDeps(t *testing.T) {
+	t.Parallel()
+
+	backing := NewMemStore()
+	bead, err := backing.Create(Bead{Title: "target"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.mu.Lock()
+	delete(cache.deps, bead.ID)
+	cache.depsComplete = true
+	cache.mu.Unlock()
+
+	cache.ApplyEvent("bead.updated", json.RawMessage(`{"id":"`+bead.ID+`","title":"target"}`))
+
+	cache.mu.RLock()
+	depsComplete := cache.depsComplete
+	lastProblem := cache.stats.LastProblem
+	cache.mu.RUnlock()
+	if depsComplete {
+		t.Fatal("depsComplete = true, want incomplete coverage after missing deps invariant break")
+	}
+	if !strings.Contains(lastProblem, "missing deps for "+bead.ID) {
+		t.Fatalf("LastProblem = %q, want missing deps diagnostic for %s", lastProblem, bead.ID)
+	}
+	if _, ok := cache.CachedReady(); ok {
+		t.Fatal("CachedReady answered from cache after dependency coverage became incomplete")
+	}
+}
+
 func TestCachingStoreApplyEventRechecksLocalMutationBeforeCommit(t *testing.T) {
 	backing := NewMemStore()
 	bead, err := backing.Create(Bead{

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -286,6 +286,9 @@ func (c *CachingStore) depsForReconcileLocked(id string, freshBead Bead, depMap 
 		return cloneDeps(depMap[id])
 	}
 	freshDeps := depsFromBeadFields(freshBead)
+	if _, ok := c.backing.(*BdStore); ok {
+		return freshDeps
+	}
 	if len(freshDeps) == 0 {
 		if cachedDeps, ok := c.deps[id]; ok && len(cachedDeps) > 0 {
 			return cloneDeps(cachedDeps)

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -108,10 +108,7 @@ func (c *CachingStore) runReconciliation() {
 			if _, keep := c.recentLocalBeadConflictLocked(id, freshBead, now); keep {
 				continue
 			}
-			freshDeps := depsFromBeadFields(freshBead)
-			if useFreshDeps {
-				freshDeps = depMap[id]
-			}
+			freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
 
 			old, exists := c.beads[id]
 			switch {
@@ -209,10 +206,7 @@ func (c *CachingStore) runReconciliation() {
 			beadForCache = current
 			preservedRecentLocal = true
 		}
-		freshDeps := depsFromBeadFields(freshBead)
-		if useFreshDeps {
-			freshDeps = depMap[id]
-		}
+		freshDeps := c.depsForReconcileLocked(id, freshBead, depMap, useFreshDeps)
 		nextBeads[id] = cloneBead(beadForCache)
 		nextDeps[id] = cloneDeps(freshDeps)
 
@@ -285,6 +279,19 @@ func (c *CachingStore) runReconciliation() {
 	c.updateStatsLocked()
 	c.mu.Unlock()
 	c.notifyChanges(notifications)
+}
+
+func (c *CachingStore) depsForReconcileLocked(id string, freshBead Bead, depMap map[string][]Dep, useFreshDeps bool) []Dep {
+	if useFreshDeps {
+		return cloneDeps(depMap[id])
+	}
+	freshDeps := depsFromBeadFields(freshBead)
+	if len(freshDeps) == 0 {
+		if cachedDeps, ok := c.deps[id]; ok && len(cachedDeps) > 0 {
+			return cloneDeps(cachedDeps)
+		}
+	}
+	return freshDeps
 }
 
 // recoverMissingFromList re-fetches any cached active bead that didn't appear

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -1254,6 +1254,107 @@ func TestCachingStoreCachedReadyUsesWriteThroughDependencies(t *testing.T) {
 	}
 }
 
+func TestCachingStoreReadyFallsBackAfterDependencyOmittingUpdateEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("external dep add", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		target, err := mem.Create(beads.Bead{Title: "Target"})
+		if err != nil {
+			t.Fatalf("Create(target): %v", err)
+		}
+		cache := beads.NewCachingStoreForTest(mem, nil)
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+
+		if err := mem.DepAdd(target.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("backing DepAdd: %v", err)
+		}
+		cache.ApplyEvent("bead.updated", dependencyOmittingUpdatePayload(t, target))
+
+		if ready, ok := cache.CachedReady(); ok {
+			t.Fatalf("CachedReady remained authoritative after dependency-omitting dep-add event: %v", ready)
+		}
+		ready, err := cache.Ready()
+		if err != nil {
+			t.Fatalf("Ready: %v", err)
+		}
+		if containsBeadID(ready, target.ID) {
+			t.Fatalf("Ready = %v, want backing dependency add to block %s", ready, target.ID)
+		}
+	})
+
+	t.Run("external dep remove", func(t *testing.T) {
+		mem := beads.NewMemStore()
+		blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+		if err != nil {
+			t.Fatalf("Create(blocker): %v", err)
+		}
+		target, err := mem.Create(beads.Bead{Title: "Target"})
+		if err != nil {
+			t.Fatalf("Create(target): %v", err)
+		}
+		if err := mem.DepAdd(target.ID, blocker.ID, "blocks"); err != nil {
+			t.Fatalf("DepAdd: %v", err)
+		}
+		cache := beads.NewCachingStoreForTest(mem, nil)
+		if err := cache.Prime(context.Background()); err != nil {
+			t.Fatalf("Prime: %v", err)
+		}
+		cache.ApplyEvent("bead.updated", dependencySnapshotUpdatePayload(t, target, []beads.Dep{{
+			IssueID:     target.ID,
+			DependsOnID: blocker.ID,
+			Type:        "blocks",
+		}}))
+
+		if err := mem.DepRemove(target.ID, blocker.ID); err != nil {
+			t.Fatalf("backing DepRemove: %v", err)
+		}
+		cache.ApplyEvent("bead.updated", dependencyOmittingUpdatePayload(t, target))
+
+		if ready, ok := cache.CachedReady(); ok {
+			t.Fatalf("CachedReady remained authoritative after dependency-omitting dep-remove event: %v", ready)
+		}
+		ready, err := cache.Ready()
+		if err != nil {
+			t.Fatalf("Ready: %v", err)
+		}
+		if !containsBeadID(ready, target.ID) {
+			t.Fatalf("Ready = %v, want backing dependency removal to unblock %s", ready, target.ID)
+		}
+	})
+}
+
+func TestCachingStoreUpdatedEventForNewBeadDoesNotTreatUnknownDepsAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	target, err := mem.Create(beads.Bead{Title: "Target", Needs: []string{blocker.ID}})
+	if err != nil {
+		t.Fatalf("Create(target): %v", err)
+	}
+	cache.ApplyEvent("bead.updated", dependencyOmittingUpdatePayload(t, target))
+
+	ready, ok := cache.CachedReady()
+	if ok && containsBeadID(ready, target.ID) {
+		t.Fatalf("CachedReady = %v, want new bead dependency coverage not treated as empty", ready)
+	}
+}
+
 func TestCachingStoreCachedReadyIgnoresStaleDependencyEventsAfterLocalMutation(t *testing.T) {
 	t.Parallel()
 
@@ -1412,17 +1513,9 @@ func TestCachingStoreCachedReadyUsesCompleteUpdatedEventDependencies(t *testing.
 		t.Fatalf("CachedReady ids = %v, want target blocked by updated dependencies", ids)
 	}
 
-	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Retitled target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
-	ready, ok = cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady reported cache unavailable after dependency-omitting title update")
-	}
-	ids = map[string]bool{}
-	for _, b := range ready {
-		ids[b.ID] = true
-	}
-	if ids[target.ID] {
-		t.Fatalf("CachedReady ids = %v, want dependency-omitting update to preserve blocker", ids)
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
+	if ready, ok = cache.CachedReady(); ok {
+		t.Fatalf("CachedReady remained authoritative after dependency-omitting update: %v", ready)
 	}
 }
 
@@ -1470,16 +1563,8 @@ func TestCachingStoreCachedReadyRefreshesEventNeedsDependencies(t *testing.T) {
 	}
 
 	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
-	ready, ok = cache.CachedReady()
-	if !ok {
-		t.Fatal("CachedReady reported cache unavailable after dependency-omitting update")
-	}
-	ids = map[string]bool{}
-	for _, b := range ready {
-		ids[b.ID] = true
-	}
-	if ids[target.ID] {
-		t.Fatalf("CachedReady ids = %v, want dependency-omitting update to preserve blocker", ids)
+	if ready, ok = cache.CachedReady(); ok {
+		t.Fatalf("CachedReady remained authoritative after dependency-omitting update: %v", ready)
 	}
 }
 
@@ -2368,6 +2453,37 @@ func containsBeadID(items []beads.Bead, id string) bool {
 		}
 	}
 	return false
+}
+
+func dependencyOmittingUpdatePayload(t *testing.T, b beads.Bead) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"id":         b.ID,
+		"title":      b.Title,
+		"status":     b.Status,
+		"issue_type": b.Type,
+		"created_at": b.CreatedAt,
+	})
+	if err != nil {
+		t.Fatalf("Marshal event payload: %v", err)
+	}
+	return payload
+}
+
+func dependencySnapshotUpdatePayload(t *testing.T, b beads.Bead, deps []beads.Dep) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"id":           b.ID,
+		"title":        b.Title,
+		"status":       b.Status,
+		"issue_type":   b.Type,
+		"created_at":   b.CreatedAt,
+		"dependencies": deps,
+	})
+	if err != nil {
+		t.Fatalf("Marshal event payload: %v", err)
+	}
+	return payload
 }
 
 func findTestBead(items []beads.Bead, id string) (beads.Bead, bool) {

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -1383,6 +1383,49 @@ func TestCachingStoreCachedReadyUsesCompleteCreatedEventDependencies(t *testing.
 	}
 }
 
+func TestCachingStoreCachedReadyUsesCompleteUpdatedEventDependencies(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	target, err := mem.Create(beads.Bead{Title: "Event target"})
+	if err != nil {
+		t.Fatalf("Create(target): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","dependencies":[{"issue_id":"`+target.ID+`","depends_on_id":"`+blocker.ID+`","type":"blocks"}]}`))
+	ready, ok := cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after dependency update")
+	}
+	ids := map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if ids[target.ID] {
+		t.Fatalf("CachedReady ids = %v, want target blocked by updated dependencies", ids)
+	}
+
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Retitled target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after dependency-omitting title update")
+	}
+	ids = map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if ids[target.ID] {
+		t.Fatalf("CachedReady ids = %v, want dependency-omitting update to preserve blocker", ids)
+	}
+}
+
 func TestCachingStoreCachedReadyUnavailableForPartialEventDependencies(t *testing.T) {
 	t.Parallel()
 	cache := beads.NewCachingStoreForTest(beads.NewMemStore(), nil)
@@ -1427,16 +1470,41 @@ func TestCachingStoreCachedReadyRefreshesEventNeedsDependencies(t *testing.T) {
 	}
 
 	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z"}`))
-	if ready, ok = cache.CachedReady(); ok {
-		t.Fatalf("CachedReady available after dependency-omitting update, ready=%v", ready)
+	ready, ok = cache.CachedReady()
+	if !ok {
+		t.Fatal("CachedReady reported cache unavailable after dependency-omitting update")
+	}
+	ids = map[string]bool{}
+	for _, b := range ready {
+		ids[b.ID] = true
+	}
+	if ids[target.ID] {
+		t.Fatalf("CachedReady ids = %v, want dependency-omitting update to preserve blocker", ids)
+	}
+}
+
+func TestCachingStoreCachedReadyClearsExplicitEventNeeds(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	blocker, err := mem.Create(beads.Bead{Title: "Blocker"})
+	if err != nil {
+		t.Fatalf("Create(blocker): %v", err)
+	}
+	target, err := mem.Create(beads.Bead{Title: "Event target", Needs: []string{blocker.ID}})
+	if err != nil {
+		t.Fatalf("Create(target): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(mem, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
 	}
 
-	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","created_at":"2026-01-01T00:00:00Z","needs":[]}`))
-	ready, ok = cache.CachedReady()
+	cache.ApplyEvent("bead.updated", []byte(`{"id":"`+target.ID+`","title":"Event target","status":"open","issue_type":"task","needs":[]}`))
+	ready, ok := cache.CachedReady()
 	if !ok {
 		t.Fatal("CachedReady reported cache unavailable after explicit needs clear")
 	}
-	ids = map[string]bool{}
+	ids := map[string]bool{}
 	for _, b := range ready {
 		ids[b.ID] = true
 	}


### PR DESCRIPTION
Follow-up remediation for post-merge review of #1600.

Fixes:
- Count survivor rows when default routed-work demand sees partial `Ready()` results.
- Route implicit default demand for named-session backing templates into named-session materialization instead of a parallel generic worker.
- Preserve cached dependency coverage for ordinary dependency-omitting bead updates and reconciliation list payloads.
- Keep explicit dep events as the cache path for real dependency mutations.
- Document fresh-city visibility for `always` named sessions.

Verification:
- Pre-commit hook passed: generated docs, golangci-lint, go vet, observable `go test -p=4 -count=1 ./...`, and `go test ./test/docsync`.
- Focused local checks also passed for `cmd/gc` default demand/named-session/cache tests and `internal/beads`.

Original landed PR: #1600.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->