### PR TITLE
fix: post-merge remediation for PR 1586

### DIFF
--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -605,11 +605,12 @@ func recordRateLimitQuarantine(session *beads.Bead, store beads.Store, clk clock
 	}
 	qUntil := clk.Now().Add(defaultRateLimitQuarantineDuration).UTC().Format(time.RFC3339)
 	batch := map[string]string{
-		"state":                string(sessionpkg.StateAsleep),
-		"quarantined_until":    qUntil,
-		"sleep_reason":         "rate_limit",
-		"last_woke_at":         "",
-		"pending_create_claim": "",
+		"state":                     string(sessionpkg.StateAsleep),
+		"quarantined_until":         qUntil,
+		"sleep_reason":              "rate_limit",
+		"last_woke_at":              "",
+		"pending_create_claim":      "",
+		"pending_create_started_at": "",
 	}
 	if err := store.SetMetadataBatch(session.ID, batch); err != nil {
 		fmt.Fprintf(os.Stderr, "recordRateLimitQuarantine: SetMetadataBatch %s: %v\n", session.ID, err) //nolint:errcheck

--- a/cmd/gc/session_reconcile_ratelimit_test.go
+++ b/cmd/gc/session_reconcile_ratelimit_test.go
@@ -88,6 +88,36 @@ func TestCheckStability_RateLimitScreen_DoesNotCountAsCrash(t *testing.T) {
 	}
 }
 
