### PR TITLE
fix(nudge,beads): make nudge close paths work under validation.on-close=error

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1263,6 +1263,14 @@ func enqueueQueuedNudgeWithStore(cityPath string, store beads.Store, item queued
 		return nil
 	})
 	if err != nil && created && store != nil && beadID != "" {
+		// Stamp metadata.close_reason before Close so BdStore.Close (per
+		// #1644) can forward it as `bd close --reason` and satisfy the
+		// validator under validation.on-close=error. Both writes are
+		// best-effort: failures here would only swap one symptom (leaked
+		// open bead) for another (leaked open bead with mismatched
+		// metadata) and the original enqueue error is the one the caller
+		// actually needs to see.
+		_ = store.SetMetadata(beadID, "close_reason", nudgeEnqueueRollbackCloseReason)
 		_ = store.Close(beadID)
 	}
 	return err

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/nudgequeue"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -1951,3 +1952,169 @@ func TestListQueuedNudges_CategorizesPendingAndDead(t *testing.T) {
 		t.Fatalf("dead = %v, want [n-stale]", deadList)
 	}
 }
+
+// TestMarkQueuedNudgeTerminalStampsCloseReason verifies that
+// markQueuedNudgeTerminal stamps a canonical close_reason on the nudge
+// bead's metadata before invoking store.Close. BdStore.Close (per #1644)
+// forwards metadata.close_reason as `bd close --reason ...`; without
+// this stamp, cities running with validation.on-close=error reject the
+// close, the withNudgeQueueState transaction rolls back, and the nudge
+// bounces between Pending and InFlight forever — generating a
+// bead.updated event per claim attempt for every wedged nudge.
+//
+// This test pins the contract that the close_reason metadata flows
+// through every state markQueuedNudgeTerminal handles. The
+// nudgeCanonicalCloseReason helper guarantees the >=20 char floor.
+func TestMarkQueuedNudgeTerminalStampsCloseReason(t *testing.T) {
+	cases := []struct {
+		name           string
+		state          string
+		reason         string
+		commitBoundary string
+	}{
+		{name: "failed_fence_mismatch", state: "failed", reason: "queued nudge session fence mismatch"},
+		{name: "expired", state: "expired", reason: "expired"},
+		{name: "superseded", state: "superseded", reason: "superseded"},
+		{name: "injected", state: "injected", reason: "", commitBoundary: "provider-nudge-return"},
+		{name: "accepted_for_injection", state: "accepted_for_injection", reason: "", commitBoundary: "hook-transport-accepted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			item := queuedNudge{
+				ID:        "nudge-" + tc.name,
+				Agent:     "deacon",
+				SessionID: "pc-qr6",
+				Source:    "session",
+				Message:   "DOG_DONE: reaper",
+				CreatedAt: time.Now().Add(-time.Minute).UTC(),
+			}
+			createdID, _, err := ensureQueuedNudgeBead(store, item)
+			if err != nil {
+				t.Fatalf("ensureQueuedNudgeBead: %v", err)
+			}
+
+			now := time.Now().UTC()
+			item.LastError = tc.reason
+			if err := markQueuedNudgeTerminal(store, item, tc.state, tc.reason, tc.commitBoundary, now); err != nil {
+				t.Fatalf("markQueuedNudgeTerminal: %v", err)
+			}
+
+			bead, err := store.Get(createdID)
+			if err != nil {
+				t.Fatalf("Get(%q): %v", createdID, err)
+			}
+			if bead.Status != "closed" {
+				t.Fatalf("bead.Status = %q, want closed", bead.Status)
+			}
+			want := nudgeCanonicalCloseReason(tc.state)
+			if got := bead.Metadata["close_reason"]; got != want {
+				t.Errorf("close_reason = %q, want %q", got, want)
+			}
+			// Existing audit metadata must remain stamped alongside close_reason.
+			if got := bead.Metadata["state"]; got != tc.state {
+				t.Errorf("state = %q, want %q", got, tc.state)
+			}
+			if got := bead.Metadata["terminal_reason"]; got != tc.reason {
+				t.Errorf("terminal_reason = %q, want %q", got, tc.reason)
+			}
+		})
+	}
+}
+
+// TestNudgeCanonicalCloseReasonMeetsValidatorThreshold pins the >=20
+// char floor for every known queue terminalization state and the
+// unknown-code fallback. The validator (bd's validation.on-close=error,
+// per gastownhall/beads#2654) rejects close reasons under 20 chars, so
+// any helper output that drops below the floor would silently break
+// nudge close under strict cities and reintroduce the queue-bounce loop.
+func TestNudgeCanonicalCloseReasonMeetsValidatorThreshold(t *testing.T) {
+	// All states that markQueuedNudgeTerminal is invoked with across the
+	// nudge codepaths (recordQueuedNudgeFailureDetailed,
+	// pruneExpiredQueuedNudges, recoverExpiredInFlightNudges,
+	// ackQueuedNudgesWithOutcome, supersession in enqueueQueuedNudgeWithStore,
+	// terminalizeBlockedQueuedNudges → ackQueuedNudgesWithOutcome).
+	knownStates := []string{
+		"failed",
+		"expired",
+		"superseded",
+		"injected",
+		"accepted_for_injection",
+	}
+	for _, s := range knownStates {
+		got := nudgeCanonicalCloseReason(s)
+		if len(got) < 20 {
+			t.Errorf("nudgeCanonicalCloseReason(%q) = %q (%d chars), want >=20", s, got, len(got))
+		}
+	}
+	// Unknown short code falls back to a >=20 char canonical phrase.
+	if got := nudgeCanonicalCloseReason("x"); len(got) < 20 {
+		t.Errorf("unknown-short-code fallback = %q (%d chars), want >=20", got, len(got))
+	}
+	// Empty input also yields a >=20 char fallback (avoids accidental
+	// short close_reason if a caller passes "").
+	if got := nudgeCanonicalCloseReason(""); len(got) < 20 {
+		t.Errorf("empty-code fallback = %q (%d chars), want >=20", got, len(got))
+	}
+	// Codes already >=20 characters pass through unchanged.
+	const long = "a-very-long-state-code-already-sufficient"
+	if got := nudgeCanonicalCloseReason(long); got != long {
+		t.Errorf("long-code passthrough = %q, want %q", got, long)
+	}
+}
+
+// TestEnqueueQueuedNudgeWithStore_RollbackStampsCloseReason verifies that
+// enqueueQueuedNudgeWithStore's rollback path stamps a canonical
+// metadata.close_reason on the partially-created nudge bead before
+// invoking store.Close. Without the stamp, BdStore.Close (per #1644)
+// has no metadata.close_reason to forward, the validator (under
+// validation.on-close=error) rejects the close, and the rollback
+// silently leaks an OPEN nudge bead with metadata.state="queued".
+//
+// Triggers the rollback by writing corrupt JSON to the queue state
+// file before the call, which fails LoadState inside withNudgeQueueState
+// and propagates the error up to the rollback site.
+func TestEnqueueQueuedNudgeWithStore_RollbackStampsCloseReason(t *testing.T) {
+	dir := t.TempDir()
+
+	// Force LoadState to fail by pre-populating state.json with corrupt
+	// JSON. WithState propagates the parse error up, which means
+	// enqueueQueuedNudgeWithStore enters its rollback branch.
+	statePath := nudgequeue.StatePath(dir)
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(statePath, []byte("{not-valid-json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	item := newQueuedNudgeWithOptions("worker", "rollback test", "session", time.Now(), queuedNudgeOptions{
+		ID: "nudge-rollback-target",
+	})
+
+	err := enqueueQueuedNudgeWithStore(dir, store, item)
+	if err == nil {
+		t.Fatal("enqueueQueuedNudgeWithStore: expected error from corrupt queue state")
+	}
+
+	bead, ok, err := findAnyQueuedNudgeBead(store, item.ID)
+	if err != nil {
+		t.Fatalf("findAnyQueuedNudgeBead: %v", err)
+	}
+	if !ok {
+		t.Fatal("findAnyQueuedNudgeBead: bead not found; rollback should leave a closed bead, not delete it")
+	}
+	if bead.Status != "closed" {
+		t.Fatalf("bead.Status = %q, want closed (rollback should have closed via store.Close)", bead.Status)
+	}
+	if got := bead.Metadata["close_reason"]; got != nudgeEnqueueRollbackCloseReason {
+		t.Errorf("close_reason = %q, want %q", got, nudgeEnqueueRollbackCloseReason)
+	}
+	// Belt-and-braces: the canonical reason itself meets the validator
+	// floor. If someone shortens it without thinking, this guard fires.
+	if got := nudgeEnqueueRollbackCloseReason; len(got) < 20 {
+		t.Errorf("nudgeEnqueueRollbackCloseReason = %q (%d chars), want >=20 to satisfy validation.on-close=error", got, len(got))
+	}
+}
+

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/nudgequeue"
+	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
 )
 
