### PR TITLE
fix(controller): move control-dispatcher trace under .gc/runtime/

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,13 +36,25 @@ const (
 	// Wrapped in `sh -c` so any appended prompt suffix is ignored as $0.
 	// The control lane is kept resident and blocks on workflow-relevant city
 	// events instead of exiting after each one-shot drain.
-	ControlDispatcherStartCommand = `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + ControlDispatcherAgentName + `'`
+	//
+	// The trace log default is under .gc/runtime/ so it sits inside the
+	// controller's fsnotify exclusion (cmd/gc/controller.go shouldIgnoreConfigWatchEvent
+	// excludes the .gc and .beads path segments). Placing it at city root
+	// caused every append to fire markDirty() through the watcher debouncer,
+	// which kept the patrol loop in continuous reconciliation and blew patrol
+	// cycle duration well past the configured patrol_interval. See
+	// engdocs/design/session-reconciler-tracing.md for the canonical
+	// .gc/runtime/ convention for trace data.
+	ControlDispatcherStartCommand = `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/.gc/runtime/control-dispatcher-trace.log}"; mkdir -p "${GC_CITY}/.gc/runtime"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + ControlDispatcherAgentName + `'`
 )
 
 // ControlDispatcherStartCommandFor returns the start command for a
-// control-dispatcher agent with the given qualified name.
+// control-dispatcher agent with the given qualified name. The trace log
+// default lives under .gc/runtime/ to stay inside the controller's
+// fsnotify exclusion; see ControlDispatcherStartCommand for the full
+// rationale.
 func ControlDispatcherStartCommandFor(qualifiedName string) string {
-	return `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/control-dispatcher-trace.log}"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
+	return `sh -c 'export GC_WORKFLOW_TRACE="${GC_WORKFLOW_TRACE:-${GC_CITY}/.gc/runtime/control-dispatcher-trace.log}"; mkdir -p "${GC_CITY}/.gc/runtime"; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
 }
 
 // BindingQualifiedName returns the binding-qualified agent identity without a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4814,3 +4814,55 @@ schedule = "0 3 * * *"
 		t.Fatalf("Trigger = %#v, want cron", cfg.Orders.Overrides[0].Trigger)
 	}
 }
+
+// TestControlDispatcherStartCommandTracesUnderGCRuntime pins the trace-log
+// default location for the built-in control-dispatcher worker.
+//
+// The control-dispatcher writes to ${GC_WORKFLOW_TRACE} every few seconds
+// while serving workflow control beads. The default path must live under
+// .gc/runtime/ so that the controller's recursive fsnotify watcher
+// (cmd/gc/controller.go shouldIgnoreConfigWatchEvent) ignores writes to it
+// — that function excludes the .gc and .beads path segments. Placing the
+// default at city root caused every append to fire markDirty() through the
+// 200ms debouncer, keeping patrol cycles in continuous reconciliation and
+// driving cycle duration well past the configured patrol_interval.
+//
+// Regression guard: do not move the trace default out of .gc/runtime/
+// without a paired update to the controller's watcher exclusion list.
+func TestControlDispatcherStartCommandTracesUnderGCRuntime(t *testing.T) {
+	const (
+		wantTracePath = "${GC_CITY}/.gc/runtime/control-dispatcher-trace.log"
+		wantMkdirSnip = `mkdir -p "${GC_CITY}/.gc/runtime"`
+		oldTracePath  = "${GC_CITY}/control-dispatcher-trace.log"
+		qualifiedName = "qcore/control-dispatcher"
+	)
+
+	t.Run("city-level constant", func(t *testing.T) {
+		got := ControlDispatcherStartCommand
+		if !strings.Contains(got, wantTracePath) {
+			t.Errorf("ControlDispatcherStartCommand missing %q\n got: %s", wantTracePath, got)
+		}
+		if !strings.Contains(got, wantMkdirSnip) {
+			t.Errorf("ControlDispatcherStartCommand missing %q (needed so .gc/runtime/ exists on first start)\n got: %s", wantMkdirSnip, got)
+		}
+		// Guard against accidental revert: the old city-root path must not
+		// reappear as a substring (the new path contains it as a suffix, so
+		// match the trailing form including the leading slash).
+		if strings.Contains(got, `"${GC_WORKFLOW_TRACE:-`+oldTracePath+`"`) {
+			t.Errorf("ControlDispatcherStartCommand still references the old city-root trace path %q\n got: %s", oldTracePath, got)
+		}
+	})
+
+	t.Run("qualified-name builder", func(t *testing.T) {
+		got := ControlDispatcherStartCommandFor(qualifiedName)
+		if !strings.Contains(got, wantTracePath) {
+			t.Errorf("ControlDispatcherStartCommandFor missing %q\n got: %s", wantTracePath, got)
+		}
+		if !strings.Contains(got, wantMkdirSnip) {
+			t.Errorf("ControlDispatcherStartCommandFor missing %q\n got: %s", wantMkdirSnip, got)
+		}
+		if !strings.Contains(got, "--follow "+qualifiedName) {
+			t.Errorf("ControlDispatcherStartCommandFor must --follow the qualified name %q\n got: %s", qualifiedName, got)
+		}
+	})
+}

