### PR TITLE
fix(session): preserve never-started pending creates

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -173,6 +173,9 @@ func sessionStartRequested(session beads.Bead, clk clock.Clock) bool {
 	return !staleCreatingState(session, clk)
 }
 
+// staleCreatingStateTimeout is the legacy cleanup window for generic creating
+// metadata and corrupt start leases. Pending creates that never reached
+// preWakeCommit use pendingCreateNeverStartedTimeout instead.
 const staleCreatingStateTimeout = time.Minute
 
 func sessionMetadataState(session beads.Bead) string {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -182,6 +182,44 @@ func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTime
 	return now.Before(started.Add(startupTimeout + staleKeyDetectDelay + 5*time.Second))
 }
 
+const pendingCreateNeverStartedTimeout = 10 * time.Minute
+
+func pendingCreateNeverStartedExpired(session beads.Bead, clk clock.Clock) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["state"]) != "creating" {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["last_woke_at"]) != "" {
+		return false
+	}
+	if session.CreatedAt.IsZero() {
+		return true
+	}
+	now := time.Now()
+	if clk != nil {
+		now = clk.Now()
+	}
+	return now.After(session.CreatedAt.Add(pendingCreateNeverStartedTimeout))
+}
+
+func pendingCreateLeaseExpiredForRollback(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["state"]) != "creating" {
+		return false
+	}
+	if pendingCreateStartInFlight(session, clk, startupTimeout) {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["last_woke_at"]) == "" {
+		return pendingCreateNeverStartedExpired(session, clk)
+	}
+	return staleCreatingState(session, clk)
+}
+
 // reconcileSessionBeads performs bead-driven reconciliation using wake/sleep
 // semantics. For each session bead, it determines if the session should be
 // awake (has a matching entry in the desired state) and manages lifecycle
