### PR TITLE
fix(tmux): drive tmux-theme.sh from session-name primitives, not role names

### DIFF
--- a/examples/gastown/packs/gastown/assets/scripts/tmux-theme.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/tmux-theme.sh
@@ -2,57 +2,48 @@
 # tmux-theme.sh — Gas Town status bar theme with colors and icons.
 # Usage: tmux-theme.sh <session> <agent> <config-dir>
 #
-# Applies role-based color theme and status bar formatting.
-# Role is extracted from the agent name (bare name or rig--name).
+# Theme tier is driven by SDK session-name primitives — no role awareness:
+#
+#   "<rig>--*"     -> rig tier   (witness, refinery, polecat, crew within a rig)
+#   "<scope>__*"   -> scope tier (mayor, deacon — city-scoped roles)
+#   "<base>-N"     -> pool tier  (dog-1, dog-2, generic pool members)
+#   anything else  -> default tier
+#
+# The "--" and "__" separators correspond to the SDK session-name mapping
+# (slash → "--", dot → "__") in internal/agent/session_name.go. Keying on
+# the separator rather than role names lets this script work for any pack,
+# including custom packs whose role taxonomy differs from gastown's. Same
+# pattern as cycle.sh (#1571) and bind-key.sh (#1573).
 SESSION="$1" AGENT="$2" CONFIGDIR="$3"
 
 # Socket-aware tmux command (uses GC_TMUX_SOCKET when set).
 gcmux() { tmux ${GC_TMUX_SOCKET:+-L "$GC_TMUX_SOCKET"} "$@"; }
 
