### PR TITLE
test: tighten standalone bd and multi-rig coverage

### DIFF
--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -232,7 +232,7 @@ func initBd(t *testing.T, dir string) string {
 	t.Helper()
 	prefix := uniqueCityName()
 	env := standaloneBDEnvForDir(dir)
-	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "-q")
+	cmd := exec.Command(bdBinary, "init", "-p", prefix, "--skip-hooks", "--skip-agents", "-q")
 	cmd.Dir = dir
 	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/test/integration/gastown_multirig_test.go
+++ b/test/integration/gastown_multirig_test.go
@@ -161,6 +161,57 @@ func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string,
 	require.NoError(t, os.WriteFile(tomlPath, []byte(b.String()), 0o644))
 }
 
+func installFakeBDForCity(t *testing.T, cityDir string) {
+	t.Helper()
+
+	shimDir := t.TempDir()
+	script := filepath.Join(shimDir, "bd")
+	content := `#!/bin/sh
+set -eu
+store="${BEADS_DIR:?}/fake-beads"
+mkdir -p "$store"
+case "${1:-}" in
+  create)
+    title="${2:?missing title}"
+    id="${GC_BEADS_PREFIX:-bd}-fake"
+    printf '%s' "$title" > "$store/$id"
+    printf 'Created issue: %s\n' "$id"
+    ;;
+  show)
+    id="${2:?missing id}"
+    if [ ! -f "$store/$id" ]; then
+      printf 'Error: issue not found: %s\n' "$id" >&2
+      exit 1
+    fi
+    printf 'ID: %s\n' "$id"
+    printf 'Title: %s\n' "$(cat "$store/$id")"
+    ;;
+  *)
+    printf 'unsupported fake bd command: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+`
+	require.NoError(t, os.WriteFile(script, []byte(content), 0o755))
+
+	loaded, ok := cityCommandEnv.Load(cityDir)
+	require.True(t, ok, "city command env should be registered for %s", cityDir)
+	env := append([]string(nil), loaded.([]string)...)
+	envMap := parseEnvList(env)
+	env = replaceEnv(env, "PATH", prependPath(shimDir, envMap["PATH"]))
+	registerCityCommandEnv(cityDir, env)
+}
+
+func seedConfiguredFakeBDWorkspace(t *testing.T, dir, prefix string) {
+	t.Helper()
+
+	beadsDir := filepath.Join(dir, ".beads")
+	require.NoError(t, os.MkdirAll(beadsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue_prefix: "+prefix+"\n"), 0o644))
+	metadata := fmt.Sprintf(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":%q}`+"\n", prefix)
+	require.NoError(t, os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0o644))
+}
+
 // TestGastown_MultiRig_ConfigLoads creates a city with 2 rigs and verifies
 // that gc config show reports both rigs.
 func TestGastown_MultiRig_ConfigLoads(t *testing.T) {
@@ -272,14 +323,19 @@ func TestGastown_MultiRig_BeadIsolation(t *testing.T) {
 	agents := []gasTownAgent{
 		{Name: "worker", StartCommand: "sleep 3600"},
 	}
+	writeMultiRigToml(t, cityDir, cityName, rigDirs, agents)
+	installFakeBDForCity(t, cityDir)
 
-	// Initialize beads in each rig directory with unique prefixes.
-	prefix0 := initBd(t, rigDirs[0])
-	prefix1 := initBd(t, rigDirs[1])
+	// Seed bd store markers after city.toml exists, then exercise only
+	// Gas City's configured rig route rather than direct cwd-based bd calls.
+	prefix0 := "r0"
+	prefix1 := "r1"
+	seedConfiguredFakeBDWorkspace(t, rigDirs[0], prefix0)
+	seedConfiguredFakeBDWorkspace(t, rigDirs[1], prefix1)
 	assert.NotEqual(t, prefix0, prefix1, "rig bead prefixes should differ")
 
-	// Create a bead from rig-0's directory.
-	out, err := bd(rigDirs[0], "create", "multi-rig bead test alpha")
+	// Create a bead through Gas City's configured rig route.
+	out, err := gc(cityDir, "bd", "--rig", "rig-0", "create", "multi-rig bead test alpha")
 	require.NoError(t, err, "bd create in rig-0: %s", out)
 	beadID := extractBeadID(t, out)
 
@@ -288,13 +344,17 @@ func TestGastown_MultiRig_BeadIsolation(t *testing.T) {
 	assert.True(t, strings.HasPrefix(beadID, prefix0),
 		"bead ID %q should start with rig-0 prefix %q", beadID, prefix0)
 
-	// Verify the bead is visible from rig-0.
-	out, err = bd(rigDirs[0], "show", beadID)
+	// Verify the bead is visible through rig-0's configured route.
+	out, err = gc(cityDir, "bd", "--rig", "rig-0", "show", beadID)
 	require.NoError(t, err, "bd show from rig-0: %s", out)
 	assert.Contains(t, out, "multi-rig bead test alpha",
 		"bead should be visible from rig-0")
 
-	writeMultiRigToml(t, cityDir, cityName, rigDirs, agents)
+	// Verify the same bead is not visible through rig-1's configured route.
+	out, err = gc(cityDir, "bd", "--rig", "rig-1", "show", beadID)
+	require.Error(t, err, "bd show from rig-1 should fail for bead %s; output: %s", beadID, out)
+	assert.NotContains(t, out, "multi-rig bead test alpha",
+		"bead should not be visible from rig-1")
 }
 
 // TestGastown_MultiRig_IndependentLifecycle starts a city with 2 rigs, stops

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -416,6 +416,7 @@ func standaloneBDEnvForDir(dir string) []string {
 		"LANG",
 		"LC_ALL",
 		"TZ",
+		"DOLT_ROOT_PATH",
 		integrationRealBDBinaryEnv,
 		integrationGCBinaryEnv,
 		integrationDoltBinaryEnv,
@@ -426,7 +427,11 @@ func standaloneBDEnvForDir(dir string) []string {
 			env = append(env, key+"="+value)
 		}
 	}
-	env = append(env, "DOLT_ROOT_PATH="+filepath.Join(dir, ".beads", "dolt-root"))
+	// Keep DOLT_ROOT_PATH from integrationEnv so standalone bd commands use
+	// the suite's seeded Dolt identity instead of an unseeded per-workspace root.
+	// BEADS_DIR and XDG_RUNTIME_DIR are temp-scoped by caller-owned test dirs;
+	// bd's embedded-mode default needs no server shutdown, and server-mode tests
+	// should use their own explicit lifecycle instead of hiding it in this env.
 	env = append(env, "XDG_RUNTIME_DIR="+dir)
 	env = append(env, "BEADS_DIR="+filepath.Join(dir, ".beads"))
 	return append(env, "BEADS_DOLT_AUTO_START=1")
@@ -444,9 +449,6 @@ func hasStandaloneBDWorkspace(dir string) bool {
 		return false
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".beads", "config.yaml")); err == nil {
-		return true
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".beads")); err == nil {
 		return true
 	}
 	return false
@@ -1293,8 +1295,8 @@ func TestStandaloneBDEnvAllowsBDAutoStart(t *testing.T) {
 	if got["BEADS_DIR"] != filepath.Join(dir, ".beads") {
 		t.Fatalf("BEADS_DIR = %q, want %q", got["BEADS_DIR"], filepath.Join(dir, ".beads"))
 	}
-	if got["DOLT_ROOT_PATH"] != filepath.Join(dir, ".beads", "dolt-root") {
-		t.Fatalf("DOLT_ROOT_PATH = %q, want %q", got["DOLT_ROOT_PATH"], filepath.Join(dir, ".beads", "dolt-root"))
+	if got["DOLT_ROOT_PATH"] != testGCHome {
+		t.Fatalf("DOLT_ROOT_PATH = %q, want seeded integration root %q", got["DOLT_ROOT_PATH"], testGCHome)
 	}
 	if got["XDG_RUNTIME_DIR"] != dir {
 		t.Fatalf("XDG_RUNTIME_DIR = %q, want %q", got["XDG_RUNTIME_DIR"], dir)
@@ -1335,8 +1337,14 @@ func TestUsesStandaloneBDWorkspaceKeepsFileProviderOnShim(t *testing.T) {
 	if usesStandaloneBDWorkspace(dir, []string{"GC_BEADS=file"}) {
 		t.Fatal("file provider city should keep using the file-store bd shim")
 	}
+	if usesStandaloneBDWorkspace(dir, []string{"GC_BEADS=dolt"}) {
+		t.Fatal("bare .beads directory should not select the standalone bd env")
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "config.yaml"), []byte("issue_prefix: test\n"), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
 	if !usesStandaloneBDWorkspace(dir, []string{"GC_BEADS=dolt"}) {
-		t.Fatal("standalone .beads workspace should use the standalone bd env")
+		t.Fatal("standalone .beads workspace with config.yaml should use the standalone bd env")
 	}
 }
 


### PR DESCRIPTION
## Summary

Post-merge remediation for #1528.

This follow-up tightens the tests around the standalone bd workspace path and configured multi-rig bead routing. It also corrects the audit trail: the production async-start Dolt identity fix landed separately; #1528 contributed awake-state test coverage and integration workspace isolation hardening.

Changes:
- keep integration standalone bd tests on the seeded Dolt identity root while still isolating `BEADS_DIR` and runtime state per workspace
- require `.beads/config.yaml` before treating a workspace as standalone bd-backed
- exercise configured multi-rig isolation through `gc bd --rig` instead of bypassing the command path
- avoid generating agent instruction artifacts during the real bd standalone smoke test

## Verification

- `go test -tags integration ./test/integration -run 'TestStandaloneBDEnvAllowsBDAutoStart|TestUsesStandaloneBDWorkspaceKeepsFileProviderOnShim|TestInitBdAllowsStandaloneCreate|TestGastown_MultiRig_BeadIsolation' -count=1`
- pre-commit hook passed: generated docs check, `golangci-lint run ./...`, `go vet ./...`, fast unit loop

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->