@@ -599,7 +637,7 @@ func reconcileSessionBeadsTraced(
 			if cfg != nil {
 				startupTimeout = cfg.Session.StartupTimeoutDuration()
 			}
-			if !pendingCreateStartInFlight(*session, clk, startupTimeout) && staleCreatingState(*session, clk) {
+			if pendingCreateLeaseExpiredForRollback(*session, clk, startupTimeout) {
 				fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: lease expired and no live runtime\n", name) //nolint:errcheck
 				if trace != nil {
 					trace.recordDecision("reconciler.session.pending_create", tp.TemplateName, name, "pending_create_lease_expired", "rollback", nil, nil, "")

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -145,16 +145,25 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 	if template == "" {
 		template = session.Metadata["template"]
 	}
+	var startupTimeout time.Duration
+	if cfg != nil {
+		startupTimeout = cfg.Session.StartupTimeoutDuration()
+	}
+	pendingCreate := strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
+		strings.TrimSpace(session.Metadata["state"]) == "creating"
+	if pendingCreate && pendingCreateLeaseExpiredForRollback(session, clk, startupTimeout) {
+		return false
+	}
 	agent := findAgentByTemplate(cfg, template)
 	if agent != nil {
 		return !agent.Suspended
 	}
 	// API config mutations and session creation can arrive in adjacent
-	// reconciler ticks. Preserve a fresh pending-create bead while the runtime
-	// config snapshot catches up so it is not falsely closed as orphaned.
-	return strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
-		strings.TrimSpace(session.Metadata["state"]) == "creating" &&
-		!staleCreatingState(session, clk)
+	// reconciler ticks. Empty-last_woke_at pending creates may also leave the
+	// desired set before preWakeCommit records a provider start lease, so use
+	// the same never-started rollback floor as the desired branch before
+	// marking them orphaned.
+	return pendingCreate
 }
 
 func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
@@ -182,6 +191,17 @@ func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTime
 	return now.Before(started.Add(startupTimeout + staleKeyDetectDelay + 5*time.Second))
 }
 
+// pendingCreateNeverStartedTimeout is the rollback floor for pending creates
+// that have not reached preWakeCommit and therefore have no last_woke_at start
+// lease. The same empty-last_woke_at shape is used after recoverable provider
+// start failures because commitStartResultTraced clears the lease before
+// recordWakeFailure applies retry/quarantine backoff, so this timeout also
+// bounds that retry-bead cleanup path.
+//
+// It is intentionally longer than staleCreatingStateTimeout: that one-minute
+// window still handles corrupt/unparseable last_woke_at metadata and generic
+// creating-state cleanup, while never-started creates need enough time to sit
+// behind a busy pool start queue.
 const pendingCreateNeverStartedTimeout = 10 * time.Minute
 
 func pendingCreateNeverStartedExpired(session beads.Bead, clk clock.Clock) bool {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2877,6 +2877,60 @@ func TestReconcileSessionBeads_ConvergesPendingCreateWhenRuntimeMatchesBead(t *t
 	}
 }
 
+func TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpires(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}
+	cfg := &config.City{Agents: []config.Agent{{Name: "helper"}}}
+	desired := map[string]TemplateParams{
+		"helper": {
+			Command:      "test-cmd",
+			SessionName:  "helper",
+			TemplateName: "helper",
+		},
+	}
+
+	bead, err := store.Create(beads.Bead{
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:helper"},
+		Metadata: map[string]string{
+			"session_name":          "helper",
+			"session_name_explicit": "true",
+			"pending_create_claim":  "true",
+			"template":              "helper",
+			"state":                 "creating",
+			"generation":            "1",
+			"continuation_epoch":    "1",
+			"instance_token":        "test-token",
+			// last_woke_at deliberately empty — preWakeCommit never fired.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(bead): %v", err)
+	}
+	bead.CreatedAt = clk.Now().Add(-5 * time.Minute)
+
+	var stdout, stderr bytes.Buffer
+	cfgNames := configuredSessionNames(cfg, "", store)
+	_ = reconcileSessionBeads(
+		context.Background(), []beads.Bead{bead}, desired, cfgNames,
+		cfg, sp, store, nil, nil, nil, newDrainTracker(), map[string]int{"helper": 1}, false, nil, "",
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+
+	got, err := store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(bead): %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed, want never-started pending create preserved until never-started lease expires; metadata=%v", got.Metadata)
+	}
+	if got.Metadata["close_reason"] != "" {
+		t.Fatalf("close_reason = %q, want empty", got.Metadata["close_reason"])
+	}
+}
+
 func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime(t *testing.T) {
 	// Regression test: a session bead in the desired set with
 	// pending_create_claim=true but no live runtime AND no active lease
@@ -2915,10 +2969,10 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntim
 	if err != nil {
 		t.Fatalf("Create(bead): %v", err)
 	}
-	// Force CreatedAt past the staleCreatingState window so the lease check
-	// flips from "fresh" to "expired". The reconciler reads CreatedAt from
-	// the passed bead slice, so modifying the local copy is sufficient.
-	bead.CreatedAt = clk.Now().Add(-5 * time.Minute)
+	// Force CreatedAt past the never-started pending-create window. The
+	// reconciler reads CreatedAt from the passed bead slice, so modifying the
+	// local copy is sufficient.
+	bead.CreatedAt = clk.Now().Add(-11 * time.Minute)
 
 	var stdout, stderr bytes.Buffer
 	cfgNames := configuredSessionNames(cfg, "", store)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2053,6 +2053,79 @@ func TestReconcileSessionBeads_FreshPendingCreateSurvivesStaleConfigSnapshot(t *
 	}
 }
 
+func TestReconcileSessionBeads_PendingCreateWithoutDesiredStateUsesNeverStartedLease(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("s-gc-late", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "creating",
+		"pending_create_claim": "true",
+		// last_woke_at deliberately empty: preWakeCommit never fired before
+		// this pending create left desired state.
+	})
+	session.CreatedAt = env.clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Minute))
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 without desired-state membership", woken)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get session: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("pending-create session was closed before never-started lease expired: %+v", got)
+	}
+	if got.Metadata["state"] == "orphaned" || got.Metadata["close_reason"] == "orphaned" {
+		t.Fatalf("pending-create session was marked orphaned before never-started lease expired: %+v", got.Metadata)
+	}
+}
+
+func TestReconcileSessionBeads_ConfiguredPendingCreateWithoutDemandUsesNeverStartedLease(t *testing.T) {
+	tests := []struct {
+		name       string
+		createdAt  time.Time
+		wantClosed bool
+	}{
+		{
+			name:       "before lease expires",
+			createdAt:  time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC).Add(-(pendingCreateNeverStartedTimeout - time.Minute)),
+			wantClosed: false,
+		},
+		{
+			name:       "after lease expires",
+			createdAt:  time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC).Add(-(pendingCreateNeverStartedTimeout + time.Second)),
+			wantClosed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newReconcilerTestEnv()
+			env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+			session := env.createSessionBead("s-gc-late", "worker")
+			env.setSessionMetadata(&session, map[string]string{
+				"state":                "creating",
+				"pending_create_claim": "true",
+				// last_woke_at deliberately empty: preWakeCommit never fired before
+				// this configured template lost pool demand.
+			})
+			session.CreatedAt = tt.createdAt
+
+			woken := env.reconcile([]beads.Bead{session})
+			if woken != 0 {
+				t.Fatalf("woken = %d, want 0 without desired-state membership", woken)
+			}
+			got, err := env.store.Get(session.ID)
+			if err != nil {
+				t.Fatalf("Get session: %v", err)
+			}
+			if got.Status == "closed" != tt.wantClosed {
+				t.Fatalf("status = %q, want closed=%v; metadata=%v", got.Status, tt.wantClosed, got.Metadata)
+			}
+		})
+	}
+}
+
 func TestReconcileSessionBeads_DependencyOrdering_DepDeadBlocksWake(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{
@@ -2909,7 +2982,7 @@ func TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpi
 	if err != nil {
 		t.Fatalf("Create(bead): %v", err)
 	}
-	bead.CreatedAt = clk.Now().Add(-5 * time.Minute)
+	bead.CreatedAt = clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Minute))
 
 	var stdout, stderr bytes.Buffer
 	cfgNames := configuredSessionNames(cfg, "", store)
