### PR TITLE
fix(beads,order): make order-tracking sweep close work under validation.on-close=error

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -31,6 +31,25 @@ const (
 	orderTrackingSweepMetadataReason       = "stale-order-tracking"
 	orderTrackingSweepMetadataInitiator    = "order-tracking-sweep"
 	orderTrackingWatchdogMetadataInitiator = "controller-watchdog"
+
+	// orphanedOrderTrackingCloseReason is the canonical close_reason
+	// stamped on orphan-sweep closes. It satisfies bd's
+	// validation.on-close=error validator (which rejects closes without
+	// an explicit --reason of >=20 characters) and provides a meaningful
+	// audit trail in the closed bead's metadata. Without this, the close
+	// is rejected, the bead stays open, and the next sweep tick re-stamps
+	// identical metadata — generating one bead.updated event per tick per
+	// bead.
+	orphanedOrderTrackingCloseReason = "order-tracking sweep: orphaned by prior controller"
+
+	// staleOrderTrackingCloseReason is the canonical close_reason stamped
+	// on stale-sweep closes (both the periodic order-tracking-sweep order
+	// and the controller's runtime watchdog). Same rationale as
+	// orphanedOrderTrackingCloseReason — without an explicit reason of
+	// >=20 chars, validation.on-close=error rejects every close, the
+	// watchdog retries every 30s, and the order-firing pipeline silently
+	// wedges (no bead.created/closed events, only metadata churn).
+	staleOrderTrackingCloseReason = "order-tracking sweep: stale tracking bead exceeded retention window"
 )
 
 // orderDispatcher evaluates order trigger conditions and dispatches due
@@ -779,7 +798,9 @@ func sweepOrphanedOrderTracking(store beads.Store) (int, error) {
 	for i, b := range all {
 		ids[i] = b.ID
 	}
-	n, err := store.CloseAll(ids, nil)
+	n, err := store.CloseAll(ids, map[string]string{
+		"close_reason": orphanedOrderTrackingCloseReason,
+	})
 	if err != nil {
 		return n, fmt.Errorf("closing orphaned order-tracking beads: %w", err)
 	}
@@ -820,6 +841,7 @@ func sweepStaleOrderTracking(store beads.Store, now time.Time, staleAfter time.D
 	}
 	metadata := map[string]string{
 		"order_tracking_sweep": orderTrackingSweepMetadataReason,
+		"close_reason":         staleOrderTrackingCloseReason,
 	}
 	if initiator != "" {
 		metadata["order_tracking_sweep_by"] = initiator

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -50,6 +50,8 @@ const (
 	// watchdog retries every 30s, and the order-firing pipeline silently
 	// wedges (no bead.created/closed events, only metadata churn).
 	staleOrderTrackingCloseReason = "order-tracking sweep: stale tracking bead exceeded retention window"
+
+	completedOrderTrackingCloseReason = "order dispatch completed: tracking bead lifecycle finished"
 )
 
 // orderDispatcher evaluates order trigger conditions and dispatches due
@@ -460,7 +462,7 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 	// Defer order matters: doneInflight runs last, after Close makes the
 	// tracking bead outcome observable to a waiting drain.
 	defer m.doneInflight()
-	defer store.Close(trackingID) //nolint:errcheck // best-effort close
+	defer closeOrderTrackingBead(store, trackingID) //nolint:errcheck // best-effort close
 
 	timeout := effectiveTimeout(a, m.maxTimeout)
 	childCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -478,6 +480,13 @@ func (m *memoryOrderDispatcher) dispatchOne(ctx context.Context, store beads.Sto
 	} else {
 		m.dispatchWisp(childCtx, store, a, cityPath, trackingID)
 	}
+}
+
+func closeOrderTrackingBead(store beads.Store, trackingID string) error {
+	_, err := store.CloseAll([]string{trackingID}, map[string]string{
+		"close_reason": completedOrderTrackingCloseReason,
+	})
+	return err
 }
 
 // dispatchExec runs an exec order's shell command.

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2623,6 +2623,103 @@ func TestStartupSweepThenBuildDispatcher(t *testing.T) {
 	}
 }
 
