### PR TITLE
fix(session): expand close_reason to >=20 chars for validation.on-close=error

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2205,7 +2205,7 @@ func TestCityRuntimeTick_RefreshesManualSessionOverlayAfterSync(t *testing.T) {
 	if got.Status == "closed" {
 		t.Fatalf("manual session bead was closed after refreshed overlay should have preserved it: %+v", got)
 	}
-	if got.Metadata["state"] == "orphaned" || got.Metadata["close_reason"] == "orphaned" {
+	if got.Metadata["state"] == "orphaned" {
 		t.Fatalf("manual session bead was marked orphaned after refreshed overlay: %+v", got.Metadata)
 	}
 }

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -1900,8 +1900,8 @@ func TestSyncSessionBeads_RecreatesDriftedNamedSessionRuntimeName(t *testing.T) 
 	if closedOld.ID == "" {
 		t.Fatalf("did not find closed drifted bead among %+v", all)
 	}
-	if closedOld.Status != "closed" || closedOld.Metadata["close_reason"] != "reconfigured" {
-		t.Fatalf("drifted bead status=%q close_reason=%q, want closed/reconfigured", closedOld.Status, closedOld.Metadata["close_reason"])
+	if want := session.CanonicalCloseReason("reconfigured"); closedOld.Status != "closed" || closedOld.Metadata["close_reason"] != want {
+		t.Fatalf("drifted bead status=%q close_reason=%q, want closed/%q", closedOld.Status, closedOld.Metadata["close_reason"], want)
 	}
 	if openNew.ID == "" {
 		t.Fatalf("did not find recreated canonical bead with session_name %q", expectedName)
@@ -2792,8 +2792,8 @@ func TestSyncSessionBeads_DuplicatePoolSessionNameKeepsVisibleOwner(t *testing.T
 	if duplicateAfter.Status != "closed" {
 		t.Fatalf("duplicate bead %s status = %q, want closed", duplicate.ID, duplicateAfter.Status)
 	}
-	if got := duplicateAfter.Metadata["close_reason"]; got != "duplicate" {
-		t.Fatalf("duplicate close_reason = %q, want duplicate", got)
+	if want := session.CanonicalCloseReason("duplicate"); duplicateAfter.Metadata["close_reason"] != want {
+		t.Fatalf("duplicate close_reason = %q, want %q", duplicateAfter.Metadata["close_reason"], want)
 	}
 }
 
@@ -3417,8 +3417,8 @@ func TestSyncSessionBeads_PoolSessionNameFailureLeavesReachableFailedCreate(t *t
 	if got := strings.TrimSpace(failed.Metadata["session_name"]); got == "" {
 		t.Fatalf("failed-create bead session_name is empty: %+v", failed)
 	}
-	if got := failed.Metadata["close_reason"]; got != "failed-create" {
-		t.Fatalf("failed-create close_reason = %q, want failed-create", got)
+	if want := session.CanonicalCloseReason("failed-create"); failed.Metadata["close_reason"] != want {
+		t.Fatalf("failed-create close_reason = %q, want %q", failed.Metadata["close_reason"], want)
 	}
 	if got := failed.Metadata["pending_create_claim"]; got != "" {
 		t.Fatalf("failed-create pending_create_claim = %q, want cleared", got)
@@ -3565,8 +3565,8 @@ func TestSyncSessionBeads_OrphanDetection(t *testing.T) {
 	if oldBead.Metadata["state"] != "orphaned" {
 		t.Errorf("old-agent state = %q, want %q", oldBead.Metadata["state"], "orphaned")
 	}
-	if oldBead.Metadata["close_reason"] != "orphaned" {
-		t.Errorf("old-agent close_reason = %q, want %q", oldBead.Metadata["close_reason"], "orphaned")
+	if want := session.CanonicalCloseReason("orphaned"); oldBead.Metadata["close_reason"] != want {
+		t.Errorf("old-agent close_reason = %q, want %q", oldBead.Metadata["close_reason"], want)
 	}
 	if oldBead.Metadata["closed_at"] == "" {
 		t.Error("old-agent closed_at is empty")
@@ -3733,9 +3733,9 @@ func TestSyncSessionBeads_PoolInstanceOrphaned(t *testing.T) {
 			t.Errorf("pool instance %s state = %q, want %q",
 				b.Metadata["session_name"], b.Metadata["state"], "orphaned")
 		}
-		if b.Metadata["close_reason"] != "orphaned" {
+		if want := session.CanonicalCloseReason("orphaned"); b.Metadata["close_reason"] != want {
 			t.Errorf("pool instance %s close_reason = %q, want %q",
-				b.Metadata["session_name"], b.Metadata["close_reason"], "orphaned")
+				b.Metadata["session_name"], b.Metadata["close_reason"], want)
 		}
 	}
 }
@@ -3884,8 +3884,8 @@ func TestSyncSessionBeads_SuspendedAgentNotOrphaned(t *testing.T) {
 	if workerBead.Metadata["state"] != "suspended" {
 		t.Errorf("worker state = %q, want %q", workerBead.Metadata["state"], "suspended")
 	}
-	if workerBead.Metadata["close_reason"] != "suspended" {
-		t.Errorf("worker close_reason = %q, want %q", workerBead.Metadata["close_reason"], "suspended")
+	if want := session.CanonicalCloseReason("suspended"); workerBead.Metadata["close_reason"] != want {
+		t.Errorf("worker close_reason = %q, want %q", workerBead.Metadata["close_reason"], want)
 	}
 }
 
@@ -4370,8 +4370,8 @@ func TestSyncSessionBeads_OrphansLegacyPoolBaseSession(t *testing.T) {
 	if closedLegacy.Status != "closed" {
 		t.Fatalf("legacy bead status = %q, want closed", closedLegacy.Status)
 	}
-	if closedLegacy.Metadata["close_reason"] != "orphaned" {
-		t.Fatalf("legacy bead close_reason = %q, want orphaned", closedLegacy.Metadata["close_reason"])
+	if want := session.CanonicalCloseReason("orphaned"); closedLegacy.Metadata["close_reason"] != want {
+		t.Fatalf("legacy bead close_reason = %q, want %q", closedLegacy.Metadata["close_reason"], want)
 	}
 	if openPool.ID == "" {
 		t.Fatalf("did not find new pool session bead in %+v", all)
@@ -4934,9 +4934,9 @@ func TestReapStaleSessionBeads(t *testing.T) {
 			if tt.wantReaped > 0 {
 				all := allSessionBeads(t, store)
 				for _, b := range all {
-					if b.Status == "closed" && b.Metadata["close_reason"] != "stale-session" {
+					if want := session.CanonicalCloseReason("stale-session"); b.Status == "closed" && b.Metadata["close_reason"] != want {
 						t.Errorf("closed bead %s has close_reason=%q, want %q",
-							b.ID, b.Metadata["close_reason"], "stale-session")
+							b.ID, b.Metadata["close_reason"], want)
 					}
 				}
 				if !strings.Contains(stderr.String(), "WARN: reconciler: reaped stuck-creating session bead") {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2501,7 +2501,7 @@ func TestReconcileSessionBeads_PendingCreateLeasePreventsOrphanClose(t *testing.
 	if got.Status == "closed" {
 		t.Fatalf("pending-create session was closed as orphan: %+v", got)
 	}
-	if got.Metadata["state"] == "orphaned" || got.Metadata["close_reason"] == "orphaned" {
+	if got.Metadata["state"] == "orphaned" {
 		t.Fatalf("pending-create session was marked orphaned: %+v", got.Metadata)
 	}
 }
@@ -2525,7 +2525,7 @@ func TestReconcileSessionBeads_FreshPendingCreateSurvivesStaleConfigSnapshot(t *
 	if got.Status == "closed" {
 		t.Fatalf("fresh pending-create session was closed as orphan: %+v", got)
 	}
-	if got.Metadata["state"] == "orphaned" || got.Metadata["close_reason"] == "orphaned" {
+	if got.Metadata["state"] == "orphaned" {
 		t.Fatalf("fresh pending-create session was marked orphaned: %+v", got.Metadata)
 	}
 }
@@ -2554,7 +2554,7 @@ func TestReconcileSessionBeads_PendingCreateWithoutDesiredStateUsesNeverStartedL
 	if got.Status == "closed" {
 		t.Fatalf("pending-create session was closed before never-started lease expired: %+v", got)
 	}
-	if got.Metadata["state"] == "orphaned" || got.Metadata["close_reason"] == "orphaned" {
+	if got.Metadata["state"] == "orphaned" {
 		t.Fatalf("pending-create session was marked orphaned before never-started lease expired: %+v", got.Metadata)
 	}
 }
@@ -3834,8 +3834,8 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntim
 	if got.Status != "closed" {
 		t.Fatalf("status = %q, want closed (stale lease + no runtime should rollback)", got.Status)
 	}
-	if got.Metadata["close_reason"] != "failed-create" {
-		t.Fatalf("close_reason = %q, want failed-create", got.Metadata["close_reason"])
+	if want := sessionpkg.CanonicalCloseReason(string(sessionpkg.StateFailedCreate)); got.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
 	}
 }
 
@@ -4237,8 +4237,8 @@ func TestReconcileSessionBeads_RollbackBudgetDefersExcessMismatchesAndStillStart
 			t.Fatalf("Get(%s): %v", sessions[i].ID, err)
 		}
 		if got.Status == "closed" {
-			if got.Metadata["close_reason"] != "failed-create" {
-				t.Fatalf("%s close_reason = %q, want failed-create", name, got.Metadata["close_reason"])
+			if want := sessionpkg.CanonicalCloseReason(string(sessionpkg.StateFailedCreate)); got.Metadata["close_reason"] != want {
+				t.Fatalf("%s close_reason = %q, want %q", name, got.Metadata["close_reason"], want)
 			}
 			closedMismatches++
 			continue
@@ -4307,8 +4307,8 @@ func TestReconcileSessionBeads_RollbackBudgetDefersExcessStaleNoRuntimeCreatesAn
 			t.Fatalf("Get(%s): %v", sessions[i].ID, err)
 		}
 		if got.Status == "closed" {
-			if got.Metadata["close_reason"] != "failed-create" {
-				t.Fatalf("%s close_reason = %q, want failed-create", name, got.Metadata["close_reason"])
+			if want := sessionpkg.CanonicalCloseReason(string(sessionpkg.StateFailedCreate)); got.Metadata["close_reason"] != want {
+				t.Fatalf("%s close_reason = %q, want %q", name, got.Metadata["close_reason"], want)
 			}
 			closedCreates++
 			continue
@@ -6207,8 +6207,8 @@ func TestReconcileSessionBeads_SyncReplacesFailedCreateNamedSession(t *testing.T
 	if gotFailed.Status != "closed" {
 		t.Fatalf("failed-create named bead status = %q, want closed; stderr:\n%s", gotFailed.Status, stderr.String())
 	}
-	if gotFailed.Metadata["close_reason"] != string(sessionpkg.StateFailedCreate) {
-		t.Fatalf("failed-create named bead close_reason = %q, want %q", gotFailed.Metadata["close_reason"], sessionpkg.StateFailedCreate)
+	if want := sessionpkg.CanonicalCloseReason(string(sessionpkg.StateFailedCreate)); gotFailed.Metadata["close_reason"] != want {
+		t.Fatalf("failed-create named bead close_reason = %q, want %q", gotFailed.Metadata["close_reason"], want)
 	}
 	if gotFailed.Metadata["pending_create_claim"] != "" {
 		t.Fatalf("failed-create named bead pending_create_claim = %q, want cleared", gotFailed.Metadata["pending_create_claim"])
@@ -6338,8 +6338,8 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 	if got.Status != "closed" {
 		t.Fatalf("failed-create bead status = %q, want closed", got.Status)
 	}
-	if got.Metadata["close_reason"] != string(sessionpkg.StateFailedCreate) {
-		t.Fatalf("failed-create bead close_reason = %q, want %q", got.Metadata["close_reason"], sessionpkg.StateFailedCreate)
+	if want := sessionpkg.CanonicalCloseReason(string(sessionpkg.StateFailedCreate)); got.Metadata["close_reason"] != want {
+		t.Fatalf("failed-create bead close_reason = %q, want %q", got.Metadata["close_reason"], want)
 	}
 	if got.Metadata["pending_create_claim"] != "" || got.Metadata["pending_create_started_at"] != "" {
 		t.Fatalf("failed-create pending metadata = claim %q started_at %q, want cleared",

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -472,8 +472,11 @@ func TestReconcileSessionBeads_UndesiredDrainAckStopsAndCloses(t *testing.T) {
 	if got.Status != "closed" {
 		t.Fatalf("status = %q, want closed; metadata=%v", got.Status, got.Metadata)
 	}
-	if got.Metadata["close_reason"] != "drained" {
-		t.Fatalf("close_reason = %q, want drained", got.Metadata["close_reason"])
+	if want := sessionpkg.CanonicalCloseReason("drained"); got.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
+	}
+	if got.Metadata["state"] != "drained" {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], "drained")
 	}
 }
 
@@ -1058,8 +1061,11 @@ func TestReconcileSessionBeads_CloseGatePreservesSleepReason(t *testing.T) {
 			if got.Status != "closed" {
 				t.Fatalf("status = %q, want closed", got.Status)
 			}
-			if got.Metadata["close_reason"] != tc.wantReason {
-				t.Fatalf("close_reason = %q, want %q — close gate must preserve the originating sleep_reason for forensic fidelity", got.Metadata["close_reason"], tc.wantReason)
+			if want := sessionpkg.CanonicalCloseReason(tc.wantReason); got.Metadata["close_reason"] != want {
+				t.Fatalf("close_reason = %q, want %q (canonical for %q) — close gate must preserve the originating sleep_reason for forensic fidelity", got.Metadata["close_reason"], want, tc.wantReason)
+			}
+			if got.Metadata["state"] != tc.wantReason {
+				t.Fatalf("state = %q, want %q — state preserves the short sleep_reason code", got.Metadata["state"], tc.wantReason)
 			}
 		})
 	}
@@ -2981,8 +2987,11 @@ func TestReconcileSessionBeads_OrphanNotRunningClosed(t *testing.T) {
 	if b.Status != "closed" {
 		t.Errorf("orphan bead status = %q, want closed", b.Status)
 	}
-	if b.Metadata["close_reason"] != "orphaned" {
-		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], "orphaned")
+	if want := sessionpkg.CanonicalCloseReason("orphaned"); b.Metadata["close_reason"] != want {
+		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], want)
+	}
+	if b.Metadata["state"] != "orphaned" {
+		t.Errorf("state = %q, want %q", b.Metadata["state"], "orphaned")
 	}
 }
 
@@ -3021,8 +3030,11 @@ func TestReconcileSessionBeads_SuspendedNotRunningClosed(t *testing.T) {
 	if b.Status != "closed" {
 		t.Errorf("suspended bead status = %q, want closed", b.Status)
 	}
-	if b.Metadata["close_reason"] != "suspended" {
-		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], "suspended")
+	if want := sessionpkg.CanonicalCloseReason("suspended"); b.Metadata["close_reason"] != want {
+		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], want)
+	}
+	if b.Metadata["state"] != "suspended" {
+		t.Errorf("state = %q, want %q", b.Metadata["state"], "suspended")
 	}
 }
 
@@ -3313,8 +3325,11 @@ func TestReconcileSessionBeads_InvalidNamedSessionConfigDoesNotPreserveBead(t *t
 	if b.Status != "closed" {
 		t.Fatalf("status = %q, want closed", b.Status)
 	}
-	if b.Metadata["close_reason"] != "suspended" {
-		t.Fatalf("close_reason = %q, want suspended", b.Metadata["close_reason"])
+	if want := sessionpkg.CanonicalCloseReason("suspended"); b.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", b.Metadata["close_reason"], want)
+	}
+	if b.Metadata["state"] != "suspended" {
+		t.Fatalf("state = %q, want %q", b.Metadata["state"], "suspended")
 	}
 }
 
@@ -3624,8 +3639,11 @@ func TestReconcileSessionBeads_RollsBackAdHocCreateOnRuntimeCollision(t *testing
 	if got.Metadata["session_name"] != "" {
 		t.Fatalf("session_name = %q, want empty after rollback", got.Metadata["session_name"])
 	}
-	if got.Metadata["close_reason"] != "failed-create" {
-		t.Fatalf("close_reason = %q, want failed-create", got.Metadata["close_reason"])
+	if want := sessionpkg.CanonicalCloseReason("failed-create"); got.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
+	}
+	if got.Metadata["state"] != "failed-create" {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], "failed-create")
 	}
 	if got.Metadata["wake_attempts"] != "" {
 		t.Fatalf("wake_attempts = %q, want empty", got.Metadata["wake_attempts"])
@@ -4164,8 +4182,11 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenConflictingRuntimeAlrea
 	if got.Metadata["session_name"] != "" {
 		t.Fatalf("session_name = %q, want empty after rollback", got.Metadata["session_name"])
 	}
-	if got.Metadata["close_reason"] != "failed-create" {
-		t.Fatalf("close_reason = %q, want failed-create", got.Metadata["close_reason"])
+	if want := sessionpkg.CanonicalCloseReason("failed-create"); got.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
+	}
+	if got.Metadata["state"] != "failed-create" {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], "failed-create")
 	}
 }
 
@@ -4487,8 +4508,11 @@ func TestReconcileSessionBeads_RollsBackPendingCreateOnProviderError(t *testing.
 	if got.Metadata["session_name"] != "" {
 		t.Fatalf("session_name = %q, want empty after rollback", got.Metadata["session_name"])
 	}
-	if got.Metadata["close_reason"] != "failed-create" {
-		t.Fatalf("close_reason = %q, want failed-create", got.Metadata["close_reason"])
+	if want := sessionpkg.CanonicalCloseReason("failed-create"); got.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
+	}
+	if got.Metadata["state"] != "failed-create" {
+		t.Fatalf("state = %q, want %q", got.Metadata["state"], "failed-create")
 	}
 	if got.Metadata["wake_attempts"] != "" {
 		t.Fatalf("wake_attempts = %q, want empty", got.Metadata["wake_attempts"])

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -358,11 +358,12 @@ func ClosePatch(now time.Time, stateCode string) MetadataPatch {
 // close reason of at least 20 characters, suitable for use as
 // `bd close --reason` under validation.on-close=error.
 //
-// Unknown codes fall back to "session terminated: <code>" which is
-// always >= 20 characters for any non-empty code shorter than 20 chars.
+// Unknown non-empty codes fall back to "session terminated: <code>".
 // Codes already 20+ characters pass through unchanged.
 func CanonicalCloseReason(stateCode string) string {
 	switch stateCode {
+	case "":
+		return "session terminated: unknown state"
 	case "gc_swept":
 		return "session swept: no assigned work in any rig"
 	case "orphaned":

--- a/internal/session/lifecycle_transition.go
+++ b/internal/session/lifecycle_transition.go
@@ -335,14 +335,57 @@ func ArchivePatch(now time.Time, reason string, continuityEligible bool) Metadat
 }
 
 // ClosePatch records terminal close metadata before the bead status is closed.
-func ClosePatch(now time.Time, reason string) MetadataPatch {
+//
+// state retains the canonical short stateCode (used by reconciler logic and
+// closedNamedSessionReopenEligible). close_reason is expanded via
+// CanonicalCloseReason so cities running with validation.on-close=error
+// (which rejects close reasons under 20 characters) accept the close.
+// Without the expansion, every short-code session-close call (gc_swept,
+// orphaned, drained, failed-create, ...) is silently rejected by the
+// validator, leaving close_reason/closed_at stamped on an OPEN bead and
+// triggering reconciler flap as the next tick clears them.
+func ClosePatch(now time.Time, stateCode string) MetadataPatch {
 	ts := now.UTC().Format(time.RFC3339)
 	return MetadataPatch{
-		"state":        reason,
-		"close_reason": reason,
+		"state":        stateCode,
+		"close_reason": CanonicalCloseReason(stateCode),
 		"closed_at":    ts,
 		"synced_at":    ts,
 	}
+}
+
+// CanonicalCloseReason maps a short session stateCode to a human-readable
+// close reason of at least 20 characters, suitable for use as
+// `bd close --reason` under validation.on-close=error.
+//
+// Unknown codes fall back to "session terminated: <code>" which is
+// always >= 20 characters for any non-empty code shorter than 20 chars.
+// Codes already 20+ characters pass through unchanged.
+func CanonicalCloseReason(stateCode string) string {
+	switch stateCode {
+	case "gc_swept":
+		return "session swept: no assigned work in any rig"
+	case "orphaned":
+		return "session orphaned: configured agent removed"
+	case "drained":
+		return "session drained: pool slot retired by reconciler"
+	case "failed-create":
+		return "session create failed: aborted before creation_complete"
+	case "stale-session":
+		return "session stale: no liveness signal beyond threshold"
+	case "duplicate":
+		return "session retired: duplicate of canonical bead"
+	case "duplicate-repair":
+		return "session retired: duplicate-repair canonicalization"
+	case "reconfigured":
+		return "session reconfigured: superseded by new agent config"
+	case "suspended":
+		return "session suspended: agent disabled in city config"
+	}
+	if len(stateCode) >= 20 {
+		return stateCode
+	}
+	return fmt.Sprintf("session terminated: %s", stateCode)
 }
 
 // RetireNamedSessionPatch archives a named-session bead without closing it so

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -261,7 +261,7 @@ func TestLifecycleTransitionPatchesSetCompleteMetadata(t *testing.T) {
 			patch: ClosePatch(now, "orphaned"),
 			want: MetadataPatch{
 				"state":        "orphaned",
-				"close_reason": "orphaned",
+				"close_reason": "session orphaned: configured agent removed",
 				"closed_at":    now.Format(time.RFC3339),
 				"synced_at":    now.Format(time.RFC3339),
 			},
@@ -632,5 +632,53 @@ func TestReactivatePatchDoesNotForceHistoricalBeadEligible(t *testing.T) {
 	}
 	if merged["continuity_eligible"] != "false" {
 		t.Fatalf("continuity_eligible = %q, want false", merged["continuity_eligible"])
+	}
+}
+
+func TestCanonicalCloseReasonMeetsValidatorThreshold(t *testing.T) {
+	// bd's validation.on-close=error rejects close reasons under 20 chars.
+	// Every short stateCode that ClosePatch may stamp must round-trip to a
+	// reason >=20 chars; this guards against future additions falling back
+	// to a too-short literal and reintroducing the reconciler-flap bug.
+	stateCodes := []string{
+		"gc_swept",
+		"orphaned",
+		"drained",
+		"failed-create",
+		"stale-session",
+		"duplicate",
+		"duplicate-repair",
+		"reconfigured",
+		"suspended",
+	}
+	for _, code := range stateCodes {
+		got := CanonicalCloseReason(code)
+		if len(got) < 20 {
+			t.Errorf("CanonicalCloseReason(%q) = %q (%d chars); want >=20", code, got, len(got))
+		}
+	}
+}
+
+func TestCanonicalCloseReasonUnknownCodeFallback(t *testing.T) {
+	got := CanonicalCloseReason("xyz")
+	if len(got) < 20 {
+		t.Errorf("fallback for unknown short code = %q (%d chars); want >=20", got, len(got))
+	}
+	long := "an-already-long-state-code-of-thirty-plus-characters"
+	if got := CanonicalCloseReason(long); got != long {
+		t.Errorf("CanonicalCloseReason(%q) = %q; want passthrough", long, got)
+	}
+}
+
+func TestClosePatchKeepsShortStateCode(t *testing.T) {
+	// state must remain the short canonical code so reconciler logic and
+	// closedNamedSessionReopenEligible (which switches on state) keep working.
+	patch := ClosePatch(time.Now().UTC(), "orphaned")
+	if patch["state"] != "orphaned" {
+		t.Errorf("state = %q, want %q (short stateCode preserved)", patch["state"], "orphaned")
+	}
+	if len(patch["close_reason"]) < 20 {
+		t.Errorf("close_reason = %q (%d chars); want >=20 to satisfy validator",
+			patch["close_reason"], len(patch["close_reason"]))
 	}
 }

--- a/internal/session/lifecycle_transition_test.go
+++ b/internal/session/lifecycle_transition_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -653,16 +654,21 @@ func TestCanonicalCloseReasonMeetsValidatorThreshold(t *testing.T) {
 	}
 	for _, code := range stateCodes {
 		got := CanonicalCloseReason(code)
-		if len(got) < 20 {
-			t.Errorf("CanonicalCloseReason(%q) = %q (%d chars); want >=20", code, got, len(got))
+		trimmed := strings.TrimSpace(got)
+		if len(trimmed) < 20 {
+			t.Errorf("CanonicalCloseReason(%q) = %q (%d trimmed chars); want >=20", code, got, len(trimmed))
 		}
 	}
 }
 
 func TestCanonicalCloseReasonUnknownCodeFallback(t *testing.T) {
 	got := CanonicalCloseReason("xyz")
-	if len(got) < 20 {
-		t.Errorf("fallback for unknown short code = %q (%d chars); want >=20", got, len(got))
+	if trimmed := strings.TrimSpace(got); len(trimmed) < 20 {
+		t.Errorf("fallback for unknown short code = %q (%d trimmed chars); want >=20", got, len(trimmed))
+	}
+	empty := CanonicalCloseReason("")
+	if trimmed := strings.TrimSpace(empty); len(trimmed) < 20 {
+		t.Errorf("fallback for empty code = %q (%d trimmed chars); want >=20", empty, len(trimmed))
 	}
 	long := "an-already-long-state-code-of-thirty-plus-characters"
 	if got := CanonicalCloseReason(long); got != long {
@@ -677,8 +683,8 @@ func TestClosePatchKeepsShortStateCode(t *testing.T) {
 	if patch["state"] != "orphaned" {
 		t.Errorf("state = %q, want %q (short stateCode preserved)", patch["state"], "orphaned")
 	}
-	if len(patch["close_reason"]) < 20 {
-		t.Errorf("close_reason = %q (%d chars); want >=20 to satisfy validator",
-			patch["close_reason"], len(patch["close_reason"]))
+	if trimmed := strings.TrimSpace(patch["close_reason"]); len(trimmed) < 20 {
+		t.Errorf("close_reason = %q (%d trimmed chars); want >=20 to satisfy validator",
+			patch["close_reason"], len(trimmed))
 	}
 }


### PR DESCRIPTION
Depends on #1644.

Cities running with validation.on-close=error (the bd validator added
in gastownhall/beads#2654) reject `bd close --reason` calls under
20 characters. Every short stateCode the supervisor reconciler stamps
via session.ClosePatch — gc_swept (8), orphaned (8), drained (7),
failed-create (13), stale-session (13), duplicate (9), reconfigured (12),
suspended (9) — falls below that threshold and is silently rejected.

PR #1644 (convoy autoclose) called this out as out-of-scope follow-up
work; this is the follow-up.

Failure mode without this fix: closeBead stamps metadata
(close_reason=<short>, closed_at=ts, state=<short>) THEN calls
store.Close, which fails the validator. The bead stays OPEN with
half-closed metadata; the next reconciler tick observes the invariant
violation (close_reason set on open bead) and clears it; the next tick
re-attempts the close and re-stamps the half-closed metadata. Result
is a per-tick flap generating ~1 bead.updated event per session per
10s tick, which on this machine accounts for ~93% of city event log
volume (65k/70k events).

Two coupled changes that ship together:

1. internal/session/lifecycle_transition.go — ClosePatch now keeps
   state at the canonical short stateCode but expands close_reason
   via a new CanonicalCloseReason helper that maps every known
   short code to a >=20 char human phrase. Unknown codes fall
   through to "session terminated: <code>"; codes already 20+
   chars pass through unchanged.

2. internal/session/named_config.go — closedNamedSessionReopenEligible
   no longer switches on close_reason (which is now a human phrase
   rather than the canonical state code). It relies solely on state,
   which ClosePatch sets atomically with close_reason and which has
   always been the source-of-truth field for terminal-state recognition.
   The redundant close_reason switch is removed; the surviving state
   switch keeps recognizing duplicate/duplicate-repair/gc_swept/
   orphaned/reconfigured/stale-session as not-reopen-eligible.

Tests: existing close-related assertions in session_beads_test and
session_reconciler_test are updated to compare against
session.CanonicalCloseReason("<code>") (not the raw short code) and
to also assert state preserves the canonical short code. Three new
tests in lifecycle_transition_test pin the validator-threshold
contract: every known stateCode round-trips to >=20 chars, the
unknown-code fallback is also >=20 chars, and ClosePatch keeps
state at the short code.

Out of scope:
 - Bead actor attribution (supervisor-driven bd updates show
   actor=human because eventActor() falls through; needs GC_ALIAS
   set on the supervisor process or in the bdstore subprocess env).
 - Reconciler write amplification within a tick (multi-stage state
   transitions persist intermediate states like gc_swept→orphaned).
 - Session bead.updated noise in the city event log even after
   attribution + flap fixes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->