### PR TITLE
fix: protect active test dolt cleanup roots

### DIFF
--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -157,10 +157,10 @@ func (r CleanupReport) MarshalJSON() ([]byte, error) {
 //
 // DiscoverProcesses and KillProcess are injection points for tests; in
 // production they default to the /proc walker and syscall.Kill respectively.
-// HomeDir defaults to the live $HOME and seeds the test-config-path allowlist
-// (~/.gotmp/Test* recognition). TempDir defaults to the live os.TempDir() and
-// lets the reaper recognize Go test temp roots on hosts where TMPDIR is not
-// /tmp.
+// HomeDir defaults to the live $HOME and seeds ~/.gotmp/Test* recognition.
+// TempDir defaults to the live os.TempDir() and lets the reaper recognize
+// Go test temp roots and known Gas City test prefixes on hosts where TMPDIR
+// is not /tmp.
 type cleanupOptions struct {
 	Flag           string
 	CityPort       int
@@ -188,6 +188,7 @@ type cleanupOptions struct {
 	DoltClientOpenErr error
 
 	DiscoverProcesses func() ([]DoltProcInfo, error)
+	ActiveTestRoots   []string
 	KillProcess       func(pid int, sig syscall.Signal) error
 	ReapGracePeriod   time.Duration
 }
@@ -307,7 +308,11 @@ func runReapStage(report *CleanupReport, opts cleanupOptions) {
 	if tempDir == "" {
 		tempDir = os.TempDir()
 	}
-	plan := planOrphanReap(procs, rigPorts, opts.HomeDir, tempDir)
+	activeTestRoots := opts.ActiveTestRoots
+	if activeTestRoots == nil {
+		activeTestRoots = discoverActiveTestRoots(opts.HomeDir, tempDir)
+	}
+	plan := planOrphanReap(procs, rigPorts, opts.HomeDir, tempDir, activeTestRoots)
 
 	report.Reaped.ProtectedPIDs = nil
 	for _, p := range plan.Protected {
@@ -337,7 +342,7 @@ func runReapStage(report *CleanupReport, opts cleanupOptions) {
 	gone := make(map[int]bool, len(plan.Reap))
 	sigtermSent := make(map[int]bool, len(plan.Reap))
 	for _, target := range plan.Reap {
-		switch revalidateReapTarget(report, discover, target, rigPorts, opts.HomeDir, tempDir, "SIGTERM") {
+		switch revalidateReapTarget(report, discover, target, rigPorts, opts.HomeDir, tempDir, activeTestRoots, "SIGTERM") {
 		case reapRevalidationEligible:
 		case reapRevalidationVanished:
 			appendVanishedPID(report, target.PID)
@@ -363,7 +368,7 @@ func runReapStage(report *CleanupReport, opts cleanupOptions) {
 		if gone[target.PID] || !sigtermSent[target.PID] {
 			continue
 		}
-		switch revalidateReapTarget(report, discover, target, rigPorts, opts.HomeDir, tempDir, "SIGKILL") {
+		switch revalidateReapTarget(report, discover, target, rigPorts, opts.HomeDir, tempDir, activeTestRoots, "SIGKILL") {
 		case reapRevalidationEligible:
 		case reapRevalidationVanished:
 			gone[target.PID] = true
@@ -414,7 +419,7 @@ const (
 	reapRevalidationError
 )
 
-func revalidateReapTarget(report *CleanupReport, discover func() ([]DoltProcInfo, error), target ReapTarget, rigPorts map[int]string, homeDir, tempDir, signalName string) reapRevalidationStatus {
+func revalidateReapTarget(report *CleanupReport, discover func() ([]DoltProcInfo, error), target ReapTarget, rigPorts map[int]string, homeDir, tempDir string, activeTestRoots []string, signalName string) reapRevalidationStatus {
 	refreshed, err := discover()
 	if err != nil {
 		recordReapRevalidationError(report, signalName, err)
@@ -424,7 +429,7 @@ func revalidateReapTarget(report *CleanupReport, discover func() ([]DoltProcInfo
 		if proc.PID != target.PID {
 			continue
 		}
-		recheck := classifyDoltProcess(proc, rigPorts, homeDir, tempDir)
+		recheck := classifyDoltProcess(proc, rigPorts, homeDir, tempDir, activeTestRoots)
 		if recheck.Action != "reap" || recheck.ConfigPath != target.ConfigPath || !sameReapProcessIdentity(target, proc) {
 			appendProtectedPID(report, target.PID)
 			return reapRevalidationProtected
@@ -735,9 +740,10 @@ or invalid rig port files fail closed before cleanup stages run; only
 absent rig port files can reach the legacy default.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
-Active rig dolt servers, registered rig databases, and processes
-outside the test-config-path allowlist (/tmp/Test*, os.TempDir()/Test*,
-~/.gotmp/Test*) are always protected — see the PROTECTED section of the
+Active rig dolt servers, registered rig databases, active test temp roots,
+and processes outside the test-config-path allowlist (/tmp/Test*,
+os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
+protected — see the PROTECTED section of the
 report. Destructive drops are limited to known stale test database name
 shapes and conservative SQL identifier characters; skipped stale matches
 are reported in dropped.skipped. Rig dolt_database names used for purge

--- a/cmd/gc/dolt_cleanup_discovery.go
+++ b/cmd/gc/dolt_cleanup_discovery.go
@@ -85,8 +85,85 @@ func discoverDoltProcesses() ([]DoltProcInfo, error) {
 	return out, nil
 }
 
+func discoverActiveTestRoots(homeDir, tempDir string) []string {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var roots []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		argv := splitCmdline(data)
+		if looksLikeDoltSQLServer(argv) {
+			continue
+		}
+		for _, arg := range argv {
+			root, ok := activeTestRootFromPath(arg, homeDir, tempDir)
+			if !ok {
+				continue
+			}
+			if _, exists := seen[root]; exists {
+				continue
+			}
+			seen[root] = struct{}{}
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}
+
+func activeTestRootFromPath(path, homeDir, tempDir string) (string, bool) {
+	clean := filepath.Clean(path)
+	for _, root := range []string{"/tmp", tempDir} {
+		if testRoot, ok := activeTestRootUnder(clean, root, testConfigPathPrefixes()); ok {
+			return testRoot, true
+		}
+	}
+	if homeDir == "" {
+		return "", false
+	}
+	return activeTestRootUnder(clean, filepath.Join(homeDir, ".gotmp"), []string{"Test"})
+}
+
+func activeTestRootUnder(cleanPath, root string, prefixes []string) (string, bool) {
+	if root == "" {
+		return "", false
+	}
+	cleanRoot := filepath.Clean(root)
+	if cleanRoot == "." || cleanRoot == string(filepath.Separator) {
+		return "", false
+	}
+	rootPrefix := cleanRoot + string(filepath.Separator)
+	if !strings.HasPrefix(cleanPath, rootPrefix) {
+		return "", false
+	}
+	child := strings.TrimPrefix(cleanPath, rootPrefix)
+	for _, prefix := range prefixes {
+		if !strings.HasPrefix(child, prefix) {
+			continue
+		}
+		nextSep := strings.IndexRune(child, filepath.Separator)
+		if nextSep < 0 {
+			return filepath.Join(cleanRoot, child), true
+		}
+		return filepath.Join(cleanRoot, child[:nextSep]), true
+	}
+	return "", false
+}
+
 func readProcStartTimeTicks(pid int) uint64 {
-	data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "stat"), procEnumerationTimeout)
+	data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
 	if err != nil {
 		return 0
 	}
@@ -111,7 +188,7 @@ func parseProcStartTimeTicks(data []byte) uint64 {
 }
 
 func readProcRSSBytes(pid int) int64 {
-	data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "statm"), procEnumerationTimeout)
+	data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "statm"))
 	if err != nil {
 		return 0
 	}
@@ -130,7 +207,7 @@ func readProcRSSBytes(pid int) int64 {
 // argv if and only if the process looks like `dolt sql-server`. The boolean
 // is false for any non-dolt process so callers can skip cheaply.
 func readDoltSQLServerArgv(pid int) ([]string, bool) {
-	data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"), procEnumerationTimeout)
+	data, err := readWithTimeout(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err != nil || len(data) == 0 {
 		return nil, false
 	}
@@ -256,8 +333,8 @@ func appendUniqueInt(s []int, v int) []int {
 
 // readWithTimeout reads a file with a deadline so a stuck /proc entry (a
 // kernel thread that's blocked) can't hang the discovery walk.
-func readWithTimeout(path string, timeout time.Duration) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func readWithTimeout(path string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), procEnumerationTimeout)
 	defer cancel()
 	type result struct {
 		data []byte

--- a/cmd/gc/dolt_cleanup_reaper.go
+++ b/cmd/gc/dolt_cleanup_reaper.go
@@ -75,29 +75,38 @@ func extractConfigPath(argv []string) string {
 	return ""
 }
 
-// isTestConfigPath reports whether p matches the architect-specified test
-// allowlist (§4.3 step 3): /tmp/Test*, <tempDir>/Test*, or
-// <homeDir>/.gotmp/Test*. The leading `Test` prefix matches Go's
-// testing-package convention; `go test` writes tmp dirs under those roots when
-// fixtures spin up dolt sql-server.
+// isTestConfigPath reports whether p matches the cleanup allowlist for test
+// Dolt configs: Go test temp roots, plus known Gas City unit-test prefixes
+// that use short socket-safe directories under os.TempDir().
 func isTestConfigPath(p, homeDir, tempDir string) bool {
 	if p == "" {
 		return false
 	}
 	clean := filepath.Clean(p)
-	if hasTestChildPrefix(clean, "/tmp") {
+	if hasTestChildPrefix(clean, "/tmp", testConfigPathPrefixes()) {
 		return true
 	}
-	if hasTestChildPrefix(clean, tempDir) {
+	if hasTestChildPrefix(clean, tempDir, testConfigPathPrefixes()) {
 		return true
 	}
 	if homeDir == "" {
 		return false
 	}
-	return hasTestChildPrefix(clean, filepath.Join(homeDir, ".gotmp"))
+	return hasTestChildPrefix(clean, filepath.Join(homeDir, ".gotmp"), []string{"Test"})
 }
 
-func hasTestChildPrefix(cleanPath, root string) bool {
+func testConfigPathPrefixes() []string {
+	return []string{
+		"Test",
+		"gc-state-runtime-builtin-",
+		"gc-state-mutation-builtin-",
+		"gc-supervisor-city-",
+		"gc-reload-invalid-",
+		"gc-rename-",
+	}
+}
+
+func hasTestChildPrefix(cleanPath, root string, prefixes []string) bool {
 	if root == "" {
 		return false
 	}
@@ -109,7 +118,30 @@ func hasTestChildPrefix(cleanPath, root string) bool {
 	if !strings.HasPrefix(cleanPath, rootPrefix) {
 		return false
 	}
-	return strings.HasPrefix(strings.TrimPrefix(cleanPath, rootPrefix), "Test")
+	child := strings.TrimPrefix(cleanPath, rootPrefix)
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(child, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func configUnderActiveTestRoot(configPath string, activeTestRoots []string) bool {
+	if configPath == "" {
+		return false
+	}
+	cleanConfig := filepath.Clean(configPath)
+	for _, root := range activeTestRoots {
+		cleanRoot := filepath.Clean(root)
+		if cleanRoot == "." || cleanRoot == string(filepath.Separator) {
+			continue
+		}
+		if cleanConfig == cleanRoot || strings.HasPrefix(cleanConfig, cleanRoot+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyDoltProcess applies the architect's reaper decision rules (§4.3) to a
@@ -118,10 +150,11 @@ func hasTestChildPrefix(cleanPath, root string) bool {
 //  1. Any port match against rigPortByPort → protected (active rig server),
 //     even if the cmdline says it's a test path (defense in depth).
 //  2. Else extract --config path; matches /tmp/Test*, os.TempDir()/Test*,
-//     or ~/.gotmp/Test* → reap.
-//  3. Else protect with a reason that echoes the actual config path so
+//     known Gas City temp prefixes → reap.
+//  3. Else protect if the config sits under an active test root.
+//  4. Else protect with a reason that echoes the actual config path so
 //     operators can decide whether to kill it manually (architect Open Q 0).
-func classifyDoltProcess(p DoltProcInfo, rigPortByPort map[int]string, homeDir, tempDir string) reapClassification {
+func classifyDoltProcess(p DoltProcInfo, rigPortByPort map[int]string, homeDir, tempDir string, activeTestRoots []string) reapClassification {
 	for _, port := range p.Ports {
 		if name, ok := rigPortByPort[port]; ok {
 			return reapClassification{
@@ -136,6 +169,13 @@ func classifyDoltProcess(p DoltProcInfo, rigPortByPort map[int]string, homeDir, 
 		return reapClassification{
 			Action: "protect",
 			Reason: "no --config path detected; refusing to kill an unidentified dolt server",
+		}
+	}
+	if configUnderActiveTestRoot(cfgPath, activeTestRoots) {
+		return reapClassification{
+			Action:     "protect",
+			Reason:     fmt.Sprintf("config %q is under an active test root", cfgPath),
+			ConfigPath: cfgPath,
 		}
 	}
 	if isTestConfigPath(cfgPath, homeDir, tempDir) {
@@ -153,10 +193,10 @@ func classifyDoltProcess(p DoltProcInfo, rigPortByPort map[int]string, homeDir, 
 // planOrphanReap classifies each dolt sql-server process and partitions them
 // into reap targets vs protected processes. Order is preserved so the report
 // renders deterministically.
-func planOrphanReap(procs []DoltProcInfo, rigPortByPort map[int]string, homeDir, tempDir string) ReapPlan {
+func planOrphanReap(procs []DoltProcInfo, rigPortByPort map[int]string, homeDir, tempDir string, activeTestRoots []string) ReapPlan {
 	plan := ReapPlan{}
 	for _, p := range procs {
-		c := classifyDoltProcess(p, rigPortByPort, homeDir, tempDir)
+		c := classifyDoltProcess(p, rigPortByPort, homeDir, tempDir, activeTestRoots)
 		switch c.Action {
 		case "reap":
 			plan.Reap = append(plan.Reap, ReapTarget{

--- a/cmd/gc/dolt_cleanup_reaper_test.go
+++ b/cmd/gc/dolt_cleanup_reaper_test.go
@@ -59,6 +59,12 @@ func TestIsTestConfigPath_ProcessTempDirTestPrefix(t *testing.T) {
 	}
 }
 
+func TestIsTestConfigPath_KnownGCTestPrefix(t *testing.T) {
+	if !isTestConfigPath("/data/tmp/gc-state-mutation-builtin-123/.gc/runtime/packs/dolt/dolt-config.yaml", "/home/u", "/data/tmp") {
+		t.Error("expected known gc-* test prefix under os.TempDir() to be a test path")
+	}
+}
+
 func TestIsTestConfigPath_NotTest(t *testing.T) {
 	cases := []string{
 		"/tmp/be-s9d-bench-dolt/config.yaml", // benchmark
@@ -81,7 +87,7 @@ func TestClassifyDoltProcess_ProtectedByRigPort(t *testing.T) {
 		Argv:  []string{"dolt", "sql-server", "--config", "/tmp/TestFoo/config.yaml"},
 		Ports: []int{28231},
 	}
-	got := classifyDoltProcess(p, map[int]string{28231: "beads"}, "/home/u", "")
+	got := classifyDoltProcess(p, map[int]string{28231: "beads"}, "/home/u", "", nil)
 
 	if got.Action != "protect" {
 		t.Errorf("Action = %q, want protect", got.Action)
@@ -97,13 +103,29 @@ func TestClassifyDoltProcess_OrphanByTestPath(t *testing.T) {
 		Argv:  []string{"dolt", "sql-server", "--config", "/tmp/TestMailRouter9182/config.yaml"},
 		Ports: []int{},
 	}
-	got := classifyDoltProcess(p, nil, "/home/u", "")
+	got := classifyDoltProcess(p, nil, "/home/u", "", nil)
 
 	if got.Action != "reap" {
 		t.Errorf("Action = %q, want reap", got.Action)
 	}
 	if got.ConfigPath != "/tmp/TestMailRouter9182/config.yaml" {
 		t.Errorf("ConfigPath = %q", got.ConfigPath)
+	}
+}
+
+func TestClassifyDoltProcess_ProtectsActiveTestRoot(t *testing.T) {
+	p := DoltProcInfo{
+		PID:   2223,
+		Argv:  []string{"dolt", "sql-server", "--config", "/tmp/TestPersonalWorkFormulaCompileAndRun123/001/city/.gc/runtime/packs/dolt/dolt-config.yaml"},
+		Ports: []int{},
+	}
+	got := classifyDoltProcess(p, nil, "/home/u", "", []string{"/tmp/TestPersonalWorkFormulaCompileAndRun123"})
+
+	if got.Action != "protect" {
+		t.Errorf("Action = %q, want protect", got.Action)
+	}
+	if !strings.Contains(got.Reason, "active test root") {
+		t.Errorf("Reason = %q, want active-test-root reason", got.Reason)
 	}
 }
 
@@ -114,7 +136,7 @@ func TestClassifyDoltProcess_ProtectedByPathNotOnAllowlist(t *testing.T) {
 		Argv:  []string{"dolt", "sql-server", "--config", "/tmp/be-s9d-bench-dolt/config.yaml"},
 		Ports: []int{33400},
 	}
-	got := classifyDoltProcess(p, nil, "/home/u", "")
+	got := classifyDoltProcess(p, nil, "/home/u", "", nil)
 
 	if got.Action != "protect" {
 		t.Errorf("Action = %q, want protect", got.Action)
@@ -134,7 +156,7 @@ func TestClassifyDoltProcess_ProtectedWhenConfigMissing(t *testing.T) {
 		Argv:  []string{"dolt", "sql-server"},
 		Ports: []int{},
 	}
-	got := classifyDoltProcess(p, nil, "/home/u", "")
+	got := classifyDoltProcess(p, nil, "/home/u", "", nil)
 
 	if got.Action != "protect" {
 		t.Errorf("Action = %q, want protect", got.Action)
@@ -151,7 +173,7 @@ func TestClassifyDoltProcess_RigPortBeatsConfigPath(t *testing.T) {
 		Argv:  []string{"dolt", "sql-server", "--config", "/tmp/TestSomething/config.yaml"},
 		Ports: []int{28231},
 	}
-	got := classifyDoltProcess(p, map[int]string{28231: "beads"}, "/home/u", "")
+	got := classifyDoltProcess(p, map[int]string{28231: "beads"}, "/home/u", "", nil)
 
 	if got.Action != "protect" {
 		t.Errorf("Action = %q, want protect (rig port wins)", got.Action)
@@ -164,12 +186,14 @@ func TestPlanReap_BuildsOrphanAndProtectedLists(t *testing.T) {
 		{PID: 1281044, Argv: []string{"dolt", "sql-server", "--config", "/tmp/TestA/config.yaml"}},
 		{PID: 1319499, Ports: []int{33400}, Argv: []string{"dolt", "sql-server", "--config", "/tmp/be-s9d-bench-dolt/config.yaml"}},
 		{PID: 1281099, Argv: []string{"dolt", "sql-server", "--config", "/tmp/TestB/config.yaml"}},
+		{PID: 1281100, Argv: []string{"dolt", "sql-server", "--config", "/data/tmp/gc-state-runtime-builtin-1/.gc/runtime/packs/dolt/dolt-config.yaml"}},
+		{PID: 1281101, Argv: []string{"dolt", "sql-server", "--config", "/tmp/TestActive/001/city/.gc/runtime/packs/dolt/dolt-config.yaml"}},
 	}
 	rigPorts := map[int]string{28231: "beads"}
 
-	plan := planOrphanReap(procs, rigPorts, "/home/u", "")
+	plan := planOrphanReap(procs, rigPorts, "/home/u", "/data/tmp", []string{"/tmp/TestActive"})
 
-	wantReap := []int{1281044, 1281099}
+	wantReap := []int{1281044, 1281099, 1281100}
 	gotReap := make([]int, 0, len(plan.Reap))
 	for _, target := range plan.Reap {
 		gotReap = append(gotReap, target.PID)
@@ -178,7 +202,7 @@ func TestPlanReap_BuildsOrphanAndProtectedLists(t *testing.T) {
 		t.Errorf("Reap PIDs = %v, want %v", gotReap, wantReap)
 	}
 
-	wantProtected := []int{1138290, 1319499}
+	wantProtected := []int{1138290, 1319499, 1281101}
 	gotProtected := make([]int, 0, len(plan.Protected))
 	for _, e := range plan.Protected {
 		gotProtected = append(gotProtected, e.PID)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -923,9 +923,10 @@ or invalid rig port files fail closed before cleanup stages run; only
 absent rig port files can reach the legacy default.
 
 Dry-run by default. Pass --force to actually drop, purge, and kill.
-Active rig dolt servers, registered rig databases, and processes
-outside the test-config-path allowlist (/tmp/Test*, os.TempDir()/Test*,
-~/.gotmp/Test*) are always protected — see the PROTECTED section of the
+Active rig dolt servers, registered rig databases, active test temp roots,
+and processes outside the test-config-path allowlist (/tmp/Test*,
+os.TempDir()/Test*, known Gas City test prefixes, ~/.gotmp/Test*) are always
+protected — see the PROTECTED section of the
 report. Destructive drops are limited to known stale test database name
 shapes and conservative SQL identifier characters; skipped stale matches
 are reported in dropped.skipped. Rig dolt_database names used for purge


### PR DESCRIPTION
## Summary
- protect Dolt sql-server processes whose configs are under currently active test roots
- classify known Gas City short temp directory prefixes as test-owned cleanup candidates once no active test process owns them
- discover active test roots from /proc without treating dolt sql-server itself as ownership evidence
- update generated CLI docs for gc dolt-cleanup reaper behavior

## Tests
- go test ./cmd/gc -run 'Test.*DoltCleanup|Test.*Reap|Test.*ConfigPath|TestParseProcStartTimeTicks|TestSplitCmdline|TestLooksLikeDoltSQLServer'
- pre-commit hook: gofmt/docs generation, golangci-lint run, go vet, scripts/go-test-observable test -- -p=4 -count=1 ./..., go test ./test/docsync

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->