### PR TITLE
fix(dispatch): per-dispatcher trace logs in .gc/runtime/ (#1650)

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -255,6 +255,14 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	for key, value := range cityRuntimeEnvMapForCity(p.cityPath) {
 		agentEnv[key] = value
 	}
+	// Override the city-uniform GC_CONTROL_DISPATCHER_TRACE_DEFAULT with a
+	// per-dispatcher path so each control-dispatcher writes to its own
+	// trace file (closes #1650). Goes in agentEnv (last in mergeEnv) so it
+	// wins over both passthroughEnv and the uniform city default seeded by
+	// cityRuntimeEnvMapForCity above.
+	if cfgAgent.Name == config.ControlDispatcherAgentName {
+		agentEnv["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"] = citylayout.ControlDispatcherTraceDefaultPathFor(p.cityPath, qualifiedName)
+	}
 	agentEnv["GC_BEADS"] = rawBeadsProviderForScope(rigRoot, p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {
 		agentEnv["GC_BIN"] = exe

--- a/cmd/gc/template_resolve_env_test.go
+++ b/cmd/gc/template_resolve_env_test.go
@@ -134,3 +134,72 @@ func TestResolveTemplateUsesTrustedRuntimeRootForControlTraceDefault(t *testing.
 		t.Fatalf("GC_CONTROL_DISPATCHER_TRACE_DEFAULT = %q, want %q", got, wantTraceDefault)
 	}
 }
+
+// TestResolveTemplateInjectsPerDispatcherTraceDefault asserts that
+// resolveTemplate produces a per-dispatcher GC_CONTROL_DISPATCHER_TRACE_DEFAULT
+// in agentEnv for control-dispatcher agents (closes #1650). The override
+// goes in agentEnv (last in mergeEnv) so it deterministically wins over
+// the uniform city-level default seeded by cityRuntimeEnvMapForCity.
+func TestResolveTemplateInjectsPerDispatcherTraceDefault(t *testing.T) {
+	cases := []struct {
+		name          string
+		dir           string
+		qualifiedName string
+		wantFilename  string
+	}{
+		{
+			name:          "city dispatcher",
+			dir:           "",
+			qualifiedName: config.ControlDispatcherAgentName,
+			wantFilename:  "control-dispatcher-trace.log",
+		},
+		{
+			name:          "rig dispatcher uses double-dash filename",
+			dir:           "app",
+			qualifiedName: "app/control-dispatcher",
+			wantFilename:  "app--control-dispatcher-trace.log",
+		},
+		{
+			name:          "non-dispatcher agent untouched",
+			dir:           "",
+			qualifiedName: "polecat",
+			wantFilename:  "control-dispatcher-trace.log", // city-uniform default preserved
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cityPath := t.TempDir()
+			writeTemplateResolveCityConfig(t, cityPath, "file")
+			t.Setenv("GC_CITY_PATH", cityPath)
+			t.Setenv("GC_CITY_RUNTIME_DIR", "")
+
+			params := &agentBuildParams{
+				cityName:   "city",
+				cityPath:   cityPath,
+				workspace:  &config.Workspace{Provider: "test"},
+				providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+				lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+				fs:         fsys.OSFS{},
+				beaconTime: time.Unix(0, 0),
+				beadNames:  make(map[string]string),
+				stderr:     io.Discard,
+			}
+
+			agentName := config.ControlDispatcherAgentName
+			if tc.qualifiedName == "polecat" {
+				agentName = "polecat"
+			}
+			agent := &config.Agent{Name: agentName, Dir: tc.dir}
+			tp, err := resolveTemplate(params, agent, tc.qualifiedName, nil)
+			if err != nil {
+				t.Fatalf("resolveTemplate: %v", err)
+			}
+
+			wantPath := filepath.Join(cityPath, ".gc", "runtime", tc.wantFilename)
+			if got := tp.Env["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"]; got != wantPath {
+				t.Fatalf("GC_CONTROL_DISPATCHER_TRACE_DEFAULT = %q, want %q", got, wantPath)
+			}
+		})
+	}
+}

--- a/internal/citylayout/runtime.go
+++ b/internal/citylayout/runtime.go
@@ -40,6 +40,32 @@ func ControlDispatcherTraceDefaultPathForRuntimeDir(cityRoot, runtimeDir string)
 	return filepath.Join(runtimeDir, "control-dispatcher-trace.log")
 }
 
