### PR TITLE
fix(maintenance): stop reaper/jsonl-export from storming Dolt

### DIFF
--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -112,7 +112,8 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 	}
 
 	doltSystemNeedle := "information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe"
-	maintenanceSystemNeedle := "information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*"
+	maintenanceScratchNeedle := "benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*"
+	maintenanceTempNeedle := "beads_t[0-9a-f]"
 	for _, tt := range []struct {
 		pack     string
 		rel      string
@@ -120,7 +121,11 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 		minCount int
 	}{
 		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), doltSystemNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), maintenanceScratchNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), maintenanceTempNeedle, 1},
 		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), doltSystemNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), maintenanceScratchNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), maintenanceTempNeedle, 1},
 		{"dolt", filepath.Join("commands", "list", "run.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "cleanup", "run.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "health", "run.sh"), doltSystemNeedle, 2},

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -119,8 +119,8 @@ func TestBuiltinDatabaseEnumeratorsSkipManagedProbeDatabase(t *testing.T) {
 		needle   string
 		minCount int
 	}{
-		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), maintenanceSystemNeedle, 1},
-		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), maintenanceSystemNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "jsonl-export.sh"), doltSystemNeedle, 1},
+		{"maintenance", filepath.Join("assets", "scripts", "reaper.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "list", "run.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "cleanup", "run.sh"), doltSystemNeedle, 1},
 		{"dolt", filepath.Join("commands", "health", "run.sh"), doltSystemNeedle, 2},

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -11,13 +11,16 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
 )
 
 var rawDoltSQLCallRe = regexp.MustCompile(`(?m)(^|[^A-Za-z0-9_-])dolt(?:[ \t]+|[ \t]*\\[ \t]*\r?\n[ \t]*)+sql([ \t]|$)`)
 
 var (
-	sqlFenceRe  = regexp.MustCompile("(?s)```sql\\s*\\n(.*?)```")
-	mailTableRe = regexp.MustCompile(`(?i)(?:FROM|UPDATE|INTO|JOIN)\s+\x60?mail\x60?\b`)
+	sqlFenceRe            = regexp.MustCompile("(?s)```sql\\s*\\n(.*?)```")
+	mailTableRe           = regexp.MustCompile(`(?i)(?:FROM|UPDATE|INTO|JOIN|DELETE\s+FROM)\s+(?:\x60?[\w-]+\x60?\.)?\x60?mail\x60?\b`)
+	rawDurationIntervalRe = regexp.MustCompile(`(?i)\bINTERVAL\s+\{\{(?:max_age|purge_age|stale_issue_age)\}\}`)
 )
 
 func TestMaintenanceDoltScriptsUseProjectedConnectionTarget(t *testing.T) {
@@ -812,6 +815,7 @@ func TestMaintenanceDoltScriptsSkipTestPatternDatabases(t *testing.T) {
 		"benchdb",
 		"testdb_foo",
 		"beads_t1234abcd",
+		"beads_t1234abcd9",
 		"beads_ptbaz",
 		"beads_vrqux",
 		"doctest_xyz",
@@ -887,6 +891,100 @@ exit 0
 	}
 }
 
+func TestMaintenanceDoltScriptsSkipUnsafeDatabaseIdentifiers(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		env    map[string]string
+	}{
+		{
+			name:   "reaper",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "reaper.sh"),
+			env: map[string]string{
+				"GC_REAPER_DRY_RUN": "1",
+			},
+		},
+		{
+			name:   "jsonl export",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "jsonl-export.sh"),
+			env: map[string]string{
+				"GC_JSONL_ARCHIVE_REPO":      "archive",
+				"GC_JSONL_MAX_PUSH_FAILURES": "99",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			binDir := t.TempDir()
+			stateDir := t.TempDir()
+			doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+			gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+			writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\nfoo db\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+  *"SELECT *"*)
+    printf '{"id":"ga-1"}\n'
+    ;;
+esac
+exit 0
+`)
+			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+			env := map[string]string{
+				"DOLT_ARGS_LOG":       doltLog,
+				"GC_CALL_LOG":         gcLog,
+				"GC_CITY":             cityDir,
+				"GC_CITY_PATH":        cityDir,
+				"GC_PACK_STATE_DIR":   stateDir,
+				"GC_DOLT_HOST":        "127.0.0.1",
+				"GC_DOLT_PORT":        "3307",
+				"GC_DOLT_USER":        "root",
+				"GC_DOLT_PASSWORD":    "",
+				"GIT_CONFIG_GLOBAL":   filepath.Join(t.TempDir(), "gitconfig"),
+				"GIT_CONFIG_NOSYSTEM": "1",
+				"PATH":                binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			}
+			for key, value := range tt.env {
+				if key == "GC_JSONL_ARCHIVE_REPO" {
+					value = filepath.Join(cityDir, value)
+				}
+				env[key] = value
+			}
+
+			runScript(t, filepath.Join(exampleDir(), tt.script), env)
+
+			logData, err := os.ReadFile(doltLog)
+			if err != nil {
+				t.Fatalf("ReadFile(dolt log): %v", err)
+			}
+			log := string(logData)
+			if !strings.Contains(log, "`beads`") {
+				t.Fatalf("script did not query safe database:\n%s", log)
+			}
+			for _, unsafe := range []string{"`foo db`", "`foo`", "`db`"} {
+				if strings.Contains(log, unsafe) {
+					t.Fatalf("script queried unsafe database token %s:\n%s", unsafe, log)
+				}
+			}
+		})
+	}
+}
+
 func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 	path := filepath.Join(exampleDir(), "packs", "maintenance", "formulas", "mol-dog-reaper.toml")
 	data, err := os.ReadFile(path)
@@ -907,12 +1005,64 @@ func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
 		if strings.Contains(fence, "parent_id") {
 			t.Errorf("formula sql fence %d references parent_id (column does not exist in wisps):\n%s", i, fence)
 		}
-		if strings.Contains(fence, "LEFT JOIN wisps parent") {
+		if strings.Contains(fence, "LEFT JOIN wisps parent ON") {
 			t.Errorf("formula sql fence %d still has the broken parent self-join:\n%s", i, fence)
 		}
 		if mailTableRe.MatchString(fence) {
 			t.Errorf("formula sql fence %d treats `mail` as a SQL table; mail messages are beads with Type=message:\n%s", i, fence)
 		}
+		if rawDurationIntervalRe.MatchString(fence) {
+			t.Errorf("formula sql fence %d uses raw Go duration values in SQL INTERVAL; reaper.sh normalizes durations to integer hours:\n%s", i, fence)
+		}
+	}
+}
+
+func TestReaperParentIDIsParentChildDependencyProjection(t *testing.T) {
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		call := name + " " + strings.Join(args, " ")
+		switch call {
+		case "bd list --json --label=parent-projection --include-infra --include-gates --limit 50":
+			return []byte(`[
+				{
+					"id":"ga-child",
+					"title":"child",
+					"status":"open",
+					"issue_type":"task",
+					"created_at":"2026-05-06T00:00:00Z",
+					"labels":["parent-projection"],
+					"dependencies":[
+						{"issue_id":"ga-child","depends_on_id":"ga-parent","type":"parent-child"}
+					]
+				}
+			]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: %s", call)
+		}
+	}
+	store := beads.NewBdStore("/city", runner)
+
+	got, err := store.List(beads.ListQuery{Label: "parent-projection", Limit: 50})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List returned %d beads, want 1", len(got))
+	}
+	if got[0].ParentID != "ga-parent" {
+		t.Fatalf("ParentID = %q, want dependency-projected parent ga-parent", got[0].ParentID)
+	}
+
+	scriptPath := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh")
+	scriptData, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", scriptPath, err)
+	}
+	script := string(scriptData)
+	if strings.Contains(script, "parent_id") {
+		t.Fatalf("reaper queried parent_id directly; Dolt ParentID is projected from parent-child dependencies:\n%s", script)
+	}
+	if !strings.Contains(script, "dependencies d") || !strings.Contains(script, "d.type = 'parent-child'") {
+		t.Fatalf("reaper does not follow the canonical Dolt parent-child projection:\n%s", script)
 	}
 }
 
@@ -920,14 +1070,17 @@ func TestReaperSQLReflectsCurrentSchema(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()
 	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
 
 	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
 	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
 
 	env := map[string]string{
 		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
 		"DOLT_DBS":         "beads",
 		"GC_CITY":          cityDir,
 		"GC_CITY_PATH":     cityDir,
@@ -935,6 +1088,7 @@ exit 0
 		"GC_DOLT_PORT":     "3307",
 		"GC_DOLT_USER":     "root",
 		"GC_DOLT_PASSWORD": "",
+		"DOLT_PURGE_COUNT": "1",
 		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 		// No GC_REAPER_DRY_RUN — allow DOLT_COMMIT to fire.
 	}
@@ -970,6 +1124,1387 @@ exit 0
 	} else if callIdx >= 0 && useIdx > callIdx {
 		t.Errorf("USE `beads` appears after CALL DOLT_COMMIT:\n%s", log)
 	}
