### PR TITLE
fix(session): honor pending create start lease

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -151,6 +151,10 @@ func pendingCreateSessionStillLeased(session beads.Bead, cfg *config.City, clk c
 	}
 	pendingCreate := strings.TrimSpace(session.Metadata["pending_create_claim"]) == "true" &&
 		strings.TrimSpace(session.Metadata["state"]) == "creating"
+	// Configured templates without current demand are not preserved forever
+	// merely because their agent still exists. Once the pending-create lease
+	// expires, the bead falls through to orphan/rollback handling so its alias
+	// can be released.
 	if pendingCreate && pendingCreateLeaseExpiredForRollback(session, clk, startupTimeout) {
 		return false
 	}
@@ -192,11 +196,9 @@ func pendingCreateStartInFlight(session beads.Bead, clk clock.Clock, startupTime
 }
 
 // pendingCreateNeverStartedTimeout is the rollback floor for pending creates
-// that have not reached preWakeCommit and therefore have no last_woke_at start
-// lease. The same empty-last_woke_at shape is used after recoverable provider
-// start failures because commitStartResultTraced clears the lease before
-// recordWakeFailure applies retry/quarantine backoff, so this timeout also
-// bounds that retry-bead cleanup path.
+// with no last_woke_at start lease. Production-created pending beads record
+// pending_create_started_at when they enter state=creating; use that timestamp
+// as the lease anchor when present, with CreatedAt as the legacy fallback.
 //
 // It is intentionally longer than staleCreatingStateTimeout: that one-minute
 // window still handles corrupt/unparseable last_woke_at metadata and generic
@@ -214,14 +216,18 @@ func pendingCreateNeverStartedExpired(session beads.Bead, clk clock.Clock) bool 
 	if strings.TrimSpace(session.Metadata["last_woke_at"]) != "" {
 		return false
 	}
-	if session.CreatedAt.IsZero() {
+	anchor := session.CreatedAt
+	if started, ok := parseRFC3339Metadata(session.Metadata["pending_create_started_at"]); ok {
+		anchor = started
+	}
+	if anchor.IsZero() {
 		return true
 	}
 	now := time.Now()
 	if clk != nil {
 		now = clk.Now()
 	}
-	return now.After(session.CreatedAt.Add(pendingCreateNeverStartedTimeout))
+	return now.After(anchor.Add(pendingCreateNeverStartedTimeout))
 }
 
 func pendingCreateLeaseExpiredForRollback(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
@@ -235,9 +241,6 @@ func pendingCreateLeaseExpiredForRollback(session beads.Bead, clk clock.Clock, s
 		return false
 	}
 	if strings.TrimSpace(session.Metadata["last_woke_at"]) == "" {
-		if _, ok := parseRFC3339Metadata(session.Metadata["pending_create_started_at"]); ok {
-			return staleCreatingState(session, clk)
-		}
 		return pendingCreateNeverStartedExpired(session, clk)
 	}
 	return staleCreatingState(session, clk)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2420,13 +2420,15 @@ func TestReconcileSessionBeads_FreshPendingCreateSurvivesStaleConfigSnapshot(t *
 func TestReconcileSessionBeads_PendingCreateWithoutDesiredStateUsesNeverStartedLease(t *testing.T) {
 	env := newReconcilerTestEnv()
 	session := env.createSessionBead("s-gc-late", "worker")
+	startedAt := env.clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Minute))
 	env.setSessionMetadata(&session, map[string]string{
-		"state":                "creating",
-		"pending_create_claim": "true",
+		"state":                     "creating",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": pendingCreateStartedAtNow(startedAt),
 		// last_woke_at deliberately empty: preWakeCommit never fired before
 		// this pending create left desired state.
 	})
-	session.CreatedAt = env.clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Minute))
+	session.CreatedAt = env.clk.Now().Add(-24 * time.Hour)
 
 	woken := env.reconcile([]beads.Bead{session})
 	if woken != 0 {
@@ -2447,17 +2449,17 @@ func TestReconcileSessionBeads_PendingCreateWithoutDesiredStateUsesNeverStartedL
 func TestReconcileSessionBeads_ConfiguredPendingCreateWithoutDemandUsesNeverStartedLease(t *testing.T) {
 	tests := []struct {
 		name       string
-		createdAt  time.Time
+		startedAt  time.Time
 		wantClosed bool
 	}{
 		{
 			name:       "before lease expires",
-			createdAt:  time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC).Add(-(pendingCreateNeverStartedTimeout - time.Minute)),
+			startedAt:  time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC).Add(-(pendingCreateNeverStartedTimeout - time.Minute)),
 			wantClosed: false,
 		},
 		{
 			name:       "after lease expires",
-			createdAt:  time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC).Add(-(pendingCreateNeverStartedTimeout + time.Second)),
+			startedAt:  time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC).Add(-(pendingCreateNeverStartedTimeout + time.Second)),
 			wantClosed: true,
 		},
 	}
