### PR TITLE
feat(claude): add xhigh effort choice for Opus 4.7

### DIFF
--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -131,6 +131,7 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 					{Value: "low", Label: "Low", FlagArgs: []string{"--effort", "low"}},
 					{Value: "medium", Label: "Medium", FlagArgs: []string{"--effort", "medium"}},
 					{Value: "high", Label: "High", FlagArgs: []string{"--effort", "high"}},
+					{Value: "xhigh", Label: "Extra High", FlagArgs: []string{"--effort", "xhigh"}},
 					{Value: "max", Label: "Max", FlagArgs: []string{"--effort", "max"}},
 				},
 			},


### PR DESCRIPTION
# Summary

The Claude Code CLI (verified 2.1.126) supports `--effort xhigh` — described by the embedded `/effort` slash command as *"Deeper reasoning than high, just below maximum (Opus 4.7 only)"*. The provider schema in `profiles.go` has not been updated to expose it, so `option_defaults = { effort = "xhigh" }` on a city.toml agent is silently dropped at the schema-resolution boundary (`ResolveDefaultArgs` skips values that don't match a `Choice`), and the agent launches with the provider default `--effort max` instead.

This adds `xhigh` between `high` and `max` in the Claude provider's `effort` schema, restoring per-agent configurability for Opus 4.7's xhigh thinking level.

# Change

`internal/worker/builtin/profiles.go` — one new entry in the Claude provider `effort` Choices:

```diff
                  Choices: []BuiltinOptionChoice{
                      {Value: "", Label: "Default"},
                      {Value: "low", Label: "Low", FlagArgs: []string{"--effort", "low"}},
                      {Value: "medium", Label: "Medium", FlagArgs: []string{"--effort", "medium"}},
                      {Value: "high", Label: "High", FlagArgs: []string{"--effort", "high"}},
+                     {Value: "xhigh", Label: "Extra High", FlagArgs: []string{"--effort", "xhigh"}},
                      {Value: "max", Label: "Max", FlagArgs: []string{"--effort", "max"}},
                  },
```

Order: `low` → `medium` → `high` → `xhigh` → `max` (matches the CLI's own ranking; `xhigh` sits between `high` and `max`).

# `make check` status

`make check` reports three failures, all unrelated to this change and **pre-existing on `origin/main`** (verified by reverting this PR's diff locally and re-running):

```
--- FAIL: TestHandleOrderHistoryBeforeUsesBufferedBoundedFetch
--- FAIL: TestHandleOrderHistoryBeforeFiltersBeforeStoreLimit
--- FAIL: TestHandleOrderHistoryBeforeFiltersBeforeMergedLimit
```

All three fail with the same root cause — a host-timezone-dependent test bug in `internal/api/handler_orders_test.go`:

```
invalid before timestamp: must be RFC3339, got "2026-05-04T01:12:23.920326368 03:00"
```

Note the literal space before `03:00` instead of `+`. The tests build the URL with raw concatenation
(`"...&before="+midRun.CreatedAt.Format(time.RFC3339Nano)`, `handler_orders_test.go:1114`, `:1176`, `:1242`). On a host in a positive-offset timezone (this VM is UTC+3, Europe/Helsinki), `time.RFC3339Nano` emits `+03:00`; the `+` is then decoded as a space when the handler parses the query string, and the RFC3339 parser rejects the result. CI presumably runs in UTC where the offset is `Z` and the bug is silent.

The packages this PR touches all pass:
```
$ go test ./internal/worker/builtin/... ./internal/config/...
ok      github.com/gastownhall/gascity/internal/worker/builtin  (cached)
ok      github.com/gastownhall/gascity/internal/config  (cached)
```

Recommend handling the URL-escape bug separately (a 3-line fix: `url.QueryEscape(before)` or use `httptest`'s `Request.URL.Query()` mutation API).

# Risk / blast radius

- Pure additive schema entry. No existing `effort` value or default changes.
- `ResolveDefaultArgs` iterates `Choices` to map values to `FlagArgs`; adding one row only enables a new value, doesn't alter existing mapping.
- Default provider `OptionDefaults["effort"] = "max"` is unchanged, so any config that didn't explicitly set xhigh continues to launch identically.
- Schema-revision-sensitive callers (config-revision hashing, stored agent configs in dolt) will see a one-time hash change. Reconciler picks it up on next config reload — same path as any other schema bump.

# Out of scope

- Workspace-level convenience (`[workspace.option_defaults] effort = "xhigh"`) is already supported by the existing `option_defaults` merge logic (`config/resolve.go:648-656`). No code change needed for that — it just works once `xhigh` is a valid choice.
- Per-agent `option_defaults` overrides also work without further changes.
- The Codex provider already has its own `xhigh` entry with a different `FlagArgs` shape (`-c model_reasoning_effort=xhigh`); not touched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->