### PR TITLE
feat(codex): add gpt-5.4-mini to built-in provider schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Built-in Codex provider model choices now include `gpt-5.4`,
+  `gpt-5.4-mini`, and `gpt-5.4-nano`.
+
 ### Fixed
 
 - `proxy_process` services now receive a `GC_SERVICE_URL_PREFIX` that the

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1124,6 +1124,11 @@ func TestBuiltinProviders_CodexHasNilArgsAndOptionDefaults(t *testing.T) {
 	if !schemaHasChoice(codex.OptionsSchema, "model", "gpt-5.5") {
 		t.Error("codex OptionsSchema missing model choice gpt-5.5")
 	}
+	for _, model := range []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"} {
+		if !schemaHasChoice(codex.OptionsSchema, "model", model) {
+			t.Errorf("codex OptionsSchema missing model choice %s", model)
+		}
+	}
 }
 
 func TestBuiltinProviders_GeminiHasNilArgsAndOptionDefaults(t *testing.T) {

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -683,14 +683,14 @@ func TestResolveProviderChainArgsAppendAffectsResolvedArgs(t *testing.T) {
 		},
 		"codex-max": {
 			Base:       basePtr("codex"),
-			ArgsAppend: []string{"-m", "gpt-5.4"},
+			ArgsAppend: []string{"--wrapper-flag", "enabled"},
 		},
 	}
 	resolved, err := ResolveProviderChain("codex-max", custom["codex-max"], custom)
 	if err != nil {
 		t.Fatalf("ResolveProviderChain: %v", err)
 	}
-	want := []string{"run", "codex", "--", "-m", "gpt-5.4"}
+	want := []string{"run", "codex", "--", "--wrapper-flag", "enabled"}
 	if !reflect.DeepEqual(resolved.Args, want) {
 		t.Fatalf("Args = %v, want %v", resolved.Args, want)
 	}

--- a/internal/worker/builtin/profiles.go
+++ b/internal/worker/builtin/profiles.go
@@ -189,6 +189,9 @@ var builtinProviderSpecs = map[string]BuiltinProviderSpec{
 				Choices: []BuiltinOptionChoice{
 					{Value: "", Label: "Default"},
 					{Value: "gpt-5.5", Label: "GPT-5.5", FlagArgs: []string{"--model", "gpt-5.5"}, FlagAliases: [][]string{{"-m", "gpt-5.5"}}},
+					{Value: "gpt-5.4", Label: "GPT-5.4", FlagArgs: []string{"--model", "gpt-5.4"}, FlagAliases: [][]string{{"-m", "gpt-5.4"}}},
+					{Value: "gpt-5.4-mini", Label: "GPT-5.4 Mini", FlagArgs: []string{"--model", "gpt-5.4-mini"}, FlagAliases: [][]string{{"-m", "gpt-5.4-mini"}}},
+					{Value: "gpt-5.4-nano", Label: "GPT-5.4 Nano", FlagArgs: []string{"--model", "gpt-5.4-nano"}, FlagAliases: [][]string{{"-m", "gpt-5.4-nano"}}},
 					{Value: "gpt-5.3-codex-spark", Label: "GPT-5.3 Codex Spark", FlagArgs: []string{"--model", "gpt-5.3-codex-spark"}, FlagAliases: [][]string{{"-m", "gpt-5.3-codex-spark"}}},
 					{Value: "o3", Label: "o3", FlagArgs: []string{"--model", "o3"}, FlagAliases: [][]string{{"-m", "o3"}}},
 					{Value: "o4-mini", Label: "o4-mini", FlagArgs: []string{"--model", "o4-mini"}, FlagAliases: [][]string{{"-m", "o4-mini"}}},


### PR DESCRIPTION
## Summary
- Add GPT-5.4, GPT-5.4 Mini, and GPT-5.4 Nano to the built-in Codex provider model choices.
- Cover the new Codex model choices in config schema tests.
- Keep the provider args-append test focused on wrapper arguments now that `gpt-5.4` is schema-managed.

## Rationale
OpenAI's Codex rate card lists GPT-5.4 Mini with token-based Codex credit rates, while GPT-5.3-Codex-Spark remains a research preview with non-final rates:
https://help.openai.com/en/articles/20001106-codex-rate-card

OpenAI's model page lists `gpt-5.4-mini` as an available model for coding, computer use, and subagents:
https://developers.openai.com/api/docs/models/gpt-5.4-mini

This follows the provider-schema shape used by #1515 for `gpt-5.3-codex-spark`.

## Verification
- `nix shell nixpkgs#go_1_25 nixpkgs#gnumake -c go test ./internal/config/... ./internal/worker/...`
- `nix shell nixpkgs#go_1_25 nixpkgs#gnumake -c go test ./internal/config -run '^(TestBuiltinProviders_CodexHasNilArgsAndOptionDefaults|TestResolveProviderChainArgsAppendAffectsResolvedArgs)$'`
- `nix shell nixpkgs#go_1_25 nixpkgs#gnumake -c make build`
- Isolated `./bin/gc --city "$tmp/city" config show --validate` accepted `option_defaults = { model = "gpt-5.4-mini" }`.

`make test` was not used as the merge gate for this small schema patch. A prior full run while preparing this branch failed in unrelated packages (`cmd/gc/provider-readiness`, `cmd/gc/worker-session-resume`, `internal/convergence`, `internal/dispatch`, `cmd/gc/order-history`, and `TestGcBeadsBdStartRetriesAutoPortBindConflict` timeout); focused config/worker tests and build pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->