+
+// TestSweepOrphanedOrderTracking_StampsCloseReason verifies that the
+// startup-time orphan sweep also stamps close_reason. The original
+// callsite passed nil metadata; under validation.on-close=error this
+// silently failed and left orphaned tracking beads open.
+func TestSweepOrphanedOrderTracking_StampsCloseReason(t *testing.T) {
+	if got := len(orphanedOrderTrackingCloseReason); got < 20 {
+		t.Fatalf("orphanedOrderTrackingCloseReason = %q (%d chars), want >=20", orphanedOrderTrackingCloseReason, got)
+	}
+
+	store := beads.NewMemStore()
+	b, err := store.Create(beads.Bead{
+		Title:  "order:dolt-health",
+		Labels: []string{"order-run:dolt-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	closed, err := sweepOrphanedOrderTracking(store)
+	if err != nil {
+		t.Fatalf("sweepOrphanedOrderTracking: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	final, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if final.Status != "closed" {
+		t.Fatalf("status = %q, want closed", final.Status)
+	}
+	if got := final.Metadata["close_reason"]; got != orphanedOrderTrackingCloseReason {
+		t.Errorf("close_reason = %q, want %q", got, orphanedOrderTrackingCloseReason)
+	}
+}
+
+// TestSweepStaleOrderTracking_StampsCloseReason verifies that the
+// runtime stale sweep (called every tick by the order-tracking-sweep
+// order AND every 30s by the controller's runtime watchdog) stamps
+// close_reason. The pre-fix callsite stamped order_tracking_sweep
+// metadata but no close_reason; under validation.on-close=error every
+// close was rejected, the watchdog retried indefinitely, and order
+// firing silently wedged.
+func TestSweepStaleOrderTracking_StampsCloseReason(t *testing.T) {
+	if got := len(staleOrderTrackingCloseReason); got < 20 {
+		t.Fatalf("staleOrderTrackingCloseReason = %q (%d chars), want >=20", staleOrderTrackingCloseReason, got)
+	}
+
+	store := beads.NewMemStore()
+	b, err := store.Create(beads.Bead{
+		Title:  "order:dolt-health",
+		Labels: []string{"order-run:dolt-health", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Push the bead's CreatedAt into the past so it's outside the
+	// staleAfter window. MemStore stamps CreatedAt at Create time, but
+	// callers expose UpdateMetadata; we round-trip via direct field
+	// access on the returned bead by re-creating with the desired
+	// timestamp via the underlying clock isn't available, so we set
+	// staleAfter to a negative duration relative to the bead and pass
+	// a future "now" that's well past CreatedAt.
+	now := b.CreatedAt.Add(time.Hour)
+
+	closed, err := sweepStaleOrderTracking(store, now, time.Minute, nil, orderTrackingWatchdogMetadataInitiator)
+	if err != nil {
+		t.Fatalf("sweepStaleOrderTracking: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+
+	final, err := store.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if final.Status != "closed" {
+		t.Fatalf("status = %q, want closed", final.Status)
+	}
+	if got := final.Metadata["close_reason"]; got != staleOrderTrackingCloseReason {
+		t.Errorf("close_reason = %q, want %q", got, staleOrderTrackingCloseReason)
+	}
+	// Pre-fix metadata (order_tracking_sweep + initiator) must still be
+	// stamped — the new close_reason is additive, not a replacement.
+	if got := final.Metadata["order_tracking_sweep"]; got != orderTrackingSweepMetadataReason {
+		t.Errorf("order_tracking_sweep = %q, want %q", got, orderTrackingSweepMetadataReason)
+	}
+	if got := final.Metadata["order_tracking_sweep_by"]; got != orderTrackingWatchdogMetadataInitiator {
+		t.Errorf("order_tracking_sweep_by = %q, want %q", got, orderTrackingWatchdogMetadataInitiator)
+	}
+}
+
 func TestSweepOrphanedOrderTracking_RetryOnTransientError(t *testing.T) {
 	inner := beads.NewMemStore()
 	_, err := inner.Create(beads.Bead{

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -71,6 +71,10 @@ type createdAtOverrideStore struct {
 	createdAt map[string]time.Time
 }
 
+type strictCloseReasonStore struct {
+	beads.Store
+}
+
 func (s selectiveUpdateFailStore) Update(id string, opts beads.UpdateOpts) error {
 	for _, label := range opts.Labels {
 		if strings.HasPrefix(label, "order-run:") {
@@ -139,6 +143,18 @@ func (s *createdAtOverrideStore) List(query beads.ListQuery) ([]beads.Bead, erro
 		}
 	}
 	return results, nil
+}
+
+func (s strictCloseReasonStore) Close(id string) error {
+	return fmt.Errorf("strict close validation rejected reasonless close for %s", id)
+}
+
+func (s strictCloseReasonStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
+	reason := strings.TrimSpace(metadata["close_reason"])
+	if len(reason) < 20 {
+		return 0, fmt.Errorf("strict close validation rejected close_reason %q", reason)
+	}
+	return s.Store.CloseAll(ids, metadata)
 }
 
 func TestOrderDispatcherNil(t *testing.T) {
@@ -2623,7 +2639,6 @@ func TestStartupSweepThenBuildDispatcher(t *testing.T) {
 	}
 }
 
-
 // TestSweepOrphanedOrderTracking_StampsCloseReason verifies that the
 // startup-time orphan sweep also stamps close_reason. The original
 // callsite passed nil metadata; under validation.on-close=error this
@@ -3953,7 +3968,7 @@ func (r *memRecorder) hasSubject(subject string) bool {
 // --- dedup / tracking bead lifecycle tests ---
 
 func TestOrderDispatchClosesTrackingBead(t *testing.T) {
-	store := beads.NewMemStore()
+	store := strictCloseReasonStore{Store: beads.NewMemStore()}
 	var rec memRecorder
 
 	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
@@ -3978,6 +3993,9 @@ func TestOrderDispatchClosesTrackingBead(t *testing.T) {
 			if l == "order-run:health-check" {
 				if b.Status != "closed" {
 					t.Errorf("tracking bead status = %q, want %q", b.Status, "closed")
+				}
+				if got := b.Metadata["close_reason"]; got != completedOrderTrackingCloseReason {
+					t.Errorf("close_reason = %q, want %q", got, completedOrderTrackingCloseReason)
 				}
 				return
 			}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -822,21 +822,16 @@ func (s *BdStore) Ping() error {
 // CloseAll closes multiple beads in batch and sets metadata on each.
 // Idempotent: closing an already-closed bead returns nil.
 //
-// Forwards metadata["close_reason"] as the --reason argument to the
-// batch bd close, so callers can satisfy validators like
-// validation.on-close=error (which rejects close calls without an
-// explicit --reason of >=20 characters). Whitespace is trimmed; an
-// empty or whitespace-only value is treated as absent and no --reason
-// flag is added — preserving backward compatibility for callers that
-// don't pre-stamp a reason. The same map is also written via
-// SetMetadataBatch on each bead before close, so the reason is
-// persisted in the bead's metadata as well as forwarded to bd.
-//
-// CloseAll uses the shared metadata map's close_reason because callers
-// stamp the same metadata on every bead in the batch — a single batch
-// close with one --reason matches caller intent. Per-bead reasons can
-// still be written via SetMetadata before invoking the per-id Close
-// path; that path reads each bead's own metadata.
+// Forwards metadata["close_reason"] as the --reason argument to bd close,
+// so callers can satisfy validators like validation.on-close=error (which
+// rejects close calls without an explicit --reason of >=20 characters).
+// Whitespace is trimmed; an empty or whitespace-only value is treated as
+// absent and no --reason flag is added, preserving backward compatibility
+// for callers that don't pre-stamp a reason. The same map is also written
+// via SetMetadataBatch on each bead before close, so the reason is persisted
+// in the bead's metadata as well as forwarded to bd. If batch close falls
+// back to per-id closes, the same shared reason is forwarded to every
+// fallback close.
 func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
@@ -853,18 +848,15 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 	}
 
 	// Batch close: bd close [--reason "..."] id1 id2 id3 ...
-	args := []string{"close", "--force", "--json"}
-	if reason := strings.TrimSpace(metadata["close_reason"]); reason != "" {
-		args = append(args, "--reason", reason)
-	}
-	args = append(args, ids...)
+	reason := strings.TrimSpace(metadata["close_reason"])
+	args := bdCloseArgs(reason, ids...)
 	_, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		// Fall back to individual closes on batch failure.
 		closed := 0
 		var fallbackErr error
 		for _, id := range ids {
-			if closeErr := s.Close(id); closeErr == nil {
+			if closeErr := s.close(id, reason); closeErr == nil {
 				closed++
 			} else {
 				fallbackErr = errors.Join(fallbackErr, closeErr)
@@ -881,7 +873,19 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 // Close sets a bead's status to closed via bd close.
 // Idempotent: closing an already-closed bead returns nil.
 func (s *BdStore) Close(id string) error {
-	_, err := s.runner(s.dir, "bd", "close", "--force", "--json", id)
+	return s.close(id, "")
+}
+
+func bdCloseArgs(reason string, ids ...string) []string {
+	args := []string{"close", "--force", "--json"}
+	if reason != "" {
+		args = append(args, "--reason", reason)
+	}
+	return append(args, ids...)
+}
+
+func (s *BdStore) close(id, reason string) error {
+	_, err := s.runner(s.dir, "bd", bdCloseArgs(reason, id)...)
 	if err != nil {
 		// Some bd error paths collapse to a bare exit status without a helpful
 		// not-found string. Re-read the bead to distinguish "already closed" from

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -821,6 +821,22 @@ func (s *BdStore) Ping() error {
 
 // CloseAll closes multiple beads in batch and sets metadata on each.
 // Idempotent: closing an already-closed bead returns nil.
+//
+// Forwards metadata["close_reason"] as the --reason argument to the
+// batch bd close, so callers can satisfy validators like
+// validation.on-close=error (which rejects close calls without an
+// explicit --reason of >=20 characters). Whitespace is trimmed; an
+// empty or whitespace-only value is treated as absent and no --reason
+// flag is added — preserving backward compatibility for callers that
+// don't pre-stamp a reason. The same map is also written via
+// SetMetadataBatch on each bead before close, so the reason is
+// persisted in the bead's metadata as well as forwarded to bd.
+//
+// CloseAll uses the shared metadata map's close_reason because callers
+// stamp the same metadata on every bead in the batch — a single batch
+// close with one --reason matches caller intent. Per-bead reasons can
+// still be written via SetMetadata before invoking the per-id Close
+// path; that path reads each bead's own metadata.
 func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
@@ -836,8 +852,12 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 		}
 	}
 
-	// Batch close: bd close id1 id2 id3 ...
-	args := append([]string{"close", "--force", "--json"}, ids...)
+	// Batch close: bd close [--reason "..."] id1 id2 id3 ...
+	args := []string{"close", "--force", "--json"}
+	if reason := strings.TrimSpace(metadata["close_reason"]); reason != "" {
+		args = append(args, "--reason", reason)
+	}
+	args = append(args, ids...)
 	_, err := s.runner(s.dir, "bd", args...)
 	if err != nil {
 		// Fall back to individual closes on batch failure.

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -676,6 +676,56 @@ func TestBdStoreCloseAllFallbackSuccessReturnsNil(t *testing.T) {
 	}
 }
 
+func TestBdStoreCloseAllFallbackForwardsCloseReason(t *testing.T) {
+	const reason = "order-tracking sweep: stale beyond watchdog window"
+	batchErr := errors.New("batch close failed")
+	var closeCalls [][]string
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "update":
+			return []byte(`[]`), nil
+		case "close":
+			call := append([]string(nil), args...)
+			closeCalls = append(closeCalls, call)
+			key := strings.Join(args, " ")
+			switch key {
+			case "close --force --json --reason " + reason + " bd-1 bd-2":
+				return nil, batchErr
+			case "close --force --json --reason " + reason + " bd-1":
+				return []byte(`[{"id":"bd-1","title":"one","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`), nil
+			case "close --force --json --reason " + reason + " bd-2":
+				return []byte(`[{"id":"bd-2","title":"two","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`), nil
+			default:
+				return nil, fmt.Errorf("unexpected close args: %v", args)
+			}
+		case "show":
+			return []byte(`[{"id":"` + args[len(args)-1] + `","title":"open","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %v", args)
+		}
+	}
+
+	s := beads.NewBdStore("/city", runner)
+	closed, err := s.CloseAll([]string{"bd-1", "bd-2"}, map[string]string{
+		"close_reason": reason,
+	})
+	if err != nil {
+		t.Fatalf("CloseAll returned error after reason-aware fallback: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed = %d, want 2", closed)
+	}
+
+	want := [][]string{
+		{"close", "--force", "--json", "--reason", reason, "bd-1", "bd-2"},
+		{"close", "--force", "--json", "--reason", reason, "bd-1"},
+		{"close", "--force", "--json", "--reason", reason, "bd-2"},
+	}
+	if got := fmt.Sprint(closeCalls); got != fmt.Sprint(want) {
+		t.Fatalf("close calls = %v, want %v", closeCalls, want)
+	}
+}
+
 // captureCloseAllRunner returns a CommandRunner that records the args
 // of any `close` invocation into the provided slice and returns canned
 // closed-status JSON for every bead in the batch. update calls (from

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -676,6 +676,165 @@ func TestBdStoreCloseAllFallbackSuccessReturnsNil(t *testing.T) {
 	}
 }
 
+// captureCloseAllRunner returns a CommandRunner that records the args
+// of any `close` invocation into the provided slice and returns canned
+// closed-status JSON for every bead in the batch. update calls (from
+// SetMetadataBatch) succeed with empty output. Used by the
+// CloseAll-close-reason-forwarding tests below to assert the exact
+// shape of the bd close argv.
+func captureCloseAllRunner(closeArgs *[]string, ids ...string) beads.CommandRunner {
+	closedJSON := []byte(`[`)
+	for i, id := range ids {
+		if i > 0 {
+			closedJSON = append(closedJSON, ',')
+		}
+		closedJSON = append(closedJSON, []byte(`{"id":"`+id+`","title":"t","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}`)...)
+	}
+	closedJSON = append(closedJSON, ']')
+	return func(_, _ string, args ...string) ([]byte, error) {
+		if len(args) == 0 {
+			return nil, fmt.Errorf("empty args")
+		}
+		switch args[0] {
+		case "update":
+			return []byte(`[]`), nil
+		case "close":
+			*closeArgs = append([]string{}, args...)
+			return closedJSON, nil
+		}
+		return nil, fmt.Errorf("unexpected command: %v", args)
+	}
+}
+
+// TestBdStoreCloseAllForwardsCloseReason verifies that when the metadata
+// map passed to CloseAll contains a close_reason value, BdStore forwards
+// it as the --reason argument to bd close. This is required for cities
+// running with validation.on-close=error, where bd rejects close calls
+// without an explicit reason of >=20 characters. Mirrors the per-bead
+// BdStore.Close pattern for the batch path: CloseAll uses the shared
+// metadata map's close_reason because callers stamp the same metadata
+// on every bead in the batch.
+func TestBdStoreCloseAllForwardsCloseReason(t *testing.T) {
+	const reason = "order-tracking sweep: stale beyond watchdog window"
+	var closeArgs []string
+	runner := captureCloseAllRunner(&closeArgs, "bd-1", "bd-2")
+
+	s := beads.NewBdStore("/city", runner)
+	n, err := s.CloseAll([]string{"bd-1", "bd-2"}, map[string]string{
+		"close_reason": reason,
+	})
+	if err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("closed = %d, want 2", n)
+	}
+
+	// Expected argv: close --force --json --reason "<phrase>" bd-1 bd-2
+	want := []string{"close", "--force", "--json", "--reason", reason, "bd-1", "bd-2"}
+	if len(closeArgs) != len(want) {
+		t.Fatalf("close args length = %d, want %d\ngot:  %v\nwant: %v", len(closeArgs), len(want), closeArgs, want)
+	}
+	for i := range want {
+		if closeArgs[i] != want[i] {
+			t.Errorf("close args[%d] = %q, want %q\nfull args: %v", i, closeArgs[i], want[i], closeArgs)
+		}
+	}
+}
+
+// TestBdStoreCloseAllOmitsReasonWhenAbsent verifies that when no
+// close_reason is present in the metadata map, CloseAll does not pass
+// --reason and lets bd assign its default. Preserves backward
+// compatibility for callers that don't pre-stamp a reason.
+func TestBdStoreCloseAllOmitsReasonWhenAbsent(t *testing.T) {
+	var closeArgs []string
+	runner := captureCloseAllRunner(&closeArgs, "bd-1")
+
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.CloseAll([]string{"bd-1"}, map[string]string{
+		"source": "wave1",
+	}); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+
+	for _, arg := range closeArgs {
+		if arg == "--reason" {
+			t.Errorf("close args contain --reason for metadata without close_reason: %v", closeArgs)
+			return
+		}
+	}
+}
+
+// TestBdStoreCloseAllOmitsReasonWhenNilMetadata verifies that when nil
+// metadata is passed, CloseAll does not pass --reason. Same shape as
+// the absent-key case but exercises the empty-map branch (nil maps
+// read as empty in Go).
+func TestBdStoreCloseAllOmitsReasonWhenNilMetadata(t *testing.T) {
+	var closeArgs []string
+	runner := captureCloseAllRunner(&closeArgs, "bd-1")
+
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.CloseAll([]string{"bd-1"}, nil); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+
+	for _, arg := range closeArgs {
+		if arg == "--reason" {
+			t.Errorf("close args contain --reason for nil metadata: %v", closeArgs)
+			return
+		}
+	}
+}
+
+// TestBdStoreCloseAllTrimsCloseReason verifies that whitespace
+// surrounding metadata.close_reason is stripped before forwarding, so
+// leading/trailing newlines or spaces from metadata persistence don't
+// pass through to bd's validator.
+func TestBdStoreCloseAllTrimsCloseReason(t *testing.T) {
+	var closeArgs []string
+	runner := captureCloseAllRunner(&closeArgs, "bd-1")
+
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.CloseAll([]string{"bd-1"}, map[string]string{
+		"close_reason": "  order-tracking sweep: stale beyond watchdog window  \n",
+	}); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+
+	const want = "order-tracking sweep: stale beyond watchdog window"
+	for i, arg := range closeArgs {
+		if arg == "--reason" && i+1 < len(closeArgs) {
+			if closeArgs[i+1] != want {
+				t.Errorf("forwarded reason = %q, want %q (trimmed)", closeArgs[i+1], want)
+			}
+			return
+		}
+	}
+	t.Errorf("close args missing --reason: %v", closeArgs)
+}
+
+// TestBdStoreCloseAllWhitespaceCloseReason verifies that a
+// whitespace-only close_reason is treated as absent — no --reason is
+// forwarded. Mirrors the trim-then-empty-check pattern.
+func TestBdStoreCloseAllWhitespaceCloseReason(t *testing.T) {
+	var closeArgs []string
+	runner := captureCloseAllRunner(&closeArgs, "bd-1")
+
+	s := beads.NewBdStore("/city", runner)
+	if _, err := s.CloseAll([]string{"bd-1"}, map[string]string{
+		"close_reason": "   \n",
+	}); err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+
+	for _, arg := range closeArgs {
+		if arg == "--reason" {
+			t.Errorf("close args contain --reason for whitespace-only close_reason: %v", closeArgs)
+			return
+		}
+	}
+}
+
 // --- List ---
 
 func TestBdStoreList(t *testing.T) {


### PR DESCRIPTION
Closes the silent-wedge bug where bd's `validation.on-close=error` mode rejects every sweep close that doesn't carry a `close_reason` of >=20 characters.

## Two coupled changes

Both close paths must stamp a canonical reason or the sweep silently fails:

**1. `BdStore.CloseAll` parallels #1644's per-bead Close forwarding** — the batch close path now passes `metadata.close_reason` through to `bd close --reason` so callers that stamp it on every bead get the same audit trail under batch.

**2. `cmd/gc/order_dispatch.go` stamps a canonical reason on every tracking-bead close it issues** — both the startup orphan sweep (`sweepOrphanedOrderTracking`) AND the runtime stale sweep (`sweepStaleOrderTracking`, called by both the periodic `order-tracking-sweep` order and the controller's 30s watchdog).

## Why both sweep variants need fixing

Without the stamp on _either_ sweep variant, the symptom is that the entire order-firing pipeline silently wedges:

- `bead.created` / `bead.closed` / `order.fired` events drop to zero in 24h
- only `bead.updated` events fire — one per watchdog tick per bead, as the watchdog re-stamps identical metadata on the same beads it can't close

Manual repro: enable `validation.on-close=error`, watch any city tick for 2 minutes, observe the supervisor stderr loop:

```
gc supervisor: order tracking sweep watchdog: closing stale
order-tracking beads: bd close batch: exit status 1: close
reason is empty or default; provide a summary of what was done
```

I hit this on a multi-rig pipex-city deployment after enabling `validation.on-close=error`. The order pipeline went silent for ~28 hours before I traced it to the watchdog. The earlier version of this PR fixed only `sweepOrphanedOrderTracking` (the one-shot startup path); the runtime watchdog path was unaffected and continued to wedge — hence this update extends the fix to both.

## Constants

```go
orphanedOrderTrackingCloseReason = "order-tracking sweep: orphaned by prior controller"
staleOrderTrackingCloseReason    = "order-tracking sweep: stale tracking bead exceeded retention window"
```

## Tests

- `TestSweepOrphanedOrderTracking_StampsCloseReason` — startup-time path; verifies `close_reason` lands on the closed bead's metadata under `MemStore.CloseAll`.
- `TestSweepStaleOrderTracking_StampsCloseReason` — runtime path; also verifies the existing `order_tracking_sweep` and `order_tracking_sweep_by` metadata still stamps (the new `close_reason` is additive).
- `BdStore.CloseAll` regression in `internal/beads/bdstore_test.go`.

## Consistency

Both sweep functions are now consistent with each other and with `session.CanonicalCloseReason` from #1680 — every controller-side close path that runs under `validation.on-close=error` carries an explicit, descriptive reason that satisfies the validator and lands in the closed bead's metadata for audit.

## Checklist

- [x] Linked to validation.on-close=error campaign (#1644 / #1680 / #1693 family)
- [x] Tests for both sweep variants
- [x] Tested live: my city's wedged supervisor unblocks once the patched binary deploys
- [x] No breaking changes; behavior unchanged for cities not running `validation.on-close=error`
