### PR TITLE
fix(maintenance): rewrite gate-sweep.sh to use real bd primitives

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
@@ -1,50 +1,17 @@
 #!/usr/bin/env bash
 # gate-sweep — evaluate and close pending gates.
 #
-# Replaces the deacon patrol check-gates step. All gate evaluation is
-# deterministic: timer gates are timestamp comparison, condition gates
-# are exit code checks, GitHub gates are API status queries.
+# Runs as an exec order (no LLM, no agent, no wisp). bd dispatches per
+# type. `|| true` is load-bearing: bd shells out to `gh` for gh:run /
+# gh:pr gates, and fresh cities without `gh auth` would otherwise fail
+# this order on every 30s cooldown. bd's combined output reaches the
+# controller log only on non-zero exit (cmd/gc/order_dispatch.go:466-475),
+# so the suppression also hides real bd errors — diagnose by hand.
 #
-# Runs as an exec order (no LLM, no agent, no wisp).
+# Bead-type gates are skipped: checkBeadGate is hard-coded to fail in
+# beads v1.0.2 (cmd/bd/gate.go:732, multi-rig routing removed). Restore
+# `bd gate check --type=bead --escalate` when beads adds it back.
 set -euo pipefail
 
-CITY="${GC_CITY:-.}"
-
-# Step 1: Close elapsed timer gates.
-# bd gate check evaluates all open gate beads, closes those past their
-# timeout, and prints a summary. --escalate sends mail for expired gates.
-bd gate check --type=timer --escalate 2>/dev/null || true
-
-# Step 2: Evaluate condition gates.
-# For each open condition gate, run its check command. Close if exit 0.
-CONDITION_GATES=$(bd gate list --type=condition --status=open --json 2>/dev/null) || true
-if [ -n "$CONDITION_GATES" ] && [ "$CONDITION_GATES" != "[]" ]; then
-    echo "$CONDITION_GATES" | jq -r '.[] | "\(.id)\t\(.metadata.check)"' 2>/dev/null | while IFS=$'\t' read -r gate_id check_cmd; do
-        if [ -n "$check_cmd" ] && eval "$check_cmd" >/dev/null 2>&1; then
-            bd gate close "$gate_id" --reason "condition satisfied" 2>/dev/null || true
-        fi
-    done
-fi
-
-# Step 3: Evaluate GitHub gates (gh:run, gh:pr).
-# For each open GitHub gate, check the workflow/PR status and close if done.
-GH_GATES=$(bd gate list --type=gh --status=open --json 2>/dev/null) || true
-if [ -n "$GH_GATES" ] && [ "$GH_GATES" != "[]" ]; then
-    echo "$GH_GATES" | jq -r '.[] | "\(.id)\t\(.metadata.await_type)\t\(.metadata.ref)"' 2>/dev/null | while IFS=$'\t' read -r gate_id await_type ref; do
-        case "$await_type" in
-            gh:run)
-                STATUS=$(gh run view "$ref" --json status -q .status 2>/dev/null) || continue
-                if [ "$STATUS" = "completed" ]; then
-                    CONCLUSION=$(gh run view "$ref" --json conclusion -q .conclusion 2>/dev/null)
-                    bd gate close "$gate_id" --reason "workflow $CONCLUSION" 2>/dev/null || true
-                fi
-                ;;
-            gh:pr)
-                STATE=$(gh pr view "$ref" --json state -q .state 2>/dev/null) || continue
-                if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
-                    bd gate close "$gate_id" --reason "PR $STATE" 2>/dev/null || true
-                fi
-                ;;
-        esac
-    done
-fi
+bd gate check --type=timer --escalate || true
+bd gate check --type=gh --escalate || true

--- a/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
@@ -8,9 +8,9 @@
 # controller log only on non-zero exit (cmd/gc/order_dispatch.go:466-475),
 # so the suppression also hides real bd errors — diagnose by hand.
 #
-# Bead-type gates are skipped: checkBeadGate is hard-coded to fail in
-# beads v1.0.2 (cmd/bd/gate.go:732, multi-rig routing removed). Restore
-# `bd gate check --type=bead --escalate` when beads adds it back.
+# Bead-type gates are skipped: in beads v1.0.2, checkBeadGate is
+# hard-coded to fail because cross-rig routing was removed upstream.
+# Restore `bd gate check --type=bead --escalate` when beads adds it back.
 set -euo pipefail
 
 bd gate check --type=timer --escalate || true

