### PR TITLE
fix(reconciler): suppress per-tick re-stamp on attached config-drift deferral

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1820,6 +1820,21 @@ func recordSessionAttachedConfigDriftDeferral(session beads.Bead, store beads.St
 	if clk != nil {
 		now = clk.Now().UTC()
 	}
+	// Skip the write when the same drift key is already deferred and the
+	// existing stamp is comfortably within the false-negative TTL window.
+	// Without this guard the reconciler emits a bead.updated event on every
+	// tick (~1.4s) for every attached session with persistent drift.
+	// Refreshing at TTL/2 leaves enough headroom that a paused reconcile
+	// loop cannot accidentally let the deferral expire.
+	if driftKey != "" && session.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata] == driftKey {
+		if raw := session.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]; raw != "" {
+			if existing, err := time.Parse(time.RFC3339, raw); err == nil &&
+				!existing.After(now) &&
+				now.Sub(existing) < sessionAttachedConfigDriftFalseNegativeLimit/2 {
+				return nil
+			}
+		}
+	}
 	return store.SetMetadataBatch(session.ID, map[string]string{
 		sessionAttachedConfigDriftDeferredAtMetadata:  now.Format(time.RFC3339),
 		sessionAttachedConfigDriftDeferredKeyMetadata: driftKey,

--- a/cmd/gc/session_reconciler_drift_defer_test.go
+++ b/cmd/gc/session_reconciler_drift_defer_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL verifies
+// that a second deferral with the same drift key, taken well within the
+// false-negative TTL window, does NOT re-stamp the deferred_at timestamp.
+//
+// On parent (pre-fix), recordSessionAttachedConfigDriftDeferral always writes
+// now() into deferred_at, producing a bead.updated event every reconcile tick
+// (~1.4s) on every attached session bead with persistent drift. This test
+// fails on parent and passes after the fix.
+func TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("worker", "worker")
+	const driftKey = "old-hash:new-hash"
+
+	if err := recordSessionAttachedConfigDriftDeferral(session, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	first, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after first: %v", err)
+	}
+	firstStamp := first.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
+	if firstStamp == "" {
+		t.Fatal("first call must stamp deferred_at")
+	}
+	if first.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata] != driftKey {
+		t.Fatalf("first key = %q, want %q", first.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata], driftKey)
+	}
+
+	// Advance the clock well within TTL/2 (TTL is 30s; advance 5s).
+	env.clk.Time = env.clk.Time.Add(5 * time.Second)
+
+	if err := recordSessionAttachedConfigDriftDeferral(first, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("second record: %v", err)
+	}
+	second, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after second: %v", err)
+	}
+	secondStamp := second.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
+	if secondStamp != firstStamp {
+		t.Fatalf("deferred_at must not be re-stamped within TTL/2; got %q want unchanged %q",
+			secondStamp, firstStamp)
+	}
+}
+
+// TestRecordSessionAttachedConfigDriftDeferral_RewritesWhenKeyChanges verifies
+// that a different drift key forces a rewrite even within the TTL window — the
+// guard must only suppress writes for the same drift situation, not for
+// genuinely new drift.
+func TestRecordSessionAttachedConfigDriftDeferral_RewritesWhenKeyChanges(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("worker", "worker")
+
+	if err := recordSessionAttachedConfigDriftDeferral(session, env.store, env.clk, "key-A"); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	first, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after first: %v", err)
+	}
+	firstStamp := first.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
+
+	env.clk.Time = env.clk.Time.Add(5 * time.Second)
+
+	if err := recordSessionAttachedConfigDriftDeferral(first, env.store, env.clk, "key-B"); err != nil {
+		t.Fatalf("second record: %v", err)
+	}
+	second, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after second: %v", err)
+	}
+	if second.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata] != "key-B" {
+		t.Fatalf("key after key-change call = %q, want key-B",
+			second.Metadata[sessionAttachedConfigDriftDeferredKeyMetadata])
+	}
+	if second.Metadata[sessionAttachedConfigDriftDeferredAtMetadata] == firstStamp {
+		t.Fatalf("deferred_at must be re-stamped on key change; got unchanged %q", firstStamp)
+	}
+}
+
+// TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL verifies
+// that once the existing stamp is older than TTL/2, the next call refreshes
+// it. This keeps the 30s false-negative TTL semantically intact: the
+// deferral cannot be allowed to age past TTL just because the same key
+// keeps being observed.
+func TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("worker", "worker")
+	const driftKey = "old-hash:new-hash"
+
+	if err := recordSessionAttachedConfigDriftDeferral(session, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	first, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after first: %v", err)
+	}
+	firstStamp := first.Metadata[sessionAttachedConfigDriftDeferredAtMetadata]
+
+	// Advance past TTL/2 (TTL is 30s; advance 16s).
+	env.clk.Time = env.clk.Time.Add(sessionAttachedConfigDriftFalseNegativeLimit/2 + time.Second)
+
+	if err := recordSessionAttachedConfigDriftDeferral(first, env.store, env.clk, driftKey); err != nil {
+		t.Fatalf("second record: %v", err)
+	}
+	second, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after second: %v", err)
+	}
+	if second.Metadata[sessionAttachedConfigDriftDeferredAtMetadata] == firstStamp {
+		t.Fatalf("deferred_at must be refreshed past TTL/2; got unchanged %q", firstStamp)
+	}
+}