@@ -2468,12 +2470,13 @@ func TestReconcileSessionBeads_ConfiguredPendingCreateWithoutDemandUsesNeverStar
 			env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
 			session := env.createSessionBead("s-gc-late", "worker")
 			env.setSessionMetadata(&session, map[string]string{
-				"state":                "creating",
-				"pending_create_claim": "true",
+				"state":                     "creating",
+				"pending_create_claim":      "true",
+				"pending_create_started_at": pendingCreateStartedAtNow(tt.startedAt),
 				// last_woke_at deliberately empty: preWakeCommit never fired before
 				// this configured template lost pool demand.
 			})
-			session.CreatedAt = tt.createdAt
+			session.CreatedAt = env.clk.Now().Add(-24 * time.Hour)
 
 			woken := env.reconcile([]beads.Bead{session})
 			if woken != 0 {
@@ -3381,21 +3384,22 @@ func TestReconcileSessionBeads_PreservesNeverStartedPendingCreateBeforeLeaseExpi
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "template:helper"},
 		Metadata: map[string]string{
-			"session_name":          "helper",
-			"session_name_explicit": "true",
-			"pending_create_claim":  "true",
-			"template":              "helper",
-			"state":                 "creating",
-			"generation":            "1",
-			"continuation_epoch":    "1",
-			"instance_token":        "test-token",
+			"session_name":              "helper",
+			"session_name_explicit":     "true",
+			"pending_create_claim":      "true",
+			"pending_create_started_at": pendingCreateStartedAtNow(clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Minute))),
+			"template":                  "helper",
+			"state":                     "creating",
+			"generation":                "1",
+			"continuation_epoch":        "1",
+			"instance_token":            "test-token",
 			// last_woke_at deliberately empty — preWakeCommit never fired.
 		},
 	})
 	if err != nil {
 		t.Fatalf("Create(bead): %v", err)
 	}
-	bead.CreatedAt = clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Minute))
+	bead.CreatedAt = clk.Now().Add(-24 * time.Hour)
 
 	var stdout, stderr bytes.Buffer
 	cfgNames := configuredSessionNames(cfg, "", store)
@@ -3441,24 +3445,24 @@ func TestReconcileSessionBeads_RollsBackPendingCreateWhenLeaseExpiredAndNoRuntim
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "template:helper"},
 		Metadata: map[string]string{
-			"session_name":          "helper",
-			"session_name_explicit": "true",
-			"pending_create_claim":  "true",
-			"template":              "helper",
-			"state":                 "creating",
-			"generation":            "1",
-			"continuation_epoch":    "1",
-			"instance_token":        "test-token",
+			"session_name":              "helper",
+			"session_name_explicit":     "true",
+			"pending_create_claim":      "true",
+			"pending_create_started_at": pendingCreateStartedAtNow(clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second))),
+			"template":                  "helper",
+			"state":                     "creating",
+			"generation":                "1",
+			"continuation_epoch":        "1",
+			"instance_token":            "test-token",
 			// last_woke_at deliberately empty — preWakeCommit never fired.
 		},
 	})
 	if err != nil {
 		t.Fatalf("Create(bead): %v", err)
 	}
