### PR TITLE
fix: address named session circuit breaker review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix is now the full `/v0/city/<cityName>/svc/<svcName>` path. The
   per-city router contract (`config.Service.MountPathOrDefault`) is
   unchanged.
+- `gc session reset` now documents its named-session circuit-breaker behavior:
+  when the target is a named session, reset clears a tripped respawn breaker
+  before requesting a fresh restart.
 
 ### Changed
 

--- a/cmd/gc/cmd_session_reset.go
+++ b/cmd/gc/cmd_session_reset.go
@@ -17,7 +17,9 @@ func newSessionResetCmd(stdout, stderr io.Writer) *cobra.Command {
 
 The controller stops the current runtime and starts the same session again with
 fresh provider conversation state. Session identity, alias, mail, and queued
-work remain attached to the existing session bead.
+work remain attached to the existing session bead. For named sessions, reset
+also clears any tripped named-session respawn circuit breaker before requesting
+the fresh restart.
 
 Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).`,
 		Args: cobra.ExactArgs(1),
@@ -76,12 +78,11 @@ func cmdSessionReset(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	identity := namedSessionIdentity(bead)
-	if identity == "" {
-		identity = args[0]
-	}
-	if err := resetSessionCircuitBreakerOnController(cityPath, sessionID, identity); err != nil {
-		fmt.Fprintf(stderr, "gc session reset: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
-		return 1
+	if identity != "" {
+		if err := resetSessionCircuitBreakerOnController(cityPath, sessionID, identity); err != nil {
+			fmt.Fprintf(stderr, "gc session reset: clearing session circuit breaker for %q: %v\n", identity, err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
 	}
 
 	if err := handle.Reset(context.Background()); err != nil {

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -145,11 +145,11 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 	}
 	defer lis.Close() //nolint:errcheck
 
-	commands := make(chan string, 4)
+	commands := make(chan string, 3)
 	errCh := make(chan error, 1)
 	go func() {
 		defer close(commands)
-		for i := 0; i < 4; i++ {
+		for i := 0; i < 3; i++ {
 			conn, err := lis.Accept()
 			if err != nil {
 				errCh <- err
@@ -167,8 +167,6 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 			reply := "ok\n"
 			if cmd == "ping\n" {
 				reply = "123\n"
-			} else if strings.HasPrefix(cmd, "session-circuit-reset:") {
-				reply = `{"outcome":"ok"}` + "\n"
 			}
 			if _, err := conn.Write([]byte(reply)); err != nil {
 				conn.Close() //nolint:errcheck
@@ -184,9 +182,9 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 		t.Fatalf("cmdSessionReset(controller) = %d, want 0; stderr=%s", code, stderr.String())
 	}
 
-	gotCommands := make([]string, 0, 4)
+	gotCommands := make([]string, 0, 3)
 	deadline := time.After(2 * time.Second)
-	for len(gotCommands) < 4 {
+	for len(gotCommands) < 3 {
 		select {
 		case err := <-errCh:
 			if err != nil {
@@ -194,8 +192,8 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 			}
 		case cmd, ok := <-commands:
 			if !ok {
-				if len(gotCommands) != 4 {
-					t.Fatalf("controller commands = %v, want ping, poke, reset, poke", gotCommands)
+				if len(gotCommands) != 3 {
+					t.Fatalf("controller commands = %v, want ping, poke, poke", gotCommands)
 				}
 				break
 			}
@@ -204,23 +202,11 @@ func TestCmdSessionReset_RequestsFreshRestartWithController(t *testing.T) {
 			t.Fatalf("timed out waiting for controller pokes, got %v", gotCommands)
 		}
 	}
-	wantExact := []string{"ping\n", "poke\n"}
+	wantExact := []string{"ping\n", "poke\n", "poke\n"}
 	for i, want := range wantExact {
 		if gotCommands[i] != want {
 			t.Fatalf("controller command %d = %q, want %q", i, gotCommands[i], want)
 		}
-	}
-	if !strings.HasPrefix(gotCommands[2], "session-circuit-reset:") {
-		t.Fatalf("controller command 2 = %q, want session-circuit-reset", gotCommands[2])
-	}
-	if !strings.Contains(gotCommands[2], `"identity":"sky"`) {
-		t.Fatalf("controller command 2 = %q, want identity sky", gotCommands[2])
-	}
-	if !strings.Contains(gotCommands[2], `"session_id":"`+bead.ID+`"`) {
-		t.Fatalf("controller command 2 = %q, want session_id %s", gotCommands[2], bead.ID)
-	}
-	if gotCommands[3] != "poke\n" {
-		t.Fatalf("controller command 3 = %q, want poke", gotCommands[3])
 	}
 
 	reloaded, err := openCityStoreAt(cityDir)

--- a/cmd/gc/session_circuit_breaker.go
+++ b/cmd/gc/session_circuit_breaker.go
@@ -923,10 +923,6 @@ func addSessionCircuitResolverKey(resolve map[string]string, ambiguous map[strin
 	resolve[key] = identity
 }
 
-// SessionCircuitBreakerSnapshot is the exported status hook: it returns the
-// current breaker state for all tracked named-session identities. The
-// "gc status" command and any future dashboard can call this to surface
-// tripped breakers without reaching into package internals.
-func SessionCircuitBreakerSnapshot(now time.Time) []CircuitBreakerSnapshot {
+func sessionCircuitBreakerSnapshot(now time.Time) []CircuitBreakerSnapshot {
 	return defaultSessionCircuitBreaker().Snapshot(now)
 }

--- a/cmd/gc/session_circuit_breaker_test.go
+++ b/cmd/gc/session_circuit_breaker_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -934,7 +935,7 @@ func TestReconciler_CircuitOpenStatePersistsAcrossControllerRestart(t *testing.T
 	if env.sp.IsRunning("session-a") {
 		t.Fatal("session-a should not be running after persisted CIRCUIT_OPEN restore")
 	}
-	if snap := SessionCircuitBreakerSnapshot(env.clk.Now().UTC()); len(snap) != 1 || snap[0].Identity != identity || snap[0].State != circuitOpen.String() {
+	if snap := sessionCircuitBreakerSnapshot(env.clk.Now().UTC()); len(snap) != 1 || snap[0].Identity != identity || snap[0].State != circuitOpen.String() {
 		t.Fatalf("restored snapshot = %+v, want one OPEN entry for %s", snap, identity)
 	}
 }
@@ -1143,5 +1144,61 @@ func TestReconciler_CircuitTripsThroughRepeatedWakeAttempts(t *testing.T) {
 	snap := cb.Snapshot(env.clk.Now().UTC())
 	if len(snap) != 1 || snap[0].Identity != identity || snap[0].State != "CIRCUIT_OPEN" || snap[0].RestartCount != 6 {
 		t.Fatalf("snapshot after trip = %+v, want one OPEN entry with 6 restarts", snap)
+	}
+}
+
+func TestReconciler_CircuitStaysClosedWhenAssignedWorkStatusProgresses(t *testing.T) {
+	env := newReconcilerTestEnv()
+	configureAlwaysNamedSession(env)
+	env.addDesired("session-a", "template-a", false)
+
+	cb := breakerAt(30*time.Minute, 5)
+	restore := setSessionCircuitBreakerForTest(cb)
+	defer restore()
+
+	const identity = "rig-a/session-a"
+	b := createCircuitTestNamedSession(t, env, "asleep")
+	statuses := []string{"open", "in_progress", "blocked", "open", "in_progress", "closed"}
+
+	for i, status := range statuses {
+		current, err := env.store.Get(b.ID)
+		if err != nil {
+			t.Fatalf("get bead attempt %d: %v", i+1, err)
+		}
+		poolDesired := map[string]int{"template-a": 1}
+		woken := reconcileSessionBeads(
+			context.Background(), []beads.Bead{current}, env.desiredState,
+			configuredSessionNames(env.cfg, "", env.store), env.cfg, env.sp,
+			env.store, nil,
+			[]beads.Bead{{ID: "work-1", Assignee: identity, Status: status}},
+			nil, env.dt, poolDesired, false, nil, "", nil, env.clk, env.rec,
+			0, 0, &env.stdout, &env.stderr,
+		)
+		if woken != 1 {
+			t.Fatalf("attempt %d (%s): woken = %d, want 1; stderr=%s", i+1, status, woken, env.stderr.String())
+		}
+		if cb.IsOpen(identity, env.clk.Now().UTC()) {
+			t.Fatalf("attempt %d (%s): breaker should stay CLOSED after assigned work progress", i+1, status)
+		}
+		if !env.sp.IsRunning("session-a") {
+			t.Fatalf("attempt %d (%s): session-a should be running after CLOSED breaker wake", i+1, status)
+		}
+		if err := env.sp.Stop("session-a"); err != nil {
+			t.Fatalf("attempt %d (%s): stop session-a: %v", i+1, status, err)
+		}
+		if err := env.store.SetMetadata(b.ID, "state", "asleep"); err != nil {
+			t.Fatalf("attempt %d (%s): set state asleep: %v", i+1, status, err)
+		}
+		if i < len(statuses)-1 {
+			env.clk.Advance(6 * time.Minute)
+		}
+	}
+
+	snap := cb.Snapshot(env.clk.Now().UTC())
+	if len(snap) != 1 || snap[0].Identity != identity || snap[0].State != circuitClosed.String() || snap[0].RestartCount != len(statuses) {
+		t.Fatalf("snapshot after progressing work = %+v, want one CLOSED entry with %d restarts", snap, len(statuses))
+	}
+	if strings.Contains(env.stderr.String(), "CIRCUIT_OPEN") {
+		t.Fatalf("did not expect CIRCUIT_OPEN log, got: %q", env.stderr.String())
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2352,7 +2352,9 @@ Request a fresh restart for an existing session without closing its bead.
 
 The controller stops the current runtime and starts the same session again with
 fresh provider conversation state. Session identity, alias, mail, and queued
-work remain attached to the existing session bead.
+work remain attached to the existing session bead. For named sessions, reset
+also clears any tripped named-session respawn circuit breaker before requesting
+the fresh restart.
 
 Accepts a session ID (e.g., gc-42) or session alias (e.g., mayor).
 


### PR DESCRIPTION
Follow-up to https://github.com/gastownhall/gascity/pull/563 (`fix: add respawn circuit breaker for named sessions`).

Original PR state: merged.
Configured base branch: `main`.
Original GitHub base branch: `main`.
Base mismatch: none.

This follow-up contains the maintainer-side review fixes that were still required after the original PR had already been merged. The original contribution added the named-session respawn circuit breaker; this branch keeps that change in `main` and adds the final polish from the adoption review.

Review fixes included here:
- Restrict controller-side breaker clearing in `gc session reset` to named-session identities.
- Update CLI help, generated CLI reference, and changelog text for the breaker-clear behavior.
- Keep the circuit-breaker snapshot helper internal until there is a real consumer.
- Add regression coverage proving assigned work status progress keeps the breaker closed.

The adoption review approved the final branch after the fix iteration, and the base refresh replayed the reviewed patch onto current `main` without changing the patch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->