+// ControlDispatcherTraceLogFileName returns the per-dispatcher trace log
+// filename for a qualified agent name. The "/" → "--" mapping mirrors how
+// rig-qualified agent names are encoded in tmux session aliases (e.g., the
+// "app/control-dispatcher" dispatcher runs in the "app--control-dispatcher"
+// tmux session). Closes #1650 when used as a per-dispatcher TRACE_DEFAULT.
+func ControlDispatcherTraceLogFileName(qualifiedName string) string {
+	safe := strings.ReplaceAll(qualifiedName, "/", "--")
+	return safe + "-trace.log"
+}
+
+// ControlDispatcherTraceDefaultPathFor returns the per-dispatcher default
+// trace file under cityRoot's canonical runtime root. Each dispatcher
+// resolves to a distinct file so operators can attribute every trace line
+// without correlating against process titles or session lists.
+func ControlDispatcherTraceDefaultPathFor(cityRoot, qualifiedName string) string {
+	return filepath.Join(RuntimeDataDir(cityRoot), ControlDispatcherTraceLogFileName(qualifiedName))
+}
+
+// ControlDispatcherTraceDefaultPathForRuntimeDirAndName returns the
+// per-dispatcher default trace file for the provided runtime root. Same
+// runtime-dir normalization rules as ControlDispatcherTraceDefaultPathForRuntimeDir.
+func ControlDispatcherTraceDefaultPathForRuntimeDirAndName(cityRoot, runtimeDir, qualifiedName string) string {
+	runtimeDir = normalizeRuntimeDir(cityRoot, runtimeDir)
+	return filepath.Join(runtimeDir, ControlDispatcherTraceLogFileName(qualifiedName))
+}
+
 // RuntimePacksDir returns the canonical root for pack-owned runtime state.
 func RuntimePacksDir(cityRoot string) string {
 	return RuntimePath(cityRoot, "runtime", "packs")

--- a/internal/citylayout/runtime_test.go
+++ b/internal/citylayout/runtime_test.go
@@ -102,6 +102,88 @@ func TestCityRuntimeEnvForRuntimeDir(t *testing.T) {
 	})
 }
 
