### PR TITLE
test(dispatch): cover ralph pending dependency repair

### DIFF
--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -995,6 +995,58 @@ func TestProcessRalphControlReturnsPendingForOpenIteration(t *testing.T) {
 	}
 }
 
+func TestProcessRalphControlPendingIterationAddsBlockingDep(t *testing.T) {
+	t.Parallel()
+	store := beads.NewMemStore()
+
+	root := mustCreate(t, store, beads.Bead{
+		Title:    "workflow",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	control := mustCreate(t, store, beads.Bead{
+		Title: "review loop",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop",
+			"gc.step_id":      "review-loop",
+			"gc.max_attempts": "2",
+		},
+	})
+	iteration := mustCreate(t, store, beads.Bead{
+		Title: "review loop iteration 1",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "mol-test.review-loop.iteration.1",
+			"gc.scope_role":   "body",
+			"gc.attempt":      "1",
+		},
+	})
+
+	_, err := processRalphControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+	if !errors.Is(err, ErrControlPending) {
+		t.Fatalf("error = %v, want %v", err, ErrControlPending)
+	}
+
+	deps, err := store.DepList(control.ID, "down")
+	if err != nil {
+		t.Fatalf("DepList: %v", err)
+	}
+	if len(deps) != 1 || deps[0].DependsOnID != iteration.ID || deps[0].Type != "blocks" {
+		t.Fatalf("deps = %#v, want one blocks dep on pending iteration %s", deps, iteration.ID)
+	}
+	ready, err := store.Ready()
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	for _, bead := range ready {
+		if bead.ID == control.ID {
+			t.Fatalf("control bead stayed ready while pending iteration %s is open", iteration.ID)
+		}
+	}
+}
+
 // TestReconcileClosedScopeMemberRalphPass covers the pass-side symmetry of
 // TestProcessRalphControlClosesEnclosingScopeOnIterationFailure: when a scoped
 // ralph control closes with gc.outcome=pass, reconcileClosedScopeMember must


### PR DESCRIPTION
Follow-up for post-merge review of #1651.

Adds the missing Ralph pending-iteration regression test for dependency repair when the control bead reaches dispatch without its blocking dependency. The test asserts processRalphControl returns ErrControlPending, creates the blocks edge to the open iteration, and removes the control bead from the ready set.

Tests:
- go test ./internal/dispatch -run 'TestProcess(Retry|Ralph)Control.*Pending.*Dep|TestProcessRalphControlReturnsPendingForOpenIteration'
- go test ./internal/dispatch -count=1
- pre-commit hook ran lint, vet, and go test ./... during commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->