### PR TITLE
fix: keep assigned workflow sessions waking

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -585,12 +585,12 @@ func collectAssignedWorkBeadsWithStores(
 	}
 	skipReadyAssignees := assignedWorkAssigneeSet(result)
 	expandSkipAssigneesWithSessionIdentities(skipReadyAssignees, sessionBeads)
-	if len(skipReadyAssignees) > 0 {
+	assignees := readyAssignedWorkAssignees(cfg, sessionBeads, skipReadyAssignees)
+	if len(skipReadyAssignees) > 0 && len(assignees) == 0 {
 		return result, resultStores, resultStoreRefs, partial
 	}
 
 	readyResults := make([]storeAssignedWorkResult, len(stores))
-	assignees := readyAssignedWorkAssignees(cfg, sessionBeads, skipReadyAssignees)
 	for idx, source := range stores {
 		idx, source := idx, source
 		wg.Add(1)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -39,10 +39,8 @@ type DesiredStateResult struct {
 	// this scope before treating a bead as reachable work for that agent.
 	AssignedWorkStoreRefs []string
 	// NamedSessionDemand records which named-session identities have active
-	// demand — either direct assignee demand (Assignee == identity) or
-	// work_query-detected ready work. The reconciler merges this into
-	// poolDesired so that on-demand named sessions remain config-eligible
-	// even when no gc.routed_to metadata exists for the template.
+	// direct assignee demand (Assignee == identity). The reconciler merges this
+	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
 	// StoreQueryPartial is true when one or more bead store queries failed
 	// during assigned-work snapshot collection. When set, the reconciler must NOT
@@ -295,7 +293,7 @@ func buildDesiredStateWithSessionBeads(
 	var storePartial bool
 	var scaleCheckCounts map[string]int
 	if store != nil {
-		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths)
+		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
 		if storePartial {
 			fmt.Fprintf(stderr, "assignedWorkBeads: PARTIAL — store query failed, drain decisions suppressed\n") //nolint:errcheck
 		}
@@ -357,9 +355,9 @@ func buildDesiredStateWithSessionBeads(
 	}
 
 	// Named sessions: materialize session beads for configured [[named_session]]
-	// entries. "always" mode sessions are unconditionally materialized; "on_demand"
-	// sessions are materialized only when they already have a canonical bead or
-	// when their work query returns ready work.
+	// entries. "always" mode sessions are unconditionally materialized;
+	// "on_demand" sessions are materialized only when they already have a
+	// canonical bead or direct assigned work.
 	namedSpecs := make(map[string]namedSessionSpec)
 	for i := range cfg.NamedSessions {
 		identity := cfg.NamedSessions[i].QualifiedName()
@@ -377,10 +375,8 @@ func buildDesiredStateWithSessionBeads(
 	// session's identity, that session has direct demand.
 	//
 	// Raw gc.routed_to metadata is intentionally NOT treated as direct named
-	// demand here. Routed metadata feeds the named agent's work_query, and the
-	// on-demand session only materializes from that path once the work is
-	// actually actionable. This keeps blocked or merely routed work from
-	// waking/materializing the named session prematurely.
+	// demand here. The controller only uses assignment/readiness state; routed
+	// metadata is consumed by the agent-side gc hook path.
 	for identity, spec := range namedSpecs {
 		for i, wb := range assignedWorkBeads {
 			if wb.Status != "open" && wb.Status != "in_progress" {
@@ -400,30 +396,6 @@ func buildDesiredStateWithSessionBeads(
 	}
 	if len(assignedWorkBeads) > 0 {
 		fmt.Fprintf(stderr, "namedWorkReady: %d assigned beads, %d named specs, ready=%v\n", len(assignedWorkBeads), len(namedSpecs), namedWorkReady) //nolint:errcheck
-	}
-	for identity, spec := range namedSpecs {
-		if spec.Mode == "always" || namedWorkReady[identity] || !namedSessionAllowsControllerWorkQuery(cityPath, cfg, spec) {
-			continue
-		}
-		// Controller-side work_query demand stays intentionally narrow.
-		// Generic city-scoped named sessions materialize from direct continuity
-		// (canonical bead or explicit assignee demand), while rig-scoped named
-		// sessions still probe here so the controller validates rig-local query
-		// env such as scoped Dolt credentials.
-		wq := spec.Agent.EffectiveWorkQuery()
-		if wq == "" {
-			continue
-		}
-		wq = expandAgentCommandTemplate(cityPath, cityName, spec.Agent, cfg.Rigs, "work_query", wq, stderr)
-		dir := agentCommandDir(cityPath, spec.Agent, cfg.Rigs)
-		probeEnv := controllerQueryRuntimeEnv(cityPath, cfg, spec.Agent)
-		out, err := shellScaleCheck(prefixShellEnv(controllerQueryPrefixEnv(probeEnv), wq), dir, probeEnv)
-		if err != nil {
-			continue
-		}
-		if workQueryHasReadyWork(strings.TrimSpace(out)) {
-			namedWorkReady[identity] = true
-		}
 	}
 	for identity, spec := range namedSpecs {
 		canonicalBead, hasCanonical := findCanonicalNamedSessionBead(bp.sessionBeads, spec)
@@ -561,7 +533,7 @@ func collectAssignedWorkBeads(
 	cfg *config.City,
 	cityStore beads.Store,
 ) ([]beads.Bead, bool) {
-	result, _, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil)
+	result, _, _, partial := collectAssignedWorkBeadsWithStores(cfg, cityStore, nil, nil, nil)
 	return result, partial
 }
 
@@ -570,6 +542,7 @@ func collectAssignedWorkBeadsWithStores(
 	cityStore beads.Store,
 	rigStores map[string]beads.Store,
 	suspendedRigPaths map[string]bool,
+	sessionBeads *sessionBeadSnapshot,
 ) ([]beads.Bead, []beads.Store, []string, bool) {
 	// Use CachingStore-wrapped stores. Creating raw bdStoreForCity per rig
 	// spawns bd subprocesses on every tick, saturating dolt.
@@ -606,23 +579,15 @@ func collectAssignedWorkBeadsWithStores(
 			var errs []error
 			seen := make(map[string]struct{})
 			// In-progress beads with an assignee (active work), plus stranded
-			// unassigned pool work that needs to be reopened.
+			// unassigned pool work that needs to be reopened. This pass runs
+			// across every store before any ready handoff probes, so already
+			// active work never waits behind unrelated ready scans.
 			if inProgress, err := listForControllerDemand(source.store, beads.ListQuery{Status: "in_progress"}); err == nil {
 				appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
 			} else {
 				errs = append(errs, fmt.Errorf("List(in_progress): %w", err))
 				if beads.IsPartialResult(err) && len(inProgress) > 0 {
 					appendInProgressWorkUnique(cfg, &result, &resultStores, &resultStoreRefs, inProgress, seen, source.store, source.ref)
-				}
-			}
-			// Ready beads with an assignee (queued direct handoff work that is
-			// actually runnable, not merely open).
-			if ready, err := readyForControllerDemand(source.store); err == nil {
-				appendAssignedUnique(&result, &resultStores, &resultStoreRefs, ready, seen, source.store, source.ref)
-			} else {
-				errs = append(errs, fmt.Errorf("Ready(): %w", err))
-				if beads.IsPartialResult(err) && len(ready) > 0 {
-					appendAssignedUnique(&result, &resultStores, &resultStoreRefs, ready, seen, source.store, source.ref)
 				}
 			}
 			results[idx] = storeAssignedWorkResult{beads: result, stores: resultStores, storeRefs: resultStoreRefs, errs: errs}
@@ -643,7 +608,150 @@ func collectAssignedWorkBeadsWithStores(
 			partial = true
 		}
 	}
+	skipReadyAssignees := assignedWorkAssigneeSet(result)
+	expandSkipAssigneesWithSessionIdentities(skipReadyAssignees, sessionBeads)
+	if len(skipReadyAssignees) > 0 {
+		return result, resultStores, resultStoreRefs, partial
+	}
+
+	readyResults := make([]storeAssignedWorkResult, len(stores))
+	assignees := readyAssignedWorkAssignees(cfg, sessionBeads, skipReadyAssignees)
+	for idx, source := range stores {
+		idx, source := idx, source
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var ready []beads.Bead
+			var err error
+			var errs []error
+			if len(assignees) == 0 {
+				ready, err = readyForControllerDemandQuery(source.store, beads.ReadyQuery{Limit: assignedWorkReadyLimit(cfg)})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("Ready(): %w", err))
+				}
+			} else {
+				for _, assignee := range assignees {
+					part, partErr := readyForControllerDemandQuery(source.store, beads.ReadyQuery{Assignee: assignee, Limit: assignedWorkReadyLimit(cfg)})
+					if partErr != nil {
+						errs = append(errs, fmt.Errorf("Ready(assignee=%q): %w", assignee, partErr))
+					}
+					ready = append(ready, part...)
+				}
+			}
+			var readyBeads []beads.Bead
+			var readyStores []beads.Store
+			var readyStoreRefs []string
+			seen := make(map[string]struct{})
+			appendAssignedUnique(&readyBeads, &readyStores, &readyStoreRefs, ready, seen, source.store, source.ref)
+			readyResults[idx] = storeAssignedWorkResult{beads: readyBeads, stores: readyStores, storeRefs: readyStoreRefs, errs: errs}
+		}()
+	}
+	wg.Wait()
+	for _, r := range readyResults {
+		result = append(result, r.beads...)
+		resultStores = append(resultStores, r.stores...)
+		resultStoreRefs = append(resultStoreRefs, r.storeRefs...)
+		for _, err := range r.errs {
+			log.Printf("collectAssignedWorkBeads: %v", err)
+			partial = true
+		}
+	}
 	return result, resultStores, resultStoreRefs, partial
+}
+
+func assignedWorkReadyLimit(cfg *config.City) int {
+	if cfg == nil {
+		return config.DefaultMaxWakesPerTick
+	}
+	return cfg.Daemon.MaxWakesPerTickOrDefault()
+}
+
+func assignedWorkAssigneeSet(work []beads.Bead) map[string]struct{} {
+	if len(work) == 0 {
+		return nil
+	}
+	result := make(map[string]struct{})
+	for _, bead := range work {
+		assignee := strings.TrimSpace(bead.Assignee)
+		if assignee == "" {
+			continue
+		}
+		if bead.Status != "open" && bead.Status != "in_progress" {
+			continue
+		}
+		result[assignee] = struct{}{}
+	}
+	return result
+}
+
+func expandSkipAssigneesWithSessionIdentities(skip map[string]struct{}, sessionBeads *sessionBeadSnapshot) {
+	if len(skip) == 0 || sessionBeads == nil {
+		return
+	}
+	for _, session := range sessionBeads.Open() {
+		ids := []string{
+			session.ID,
+			session.Metadata["session_name"],
+			session.Metadata["configured_named_identity"],
+		}
+		matched := false
+		for _, id := range ids {
+			if _, ok := skip[strings.TrimSpace(id)]; ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		for _, id := range ids {
+			id = strings.TrimSpace(id)
+			if id != "" {
+				skip[id] = struct{}{}
+			}
+		}
+	}
+}
+
+func readyAssignedWorkAssignees(cfg *config.City, sessionBeads *sessionBeadSnapshot, skip map[string]struct{}) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := skip[value]; ok {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	if sessionBeads != nil {
+		for _, session := range sessionBeads.Open() {
+			if session.Status == "closed" {
+				continue
+			}
+			if strings.TrimSpace(session.Metadata["state"]) != "asleep" {
+				continue
+			}
+			add(session.ID)
+			add(session.Metadata["session_name"])
+			add(session.Metadata["configured_named_identity"])
+		}
+	}
+	if cfg != nil {
+		for i := range cfg.NamedSessions {
+			if cfg.NamedSessions[i].Mode != "on_demand" {
+				continue
+			}
+			add(cfg.NamedSessions[i].QualifiedName())
+		}
+	}
+	return result
 }
 
 func defaultScaleCheckTargetForAgent(
@@ -757,6 +865,34 @@ func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
 		}
 	}
 	return beads.ReadyLive(store)
+}
+
+func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
+	if cached, ok := store.(interface {
+		CachedReady() ([]beads.Bead, bool)
+	}); ok {
+		if ready, ok := cached.CachedReady(); ok {
+			return filterReadyForControllerDemand(ready, query), nil
+		}
+	}
+	return store.Ready(query)
+}
+
+func filterReadyForControllerDemand(ready []beads.Bead, query beads.ReadyQuery) []beads.Bead {
+	if query == (beads.ReadyQuery{}) {
+		return ready
+	}
+	result := make([]beads.Bead, 0, len(ready))
+	for _, bead := range ready {
+		if query.Assignee != "" && bead.Assignee != query.Assignee {
+			continue
+		}
+		result = append(result, bead)
+		if query.Limit > 0 && len(result) >= query.Limit {
+			break
+		}
+	}
+	return result
 }
 
 // mergeNamedSessionDemand ensures that named-session assignee demand is
@@ -1462,16 +1598,6 @@ func agentInSuspendedRig(
 		return false
 	}
 	return suspendedRigPaths[filepath.Clean(rigRootForName(rigName, rigs))]
-}
-
-func namedSessionAllowsControllerWorkQuery(cityPath string, cfg *config.City, spec namedSessionSpec) bool {
-	if cfg == nil || spec.Agent == nil {
-		return false
-	}
-	if spec.Named != nil && strings.TrimSpace(spec.Named.Dir) != "" {
-		return true
-	}
-	return configuredRigName(cityPath, spec.Agent, cfg.Rigs) != ""
 }
 
 // prepareTemplateResolution installs any hook-backed files that must exist

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -750,9 +750,6 @@ func readyAssignedWorkAssignees(cfg *config.City, sessionBeads *sessionBeadSnaps
 			if session.Status == "closed" {
 				continue
 			}
-			if strings.TrimSpace(session.Metadata["state"]) != "asleep" {
-				continue
-			}
 			add(session.ID)
 			add(session.Metadata["session_name"])
 			add(session.Metadata["configured_named_identity"])

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -234,13 +234,6 @@ func buildDesiredStateWithSessionBeads(
 		if cfg.Agents[i].Suspended {
 			continue
 		}
-		backsNamedSession := false
-		for j := range cfg.NamedSessions {
-			if cfg.NamedSessions[j].TemplateQualifiedName() == cfg.Agents[i].QualifiedName() {
-				backsNamedSession = true
-				break
-			}
-		}
 
 		sp := scaleParamsFor(&cfg.Agents[i])
 		// Expand {{.Rig}}/{{.AgentBase}} before the scale_check enters the
@@ -248,24 +241,6 @@ func buildDesiredStateWithSessionBeads(
 		sp.Check = expandAgentCommandTemplate(cityPath, cityName, &cfg.Agents[i], cfg.Rigs, "scale_check", sp.Check, stderr)
 
 		if !cfg.Agents[i].SupportsGenericEphemeralSessions() {
-			continue
-		}
-		if backsNamedSession {
-			rigName := configuredRigName(cityPath, &cfg.Agents[i], cfg.Rigs)
-			if rigName != "" && suspendedRigPaths[filepath.Clean(rigRootForName(rigName, cfg.Rigs))] {
-				continue
-			}
-			// Named-session materialization is handled in the named-session pass,
-			// but explicit scale_check/min demand for the backing template still
-			// creates ephemeral capacity through the pool pipeline. The default
-			// routed-work scale_check is skipped here so routed metadata alone
-			// does not create a parallel generic worker for the same backing
-			// template.
-			poolDir := agentCommandDir(cityPath, &cfg.Agents[i], cfg.Rigs)
-			if store != nil && strings.TrimSpace(cfg.Agents[i].ScaleCheck) == "" {
-				continue
-			}
-			pendingPools = append(pendingPools, poolEvalWork{agentIdx: i, sp: sp, poolDir: poolDir, newDemand: store != nil})
 			continue
 		}
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -739,6 +739,85 @@ func TestCollectAssignedWorkBeads_SkipsCityReadyProbeForRigInProgressAssignee(t 
 	}
 }
 
+func TestCollectAssignedWorkBeads_ReadyProbeStillRunsForOtherAssignees(t *testing.T) {
+	store := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	activeSession, err := store.Create(beads.Bead{
+		Title:  "active worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-active",
+			"template":     "worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create active session bead: %v", err)
+	}
+	readySession, err := store.Create(beads.Bead{
+		Title:  "ready worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-ready",
+			"template":     "worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create ready session bead: %v", err)
+	}
+	activeWork, err := store.Create(beads.Bead{
+		Title:    "active work",
+		Type:     "task",
+		Assignee: "worker-active",
+	})
+	if err != nil {
+		t.Fatalf("create active work bead: %v", err)
+	}
+	if err := store.Update(activeWork.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("mark active work in_progress: %v", err)
+	}
+	activeWork, err = store.Get(activeWork.ID)
+	if err != nil {
+		t.Fatalf("reload active work: %v", err)
+	}
+	readyWork, err := store.Create(beads.Bead{
+		Title:    "ready work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker-ready",
+	})
+	if err != nil {
+		t.Fatalf("create ready work bead: %v", err)
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, readySession})
+
+	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	gotIDs := make(map[string]bool)
+	for _, bead := range got {
+		gotIDs[bead.ID] = true
+	}
+	for _, want := range []string{activeWork.ID, readyWork.ID} {
+		if !gotIDs[want] {
+			t.Fatalf("collected work IDs = %#v, want %s", gotIDs, want)
+		}
+	}
+	queried := make(map[string]bool)
+	for _, query := range store.readyQueries {
+		queried[query.Assignee] = true
+	}
+	if queried["worker-active"] || queried[activeSession.ID] {
+		t.Fatalf("Ready queries = %#v, want no probe for active assignee", store.readyQueries)
+	}
+	if !queried["worker-ready"] {
+		t.Fatalf("Ready queries = %#v, want probe for worker-ready", store.readyQueries)
+	}
+}
+
 func TestReadyAssignedWorkAssigneesExcludeBroadIdentities(t *testing.T) {
 	got := readyAssignedWorkAssignees(&config.City{
 		Agents: []config.Agent{{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -905,6 +905,61 @@ func TestCollectAssignedWorkBeads_ReadyProbeStillRunsForOtherAssignees(t *testin
 	}
 }
 
+func TestCollectAssignedWorkBeads_ReadyProbeIncludesActiveSessionAssignees(t *testing.T) {
+	store := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	activeSession, err := store.Create(beads.Bead{
+		Title:  "active worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-active",
+			"template":     "worker",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create active session bead: %v", err)
+	}
+	sleepySession, err := store.Create(beads.Bead{
+		Title:  "sleepy worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-sleepy",
+			"template":     "worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create sleepy session bead: %v", err)
+	}
+	readyWork, err := store.Create(beads.Bead{
+		Title:    "ready active work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: "worker-active",
+	})
+	if err != nil {
+		t.Fatalf("create ready work bead: %v", err)
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{activeSession, sleepySession})
+
+	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != readyWork.ID {
+		t.Fatalf("got = %#v, want ready active-session work %s", got, readyWork.ID)
+	}
+	queried := make(map[string]bool)
+	for _, query := range store.readyQueries {
+		queried[query.Assignee] = true
+	}
+	if !queried["worker-active"] {
+		t.Fatalf("Ready queries = %#v, want probe for active session assignee", store.readyQueries)
+	}
+}
+
 func TestReadyAssignedWorkAssigneesExcludeBroadIdentities(t *testing.T) {
 	got := readyAssignedWorkAssignees(&config.City{
 		Agents: []config.Agent{{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -52,6 +52,20 @@ func (s *readyStaticStore) Ready(...beads.ReadyQuery) ([]beads.Bead, error) {
 	return out, nil
 }
 
+type readyQueryRecordingStore struct {
+	*beads.MemStore
+	readyQueries []beads.ReadyQuery
+}
+
+func (s *readyQueryRecordingStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	if len(query) == 0 {
+		s.readyQueries = append(s.readyQueries, beads.ReadyQuery{})
+	} else {
+		s.readyQueries = append(s.readyQueries, query[0])
+	}
+	return s.MemStore.Ready(query...)
+}
+
 type demandListCountingStore struct {
 	beads.Store
 	liveInProgressLists int
@@ -584,7 +598,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialInProgressSurvivors(t *testing
 		t.Fatalf("reload work bead: %v", err)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
+	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -615,7 +629,7 @@ func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
 		t.Fatalf("create work bead: %v", err)
 	}
 
-	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil)
+	got, stores, storeRefs, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, nil)
 	if !partial {
 		t.Fatal("partial = false, want true")
 	}
@@ -627,6 +641,131 @@ func TestCollectAssignedWorkBeads_PreservesPartialReadySurvivors(t *testing.T) {
 	}
 	if len(storeRefs) != 1 || storeRefs[0] != "" {
 		t.Fatalf("storeRefs = %#v, want city store ref for partial survivor", storeRefs)
+	}
+}
+
+func TestCollectAssignedWorkBeads_SkipsReadyProbeForInProgressAssignee(t *testing.T) {
+	store := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	session, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-session",
+			"template":     "worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "active work",
+		Type:     "task",
+		Assignee: "worker-session",
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload work: %v", err)
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
+
+	got, _, _, partial := collectAssignedWorkBeadsWithStores(&config.City{}, store, nil, nil, snapshot)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("got = %#v, want in-progress work %s", got, work.ID)
+	}
+	if len(store.readyQueries) != 0 {
+		t.Fatalf("Ready queried while in-progress work was already known: %#v", store.readyQueries)
+	}
+}
+
+func TestCollectAssignedWorkBeads_SkipsCityReadyProbeForRigInProgressAssignee(t *testing.T) {
+	cityStore := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	rigStore := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	session, err := cityStore.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name": "worker-session",
+			"template":     "worker",
+			"state":        "asleep",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	work, err := rigStore.Create(beads.Bead{
+		Title:    "active rig work",
+		Type:     "task",
+		Assignee: "worker-session",
+	})
+	if err != nil {
+		t.Fatalf("create work bead: %v", err)
+	}
+	if err := rigStore.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("mark work in_progress: %v", err)
+	}
+	work, err = rigStore.Get(work.ID)
+	if err != nil {
+		t.Fatalf("reload work: %v", err)
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{session})
+
+	got, _, _, partial := collectAssignedWorkBeadsWithStores(
+		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "repo"}}},
+		cityStore,
+		map[string]beads.Store{"repo": rigStore},
+		nil,
+		snapshot,
+	)
+	if partial {
+		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")
+	}
+	if len(got) != 1 || got[0].ID != work.ID {
+		t.Fatalf("got = %#v, want rig in-progress work %s", got, work.ID)
+	}
+	if len(cityStore.readyQueries) != 0 || len(rigStore.readyQueries) != 0 {
+		t.Fatalf("Ready queried while cross-store in-progress work was already known: city=%#v rig=%#v", cityStore.readyQueries, rigStore.readyQueries)
+	}
+}
+
+func TestReadyAssignedWorkAssigneesExcludeBroadIdentities(t *testing.T) {
+	got := readyAssignedWorkAssignees(&config.City{
+		Agents: []config.Agent{{
+			Dir:  "repo",
+			Name: "worker",
+		}},
+		NamedSessions: []config.NamedSession{
+			{Template: "mayor", Mode: "always"},
+			{Dir: "repo", Template: "named-worker", Mode: "on_demand"},
+		},
+	}, nil, nil)
+
+	for _, disallowed := range []string{"repo/worker", "mayor"} {
+		for _, value := range got {
+			if value == disallowed {
+				t.Fatalf("ready assignees = %#v, want no broad identity %q", got, disallowed)
+			}
+		}
+	}
+	foundNamed := false
+	for _, value := range got {
+		if value == "repo/named-worker" {
+			foundNamed = true
+		}
+	}
+	if !foundNamed {
+		t.Fatalf("ready assignees = %#v, want on-demand named-session identity", got)
 	}
 }
 
@@ -654,6 +793,7 @@ func TestCollectAssignedWorkBeadsWithStores_TracksRigStore(t *testing.T) {
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
+		nil,
 		nil,
 	)
 	if partial {
@@ -713,6 +853,7 @@ func TestCollectAssignedWorkBeadsWithStores_PreservesCrossStoreIDCollisions(t *t
 		&config.City{Rigs: []config.Rig{{Name: "repo", Path: "/repo"}}},
 		cityStore,
 		map[string]beads.Store{"repo": rigStore},
+		nil,
 		nil,
 	)
 	if partial {
@@ -1873,7 +2014,7 @@ func TestBuildDesiredState_OnDemandNamedSession_ScaleCheckNonIntegerDoesNotFallT
 	}
 }
 
-func TestBuildDesiredState_OnDemandNamedSession_WorkQueryUsesExplicitRigPassword(t *testing.T) {
+func TestBuildDesiredState_OnDemandNamedSession_RigWorkQueryDoesNotMaterialize(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
@@ -1937,8 +2078,8 @@ func TestBuildDesiredState_OnDemandNamedSession_WorkQueryUsesExplicitRigPassword
 			break
 		}
 	}
-	if !found {
-		t.Fatal("on-demand rig named session should materialize when work_query sees rig-scoped password")
+	if found {
+		t.Fatal("on-demand rig named session materialized from controller-side work_query")
 	}
 }
 
@@ -3902,11 +4043,7 @@ func TestBuildDesiredState_RigScopedScaleCheckExpandsRigTemplate(t *testing.T) {
 	}
 }
 
-// TestBuildDesiredState_NamedSessionWorkQueryExpandsRigTemplate verifies that
-// {{.Rig}} in a named-session agent's work_query is substituted before the
-// controller's work-readiness probe runs — regression test for #793, named
-// session path at build_desired_state.go:341.
-func TestBuildDesiredState_NamedSessionWorkQueryExpandsRigTemplate(t *testing.T) {
+func TestBuildDesiredState_NamedSessionWorkQueryDoesNotDriveControllerDemand(t *testing.T) {
 	cityPath := t.TempDir()
 	rigDir := filepath.Join(cityPath, "alpha")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
@@ -3922,11 +4059,7 @@ func TestBuildDesiredState_NamedSessionWorkQueryExpandsRigTemplate(t *testing.T)
 			StartCommand:      "true",
 			MinActiveSessions: intPtr(0),
 			MaxActiveSessions: intPtr(1),
-			// work_query must produce non-empty output for on_demand demand.
-			// When {{.Rig}} is expanded the echo yields "alpha", which is
-			// treated as ready work. Unexpanded, the literal "{{.Rig}}" is
-			// still non-empty — so to discriminate, use a grep filter.
-			WorkQuery: "echo {{.Rig}} | grep alpha",
+			WorkQuery:         "echo {{.Rig}} | grep alpha",
 		}},
 		NamedSessions: []config.NamedSession{{
 			Template: "alpha/dog",
@@ -3936,7 +4069,7 @@ func TestBuildDesiredState_NamedSessionWorkQueryExpandsRigTemplate(t *testing.T)
 
 	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
 
-	if !dsResult.NamedSessionDemand["alpha/dog"] {
-		t.Errorf("NamedSessionDemand[alpha/dog] = false, want true (work_query {{.Rig}} should expand to alpha and grep match)")
+	if dsResult.NamedSessionDemand["alpha/dog"] {
+		t.Fatal("NamedSessionDemand[alpha/dog] came from controller-side work_query")
 	}
 }

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1365,7 +1365,7 @@ func TestBuildDesiredState_PoolInFlightSessionsPreservePartialScaleDemand(t *tes
 	}
 }
 
-func TestBuildDesiredState_OnDemandNamedSession_RoutedMetadataAloneDoesNotMaterialize(t *testing.T) {
+func TestBuildDesiredState_OnDemandNamedSession_RoutedMetadataCreatesEphemeralOnly(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
 	if _, err := store.Create(beads.Bead{
@@ -1393,10 +1393,21 @@ func TestBuildDesiredState_OnDemandNamedSession_RoutedMetadataAloneDoesNotMateri
 	}
 
 	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	foundEphemeral := false
 	for _, tp := range dsResult.State {
-		if tp.TemplateName == "mayor" {
+		if tp.TemplateName != "mayor" {
+			continue
+		}
+		if tp.ConfiguredNamedIdentity == "mayor" {
 			t.Fatalf("routed metadata alone should not materialize on-demand named session: %+v", tp)
 		}
+		foundEphemeral = true
+	}
+	if !foundEphemeral {
+		t.Fatal("routed metadata should create an ephemeral session for the backing template")
+	}
+	if dsResult.NamedSessionDemand["mayor"] {
+		t.Fatal("routed metadata should not record named-session demand")
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1310,13 +1310,10 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		readyWaitSet = nil
 	}
 
-	// workSet: defense-in-depth wake signal from work_query. When work_query
-	// detects pending work but scale_check hasn't caught up yet, workSet
-	// ensures at least one session wakes without waiting for the next tick.
-	workSet := result.WorkSet
-	if workSet == nil {
-		workSet = computeWorkSet(cr.cfg, shellScaleCheck, cityName, cr.cityPath, store, sessionBeads, cr.stderr)
-	}
+	// Controller wake demand comes from assigned-work scans and scale_check.
+	// work_query remains the agent-side gc hook claim path; running every
+	// work_query here can block assigned-work resumes behind unrelated probes.
+	workSet := make(map[string]bool)
 	if trace != nil {
 		templateNames := make(map[string]struct{})
 		openCounts := make(map[string]int)
@@ -1835,7 +1832,7 @@ func (cr *CityRuntime) loadDemandSnapshot(
 			result.PoolDesiredCounts = make(map[string]int)
 		}
 		mergeNamedSessionDemand(result.PoolDesiredCounts, result.NamedSessionDemand, cr.cfg)
-		result.WorkSet = computeWorkSet(cr.cfg, shellScaleCheck, cr.cityName, cr.cityPath, cr.cityBeadStore(), sessionBeads, cr.stderr)
+		result.WorkSet = make(map[string]bool)
 		cr.demandSnapshot = &runtimeDemandSnapshot{
 			createdAt:          time.Now(),
 			sessionFingerprint: sessionFingerprint,
@@ -1879,7 +1876,7 @@ func demandSnapshotDemandSourcesEventBacked(cfg *config.City) bool {
 		return false
 	}
 	for i := range cfg.Agents {
-		if strings.TrimSpace(cfg.Agents[i].ScaleCheck) != "" || strings.TrimSpace(cfg.Agents[i].WorkQuery) != "" {
+		if strings.TrimSpace(cfg.Agents[i].ScaleCheck) != "" {
 			return false
 		}
 	}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -576,8 +576,9 @@ func TestOrderTrackingSweepWatchdogOnlyClosesSweepOrderTracking(t *testing.T) {
 
 func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testing.T) {
 	cases := []struct {
-		name  string
-		agent config.Agent
+		name       string
+		agent      config.Agent
+		wantBuilds int
 	}{
 		{
 			name: "custom scale_check",
@@ -585,6 +586,7 @@ func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testin
 				Name:       "worker",
 				ScaleCheck: "test -f external-queue && echo 1 || echo 0",
 			},
+			wantBuilds: 2,
 		},
 		{
 			name: "custom work_query",
@@ -592,6 +594,7 @@ func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testin
 				Name:      "worker",
 				WorkQuery: "gh issue list --json number --limit 1",
 			},
+			wantBuilds: 1,
 		},
 	}
 
@@ -619,10 +622,37 @@ func TestCityRuntimeDemandSnapshotRefreshesWhenDemandCommandsAreCustom(t *testin
 			_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
 			_ = cr.loadDemandSnapshot(sessionBeads, nil, "patrol", false)
 
-			if buildCalls != 2 {
-				t.Fatalf("buildDesiredState call count = %d, want 2 when demand command is not event-backed", buildCalls)
+			if buildCalls != tc.wantBuilds {
+				t.Fatalf("buildDesiredState call count = %d, want %d", buildCalls, tc.wantBuilds)
 			}
 		})
+	}
+}
+
+func TestCityRuntimeDemandSnapshotDoesNotRunControllerWorkQuery(t *testing.T) {
+	cr := &CityRuntime{
+		cityName: "test-city",
+		cityPath: t.TempDir(),
+		cfg: &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Agents: []config.Agent{{
+				Name:      "worker",
+				WorkQuery: `printf '[{"id":"work-1"}]'`,
+			}},
+		},
+		cs: &controllerState{
+			eventProv: events.NewFake(),
+		},
+		stderr: io.Discard,
+	}
+	cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	snapshot := cr.loadDemandSnapshot(newSessionBeadSnapshot(nil), nil, "patrol", false)
+
+	if len(snapshot.result.WorkSet) != 0 {
+		t.Fatalf("WorkSet = %#v, want empty; controller demand must not run work_query", snapshot.result.WorkSet)
 	}
 }
 

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -99,6 +99,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 	// compatible wake causes (pending create, named-always, assigned work) may
 	// still reuse the same bead.
 	desired := make(map[string]string) // sessionName → reason
+	concreteAssignedWork := make(map[string]bool)
 
 	// Newly created beads that still carry a controller create claim must be
 	// launched at least once, even if the work signal that materialized them
@@ -206,9 +207,6 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		if bead.State == "closed" {
 			continue
 		}
-		if _, already := desired[bead.SessionName]; already {
-			continue
-		}
 		if agent, ok := agentsByName[bead.Template]; ok && agent.Suspended {
 			continue
 		}
@@ -217,7 +215,12 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
 				continue
 			}
-			if assignee == bead.ID || assignee == bead.SessionName || (bead.NamedIdentity != "" && assignee == bead.NamedIdentity) {
+			if assignee == bead.ID || assignee == bead.SessionName {
+				desired[bead.SessionName] = "assigned-work"
+				concreteAssignedWork[bead.SessionName] = true
+				break
+			}
+			if bead.NamedIdentity != "" && assignee == bead.NamedIdentity {
 				desired[bead.SessionName] = "assigned-work"
 				break
 			}
@@ -299,7 +302,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			case isOnDemandSession(input.NamedSessions, bead):
 				idleTimeout = defaultOnDemandIdleTimeout
 			}
-			if idleTimeout > 0 && input.Now.Sub(bead.IdleSince) >= idleTimeout {
+			if idleTimeout > 0 && input.Now.Sub(bead.IdleSince) >= idleTimeout && !concreteAssignedWork[name] {
 				decision.ShouldWake = false
 				decision.Reason = "idle-sleep"
 			}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -960,6 +960,24 @@ func TestRegression_AsleepEphemeralWithAssignedWork_WakesViaAssignedWork(t *test
 	}
 }
 
+func TestRegression_ConcreteAssignedWorkSuppressesIdleSleep(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat", SleepAfterIdle: 2 * time.Hour}},
+		SessionBeads: []AwakeSessionBead{
+			{
+				ID: "mc-sctve", SessionName: "polecat-mc-sctve", Template: "hello-world/polecat", State: "active",
+				IdleSince: now.Add(-3 * time.Hour),
+			},
+		},
+		WorkBeads:        []AwakeWorkBead{{ID: "hw-8lb", Assignee: "polecat-mc-sctve", Status: "in_progress"}},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 1},
+		RunningSessions:  map[string]bool{"polecat-mc-sctve": true},
+		Now:              now,
+	})
+	assertAwake(t, result, "polecat-mc-sctve")
+	assertReason(t, result, "polecat-mc-sctve", "assigned-work")
+}
+
 // ---------------------------------------------------------------------------
 // WorkSet — work_query demand signal (defense-in-depth alongside ScaleCheck)
 // ---------------------------------------------------------------------------

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -249,6 +249,7 @@ func TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery
 		store,
 		nil,
 		nil,
+		nil,
 	)
 	if partial {
 		t.Fatal("collectAssignedWorkBeadsWithStores reported partial results")

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -622,7 +622,8 @@ func buildPreparedStart(
 	}
 	firstStart := session.Metadata["started_config_hash"] == ""
 	forceFresh := session.Metadata["wake_mode"] == "fresh"
-	if !firstStart && !forceFresh {
+	hasResumeKey := strings.TrimSpace(session.Metadata["session_key"]) != ""
+	if !firstStart && !forceFresh && hasResumeKey {
 		agentCfg.PromptSuffix = ""
 		agentCfg.PromptFlag = ""
 		agentCfg.Nudge = tp.Hints.Nudge

--- a/cmd/gc/session_lifecycle_parallel_phase2_test.go
+++ b/cmd/gc/session_lifecycle_parallel_phase2_test.go
@@ -133,16 +133,20 @@ func preparePhase2Start(t *testing.T, tc phase2ProviderCase, startedConfigHash s
 	}
 
 	store := beads.NewMemStore()
+	metadata := map[string]string{
+		"session_name":        "phase2-" + tc.family,
+		"template":            "worker",
+		"template_overrides":  string(rawOverrides),
+		"started_config_hash": startedConfigHash,
+	}
+	if startedConfigHash != "" {
+		metadata["session_key"] = "phase2-resume-key"
+	}
 	session, err := store.Create(beads.Bead{
-		Title:  "phase2-" + tc.family,
-		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel},
-		Metadata: map[string]string{
-			"session_name":        "phase2-" + tc.family,
-			"template":            "worker",
-			"template_overrides":  string(rawOverrides),
-			"started_config_hash": startedConfigHash,
-		},
+		Title:    "phase2-" + tc.family,
+		Type:     sessionBeadType,
+		Labels:   []string{sessionBeadLabel},
+		Metadata: metadata,
 	})
 	if err != nil {
 		t.Fatalf("Create session bead: %v", err)

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -874,6 +874,59 @@ func TestPrepareStartCandidate_GeneratesMissingSessionKeyBeforeWake(t *testing.T
 	}
 }
 
+func TestPrepareStartCandidate_ResumeCapableWithoutSessionKeyKeepsStartupPrompt(t *testing.T) {
+	store := beads.NewMemStore()
+	session, err := store.Create(beads.Bead{
+		Title:  "codex-worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:codex-worker"},
+		Metadata: map[string]string{
+			"template":            "codex-worker",
+			"session_name":        "codex-worker",
+			"started_config_hash": "previous-start",
+			"session_key":         "",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareStartCandidate(startCandidate{
+		session: &session,
+		tp: TemplateParams{
+			TemplateName: "codex-worker",
+			SessionName:  "codex-worker",
+			Command:      "aimux run codex -- --dangerously-bypass-approvals-and-sandbox",
+			Prompt:       "You are a routed workflow lane. Run gc hook first.",
+			ResolvedProvider: &config.ResolvedProvider{
+				Name:          "codex",
+				PromptMode:    "arg",
+				ResumeFlag:    "resume",
+				ResumeStyle:   "subcommand",
+				ResumeCommand: "aimux run codex -- resume {{.SessionKey}}",
+			},
+		},
+		order: 0,
+	}, &config.City{}, store, &clock.Fake{Time: time.Date(2026, 5, 5, 4, 20, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("prepareStartCandidate: %v", err)
+	}
+
+	if prepared.cfg.PromptSuffix == "" {
+		t.Fatal("PromptSuffix should be retained when there is no session_key to resume")
+	}
+	parts := shellquote.Split(prepared.cfg.PromptSuffix)
+	if len(parts) != 1 {
+		t.Fatalf("PromptSuffix parsed parts = %#v, want single prompt payload", parts)
+	}
+	if !strings.Contains(parts[0], "Run gc hook first") {
+		t.Fatalf("prompt payload = %q, want startup workflow prompt", parts[0])
+	}
+	if strings.Contains(prepared.cfg.Command, "resume") {
+		t.Fatalf("prepared.cfg.Command = %q, should not use resume without a session_key", prepared.cfg.Command)
+	}
+}
+
 func TestPrepareStartCandidate_DoesNotAppendCLIResumeFlagForACP(t *testing.T) {
 	store := beads.NewMemStore()
 	session, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary
- stop controller-side `work_query` from driving wake demand; controller demand now comes from assigned-work scans and scale_check
- collect in-progress assigned work across city/rig stores before ready handoff scans, and skip redundant ready probes for already-active assignees
- keep concretely assigned sessions out of idle sleep and preserve startup prompts when a resume-capable session has no `session_key`

## Tests
- `go test ./cmd/gc -run 'TestCollectAssignedWorkBeadsUsesCachedReadyReadModel|TestCollectAssignedWorkBeads_(SkipsCityReadyProbeForRigInProgressAssignee|SkipsReadyProbeForInProgressAssignee|PreservesPartialReadySurvivors|PreservesPartialInProgressSurvivors)|TestReadyAssignedWorkAssigneesExcludeBroadIdentities|TestCityRuntimeDemandSnapshot(RefreshesWhenDemandCommandsAreCustom|DoesNotRunControllerWorkQuery)|TestBuildDesiredState_OnDemandNamedSession_(RigWorkQueryDoesNotMaterialize|NoExplicitScaleCheckUsesWorkQuery|ScaleCheckErrorDoesNotFallToWorkQuery|ScaleCheckNonIntegerDoesNotFallToWorkQuery)|TestBuildDesiredState_NamedSessionWorkQueryDoesNotDriveControllerDemand|TestRegression_ConcreteAssignedWorkSuppressesIdleSleep|TestPrepareStartCandidate_ResumeCapableWithoutSessionKeyKeepsStartupPrompt|TestPhase2InitialInputDelivery' -count=1`
- `GC_FAST_UNIT=1 go test ./cmd/gc -count=1`
- pre-commit hook: generated docs, golangci-lint, go vet, `make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->