### PR TITLE
fix(beadmail): Thread accepts message-id, not just thread-id (#1526)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,19 +1,19 @@
 vulnerabilities:
-  - id: CVE-2026-34986
+  - id: CVE-2026-41602
     paths:
       - "usr/local/bin/dolt"
-    expired_at: 2026-05-29
-    statement: Latest Dolt 1.86.6 still embeds go-jose v4.1.3; remove after a Dolt release includes go-jose v4.1.4 or later.
-  - id: CVE-2026-39883
-    paths:
-      - "usr/local/bin/dolt"
-    expired_at: 2026-05-29
-    statement: Latest Dolt 1.86.6 still embeds opentelemetry-go v1.40.0; remove after a Dolt release includes otel/sdk v1.43.0 or later.
+    expired_at: 2026-06-07
+    statement: Latest Dolt 1.88.0 still embeds github.com/apache/thrift v0.13.1; remove after a Dolt release includes thrift 0.23.0 or later.
   - id: CVE-2026-34986
     paths:
       - "usr/local/bin/bd"
     expired_at: 2026-05-29
     statement: Latest bd v1.0.3 still embeds go-jose v4.1.3; remove after a beads release includes go-jose v4.1.4 or later.
+  - id: CVE-2026-41602
+    paths:
+      - "usr/local/bin/bd"
+    expired_at: 2026-06-07
+    statement: Latest bd v1.0.3 still embeds github.com/apache/thrift v0.19.0; remove after a beads release includes thrift 0.23.0 or later.
   - id: CVE-2026-27962
     paths:
       - "usr/local/lib/python3.12/site-packages/authlib-1.5.2.dist-info/METADATA"

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -1076,9 +1076,9 @@ deleted in a single batch round-trip.`,
 
 func newMailThreadCmd(stdout, stderr io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use:   "thread <thread-id>",
+		Use:   "thread <id>",
 		Short: "List all messages in a thread",
-		Long:  `Show all messages sharing a thread ID, ordered by time.`,
+		Long:  `Show all messages sharing a thread ID or message ID, ordered by time.`,
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdMailThread(args, stdout, stderr) != 0 {
@@ -1666,19 +1666,19 @@ func cmdMailThread(args []string, stdout, stderr io.Writer) int {
 // doMailThread shows all messages in a thread.
 func doMailThread(mp mail.Provider, args []string, stdout, stderr io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(stderr, "gc mail thread: missing thread ID") //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "gc mail thread: missing thread or message ID") //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	threadID := args[0]
+	id := args[0]
 
-	msgs, err := mp.Thread(threadID)
+	msgs, err := mp.Thread(id)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc mail thread: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 
 	if len(msgs) == 0 {
-		fmt.Fprintf(stdout, "No messages in thread %s\n", threadID) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(stdout, "No messages in thread %s\n", id) //nolint:errcheck // best-effort stdout
 		return 0
 	}
 

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -8662,7 +8662,7 @@ export interface operations {
             path: {
                 /** @description City name. */
                 cityName: string;
-                /** @description Thread ID. */
+                /** @description Thread ID, or any message ID in the thread. */
                 id: string;
             };
             cookie?: never;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -7278,7 +7278,7 @@ export type GetV0CityByCityNameMailThreadByIdData = {
          */
         cityName: string;
         /**
-         * Thread ID.
+         * Thread ID, or any message ID in the thread.
          */
         id: string;
     };

--- a/contrib/k8s/Dockerfile.base
+++ b/contrib/k8s/Dockerfile.base
@@ -12,7 +12,7 @@ FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG CLAUDE_CODE_VERSION=2.1.123
-ARG DOLT_VERSION=1.86.6
+ARG DOLT_VERSION=1.88.0
 
 # System packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/contrib/k8s/dolt-statefulset.yaml
+++ b/contrib/k8s/dolt-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: init-user
-        image: dolthub/dolt:1.86.6
+        image: dolthub/dolt:1.88.0
         env:
         - name: HOME
           value: /tmp
@@ -56,7 +56,7 @@ spec:
           mountPath: /tmp
       containers:
       - name: dolt
-        image: dolthub/dolt:1.86.6
+        image: dolthub/dolt:1.88.0
         env:
         - name: HOME
           value: /tmp

--- a/contrib/mail-scripts/gc-mail-mcp-agent-mail
+++ b/contrib/mail-scripts/gc-mail-mcp-agent-mail
@@ -749,7 +749,11 @@ case "$op" in
     ;;
 
   thread)
-    thread_id="${1:?usage: gc-mail-mcp-agent-mail thread <thread-id>}"
+    id="${1:?usage: gc-mail-mcp-agent-mail thread <id>}"
+    thread_id="$(get_cached_thread_id "$id")"
+    if [ -z "$thread_id" ]; then
+      thread_id="$id"
+    fi
     # mcp_agent_mail doesn't have a native thread query.
     # Search local cache for messages with matching thread ID.
     result="[]"

--- a/deps.env
+++ b/deps.env
@@ -4,7 +4,7 @@
 # Update these when bumping minimum versions. The internal/deps package
 # defines the minimum compatible versions (may lag behind these pins).
 
-DOLT_VERSION=1.86.6
+DOLT_VERSION=1.88.0
 BD_REPO=gastownhall/beads
 BD_VERSION=v1.0.3
 BR_VERSION=0.1.20

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1525,10 +1525,10 @@ gc mail send mayor "Build is green"
 
 ## gc mail thread
 
-Show all messages sharing a thread ID, ordered by time.
+Show all messages sharing a thread ID or message ID, ordered by time.
 
 ```
-gc mail thread <thread-id>
+gc mail thread <id>
 ```
 
 ## gc mcp

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -17245,12 +17245,12 @@
             }
           },
           {
-            "description": "Thread ID.",
+            "description": "Thread ID, or any message ID in the thread.",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "description": "Thread ID.",
+              "description": "Thread ID, or any message ID in the thread.",
               "type": "string"
             }
           },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -17245,12 +17245,12 @@
             }
           },
           {
-            "description": "Thread ID.",
+            "description": "Thread ID, or any message ID in the thread.",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "description": "Thread ID.",
+              "description": "Thread ID, or any message ID in the thread.",
               "type": "string"
             }
           },

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -4588,5 +4589,146 @@ func TestJsonlExportHaltMailFailurePreservesExistingPendingAlerts(t *testing.T) 
 	}
 	if _, ok := pendingAlerts["beads"]; !ok {
 		t.Fatalf("expected new pending alert to be added, got:\n%s", stateData)
+	}
+}
+
+func TestWispCompactReportsNonZeroCounters(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+
+	pastTTL := "2020-01-01T00:00:00Z"
+	withinTTL := time.Now().UTC().Format(time.RFC3339)
+	beadsJSON := fmt.Sprintf(`[
+  {"id":"ga-old-1","status":"closed","ephemeral":true,"updated_at":"%s","comment_count":0,"labels":[]},
+  {"id":"ga-old-2","status":"closed","ephemeral":true,"updated_at":"%s","comment_count":0,"labels":[]},
+  {"id":"ga-stuck","status":"open","ephemeral":true,"updated_at":"%s","comment_count":0,"labels":[]},
+  {"id":"ga-fresh","status":"closed","ephemeral":true,"updated_at":"%s","comment_count":0,"labels":[]}
+]`, pastTTL, pastTTL, pastTTL, withinTTL)
+
+	writeExecutable(t, filepath.Join(binDir, "bd"), fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> "$BD_LOG"
+case "$1 $2" in
+  "list --json")
+    cat <<'JSON'
+%s
+JSON
+    ;;
+esac
+exit 0
+`, beadsJSON))
+
+	env := map[string]string{
+		"BD_LOG":       bdLog,
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+
+	logData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(logData), "list --json --all -n 0") {
+		t.Fatalf("bd list call not observed:\n%s", logData)
+	}
+
+	want := "wisp-compact: promoted=1 deleted=2 skipped=1"
+	if !strings.Contains(string(out), want) {
+		t.Fatalf("wisp-compact summary missing or wrong (subshell counter regression?)\nwant substring: %q\ngot output:\n%s", want, out)
+	}
+}
+
+func TestCrossRigDepsReportsNonZeroCounter(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+
+	closedJSON := `[{"id":"ga-closed-1"},{"id":"ga-closed-2"},{"id":"ga-closed-internal"}]`
+	depsForClosed1 := `[{"id":"external:rig-a/ga-dep-1"},{"id":"external:rig-b/ga-dep-2"}]`
+	depsForClosed2 := `[{"id":"external:rig-a/ga-dep-3"},{"id":"external:rig-c/ga-dep-4"}]`
+	depsForClosedInternal := `[{"id":"ga-internal-1"},{"id":"ga-internal-2"}]`
+
+	writeExecutable(t, filepath.Join(binDir, "bd"), fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> "$BD_LOG"
+case "$1" in
+  list)
+    cat <<'JSON'
+%s
+JSON
+    exit 0
+    ;;
+  dep)
+    case "$2 $3" in
+      "list ga-closed-1")
+        cat <<'JSON'
+%s
+JSON
+        exit 0
+        ;;
+      "list ga-closed-2")
+        cat <<'JSON'
+%s
+JSON
+        exit 0
+        ;;
+      "list ga-closed-internal")
+        cat <<'JSON'
+%s
+JSON
+        exit 0
+        ;;
+      "remove "*|"add "*)
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+`, closedJSON, depsForClosed1, depsForClosed2, depsForClosedInternal))
+
+	env := map[string]string{
+		"BD_LOG":       bdLog,
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "cross-rig-deps.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+
+	logData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	for _, want := range []string{
+		"dep list ga-closed-1",
+		"dep list ga-closed-2",
+		"dep list ga-closed-internal",
+	} {
+		if !strings.Contains(string(logData), want) {
+			t.Fatalf("bd dep list call %q not observed:\n%s", want, logData)
+		}
+	}
+	if strings.Contains(string(logData), `dep remove "" `) || strings.Contains(string(logData), "dep remove  ") {
+		t.Fatalf("bogus empty-dep_id call observed (empty-filter guard regression?):\n%s", logData)
+	}
+
+	want := "cross-rig-deps: resolved 4 cross-rig dependencies"
+	if !strings.Contains(string(out), want) {
+		t.Fatalf("cross-rig-deps summary missing or wrong (subshell counter regression?)\nwant substring: %q\ngot output:\n%s\nbd log:\n%s", want, out, logData)
 	}
 }

--- a/examples/gastown/packs/maintenance/assets/scripts/cross-rig-deps.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/cross-rig-deps.sh
@@ -29,22 +29,35 @@ if [ -z "$CLOSED" ] || [ "$CLOSED" = "[]" ]; then
 fi
 
 # Step 2: For each closed issue, check for cross-rig dependents.
+# Capture jq output into variables (instead of piping into the loops) so
+# producer failures still trip pipefail+set -e fail-loud, and the loop
+# bodies run in the parent shell — RESOLVED is incremented in scope and
+# survives to the summary echo below. CLOSED is pre-validated as a
+# non-empty array on lines 26-29, so CLOSED_IDS is non-empty here.
 RESOLVED=0
-echo "$CLOSED" | jq -r '.[].id' 2>/dev/null | while IFS= read -r closed_id; do
+CLOSED_IDS=$(echo "$CLOSED" | jq -r '.[].id' 2>/dev/null)
+while IFS= read -r closed_id; do
     # Find beads that have a blocks dep on this closed issue.
     DEPS=$(bd dep list "$closed_id" --direction=up --type=blocks --json 2>/dev/null) || continue
     if [ -z "$DEPS" ] || [ "$DEPS" = "[]" ]; then
         continue
     fi
 
-    # Filter for external (cross-rig) deps.
-    echo "$DEPS" | jq -r '.[] | select(.id | startswith("external:")) | .id' 2>/dev/null | while IFS= read -r dep_id; do
+    # Filter for external (cross-rig) deps. The select() filter may yield
+    # zero matches, in which case we skip rather than feed an empty
+    # here-string into `read` (which would produce one bogus iteration
+    # with dep_id="").
+    EXTERNAL_DEPS=$(echo "$DEPS" | jq -r '.[] | select(.id | startswith("external:")) | .id' 2>/dev/null)
+    if [ -z "$EXTERNAL_DEPS" ]; then
+        continue
+    fi
+    while IFS= read -r dep_id; do
         # Convert blocks → related: remove blocking semantics, keep audit trail.
         bd dep remove "$dep_id" "external:$closed_id" 2>/dev/null || true
         bd dep add "$dep_id" "external:$closed_id" --type=related 2>/dev/null || true
         RESOLVED=$((RESOLVED + 1))
-    done
-done
+    done <<< "$EXTERNAL_DEPS"
+done <<< "$CLOSED_IDS"
 
 if [ "$RESOLVED" -gt 0 ]; then
     echo "cross-rig-deps: resolved $RESOLVED cross-rig dependencies"

--- a/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
@@ -31,8 +31,14 @@ PROMOTED=0
 DELETED=0
 SKIPPED=0
 
-# Process each ephemeral bead.
-echo "$EPHEMERALS" | jq -c '.[]' 2>/dev/null | while IFS= read -r bead; do
+# Process each ephemeral bead. Capturing jq output into BEADS first
+# (instead of piping into the loop) preserves the original pipefail
+# fail-loud on jq error AND keeps PROMOTED/DELETED/SKIPPED in the parent
+# shell so they survive to the summary echo below. EPHEMERALS is
+# pre-validated as a non-empty array on lines 22-27, so BEADS is
+# guaranteed non-empty here.
+BEADS=$(echo "$EPHEMERALS" | jq -c '.[]' 2>/dev/null)
+while IFS= read -r bead; do
     id=$(echo "$bead" | jq -r '.id')
     status=$(echo "$bead" | jq -r '.status')
     updated_at=$(echo "$bead" | jq -r '.updated_at // .created_at')
@@ -73,7 +79,7 @@ echo "$EPHEMERALS" | jq -c '.[]' 2>/dev/null | while IFS= read -r bead; do
     # Closed + past TTL + no special attributes → delete.
     bd delete "$id" --force 2>/dev/null || true
     DELETED=$((DELETED + 1))
-done
+done <<< "$BEADS"
 
 TOTAL=$((PROMOTED + DELETED))
 if [ "$TOTAL" -gt 0 ]; then

--- a/internal/api/huma_types_mail.go
+++ b/internal/api/huma_types_mail.go
@@ -107,7 +107,7 @@ type MailDeleteInput struct {
 // MailThreadInput is the Huma input for GET /v0/city/{cityName}/mail/thread/{id}.
 type MailThreadInput struct {
 	CityScope
-	ID  string `path:"id" doc:"Thread ID."`
+	ID  string `path:"id" doc:"Thread ID, or any message ID in the thread."`
 	Rig string `query:"rig" required:"false" doc:"Filter by rig."`
 }
 

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -17245,12 +17245,12 @@
             }
           },
           {
-            "description": "Thread ID.",
+            "description": "Thread ID, or any message ID in the thread.",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "description": "Thread ID.",
+              "description": "Thread ID, or any message ID in the thread.",
               "type": "string"
             }
           },

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -395,10 +394,16 @@ func deriveReplyTitle(subject, originalTitle, body string) string {
 // so callers that already know the thread ID still work.
 func (p *Provider) Thread(id string) ([]mail.Message, error) {
 	threadID := id
-	if msgBead, err := p.store.Get(id); err == nil {
+	msgBead, err := p.store.Get(id)
+	switch {
+	case err == nil:
 		if t := extractLabel(msgBead.Labels, "thread:"); t != "" {
 			threadID = t
 		}
+	case errors.Is(err, beads.ErrNotFound):
+		// Caller passed a non-bead-id (e.g., a real thread-id); fall through.
+	default:
+		return nil, fmt.Errorf("beadmail thread: resolving %q: %w", id, err)
 	}
 	bs, err := p.store.List(beads.ListQuery{
 		Label: "thread:" + threadID,
@@ -412,10 +417,8 @@ func (p *Provider) Thread(id string) ([]mail.Message, error) {
 	for i, b := range bs {
 		msgs[i] = beadToMessage(b)
 	}
-	// Sort by creation time ascending.
-	sort.Slice(msgs, func(i, j int) bool {
-		return msgs[i].CreatedAt.Before(msgs[j].CreatedAt)
-	})
+	// Note: store.List already sorts by SortCreatedAsc with an ID tie-break
+	// (see sortBeadsForQuery in internal/beads/query.go), so no post-sort here.
 	return msgs, nil
 }
 

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -388,7 +388,18 @@ func deriveReplyTitle(subject, originalTitle, body string) string {
 }
 
 // Thread returns all messages sharing a thread ID, ordered by creation time.
-func (p *Provider) Thread(threadID string) ([]mail.Message, error) {
+// Callers may pass either an actual thread ID or any message bead ID in the
+// thread — the latter is what `gc mail thread <id>` from the CLI hands us.
+// If the input resolves to an existing message bead, its `thread:` label is
+// used; otherwise the input is treated as a thread ID directly so callers
+// that already know the thread ID still work.
+func (p *Provider) Thread(id string) ([]mail.Message, error) {
+	threadID := id
+	if msgBead, err := p.store.Get(id); err == nil {
+		if t := extractLabel(msgBead.Labels, "thread:"); t != "" {
+			threadID = t
+		}
+	}
 	bs, err := p.store.List(beads.ListQuery{
 		Label: "thread:" + threadID,
 		Type:  "message",

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -390,9 +390,9 @@ func deriveReplyTitle(subject, originalTitle, body string) string {
 // Thread returns all messages sharing a thread ID, ordered by creation time.
 // Callers may pass either an actual thread ID or any message bead ID in the
 // thread — the latter is what `gc mail thread <id>` from the CLI hands us.
-// If the input resolves to an existing message bead, its `thread:` label is
-// used; otherwise the input is treated as a thread ID directly so callers
-// that already know the thread ID still work.
+// If the input resolves to an existing message bead with a `thread:` label,
+// that label is used; otherwise the input is treated as a thread ID directly
+// so callers that already know the thread ID still work.
 func (p *Provider) Thread(id string) ([]mail.Message, error) {
 	threadID := id
 	if msgBead, err := p.store.Get(id); err == nil {

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -397,6 +397,9 @@ func (p *Provider) Thread(id string) ([]mail.Message, error) {
 	msgBead, err := p.store.Get(id)
 	switch {
 	case err == nil:
+		if msgBead.Type != "message" {
+			return nil, fmt.Errorf("beadmail thread: bead %q is type %q, want message", id, msgBead.Type)
+		}
 		if t := extractLabel(msgBead.Labels, "thread:"); t != "" {
 			threadID = t
 		}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1422,6 +1422,33 @@ func TestThreadAcceptsMessageIDOfOriginal(t *testing.T) {
 	}
 }
 
+// TestThreadSurfacesNonNotFoundStoreErrors verifies that a real store I/O
+// failure during message-id resolution propagates to the caller instead of
+// being silently swallowed as "treat input as thread-id".
+func TestThreadSurfacesNonNotFoundStoreErrors(t *testing.T) {
+	mem := beads.NewMemStore()
+	failing := &getErrorStore{MemStore: mem, getErr: errors.New("simulated I/O failure")}
+	p := New(failing)
+
+	_, err := p.Thread("anything")
+	if err == nil {
+		t.Fatal("Thread: expected error from underlying store, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated I/O failure") {
+		t.Errorf("Thread: error %q does not wrap underlying store error", err)
+	}
+}
+
+// getErrorStore returns a custom error from Get; List defers to MemStore.
+type getErrorStore struct {
+	*beads.MemStore
+	getErr error
+}
+
+func (s *getErrorStore) Get(id string) (beads.Bead, error) {
+	return beads.Bead{}, s.getErr
+}
+
 // TestThreadAcceptsMessageIDOfReply ensures the resolution works regardless
 // of which message in the thread the caller hands us — the parent OR any
 // reply should both surface the full thread.

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1439,6 +1439,27 @@ func TestThreadSurfacesNonNotFoundStoreErrors(t *testing.T) {
 	}
 }
 
+func TestThreadRejectsNonMessageBeadID(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+	task, err := store.Create(beads.Bead{
+		Title:  "not mail",
+		Type:   "task",
+		Labels: []string{"thread:looks-mail-like"},
+	})
+	if err != nil {
+		t.Fatalf("Create task: %v", err)
+	}
+
+	_, err = p.Thread(task.ID)
+	if err == nil {
+		t.Fatal("Thread(non-message bead ID): expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `bead "`) || !strings.Contains(err.Error(), "want message") {
+		t.Fatalf("Thread(non-message bead ID) error = %q, want clear non-message diagnostic", err)
+	}
+}
+
 // getErrorStore returns a custom error from Get; List defers to MemStore.
 type getErrorStore struct {
 	*beads.MemStore

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1445,7 +1445,7 @@ type getErrorStore struct {
 	getErr error
 }
 
-func (s *getErrorStore) Get(id string) (beads.Bead, error) {
+func (s *getErrorStore) Get(_ string) (beads.Bead, error) {
 	return beads.Bead{}, s.getErr
 }
 

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1394,6 +1394,62 @@ func TestThreadEmpty(t *testing.T) {
 	}
 }
 
+// TestThreadAcceptsMessageIDOfOriginal locks in the fix for #1526. Callers
+// (notably `gc mail thread <id>` from cmd/gc/cmd_mail.go) pass a *message*
+// bead-ID, not the underlying thread-ID. Provider.Thread must resolve the
+// message-ID to its thread label and return the thread.
+func TestThreadAcceptsMessageIDOfOriginal(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "Hello", "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Reply(sent.ID, "bob", "Re: Hello", "second"); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := p.Thread(sent.ID)
+	if err != nil {
+		t.Fatalf("Thread(%q): %v", sent.ID, err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("Thread(messageID) = %d messages, want 2", len(msgs))
+	}
+	if msgs[0].Body != "first" || msgs[1].Body != "second" {
+		t.Errorf("Thread(messageID) bodies = [%q, %q], want [first, second]", msgs[0].Body, msgs[1].Body)
+	}
+}
+
+// TestThreadAcceptsMessageIDOfReply ensures the resolution works regardless
+// of which message in the thread the caller hands us — the parent OR any
+// reply should both surface the full thread.
+func TestThreadAcceptsMessageIDOfReply(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("alice", "bob", "Hello", "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, err := p.Reply(sent.ID, "bob", "Re: Hello", "second")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := p.Thread(reply.ID)
+	if err != nil {
+		t.Fatalf("Thread(%q): %v", reply.ID, err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("Thread(replyID) = %d messages, want 2", len(msgs))
+	}
+	if msgs[0].Body != "first" || msgs[1].Body != "second" {
+		t.Errorf("Thread(replyID) bodies = [%q, %q], want [first, second]", msgs[0].Body, msgs[1].Body)
+	}
+}
+
 // --- Count ---
 
 func TestCount(t *testing.T) {

--- a/internal/mail/exec/conformance_test.go
+++ b/internal/mail/exec/conformance_test.go
@@ -174,7 +174,11 @@ case "$op" in
     printf '{"id":"%s","from":"%s","to":"%s","subject":"%s","body":"%s","created_at":"%s","thread_id":"%s","reply_to":"%s"}\n' "$new_msgid" "$from" "$orig_from" "$subject" "$body" "$ts" "$orig_thread" "$msgid"
     ;;
   thread)
-    thread_id="$1"
+    id="$1"
+    thread_id="$id"
+    if [ -f "$STATE/messages/$id" ]; then
+      thread_id=$(sed -n '8p' "$STATE/messages/$id")
+    fi
     result=""
     for f in "$STATE"/messages/*; do
       [ -f "$f" ] || continue

--- a/internal/mail/exec/exec.go
+++ b/internal/mail/exec/exec.go
@@ -183,10 +183,11 @@ func (p *Provider) Reply(id, from, subject, body string) (mail.Message, error) {
 	return unmarshalMessage(out)
 }
 
-// Thread delegates to: script thread <thread-id>
-func (p *Provider) Thread(threadID string) ([]mail.Message, error) {
+// Thread delegates to: script thread <id>, where id may be a thread ID or
+// any message ID in that thread.
+func (p *Provider) Thread(id string) ([]mail.Message, error) {
 	p.ensureRunning()
-	out, err := p.run(nil, "thread", threadID)
+	out, err := p.run(nil, "thread", id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mail/fake.go
+++ b/internal/mail/fake.go
@@ -255,11 +255,19 @@ func (f *Fake) Reply(id, from, subject, body string) (Message, error) {
 }
 
 // Thread returns all messages sharing a thread ID, ordered by time.
-func (f *Fake) Thread(threadID string) ([]Message, error) {
+// id may be either the thread ID or any message ID in that thread.
+func (f *Fake) Thread(id string) ([]Message, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.broken {
 		return nil, fmt.Errorf("mail provider unavailable")
+	}
+	threadID := id
+	for _, fm := range f.messages {
+		if fm.msg.ID == id {
+			threadID = fm.msg.ThreadID
+			break
+		}
 	}
 	var result []Message
 	for _, fm := range f.messages {

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -104,7 +104,8 @@ type Provider interface {
 	Reply(id, from, subject, body string) (Message, error)
 
 	// Thread returns all messages sharing a thread ID, ordered by time.
-	Thread(threadID string) ([]Message, error)
+	// The id may be either the thread ID or any message ID in that thread.
+	Thread(id string) ([]Message, error)
 
 	// All returns all open messages (read and unread) for the recipient.
 	All(recipient string) ([]Message, error)

--- a/internal/mail/mailtest/conformance.go
+++ b/internal/mail/mailtest/conformance.go
@@ -405,6 +405,27 @@ func RunProviderTests(t *testing.T, newProvider func(t *testing.T) mail.Provider
 		}
 	})
 
+	t.Run("Thread_ReturnsAllForMessageID", func(t *testing.T) {
+		p := newProvider(t)
+		sent, err := p.Send("alice", "bob", "Hello", "first")
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		reply, err := p.Reply(sent.ID, "bob", "RE: Hello", "second")
+		if err != nil {
+			t.Fatalf("Reply: %v", err)
+		}
+		for _, id := range []string{sent.ID, reply.ID} {
+			msgs, err := p.Thread(id)
+			if err != nil {
+				t.Fatalf("Thread(%q): %v", id, err)
+			}
+			if len(msgs) != 2 {
+				t.Fatalf("Thread(%q) = %d messages, want 2", id, len(msgs))
+			}
+		}
+	})
+
 	t.Run("Thread_Empty", func(t *testing.T) {
 		p := newProvider(t)
 		msgs, err := p.Thread("nonexistent-thread")


### PR DESCRIPTION
## Summary

`gc mail thread <id>` returned `No messages in thread` for both the parent and reply IDs even immediately after a successful `gc mail reply` between two known beads — exactly the reproducer in #1526.

Closes #1526.

## Root cause

`Send` and `Reply` correctly persist a `thread:<uuid>` label on every message bead, and `Reply` additionally writes `reply-to:<parentID>`. The bug is purely in how `Provider.Thread` interprets its argument.

`cmd/gc/cmd_mail.go:1624` passes the user's CLI argument straight through:

\`\`\`go
threadID := args[0]
msgs, err := mp.Thread(threadID)
\`\`\`

But `<id>` is a **message bead-ID** (e.g., `mg-wisp-pn9`), not a thread-id. `Provider.Thread` was querying `Label: \"thread:\" + msgID`, while the bead's actual label is `thread:<generated-uuid>` — so the query always returned the empty list.

## Fix

`internal/mail/beadmail/beadmail.go` — resolve the input via `store.Get` and use the bead's `thread:` label as the query key. Backward-compatible: callers that already know the thread-id (e.g., the existing `TestThread`, internal callers) hit the Get-not-found fallback and use the input directly.

\`\`\`go
func (p *Provider) Thread(id string) ([]mail.Message, error) {
    threadID := id
    if msgBead, err := p.store.Get(id); err == nil {
        if t := extractLabel(msgBead.Labels, \"thread:\"); t != \"\" {
            threadID = t
        }
    }
    bs, err := p.store.List(beads.ListQuery{
        Label: \"thread:\" + threadID,
        Type:  \"message\",
        Sort:  beads.SortCreatedAsc,
    })
    ...
}
\`\`\`

The fix is intentionally scoped to the data layer — no overlap with the in-flight #1149 read-path routing rewrite (which modifies \`cmd/gc/cmd_mail.go\` and \`internal/api/decode_mail.go\`). When #1149 lands and reroutes \`gc mail thread\` through the supervisor API, the same correct \`Provider.Thread\` will be invoked behind the new transport.

## Tests

\`internal/mail/beadmail/beadmail_test.go\` — two new tests reproducing the issue, plus pre-existing tests preserved as regression cover:

| Test | What it locks in |
|---|---|
| **NEW** \`TestThreadAcceptsMessageIDOfOriginal\` | \`Send\` → \`Reply\` → \`Thread(parent.ID)\` returns [parent, reply] |
| **NEW** \`TestThreadAcceptsMessageIDOfReply\` | Same, but \`Thread(reply.ID)\` — symmetric path |
| existing \`TestThread\` | \`Thread(sent.ThreadID)\` (actual thread-id) still works — backward-compat regression cover |
| existing \`TestThreadEmpty\` | \`Thread(\"nonexistent\")\` returns empty without error |

## Test plan

- [x] \`go test ./internal/mail/...\` — green
- [x] \`go vet ./internal/mail/...\` — clean
- [x] \`make check\` (fmt-check + lint + vet + test) — green
- [ ] CI green
- [ ] Manual reproducer per #1526 acceptance criteria:
  1. \`gc mail send mayor -s \"T\" -m \"ping\"\` → note id A
  2. \`gc mail reply A -s \"Re: T\" -m \"pong\"\` → note id B
  3. \`gc mail thread A\` returns both A and B in chronological order
  4. \`gc mail thread B\` same

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->