### PR TITLE
fix(cache): skip no-op metadata writes at the cache layer

### DIFF
--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -203,6 +203,18 @@ func (c *CachingStore) CloseAll(ids []string, metadata map[string]string) (int, 
 
 // SetMetadata sets a single metadata key-value on a bead.
 func (c *CachingStore) SetMetadata(id, key, value string) error {
+	// Idempotence: if the cached bead already has metadata[key] == value,
+	// the backing call is a no-op semantically. Skipping it avoids the
+	// bd subprocess invocation and — crucially — avoids firing bd's
+	// on_update hook, which calls "gc event emit bead.updated" and
+	// appends a line to the city's events.jsonl. Reconciler tick logic
+	// repeatedly writes the same heartbeat / deferral fields every ~2s,
+	// producing thousands of no-op events per hour. The cache is the
+	// supervisor's authoritative read source, so a value-match here is
+	// a value-match in the store.
+	if c.metadataAlreadyMatchesCached(id, map[string]string{key: value}) {
+		return nil
+	}
 	if err := c.backing.SetMetadata(id, key, value); err != nil {
 		return err
 	}
@@ -226,6 +238,18 @@ func (c *CachingStore) SetMetadata(id, key, value string) error {
 
 // SetMetadataBatch sets multiple metadata key-values on a bead.
 func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if len(kvs) == 0 {
+		return nil
+	}
+	// Idempotence: see SetMetadata. If every kv pair already matches the
+	// cached bead's metadata, skip the backing write — no bd subprocess,
+	// no on_update hook fire, no events.jsonl entry. Reconciler ticks
+	// re-stamp deferral timestamps and other "I observed this" markers
+	// on every cycle; without this guard each cycle generates a
+	// bead.updated event even when nothing changed.
+	if c.metadataAlreadyMatchesCached(id, kvs) {
+		return nil
+	}
 	if err := c.backing.SetMetadataBatch(id, kvs); err != nil {
 		return err
 	}
@@ -247,6 +271,41 @@ func (c *CachingStore) SetMetadataBatch(id string, kvs map[string]string) error 
 	c.updateStatsLocked()
 	c.mu.Unlock()
 	return nil
+}
+
+// metadataAlreadyMatchesCached returns true when the cache holds a primed
+// copy of the bead and every key/value in kvs is already present with the
+// same value. A cache miss returns false (we cannot prove no-op), so the
+// caller falls through to the backing write. Empty maps (no keys) match
+// trivially, but callers should handle len==0 explicitly to avoid acquiring
+// the lock for a guaranteed no-op.
+func (c *CachingStore) metadataAlreadyMatchesCached(id string, kvs map[string]string) bool {
+	if id == "" {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	b, ok := c.beads[id]
+	if !ok {
+		return false
+	}
+	if b.Metadata == nil {
+		// Cache has the bead but no metadata map — any non-empty value
+		// would be a write; an empty value (clearing a never-set key)
+		// is already the desired state.
+		for _, v := range kvs {
+			if v != "" {
+				return false
+			}
+		}
+		return true
+	}
+	for k, v := range kvs {
+		if b.Metadata[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // DepAdd adds a dependency and updates the cache.

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -1,0 +1,204 @@
+package beads
+
+import (
+	"context"
+	"testing"
+)
+
+// countingBackingStore wraps a Store and counts SetMetadata /
+// SetMetadataBatch invocations so tests can assert when CachingStore
+// short-circuits a no-op write before the backing call.
+type countingBackingStore struct {
+	Store
+	setMetadataCalls      int
+	setMetadataBatchCalls int
+}
+
+func (c *countingBackingStore) SetMetadata(id, key, value string) error {
+	c.setMetadataCalls++
+	return c.Store.SetMetadata(id, key, value)
+}
+
+func (c *countingBackingStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	c.setMetadataBatchCalls++
+	return c.Store.SetMetadataBatch(id, kvs)
+}
+
+// TestCachingStoreSetMetadataSkipsBackingWhenCachedValueMatches verifies that
+// SetMetadata short-circuits before the backing call when the cached bead
+// already has metadata[key]==value. Without this guard, no-op writes still
+// fire bd's on_update hook and emit a bead.updated event.
+func TestCachingStoreSetMetadataSkipsBackingWhenCachedValueMatches(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := backing.SetMetadata(bead.ID, "foo", "bar"); err != nil {
+		t.Fatalf("seed SetMetadata: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.setMetadataCalls = 0
+
+	if err := cache.SetMetadata(bead.ID, "foo", "bar"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if backing.setMetadataCalls != 0 {
+		t.Errorf("backing.SetMetadata called %d times; want 0 (no-op write must short-circuit)",
+			backing.setMetadataCalls)
+	}
+}
+
+// TestCachingStoreSetMetadataFallsThroughOnValueMismatch verifies that a
+// real value change still propagates to the backing store.
+func TestCachingStoreSetMetadataFallsThroughOnValueMismatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := backing.SetMetadata(bead.ID, "foo", "old"); err != nil {
+		t.Fatalf("seed SetMetadata: %v", err)
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.setMetadataCalls = 0
+
+	if err := cache.SetMetadata(bead.ID, "foo", "new"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if backing.setMetadataCalls != 1 {
+		t.Errorf("backing.SetMetadata called %d times; want 1 (real change must propagate)",
+			backing.setMetadataCalls)
+	}
+}
+
+// TestCachingStoreSetMetadataFallsThroughOnCacheMiss verifies that
+// SetMetadata calls the backing store when the cache has no entry for the
+// bead — without a primed copy we cannot prove the write is a no-op.
+func TestCachingStoreSetMetadataFallsThroughOnCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	bead, err := backing.Create(Bead{Title: "post-prime"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	backing.setMetadataCalls = 0
+
+	if err := cache.SetMetadata(bead.ID, "foo", "bar"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if backing.setMetadataCalls != 1 {
+		t.Errorf("backing.SetMetadata called %d times; want 1 (cache miss must fall through)",
+			backing.setMetadataCalls)
+	}
+}
+
+// TestCachingStoreSetMetadataBatchSkipsBackingWhenAllCachedValuesMatch
+// verifies that SetMetadataBatch short-circuits when every kv pair already
+// matches the cached metadata.
+func TestCachingStoreSetMetadataBatchSkipsBackingWhenAllCachedValuesMatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for k, v := range map[string]string{"foo": "1", "bar": "2", "baz": "3"} {
+		if err := backing.SetMetadata(bead.ID, k, v); err != nil {
+			t.Fatalf("seed SetMetadata(%s): %v", k, err)
+		}
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.setMetadataBatchCalls = 0
+
+	if err := cache.SetMetadataBatch(bead.ID, map[string]string{"foo": "1", "bar": "2"}); err != nil {
+		t.Fatalf("SetMetadataBatch: %v", err)
+	}
+	if backing.setMetadataBatchCalls != 0 {
+		t.Errorf("backing.SetMetadataBatch called %d times; want 0 (all-match must short-circuit)",
+			backing.setMetadataBatchCalls)
+	}
+}
+
+// TestCachingStoreSetMetadataBatchFallsThroughOnAnyMismatch verifies that
+// even one mismatching kv forces the backing call — partial matches do not
+// suffice to skip the write.
+func TestCachingStoreSetMetadataBatchFallsThroughOnAnyMismatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for k, v := range map[string]string{"foo": "1", "bar": "2"} {
+		if err := backing.SetMetadata(bead.ID, k, v); err != nil {
+			t.Fatalf("seed SetMetadata(%s): %v", k, err)
+		}
+	}
+
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.setMetadataBatchCalls = 0
+
+	// foo matches the cached value, bar does not. The mismatch must force
+	// the full batch to the backing store.
+	if err := cache.SetMetadataBatch(bead.ID, map[string]string{"foo": "1", "bar": "DIFFERENT"}); err != nil {
+		t.Fatalf("SetMetadataBatch: %v", err)
+	}
+	if backing.setMetadataBatchCalls != 1 {
+		t.Errorf("backing.SetMetadataBatch called %d times; want 1 (mismatch must propagate)",
+			backing.setMetadataBatchCalls)
+	}
+}
+
+// TestCachingStoreSetMetadataBatchEmptyKVsIsNoop verifies that an empty kvs
+// map returns nil immediately without calling the backing store. This is
+// the early-return branch before metadataAlreadyMatchesCached.
+func TestCachingStoreSetMetadataBatchEmptyKVsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "test"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cache := NewCachingStoreForTest(backing, nil)
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.setMetadataBatchCalls = 0
+
+	if err := cache.SetMetadataBatch(bead.ID, map[string]string{}); err != nil {
+		t.Fatalf("SetMetadataBatch(empty): %v", err)
+	}
+	if backing.setMetadataBatchCalls != 0 {
+		t.Errorf("backing.SetMetadataBatch called %d times; want 0 (empty kvs must short-circuit)",
+			backing.setMetadataBatchCalls)
+	}
+}


### PR DESCRIPTION
CachingStore.SetMetadata and SetMetadataBatch unconditionally forwarded
to the backing store, which spawns a bd subprocess and fires bd's
on_update hook. The hook calls "gc event emit bead.updated", appending
a line to the city's events.jsonl on every write — even when the new
value equals what's already stored.

Reconciler tick logic re-stamps "I observed this" markers (deferral
timestamps, heartbeat fields, ack receipts) every 1-2 seconds whenever
their condition holds. Most ticks write the same value the bead
already carries; the cache holds an authoritative copy of that value
and can short-circuit before the bd subprocess fires.

Empirical: the mayor session bead (one persistent attached config-drift
deferral via recordSessionAttachedConfigDriftDeferral) emitted ~30
bead.updated events/min, every event a no-op (only the
attached_config_drift_deferred_at timestamp moved within the same
30-second false-negative window).

Add metadataAlreadyMatchesCached: a read-locked check that returns
true iff the cache has a primed copy of the bead and every requested
kv pair already matches. Both write entrypoints consult it before the
backing call. Cache-miss callers fall through to the original write
path, preserving correctness when state is unknown.

This is the most-upstream point in the supervisor that has the data
to diff cheaply. Gating here:
  - eliminates the bd subprocess (CPU + fork latency)
  - eliminates the on_update hook fire
  - eliminates the events.jsonl append
  - has zero observable behavior change for callers — the bead's
    persisted state is already what the caller asked for

Tests (6) cover the new short-circuit + the fall-through paths it must
not break:
  - SetMetadata: skips backing when cached value matches; falls through
    on value mismatch; falls through on cache miss.
  - SetMetadataBatch: skips backing when all cached values match; falls
    through when any value mismatches; treats empty kvs as a no-op
    early-return.
The three short-circuit tests are RED on the parent commit (the
backing store records 1 call where 0 is expected) and GREEN with this
fix; the three fall-through tests are regression tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->