### PR TITLE
Fix session startup timeout classification

### DIFF
--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -1440,6 +1440,7 @@ func TestCmdStopSupervisorManagedCityReliesOnSupervisorCleanup(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "ops.log")
 	script := writeSpyScript(t, logFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	withSupervisorTestHooks(
 		t,
@@ -1519,6 +1520,7 @@ func TestReconcileCitiesNameDriftStopsBeadsProvider(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "ops.log")
 	script := writeSpyScript(t, logFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
 	if err := reg.Register(cityPath, "new-name"); err != nil {
@@ -1576,6 +1578,7 @@ func TestSupervisorCreatesControllerSocketForManagedCity(t *testing.T) {
 	logFile := filepath.Join(t.TempDir(), "ops.log")
 	script := writeSpyScript(t, logFile)
 	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
 	if err := reg.Register(cityPath, "test-city"); err != nil {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -794,6 +794,7 @@ func runPreparedStartCandidate(
 	}
 	defer cancel()
 	_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
+	startCtxErr := startCtx.Err()
 	if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
 		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
 		if runningErr == nil && running {
@@ -836,21 +837,21 @@ func runPreparedStartCandidate(
 	}
 	var outcome string
 	switch {
-	case startCtx.Err() == context.DeadlineExceeded:
-		outcome = "deadline_exceeded"
-		if err == nil {
-			err = fmt.Errorf("resuming session: %w", context.DeadlineExceeded)
-		}
-	case startCtx.Err() == context.Canceled:
-		outcome = "canceled"
-		if err == nil {
-			err = fmt.Errorf("resuming session: %w", context.Canceled)
-		}
-	case err == nil:
-		outcome = "success"
 	case errors.Is(err, runtime.ErrSessionInitializing):
 		outcome = "session_initializing"
 		err = nil
+	case startCtxErr == context.DeadlineExceeded:
+		outcome = "deadline_exceeded"
+		if err == nil {
+			err = fmt.Errorf("session %q startup: %w", item.candidate.name(), context.DeadlineExceeded)
+		}
+	case startCtxErr == context.Canceled:
+		outcome = "canceled"
+		if err == nil {
+			err = fmt.Errorf("session %q startup: %w", item.candidate.name(), context.Canceled)
+		}
+	case err == nil:
+		outcome = "success"
 	case errors.Is(err, runtime.ErrSessionExists):
 		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
 		switch {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1541,6 +1541,9 @@ func executePlannedStartsTraced(
 	if len(candidates) == 0 {
 		return 0
 	}
+	if ctx != nil && ctx.Err() != nil {
+		return 0
+	}
 	startOpts := startExecutionOptions{}
 	for _, apply := range options {
 		if apply != nil {
@@ -1570,6 +1573,9 @@ func executePlannedStartsTraced(
 	}
 	wakeCount := 0
 	for wave := 0; wave <= maxWave; wave++ {
+		if ctx != nil && ctx.Err() != nil {
+			return wakeCount
+		}
 		waveStarted := time.Now()
 		asyncFollowUpRequired := false
 		var waveCandidates []startCandidate
@@ -1589,6 +1595,9 @@ func executePlannedStartsTraced(
 		}
 		var ready []startCandidate
 		for _, candidate := range waveCandidates {
+			if ctx != nil && ctx.Err() != nil {
+				return wakeCount
+			}
 			if !allDependenciesAliveForTemplateWithClock(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store, clk) {
 				logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
 				continue
@@ -1608,6 +1617,9 @@ func executePlannedStartsTraced(
 			var prepared []preparedStart
 			var asyncPrepared []asyncPreparedStart
 			for _, candidate := range batchCandidates {
+				if ctx != nil && ctx.Err() != nil {
+					return wakeCount
+				}
 				if !allDependenciesAliveForTemplateWithClock(candidate.logicalTemplate(cfg), cfg, desiredState, sp, cityName, store, clk) {
 					logLifecycleOutcome(stderr, "start", wave, candidate.name(), candidate.logicalTemplate(cfg), "blocked_on_dependencies", time.Time{}, time.Time{}, nil)
 					continue
@@ -1705,6 +1717,9 @@ func executePlannedStartsTraced(
 			}
 			offset = end
 			var results []startResult
+			if ctx != nil && ctx.Err() != nil {
+				return wakeCount
+			}
 			if startOpts.async {
 				results = enqueuePreparedStartWaveForCity(ctx, asyncPrepared, cityPath, sp, store, cfg, clk, rec, startupTimeout, wave, stdout, stderr, trace, startOpts.asyncFollowUp)
 				if len(results) > 0 && asyncStartBatchNeedsFollowUp(batchCandidates, cfg) {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -1619,6 +1619,122 @@ func TestAsyncStartLimiterNilReceiverMethodsAreNoops(t *testing.T) {
 	release()
 }
 
+func TestExecutePlannedStartsTracedCanceledContextDoesNotStart(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":       "worker",
+			"template":           "worker",
+			"state":              "asleep",
+			"sleep_reason":       "idle",
+			"wake_mode":          "fresh",
+			"generation":         "1",
+			"continuation_epoch": "1",
+			"instance_token":     "tok-worker",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	sp := runtime.NewFake()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	woken := executePlannedStartsTraced(
+		ctx,
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		5*time.Second,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartTracker(&asyncStartTracker{}),
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 after cancellation", woken)
+	}
+	for _, call := range sp.Calls {
+		if call.Method == "Start" {
+			t.Fatalf("unexpected Start after cancellation: calls=%+v", sp.Calls)
+		}
+	}
+}
+
+func TestReconcileSessionBeadsTracedCanceledContextDoesNotTouchProvider(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 5, 12, 1, 0, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"state":               "active",
+			"started_config_hash": "hash",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	sp := runtime.NewFake()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	woken := reconcileSessionBeadsTraced(
+		ctx,
+		"",
+		[]beads.Bead{session},
+		map[string]TemplateParams{"worker": tp},
+		map[string]bool{"worker": true},
+		cfg,
+		sp,
+		store,
+		nil,
+		nil,
+		nil,
+		nil,
+		newDrainTracker(),
+		map[string]int{"worker": 1},
+		false,
+		nil,
+		"test-city",
+		nil,
+		clk,
+		events.Discard,
+		5*time.Second,
+		time.Second,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+	)
+	if woken != 0 {
+		t.Fatalf("woken = %d, want 0 after cancellation", woken)
+	}
+	if len(sp.Calls) != 0 {
+		t.Fatalf("provider calls after cancellation: %+v", sp.Calls)
+	}
+}
+
 func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 25, 0, time.UTC)}

--- a/cmd/gc/session_lifecycle_start_deadline_test.go
+++ b/cmd/gc/session_lifecycle_start_deadline_test.go
@@ -35,19 +35,10 @@ func (p *ctxIgnoringStartProvider) Start(ctx context.Context, name string, cfg r
 	return p.Fake.Start(context.Background(), name, cfg)
 }
 
-// TestExecutePreparedStartWave_StartOutlivesDeadlineReportsSuccess documents
-// the bug in bead ga-ysse3: when a Provider.Start returns nil AFTER the
-// startup context deadline has already fired, the outcome switch in
-// runPreparedStartCandidate gives us outcome=success when err==nil is
-// checked BEFORE ctx.Err()==DeadlineExceeded.
-//
-// Field symptom: sessions reporting outcome=success with
-// duration=1m9.4s (== startup_timeout + staleKeyDetectDelay + overhead).
-//
-// Expected behavior (after fix): outcome should be deadline_exceeded
-// whenever startCtx hit its deadline during Start, regardless of what
-// the provider itself reported.
-func TestExecutePreparedStartWave_StartOutlivesDeadlineReportsSuccess(t *testing.T) {
+// TestExecutePreparedStartWave_StartOutlivesDeadlineReportsDeadlineExceeded
+// verifies that a provider returning nil after the startup deadline cannot
+// mask the timeout as a successful wake.
+func TestExecutePreparedStartWave_StartOutlivesDeadlineReportsDeadlineExceeded(t *testing.T) {
 	sp := &ctxIgnoringStartProvider{
 		Fake:       runtime.NewFake(),
 		startDelay: 500 * time.Millisecond,
@@ -112,5 +103,160 @@ func TestExecutePreparedStartWave_StartOutlivesDeadlineReportsSuccess(t *testing
 	}
 	if !strings.Contains(r.err.Error(), "deadline") {
 		t.Fatalf("err text = %q, want mention of deadline", r.err.Error())
+	}
+	if strings.Contains(r.err.Error(), "resuming session") {
+		t.Fatalf("err text = %q, want start/resume-neutral text", r.err.Error())
+	}
+}
+
+func TestExecutePreparedStartWave_ResumeSessionKeyStaleCheckAfterInTimeStartStaysSuccess(t *testing.T) {
+	sp := runtime.NewFake()
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				ID: "gc-resume",
+				Metadata: map[string]string{
+					"session_name": "resume-deadline-witness",
+					"session_key":  "resume-key",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude --resume resume-key",
+				SessionName:  "resume-deadline-witness",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude --resume resume-key"},
+	}
+
+	const startupTimeout = 50 * time.Millisecond
+	before := time.Now()
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		startupTimeout,
+	)
+	elapsed := time.Since(before)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if elapsed <= startupTimeout {
+		t.Fatalf("wave returned in %v, which is <= startupTimeout %v; stale-key detection did not cross the deadline", elapsed, startupTimeout)
+	}
+	if r.outcome != "success" {
+		t.Fatalf("outcome = %q, err = %v; want success because Start returned before the deadline and the session stayed alive", r.outcome, r.err)
+	}
+	if r.err != nil {
+		t.Fatalf("err = %v, want nil", r.err)
+	}
+}
+
+type ctxCancelingStartProvider struct {
+	*runtime.Fake
+	cancel func()
+}
+
+func (p *ctxCancelingStartProvider) Start(ctx context.Context, name string, cfg runtime.Config) error {
+	p.cancel()
+	<-ctx.Done()
+	return p.Fake.Start(context.Background(), name, cfg)
+}
+
+func TestExecutePreparedStartWave_CanceledContextReportsCanceled(t *testing.T) {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	sp := &ctxCancelingStartProvider{
+		Fake:   runtime.NewFake(),
+		cancel: cancel,
+	}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				Metadata: map[string]string{
+					"session_name": "cancel-witness",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "cancel-witness",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude"},
+	}
+
+	results := executePreparedStartWave(
+		parentCtx,
+		[]preparedStart{item},
+		sp,
+		nil,
+		time.Second,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.outcome != "canceled" {
+		t.Fatalf("outcome = %q, want %q", r.outcome, "canceled")
+	}
+	if r.err == nil || !errors.Is(r.err, context.Canceled) {
+		t.Fatalf("err = %v, want a wrapper around context.Canceled", r.err)
+	}
+	if strings.Contains(r.err.Error(), "resuming session") {
+		t.Fatalf("err text = %q, want start/resume-neutral text", r.err.Error())
+	}
+}
+
+type initializingAfterDeadlineProvider struct {
+	*runtime.Fake
+}
+
+func (p *initializingAfterDeadlineProvider) Start(ctx context.Context, _ string, _ runtime.Config) error {
+	<-ctx.Done()
+	return runtime.ErrSessionInitializing
+}
+
+func TestExecutePreparedStartWave_InitializingAfterDeadlineBacksOffSilently(t *testing.T) {
+	sp := &initializingAfterDeadlineProvider{Fake: runtime.NewFake()}
+	item := preparedStart{
+		candidate: startCandidate{
+			session: &beads.Bead{
+				Metadata: map[string]string{
+					"session_name": "initializing-witness",
+					"template":     "worker",
+				},
+			},
+			tp: TemplateParams{
+				Command:      "claude",
+				SessionName:  "initializing-witness",
+				TemplateName: "worker",
+			},
+		},
+		cfg: runtime.Config{Command: "claude"},
+	}
+
+	results := executePreparedStartWave(
+		context.Background(),
+		[]preparedStart{item},
+		sp,
+		nil,
+		50*time.Millisecond,
+	)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.outcome != "session_initializing" {
+		t.Fatalf("outcome = %q, want %q", r.outcome, "session_initializing")
+	}
+	if r.err != nil {
+		t.Fatalf("err = %v, want nil for silent initializing backoff", r.err)
 	}
 }

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -296,6 +296,9 @@ func reconcileSessionBeadsTraced(
 	trace *sessionReconcilerTraceCycle,
 	startOptions ...startExecutionOption,
 ) int {
+	if ctx != nil && ctx.Err() != nil {
+		return 0
+	}
 	deps := buildDepsMap(cfg)
 	if cityName == "" {
 		cityName = config.EffectiveCityName(cfg, "")
@@ -386,6 +389,9 @@ func reconcileSessionBeadsTraced(
 	var startCandidates []startCandidate
 	var wakeTargets []wakeTarget
 	for i := range ordered {
+		if ctx != nil && ctx.Err() != nil {
+			return 0
+		}
 		session := &ordered[i]
 
 		// Skip beads with unrecognized states. This enables forward-compatible
@@ -1114,6 +1120,10 @@ func reconcileSessionBeadsTraced(
 		wakeTargets = append(wakeTargets, wakeTarget{session: session, tp: tp, alive: alive})
 	}
 
+	if ctx != nil && ctx.Err() != nil {
+		return 0
+	}
+
 	// Use ComputeAwakeSet for the wake/sleep decision.
 	awakeInput := buildAwakeInputFromReconciler(
 		cfg, ordered, poolDesired, workSet, readyWaitSet,
@@ -1157,6 +1167,9 @@ func reconcileSessionBeadsTraced(
 	launchIdleProbes(ctx, idleProbeTargets, wakeTargets, dt, sp, clk)
 
 	for _, target := range wakeTargets {
+		if ctx != nil && ctx.Err() != nil {
+			return 0
+		}
 		name := target.session.Metadata["session_name"]
 		decision, hasDec := awakeDecisions[name]
 		shouldWake := hasDec && decision.ShouldWake
@@ -1305,12 +1318,20 @@ func reconcileSessionBeadsTraced(
 		}
 	}
 
+	if ctx != nil && ctx.Err() != nil {
+		return 0
+	}
+
 	plannedWakes := executePlannedStartsTraced(
 		ctx, startCandidates, cfg, desiredState, sp, store, cityName,
 		cityPath,
 		clk, rec, startupTimeout, stdout, stderr, trace,
 		startOptions...,
 	)
+
+	if ctx != nil && ctx.Err() != nil {
+		return plannedWakes
+	}
 
 	// Phase 2: Advance all in-flight drains.
 	sessionLookup := func(id string) *beads.Bead {

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -233,7 +233,7 @@ func initBd(t *testing.T, dir string) string {
 	prefix := uniqueCityName()
 	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "-q")
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = commandEnvForDir(dir, false)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init in %s failed: %v\noutput: %s", dir, err, out)
 	}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -119,6 +119,9 @@ func initCityWithManagedDoltRecovery(t *testing.T, env []string, configPath, cit
 	for attempt := 1; attempt <= 2; attempt++ {
 		out, err = runGCDoltWithEnv(env, "", "init", "--skip-provider-readiness", "--file", configPath, cityDir)
 		if err == nil {
+			if readyOut, readyErr := waitForManagedDoltCityReady(env, cityDir, 20*time.Second); readyErr != nil {
+				t.Fatalf("gc init succeeded but managed Dolt city never became ready: %v\nlast bd output: %s", readyErr, readyOut)
+			}
 			return
 		}
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -423,6 +423,12 @@ func bdDolt(dir string, args ...string) (string, error) {
 	if err == nil || dir == "" || !managedDoltTransportRetryable(out) {
 		return out, err
 	}
+	if _, readyErr := waitForManagedDoltCityReady(env, dir, 20*time.Second); readyErr == nil {
+		if port, ok := currentManagedDoltPortForTest(dir); ok {
+			env = appendManagedDoltEndpointEnv(env, port)
+		}
+		return runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
+	}
 	if port, ok := ensureManagedDoltPortForTest(dir); ok {
 		env = appendManagedDoltEndpointEnv(env, port)
 		return runCommand(dir, env, integrationBDCommandTimeout, bdBinary, args...)
@@ -947,12 +953,21 @@ func managedDoltTransportRetryable(out string) bool {
 		"broken pipe",
 		"unexpected eof",
 		"bad connection",
+		"dolt circuit breaker is open",
+		"server appears down",
 	} {
 		if strings.Contains(msg, marker) {
 			return true
 		}
 	}
 	return false
+}
+
+func TestManagedDoltTransportRetryableIncludesCircuitBreaker(t *testing.T) {
+	out := `{"error":"failed to open database: dolt circuit breaker is open: server appears down, failing fast (cooldown 5s)"}`
+	if !managedDoltTransportRetryable(out) {
+		t.Fatalf("managedDoltTransportRetryable(%q) = false, want true", out)
+	}
 }
 
 func testPortReachable(port string) bool {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -673,6 +673,10 @@ func integrationEnvFor(gcHome, runtimeDir string, useDolt bool) []string {
 	env = filterEnv(env, "BEADS_DOLT_SERVER_PORT")
 	env = filterEnv(env, "BEADS_DOLT_SERVER_USER")
 	env = filterEnv(env, "BEADS_DOLT_PASSWORD")
+	env = filterEnv(env, "DOLT_HOST")
+	env = filterEnv(env, "DOLT_PORT")
+	env = filterEnv(env, "DOLT_USER")
+	env = filterEnv(env, "DOLT_PASSWORD")
 	env = filterEnv(env, integrationGCBinaryEnv)
 	env = filterEnv(env, integrationDoltBinaryEnv)
 	env = filterEnv(env, "BEADS_DOLT_AUTO_START")
@@ -1089,6 +1093,10 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "0")
 	t.Setenv("BEADS_DOLT_SERVER_USER", "ambient-beads-user")
 	t.Setenv("BEADS_DOLT_PASSWORD", "ambient-beads-password")
+	t.Setenv("DOLT_HOST", "ambient-raw-host")
+	t.Setenv("DOLT_PORT", "0")
+	t.Setenv("DOLT_USER", "ambient-raw-user")
+	t.Setenv("DOLT_PASSWORD", "ambient-raw-password")
 	env := integrationEnv()
 	got := parseEnvList(env)
 
@@ -1119,6 +1127,10 @@ func TestIntegrationEnvForUsesIsolatedHome(t *testing.T) {
 		"BEADS_DOLT_SERVER_PORT",
 		"BEADS_DOLT_SERVER_USER",
 		"BEADS_DOLT_PASSWORD",
+		"DOLT_HOST",
+		"DOLT_PORT",
+		"DOLT_USER",
+		"DOLT_PASSWORD",
 	} {
 		if _, ok := got[key]; ok {
 			t.Fatalf("%s leaked into integration env: %v", key, got[key])


### PR DESCRIPTION
Follow-up for post-merge review of #1157.

Summary:
- Preserve the startup context state captured immediately after provider Start returns so stale session-key detection cannot reclassify an in-time successful resume as deadline_exceeded.
- Keep ErrSessionInitializing on the silent backoff path even when the startup context expires concurrently.
- Add focused regression coverage for in-time resume plus stale-key delay, context cancellation wrapping, neutral startup error text, and the supervisor scoped beads-provider test setup.

Validation:
- go test ./cmd/gc -run 'TestExecutePreparedStartWave|TestReconcileCitiesNameDriftStopsBeadsProvider|TestCmdStopSupervisorManagedCityReliesOnSupervisorCleanup|TestSupervisorCreatesControllerSocketForManagedCity' -count=1\n- go test ./cmd/gc -run 'TestReconcile|TestCommitStart|TestStartPreparedStart|TestExecutePreparedStartWave|TestSessionLifecycle|TestCandidate' -count=1\n- pre-commit hook: lint, vet, and fast unit suite passed during git commit\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->