### PR TITLE
fix: address PR 1111 post-merge findings

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand/v2"
 	"net"
 	"os"
 	"os/exec"
@@ -38,6 +37,18 @@ var cityDoltConfigs sync.Map // cityPath → config.DoltConfig
 // hammers the server back down. Each semaphore allows at most 1
 // concurrent provider operation per city (serialize lifecycle ops).
 var providerOpSemaphores sync.Map // cityPath → chan struct{}
+
+func cityDoltConfigHasLifecycleFields(cfg config.DoltConfig) bool {
+	return cfg.Host != "" || cfg.Port != 0 || cfg.ArchiveLevel != nil
+}
+
+func registerCityDoltConfig(cityPath string, cfg config.DoltConfig) {
+	cityDoltConfigs.Store(normalizePathForCompare(cityPath), cfg)
+}
+
+func clearCityDoltConfig(cityPath string) {
+	cityDoltConfigs.Delete(normalizePathForCompare(cityPath))
+}
 
 var resolveProviderLifecycleGCBinary = func() string {
 	if isTestBinary() {
@@ -103,10 +114,10 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, _ io.Writer) erro
 	// registration point — supervisor, standalone, and reload all flow
 	// through here. Always write (or clear) to handle config reload:
 	// removing [dolt] after a reload must not leave stale entries.
-	if cfg.Dolt.Host != "" || cfg.Dolt.Port != 0 {
-		cityDoltConfigs.Store(cityPath, cfg.Dolt)
+	if cityDoltConfigHasLifecycleFields(cfg.Dolt) {
+		registerCityDoltConfig(cityPath, cfg.Dolt)
 	} else {
-		cityDoltConfigs.Delete(cityPath)
+		clearCityDoltConfig(cityPath)
 	}
 	// Skip local Dolt startup only when canonical or compatibility topology
 	// says the city endpoint is external. Managed-local cities may not have a
@@ -230,6 +241,7 @@ func desiredScopeDoltConfigStateForInit(cityPath, dir, prefix string) (contract.
 	if strings.TrimSpace(dir) == "" || strings.TrimSpace(prefix) == "" {
 		return contract.ConfigState{}, false, nil
 	}
+	cityPath = normalizePathForCompare(cityPath)
 	cityDolt := config.DoltConfig{}
 	if cfg, err := loadCityConfig(cityPath, io.Discard); err == nil {
 		resolveRigPaths(cityPath, cfg.Rigs)
@@ -431,7 +443,10 @@ func ensureBeadsProvider(cityPath string) error {
 	}
 	provider := beadsProvider(cityPath)
 	if strings.HasPrefix(provider, "exec:") {
-		release := acquireProviderSemaphore(cityPath)
+		release, err := acquireProviderSemaphoreForOp(cityPath, "start")
+		if err != nil {
+			return err
+		}
 		defer release()
 
 		script := strings.TrimPrefix(provider, "exec:")
@@ -629,6 +644,7 @@ func forcedScopeDoltConfigStateForInit(cityPath, dir, prefix string) (contract.C
 	if strings.TrimSpace(dir) == "" || strings.TrimSpace(prefix) == "" {
 		return contract.ConfigState{}, false, nil
 	}
+	cityPath = normalizePathForCompare(cityPath)
 	cityDolt := config.DoltConfig{}
 	if cfg, err := loadCityConfig(cityPath, io.Discard); err == nil {
 		resolveRigPaths(cityPath, cfg.Rigs)
@@ -671,15 +687,17 @@ func initFileStoreForDir(cityPath, dir string) error {
 // provider, always healthy (no-op).
 //
 // Acquires a per-city semaphore to prevent concurrent health/recovery
-// operations from causing a thundering herd when dolt bounces. A random
-// jitter (0-2s) before recovery staggers reconnect attempts across callers.
+// operations from causing a thundering herd when dolt bounces.
 func healthBeadsProvider(cityPath string) error {
 	if cityUsesBdStoreContract(cityPath) && strings.TrimSpace(os.Getenv("GC_DOLT")) == "skip" {
 		return nil
 	}
 	provider := beadsProvider(cityPath)
 	if strings.HasPrefix(provider, "exec:") {
-		release := acquireProviderSemaphore(cityPath)
+		release, err := acquireProviderSemaphoreForOp(cityPath, "health")
+		if err != nil {
+			return err
+		}
 		defer release()
 
 		script := strings.TrimPrefix(provider, "exec:")
@@ -687,13 +705,6 @@ func healthBeadsProvider(cityPath string) error {
 		if err := runProviderOpWithEnv(script, providerEnv, "health"); err != nil {
 			if providerUsesBdStoreContract(provider) && isExternalDolt(cityPath) {
 				return err
-			}
-			// Jitter before recovery to stagger reconnect attempts when
-			// multiple callers detect dolt failure simultaneously.
-			// Skip jitter when the provider script doesn't exist —
-			// there's no dolt process to stagger against.
-			if _, statErr := os.Stat(script); statErr == nil {
-				time.Sleep(providerRecoveryJitter())
 			}
 			if recErr := runProviderOpWithEnv(script, providerEnv, "recover"); recErr != nil {
 				return fmt.Errorf("unhealthy (%w) and recovery failed: %w", err, recErr)
@@ -810,6 +821,7 @@ func configuredCityDoltTarget(cityPath string) (string, string, bool) {
 }
 
 func resolveConfiguredCityDoltTarget(cityPath string) (string, string, bool, bool) {
+	cityPath = normalizePathForCompare(cityPath)
 	resolved, err := contract.ResolveScopeConfigState(fsys.OSFS{}, cityPath, cityPath, "")
 	if err != nil {
 		var invalid *contract.InvalidCanonicalConfigError
@@ -1418,25 +1430,39 @@ func providerLifecycleProcessEnv(cityPath, provider string) []string {
 	return env
 }
 
-// acquireProviderSemaphore returns a per-city semaphore channel and
-// blocks until a slot is available. Call the returned function to release.
+// acquireProviderSemaphore returns a per-city semaphore channel and waits
+// until a slot is available or ctx is canceled. Call the returned function to
+// release. Semaphore entries intentionally live for the process lifetime:
+// deleting an entry while a lifecycle operation is still running would allow a
+// second channel for the same city and break serialization. The map is bounded
+// by city roots seen by this controller process.
 // This serializes lifecycle operations per city to prevent thundering herd
 // when dolt bounces: without this, concurrent health checks all trigger
 // recovery simultaneously, spawning a storm of processes that overwhelm
 // dolt on restart.
-func acquireProviderSemaphore(cityPath string) func() {
+func acquireProviderSemaphore(ctx context.Context, cityPath string) (func(), error) {
 	cityPath = normalizePathForCompare(cityPath)
 	v, _ := providerOpSemaphores.LoadOrStore(cityPath, make(chan struct{}, 1))
 	sem := v.(chan struct{})
-	sem <- struct{}{}
-	return func() { <-sem }
+	select {
+	case sem <- struct{}{}:
+		return func() { <-sem }, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for provider lifecycle slot for %q: %w", cityPath, ctx.Err())
+	}
 }
 
-// providerRecoveryJitter returns a random duration between 0 and 2 seconds.
-// Applied before recovery attempts to stagger reconnects when multiple
-// callers detect dolt failure simultaneously.
-var providerRecoveryJitter = func() time.Duration {
-	return time.Duration(rand.Int64N(int64(2 * time.Second)))
+func acquireProviderSemaphoreForOp(cityPath, op string) (func(), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), providerOpTimeout(op))
+	release, err := acquireProviderSemaphore(ctx, cityPath)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	return func() {
+		release()
+		cancel()
+	}, nil
 }
 
 // providerOpTimeout returns the context timeout for a given lifecycle

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -221,6 +221,36 @@ func TestGcBeadsBdReadOnlyFallbackDoesNotTargetLegacyProbeDatabase(t *testing.T)
 	}
 }
 
+func TestGcBeadsBdShellFallbackSanitizesArchiveLevel(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	script := string(scriptData)
+	for _, forbidden := range []string{
+		`--archive-level "${GC_DOLT_ARCHIVE_LEVEL:-0}"`,
+		"archive_level: ${GC_DOLT_ARCHIVE_LEVEL:-0}",
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("gc-beads-bd shell fallback uses unsanitized archive level pattern %q", forbidden)
+		}
+	}
+	for _, want := range []string{
+		"archive_level=${GC_DOLT_ARCHIVE_LEVEL:-0}",
+		"*[!0-9]*",
+		"--archive-level \"$archive_level\"",
+		"archive_level: $archive_level",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("gc-beads-bd shell fallback missing sanitized archive level pattern %q", want)
+		}
+	}
+}
+
 func TestGcBeadsBdInitRejectsManagedProbeDatabaseName(t *testing.T) {
 	for _, dbName := range []string{
 		managedDoltProbeDatabase,
@@ -8557,6 +8587,40 @@ func TestStartBeadsLifecycleRegistersDoltConfig(t *testing.T) {
 	}
 }
 
+func TestStartBeadsLifecycleRegistersArchiveLevelOnlyDoltConfig(t *testing.T) {
+	realCity := t.TempDir()
+	aliasRoot := t.TempDir()
+	aliasCity := filepath.Join(aliasRoot, "city-link")
+	if err := os.Symlink(realCity, aliasCity); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", aliasCity)
+	t.Setenv("GC_DOLT", "skip")
+
+	archiveLevel := 1
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Dolt:      config.DoltConfig{ArchiveLevel: &archiveLevel},
+	}
+	if err := startBeadsLifecycle(aliasCity, "test-city", cfg, io.Discard); err != nil {
+		t.Fatalf("startBeadsLifecycle: %v", err)
+	}
+	t.Cleanup(func() { cityDoltConfigs.Delete(normalizePathForCompare(realCity)) })
+
+	envEntries := providerLifecycleProcessEnv(realCity, "exec:"+gcBeadsBdScriptPath(realCity))
+	env := map[string]string{}
+	for _, entry := range envEntries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	if got := env["GC_DOLT_ARCHIVE_LEVEL"]; got != "1" {
+		t.Fatalf("GC_DOLT_ARCHIVE_LEVEL = %q, want 1", got)
+	}
+}
+
 func TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState(t *testing.T) {
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "rig")
@@ -9105,12 +9169,18 @@ func TestAcquireProviderSemaphore_SerializesConcurrentOps(t *testing.T) {
 	cityPath := t.TempDir()
 
 	// First acquire succeeds immediately.
-	release1 := acquireProviderSemaphore(cityPath)
+	release1, err := acquireProviderSemaphore(context.Background(), cityPath)
+	if err != nil {
+		t.Fatalf("acquireProviderSemaphore first: %v", err)
+	}
 
 	// Second acquire should block.
 	acquired := make(chan struct{})
 	go func() {
-		release2 := acquireProviderSemaphore(cityPath)
+		release2, err := acquireProviderSemaphore(context.Background(), cityPath)
+		if err != nil {
+			return
+		}
 		close(acquired)
 		release2()
 	}()
@@ -9138,13 +9208,19 @@ func TestAcquireProviderSemaphore_IndependentCities(t *testing.T) {
 	city1 := t.TempDir()
 	city2 := t.TempDir()
 
-	release1 := acquireProviderSemaphore(city1)
+	release1, err := acquireProviderSemaphore(context.Background(), city1)
+	if err != nil {
+		t.Fatalf("acquireProviderSemaphore city1: %v", err)
+	}
 	defer release1()
 
 	// Different city should not block.
 	acquired := make(chan struct{})
 	go func() {
-		release2 := acquireProviderSemaphore(city2)
+		release2, err := acquireProviderSemaphore(context.Background(), city2)
+		if err != nil {
+			return
+		}
 		close(acquired)
 		release2()
 	}()
@@ -9157,22 +9233,116 @@ func TestAcquireProviderSemaphore_IndependentCities(t *testing.T) {
 	}
 }
 
-func TestProviderRecoveryJitter_Range(t *testing.T) {
+func TestAcquireProviderSemaphoreHonorsContextDeadline(t *testing.T) {
 	t.Parallel()
-	for range 100 {
-		d := providerRecoveryJitter()
-		if d < 0 || d >= 2*time.Second {
-			t.Fatalf("jitter = %v, want [0, 2s)", d)
-		}
+	cityPath := t.TempDir()
+
+	release1, err := acquireProviderSemaphore(context.Background(), cityPath)
+	if err != nil {
+		t.Fatalf("acquireProviderSemaphore first: %v", err)
+	}
+	defer release1()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	release2, err := acquireProviderSemaphore(ctx, cityPath)
+	if err == nil {
+		release2()
+		t.Fatal("second acquire succeeded while first still held")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("acquireProviderSemaphore error = %v, want context deadline", err)
 	}
 }
 
-func TestProviderRecoveryJitter_Overridable(t *testing.T) {
-	orig := providerRecoveryJitter
-	providerRecoveryJitter = func() time.Duration { return 0 }
-	defer func() { providerRecoveryJitter = orig }()
+func TestEnsureBeadsProviderSerializesConcurrentExecStarts(t *testing.T) {
+	cityPath := t.TempDir()
+	script := filepath.Join(cityPath, "provider.sh")
+	lockDir := filepath.Join(cityPath, "provider.lock")
+	callLog := filepath.Join(cityPath, "provider.log")
+	scriptBody := fmt.Sprintf(`#!/bin/sh
+set -eu
+if [ "$1" = "start" ]; then
+  if ! mkdir %q 2>/dev/null; then
+    echo "overlap" >&2
+    exit 1
+  fi
+  echo "start" >> %q
+  sleep 0.1
+  rmdir %q
+  exit 0
+fi
+exit 2
+`, lockDir, callLog, lockDir)
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 
-	if d := providerRecoveryJitter(); d != 0 {
-		t.Fatalf("overridden jitter = %v, want 0", d)
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errs <- ensureBeadsProvider(cityPath)
+		}()
+	}
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("ensureBeadsProvider: %v", err)
+		}
+	}
+
+	data, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if got := strings.Count(string(data), "start"); got != 2 {
+		t.Fatalf("start call count = %d, want 2; log:\n%s", got, data)
+	}
+}
+
+func TestHealthBeadsProviderSerializesConcurrentExecHealthChecks(t *testing.T) {
+	cityPath := t.TempDir()
+	script := filepath.Join(cityPath, "provider.sh")
+	lockDir := filepath.Join(cityPath, "provider.lock")
+	callLog := filepath.Join(cityPath, "provider.log")
+	scriptBody := fmt.Sprintf(`#!/bin/sh
+set -eu
+if [ "$1" = "health" ]; then
+  if ! mkdir %q 2>/dev/null; then
+    echo "overlap" >&2
+    exit 1
+  fi
+  echo "health" >> %q
+  sleep 0.1
+  rmdir %q
+  exit 0
+fi
+exit 2
+`, lockDir, callLog, lockDir)
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "exec:"+script)
+	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
+
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errs <- healthBeadsProvider(cityPath)
+		}()
+	}
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("healthBeadsProvider: %v", err)
+		}
+	}
+
+	data, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if got := strings.Count(string(data), "health"); got != 2 {
+		t.Fatalf("health call count = %d, want 2; log:\n%s", got, data)
 	}
 }

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -229,9 +229,9 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		fmt.Fprintf(stderr, "gc rig add: loading config: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if cityUsesBdStoreContract(cityPath) && (cfg.Dolt.Host != "" || cfg.Dolt.Port != 0) {
-		cityDoltConfigs.Store(cityPath, cfg.Dolt)
-		defer cityDoltConfigs.Delete(cityPath)
+	if cityUsesBdStoreContract(cityPath) && cityDoltConfigHasLifecycleFields(cfg.Dolt) {
+		registerCityDoltConfig(cityPath, cfg.Dolt)
+		defer clearCityDoltConfig(cityPath)
 	}
 	rootDefaultRigImports, err := config.LoadRootPackDefaultRigImports(fs, cityPath)
 	if err != nil {

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1022,7 +1022,13 @@ cleanup_stale_locks() {
 # Overwritten on each server start. Without read/write timeouts, CLOSE_WAIT connections
 # accumulate and the server enters unrecoverable read-only mode.
 write_config_yaml() {
-    local gc_bin
+    local archive_level gc_bin
+    archive_level=${GC_DOLT_ARCHIVE_LEVEL:-0}
+    case "$archive_level" in
+        ''|*[!0-9]*)
+            archive_level=0
+            ;;
+    esac
     gc_bin=$(resolve_gc_helper_bin)
     if [ -n "$gc_bin" ]; then
         "$gc_bin" dolt-config write-managed \
@@ -1031,7 +1037,7 @@ write_config_yaml() {
             --port "$DOLT_PORT" \
             --data-dir "$DATA_DIR" \
             --log-level "$DOLT_LOGLEVEL" \
-            --archive-level "${GC_DOLT_ARCHIVE_LEVEL:-0}" || die "failed to write managed dolt config via gc helper $gc_bin"
+            --archive-level "$archive_level" || die "failed to write managed dolt config via gc helper $gc_bin"
         return 0
     fi
     local tmp
@@ -1058,7 +1064,7 @@ data_dir: "$DATA_DIR"
 behavior:
   auto_gc_behavior:
     enable: true
-    archive_level: ${GC_DOLT_ARCHIVE_LEVEL:-0}
+    archive_level: $archive_level
 YAML
     mv "$tmp" "$CONFIG_FILE"
 }

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -691,14 +691,23 @@ func (s *BdStore) waitForParentProjection(ctx context.Context, id, oldParentID, 
 
 	var lastErr error
 	for {
-		matches, err := s.parentProjectionMatches(id, oldParentID, newParentID)
-		if err == nil && matches {
-			return nil
+		current, err := s.Get(id)
+		if err == nil {
+			switch current.ParentID {
+			case newParentID:
+				matches, matchErr := s.parentProjectionMatches(id, oldParentID, newParentID)
+				if matchErr == nil && matches {
+					return nil
+				}
+				lastErr = matchErr
+			case oldParentID:
+				lastErr = nil
+			default:
+				return fmt.Errorf("updating bead %q: %w", id, ErrParentProjectionSuperseded)
+			}
+		} else {
+			lastErr = err
 		}
-		if superseded, supersededErr := s.parentProjectionSuperseded(id, oldParentID, newParentID); supersededErr == nil && superseded {
-			return fmt.Errorf("updating bead %q: %w", id, ErrParentProjectionSuperseded)
-		}
-		lastErr = err
 		select {
 		case <-ctx.Done():
 			if lastErr != nil {
@@ -708,17 +717,6 @@ func (s *BdStore) waitForParentProjection(ctx context.Context, id, oldParentID, 
 		case <-ticker.C:
 		}
 	}
-}
-
-func (s *BdStore) parentProjectionSuperseded(id, oldParentID, newParentID string) (bool, error) {
-	current, err := s.Get(id)
-	if err != nil {
-		return false, err
-	}
-	if current.ParentID == newParentID || current.ParentID == oldParentID {
-		return false, nil
-	}
-	return true, nil
 }
 
 func (s *BdStore) parentProjectionMatches(id, oldParentID, newParentID string) (bool, error) {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -423,6 +423,7 @@ func TestBdStoreUpdatePassesPriority(t *testing.T) {
 
 func TestBdStoreWaitForParentProjection(t *testing.T) {
 	var mu sync.Mutex
+	showCalls := 0
 	parentListCalls := 0
 
 	runner := func(_, _ string, args ...string) ([]byte, error) {
@@ -432,6 +433,12 @@ func TestBdStoreWaitForParentProjection(t *testing.T) {
 		defer mu.Unlock()
 
 		switch cmd {
+		case "show --json bd-child":
+			showCalls++
+			if showCalls == 1 {
+				return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`), nil
+			}
+			return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","parent":"bd-parent"}]`), nil
 		case "list --json --include-infra --include-gates --limit 0 --parent bd-parent":
 			parentListCalls++
 			if parentListCalls == 1 {
@@ -454,6 +461,7 @@ func TestBdStoreWaitForParentProjection(t *testing.T) {
 
 func TestBdStoreWaitForParentRemovalProjection(t *testing.T) {
 	var mu sync.Mutex
+	showCalls := 0
 	oldParentListCalls := 0
 
 	runner := func(_, _ string, args ...string) ([]byte, error) {
@@ -463,6 +471,12 @@ func TestBdStoreWaitForParentRemovalProjection(t *testing.T) {
 		defer mu.Unlock()
 
 		switch cmd {
+		case "show --json bd-child":
+			showCalls++
+			if showCalls == 1 {
+				return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","parent":"bd-parent"}]`), nil
+			}
+			return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`), nil
 		case "list --json --include-infra --include-gates --limit 0 --parent bd-parent":
 			oldParentListCalls++
 			if oldParentListCalls == 1 {
@@ -502,6 +516,48 @@ func TestBdStoreWaitForParentProjectionDetectsSupersededParent(t *testing.T) {
 	err := s.WaitForParentProjection(context.Background(), "bd-child", "bd-old", "bd-new")
 	if !errors.Is(err, beads.ErrParentProjectionSuperseded) {
 		t.Fatalf("err = %v, want ErrParentProjectionSuperseded", err)
+	}
+}
+
+func TestBdStoreWaitForParentProjectionGetsBeforeListing(t *testing.T) {
+	var mu sync.Mutex
+	showCalls := 0
+	listedBeforeCurrentParentChanged := false
+
+	runner := func(_, _ string, args ...string) ([]byte, error) {
+		cmd := strings.Join(args, " ")
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch cmd {
+		case "show --json bd-child":
+			showCalls++
+			if showCalls == 1 {
+				return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","parent":"bd-old"}]`), nil
+			}
+			return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","parent":"bd-new"}]`), nil
+		case "list --json --include-infra --include-gates --limit 0 --parent bd-old":
+			if showCalls < 2 {
+				listedBeforeCurrentParentChanged = true
+			}
+			return []byte(`[]`), nil
+		case "list --json --include-infra --include-gates --limit 0 --parent bd-new":
+			if showCalls < 2 {
+				listedBeforeCurrentParentChanged = true
+			}
+			return []byte(`[{"id":"bd-child","title":"child","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","parent":"bd-new"}]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: bd %s", cmd)
+		}
+	}
+
+	s := beads.NewBdStore("/city", runner)
+	if err := s.WaitForParentProjection(context.Background(), "bd-child", "bd-old", "bd-new"); err != nil {
+		t.Fatalf("WaitForParentProjection: %v", err)
+	}
+	if listedBeforeCurrentParentChanged {
+		t.Fatal("WaitForParentProjection listed parent children before Get observed the new parent")
 	}
 }
 

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2523,7 +2523,7 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 				drifted = append(drifted, fmt.Sprintf("%s (got %v, want %v)", exp.Path, got, want))
 			}
 		case int:
-			if !yamlIntEqual(got, want) {
+			if !doltConfigExpectedIntEqual(exp.Path, got, want) {
 				drifted = append(drifted, fmt.Sprintf("%s (got %v, want %d)", exp.Path, got, want))
 			}
 		default:
@@ -2552,6 +2552,20 @@ func (c *DoltConfigCheck) Run(_ *CheckContext) *CheckResult {
 	r.Status = StatusOK
 	r.Message = "dolt config OK"
 	return r
+}
+
+func doltConfigExpectedIntEqual(path string, got any, want int) bool {
+	if yamlIntEqual(got, want) {
+		return true
+	}
+	// Managed configs written before archive_level defaulted to 0 can contain
+	// archive_level: 1. Accept that one-release compatibility value so first
+	// post-upgrade doctor runs do not report drift before gc start rewrites the
+	// managed config.
+	if path == "behavior.auto_gc_behavior.archive_level" && want == 0 {
+		return yamlIntEqual(got, 1)
+	}
+	return false
 }
 
 // CanFix returns false. TODO: wire Fix() into the same code path as

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -3075,6 +3075,18 @@ func TestDoltConfigCheck_OK(t *testing.T) {
 	}
 }
 
+func TestDoltConfigCheck_AcceptsLegacyArchiveLevelOne(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"behavior.auto_gc_behavior.archive_level": 1,
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK for one-release archive_level=1 compatibility; msg = %s", r.Status, r.Message)
+	}
+}
+
 func TestDoltConfigCheck_UsesTrustedCityRuntimeDir(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	customRuntimeDir := filepath.Join(t.TempDir(), "runtime-root")


### PR DESCRIPTION
Post-merge remediation follow-up for #1111.

## Summary
- Preserve `[dolt] archive_level` through managed Dolt lifecycle registration, including archive-level-only city config.
- Bound per-city provider lifecycle semaphore acquisition and remove misleading recovery jitter behavior while keeping lifecycle operations serialized.
- Reduce parent projection polling pressure by checking the bead's current parent before listing parent children.
- Add one-release doctor compatibility for legacy managed `archive_level: 1` configs.
- Sanitize `GC_DOLT_ARCHIVE_LEVEL` in the shell fallback before writing managed Dolt YAML.

## Tests
- `go test ./cmd/gc -run 'Test(StartBeadsLifecycleRegistersArchiveLevelOnlyDoltConfig|AcquireProviderSemaphore|EnsureBeadsProviderSerializesConcurrentExecStarts|HealthBeadsProviderSerializesConcurrentExecHealthChecks|GcBeadsBdShellFallbackSanitizesArchiveLevel)'`
- `go test ./internal/beads -run 'TestBdStoreWaitForParent'`
- `go test ./internal/doctor -run 'TestDoltConfigCheck_(OK|AcceptsLegacyArchiveLevelOne)'`
- `make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->