@@ -1983,7 +1983,7 @@ func TestMarkQueuedNudgeTerminalStampsCloseReason(t *testing.T) {
 			store := beads.NewMemStore()
 			item := queuedNudge{
 				ID:        "nudge-" + tc.name,
-				Agent:     "deacon",
+				Agent:     "agent-terminal",
 				SessionID: "pc-qr6",
 				Source:    "session",
 				Message:   "DOG_DONE: reaper",
@@ -2117,4 +2117,3 @@ func TestEnqueueQueuedNudgeWithStore_RollbackStampsCloseReason(t *testing.T) {
 		t.Errorf("nudgeEnqueueRollbackCloseReason = %q (%d chars), want >=20 to satisfy validation.on-close=error", got, len(got))
 	}
 }
-

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -14,6 +14,17 @@ import (
 const (
 	nudgeBeadType  = "chore"
 	nudgeBeadLabel = "gc:nudge"
+
+	// nudgeEnqueueRollbackCloseReason is the close_reason metadata value
+	// stamped on partially-created nudge beads when enqueueQueuedNudgeWithStore's
+	// withNudgeQueueState transaction returns an error after the backing
+	// bead was successfully created. The rollback path closes the bead to
+	// avoid leaking it; the close goes through BdStore.Close (per #1644)
+	// which forwards metadata.close_reason as `bd close --reason`. Without
+	// this stamp, cities running with validation.on-close=error reject the
+	// rollback close and the bead leaks open with metadata.state="queued".
+	// The 42-character form satisfies the >=20 char validator floor.
+	nudgeEnqueueRollbackCloseReason = "nudge rollback: enqueue transaction failed"
 )
 
 type nudgeReference = nudgequeue.Reference
@@ -129,6 +140,7 @@ func markQueuedNudgeTerminal(store beads.Store, item queuedNudge, state, reason,
 		"terminal_reason": reason,
 		"commit_boundary": commitBoundary,
 		"terminal_at":     now.UTC().Format(time.RFC3339),
+		"close_reason":    nudgeCanonicalCloseReason(state),
 	}
 
 	tryTerminalize := func(beadID string) error {
@@ -167,6 +179,44 @@ func markQueuedNudgeTerminal(store beads.Store, item queuedNudge, state, reason,
 		return err
 	}
 	return nil
+}
+
+// nudgeCanonicalCloseReason maps a nudge queue terminalization state code
+// to a human-readable close_reason of at least 20 characters, suitable for
+// use as `bd close --reason` under validation.on-close=error.
+//
+// markQueuedNudgeTerminal stamps the result in metadata.close_reason
+// before invoking store.Close. BdStore.Close (per #1644) forwards
+// metadata.close_reason as the --reason argument, which is what allows
+// cities running with validation.on-close=error to accept the close.
+// Without the canonical reason, the validator rejects close calls with
+// reason <20 chars, the close fails, the entire withNudgeQueueState
+// transaction rolls back, and the nudge bounces between InFlight and
+// Pending forever (one bead.updated event per claim attempt) until
+// expires_at cuts in.
+//
+// Unknown codes fall back to "nudge terminated: <code>" which is always
+// >=20 characters for non-empty short codes. Codes already 20+ chars
+// pass through unchanged.
+func nudgeCanonicalCloseReason(stateCode string) string {
+	switch stateCode {
+	case "failed":
+		return "nudge failed: queue terminalization rejected delivery"
+	case "expired":
+		return "nudge expired past deliver-by deadline"
+	case "superseded":
+		return "nudge superseded by newer queued entry"
+	case "injected":
+		return "nudge delivered via provider injection"
+	case "accepted_for_injection":
+		return "nudge accepted for hook-transport injection"
+	}
+	if len(stateCode) >= 20 {
+		return stateCode
+	}
+	// Prefix is exactly 20 chars so that the empty-code fallback meets
+	// the validator threshold and any non-empty addition exceeds it.
+	return "nudge terminalized: " + stateCode
 }
 
 func isMissingQueuedNudgeBeadErr(err error, beadID string) bool {


### PR DESCRIPTION
## Summary

Depends on #1644.

Cities running with `validation.on-close=error` (the bd validator added in gastownhall/beads#2654) reject `bd close --reason` calls under 20 characters. Two `cmd/gc/cmd_nudge.go` paths invoke `store.Close` on nudge beads without first stamping `metadata.close_reason`; per #1644's `BdStore.Close` mechanism, the close therefore lands without `--reason`, the validator rejects it, and the bead leaks open with stamped non-terminal metadata.

## Path 1 — terminalization (`markQueuedNudgeTerminal`)

All seven queue terminalization paths funnel through `markQueuedNudgeTerminal`:
- `recordQueuedNudgeFailureDetailed` — fence mismatch / write errors
- `pruneExpiredQueuedNudges` — past `expires_at`
- `recoverExpiredInFlightNudges` — past `expires_at` + in flight
- `enqueueQueuedNudgeWithStore` supersession (pending + inflight)
- `ackQueuedNudgesWithOutcome` — covers `injected`, `accepted_for_injection`, and `failed` (via `terminalizeBlockedQueuedNudges`)

**Failure mode**: when the validator rejects the close, the entire `withNudgeQueueState` transaction rolls back, the nudge stays in `InFlight`, its lease eventually expires, `recoverExpiredInFlightNudges` moves it back to `Pending` with cleared timestamps, the next claim cycle re-attempts and re-fails identically. Each cycle fires bd's `on_update` hook and generates a `bead.updated` event per claim attempt indefinitely until `expires_at` cuts in.

**Production reproduction**: a deacon `DOG_DONE` nudge queued with `continuation_epoch=30` across a session restart to epoch 45+ stayed OPEN despite metadata showing `state=failed`, `terminal_at=<recent>`, and `terminal_reason="queued nudge session fence mismatch"` — five retry events in 30 minutes, all identical except for the timestamp.

## Path 2 — enqueue rollback (`enqueueQueuedNudgeWithStore`)

`enqueueQueuedNudgeWithStore` creates a backing bead via `ensureQueuedNudgeBead` and then calls `withNudgeQueueState` to insert the queue entry. If the queue write fails after the bead create succeeds (`LoadState` parse error, file lock failure, etc.), the function rolls back by calling `store.Close` on the orphaned bead.

Pre-fix this `Close` had no `metadata.close_reason`, the validator rejected it, the rollback ignored the error (`_ = store.Close`), and the partially-created bead leaked open with `metadata.state="queued"` and no terminal markers. The leak survives queue retention pruning because the queue never tracked the bead at all.

## The fix

Two coupled changes that ship together:

1. **`cmd/gc/nudge_beads.go`** — `markQueuedNudgeTerminal` stamps `metadata.close_reason` in its existing `SetMetadataBatch` update alongside `terminal_reason`, `last_error`, and `state`. New package-private `nudgeCanonicalCloseReason` helper maps each known queue terminalization state (`failed`, `expired`, `superseded`, `injected`, `accepted_for_injection`) to a ≥20 char human phrase, mirroring `session.CanonicalCloseReason` from #1680. Unknown short codes fall back to `"nudge terminalized: <code>"` (prefix is exactly 20 chars so the empty-code edge case meets the floor); codes already 20+ chars pass through unchanged.

2. **`cmd/gc/cmd_nudge.go`** — `enqueueQueuedNudgeWithStore`'s rollback branch stamps `metadata.close_reason` via a best-effort `SetMetadata` call before invoking `store.Close`. New package-level constant `nudgeEnqueueRollbackCloseReason` (`"nudge rollback: enqueue transaction failed"`, 42 chars) is the canonical reason.

## Effect

- Cities running with `validation.on-close=error` now accept both auto-terminalized nudge beads (every fence-mismatch, expiry, supersession, blocked-wait, or successful injection ack) and rollback-closed nudge beads (every enqueue queue-state failure after a successful bead create).
- Cities without strict validation get meaningful audit-trail entries on closed nudge beads instead of bd's generic `"Closed"` default.

## Tests

- `TestMarkQueuedNudgeTerminalStampsCloseReason` — table-driven across all five known terminal states; asserts `close_reason` gets stamped to the canonical helper output and existing audit metadata (`state`, `terminal_reason`) survives unchanged. **Fails on parent** — parent `markQueuedNudgeTerminal` does not stamp `close_reason`.
- `TestNudgeCanonicalCloseReasonMeetsValidatorThreshold` — pins the ≥20 char floor for every known state, the unknown-short-code fallback, the empty-code edge case, and the long-code passthrough.
- `TestEnqueueQueuedNudgeWithStore_RollbackStampsCloseReason` — drives the rollback path by writing corrupt JSON to the queue state file before the call, which fails `LoadState` inside `withNudgeQueueState` and propagates the error to the rollback site; asserts the partially-created bead is closed with the canonical `nudgeEnqueueRollbackCloseReason`. **Also fails on parent.**
- All four existing `markQueuedNudgeTerminal` tests (`FallsBackWhenStoredBeadIDEmpty`, `FallsBackFromMissingStoredBeadID`, `ReturnsUnrelatedNotFoundErrors`, `HandlesAmbiguousBeadID`) remain green; they assert `state` and `terminal_reason` metadata which the changes do not touch.

## Validation

- `go build ./...` clean; `go vet ./cmd/gc/` clean.
- `internal/beads/` and `internal/session/` tests pass.
- **RED→GREEN demonstrated locally** for both new tests: each fails with `close_reason=""` when the helper / constant exists but the writer is not referencing it; passes once the metadata stamp is added.
- **End-to-end production verification**: built `gc` with the terminalization fix stacked on top of #1644, ran against a city with `validation.on-close=error` that had four wedged nudges (continuation_epochs 30, 30, 43, 45 against a deacon at epoch 46). On the next poll cycle all four moved cleanly into `state.Dead` with correct canonical `close_reason` metadata; bd close accepted the `--reason` forwarded by `BdStore.Close`. Final queue state: `pending=0 in_flight=0 dead=4`, with zero further `bead.updated` retry flapping in the event log. One pre-fix orphaned nudge bead (from the expiry path before this PR landed) was cleaned up manually with the same fix pattern.
- Pre-existing `cmd_wait_test.go` failures (`TestDispatchReadyWaitNudges_EnqueuesDeterministicNudge`, `…StartsCodexPoller`, `TestWithdrawQueuedWaitNudges_RemovesQueuedNudge`) are present on plain `github/main` without this change.