@@ -2934,10 +3007,10 @@ func TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpi
 func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime(t *testing.T) {
 	// Regression test: a session bead in the desired set with
 	// pending_create_claim=true but no live runtime AND no active lease
-	// (last_woke_at empty AND CreatedAt past staleCreatingState window) is
-	// stuck. Without this rollback, the bead lives forever holding its alias,
-	// blocking new spawn attempts ("alias already belongs to gm-XXXX") for
-	// any session whose template still has demand.
+	// (last_woke_at empty AND CreatedAt past the never-started pending-create
+	// window) is stuck. Without this rollback, the bead lives forever holding
+	// its alias, blocking new spawn attempts ("alias already belongs to
+	// gm-XXXX") for any session whose template still has demand.
 	store := beads.NewMemStore()
 	sp := runtime.NewFake() // no runtime started
 	clk := &clock.Fake{Time: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}
@@ -2972,7 +3045,7 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntim
 	// Force CreatedAt past the never-started pending-create window. The
 	// reconciler reads CreatedAt from the passed bead slice, so modifying the
 	// local copy is sufficient.
-	bead.CreatedAt = clk.Now().Add(-11 * time.Minute)
+	bead.CreatedAt = clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second))
 
 	var stdout, stderr bytes.Buffer
 	cfgNames := configuredSessionNames(cfg, "", store)
