### PR TITLE
Fix ambiguous Codex session log resolution

### DIFF
--- a/cmd/gc/cmd_session_logs.go
+++ b/cmd/gc/cmd_session_logs.go
@@ -84,7 +84,12 @@ func cmdSessionLogs(args []string, follow bool, tail int, stdout, stderr io.Writ
 		ok       bool
 	)
 	if err == nil && store != nil {
-		path, provider, ok = resolveStoredSessionLogSource(cityPath, cfg, store, identifier, searchPaths)
+		var diagnostic string
+		path, provider, ok, diagnostic = resolveStoredSessionLogSource(cityPath, cfg, store, identifier, searchPaths)
+		if ok && path == "" && diagnostic != "" {
+			fmt.Fprintf(stderr, "gc session logs: %s\n", diagnostic) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 	if !ok {
 		workDir, found := resolveConfiguredSessionLogContext(cityPath, cfg, identifier)
@@ -110,16 +115,16 @@ func resolveSessionLogPath(searchPaths []string, logCtx sessionLogContext) strin
 	return factory.DiscoverTranscript(logCtx.provider, logCtx.workDir, logCtx.sessionKey)
 }
 
-func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store beads.Store, identifier string, searchPaths []string) (string, string, bool) {
+func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store beads.Store, identifier string, searchPaths []string) (string, string, bool, string) {
 	logCtx, ok := resolveSessionLogContext(cityPath, cfg, store, identifier)
 	if !ok {
-		return "", "", false
+		return "", "", false, ""
 	}
 	if logCtx.sessionID != "" {
 		handle, err := workerHandleForSessionWithConfig(cityPath, store, newSessionProvider(), cfg, logCtx.sessionID)
 		if err == nil {
 			if path, pathErr := handle.TranscriptPath(context.Background()); pathErr == nil && strings.TrimSpace(path) != "" {
-				return path, logCtx.provider, true
+				return path, logCtx.provider, true, ""
 			}
 		}
 	}
@@ -145,7 +150,10 @@ func resolveStoredSessionLogSource(cityPath string, cfg *config.City, store bead
 	if !sessionLogPathFreshEnough(path, logCtx.createdAt) {
 		path = ""
 	}
-	return path, logCtx.provider, true
+	if path == "" && !fallbackAllowed {
+		return "", logCtx.provider, true, ambiguousSessionLogDiagnostic(logCtx)
+	}
+	return path, logCtx.provider, true, ""
 }
 
 func resolveSessionKeyedLogPath(searchPaths []string, logCtx sessionLogContext) string {
@@ -285,6 +293,21 @@ func sessionLogFallbackCandidateLive(b beads.Bead) bool {
 	default:
 		return false
 	}
+}
+
+func ambiguousSessionLogDiagnostic(logCtx sessionLogContext) string {
+	sessionID := strings.TrimSpace(logCtx.sessionID)
+	if sessionID == "" {
+		sessionID = "requested session"
+	}
+	provider := strings.TrimSpace(logCtx.provider)
+	if provider == "" {
+		provider = "provider"
+	}
+	if strings.TrimSpace(logCtx.sessionKey) == "" {
+		return fmt.Sprintf("session %q has no session_key and workdir fallback is ambiguous for %s work_dir %q", sessionID, provider, logCtx.workDir)
+	}
+	return fmt.Sprintf("no exact transcript found for session %q and workdir fallback is ambiguous for %s work_dir %q", sessionID, provider, logCtx.workDir)
 }
 
 func resolveConfiguredSessionLogContext(cityPath string, cfg *config.City, identifier string) (string, bool) {

--- a/cmd/gc/cmd_session_logs_test.go
+++ b/cmd/gc/cmd_session_logs_test.go
@@ -55,6 +55,22 @@ func (s *noLabelScanSessionLogStore) ListByLabel(label string, _ int, _ ...beads
 	return nil, fmt.Errorf("unexpected label scan for %q", label)
 }
 
+func writeCodexTestSession(t *testing.T, searchBase, workDir, fileName string, lines ...string) string {
+	t.Helper()
+	dayDir := filepath.Join(searchBase, "2026", "05", "04")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dayDir, fileName)
+	allLines := append([]string{
+		fmt.Sprintf(`{"timestamp":"2026-05-04T00:00:00Z","type":"session_meta","payload":{"cwd":%q}}`, workDir),
+	}, lines...)
+	if err := os.WriteFile(path, []byte(strings.Join(allLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func TestDoSessionLogsBasic(t *testing.T) {
 	searchBase := t.TempDir()
 	workDir := t.TempDir()
@@ -335,9 +351,12 @@ func TestResolveStoredSessionLogSource_UniqueWorkDirFallsBackBeyondLatestAlias(t
 		},
 	})
 
-	got, provider, ok := resolveStoredSessionLogSource("", nil, store, "mayor", []string{searchBase})
+	got, provider, ok, diagnostic := resolveStoredSessionLogSource("", nil, store, "mayor", []string{searchBase})
 	if !ok {
 		t.Fatal("resolveStoredSessionLogSource() = not found, want found")
+	}
+	if diagnostic != "" {
+		t.Fatalf("resolveStoredSessionLogSource() diagnostic = %q, want empty", diagnostic)
 	}
 	if provider != "claude" {
 		t.Fatalf("resolveStoredSessionLogSource() provider = %q, want %q", provider, "claude")
@@ -379,7 +398,7 @@ func TestResolveStoredSessionLogSource_DoesNotCrossAmbiguousWorkDir(t *testing.T
 		},
 	})
 
-	got, provider, ok := resolveStoredSessionLogSource("", nil, store, "mayor", []string{searchBase})
+	got, provider, ok, diagnostic := resolveStoredSessionLogSource("", nil, store, "mayor", []string{searchBase})
 	if !ok {
 		t.Fatal("resolveStoredSessionLogSource() = not found, want found")
 	}
@@ -388,6 +407,49 @@ func TestResolveStoredSessionLogSource_DoesNotCrossAmbiguousWorkDir(t *testing.T
 	}
 	if got != "" {
 		t.Fatalf("resolveStoredSessionLogSource() path = %q, want empty for ambiguous same-workdir transcript", got)
+	}
+	if !strings.Contains(diagnostic, "ambiguous") {
+		t.Fatalf("resolveStoredSessionLogSource() diagnostic = %q, want ambiguous", diagnostic)
+	}
+}
+
+func TestResolveStoredSessionLogSource_CodexDoesNotUseAmbiguousWorkDirFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	workDir := t.TempDir()
+	searchBase := t.TempDir()
+	writeCodexTestSession(t, searchBase, workDir, "rollout-current.jsonl",
+		`{"timestamp":"2026-05-04T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"wrong session"}]}}`,
+	)
+
+	for _, name := range []string{"workflows__codex-max-mc-one", "workflows__codex-max-mc-two"} {
+		b, _ := store.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"alias":         name,
+				"provider":      "codex",
+				"provider_kind": "codex",
+				"session_key":   "019df2fd-078f-7cb2-93c8-5c649a15eabe",
+				"session_name":  name,
+				"state":         "gc_swept",
+				"work_dir":      workDir,
+			},
+		})
+		_ = store.Close(b.ID)
+	}
+
+	got, provider, ok, diagnostic := resolveStoredSessionLogSource("", nil, store, "workflows__codex-max-mc-one", []string{searchBase})
+	if !ok {
+		t.Fatal("resolveStoredSessionLogSource() = not found, want found")
+	}
+	if provider != "codex" {
+		t.Fatalf("resolveStoredSessionLogSource() provider = %q, want codex", provider)
+	}
+	if got != "" {
+		t.Fatalf("resolveStoredSessionLogSource() path = %q, want empty for ambiguous codex workdir", got)
+	}
+	if !strings.Contains(diagnostic, "ambiguous") {
+		t.Fatalf("resolveStoredSessionLogSource() diagnostic = %q, want ambiguous", diagnostic)
 	}
 }
 

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -825,7 +825,8 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 	}
 
 	all, err := m.store.List(beads.ListQuery{
-		Label: LabelSession,
+		Label:         LabelSession,
+		IncludeClosed: b.Status == "closed",
 	})
 	if err != nil {
 		return "", fmt.Errorf("listing sessions: %w", err)
@@ -835,12 +836,17 @@ func (m *Manager) TranscriptPath(id string, searchPaths []string) (string, error
 		if !IsSessionBeadOrRepairable(other) {
 			continue
 		}
-		// Only count active sessions — closed historical sessions should not
-		// make the lookup ambiguous for the one live session.
-		if other.Status == "closed" {
+		// For a live target, closed historical sessions should not make the
+		// lookup ambiguous. For a closed target, historical siblings sharing
+		// the same workdir are the ambiguity we need to preserve.
+		if b.Status != "closed" && other.Status == "closed" {
 			continue
 		}
-		if provider != "" && strings.TrimSpace(other.Metadata["provider"]) != provider {
+		otherProvider := strings.TrimSpace(other.Metadata["provider_kind"])
+		if otherProvider == "" {
+			otherProvider = strings.TrimSpace(other.Metadata["provider"])
+		}
+		if provider != "" && otherProvider != provider {
 			continue
 		}
 		if other.Metadata["work_dir"] == workDir {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3071,6 +3071,47 @@ func TestTranscriptPathSkipsAmbiguousWorkDirFallback(t *testing.T) {
 	}
 }
 
+func TestTranscriptPathClosedSessionSkipsAmbiguousHistoricalWorkDirFallback(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	workDir := t.TempDir()
+	info1, err := mgr.Create(context.Background(), "helper", "one", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create one: %v", err)
+	}
+	info2, err := mgr.Create(context.Background(), "helper", "two", "codex", workDir, "codex", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create two: %v", err)
+	}
+	if err := mgr.Close(info1.ID); err != nil {
+		t.Fatalf("Close one: %v", err)
+	}
+	if err := mgr.Close(info2.ID); err != nil {
+		t.Fatalf("Close two: %v", err)
+	}
+
+	searchBase := t.TempDir()
+	dayDir := filepath.Join(searchBase, "2026", "05", "04")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	codexPath := filepath.Join(dayDir, "rollout-current.jsonl")
+	meta := `{"type":"session_meta","payload":{"cwd":"` + workDir + `"}}`
+	if err := os.WriteFile(codexPath, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	path, err := mgr.TranscriptPath(info1.ID, []string{searchBase})
+	if err != nil {
+		t.Fatalf("TranscriptPath: %v", err)
+	}
+	if path != "" {
+		t.Errorf("TranscriptPath = %q, want empty for ambiguous historical codex workdir", path)
+	}
+}
+
 func TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary
- stop `gc session logs <session-id>` from falling back to a shared Codex workdir when multiple stored sessions could match
- include closed historical session siblings in manager ambiguity checks for closed targets
- surface an explicit ambiguity diagnostic instead of printing an unrelated transcript

## Tests
- `go test ./cmd/gc ./internal/session -run 'TestResolveStoredSessionLogSource_CodexDoesNotUseAmbiguousWorkDirFallback|TestResolveStoredSessionLogSource_DoesNotCrossAmbiguousWorkDir|TestResolveStoredSessionLogSource_UniqueWorkDirFallsBackBeyondLatestAlias|TestTranscriptPathClosedSessionSkipsAmbiguousHistoricalWorkDirFallback|TestTranscriptPathSkipsAmbiguousWorkDirFallback|TestTranscriptPathSameWorkDirDifferentProvidersUsesProviderSpecificFallback'`\n- `go test ./internal/session ./internal/worker/...`\n- `/tmp/gc-session-log-fix session logs mc-5y53ihj` now reports ambiguity instead of printing the startup transcript\n\nNote: full `GC_FAST_UNIT=1 go test ./...` via pre-commit failed on unrelated `TestCityRuntimeRunStopsBeforeStartedWhenCanceledDuringStartup` in `cmd/gc/city_runtime_test.go`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->