### PR TITLE
Fix dolt cleanup post-merge safety gaps

### DIFF
--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -217,8 +217,10 @@ func runDoltCleanup(opts cleanupOptions, stdout, stderr io.Writer) int {
 		},
 		RigsProtected: protections,
 	}
-	for _, e := range protectionErrors {
-		recordCleanupError(&report, "rig", e.rig, e.err)
+	if opts.Force {
+		for _, e := range protectionErrors {
+			recordCleanupError(&report, "rig", e.rig, e.err)
+		}
 	}
 	recordUnsafeRigDatabaseNames(&report)
 
@@ -401,7 +403,7 @@ func protectedDoltPortsForReap(opts cleanupOptions) map[int]string {
 	if opts.PortResolution.Port <= 0 {
 		return ports
 	}
-	if opts.PortResolution.Fallback || opts.PortResolution.Source == "legacy default" {
+	if opts.PortResolution.Fallback {
 		return ports
 	}
 	source := opts.PortResolution.Source

--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -255,9 +255,10 @@ func runDoltCleanup(opts cleanupOptions, stdout, stderr io.Writer) int {
 		}
 	}
 
-	runDropStage(&report, opts)
-	runPurgeStage(&report, opts)
-	runReapStage(&report, opts)
+	if runDropStage(&report, opts) {
+		runPurgeStage(&report, opts)
+		runReapStage(&report, opts)
+	}
 	report.Summary.BytesFreedDisk = report.Purge.BytesReclaimed
 
 	emitReport(report, resolution, opts, stdout, stderr)
@@ -749,8 +750,9 @@ default is a connection fallback only; it does not protect port 3307
 from orphan-process reaping.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
-Pass --max-orphan-dbs with --force to refuse destructive drops if the
-live apply-time stale database count exceeds the scan-time threshold.
+Pass --max-orphan-dbs with --force to refuse all destructive cleanup
+stages if the live apply-time stale database count exceeds the
+scan-time threshold.
 Active rig dolt servers, registered rig databases, active test temp roots,
 and processes outside the test-config-path allowlist (/tmp/Test*,
 os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
@@ -825,7 +827,7 @@ return successfully after emitting the report.`,
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON envelope (gc.dolt.cleanup.v1)")
 	cmd.Flags().BoolVar(&probe, "probe", false, "TCP-probe the resolved port; fail if unreachable")
 	cmd.Flags().BoolVar(&force, "force", false, "actually drop, purge, and kill orphaned resources (default: dry-run)")
-	cmd.Flags().IntVar(&maxOrphanDBs, "max-orphan-dbs", 0, "with --force, refuse drops when live stale database count exceeds this limit")
+	cmd.Flags().IntVar(&maxOrphanDBs, "max-orphan-dbs", 0, "with --force, refuse cleanup when live stale database count exceeds this limit")
 	return cmd
 }
 

--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -173,6 +173,7 @@ type cleanupOptions struct {
 	Host           string
 	HomeDir        string
 	TempDir        string
+	MaxOrphanDBs   int
 
 	// StalePrefixes overrides defaultStaleDatabasePrefixes when non-empty.
 	// Set by tests; production passes nil and falls back to the built-in.
@@ -400,6 +401,9 @@ func protectedDoltPortsForReap(opts cleanupOptions) map[int]string {
 	if opts.PortResolution.Port <= 0 {
 		return ports
 	}
+	if opts.PortResolution.Fallback || opts.PortResolution.Source == "legacy default" {
+		return ports
+	}
 	source := opts.PortResolution.Source
 	if source == "" {
 		source = "selected"
@@ -476,7 +480,7 @@ func fatalPortResolutionAttempt(resolution PortResolution) (PortResolutionAttemp
 		if attempt.Status != "error" {
 			continue
 		}
-		if attempt.Source != "--port flag" && !isRigPortFileSource(attempt.Source) {
+		if attempt.Source != "--port flag" && attempt.Source != "city config dolt.port" && !isRigPortFileSource(attempt.Source) {
 			continue
 		}
 		if attempt.Detail != "" {
@@ -721,10 +725,11 @@ func probeDoltPort(host string, port int) error {
 // delegate to this Go-side command once feature parity lands.
 func newDoltCleanupCmd(stdout, stderr io.Writer) *cobra.Command {
 	var (
-		portFlag string
-		jsonOut  bool
-		probe    bool
-		force    bool
+		portFlag     string
+		jsonOut      bool
+		probe        bool
+		force        bool
+		maxOrphanDBs int
 	)
 
 	cmd := &cobra.Command{
@@ -736,10 +741,14 @@ cleanup tool. It resolves the Dolt server port via the AD-04 chain
 drops stale test/agent databases, calls DOLT_PURGE_DROPPED_DATABASES
 to reclaim disk, and reaps orphaned dolt sql-server processes left
 over from leaked test harnesses. Invalid explicit ports and unreadable
-or invalid rig port files fail closed before cleanup stages run; only
-absent rig port files can reach the legacy default.
+or invalid city/rig port settings fail closed before cleanup stages run;
+only absent rig port files can reach the legacy default. The legacy
+default is a connection fallback only; it does not protect port 3307
+from orphan-process reaping.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
+Pass --max-orphan-dbs with --force to refuse destructive drops if the
+live apply-time stale database count exceeds the scan-time threshold.
 Active rig dolt servers, registered rig databases, active test temp roots,
 and processes outside the test-config-path allowlist (/tmp/Test*,
 os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
@@ -748,9 +757,13 @@ report. Destructive drops are limited to known stale test database name
 shapes and conservative SQL identifier characters; skipped stale matches
 are reported in dropped.skipped. Rig dolt_database names used for purge
 must use the same identifier shape: ASCII letters, digits, underscores,
-and non-leading hyphens.
+and non-leading hyphens. Missing or silent rig metadata disables forced
+drop/purge because the live database name cannot be proven safe.
 
-JSON envelope schema is stable: gc.dolt.cleanup.v1.`,
+JSON envelope schema is stable: gc.dolt.cleanup.v1. Automation that
+uses --json must inspect summary.errors_total and errors; cleanup stage
+errors are reported in the envelope even when the command can still
+return successfully after emitting the report.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cityPath, err := resolveCity()
@@ -766,16 +779,17 @@ JSON envelope schema is stable: gc.dolt.cleanup.v1.`,
 			rigs := loadResolverRigs(cityPath, cfg)
 			homeDir, _ := os.UserHomeDir()
 			opts := cleanupOptions{
-				Flag:     portFlag,
-				CityPort: cfg.Dolt.Port,
-				Rigs:     rigs,
-				FS:       fsys.OSFS{},
-				JSON:     jsonOut,
-				Probe:    probe,
-				Force:    force,
-				Host:     cfg.Dolt.Host,
-				HomeDir:  homeDir,
-				TempDir:  os.TempDir(),
+				Flag:         portFlag,
+				CityPort:     cfg.Dolt.Port,
+				Rigs:         rigs,
+				FS:           fsys.OSFS{},
+				JSON:         jsonOut,
+				Probe:        probe,
+				Force:        force,
+				Host:         cfg.Dolt.Host,
+				HomeDir:      homeDir,
+				TempDir:      os.TempDir(),
+				MaxOrphanDBs: maxOrphanDBs,
 			}
 
 			// Resolve the port first so we can open a Dolt connection at the
@@ -809,17 +823,16 @@ JSON envelope schema is stable: gc.dolt.cleanup.v1.`,
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit JSON envelope (gc.dolt.cleanup.v1)")
 	cmd.Flags().BoolVar(&probe, "probe", false, "TCP-probe the resolved port; fail if unreachable")
 	cmd.Flags().BoolVar(&force, "force", false, "actually drop, purge, and kill orphaned resources (default: dry-run)")
+	cmd.Flags().IntVar(&maxOrphanDBs, "max-orphan-dbs", 0, "with --force, refuse drops when live stale database count exceeds this limit")
 	return cmd
 }
 
 // rigProtections projects the resolver's rig list into the JSON-envelope
 // rigs_protected entries. The DB name is read from each rig's
-// <rigPath>/.beads/metadata.json `dolt_database` field; rig.Name is used as
-// an authoritative default only when metadata is absent or silent on
-// dolt_database. Unreadable or corrupt metadata is returned as an error so
-// forced destructive work can fail closed instead of pretending the fallback is
-// the live DB identity. Order is HQ-first to match the port-resolution
-// preference.
+// <rigPath>/.beads/metadata.json `dolt_database` field. Missing, silent,
+// unreadable, or corrupt metadata is returned as an error so forced destructive
+// work can fail closed instead of pretending the fallback is the live DB
+// identity. Order is HQ-first to match the port-resolution preference.
 func rigProtections(rigs []resolverRig, fs fsys.FS) ([]CleanupRigProtection, []rigProtectionError) {
 	out := make([]CleanupRigProtection, 0, len(rigs))
 	var errs []rigProtectionError
@@ -857,7 +870,8 @@ func hasRigProtectionError(report *CleanupReport) bool {
 }
 
 // rigDoltDatabaseName returns the rig's dolt database name as recorded in its
-// metadata.json, falling back to rig.Name only for authoritative defaults.
+// metadata.json, falling back to rig.Name only as a report label when metadata
+// is missing or silent.
 func rigDoltDatabaseName(r resolverRig, fs fsys.FS) string {
 	return resolveRigDoltDatabase(r, fs).name
 }
@@ -869,13 +883,19 @@ type rigDoltDatabaseResolution struct {
 
 func resolveRigDoltDatabase(r resolverRig, fs fsys.FS) rigDoltDatabaseResolution {
 	if fs == nil {
-		return rigDoltDatabaseResolution{name: r.Name}
+		return rigDoltDatabaseResolution{
+			name: r.Name,
+			err:  fmt.Errorf("missing filesystem for rig metadata; cannot verify live dolt database name"),
+		}
 	}
 	metadataPath := filepath.Join(r.Path, ".beads", "metadata.json")
 	data, err := fs.ReadFile(metadataPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return rigDoltDatabaseResolution{name: r.Name}
+			return rigDoltDatabaseResolution{
+				name: r.Name,
+				err:  fmt.Errorf("missing rig metadata %s; cannot verify live dolt database name", metadataPath),
+			}
 		}
 		return rigDoltDatabaseResolution{
 			name: r.Name,
@@ -895,7 +915,10 @@ func resolveRigDoltDatabase(r resolverRig, fs fsys.FS) rigDoltDatabaseResolution
 			return rigDoltDatabaseResolution{name: s}
 		}
 	}
-	return rigDoltDatabaseResolution{name: r.Name}
+	return rigDoltDatabaseResolution{
+		name: r.Name,
+		err:  fmt.Errorf("rig metadata %s lacks dolt_database; cannot verify live dolt database name", metadataPath),
+	}
 }
 
 // loadResolverRigs builds the resolver's rig list from a city config. The HQ

--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -33,6 +33,7 @@ type CleanupReport struct {
 	Schema        string                 `json:"schema"`
 	Port          CleanupPortReport      `json:"port"`
 	RigsProtected []CleanupRigProtection `json:"rigs_protected"`
+	ForceBlockers []CleanupForceBlocker  `json:"force_blockers"`
 	Dropped       CleanupDroppedReport   `json:"dropped"`
 	Purge         CleanupPurgeReport     `json:"purge"`
 	Reaped        CleanupReapedReport    `json:"reaped"`
@@ -52,6 +53,14 @@ type CleanupPortReport struct {
 type CleanupRigProtection struct {
 	Rig string `json:"rig"`
 	DB  string `json:"db"`
+}
+
+// CleanupForceBlocker records a condition that would block a future forced
+// cleanup but does not make dry-run output an error.
+type CleanupForceBlocker struct {
+	Kind  string `json:"kind"`
+	Name  string `json:"name,omitempty"`
+	Error string `json:"error"`
 }
 
 // CleanupDroppedReport summarizes the drop step.
@@ -113,9 +122,16 @@ type CleanupSummary struct {
 // it. Stage values are e.g. "drop", "purge", "reap", "port".
 type CleanupError struct {
 	Stage string `json:"stage"`
+	Kind  string `json:"kind,omitempty"`
 	Name  string `json:"name,omitempty"`
 	Error string `json:"error"`
 }
+
+const (
+	cleanupErrorKindInvalidMaxOrphanDBs = "invalid-max-orphan-dbs"
+	cleanupErrorKindMaxOrphanRefusal    = "max-orphan-refusal"
+	cleanupErrorKindRigProtection       = "rig-protection"
+)
 
 // MarshalJSON ensures slices serialize as `[]` rather than `null` for empty
 // values. The JSON contract documents these as always-present arrays.
@@ -123,6 +139,9 @@ func (r CleanupReport) MarshalJSON() ([]byte, error) {
 	type alias CleanupReport
 	if r.RigsProtected == nil {
 		r.RigsProtected = []CleanupRigProtection{}
+	}
+	if r.ForceBlockers == nil {
+		r.ForceBlockers = []CleanupForceBlocker{}
 	}
 	if r.Dropped.Failed == nil {
 		r.Dropped.Failed = []CleanupDropFailure{}
@@ -217,9 +236,12 @@ func runDoltCleanup(opts cleanupOptions, stdout, stderr io.Writer) int {
 		},
 		RigsProtected: protections,
 	}
+	for _, e := range protectionErrors {
+		recordCleanupForceBlocker(&report, cleanupErrorKindRigProtection, e.rig, e.err)
+	}
 	if opts.Force {
 		for _, e := range protectionErrors {
-			recordCleanupError(&report, "rig", e.rig, e.err)
+			recordCleanupErrorKind(&report, "rig", cleanupErrorKindRigProtection, e.rig, e.err)
 		}
 	}
 	recordUnsafeRigDatabaseNames(&report)
@@ -281,12 +303,24 @@ func cleanupPortResolution(opts cleanupOptions) PortResolution {
 }
 
 func recordCleanupError(report *CleanupReport, stage, name string, err error) {
-	entry := CleanupError{Stage: stage, Error: err.Error()}
+	recordCleanupErrorKind(report, stage, "", name, err)
+}
+
+func recordCleanupErrorKind(report *CleanupReport, stage, kind, name string, err error) {
+	entry := CleanupError{Stage: stage, Kind: kind, Error: err.Error()}
 	if name != "" {
 		entry.Name = name
 	}
 	report.Errors = append(report.Errors, entry)
 	report.Summary.ErrorsTotal++
+}
+
+func recordCleanupForceBlocker(report *CleanupReport, kind, name string, err error) {
+	entry := CleanupForceBlocker{Kind: kind, Error: err.Error()}
+	if name != "" {
+		entry.Name = name
+	}
+	report.ForceBlockers = append(report.ForceBlockers, entry)
 }
 
 // runReapStage discovers live `dolt sql-server` processes, classifies them
@@ -752,7 +786,8 @@ from orphan-process reaping.
 Dry-run by default. Pass --force to actually drop, purge, and kill.
 Pass --max-orphan-dbs with --force to refuse all destructive cleanup
 stages if the live apply-time stale database count exceeds the
-scan-time threshold.
+scan-time threshold. The default 0 disables this guard; negative values
+are rejected before any city lookup or cleanup stage runs.
 Active rig dolt servers, registered rig databases, active test temp roots,
 and processes outside the test-config-path allowlist (/tmp/Test*,
 os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
@@ -765,11 +800,24 @@ and non-leading hyphens. Missing or silent rig metadata disables forced
 drop/purge because the live database name cannot be proven safe.
 
 JSON envelope schema is stable: gc.dolt.cleanup.v1. Automation that
-uses --json must inspect summary.errors_total and errors; cleanup stage
-errors are reported in the envelope even when the command can still
-return successfully after emitting the report.`,
+uses --json must inspect summary.errors_total and errors; dry-run
+force_blockers reports conditions that would block forced cleanup without
+incrementing errors_total. Cleanup stage errors are reported in the
+envelope even when the command can still return successfully after
+emitting the report.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if maxOrphanDBs < 0 {
+				err := fmt.Errorf("--max-orphan-dbs must be >= 0")
+				if jsonOut {
+					report := CleanupReport{Schema: CleanupSchemaVersion}
+					recordCleanupErrorKind(&report, "options", cleanupErrorKindInvalidMaxOrphanDBs, "", err)
+					emitReport(report, PortResolution{}, cleanupOptions{JSON: true}, stdout, stderr)
+				} else {
+					fmt.Fprintf(stderr, "gc dolt-cleanup: %v\n", err) //nolint:errcheck
+				}
+				return errExit
+			}
 			cityPath, err := resolveCity()
 			if err != nil {
 				fmt.Fprintf(stderr, "gc dolt-cleanup: %v\n", err) //nolint:errcheck
@@ -860,13 +908,15 @@ func recordUnsafeRigDatabaseNames(report *CleanupReport) {
 		if validDoltDatabaseIdentifier(rp.DB) {
 			continue
 		}
-		recordCleanupError(report, "rig", rp.Rig, fmt.Errorf("rig %q dolt_database %q is not cleanup-safe", rp.Rig, rp.DB))
+		err := fmt.Errorf("rig %q dolt_database %q is not cleanup-safe", rp.Rig, rp.DB)
+		recordCleanupForceBlocker(report, cleanupErrorKindRigProtection, rp.Rig, err)
+		recordCleanupErrorKind(report, "rig", cleanupErrorKindRigProtection, rp.Rig, err)
 	}
 }
 
 func hasRigProtectionError(report *CleanupReport) bool {
 	for _, e := range report.Errors {
-		if e.Stage == "rig" {
+		if e.Kind == cleanupErrorKindRigProtection || e.Stage == "rig" {
 			return true
 		}
 	}

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -1158,6 +1158,37 @@ func TestRunDoltCleanup_DryRunReportsUnsafeRigDatabaseName(t *testing.T) {
 	}
 }
 
+func TestRunDoltCleanup_DryRunDoesNotCountMissingRigMetadataAsError(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/rigs/silent/.beads/metadata.json"] = []byte(`{"database":"sqlite"}`)
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "missing", Path: "/rigs/missing"},
+			{Name: "silent", Path: "/rigs/silent"},
+		},
+		FS:                fs,
+		JSON:              true,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%s", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0 for dry-run metadata gaps; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	if len(r.Errors) != 0 {
+		t.Fatalf("Errors = %+v, want none for dry-run metadata gaps", r.Errors)
+	}
+}
+
 func TestRunDoltCleanup_ForceDisablesDropAndPurgeWhenRigMetadataMissing(t *testing.T) {
 	fs := fsys.NewFake()
 	putFakeDirTree(fs, "/rigs/foo/.beads/dolt/.dolt_dropped_databases", map[string]int64{
@@ -1264,14 +1295,14 @@ func TestRunDoltCleanup_ForceRefusesDropWhenApplyPlanExceedsMaxOrphanDBs(t *test
 	if len(client.dropped) != 0 {
 		t.Fatalf("dropped = %v, want no forced drops when apply plan exceeds max", client.dropped)
 	}
-	if r.Dropped.Count != 0 || len(r.Dropped.Names) != 0 {
-		t.Fatalf("Dropped = %+v, want no actual drops when max-orphan guard refuses", r.Dropped)
+	if r.Dropped.Count != 3 || !equalStringSlice(r.Dropped.Names, []string{"testdb_a", "testdb_b", "testdb_c"}) {
+		t.Fatalf("Dropped = %+v, want planned drops when max-orphan guard refuses", r.Dropped)
 	}
 	if r.Summary.ErrorsTotal != 1 {
 		t.Fatalf("Summary.ErrorsTotal = %d, want 1; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
 	}
-	if len(r.Errors) != 1 || r.Errors[0].Stage != "drop" || !strings.Contains(r.Errors[0].Error, "max_orphans_for_sql") {
-		t.Fatalf("Errors = %+v, want max orphan DB refusal", r.Errors)
+	if len(r.Errors) != 1 || r.Errors[0].Stage != "drop" || !strings.Contains(r.Errors[0].Error, "--max-orphan-dbs") || strings.Contains(r.Errors[0].Error, "max_orphans_for_sql") {
+		t.Fatalf("Errors = %+v, want user-facing max orphan DB refusal", r.Errors)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -205,7 +205,7 @@ func TestRunDoltCleanup_ForceProtectsSelectedPortWithoutRigPortFile(t *testing.T
 }
 
 func TestRunDoltCleanup_InvalidPortFlagIsFatal(t *testing.T) {
-	for _, flag := range []string{"not-a-number", "0", "-1"} {
+	for _, flag := range []string{"not-a-number", "0", "-1", "65536", "70000"} {
 		t.Run(flag, func(t *testing.T) {
 			client := &fakeCleanupDoltClient{
 				databases: []string{"testdb_abc"},
@@ -257,6 +257,51 @@ func TestRunDoltCleanup_InvalidPortFlagIsFatal(t *testing.T) {
 	}
 }
 
+func TestRunDoltCleanup_InvalidCityConfigPortIsFatal(t *testing.T) {
+	client := &fakeCleanupDoltClient{
+		databases: []string{"testdb_abc"},
+	}
+	var killed []syscall.Signal
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		CityPort:   70000,
+		FS:         fsys.NewFake(),
+		JSON:       true,
+		Force:      true,
+		DoltClient: client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{{PID: 4444, Argv: []string{"dolt", "sql-server", "--config", "/tmp/TestX/config.yaml"}}}, nil
+		},
+		KillProcess: func(_ int, sig syscall.Signal) error {
+			killed = append(killed, sig)
+			return nil
+		},
+		ReapGracePeriod: 1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("exit=0, want invalid city config port to fail\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(client.dropped) != 0 {
+		t.Fatalf("DropDatabase called for invalid city config port: %v", client.dropped)
+	}
+	if len(killed) != 0 {
+		t.Fatalf("KillProcess called for invalid city config port: %v", killed)
+	}
+	if r.Port.Resolved != 0 {
+		t.Fatalf("Port.Resolved = %d, want 0 for unresolved fatal city config port", r.Port.Resolved)
+	}
+	if len(r.Errors) != 1 || r.Errors[0].Stage != "port" || r.Errors[0].Name != "city config dolt.port" || !strings.Contains(r.Errors[0].Error, "65535") {
+		t.Fatalf("Errors = %+v, want fatal city config port validation error", r.Errors)
+	}
+}
+
 func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -272,6 +317,11 @@ func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 			name:      "malformed",
 			setup:     func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("not-a-port\n") },
 			wantError: "invalid port",
+		},
+		{
+			name:      "out of range",
+			setup:     func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("70000\n") },
+			wantError: "65535",
 		},
 		{
 			name:      "unreadable",
@@ -331,6 +381,48 @@ func TestRunDoltCleanup_BadRigPortFileIsFatal(t *testing.T) {
 				t.Fatalf("Errors missing fatal rig port-file entry containing %q: %+v", tc.wantError, r.Errors)
 			}
 		})
+	}
+}
+
+func TestRunDoltCleanup_ForceDoesNotProtectLegacyFallbackPort(t *testing.T) {
+	var signals []syscall.Signal
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:      fsys.NewFake(),
+		JSON:    true,
+		Force:   true,
+		HomeDir: "/home/u",
+		DiscoverProcesses: func() ([]DoltProcInfo, error) {
+			return []DoltProcInfo{{
+				PID:            4444,
+				Ports:          []int{LegacyDefaultDoltPort},
+				Argv:           []string{"dolt", "sql-server", "--config", "/tmp/TestLegacyFallback/config.yaml"},
+				StartTimeTicks: 10,
+			}}, nil
+		},
+		KillProcess: func(_ int, sig syscall.Signal) error {
+			signals = append(signals, sig)
+			return syscall.ESRCH
+		},
+		ReapGracePeriod: 1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%s", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if r.Port.Resolved != LegacyDefaultDoltPort || !r.Port.Fallback {
+		t.Fatalf("Port = %+v, want legacy fallback", r.Port)
+	}
+	if !equalIntSlice(r.Reaped.ProtectedPIDs, nil) {
+		t.Fatalf("ProtectedPIDs = %v, want none for legacy fallback test process", r.Reaped.ProtectedPIDs)
+	}
+	if len(signals) != 1 || signals[0] != syscall.SIGTERM {
+		t.Fatalf("signals = %v, want legacy fallback process to stay eligible for SIGTERM", signals)
 	}
 }
 
@@ -888,6 +980,60 @@ func TestRunDoltCleanup_ForceSkipsSIGKILLWhenRevalidationDiscoverErrors(t *testi
 	}
 }
 
+func TestRunDoltCleanup_ForceSkipsSIGKILLWhenProcessBecomesProtected(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")
+
+	discoverCalls := 0
+	var signals []syscall.Signal
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs:    []resolverRig{{Name: "hq", Path: "/city", HQ: true}},
+		FS:      fs,
+		JSON:    true,
+		Force:   true,
+		HomeDir: "/home/u",
+		DiscoverProcesses: func() ([]DoltProcInfo, error) {
+			discoverCalls++
+			proc := DoltProcInfo{
+				PID:            4444,
+				Argv:           []string{"dolt", "sql-server", "--config", "/tmp/TestX/config.yaml"},
+				StartTimeTicks: 10,
+			}
+			if discoverCalls >= 3 {
+				proc.Ports = []int{28231}
+			}
+			return []DoltProcInfo{proc}, nil
+		},
+		KillProcess: func(_ int, sig syscall.Signal) error {
+			signals = append(signals, sig)
+			return nil
+		},
+		ReapGracePeriod: 1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%s", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if discoverCalls != 3 {
+		t.Fatalf("DiscoverProcesses calls = %d, want initial, pre-SIGTERM, pre-SIGKILL", discoverCalls)
+	}
+	if len(signals) != 1 || signals[0] != syscall.SIGTERM {
+		t.Fatalf("signals = %v, want only SIGTERM before protected SIGKILL revalidation", signals)
+	}
+	if r.Reaped.Count != 0 {
+		t.Errorf("Reaped.Count = %d, want 0 because SIGKILL was skipped", r.Reaped.Count)
+	}
+	if !equalIntSlice(r.Reaped.ProtectedPIDs, []int{4444}) {
+		t.Errorf("ProtectedPIDs = %v, want [4444]", r.Reaped.ProtectedPIDs)
+	}
+}
+
 func TestRunDoltCleanup_ForceRecordsKillError(t *testing.T) {
 	procs := []DoltProcInfo{
 		{PID: 4444, Argv: []string{"dolt", "sql-server", "--config", "/tmp/TestX/config.yaml"}, StartTimeTicks: 10},
@@ -1009,6 +1155,123 @@ func TestRunDoltCleanup_DryRunReportsUnsafeRigDatabaseName(t *testing.T) {
 	}
 	if len(r.Errors) != 1 || r.Errors[0].Stage != "rig" || r.Errors[0].Name != "foo" || !strings.Contains(r.Errors[0].Error, "foo db") {
 		t.Fatalf("Errors = %+v, want typed rig error naming unsafe dolt_database", r.Errors)
+	}
+}
+
+func TestRunDoltCleanup_ForceDisablesDropAndPurgeWhenRigMetadataMissing(t *testing.T) {
+	fs := fsys.NewFake()
+	putFakeDirTree(fs, "/rigs/foo/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_a/data.bin": 100,
+	})
+	client := &fakeCleanupDoltClient{
+		databases: []string{"foo", "testdb_foo_live"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs:              []resolverRig{{Name: "foo", Path: "/rigs/foo"}},
+		FS:                fs,
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(client.dropped) != 0 {
+		t.Fatalf("dropped = %v, want no forced drops when rig metadata is missing", client.dropped)
+	}
+	if client.purged != 0 {
+		t.Fatalf("purged = %d, want no forced purge when rig metadata is missing", client.purged)
+	}
+	if r.Summary.ErrorsTotal != 1 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 1; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	if len(r.Errors) != 1 || r.Errors[0].Stage != "rig" || r.Errors[0].Name != "foo" || !strings.Contains(r.Errors[0].Error, "missing") {
+		t.Fatalf("Errors = %+v, want missing metadata rig protection error", r.Errors)
+	}
+}
+
+func TestRunDoltCleanup_ForceDisablesDropAndPurgeWhenRigMetadataLacksDoltDatabase(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/rigs/foo/.beads/metadata.json"] = []byte(`{"database":"sqlite"}`)
+	client := &fakeCleanupDoltClient{
+		databases: []string{"foo", "testdb_foo_live"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs:              []resolverRig{{Name: "foo", Path: "/rigs/foo"}},
+		FS:                fs,
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(client.dropped) != 0 {
+		t.Fatalf("dropped = %v, want no forced drops when rig metadata lacks dolt_database", client.dropped)
+	}
+	if client.purged != 0 {
+		t.Fatalf("purged = %d, want no forced purge when rig metadata lacks dolt_database", client.purged)
+	}
+	if r.Summary.ErrorsTotal != 1 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 1; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	if len(r.Errors) != 1 || r.Errors[0].Stage != "rig" || r.Errors[0].Name != "foo" || !strings.Contains(r.Errors[0].Error, "dolt_database") {
+		t.Fatalf("Errors = %+v, want missing dolt_database rig protection error", r.Errors)
+	}
+}
+
+func TestRunDoltCleanup_ForceRefusesDropWhenApplyPlanExceedsMaxOrphanDBs(t *testing.T) {
+	client := &fakeCleanupDoltClient{
+		databases: []string{"testdb_a", "testdb_b", "testdb_c"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		FS:                fsys.NewFake(),
+		JSON:              true,
+		Force:             true,
+		MaxOrphanDBs:      2,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(client.dropped) != 0 {
+		t.Fatalf("dropped = %v, want no forced drops when apply plan exceeds max", client.dropped)
+	}
+	if r.Dropped.Count != 0 || len(r.Dropped.Names) != 0 {
+		t.Fatalf("Dropped = %+v, want no actual drops when max-orphan guard refuses", r.Dropped)
+	}
+	if r.Summary.ErrorsTotal != 1 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 1; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	if len(r.Errors) != 1 || r.Errors[0].Stage != "drop" || !strings.Contains(r.Errors[0].Error, "max_orphans_for_sql") {
+		t.Fatalf("Errors = %+v, want max orphan DB refusal", r.Errors)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -1306,6 +1306,76 @@ func TestRunDoltCleanup_ForceRefusesDropWhenApplyPlanExceedsMaxOrphanDBs(t *test
 	}
 }
 
+func TestRunDoltCleanup_MaxOrphanRefusalAbortsForcedPurgeAndReap(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/rigs/foo/.beads/metadata.json"] = []byte(`{"dolt_database":"foo"}`)
+	putFakeDirTree(fs, "/rigs/foo/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"dropped/data.bin": 100,
+	})
+
+	client := &fakeCleanupDoltClient{
+		databases: []string{"foo", "testdb_a", "testdb_b", "testdb_c"},
+	}
+	procs := []DoltProcInfo{{
+		PID:            4444,
+		Argv:           []string{"dolt", "sql-server", "--config", "/tmp/TestX/config.yaml"},
+		StartTimeTicks: 10,
+	}}
+	var signals []syscall.Signal
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs:         []resolverRig{{Name: "foo", Path: "/rigs/foo"}},
+		FS:           fs,
+		JSON:         true,
+		Force:        true,
+		MaxOrphanDBs: 2,
+		DoltClient:   client,
+		HomeDir:      "/home/u",
+		DiscoverProcesses: func() ([]DoltProcInfo, error) {
+			return procs, nil
+		},
+		KillProcess: func(_ int, sig syscall.Signal) error {
+			signals = append(signals, sig)
+			return nil
+		},
+		ReapGracePeriod: 1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(client.dropped) != 0 {
+		t.Fatalf("dropped = %v, want no forced drops when apply plan exceeds max", client.dropped)
+	}
+	if client.purged != 0 {
+		t.Fatalf("purged = %d, want max-orphan refusal to skip forced purge", client.purged)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("signals = %v, want max-orphan refusal to skip forced reap", signals)
+	}
+	if r.Purge.BytesReclaimed != 0 || r.Purge.OK {
+		t.Fatalf("Purge = %+v, want no forced purge result after max-orphan refusal", r.Purge)
+	}
+	if r.Reaped.Count != 0 || len(r.Reaped.Targets) != 0 {
+		t.Fatalf("Reaped = %+v, want no forced reap result after max-orphan refusal", r.Reaped)
+	}
+	if r.Summary.BytesFreedDisk != 0 || r.Summary.BytesFreedRSS != 0 {
+		t.Fatalf("Summary = %+v, want no freed resources after max-orphan refusal", r.Summary)
+	}
+	if r.Summary.ErrorsTotal != 1 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 1; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	if len(r.Errors) != 1 || r.Errors[0].Stage != "drop" || !strings.Contains(r.Errors[0].Error, "--max-orphan-dbs") {
+		t.Fatalf("Errors = %+v, want max-orphan drop refusal only", r.Errors)
+	}
+}
+
 func equalStringSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -37,6 +37,7 @@ func TestCleanupReportJSONShape(t *testing.T) {
 		`"schema":"gc.dolt.cleanup.v1"`,
 		`"port":{`,
 		`"rigs_protected":[]`,
+		`"force_blockers":[]`,
 		`"dropped":{`,
 		`"purge":{`,
 		`"reaped":{`,
@@ -53,6 +54,26 @@ func TestCleanupReportJSONShape(t *testing.T) {
 		if strings.Contains(got, key) {
 			t.Errorf("JSON leaked Go field name %q\nfull JSON:\n%s", key, got)
 		}
+	}
+}
+
+func TestDoltCleanupCmdRejectsNegativeMaxOrphanDBsBeforeCityResolution(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	cmd := newDoltCleanupCmd(&stdout, &stderr)
+	cmd.SetArgs([]string{"--json", "--max-orphan-dbs", "-1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute succeeded; want negative --max-orphan-dbs rejected")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"kind":"invalid-max-orphan-dbs"`) {
+		t.Fatalf("stdout missing structured max-orphan validation kind:\nstdout=%s\nstderr=%s", out, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "not in a Gas City workspace") {
+		t.Fatalf("negative max-orphan validation happened after city resolution:\nstdout=%s\nstderr=%s", out, stderr.String())
 	}
 }
 
@@ -1187,6 +1208,17 @@ func TestRunDoltCleanup_DryRunDoesNotCountMissingRigMetadataAsError(t *testing.T
 	if len(r.Errors) != 0 {
 		t.Fatalf("Errors = %+v, want none for dry-run metadata gaps", r.Errors)
 	}
+	out := stdout.String()
+	for _, want := range []string{
+		`"force_blockers":[`,
+		`"kind":"rig-protection"`,
+		`"name":"missing"`,
+		`"name":"silent"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing dry-run force blocker %q:\n%s", want, out)
+		}
+	}
 }
 
 func TestRunDoltCleanup_ForceDisablesDropAndPurgeWhenRigMetadataMissing(t *testing.T) {
@@ -1304,6 +1336,9 @@ func TestRunDoltCleanup_ForceRefusesDropWhenApplyPlanExceedsMaxOrphanDBs(t *test
 	if len(r.Errors) != 1 || r.Errors[0].Stage != "drop" || !strings.Contains(r.Errors[0].Error, "--max-orphan-dbs") || strings.Contains(r.Errors[0].Error, "max_orphans_for_sql") {
 		t.Fatalf("Errors = %+v, want user-facing max orphan DB refusal", r.Errors)
 	}
+	if !strings.Contains(stdout.String(), `"kind":"max-orphan-refusal"`) {
+		t.Fatalf("stdout missing structured max-orphan refusal kind:\n%s", stdout.String())
+	}
 }
 
 func TestRunDoltCleanup_MaxOrphanRefusalAbortsForcedPurgeAndReap(t *testing.T) {
@@ -1373,6 +1408,9 @@ func TestRunDoltCleanup_MaxOrphanRefusalAbortsForcedPurgeAndReap(t *testing.T) {
 	}
 	if len(r.Errors) != 1 || r.Errors[0].Stage != "drop" || !strings.Contains(r.Errors[0].Error, "--max-orphan-dbs") {
 		t.Fatalf("Errors = %+v, want max-orphan drop refusal only", r.Errors)
+	}
+	if !strings.Contains(stdout.String(), `"kind":"max-orphan-refusal"`) {
+		t.Fatalf("stdout missing structured max-orphan refusal kind:\n%s", stdout.String())
 	}
 }
 

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -33,7 +33,7 @@ func loadRigDoltPorts(rigs []resolverRig, fs fsys.FS) map[int]string {
 			continue
 		}
 		port, err := strconv.Atoi(text)
-		if err != nil || port <= 0 {
+		if err != nil || !validDoltPort(port) {
 			continue
 		}
 		out[port] = rig.Name

--- a/cmd/gc/dolt_cleanup_drop.go
+++ b/cmd/gc/dolt_cleanup_drop.go
@@ -81,11 +81,13 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 		return
 	}
 	if opts.MaxOrphanDBs > 0 && len(plan.ToDrop) > opts.MaxOrphanDBs {
+		report.Dropped.Count = len(plan.ToDrop)
+		report.Dropped.Names = append([]string{}, plan.ToDrop...)
 		recordCleanupError(
 			report,
 			"drop",
 			"",
-			fmt.Errorf("apply-time stale database count %d exceeds max_orphans_for_sql=%d; refusing forced drops", len(plan.ToDrop), opts.MaxOrphanDBs),
+			fmt.Errorf("apply-time stale database count %d exceeds --max-orphan-dbs=%d; refusing forced drops", len(plan.ToDrop), opts.MaxOrphanDBs),
 		)
 		return
 	}

--- a/cmd/gc/dolt_cleanup_drop.go
+++ b/cmd/gc/dolt_cleanup_drop.go
@@ -68,8 +68,6 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 	}
 
 	plan := planDoltDrops(all, stalePrefixes, protected)
-	report.Dropped.Count = len(plan.ToDrop)
-	report.Dropped.Names = append([]string{}, plan.ToDrop...)
 	report.Dropped.Skipped = append([]DoltDropSkip{}, plan.Skipped...)
 	for _, skipped := range plan.Skipped {
 		if skipped.Reason == DropSkipReasonInvalidIdentifier {
@@ -78,6 +76,17 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 	}
 
 	if !opts.Force {
+		report.Dropped.Count = len(plan.ToDrop)
+		report.Dropped.Names = append([]string{}, plan.ToDrop...)
+		return
+	}
+	if opts.MaxOrphanDBs > 0 && len(plan.ToDrop) > opts.MaxOrphanDBs {
+		recordCleanupError(
+			report,
+			"drop",
+			"",
+			fmt.Errorf("apply-time stale database count %d exceeds max_orphans_for_sql=%d; refusing forced drops", len(plan.ToDrop), opts.MaxOrphanDBs),
+		)
 		return
 	}
 

--- a/cmd/gc/dolt_cleanup_drop.go
+++ b/cmd/gc/dolt_cleanup_drop.go
@@ -36,16 +36,17 @@ const cleanupListTimeout = 30 * time.Second
 // runDropStage discovers all databases on the resolved Dolt server,
 // classifies them with planDoltDrops against the protection list, and (when
 // --force is set) drops each stale name. Errors are recorded into the
-// report but never abort the run.
-func runDropStage(report *CleanupReport, opts cleanupOptions) {
+// report. It returns false only when a force-mode safety guard refuses cleanup
+// and the caller must skip the remaining destructive stages.
+func runDropStage(report *CleanupReport, opts cleanupOptions) bool {
 	if opts.DoltClient == nil {
 		if opts.DoltClientOpenErr != nil {
 			recordCleanupError(report, "drop", "", opts.DoltClientOpenErr)
 		}
-		return
+		return true
 	}
 	if opts.Force && hasRigProtectionError(report) {
-		return
+		return true
 	}
 
 	listCtx, listCancel := context.WithTimeout(context.Background(), cleanupListTimeout)
@@ -55,7 +56,7 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 	if err != nil {
 		report.Errors = append(report.Errors, CleanupError{Stage: "drop", Error: err.Error()})
 		report.Summary.ErrorsTotal++
-		return
+		return true
 	}
 
 	stalePrefixes := opts.StalePrefixes
@@ -78,7 +79,7 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 	if !opts.Force {
 		report.Dropped.Count = len(plan.ToDrop)
 		report.Dropped.Names = append([]string{}, plan.ToDrop...)
-		return
+		return true
 	}
 	if opts.MaxOrphanDBs > 0 && len(plan.ToDrop) > opts.MaxOrphanDBs {
 		report.Dropped.Count = len(plan.ToDrop)
@@ -87,9 +88,9 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 			report,
 			"drop",
 			"",
-			fmt.Errorf("apply-time stale database count %d exceeds --max-orphan-dbs=%d; refusing forced drops", len(plan.ToDrop), opts.MaxOrphanDBs),
+			fmt.Errorf("apply-time stale database count %d exceeds --max-orphan-dbs=%d; refusing forced cleanup", len(plan.ToDrop), opts.MaxOrphanDBs),
 		)
-		return
+		return false
 	}
 
 	droppedNames := make([]string, 0, len(plan.ToDrop))
@@ -116,6 +117,7 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) {
 	// matches the live world rather than the planned set.
 	report.Dropped.Names = droppedNames
 	report.Dropped.Count = len(droppedNames)
+	return true
 }
 
 // sqlCleanupDoltClient wraps a *sql.DB to satisfy CleanupDoltClient.

--- a/cmd/gc/dolt_cleanup_drop.go
+++ b/cmd/gc/dolt_cleanup_drop.go
@@ -84,9 +84,10 @@ func runDropStage(report *CleanupReport, opts cleanupOptions) bool {
 	if opts.MaxOrphanDBs > 0 && len(plan.ToDrop) > opts.MaxOrphanDBs {
 		report.Dropped.Count = len(plan.ToDrop)
 		report.Dropped.Names = append([]string{}, plan.ToDrop...)
-		recordCleanupError(
+		recordCleanupErrorKind(
 			report,
 			"drop",
+			cleanupErrorKindMaxOrphanRefusal,
 			"",
 			fmt.Errorf("apply-time stale database count %d exceeds --max-orphan-dbs=%d; refusing forced cleanup", len(plan.ToDrop), opts.MaxOrphanDBs),
 		)

--- a/cmd/gc/dolt_cleanup_drop_test.go
+++ b/cmd/gc/dolt_cleanup_drop_test.go
@@ -131,6 +131,9 @@ func TestRunDoltCleanup_ForceDropsStaleDatabases(t *testing.T) {
 	client := &fakeCleanupDoltClient{
 		databases: []string{"hq", "beads", "testdb_abc", "doctest_x"},
 	}
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	fs.Files["/beads/.beads/metadata.json"] = []byte(`{"dolt_database":"beads"}`)
 	rigs := []resolverRig{
 		{Name: "hq", Path: "/city", HQ: true},
 		{Name: "beads", Path: "/beads"},
@@ -139,7 +142,7 @@ func TestRunDoltCleanup_ForceDropsStaleDatabases(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	opts := cleanupOptions{
 		Rigs:              rigs,
-		FS:                fsys.NewFake(),
+		FS:                fs,
 		JSON:              true,
 		Force:             true,
 		DoltClient:        client,

--- a/cmd/gc/dolt_cleanup_port.go
+++ b/cmd/gc/dolt_cleanup_port.go
@@ -15,6 +15,8 @@ import (
 // shell-side cleanup script when no other source can be resolved.
 const LegacyDefaultDoltPort = 3307
 
+const maxTCPPort = 65535
+
 // PortResolverInput bundles the inputs needed for the dolt port discovery
 // chain (per AD-04 §4.1).
 type PortResolverInput struct {
@@ -127,11 +129,11 @@ func tryFlagPort(flag string) (PortResolutionAttempt, int, bool) {
 			Detail: fmt.Sprintf("invalid port %q: %v", flag, err),
 		}, 0, false
 	}
-	if port <= 0 {
+	if !validDoltPort(port) {
 		return PortResolutionAttempt{
 			Source: src,
 			Status: "error",
-			Detail: fmt.Sprintf("invalid port %d (must be > 0)", port),
+			Detail: invalidDoltPortMessage(port),
 		}, 0, false
 	}
 	return PortResolutionAttempt{Source: src, Status: "found", Detail: strconv.Itoa(port)}, port, true
@@ -139,8 +141,15 @@ func tryFlagPort(flag string) (PortResolutionAttempt, int, bool) {
 
 func tryCityConfigPort(port int) (PortResolutionAttempt, int, bool) {
 	src := "city config dolt.port"
-	if port <= 0 {
+	if port == 0 {
 		return PortResolutionAttempt{Source: src, Status: "not-set"}, 0, false
+	}
+	if !validDoltPort(port) {
+		return PortResolutionAttempt{
+			Source: src,
+			Status: "error",
+			Detail: invalidDoltPortMessage(port),
+		}, 0, false
 	}
 	return PortResolutionAttempt{Source: src, Status: "found", Detail: strconv.Itoa(port)}, port, true
 }
@@ -173,14 +182,22 @@ func tryRigPortFile(fs fsys.FS, path string) (PortResolutionAttempt, int, bool) 
 			Detail: fmt.Sprintf("invalid port %q: %v", text, err),
 		}, 0, false
 	}
-	if port <= 0 {
+	if !validDoltPort(port) {
 		return PortResolutionAttempt{
 			Source: path,
 			Status: "error",
-			Detail: fmt.Sprintf("invalid port %d (must be > 0)", port),
+			Detail: invalidDoltPortMessage(port),
 		}, 0, false
 	}
 	return PortResolutionAttempt{Source: path, Status: "found", Detail: strconv.Itoa(port)}, port, true
+}
+
+func validDoltPort(port int) bool {
+	return port >= 1 && port <= maxTCPPort
+}
+
+func invalidDoltPortMessage(port int) string {
+	return fmt.Sprintf("invalid port %d (must be between 1 and %d)", port, maxTCPPort)
 }
 
 // orderRigsHQFirst returns the rigs reordered so the HQ rig (if any) is

--- a/cmd/gc/dolt_cleanup_port.go
+++ b/cmd/gc/dolt_cleanup_port.go
@@ -17,6 +17,8 @@ const LegacyDefaultDoltPort = 3307
 
 const maxTCPPort = 65535
 
+const cityConfigDoltPortSource = "city config dolt.port"
+
 // PortResolverInput bundles the inputs needed for the dolt port discovery
 // chain (per AD-04 §4.1).
 type PortResolverInput struct {
@@ -140,7 +142,7 @@ func tryFlagPort(flag string) (PortResolutionAttempt, int, bool) {
 }
 
 func tryCityConfigPort(port int) (PortResolutionAttempt, int, bool) {
-	src := "city config dolt.port"
+	src := cityConfigDoltPortSource
 	if port == 0 {
 		return PortResolutionAttempt{Source: src, Status: "not-set"}, 0, false
 	}

--- a/cmd/gc/dolt_cleanup_port_test.go
+++ b/cmd/gc/dolt_cleanup_port_test.go
@@ -180,6 +180,11 @@ func TestResolveDoltPort_BadRigPortFileStopsBeforeLegacyFallback(t *testing.T) {
 			wantDetail: "invalid port",
 		},
 		{
+			name:       "out of range",
+			setup:      func(fs *fsys.Fake) { fs.Files["/city/.beads/dolt-server.port"] = []byte("70000\n") },
+			wantDetail: "must be between 1 and 65535",
+		},
+		{
 			name:       "unreadable",
 			setup:      func(fs *fsys.Fake) { fs.Errors["/city/.beads/dolt-server.port"] = os.ErrPermission },
 			wantDetail: "permission",

--- a/cmd/gc/dolt_cleanup_purge.go
+++ b/cmd/gc/dolt_cleanup_purge.go
@@ -41,8 +41,9 @@ func runPurgeStage(report *CleanupReport, opts cleanupOptions) {
 
 	var totalBytes int64
 	bytesByRigDB := map[string]int64{}
+	eligibleRigDBs := map[string]bool{}
 	for _, rig := range opts.Rigs {
-		if opts.Force && !rigSharesResolvedDoltServer(rig, opts) {
+		if !rigSharesResolvedDoltServer(rig, opts) {
 			continue
 		}
 		root := filepath.Join(rig.Path, droppedDatabasesDir)
@@ -52,7 +53,9 @@ func runPurgeStage(report *CleanupReport, opts cleanupOptions) {
 			continue
 		}
 		totalBytes += bytes
-		bytesByRigDB[rigDoltDatabaseName(rig, opts.FS)] += bytes
+		dbName := rigDoltDatabaseName(rig, opts.FS)
+		bytesByRigDB[dbName] += bytes
+		eligibleRigDBs[dbName] = true
 	}
 
 	if !opts.Force {
@@ -82,6 +85,9 @@ func runPurgeStage(report *CleanupReport, opts cleanupOptions) {
 	allOK := true
 	var reclaimedBytes int64
 	for _, rp := range report.RigsProtected {
+		if !eligibleRigDBs[rp.DB] {
+			continue
+		}
 		if !live[rp.DB] {
 			if bytesByRigDB[rp.DB] > 0 {
 				allOK = false
@@ -119,7 +125,7 @@ func rigSharesResolvedDoltServer(rig resolverRig, opts cleanupOptions) bool {
 	}
 	port, ok := rigPortFileValue(rig, opts.FS)
 	if !ok {
-		return true
+		return opts.PortResolution.Fallback
 	}
 	return port == opts.PortResolution.Port
 }

--- a/cmd/gc/dolt_cleanup_purge.go
+++ b/cmd/gc/dolt_cleanup_purge.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	iofs "io/fs"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -40,6 +42,9 @@ func runPurgeStage(report *CleanupReport, opts cleanupOptions) {
 	var totalBytes int64
 	bytesByRigDB := map[string]int64{}
 	for _, rig := range opts.Rigs {
+		if opts.Force && !rigSharesResolvedDoltServer(rig, opts) {
+			continue
+		}
 		root := filepath.Join(rig.Path, droppedDatabasesDir)
 		bytes, err := sumBytesUnder(opts.FS, root)
 		if err != nil {
@@ -106,6 +111,33 @@ func runPurgeStage(report *CleanupReport, opts cleanupOptions) {
 	}
 	report.Purge.BytesReclaimed = reclaimedBytes
 	report.Purge.OK = allOK
+}
+
+func rigSharesResolvedDoltServer(rig resolverRig, opts cleanupOptions) bool {
+	if opts.PortResolution.Port <= 0 || opts.FS == nil {
+		return true
+	}
+	port, ok := rigPortFileValue(rig, opts.FS)
+	if !ok {
+		return true
+	}
+	return port == opts.PortResolution.Port
+}
+
+func rigPortFileValue(rig resolverRig, fs fsys.FS) (int, bool) {
+	data, err := fs.ReadFile(filepath.Join(rig.Path, ".beads", "dolt-server.port"))
+	if err != nil {
+		return 0, false
+	}
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return 0, false
+	}
+	port, err := strconv.Atoi(text)
+	if err != nil || !validDoltPort(port) {
+		return 0, false
+	}
+	return port, true
 }
 
 // sumBytesUnder walks the given root recursively and returns the total

--- a/cmd/gc/dolt_cleanup_purge.go
+++ b/cmd/gc/dolt_cleanup_purge.go
@@ -125,9 +125,15 @@ func rigSharesResolvedDoltServer(rig resolverRig, opts cleanupOptions) bool {
 	}
 	port, ok := rigPortFileValue(rig, opts.FS)
 	if !ok {
-		return opts.PortResolution.Fallback
+		return opts.PortResolution.Fallback || cityConfigPortSelectsRig(rig, opts)
 	}
 	return port == opts.PortResolution.Port
+}
+
+func cityConfigPortSelectsRig(rig resolverRig, opts cleanupOptions) bool {
+	return rig.HQ &&
+		opts.PortResolution.Source == cityConfigDoltPortSource &&
+		opts.CityPort == opts.PortResolution.Port
 }
 
 func rigPortFileValue(rig resolverRig, fs fsys.FS) (int, bool) {

--- a/cmd/gc/dolt_cleanup_purge.go
+++ b/cmd/gc/dolt_cleanup_purge.go
@@ -123,33 +123,47 @@ func rigSharesResolvedDoltServer(rig resolverRig, opts cleanupOptions) bool {
 	if opts.PortResolution.Port <= 0 || opts.FS == nil {
 		return true
 	}
-	port, ok := rigPortFileValue(rig, opts.FS)
-	if !ok {
+	port, state := rigPortFileValue(rig, opts.FS)
+	switch state {
+	case rigPortFileValid:
+		return port == opts.PortResolution.Port
+	case rigPortFileMissing:
 		return opts.PortResolution.Fallback || cityConfigPortSelectsRig(rig, opts)
+	default:
+		return false
 	}
-	return port == opts.PortResolution.Port
 }
 
-func cityConfigPortSelectsRig(rig resolverRig, opts cleanupOptions) bool {
-	return rig.HQ &&
-		opts.PortResolution.Source == cityConfigDoltPortSource &&
+func cityConfigPortSelectsRig(_ resolverRig, opts cleanupOptions) bool {
+	return opts.PortResolution.Source == cityConfigDoltPortSource &&
 		opts.CityPort == opts.PortResolution.Port
 }
 
-func rigPortFileValue(rig resolverRig, fs fsys.FS) (int, bool) {
+type rigPortFileState int
+
+const (
+	rigPortFileMissing rigPortFileState = iota
+	rigPortFileInvalid
+	rigPortFileValid
+)
+
+func rigPortFileValue(rig resolverRig, fs fsys.FS) (int, rigPortFileState) {
 	data, err := fs.ReadFile(filepath.Join(rig.Path, ".beads", "dolt-server.port"))
 	if err != nil {
-		return 0, false
+		if errors.Is(err, iofs.ErrNotExist) {
+			return 0, rigPortFileMissing
+		}
+		return 0, rigPortFileInvalid
 	}
 	text := strings.TrimSpace(string(data))
 	if text == "" {
-		return 0, false
+		return 0, rigPortFileInvalid
 	}
 	port, err := strconv.Atoi(text)
 	if err != nil || !validDoltPort(port) {
-		return 0, false
+		return 0, rigPortFileInvalid
 	}
-	return port, true
+	return port, rigPortFileValid
 }
 
 // sumBytesUnder walks the given root recursively and returns the total

--- a/cmd/gc/dolt_cleanup_purge_test.go
+++ b/cmd/gc/dolt_cleanup_purge_test.go
@@ -348,6 +348,62 @@ func TestRunDoltCleanup_ForceSkipsPurgeForMissingRigDatabases(t *testing.T) {
 	}
 }
 
+func TestRunDoltCleanup_ForceSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231")
+	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_a/data.bin": 100,
+	})
+	fs.Files["/rigs/other/.beads/metadata.json"] = []byte(`{"dolt_database":"other_db"}`)
+	fs.Files["/rigs/other/.beads/dolt-server.port"] = []byte("28232")
+	putFakeDirTree(fs, "/rigs/other/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_b/data.bin": 200,
+	})
+
+	rigs := []resolverRig{
+		{Name: "city", Path: "/city", HQ: true},
+		{Name: "other", Path: "/rigs/other"},
+	}
+	purgedNames := []string{}
+	client := &fakeCleanupDoltClientCustomPurge{
+		databases: []string{"hq"},
+		onPurge:   func(name string) error { purgedNames = append(purgedNames, name); return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs:              rigs,
+		FS:                fs,
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if !r.Purge.OK {
+		t.Errorf("Purge.OK = false, want true because non-resolved server was skipped")
+	}
+	if r.Purge.BytesReclaimed != 100 {
+		t.Errorf("Purge.BytesReclaimed = %d, want only resolved-server bytes", r.Purge.BytesReclaimed)
+	}
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	wantPurged := []string{"hq"}
+	if !equalStringSlice(purgedNames, wantPurged) {
+		t.Errorf("purged DBs = %v, want %v", purgedNames, wantPurged)
+	}
+}
+
 // fakeCleanupDoltClientCustomPurge is like fakeCleanupDoltClient but lets a
 // test inject custom purge behavior so it can exercise failure paths and
 // observe call order.

--- a/cmd/gc/dolt_cleanup_purge_test.go
+++ b/cmd/gc/dolt_cleanup_purge_test.go
@@ -404,6 +404,96 @@ func TestRunDoltCleanup_ForceSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T)
 	}
 }
 
+func TestRunDoltCleanup_DryRunSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231")
+	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_a/data.bin": 100,
+	})
+	fs.Files["/rigs/other/.beads/metadata.json"] = []byte(`{"dolt_database":"other_db"}`)
+	fs.Files["/rigs/other/.beads/dolt-server.port"] = []byte("28232")
+	putFakeDirTree(fs, "/rigs/other/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_b/data.bin": 200,
+	})
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "city", Path: "/city", HQ: true},
+			{Name: "other", Path: "/rigs/other"},
+		},
+		FS:                fs,
+		JSON:              true,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if r.Purge.BytesReclaimed != 100 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want only resolved-server bytes", r.Purge.BytesReclaimed)
+	}
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+}
+
+func TestRunDoltCleanup_ForceSkipsPurgeWhenRigPortIsUnknownWithResolvedPort(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231")
+	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_a/data.bin": 100,
+	})
+	fs.Files["/rigs/unknown/.beads/metadata.json"] = []byte(`{"dolt_database":"unknown_db"}`)
+	putFakeDirTree(fs, "/rigs/unknown/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_b/data.bin": 200,
+	})
+
+	purgedNames := []string{}
+	client := &fakeCleanupDoltClientCustomPurge{
+		databases: []string{"hq", "unknown_db"},
+		onPurge:   func(name string) error { purgedNames = append(purgedNames, name); return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "city", Path: "/city", HQ: true},
+			{Name: "unknown", Path: "/rigs/unknown"},
+		},
+		FS:                fs,
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if r.Purge.BytesReclaimed != 100 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want only proven resolved-server bytes", r.Purge.BytesReclaimed)
+	}
+	wantPurged := []string{"hq"}
+	if !equalStringSlice(purgedNames, wantPurged) {
+		t.Fatalf("purged DBs = %v, want %v", purgedNames, wantPurged)
+	}
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+}
+
 // fakeCleanupDoltClientCustomPurge is like fakeCleanupDoltClient but lets a
 // test inject custom purge behavior so it can exercise failure paths and
 // observe call order.

--- a/cmd/gc/dolt_cleanup_purge_test.go
+++ b/cmd/gc/dolt_cleanup_purge_test.go
@@ -474,8 +474,8 @@ func TestRunDoltCleanup_DryRunCountsCityConfigPortRigWithoutPortFile(t *testing.
 	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
 		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
 	}
-	if r.Purge.BytesReclaimed != 100 {
-		t.Fatalf("Purge.BytesReclaimed = %d, want selected city-config rig bytes only", r.Purge.BytesReclaimed)
+	if r.Purge.BytesReclaimed != 300 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want city-config inherited rig bytes included", r.Purge.BytesReclaimed)
 	}
 	if r.Summary.ErrorsTotal != 0 {
 		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
@@ -525,15 +525,171 @@ func TestRunDoltCleanup_ForcePurgesCityConfigPortRigWithoutPortFile(t *testing.T
 	if !r.Purge.OK {
 		t.Errorf("Purge.OK = false, want true")
 	}
-	if r.Purge.BytesReclaimed != 100 {
-		t.Fatalf("Purge.BytesReclaimed = %d, want selected city-config rig bytes only", r.Purge.BytesReclaimed)
+	if r.Purge.BytesReclaimed != 300 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want city-config inherited rig bytes included", r.Purge.BytesReclaimed)
 	}
-	wantPurged := []string{"hq"}
+	wantPurged := []string{"hq", "unknown_db"}
 	if !equalStringSlice(purgedNames, wantPurged) {
 		t.Fatalf("purged DBs = %v, want %v", purgedNames, wantPurged)
 	}
 	if r.Summary.ErrorsTotal != 0 {
 		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+}
+
+func TestRunDoltCleanup_DryRunSkipsPurgeBytesForInvalidRigPortWithCityConfig(t *testing.T) {
+	portFile := "/rigs/unknown/.beads/dolt-server.port"
+	tests := []struct {
+		name  string
+		setup func(*fsys.Fake)
+	}{
+		{
+			name: "unreadable",
+			setup: func(fs *fsys.Fake) {
+				fs.Files[portFile] = []byte("28231")
+				fs.Errors[portFile] = os.ErrPermission
+			},
+		},
+		{
+			name: "malformed",
+			setup: func(fs *fsys.Fake) {
+				fs.Files[portFile] = []byte("not-a-port")
+			},
+		},
+		{
+			name: "out-of-range",
+			setup: func(fs *fsys.Fake) {
+				fs.Files[portFile] = []byte("70000")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := fsys.NewFake()
+			fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+			putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+				"db_a/data.bin": 100,
+			})
+			fs.Files["/rigs/unknown/.beads/metadata.json"] = []byte(`{"dolt_database":"unknown_db"}`)
+			putFakeDirTree(fs, "/rigs/unknown/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+				"db_b/data.bin": 200,
+			})
+			tt.setup(fs)
+
+			var stdout, stderr bytes.Buffer
+			opts := cleanupOptions{
+				Rigs: []resolverRig{
+					{Name: "city", Path: "/city", HQ: true},
+					{Name: "unknown", Path: "/rigs/unknown"},
+				},
+				CityPort:          28231,
+				PortResolution:    PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
+				FS:                fs,
+				JSON:              true,
+				DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+			}
+			code := runDoltCleanup(opts, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+			}
+			var r CleanupReport
+			if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+				t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+			}
+			if r.Purge.BytesReclaimed != 100 {
+				t.Fatalf("Purge.BytesReclaimed = %d, want only city rig bytes", r.Purge.BytesReclaimed)
+			}
+			if r.Summary.ErrorsTotal != 0 {
+				t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+			}
+		})
+	}
+}
+
+func TestRunDoltCleanup_ForceSkipsPurgeForInvalidRigPortWithCityConfig(t *testing.T) {
+	portFile := "/rigs/unknown/.beads/dolt-server.port"
+	tests := []struct {
+		name  string
+		setup func(*fsys.Fake)
+	}{
+		{
+			name: "unreadable",
+			setup: func(fs *fsys.Fake) {
+				fs.Files[portFile] = []byte("28231")
+				fs.Errors[portFile] = os.ErrPermission
+			},
+		},
+		{
+			name: "malformed",
+			setup: func(fs *fsys.Fake) {
+				fs.Files[portFile] = []byte("not-a-port")
+			},
+		},
+		{
+			name: "out-of-range",
+			setup: func(fs *fsys.Fake) {
+				fs.Files[portFile] = []byte("70000")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := fsys.NewFake()
+			fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+			putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+				"db_a/data.bin": 100,
+			})
+			fs.Files["/rigs/unknown/.beads/metadata.json"] = []byte(`{"dolt_database":"unknown_db"}`)
+			putFakeDirTree(fs, "/rigs/unknown/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+				"db_b/data.bin": 200,
+			})
+			tt.setup(fs)
+
+			purgedNames := []string{}
+			client := &fakeCleanupDoltClientCustomPurge{
+				databases: []string{"hq", "unknown_db"},
+				onPurge:   func(name string) error { purgedNames = append(purgedNames, name); return nil },
+			}
+
+			var stdout, stderr bytes.Buffer
+			opts := cleanupOptions{
+				Rigs: []resolverRig{
+					{Name: "city", Path: "/city", HQ: true},
+					{Name: "unknown", Path: "/rigs/unknown"},
+				},
+				CityPort:          28231,
+				PortResolution:    PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
+				FS:                fs,
+				JSON:              true,
+				Force:             true,
+				DoltClient:        client,
+				DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+				ReapGracePeriod:   1,
+			}
+			code := runDoltCleanup(opts, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+			}
+			var r CleanupReport
+			if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+				t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+			}
+			if !r.Purge.OK {
+				t.Errorf("Purge.OK = false, want true")
+			}
+			if r.Purge.BytesReclaimed != 100 {
+				t.Fatalf("Purge.BytesReclaimed = %d, want only city rig bytes", r.Purge.BytesReclaimed)
+			}
+			wantPurged := []string{"hq"}
+			if !equalStringSlice(purgedNames, wantPurged) {
+				t.Fatalf("purged DBs = %v, want %v", purgedNames, wantPurged)
+			}
+			if r.Summary.ErrorsTotal != 0 {
+				t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/dolt_cleanup_purge_test.go
+++ b/cmd/gc/dolt_cleanup_purge_test.go
@@ -443,6 +443,100 @@ func TestRunDoltCleanup_DryRunSkipsPurgeBytesForRigsOnDifferentPort(t *testing.T
 	}
 }
 
+func TestRunDoltCleanup_DryRunCountsCityConfigPortRigWithoutPortFile(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_a/data.bin": 100,
+	})
+	fs.Files["/rigs/unknown/.beads/metadata.json"] = []byte(`{"dolt_database":"unknown_db"}`)
+	putFakeDirTree(fs, "/rigs/unknown/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_b/data.bin": 200,
+	})
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "city", Path: "/city", HQ: true},
+			{Name: "unknown", Path: "/rigs/unknown"},
+		},
+		CityPort:          28231,
+		PortResolution:    PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
+		FS:                fs,
+		JSON:              true,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if r.Purge.BytesReclaimed != 100 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want selected city-config rig bytes only", r.Purge.BytesReclaimed)
+	}
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+}
+
+func TestRunDoltCleanup_ForcePurgesCityConfigPortRigWithoutPortFile(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)
+	putFakeDirTree(fs, "/city/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_a/data.bin": 100,
+	})
+	fs.Files["/rigs/unknown/.beads/metadata.json"] = []byte(`{"dolt_database":"unknown_db"}`)
+	putFakeDirTree(fs, "/rigs/unknown/.beads/dolt/.dolt_dropped_databases", map[string]int64{
+		"db_b/data.bin": 200,
+	})
+
+	purgedNames := []string{}
+	client := &fakeCleanupDoltClientCustomPurge{
+		databases: []string{"hq", "unknown_db"},
+		onPurge:   func(name string) error { purgedNames = append(purgedNames, name); return nil },
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "city", Path: "/city", HQ: true},
+			{Name: "unknown", Path: "/rigs/unknown"},
+		},
+		CityPort:          28231,
+		PortResolution:    PortResolution{Port: 28231, Source: cityConfigDoltPortSource},
+		FS:                fs,
+		JSON:              true,
+		Force:             true,
+		DoltClient:        client,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+		ReapGracePeriod:   1,
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s", err, stdout.String())
+	}
+	if !r.Purge.OK {
+		t.Errorf("Purge.OK = false, want true")
+	}
+	if r.Purge.BytesReclaimed != 100 {
+		t.Fatalf("Purge.BytesReclaimed = %d, want selected city-config rig bytes only", r.Purge.BytesReclaimed)
+	}
+	wantPurged := []string{"hq"}
+	if !equalStringSlice(purgedNames, wantPurged) {
+		t.Fatalf("purged DBs = %v, want %v", purgedNames, wantPurged)
+	}
+	if r.Summary.ErrorsTotal != 0 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 0; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+}
+
 func TestRunDoltCleanup_ForceSkipsPurgeWhenRigPortIsUnknownWithResolvedPort(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.beads/metadata.json"] = []byte(`{"dolt_database":"hq"}`)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -925,8 +925,9 @@ default is a connection fallback only; it does not protect port 3307
 from orphan-process reaping.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
-Pass --max-orphan-dbs with --force to refuse destructive drops if the
-live apply-time stale database count exceeds the scan-time threshold.
+Pass --max-orphan-dbs with --force to refuse all destructive cleanup
+stages if the live apply-time stale database count exceeds the
+scan-time threshold.
 Active rig dolt servers, registered rig databases, active test temp roots,
 and processes outside the test-config-path allowlist (/tmp/Test*,
 os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
@@ -951,7 +952,7 @@ gc dolt-cleanup [flags]
 |------|------|---------|-------------|
 | `--force` | bool |  | actually drop, purge, and kill orphaned resources (default: dry-run) |
 | `--json` | bool |  | emit JSON envelope (gc.dolt.cleanup.v1) |
-| `--max-orphan-dbs` | int |  | with --force, refuse drops when live stale database count exceeds this limit |
+| `--max-orphan-dbs` | int |  | with --force, refuse cleanup when live stale database count exceeds this limit |
 | `--port` | string |  | override the resolved Dolt port |
 | `--probe` | bool |  | TCP-probe the resolved port; fail if unreachable |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -919,10 +919,14 @@ cleanup tool. It resolves the Dolt server port via the AD-04 chain
 drops stale test/agent databases, calls DOLT_PURGE_DROPPED_DATABASES
 to reclaim disk, and reaps orphaned dolt sql-server processes left
 over from leaked test harnesses. Invalid explicit ports and unreadable
-or invalid rig port files fail closed before cleanup stages run; only
-absent rig port files can reach the legacy default.
+or invalid city/rig port settings fail closed before cleanup stages run;
+only absent rig port files can reach the legacy default. The legacy
+default is a connection fallback only; it does not protect port 3307
+from orphan-process reaping.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
+Pass --max-orphan-dbs with --force to refuse destructive drops if the
+live apply-time stale database count exceeds the scan-time threshold.
 Active rig dolt servers, registered rig databases, active test temp roots,
 and processes outside the test-config-path allowlist (/tmp/Test*,
 os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
@@ -931,9 +935,13 @@ report. Destructive drops are limited to known stale test database name
 shapes and conservative SQL identifier characters; skipped stale matches
 are reported in dropped.skipped. Rig dolt_database names used for purge
 must use the same identifier shape: ASCII letters, digits, underscores,
-and non-leading hyphens.
+and non-leading hyphens. Missing or silent rig metadata disables forced
+drop/purge because the live database name cannot be proven safe.
 
-JSON envelope schema is stable: gc.dolt.cleanup.v1.
+JSON envelope schema is stable: gc.dolt.cleanup.v1. Automation that
+uses --json must inspect summary.errors_total and errors; cleanup stage
+errors are reported in the envelope even when the command can still
+return successfully after emitting the report.
 
 ```
 gc dolt-cleanup [flags]
@@ -943,6 +951,7 @@ gc dolt-cleanup [flags]
 |------|------|---------|-------------|
 | `--force` | bool |  | actually drop, purge, and kill orphaned resources (default: dry-run) |
 | `--json` | bool |  | emit JSON envelope (gc.dolt.cleanup.v1) |
+| `--max-orphan-dbs` | int |  | with --force, refuse drops when live stale database count exceeds this limit |
 | `--port` | string |  | override the resolved Dolt port |
 | `--probe` | bool |  | TCP-probe the resolved port; fail if unreachable |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -927,7 +927,8 @@ from orphan-process reaping.
 Dry-run by default. Pass --force to actually drop, purge, and kill.
 Pass --max-orphan-dbs with --force to refuse all destructive cleanup
 stages if the live apply-time stale database count exceeds the
-scan-time threshold.
+scan-time threshold. The default 0 disables this guard; negative values
+are rejected before any city lookup or cleanup stage runs.
 Active rig dolt servers, registered rig databases, active test temp roots,
 and processes outside the test-config-path allowlist (/tmp/Test*,
 os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
@@ -940,9 +941,11 @@ and non-leading hyphens. Missing or silent rig metadata disables forced
 drop/purge because the live database name cannot be proven safe.
 
 JSON envelope schema is stable: gc.dolt.cleanup.v1. Automation that
-uses --json must inspect summary.errors_total and errors; cleanup stage
-errors are reported in the envelope even when the command can still
-return successfully after emitting the report.
+uses --json must inspect summary.errors_total and errors; dry-run
+force_blockers reports conditions that would block forced cleanup without
+incrementing errors_total. Cleanup stage errors are reported in the
+envelope even when the command can still return successfully after
+emitting the report.
 
 ```
 gc dolt-cleanup [flags]

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -192,6 +192,23 @@ else
     fail_open_after_drain "gc dolt-cleanup apply returned invalid JSON; leaving work bead open"
   fi
 
+  APPLY_ERRS=$(jq -r '.summary.errors_total // 0' "$APPLY_FILE")
+  APPLY_MAX_ORPHAN_REFUSALS=$(jq -r '[.errors[]? | (.error // "" | ascii_downcase) | select((contains("--max-orphan-dbs") or contains("max-orphan") or contains("orphan databases")) and (contains("refus") or contains("exceed")))] | length' "$APPLY_FILE")
+  if [ "$APPLY_ERRS" -gt 0 ] || [ "$APPLY_MAX_ORPHAN_REFUSALS" -gt 0 ]; then
+    ESCALATED=1
+    APPLY_REFUSAL_MESSAGE="apply reported ${APPLY_ERRS} error(s); leaving work bead open"
+    if [ "$APPLY_MAX_ORPHAN_REFUSALS" -gt 0 ]; then
+      APPLY_REFUSAL_MESSAGE="apply refused by max-orphan safety guard; leaving work bead open"
+    fi
+    append_report_note "apply (--force, refused)" "$APPLY_FILE"
+    run_or_warn "send apply refusal escalation mail" gc mail send mayor \
+      "ESCALATION: gc dolt-cleanup apply refused [HIGH]" \
+      "gc dolt-cleanup --probe --force refused or reported ${APPLY_ERRS} error(s). Do not retry from an agent. Operator must inspect the attached apply report before deciding whether any manual cleanup is appropriate."
+    run_or_warn "emit apply refusal escalation" gc event emit mol-dog-stale-db.escalate \
+      --message "$APPLY_REFUSAL_MESSAGE"
+    fail_open_after_drain "gc dolt-cleanup ${APPLY_REFUSAL_MESSAGE}"
+  fi
+
   DROP_OK=$(jq -r '.dropped.count // 0' "$APPLY_FILE")
   DROP_FAIL=$(jq -r '.dropped.failed | length' "$APPLY_FILE")
   PURGE_BYTES=$(jq -r '.purge.bytes_reclaimed // 0' "$APPLY_FILE")

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -175,7 +175,7 @@ elif [ "$ORPHAN_DBS" -gt "{{max_orphans_for_sql}}" ]; then
   run_or_warn "emit max-orphan escalation" gc event emit mol-dog-stale-db.escalate \
     --message "$ORPHAN_DBS stale databases > max_orphans_for_sql={{max_orphans_for_sql}} -> mail sent to mayor"
 else
-  if ! gc dolt-cleanup --json --probe --force > "$APPLY_FILE"; then
+  if ! gc dolt-cleanup --json --probe --force --max-orphan-dbs "{{max_orphans_for_sql}}" > "$APPLY_FILE"; then
     ESCALATED=1
     append_report_note "apply (--force, failed)" "$APPLY_FILE"
     run_or_warn "send apply refusal escalation mail" gc mail send mayor \

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -247,16 +247,14 @@ fi
 run_or_warn "emit done event" gc event emit mol-dog-stale-db.done \
   --message "$DONE_MESSAGE"
 
-if [ "$APPLIED" -eq 1 ] && [ "$DONE_ERRS" -gt 0 ]; then
-  ESCALATED=1
-  run_or_warn "emit apply error escalation" gc event emit mol-dog-stale-db.escalate \
-    --message "apply reported ${DONE_ERRS} error(s); leaving work bead open"
-fi
-
 if [ "$APPLIED" -eq 1 ] && [ "$MISSED_PURGE_BYTES" -gt 0 ]; then
   ESCALATED=1
   run_or_warn "emit missed purge escalation" gc event emit mol-dog-stale-db.escalate \
     --message "apply missed ${MISSED_PURGE_BYTES} reclaimable bytes; leaving work bead open"
+elif [ "$APPLIED" -eq 1 ] && [ "$DONE_ERRS" -gt 0 ]; then
+  ESCALATED=1
+  run_or_warn "emit apply error escalation" gc event emit mol-dog-stale-db.escalate \
+    --message "apply reported ${DONE_ERRS} error(s); leaving work bead open"
 fi
 
 if [ "$ORPHAN_TOTAL" -ge "{{warn_threshold}}" ]; then
@@ -264,6 +262,10 @@ if [ "$ORPHAN_TOTAL" -ge "{{warn_threshold}}" ]; then
 fi
 
 gc session nudge deacon "DOG_DONE: stale-db - orphans: ${ORPHAN_TOTAL}, applied: ${APPLIED}, escalated: ${ESCALATED}" || true
+
+if [ "$APPLIED" -eq 1 ] && [ "$MISSED_PURGE_BYTES" -gt 0 ]; then
+  fail_open_after_drain "gc dolt-cleanup apply missed ${MISSED_PURGE_BYTES} reclaimable bytes; leaving work bead open"
+fi
 
 if [ "$APPLIED" -eq 1 ] && [ "$DONE_ERRS" -gt 0 ]; then
   fail_open_after_drain "gc dolt-cleanup apply reported ${DONE_ERRS} error(s); leaving work bead open"

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -193,7 +193,7 @@ else
   fi
 
   APPLY_ERRS=$(jq -r '.summary.errors_total // 0' "$APPLY_FILE")
-  APPLY_MAX_ORPHAN_REFUSALS=$(jq -r '[.errors[]? | (.error // "" | ascii_downcase) | select((contains("--max-orphan-dbs") or contains("max-orphan") or contains("orphan databases")) and (contains("refus") or contains("exceed")))] | length' "$APPLY_FILE")
+  APPLY_MAX_ORPHAN_REFUSALS=$(jq -r '[.errors[]? | select((.kind // "") == "max-orphan-refusal" or (((.error // "" | ascii_downcase) | (contains("--max-orphan-dbs") or contains("max-orphan") or contains("orphan databases")) and (contains("refus") or contains("exceed")))))] | length' "$APPLY_FILE")
   if [ "$APPLY_ERRS" -gt 0 ] || [ "$APPLY_MAX_ORPHAN_REFUSALS" -gt 0 ]; then
     ESCALATED=1
     APPLY_REFUSAL_MESSAGE="apply reported ${APPLY_ERRS} error(s); leaving work bead open"

--- a/examples/dolt/stale_db_formula_test.go
+++ b/examples/dolt/stale_db_formula_test.go
@@ -159,11 +159,22 @@ esac
 	}
 	for _, want := range []string{
 		"bd update bead-1 --append-notes",
-		"gc event emit mol-dog-stale-db.done",
+		"## apply (--force, refused)",
 		"gc event emit mol-dog-stale-db.escalate",
+		"gc runtime drain-ack",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("command log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
+	}
+	for _, forbidden := range []string{
+		"gc event emit mol-dog-stale-db.drop",
+		"gc event emit mol-dog-stale-db.purge",
+		"gc event emit mol-dog-stale-db.reap",
+		"gc event emit mol-dog-stale-db.done",
+	} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("rendered script logged forbidden success path %q despite apply errors\nlog:\n%s\noutput:\n%s", forbidden, log, out)
 		}
 	}
 	if strings.Contains(log, "bd close bead-1") {
@@ -581,6 +592,43 @@ esac
 	}
 	if strings.Contains(log, "bd close bead-1") {
 		t.Fatalf("rendered script closed bead despite SQL-backed apply failure\nlog:\n%s\noutput:\n%s", log, out)
+	}
+}
+
+func TestStaleDBFormulaExitZeroMaxOrphanRefusalLeavesWorkOpenWithoutSuccessEvents(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not found: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq not found: %v", err)
+	}
+
+	log, out, err := runStaleDBFormulaFailureCase(t, staleDBFailureCase{
+		scanJSON:  `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":20,"failed":[]},"purge":{"bytes_reclaimed":4096},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":4096,"bytes_freed_rss":0,"errors_total":0}}`,
+		applyJSON: `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":21,"failed":[]},"purge":{"ok":false,"bytes_reclaimed":0},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":0,"bytes_freed_rss":0,"errors_total":1},"errors":[{"stage":"drop","error":"refusing to drop 21 orphan databases; exceeds --max-orphan-dbs=20"}]}`,
+	})
+	if err == nil {
+		t.Fatalf("rendered script exited successfully; want exit-zero max-orphan refusal to keep work open\nlog:\n%s\noutput:\n%s", log, out)
+	}
+	for _, forbidden := range []string{
+		"gc event emit mol-dog-stale-db.drop",
+		"gc event emit mol-dog-stale-db.purge",
+		"gc event emit mol-dog-stale-db.reap",
+		"bd close bead-1",
+	} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("exit-zero max-orphan refusal logged forbidden success path %q\nlog:\n%s\noutput:\n%s", forbidden, log, out)
+		}
+	}
+	for _, want := range []string{
+		"bd update bead-1 --append-notes",
+		"## apply (--force, refused)",
+		"gc event emit mol-dog-stale-db.escalate",
+		"gc runtime drain-ack",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("exit-zero max-orphan refusal log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
 	}
 }
 

--- a/examples/dolt/stale_db_formula_test.go
+++ b/examples/dolt/stale_db_formula_test.go
@@ -33,7 +33,7 @@ func TestStaleDBFormulaRuntimeContract(t *testing.T) {
 		`trap cleanup EXIT`,
 		`drain_ack_once()`,
 		`gc dolt-cleanup --json --probe > "$SCAN_FILE"`,
-		`gc dolt-cleanup --json --probe --force > "$APPLY_FILE"`,
+		`gc dolt-cleanup --json --probe --force --max-orphan-dbs "{{max_orphans_for_sql}}" > "$APPLY_FILE"`,
 		`jq -r '.dropped.count // 0'`,
 		`jq -r '[.dropped.skipped[]? | select(.reason == "invalid-identifier")] | length'`,
 		`jq -r '.reaped.targets | length'`,
@@ -397,7 +397,7 @@ esac
 		t.Fatalf("rendered script failed: %v\nlog:\n%s\noutput:\n%s", err, log, out)
 	}
 	for _, want := range []string{
-		"gc dolt-cleanup --json --probe --force",
+		"gc dolt-cleanup --json --probe --force --max-orphan-dbs 20",
 		"gc event emit mol-dog-stale-db.done --message 1200 bytes freed; 0 errors",
 		"bd close bead-1",
 	} {
@@ -482,7 +482,7 @@ esac
 		t.Fatalf("rendered script failed: %v\nlog:\n%s\noutput:\n%s", err, log, out)
 	}
 	for _, want := range []string{
-		"gc dolt-cleanup --json --probe --force",
+		"gc dolt-cleanup --json --probe --force --max-orphan-dbs 20",
 		"gc event emit mol-dog-stale-db.done --message 4096 bytes freed; 0 errors",
 		"bd close bead-1",
 	} {
@@ -570,7 +570,7 @@ esac
 		t.Fatalf("rendered script exited successfully; want SQL-backed apply failure to keep work open\nlog:\n%s\noutput:\n%s", log, out)
 	}
 	for _, want := range []string{
-		"gc dolt-cleanup --json --probe --force",
+		"gc dolt-cleanup --json --probe --force --max-orphan-dbs 20",
 		"bd update bead-1 --append-notes",
 		"## apply (--force, failed)",
 		`"stage":"purge"`,

--- a/examples/dolt/stale_db_formula_test.go
+++ b/examples/dolt/stale_db_formula_test.go
@@ -605,7 +605,7 @@ func TestStaleDBFormulaExitZeroMaxOrphanRefusalLeavesWorkOpenWithoutSuccessEvent
 
 	log, out, err := runStaleDBFormulaFailureCase(t, staleDBFailureCase{
 		scanJSON:  `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":20,"failed":[]},"purge":{"bytes_reclaimed":4096},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":4096,"bytes_freed_rss":0,"errors_total":0}}`,
-		applyJSON: `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":21,"failed":[]},"purge":{"ok":false,"bytes_reclaimed":0},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":0,"bytes_freed_rss":0,"errors_total":1},"errors":[{"stage":"drop","error":"refusing to drop 21 orphan databases; exceeds --max-orphan-dbs=20"}]}`,
+		applyJSON: `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":21,"failed":[]},"purge":{"ok":false,"bytes_reclaimed":0},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":0,"bytes_freed_rss":0,"errors_total":1},"errors":[{"stage":"drop","kind":"max-orphan-refusal","error":"stale database threshold tripped"}]}`,
 	})
 	if err == nil {
 		t.Fatalf("rendered script exited successfully; want exit-zero max-orphan refusal to keep work open\nlog:\n%s\noutput:\n%s", log, out)
@@ -623,6 +623,7 @@ func TestStaleDBFormulaExitZeroMaxOrphanRefusalLeavesWorkOpenWithoutSuccessEvent
 	for _, want := range []string{
 		"bd update bead-1 --append-notes",
 		"## apply (--force, refused)",
+		"apply refused by max-orphan safety guard",
 		"gc event emit mol-dog-stale-db.escalate",
 		"gc runtime drain-ack",
 	} {

--- a/examples/dolt/stale_db_formula_test.go
+++ b/examples/dolt/stale_db_formula_test.go
@@ -641,6 +641,7 @@ type staleDBFailureCase struct {
 	wantNote     string
 	wantLog      string
 	forbidLog    string
+	forbidOutput string
 }
 
 func TestStaleDBFormulaFailurePathsDrainAck(t *testing.T) {
@@ -693,10 +694,12 @@ func TestStaleDBFormulaFailurePathsDrainAck(t *testing.T) {
 		{
 			name: "apply misses dry-run reclaimable bytes",
 			spec: staleDBFailureCase{
-				scanJSON:  `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":1,"failed":[]},"purge":{"bytes_reclaimed":4096},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":4096,"bytes_freed_rss":0,"errors_total":0}}`,
-				applyJSON: `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":1,"failed":[]},"purge":{"ok":true,"bytes_reclaimed":0},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":0,"bytes_freed_rss":0,"errors_total":0}}`,
-				wantNote:  "## apply (--force)",
-				wantLog:   "apply missed 4096 reclaimable bytes",
+				scanJSON:     `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":1,"failed":[]},"purge":{"bytes_reclaimed":4096},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":4096,"bytes_freed_rss":0,"errors_total":0}}`,
+				applyJSON:    `{"schema":"gc.dolt.cleanup.v1","dropped":{"count":1,"failed":[]},"purge":{"ok":true,"bytes_reclaimed":0},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":0,"bytes_freed_rss":0,"errors_total":0}}`,
+				wantNote:     "## apply (--force)",
+				wantLog:      "apply missed 4096 reclaimable bytes",
+				forbidLog:    "apply reported",
+				forbidOutput: "apply reported",
 			},
 		},
 		{
@@ -724,6 +727,9 @@ func TestStaleDBFormulaFailurePathsDrainAck(t *testing.T) {
 			}
 			if tc.spec.forbidLog != "" && strings.Contains(log, tc.spec.forbidLog) {
 				t.Fatalf("failure path log still contains unsupported copy %q\nlog:\n%s\noutput:\n%s", tc.spec.forbidLog, log, out)
+			}
+			if tc.spec.forbidOutput != "" && strings.Contains(string(out), tc.spec.forbidOutput) {
+				t.Fatalf("failure path output still contains unsupported copy %q\nlog:\n%s\noutput:\n%s", tc.spec.forbidOutput, log, out)
 			}
 			if strings.Contains(log, "bd close bead-1") {
 				t.Fatalf("failure path closed bead despite non-zero outcome\nlog:\n%s\noutput:\n%s", log, out)

--- a/internal/beads/bdstore_exec_internal_test.go
+++ b/internal/beads/bdstore_exec_internal_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package beads
 
 import (
@@ -48,7 +50,7 @@ wait
 		t.Fatal("child pid was empty")
 	}
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if err := exec.Command("kill", "-0", pid).Run(); err != nil {
 			return
 		}

--- a/internal/beads/exec_timeout_unix.go
+++ b/internal/beads/exec_timeout_unix.go
@@ -19,7 +19,7 @@ func killCommandTree(cmd *exec.Cmd) error {
 	}
 	pgid, err := syscall.Getpgid(cmd.Process.Pid)
 	if err == nil {
-		if killErr := syscall.Kill(-pgid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+		if killErr := syscall.Kill(-pgid, syscall.SIGKILL); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) && !errors.Is(killErr, syscall.ESRCH) {
 			return killErr
 		}
 		return nil


### PR DESCRIPTION
Follow-up to post-merge review for #1548.

Addresses blocked findings around dolt cleanup safety:
- rejects out-of-range TCP ports from flags, city config, and rig port files
- keeps legacy fallback port 3307 eligible for reap instead of auto-protecting it
- disables forced drop/purge when rig database metadata is missing or unreadable
- adds an apply-time --max-orphan-dbs guard for stale database drift
- skips force-mode purge byte accounting for rigs on a different dolt server port
- revalidates protection after SIGTERM before SIGKILL
- documents force-mode metadata requirements and JSON error fields

Verification:
- make test
- pre-commit hook: generated docs check, golangci-lint, go vet, fast unit tests, doc sync

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->