### PR TITLE
bd-nq6kg.10: refresh empty controller ready demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -746,14 +746,26 @@ func listForControllerDemand(store beads.Store, query beads.ListQuery) ([]beads.
 }
 
 func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
+	if cache, ok := store.(interface {
+		Backing() beads.Store
+	}); ok {
+		if _, ok := cache.Backing().(*beads.FileStore); ok {
+			return beads.ReadyLive(store)
+		}
+	}
 	// Controller demand reads are intentionally cache-tolerant, not
 	// authoritative lifecycle gates; CachedReady falls back whenever the cache
-	// has dirty or unknown dependency coverage.
+	// has dirty or unknown dependency coverage. An empty cached ready set is
+	// also not authoritative for long-running controllers because work can be
+	// added by an external `gc sling`/`bd` process after the cache was primed.
 	if cached, ok := store.(interface {
 		CachedReady() ([]beads.Bead, bool)
 	}); ok {
 		if ready, ok := cached.CachedReady(); ok {
-			return ready, nil
+			if len(ready) > 0 {
+				return ready, nil
+			}
+			return beads.ReadyLive(store)
 		}
 	}
 	return beads.ReadyLive(store)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -180,6 +180,60 @@ func TestCollectAssignedWorkBeadsUsesCachedReadyReadModel(t *testing.T) {
 	}
 }
 
+func TestCollectAssignedWorkBeadsFallsBackLiveWhenCachedReadyEmpty(t *testing.T) {
+	backing := beads.NewMemStore()
+	cache := beads.NewCachingStoreForTest(backing, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	handoff, err := backing.Create(beads.Bead{
+		Title:    "externally slung handoff",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("Create(handoff): %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+	if len(got) != 1 || got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want externally-created handoff %s", got, handoff.ID)
+	}
+}
+
+func TestCollectAssignedWorkBeadsUsesLiveReadyForFileBackedCache(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "beads.json")
+	controllerStore, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatalf("OpenFileStore(controller): %v", err)
+	}
+	cache := beads.NewCachingStoreForTest(controllerStore, nil)
+	if err := cache.PrimeActive(); err != nil {
+		t.Fatalf("PrimeActive: %v", err)
+	}
+
+	writerStore, err := beads.OpenFileStore(fsys.OSFS{}, path)
+	if err != nil {
+		t.Fatalf("OpenFileStore(writer): %v", err)
+	}
+	handoff, err := writerStore.Create(beads.Bead{
+		Title:    "externally slung handoff",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "repo/refinery",
+	})
+	if err != nil {
+		t.Fatalf("Create(handoff): %v", err)
+	}
+
+	got, _ := collectAssignedWorkBeads(&config.City{}, cache)
+	if len(got) != 1 || got[0].ID != handoff.ID {
+		t.Fatalf("collectAssignedWorkBeads returned %#v, want externally-created handoff %s", got, handoff.ID)
+	}
+}
+
 func TestCollectAssignedWorkBeadsUsesCachedInProgressReadModel(t *testing.T) {
 	backing := &demandListCountingStore{Store: beads.NewMemStore()}
 	work, err := backing.Create(beads.Bead{


### PR DESCRIPTION
Feature-Key: bd-nq6kg.10
Agent: codex-tech-lead

## Summary
- Treat empty cached ready demand as non-authoritative for controller demand so externally slung work is discovered after the controller cache was primed.
- Force file-backed cached stores through live ready reads for cross-process correctness.
- Add regressions for empty-cache external writes and file-backed external writes.

## Validation
- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeads(FallsBackLiveWhenCachedReadyEmpty|UsesLiveReadyForFileBackedCache|UsesCachedReadyReadModel)'`
- `git diff --check`
- BD Symphony native integration gate passed with this patched gc: `BD_SYMPHONY_GC_VERSION=dev PATH=/tmp/agents/bd-nq6kg.10/gascity/.tmp:$PATH scripts/native-integration-gate.sh`

## Notes
- A broad `go test ./cmd/gc` run was started but killed after hanging without output; targeted regression tests and the full BD Symphony integration proof passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->