@@ -3048,6 +3121,76 @@ func TestReconcileSessionBeads_PreservesPendingCreateWhenLeaseRecentNoRuntime(t 
 	}
 	if strings.TrimSpace(got.Metadata["pending_create_claim"]) != "true" {
 		t.Fatalf("pending_create_claim = %q, want still 'true'", got.Metadata["pending_create_claim"])
+	}
+}
+
+func TestPendingCreateNeverStartedExpiredEdges(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}
+	base := beads.Bead{
+		Metadata: map[string]string{
+			"pending_create_claim": "true",
+			"state":                "creating",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		want      bool
+	}{
+		{
+			name:      "before boundary",
+			createdAt: clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Second)),
+			want:      false,
+		},
+		{
+			name:      "exact boundary",
+			createdAt: clk.Now().Add(-pendingCreateNeverStartedTimeout),
+			want:      false,
+		},
+		{
+			name:      "after boundary",
+			createdAt: clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second)),
+			want:      true,
+		},
+		{
+			name:      "zero created at",
+			createdAt: time.Time{},
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bead := base
+			bead.CreatedAt = tt.createdAt
+			if got := pendingCreateNeverStartedExpired(bead, clk); got != tt.want {
+				t.Fatalf("pendingCreateNeverStartedExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPendingCreateLeaseExpiredForRollbackFallsBackToStaleWindowForInvalidLastWokeAt(t *testing.T) {
+	clk := &clock.Fake{Time: time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)}
+	base := beads.Bead{
+		Metadata: map[string]string{
+			"pending_create_claim": "true",
+			"state":                "creating",
+			"last_woke_at":         "not-a-timestamp",
+		},
+	}
+
+	recent := base
+	recent.CreatedAt = clk.Now().Add(-(staleCreatingStateTimeout - time.Second))
+	if pendingCreateLeaseExpiredForRollback(recent, clk, time.Minute) {
+		t.Fatal("invalid last_woke_at used never-started lease; want legacy stale window before rollback")
+	}
+
+	stale := base
+	stale.CreatedAt = clk.Now().Add(-(staleCreatingStateTimeout + time.Second))
+	if !pendingCreateLeaseExpiredForRollback(stale, clk, time.Minute) {
+		t.Fatal("invalid last_woke_at preserved after stale window; want rollback")
 	}
 }
 

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -231,13 +231,51 @@ func tailText(s string, maxLines int) string {
 func initBd(t *testing.T, dir string) string {
 	t.Helper()
 	prefix := uniqueCityName()
-	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "-q")
-	cmd.Dir = dir
-	cmd.Env = os.Environ()
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := bdStandalone(t, dir, "init", "-p", prefix, "--skip-hooks", "--skip-agents", "-q")
+	if err != nil {
 		t.Fatalf("bd init in %s failed: %v\noutput: %s", dir, err, out)
 	}
 	return prefix
+}
+
+func bdStandalone(t testing.TB, dir string, args ...string) (string, error) {
+	t.Helper()
+	return runCommand(dir, standaloneBDEnv(t, dir), integrationBDCommandTimeout, bdBinary, args...)
+}
+
+func standaloneBDEnv(t testing.TB, dir string) []string {
+	t.Helper()
+	bdHome := filepath.Join(dir, ".bd-home")
+	xdgConfigHome := filepath.Join(bdHome, ".config")
+	xdgCacheHome := filepath.Join(bdHome, ".cache")
+	for _, path := range []string{bdHome, xdgConfigHome, xdgCacheHome} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("creating standalone bd env dir %s: %v", path, err)
+		}
+	}
+
+	env := []string{
+		"HOME=" + bdHome,
+		"XDG_CONFIG_HOME=" + xdgConfigHome,
+		"XDG_CACHE_HOME=" + xdgCacheHome,
+		"DOLT_ROOT_PATH=" + bdHome,
+		"BEADS_DOLT_AUTO_START=1",
+		"BD_NON_INTERACTIVE=1",
+	}
+	addIfSet := func(name, value string) {
+		if strings.TrimSpace(value) != "" {
+			env = append(env, name+"="+value)
+		}
+	}
+	addIfSet("PATH", prependPath(integrationToolBinDir, os.Getenv("PATH")))
+	addIfSet("TMPDIR", os.TempDir())
+	addIfSet("USER", os.Getenv("USER"))
+	addIfSet("LOGNAME", os.Getenv("LOGNAME"))
+	addIfSet("SHELL", os.Getenv("SHELL"))
+	addIfSet("LANG", os.Getenv("LANG"))
+	addIfSet(integrationRealBDBinaryEnv, realBDBinary)
+	addIfSet(integrationDoltBinaryEnv, doltBinary)
+	return env
 }
 
 // createBead creates a bead and returns its ID.