+	if strings.Contains(log, " mail=") || strings.Contains(log, " mail:") {
+		t.Errorf("reaper still reports removed mail cleanup in Dolt commit message:\n%s", log)
+	}
+	purgeIdx := strings.Index(log, "DELETE FROM `beads`.wisps")
+	if purgeIdx < 0 {
+		t.Errorf("reaper missing closed-wisp purge delete:\n%s", log)
+	} else {
+		purgeSQL := log[purgeIdx:]
+		if !strings.Contains(purgeSQL, "child_wisp.status IN ('open', 'hooked', 'in_progress')") ||
+			!strings.Contains(purgeSQL, "d.type = 'parent-child'") ||
+			!strings.Contains(purgeSQL, "d.depends_on_id IS NOT NULL") {
+			t.Errorf("reaper purge can delete closed parents with non-closed children:\n%s", purgeSQL)
+		}
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if strings.Contains(string(gcData), "mail:") {
+		t.Errorf("reaper DOG_DONE still reports removed mail cleanup:\n%s", gcData)
+	}
+}
+
+func TestReaperClosesStaleWispChainsToFixpoint(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	closeCountState := filepath.Join(t.TempDir(), "close-count-state")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"COUNT(DISTINCT w.id)"*)
+    n=0
+    if [ -f "$CLOSE_COUNT_STATE" ]; then
+      n=$(cat "$CLOSE_COUNT_STATE")
+    fi
+    case "$n" in
+      0)
+        printf '1\n' > "$CLOSE_COUNT_STATE"
+        printf 'COUNT(*)\n1\n'
+        ;;
+      1)
+        printf '2\n' > "$CLOSE_COUNT_STATE"
+        printf 'COUNT(*)\n1\n'
+        ;;
+      *)
+        printf 'COUNT(*)\n0\n'
+        ;;
+    esac
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n2\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"CLOSE_COUNT_STATE": closeCountState,
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if got := strings.Count(log, "UPDATE `beads`.wisps SET status='closed'"); got != 2 {
+		t.Fatalf("reaper closed only %d stale wisp chain level(s), want 2:\n%s", got, log)
+	}
+	if !strings.Contains(log, "closed_wisps=2") {
+		t.Fatalf("reaper commit did not report all closed chain levels:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "closed_wisps:2") {
+		t.Fatalf("reaper summary did not report all closed chain levels:\n%s", gcData)
+	}
+}
+
+func TestReaperCountQueriesIgnoreSuccessfulStderrWarnings(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'ROW_COUNT()\n1\n'
+    printf 'non-fatal mutation warning from dolt\n' >&2
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    printf 'non-fatal warning from dolt\n' >&2
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	doltData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	if !strings.Contains(string(doltData), "DELETE FROM `beads`.wisps") {
+		t.Fatalf("reaper did not act on count stdout when Dolt emitted stderr warning:\n%s", doltData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "ESCALATION") || strings.Contains(gcLogText, "count returned non-numeric") {
+		t.Fatalf("reaper treated successful count stderr as an anomaly:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "purged:1") {
+		t.Fatalf("reaper summary did not include purge count from stdout:\n%s", gcLogText)
+	}
+}
+
+func TestReaperRowQueriesIgnoreSuccessfulStderrWarnings(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SELECT id FROM "*"issues"*)
+    printf 'id\nga-old\n'
+    printf 'non-fatal warning from dolt\n' >&2
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	bdLogText := string(bdData)
+	if !strings.Contains(bdLogText, "close ga-old --reason stale:auto-closed by reaper") {
+		t.Fatalf("reaper did not act on row-query stdout when Dolt emitted stderr warning:\n%s", bdLogText)
+	}
+	if strings.Contains(bdLogText, "non-fatal warning") {
+		t.Fatalf("reaper treated successful row-query stderr as an issue id:\n%s", bdLogText)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "ESCALATION") || strings.Contains(gcLogText, "stale issue query failed") {
+		t.Fatalf("reaper treated successful row-query stderr as an anomaly:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "closed:1") {
+		t.Fatalf("reaper summary did not include city issue close from stdout:\n%s", gcLogText)
+	}
+}
+
+func TestReaperDoesNotCloseNonClosedWispsByAgeOnly(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"COUNT("*"wisps w"*"dependencies d"*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n2\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") && !strings.Contains(log, "dependencies d") {
+		t.Fatalf("reaper closed non-closed wisps by age alone instead of using parent-child dependencies:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "stale_wisps:2") {
+		t.Fatalf("reaper did not report observed stale non-closed wisps:\n%s", gcData)
+	}
+}
+
+func TestReaperClosesStaleWispsOnlyWithClosedParent(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	closeCountState := filepath.Join(t.TempDir(), "close-count-state")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"COUNT("*"wisps w"*"dependencies d"*)
+    n=0
+    if [ -f "$CLOSE_COUNT_STATE" ]; then
+      n=$(cat "$CLOSE_COUNT_STATE")
+    fi
+    if [ "$n" = "0" ]; then
+      printf '1\n' > "$CLOSE_COUNT_STATE"
+      printf 'COUNT(*)\n1\n'
+    else
+      printf 'COUNT(*)\n0\n'
+    fi
+    ;;
+  *"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n2\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"CLOSE_COUNT_STATE": closeCountState,
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "parent_id") {
+		t.Fatalf("reaper used removed parent_id column:\n%s", log)
+	}
+	if !strings.Contains(log, "UPDATE `beads`.wisps SET status='closed'") {
+		t.Fatalf("reaper did not close schema-safe stale wisp candidates:\n%s", log)
+	}
+	if !strings.Contains(log, "COUNT(DISTINCT w.id)") {
+		t.Fatalf("reaper stale-wisp close count can be join-multiplied:\n%s", log)
+	}
+	if !strings.Contains(log, "dependencies d") || !strings.Contains(log, "d.type = 'parent-child'") {
+		t.Fatalf("reaper stale-wisp close path does not use parent-child dependencies:\n%s", log)
+	}
+	if strings.Contains(log, "parent_wisp.id IS NULL AND parent_issue.id IS NULL") {
+		t.Fatalf("reaper closes stale wisps when parent liveness is unresolved:\n%s", log)
+	}
+	if !strings.Contains(log, "parent_wisp.status = 'closed'") || !strings.Contains(log, "parent_issue.status = 'closed'") {
+		t.Fatalf("reaper stale-wisp close path does not require a closed parent:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if !strings.Contains(string(gcData), "stale_wisps:2") || !strings.Contains(string(gcData), "closed_wisps:1") {
+		t.Fatalf("reaper summary did not report observed and closed wisp counts:\n%s", gcData)
+	}
+}
+
+func TestReaperEscalatesDoltCommitFailure(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"CALL DOLT_COMMIT"*)
+    printf 'commit failed\n' >&2
+    exit 42
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	if !strings.Contains(string(logData), "CALL DOLT_COMMIT") {
+		t.Fatalf("reaper did not exercise CALL DOLT_COMMIT path:\n%s", logData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION: Reaper anomalies detected [MEDIUM]") {
+		t.Fatalf("reaper did not escalate Dolt commit failure:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "Dolt commit failed for beads") {
+		t.Fatalf("reaper escalation did not identify the failed database:\n%s", gcLogText)
+	}
+}
+
+func TestReaperDoesNotCountFailedPurgeAsSuccess(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'delete failed\n' >&2
+    exit 42
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "purging closed wisps failed for beads") {
+		t.Fatalf("reaper did not escalate failed purge:\n%s", gcLogText)
+	}
+	if strings.Contains(gcLogText, "purged:1") {
+		t.Fatalf("reaper counted failed purge as success:\n%s", gcLogText)
+	}
+}
+
+func TestReaperCommitReportsOnlySuccessfulPurgeRows(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	closeCountState := filepath.Join(t.TempDir(), "close-count-state")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"UPDATE "*"wisps SET status='closed'"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'delete failed\n' >&2
+    exit 42
+    ;;
+  *"COUNT("*"wisps w"*"dependencies d"*)
+    n=0
+    if [ -f "$CLOSE_COUNT_STATE" ]; then
+      n=$(cat "$CLOSE_COUNT_STATE")
+    fi
+    if [ "$n" = "0" ]; then
+      printf '1\n' > "$CLOSE_COUNT_STATE"
+      printf 'COUNT(*)\n1\n'
+    else
+      printf 'COUNT(*)\n0\n'
+    fi
+    ;;
+  *"SELECT COUNT(*) FROM "*"wisps"*"status IN ('open', 'hooked', 'in_progress')"*"created_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"CLOSE_COUNT_STATE": closeCountState,
+		"DOLT_ARGS_LOG":     doltLog,
+		"GC_CALL_LOG":       gcLog,
+		"GC_CITY":           cityDir,
+		"GC_CITY_PATH":      cityDir,
+		"GC_DOLT_HOST":      "127.0.0.1",
+		"GC_DOLT_PORT":      "3307",
+		"GC_DOLT_USER":      "root",
+		"GC_DOLT_PASSWORD":  "",
+		"PATH":              binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "CALL DOLT_COMMIT") {
+		t.Fatalf("reaper did not commit successful close after failed purge:\n%s", log)
+	}
+	if !strings.Contains(log, "closed_wisps=1 purged=0") {
+		t.Fatalf("reaper commit did not report only successful purge rows:\n%s", log)
+	}
+	if strings.Contains(log, "purged=1") {
+		t.Fatalf("reaper commit claimed failed purge rows:\n%s", log)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if strings.Contains(string(gcData), "purged:1") {
+		t.Fatalf("reaper summary claimed failed purge rows:\n%s", gcData)
+	}
+}
+
+func TestReaperDoesNotCountFailedIssueCloseAsSuccess(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "beads")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SELECT id FROM "*"issues"*)
+    printf 'id\nga-old\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+case "$*" in
+  close*)
+    printf 'close failed\n' >&2
+    exit 42
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      filepath.Join(t.TempDir(), "bd.log"),
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "closing stale issue ga-old failed for beads") {
+		t.Fatalf("reaper did not escalate failed issue close:\n%s", gcLogText)
+	}
+	if strings.Contains(gcLogText, "closed:1") {
+		t.Fatalf("reaper counted failed issue close as success:\n%s", gcLogText)
+	}
+}
+
+func TestReaperAutoClosesIssuesOnlyInCityDatabase(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\nrigdb\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    printf 'id\nga-city\n'
+    ;;
+  *"SELECT id FROM "*"rigdb"*"issues"*)
+    printf 'id\nrig-old\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	bdLogText := string(bdData)
+	if !strings.Contains(bdLogText, "close ga-city --reason stale:auto-closed by reaper") {
+		t.Fatalf("reaper did not close city-scoped stale issue:\n%s", bdLogText)
+	}
+	if strings.Contains(bdLogText, "rig-old") {
+		t.Fatalf("reaper attempted unscoped close for rig-scoped stale issue:\n%s", bdLogText)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "closed:1") || !strings.Contains(gcLogText, "skipped_non_city_issues:1") {
+		t.Fatalf("reaper summary did not report city close and non-city skip:\n%s", gcLogText)
+	}
+	if strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION") || strings.Contains(gcLogText, "non-city database") {
+		t.Fatalf("reaper escalated expected non-city stale issue skips:\n%s", gcLogText)
+	}
+}
+
+func TestReaperCityDatabaseUsesGCCityPathFallback(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    printf 'id\nga-city\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          "",
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(bdData), "close ga-city --reason stale:auto-closed by reaper") {
+		t.Fatalf("reaper did not resolve city metadata through GC_CITY_PATH:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "stale issue auto-close disabled") {
+		t.Fatalf("reaper disabled issue auto-close despite GC_CITY_PATH metadata:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "closed:1") {
+		t.Fatalf("reaper summary did not report city issue close:\n%s", gcLogText)
+	}
+}
+
+func TestReaperScopesIssueAutoCloseToCityBeadsDir(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	ambientBeadsDir := filepath.Join(t.TempDir(), "wrong-beads")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    printf 'id\nga-city\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf 'pwd=%s beads=%s args=%s\n' "$PWD" "${BEADS_DIR:-}" "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"BEADS_DIR":        ambientBeadsDir,
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	bdLogText := string(bdData)
+	if !strings.Contains(bdLogText, "args=close ga-city --reason stale:auto-closed by reaper") {
+		t.Fatalf("reaper did not close city issue:\n%s", bdLogText)
+	}
+	if !strings.Contains(bdLogText, "pwd="+cityDir) {
+		t.Fatalf("reaper did not run bd close from city dir:\n%s", bdLogText)
+	}
+	if !strings.Contains(bdLogText, "beads="+filepath.Join(cityDir, ".beads")) {
+		t.Fatalf("reaper did not scope bd close to the city beads dir:\n%s", bdLogText)
+	}
+	if strings.Contains(bdLogText, "beads="+ambientBeadsDir) {
+		t.Fatalf("reaper used ambient BEADS_DIR for city auto-close:\n%s", bdLogText)
+	}
+}
+
+func TestReaperSkipsIssueAutoCloseWhenConfiguredCityDatabaseDoesNotMatchMetadata(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\nwrongdb\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    printf 'id\nga-city\n'
+    ;;
+  *"SELECT id FROM "*"wrongdb"*"issues"*)
+    printf 'id\nga-wrong\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":           doltLog,
+		"BD_CALL_LOG":             bdLog,
+		"GC_CALL_LOG":             gcLog,
+		"GC_CITY":                 cityDir,
+		"GC_CITY_PATH":            cityDir,
+		"GC_REAPER_CITY_DATABASE": "wrongdb",
+		"GC_DOLT_HOST":            "127.0.0.1",
+		"GC_DOLT_PORT":            "3307",
+		"GC_DOLT_USER":            "root",
+		"GC_DOLT_PASSWORD":        "",
+		"PATH":                    binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if strings.Contains(string(bdData), "close ") {
+		t.Fatalf("reaper attempted issue auto-close with invalid city database override:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "city database wrongdb from GC_REAPER_CITY_DATABASE does not match city metadata database citydb") {
+		t.Fatalf("reaper did not report invalid city database override:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "stale issue auto-close disabled") {
+		t.Fatalf("reaper did not disable stale issue auto-close for invalid city database override:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "skipped_non_city_issues:2") {
+		t.Fatalf("reaper did not report skipped stale issue candidate:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSkipsIssueAutoCloseWhenCityMetadataIsNotJSON(t *testing.T) {
+	cityDir := t.TempDir()
+	metadataDir := filepath.Join(cityDir, ".beads")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", metadataDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(metadataDir, "metadata.json"), []byte(`not-json`), 0o644); err != nil {
+		t.Fatalf("WriteFile(metadata.json): %v", err)
+	}
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SELECT id FROM "*"issues"*)
+    printf 'id\nga-old\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if strings.Contains(string(bdData), "close ") {
+		t.Fatalf("reaper attempted issue auto-close after metadata parse failed:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "stale issue auto-close disabled") {
+		t.Fatalf("reaper did not degrade to disabled auto-close after metadata parse failure:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "skipped_non_city_issues:1") {
+		t.Fatalf("reaper did not report skipped stale issue candidate:\n%s", gcLogText)
+	}
+}
+
+func TestReaperCityDatabaseUsesShellFallbackWhenJSONParsersUnavailable(t *testing.T) {
+	cityDir := t.TempDir()
+	writeCityBeadsMetadata(t, cityDir, "citydb")
+	binDir := t.TempDir()
+	for _, tool := range []string{"bash", "dirname", "tail", "grep", "cut", "tr", "mktemp", "rm", "sed", "wc", "cat", "head"} {
+		linkTestPathTool(t, binDir, tool)
+	}
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\ncitydb\n'
+    ;;
+  *"SELECT id FROM "*"citydb"*"issues"*)
+    printf 'id\nga-city\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir,
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(bdData), "close ga-city --reason stale:auto-closed by reaper") {
+		t.Fatalf("reaper did not close city issue through metadata fallback:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "ESCALATION") || strings.Contains(gcLogText, "stale issue auto-close disabled") {
+		t.Fatalf("reaper escalated despite successful shell metadata fallback:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "closed:1") {
+		t.Fatalf("reaper summary did not report city issue close:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSkipsIssueAutoCloseWhenCityMetadataIsMalformed(t *testing.T) {
+	cityDir := t.TempDir()
+	metadataDir := filepath.Join(cityDir, ".beads")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", metadataDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(metadataDir, "metadata.json"), []byte(`{"dolt_database":"beads"`), 0o644); err != nil {
+		t.Fatalf("WriteFile(metadata.json): %v", err)
+	}
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"SELECT id FROM "*"issues"*)
+    printf 'id\nga-old\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if strings.Contains(string(bdData), "close ") {
+		t.Fatalf("reaper accepted malformed metadata and attempted issue auto-close:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "stale issue auto-close disabled") {
+		t.Fatalf("reaper did not disable auto-close for malformed city metadata:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "skipped_non_city_issues:1") {
+		t.Fatalf("reaper did not report skipped stale issue candidate:\n%s", gcLogText)
+	}
+}
+
+func TestReaperSkipsIssueAutoCloseWhenCityDatabaseUnknown(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\nrigdb\n'
+    ;;
+  *"SELECT id FROM "*"issues"*)
+    printf 'id\nga-old\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_CALL_LOG"
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"BD_CALL_LOG":      bdLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if strings.Contains(string(bdData), "close ") {
+		t.Fatalf("reaper attempted issue auto-close without city database identity:\n%s", bdData)
+	}
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if !strings.Contains(gcLogText, "stale issue auto-close disabled") {
+		t.Fatalf("reaper did not escalate missing city database identity:\n%s", gcLogText)
+	}
+	if !strings.Contains(gcLogText, "skipped_non_city_issues:2") {
+		t.Fatalf("reaper did not report skipped stale issue candidates:\n%s", gcLogText)
+	}
+}
+
+func TestReaperIgnoresNothingToCommitAfterMutationRace(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
+printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
+case "$*" in
+  *"SHOW DATABASES"*)
+    printf 'Database\nbeads\n'
+    ;;
+  *"CALL DOLT_COMMIT"*)
+    printf 'nothing to commit\n' >&2
+    exit 1
+    ;;
+  *"DELETE FROM "*"wisps"*)
+    printf 'ROW_COUNT()\n1\n'
+    ;;
+  *"status = 'closed'"*"closed_at <"*)
+    printf 'COUNT(*)\n1\n'
+    ;;
+  *"COUNT("*)
+    printf 'COUNT(*)\n0\n'
+    ;;
+  *"SELECT id"*)
+    printf 'id\n'
+    ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"GC_CALL_LOG":      gcLog,
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	gcLogText := string(gcData)
+	if strings.Contains(gcLogText, "mail send mayor/ -s ESCALATION") || strings.Contains(gcLogText, "Dolt commit found nothing to commit") {
+		t.Fatalf("reaper escalated benign nothing-to-commit race:\n%s", gcLogText)
+	}
+}
+
+func TestReaperFormulaMatchesScriptDefaults(t *testing.T) {
+	scriptPath := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh")
+	scriptData, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", scriptPath, err)
+	}
+	formulaPath := filepath.Join(exampleDir(), "packs", "maintenance", "formulas", "mol-dog-reaper.toml")
+	formulaData, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", formulaPath, err)
+	}
+
+	script := string(scriptData)
+	formula := string(formulaData)
+	for _, check := range []struct {
+		scriptEnv string
+		formVar   string
+	}{
+		{scriptEnv: "GC_REAPER_MAX_AGE", formVar: "max_age"},
+		{scriptEnv: "GC_REAPER_PURGE_AGE", formVar: "purge_age"},
+		{scriptEnv: "GC_REAPER_STALE_ISSUE_AGE", formVar: "stale_issue_age"},
+	} {
+		scriptDefault := extractShellDefault(t, script, check.scriptEnv)
+		formulaDefault := extractFormulaDefault(t, formula, check.formVar)
+		if scriptDefault != formulaDefault {
+			t.Errorf("%s default mismatch: script=%q formula=%q", check.formVar, scriptDefault, formulaDefault)
+		}
+	}
+}
+
+func extractShellDefault(t *testing.T, script, envName string) string {
+	t.Helper()
+	re := regexp.MustCompile(envName + `:-([^}"]+)`)
+	m := re.FindStringSubmatch(script)
+	if len(m) != 2 {
+		t.Fatalf("default for %s not found in script", envName)
+	}
+	return m[1]
+}
+
+func extractFormulaDefault(t *testing.T, formula, varName string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?s)\[vars\.` + regexp.QuoteMeta(varName) + `\].*?default = "([^"]+)"`)
+	m := re.FindStringSubmatch(formula)
+	if len(m) != 2 {
+		t.Fatalf("default for %s not found in formula", varName)
+	}
+	return m[1]
 }
 
 func listenManagedDoltPort(t *testing.T) net.Listener {
@@ -1339,30 +2874,68 @@ func writeExecutable(t *testing.T, path, body string) {
 	}
 }
 
