### PR TITLE
fix(api): harden agent visibility recovery

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -243,6 +243,10 @@ func TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving(t *test
 	if err := cs.CreateAgent(config.Agent{Name: "helper", Dir: "alpha", Provider: "bash"}); err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
+	pendingRev := cs.pendingConfigRevision()
+	if pendingRev == "" {
+		t.Fatal("CreateAgent did not mark a pending config revision")
+	}
 
 	stale := &config.City{
 		Workspace: config.Workspace{Name: "city1"},
@@ -250,11 +254,31 @@ func TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving(t *test
 		Rigs:      []config.Rig{{Name: "alpha", Path: rigDir}},
 		Agents:    []config.Agent{{Name: "worker", Dir: "alpha", Provider: "bash"}},
 	}
-	cs.updateFromRuntime(stale, runtime.NewFake(), "stale-rev")
+	cs.updateFromRuntime(stale, runtime.NewFake(), pendingRev)
+	if got := cs.Config(); configHasAgent(got, "alpha/helper") {
+		t.Fatalf("stale runtime update did not hide alpha/helper; agents = %+v", got.Agents)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := cs.WaitForAgentVisibility(ctx, "alpha/helper"); err != nil {
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cs.WaitForAgentVisibility(ctx, "alpha/helper")
+	}()
+
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForAgentVisibility returned before fresh runtime update: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	fresh, freshRev, err := cs.loadCurrentConfigSnapshot()
+	if err != nil {
+		t.Fatalf("load fresh config snapshot: %v", err)
+	}
+	cs.updateFromRuntime(fresh, runtime.NewFake(), freshRev)
+
+	if err := <-waitErr; err != nil {
 		t.Fatalf("WaitForAgentVisibility after stale runtime update: %v", err)
 	}
 	got := cs.Config()

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -229,7 +229,10 @@ export interface paths {
         /** Get v0 city by city name agents */
         get: operations["get-v0-city-by-city-name-agents"];
         put?: never;
-        /** Create an agent */
+        /**
+         * Create an agent
+         * @description Creates an agent and waits until it is visible to immediate follow-up operations. If the agent is durably created but visibility confirmation is canceled or times out, the retryable 503/504 response includes a Retry-After header.
+         */
         post: operations["create-agent"];
         delete?: never;
         options?: never;

--- a/cmd/gc/dashboard/web/src/generated/sdk.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/sdk.gen.ts
@@ -142,6 +142,8 @@ export const getV0CityByCityNameAgents = <ThrowOnError extends boolean = false>(
 
 /**
  * Create an agent
+ *
+ * Creates an agent and waits until it is visible to immediate follow-up operations. If the agent is durably created but visibility confirmation is canceled or times out, the retryable 503/504 response includes a Retry-After header.
  */
 export const createAgent = <ThrowOnError extends boolean = false>(options: Options<CreateAgentData, ThrowOnError>) => (options.client ?? client).post<CreateAgentResponses, CreateAgentErrors, ThrowOnError>({
     url: '/v0/city/{cityName}/agents',

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -13076,6 +13076,7 @@
         "summary": "Get v0 city by city name agents"
       },
       "post": {
+        "description": "Creates an agent and waits until it is visible to immediate follow-up operations. If the agent is durably created but visibility confirmation is canceled or times out, the retryable 503/504 response includes a Retry-After header.",
         "operationId": "create-agent",
         "parameters": [
           {

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -13076,6 +13076,7 @@
         "summary": "Get v0 city by city name agents"
       },
       "post": {
+        "description": "Creates an agent and waits until it is visible to immediate follow-up operations. If the agent is durably created but visibility confirmation is canceled or times out, the retryable 503/504 response includes a Retry-After header.",
         "operationId": "create-agent",
         "parameters": [
           {

--- a/internal/api/handler_agent_crud_test.go
+++ b/internal/api/handler_agent_crud_test.go
@@ -142,15 +142,13 @@ func TestHandleAgentCreate_MakesImmediateSlingTargetVisible(t *testing.T) {
 }
 
 func TestHandleAgentCreate_VisibilityWaiterTimeoutIsBounded(t *testing.T) {
-	oldTimeout := agentVisibilityWaitTimeout
-	agentVisibilityWaitTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { agentVisibilityWaitTimeout = oldTimeout })
-
 	fs := &agentVisibilityFakeState{
 		fakeMutatorState:     newFakeMutatorState(t),
 		waitUntilContextDone: true,
 	}
-	h := newTestCityHandler(t, fs)
+	srv := New(fs)
+	srv.agentVisibilityWaitTimeout = 10 * time.Millisecond
+	h := newTestCityHandlerWith(t, fs, srv)
 
 	req := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(
 		`{"name":"coder","dir":"myrig","provider":"test-agent"}`,
@@ -164,6 +162,9 @@ func TestHandleAgentCreate_VisibilityWaiterTimeoutIsBounded(t *testing.T) {
 	}
 	if rec.Code != http.StatusGatewayTimeout {
 		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())
+	}
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want 1", got)
 	}
 	if strings.Contains(rec.Body.String(), context.DeadlineExceeded.Error()) {
 		t.Fatalf("response leaked raw context error: %s", rec.Body.String())
@@ -185,6 +186,9 @@ func TestHandleAgentCreate_VisibilityWaiterCancelIsServiceUnavailable(t *testing
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want 1", got)
 	}
 	if strings.Contains(rec.Body.String(), context.Canceled.Error()) {
 		t.Fatalf("response leaked raw context error: %s", rec.Body.String())

--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -23,10 +23,17 @@ const lookPathCacheTTL = 30 * time.Second
 // from blocking the caller for a perceptible time on the happy path.
 const agentVisibilityPollInterval = 50 * time.Millisecond
 
-// agentVisibilityWaitTimeout bounds the POST /agents read-after-write wait.
+// defaultAgentVisibilityWaitTimeout bounds the POST /agents read-after-write wait.
 // The controller should converge much faster; this timeout prevents a broken
 // projection from tying up the handler after the config mutation succeeded.
-var agentVisibilityWaitTimeout = 3 * time.Second
+const defaultAgentVisibilityWaitTimeout = 3 * time.Second
+
+func (s *Server) agentCreateVisibilityWaitTimeout() time.Duration {
+	if s.agentVisibilityWaitTimeout > 0 {
+		return s.agentVisibilityWaitTimeout
+	}
+	return defaultAgentVisibilityWaitTimeout
+}
 
 type agentResponse struct {
 	Name        string       `json:"name"`

--- a/internal/api/huma_handlers_agents.go
+++ b/internal/api/huma_handlers_agents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -261,7 +262,7 @@ func (s *Server) humaHandleAgentCreate(ctx context.Context, input *AgentCreateIn
 	// target resolution reads the agent projection immediately after create.
 	qualifiedName := a.QualifiedName()
 	if waiter, ok := s.state.(AgentVisibilityWaiter); ok {
-		waitCtx, cancel := context.WithTimeout(ctx, agentVisibilityWaitTimeout)
+		waitCtx, cancel := context.WithTimeout(ctx, s.agentCreateVisibilityWaitTimeout())
 		err := waiter.WaitForAgentVisibility(waitCtx, qualifiedName)
 		cancel()
 		if err != nil {
@@ -278,12 +279,16 @@ func (s *Server) humaHandleAgentCreate(ctx context.Context, input *AgentCreateIn
 func agentVisibilityWaitHTTPError(err error) error {
 	switch {
 	case errors.Is(err, context.Canceled):
-		return huma.Error503ServiceUnavailable("agent was created, but visibility confirmation was canceled")
+		return agentVisibilityRetryableError(huma.Error503ServiceUnavailable("agent was created, but visibility confirmation was canceled"))
 	case errors.Is(err, context.DeadlineExceeded):
-		return huma.Error504GatewayTimeout("agent was created, but visibility was not confirmed before timeout")
+		return agentVisibilityRetryableError(huma.Error504GatewayTimeout("agent was created, but visibility was not confirmed before timeout"))
 	default:
 		return huma.Error500InternalServerError("agent was created, but visibility confirmation failed")
 	}
+}
+
+func agentVisibilityRetryableError(err error) error {
+	return huma.ErrorWithHeaders(err, http.Header{"Retry-After": []string{"1"}})
 }
 
 // humaHandleAgentUpdate is the Huma-typed handler for

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -105,7 +105,7 @@ func withCORS(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Last-Event-ID, X-GC-Request")
-			w.Header().Set("Access-Control-Expose-Headers", "X-GC-Index, X-GC-Request-Id")
+			w.Header().Set("Access-Control-Expose-Headers", "X-GC-Index, X-GC-Request-Id, Retry-After")
 		}
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -13076,6 +13076,7 @@
         "summary": "Get v0 city by city name agents"
       },
       "post": {
+        "description": "Creates an agent and waits until it is visible to immediate follow-up operations. If the agent is durably created but visibility confirmation is canceled or times out, the retryable 503/504 response includes a Retry-After header.",
         "operationId": "create-agent",
         "parameters": [
           {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,6 +65,10 @@ type Server struct {
 	lookPathMu      sync.Mutex
 	lookPathEntries map[string]lookPathEntry
 
+	// agentVisibilityWaitTimeout overrides the POST /agents visibility wait
+	// in tests. Zero uses defaultAgentVisibilityWaitTimeout.
+	agentVisibilityWaitTimeout time.Duration
+
 	// responseCache memoizes expensive read responses for a short TTL so
 	// repeated UI polls do not re-run the same bead-store subprocesses when
 	// nothing material has changed.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -49,8 +49,8 @@ func TestCORSOnRegularRequest(t *testing.T) {
 	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://127.0.0.1:8080" {
 		t.Errorf("CORS origin = %q, want %q", got, "http://127.0.0.1:8080")
 	}
-	if got := rec.Header().Get("Access-Control-Expose-Headers"); got != "X-GC-Index, X-GC-Request-Id" {
-		t.Errorf("CORS expose = %q, want %q", got, "X-GC-Index, X-GC-Request-Id")
+	if got := rec.Header().Get("Access-Control-Expose-Headers"); got != "X-GC-Index, X-GC-Request-Id, Retry-After" {
+		t.Errorf("CORS expose = %q, want %q", got, "X-GC-Index, X-GC-Request-Id, Retry-After")
 	}
 }
 

--- a/internal/api/supervisor_city_routes.go
+++ b/internal/api/supervisor_city_routes.go
@@ -61,6 +61,7 @@ func (sm *SupervisorMux) registerCityRoutes() {
 		Method:        http.MethodPost,
 		Path:          "/agents",
 		Summary:       "Create an agent",
+		Description:   "Creates an agent and waits until it is visible to immediate follow-up operations. If the agent is durably created but visibility confirmation is canceled or times out, the retryable 503/504 response includes a Retry-After header.",
 		DefaultStatus: http.StatusCreated,
 	}, (*Server).humaHandleAgentCreate)
 	cityPatch(sm, "/agent/{dir}/{base}", (*Server).humaHandleAgentUpdateQualified)

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -32,7 +32,8 @@ type Provenance struct {
 	// Warnings collects non-fatal collision warnings from composition.
 	Warnings []string
 
-	sourceContents map[string][]byte
+	sourceContents   map[string][]byte
+	revisionSnapshot *revisionSnapshot
 }
 
 // LoadOptions controls optional config-loading behavior.
@@ -323,7 +324,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	// Resolve named pack references to cache paths before any expansion.
 	resolveNamedPacks(root, cityRoot)
 
-	implicitImports, implicitPath, implicitErr := ReadImplicitImports()
+	implicitImports, implicitPath, implicitData, implicitErr := readImplicitImportsWithData()
 	if implicitErr != nil {
 		return nil, nil, implicitErr
 	}
@@ -375,6 +376,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		if addedImplicit && implicitPath != "" {
 			prov.Sources = append(prov.Sources, implicitPath)
+			if implicitData != nil {
+				prov.recordSource(implicitPath, implicitData)
+			}
 		}
 	}
 
@@ -500,6 +504,16 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		return nil, nil, fmt.Errorf("%s: provider cache build failed: %w", path, err)
 	}
 
+	// v0.15.1: enrich every agent with its convention-discovered
+	// agent-local asset paths (agents/<name>/skills/, agents/<name>/mcp/).
+	// DiscoverPackAgents only does this for agents it creates — it skips
+	// names already present in pack.toml [[agent]] or city.toml
+	// [[agent]] entries, so those agents leave the discovery pass with
+	// empty SkillsDir/MCPDir even when agents/<name>/skills/ exists on
+	// disk. The materializer and collision validator both key off
+	// SkillsDir, so that gap silently loses agent-local skills for every
+	// explicitly-declared agent. Populate the fields here so the
+	// convention works uniformly.
 	populateAgentLocalAssetDirs(fs, root, cityRoot)
 
 	// Load namepool files for pool agents.
@@ -518,16 +532,10 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, warning)
 	}
 
-	// v0.15.1: enrich every agent with its convention-discovered
-	// agent-local asset paths (agents/<name>/skills/, agents/<name>/mcp/).
-	// DiscoverPackAgents only does this for agents it creates — it skips
-	// names already present in pack.toml [[agent]] or city.toml
-	// [[agent]] entries, so those agents leave the discovery pass with
-	// empty SkillsDir/MCPDir even when agents/<name>/skills/ exists on
-	// disk. The materializer and collision validator both key off
-	// SkillsDir, so that gap silently loses agent-local skills for every
-	// explicitly-declared agent. Populate the fields here so the
-	// convention works uniformly.
+	// Capture revision inputs after all config and pack discovery so callers
+	// can compare the loaded snapshot to future reloads without re-reading
+	// mutable files from disk.
+	prov.captureRevisionSnapshot(fs, root, cityRoot)
 	return root, prov, nil
 }
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -31,6 +31,8 @@ type Provenance struct {
 	Workspace map[string]string
 	// Warnings collects non-fatal collision warnings from composition.
 	Warnings []string
+
+	sourceContents map[string][]byte
 }
 
 // LoadOptions controls optional config-loading behavior.
@@ -62,6 +64,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 	cityRoot := filepath.Dir(path)
 	prov := newProvenance(path)
+	prov.recordSource(path, data)
 	prov.Warnings = append(prov.Warnings, rootWarnings...)
 	cityAgentsForProvenance := root.Agents
 
@@ -176,6 +179,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Track pack.toml agents in provenance.
 		trackAgents(prov, pc.Agents, packPath)
 		prov.Sources = append(prov.Sources, packPath)
+		prov.recordSource(packPath, packData)
 
 		packCommands, err := DiscoverPackCommands(fs, cityRoot, pc.Pack.Name)
 		if err != nil {
@@ -294,6 +298,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		// Merge fragment into root.
 		mergeFragment(root, frag, fragMeta, fragPath, prov)
 		prov.Sources = append(prov.Sources, fragPath)
+		prov.recordSource(fragPath, fragData)
 	}
 
 	// Inject system pack includes into Workspace.Includes. These are
@@ -1201,6 +1206,15 @@ func newProvenance(rootPath string) *Provenance {
 		Rigs:      make(map[string]string),
 		Workspace: make(map[string]string),
 	}
+}
+
+func (p *Provenance) recordSource(path string, data []byte) {
+	if p.sourceContents == nil {
+		p.sourceContents = make(map[string][]byte)
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	p.sourceContents[path] = cp
 }
 
 func trackAgents(prov *Provenance, agents []Agent, source string) {

--- a/internal/config/implicit.go
+++ b/internal/config/implicit.go
@@ -28,29 +28,34 @@ type implicitImportFile struct {
 // ReadImplicitImports reads ~/.gc/implicit-import.toml (or $GC_HOME) and
 // returns its imports. Missing files are treated as empty.
 func ReadImplicitImports() (map[string]ImplicitImport, string, error) {
+	imports, path, _, err := readImplicitImportsWithData()
+	return imports, path, err
+}
+
+func readImplicitImportsWithData() (map[string]ImplicitImport, string, []byte, error) {
 	path := implicitImportPath()
 	if path == "" {
-		return map[string]ImplicitImport{}, "", nil
+		return map[string]ImplicitImport{}, "", nil, nil
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return map[string]ImplicitImport{}, path, nil
+			return map[string]ImplicitImport{}, path, nil, nil
 		}
-		return nil, path, fmt.Errorf("reading implicit imports: %w", err)
+		return nil, path, nil, fmt.Errorf("reading implicit imports: %w", err)
 	}
 
 	var file implicitImportFile
 	if _, err := toml.Decode(string(data), &file); err != nil {
-		return nil, path, fmt.Errorf("parsing implicit imports: %w", err)
+		return nil, path, nil, fmt.Errorf("parsing implicit imports: %w", err)
 	}
 	if file.Schema != 0 && file.Schema != implicitImportSchema {
-		return nil, path, fmt.Errorf("unsupported implicit import schema %d", file.Schema)
+		return nil, path, nil, fmt.Errorf("unsupported implicit import schema %d", file.Schema)
 	}
 	if file.Imports == nil {
 		file.Imports = make(map[string]ImplicitImport)
 	}
-	return file.Imports, path, nil
+	return file.Imports, path, data, nil
 }
 
 func implicitImportPath() string {

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -27,9 +27,13 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	copy(sources, prov.Sources)
 	sort.Strings(sources)
 	for _, path := range sources {
-		data, err := fs.ReadFile(path)
-		if err != nil {
-			continue
+		data, ok := prov.sourceContents[path]
+		if !ok {
+			var err error
+			data, err = fs.ReadFile(path)
+			if err != nil {
+				continue
+			}
 		}
 		h.Write([]byte(path)) //nolint:errcheck // hash.Write never errors
 		h.Write([]byte{0})    //nolint:errcheck // hash.Write never errors

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/sha256"
 	"fmt"
+	"hash"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,6 +12,13 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/pathutil"
 )
+
+type revisionSnapshot struct {
+	dirHashes      map[string]string
+	fileContents   map[string][]byte
+	fileKnown      map[string]bool
+	conventionDirs []string
+}
 
 // Revision computes a deterministic bundle hash from all resolved config
 // source files. This serves as a revision identifier — if the revision
@@ -46,22 +54,14 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	for _, r := range rigs {
 		for _, ref := range r.Includes {
 			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
-			topoHash := PackContentHashRecursive(fs, topoDir)
-			h.Write([]byte("pack:" + r.Name + ":" + ref)) //nolint:errcheck // hash.Write never errors
-			h.Write([]byte{0})                            //nolint:errcheck // hash.Write never errors
-			h.Write([]byte(topoHash))                     //nolint:errcheck // hash.Write never errors
-			h.Write([]byte{0})                            //nolint:errcheck // hash.Write never errors
+			writeRevisionDirHash(h, prov, "pack:"+r.Name+":"+ref, fs, topoDir)
 		}
 	}
 
 	// Hash city-level pack directory contents.
 	for _, ref := range cfg.Workspace.Includes {
 		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
-		topoHash := PackContentHashRecursive(fs, topoDir)
-		h.Write([]byte("city-pack:" + ref)) //nolint:errcheck // hash.Write never errors
-		h.Write([]byte{0})                  //nolint:errcheck // hash.Write never errors
-		h.Write([]byte(topoHash))           //nolint:errcheck // hash.Write never errors
-		h.Write([]byte{0})                  //nolint:errcheck // hash.Write never errors
+		writeRevisionDirHash(h, prov, "city-pack:"+ref, fs, topoDir)
 	}
 
 	// Remote PackV2 imports resolve through packs.lock, so lockfile changes
@@ -69,7 +69,11 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 	// untouched.
 	if tracksPackV2Imports(cfg) {
 		lockPath := filepath.Join(cityRoot, "packs.lock")
-		if data, err := fs.ReadFile(lockPath); err == nil {
+		if data, known, exists := revisionSnapshotFile(prov, lockPath); known {
+			if exists {
+				writeRevisionBytes(h, lockPath, data)
+			}
+		} else if data, err := fs.ReadFile(lockPath); err == nil {
 			h.Write([]byte(lockPath)) //nolint:errcheck // hash.Write never errors
 			h.Write([]byte{0})        //nolint:errcheck // hash.Write never errors
 			h.Write(data)             //nolint:errcheck // hash.Write never errors
@@ -85,11 +89,7 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 		if strings.TrimSpace(dir) == "" {
 			continue
 		}
-		topoHash := PackContentHashRecursive(fs, dir)
-		h.Write([]byte("city-packdir:" + dir)) //nolint:errcheck // hash.Write never errors
-		h.Write([]byte{0})                     //nolint:errcheck // hash.Write never errors
-		h.Write([]byte(topoHash))              //nolint:errcheck // hash.Write never errors
-		h.Write([]byte{0})                     //nolint:errcheck // hash.Write never errors
+		writeRevisionDirHash(h, prov, "city-packdir:"+dir, fs, dir)
 	}
 	rigPackDirNames := make([]string, 0, len(cfg.RigPackDirs))
 	for name := range cfg.RigPackDirs {
@@ -101,24 +101,133 @@ func Revision(fs fsys.FS, prov *Provenance, cfg *City, cityRoot string) string {
 			if strings.TrimSpace(dir) == "" {
 				continue
 			}
-			topoHash := PackContentHashRecursive(fs, dir)
-			h.Write([]byte("rig-packdir:" + rigName + ":" + dir)) //nolint:errcheck // hash.Write never errors
-			h.Write([]byte{0})                                    //nolint:errcheck // hash.Write never errors
-			h.Write([]byte(topoHash))                             //nolint:errcheck // hash.Write never errors
-			h.Write([]byte{0})                                    //nolint:errcheck // hash.Write never errors
+			writeRevisionDirHash(h, prov, "rig-packdir:"+rigName+":"+dir, fs, dir)
 		}
 	}
 	// Hash convention-discovered city-pack trees so adding or editing
 	// agents/commands/doctor content changes the effective revision too.
-	for _, dir := range existingConventionDiscoveryDirsFS(fs, cityRoot) {
-		topoHash := PackContentHashRecursive(fs, dir)
-		h.Write([]byte("city-discovery:" + dir)) //nolint:errcheck // hash.Write never errors
-		h.Write([]byte{0})                       //nolint:errcheck // hash.Write never errors
-		h.Write([]byte(topoHash))                //nolint:errcheck // hash.Write never errors
-		h.Write([]byte{0})                       //nolint:errcheck // hash.Write never errors
+	for _, dir := range revisionConventionDirs(prov, fs, cityRoot) {
+		writeRevisionDirHash(h, prov, "city-discovery:"+dir, fs, dir)
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func (p *Provenance) captureRevisionSnapshot(fs fsys.FS, cfg *City, cityRoot string) {
+	if p == nil || cfg == nil {
+		return
+	}
+	p.recordMissingSourceContents(fs)
+	snap := &revisionSnapshot{
+		dirHashes:    make(map[string]string),
+		fileContents: make(map[string][]byte),
+		fileKnown:    make(map[string]bool),
+	}
+	recordDir := func(label, dir string) {
+		snap.dirHashes[label] = PackContentHashRecursive(fs, dir)
+	}
+
+	for _, r := range cfg.Rigs {
+		for _, ref := range r.Includes {
+			topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+			recordDir("pack:"+r.Name+":"+ref, topoDir)
+		}
+	}
+	for _, ref := range cfg.Workspace.Includes {
+		topoDir, _ := resolvePackRef(ref, cityRoot, cityRoot)
+		recordDir("city-pack:"+ref, topoDir)
+	}
+	if tracksPackV2Imports(cfg) {
+		lockPath := filepath.Join(cityRoot, "packs.lock")
+		snap.fileKnown[lockPath] = true
+		if data, err := fs.ReadFile(lockPath); err == nil {
+			snap.fileContents[lockPath] = cloneBytes(data)
+		}
+	}
+	for _, dir := range cfg.PackDirs {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		recordDir("city-packdir:"+dir, dir)
+	}
+	rigPackDirNames := make([]string, 0, len(cfg.RigPackDirs))
+	for name := range cfg.RigPackDirs {
+		rigPackDirNames = append(rigPackDirNames, name)
+	}
+	sort.Strings(rigPackDirNames)
+	for _, rigName := range rigPackDirNames {
+		for _, dir := range cfg.RigPackDirs[rigName] {
+			if strings.TrimSpace(dir) == "" {
+				continue
+			}
+			recordDir("rig-packdir:"+rigName+":"+dir, dir)
+		}
+	}
+	snap.conventionDirs = existingConventionDiscoveryDirsFS(fs, cityRoot)
+	for _, dir := range snap.conventionDirs {
+		recordDir("city-discovery:"+dir, dir)
+	}
+	p.revisionSnapshot = snap
+}
+
+func (p *Provenance) recordMissingSourceContents(fs fsys.FS) {
+	if p == nil {
+		return
+	}
+	for _, path := range p.Sources {
+		if _, ok := p.sourceContents[path]; ok {
+			continue
+		}
+		data, err := fs.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		p.recordSource(path, data)
+	}
+}
+
+func writeRevisionDirHash(h hash.Hash, prov *Provenance, label string, fs fsys.FS, dir string) {
+	topoHash, ok := revisionSnapshotDirHash(prov, label)
+	if !ok {
+		topoHash = PackContentHashRecursive(fs, dir)
+	}
+	writeRevisionBytes(h, label, []byte(topoHash))
+}
+
+func writeRevisionBytes(h hash.Hash, label string, data []byte) {
+	h.Write([]byte(label)) //nolint:errcheck // hash.Write never errors
+	h.Write([]byte{0})     //nolint:errcheck // hash.Write never errors
+	h.Write(data)          //nolint:errcheck // hash.Write never errors
+	h.Write([]byte{0})     //nolint:errcheck // hash.Write never errors
+}
+
+func revisionSnapshotDirHash(prov *Provenance, label string) (string, bool) {
+	if prov == nil || prov.revisionSnapshot == nil {
+		return "", false
+	}
+	v, ok := prov.revisionSnapshot.dirHashes[label]
+	return v, ok
+}
+
+func revisionSnapshotFile(prov *Provenance, path string) ([]byte, bool, bool) {
+	if prov == nil || prov.revisionSnapshot == nil || !prov.revisionSnapshot.fileKnown[path] {
+		return nil, false, false
+	}
+	data, exists := prov.revisionSnapshot.fileContents[path]
+	return data, true, exists
+}
+
+func revisionConventionDirs(prov *Provenance, fs fsys.FS, cityRoot string) []string {
+	if prov == nil || prov.revisionSnapshot == nil {
+		return existingConventionDiscoveryDirsFS(fs, cityRoot)
+	}
+	return append([]string(nil), prov.revisionSnapshot.conventionDirs...)
+}
+
+func cloneBytes(data []byte) []byte {
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	return cp
 }
 
 // WatchTarget describes a filesystem path that should be watched for config

--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -50,6 +50,37 @@ name = "changed"
 	}
 }
 
+func TestRevision_UsesLoadedSourceSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+`)
+
+	cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	loadedRevision := Revision(fsys.OSFS{}, prov, cfg, dir)
+
+	writeFile(t, dir, "city.toml", `[workspace]
+name = "changed"
+`)
+	afterWriteRevision := Revision(fsys.OSFS{}, prov, cfg, dir)
+	if afterWriteRevision != loadedRevision {
+		t.Fatalf("revision changed after source file write; got %q, want loaded snapshot %q", afterWriteRevision, loadedRevision)
+	}
+
+	reloadedCfg, reloadedProv, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("reloading config: %v", err)
+	}
+	reloadedRevision := Revision(fsys.OSFS{}, reloadedProv, reloadedCfg, dir)
+	if reloadedRevision == loadedRevision {
+		t.Fatal("revision did not change after reloading changed source file")
+	}
+}
+
 func TestRevision_IncludesFragments(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "city.toml", `[workspace]

--- a/internal/config/revision_test.go
+++ b/internal/config/revision_test.go
@@ -81,6 +81,250 @@ name = "changed"
 	}
 }
 
+func TestRevision_UsesLoadedSnapshotForResolvedInputs(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, dir string)
+		mutate func(t *testing.T, dir string)
+	}{
+		{
+			name: "fragment",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `
+include = ["agents.toml"]
+
+[workspace]
+name = "test"
+`)
+				writeFile(t, dir, "agents.toml", `[[agent]]
+name = "builder"
+`)
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "agents.toml", `[[agent]]
+name = "builder-renamed"
+`)
+			},
+		},
+		{
+			name: "city pack.toml",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+`)
+				writeFile(t, dir, "pack.toml", `[pack]
+name = "citypack"
+schema = 1
+
+[[agent]]
+name = "builder"
+`)
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "pack.toml", `[pack]
+name = "citypack"
+schema = 1
+
+[[agent]]
+name = "builder-renamed"
+`)
+			},
+		},
+		{
+			name: "implicit imports file",
+			setup: func(t *testing.T, dir string) {
+				gcHome := filepath.Join(dir, "gc-home")
+				t.Setenv("GC_HOME", gcHome)
+				writeFile(t, gcHome, "implicit-import.toml", `schema = 1
+
+[imports.core]
+source = "github.com/gastownhall/gc-core"
+version = "0.1.0"
+`)
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+`)
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, filepath.Join(dir, "gc-home"), "implicit-import.toml", `schema = 1
+
+[imports.core]
+source = "github.com/gastownhall/gc-core"
+version = "0.1.1"
+`)
+			},
+		},
+		{
+			name: "legacy city include pack tree",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+includes = ["packs/shared"]
+`)
+				writeFile(t, dir, "packs/shared/pack.toml", `[pack]
+name = "shared"
+schema = 1
+
+[[agent]]
+name = "builder"
+prompt_template = "prompts/builder.template.md"
+`)
+				writeFile(t, dir, "packs/shared/prompts/builder.template.md", "first prompt\n")
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "packs/shared/prompts/builder.template.md", "second prompt\n")
+			},
+		},
+		{
+			name: "legacy rig include pack tree",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../frontend"
+includes = ["packs/rig"]
+`)
+				writeFile(t, dir, "packs/rig/pack.toml", `[pack]
+name = "rigpack"
+schema = 1
+
+[[agent]]
+name = "runner"
+scope = "rig"
+prompt_template = "prompts/runner.template.md"
+`)
+				writeFile(t, dir, "packs/rig/prompts/runner.template.md", "first prompt\n")
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "packs/rig/prompts/runner.template.md", "second prompt\n")
+			},
+		},
+		{
+			name: "packs.lock",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+
+[imports.shared]
+source = "./packs/shared"
+`)
+				writeFile(t, dir, "packs/shared/pack.toml", `[pack]
+name = "shared"
+schema = 1
+`)
+				writeFile(t, dir, "packs.lock", `schema = 1
+
+[packs."./packs/shared"]
+version = "1.0.0"
+commit = "aaaa"
+`)
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "packs.lock", `schema = 1
+
+[packs."./packs/shared"]
+version = "1.0.1"
+commit = "bbbb"
+`)
+			},
+		},
+		{
+			name: "PackV2 city import tree",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+
+[imports.shared]
+source = "./packs/shared"
+`)
+				writeFile(t, dir, "packs/shared/pack.toml", `[pack]
+name = "shared"
+schema = 1
+
+[[agent]]
+name = "builder"
+prompt_template = "prompts/builder.template.md"
+`)
+				writeFile(t, dir, "packs/shared/prompts/builder.template.md", "first prompt\n")
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "packs/shared/prompts/builder.template.md", "second prompt\n")
+			},
+		},
+		{
+			name: "PackV2 rig import tree",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+
+[[rigs]]
+name = "frontend"
+path = "../frontend"
+
+[rigs.imports.shared]
+source = "./packs/shared"
+`)
+				writeFile(t, dir, "packs/shared/pack.toml", `[pack]
+name = "shared"
+schema = 1
+
+[[agent]]
+name = "runner"
+scope = "rig"
+prompt_template = "prompts/runner.template.md"
+`)
+				writeFile(t, dir, "packs/shared/prompts/runner.template.md", "first prompt\n")
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "packs/shared/prompts/runner.template.md", "second prompt\n")
+			},
+		},
+		{
+			name: "convention discovery tree",
+			setup: func(t *testing.T, dir string) {
+				writeFile(t, dir, "city.toml", `[workspace]
+name = "test"
+`)
+				writeFile(t, dir, "agents/builder/prompt.template.md", "first prompt\n")
+			},
+			mutate: func(t *testing.T, dir string) {
+				writeFile(t, dir, "agents/builder/prompt.template.md", "second prompt\n")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cityPath := filepath.Join(dir, "city.toml")
+			tt.setup(t, dir)
+
+			cfg, prov, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+			if err != nil {
+				t.Fatalf("LoadWithIncludes: %v", err)
+			}
+			loadedRevision := Revision(fsys.OSFS{}, prov, cfg, dir)
+
+			tt.mutate(t, dir)
+			afterWriteRevision := Revision(fsys.OSFS{}, prov, cfg, dir)
+			if afterWriteRevision != loadedRevision {
+				t.Fatalf("revision changed after post-load mutation; got %q, want loaded snapshot %q", afterWriteRevision, loadedRevision)
+			}
+
+			reloadedCfg, reloadedProv, err := LoadWithIncludes(fsys.OSFS{}, cityPath)
+			if err != nil {
+				t.Fatalf("reloading config: %v", err)
+			}
+			reloadedRevision := Revision(fsys.OSFS{}, reloadedProv, reloadedCfg, dir)
+			if reloadedRevision == loadedRevision {
+				t.Fatal("revision did not change after reloading changed input")
+			}
+		})
+	}
+}
+
 func TestRevision_IncludesFragments(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "city.toml", `[workspace]


### PR DESCRIPTION
Follow-up to merged PR #1592 from the post-merge review workflow.

This keeps the maintainer fixup narrowly scoped to the review findings:

- hashes config revisions from the source bytes loaded into `Provenance`, so a stale loaded config cannot be paired with a revision computed from newer files
- strengthens the stale runtime interleaving regression test to prove `WaitForAgentVisibility` stays blocked until a fresh runtime snapshot arrives
- returns a machine-readable `Retry-After` contract for retryable POST `/agents` visibility timeout/cancel responses and exposes it through CORS
- moves the visibility timeout test override onto the `Server` instance instead of mutating package global state

Verification:

- `go test ./internal/config`
- `go test ./internal/api`
- `go test ./cmd/gc -run 'TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving|TestControllerStateRuntimeUpdateIgnoresEmptyRevisionDuringPendingMutation|TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision|TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending'`
- `make test`
- `make dashboard-check`
- `npm run preview -- --host 127.0.0.1 --port 4174` from `cmd/gc/dashboard/web`, verified with `curl -fsS http://127.0.0.1:4174/`
- pre-commit hook ran during commit and passed lint, vet, tests, docs sync, and dashboard checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->