### PR TITLE
fix: resolve multi-dash sling beads from source store

### DIFF
--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -212,6 +212,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	cityName := loadedCityName(cfg, cityPath)
 
 	var target, beadOrFormula string
+	var sourceBead existingSlingSourceBead
 	switch {
 	case fromStdin:
 		target = args[0]
@@ -219,6 +220,13 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	case len(args) == 2:
 		target = args[0]
 		beadOrFormula = args[1]
+		if !isFormula {
+			sourceBead, err = probeExistingSlingSourceBead(cfg, cityPath, beadOrFormula)
+			if err != nil {
+				fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
 	default:
 		// 1-arg: bead ID only, resolve target from rig's default_sling_target.
 		beadOrFormula = args[0]
@@ -226,7 +234,12 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 			fmt.Fprintf(stderr, "gc sling: --formula requires explicit target\n") //nolint:errcheck // best-effort stderr
 			return 1
 		}
-		if !canInferSlingDefaultTargetFromBead(cfg, beadOrFormula) {
+		sourceBead, err = probeExistingSlingSourceBead(cfg, cityPath, beadOrFormula)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if !canInferSlingDefaultTargetFromBead(cfg, beadOrFormula) && !sourceBead.exists {
 			fmt.Fprintf(stderr, "gc sling: inline text requires explicit target\n  usage: gc sling <target> %q\n", beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
 		}
@@ -261,20 +274,38 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 
 	sp := newSessionProvider()
 
-	storeDir, store, err := openSlingStoreForSource(cfg, cityPath, beadOrFormula, a)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
+	var storeDir string
+	var store beads.Store
+	if sourceBead.exists {
+		storeDir = sourceBead.storeDir
+		store, err = openStoreAtForCity(storeDir, cityPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc sling: opening store %s: %v\n", storeDir, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+	} else {
+		storeDir, store, err = openSlingStoreForSource(cfg, cityPath, beadOrFormula, a)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 	storeRef := workflowStoreRefForDir(storeDir, cityPath, cityName, cfg)
 	storeEnv := slingStoreEnv(cfg, cityPath, storeDir)
+	if sourceBead.exists && looksLikeInlineText(cfg, beadOrFormula) {
+		fmt.Fprintf(stderr, "gc sling: found existing bead %q in %s; routing it instead of creating inline text\n", beadOrFormula, storeRef) //nolint:errcheck // best-effort stderr
+	}
 
 	// Inline text mode: if the argument doesn't look like a bead ID
 	// (and we're not in formula mode), create a task bead from the text.
 	// During dry-run, mark the text as preview-only instead of creating it.
 	inlineText := false
 	if !isFormula {
-		createInlineBead, previewInlineText, err := resolveInlineBeadAction(cfg, beadOrFormula, dryRun, store)
+		inlineProbeStore := store
+		if !sourceBead.exists && looksLikeInlineText(cfg, beadOrFormula) {
+			inlineProbeStore = nil
+		}
+		createInlineBead, previewInlineText, err := resolveInlineBeadAction(cfg, beadOrFormula, dryRun, inlineProbeStore)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc sling: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -435,6 +466,48 @@ func openSlingStoreForSource(cfg *config.City, cityPath, beadOrFormula string, a
 		return "", nil, fmt.Errorf("opening store %s: %w", storeDir, err)
 	}
 	return storeDir, store, nil
+}
+
+type existingSlingSourceBead struct {
+	exists   bool
+	storeDir string
+}
+
+func probeExistingSlingSourceBead(cfg *config.City, cityPath, beadID string) (existingSlingSourceBead, error) {
+	storeDir, ok := slingSourceStoreRootForCandidate(cfg, cityPath, beadID)
+	if !ok {
+		return existingSlingSourceBead{}, nil
+	}
+	store, err := openStoreAtForCity(storeDir, cityPath)
+	if err != nil {
+		return existingSlingSourceBead{}, fmt.Errorf("opening store %s: %w", storeDir, err)
+	}
+	exists, err := sling.ProbeBeadInStore(store, beadID)
+	if err != nil {
+		return existingSlingSourceBead{}, fmt.Errorf("checking bead candidate %q: %w", beadID, err)
+	}
+	if !exists {
+		return existingSlingSourceBead{}, nil
+	}
+	return existingSlingSourceBead{exists: true, storeDir: storeDir}, nil
+}
+
+func slingSourceStoreRootForCandidate(cfg *config.City, cityPath, beadID string) (string, bool) {
+	if cfg == nil || !isBeadIDCandidate(beadID) {
+		return "", false
+	}
+	bp := beadPrefix(cfg, beadID)
+	if bp == "" {
+		return "", false
+	}
+	if sling.IsHQPrefix(cfg, bp) {
+		return resolveStoreScopeRoot(cityPath, cityPath), true
+	}
+	rig, found := findRigByPrefix(cfg, bp)
+	if !found || strings.TrimSpace(rig.Path) == "" {
+		return "", false
+	}
+	return resolveStoreScopeRoot(cityPath, rig.Path), true
 }
 
 func canInferSlingDefaultTargetFromBead(cfg *config.City, beadOrFormula string) bool {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -244,6 +244,9 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 			return 1
 		}
 		bp := sling.BeadPrefixForCity(cfg, beadOrFormula)
+		if sourceBead.prefix != "" {
+			bp = sourceBead.prefix
+		}
 		if bp == "" {
 			fmt.Fprintf(stderr, "gc sling: cannot derive rig from bead %q (no prefix)\n", beadOrFormula) //nolint:errcheck // best-effort stderr
 			return 1
@@ -302,7 +305,7 @@ func cmdSling(args []string, isFormula, doNudge, force bool, title string, vars 
 	inlineText := false
 	if !isFormula {
 		inlineProbeStore := store
-		if !sourceBead.exists && looksLikeInlineText(cfg, beadOrFormula) {
+		if !sourceBead.exists && sourceBead.checked && looksLikeInlineText(cfg, beadOrFormula) {
 			inlineProbeStore = nil
 		}
 		createInlineBead, previewInlineText, err := resolveInlineBeadAction(cfg, beadOrFormula, dryRun, inlineProbeStore)
@@ -470,11 +473,13 @@ func openSlingStoreForSource(cfg *config.City, cityPath, beadOrFormula string, a
 
 type existingSlingSourceBead struct {
 	exists   bool
+	checked  bool
 	storeDir string
+	prefix   string
 }
 
 func probeExistingSlingSourceBead(cfg *config.City, cityPath, beadID string) (existingSlingSourceBead, error) {
-	storeDir, ok := slingSourceStoreRootForCandidate(cfg, cityPath, beadID)
+	storeDir, prefix, ok := slingSourceStoreRootForCandidate(cfg, cityPath, beadID)
 	if !ok {
 		return existingSlingSourceBead{}, nil
 	}
@@ -487,27 +492,27 @@ func probeExistingSlingSourceBead(cfg *config.City, cityPath, beadID string) (ex
 		return existingSlingSourceBead{}, fmt.Errorf("checking bead candidate %q: %w", beadID, err)
 	}
 	if !exists {
-		return existingSlingSourceBead{}, nil
+		return existingSlingSourceBead{checked: true, storeDir: storeDir, prefix: prefix}, nil
 	}
-	return existingSlingSourceBead{exists: true, storeDir: storeDir}, nil
+	return existingSlingSourceBead{exists: true, checked: true, storeDir: storeDir, prefix: prefix}, nil
 }
 
-func slingSourceStoreRootForCandidate(cfg *config.City, cityPath, beadID string) (string, bool) {
+func slingSourceStoreRootForCandidate(cfg *config.City, cityPath, beadID string) (string, string, bool) {
 	if cfg == nil || !isBeadIDCandidate(beadID) {
-		return "", false
+		return "", "", false
 	}
-	bp := beadPrefix(cfg, beadID)
+	bp := sling.BeadPrefixForCity(cfg, beadID)
 	if bp == "" {
-		return "", false
+		return "", "", false
 	}
 	if sling.IsHQPrefix(cfg, bp) {
-		return resolveStoreScopeRoot(cityPath, cityPath), true
+		return resolveStoreScopeRoot(cityPath, cityPath), bp, true
 	}
 	rig, found := findRigByPrefix(cfg, bp)
 	if !found || strings.TrimSpace(rig.Path) == "" {
-		return "", false
+		return "", "", false
 	}
-	return resolveStoreScopeRoot(cityPath, rig.Path), true
+	return resolveStoreScopeRoot(cityPath, rig.Path), bp, true
 }
 
 func canInferSlingDefaultTargetFromBead(cfg *config.City, beadOrFormula string) bool {

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -1906,9 +1906,9 @@ func resolveInlineBeadAction(cfg *config.City, beadOrFormula string, dryRun bool
 }
 
 // isBeadIDCandidate reports whether s has the shape of a potential bead ID:
-// no whitespace, starts with a letter, contains only letters, digits, and
-// hyphens, and has at least one hyphen. Used to gate the store probe before
-// falling back to inline-text creation.
+// no whitespace, starts with a letter, contains only letters, digits, hyphens,
+// underscores, and dots, and has at least one hyphen. Used to gate the store
+// probe before falling back to inline-text creation.
 func isBeadIDCandidate(s string) bool {
 	if s == "" || strings.ContainsAny(s, " \t\n") {
 		return false
@@ -1922,6 +1922,7 @@ func isBeadIDCandidate(s string) bool {
 		switch {
 		case c == '-':
 			hasDash = true
+		case c == '_' || c == '.':
 		case 'a' <= c && c <= 'z', 'A' <= c && c <= 'Z', '0' <= c && c <= '9':
 		default:
 			return false

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1622,6 +1622,11 @@ func TestCmdSlingConfiguredPrefixAllAlphaExistingBeadUsesPrefixStore(t *testing.
 	t.Setenv("GC_BEADS", "file")
 
 	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
 	frontendDir := filepath.Join(cityDir, "frontend")
 	ordersDir := filepath.Join(cityDir, "orders")
 	for _, dir := range []string{frontendDir, ordersDir} {
@@ -1887,6 +1892,11 @@ func setupCmdSlingConfiguredPrefixAllAlphaFrontendFixture(t *testing.T, defaultT
 	t.Setenv("GC_BEADS", "file")
 
 	cityDir = t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
 	frontendDir = filepath.Join(cityDir, "frontend")
 	if err := os.MkdirAll(frontendDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(frontend): %v", err)
@@ -2057,11 +2067,185 @@ func TestCmdSlingAcceptsExistingBead(t *testing.T) {
 func TestCmdSlingMultiDashBeadIDRoutesExistingBead(t *testing.T) {
 	// gc sling target fo-spawn-storm must route the existing bead and must
 	// not create a new inline bead, when "fo-spawn-storm" exists in the store.
+	cityDir, rigDir := setupCmdSlingMultiDashBeadFixture(t, true)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"foundations/worker", "fo-spawn-storm"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Errorf("created new inline bead instead of routing existing one; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "found existing bead") {
+		t.Errorf("stderr = %q, want existing-bead routing breadcrumb", stderr.String())
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get("fo-spawn-storm")
+	if err != nil {
+		t.Fatalf("rigStore.Get(fo-spawn-storm): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "foundations/worker" {
+		t.Fatalf("rig bead gc.routed_to = %q, want foundations/worker", routed.Metadata["gc.routed_to"])
+	}
+	all, err := rigStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("rigStore.List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("rig store bead count = %d, want 1: %#v", len(all), all)
+	}
+}
+
+func TestCmdSlingOneArgMultiDashExistingBeadUsesDefaultTarget(t *testing.T) {
+	cityDir, rigDir := setupCmdSlingMultiDashBeadFixture(t, true)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"fo-spawn-storm"},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "found existing bead") {
+		t.Errorf("stderr = %q, want existing-bead routing breadcrumb", stderr.String())
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get("fo-spawn-storm")
+	if err != nil {
+		t.Fatalf("rigStore.Get(fo-spawn-storm): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "foundations/worker" {
+		t.Fatalf("rig bead gc.routed_to = %q, want foundations/worker", routed.Metadata["gc.routed_to"])
+	}
+	all, err := rigStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("rigStore.List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("rig store bead count = %d, want 1: %#v", len(all), all)
+	}
+}
+
+func TestCmdSlingCrossRigMultiDashExistingBeadUsesPrefixStore(t *testing.T) {
+	cityDir, rigDir := setupCmdSlingMultiDashBeadFixture(t, false)
+	ordersDir := filepath.Join(cityDir, "orders")
+	if err := os.MkdirAll(ordersDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(orders): %v", err)
+	}
+	if err := ensurePersistedScopeLocalFileStore(ordersDir); err != nil {
+		t.Fatalf("ensurePersistedScopeLocalFileStore(orders): %v", err)
+	}
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "foundations"
+path = "foundations"
+prefix = "fo"
+
+[[rigs]]
+name = "orders"
+path = "orders"
+prefix = "od"
+
+[[agent]]
+name = "worker"
+dir = "orders"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"orders/worker", "fo-spawn-storm"},
+		false, false, true,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "found existing bead") {
+		t.Errorf("stderr = %q, want existing-bead routing breadcrumb", stderr.String())
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get("fo-spawn-storm")
+	if err != nil {
+		t.Fatalf("rigStore.Get(fo-spawn-storm): %v", err)
+	}
+	if routed.Metadata["gc.routed_to"] != "orders/worker" {
+		t.Fatalf("rig bead gc.routed_to = %q, want orders/worker", routed.Metadata["gc.routed_to"])
+	}
+	all, err := rigStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("rigStore.List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("rig store bead count = %d, want 1: %#v", len(all), all)
+	}
+
+	ordersStore, err := openStoreAtForCity(ordersDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(orders): %v", err)
+	}
+	ordersBeads, err := ordersStore.List(beads.ListQuery{AllowScan: true})
+	if err != nil {
+		t.Fatalf("ordersStore.List: %v", err)
+	}
+	if len(ordersBeads) != 0 {
+		t.Fatalf("orders store bead count = %d, want 0: %#v", len(ordersBeads), ordersBeads)
+	}
+}
+
+func setupCmdSlingMultiDashBeadFixture(t *testing.T, defaultTarget bool) (cityDir, rigDir string) {
+	t.Helper()
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "file")
 
-	cityDir := t.TempDir()
-	rigDir := filepath.Join(cityDir, "foundations")
+	cityDir = t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	rigDir = filepath.Join(cityDir, "foundations")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(rig): %v", err)
 	}
@@ -2080,6 +2264,10 @@ func TestCmdSlingMultiDashBeadIDRoutesExistingBead(t *testing.T) {
 		Status:   "open",
 		Metadata: map[string]string{},
 	}})
+	defaultTargetLine := ""
+	if defaultTarget {
+		defaultTargetLine = "default_sling_target = \"foundations/worker\"\n"
+	}
 	cityToml := `[workspace]
 name = "demo"
 
@@ -2087,6 +2275,7 @@ name = "demo"
 name = "foundations"
 path = "foundations"
 prefix = "fo"
+` + defaultTargetLine + `
 
 [[agent]]
 name = "worker"
@@ -2096,23 +2285,7 @@ dir = "foundations"
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	t.Chdir(cityDir)
-
-	var stdout, stderr bytes.Buffer
-	_ = cmdSling(
-		[]string{"foundations/worker", "fo-spawn-storm"},
-		false, false, false,
-		"", nil, "",
-		true, false, "",
-		false, false, false,
-		"", "",
-		&stdout, &stderr,
-	)
-	if strings.Contains(stdout.String(), "Created ") {
-		t.Errorf("created new inline bead instead of routing existing one; stdout=%s stderr=%s", stdout.String(), stderr.String())
-	}
-	if strings.Contains(stderr.String(), "not found") {
-		t.Errorf("unexpected 'not found' error; stderr=%s", stderr.String())
-	}
+	return cityDir, rigDir
 }
 
 func TestCmdSlingRefusesMissingConfiguredFallbackBeadID(t *testing.T) {

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2331,6 +2331,85 @@ dir = "orders"
 	}
 }
 
+func TestCmdSlingUnderscoredPrefixMultiDashExistingBeadUsesPrefixStore(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	rigDir := filepath.Join(cityDir, "live-docs")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(rig): %v", err)
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	const beadID = "live_docs-spawn-storm"
+	writeTestFileStoreBeads(t, rigDir, []beads.Bead{{
+		ID:       beadID,
+		Title:    "spawn storm bead",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{},
+	}})
+	cityToml := `[workspace]
+name = "demo"
+
+[[rigs]]
+name = "live_docs"
+path = "live-docs"
+prefix = "live_docs"
+
+[[agent]]
+name = "worker"
+dir = "live_docs"
+`
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"live_docs/worker", beadID},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+
+	rigStore, err := openStoreAtForCity(rigDir, cityDir)
+	if err != nil {
+		t.Fatalf("openStoreAtForCity(rig): %v", err)
+	}
+	routed, err := rigStore.Get(beadID)
+	if err != nil {
+		t.Fatalf("rigStore.Get(%s): %v", beadID, err)
+	}
+	if routed.Metadata["gc.routed_to"] != "live_docs/worker" {
+		t.Fatalf("rig bead gc.routed_to = %q, want live_docs/worker", routed.Metadata["gc.routed_to"])
+	}
+
+	assertStoreHasNoBeadTitle(t, cityDir, cityDir, beadID)
+}
+
 func setupCmdSlingMultiDashBeadFixture(t *testing.T, defaultTarget bool) (cityDir, rigDir string) {
 	t.Helper()
 	configureIsolatedRuntimeEnv(t)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -2390,6 +2390,11 @@ func TestCmdSlingRefusesMissingConfiguredFallbackBeadID(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
 	rigDir := filepath.Join(cityDir, "orders")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(rig): %v", err)

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -1718,57 +1718,12 @@ dir = "orders"
 // hyphen ("agent-diagnostics-hnn" in rig "agent-diagnostics") routes
 // to the rig store without auto-creating a city orphan.
 func TestCmdSlingHyphenatedRigPrefixExistingBeadDoesNotOrphan(t *testing.T) {
-	configureIsolatedRuntimeEnv(t)
-	t.Setenv("GC_BEADS", "file")
-
-	cityDir := t.TempDir()
-	rigDir := filepath.Join(cityDir, "agent-diagnostics")
-	otherDir := filepath.Join(cityDir, "other")
-	for _, dir := range []string{rigDir, otherDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", dir, err)
-		}
-	}
-	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
-		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
-	}
-	for _, dir := range []string{cityDir, rigDir, otherDir} {
-		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
-			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
-		}
-	}
-	writeTestFileStoreBeads(t, rigDir, []beads.Bead{{
-		ID:       "agent-diagnostics-hnn",
-		Title:    "existing diagnostics work",
-		Type:     "task",
-		Status:   "open",
-		Metadata: map[string]string{},
-	}})
-	cityToml := `[workspace]
-name = "demo"
-
-[[rigs]]
-name = "agent-diagnostics"
-path = "agent-diagnostics"
-prefix = "agent-diagnostics"
-
-[[rigs]]
-name = "other"
-path = "other"
-prefix = "OT"
-
-[[agent]]
-name = "worker"
-dir = "agent-diagnostics"
-`
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	t.Chdir(cityDir)
+	beadID := "agent-diagnostics-hnn"
+	cityDir, rigDir, _ := setupCmdSlingHyphenatedRigPrefixBeadFixture(t, beadID, "agent-diagnostics")
 
 	var stdout, stderr bytes.Buffer
 	code := cmdSling(
-		[]string{"agent-diagnostics/worker", "agent-diagnostics-hnn"},
+		[]string{"agent-diagnostics/worker", beadID},
 		false, false, true,
 		"", nil, "",
 		true, false, "",
@@ -1785,30 +1740,172 @@ dir = "agent-diagnostics"
 		t.Fatalf("orphan auto-create regression: stdout = %q", stdout.String())
 	}
 
+	assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t, cityDir, rigDir, beadID, "agent-diagnostics/worker")
+}
+
+func TestCmdSlingHyphenatedRigPrefixMultiDashExistingBeadDoesNotOrphan(t *testing.T) {
+	beadID := "agent-diagnostics-spawn-storm"
+	cityDir, rigDir, _ := setupCmdSlingHyphenatedRigPrefixBeadFixture(t, beadID, "agent-diagnostics")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"agent-diagnostics/worker", beadID},
+		false, false, true,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("orphan auto-create regression: stdout = %q", stdout.String())
+	}
+
+	assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t, cityDir, rigDir, beadID, "agent-diagnostics/worker")
+}
+
+func TestCmdSlingOneArgHyphenatedPrefixMultiDashExistingBeadUsesDefaultTarget(t *testing.T) {
+	beadID := "agent-diagnostics-spawn-storm"
+	cityDir, rigDir, _ := setupCmdSlingHyphenatedRigPrefixBeadFixture(t, beadID, "agent-diagnostics")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{beadID},
+		false, false, false,
+		"", nil, "",
+		true, false, "",
+		false, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("orphan auto-create regression: stdout = %q", stdout.String())
+	}
+
+	assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t, cityDir, rigDir, beadID, "agent-diagnostics/worker")
+}
+
+func TestCmdSlingCrossRigHyphenatedPrefixMultiDashExistingBeadUsesPrefixStore(t *testing.T) {
+	beadID := "agent-diagnostics-spawn-storm"
+	cityDir, rigDir, otherDir := setupCmdSlingHyphenatedRigPrefixBeadFixture(t, beadID, "other")
+
+	var stdout, stderr bytes.Buffer
+	code := cmdSling(
+		[]string{"other/worker", beadID},
+		false, false, true,
+		"", nil, "",
+		true, false, "",
+		true, false, false,
+		"", "",
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("cmdSling returned %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created ") {
+		t.Fatalf("stdout = %q, want existing bead route without inline creation", stdout.String())
+	}
+
+	assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t, cityDir, rigDir, beadID, "other/worker")
+	assertStoreHasNoBeadTitle(t, cityDir, otherDir, beadID)
+}
+
+func setupCmdSlingHyphenatedRigPrefixBeadFixture(t *testing.T, beadID, agentDir string) (cityDir, rigDir, otherDir string) {
+	t.Helper()
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir = t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_RIG_ROOT", "")
+	rigDir = filepath.Join(cityDir, "agent-diagnostics")
+	otherDir = filepath.Join(cityDir, "other")
+	for _, dir := range []string{rigDir, otherDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+	}
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
+	}
+	for _, dir := range []string{cityDir, rigDir, otherDir} {
+		if err := ensurePersistedScopeLocalFileStore(dir); err != nil {
+			t.Fatalf("ensurePersistedScopeLocalFileStore(%s): %v", dir, err)
+		}
+	}
+	writeTestFileStoreBeads(t, rigDir, []beads.Bead{{
+		ID:       beadID,
+		Title:    "existing diagnostics work",
+		Type:     "task",
+		Status:   "open",
+		Metadata: map[string]string{},
+	}})
+	cityToml := fmt.Sprintf(`[workspace]
+name = "demo"
+
+[[rigs]]
+name = "agent-diagnostics"
+path = "agent-diagnostics"
+prefix = "agent-diagnostics"
+default_sling_target = "agent-diagnostics/worker"
+
+[[rigs]]
+name = "other"
+path = "other"
+prefix = "OT"
+
+[[agent]]
+name = "worker"
+dir = %q
+`, agentDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+	t.Chdir(cityDir)
+	return cityDir, rigDir, otherDir
+}
+
+func assertHyphenatedRigBeadRoutedWithoutInlineOrphan(t *testing.T, cityDir, rigDir, beadID, wantTarget string) {
+	t.Helper()
+
 	rigStore, err := openStoreAtForCity(rigDir, cityDir)
 	if err != nil {
 		t.Fatalf("openStoreAtForCity(rig): %v", err)
 	}
-	routed, err := rigStore.Get("agent-diagnostics-hnn")
+	routed, err := rigStore.Get(beadID)
 	if err != nil {
-		t.Fatalf("rigStore.Get(agent-diagnostics-hnn): %v", err)
+		t.Fatalf("rigStore.Get(%s): %v", beadID, err)
 	}
-	if routed.Metadata["gc.routed_to"] != "agent-diagnostics/worker" {
-		t.Fatalf("rig bead gc.routed_to = %q, want agent-diagnostics/worker (routing must land on the existing bead, not an orphan)", routed.Metadata["gc.routed_to"])
+	if routed.Metadata["gc.routed_to"] != wantTarget {
+		t.Fatalf("rig bead gc.routed_to = %q, want %s (routing must land on the existing bead, not an orphan)", routed.Metadata["gc.routed_to"], wantTarget)
 	}
 
 	// City store must NOT contain a stray bead from the auto-create path.
-	cityStore, err := openStoreAtForCity(cityDir, cityDir)
+	assertStoreHasNoBeadTitle(t, cityDir, cityDir, beadID)
+}
+
+func assertStoreHasNoBeadTitle(t *testing.T, cityDir, storeDir, beadTitle string) {
+	t.Helper()
+	store, err := openStoreAtForCity(storeDir, cityDir)
 	if err != nil {
-		t.Fatalf("openStoreAtForCity(city): %v", err)
+		t.Fatalf("openStoreAtForCity(%s): %v", storeDir, err)
 	}
-	cityBeads, err := cityStore.List(beads.ListQuery{AllowScan: true})
+	storeBeads, err := store.List(beads.ListQuery{AllowScan: true})
 	if err != nil {
-		t.Fatalf("cityStore.List: %v", err)
+		t.Fatalf("store.List(%s): %v", storeDir, err)
 	}
-	for _, b := range cityBeads {
-		if b.Title == "agent-diagnostics-hnn" {
-			t.Fatalf("city store has orphan bead %q (title %q): inline-text auto-create fired for a known-rig bead ID", b.ID, b.Title)
+	for _, b := range storeBeads {
+		if b.Title == beadTitle {
+			t.Fatalf("store %s has orphan bead %q (title %q): inline-text auto-create fired for a known-rig bead ID", storeDir, b.ID, b.Title)
 		}
 	}
 }

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -412,12 +412,14 @@ func BeadPrefix(beadID string) string {
 }
 
 // BeadPrefixForCity returns the configured rig (or HQ) prefix that beadID
-// belongs to, preferring the longest match so hyphenated rig prefixes
-// resolve correctly. Falls back to BeadPrefix when no configured prefix
-// matches. Returns "" if the bead has no dash and no configured-prefix
+// belongs to, preferring the longest match so hyphenated rig prefixes resolve
+// correctly. It does not require the suffix to pass the short bead-ID shape
+// gate; callers that need to decide bead ID vs inline text should use
+// LooksLikeConfiguredBeadID. Falls back to BeadPrefix when no configured
+// prefix matches. Returns "" if the bead has no dash and no configured-prefix
 // match.
 func BeadPrefixForCity(cfg *config.City, beadID string) string {
-	if p := matchConfiguredBeadPrefix(cfg, beadID); p != "" {
+	if p := matchConfiguredBeadPrefixCandidate(cfg, beadID); p != "" {
 		return p
 	}
 	return BeadPrefix(beadID)
@@ -439,6 +441,14 @@ func LooksLikeConfiguredBeadID(cfg *config.City, s string) bool {
 // prefix; the returned value is the lower-cased configured prefix.
 // Returns "" if no configured prefix matches.
 func matchConfiguredBeadPrefix(cfg *config.City, beadID string) string {
+	return matchConfiguredBeadPrefixBySuffix(cfg, beadID, true)
+}
+
+func matchConfiguredBeadPrefixCandidate(cfg *config.City, beadID string) string {
+	return matchConfiguredBeadPrefixBySuffix(cfg, beadID, false)
+}
+
+func matchConfiguredBeadPrefixBySuffix(cfg *config.City, beadID string, requireValidSuffix bool) string {
 	beadID = strings.TrimSpace(beadID)
 	if cfg == nil || beadID == "" || strings.ContainsAny(beadID, " \t\n") {
 		return ""
@@ -457,9 +467,11 @@ func matchConfiguredBeadPrefix(cfg *config.City, beadID string) string {
 		if !strings.HasPrefix(lower, lp+"-") {
 			continue
 		}
-		suffix := beadID[len(lp)+1:]
-		if !validBeadSuffix(suffix) {
-			continue
+		if requireValidSuffix {
+			suffix := beadID[len(lp)+1:]
+			if !validBeadSuffix(suffix) {
+				continue
+			}
 		}
 		best = lp
 		bestLen = len(lp)

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -322,6 +322,7 @@ func TestBeadPrefixForCityLongestMatch(t *testing.T) {
 		want string
 	}{
 		{"agent-diagnostics-hnn", "agent-diagnostics"},
+		{"agent-diagnostics-spawn-storm", "agent-diagnostics"},
 		{"agent-x1", "agent"},
 		{"fe-42", "fe"},
 		{"unknown-7", "unknown"}, // falls back to BeadPrefix.

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -233,7 +233,7 @@ func initBd(t *testing.T, dir string) string {
 	prefix := uniqueCityName()
 	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "-q")
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = commandEnvForDir(dir, false)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init in %s failed: %v\noutput: %s", dir, err, out)
 	}

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -230,20 +230,7 @@ func tailText(s string, maxLines int) string {
 // city.toml configuration.
 func initBd(t *testing.T, dir string) string {
 	t.Helper()
-	env := newIsolatedToolEnv(t, false)
-	env = filterEnvMany(env,
-		"GC_CITY",
-		"GC_CITY_PATH",
-		"GC_CITY_ROOT",
-		"GC_CITY_RUNTIME_DIR",
-		"GC_RIG",
-		"GC_RIG_ROOT",
-		"GC_BEADS",
-		"GC_DOLT",
-		"BEADS_DIR",
-		"BEADS_DOLT_AUTO_START",
-	)
-	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
+	env := standaloneBdEnv(t, dir)
 
 	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
 		if !os.IsNotExist(err) {
@@ -267,6 +254,39 @@ func initBd(t *testing.T, dir string) string {
 	registerCityCommandEnv(dir, env)
 	t.Cleanup(func() { unregisterCityCommandEnv(dir) })
 	return prefix
+}
+
+func standaloneBdEnv(t *testing.T, dir string) []string {
+	t.Helper()
+
+	env := newIsolatedToolEnv(t, false)
+	env = filterEnvMany(env,
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_CITY_ROOT",
+		"GC_CITY_RUNTIME_DIR",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_DOLT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+		"BEADS_DIR",
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_PASSWORD",
+	)
+	if gcHome := parseEnvList(env)["GC_HOME"]; gcHome != "" {
+		env = replaceEnv(env, "HOME", gcHome)
+	}
+	env = replaceEnv(env, "BD_NON_INTERACTIVE", "1")
+	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
+	return env
 }
 
 // createBead creates a bead and returns its ID.

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -230,13 +230,42 @@ func tailText(s string, maxLines int) string {
 // city.toml configuration.
 func initBd(t *testing.T, dir string) string {
 	t.Helper()
+	env := newIsolatedToolEnv(t, false)
+	env = filterEnvMany(env,
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_CITY_ROOT",
+		"GC_CITY_RUNTIME_DIR",
+		"GC_RIG",
+		"GC_RIG_ROOT",
+		"GC_BEADS",
+		"GC_DOLT",
+		"BEADS_DIR",
+		"BEADS_DOLT_AUTO_START",
+	)
+	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
+
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("stat %s/.git: %v", dir, err)
+		}
+		gitCmd := exec.Command("git", "init", "--quiet")
+		gitCmd.Dir = dir
+		gitCmd.Env = env
+		if out, err := gitCmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init in %s failed: %v\noutput: %s", dir, err, out)
+		}
+	}
+
 	prefix := uniqueCityName()
 	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "-q")
 	cmd.Dir = dir
-	cmd.Env = commandEnvForDir(dir, false)
+	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init in %s failed: %v\noutput: %s", dir, err, out)
 	}
+	registerCityCommandEnv(dir, env)
+	t.Cleanup(func() { unregisterCityCommandEnv(dir) })
 	return prefix
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1154,6 +1154,63 @@ func TestCommandEnvLookupDirUsesRegisteredPathArg(t *testing.T) {
 	}
 }
 
+func TestStandaloneBdEnvIsolatesAmbientDoltConfig(t *testing.T) {
+	t.Setenv("HOME", "/host/home")
+	t.Setenv("GC_CITY", "/host/city")
+	t.Setenv("GC_CITY_PATH", "/host/city")
+	t.Setenv("GC_RIG", "host-rig")
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "/host/repo")
+	t.Setenv("GC_DOLT", "server")
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PORT", "0")
+	t.Setenv("GC_DOLT_USER", "ambient-user")
+	t.Setenv("GC_DOLT_PASSWORD", "ambient-password")
+	t.Setenv("BEADS_DIR", "/host/beads")
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "127.0.0.1")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
+	t.Setenv("BEADS_DOLT_SERVER_USER", "ambient-user")
+	t.Setenv("BEADS_DOLT_PASSWORD", "ambient-password")
+
+	dir := filepath.Join(t.TempDir(), "standalone")
+	got := parseEnvList(standaloneBdEnv(t, dir))
+
+	if got["HOME"] == "/host/home" || got["HOME"] == "" {
+		t.Fatalf("HOME = %q, want isolated non-empty home", got["HOME"])
+	}
+	if got["HOME"] != got["GC_HOME"] {
+		t.Fatalf("HOME = %q, want GC_HOME %q", got["HOME"], got["GC_HOME"])
+	}
+	if got["BEADS_DIR"] != filepath.Join(dir, ".beads") {
+		t.Fatalf("BEADS_DIR = %q, want standalone beads dir", got["BEADS_DIR"])
+	}
+	if got["BD_NON_INTERACTIVE"] != "1" {
+		t.Fatalf("BD_NON_INTERACTIVE = %q, want 1", got["BD_NON_INTERACTIVE"])
+	}
+	for _, key := range []string{
+		"GC_CITY",
+		"GC_CITY_PATH",
+		"GC_RIG",
+		"GC_BEADS",
+		"GC_BEADS_SCOPE_ROOT",
+		"GC_DOLT",
+		"GC_DOLT_HOST",
+		"GC_DOLT_PORT",
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+		"BEADS_DOLT_AUTO_START",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_SERVER_USER",
+		"BEADS_DOLT_PASSWORD",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("%s leaked into standalone bd env: %v", key, got)
+		}
+	}
+}
+
 func TestRenderE2ETomlPlainAgentUsesNamedSessionWithoutSingletonCap(t *testing.T) {
 	toml := renderE2EToml(e2eCity{
 		Agents: []e2eAgent{{Name: "worker", StartCommand: "sleep 3600"}},

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -659,6 +659,7 @@ func integrationEnvDolt() []string {
 
 func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env := filterEnv(os.Environ(), "GC_BEADS")
+	env = filterEnv(env, "BEADS_DIR")
 	env = filterEnv(env, "GC_DOLT")
 	env = filterEnv(env, "PATH")
 	env = filterEnv(env, "GC_HOME")
@@ -1085,6 +1086,7 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	t.Setenv("GC_DOLT_PORT", "0")
 	t.Setenv("GC_DOLT_USER", "ambient-user")
 	t.Setenv("GC_DOLT_PASSWORD", "ambient-password")
+	t.Setenv("BEADS_DIR", "/host/beads")
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "ambient-beads-host")
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
 	t.Setenv("BEADS_DOLT_SERVER_USER", "ambient-beads-user")
@@ -1115,6 +1117,7 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 		"GC_DOLT_PORT",
 		"GC_DOLT_USER",
 		"GC_DOLT_PASSWORD",
+		"BEADS_DIR",
 		"BEADS_DOLT_SERVER_HOST",
 		"BEADS_DOLT_SERVER_PORT",
 		"BEADS_DOLT_SERVER_USER",


### PR DESCRIPTION
Follow-up to #1595 from the post-merge review.

This routes inline-looking, bead-shaped sling arguments from the prefix-derived source store before falling back to inline task creation, so default-target and cross-rig routes do not create phantom beads when the source bead already exists. It also emits a concise breadcrumb when an inline-looking token is resolved as an existing bead.

Verification:
- go test ./cmd/gc -count=1 -run 'TestResolveInlineBeadAction|TestCmdSlingMultiDashBeadIDRoutesExistingBead|TestCmdSlingOneArgMultiDashExistingBeadUsesDefaultTarget|TestCmdSlingCrossRigMultiDashExistingBeadUsesPrefixStore'\n- go test ./internal/sling -count=1 -run 'TestProbeBeadInStore'\n- pre-commit hook ran golangci-lint, go vet, and the sanitized fast unit loop during commit\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->