### PR TITLE
fix(beads): add Ready query parameters

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -33,7 +33,7 @@ type readyFailStore struct {
 	readyCalls int
 }
 
-func (s *readyFailStore) Ready() ([]beads.Bead, error) {
+func (s *readyFailStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
 	s.readyCalls++
 	return nil, errors.New("backing ready should not be used")
 }
@@ -44,7 +44,7 @@ type readyStaticStore struct {
 	readyCalls int
 }
 
-func (s *readyStaticStore) Ready() ([]beads.Bead, error) {
+func (s *readyStaticStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
 	s.readyCalls++
 	out := make([]beads.Bead, len(s.ready))
 	copy(out, s.ready)
@@ -113,8 +113,8 @@ func (s *partialAssignedWorkStore) List(query beads.ListQuery) ([]beads.Bead, er
 	return rows, nil
 }
 
-func (s *partialAssignedWorkStore) Ready() ([]beads.Bead, error) {
-	rows, err := s.MemStore.Ready()
+func (s *partialAssignedWorkStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	rows, err := s.MemStore.Ready(query...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gc/error_store.go
+++ b/cmd/gc/error_store.go
@@ -14,7 +14,7 @@ func (s unavailableStore) Reopen(string) error                               { r
 func (s unavailableStore) CloseAll([]string, map[string]string) (int, error) { return 0, s.err }
 func (s unavailableStore) List(beads.ListQuery) ([]beads.Bead, error)        { return nil, s.err }
 func (s unavailableStore) ListOpen(...string) ([]beads.Bead, error)          { return nil, s.err }
-func (s unavailableStore) Ready() ([]beads.Bead, error)                      { return nil, s.err }
+func (s unavailableStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error)   { return nil, s.err }
 func (s unavailableStore) Children(string, ...beads.QueryOpt) ([]beads.Bead, error) {
 	return nil, s.err
 }

--- a/internal/api/handler_beads_partial_test.go
+++ b/internal/api/handler_beads_partial_test.go
@@ -35,14 +35,14 @@ func (f *failingBeadStore) List(q beads.ListQuery) ([]beads.Bead, error) {
 	return f.Store.List(q)
 }
 
-func (f *failingBeadStore) Ready() ([]beads.Bead, error) {
+func (f *failingBeadStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
 	if f.readyErr != nil {
 		if f.readyResult != nil {
 			return f.readyResult, f.readyErr
 		}
 		return nil, f.readyErr
 	}
-	return f.Store.Ready()
+	return f.Store.Ready(query...)
 }
 
 func (f *failingBeadStore) Update(id string, opts beads.UpdateOpts) error {

--- a/internal/api/handler_beads_test.go
+++ b/internal/api/handler_beads_test.go
@@ -194,8 +194,8 @@ func (s *prefixedAliasStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	return out, nil
 }
 
-func (s *prefixedAliasStore) Ready() ([]beads.Bead, error) {
-	items, err := s.base.Ready()
+func (s *prefixedAliasStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	items, err := s.base.Ready(query...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -947,9 +947,19 @@ func (s *BdStore) Children(parentID string, opts ...QueryOpt) ([]Bead, error) {
 	})
 }
 
-// Ready returns all open beads via bd ready.
-func (s *BdStore) Ready() ([]Bead, error) {
-	out, err := s.runner(s.dir, "bd", "ready", "--json", "--limit", "0")
+// Ready returns open ready beads via bd ready.
+func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
+	q := readyQueryFromArgs(query)
+	args := []string{"ready", "--json"}
+	if q.Assignee != "" {
+		args = append(args, "--assignee", q.Assignee)
+	}
+	if q.Limit > 0 {
+		args = append(args, "--limit", strconv.Itoa(q.Limit))
+	} else {
+		args = append(args, "--limit", "0")
+	}
+	out, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		return nil, fmt.Errorf("bd ready: %w", err)
 	}
@@ -958,6 +968,9 @@ func (s *BdStore) Ready() ([]Bead, error) {
 	for i := range issues {
 		bead := issues[i].toBead()
 		if IsReadyExcludedType(bead.Type) {
+			continue
+		}
+		if q.Assignee != "" && bead.Assignee != q.Assignee {
 			continue
 		}
 		result = append(result, bead)

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -779,6 +779,31 @@ func TestBdStoreReady(t *testing.T) {
 	}
 }
 
+func TestBdStoreReadyWithAssigneeAndLimit(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --assignee worker-1 --limit 3`: {
+			out: []byte(`[
+				{"id":"bd-worker","title":"ready one","status":"open","issue_type":"task","assignee":"worker-1","created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-other","title":"wrong assignee","status":"open","issue_type":"task","assignee":"worker-2","created_at":"2025-01-15T10:31:00Z"}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready(beads.ReadyQuery{Assignee: "worker-1", Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Ready(assignee) returned %d beads, want 1", len(got))
+	}
+	if got[0].ID != "bd-worker" {
+		t.Fatalf("Ready(assignee)[0].ID = %q, want bd-worker", got[0].ID)
+	}
+}
+
 func TestBdStoreReadyFiltersInfraTypes(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -171,8 +171,8 @@ type Store interface {
 	// Ready returns open, unblocked beads representing actionable work.
 	// Infrastructure types (molecule, message, gate, etc.) are excluded
 	// to match the bd CLI's GetReadyWork semantics. Same ordering note
-	// as List.
-	Ready() ([]Bead, error)
+	// as List. Pass ReadyQuery to constrain the ready lookup.
+	Ready(query ...ReadyQuery) ([]Bead, error)
 
 	// Legacy helper; prefer List with ListQuery in new code.
 	// Children returns all beads whose ParentID matches the given ID,

--- a/internal/beads/caching_store_internal_test.go
+++ b/internal/beads/caching_store_internal_test.go
@@ -1393,9 +1393,9 @@ type readyCountingPartialListStore struct {
 	readyCalls int
 }
 
-func (s *readyCountingPartialListStore) Ready() ([]Bead, error) {
+func (s *readyCountingPartialListStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	s.readyCalls++
-	return s.partialListErrorStore.Ready()
+	return s.partialListErrorStore.Ready(query...)
 }
 
 func hasBead(items []Bead, id string) bool {

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -322,16 +322,19 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 }
 
 // Ready returns open beads whose blocking deps are all closed.
-func (c *CachingStore) Ready() ([]Bead, error) {
+func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
+	if readyQueryFromArgs(query) != (ReadyQuery{}) {
+		return c.backing.Ready(query...)
+	}
 	c.mu.RLock()
 	if c.state == cacheLive && c.depsComplete {
 		if len(c.dirty) > 0 {
 			c.mu.RUnlock()
-			return c.backing.Ready()
+			return c.backing.Ready(query...)
 		}
 		if c.primePartialErr != nil {
 			c.mu.RUnlock()
-			return c.backing.Ready()
+			return c.backing.Ready(query...)
 		}
 		statusByID := make(map[string]string, len(c.beads))
 		depsByID := make(map[string][]Dep, len(c.deps))
@@ -369,7 +372,7 @@ func (c *CachingStore) Ready() ([]Bead, error) {
 		return result, nil
 	}
 	c.mu.RUnlock()
-	return c.backing.Ready()
+	return c.backing.Ready(query...)
 }
 
 // CachedReady returns ready beads from the in-memory active read model.

--- a/internal/beads/exec/exec.go
+++ b/internal/beads/exec/exec.go
@@ -335,7 +335,7 @@ func (s *Store) ListOpen(status ...string) ([]beads.Bead, error) {
 
 // Ready returns actionable open beads (excluding infrastructure types):
 // script ready
-func (s *Store) Ready() ([]beads.Bead, error) {
+func (s *Store) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
 	out, err := s.run(nil, "ready")
 	if err != nil {
 		return nil, fmt.Errorf("exec beads ready: %w", err)
@@ -350,7 +350,11 @@ func (s *Store) Ready() ([]beads.Bead, error) {
 			result = append(result, b)
 		}
 	}
-	return result, nil
+	if len(query) == 0 {
+		return result, nil
+	}
+	q := query[0]
+	return beads.ApplyListQuery(result, beads.ListQuery{Assignee: q.Assignee, Limit: q.Limit}), nil
 }
 
 // Children returns non-closed beads whose ParentID matches by default:

--- a/internal/beads/filestore.go
+++ b/internal/beads/filestore.go
@@ -396,13 +396,13 @@ func (fs *FileStore) ListOpen(status ...string) ([]Bead, error) {
 }
 
 // Ready reloads the on-disk store before listing ready beads.
-func (fs *FileStore) Ready() ([]Bead, error) {
+func (fs *FileStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	fs.fmu.Lock()
 	defer fs.fmu.Unlock()
 	if err := fs.refreshReadStateLocked(); err != nil {
 		return nil, err
 	}
-	return fs.MemStore.Ready()
+	return fs.MemStore.Ready(query...)
 }
 
 // Children reloads the on-disk store before listing child beads.

--- a/internal/beads/live_ready.go
+++ b/internal/beads/live_ready.go
@@ -3,12 +3,12 @@ package beads
 // ReadyLive returns ready beads using the backing store when a caching layer is
 // present. Other Store implementations ignore the live-read intent and fall
 // back to their normal Ready behavior.
-func ReadyLive(store Store) ([]Bead, error) {
+func ReadyLive(store Store, query ...ReadyQuery) ([]Bead, error) {
 	type backingStore interface {
 		Backing() Store
 	}
 	if cached, ok := store.(backingStore); ok && cached.Backing() != nil {
-		return cached.Backing().Ready()
+		return cached.Backing().Ready(query...)
 	}
-	return store.Ready()
+	return store.Ready(query...)
 }

--- a/internal/beads/live_ready_test.go
+++ b/internal/beads/live_ready_test.go
@@ -11,11 +11,11 @@ type flakyReadyStore struct {
 	failReady error
 }
 
-func (s *flakyReadyStore) Ready() ([]Bead, error) {
+func (s *flakyReadyStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	if s.failReady != nil {
 		return nil, s.failReady
 	}
-	return s.MemStore.Ready()
+	return s.MemStore.Ready(query...)
 }
 
 func TestReadyLiveBypassesCachingStore(t *testing.T) {

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -245,7 +245,8 @@ func (m *MemStore) ListOpen(status ...string) ([]Bead, error) {
 
 // Ready returns all open beads with no open blocking dependencies, in
 // creation order.
-func (m *MemStore) Ready() ([]Bead, error) {
+func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
+	q := readyQueryFromArgs(query)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -260,6 +261,9 @@ func (m *MemStore) Ready() ([]Bead, error) {
 			continue
 		}
 		if IsReadyExcludedType(b.Type) {
+			continue
+		}
+		if q.Assignee != "" && b.Assignee != q.Assignee {
 			continue
 		}
 		blocked := false
@@ -279,6 +283,9 @@ func (m *MemStore) Ready() ([]Bead, error) {
 		}
 		if !blocked {
 			result = append(result, cloneBead(b))
+			if q.Limit > 0 && len(result) >= q.Limit {
+				break
+			}
 		}
 	}
 	return result, nil

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -43,6 +43,21 @@ type ListQuery struct {
 	Sort SortOrder
 }
 
+// ReadyQuery describes optional filters for ready-work lookup. A zero-value
+// query preserves Ready's historical behavior: all open, unblocked actionable
+// work.
+type ReadyQuery struct {
+	Assignee string
+	Limit    int
+}
+
+func readyQueryFromArgs(queries []ReadyQuery) ReadyQuery {
+	if len(queries) == 0 {
+		return ReadyQuery{}
+	}
+	return queries[0]
+}
+
 // HasFilter reports whether the query includes at least one indexed selector.
 func (q ListQuery) HasFilter() bool {
 	return q.Status != "" ||


### PR DESCRIPTION
## Summary
- add optional `beads.ReadyQuery` parameters to `Store.Ready` and `ReadyLive`
- support assignee and limit filters across bd, memory, file, exec, and cache-backed stores
- keep zero-value Ready behavior unchanged while routing filtered cached reads to the backing store

## Verification
- `git diff --check --cached`
- `go test ./internal/beads ./internal/beads/exec ./internal/api ./cmd/gc -run 'Ready|BuildDesired|Partial|Beads' -count=1`
- pre-commit hook: generated docs/schema, golangci-lint, go vet, `GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->