### PR TITLE
test: stop managed dolt in controller tests

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -256,6 +256,7 @@ func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
 	t.Setenv("GC_BEADS", "")
 
 	cityDir := shortSocketTempDir(t, "gc-state-runtime-builtin-")
+	cleanupManagedDoltTestCity(t, cityDir)
 	tomlPath := filepath.Join(cityDir, "city.toml")
 	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 		t.Fatalf("write initial city.toml: %v", err)
@@ -292,6 +293,7 @@ func TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending(t *tes
 	t.Setenv("GC_BEADS", "")
 
 	cityDir := shortSocketTempDir(t, "gc-state-mutation-builtin-")
+	cleanupManagedDoltTestCity(t, cityDir)
 	tomlPath := filepath.Join(cityDir, "city.toml")
 	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -426,6 +426,7 @@ func TestSendReloadControlRequestNoChange(t *testing.T) {
 	}
 
 	dir := shortSocketTempDir(t, "gc-reload-no-change-")
+	cleanupManagedDoltTestCity(t, dir)
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -494,6 +495,7 @@ func TestSendReloadControlRequestInvalidConfig(t *testing.T) {
 	}
 
 	dir := shortSocketTempDir(t, "gc-reload-invalid-")
+	cleanupManagedDoltTestCity(t, dir)
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -1564,6 +1564,7 @@ func TestSupervisorCreatesControllerSocketForManagedCity(t *testing.T) {
 	t.Setenv("GC_HOME", gcHome)
 
 	cityPath := shortSocketTempDir(t, "gc-supervisor-city-")
+	cleanupManagedDoltTestCity(t, cityPath)
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1796,6 +1796,7 @@ func TestControllerReloadCityNameChange(t *testing.T) {
 	t.Cleanup(func() { debounceDelay = old })
 
 	dir := shortSocketTempDir(t, "gc-rename-")
+	cleanupManagedDoltTestCity(t, dir)
 	tomlPath := writeCityTOML(t, dir, "test", "mayor")
 
 	cfg, err := config.Load(osFS{}, tomlPath)

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"io"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/testutil"
 )
@@ -42,4 +44,26 @@ func clearInheritedBeadsEnv(t *testing.T) {
 	} {
 		t.Setenv(key, "")
 	}
+}
+
+func cleanupManagedDoltTestCity(t *testing.T, cityPath string) {
+	t.Helper()
+	t.Cleanup(func() {
+		tryStopController(cityPath, io.Discard)
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if controllerAlive(cityPath) == 0 {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		if port := currentManagedDoltPort(cityPath); port != "" {
+			if _, err := stopManagedDoltProcess(cityPath, port); err != nil {
+				t.Logf("stopManagedDoltProcess(%s, %s): %v", cityPath, port, err)
+			}
+		}
+		if err := shutdownBeadsProvider(cityPath); err != nil {
+			t.Logf("shutdownBeadsProvider(%s): %v", cityPath, err)
+		}
+	})
 }

--- a/cmd/gc/script_resolve_test.go
+++ b/cmd/gc/script_resolve_test.go
@@ -312,6 +312,7 @@ func TestPruneLegacyConfiguredScripts_FallbackPreservesTopLevelScriptsTargets(t 
 func TestPrepareCityForSupervisorPrunesLegacyScripts(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "city")
+	cleanupManagedDoltTestCity(t, cityPath)
 	rigPath := filepath.Join(dir, "rig")
 	cityPackScripts := filepath.Join(dir, "packs/city/assets/scripts")
 	rigPackScripts := filepath.Join(dir, "packs/rig/assets/scripts")


### PR DESCRIPTION
## Summary
- add a test cleanup helper that stops controller-owned managed Dolt processes before test teardown
- wire the helper into controller/reload/supervisor tests that create managed test cities
- prevent these tests from leaving /data/tmp gc-* Dolt sql-server processes behind

## Tests
- go test ./cmd/gc -run 'TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision|TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending|TestSendReloadControlRequestNoChange|TestSendReloadControlRequestInvalidConfig|TestControllerReloadCityNameChange|TestSupervisorCreatesControllerSocketForManagedCity|TestPrepareCityForSupervisorPrunesLegacyScripts'
- pre-commit hook: gofmt, docs check, golangci-lint run, go vet, scripts/go-test-observable test -- -p=4 -count=1 ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->