### PR TITLE
test: cover configured file-provider bd shim

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1401,6 +1401,9 @@ func TestUsesStandaloneBDWorkspaceKeepsFileProviderOnShim(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".beads", "config.yaml"), []byte("issue_prefix: test\n"), 0o644); err != nil {
 		t.Fatalf("write config.yaml: %v", err)
 	}
+	if usesStandaloneBDWorkspace(dir, []string{"GC_BEADS=file"}) {
+		t.Fatal("file provider city with config.yaml should keep using the file-store bd shim")
+	}
 	if !usesStandaloneBDWorkspace(dir, []string{"GC_BEADS=dolt"}) {
 		t.Fatal("standalone .beads workspace with config.yaml should use the standalone bd env")
 	}


### PR DESCRIPTION
Post-merge follow-up for #1696.

Addresses the required review finding that `TestUsesStandaloneBDWorkspaceKeepsFileProviderOnShim` did not cover `GC_BEADS=file` after `.beads/config.yaml` exists.

Tests:
- `go test -tags=integration ./test/integration -run TestUsesStandaloneBDWorkspaceKeepsFileProviderOnShim -count=1`
- `go test -tags=integration ./test/integration -run 'TestGastown_MultiRig_BeadIsolation|TestStandaloneBDEnvAllowsBDAutoStart|TestUsesStandaloneBDWorkspaceKeepsFileProviderOnShim' -count=1`\n- pre-commit hook (`golangci-lint`, `go vet`, fast unit suite)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->