+func TestCheckStability_RateLimitPendingCreateClearsStartedAt(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	store := newTestStore()
+	dt := newDrainTracker()
+
+	session := makeBead("b1", map[string]string{
+		"last_woke_at":              now.Add(-2 * time.Minute).Format(time.RFC3339),
+		"session_key":               "keep-session",
+		"started_config_hash":       "keep-hash",
+		"wake_attempts":             "3",
+		"pending_create_claim":      "true",
+		"pending_create_started_at": now.Add(-20 * time.Second).Format(time.RFC3339),
+	})
+
+	peek := func(_ int) (string, error) {
+		return "You've hit your limit, Pro plan\n\n/rate-limit-options", nil
+	}
+
+	if !checkStability(&session, nil, false, dt, store, clk, peek) {
+		t.Fatal("checkStability should return true when it records a rate-limit hold")
+	}
+	if session.Metadata["pending_create_claim"] != "" {
+		t.Error("pending_create_claim should be cleared after rate-limit detection")
+	}
+	if session.Metadata["pending_create_started_at"] != "" {
+		t.Error("pending_create_started_at should be cleared with pending_create_claim")
+	}
+}
+
 func TestCheckRateLimitStability_BeforeHealPreservesResumeMetadata(t *testing.T) {
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 	clk := &clock.Fake{Time: now}

--- a/internal/api/handler_session_stream.go
+++ b/internal/api/handler_session_stream.go
@@ -110,7 +110,7 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	running := workerPhaseHasLiveOutput(state.Phase)
-	if !hasHistory && !running && format != "raw" {
+	if !hasHistory && !running {
 		writeError(w, http.StatusNotFound, "not_found", "session "+id+" has no live output")
 		return
 	}
@@ -159,18 +159,7 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 		// No log file yet. If the session is running, poll tmux pane content
 		// and wrap it as a fake raw JSONL assistant message so a real-world app's existing
 		// rendering pipeline shows terminal output (e.g. OAuth prompts).
-		if running {
-			s.streamSessionPeekRaw(ctx, w, info, handle)
-		} else {
-			data, _ := json.Marshal(SessionStreamRawMessageEvent{
-				ID:       info.ID,
-				Template: info.Template,
-				Provider: info.Provider,
-				Format:   "raw",
-				Messages: []SessionRawMessageFrame{},
-			})
-			writeSSE(w, "message", 1, data)
-		}
+		s.streamSessionPeekRaw(ctx, w, info, handle)
 		return
 	default:
 		s.streamSessionPeek(ctx, w, info, handle)

--- a/internal/api/handler_sessions_test.go
+++ b/internal/api/handler_sessions_test.go
@@ -4695,7 +4695,7 @@ func TestHandleSessionStreamStoppedWithoutOutputReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestHandleSessionStreamRawStoppedWithoutOutputReturnsEmptyStream(t *testing.T) {
+func TestHandleSessionStreamRawStoppedWithoutOutputReturnsNotFound(t *testing.T) {
 	fs := newSessionFakeState(t)
 	srv := New(fs)
 	h := newTestCityHandlerWith(t, fs, srv)
@@ -4714,14 +4714,31 @@ func TestHandleSessionStreamRawStoppedWithoutOutputReturnsEmptyStream(t *testing
 	req := httptest.NewRequest("GET", cityURL(fs, "/session/")+info.ID+"/stream?format=raw", nil)
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("got status %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("got status %d, want %d; body: %s", rec.Code, http.StatusNotFound, rec.Body.String())
 	}
-	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
-		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+}
+
+func TestLegacySessionStreamRawStoppedWithoutOutputReturnsNotFound(t *testing.T) {
+	fs := newSessionFakeState(t)
+	srv := New(fs)
+	srv.sessionLogSearchPaths = []string{t.TempDir()}
+
+	mgr := session.NewManager(fs.cityBeadStore, fs.sp)
+	info, err := mgr.Create(context.Background(), "default", "No Output", "echo test", t.TempDir(), "test", nil, session.ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	if !strings.Contains(rec.Body.String(), `"format":"raw"`) || !strings.Contains(rec.Body.String(), `"messages":[]`) {
-		t.Fatalf("raw stream body missing empty raw frame: %s", rec.Body.String())
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v0/session/"+info.ID+"/stream?format=raw", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("got status %d, want %d; body: %s", rec.Code, http.StatusNotFound, rec.Body.String())
 	}
 }
 

--- a/internal/api/huma_handlers_sessions_stream.go
+++ b/internal/api/huma_handlers_sessions_stream.go
@@ -51,7 +51,7 @@ func (s *Server) resolveSessionStream(ctx context.Context, input *SessionStreamI
 		return nil, humaSessionManagerError(stateErr)
 	}
 	running := workerPhaseHasLiveOutput(state.Phase)
-	if !hasHistory && !running && input.Format != "raw" {
+	if !hasHistory && !running {
 		return nil, huma.Error404NotFound("session " + id + " has no live output")
 	}
 
@@ -136,17 +136,7 @@ func (s *Server) streamSession(hctx huma.Context, input *SessionStreamInput, sen
 			s.streamSessionTranscriptLogHuma(reqCtx, send, info, handle, history)
 		}
 	case format == "raw":
-		if running {
-			s.streamSessionPeekRawHuma(reqCtx, send, info)
-		} else {
-			_ = send(sse.Message{ID: 1, Data: SessionStreamRawMessageEvent{
-				ID:       info.ID,
-				Template: info.Template,
-				Provider: info.Provider,
-				Format:   "raw",
-				Messages: []SessionRawMessageFrame{},
-			}})
-		}
+		s.streamSessionPeekRawHuma(reqCtx, send, info)
 	default:
 		s.streamSessionPeekHuma(reqCtx, send, info)
 	}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -570,6 +570,32 @@ func TestCreateBeadOnlyNamed_UsesExplicitSessionName(t *testing.T) {
 	}
 }
 
+func TestCreateAliasedBeadOnlyNamed_SetsPendingCreateMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	sp := runtime.NewFake()
+	mgr := NewManager(store, sp)
+
+	info, err := mgr.CreateAliasedBeadOnlyNamed("worker", "test-city--worker", "worker", "queued", "claude", "/tmp", "claude", "", nil, ProviderResume{})
+	if err != nil {
+		t.Fatalf("CreateAliasedBeadOnlyNamed: %v", err)
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := b.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want true", got)
+	}
+	startedAt := b.Metadata["pending_create_started_at"]
+	if startedAt == "" {
+		t.Fatal("pending_create_started_at is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, startedAt); err != nil {
+		t.Fatalf("pending_create_started_at = %q, want RFC3339: %v", startedAt, err)
+	}
+}
+
 func TestCreateBeadOnly_SetsPendingCreateClaimForWakeSignal(t *testing.T) {
 	store := beads.NewMemStore()
 	sp := runtime.NewFake()


### PR DESCRIPTION
## Summary

Post-merge remediation for #1586.

- restores the raw session stream no-history stopped-session contract to return 404 instead of an empty raw SSE stream
- clears `pending_create_started_at` with `pending_create_claim` when rate-limit quarantine records a stopped pending create
- adds targeted coverage for named aliased bead creation pending-create metadata

## Testing

- `go test ./internal/api -run 'Test(HandleSessionStreamRawStoppedWithoutOutputReturnsNotFound|LegacySessionStreamRawStoppedWithoutOutputReturnsNotFound)' -count=1`
- `GC_FAST_UNIT=1 go test ./cmd/gc -run 'TestCheckStability_RateLimit(Screen_DoesNotCountAsCrash|PendingCreateClearsStartedAt)|TestExecutePreparedStartWave_RateLimitPendingCreateDeathClearsClaim' -count=1`
- `go test ./internal/session -run TestCreateAliasedBeadOnlyNamed_SetsPendingCreateMetadata -count=1`
- `go test ./internal/api ./internal/session -count=1`
- `git diff --check`
- `make dashboard-check`
- `make test`
- repository pre-commit hook on commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->