--- a/test/integration/gastown_multirig_test.go
+++ b/test/integration/gastown_multirig_test.go
@@ -276,7 +276,7 @@ func TestGastown_MultiRig_BeadIsolation(t *testing.T) {
 	assert.NotEqual(t, prefix0, prefix1, "rig bead prefixes should differ")
 
 	// Create a bead from rig-0's directory.
-	out, err := bd(rigDirs[0], "create", "multi-rig bead test alpha")
+	out, err := bdStandalone(t, rigDirs[0], "create", "multi-rig bead test alpha")
 	require.NoError(t, err, "bd create in rig-0: %s", out)
 	beadID := extractBeadID(t, out)
 
@@ -286,7 +286,7 @@ func TestGastown_MultiRig_BeadIsolation(t *testing.T) {
 		"bead ID %q should start with rig-0 prefix %q", beadID, prefix0)
 
 	// Verify the bead is visible from rig-0.
-	out, err = bd(rigDirs[0], "show", beadID)
+	out, err = bdStandalone(t, rigDirs[0], "show", beadID)
 	require.NoError(t, err, "bd show from rig-0: %s", out)
 	assert.Contains(t, out, "multi-rig bead test alpha",
 		"bead should be visible from rig-0")

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -659,6 +659,8 @@ func integrationEnvDolt() []string {
 
 func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env := filterEnv(os.Environ(), "GC_BEADS")
+	env = filterEnv(env, "BEADS_DIR")
+	env = filterEnv(env, "GC_BEADS_SCOPE_ROOT")
 	env = filterEnv(env, "GC_DOLT")
 	env = filterEnv(env, "PATH")
 	env = filterEnv(env, "GC_HOME")
@@ -672,6 +674,11 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env = filterEnv(env, "BEADS_DOLT_SERVER_HOST")
 	env = filterEnv(env, "BEADS_DOLT_SERVER_PORT")
 	env = filterEnv(env, "BEADS_DOLT_SERVER_USER")
+	env = filterEnv(env, "BEADS_DOLT_HOST")
+	env = filterEnv(env, "BEADS_DOLT_PORT")
+	env = filterEnv(env, "BEADS_DOLT_USER")
+	env = filterEnv(env, "BEADS_DOLT_DATABASE")
+	env = filterEnv(env, "BEADS_DOLT_DATA_DIR")
 	env = filterEnv(env, "BEADS_DOLT_PASSWORD")
 	env = filterEnv(env, integrationGCBinaryEnv)
 	env = filterEnv(env, integrationDoltBinaryEnv)
@@ -1081,6 +1088,8 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	integrationToolBinDir = filepath.Join(t.TempDir(), "bin")
 
 	t.Setenv("HOME", "/host/home")
+	t.Setenv("BEADS_DIR", "/host/beads")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "/host/scope")
 	t.Setenv("GC_DOLT_HOST", "ambient-host")
 	t.Setenv("GC_DOLT_PORT", "0")
 	t.Setenv("GC_DOLT_USER", "ambient-user")
@@ -1088,6 +1097,11 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "ambient-beads-host")
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
 	t.Setenv("BEADS_DOLT_SERVER_USER", "ambient-beads-user")