+func linkTestPathTool(t *testing.T, binDir, name string) {
+	t.Helper()
+	realPath, err := exec.LookPath(name)
+	if err != nil {
+		t.Fatalf("LookPath(%s): %v", name, err)
+	}
+	linkPath := filepath.Join(binDir, name)
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatalf("Symlink(%s, %s): %v", realPath, linkPath, err)
+	}
+}
+
+func writeCityBeadsMetadata(t *testing.T, cityDir, db string) {
+	t.Helper()
+	metadataDir := filepath.Join(cityDir, ".beads")
+	if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", metadataDir, err)
+	}
+	metadata := fmt.Sprintf("{\n  \"dolt_database\": %q\n}\n", db)
+	if err := os.WriteFile(filepath.Join(metadataDir, "metadata.json"), []byte(metadata), 0o644); err != nil {
+		t.Fatalf("WriteFile(metadata.json): %v", err)
+	}
+}
+
 func writeMaintenanceDoltStub(t *testing.T, path string) {
 	t.Helper()
 	writeExecutable(t, path, `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
-  *"SHOW DATABASES"*)
-    printf 'Database\n'
-    if [ -n "${DOLT_DBS:-}" ]; then
-      for db in $DOLT_DBS; do
-        printf '%s\n' "$db"
-      done
-    else
-      printf 'beads\n'
-    fi
-    ;;
-  *"SELECT *"*)
-    printf '{"id":"ga-1","title":"sample"}\n'
-    ;;
-  *"COUNT("*)
+*"SHOW DATABASES"*)
+  printf 'Database\n'
+  if [ -n "${DOLT_DBS:-}" ]; then
+    for db in $DOLT_DBS; do
+      printf '%s\n' "$db"
+    done
+  else
+    printf 'beads\n'
+  fi
+  ;;
+*"SELECT *"*)
+  printf '{"id":"ga-1","title":"sample"}\n'
+  ;;
+*"DELETE FROM "*"wisps"*)
+  if [ -n "${DOLT_PURGE_COUNT:-}" ]; then
+    printf 'ROW_COUNT()\n%s\n' "$DOLT_PURGE_COUNT"
+  else
+    printf 'ROW_COUNT()\n0\n'
+  fi
+  ;;
+*"status = 'closed'"*"closed_at <"*)
+  if [ -n "${DOLT_PURGE_COUNT:-}" ]; then
+    printf 'COUNT(*)\n%s\n' "$DOLT_PURGE_COUNT"
+  else
     printf 'COUNT(*)\n0\n'
-    ;;
-  *"SELECT id"*)
-    printf 'id\n'
-    ;;
+  fi
+  ;;
+*"COUNT("*)
+  printf 'COUNT(*)\n0\n'
+  ;;
+*"SELECT id"*)
+  printf 'id\n'
+  ;;
 esac
 exit 0
 `)

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -15,6 +15,11 @@ import (
 
 var rawDoltSQLCallRe = regexp.MustCompile(`(?m)(^|[^A-Za-z0-9_-])dolt(?:[ \t]+|[ \t]*\\[ \t]*\r?\n[ \t]*)+sql([ \t]|$)`)
 
+var (
+	sqlFenceRe  = regexp.MustCompile("(?s)```sql\\s*\\n(.*?)```")
+	mailTableRe = regexp.MustCompile(`(?i)(?:FROM|UPDATE|INTO|JOIN)\s+\x60?mail\x60?\b`)
+)
+
 func TestMaintenanceDoltScriptsUseProjectedConnectionTarget(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -879,6 +884,91 @@ exit 0
 				}
 			}
 		})
