### PR TITLE
Fix gc status and doctor hangs

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -56,6 +56,17 @@ func openCityStatusStore(cityPath string, stderr io.Writer) (beads.Store, int) {
 }
 
 func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath string, store beads.Store, stderr io.Writer) cityStatusSnapshot {
+	return collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, loadStatusSessionSnapshot(store), stderr)
+}
+
+func collectCityStatusSnapshotFromStoreSnapshot(
+	sp runtime.Provider,
+	cfg *config.City,
+	cityPath string,
+	store beads.Store,
+	statusSnapshot *sessionBeadSnapshot,
+	stderr io.Writer,
+) cityStatusSnapshot {
 	suspended := os.Getenv("GC_SUSPENDED") == "1"
 	if cfg != nil {
 		suspended = citySuspended(cfg)
@@ -66,6 +77,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 		Suspended:  suspended,
 	}
 	snapshot.CityName = loadedCityName(cfg, cityPath)
+	registerStatusProviderACPRoutes(sp, statusSnapshot, snapshot.CityName, cfg)
 	if cfg == nil {
 		return snapshot
 	}
@@ -109,8 +121,8 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			scaleLabel := fmt.Sprintf("scaled (min=%d, %s)", sp0.Min, maxDisplay)
 			headerShown := false
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, snapshot.CityName, cfg.Workspace.SessionTemplate, sp) {
-				sn := sessionName(nil, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
-				obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
+				target := statusObservationTargetForIdentity(statusSnapshot, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
+				obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, target, stderr)
 				_, instanceName := config.ParseQualifiedName(qualifiedInstance)
 				row := cityStatusAgentRow{
 					Agent: StatusAgentJSON{
@@ -121,7 +133,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 						Suspended:     suspended || obs.Suspended,
 						Pool:          nil,
 					},
-					SessionName: sn,
+					SessionName: target.runtimeSessionName,
 					GroupName:   a.QualifiedName(),
 					Expanded:    true,
 				}
@@ -139,8 +151,8 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			continue
 		}
 
-		sn := sessionName(nil, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-		obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
+		target := statusObservationTargetForIdentity(statusSnapshot, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
+		obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, target, stderr)
 		snapshot.Agents = append(snapshot.Agents, cityStatusAgentRow{
 			Agent: StatusAgentJSON{
 				Name:          a.Name,
@@ -149,7 +161,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 				Running:       obs.Running,
 				Suspended:     suspended || obs.Suspended,
 			},
-			SessionName: sn,
+			SessionName: target.runtimeSessionName,
 			GroupName:   a.QualifiedName(),
 			Expanded:    false,
 		})

--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -109,7 +109,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			scaleLabel := fmt.Sprintf("scaled (min=%d, %s)", sp0.Min, maxDisplay)
 			headerShown := false
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, snapshot.CityName, cfg.Workspace.SessionTemplate, sp) {
-				sn := cliSessionName(cityPath, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
+				sn := sessionName(nil, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
 				obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
 				_, instanceName := config.ParseQualifiedName(qualifiedInstance)
 				row := cityStatusAgentRow{
@@ -139,7 +139,7 @@ func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath s
 			continue
 		}
 
-		sn := cliSessionName(cityPath, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
+		sn := sessionName(nil, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
 		obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, sn, stderr)
 		snapshot.Agents = append(snapshot.Agents, cityStatusAgentRow{
 			Agent: StatusAgentJSON{

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -94,6 +94,35 @@ func (s *failingStatusStore) Get(id string) (beads.Bead, error) {
 	return s.MemStore.Get(id)
 }
 
+type getSpyStatusStore struct {
+	*beads.MemStore
+	ids []string
+}
+
+func (s *getSpyStatusStore) Get(id string) (beads.Bead, error) {
+	s.ids = append(s.ids, id)
+	return s.MemStore.Get(id)
+}
+
+func TestCityStatusAgentObservationDoesNotResolveRuntimeNamesThroughStore(t *testing.T) {
+	sp := runtime.NewFake()
+	store := &getSpyStatusStore{MemStore: beads.NewMemStore()}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "dog", MaxActiveSessions: intPtr(2)},
+		},
+	}
+
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if len(snapshot.Agents) != 2 {
+		t.Fatalf("agents = %d, want 2", len(snapshot.Agents))
+	}
+	if len(store.ids) != 0 {
+		t.Fatalf("status observation performed bead Get calls for runtime names: %v", store.ids)
+	}
+}
+
 func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
 	sp := runtime.NewFake()
 	dops := newFakeDrainOps()

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"path/filepath"
@@ -120,6 +121,223 @@ func TestCityStatusAgentObservationDoesNotResolveRuntimeNamesThroughStore(t *tes
 	}
 	if len(store.ids) != 0 {
 		t.Fatalf("status observation performed bead Get calls for runtime names: %v", store.ids)
+	}
+}
+
+func TestCityStatusUsesBeadBackedRuntimeNameForSingletonAgent(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "custom-mayor", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "agent:mayor"},
+		Metadata: map[string]string{
+			"agent_name":   "mayor",
+			"template":     "mayor",
+			"session_name": "custom-mayor",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents:    []config.Agent{{Name: "mayor", MaxActiveSessions: intPtr(1)}},
+	}
+
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if len(snapshot.Agents) != 1 {
+		t.Fatalf("agents = %d, want 1", len(snapshot.Agents))
+	}
+	if !snapshot.Agents[0].Agent.Running {
+		t.Fatalf("singleton agent running = false, want true with bead-backed runtime name")
+	}
+	if got := snapshot.Agents[0].SessionName; got != "custom-mayor" {
+		t.Fatalf("SessionName = %q, want %q", got, "custom-mayor")
+	}
+}
+
+func TestCityStatusUsesSessionBackedObservationForSuspendedCustomRuntimeName(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "custom-mayor", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "mayor",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "agent:mayor"},
+		Metadata: map[string]string{
+			"agent_name":   "mayor",
+			"template":     "mayor",
+			"session_name": "custom-mayor",
+			"state":        string(session.StateSuspended),
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents:    []config.Agent{{Name: "mayor", MaxActiveSessions: intPtr(1)}},
+	}
+
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if len(snapshot.Agents) != 1 {
+		t.Fatalf("agents = %d, want 1", len(snapshot.Agents))
+	}
+	if !snapshot.Agents[0].Agent.Running {
+		t.Fatalf("running = false, want true")
+	}
+	if !snapshot.Agents[0].Agent.Suspended {
+		t.Fatalf("suspended = false, want true from session-backed observation")
+	}
+}
+
+func TestCityStatusUsesStatusSnapshotToRouteACPDrainMetadata(t *testing.T) {
+	oldBuild := buildSessionProviderByName
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	defaultSP := runtime.NewFake()
+	acpSP := runtime.NewFake()
+	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+		if name == "acp" {
+			return acpSP, nil
+		}
+		return defaultSP, nil
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Session:   config.SessionConfig{Provider: "fake"},
+		Agents:    []config.Agent{{Name: "reviewer", Session: "acp", MaxActiveSessions: intPtr(1)}},
+	}
+	sp := newStatusSessionProviderForCity(cfg, t.TempDir())
+	if err := acpSP.Start(context.Background(), "custom-reviewer", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := acpSP.SetMeta("custom-reviewer", "GC_DRAIN", "123"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "reviewer",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "agent:reviewer"},
+		Metadata: map[string]string{
+			"agent_name":   "reviewer",
+			"template":     "reviewer",
+			"transport":    "acp",
+			"session_name": "custom-reviewer",
+			"state":        string(session.StateActive),
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if len(snapshot.Agents) != 1 {
+		t.Fatalf("agents = %d, want 1", len(snapshot.Agents))
+	}
+	if !snapshot.Agents[0].Agent.Running {
+		t.Fatalf("running = false, want true")
+	}
+
+	var stdout bytes.Buffer
+	renderCityStatusText(snapshot, newDrainOps(sp), &stdout)
+	if !strings.Contains(stdout.String(), "running  (draining)") {
+		t.Fatalf("stdout = %q, want draining status for ACP-backed custom runtime name", stdout.String())
+	}
+}
+
+func TestCityStatusUsesBeadBackedRuntimeNameForPoolInstance(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "custom-dog-1", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "dog",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "agent:dog-1"},
+		Metadata: map[string]string{
+			"agent_name":   "dog-1",
+			"template":     "dog",
+			"session_name": "custom-dog-1",
+			"pool_slot":    "1",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{
+			{Name: "dog", MaxActiveSessions: intPtr(2)},
+		},
+	}
+
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if len(snapshot.Agents) != 2 {
+		t.Fatalf("agents = %d, want 2", len(snapshot.Agents))
+	}
+	if got := snapshot.Agents[0].Agent.QualifiedName; got != "dog-1" {
+		t.Fatalf("first QualifiedName = %q, want dog-1", got)
+	}
+	if !snapshot.Agents[0].Agent.Running {
+		t.Fatalf("pool instance dog-1 running = false, want true with bead-backed runtime name")
+	}
+	if got := snapshot.Agents[0].SessionName; got != "custom-dog-1" {
+		t.Fatalf("dog-1 SessionName = %q, want %q", got, "custom-dog-1")
+	}
+	if snapshot.Agents[1].Agent.Running {
+		t.Fatalf("pool instance dog-2 running = true, want false")
+	}
+}
+
+func TestCityStatusUsesBeadBackedRuntimeNameForStampedPoolSlotBead(t *testing.T) {
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "custom-dog-1", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "dog",
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession, "agent:frontend/dog"},
+		Metadata: map[string]string{
+			"agent_name":   "frontend/dog",
+			"template":     "frontend/dog",
+			"session_name": "custom-dog-1",
+			"pool_slot":    "1",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Rigs:      []config.Rig{{Name: "frontend", Path: "/tmp/frontend"}},
+		Agents: []config.Agent{
+			{Name: "dog", Dir: "frontend", MaxActiveSessions: intPtr(2)},
+		},
+	}
+
+	snapshot := collectCityStatusSnapshot(sp, cfg, "/home/user/city", store, io.Discard)
+	if len(snapshot.Agents) != 2 {
+		t.Fatalf("agents = %d, want 2", len(snapshot.Agents))
+	}
+	if got := snapshot.Agents[0].Agent.QualifiedName; got != "frontend/dog-1" {
+		t.Fatalf("first QualifiedName = %q, want frontend/dog-1", got)
+	}
+	if !snapshot.Agents[0].Agent.Running {
+		t.Fatalf("pool instance frontend/dog-1 running = false, want true with stamped pool-slot bead")
+	}
+	if got := snapshot.Agents[0].SessionName; got != "custom-dog-1" {
+		t.Fatalf("frontend/dog-1 SessionName = %q, want %q", got, "custom-dog-1")
 	}
 }
 

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -24,7 +24,11 @@ rig directory to find the correct .beads database. This command resolves
 the rig automatically from the --rig flag or by detecting the bead prefix
 in the arguments.
 
-All arguments after "gc bd" are forwarded to bd unchanged.`,
+All arguments after "gc bd" are forwarded to bd unchanged.
+
+gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
+from wedging the wrapper after printing command output. If you need
+auto-export behavior, invoke bd directly.`,
 		Example: `  gc bd --rig my-project list
   gc bd --rig my-project create "New task"
   gc bd show my-project-abc          # auto-detects rig from bead prefix

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -62,6 +62,9 @@ func bdCommandEnv(cityPath string, cfg *config.City, target execStoreTarget) []s
 	overrides["GC_STORE_ROOT"] = target.ScopeRoot
 	overrides["GC_STORE_SCOPE"] = target.ScopeKind
 	overrides["GC_BEADS_PREFIX"] = target.Prefix
+	// GC owns the Dolt-backed beads lifecycle; bd's git auto-export can run
+	// after command output and wedge the wrapper on git staging failures.
+	overrides["BD_EXPORT_AUTO"] = "false"
 	return mergeRuntimeEnv(os.Environ(), overrides)
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -468,6 +468,69 @@ set -eu
 	}
 }
 
+func TestGcBdSuppressesBdAutoExportForJsonShowAndUpdate(t *testing.T) {
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	defer func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	}()
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+set -eu
+if [ "${BD_EXPORT_AUTO:-}" != "false" ]; then
+  echo "BD_EXPORT_AUTO=${BD_EXPORT_AUTO:-}" >&2
+  exit 73
+fi
+case "${1:-}" in
+  show)
+    printf '[{"id":"gc-1","title":"ok"}]\n'
+    ;;
+  update)
+    printf '{"id":"gc-1","status":"in_progress"}\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("BD_EXPORT_AUTO", "true")
+
+	for _, args := range [][]string{
+		{"show", "gc-1", "--json"},
+		{"update", "gc-1", "--claim", "--json"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if got := doBd(args, &stdout, &stderr); got != 0 {
+			t.Fatalf("doBd(%v) = %d, want 0; stdout=%q stderr=%q", args, got, stdout.String(), stderr.String())
+		}
+		if strings.TrimSpace(stdout.String()) == "" {
+			t.Fatalf("doBd(%v) produced empty stdout", args)
+		}
+		if stderr.String() != "" {
+			t.Fatalf("doBd(%v) stderr = %q, want empty", args, stderr.String())
+		}
+	}
+}
+
 func TestGcBdDoesNotAutoRouteHyphenatedFlagValue(t *testing.T) {
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -105,7 +105,7 @@ func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int
 		return 1
 	}
 
-	sp := newSessionProvider()
+	sp := newStatusSessionProviderForCity(cfg, cityPath)
 	dops := newDrainOps(sp)
 	if jsonOutput {
 		return doCityStatusJSON(sp, cfg, cityPath, stdout, stderr)
@@ -122,7 +122,10 @@ func observeSessionTargetWithWarning(
 	target string,
 	stderr io.Writer,
 ) worker.LiveObservation {
-	obs, err := observeSessionTargetForStatus(cityPath, store, sp, cfg, target)
+	// Status already passes a concrete runtime session name. Resolving that
+	// string back through the bead store turns stopped pool instances such as
+	// "dog-1" into invalid bd show lookups, which can block the overview.
+	obs, err := observeSessionTargetForStatus(cityPath, nil, sp, cfg, target)
 	if err != nil && stderr != nil {
 		fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName, target, err) //nolint:errcheck // best-effort stderr
 	}

--- a/cmd/gc/cmd_citystatus.go
+++ b/cmd/gc/cmd_citystatus.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -105,12 +106,17 @@ func cmdCityStatus(args []string, jsonOutput bool, stdout, stderr io.Writer) int
 		return 1
 	}
 
-	sp := newStatusSessionProviderForCity(cfg, cityPath)
+	store, code := openCityStatusStore(cityPath, stderr)
+	if code != 0 {
+		return code
+	}
+	statusSnapshot := loadStatusSessionSnapshot(store)
+	sp := newStatusSessionProviderForCityWithSnapshot(cfg, cityPath, statusSnapshot)
 	dops := newDrainOps(sp)
 	if jsonOutput {
-		return doCityStatusJSON(sp, cfg, cityPath, stdout, stderr)
+		return doCityStatusJSONWithStoreAndSnapshot(sp, cfg, cityPath, store, statusSnapshot, stdout, stderr)
 	}
-	return doCityStatus(sp, dops, cfg, cityPath, stdout, stderr)
+	return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, statusSnapshot, stdout, stderr)
 }
 
 func observeSessionTargetWithWarning(
@@ -119,17 +125,61 @@ func observeSessionTargetWithWarning(
 	store beads.Store,
 	sp runtime.Provider,
 	cfg *config.City,
-	target string,
+	target statusObservationTarget,
 	stderr io.Writer,
 ) worker.LiveObservation {
+	if store != nil && target.sessionID != "" {
+		handle, err := workerHandleForSessionWithConfig(cityPath, store, sp, cfg, target.sessionID)
+		if err == nil {
+			obs, err := worker.ObserveHandle(context.Background(), handle)
+			if err == nil {
+				return obs
+			}
+		}
+	}
+
 	// Status already passes a concrete runtime session name. Resolving that
 	// string back through the bead store turns stopped pool instances such as
 	// "dog-1" into invalid bd show lookups, which can block the overview.
-	obs, err := observeSessionTargetForStatus(cityPath, nil, sp, cfg, target)
+	obs, err := observeSessionTargetForStatus(cityPath, nil, sp, cfg, target.runtimeSessionName)
 	if err != nil && stderr != nil {
-		fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName, target, err) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "%s: observing %q: %v\n", cmdName, target.runtimeSessionName, err) //nolint:errcheck // best-effort stderr
 	}
 	return obs
+}
+
+type statusObservationTarget struct {
+	runtimeSessionName string
+	sessionID          string
+}
+
+func loadStatusSessionSnapshot(store beads.Store) *sessionBeadSnapshot {
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		return nil
+	}
+	return snapshot
+}
+
+func statusObservationTargetForIdentity(
+	snapshot *sessionBeadSnapshot,
+	cityName string,
+	identity string,
+	sessionTemplate string,
+) statusObservationTarget {
+	if snapshot != nil {
+		if bead, ok := snapshot.FindSessionBeadByTemplate(identity); ok {
+			if sessionName := strings.TrimSpace(bead.Metadata["session_name"]); sessionName != "" {
+				return statusObservationTarget{
+					runtimeSessionName: sessionName,
+					sessionID:          bead.ID,
+				}
+			}
+		}
+	}
+	return statusObservationTarget{
+		runtimeSessionName: sessionName(nil, cityName, identity, sessionTemplate),
+	}
 }
 
 func namedSessionBlockedBySuspension(cfg *config.City, agentCfg *config.Agent, suspendedRigs map[string]bool) bool {
@@ -158,8 +208,19 @@ func doCityStatus(
 	if code != 0 {
 		return code
 	}
+	return doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, loadStatusSessionSnapshot(store), stdout, stderr)
+}
 
-	snapshot := collectCityStatusSnapshot(sp, cfg, cityPath, store, stderr)
+func doCityStatusWithStoreAndSnapshot(
+	sp runtime.Provider,
+	dops drainOps,
+	cfg *config.City,
+	cityPath string,
+	store beads.Store,
+	statusSnapshot *sessionBeadSnapshot,
+	stdout, stderr io.Writer,
+) int {
+	snapshot := collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, statusSnapshot, stderr)
 	renderCityStatusText(snapshot, dops, stdout)
 
 	if store != nil {
@@ -189,8 +250,18 @@ func doCityStatusJSON(
 	if code != 0 {
 		return code
 	}
+	return doCityStatusJSONWithStoreAndSnapshot(sp, cfg, cityPath, store, loadStatusSessionSnapshot(store), stdout, stderr)
+}
 
-	snapshot := collectCityStatusSnapshot(sp, cfg, cityPath, store, stderr)
+func doCityStatusJSONWithStoreAndSnapshot(
+	sp runtime.Provider,
+	cfg *config.City,
+	cityPath string,
+	store beads.Store,
+	statusSnapshot *sessionBeadSnapshot,
+	stdout, stderr io.Writer,
+) int {
+	snapshot := collectCityStatusSnapshotFromStoreSnapshot(sp, cfg, cityPath, store, statusSnapshot, stderr)
 	if store != nil {
 		sessions, err := collectCitySessionCounts(cityPath, store, sp, cfg)
 		if err != nil {

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -76,7 +76,7 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 	}
 
 	cityName := loadedCityName(cfg, cityPath)
-	sp := newSessionProvider()
+	sp := newStatusSessionProviderForCity(cfg, cityPath)
 	dops := newDrainOps(sp)
 	return doRigStatus(sp, dops, rig, rigAgents, cityPath, cityName, cfg.Workspace.SessionTemplate, stdout, stderr)
 }
@@ -111,13 +111,13 @@ func doRigStatus(
 	for _, a := range agents {
 		sp0 := scaleParamsFor(&a)
 		if !a.SupportsInstanceExpansion() {
-			sn := cliSessionName(cityPath, cityName, a.QualifiedName(), sessionTemplate)
+			sn := sessionName(nil, cityName, a.QualifiedName(), sessionTemplate)
 			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, nil, sn, stderr)
 			status := agentStatusLine(obs.Running, dops, sn, a.Suspended || obs.Suspended)
 			fmt.Fprintf(stdout, "    %-12s%s\n", a.QualifiedName(), status) //nolint:errcheck // best-effort stdout
 		} else {
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp) {
-				sn := cliSessionName(cityPath, cityName, qualifiedInstance, sessionTemplate)
+				sn := sessionName(nil, cityName, qualifiedInstance, sessionTemplate)
 				obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, nil, sn, stderr)
 				status := agentStatusLine(obs.Running, dops, sn, a.Suspended || obs.Suspended)
 				fmt.Fprintf(stdout, "    %-12s%s\n", qualifiedInstance, status) //nolint:errcheck // best-effort stdout

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -76,9 +76,16 @@ func cmdRigStatus(args []string, stdout, stderr io.Writer) int {
 	}
 
 	cityName := loadedCityName(cfg, cityPath)
-	sp := newStatusSessionProviderForCity(cfg, cityPath)
+	var store beads.Store
+	if cityPath != "" {
+		if opened, err := openCityStoreAt(cityPath); err == nil {
+			store = opened
+		}
+	}
+	statusSnapshot := loadStatusSessionSnapshot(store)
+	sp := newStatusSessionProviderForCityWithSnapshot(cfg, cityPath, statusSnapshot)
 	dops := newDrainOps(sp)
-	return doRigStatus(sp, dops, rig, rigAgents, cityPath, cityName, cfg.Workspace.SessionTemplate, stdout, stderr)
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, rigAgents, cityPath, cityName, cfg.Workspace.SessionTemplate, cfg, store, statusSnapshot, stdout, stderr)
 }
 
 // doRigStatus prints rig info and per-agent running state.
@@ -88,6 +95,7 @@ func doRigStatus(
 	rig config.Rig,
 	agents []config.Agent,
 	cityPath, cityName, sessionTemplate string,
+	cfg *config.City,
 	stdout, stderr io.Writer,
 ) int {
 	_ = stderr // reserved for future error reporting
@@ -97,6 +105,21 @@ func doRigStatus(
 			store = opened
 		}
 	}
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, cityName, sessionTemplate, cfg, store, loadStatusSessionSnapshot(store), stdout, stderr)
+}
+
+func doRigStatusWithStoreAndSnapshot(
+	sp runtime.Provider,
+	dops drainOps,
+	rig config.Rig,
+	agents []config.Agent,
+	cityPath, cityName, sessionTemplate string,
+	cfg *config.City,
+	store beads.Store,
+	statusSnapshot *sessionBeadSnapshot,
+	stdout, stderr io.Writer,
+) int {
+	registerStatusProviderACPRoutes(sp, statusSnapshot, cityName, cfg)
 
 	suspStr := "no"
 	if rig.Suspended {
@@ -111,15 +134,15 @@ func doRigStatus(
 	for _, a := range agents {
 		sp0 := scaleParamsFor(&a)
 		if !a.SupportsInstanceExpansion() {
-			sn := sessionName(nil, cityName, a.QualifiedName(), sessionTemplate)
-			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, nil, sn, stderr)
-			status := agentStatusLine(obs.Running, dops, sn, a.Suspended || obs.Suspended)
+			target := statusObservationTargetForIdentity(statusSnapshot, cityName, a.QualifiedName(), sessionTemplate)
+			obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, cfg, target, stderr)
+			status := agentStatusLine(obs.Running, dops, target.runtimeSessionName, a.Suspended || obs.Suspended)
 			fmt.Fprintf(stdout, "    %-12s%s\n", a.QualifiedName(), status) //nolint:errcheck // best-effort stdout
 		} else {
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp) {
-				sn := sessionName(nil, cityName, qualifiedInstance, sessionTemplate)
-				obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, nil, sn, stderr)
-				status := agentStatusLine(obs.Running, dops, sn, a.Suspended || obs.Suspended)
+				target := statusObservationTargetForIdentity(statusSnapshot, cityName, qualifiedInstance, sessionTemplate)
+				obs := observeSessionTargetWithWarning("gc rig status", cityPath, store, sp, cfg, target, stderr)
+				status := agentStatusLine(obs.Running, dops, target.runtimeSessionName, a.Suspended || obs.Suspended)
 				fmt.Fprintf(stdout, "    %-12s%s\n", qualifiedInstance, status) //nolint:errcheck // best-effort stdout
 			}
 		}

--- a/cmd/gc/cmd_status_test.go
+++ b/cmd/gc/cmd_status_test.go
@@ -32,7 +32,7 @@ func TestDoRigStatus(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -67,7 +67,7 @@ func TestDoRigStatusSuspendedRig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -91,7 +91,7 @@ func TestDoRigStatusWithDraining(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -113,7 +113,7 @@ func TestDoRigStatusSuspendedAgent(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -140,7 +140,7 @@ func TestDoRigStatusReportsObservationErrors(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "/tmp/city", "city", "", &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "/tmp/city", "city", "", nil, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/doctor_session_model.go
+++ b/cmd/gc/doctor_session_model.go
@@ -33,7 +33,7 @@ func (c *sessionModelDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResul
 		r.Message = fmt.Sprintf("session model diagnostics skipped: %v", err)
 		return r
 	}
-	all, err := store.List(beads.ListQuery{AllowScan: true, IncludeClosed: true, Sort: beads.SortCreatedAsc})
+	all, err := loadSessionModelDoctorBeads(store)
 	if err != nil {
 		r.Status = doctor.StatusWarning
 		r.Message = fmt.Sprintf("session model diagnostics skipped: %v", err)
@@ -120,6 +120,44 @@ func (c *sessionModelDoctorCheck) Run(_ *doctor.CheckContext) *doctor.CheckResul
 	r.Message = fmt.Sprintf("%d session model finding(s)", len(findings))
 	r.Details = findings
 	return r
+}
+
+func loadSessionModelDoctorBeads(store beads.Store) ([]beads.Bead, error) {
+	type listStep struct {
+		name  string
+		query beads.ListQuery
+	}
+	steps := []listStep{
+		{
+			name:  "session label",
+			query: beads.ListQuery{Label: session.LabelSession, IncludeClosed: true, Sort: beads.SortCreatedAsc},
+		},
+		{
+			name:  "session type",
+			query: beads.ListQuery{Type: session.BeadType, IncludeClosed: true, Sort: beads.SortCreatedAsc},
+		},
+		{
+			name:  "open work",
+			query: beads.ListQuery{AllowScan: true, Sort: beads.SortCreatedAsc},
+		},
+	}
+
+	seen := make(map[string]bool)
+	var all []beads.Bead
+	for _, step := range steps {
+		items, err := store.List(step.query)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", step.name, err)
+		}
+		for _, item := range items {
+			if seen[item.ID] {
+				continue
+			}
+			seen[item.ID] = true
+			all = append(all, item)
+		}
+	}
+	return all, nil
 }
 
 func isRetiredSessionModelOwner(b beads.Bead) bool {

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -169,6 +169,21 @@ func newStatusSessionProviderForCity(cfg *config.City, cityPath string) runtime.
 	return newSessionProviderFromContext(ctx, nil)
 }
 
+func newStatusSessionProviderForCityWithSnapshot(cfg *config.City, cityPath string, sessionBeads *sessionBeadSnapshot) runtime.Provider {
+	ctx := sessionProviderContextForCity(cfg, cityPath, os.Getenv("GC_SESSION"))
+	return newSessionProviderFromContext(ctx, sessionBeads)
+}
+
+func registerStatusProviderACPRoutes(sp runtime.Provider, snapshot *sessionBeadSnapshot, cityName string, cfg *config.City) {
+	router, ok := sp.(interface{ RouteACP(string) })
+	if !ok {
+		return
+	}
+	for _, sessName := range configuredACPRouteNames(snapshot, cityName, cfg) {
+		router.RouteACP(sessName)
+	}
+}
+
 func loadProviderSessionSnapshot(ctx sessionProviderContext) *sessionBeadSnapshot {
 	if ctx.cityPath == "" || ctx.providerName == "acp" {
 		return nil

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -164,6 +164,11 @@ func newSessionProviderForCity(cfg *config.City, cityPath string) runtime.Provid
 	return newSessionProviderFromContext(ctx, sessionBeads)
 }
 
+func newStatusSessionProviderForCity(cfg *config.City, cityPath string) runtime.Provider {
+	ctx := sessionProviderContextForCity(cfg, cityPath, os.Getenv("GC_SESSION"))
+	return newSessionProviderFromContext(ctx, nil)
+}
+
 func loadProviderSessionSnapshot(ctx sessionProviderContext) *sessionBeadSnapshot {
 	if ctx.cityPath == "" || ctx.providerName == "acp" {
 		return nil

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -698,6 +698,28 @@ func TestLoadProviderSessionSnapshotLoadsStoreWithoutACPAgents(t *testing.T) {
 	}
 }
 
+func TestStatusSessionProviderSkipsSessionSnapshot(t *testing.T) {
+	oldOpen := openSessionProviderStore
+	t.Cleanup(func() { openSessionProviderStore = oldOpen })
+
+	calls := 0
+	openSessionProviderStore = func(string) (beads.Store, error) {
+		calls++
+		return nil, errors.New("session snapshot should not load for status")
+	}
+
+	sp := newStatusSessionProviderForCity(&config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Session:   config.SessionConfig{Provider: "subprocess"},
+	}, "/tmp/city")
+	if sp == nil {
+		t.Fatal("newStatusSessionProviderForCity() = nil")
+	}
+	if calls != 0 {
+		t.Fatalf("openSessionProviderStore called %d times, want 0", calls)
+	}
+}
+
 func TestLoadProviderSessionSnapshotLoadsOpenACPAgents(t *testing.T) {
 	oldOpen := openSessionProviderStore
 	t.Cleanup(func() { openSessionProviderStore = oldOpen })

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -720,6 +720,40 @@ func TestStatusSessionProviderSkipsSessionSnapshot(t *testing.T) {
 	}
 }
 
+func TestStatusSessionProviderUsesProvidedSnapshotToWrapObservedACPSessions(t *testing.T) {
+	oldBuild := buildSessionProviderByName
+	t.Cleanup(func() { buildSessionProviderByName = oldBuild })
+
+	defaultSP := runtime.NewFake()
+	acpSP := runtime.NewFake()
+	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+		if name == "acp" {
+			return acpSP, nil
+		}
+		return defaultSP, nil
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Session:   config.SessionConfig{Provider: "fake"},
+		Agents:    []config.Agent{{Name: "mayor"}},
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "orphan-acp",
+			"transport":    "acp",
+			"session_name": "provider-session",
+		},
+	}})
+
+	sp := newStatusSessionProviderForCityWithSnapshot(cfg, t.TempDir(), snapshot)
+	if err := sp.Attach("provider-session"); err == nil || !strings.Contains(err.Error(), "ACP transport") {
+		t.Fatalf("Attach(provider-session) error = %v, want ACP transport error from snapshot-backed wrapper", err)
+	}
+}
+
 func TestLoadProviderSessionSnapshotLoadsOpenACPAgents(t *testing.T) {
 	oldOpen := openSessionProviderStore
 	t.Cleanup(func() { openSessionProviderStore = oldOpen })

--- a/cmd/gc/session_bead_snapshot.go
+++ b/cmd/gc/session_bead_snapshot.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
@@ -15,6 +17,8 @@ import (
 // explicitly.
 type sessionBeadSnapshot struct {
 	open                      []beads.Bead
+	beadIDByAgentName         map[string]string
+	beadIDByTemplateHint      map[string]string
 	sessionNameByAgentName    map[string]string
 	sessionNameByTemplateHint map[string]string
 }
@@ -40,6 +44,8 @@ func loadSessionBeadSnapshot(store beads.Store) (*sessionBeadSnapshot, error) {
 
 func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 	filtered := make([]beads.Bead, 0, len(beadsIn))
+	beadIDByAgentName := make(map[string]string)
+	beadIDByTemplateHint := make(map[string]string)
 	sessionNameByAgentName := make(map[string]string)
 	sessionNameByTemplateHint := make(map[string]string)
 
@@ -56,7 +62,7 @@ func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 		isCanonicalNamed := strings.TrimSpace(b.Metadata["configured_named_identity"]) != ""
 		if agentName := sessionBeadAgentName(b); agentName != "" {
 			if isPoolManagedSessionBead(b) && agentName == b.Metadata["template"] {
-				agentName = ""
+				agentName = stampedPoolQualifiedIdentity(b)
 			}
 			if agentName == "" {
 				continue
@@ -65,6 +71,7 @@ func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 			// resolveSessionName returns the correct session_name even
 			// when leaked pool-style beads exist for the same template.
 			if _, exists := sessionNameByAgentName[agentName]; !exists || isCanonicalNamed {
+				beadIDByAgentName[agentName] = b.ID
 				sessionNameByAgentName[agentName] = sn
 			}
 		}
@@ -73,11 +80,13 @@ func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 		}
 		if template := b.Metadata["template"]; template != "" {
 			if _, exists := sessionNameByTemplateHint[template]; !exists || isCanonicalNamed {
+				beadIDByTemplateHint[template] = b.ID
 				sessionNameByTemplateHint[template] = sn
 			}
 		}
 		if commonName := b.Metadata["common_name"]; commonName != "" {
 			if _, exists := sessionNameByTemplateHint[commonName]; !exists {
+				beadIDByTemplateHint[commonName] = b.ID
 				sessionNameByTemplateHint[commonName] = sn
 			}
 		}
@@ -85,6 +94,8 @@ func newSessionBeadSnapshot(beadsIn []beads.Bead) *sessionBeadSnapshot {
 
 	return &sessionBeadSnapshot{
 		open:                      filtered,
+		beadIDByAgentName:         beadIDByAgentName,
+		beadIDByTemplateHint:      beadIDByTemplateHint,
 		sessionNameByAgentName:    sessionNameByAgentName,
 		sessionNameByTemplateHint: sessionNameByTemplateHint,
 	}
@@ -132,6 +143,19 @@ func (s *sessionBeadSnapshot) FindSessionNameByTemplate(template string) string 
 	return s.sessionNameByTemplateHint[template]
 }
 
+func (s *sessionBeadSnapshot) FindSessionBeadByTemplate(template string) (beads.Bead, bool) {
+	if s == nil {
+		return beads.Bead{}, false
+	}
+	if id := s.beadIDByAgentName[template]; id != "" {
+		return s.FindByID(id)
+	}
+	if id := s.beadIDByTemplateHint[template]; id != "" {
+		return s.FindByID(id)
+	}
+	return beads.Bead{}, false
+}
+
 func (s *sessionBeadSnapshot) FindByID(id string) (beads.Bead, bool) {
 	if s == nil || strings.TrimSpace(id) == "" {
 		return beads.Bead{}, false
@@ -157,4 +181,27 @@ func (s *sessionBeadSnapshot) FindSessionNameByNamedIdentity(identity string) st
 		}
 	}
 	return ""
+}
+
+func stampedPoolQualifiedIdentity(bead beads.Bead) string {
+	if !isPoolManagedSessionBead(bead) {
+		return ""
+	}
+	slot, err := strconv.Atoi(strings.TrimSpace(bead.Metadata["pool_slot"]))
+	if err != nil || slot <= 0 {
+		return ""
+	}
+	template := strings.TrimSpace(bead.Metadata["template"])
+	if template == "" {
+		return ""
+	}
+	scope, name := config.ParseQualifiedName(template)
+	if name == "" {
+		return ""
+	}
+	instance := fmt.Sprintf("%s-%d", name, slot)
+	if scope != "" {
+		return scope + "/" + instance
+	}
+	return instance
 }

--- a/cmd/gc/session_model_phase0_doctor_spec_test.go
+++ b/cmd/gc/session_model_phase0_doctor_spec_test.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/session"
 )
@@ -305,6 +308,62 @@ mode = "on_demand"
 	out := stdout.String() + stderr.String()
 	if !strings.Contains(out, "configured-named-conflict") {
 		t.Fatalf("doctor output missing configured-named-conflict finding:\n%s", out)
+	}
+}
+
+type sessionModelDoctorQuerySpyStore struct {
+	*beads.MemStore
+	queries []beads.ListQuery
+}
+
+func (s *sessionModelDoctorQuerySpyStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	s.queries = append(s.queries, query)
+	if query.AllowScan && query.IncludeClosed && query.Label == "" && query.Type == "" {
+		return nil, errors.New("unfiltered closed scan")
+	}
+	return s.MemStore.List(query)
+}
+
+func TestPhase0DoctorSessionModelAvoidsUnfilteredClosedScan(t *testing.T) {
+	store := &sessionModelDoctorQuerySpyStore{MemStore: beads.NewMemStore()}
+	closed, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"session_name": "s-gc-closed",
+			"template":     "worker",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close(%s): %v", closed.ID, err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:     "task",
+		Status:   "open",
+		Title:    "stale owner",
+		Assignee: closed.ID,
+	}); err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+
+	check := &sessionModelDoctorCheck{
+		cfg:      &config.City{},
+		cityPath: "/city",
+		newStore: func(string) (beads.Store, error) {
+			return store, nil
+		},
+	}
+	result := check.Run(&doctor.CheckContext{Verbose: true})
+	if result.Status != doctor.StatusWarning || !strings.Contains(strings.Join(result.Details, "\n"), "closed-bead-owner") {
+		t.Fatalf("session-model result = %#v, want closed-bead-owner warning", result)
+	}
+	for _, query := range store.queries {
+		if query.AllowScan && query.IncludeClosed && query.Label == "" && query.Type == "" {
+			t.Fatalf("session-model used unfiltered closed scan: %#v", query)
+		}
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -150,6 +150,10 @@ in the arguments.
 
 All arguments after "gc bd" are forwarded to bd unchanged.
 
+gc bd forces BD_EXPORT_AUTO=false to prevent bd's git auto-export hook
+from wedging the wrapper after printing command output. If you need
+auto-export behavior, invoke bd directly.
+
 ```
 gc bd [bd-args...]
 ```


### PR DESCRIPTION
## Summary
- avoid bead-backed session snapshot and per-agent session-name lookups on status/rig status render paths
- keep status runtime observation from resolving concrete pool names through bd
- make doctor session-model diagnostics avoid an unfiltered closed-bead scan
- includes the gc bd auto-export suppression already validated under gc-7m25qw

## Verification
- go test ./cmd/gc -run 'TestGcBdSuppressesBdAutoExportForJsonShowAndUpdate|TestStatusSessionProviderSkipsSessionSnapshot|TestPhase0Doctor|TestCityStatus|TestRigStatus|TestLoadProviderSessionSnapshot' -count=1
- go build -o /tmp/gc-status-probe ./cmd/gc
- /tmp/gc-status-probe status completed under watchdog with rc=0
- /tmp/gc-status-probe doctor --verbose completed under watchdog; rc=1 from existing doctor health failure, not a hang

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->