+	t.Setenv("BEADS_DOLT_HOST", "ambient-legacy-host")
+	t.Setenv("BEADS_DOLT_PORT", "0")
+	t.Setenv("BEADS_DOLT_USER", "ambient-legacy-user")
+	t.Setenv("BEADS_DOLT_DATABASE", "ambient-legacy-db")
+	t.Setenv("BEADS_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "ambient-dolt-data"))
 	t.Setenv("BEADS_DOLT_PASSWORD", "ambient-beads-password")
 	env := integrationEnv()
 	got := parseEnvList(env)
@@ -1111,6 +1125,8 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 		t.Fatalf("BEADS_DOLT_AUTO_START = %q, want %q; tests must match bdRuntimeEnv and suppress bd's rogue auto-start", got["BEADS_DOLT_AUTO_START"], "0")
 	}
 	for _, key := range []string{
+		"BEADS_DIR",
+		"GC_BEADS_SCOPE_ROOT",
 		"GC_DOLT_HOST",
 		"GC_DOLT_PORT",
 		"GC_DOLT_USER",
@@ -1118,10 +1134,88 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 		"BEADS_DOLT_SERVER_HOST",
 		"BEADS_DOLT_SERVER_PORT",
 		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_HOST",
+		"BEADS_DOLT_PORT",
+		"BEADS_DOLT_USER",
+		"BEADS_DOLT_DATABASE",
+		"BEADS_DOLT_DATA_DIR",
 		"BEADS_DOLT_PASSWORD",
 	} {
 		if _, ok := got[key]; ok {
 			t.Fatalf("%s leaked into integration env: %v", key, got[key])
+		}
+	}
+}
+
+func TestStandaloneBDEnvUsesIsolatedDoltHomeAndAllowsAutoStart(t *testing.T) {
+	oldGCHome, oldRuntimeDir := testGCHome, testRuntimeDir
+	oldGCBinary, oldBDBinary, oldRealBDBinary := gcBinary, bdBinary, realBDBinary
+	oldToolBinDir, oldDoltBinary := integrationToolBinDir, doltBinary
+	t.Cleanup(func() {
+		testGCHome = oldGCHome
+		testRuntimeDir = oldRuntimeDir
+		gcBinary = oldGCBinary
+		bdBinary = oldBDBinary
+		realBDBinary = oldRealBDBinary
+		integrationToolBinDir = oldToolBinDir
+		doltBinary = oldDoltBinary
+	})
+
+	testGCHome = filepath.Join(t.TempDir(), "gc-home")
+	testRuntimeDir = filepath.Join(t.TempDir(), "runtime")
+	gcBinary = filepath.Join(t.TempDir(), "gc")
+	bdBinary = filepath.Join(t.TempDir(), "bd")
+	realBDBinary = "/usr/bin/bd"
+	doltBinary = "/usr/bin/dolt"
+	integrationToolBinDir = filepath.Join(t.TempDir(), "bin")
+
+	t.Setenv("HOME", "/host/home")
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "ambient-host")
+	t.Setenv("GC_DOLT_PORT", "0")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "ambient-beads-host")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
+	t.Setenv("BEADS_DOLT_HOST", "ambient-legacy-host")
+	t.Setenv("BEADS_DOLT_PORT", "0")
+	t.Setenv("BEADS_DOLT_USER", "ambient-legacy-user")
+	t.Setenv("BEADS_DOLT_DATABASE", "ambient-legacy-db")
+	t.Setenv("BEADS_DOLT_DATA_DIR", filepath.Join(t.TempDir(), "ambient-dolt-data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "ambient-config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), "ambient-cache"))
+
+	dir := t.TempDir()
+	got := parseEnvList(standaloneBDEnv(t, dir))
+	wantHome := filepath.Join(dir, ".bd-home")
+	if got["HOME"] != wantHome {
+		t.Fatalf("HOME = %q, want %q", got["HOME"], wantHome)
+	}
+	if got["DOLT_ROOT_PATH"] != wantHome {
+		t.Fatalf("DOLT_ROOT_PATH = %q, want %q", got["DOLT_ROOT_PATH"], wantHome)
+	}
+	if got["XDG_CONFIG_HOME"] != filepath.Join(wantHome, ".config") {
+		t.Fatalf("XDG_CONFIG_HOME = %q, want isolated config under %q", got["XDG_CONFIG_HOME"], wantHome)
+	}
+	if got["XDG_CACHE_HOME"] != filepath.Join(wantHome, ".cache") {
+		t.Fatalf("XDG_CACHE_HOME = %q, want isolated cache under %q", got["XDG_CACHE_HOME"], wantHome)
+	}
+	if got["BEADS_DOLT_AUTO_START"] != "1" {
+		t.Fatalf("BEADS_DOLT_AUTO_START = %q, want %q", got["BEADS_DOLT_AUTO_START"], "1")
+	}
+	for _, key := range []string{
+		"GC_DOLT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_HOST",
+		"BEADS_DOLT_PORT",
+		"BEADS_DOLT_USER",
+		"BEADS_DOLT_DATABASE",
+		"BEADS_DOLT_DATA_DIR",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("%s leaked into standalone bd env: %v", key, got[key])
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a separate lease window for pending creates that have not reached preWakeCommit
- preserve queued pool starts for that window instead of rolling them back after the stale creating timeout
- keep rollback behavior for truly expired never-started creates

## Tests
- go test ./cmd/gc -run 'TestReconcileSessionBeads_(PreservesNeverStartedPendingCreateBeforeLeaseExpires|RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime|PreservesPendingCreateWhenLeaseRecentNoRuntime)'\n- pre-commit hook ran full local suite during commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->