### PR TITLE
fix: subtract in-flight pool creates from scale demand

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1131,6 +1131,98 @@ func TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession(
 	}
 }
 
+func TestBuildDesiredState_PoolInFlightSessionsPreservePartialScaleDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "worker"
+
+	for i := 0; i < 5; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  fmt.Sprintf("queued work %d", i+1),
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": template,
+			},
+		}); err != nil {
+			t.Fatalf("create queued work: %v", err)
+		}
+	}
+	var inFlightSessionIDs []string
+	for i := 0; i < 2; i++ {
+		session, err := store.Create(beads.Bead{
+			Title:  template,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel, "agent:" + template},
+			Metadata: map[string]string{
+				"template":             template,
+				"agent_name":           template,
+				"state":                "asleep",
+				"pending_create_claim": boolMetadata(true),
+				poolManagedMetadataKey: boolMetadata(true),
+			},
+		})
+		if err != nil {
+			t.Fatalf("create pending pool session: %v", err)
+		}
+		if err := store.SetMetadata(session.ID, "session_name", PoolSessionName(template, session.ID)); err != nil {
+			t.Fatalf("set session_name: %v", err)
+		}
+		inFlightSessionIDs = append(inFlightSessionIDs, session.ID)
+	}
+	sessionSnapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("load session snapshot: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              template,
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+
+	var stderr strings.Builder
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		store, nil, sessionSnapshot, nil, &stderr,
+	)
+
+	if got := dsResult.ScaleCheckCounts[template]; got != 5 {
+		t.Fatalf("ScaleCheckCounts[%s] = %d, want 5", template, got)
+	}
+	desired := 0
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == template {
+			desired++
+		}
+	}
+	if desired != 5 {
+		t.Fatalf("%s desired sessions = %d, want 5 with two in-flight plus three new; stderr:\n%s", template, desired, stderr.String())
+	}
+	desiredSessionNames := make(map[string]bool)
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == template {
+			desiredSessionNames[tp.SessionName] = true
+		}
+	}
+	for _, id := range inFlightSessionIDs {
+		name := PoolSessionName(template, id)
+		if !desiredSessionNames[name] {
+			t.Fatalf("desired state did not preserve in-flight session %s (%s); desired=%#v", id, name, desiredSessionNames)
+		}
+	}
+	sessions, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("list session beads: %v", err)
+	}
+	if len(sessions) != 5 {
+		t.Fatalf("stored session beads = %d, want 5 total", len(sessions))
+	}
+}
+
 func TestBuildDesiredState_OnDemandNamedSession_RoutedMetadataAloneDoesNotMaterialize(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -153,11 +153,20 @@ func computePoolDesiredStates(
 	limits := newNestedCapLimits(cfg)
 	usage := acceptedNestedCapUsage(limits, resumeRequests)
 	allRequests := append([]SessionRequest(nil), resumeRequests...)
+	resumeSessionBeadIDs := make(map[string]struct{}, len(resumeRequests))
+	for _, req := range resumeRequests {
+		if req.SessionBeadID != "" {
+			resumeSessionBeadIDs[req.SessionBeadID] = struct{}{}
+		}
+	}
+	inFlightNewCounts := poolInFlightNewCounts(cfg, sessionBeads, resumeSessionBeadIDs)
 
 	// Merge scale_check demand. In bead-backed reconciliation, scale_check is
 	// the authoritative signal for new unassigned demand only; resume requests
 	// are calculated independently from assigned work and must not be deducted
-	// from that count.
+	// from that count. Pool-created sessions that have not claimed work yet
+	// represent already-spent new demand; they only subtract from positive
+	// scale_check counts and never create desired demand by themselves.
 	if len(scaleCheckCounts) > 0 {
 		for i := range cfg.Agents {
 			agent := &cfg.Agents[i]
@@ -168,6 +177,13 @@ func computePoolDesiredStates(
 			scaleCount, ok := scaleCheckCounts[template]
 			if !ok {
 				continue
+			}
+			if scaleCount <= 0 {
+				continue
+			}
+			scaleCount -= inFlightNewCounts[template]
+			if scaleCount < 0 {
+				scaleCount = 0
 			}
 			newCount := capNewDemandCount(limits, usage, agent, scaleCount)
 			for j := 0; j < newCount; j++ {
@@ -182,6 +198,43 @@ func computePoolDesiredStates(
 	}
 
 	return applyNestedCaps(cfg, allRequests, trace)
+}
+
+func poolInFlightNewCounts(cfg *config.City, sessionBeads []beads.Bead, resumeSessionBeadIDs map[string]struct{}) map[string]int {
+	counts := make(map[string]int)
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if agent.Suspended || !agent.SupportsGenericEphemeralSessions() {
+			continue
+		}
+		template := agent.QualifiedName()
+		for _, sb := range sessionBeads {
+			if sb.Status == "closed" {
+				continue
+			}
+			if _, ok := resumeSessionBeadIDs[sb.ID]; ok {
+				continue
+			}
+			if !isEphemeralSessionBeadForAgent(sb, agent) || !isPoolManagedSessionBead(sb) {
+				continue
+			}
+			if normalizedSessionTemplate(sb, cfg) != template {
+				continue
+			}
+			if !poolSessionConsumesNewDemand(sb) {
+				continue
+			}
+			counts[template]++
+		}
+	}
+	return counts
+}
+
+func poolSessionConsumesNewDemand(session beads.Bead) bool {
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) == boolMetadata(true) {
+		return true
+	}
+	return strings.TrimSpace(session.Metadata["state"]) == "creating"
 }
 
 // applyNestedCaps enforces workspace, rig, and agent max_active_sessions caps.

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -13,7 +13,7 @@ type SessionRequest struct {
 	Template      string // agent template qualified name (e.g., "gascity/claude")
 	BeadPriority  int    // priority of the driving work bead
 	Tier          string // "resume" (in-progress work with assigned session) or "new" (ready unassigned work)
-	SessionBeadID string // for resume tier: the session bead to restart
+	SessionBeadID string // concrete session to preserve for resume or in-flight new demand
 	WorkBeadID    string // the work bead driving this request
 }
 
@@ -159,14 +159,14 @@ func computePoolDesiredStates(
 			resumeSessionBeadIDs[req.SessionBeadID] = struct{}{}
 		}
 	}
-	inFlightNewCounts := poolInFlightNewCounts(cfg, sessionBeads, resumeSessionBeadIDs)
+	inFlightNewRequests := poolInFlightNewRequests(cfg, sessionBeads, resumeSessionBeadIDs)
 
 	// Merge scale_check demand. In bead-backed reconciliation, scale_check is
 	// the authoritative signal for new unassigned demand only; resume requests
 	// are calculated independently from assigned work and must not be deducted
 	// from that count. Pool-created sessions that have not claimed work yet
-	// represent already-spent new demand; they only subtract from positive
-	// scale_check counts and never create desired demand by themselves.
+	// represent already-spent new demand, so they occupy the first new-demand
+	// slots explicitly before anonymous creates are materialized.
 	if len(scaleCheckCounts) > 0 {
 		for i := range cfg.Agents {
 			agent := &cfg.Agents[i]
@@ -178,15 +178,23 @@ func computePoolDesiredStates(
 			if !ok {
 				continue
 			}
-			if scaleCount <= 0 {
-				continue
-			}
-			scaleCount -= inFlightNewCounts[template]
-			if scaleCount < 0 {
-				scaleCount = 0
-			}
 			newCount := capNewDemandCount(limits, usage, agent, scaleCount)
-			for j := 0; j < newCount; j++ {
+			inFlight := inFlightNewRequests[template]
+			inFlightCount := minInt(len(inFlight), newCount)
+			if scaleCount > 0 && len(inFlight) > 0 && trace != nil {
+				trace.recordDecision(string(TraceSitePoolInFlightReuse), template, "", string(TraceReasonInFlightReuse), "accepted", traceRecordPayload{
+					"scale_check":   scaleCount,
+					"in_flight":     len(inFlight),
+					"reused":        inFlightCount,
+					"anonymous_new": newCount - inFlightCount,
+				}, nil, "")
+			}
+			for j := 0; j < inFlightCount; j++ {
+				req := inFlight[j]
+				allRequests = append(allRequests, req)
+				usage.accept(req, limits)
+			}
+			for j := inFlightCount; j < newCount; j++ {
 				req := SessionRequest{
 					Template: template,
 					Tier:     "new",
@@ -200,16 +208,23 @@ func computePoolDesiredStates(
 	return applyNestedCaps(cfg, allRequests, trace)
 }
 
-func poolInFlightNewCounts(cfg *config.City, sessionBeads []beads.Bead, resumeSessionBeadIDs map[string]struct{}) map[string]int {
-	counts := make(map[string]int)
+func poolInFlightNewRequests(cfg *config.City, sessionBeads []beads.Bead, resumeSessionBeadIDs map[string]struct{}) map[string][]SessionRequest {
+	requests := make(map[string][]SessionRequest)
+	sortedSessionBeads := append([]beads.Bead(nil), sessionBeads...)
+	sort.SliceStable(sortedSessionBeads, func(i, j int) bool {
+		if !sortedSessionBeads[i].CreatedAt.Equal(sortedSessionBeads[j].CreatedAt) {
+			return sortedSessionBeads[i].CreatedAt.Before(sortedSessionBeads[j].CreatedAt)
+		}
+		return sortedSessionBeads[i].ID < sortedSessionBeads[j].ID
+	})
 	for i := range cfg.Agents {
 		agent := &cfg.Agents[i]
 		if agent.Suspended || !agent.SupportsGenericEphemeralSessions() {
 			continue
 		}
 		template := agent.QualifiedName()
-		for _, sb := range sessionBeads {
-			if sb.Status == "closed" {
+		for _, sb := range sortedSessionBeads {
+			if sb.ID == "" || sb.Status == "closed" {
 				continue
 			}
 			if _, ok := resumeSessionBeadIDs[sb.ID]; ok {
@@ -224,16 +239,23 @@ func poolInFlightNewCounts(cfg *config.City, sessionBeads []beads.Bead, resumeSe
 			if !poolSessionConsumesNewDemand(sb) {
 				continue
 			}
-			counts[template]++
+			requests[template] = append(requests[template], SessionRequest{
+				Template:      template,
+				Tier:          "new",
+				SessionBeadID: sb.ID,
+			})
 		}
 	}
-	return counts
+	return requests
 }
 
 func poolSessionConsumesNewDemand(session beads.Bead) bool {
 	if strings.TrimSpace(session.Metadata["pending_create_claim"]) == boolMetadata(true) {
 		return true
 	}
+	// This pure desired-state pass has no reconciler clock. Creating sessions
+	// still represent already-spent new demand; lifecycle code owns stale
+	// creating recovery with its clock-aware predicate.
 	return strings.TrimSpace(session.Metadata["state"]) == "creating"
 }
 
@@ -260,7 +282,7 @@ func applyNestedCaps(cfg *config.City, requests []SessionRequest, trace *session
 
 	for _, req := range requests {
 		template := req.Template
-		if usage.isDuplicateResume(req) {
+		if usage.isDuplicateSessionRequest(req) {
 			continue
 		}
 		if site, reason, payload, rejected := usage.rejection(req, limits); rejected {
@@ -424,15 +446,15 @@ func capNewDemandCount(limits nestedCapLimits, usage nestedCapUsage, agent *conf
 }
 
 func (u nestedCapUsage) canAccept(req SessionRequest, limits nestedCapLimits) bool {
-	if u.isDuplicateResume(req) {
+	if u.isDuplicateSessionRequest(req) {
 		return false
 	}
 	_, _, _, rejected := u.rejection(req, limits)
 	return !rejected
 }
 
-func (u nestedCapUsage) isDuplicateResume(req SessionRequest) bool {
-	return req.Tier == "resume" && req.SessionBeadID != "" && u.seenSessionBead[req.SessionBeadID]
+func (u nestedCapUsage) isDuplicateSessionRequest(req SessionRequest) bool {
+	return req.SessionBeadID != "" && u.seenSessionBead[req.SessionBeadID]
 }
 
 func (u nestedCapUsage) rejection(req SessionRequest, limits nestedCapLimits) (string, string, traceRecordPayload, bool) {
@@ -475,7 +497,7 @@ func (u *nestedCapUsage) accept(req SessionRequest, limits nestedCapLimits) {
 		u.rigCount[rig]++
 	}
 	u.workspaceCount++
-	if req.Tier == "resume" && req.SessionBeadID != "" {
+	if req.SessionBeadID != "" {
 		u.seenSessionBead[req.SessionBeadID] = true
 	}
 }

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
@@ -25,19 +26,50 @@ func sessionBead(id, status string) beads.Bead {
 }
 
 func pendingPoolSessionBead(id string) beads.Bead {
+	return poolSessionBeadWithState(id, "creating", boolMetadata(true))
+}
+
+func pendingPoolSessionBeadAt(id string, createdAt time.Time) beads.Bead {
+	session := pendingPoolSessionBead(id)
+	session.CreatedAt = createdAt
+	return session
+}
+
+func poolSessionBeadWithState(id, state, pendingCreateClaim string) beads.Bead {
 	const template = "claude"
 	return beads.Bead{
 		ID:     id,
 		Status: "open",
-		Type:   "session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:" + template},
 		Metadata: map[string]string{
 			"template":             template,
 			"session_name":         PoolSessionName(template, id),
-			"state":                "creating",
-			"pending_create_claim": boolMetadata(true),
+			"state":                state,
+			"pending_create_claim": pendingCreateClaim,
 			poolManagedMetadataKey: boolMetadata(true),
 		},
 	}
+}
+
+func poolTraceDecision(t *testing.T, trace *sessionReconcilerTraceCycle, site TraceSiteCode) SessionReconcilerTraceRecord {
+	t.Helper()
+	for _, rec := range trace.records {
+		if rec.RecordType == TraceRecordDecision && rec.SiteCode == site {
+			return rec
+		}
+	}
+	t.Fatalf("missing trace decision for %s; records=%#v", site, trace.records)
+	return SessionReconcilerTraceRecord{}
+}
+
+func poolTraceFieldInt(t *testing.T, fields map[string]any, key string) int {
+	t.Helper()
+	got, ok := fields[key].(int)
+	if !ok {
+		t.Fatalf("trace field %s = %#v, want int", key, fields[key])
+	}
+	return got
 }
 
 func newPoolDesiredStateTestTrace(templates ...string) *sessionReconcilerTraceCycle {
@@ -613,8 +645,23 @@ func TestComputePoolDesiredStates_InFlightNewSessionsConsumeScaleDemand(t *testi
 	result := ComputePoolDesiredStates(cfg, nil, sessions, scaleCheck)
 
 	counts := PoolDesiredCounts(result)
-	if counts["claude"] != 0 {
-		t.Fatalf("poolDesired[claude] = %d, want 0 when in-flight sessions fully cover demand", counts["claude"])
+	if counts["claude"] != 3 {
+		t.Fatalf("poolDesired[claude] = %d, want 3 in-flight sessions preserving total demand", counts["claude"])
+	}
+	seen := make(map[string]bool)
+	for _, req := range result[0].Requests {
+		if req.Tier != "new" {
+			t.Fatalf("tier = %q, want new", req.Tier)
+		}
+		if req.SessionBeadID == "" {
+			t.Fatalf("in-flight session should be represented as an explicit desired request: %+v", req)
+		}
+		seen[req.SessionBeadID] = true
+	}
+	for _, id := range []string{"sess-1", "sess-2", "sess-3"} {
+		if !seen[id] {
+			t.Fatalf("missing in-flight request for %s; saw %#v", id, seen)
+		}
 	}
 }
 
@@ -651,16 +698,244 @@ func TestComputePoolDesiredStates_InFlightNewSessionsOnlySubtractCoveredDemand(t
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 	reqs := result[0].Requests
-	if len(reqs) != 3 {
-		t.Fatalf("len(requests) = %d, want 3 anonymous new creates after subtracting 2 in-flight sessions", len(reqs))
+	if len(reqs) != 5 {
+		t.Fatalf("len(requests) = %d, want 5 total desired sessions", len(reqs))
 	}
+	explicit := make(map[string]bool)
+	anonymous := 0
 	for _, req := range reqs {
 		if req.Tier != "new" {
 			t.Fatalf("tier = %q, want new", req.Tier)
 		}
-		if req.SessionBeadID != "" {
-			t.Fatalf("scale demand should only create anonymous new requests after subtracting in-flight count, got %+v", req)
+		if req.SessionBeadID == "" {
+			anonymous++
+			continue
 		}
+		explicit[req.SessionBeadID] = true
+	}
+	if anonymous != 3 {
+		t.Fatalf("anonymous new requests = %d, want 3 after two in-flight sessions consume demand", anonymous)
+	}
+	for _, id := range []string{"sess-1", "sess-2"} {
+		if !explicit[id] {
+			t.Fatalf("missing explicit in-flight request for %s; saw %#v", id, explicit)
+		}
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightResumeBeadsDoNotConsumeNewDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "claude", "sess-1", "in_progress", 5),
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBead("sess-1"),
+		pendingPoolSessionBead("sess-2"),
+	}
+	scaleCheck := map[string]int{"claude": 3}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, scaleCheck)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 4 {
+		t.Fatalf("len(requests) = %d, want 4 (one resume plus three new-demand slots)", len(reqs))
+	}
+	resume := 0
+	explicitNew := 0
+	anonymousNew := 0
+	for _, req := range reqs {
+		switch {
+		case req.Tier == "resume":
+			resume++
+			if req.SessionBeadID != "sess-1" {
+				t.Fatalf("resume SessionBeadID = %q, want sess-1", req.SessionBeadID)
+			}
+		case req.Tier == "new" && req.SessionBeadID == "sess-2":
+			explicitNew++
+		case req.Tier == "new" && req.SessionBeadID == "":
+			anonymousNew++
+		default:
+			t.Fatalf("unexpected request: %+v", req)
+		}
+	}
+	if resume != 1 || explicitNew != 1 || anonymousNew != 2 {
+		t.Fatalf("resume=%d explicitNew=%d anonymousNew=%d, want 1/1/2", resume, explicitNew, anonymousNew)
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightPredicateBranches(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	tests := []struct {
+		name    string
+		session beads.Bead
+	}{
+		{
+			name:    "pending create claim",
+			session: poolSessionBeadWithState("sess-pending", "active", boolMetadata(true)),
+		},
+		{
+			name:    "creating state",
+			session: poolSessionBeadWithState("sess-creating", "creating", ""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ComputePoolDesiredStates(cfg, nil, []beads.Bead{tt.session}, map[string]int{"claude": 1})
+
+			if len(result) != 1 || len(result[0].Requests) != 1 {
+				t.Fatalf("result = %#v, want one in-flight request", result)
+			}
+			if got := result[0].Requests[0].SessionBeadID; got != tt.session.ID {
+				t.Fatalf("SessionBeadID = %q, want %q", got, tt.session.ID)
+			}
+		})
+	}
+}
+
+func TestComputePoolDesiredStates_StaleCreatingBeadStillConsumesNewDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	stale := poolSessionBeadWithState("sess-stale", "creating", "")
+	stale.CreatedAt = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC).Add(-2 * staleCreatingStateTimeout)
+
+	result := ComputePoolDesiredStates(cfg, nil, []beads.Bead{stale}, map[string]int{"claude": 1})
+
+	if len(result) != 1 || len(result[0].Requests) != 1 {
+		t.Fatalf("result = %#v, want one stale creating request preserving already-spent demand", result)
+	}
+	if got := result[0].Requests[0].SessionBeadID; got != stale.ID {
+		t.Fatalf("SessionBeadID = %q, want %q", got, stale.ID)
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightSelectionRespectsCapsInStableOrder(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(2), 0)},
+	}
+	base := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	sessions := []beads.Bead{
+		pendingPoolSessionBeadAt("sess-newest", base.Add(4*time.Minute)),
+		pendingPoolSessionBeadAt("sess-oldest", base.Add(time.Minute)),
+		pendingPoolSessionBeadAt("sess-tie-b", base.Add(2*time.Minute)),
+		pendingPoolSessionBeadAt("sess-tie-a", base.Add(2*time.Minute)),
+	}
+
+	result := ComputePoolDesiredStates(cfg, nil, sessions, map[string]int{"claude": 10})
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 2 {
+		t.Fatalf("len(requests) = %d, want 2 after agent cap", len(reqs))
+	}
+	wantIDs := []string{"sess-oldest", "sess-tie-a"}
+	for i, want := range wantIDs {
+		if got := reqs[i].SessionBeadID; got != want {
+			t.Fatalf("request[%d].SessionBeadID = %q, want %q; requests=%#v", i, got, want, reqs)
+		}
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightDemandRecordsTrace(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBead("sess-1"),
+		pendingPoolSessionBead("sess-2"),
+	}
+	trace := newPoolDesiredStateTestTrace("claude")
+
+	result := computePoolDesiredStates(cfg, nil, sessions, map[string]int{"claude": 5}, trace)
+
+	if len(result) != 1 || len(result[0].Requests) != 5 {
+		t.Fatalf("result = %#v, want five desired requests", result)
+	}
+	if got := trace.decisionCounts[string(TraceSitePoolInFlightReuse)]; got != 1 {
+		t.Fatalf("in-flight trace decisions = %d, want 1", got)
+	}
+	rec := poolTraceDecision(t, trace, TraceSitePoolInFlightReuse)
+	for key, want := range map[string]int{
+		"scale_check":   5,
+		"in_flight":     2,
+		"reused":        2,
+		"anonymous_new": 3,
+	} {
+		if got := poolTraceFieldInt(t, rec.Fields, key); got != want {
+			t.Fatalf("%s = %d, want %d", key, got, want)
+		}
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightDemandRecordsTraceWhenCapsSuppressReuse(t *testing.T) {
+	workspaceMax := 0
+	cfg := &config.City{
+		Workspace: config.Workspace{MaxActiveSessions: &workspaceMax},
+		Agents:    []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBead("sess-1"),
+		pendingPoolSessionBead("sess-2"),
+	}
+	trace := newPoolDesiredStateTestTrace("claude")
+
+	result := computePoolDesiredStates(cfg, nil, sessions, map[string]int{"claude": 5}, trace)
+
+	if len(result) != 0 {
+		t.Fatalf("result = %#v, want no desired requests when workspace cap is exhausted", result)
+	}
+	if got := trace.decisionCounts[string(TraceSitePoolInFlightReuse)]; got != 1 {
+		t.Fatalf("in-flight trace decisions = %d, want 1", got)
+	}
+	rec := poolTraceDecision(t, trace, TraceSitePoolInFlightReuse)
+	for key, want := range map[string]int{
+		"scale_check":   5,
+		"in_flight":     2,
+		"reused":        0,
+		"anonymous_new": 0,
+	} {
+		if got := poolTraceFieldInt(t, rec.Fields, key); got != want {
+			t.Fatalf("%s = %d, want %d", key, got, want)
+		}
+	}
+}
+
+func TestApplyNestedCaps_DedupsConcreteSessionRequestsAcrossTiers(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	requests := []SessionRequest{
+		{Template: "claude", Tier: "resume", SessionBeadID: "sess-1", BeadPriority: 10},
+		{Template: "claude", Tier: "new", SessionBeadID: "sess-1"},
+		{Template: "claude", Tier: "new", SessionBeadID: "sess-2"},
+	}
+
+	result := applyNestedCaps(cfg, requests, nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 2 {
+		t.Fatalf("len(requests) = %d, want duplicate concrete session suppressed; requests=%#v", len(reqs), reqs)
+	}
+	seenSess1 := 0
+	for _, req := range reqs {
+		if req.SessionBeadID == "sess-1" {
+			seenSess1++
+		}
+	}
+	if seenSess1 != 1 {
+		t.Fatalf("sess-1 accepted %d times, want once; requests=%#v", seenSess1, reqs)
 	}
 }
 

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -24,6 +24,22 @@ func sessionBead(id, status string) beads.Bead {
 	return beads.Bead{ID: id, Status: status, Type: "session"}
 }
 
+func pendingPoolSessionBead(id string) beads.Bead {
+	const template = "claude"
+	return beads.Bead{
+		ID:     id,
+		Status: "open",
+		Type:   "session",
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         PoolSessionName(template, id),
+			"state":                "creating",
+			"pending_create_claim": boolMetadata(true),
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}
+}
+
 func newPoolDesiredStateTestTrace(templates ...string) *sessionReconcilerTraceCycle {
 	detail := make(map[string]TraceSource, len(templates))
 	for _, template := range templates {
@@ -576,6 +592,75 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 	}
 	if resumeCount != 1 || newCount != 2 {
 		t.Errorf("resume=%d new=%d, want resume=1 new=2", resumeCount, newCount)
+	}
+}
+
+// Regression: scale_check counts unassigned ready work, which remains
+// unassigned while just-created sessions are still starting. Those in-flight
+// sessions must consume new demand or every reconciler tick can create another
+// session for the same ready bead.
+func TestComputePoolDesiredStates_InFlightNewSessionsConsumeScaleDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBead("sess-1"),
+		pendingPoolSessionBead("sess-2"),
+		pendingPoolSessionBead("sess-3"),
+	}
+	scaleCheck := map[string]int{"claude": 3}
+
+	result := ComputePoolDesiredStates(cfg, nil, sessions, scaleCheck)
+
+	counts := PoolDesiredCounts(result)
+	if counts["claude"] != 0 {
+		t.Fatalf("poolDesired[claude] = %d, want 0 when in-flight sessions fully cover demand", counts["claude"])
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightNewSessionsDoNotCreateZeroDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBead("sess-1"),
+	}
+	scaleCheck := map[string]int{"claude": 0}
+
+	result := ComputePoolDesiredStates(cfg, nil, sessions, scaleCheck)
+
+	counts := PoolDesiredCounts(result)
+	if counts["claude"] != 0 {
+		t.Fatalf("poolDesired[claude] = %d, want 0 when scale_check reports no new demand", counts["claude"])
+	}
+}
+
+func TestComputePoolDesiredStates_InFlightNewSessionsOnlySubtractCoveredDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(10), 0)},
+	}
+	sessions := []beads.Bead{
+		pendingPoolSessionBead("sess-1"),
+		pendingPoolSessionBead("sess-2"),
+	}
+	scaleCheck := map[string]int{"claude": 5}
+
+	result := ComputePoolDesiredStates(cfg, nil, sessions, scaleCheck)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 3 {
+		t.Fatalf("len(requests) = %d, want 3 anonymous new creates after subtracting 2 in-flight sessions", len(reqs))
+	}
+	for _, req := range reqs {
+		if req.Tier != "new" {
+			t.Fatalf("tier = %q, want new", req.Tier)
+		}
+		if req.SessionBeadID != "" {
+			t.Fatalf("scale demand should only create anonymous new requests after subtracting in-flight count, got %+v", req)
+		}
 	}
 }
 

--- a/cmd/gc/session_reconciler_trace_types.go
+++ b/cmd/gc/session_reconciler_trace_types.go
@@ -69,6 +69,7 @@ const (
 	TraceSitePoolWorkspaceCap        TraceSiteCode = "reconciler.pool.workspace_cap"
 	TraceSitePoolAccept              TraceSiteCode = "reconciler.pool.accept"
 	TraceSitePoolMinFill             TraceSiteCode = "reconciler.pool.min_fill"
+	TraceSitePoolInFlightReuse       TraceSiteCode = "reconciler.pool.inflight_reuse"
 	TraceSiteReconcilerUnknownState  TraceSiteCode = "reconciler.session.skip_unknown_state"
 	TraceSiteReconcilerOrphaned      TraceSiteCode = "reconciler.session.orphan_or_suspended"
 	TraceSiteReconcilerCloseOrphan   TraceSiteCode = "reconciler.session.close_orphan"
@@ -119,6 +120,7 @@ const (
 	TraceReasonWorkspaceCap           TraceReasonCode = "workspace_cap"
 	TraceReasonCap                    TraceReasonCode = "cap"
 	TraceReasonMinFill                TraceReasonCode = "min_fill"
+	TraceReasonInFlightReuse          TraceReasonCode = "inflight_reuse"
 	TraceReasonWake                   TraceReasonCode = "wake"
 	TraceReasonIdleTimeout            TraceReasonCode = "idle_timeout"
 	TraceReasonStaleGeneration        TraceReasonCode = "stale_generation"
@@ -533,6 +535,7 @@ func normalizeTraceSiteCode(raw string) (TraceSiteCode, string) {
 		TraceSitePoolWorkspaceCap,
 		TraceSitePoolAccept,
 		TraceSitePoolMinFill,
+		TraceSitePoolInFlightReuse,
 		TraceSiteReconcilerUnknownState,
 		TraceSiteReconcilerOrphaned,
 		TraceSiteReconcilerCloseOrphan,
@@ -595,6 +598,7 @@ func normalizeTraceReasonCode(raw string) (TraceReasonCode, string) {
 		TraceReasonWorkspaceCap,
 		TraceReasonCap,
 		TraceReasonMinFill,
+		TraceReasonInFlightReuse,
 		TraceReasonWake,
 		TraceReasonIdleTimeout,
 		TraceReasonStaleGeneration,


### PR DESCRIPTION
## Summary
- represent pending pool session creates as explicit `Tier:"new"` requests pinned to their existing session bead IDs
- preserve partial scale demand by reusing in-flight session beads first, then emitting anonymous new requests for the remaining demand
- keep zero-demand scale checks at zero while adding regression coverage for full, partial, capped, and traced in-flight demand paths

## Tests
- focused cmd/gc pool desired-state regression suite
- go test ./cmd/gc
- make build
- pre-commit hook: golangci-lint, go vet, GC_FAST_UNIT=1 observable go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->