--- a/test/integration/graph_dispatch_test.go
+++ b/test/integration/graph_dispatch_test.go
@@ -141,7 +141,7 @@ func TestGraphWorkflowFailureRunsCleanup(t *testing.T) {
 func assertControlDispatcherLane(t *testing.T, cityDir string) {
 	t.Helper()
 
-	workflowTrace := readOptionalFile(filepath.Join(cityDir, "control-dispatcher-trace.log"))
+	workflowTrace := readOptionalFile(filepath.Join(cityDir, ".gc", "runtime", "control-dispatcher-trace.log"))
 	if !strings.Contains(workflowTrace, "serve process bead=") {
 		t.Fatalf("control-dispatcher trace missing processed control bead evidence:\n%s", workflowTrace)
 	}
@@ -270,7 +270,7 @@ func waitForBeadClosed(t *testing.T, cityDir, beadID string, timeout time.Durati
 		sessionPeekOut = fmt.Sprintf("gc session peek worker failed: %v\noutput: %s", sessionPeekErr, sessionPeekOut)
 	}
 	traceOut := readOptionalFile(filepath.Join(cityDir, "graph-workflow-trace.log"))
-	workflowTraceOut := readOptionalFile(filepath.Join(cityDir, "control-dispatcher-trace.log"))
+	workflowTraceOut := readOptionalFile(filepath.Join(cityDir, ".gc", "runtime", "control-dispatcher-trace.log"))
 	t.Fatalf("waiting for bead %s to close failed: %v\nready:\n%s\nready worker:\n%s\nsessions:\n%s\nworker peek:\n%s\ntrace:\n%s\nworkflow trace:\n%s\nbeads:\n%s",
 		beadID, waitErr, readyOut, readyAssigneeOut, sessionListOut, sessionPeekOut, traceOut, workflowTraceOut, out)
 	return graphBead{}


### PR DESCRIPTION
## What

Moves the default `GC_WORKFLOW_TRACE` path from `${GC_CITY}/control-dispatcher-trace.log` to `${GC_CITY}/.gc/runtime/control-dispatcher-trace.log`. Two-line edit in `internal/config/config.go` (the constant + the qualified-name builder), plus a `mkdir -p "${GC_CITY}/.gc/runtime"` in the `sh -c` prelude so the directory exists on first start.

## Why

The trace log path defaults to a file at city root. The controller's recursive fsnotify watcher (`cmd/gc/controller.go:832 shouldIgnoreConfigWatchEvent`) only excludes the `.gc` and `.beads` path segments, so the trace log is inside the watched set. The control-dispatcher appends to it every ~3-7 s while serving workflow control beads, and each append fires a `markDirty()` through the 200 ms watcher debouncer. The reconciler is therefore in continuous "config-changed" reconciliation; the configured `patrol_interval` ticker never gets a quiet window.

Field evidence on `qlandia` (gc `06c50c47-dirty`, single-host mac):
- patrol cycles consistently 4-8 min instead of the configured 30 s
- 54 MB+ trace log accumulating at city root
- `gc handoff` cycle (drain → respawn → first message) 9-14 min wall-clock vs. the <2 min target
- knock-on: the supervisor's Dolt circuit breaker trips on order-dispatch `bd list` calls during slow ticks (500+ trips over 4 days), which breaks `pending create` flows with "lease expired and no live runtime"

## Principle

`.gc/runtime/` is the established convention for trace data in this codebase:

- `engdocs/design/session-reconciler-tracing.md` (Codex, 2026-04-04) puts the new reconciler trace stream at `.gc/runtime/session-reconciler-trace/` with `0700/0600` perms.
- `engdocs/contributors/reconciler-debugging.md` directs operators to that same location.

The control-dispatcher trace at city root contradicts this convention; aligning brings the watcher behavior and the trace location into the same plane (\"trace data lives where the watcher already excludes\").

## Alternative considered

Extend `shouldIgnoreConfigWatchEvent` to ignore basenames matching `control-dispatcher-trace.log` (or `*-trace.log` more generally). Rejected:

- Splitting watcher policy from writer policy means future trace files have to remember to opt out, and existing convention (`.gc/runtime/`) already exists.
- #1518's path-segment exclusion list (`.cache`, `state`, `__pycache__`) does not match this basename, so that PR doesn't cover this case.
- Moving the writer is the smaller change and aligns surfaces.

The env-var fallback (`\${GC_WORKFLOW_TRACE:-...}`) is preserved, so any explicit setter is unaffected; only the default moves. Backward-compat for operators who export `GC_WORKFLOW_TRACE` themselves is intact.

## Related

- **#926** — introduced the recursive cityRoot watcher with the current `.gc` / `.beads` exclusion model.
- **#1650** (open) — flags that city and rig control-dispatchers share the same trace log. This path move is compatible with whatever per-dispatcher rename direction that issue lands on (both move \"into\" `.gc/runtime/`, just with different basenames).
- **#1565** (draft) — adds slow-tick observability for the same symptom but doesn't address the underlying cause; complementary, not redundant.

## Tests

- New `TestControlDispatcherStartCommandTracesUnderGCRuntime` in `internal/config/config_test.go` (two sub-tests: city-level constant, qualified-name builder). Pins the trace path under `.gc/runtime/`, asserts the `mkdir -p` prelude, and guards against the old city-root path reappearing.
- `test/integration/graph_dispatch_test.go` updates two `readOptionalFile` callsites to read from the new path; the integration test compiles and vets clean under `-tags integration`.

`go test ./internal/config/` passes (5.4 s, all 257 tests). `go vet ./...` clean. `golangci-lint fmt --diff` clean.

## Watch list

- [ ] CI green
- [ ] Review feedback addressed
- [ ] On merge → drop our local `[[agent]]` overrides in `qlandia/city.toml` once `make install`-ed past this commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->