### PR TITLE
test(controller): plug dolt leak in TestControllerReloadInvalidConfig

### DIFF
--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1249,7 +1249,8 @@ func TestControllerReloadInvalidConfig(t *testing.T) {
 	debounceDelay = 5 * time.Millisecond
 	t.Cleanup(func() { debounceDelay = old })
 
-	dir := shortSocketTempDir(t, "gc-invalid-")
+	dir := shortSocketTempDir(t, "gc-reload-invalid-")
+	cleanupManagedDoltTestCity(t, dir)
 	tomlPath := writeCityTOML(t, dir, "test", "mayor")
 
 	cfg, err := config.Load(osFS{}, tomlPath)


### PR DESCRIPTION
The test calls controllerLoop with runtime.NewFake() but inherits
GC_BEADS=bd from the surrounding env, which spawns a real dolt
sql-server via gc-beads-bd.sh. Because the test never calls
shutdownBeadsProvider, that process orphans on test exit.

Mirror the canonical pattern from TestSendReloadControlRequestInvalidConfig
(cmd_reload_test.go:481):

  - rename prefix gc-invalid- -> gc-reload-invalid- (the existing entry
    in testConfigPathPrefixes() at dolt_cleanup_reaper.go:104, so any
    residual orphan is reapable by gc dolt-cleanup)
  - register cleanupManagedDoltTestCity, which calls shutdownBeadsProvider
    on teardown

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->