### PR DESCRIPTION
## Problem

`recordSessionAttachedConfigDriftDeferral` writes `attached_config_drift_deferred_at = now()` unconditionally on every reconcile tick (~1.4s) for every attached session bead with persistent drift. Each write produces a `bead.updated` event.

On a quiescent machine with two attached named sessions (e.g. mayor + deacon), this is the dominant remaining `bead.updated` source after #1681 / #1682 land — observed steady-state ~22 events/min on a single attached session in the field, scaling linearly with attached-session count.

The cache no-op short-circuit in #1682 cannot suppress this because the timestamp value is genuinely changing tick-to-tick. The 30s false-negative TTL (`sessionAttachedConfigDriftFalseNegativeLimit`) exists to tolerate transient `IsAttached` probe misses; the per-tick refresh is far more aggressive than that semantic requires.

## Fix

Skip the write when the same drift key is already deferred and the existing stamp is within `sessionAttachedConfigDriftFalseNegativeLimit / 2` (15 s of the 30 s TTL). The TTL semantic is preserved:

- A paused reconcile loop has 15 s of headroom before the deferral expires (reconcile loop runs at ~1.4 s, so this is comfortable).
- A genuine drift-key change still re-stamps immediately.
- An aged stamp (>= TTL/2) still refreshes.

Net effect on the field: per-tick reconciler writes on attached session beads drop from ~1/1.4s to ~1/15s = **~10× reduction** on the remaining `bead.updated` noise floor.

## Tests

Three discriminators in `cmd/gc/session_reconciler_drift_defer_test.go`:

- `TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL` — same key + 5 s elapsed → must NOT re-stamp (RED on parent, GREEN with fix)
- `TestRecordSessionAttachedConfigDriftDeferral_RewritesWhenKeyChanges` — different key → must re-stamp (always GREEN; regression guard)
- `TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL` — same key + (TTL/2 + 1 s) elapsed → must refresh (always GREEN; regression guard)

Verified RED→GREEN locally:

```
$ git checkout 481ea61b -- cmd/gc/session_reconciler.go  # parent
$ go test ./cmd/gc/ -run TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL -v
--- FAIL: TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL
    deferred_at must not be re-stamped within TTL/2; got "...12:00:05Z" want unchanged "...12:00:00Z"

$ git checkout fix-branch -- cmd/gc/session_reconciler.go
$ go test ./cmd/gc/ -run TestRecordSessionAttachedConfigDriftDeferral_ -v
--- PASS: TestRecordSessionAttachedConfigDriftDeferral_SkipsWriteWithinHalfTTL
--- PASS: TestRecordSessionAttachedConfigDriftDeferral_RewritesWhenKeyChanges
--- PASS: TestRecordSessionAttachedConfigDriftDeferral_RewritesAfterHalfTTL
PASS
```

Two unrelated `cmd/gc` test failures observed on the broader package run (`TestControllerStateCreateRigPokesReconciler` missing fixture script; `TestReconcileCitiesNameDriftStopsBeadsProvider` expected stop-op) are pre-existing on parent (`481ea61b`) and not affected by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->