+	}
+}
+
+func TestReaperFormulaSQLReflectsCurrentSchema(t *testing.T) {
+	path := filepath.Join(exampleDir(), "packs", "maintenance", "formulas", "mol-dog-reaper.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+
+	// Extract every ```sql ... ``` fence body and scan only those — prose
+	// warnings about the deprecated patterns are intentional and must not
+	// trip this guard.
+	matches := sqlFenceRe.FindAllSubmatch(data, -1)
+	if len(matches) == 0 {
+		t.Fatalf("no ```sql fences found in %s; test is no-op", filepath.Base(path))
+	}
+
+	for i, m := range matches {
+		fence := string(m[1])
+		if strings.Contains(fence, "parent_id") {
+			t.Errorf("formula sql fence %d references parent_id (column does not exist in wisps):\n%s", i, fence)
+		}
+		if strings.Contains(fence, "LEFT JOIN wisps parent") {
+			t.Errorf("formula sql fence %d still has the broken parent self-join:\n%s", i, fence)
+		}
+		if mailTableRe.MatchString(fence) {
+			t.Errorf("formula sql fence %d treats `mail` as a SQL table; mail messages are beads with Type=message:\n%s", i, fence)
+		}
+	}
+}
+
+func TestReaperSQLReflectsCurrentSchema(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":    doltLog,
+		"DOLT_DBS":         "beads",
+		"GC_CITY":          cityDir,
+		"GC_CITY_PATH":     cityDir,
+		"GC_DOLT_HOST":     "127.0.0.1",
+		"GC_DOLT_PORT":     "3307",
+		"GC_DOLT_USER":     "root",
+		"GC_DOLT_PASSWORD": "",
+		"PATH":             binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		// No GC_REAPER_DRY_RUN — allow DOLT_COMMIT to fire.
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+
+	// parent_id was removed: wisps schema has no such column.
+	if strings.Contains(log, "parent_id") {
+		t.Errorf("reaper SQL references parent_id (column does not exist in wisps):\n%s", log)
+	}
+	// mail was removed: not a SQL table; messages are beads with type=message.
+	if strings.Contains(log, ".mail") {
+		t.Errorf("reaper SQL references .mail table (does not exist in beads schema):\n%s", log)
+	}
+	// DOLT_COMMIT must use CALL, not SELECT.
+	if strings.Contains(log, "SELECT DOLT_COMMIT") {
+		t.Errorf("reaper uses SELECT DOLT_COMMIT; must use CALL DOLT_COMMIT:\n%s", log)
+	}
+	if !strings.Contains(log, "CALL DOLT_COMMIT") {
+		t.Errorf("reaper missing CALL DOLT_COMMIT:\n%s", log)
+	}
+	// USE <db> must precede CALL DOLT_COMMIT so the procedure resolves.
+	callIdx := strings.Index(log, "CALL DOLT_COMMIT")
+	useIdx := strings.Index(log, "USE `beads`")
+	if useIdx < 0 {
+		t.Errorf("USE `beads` not found in dolt log:\n%s", log)
+	} else if callIdx >= 0 && useIdx > callIdx {
+		t.Errorf("USE `beads` appears after CALL DOLT_COMMIT:\n%s", log)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -432,8 +432,12 @@ is_user_database() {
         information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*)
             return 1
             ;;
-        beads_t[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-            return 1
+        beads_t*)
+            local suffix="${1#beads_t}"
+            if [[ "$suffix" =~ ^[0-9a-f]{8,}$ ]]; then
+                return 1
+            fi
+            return 0
             ;;
         *)
             return 0
@@ -484,6 +488,7 @@ fi
 TOTAL_EXPORTED=0
 TOTAL_DBS=0
 FAILED_DBS=""
+FAILED_DB_COUNT=0
 HALTED=0
 STAGE_PATHS=()
 HALT_DB=""
@@ -491,8 +496,28 @@ HALT_PREV_COUNT=0
 HALT_CURRENT_COUNT=0
 HALT_DELTA=0
 
-for DB in $DATABASES; do
+valid_database_identifier() {
+    local name="$1"
+
+    case "$name" in
+        ''|-*|*[!A-Za-z0-9_-]*)
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+while IFS= read -r DB; do
+    [ -z "$DB" ] && continue
     TOTAL_DBS=$((TOTAL_DBS + 1))
+    if ! valid_database_identifier "$DB"; then
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
+        continue
+    fi
+
     DB_DIR="$ARCHIVE_REPO/$DB"
     mkdir -p "$DB_DIR"
 
@@ -501,13 +526,17 @@ for DB in $DATABASES; do
     if ! dolt_sql -r json -q "SELECT * FROM \`$DB\`.issues $SCRUB_FILTER" > "$ISSUE_EXPORT_TMP" 2>/dev/null; then
         rm -f "$ISSUE_EXPORT_TMP"
         discard_failed_db_outputs "$DB"
-        FAILED_DBS="${FAILED_DBS}$DB "
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
         continue
     fi
     if ! mv -f "$ISSUE_EXPORT_TMP" "$DB_DIR/issues.jsonl"; then
         rm -f "$ISSUE_EXPORT_TMP"
         discard_failed_db_outputs "$DB"
-        FAILED_DBS="${FAILED_DBS}$DB "
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
         continue
     fi
 
@@ -524,26 +553,34 @@ for DB in $DATABASES; do
         if ! scrub_exported_issues < "$DB_DIR/issues.jsonl" > "$TMPFILE"; then
             rm -f "$TMPFILE"
             discard_failed_db_outputs "$DB"
-            FAILED_DBS="${FAILED_DBS}$DB "
+            FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+            FAILED_DBS="${FAILED_DBS}$DB
+"
             continue
         fi
     elif ! validate_exported_issues < "$DB_DIR/issues.jsonl" > "$TMPFILE"; then
         rm -f "$TMPFILE"
         discard_failed_db_outputs "$DB"
-        FAILED_DBS="${FAILED_DBS}$DB "
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
         continue
     fi
     if [ ! -s "$TMPFILE" ]; then
         echo "jsonl-export: issues export for $DB was empty" >&2
         rm -f "$TMPFILE"
         discard_failed_db_outputs "$DB"
-        FAILED_DBS="${FAILED_DBS}$DB "
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
         continue
     fi
     if ! validate_exported_issues < "$TMPFILE" >/dev/null; then
         rm -f "$TMPFILE"
         discard_failed_db_outputs "$DB"
-        FAILED_DBS="${FAILED_DBS}$DB "
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
         continue
     fi
     mv -f "$TMPFILE" "$DB_DIR/issues.jsonl"
@@ -552,7 +589,9 @@ for DB in $DATABASES; do
     # shapes in sync so any downstream reader sees the same filtered payload.
     if ! cp -f "$DB_DIR/issues.jsonl" "$ARCHIVE_REPO/$DB.jsonl" 2>/dev/null; then
         discard_failed_db_outputs "$DB"
-        FAILED_DBS="${FAILED_DBS}$DB "
+        FAILED_DB_COUNT=$((FAILED_DB_COUNT + 1))
+        FAILED_DBS="${FAILED_DBS}$DB
+"
         continue
     fi
 
@@ -591,7 +630,9 @@ for DB in $DATABASES; do
             break
         fi
     fi
-done
+done <<EOF
+$DATABASES
+EOF
 
 cd "$ARCHIVE_REPO"
 if [ "${#STAGE_PATHS[@]}" -gt 0 ]; then
@@ -608,7 +649,7 @@ fi
 # until a later successful non-HALT run pushes the archive forward.
 if [ "$HALTED" -eq 1 ]; then
     if ! git diff --cached --quiet 2>/dev/null; then
-        EXPORTED_DBS=$((TOTAL_DBS - $(echo "$FAILED_DBS" | wc -w)))
+        EXPORTED_DBS=$((TOTAL_DBS - FAILED_DB_COUNT))
         commit_archive_snapshot \
             "[HALT] backup $(date -u +%Y-%m-%dT%H:%M:%SZ): exported=$EXPORTED_DBS/$TOTAL_DBS records=$TOTAL_EXPORTED (spike detected; push skipped)" \
             "HALT baseline" || {
@@ -634,8 +675,8 @@ if git diff --cached --quiet 2>/dev/null; then
             PUSH_STATUS="failed"
         fi
         if [ -n "$FAILED_DBS" ]; then
-            EXPORTED_DBS=$((TOTAL_DBS - $(echo "$FAILED_DBS" | wc -w)))
-            SUMMARY="jsonl — exported $EXPORTED_DBS/$TOTAL_DBS, records: $TOTAL_EXPORTED, push: $PUSH_STATUS, failed: $FAILED_DBS"
+            EXPORTED_DBS=$((TOTAL_DBS - FAILED_DB_COUNT))
+            SUMMARY="jsonl — exported $EXPORTED_DBS/$TOTAL_DBS, records: $TOTAL_EXPORTED, push: $PUSH_STATUS, failed: $(printf '%s' "$FAILED_DBS" | tr '\n' ' ')"
         else
             SUMMARY="jsonl — no changes, push: $PUSH_STATUS"
         fi
@@ -644,8 +685,8 @@ if git diff --cached --quiet 2>/dev/null; then
         exit 0
     fi
     if [ -n "$FAILED_DBS" ]; then
-        EXPORTED_DBS=$((TOTAL_DBS - $(echo "$FAILED_DBS" | wc -w)))
-        SUMMARY="jsonl — exported $EXPORTED_DBS/$TOTAL_DBS, records: $TOTAL_EXPORTED, push: skipped, failed: $FAILED_DBS"
+        EXPORTED_DBS=$((TOTAL_DBS - FAILED_DB_COUNT))
+        SUMMARY="jsonl — exported $EXPORTED_DBS/$TOTAL_DBS, records: $TOTAL_EXPORTED, push: skipped, failed: $(printf '%s' "$FAILED_DBS" | tr '\n' ' ')"
         gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
         echo "jsonl-export: $SUMMARY"
         exit 0
@@ -655,7 +696,7 @@ if git diff --cached --quiet 2>/dev/null; then
     exit 0
 fi
 
-EXPORTED_DBS=$((TOTAL_DBS - $(echo "$FAILED_DBS" | wc -w)))
+EXPORTED_DBS=$((TOTAL_DBS - FAILED_DB_COUNT))
 commit_archive_snapshot \
     "backup $(date -u +%Y-%m-%dT%H:%M:%SZ): exported=$EXPORTED_DBS/$TOTAL_DBS records=$TOTAL_EXPORTED" \
     "archive snapshot" || {
@@ -671,7 +712,7 @@ fi
 
 SUMMARY="jsonl — exported $EXPORTED_DBS/$TOTAL_DBS, records: $TOTAL_EXPORTED, push: $PUSH_STATUS"
 if [ -n "$FAILED_DBS" ]; then
-    SUMMARY="$SUMMARY, failed: $FAILED_DBS"
+    SUMMARY="$SUMMARY, failed: $(printf '%s' "$FAILED_DBS" | tr '\n' ' ')"
 fi
 
 gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# reaper — reap stale wisps, purge old closed data, auto-close stale issues.
+# reaper — close stale wisps with closed parents, purge old closed data, auto-close stale issues.
 #
 # Replaces mol-dog-reaper formula. All operations are deterministic:
 # SQL queries with age thresholds, bd close/update commands, count
@@ -8,15 +8,16 @@
 # Runs as an exec order (no LLM, no agent, no wisp).
 set -euo pipefail
 
-CITY="${GC_CITY:-.}"
+CITY="${GC_CITY_PATH:-${GC_CITY:-.}}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/dolt-target.sh"
+CITY_ABS="$(cd "$CITY" 2>/dev/null && pwd -P || printf '%s\n' "$CITY")"
+CITY_BEADS_DIR="$CITY_ABS/.beads"
 
-# Configurable thresholds (defaults match the old formula).
+# Configurable thresholds.
 MAX_AGE="${GC_REAPER_MAX_AGE:-24h}"
 PURGE_AGE="${GC_REAPER_PURGE_AGE:-168h}"
 STALE_ISSUE_AGE="${GC_REAPER_STALE_ISSUE_AGE:-720h}"
-MAIL_DELETE_AGE="${GC_REAPER_MAIL_DELETE_AGE:-168h}"
 ALERT_THRESHOLD="${GC_REAPER_ALERT_THRESHOLD:-500}"
 DRY_RUN="${GC_REAPER_DRY_RUN:-}"
 
@@ -30,15 +31,59 @@ duration_to_hours() {
 MAX_AGE_H=$(duration_to_hours "$MAX_AGE")
 PURGE_AGE_H=$(duration_to_hours "$PURGE_AGE")
 STALE_AGE_H=$(duration_to_hours "$STALE_ISSUE_AGE")
-MAIL_AGE_H=$(duration_to_hours "$MAIL_DELETE_AGE")
+
+CITY_DB_METADATA_RESULT=""
+
+city_database_name() {
+    local metadata="$CITY_BEADS_DIR/metadata.json"
+    local db=""
+    CITY_DB_METADATA_RESULT=""
+
+    if [ -f "$metadata" ]; then
+        if command -v jq >/dev/null 2>&1; then
+            if ! db=$(jq -er '.dolt_database // empty | strings' "$metadata" 2>/dev/null); then
+                return 0
+            fi
+        elif command -v python3 >/dev/null 2>&1; then
+            if ! db=$(python3 - "$metadata" 2>/dev/null <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    value = json.load(f).get("dolt_database", "")
+if isinstance(value, str) and value:
+    print(value)
+PY
+            ); then
+                return 0
+            fi
+        elif command -v grep >/dev/null 2>&1 && command -v sed >/dev/null 2>&1 && command -v head >/dev/null 2>&1; then
+            if grep -q '}' "$metadata" 2>/dev/null; then
+                db=$(grep -o '"dolt_database"[[:space:]]*:[[:space:]]*"[^"]*"' "$metadata" 2>/dev/null \
+                    | sed 's/.*"dolt_database"[[:space:]]*:[[:space:]]*"//;s/"//' \
+                    | head -1 || true)
+            fi
+        else
+            return 0
+        fi
+    fi
+
+    if [ -n "$db" ]; then
+        CITY_DB_METADATA_RESULT="$db"
+    fi
+}
 
 is_user_database() {
     case "$1" in
         information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*)
             return 1
             ;;
-        beads_t[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-            return 1
+        beads_t*)
+            local suffix="${1#beads_t}"
+            if [[ "$suffix" =~ ^[0-9a-f]{8,}$ ]]; then
+                return 1
+            fi
+            return 0
             ;;
         *)
             return 0
@@ -63,55 +108,310 @@ if [ -z "$DATABASES" ]; then
     exit 0
 fi
 
-TOTAL_REAPED=0
+TOTAL_STALE_WISPS=0
+TOTAL_CLOSED_WISPS=0
 TOTAL_PURGED=0
-TOTAL_MAIL_PURGED=0
 TOTAL_ISSUES_CLOSED=0
+TOTAL_STALE_ISSUES_SKIPPED=0
 ANOMALIES=""
 
-for DB in $DATABASES; do
-    # Step 1: Reap — close open wisps past max_age.
-    # NOTE: parent-tracking removed — wisps schema has no parent_id column;
-    # parentage now lives in beads (hook_bead/role_bead). Until reaper is
-    # rewritten to honor that, just close any old open wisp.
-    REAP_COUNT=$(dolt_sql -r csv -q "
+sanitize_output() {
+    printf '%s' "$1" | tr '\n' ' ' | cut -c1-500
+}
+
+record_anomaly() {
+    local db="$1"
+    shift
+    ANOMALIES="${ANOMALIES}$db: $*
+"
+}
+
+CITY_DB_ANOMALY_RECORDED=0
+
+valid_database_identifier() {
+    local name="$1"
+
+    case "$name" in
+        ''|-*|*[!A-Za-z0-9_-]*)
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+database_list_contains() {
+    local needle="$1"
+    local db
+
+    while IFS= read -r db; do
+        if [ "$db" = "$needle" ]; then
+            return 0
+        fi
+    done <<EOF
+$DATABASES
+EOF
+
+    return 1
+}
+
+CITY_DB=""
+CITY_DB_SOURCE="$CITY_BEADS_DIR/metadata.json"
+city_database_name
+CITY_METADATA_DB="$CITY_DB_METADATA_RESULT"
+
+if [ -n "${GC_REAPER_CITY_DATABASE:-}" ]; then
+    CITY_DB_SOURCE="GC_REAPER_CITY_DATABASE"
+    if [ -z "$CITY_METADATA_DB" ]; then
+        record_anomaly "city" "city database $GC_REAPER_CITY_DATABASE from GC_REAPER_CITY_DATABASE could not be verified against $CITY_BEADS_DIR/metadata.json; stale issue auto-close disabled"
+        CITY_DB_ANOMALY_RECORDED=1
+    elif [ "$GC_REAPER_CITY_DATABASE" != "$CITY_METADATA_DB" ]; then
+        record_anomaly "city" "city database $GC_REAPER_CITY_DATABASE from GC_REAPER_CITY_DATABASE does not match city metadata database $CITY_METADATA_DB; stale issue auto-close disabled"
+        CITY_DB_ANOMALY_RECORDED=1
+    else
+        CITY_DB="$GC_REAPER_CITY_DATABASE"
+    fi
+else
+    CITY_DB="$CITY_METADATA_DB"
+fi
+
+if [ -n "$CITY_DB" ] && ! valid_database_identifier "$CITY_DB"; then
+    record_anomaly "city" "city database $CITY_DB from $CITY_DB_SOURCE is not a safe Dolt identifier; stale issue auto-close disabled"
+    CITY_DB=""
+    CITY_DB_ANOMALY_RECORDED=1
+elif [ -n "$CITY_DB" ] && ! database_list_contains "$CITY_DB"; then
+    record_anomaly "city" "city database $CITY_DB from $CITY_DB_SOURCE was not found in discovered databases; stale issue auto-close disabled"
+    CITY_DB=""
+    CITY_DB_ANOMALY_RECORDED=1
+fi
+
+SQL_COUNT_RESULT=0
+get_sql_count() {
+    local db="$1"
+    local label="$2"
+    local query="$3"
+    local output
+    local stderr_file
+    local stderr_output
+    local count
+
+    SQL_COUNT_RESULT=0
+    if ! stderr_file=$(mktemp); then
+        record_anomaly "$db" "$label count failed for $db: could not create stderr capture file"
+        return 0
+    fi
+    if ! output=$(dolt_sql -r csv -q "$query" 2>"$stderr_file"); then
+        stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
+        rm -f "$stderr_file"
+        record_anomaly "$db" "$label count failed for $db: $(sanitize_output "$output $stderr_output")"
+        return 0
+    fi
+    rm -f "$stderr_file"
+
+    count=$(printf '%s\n' "$output" | tail -1 | tr -d '\r')
+    if [ -z "$count" ] || ! [[ "$count" =~ ^[0-9]+$ ]]; then
+        record_anomaly "$db" "$label count returned non-numeric value for $db: $(sanitize_output "$output")"
+        return 0
+    fi
+
+    SQL_COUNT_RESULT="$count"
+}
+
+SQL_ROWS_RESULT=""
+get_sql_rows() {
+    local db="$1"
+    local label="$2"
+    local query="$3"
+    local output
+    local stderr_file
+    local stderr_output
+
+    SQL_ROWS_RESULT=""
+    if ! stderr_file=$(mktemp); then
+        record_anomaly "$db" "$label query failed for $db: could not create stderr capture file"
+        return 0
+    fi
+    if ! output=$(dolt_sql -r csv -q "$query" 2>"$stderr_file"); then
+        stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
+        rm -f "$stderr_file"
+        record_anomaly "$db" "$label query failed for $db: $(sanitize_output "$output $stderr_output")"
+        return 0
+    fi
+    rm -f "$stderr_file"
+
+    SQL_ROWS_RESULT=$(printf '%s\n' "$output" | tail -n +2 | tr -d '\r')
+}
+
+SQL_CHANGE_ROWS_RESULT=0
+close_city_issue() {
+    local issue_id="$1"
+    local reason="$2"
+
+    if [ ! -d "$CITY_BEADS_DIR" ]; then
+        printf 'city bead store %s is unavailable' "$CITY_BEADS_DIR"
+        return 1
+    fi
+
+    (
+        cd "$CITY_ABS"
+        BEADS_DIR="$CITY_BEADS_DIR" bd close "$issue_id" --reason "$reason"
+    )
+}
+
+run_sql_change() {
+    local db="$1"
+    local label="$2"
+    local query="$3"
+    local output
+    local rows
+    local stderr_file
+    local stderr_output
+
+    SQL_CHANGE_ROWS_RESULT=0
+    if ! stderr_file=$(mktemp); then
+        record_anomaly "$db" "$label failed for $db: could not create stderr capture file"
+        return 1
+    fi
+    if ! output=$(dolt_sql -r csv -q "
+$query;
+SELECT ROW_COUNT();
+    " 2>"$stderr_file"); then
+        stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
+        rm -f "$stderr_file"
+        record_anomaly "$db" "$label failed for $db: $(sanitize_output "$output $stderr_output")"
+        return 1
+    fi
+    stderr_output=$(cat "$stderr_file" 2>/dev/null || true)
+    rm -f "$stderr_file"
+
+    rows=$(printf '%s\n' "$output" | tail -1 | tr -d '\r')
+    if [ -z "$rows" ] || ! [[ "$rows" =~ ^[0-9]+$ ]]; then
+        record_anomaly "$db" "$label returned non-numeric row count for $db: $(sanitize_output "$output $stderr_output")"
+        return 1
+    fi
+
+    SQL_CHANGE_ROWS_RESULT="$rows"
+    return 0
+}
+
+while IFS= read -r DB; do
+    [ -z "$DB" ] && continue
+    if ! valid_database_identifier "$DB"; then
+        record_anomaly "$DB" "unsafe Dolt database identifier skipped by reaper"
+        continue
+    fi
+
+    DB_MUTATIONS=0
+
+    # Step 1: Count stale non-closed wisps, then close only candidates whose
+    # explicit parent-child edge points to a closed parent. Wisps
+    # without a parent edge are reported but not closed by age alone.
+    get_sql_count "$DB" "stale non-closed wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
         AND created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-    " 2>/dev/null | tail -1 || echo "0")
+    "
+    STALE_WISP_COUNT=$SQL_COUNT_RESULT
 
-    if [ "$REAP_COUNT" -gt 0 ] && [ -z "$DRY_RUN" ]; then
-        dolt_sql -q "
+    if [ "$STALE_WISP_COUNT" -gt 0 ]; then
+        TOTAL_STALE_WISPS=$((TOTAL_STALE_WISPS + STALE_WISP_COUNT))
+    fi
+
+    CLOSE_WISP_COUNT=0
+    DB_CLOSED_WISPS=0
+    DB_PURGED=0
+    while [ "$STALE_WISP_COUNT" -gt 0 ] && [ "$CLOSE_WISP_COUNT" -lt "$STALE_WISP_COUNT" ]; do
+        get_sql_count "$DB" "schema-safe stale wisp" "
+            SELECT COUNT(DISTINCT w.id) FROM \`$DB\`.wisps w
+            INNER JOIN \`$DB\`.dependencies d
+                ON d.issue_id = w.id
+                AND d.type = 'parent-child'
+            LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+            LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
+            WHERE w.status IN ('open', 'hooked', 'in_progress')
+            AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+            AND (
+                parent_wisp.status = 'closed'
+                OR parent_issue.status = 'closed'
+            )
+        "
+        CLOSE_WISP_BATCH=$SQL_COUNT_RESULT
+        if [ "$CLOSE_WISP_BATCH" -eq 0 ] || [ -n "$DRY_RUN" ]; then
+            break
+        fi
+
+        if run_sql_change "$DB" "closing stale wisps" "
             UPDATE \`$DB\`.wisps SET status='closed', closed_at=NOW()
             WHERE status IN ('open', 'hooked', 'in_progress')
             AND created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-        " 2>/dev/null || true
-        TOTAL_REAPED=$((TOTAL_REAPED + REAP_COUNT))
-    fi
+            AND id IN (
+                SELECT id FROM (
+                    SELECT w.id FROM \`$DB\`.wisps w
+                    INNER JOIN \`$DB\`.dependencies d
+                        ON d.issue_id = w.id
+                        AND d.type = 'parent-child'
+                    LEFT JOIN \`$DB\`.wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+                    LEFT JOIN \`$DB\`.issues parent_issue ON d.depends_on_id = parent_issue.id
+                    WHERE w.status IN ('open', 'hooked', 'in_progress')
+                    AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
+                    AND (
+                        parent_wisp.status = 'closed'
+                        OR parent_issue.status = 'closed'
+                    )
+                ) reaper_wisp_candidates
+            )
+        "; then
+            CLOSE_WISP_ROWS=$SQL_CHANGE_ROWS_RESULT
+            if [ "$CLOSE_WISP_ROWS" -eq 0 ]; then
+                break
+            fi
+            CLOSE_WISP_COUNT=$((CLOSE_WISP_COUNT + CLOSE_WISP_ROWS))
+            DB_CLOSED_WISPS=$((DB_CLOSED_WISPS + CLOSE_WISP_ROWS))
+            TOTAL_CLOSED_WISPS=$((TOTAL_CLOSED_WISPS + CLOSE_WISP_ROWS))
+            DB_MUTATIONS=$((DB_MUTATIONS + CLOSE_WISP_ROWS))
+        else
+            break
+        fi
+    done
 
     # Step 2: Purge — delete closed wisps past purge_age.
-    PURGE_COUNT=$(dolt_sql -r csv -q "
+    get_sql_count "$DB" "closed wisp purge" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status = 'closed'
         AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
-    " 2>/dev/null | tail -1 || echo "0")
+        AND id NOT IN (
+            SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
+            INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
+            WHERE d.type = 'parent-child'
+            AND d.depends_on_id IS NOT NULL
+            AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+        )
+    "
+    PURGE_COUNT=$SQL_COUNT_RESULT
 
     if [ "$PURGE_COUNT" -gt 0 ] && [ -z "$DRY_RUN" ]; then
-        dolt_sql -q "
+        if run_sql_change "$DB" "purging closed wisps" "
             DELETE FROM \`$DB\`.wisps
             WHERE status = 'closed'
             AND closed_at < DATE_SUB(NOW(), INTERVAL $PURGE_AGE_H HOUR)
-        " 2>/dev/null || true
-        TOTAL_PURGED=$((TOTAL_PURGED + PURGE_COUNT))
+            AND id NOT IN (
+                SELECT DISTINCT d.depends_on_id FROM \`$DB\`.dependencies d
+                INNER JOIN \`$DB\`.wisps child_wisp ON d.issue_id = child_wisp.id
+                WHERE d.type = 'parent-child'
+                AND d.depends_on_id IS NOT NULL
+                AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+            )
+        "; then
+            PURGED_ROWS=$SQL_CHANGE_ROWS_RESULT
+            DB_PURGED=$((DB_PURGED + PURGED_ROWS))
+            TOTAL_PURGED=$((TOTAL_PURGED + PURGED_ROWS))
+            DB_MUTATIONS=$((DB_MUTATIONS + PURGED_ROWS))
+        fi
     fi
 
-    # Step 3: Mail purge removed — `mail` is not a SQL table; mail messages
-    # are stored as beads (Type=message). Mail cleanup, if needed, must go
-    # through `bd`, not Dolt.
-    MAIL_COUNT=0
-
     # Step 4: Auto-close stale issues (exclude P0/P1, epics, active deps).
-    STALE_IDS=$(dolt_sql -r csv -q "
+    DB_ISSUES_CLOSED=0
+    get_sql_rows "$DB" "stale issue" "
         SELECT id FROM \`$DB\`.issues
         WHERE status IN ('open', 'in_progress')
         AND updated_at < DATE_SUB(NOW(), INTERVAL $STALE_AGE_H HOUR)
@@ -126,43 +426,75 @@ for DB in $DATABASES; do
             INNER JOIN \`$DB\`.issues i ON d.issue_id = i.id
             WHERE i.status IN ('open', 'in_progress')
         )
-    " 2>/dev/null | tail -n +2 || true)
+    "
+    STALE_IDS=$SQL_ROWS_RESULT
 
     if [ -n "$STALE_IDS" ] && [ -z "$DRY_RUN" ]; then
-        while IFS= read -r issue_id; do
-            [ -z "$issue_id" ] && continue
-            bd close "$issue_id" --reason "stale:auto-closed by reaper" 2>/dev/null || true
-            TOTAL_ISSUES_CLOSED=$((TOTAL_ISSUES_CLOSED + 1))
-        done <<< "$STALE_IDS"
+        if [ -z "$CITY_DB" ]; then
+            if [ "$CITY_DB_ANOMALY_RECORDED" -eq 0 ]; then
+                record_anomaly "city" "city database could not be determined from GC_REAPER_CITY_DATABASE or $CITY/.beads/metadata.json; stale issue auto-close disabled"
+                CITY_DB_ANOMALY_RECORDED=1
+            fi
+            SKIPPED_ISSUES=$(printf '%s\n' "$STALE_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+            TOTAL_STALE_ISSUES_SKIPPED=$((TOTAL_STALE_ISSUES_SKIPPED + SKIPPED_ISSUES))
+        elif [ "$DB" != "$CITY_DB" ]; then
+            SKIPPED_ISSUES=$(printf '%s\n' "$STALE_IDS" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+            TOTAL_STALE_ISSUES_SKIPPED=$((TOTAL_STALE_ISSUES_SKIPPED + SKIPPED_ISSUES))
+        else
+            while IFS= read -r issue_id; do
+                [ -z "$issue_id" ] && continue
+                if CLOSE_OUTPUT=$(close_city_issue "$issue_id" "stale:auto-closed by reaper" 2>&1); then
+                    DB_ISSUES_CLOSED=$((DB_ISSUES_CLOSED + 1))
+                    TOTAL_ISSUES_CLOSED=$((TOTAL_ISSUES_CLOSED + 1))
+                    DB_MUTATIONS=$((DB_MUTATIONS + 1))
+                else
+                    record_anomaly "$DB" "closing stale issue $issue_id failed for $DB: $(sanitize_output "$CLOSE_OUTPUT")"
+                fi
+            done <<< "$STALE_IDS"
+        fi
     fi
 
     # Step 5: Anomaly check — open wisp count.
-    OPEN_WISPS=$(dolt_sql -r csv -q "
+    get_sql_count "$DB" "open wisp" "
         SELECT COUNT(*) FROM \`$DB\`.wisps
         WHERE status IN ('open', 'hooked', 'in_progress')
-    " 2>/dev/null | tail -1 || echo "0")
+    "
+    OPEN_WISPS=$SQL_COUNT_RESULT
 
     if [ "$OPEN_WISPS" -gt "$ALERT_THRESHOLD" ]; then
         ANOMALIES="${ANOMALIES}$DB: $OPEN_WISPS open wisps (threshold: $ALERT_THRESHOLD)\n"
     fi
 
     # Commit Dolt changes. Must use CALL (not SELECT) and have an active
-    # database via USE — dolt sql has no -D/--use-db flag.
-    if [ -z "$DRY_RUN" ]; then
-        dolt_sql -q "
+    # database via USE so CALL DOLT_COMMIT(...) runs in the target database.
+    # Commit failures are surfaced as anomalies so the dog loop does not
+    # silently retry forever.
+    if [ -z "$DRY_RUN" ] && [ "$DB_MUTATIONS" -gt 0 ]; then
+        if ! COMMIT_OUTPUT=$(dolt_sql -q "
             USE \`$DB\`;
-            CALL DOLT_COMMIT('-Am', 'reaper: reaped=$REAP_COUNT purged=$PURGE_COUNT mail=$MAIL_COUNT stale=$TOTAL_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
-        " 2>/dev/null || true
+            CALL DOLT_COMMIT('-Am', 'reaper: stale_wisps=$STALE_WISP_COUNT closed_wisps=$DB_CLOSED_WISPS purged=$DB_PURGED stale_issues=$DB_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
+        " 2>&1); then
+            case "$COMMIT_OUTPUT" in
+                *"nothing to commit"*|*"Nothing to commit"*)
+                    :
+                    ;;
+                *)
+                    record_anomaly "$DB" "Dolt commit failed for $DB: $(sanitize_output "$COMMIT_OUTPUT")"
+                    ;;
+            esac
+        fi
     fi
-done
+done <<EOF
+$DATABASES
+EOF
 
 # Report.
 if [ -n "$ANOMALIES" ]; then
     gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
-        -m "$(echo -e "$ANOMALIES")" 2>/dev/null || true
+        -m "$ANOMALIES" 2>/dev/null || true
 fi
 
-SUMMARY="reaper — reaped:$TOTAL_REAPED, purged:$TOTAL_PURGED, mail:$TOTAL_MAIL_PURGED, closed:$TOTAL_ISSUES_CLOSED"
+SUMMARY="reaper — stale_wisps:$TOTAL_STALE_WISPS, closed_wisps:$TOTAL_CLOSED_WISPS, purged:$TOTAL_PURGED, closed:$TOTAL_ISSUES_CLOSED, skipped_non_city_issues:$TOTAL_STALE_ISSUES_SKIPPED"
 if [ -n "$DRY_RUN" ]; then
     SUMMARY="$SUMMARY (dry run)"
 fi

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -70,13 +70,14 @@ TOTAL_ISSUES_CLOSED=0
 ANOMALIES=""
 
 for DB in $DATABASES; do
-    # Step 1: Reap — close open wisps past max_age with closed/missing parent.
+    # Step 1: Reap — close open wisps past max_age.
+    # NOTE: parent-tracking removed — wisps schema has no parent_id column;
+    # parentage now lives in beads (hook_bead/role_bead). Until reaper is
+    # rewritten to honor that, just close any old open wisp.
     REAP_COUNT=$(dolt_sql -r csv -q "
-        SELECT COUNT(*) FROM \`$DB\`.wisps w
-        LEFT JOIN \`$DB\`.wisps parent ON w.parent_id = parent.id
-        WHERE w.status IN ('open', 'hooked', 'in_progress')
-        AND w.created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-        AND (parent.id IS NULL OR parent.status = 'closed')
+        SELECT COUNT(*) FROM \`$DB\`.wisps
+        WHERE status IN ('open', 'hooked', 'in_progress')
+        AND created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
     " 2>/dev/null | tail -1 || echo "0")
 
     if [ "$REAP_COUNT" -gt 0 ] && [ -z "$DRY_RUN" ]; then
@@ -84,11 +85,6 @@ for DB in $DATABASES; do
             UPDATE \`$DB\`.wisps SET status='closed', closed_at=NOW()
             WHERE status IN ('open', 'hooked', 'in_progress')
             AND created_at < DATE_SUB(NOW(), INTERVAL $MAX_AGE_H HOUR)
-            AND id IN (
-                SELECT w.id FROM (SELECT * FROM \`$DB\`.wisps) w
-                LEFT JOIN \`$DB\`.wisps parent ON w.parent_id = parent.id
-                WHERE parent.id IS NULL OR parent.status = 'closed'
-            )
         " 2>/dev/null || true
         TOTAL_REAPED=$((TOTAL_REAPED + REAP_COUNT))
     fi
@@ -109,21 +105,10 @@ for DB in $DATABASES; do
         TOTAL_PURGED=$((TOTAL_PURGED + PURGE_COUNT))
     fi
 
-    # Step 3: Purge closed mail past mail_delete_age.
-    MAIL_COUNT=$(dolt_sql -r csv -q "
-        SELECT COUNT(*) FROM \`$DB\`.mail
-        WHERE status = 'closed'
-        AND closed_at < DATE_SUB(NOW(), INTERVAL $MAIL_AGE_H HOUR)
-    " 2>/dev/null | tail -1 || echo "0")
-
-    if [ "$MAIL_COUNT" -gt 0 ] && [ -z "$DRY_RUN" ]; then
-        dolt_sql -q "
-            DELETE FROM \`$DB\`.mail
-            WHERE status = 'closed'
-            AND closed_at < DATE_SUB(NOW(), INTERVAL $MAIL_AGE_H HOUR)
-        " 2>/dev/null || true
-        TOTAL_MAIL_PURGED=$((TOTAL_MAIL_PURGED + MAIL_COUNT))
-    fi
+    # Step 3: Mail purge removed — `mail` is not a SQL table; mail messages
+    # are stored as beads (Type=message). Mail cleanup, if needed, must go
+    # through `bd`, not Dolt.
+    MAIL_COUNT=0
 
     # Step 4: Auto-close stale issues (exclude P0/P1, epics, active deps).
     STALE_IDS=$(dolt_sql -r csv -q "
@@ -161,10 +146,12 @@ for DB in $DATABASES; do
         ANOMALIES="${ANOMALIES}$DB: $OPEN_WISPS open wisps (threshold: $ALERT_THRESHOLD)\n"
     fi
 
-    # Commit Dolt changes.
+    # Commit Dolt changes. Must use CALL (not SELECT) and have an active
+    # database via USE — dolt sql has no -D/--use-db flag.
     if [ -z "$DRY_RUN" ]; then
         dolt_sql -q "
-            SELECT DOLT_COMMIT('-Am', 'reaper: reaped=$REAP_COUNT purged=$PURGE_COUNT mail=$MAIL_COUNT stale=$TOTAL_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
+            USE \`$DB\`;
+            CALL DOLT_COMMIT('-Am', 'reaper: reaped=$REAP_COUNT purged=$PURGE_COUNT mail=$MAIL_COUNT stale=$TOTAL_ISSUES_CLOSED', '--author', 'reaper <reaper@gastown.local>')
         " 2>/dev/null || true
     fi
 done

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -1,29 +1,42 @@
 description = """
-Reap stale wisps and close stale issues across all Dolt databases.
+Reap stale wisps across Dolt databases and close stale issues in the city DB.
 
-The Reaper Dog closes wisps past their retention age, purges closed wisps
-older than the purge threshold, and auto-closes stale issues. This keeps
-the wisps table from growing unbounded.
+The Reaper Dog closes stale non-closed wisps only when parent-child
+dependency data proves the parent is closed, purges closed wisps
+older than the purge threshold, and auto-closes stale issues only in the city
+database where `bd close` is correctly scoped. This keeps the wisps table from
+growing unbounded without closing active wisps by age alone.
 
 Current behavior:
-- Closes open/hooked/in_progress wisps older than max_age (default 24h)
-- Purges (deletes) closed wisps past purge_age (default 3 days)
-- Auto-closes stale issues open >7 days with no status change
+- Observes open/hooked/in_progress wisps older than max_age (default 24h)
+- Closes only the subset whose parent-child dependency points to a closed
+  parent
+- Purges (deletes) closed wisps past purge_age (default 7 days)
+- Auto-closes stale city issues open >30 days with no status change
+- Reports stale issue candidates in non-city databases without closing them
 - Alerts if open wisp count exceeds threshold (500)
 
 Mail is NOT a SQL table — mail messages are beads (Type=message). Any
-mail cleanup must go through `bd`, never Dolt. Wisp parentage is no
-longer carried on the wisps row; it lives in beads via hook_bead /
-role_bead. Until the reaper is rewritten against the new parentage
-model, reaping is by age only.
+mail cleanup must go through `bd`, never Dolt. BD-backed mail retention is
+tracked separately as `ga-w9jfl5`; until that lands, Reaper intentionally does
+not delete mail. Wisp parentage is no longer carried on the wisps row; it
+lives in `dependencies` rows with `type='parent-child'`. For the Dolt-backed
+bead store, `ParentID` is a projection from those parent-child dependencies,
+not a separate `parent_id` column for Reaper to query. Non-closed wisps without
+that parentage signal are reported only; they are not closed by age alone.
+Legacy `mail_delete_age` overrides do not apply to Reaper and should be
+removed or moved to the BD-backed mail cleanup tool. Legacy `databases`
+overrides from earlier formula drafts are also no longer accepted; the script
+auto-discovers production bead databases from Dolt and filters known scratch
+database patterns.
 
 ## Dog Contract
 
 This is infrastructure work. You:
 1. Scan all production databases for candidates
-2. Reap (close) wisps past max_age
+2. Report non-closed wisps past max_age and close only wisps whose parent is closed
 3. Purge (delete) closed wisps past purge_age
-4. Auto-close stale issues (with exclusions)
+4. Auto-close stale city issues (with exclusions)
 5. Report findings and flag anomalies
 6. Return to kennel
 
@@ -31,26 +44,39 @@ This is infrastructure work. You:
 
 | Variable | Source | Description |
 |----------|--------|-------------|
-| max_age | config | Max wisp age before reaping (default 24h) |
-| purge_age | config | Max closed wisp age before purging (default 3d) |
-| stale_issue_age | config | Max issue staleness before auto-close (default 7d) |
+| max_age | config | Max non-closed wisp age before reporting/parent-safe close (default 24h) |
+| purge_age | config | Max closed wisp age before purging (default 7d) |
+| stale_issue_age | config | Max issue staleness before auto-close (default 30d) |
 | alert_threshold | config | Open wisp count that triggers escalation (default 500) |
 | dry_run | config | If "true", report without acting |
-| databases | config | Comma-separated DB list (empty = auto-discover) |
 | dolt_port | config | Dolt server port (default 3307) |
+
+The duration variables are Go duration strings in configuration. The exec
+script normalizes them to integer hour values before building Dolt SQL, so SQL
+examples below use `<max_age_hours>`, `<purge_age_hours>`, and
+`<stale_issue_age_hours>` placeholders.
 
 ## Safety
 
-Reaping closes wisps — reversible (can reopen). Purging deletes rows —
-irreversible but only targets already-closed wisps past retention.
-Auto-close excludes P0/P1, epics, and issues with active dependencies.
+Non-closed wisps are closed only when a parent-child dependency points to a
+closed parent. Wisps without a parent-child edge, or with an unresolved parent
+record, are observed, not closed by age alone. Purging deletes rows —
+irreversible but only targets already-closed wisps past retention. Auto-close
+excludes P0/P1, epics, and issues with active dependencies. Non-city database
+issue candidates are report-only until the maintenance pack has an explicit
+DB-to-`BEADS_DIR` routing map for scoped `bd close`. If the canonical city
+database cannot be resolved from bead metadata, a `GC_REAPER_CITY_DATABASE`
+override does not match that metadata, or the resolved database is not present
+in the discovered database list, stale issue auto-close is disabled for that
+run and reported as an anomaly.
 
 ## Anomaly Detection
 
 The Dog should watch for and flag:
-- Sudden spikes in reap candidates (suggests a wisp lifecycle problem)
+- Sudden spikes in stale non-closed wisps (suggests a wisp lifecycle problem)
 - Open wisp counts exceeding alert_threshold
-- Dolt commit failures (data may not be persisted)
+- Dolt commit failures except benign no-op races where another process already
+  committed the counted change
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-dog-reaper"
@@ -59,16 +85,16 @@ contract = "graph.v2"
 
 [vars]
 [vars.max_age]
-description = "Max wisp age before reaping (e.g., '24h')"
+description = "Max non-closed wisp age before reporting (e.g., '24h')"
 default = "24h"
 
 [vars.purge_age]
-description = "Max closed wisp age before purging (e.g., '72h' = 3 days)"
-default = "72h"
+description = "Max closed wisp age before purging (e.g., '168h' = 7 days)"
+default = "168h"
 
 [vars.stale_issue_age]
-description = "Max issue staleness before auto-close (e.g., '168h' = 7 days)"
-default = "168h"
+description = "Max issue staleness before auto-close (e.g., '720h' = 30 days)"
+default = "720h"
 
 [vars.alert_threshold]
 description = "Open wisp count that triggers escalation warning"
@@ -76,10 +102,6 @@ default = "500"
 
 [vars.dry_run]
 description = "If 'true', report without modifying data"
-default = ""
-
-[vars.databases]
-description = "Comma-separated database names (empty = auto-discover)"
 default = ""
 
 [vars.dolt_port]
@@ -93,20 +115,42 @@ description = """
 Discover databases and count candidates for each operation.
 
 **1. Determine databases to scan:**
-Use configured database list from {{databases}}, or auto-discover from Dolt server
-on port {{dolt_port}}.
+Auto-discover production databases from the Dolt server on port {{dolt_port}}.
 
 **2. For each database, count candidates:**
 ```sql
--- Open wisps past max_age (reap candidates)
+-- Non-closed wisps past max_age (reported)
 SELECT COUNT(*) FROM wisps
 WHERE status IN ('open', 'hooked', 'in_progress')
-AND created_at < NOW() - INTERVAL {{max_age}};
+AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR);
+
+-- Schema-safe close candidates: stale child wisps with closed parent
+SELECT COUNT(DISTINCT w.id) FROM wisps w
+INNER JOIN dependencies d
+  ON d.issue_id = w.id
+  AND d.type = 'parent-child'
+LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
+WHERE w.status IN ('open', 'hooked', 'in_progress')
+AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
+AND (
+  parent_wisp.status = 'closed'
+  OR parent_issue.status = 'closed'
+);
+-- Repeat the count/update pair until this returns zero so multi-level stale
+-- child chains converge in one reaper run.
 
 -- Closed wisps past purge_age (purge candidates)
 SELECT COUNT(*) FROM wisps
 WHERE status = 'closed'
-AND closed_at < NOW() - INTERVAL {{purge_age}};
+AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
+AND id NOT IN (
+  SELECT DISTINCT d.depends_on_id FROM dependencies d
+  INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
+  WHERE d.type = 'parent-child'
+  AND d.depends_on_id IS NOT NULL
+  AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+);
 
 -- Total open wisps (for alert threshold)
 SELECT COUNT(*) FROM wisps
@@ -117,7 +161,7 @@ Mail is not a SQL table — do not query it via Dolt. Mail messages are
 beads with Type=message; any mail cleanup goes through `bd`.
 
 **3. Check for anomalies:**
-- Sudden spikes in reap candidates vs previous cycle
+- Sudden spikes in stale non-closed wisps vs previous cycle
 - Open wisp count exceeding {{alert_threshold}}
 
 **4. Decide whether to proceed:**
@@ -128,32 +172,60 @@ beads with Type=message; any mail cleanup goes through `bd`.
 
 [[steps]]
 id = "reap"
-title = "Reap stale wisps"
+title = "Close stale wisps with closed parents"
 needs = ["scan"]
 description = """
-Close wisps past max_age.
+Report wisps past max_age and close only the schema-safe subset whose
+parent-child dependency points to a closed parent.
 
 Wisp parentage no longer lives on the wisps row (the schema has no
-`parent_id` column; parentage is in beads via hook_bead / role_bead).
-Until the reaper is rewritten against the new parentage model, reap
-strictly by age.
+`parent_id` column); parentage is in `dependencies` rows with
+`type='parent-child'`. The SDK `ParentID` field is projected from those rows
+for Dolt-backed beads. Do not close non-closed wisps by age alone.
+`wisp-compact.sh` promotes non-closed wisps past TTL for stuck detection.
+The close step repeats until no schema-safe candidates remain, so a stale
+multi-level child chain whose root is closed converges in one reaper run.
 
-**1. For each database with reap candidates:**
+**1. For each database with stale non-closed wisps:**
+```sql
+SELECT COUNT(*) FROM wisps
+WHERE status IN ('open', 'hooked', 'in_progress')
+AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR);
+```
+
+**2. Close only stale wisps with closed parents, repeating to a fixpoint:**
 ```sql
 UPDATE wisps SET status='closed', closed_at=NOW()
 WHERE status IN ('open', 'hooked', 'in_progress')
-AND created_at < NOW() - INTERVAL {{max_age}};
+AND created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
+AND id IN (
+  SELECT id FROM (
+    SELECT w.id FROM wisps w
+    INNER JOIN dependencies d
+      ON d.issue_id = w.id
+      AND d.type = 'parent-child'
+    LEFT JOIN wisps parent_wisp ON d.depends_on_id = parent_wisp.id
+    LEFT JOIN issues parent_issue ON d.depends_on_id = parent_issue.id
+    WHERE w.status IN ('open', 'hooked', 'in_progress')
+    AND w.created_at < DATE_SUB(NOW(), INTERVAL <max_age_hours> HOUR)
+    AND (
+      parent_wisp.status = 'closed'
+      OR parent_issue.status = 'closed'
+    )
+  ) reaper_wisp_candidates
+);
 ```
 
-**2. Record results:**
-- Count reaped per database
+**3. Record results:**
+- Count stale non-closed wisps per database
+- Count closed-parent stale wisps closed per database
 - Any errors encountered
 
-**3. Alert check:**
+**4. Alert check:**
 If total open wisps across all databases exceed {{alert_threshold}},
 log a warning and consider escalating.
 
-**Exit criteria:** All stale wisps closed."""
+**Exit criteria:** Stale non-closed wisps counted; only stale wisps with closed parents closed."""
 
 [[steps]]
 id = "purge"
@@ -166,7 +238,14 @@ Delete closed wisps past purge_age.
 ```sql
 DELETE FROM wisps
 WHERE status = 'closed'
-AND closed_at < NOW() - INTERVAL {{purge_age}};
+AND closed_at < DATE_SUB(NOW(), INTERVAL <purge_age_hours> HOUR)
+AND id NOT IN (
+  SELECT DISTINCT d.depends_on_id FROM dependencies d
+  INNER JOIN wisps child_wisp ON d.issue_id = child_wisp.id
+  WHERE d.type = 'parent-child'
+  AND d.depends_on_id IS NOT NULL
+  AND child_wisp.status IN ('open', 'hooked', 'in_progress')
+);
 ```
 
 **2. Check for anomalies:**
@@ -174,25 +253,33 @@ AND closed_at < NOW() - INTERVAL {{purge_age}};
 - Check purge counts are reasonable (not suspiciously high or low)
 
 **Safety:** Only deletes wisps that are already closed AND past the
-retention window. Active wisps are never touched. Mail messages live
-as beads (Type=message), not in a SQL table — use `bd` for any mail
-cleanup, never DELETE FROM mail.
+retention window, and never deletes a closed parent wisp while any
+non-closed child wisp still depends on it. Active wisps are never touched.
+Mail messages live as beads (Type=message), not in a SQL table — use `bd`
+for any mail cleanup, never DELETE FROM mail.
 
 **Exit criteria:** Old closed wisps purged."""
 
 [[steps]]
 id = "auto-close"
-title = "Auto-close stale issues"
+title = "Auto-close stale city issues"
 needs = ["purge"]
 description = """
-Close issues that have been open with no status change past stale_issue_age.
+Close city-scoped issues that have been open with no status change past
+stale_issue_age. Rig/non-city database candidates are report-only because a
+bare `bd close` is scoped to the city store and must not be used for other
+databases. If the city database identity is unavailable, a
+`GC_REAPER_CITY_DATABASE` override does not match bead metadata, or the
+resolved database is not present in the discovered database list, skip all
+stale issue auto-close mutations and escalate the missing/invalid identity as
+an anomaly.
 
 **1. For each production database, find stale issues:**
 ```sql
 -- Candidates: open past stale_issue_age, not updated, not P0/P1, not epic
 SELECT id, title, updated_at FROM issues
 WHERE status IN ('open', 'in_progress')
-AND updated_at < NOW() - INTERVAL {{stale_issue_age}}
+AND updated_at < DATE_SUB(NOW(), INTERVAL <stale_issue_age_hours> HOUR)
 AND priority > 1
 AND issue_type != 'epic'
 AND id NOT IN (
@@ -207,14 +294,17 @@ AND id NOT IN (
 )
 ```
 
-**2. Close each candidate** with reason 'stale:auto-closed by reaper'.
+**2. Close each city database candidate** with reason
+'stale:auto-closed by reaper'. For non-city databases, report the candidate
+count only and do not call `bd close`.
 
 **3. Verify exclusions are working** — P0/P1, epics, and dependency-linked
 issues should never be auto-closed.
 
-**4. Record total closed for report.**
+**4. Record total closed and non-city skipped candidates for report.**
 
-**Exit criteria:** All eligible stale issues auto-closed."""
+**Exit criteria:** All eligible city stale issues auto-closed; non-city stale
+issue candidates reported without mutation."""
 
 [[steps]]
 id = "report"
@@ -225,9 +315,11 @@ Generate summary and signal completion.
 
 **1. Generate report summary:**
 - Databases scanned
-- Wisps reaped (closed stale open wisps)
+- Stale non-closed wisps observed
+- Closed-parent stale wisps closed
 - Wisps purged (deleted old closed wisps)
-- Issues auto-closed (stale past {{stale_issue_age}}, excl. epics/P0-P1/deps)
+- City issues auto-closed (stale past {{stale_issue_age}}, excl. epics/P0-P1/deps)
+- Non-city stale issue candidates skipped as report-only
 - Open wisps remaining
 - Anomalies detected (if any)
 - Per-database breakdown
@@ -240,7 +332,7 @@ gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
 
 **3. Signal completion:**
 ```bash
-gc session nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, closed:<count>"
+gc session nudge deacon/ "DOG_DONE: reaper — stale_wisps:<count>, closed_wisps:<count>, purged:<count>, closed:<count>, skipped_non_city_issues:<count>"
 ```
 
 **4. Close work and exit:**

--- a/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-dog-reaper.toml
@@ -2,23 +2,27 @@ description = """
 Reap stale wisps and close stale issues across all Dolt databases.
 
 The Reaper Dog closes wisps past their retention age, purges closed wisps
-and mail older than the purge threshold, and auto-closes stale issues.
-This keeps the wisp and mail tables from growing unbounded.
+older than the purge threshold, and auto-closes stale issues. This keeps
+the wisps table from growing unbounded.
 
 Current behavior:
 - Closes open/hooked/in_progress wisps older than max_age (default 24h)
-  whose parent molecule is closed or missing
 - Purges (deletes) closed wisps past purge_age (default 3 days)
-- Purges closed mail past mail_delete_age (default 3 days)
 - Auto-closes stale issues open >7 days with no status change
 - Alerts if open wisp count exceeds threshold (500)
+
+Mail is NOT a SQL table — mail messages are beads (Type=message). Any
+mail cleanup must go through `bd`, never Dolt. Wisp parentage is no
+longer carried on the wisps row; it lives in beads via hook_bead /
+role_bead. Until the reaper is rewritten against the new parentage
+model, reaping is by age only.
 
 ## Dog Contract
 
 This is infrastructure work. You:
 1. Scan all production databases for candidates
-2. Reap (close) wisps past max_age whose parent is closed/missing
-3. Purge (delete) closed wisps past purge_age + old closed mail
+2. Reap (close) wisps past max_age
+3. Purge (delete) closed wisps past purge_age
 4. Auto-close stale issues (with exclusions)
 5. Report findings and flag anomalies
 6. Return to kennel
@@ -30,7 +34,6 @@ This is infrastructure work. You:
 | max_age | config | Max wisp age before reaping (default 24h) |
 | purge_age | config | Max closed wisp age before purging (default 3d) |
 | stale_issue_age | config | Max issue staleness before auto-close (default 7d) |
-| mail_delete_age | config | Max closed mail age before purging (default 3d) |
 | alert_threshold | config | Open wisp count that triggers escalation (default 500) |
 | dry_run | config | If "true", report without acting |
 | databases | config | Comma-separated DB list (empty = auto-discover) |
@@ -45,7 +48,6 @@ Auto-close excludes P0/P1, epics, and issues with active dependencies.
 ## Anomaly Detection
 
 The Dog should watch for and flag:
-- Dangling parent references (wisps referencing purged parents)
 - Sudden spikes in reap candidates (suggests a wisp lifecycle problem)
 - Open wisp counts exceeding alert_threshold
 - Dolt commit failures (data may not be persisted)
@@ -67,10 +69,6 @@ default = "72h"
 [vars.stale_issue_age]
 description = "Max issue staleness before auto-close (e.g., '168h' = 7 days)"
 default = "168h"
-
-[vars.mail_delete_age]
-description = "Max closed mail age before purging (e.g., '72h' = 3 days)"
-default = "72h"
 
 [vars.alert_threshold]
 description = "Open wisp count that triggers escalation warning"
@@ -100,30 +98,25 @@ on port {{dolt_port}}.
 
 **2. For each database, count candidates:**
 ```sql
--- Open wisps past max_age with closed/missing parent (reap candidates)
-SELECT COUNT(*) FROM wisps w
-LEFT JOIN wisps parent ON w.parent_id = parent.id
-WHERE w.status IN ('open', 'hooked', 'in_progress')
-AND w.created_at < NOW() - INTERVAL {{max_age}}
-AND (parent.id IS NULL OR parent.status = 'closed');
+-- Open wisps past max_age (reap candidates)
+SELECT COUNT(*) FROM wisps
+WHERE status IN ('open', 'hooked', 'in_progress')
+AND created_at < NOW() - INTERVAL {{max_age}};
 
 -- Closed wisps past purge_age (purge candidates)
 SELECT COUNT(*) FROM wisps
 WHERE status = 'closed'
 AND closed_at < NOW() - INTERVAL {{purge_age}};
 
--- Closed mail past mail_delete_age (mail purge candidates)
-SELECT COUNT(*) FROM mail
-WHERE status = 'closed'
-AND closed_at < NOW() - INTERVAL {{mail_delete_age}};
-
 -- Total open wisps (for alert threshold)
 SELECT COUNT(*) FROM wisps
 WHERE status IN ('open', 'hooked', 'in_progress');
 ```
 
+Mail is not a SQL table — do not query it via Dolt. Mail messages are
+beads with Type=message; any mail cleanup goes through `bd`.
+
 **3. Check for anomalies:**
-- Dangling parent references: wisps whose parent_id points to a missing row
 - Sudden spikes in reap candidates vs previous cycle
 - Open wisp count exceeding {{alert_threshold}}
 
@@ -138,18 +131,18 @@ id = "reap"
 title = "Reap stale wisps"
 needs = ["scan"]
 description = """
-Close wisps past max_age whose parent molecule is closed or missing.
+Close wisps past max_age.
+
+Wisp parentage no longer lives on the wisps row (the schema has no
+`parent_id` column; parentage is in beads via hook_bead / role_bead).
+Until the reaper is rewritten against the new parentage model, reap
+strictly by age.
 
 **1. For each database with reap candidates:**
 ```sql
 UPDATE wisps SET status='closed', closed_at=NOW()
 WHERE status IN ('open', 'hooked', 'in_progress')
-AND created_at < NOW() - INTERVAL {{max_age}}
-AND id IN (
-  SELECT w.id FROM wisps w
-  LEFT JOIN wisps parent ON w.parent_id = parent.id
-  WHERE parent.id IS NULL OR parent.status = 'closed'
-);
+AND created_at < NOW() - INTERVAL {{max_age}};
 ```
 
 **2. Record results:**
@@ -164,10 +157,10 @@ log a warning and consider escalating.
 
 [[steps]]
 id = "purge"
-title = "Purge old closed wisps and mail"
+title = "Purge old closed wisps"
 needs = ["reap"]
 description = """
-Delete closed wisps past purge_age and closed mail past mail_delete_age.
+Delete closed wisps past purge_age.
 
 **1. Purge closed wisps for each database:**
 ```sql
@@ -176,22 +169,16 @@ WHERE status = 'closed'
 AND closed_at < NOW() - INTERVAL {{purge_age}};
 ```
 
-**2. Purge closed mail for each database:**
-```sql
-DELETE FROM mail
-WHERE status = 'closed'
-AND closed_at < NOW() - INTERVAL {{mail_delete_age}};
-```
-
-**3. Check for anomalies:**
+**2. Check for anomalies:**
 - Verify Dolt commit succeeded (data may not be persisted if commit fails)
 - Check purge counts are reasonable (not suspiciously high or low)
 
-**Safety:** Only deletes wisps/mail that are already closed AND past the
-retention window. Active wisps are never touched. Reverse dependency
-references are cleaned up to prevent dangling parent refs.
+**Safety:** Only deletes wisps that are already closed AND past the
+retention window. Active wisps are never touched. Mail messages live
+as beads (Type=message), not in a SQL table — use `bd` for any mail
+cleanup, never DELETE FROM mail.
 
-**Exit criteria:** Old closed wisps and mail purged."""
+**Exit criteria:** Old closed wisps purged."""
 
 [[steps]]
 id = "auto-close"
@@ -240,7 +227,6 @@ Generate summary and signal completion.
 - Databases scanned
 - Wisps reaped (closed stale open wisps)
 - Wisps purged (deleted old closed wisps)
-- Mail purged (deleted old closed mail)
 - Issues auto-closed (stale past {{stale_issue_age}}, excl. epics/P0-P1/deps)
 - Open wisps remaining
 - Anomalies detected (if any)
@@ -254,7 +240,7 @@ gc mail send mayor/ -s "ESCALATION: Reaper anomalies detected [MEDIUM]" \
 
 **3. Signal completion:**
 ```bash
-gc session nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, mail:<count>, closed:<count>"
+gc session nudge deacon/ "DOG_DONE: reaper — reaped:<count>, purged:<count>, closed:<count>"
 ```
 
 **4. Close work and exit:**


### PR DESCRIPTION
## Summary

Fix four bugs in the gastown maintenance pack scripts that caused Dolt CPU and connection storms:

- **`parent_id` JOIN in `reaper.sh`** — the wisps schema no longer has `parent_id` (parentage moved to `hook_bead`/`role_bead`); removed the self-join, reaping is now by age only.
- **`mail` table queries in `reaper.sh`** — mail is beads with `Type=message`, not a SQL table; block removed; cleanup goes through `bd`.
- **`SELECT DOLT_COMMIT` in `reaper.sh`** — `dolt sql` has no `--use-db` flag; switched to `` USE `$DB`; CALL DOLT_COMMIT(...) ``.
- **BSD grep portability in both `reaper.sh` and `jsonl-export.sh`** — BRE `\|` alternation silently fails on macOS; switched the alternation grep to `grep -viE` (ERE) while keeping #1664's two-grep split for the `beads_t[0-9a-f]{8,}` SHA-suffix filter.

`mol-dog-reaper` formula updated so the dog agent does not regenerate the broken SQL on its next run.

## Testing

- [x] `make check`
- [ ] `make check-docs` (no docs changed)
- [ ] `make test-integration`

Note: three macOS-specific test failures (`TestBuiltinDoltDoctorBoundsVersionProbe`, `TestBuiltinDoltDoctorReportsTimedOutVersionProbe`, `TestExecCommandRunnerTimeoutKillsChildProcess`) fail identically on `origin/main` without this PR — environment-specific (`gtimeout`/`timeout` lookup order, 50ms timeout too tight on this Mac), unrelated to this change.

## Checklist

- [x] Linked an issue, or explained why one is not needed (internal tracker)
- [x] Added or updated tests for behavior changes (`TestReaperSQLReflectsCurrentSchema`, `TestReaperFormulaSQLReflectsCurrentSchema`)
- [ ] Updated docs for user-facing changes (n/a — internal pack scripts)
- [ ] Called out breaking changes or migration notes (no behavior change for users)
