### PR TITLE
fix: suppress bd auto-export in gc bd wrapper

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -62,6 +62,9 @@ func bdCommandEnv(cityPath string, cfg *config.City, target execStoreTarget) []s
 	overrides["GC_STORE_ROOT"] = target.ScopeRoot
 	overrides["GC_STORE_SCOPE"] = target.ScopeKind
 	overrides["GC_BEADS_PREFIX"] = target.Prefix
+	// GC owns the Dolt-backed beads lifecycle; bd's git auto-export can run
+	// after command output and wedge the wrapper on git staging failures.
+	overrides["BD_EXPORT_AUTO"] = "false"
 	return mergeRuntimeEnv(os.Environ(), overrides)
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -468,6 +468,69 @@ set -eu
 	}
 }
 
+func TestGcBdSuppressesBdAutoExportForJsonShowAndUpdate(t *testing.T) {
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	defer func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	}()
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+set -eu
+if [ "${BD_EXPORT_AUTO:-}" != "false" ]; then
+  echo "BD_EXPORT_AUTO=${BD_EXPORT_AUTO:-}" >&2
+  exit 73
+fi
+case "${1:-}" in
+  show)
+    printf '[{"id":"gc-1","title":"ok"}]\n'
+    ;;
+  update)
+    printf '{"id":"gc-1","status":"in_progress"}\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("BD_EXPORT_AUTO", "true")
+
+	for _, args := range [][]string{
+		{"show", "gc-1", "--json"},
+		{"update", "gc-1", "--claim", "--json"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if got := doBd(args, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(%v) = %d, want 0; stdout=%q stderr=%q", args, got, stdout.String(), stderr.String())
+		}
+		if strings.TrimSpace(stdout.String()) == "" {
+			t.Fatalf("doBd(%v) produced empty stdout", args)
+		}
+		if stderr.String() != "" {
+			t.Fatalf("doBd(%v) stderr = %q, want empty", args, stderr.String())
+		}
+	}
+}
+
 func TestGcBdDoesNotAutoRouteHyphenatedFlagValue(t *testing.T) {
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag


### PR DESCRIPTION
## Summary
- project BD_EXPORT_AUTO=false from gc bd so bd does not run git auto-export after command output
- add regression coverage for JSON show and update paths with ambient auto-export enabled

## Validation
- go test ./cmd/gc -run 'TestGcBd(UsesProjectionNotAmbientEnv|SuppressesBdAutoExportForJsonShowAndUpdate|DoesNotAutoRouteHyphenatedFlagValue)$' -count=1
- go build ./cmd/gc
- built /tmp/gc-bd-auto-export-fix and validated live JSON show/update against /Users/danny/gas-city with ambient BD_EXPORT_AUTO=true

## Notes
- broader bd-wrapper group still has pre-existing isolated failure in TestGcBdRejectsGCBeadsFileOverride; filed follow-up bead gc-3zktru

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->