### PR TITLE
fix(sessionlog): forward Codex custom tool calls and error frames

### DIFF
--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -5739,6 +5739,65 @@ func TestHandleSessionTranscriptRawIncludesAllTypes(t *testing.T) {
 	}
 }
 
+func TestHandleSessionTranscriptRawIncludesCodexCustomToolCalls(t *testing.T) {
+	fs := newSessionFakeState(t)
+	searchBase := t.TempDir()
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+	_ = h
+	srv.sessionLogSearchPaths = []string{searchBase}
+
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	resume := session.ProviderResume{
+		ResumeFlag:    "--resume",
+		ResumeStyle:   "flag",
+		SessionIDFlag: "--session-id",
+	}
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "myrig/worker", "Chat", "codex", workDir, "codex", nil, resume, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	codexDir := filepath.Join(searchBase, "2026", "05", "02")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll codex session dir: %v", err)
+	}
+	codexPayload := strings.Join([]string{
+		fmt.Sprintf(`{"timestamp":"2025-01-01T00:00:00Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		`{"timestamp":"2025-01-01T00:00:04Z","type":"response_item","payload":{"type":"custom_tool_call","call_id":"call-edit","name":"apply_patch","input":"*** Begin Patch\n*** Update File: city.toml\n@@\n+# Created by Chris Sells\n [workspace]\n*** End Patch\n"}}`,
+		`{"timestamp":"2025-01-01T00:00:05Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-edit","output":"{\"output\":\"Success. Updated the following files:\\nM city.toml\\n\"}"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "rollout-2026-05-02T00-00-00-test.jsonl"), []byte(codexPayload), 0o644); err != nil {
+		t.Fatalf("WriteFile codex session: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID+"/transcript?format=raw&tail=0", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp SessionStreamRawMessageEvent
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Messages) != 2 {
+		t.Fatalf("got %d raw messages, want 2 Codex custom tool frames", len(resp.Messages))
+	}
+	rawJSON, err := json.Marshal(resp.Messages)
+	if err != nil {
+		t.Fatalf("marshal raw transcript messages: %v", err)
+	}
+	rawJoined := string(rawJSON)
+	if !strings.Contains(rawJoined, `"custom_tool_call"`) ||
+		!strings.Contains(rawJoined, `"custom_tool_call_output"`) {
+		t.Fatalf("raw transcript missing Codex custom tool frames: %s", rawJoined)
+	}
+}
+
 func TestHandleSessionGetActivity(t *testing.T) {
 	fs := newSessionFakeState(t)
 	searchBase := t.TempDir()

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -5796,6 +5796,112 @@ func TestHandleSessionTranscriptRawIncludesCodexCustomToolCalls(t *testing.T) {
 		!strings.Contains(rawJoined, `"custom_tool_call_output"`) {
 		t.Fatalf("raw transcript missing Codex custom tool frames: %s", rawJoined)
 	}
+	if !strings.Contains(rawJoined, "apply_patch") ||
+		!strings.Contains(rawJoined, "Created by Chris Sells") ||
+		!strings.Contains(rawJoined, "Success. Updated the following files") {
+		t.Fatalf("raw transcript missing Codex custom tool payloads: %s", rawJoined)
+	}
+}
+
+func TestHandleSessionTranscriptConversationIncludesCodexErrorFrame(t *testing.T) {
+	fs := newSessionFakeState(t)
+	searchBase := t.TempDir()
+	srv := New(fs)
+	h := newTestCityHandlerWith(t, fs, srv)
+	_ = h
+	srv.sessionLogSearchPaths = []string{searchBase}
+
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	resume := session.ProviderResume{
+		ResumeFlag:    "--resume",
+		ResumeStyle:   "flag",
+		SessionIDFlag: "--session-id",
+	}
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "myrig/worker", "Chat", "codex", workDir, "codex", nil, resume, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	codexDir := filepath.Join(searchBase, "2026", "05", "02")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll codex session dir: %v", err)
+	}
+	codexPayload := strings.Join([]string{
+		fmt.Sprintf(`{"timestamp":"2025-01-01T00:00:00Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		`{"timestamp":"2025-01-01T00:00:04Z","type":"event_msg","payload":{"type":"error","message":"You've hit your usage limit.","codex_error_info":"usage_limit_exceeded"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "rollout-2026-05-02T00-00-00-test.jsonl"), []byte(codexPayload), 0o644); err != nil {
+		t.Fatalf("WriteFile codex session: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID+"/transcript?tail=0", nil)
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp sessionTranscriptResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Format != "conversation" {
+		t.Fatalf("Format = %q, want conversation", resp.Format)
+	}
+	if got := len(resp.Turns); got != 1 {
+		t.Fatalf("turns = %d, want Codex error turn; body: %s", got, w.Body.String())
+	}
+	if resp.Turns[0].Role != "system" {
+		t.Fatalf("turn role = %q, want system", resp.Turns[0].Role)
+	}
+	if !strings.Contains(resp.Turns[0].Text, "usage_limit_exceeded") || !strings.Contains(resp.Turns[0].Text, "You've hit your usage limit.") {
+		t.Fatalf("turn text = %q, want Codex error code and message", resp.Turns[0].Text)
+	}
+}
+
+func TestHandleSessionStreamConversationIncludesCodexErrorFrame(t *testing.T) {
+	fs := newSessionFakeState(t)
+	searchBase := t.TempDir()
+	srv := New(fs)
+	srv.sessionLogSearchPaths = []string{searchBase}
+
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	resume := session.ProviderResume{
+		ResumeFlag:    "--resume",
+		ResumeStyle:   "flag",
+		SessionIDFlag: "--session-id",
+	}
+	workDir := t.TempDir()
+	info, err := mgr.Create(context.Background(), "myrig/worker", "Chat", "codex", workDir, "codex", nil, resume, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	codexDir := filepath.Join(searchBase, "2026", "05", "02")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll codex session dir: %v", err)
+	}
+	codexPayload := strings.Join([]string{
+		fmt.Sprintf(`{"timestamp":"2025-01-01T00:00:00Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+		`{"timestamp":"2025-01-01T00:00:04Z","type":"event_msg","payload":{"type":"error","message":"You've hit your usage limit.","codex_error_info":"usage_limit_exceeded"}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "rollout-2026-05-02T00-00-00-test.jsonl"), []byte(codexPayload), 0o644); err != nil {
+		t.Fatalf("WriteFile codex session: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/v0/session/"+info.ID+"/stream", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "usage_limit_exceeded") || !strings.Contains(body, "You've hit your usage limit.") {
+		t.Fatalf("conversation stream body missing Codex error frame: %s", body)
+	}
 }
 
 func TestHandleSessionGetActivity(t *testing.T) {

--- a/internal/sessionlog/codex_reader.go
+++ b/internal/sessionlog/codex_reader.go
@@ -201,7 +201,8 @@ func convertResponseItem(payload json.RawMessage, rawLine string, idx int, ts ti
 			Raw: json.RawMessage(rawLine),
 		}
 
-	case "function_call":
+	case "function_call", "custom_tool_call":
+		callID := firstNonEmpty(ri.CallID, ri.ID)
 		return &Entry{
 			UUID:      uuid,
 			Type:      "assistant",
@@ -210,19 +211,20 @@ func convertResponseItem(payload json.RawMessage, rawLine string, idx int, ts ti
 				Role: "assistant",
 				Content: mustMarshal([]ContentBlock{{
 					Type: "tool_use",
-					ID:   ri.CallID,
+					ID:   callID,
 					Name: ri.Name,
 				}}),
 			}),
 			Raw: json.RawMessage(rawLine),
 		}
 
-	case "function_call_output":
+	case "function_call_output", "custom_tool_call_output":
+		callID := firstNonEmpty(ri.CallID, ri.ID)
 		return &Entry{
 			UUID:      uuid,
 			Type:      "tool_result",
 			Timestamp: ts,
-			ToolUseID: ri.CallID,
+			ToolUseID: callID,
 			Raw:       json.RawMessage(rawLine),
 		}
 
@@ -293,7 +295,7 @@ type codexEventMsg struct {
 }
 
 type codexResponseItem struct {
-	Type      string             `json:"type"` // message, reasoning, function_call, function_call_output, interaction
+	Type      string             `json:"type"` // message, reasoning, function_call, custom_tool_call, function_call_output, custom_tool_call_output, interaction
 	Role      string             `json:"role,omitempty"`
 	Content   []codexTextContent `json:"content,omitempty"`
 	Summary   []codexTextContent `json:"summary,omitempty"`

--- a/internal/sessionlog/codex_reader.go
+++ b/internal/sessionlog/codex_reader.go
@@ -141,6 +141,30 @@ func ReadCodexFile(path string, _ int) (*Session, error) {
 				lastUUID = entry.UUID
 				messages = append(messages, entry)
 				idx++
+
+			case "error", "stream_error", "turn_aborted":
+				entry := &Entry{
+					UUID:      fmt.Sprintf("codex-event-%d", idx),
+					Type:      "error",
+					Timestamp: ts,
+					Raw:       json.RawMessage(e.line),
+				}
+				entry.ParentUUID = lastUUID
+				lastUUID = entry.UUID
+				messages = append(messages, entry)
+				idx++
+
+			default:
+				entry := &Entry{
+					UUID:      fmt.Sprintf("codex-event-%d", idx),
+					Type:      "event_msg",
+					Timestamp: ts,
+					Raw:       json.RawMessage(e.line),
+				}
+				entry.ParentUUID = lastUUID
+				lastUUID = entry.UUID
+				messages = append(messages, entry)
+				idx++
 			}
 		}
 	}

--- a/internal/sessionlog/codex_reader.go
+++ b/internal/sessionlog/codex_reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -145,9 +146,13 @@ func ReadCodexFile(path string, _ int) (*Session, error) {
 			case "error", "stream_error", "turn_aborted":
 				entry := &Entry{
 					UUID:      fmt.Sprintf("codex-event-%d", idx),
-					Type:      "error",
+					Type:      "system",
 					Timestamp: ts,
-					Raw:       json.RawMessage(e.line),
+					Message: mustMarshal(MessageContent{
+						Role:    "system",
+						Content: mustMarshal([]ContentBlock{{Type: "text", Text: codexErrorText(em)}}),
+					}),
+					Raw: json.RawMessage(e.line),
 				}
 				entry.ParentUUID = lastUUID
 				lastUUID = entry.UUID
@@ -155,6 +160,9 @@ func ReadCodexFile(path string, _ int) (*Session, error) {
 				idx++
 
 			default:
+				if skipCodexEventMsgType(em.Type) {
+					continue
+				}
 				entry := &Entry{
 					UUID:      fmt.Sprintf("codex-event-%d", idx),
 					Type:      "event_msg",
@@ -234,9 +242,10 @@ func convertResponseItem(payload json.RawMessage, rawLine string, idx int, ts ti
 			Message: mustMarshal(MessageContent{
 				Role: "assistant",
 				Content: mustMarshal([]ContentBlock{{
-					Type: "tool_use",
-					ID:   callID,
-					Name: ri.Name,
+					Type:  "tool_use",
+					ID:    callID,
+					Name:  ri.Name,
+					Input: cloneRawJSON(ri.Input),
 				}}),
 			}),
 			Raw: json.RawMessage(rawLine),
@@ -249,7 +258,15 @@ func convertResponseItem(payload json.RawMessage, rawLine string, idx int, ts ti
 			Type:      "tool_result",
 			Timestamp: ts,
 			ToolUseID: callID,
-			Raw:       json.RawMessage(rawLine),
+			Message: mustMarshal(MessageContent{
+				Role: "tool",
+				Content: mustMarshal([]ContentBlock{{
+					Type:      "tool_result",
+					ToolUseID: callID,
+					Content:   cloneRawJSON(ri.Output),
+				}}),
+			}),
+			Raw: json.RawMessage(rawLine),
 		}
 
 	case "interaction":
@@ -277,6 +294,40 @@ func convertResponseItem(payload json.RawMessage, rawLine string, idx int, ts ti
 	}
 
 	return nil
+}
+
+func codexErrorText(em codexEventMsg) string {
+	label := strings.TrimSpace(em.CodexErrorInfo)
+	if label == "" {
+		label = strings.TrimSpace(em.Type)
+	}
+	message := strings.TrimSpace(em.Message)
+	switch {
+	case label != "" && message != "":
+		return label + ": " + message
+	case message != "":
+		return message
+	default:
+		return label
+	}
+}
+
+func skipCodexEventMsgType(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case "token_count",
+		"exec_command_begin",
+		"exec_command_end",
+		"patch_apply_begin",
+		"patch_apply_end",
+		"task_started",
+		"task_complete",
+		"item_started",
+		"item_completed",
+		"context_compacted":
+		return true
+	default:
+		return false
+	}
 }
 
 func codexSessionID(path string) string {
@@ -313,9 +364,10 @@ type codexEntry struct {
 }
 
 type codexEventMsg struct {
-	Type    string `json:"type"`    // user_message, agent_message, agent_reasoning, token_count
-	Message string `json:"message"` // for user_message, agent_message
-	Text    string `json:"text"`    // for agent_reasoning
+	Type           string `json:"type"`             // user_message, agent_message, agent_reasoning, token_count
+	Message        string `json:"message"`          // for user_message, agent_message, error
+	Text           string `json:"text"`             // for agent_reasoning
+	CodexErrorInfo string `json:"codex_error_info"` // for usage_limit_exceeded and related errors
 }
 
 type codexResponseItem struct {
@@ -325,7 +377,8 @@ type codexResponseItem struct {
 	Summary   []codexTextContent `json:"summary,omitempty"`
 	CallID    string             `json:"call_id,omitempty"`
 	Name      string             `json:"name,omitempty"`
-	Output    string             `json:"output,omitempty"`
+	Input     json.RawMessage    `json:"input,omitempty"`
+	Output    json.RawMessage    `json:"output,omitempty"`
 	RequestID string             `json:"request_id,omitempty"`
 	ID        string             `json:"id,omitempty"`
 	Kind      string             `json:"kind,omitempty"`

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -1446,6 +1446,78 @@ func TestReadCodexFileInteractionLifecycleUsesDistinctEntryIDs(t *testing.T) {
 	}
 }
 
+func TestReadCodexFileErrorEventMsgTypes(t *testing.T) {
+	errorLine := `{"timestamp":"2026-05-03T00:05:41.798Z","type":"event_msg","payload":{"type":"error","message":"You've hit your usage limit.","codex_error_info":"usage_limit_exceeded"}}`
+	streamErrorLine := `{"timestamp":"2026-05-03T00:06:00.000Z","type":"event_msg","payload":{"type":"stream_error","message":"stream interrupted"}}`
+	turnAbortedLine := `{"timestamp":"2026-05-03T00:07:00.000Z","type":"event_msg","payload":{"type":"turn_aborted","message":"turn was aborted"}}`
+	userMsgLine := `{"timestamp":"2026-05-03T00:04:00.000Z","type":"event_msg","payload":{"type":"user_message","message":"hello"}}`
+	responseLine := `{"timestamp":"2026-05-03T00:04:30.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"hi"}]}}`
+
+	path := writeJSONL(t, userMsgLine, responseLine, errorLine, streamErrorLine, turnAbortedLine)
+
+	sess, err := ReadCodexFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect: user_message (event_msg, but no response_item user → included),
+	// response_item/message, error, stream_error, turn_aborted = 5 entries.
+	if got := len(sess.Messages); got != 5 {
+		t.Fatalf("Messages = %d, want 5", got)
+	}
+
+	// Verify the three error-category entries.
+	for i, want := range []struct {
+		idx     int
+		entType string
+		rawLine string
+	}{
+		{2, "error", errorLine},
+		{3, "error", streamErrorLine},
+		{4, "error", turnAbortedLine},
+	} {
+		msg := sess.Messages[want.idx]
+		if msg.Type != want.entType {
+			t.Errorf("[%d] Type = %q, want %q", i, msg.Type, want.entType)
+		}
+		if string(msg.Raw) != want.rawLine {
+			t.Errorf("[%d] Raw mismatch:\n got: %s\nwant: %s", i, msg.Raw, want.rawLine)
+		}
+		if msg.UUID != fmt.Sprintf("codex-event-%d", want.idx) {
+			t.Errorf("[%d] UUID = %q, want codex-event-%d", i, msg.UUID, want.idx)
+		}
+	}
+
+	// Verify parent chain is linked.
+	for i := 1; i < len(sess.Messages); i++ {
+		if sess.Messages[i].ParentUUID != sess.Messages[i-1].UUID {
+			t.Errorf("Messages[%d].ParentUUID = %q, want %q", i, sess.Messages[i].ParentUUID, sess.Messages[i-1].UUID)
+		}
+	}
+}
+
+func TestReadCodexFileUnknownEventMsgForwarded(t *testing.T) {
+	unknownLine := `{"timestamp":"2026-05-03T00:08:00.000Z","type":"event_msg","payload":{"type":"new_future_type","data":"something"}}`
+
+	path := writeJSONL(t, unknownLine)
+
+	sess, err := ReadCodexFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(sess.Messages); got != 1 {
+		t.Fatalf("Messages = %d, want 1 (unknown event_msg should be forwarded)", got)
+	}
+	msg := sess.Messages[0]
+	if msg.Type != "event_msg" {
+		t.Fatalf("Type = %q, want event_msg", msg.Type)
+	}
+	if string(msg.Raw) != unknownLine {
+		t.Fatalf("Raw mismatch:\n got: %s\nwant: %s", msg.Raw, unknownLine)
+	}
+}
+
 func TestFindCodexSessionFileIn(t *testing.T) {
 	sessDir := t.TempDir()
 	workDir := "/data/projects/myproject"

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1472,9 +1473,9 @@ func TestReadCodexFileErrorEventMsgTypes(t *testing.T) {
 		entType string
 		rawLine string
 	}{
-		{2, "error", errorLine},
-		{3, "error", streamErrorLine},
-		{4, "error", turnAbortedLine},
+		{2, "system", errorLine},
+		{3, "system", streamErrorLine},
+		{4, "system", turnAbortedLine},
 	} {
 		msg := sess.Messages[want.idx]
 		if msg.Type != want.entType {
@@ -1486,6 +1487,12 @@ func TestReadCodexFileErrorEventMsgTypes(t *testing.T) {
 		if msg.UUID != fmt.Sprintf("codex-event-%d", want.idx) {
 			t.Errorf("[%d] UUID = %q, want codex-event-%d", i, msg.UUID, want.idx)
 		}
+		if msg.TextContent() == "" && len(msg.ContentBlocks()) == 0 {
+			t.Errorf("[%d] error entry has no visible message content", i)
+		}
+	}
+	if text := sess.Messages[2].ContentBlocks()[0].Text; !strings.Contains(text, "usage_limit_exceeded") || !strings.Contains(text, "You've hit your usage limit.") {
+		t.Fatalf("error text = %q, want code and message", text)
 	}
 
 	// Verify parent chain is linked.
@@ -1515,6 +1522,81 @@ func TestReadCodexFileUnknownEventMsgForwarded(t *testing.T) {
 	}
 	if string(msg.Raw) != unknownLine {
 		t.Fatalf("Raw mismatch:\n got: %s\nwant: %s", msg.Raw, unknownLine)
+	}
+}
+
+func TestReadCodexFileTokenCountEventMsgSkipped(t *testing.T) {
+	path := writeJSONL(t,
+		`{"timestamp":"2026-05-03T00:08:00.000Z","type":"event_msg","payload":{"type":"token_count","input_tokens":10,"output_tokens":2}}`,
+		`{"timestamp":"2026-05-03T00:08:01.000Z","type":"event_msg","payload":{"type":"new_future_type","data":"diagnostic"}}`,
+	)
+
+	sess, err := ReadCodexFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(sess.Messages); got != 1 {
+		t.Fatalf("Messages = %d, want only unknown diagnostic event", got)
+	}
+	if sess.Messages[0].Type != "event_msg" {
+		t.Fatalf("Type = %q, want event_msg", sess.Messages[0].Type)
+	}
+	if !strings.Contains(string(sess.Messages[0].Raw), "new_future_type") {
+		t.Fatalf("Raw = %s, want unknown diagnostic event", sess.Messages[0].Raw)
+	}
+}
+
+func TestReadCodexFileCustomToolPayloadsPreserved(t *testing.T) {
+	path := writeJSONL(t,
+		`{"timestamp":"2026-05-03T00:08:00.000Z","type":"response_item","payload":{"type":"custom_tool_call","call_id":"call-edit","name":"apply_patch","input":{"patch":"*** Begin Patch\n*** End Patch"}}}`,
+		`{"timestamp":"2026-05-03T00:08:01.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-edit","output":{"output":"Success. Updated files."}}}`,
+	)
+
+	sess, err := ReadCodexFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(sess.Messages); got != 2 {
+		t.Fatalf("Messages = %d, want 2", got)
+	}
+	toolUseBlocks := sess.Messages[0].ContentBlocks()
+	if len(toolUseBlocks) != 1 {
+		t.Fatalf("tool use blocks = %d, want 1", len(toolUseBlocks))
+	}
+	if toolUseBlocks[0].Type != "tool_use" || toolUseBlocks[0].ID != "call-edit" {
+		t.Fatalf("tool use block = %#v, want call-edit tool_use", toolUseBlocks[0])
+	}
+	assertRawMetadata(t, toolUseBlocks[0].Input, map[string]any{"patch": "*** Begin Patch\n*** End Patch"})
+
+	toolResultBlocks := sess.Messages[1].ContentBlocks()
+	if len(toolResultBlocks) != 1 {
+		t.Fatalf("tool result blocks = %d, want 1", len(toolResultBlocks))
+	}
+	if toolResultBlocks[0].Type != "tool_result" || toolResultBlocks[0].ToolUseID != "call-edit" {
+		t.Fatalf("tool result block = %#v, want call-edit tool_result", toolResultBlocks[0])
+	}
+	assertRawMetadata(t, toolResultBlocks[0].Content, map[string]any{"output": "Success. Updated files."})
+}
+
+func TestReadCodexFileFunctionCallFallsBackToID(t *testing.T) {
+	path := writeJSONL(t,
+		`{"timestamp":"2026-05-03T00:08:00.000Z","type":"response_item","payload":{"type":"function_call","id":"call-from-id","name":"Read"}}`,
+	)
+
+	sess, err := ReadCodexFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(sess.Messages); got != 1 {
+		t.Fatalf("Messages = %d, want 1", got)
+	}
+	blocks := sess.Messages[0].ContentBlocks()
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(blocks))
+	}
+	if blocks[0].ID != "call-from-id" {
+		t.Fatalf("tool_use id = %q, want id fallback", blocks[0].ID)
 	}
 }
 

--- a/internal/worker/sessionlog_adapter.go
+++ b/internal/worker/sessionlog_adapter.go
@@ -347,7 +347,7 @@ func actorForEntry(entry *sessionlog.Entry) Actor {
 		return ActorUser
 	case "tool_result":
 		return ActorTool
-	case "system":
+	case "system", "error":
 		return ActorSystem
 	}
 

--- a/internal/worker/sessionlog_adapter_test.go
+++ b/internal/worker/sessionlog_adapter_test.go
@@ -105,8 +105,8 @@ func TestSessionLogAdapterLoadHistoryCodex(t *testing.T) {
 	lines := []string{
 		fmt.Sprintf(`{"timestamp":"2026-01-02T00:00:00Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
 		`{"timestamp":"2026-01-02T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"hello codex"}]}}`,
-		`{"timestamp":"2026-01-02T00:00:02Z","type":"response_item","payload":{"type":"function_call","call_id":"call-1","name":"Read"}}`,
-		`{"timestamp":"2026-01-02T00:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"file"}}`,
+		`{"timestamp":"2026-01-02T00:00:02Z","type":"response_item","payload":{"type":"custom_tool_call","call_id":"call-1","name":"apply_patch","input":{"patch":"*** Begin Patch\n*** End Patch"}}}`,
+		`{"timestamp":"2026-01-02T00:00:03Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-1","output":{"output":"Success. Updated files."}}}`,
 		`{"timestamp":"2026-01-02T00:00:04Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"done"}]}}`,
 	}
 	writeLines(t, path, lines...)
@@ -138,11 +138,14 @@ func TestSessionLogAdapterLoadHistoryCodex(t *testing.T) {
 	if snapshot.Entries[1].Blocks[0].Kind != BlockKindToolUse {
 		t.Fatalf("function call block kind = %q, want %q", snapshot.Entries[1].Blocks[0].Kind, BlockKindToolUse)
 	}
+	if got := strings.TrimSpace(string(snapshot.Entries[1].Blocks[0].Input)); got != `{"patch":"*** Begin Patch\n*** End Patch"}` {
+		t.Fatalf("custom tool call input = %s, want patch payload", got)
+	}
 	if snapshot.Entries[2].Blocks[0].Kind != BlockKindToolResult {
 		t.Fatalf("function output block kind = %q, want %q", snapshot.Entries[2].Blocks[0].Kind, BlockKindToolResult)
 	}
-	if !snapshot.Entries[2].Blocks[0].Derived {
-		t.Fatalf("expected codex tool_result block to be derived")
+	if got := strings.TrimSpace(string(snapshot.Entries[2].Blocks[0].Content)); got != `{"output":"Success. Updated files."}` {
+		t.Fatalf("custom tool output content = %s, want output payload", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Custom tool calls**: Codex uses `custom_tool_call` / `custom_tool_call_output` response_item types (in addition to the existing `function_call` / `function_call_output`). These were silently dropped by `convertResponseItem`, so tool-use frames from Codex sessions never reached the transcript or SSE stream. Added both types to the existing switch cases with `firstNonEmpty(ri.CallID, ri.ID)` fallback since custom tool calls may use `id` instead of `call_id`.

- **Error event_msg types**: Codex writes `event_msg` frames with payload types `error`, `stream_error`, and `turn_aborted` (e.g. usage limit exceeded). The `event_msg` switch only handled `user_message`, `agent_message`, and `agent_reasoning` — everything else fell through silently. Added explicit cases for the three failure types (emitted as `Entry.Type = "error"`) and a default fallthrough that forwards any unrecognized `event_msg` payload as a raw frame (`Type = "event_msg"`), so future Codex event types won't be dropped.

- **Actor mapping**: Added `"error"` to `actorForEntry` in the sessionlog adapter so error entries map to `ActorSystem` instead of falling through to `ActorUnknown`.

## Files changed

| File | What |
|------|------|
| `internal/sessionlog/codex_reader.go` | Add `custom_tool_call`/`custom_tool_call_output` to `convertResponseItem`; add `error`/`stream_error`/`turn_aborted` + default to `event_msg` switch |
| `internal/worker/sessionlog_adapter.go` | Map `"error"` entry type → `ActorSystem` |
| `internal/api/handler_sessions_test.go` | API-level test: Codex custom tool call frames appear in raw transcript |
| `internal/sessionlog/sessionlog_test.go` | Unit tests: error event forwarding + unknown event_msg fallthrough |

## Test plan

- [x] `go test ./internal/sessionlog/...` — all pass including new `TestReadCodexFileErrorEventMsgTypes` and `TestReadCodexFileUnknownEventMsgForwarded`
- [x] `go test ./internal/worker/...` — all pass, `actorForEntry` correctly maps error entries
- [x] `go test ./internal/api/...` — all pass including new `TestHandleSessionTranscriptRawIncludesCodexCustomToolCalls`
- [x] `go vet ./internal/sessionlog/... ./internal/worker/... ./internal/api/...` — clean
- [ ] Manual: rebuild `gc`, restart supervisor, hit `GET /v0/city/{city}/session/{id}/transcript?format=raw` for a Codex session with error frames and verify they appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->