--- a/examples/gastown/packs/maintenance/orders/gate-sweep.toml
+++ b/examples/gastown/packs/maintenance/orders/gate-sweep.toml
@@ -1,10 +1,8 @@
-# Replaces deacon patrol step: check-gates
-#
-# Gate evaluation is 100% mechanical — timer comparison, cron matching,
-# condition exit codes. No LLM judgment needed. The controller runs this
+# Gate evaluation is 100% mechanical — timer comparison and GitHub API
+# status decoding. No LLM judgment needed. The controller runs this
 # directly via exec instead of burning agent context.
 [order]
-description = "Evaluate and close pending gates (timer, condition, GitHub)"
+description = "Evaluate and close pending gates (timer, GitHub)"
 trigger = "cooldown"
 interval = "30s"
 exec = "$PACK_DIR/assets/scripts/gate-sweep.sh"


### PR DESCRIPTION
## Summary

`scripts/gate-sweep.sh` in the maintenance pack was calling `bd gate list --type=… --status=…`. Neither flag exists on `bd gate list` (per `bd gate list --help`); both live on `bd gate check`. The script also referenced a `condition` gate type that isn't supported (real types per `bd gate check --help`: `timer`, `gh`, `gh:run`, `gh:pr`, `bead`).

Errors were masked via `2>/dev/null || true`, so two of three evaluation steps were silent dead code. Net effect: only `timer` gates were actually being evaluated. GitHub-gate evaluation was silently dropped.

`bash -x` trace of one cycle reproduced the issue:

```
+ bd gate check --type=timer --escalate
No open gates of type 'timer' found.
++ bd gate list --type=condition --status=open --json
+ CONDITION_GATES=
++ bd gate list --type=gh --status=open --json
+ GH_GATES=
```

`bd gate list --type=condition` returns `Error: unknown flag: --type` when the `2>/dev/null` is removed.

## Fix

Replace the broken plumbing with two explicit `bd gate check --type=X --escalate` calls:

- **timer**: was already correct; preserved as-is.
- **gh**: new — the previous path was no-op due to broken flags. bd queries the `gh` CLI internally for `gh:run` / `gh:pr`.

`bead`-type gates are excluded by design: in beads v1.0.2, `checkBeadGate` is hard-coded to fail after multi-rig routing was removed (`cmd/bd/gate.go:732`). The script comment notes where to restore `--type=bead` once cross-rig resolution lands upstream.

The `|| true` swallow is preserved with an updated comment that names both the reason (fresh cities without `gh auth` would otherwise fail this order on every 30s cooldown) and the diagnostic trade-off: exec orders only persist a command's combined output to the controller log on non-zero exit (`cmd/gc/order_dispatch.go:466-475`), so suppressed errors are visible only by running the script by hand.

Drive-by: cleaned stale `condition` mentions in `orders/gate-sweep.toml` (header comment + order description).

## Behavior change

Cities running this order will start auto-resolving `gh:run` / `gh:pr` gates that were previously silently skipped. Cities without `gh auth` configured see no observable change due to `|| true`.

## Out of scope (filing as follow-ups)

- **No script-body test for `gate-sweep.sh`.** This is a pack-wide gap — none of the eight maintenance scripts have body coverage; tests only assert materialization + env wiring (`cmd/gc/embed_builtin_packs_test.go`, `cmd/gc/order_dispatch_test.go`). The original bug shipped because no test invoked the script. Adding script-level coverage is a separate concern and worth maintainer guidance on the right tier (testscript with stub `bd` on PATH? acceptance test against a real city?).

## Test plan

- [x] `bash -n examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh` (syntax)
- [x] `make build`
- [x] `make check` (vet + lint + tests, all clean)
- [x] Manually verified `bd gate check --type=timer --escalate` and `bd gate check --type=gh --escalate` are valid against `bd` v1.0.2
- [x] Confirmed no caller parses gate-sweep stdout/stderr (tutorial goldens reference order name only)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->