+func TestControlDispatcherTraceLogFileName(t *testing.T) {
+	cases := []struct {
+		name          string
+		qualifiedName string
+		want          string
+	}{
+		{
+			name:          "city dispatcher (no rig)",
+			qualifiedName: "control-dispatcher",
+			want:          "control-dispatcher-trace.log",
+		},
+		{
+			name:          "rig dispatcher uses double-dash",
+			qualifiedName: "app/control-dispatcher",
+			want:          "app--control-dispatcher-trace.log",
+		},
+		{
+			name:          "rig name with hyphen preserved",
+			qualifiedName: "my-rig/control-dispatcher",
+			want:          "my-rig--control-dispatcher-trace.log",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ControlDispatcherTraceLogFileName(tc.qualifiedName); got != tc.want {
+				t.Fatalf("ControlDispatcherTraceLogFileName(%q) = %q, want %q", tc.qualifiedName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestControlDispatcherTraceDefaultPathFor(t *testing.T) {
+	cases := []struct {
+		name          string
+		cityRoot      string
+		qualifiedName string
+		want          string
+	}{
+		{
+			name:          "city dispatcher",
+			cityRoot:      "/city",
+			qualifiedName: "control-dispatcher",
+			want:          "/city/.gc/runtime/control-dispatcher-trace.log",
+		},
+		{
+			name:          "rig dispatcher",
+			cityRoot:      "/city",
+			qualifiedName: "app/control-dispatcher",
+			want:          "/city/.gc/runtime/app--control-dispatcher-trace.log",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ControlDispatcherTraceDefaultPathFor(tc.cityRoot, tc.qualifiedName); got != tc.want {
+				t.Fatalf("ControlDispatcherTraceDefaultPathFor(%q, %q) = %q, want %q", tc.cityRoot, tc.qualifiedName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestControlDispatcherTraceDefaultPathForRuntimeDirAndName(t *testing.T) {
+	t.Run("external runtime root preserved", func(t *testing.T) {
+		cityRoot := "/city"
+		runtimeDir := "/var/tmp/gascity-runtime"
+		got := ControlDispatcherTraceDefaultPathForRuntimeDirAndName(cityRoot, runtimeDir, "app/control-dispatcher")
+		want := "/var/tmp/gascity-runtime/app--control-dispatcher-trace.log"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("watcher-visible in-city root coerced", func(t *testing.T) {
+		cityRoot := "/city"
+		runtimeDir := "/city/rigs/alpha"
+		got := ControlDispatcherTraceDefaultPathForRuntimeDirAndName(cityRoot, runtimeDir, "app/control-dispatcher")
+		want := "/city/.gc/runtime/app--control-dispatcher-trace.log"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+}
+
 func TestTrustedAmbientCityRuntimeDirAcceptsLegacyCityRootAnchor(t *testing.T) {
 	cityRoot := t.TempDir()
 	runtimeDir := filepath.Join(cityRoot, ".gc", "runtime")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,13 @@ const (
 	// subtree recursively, so defaults must stay under it to avoid self-triggered
 	// config-watch churn. The trace intentionally stays a flat, well-known file
 	// under .gc/runtime because operators and tests tail a single canonical path.
+	//
+	// Per-dispatcher distinction (closes #1650) is layered on top in
+	// cmd/gc/template_resolve.go at session-spawn time: agentEnv there
+	// overrides GC_CONTROL_DISPATCHER_TRACE_DEFAULT with a per-name absolute
+	// path, which the ${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-...} expression
+	// below consumes. The shell template stays uniform so the trust decision
+	// lives in Go.
 	controlDispatcherDefaultTracePathExpr = `${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-${GC_CITY}/` + citylayout.RuntimeDataRoot + `/control-dispatcher-trace.log}`
 	// controlDispatcherTraceInit exports the resolved trace path. Explicit
 	// GC_WORKFLOW_TRACE overrides win first; otherwise the runtime injects a
@@ -63,10 +70,10 @@ const (
 )
 
 // ControlDispatcherStartCommandFor returns the start command for a
-// control-dispatcher agent with the given qualified name. The trace log
-// default lives under .gc/runtime/ to stay inside the controller's
-// fsnotify exclusion; see ControlDispatcherStartCommand for the full
-// rationale.
+// control-dispatcher agent with the given qualified name. The shell-level
+// trace default is uniform across dispatchers; per-dispatcher distinction
+// (closes #1650) is injected via agentEnv in cmd/gc/template_resolve.go at
+// session-spawn time so the trust decision happens in Go.
 func ControlDispatcherStartCommandFor(qualifiedName string) string {
 	return `sh -c '` + controlDispatcherTraceInit + `; ` + controlDispatcherTraceDirInit + `; exec "${GC_BIN:-gc}" convoy control --serve --follow ` + qualifiedName + `'`
 }
@@ -2490,6 +2497,13 @@ func injectControlDispatcherAgents(cfg *City, existing map[agentKey]bool) {
 }
 
 // newControlDispatcherAgent creates a control-dispatcher agent for the given scope.
+//
+// Per-dispatcher GC_CONTROL_DISPATCHER_TRACE_DEFAULT injection (closes #1650)
+// happens in cmd/gc/template_resolve.go at session-spawn time, where
+// agentEnv has the right priority in mergeEnv to override the uniform
+// city-level default seeded by cityRuntimeEnvMapForCity. See
+// citylayout.ControlDispatcherTraceDefaultPathFor for the path computation.
+// Operators retain GC_WORKFLOW_TRACE as the topmost override.
 func newControlDispatcherAgent(dir string) Agent {
 	qualifiedName := ControlDispatcherAgentName
 	if dir != "" {


### PR DESCRIPTION
Closes #1650.

Each control-dispatcher writes its own trace file under `.gc/runtime/`, distinguished by qualified name:

```
"control-dispatcher"      → $GC_CITY/.gc/runtime/control-dispatcher-trace.log
"demo/control-dispatcher" → $GC_CITY/.gc/runtime/demo--control-dispatcher-trace.log
```

The `/` → `--` mapping mirrors the tmux session-alias convention (e.g., the `app/control-dispatcher` agent already runs in the `app--control-dispatcher` tmux session).

## Mechanism

The per-dispatcher distinction is injected into `agentEnv` at session-spawn time in `cmd/gc/template_resolve.go`. `agentEnv` is the **last** map merged in `template_resolve.go` — after `passthroughEnv`, `resolved.Env`, and `cfgAgent.Env` — so the per-dispatcher value deterministically wins over the city-uniform default seeded by `cityRuntimeEnvMapForCity`.

The shell template stays uniform — matches main's

```
${GC_WORKFLOW_TRACE:-${GC_CONTROL_DISPATCHER_TRACE_DEFAULT:-${GC_CITY}/.gc/runtime/control-dispatcher-trace.log}}
```

expression and the `TestControlDispatcherStartCommandTracesUnderGCRuntime` regression guard. The trust decision happens in Go, consistent with the watcher-safety design that landed alongside the `.gc/runtime/` migration.

## Why .gc/runtime/

The trace file lives inside the controller's fsnotify exclusion (`cmd/gc/controller.go` `shouldIgnoreConfigWatchEvent` excludes the `.gc` and `.beads` path segments). Placing trace data at city root caused every append to fire `markDirty()` through the watcher debouncer, keeping patrol cycles in continuous reconciliation.

## Override semantics

`GC_WORKFLOW_TRACE` in the environment continues to override the default for any dispatcher.

## Scope

| File | Change |
| --- | --- |
| `internal/citylayout/runtime.go` | Three new exported helpers: `ControlDispatcherTraceLogFileName`, `ControlDispatcherTraceDefaultPathFor`, `ControlDispatcherTraceDefaultPathForRuntimeDirAndName`. |
| `cmd/gc/template_resolve.go` | `agentEnv` override for control-dispatcher agents (8 lines). |
| `cmd/gc/template_resolve_env_test.go` | `TestResolveTemplateInjectsPerDispatcherTraceDefault` (3 sub-tests: city dispatcher, rig dispatcher, non-dispatcher untouched). |
| `internal/citylayout/runtime_test.go` | Tests for the three new helpers. |
| `internal/config/config.go` | Comment updates pointing to the `template_resolve.go` injection site. |

## Test plan

Existing main regression guards pass UNCHANGED — the shell template did not move:

- `TestControlDispatcherStartCommandTracesUnderGCRuntime` (constant + qualified-name builder)
- `TestControlDispatcherStartCommandExecResolvesRuntimeTracePath` (default runtime root, injected trusted default override, explicit trace override)

End-to-end verified by running the patched `gc` binary in a multi-rig city. Inspecting each running dispatcher subprocess's environment confirms a per-dispatcher absolute `GC_CONTROL_DISPATCHER_TRACE_DEFAULT`, which the uniform shell template consumes to produce three distinct trace files on disk:

```
$ ls -la $GC_CITY/.gc/runtime/*.log
... app--control-dispatcher-trace.log
... control-dispatcher-trace.log
... engine--control-dispatcher-trace.log
```

## Checklist

- [x] Linked an issue (#1650) with reproducer and root cause analysis
- [x] Added tests for behavior changes (4 new test functions, 12 sub-tests)
- [x] Backward-compatible — `GC_WORKFLOW_TRACE` env-var override unchanged
- [x] Upstream regression tests pass UNCHANGED
- [x] No breaking changes for users not relying on the implicit default path
- [x] No docs changes required (`GC_WORKFLOW_TRACE` is documented as an override; default path was implicit)