-# ── Determine role from agent name ──────────────────────────────────────
-# Rig-scoped: "myrig--polecat-1" → role "polecat"
-# City-scoped: "mayor" → role "mayor", "dog-2" → role "dog"
-case "$AGENT" in
-    */polecat-*|*--polecat-*) role="polecat" ;;
-    */polecat|*--polecat)     role="polecat" ;;
-    */witness|*--witness)     role="witness" ;;
-    */refinery|*--refinery)   role="refinery" ;;
-    */crew/*|*--crew--*)      role="crew" ;;
-    mayor)                    role="mayor" ;;
-    deacon)                   role="deacon" ;;
-    boot)                     role="boot" ;;
-    dog-[0-9]*|dog)           role="dog" ;;
-    *)                        role="" ;;
+# Determine theme tier by session-name shape.
+case "$SESSION" in
+    *--*)       tier="rig" ;;
+    *__*)       tier="scope" ;;
+    *-[0-9]*)   tier="pool" ;;
+    *)          tier="default" ;;
 esac
 
-# ── Color theme (bg/fg) per role ────────────────────────────────────────
-# Matches the Go palette in internal/session/tmux/theme.go.
-case "$role" in
-    mayor)   bg="#3d3200" fg="#ffd700" ;;  # gold/dark
-    deacon)  bg="#2d1f3d" fg="#c0b0d0" ;;  # purple/silver
-    dog)     bg="#3d2f1f" fg="#d0c0a0" ;;  # brown/tan
-    witness) bg="#0d5c63" fg="#e0e0e0" ;;  # teal
-    refinery) bg="#4a5568" fg="#e0e0e0" ;; # slate
-    polecat) bg="#1e3a5f" fg="#e0e0e0" ;;  # ocean
-    crew)    bg="#2d5a3d" fg="#e0e0e0" ;;  # forest
-    boot)    bg="#1a1a2e" fg="#c0c0c0" ;;  # midnight
-    *)       bg="#4a5568" fg="#e0e0e0" ;;  # slate (default)
+# Tier color theme (bg/fg).
+case "$tier" in
+    rig)     bg="#1e3a5f" fg="#e0e0e0" ;;  # ocean
+    scope)   bg="#2d1f3d" fg="#c0b0d0" ;;  # purple/silver
+    pool)    bg="#3d2f1f" fg="#d0c0a0" ;;  # brown/tan
+    *)       bg="#4a5568" fg="#e0e0e0" ;;  # slate
 esac
 
-# ── Role icon ───────────────────────────────────────────────────────────
-case "$role" in
-    mayor)   icon="🎩" ;;
-    deacon)  icon="🐺" ;;
-    witness) icon="🦉" ;;
-    refinery) icon="🏭" ;;
-    crew)    icon="👷" ;;
-    polecat) icon="😺" ;;
-    dog)     icon="🐕" ;;
-    boot)    icon="⚡" ;;
+# Tier icon.
+case "$tier" in
+    rig)     icon="⛏" ;;
+    scope)   icon="🏛" ;;
+    pool)    icon="🌊" ;;
     *)       icon="●" ;;
 esac
 
-# ── Apply theme ─────────────────────────────────────────────────────────
+# Apply theme.
 gcmux set-option -t "$SESSION" status-position bottom
 gcmux set-option -t "$SESSION" status-style "bg=$bg,fg=$fg"
 gcmux set-option -t "$SESSION" status-left-length 25
@@ -61,6 +52,6 @@ gcmux set-option -t "$SESSION" status-right-length 80
 gcmux set-option -t "$SESSION" status-interval 5
 gcmux set-option -t "$SESSION" status-right "#($CONFIGDIR/assets/scripts/status-line.sh $AGENT) %H:%M"
 
-# ── Mouse + clipboard ─────────────────────────────────────────────────
+# Mouse + clipboard.
 gcmux set-option -t "$SESSION" mouse on
 gcmux set-option -t "$SESSION" set-clipboard on

--- a/examples/gastown/tmux_theme_script_test.go
+++ b/examples/gastown/tmux_theme_script_test.go
@@ -1,0 +1,180 @@
+package gastown_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTmuxThemeScriptDrivesByScopeTier exercises tmux-theme.sh against a
+// stubbed tmux that logs every set-option call. The script under test
+// keys on session-name shape (no role awareness):
+//
+//	"<rig>--*"     -> rig tier   (color: ocean,  icon: ⛏)
+//	"<scope>__*"   -> scope tier (color: plum,   icon: 🏛)
+//	"<base>-N"     -> pool tier  (color: tan,    icon: 🌊)
+//	anything else  -> default    (color: slate,  icon: ●)
+//
+// The cases below cover one example per tier plus regression coverage
+// for the original bug: a crew agent (gascity--navani) used to fall to
+// the default tier because the role-detection regex looked for a literal
+// "crew" substring that the SDK session-name primitive never produces.
+func TestTmuxThemeScriptDrivesByScopeTier(t *testing.T) {
+	themeScript := filepath.Join(exampleDir(), "packs", "gastown", "assets", "scripts", "tmux-theme.sh")
+	if _, err := os.Stat(themeScript); err != nil {
+		t.Fatalf("tmux-theme.sh not found at %s: %v", themeScript, err)
+	}
+
+	tests := []struct {
+		name    string
+		session string
+		agent   string
+		// wantBG / wantIcon anchor the assertion. Empty wantBG means "skip color check".
+		wantBG   string
+		wantIcon string
+	}{
+		{
+			name:     "rig tier: rig-scoped agent",
+			session:  "gascity--witness",
+			agent:    "gascity/witness",
+			wantBG:   "#1e3a5f",
+			wantIcon: "⛏",
+		},
+		{
+			name:     "rig tier: crew (regression for original bug)",
+			session:  "gascity--navani",
+			agent:    "gascity/navani",
+			wantBG:   "#1e3a5f",
+			wantIcon: "⛏",
+		},
+		{
+			name:     "rig tier: rig-scoped pool member (--polecat-1)",
+			session:  "gascity--polecat-1",
+			agent:    "gascity/polecat-1",
+			wantBG:   "#1e3a5f",
+			wantIcon: "⛏",
+		},
+		{
+			name:     "scope tier: city-scoped role",
+			session:  "gastown__mayor",
+			agent:    "gastown.mayor",
+			wantBG:   "#2d1f3d",
+			wantIcon: "🏛",
+		},
+		{
+			name:     "scope tier: another city-scoped role",
+			session:  "gastown__deacon",
+			agent:    "gastown.deacon",
+			wantBG:   "#2d1f3d",
+			wantIcon: "🏛",
+		},
+		{
+			name:     "pool tier: generic <base>-N member",
+			session:  "dog-1",
+			agent:    "dog-1",
+			wantBG:   "#3d2f1f",
+			wantIcon: "🌊",
+		},
+		{
+			name:     "default tier: bare name (no separator)",
+			session:  "boot",
+			agent:    "boot",
+			wantBG:   "#4a5568",
+			wantIcon: "●",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			optLog := filepath.Join(t.TempDir(), "tmux-set-option.log")
+
+			// Stub tmux: log every argv to the file. The script only invokes
+			// `tmux set-option ...` after the tier branches, so the log
+			// captures the tier-driven decisions.
+			writeExecutable(t, filepath.Join(binDir, "tmux"), `#!/bin/sh
+# Drop a leading "-L <socket>" pair if present (the script sets it via
+# GC_TMUX_SOCKET when configured; we leave that env unset here, but be
+# defensive in case the harness changes).
+if [ "$1" = "-L" ]; then
+    shift 2
+fi
+printf '%s\n' "$*" >> "$TMUX_OPT_LOG"
+exit 0
+`)
+
+			env := map[string]string{
+				"PATH":           binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+				"TMUX_OPT_LOG":   optLog,
+				"GC_TMUX_SOCKET": "", // disable -L flag so stub sees clean argv
+			}
+
+			cmd := exec.Command(themeScript, tt.session, tt.agent, "/tmp/cfg")
+			cmd.Env = mergeTestEnv(env)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("tmux-theme.sh failed: %v\n%s", err, out)
+			}
+
+			logBytes, _ := os.ReadFile(optLog)
+			log := string(logBytes)
+
+			// Color: search for the bg=<hex> in the status-style call.
+			if tt.wantBG != "" {
+				wantStyle := "status-style bg=" + tt.wantBG
+				if !strings.Contains(log, wantStyle) {
+					t.Errorf("expected status-style with bg=%s in log, got:\n%s", tt.wantBG, log)
+				}
+			}
+
+			// Icon: search for the icon in the status-left call.
+			if tt.wantIcon != "" {
+				wantLeft := "status-left " + tt.wantIcon + " " + tt.agent
+				if !strings.Contains(log, wantLeft) {
+					t.Errorf("expected status-left containing %q for agent %q, got:\n%s", tt.wantIcon, tt.agent, log)
+				}
+			}
+		})
+	}
+}
+
+// TestTmuxThemeScriptHasNoHardcodedRoleNames is a structural property
+// test: the new tier-based script must not contain any hardcoded role
+// names from the gastown taxonomy. The whole point of the fix is
+// pack-portability — a custom pack with different roles should be
+// themed correctly without forking this script.
+func TestTmuxThemeScriptHasNoHardcodedRoleNames(t *testing.T) {
+	themeScript := filepath.Join(exampleDir(), "packs", "gastown", "assets", "scripts", "tmux-theme.sh")
+	body, err := os.ReadFile(themeScript)
+	if err != nil {
+		t.Fatalf("read tmux-theme.sh: %v", err)
+	}
+	src := string(body)
+
+	// Strip leading-comment lines so we don't false-positive on docs that
+	// mention old role names (e.g. "(witness, refinery, polecat, crew within
+	// a rig)" in the tier-mapping comment).
+	var codeOnly strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		codeOnly.WriteString(line)
+		codeOnly.WriteString("\n")
+	}
+	code := codeOnly.String()
+
+	forbidden := []string{
+		"polecat", "witness", "refinery", "crew",
+		"mayor", "deacon", "boot", "dog",
+	}
+	for _, role := range forbidden {
+		if strings.Contains(code, role) {
+			t.Errorf("script code (excluding comments) contains hardcoded role name %q; "+
+				"the tier-based fix removes role-name awareness", role)
+		}
+	}
+}


### PR DESCRIPTION
## What

`examples/gastown/packs/gastown/assets/scripts/tmux-theme.sh` previously detected agent role from `$AGENT` via hardcoded patterns mixing both qualified-name (`*/witness`) and session-name (`*--witness`) forms, then mapped role → color/icon. The case branch for crew (`*/crew/*|*--crew--*`) never matched anything because the SDK session-name primitive (`internal/agent/session_name.go`) does not produce a literal `crew` substring — `gascity/navani` becomes `gascity--navani`, not `gascity--crew--navani`. Crew agents fell to the default `*` slate tier.

The fix drives tier selection from session-name separators alone:

```
"<rig>--*"     -> rig tier   (witness, refinery, polecat, crew within a rig)
"<scope>__*"   -> scope tier (mayor, deacon — city-scoped roles)
"<base>-N"     -> pool tier  (dog-1, dog-2, generic pool members)
anything else  -> default tier
```

No role-name awareness in the script. Switching to `$SESSION` (canonical session name with `--`/`__` separators) instead of `$AGENT` (qualified name with `/`/`.`) lets the case branches consume the SDK primitive directly.

## Architectural principle

Same pattern as #1571 (cycle.sh) and #1573 (bind-key.sh): pack scripts consume the SDK's session-name primitive instead of re-deriving identity from role-name tables. The qualified `<rig>/<agent>` and `<scope>.<agent>` forms map to `<rig>--<agent>` and `<scope>__<agent>` via the canonical contract in `internal/agent/session_name.go`; pack scripts that key on the separator work for any pack regardless of its role taxonomy.

This is the per-PR continuation of `engdocs/design/session-model-unification.md` (Codex, Accepted 2026-04-10) on a different surface — see #1623 for the "pack/CLI surface conformance to canonical SDK primitives" cluster.

## Trade-off

Loses per-role color/icon granularity within a tier (e.g. mayor + deacon both get the scope-tier color; witness + refinery + crew + polecat all get the rig-tier color). Gains: pack-portability + zero hardcoded role names in the script + bug fix for crew agents.

Custom packs that want richer theming can ship their own tmux-theme.sh overlay; the SDK ships a sane default that works everywhere.

## Test

`examples/gastown/tmux_theme_script_test.go`:
- `TestTmuxThemeScriptDrivesByScopeTier` (7 sub-tests): one example per tier (rig, scope, pool, default) plus regression coverage for the original crew bug. Stub tmux on PATH logs `set-option` calls; assertions anchor on the tier-driven `bg=` and `status-left $icon $agent`.
- `TestTmuxThemeScriptHasNoHardcodedRoleNames` (structural property): the script's executable lines (excluding comments) must not contain any name from gastown's role taxonomy. Pins the no-role-awareness invariant.

Same test pattern as `cycle_script_test.go` (stub binary on PATH, exec script, assert on logged calls).

## Watch list (if filed by us)

- [ ] CI green
- [ ] Review feedback addressed
- [ ] Merge upstream → drop local pack divergence (if applicable; our local pack at `~/qlandia/packs/gastown/...` already overrides this with a richer rig-color × role-saturation theme — that overlay stays as-is)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->