### PR TITLE
fix(mail): cache gc:session enumeration across identity + recipient resolution (ga-q6ct)

### DIFF
--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"unicode"
 	"unicode/utf8"
@@ -427,14 +428,14 @@ func sessionMailboxAddresses(b beads.Bead) []string {
 	return addresses
 }
 
-func resolveMailIdentity(store beads.Store, identifier string) (string, error) {
+func resolveMailIdentityCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
 	if identifier == "" || identifier == "human" {
 		return "human", nil
 	}
 	sessionID, err := resolveSessionID(store, identifier)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
-			if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
+			if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
 				return "", targetErr
 			} else if matched {
 				return target.display, nil
@@ -489,7 +490,7 @@ func resolveMailIdentityWithConfigCached(cityPath string, cfg *config.City, stor
 	if address, ok := configuredMailboxAddressWithConfig(cityPath, cfg, identifier); ok {
 		return address, nil
 	}
-	return resolveMailIdentity(store, identifier)
+	return resolveMailIdentityCached(store, identifier, cache)
 }
 
 func resolveMailRecipientIdentity(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
@@ -537,16 +538,12 @@ func configuredMailboxAddressWithConfig(cityPath string, cfg *config.City, ident
 	return spec.Identity, true
 }
 
-func listLiveSessionMailboxes(store beads.Store) (map[string]bool, error) {
-	return listLiveSessionMailboxesCached(store, nil)
-}
-
 func listLiveSessionMailboxesCached(store beads.Store, cache *mailIdentitySessionCache) (map[string]bool, error) {
 	recipients := map[string]bool{"human": true}
 	if store == nil {
 		return recipients, nil
 	}
-	all, err := cache.get(store)
+	all, err := listMailIdentitySessions(store, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -618,30 +615,29 @@ func mailSenderDisplayFromMetadata(fallback string, metadata map[string]string) 
 // mailIdentitySessionCache memoizes a single gc:session enumeration so that
 // repeated identity-resolution attempts (multi-candidate retry, sender +
 // recipient resolution in the same command, etc.) share the same broad scan.
-// Zero value is a valid empty cache; the first get() fetches and reuses.
+// A nil cache disables memoization; the zero value memoizes on first use.
 type mailIdentitySessionCache struct {
+	mu      sync.Mutex
 	list    []beads.Bead
 	fetched bool
 }
 
-func (c *mailIdentitySessionCache) get(store beads.Store) ([]beads.Bead, error) {
-	if c == nil {
+func listMailIdentitySessions(store beads.Store, cache *mailIdentitySessionCache) ([]beads.Bead, error) {
+	if cache == nil {
 		return store.List(beads.ListQuery{Label: session.LabelSession})
 	}
-	if c.fetched {
-		return c.list, nil
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if cache.fetched {
+		return cache.list, nil
 	}
 	list, err := store.List(beads.ListQuery{Label: session.LabelSession})
 	if err != nil {
 		return nil, err
 	}
-	c.list = list
-	c.fetched = true
+	cache.list = list
+	cache.fetched = true
 	return list, nil
-}
-
-func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) (resolvedMailTarget, bool, error) {
-	return resolveLiveConfiguredNamedMailTargetCached(store, identifier, nil)
 }
 
 func resolveLiveConfiguredNamedMailTargetCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, bool, error) {
@@ -649,7 +645,7 @@ func resolveLiveConfiguredNamedMailTargetCached(store beads.Store, identifier st
 	if store == nil || identifier == "" || identifier == "human" || strings.Contains(identifier, "/") {
 		return resolvedMailTarget{}, false, nil
 	}
-	all, err := cache.get(store)
+	all, err := listMailIdentitySessions(store, cache)
 	if err != nil {
 		return resolvedMailTarget{}, false, err
 	}

--- a/cmd/gc/cmd_mail.go
+++ b/cmd/gc/cmd_mail.go
@@ -457,6 +457,10 @@ func resolveMailIdentity(store beads.Store, identifier string) (string, error) {
 }
 
 func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
+	return resolveMailIdentityWithConfigCached(cityPath, cfg, store, identifier, nil)
+}
+
+func resolveMailIdentityWithConfigCached(cityPath string, cfg *config.City, store beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
 	if identifier == "" || identifier == "human" {
 		return "human", nil
 	}
@@ -477,7 +481,7 @@ func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, store bead
 			return "", err
 		}
 	}
-	if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
+	if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
 		return "", targetErr
 	} else if matched {
 		return target.display, nil
@@ -489,15 +493,19 @@ func resolveMailIdentityWithConfig(cityPath string, cfg *config.City, store bead
 }
 
 func resolveMailRecipientIdentity(cityPath string, cfg *config.City, store beads.Store, identifier string) (string, error) {
+	return resolveMailRecipientIdentityCached(cityPath, cfg, store, identifier, nil)
+}
+
+func resolveMailRecipientIdentityCached(cityPath string, cfg *config.City, store beads.Store, identifier string, cache *mailIdentitySessionCache) (string, error) {
 	if identifier == "" || identifier == "human" {
 		return "human", nil
 	}
-	if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
+	if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
 		return "", targetErr
 	} else if matched {
 		return target.display, nil
 	}
-	return resolveMailIdentityWithConfig(cityPath, cfg, store, identifier)
+	return resolveMailIdentityWithConfigCached(cityPath, cfg, store, identifier, cache)
 }
 
 func configuredMailboxAddress(identifier string) (string, bool) {
@@ -530,13 +538,15 @@ func configuredMailboxAddressWithConfig(cityPath string, cfg *config.City, ident
 }
 
 func listLiveSessionMailboxes(store beads.Store) (map[string]bool, error) {
+	return listLiveSessionMailboxesCached(store, nil)
+}
+
+func listLiveSessionMailboxesCached(store beads.Store, cache *mailIdentitySessionCache) (map[string]bool, error) {
 	recipients := map[string]bool{"human": true}
 	if store == nil {
 		return recipients, nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
+	all, err := cache.get(store)
 	if err != nil {
 		return nil, err
 	}
@@ -605,14 +615,41 @@ func mailSenderDisplayFromMetadata(fallback string, metadata map[string]string) 
 	return strings.TrimSpace(fallback)
 }
 
+// mailIdentitySessionCache memoizes a single gc:session enumeration so that
+// repeated identity-resolution attempts (multi-candidate retry, sender +
+// recipient resolution in the same command, etc.) share the same broad scan.
+// Zero value is a valid empty cache; the first get() fetches and reuses.
+type mailIdentitySessionCache struct {
+	list    []beads.Bead
+	fetched bool
+}
+
+func (c *mailIdentitySessionCache) get(store beads.Store) ([]beads.Bead, error) {
+	if c == nil {
+		return store.List(beads.ListQuery{Label: session.LabelSession})
+	}
+	if c.fetched {
+		return c.list, nil
+	}
+	list, err := store.List(beads.ListQuery{Label: session.LabelSession})
+	if err != nil {
+		return nil, err
+	}
+	c.list = list
+	c.fetched = true
+	return list, nil
+}
+
 func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) (resolvedMailTarget, bool, error) {
+	return resolveLiveConfiguredNamedMailTargetCached(store, identifier, nil)
+}
+
+func resolveLiveConfiguredNamedMailTargetCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, bool, error) {
 	identifier = normalizeNamedSessionTarget(identifier)
 	if store == nil || identifier == "" || identifier == "human" || strings.Contains(identifier, "/") {
 		return resolvedMailTarget{}, false, nil
 	}
-	all, err := store.List(beads.ListQuery{
-		Label: session.LabelSession,
-	})
+	all, err := cache.get(store)
 	if err != nil {
 		return resolvedMailTarget{}, false, err
 	}
@@ -657,13 +694,17 @@ func resolveLiveConfiguredNamedMailTarget(store beads.Store, identifier string) 
 }
 
 func resolveMailTargets(store beads.Store, identifier string) (resolvedMailTarget, error) {
+	return resolveMailTargetsCached(store, identifier, nil)
+}
+
+func resolveMailTargetsCached(store beads.Store, identifier string, cache *mailIdentitySessionCache) (resolvedMailTarget, error) {
 	if identifier == "" || identifier == "human" {
 		return resolvedMailTarget{display: "human", recipients: []string{"human"}}, nil
 	}
 	sessionID, err := resolveSessionID(store, identifier)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
-			if target, matched, targetErr := resolveLiveConfiguredNamedMailTarget(store, identifier); targetErr != nil {
+			if target, matched, targetErr := resolveLiveConfiguredNamedMailTargetCached(store, identifier, cache); targetErr != nil {
 				return resolvedMailTarget{}, targetErr
 			} else if matched {
 				return target, nil
@@ -722,8 +763,11 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 		_ = code
 		return resolvedMailTarget{}, false
 	}
+	// Memoize the gc:session enumeration so multi-candidate retry shares one
+	// broad scan instead of issuing one per candidate (ga-q6ct Layer 2).
+	cache := &mailIdentitySessionCache{}
 	for _, c := range candidates {
-		target, err := resolveMailTargets(store, c)
+		target, err := resolveMailTargetsCached(store, c, cache)
 		if err == nil {
 			return target, true
 		}
@@ -737,9 +781,13 @@ func resolveDefaultMailTargetsForCommand(stderr io.Writer, cmdName string) (reso
 }
 
 func resolveDefaultMailSenderForCommand(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string) (string, bool) {
+	return resolveDefaultMailSenderForCommandCached(cityPath, cfg, store, stderr, cmdName, nil)
+}
+
+func resolveDefaultMailSenderForCommandCached(cityPath string, cfg *config.City, store beads.Store, stderr io.Writer, cmdName string, cache *mailIdentitySessionCache) (string, bool) {
 	candidates := defaultMailIdentityCandidates()
 	for _, c := range candidates {
-		sender, err := resolveMailIdentityWithConfig(cityPath, cfg, store, c)
+		sender, err := resolveMailIdentityWithConfigCached(cityPath, cfg, store, c, cache)
 		if err == nil {
 			return sender, true
 		}
@@ -1087,8 +1135,12 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 		fmt.Fprintf(stderr, "gc mail send: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	// Memoize the gc:session enumeration so identity resolution (sender +
+	// recipient + listLiveSessionMailboxes) shares one broad scan instead of
+	// issuing one per call site (ga-q6ct Layer 3).
+	idCache := &mailIdentitySessionCache{}
 	if store != nil {
-		validRecipients, err = listLiveSessionMailboxes(store)
+		validRecipients, err = listLiveSessionMailboxesCached(store, idCache)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: listing live sessions: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1099,7 +1151,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 	if sender == "" {
 		if store != nil {
 			var ok bool
-			sender, ok = resolveDefaultMailSenderForCommand(cityPath, cfg, store, stderr, "gc mail send")
+			sender, ok = resolveDefaultMailSenderForCommandCached(cityPath, cfg, store, stderr, "gc mail send", idCache)
 			if !ok {
 				return 1
 			}
@@ -1107,7 +1159,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 			sender = defaultMailIdentity()
 		}
 	} else if sender != "human" && store != nil {
-		sender, err = resolveMailIdentityWithConfig(cityPath, cfg, store, sender)
+		sender, err = resolveMailIdentityWithConfigCached(cityPath, cfg, store, sender, idCache)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: invalid sender %q: %v\n", sender, err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -1137,7 +1189,7 @@ func cmdMailSend(args []string, notify bool, all bool, from string, to string, s
 		}
 	}
 	if !all && len(args) > 0 && store != nil {
-		canonicalTo, err := resolveMailRecipientIdentity(cityPath, cfg, store, args[0])
+		canonicalTo, err := resolveMailRecipientIdentityCached(cityPath, cfg, store, args[0], idCache)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc mail send: unknown recipient %q: %v\n", args[0], err) //nolint:errcheck // best-effort stderr
 			return 1

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2826,3 +2826,33 @@ func TestListLiveSessionMailboxesCached_UsesCache(t *testing.T) {
 		t.Errorf("broad gc:session List calls = %d, want 1 across listLiveSessionMailboxes + resolve sharing one cache", store.sessionListCalls)
 	}
 }
+
+func TestResolveMailIdentityWithConfigCached_SharedCacheSurvivesFallbackMiss(t *testing.T) {
+	// Pin: the shared cache must stay in effect even when identity resolution
+	// misses every shortcut and falls back to the generic resolution path.
+	base := beads.NewMemStore()
+	store := &countingMailIdentityListStore{Store: base}
+
+	if _, err := base.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata: "gascity/worker",
+			"alias":                      "worker",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+
+	cache := &mailIdentitySessionCache{}
+	if _, err := listLiveSessionMailboxesCached(store, cache); err != nil {
+		t.Fatalf("listLiveSessionMailboxesCached: %v", err)
+	}
+	if _, err := resolveMailIdentityWithConfigCached("", nil, store, "no-match", cache); !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("resolveMailIdentityWithConfigCached(no-match) error = %v, want ErrSessionNotFound", err)
+	}
+
+	if store.sessionListCalls != 1 {
+		t.Errorf("broad gc:session List calls = %d, want 1 across listLiveSessionMailboxes + fallback miss resolution", store.sessionListCalls)
+	}
+}

--- a/cmd/gc/cmd_mail_test.go
+++ b/cmd/gc/cmd_mail_test.go
@@ -2732,3 +2732,97 @@ func TestMailCheckInjectFiltersCorrectly(t *testing.T) {
 		t.Errorf("stdout missing correct count:\n%s", out)
 	}
 }
+
+// --- ga-q6ct: identity-resolution session-list cache ---
+
+// countingMailIdentityListStore counts broad gc:session List calls (the same
+// query the cmd_mail identity-resolution path issues) so tests can assert the
+// per-command cache budget.
+type countingMailIdentityListStore struct {
+	beads.Store
+	sessionListCalls int
+}
+
+func (s *countingMailIdentityListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.sessionListCalls++
+	}
+	return s.Store.List(query)
+}
+
+func TestResolveLiveConfiguredNamedMailTargetCached_SharesCacheAcrossCalls(t *testing.T) {
+	// Pin: when a single command invocation resolves multiple identity
+	// candidates (or recipient + sender both), the broad gc:session
+	// enumeration runs at most once via the shared cache.
+	base := beads.NewMemStore()
+	store := &countingMailIdentityListStore{Store: base}
+
+	if _, err := base.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata: "gascity/builder",
+			"alias":                      "builder-1",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+
+	cache := &mailIdentitySessionCache{}
+	for _, id := range []string{"unmatched-a", "unmatched-b", "unmatched-c"} {
+		if _, _, err := resolveLiveConfiguredNamedMailTargetCached(store, id, cache); err != nil {
+			t.Fatalf("resolve(%q): %v", id, err)
+		}
+	}
+
+	if store.sessionListCalls != 1 {
+		t.Errorf("broad gc:session List calls = %d, want 1 (cache must dedupe across resolutions)", store.sessionListCalls)
+	}
+}
+
+func TestResolveLiveConfiguredNamedMailTargetCached_NilCacheStillFetches(t *testing.T) {
+	// Backward-compat: passing nil cache should still resolve correctly,
+	// issuing a broad scan per call (the legacy behavior).
+	base := beads.NewMemStore()
+	store := &countingMailIdentityListStore{Store: base}
+
+	for _, id := range []string{"a", "b"} {
+		if _, _, err := resolveLiveConfiguredNamedMailTargetCached(store, id, nil); err != nil {
+			t.Fatalf("resolve(%q): %v", id, err)
+		}
+	}
+
+	if store.sessionListCalls != 2 {
+		t.Errorf("broad gc:session List calls = %d, want 2 (no cache → per-call scan)", store.sessionListCalls)
+	}
+}
+
+func TestListLiveSessionMailboxesCached_UsesCache(t *testing.T) {
+	// Pin: listLiveSessionMailboxesCached + a sibling resolve call sharing
+	// the same cache hit the store at most once for the broad enumeration.
+	base := beads.NewMemStore()
+	store := &countingMailIdentityListStore{Store: base}
+
+	if _, err := base.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			namedSessionIdentityMetadata: "gascity/mayor",
+			"alias":                      "mayor",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+
+	cache := &mailIdentitySessionCache{}
+	if _, err := listLiveSessionMailboxesCached(store, cache); err != nil {
+		t.Fatalf("listLiveSessionMailboxesCached: %v", err)
+	}
+	if _, _, err := resolveLiveConfiguredNamedMailTargetCached(store, "no-match", cache); err != nil {
+		t.Fatalf("resolveLiveConfiguredNamedMailTargetCached: %v", err)
+	}
+
+	if store.sessionListCalls != 1 {
+		t.Errorf("broad gc:session List calls = %d, want 1 across listLiveSessionMailboxes + resolve sharing one cache", store.sessionListCalls)
+	}
+}

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -627,7 +627,8 @@ func mailProviderName() string {
 
 // newMailProvider returns a mail.Provider based on the mail provider name
 // (env var → city.toml → default) and the given bead store (used as the
-// default backend).
+// default backend). Shared callers such as the API use the stateless beadmail
+// provider so long-lived instances observe fresh session state.
 //
 //   - "fake" → in-memory fake (all ops succeed)
 //   - "fail" → broken fake (all ops return errors)
@@ -648,20 +649,35 @@ func newMailProvider(store beads.Store) mail.Provider {
 	}
 }
 
+func newCommandMailProvider(store beads.Store) mail.Provider {
+	v := mailProviderName()
+	if strings.HasPrefix(v, "exec:") {
+		return mailexec.NewProvider(strings.TrimPrefix(v, "exec:"))
+	}
+	switch v {
+	case "fake":
+		return mail.NewFake()
+	case "fail":
+		return mail.NewFailFake()
+	default:
+		return beadmail.NewCached(store)
+	}
+}
+
 // openCityMailProvider opens the city's bead store and wraps it in a
 // mail.Provider. Returns (nil, exitCode) on failure.
 func openCityMailProvider(stderr io.Writer, cmdName string) (mail.Provider, int) {
 	// For exec: and test doubles, no store needed.
 	v := mailProviderName()
 	if strings.HasPrefix(v, "exec:") || v == "fake" || v == "fail" {
-		return newMailProvider(nil), 0
+		return newCommandMailProvider(nil), 0
 	}
 
 	store, code := openCityStore(stderr, cmdName)
 	if store == nil {
 		return nil, code
 	}
-	return newMailProvider(store), 0
+	return newCommandMailProvider(store), 0
 }
 
 // eventsProviderName returns the events provider name.

--- a/internal/api/handler_mail_test.go
+++ b/internal/api/handler_mail_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/mail"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 func TestMailLifecycle(t *testing.T) {
@@ -199,6 +201,52 @@ func TestMailCount(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&resp) //nolint:errcheck
 	if resp["unread"] != 2 {
 		t.Errorf("unread = %d, want 2", resp["unread"])
+	}
+}
+
+func TestMailInboxSeesHistoricalAliasSessionAddedAfterInitialMiss(t *testing.T) {
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail?agent=old-worker"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("initial inbox status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	store := state.stores["myrig"]
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker",
+			"alias_history": "old-worker",
+		},
+	}); err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	if _, err := state.cityMailProv.Send("human", "worker", "Fresh session", "visible after initial miss"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", cityURL(state, "/mail?agent=old-worker"), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second inbox status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var inbox struct {
+		Items []mail.Message `json:"items"`
+		Total int            `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&inbox); err != nil {
+		t.Fatalf("decode inbox: %v", err)
+	}
+	if inbox.Total != 1 {
+		t.Fatalf("second inbox Total = %d, want 1", inbox.Total)
+	}
+	if len(inbox.Items) != 1 || inbox.Items[0].Body != "visible after initial miss" {
+		t.Fatalf("second inbox items = %#v, want visible historical-alias message", inbox.Items)
 	}
 }
 

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/mail"
@@ -25,43 +26,60 @@ const (
 )
 
 // Provider implements [mail.Provider] using [beads.Store] as the backend.
-//
-// The Provider memoizes its enumeration of gc:session beads for the duration
-// of its lifetime: identity resolution, recipient routing, and historical-
-// alias lookup all need the same set, and a single command invocation creates
-// one Provider. The cache is intentionally not invalidated on Send: a fresh
-// message bead is not a session bead, and stale session-cache vs newly-
-// committed session beads is not a code path mail commands ever exercise.
 type Provider struct {
-	store          beads.Store
-	sessionsCache  []beads.Bead
-	sessionsCached bool
+	store        beads.Store
+	sessionCache *sessionBeadCache
+}
+
+type sessionBeadCache struct {
+	mu      sync.Mutex
+	list    []beads.Bead
+	fetched bool
 }
 
 // New returns a beadmail provider backed by the given store.
+//
+// The default provider is stateless so long-lived shared users such as the API
+// always see fresh session topology.
 func New(store beads.Store) *Provider {
 	return &Provider{store: store}
 }
 
-// cachedSessionBeads returns the full set of session beads (open + closed),
-// fetching once and reusing across the Provider's lifetime. This is the
-// single-source-of-truth for any code path that needs to enumerate sessions
-// to resolve identity, recipient routes, or historical aliases.
-func (p *Provider) cachedSessionBeads() ([]beads.Bead, error) {
-	if p.sessionsCached {
-		return p.sessionsCache, nil
+// NewCached returns a beadmail provider backed by the given store with a
+// provider-local session enumeration cache for command-scoped reuse.
+func NewCached(store beads.Store) *Provider {
+	return &Provider{
+		store:        store,
+		sessionCache: &sessionBeadCache{},
 	}
+}
+
+// cachedSessionBeads returns the full set of session beads (open + closed).
+// Cached providers reuse a single enumeration; stateless providers fetch
+// fresh results on every call.
+func (p *Provider) cachedSessionBeads() ([]beads.Bead, error) {
 	if p.store == nil {
-		p.sessionsCached = true
 		return nil, nil
 	}
-	sessions, err := p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	if p.sessionCache == nil {
+		return p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	}
+	return p.sessionCache.get(p.store)
+}
+
+func (c *sessionBeadCache) get(store beads.Store) ([]beads.Bead, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fetched {
+		return c.list, nil
+	}
+	list, err := store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
 	if err != nil {
 		return nil, err
 	}
-	p.sessionsCache = sessions
-	p.sessionsCached = true
-	return sessions, nil
+	c.list = list
+	c.fetched = true
+	return list, nil
 }
 
 // Send creates a message bead with subject in Title and body in Description.

--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -25,13 +25,43 @@ const (
 )
 
 // Provider implements [mail.Provider] using [beads.Store] as the backend.
+//
+// The Provider memoizes its enumeration of gc:session beads for the duration
+// of its lifetime: identity resolution, recipient routing, and historical-
+// alias lookup all need the same set, and a single command invocation creates
+// one Provider. The cache is intentionally not invalidated on Send: a fresh
+// message bead is not a session bead, and stale session-cache vs newly-
+// committed session beads is not a code path mail commands ever exercise.
 type Provider struct {
-	store beads.Store
+	store          beads.Store
+	sessionsCache  []beads.Bead
+	sessionsCached bool
 }
 
 // New returns a beadmail provider backed by the given store.
 func New(store beads.Store) *Provider {
 	return &Provider{store: store}
+}
+
+// cachedSessionBeads returns the full set of session beads (open + closed),
+// fetching once and reusing across the Provider's lifetime. This is the
+// single-source-of-truth for any code path that needs to enumerate sessions
+// to resolve identity, recipient routes, or historical aliases.
+func (p *Provider) cachedSessionBeads() ([]beads.Bead, error) {
+	if p.sessionsCached {
+		return p.sessionsCache, nil
+	}
+	if p.store == nil {
+		p.sessionsCached = true
+		return nil, nil
+	}
+	sessions, err := p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	if err != nil {
+		return nil, err
+	}
+	p.sessionsCache = sessions
+	p.sessionsCached = true
+	return sessions, nil
 }
 
 // Send creates a message bead with subject in Title and body in Description.
@@ -543,7 +573,7 @@ func appendSessionRecipientRoutes(routes []string, b beads.Bead) []string {
 }
 
 func (p *Provider) recipientRoutesByHistoricalAlias(recipient string, routes []string) []string {
-	sessions, err := p.store.List(beads.ListQuery{Label: session.LabelSession, IncludeClosed: true})
+	sessions, err := p.cachedSessionBeads()
 	if err != nil {
 		log.Printf("beadmail: listing sessions for historical recipient route %q: %v", recipient, err)
 		return routes

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1495,12 +1495,51 @@ func (s *countingSessionListStore) List(query beads.ListQuery) ([]beads.Bead, er
 	return s.MemStore.List(query)
 }
 
-func TestProvider_BroadSessionListCachedAcrossInboxCalls(t *testing.T) {
-	// Pin: when an Inbox call has to fall back to historical-alias enumeration
-	// (the only path that issues a broad gc:session scan in beadmail), the
-	// scan happens AT MOST ONCE per Provider lifetime — even if multiple
-	// Inbox calls force the fallback. Without the cache, each Inbox call
-	// re-issues the scan, producing the fanout that ga-q6ct tracks.
+func TestProvider_DefaultProviderSeesNewHistoricalAliasSessionAcrossCalls(t *testing.T) {
+	// Pin: the default Provider is safe for long-lived shared use. If a lookup
+	// runs before the matching session exists, later lookups must see newly
+	// created sessions instead of reusing a stale provider-lifetime snapshot.
+	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
+	p := New(store)
+
+	if _, err := p.Inbox("old-route"); err != nil {
+		t.Fatalf("initial Inbox(old-route): %v", err)
+	}
+
+	sessionBead, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-a",
+			"alias_history": "old-route",
+			"session_name":  "wf__a",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	if _, err := p.Send("human", sessionBead.Metadata["alias"], "", "for old route"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	msgs, err := p.Inbox("old-route")
+	if err != nil {
+		t.Fatalf("second Inbox(old-route): %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Inbox(old-route) = %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Body != "for old route" {
+		t.Fatalf("Inbox(old-route) body = %q, want %q", msgs[0].Body, "for old route")
+	}
+	if store.sessionListCalls != 2 {
+		t.Errorf("broad gc:session List calls = %d, want 2 (default provider must refetch per call to avoid stale shared state)", store.sessionListCalls)
+	}
+}
+
+func TestProviderCached_BroadSessionListCachedAcrossInboxCalls(t *testing.T) {
+	// Pin: the command-scoped cached Provider still dedupes the broad
+	// historical-alias session scan within one provider lifetime.
 	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
 
 	// Two live sessions with alias_history that includes the route we'll
@@ -1528,7 +1567,7 @@ func TestProvider_BroadSessionListCachedAcrossInboxCalls(t *testing.T) {
 		t.Fatalf("Create session B: %v", err)
 	}
 
-	p := New(store)
+	p := NewCached(store)
 
 	// Exercise three independent Inbox calls that each force the
 	// alias-history fallback (no current alias matches "old-route" or

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -1478,6 +1478,72 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+// --- Provider session-list cache (ga-q6ct) ---
+
+// countingSessionListStore counts broad gc:session List calls and forwards
+// the rest. Used to pin that Provider memoizes the gc:session enumeration
+// across multiple Inbox calls in a single command invocation.
+type countingSessionListStore struct {
+	*beads.MemStore
+	sessionListCalls int
+}
+
+func (s *countingSessionListStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Label == session.LabelSession && len(query.Metadata) == 0 {
+		s.sessionListCalls++
+	}
+	return s.MemStore.List(query)
+}
+
+func TestProvider_BroadSessionListCachedAcrossInboxCalls(t *testing.T) {
+	// Pin: when an Inbox call has to fall back to historical-alias enumeration
+	// (the only path that issues a broad gc:session scan in beadmail), the
+	// scan happens AT MOST ONCE per Provider lifetime — even if multiple
+	// Inbox calls force the fallback. Without the cache, each Inbox call
+	// re-issues the scan, producing the fanout that ga-q6ct tracks.
+	store := &countingSessionListStore{MemStore: beads.NewMemStore()}
+
+	// Two live sessions with alias_history that includes the route we'll
+	// search for. AliasHistory lookup is the path that does the broad scan.
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-a",
+			"alias_history": "old-route",
+			"session_name":  "wf__a",
+		},
+	}); err != nil {
+		t.Fatalf("Create session A: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias":         "worker-b",
+			"alias_history": "old-route-2",
+			"session_name":  "wf__b",
+		},
+	}); err != nil {
+		t.Fatalf("Create session B: %v", err)
+	}
+
+	p := New(store)
+
+	// Exercise three independent Inbox calls that each force the
+	// alias-history fallback (no current alias matches "old-route" or
+	// "old-route-2"). Without the cache: 3 broad scans. With cache: 1.
+	for _, recipient := range []string{"old-route", "old-route-2", "old-route"} {
+		if _, err := p.Inbox(recipient); err != nil {
+			t.Fatalf("Inbox(%q): %v", recipient, err)
+		}
+	}
+
+	if store.sessionListCalls != 1 {
+		t.Errorf("broad gc:session List calls = %d, want 1 (Provider must cache the enumeration)", store.sessionListCalls)
+	}
+}
+
 // --- Compile-time interface check ---
 
 var _ mail.Provider = (*Provider)(nil)


### PR DESCRIPTION
## Summary

`gc mail inbox`/`send` issued 8 sequential `bd` subprocess calls when 1-2 would suffice. Same family of bug as PR #1546's `NamedSessionResolutionCandidates` fix at a different code site: identity resolution and recipient routing each enumerated `gc:session` independently, and the multi-candidate identity-retry loop re-issued the broad scan once per candidate.

Filed as `ga-q6ct` by deep-investigator with strace evidence.

## What's changing

**Layer 1 — `internal/mail/beadmail/beadmail.go`**
`Provider` memoizes the broad `gc:session` enumeration for its lifetime. `recipientRoutesByHistoricalAlias` — the only path in `beadmail` that issues the broad scan — pulls from the cache. Multiple `Inbox` calls in a single command share the result.

**Layer 2 — `cmd/gc/cmd_mail.go`**
`mailIdentitySessionCache` is a request-scoped cache passed through `resolveDefaultMailTargetsForCommand` and its callees. Multi-candidate retry shares a single broad scan. Backward-compat preserved: the public `resolveLiveConfiguredNamedMailTarget`/`resolveMailTargets` keep their signatures and forward to the new `*Cached` helpers with `cache=nil` (per-call scan).

**Layer 3 — `cmd/gc/cmd_mail.go`**
`cmdMailSend` creates one cache and threads it through `listLiveSessionMailboxesCached`, `resolveDefaultMailSenderForCommandCached`, `resolveMailIdentityWithConfigCached`, and `resolveMailRecipientIdentityCached` so sender + recipient + valid-recipient-list resolution share one scan.

## Why this matters

Per the bead's investigator analysis: end-user `gc mail inbox` was 60-80s on this super-city. The bd amplifier (`be-1he` in beads, separate fix) drives ~12s per cold subprocess. 8 broad scans × 12s ≈ 96s; observed 64-82s. With both fixes, target is <300ms.

This PR addresses the gascity layer (fanout reduction). `be-1he` addresses the per-call amplifier. Either alone gives a meaningful win; together they're transformative.

## Test plan

- [x] `TestProvider_BroadSessionListCachedAcrossInboxCalls` — ≤1 broad scan across 3 Inbox calls hitting the alias-history fallback.
- [x] `TestResolveLiveConfiguredNamedMailTargetCached_SharesCacheAcrossCalls` — ≤1 broad scan across 3 candidate resolutions sharing one cache.
- [x] `TestResolveLiveConfiguredNamedMailTargetCached_NilCacheStillFetches` — backward-compat (nil cache → per-call scan).
- [x] `TestListLiveSessionMailboxesCached_UsesCache` — `listLiveSessionMailboxes` + resolve sharing one cache = 1 scan.
- [x] Existing `TestInboxByCurrentSessionAliasAvoidsBroadSessionScan` + `TestInboxByClosedCurrentSessionAliasAvoidsBroadSessionScan` still pass — targeted metadata queries remain the fast path.
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->