### PR TITLE
test(api): isolate gh readiness missing-binary probe

### DIFF
--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -1036,7 +1036,10 @@ func TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary(t *testing.
 		providerProbePathEnv = originalPathEnv
 		providerProbeGOOS = originalGOOS
 	}()
-	providerProbeGOOS = "linux"
+	// "test" — not "linux" — so searchpath.Expand skips the unconditional
+	// /snap/bin and /home/linuxbrew/.linuxbrew/bin extras that would otherwise
+	// resolve a host-installed gh and turn this assertion into "needs_auth".
+	providerProbeGOOS = "test"
 
 	state := newFakeState(t)
 	h := newTestCityHandler(t, state)


### PR DESCRIPTION
## Summary

- use a non-platform test GOOS so Linux snap/Linuxbrew probe paths do not leak host-installed gh into the assertion
- Needed because our development machine has: /home/linuxbrew/.linuxbrew/bin/gh
- Should have no unintended side-effects on other development setups, since limited to this test surface

Identified by agent, fixed by agent, reviewed by me as upstream candidate.

TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary set providerProbeGOOS to linux while constraining providerProbePathEnv to a temp directory.

On Linux, searchpath.Expand appends common package-manager directories such as /snap/bin and Linuxbrew paths. If the host has gh installed there, the readiness probe can find and execute it, returning needs_auth instead of the expected not_installed.

Use a non-platform test GOOS value so the missing-binary assertion only searches test-controlled directories while preserving production Linux path expansion.

## Testing

- [X] `make check`
- [X] (not applicable) `make check-docs` if docs, navigation, or links changed
- [X] (not applicable) `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [X] (not needed) Linked an issue, or explained why one is not needed
- [X] (test fix) Added or updated tests for behavior changes
- [X] (not applicable) Updated docs for user-facing changes
- [X] (not applicable) Called out breaking changes or migration notes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->