-	// Force CreatedAt past the never-started pending-create window. The
-	// reconciler reads CreatedAt from the passed bead slice, so modifying the
-	// local copy is sufficient.
-	bead.CreatedAt = clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second))
+	// Keep CreatedAt fresh to prove production pending_create_started_at anchors
+	// the never-started pending-create lease for desired sessions.
+	bead.CreatedAt = clk.Now().Add(-time.Minute)
 
 	var stdout, stderr bytes.Buffer
 	cfgNames := configuredSessionNames(cfg, "", store)
@@ -3683,6 +3687,7 @@ func TestPendingCreateNeverStartedExpiredEdges(t *testing.T) {
 	tests := []struct {
 		name      string
 		createdAt time.Time
+		startedAt string
 		want      bool
 	}{
 		{
@@ -3705,11 +3710,30 @@ func TestPendingCreateNeverStartedExpiredEdges(t *testing.T) {
 			createdAt: time.Time{},
 			want:      true,
 		},
+		{
+			name:      "started at overrides older created at before boundary",
+			createdAt: clk.Now().Add(-24 * time.Hour),
+			startedAt: pendingCreateStartedAtNow(clk.Now().Add(-(pendingCreateNeverStartedTimeout - time.Second))),
+			want:      false,
+		},
+		{
+			name:      "started at overrides fresh created at after boundary",
+			createdAt: clk.Now().Add(-time.Minute),
+			startedAt: pendingCreateStartedAtNow(clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second))),
+			want:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bead := base
+			if tt.startedAt != "" {
+				bead.Metadata = map[string]string{
+					"pending_create_claim":      "true",
+					"pending_create_started_at": tt.startedAt,
+					"state":                     "creating",
+				}
+			}
 			bead.CreatedAt = tt.createdAt
 			if got := pendingCreateNeverStartedExpired(bead, clk); got != tt.want {
 				t.Fatalf("pendingCreateNeverStartedExpired() = %v, want %v", got, tt.want)
@@ -3889,13 +3913,13 @@ func TestReconcileSessionBeads_RollbackBudgetDefersExcessStaleNoRuntimeCreatesAn
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "helper"}}}
 
 	var sessions []beads.Bead
-	staleStartedAt := pendingCreateStartedAtNow(env.clk.Now().Add(-2 * time.Minute))
+	staleStartedAt := pendingCreateStartedAtNow(env.clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second)))
 	for i := 0; i < 6; i++ {
 		name := fmt.Sprintf("sky-%d", i)
 		env.addDesired(name, "helper", false)
 		session := env.createSessionBead(name, "helper")
 		env.markSessionCreating(&session)
-		session.CreatedAt = env.clk.Now().Add(-2 * time.Minute)
+		session.CreatedAt = env.clk.Now().Add(-24 * time.Hour)
 		env.setSessionMetadata(&session, map[string]string{
 			"pending_create_claim":      "true",
 			"pending_create_started_at": staleStartedAt,


### PR DESCRIPTION
Post-merge remediation for #1667.

Summary:
- use pending_create_started_at as the never-started pending-create lease anchor when last_woke_at is empty
- make configured pending creates without current demand fall through to rollback after their lease expires
- add production-shaped desired and non-desired reconciler coverage for pending_create_started_at

Tests:
- go test ./cmd/gc -run 'TestReconcileSessionBeads_(PendingCreateWithoutDesiredStateUsesNeverStartedLease|ConfiguredPendingCreateWithoutDemandUsesNeverStartedLease|PreservesNeverStartedPendingCreateBeforeLeaseExpires|RollsBackPendingCreateWhenLeaseExpiredAndNoRuntime|RollbackBudgetDefersExcessStaleNoRuntimeCreatesAndStillStarts)|TestPendingCreateNeverStartedExpiredEdges|TestPendingCreateLeaseExpiredForRollbackFallsBackToStaleWindowForInvalidLastWokeAt'
- make test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->