### PR TITLE
fix(session): resolve binding-qualified agent names in 'gc session new'

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -544,8 +544,16 @@ func resolveSessionTemplate(cfg *config.City, input, currentRigDir string) (conf
 	if cfg == nil || input == "" {
 		return config.Agent{}, false
 	}
+	if currentRigDir != "" && !strings.Contains(input, "/") && strings.Contains(input, ".") {
+		for _, a := range cfg.Agents {
+			if a.QualifiedName() == currentRigDir+"/"+input {
+				return a, true
+			}
+		}
+	}
+
 	// Inputs that include a rig separator ("/") or a binding prefix (".")
-	// must match a qualified name exactly — no bare-name fallback.
+	// must match a qualified name exactly after any current-rig lookup.
 	if strings.ContainsAny(input, "/.") {
 		for _, a := range cfg.Agents {
 			if a.QualifiedName() == input {

--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -544,7 +544,9 @@ func resolveSessionTemplate(cfg *config.City, input, currentRigDir string) (conf
 	if cfg == nil || input == "" {
 		return config.Agent{}, false
 	}
-	if strings.Contains(input, "/") {
+	// Inputs that include a rig separator ("/") or a binding prefix (".")
+	// must match a qualified name exactly — no bare-name fallback.
+	if strings.ContainsAny(input, "/.") {
 		for _, a := range cfg.Agents {
 			if a.QualifiedName() == input {
 				return a, true

--- a/cmd/gc/session_model_phase0_factory_namespace_spec_test.go
+++ b/cmd/gc/session_model_phase0_factory_namespace_spec_test.go
@@ -39,6 +39,48 @@ func TestPhase0FactoryResolution_NoCrossRigUniqueBareFallbackWithoutAmbientRig(t
 	}
 }
 
+func TestResolveSessionTemplate_BindingQualifiedExactMatch(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar"},
+			{Name: "principal", BindingName: "ar"},
+		},
+	}
+	a, ok := resolveSessionTemplate(cfg, "ar.interface-lead", "")
+	if !ok {
+		t.Fatal("resolveSessionTemplate(ar.interface-lead) failed; expected match on binding-qualified name")
+	}
+	if got := a.QualifiedName(); got != "ar.interface-lead" {
+		t.Errorf("matched agent QualifiedName = %q, want ar.interface-lead", got)
+	}
+}
+
+func TestResolveSessionTemplate_BindingQualifiedNoBareFallback(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar"},
+		},
+	}
+	if _, ok := resolveSessionTemplate(cfg, "wrong.interface-lead", ""); ok {
+		t.Fatal("resolveSessionTemplate(wrong.interface-lead) succeeded; binding-qualified miss must not fall through to bare-name")
+	}
+}
+
+func TestResolveSessionTemplate_BareNameFallbackForBoundAgent(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar"},
+		},
+	}
+	a, ok := resolveSessionTemplate(cfg, "interface-lead", "")
+	if !ok {
+		t.Fatal("resolveSessionTemplate(interface-lead) failed; bare local name must still resolve when unique")
+	}
+	if got := a.QualifiedName(); got != "ar.interface-lead" {
+		t.Errorf("matched agent QualifiedName = %q, want ar.interface-lead", got)
+	}
+}
+
 func TestPhase0SessionTargeting_RejectsTemplateToken(t *testing.T) {
 	t.Setenv("GC_SESSION", "phase0")
 

--- a/cmd/gc/session_model_phase0_factory_namespace_spec_test.go
+++ b/cmd/gc/session_model_phase0_factory_namespace_spec_test.go
@@ -81,6 +81,48 @@ func TestResolveSessionTemplate_BareNameFallbackForBoundAgent(t *testing.T) {
 	}
 }
 
+func TestResolveSessionTemplate_BindingQualifiedUsesCurrentRig(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar", Dir: "demo"},
+			{Name: "interface-lead", BindingName: "ar", Dir: "other"},
+		},
+	}
+	a, ok := resolveSessionTemplate(cfg, "ar.interface-lead", "demo")
+	if !ok {
+		t.Fatal("resolveSessionTemplate(ar.interface-lead, demo) failed; expected current-rig binding-qualified match")
+	}
+	if got := a.QualifiedName(); got != "demo/ar.interface-lead" {
+		t.Errorf("matched agent QualifiedName = %q, want demo/ar.interface-lead", got)
+	}
+}
+
+func TestResolveSessionTemplate_BindingQualifiedRequiresCurrentRig(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar", Dir: "demo"},
+		},
+	}
+	if _, ok := resolveSessionTemplate(cfg, "ar.interface-lead", "other"); ok {
+		t.Fatal("resolveSessionTemplate(ar.interface-lead, other) succeeded; wrong current rig must not match")
+	}
+}
+
+func TestResolveSessionTemplate_RigBindingQualifiedExactMatch(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar", Dir: "demo"},
+		},
+	}
+	a, ok := resolveSessionTemplate(cfg, "demo/ar.interface-lead", "")
+	if !ok {
+		t.Fatal("resolveSessionTemplate(demo/ar.interface-lead) failed; expected rig binding-qualified match")
+	}
+	if got := a.QualifiedName(); got != "demo/ar.interface-lead" {
+		t.Errorf("matched agent QualifiedName = %q, want demo/ar.interface-lead", got)
+	}
+}
+
 func TestPhase0SessionTargeting_RejectsTemplateToken(t *testing.T) {
 	t.Setenv("GC_SESSION", "phase0")
 

--- a/cmd/gc/suggest.go
+++ b/cmd/gc/suggest.go
@@ -17,6 +17,13 @@ func suggestSimilar(input string, candidates []string) string {
 	best := ""
 	bestDist := len(input)/2 + 1 // threshold: must be within half the input length
 	for _, c := range candidates {
+		if c == input {
+			// Defense-in-depth: never echo the input back as a hint. If the
+			// caller's lookup said "not found" yet a candidate equals the
+			// input, the lookup itself is wrong — surfacing the same string
+			// as a suggestion just hides that bug.
+			continue
+		}
 		d := levenshtein(strings.ToLower(input), strings.ToLower(c))
 		if d < bestDist {
 			bestDist = d

--- a/cmd/gc/suggest_test.go
+++ b/cmd/gc/suggest_test.go
@@ -59,6 +59,19 @@ func TestSuggestSimilar(t *testing.T) {
 	}
 }
 
+func TestSuggestSimilarNeverEchoesInput(t *testing.T) {
+	// When a candidate equals the input exactly, the suggester must skip it.
+	// Otherwise the user sees a useless "agent X not found; did you mean X?".
+	candidates := []string{"ar.interface-lead", "ar.principal"}
+	if got := suggestSimilar("ar.interface-lead", candidates); got != "" {
+		t.Errorf("suggestSimilar should not echo the input; got %q", got)
+	}
+	// And the suggester should still suggest a close non-equal match.
+	if got := suggestSimilar("ar.interfac-lead", candidates); got == "" {
+		t.Error("suggestSimilar should still suggest a close non-equal match")
+	}
+}
+
 func TestSuggestSimilarEmptyCandidates(t *testing.T) {
 	got := suggestSimilar("mayor", nil)
 	if got != "" {

--- a/cmd/gc/suggest_test.go
+++ b/cmd/gc/suggest_test.go
@@ -67,8 +67,8 @@ func TestSuggestSimilarNeverEchoesInput(t *testing.T) {
 		t.Errorf("suggestSimilar should not echo the input; got %q", got)
 	}
 	// And the suggester should still suggest a close non-equal match.
-	if got := suggestSimilar("ar.interfac-lead", candidates); got == "" {
-		t.Error("suggestSimilar should still suggest a close non-equal match")
+	if got := suggestSimilar("ar.interfac-lead", candidates); !strings.Contains(got, "ar.interface-lead") {
+		t.Errorf("suggestSimilar should suggest the closest non-equal match; got %q", got)
 	}
 }
 

--- a/internal/agentutil/resolve.go
+++ b/internal/agentutil/resolve.go
@@ -54,8 +54,9 @@ func ResolveAgent(cfg *config.City, input string, opts ResolveOpts) (config.Agen
 		return a, true
 	}
 
-	// Step 2b: qualified pool instance — "rig/polecat-2" matches pool "rig/polecat".
-	if opts.AllowPoolMembers && strings.Contains(input, "/") {
+	// Step 2b: qualified pool instance — "rig/polecat-2" or
+	// "binding.polecat-2" matches the corresponding pool template.
+	if opts.AllowPoolMembers && strings.ContainsAny(input, "/.") {
 		if a, ok := resolvePoolInstanceQualified(cfg, input); ok {
 			return a, true
 		}
@@ -107,9 +108,8 @@ func resolveTemplate(cfg *config.City, input string) (config.Agent, bool) {
 
 // findAgentByQualified looks up an agent by its exact qualified identity.
 func findAgentByQualified(cfg *config.City, identity string) (config.Agent, bool) {
-	dir, name := config.ParseQualifiedName(identity)
 	for _, a := range cfg.Agents {
-		if a.Dir == dir && a.Name == name {
+		if config.AgentMatchesIdentity(&a, identity) {
 			return a, true
 		}
 	}

--- a/internal/agentutil/resolve_test.go
+++ b/internal/agentutil/resolve_test.go
@@ -24,6 +24,30 @@ func TestResolveAgentLiteralQualified(t *testing.T) {
 	}
 }
 
+func TestResolveAgentLiteralBindingQualified(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "interface-lead", BindingName: "ar"},
+			{Name: "interface-lead", BindingName: "ar", Dir: "demo"},
+		},
+	}
+	a, ok := ResolveAgent(cfg, "ar.interface-lead", ResolveOpts{})
+	if !ok {
+		t.Fatal("expected to resolve ar.interface-lead")
+	}
+	if got := a.QualifiedName(); got != "ar.interface-lead" {
+		t.Errorf("got %q, want ar.interface-lead", got)
+	}
+
+	a, ok = ResolveAgent(cfg, "demo/ar.interface-lead", ResolveOpts{})
+	if !ok {
+		t.Fatal("expected to resolve demo/ar.interface-lead")
+	}
+	if got := a.QualifiedName(); got != "demo/ar.interface-lead" {
+		t.Errorf("got %q, want demo/ar.interface-lead", got)
+	}
+}
+
 func TestResolveAgentBareName(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{
@@ -98,6 +122,21 @@ func TestResolveAgentPoolMemberAllowed(t *testing.T) {
 	}
 	if a.Name != "polecat-2" {
 		t.Errorf("got name %q, want polecat-2", a.Name)
+	}
+}
+
+func TestResolveAgentCityScopedBindingQualifiedPoolMemberAllowed(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "witness", BindingName: "gastown", MaxActiveSessions: intPtr(-1)},
+		},
+	}
+	a, ok := ResolveAgent(cfg, "gastown.witness-1", ResolveOpts{AllowPoolMembers: true})
+	if !ok {
+		t.Fatal("expected binding-qualified pool member to resolve")
+	}
+	if got := a.QualifiedName(); got != "gastown.witness-1" {
+		t.Errorf("got %q, want gastown.witness-1", got)
 	}
 }
 


### PR DESCRIPTION
## What

`gc session new <binding-qualified-name>` (e.g. `gc session new ar.interface-lead`) fails with a misleading "did you mean" hint that echoes the input back:

```
$ gc session new ar.interface-lead
gc session new: agent "ar.interface-lead" not found in city.toml; did you mean "ar.interface-lead"?
```

The qualified form is exactly what `gc status` prints, so the failure is surprising. Local form (`gc session new interface-lead`) works because it falls through to a bare-name match.

## Why

`resolveSessionTemplate` in `cmd/gc/cmd_session.go` only treats inputs containing `/` (rig separator) as qualified. Binding-qualified inputs (containing `.`, e.g. `ar.interface-lead` from a packV2 import) fall through to the bare-name branch, which compares against `a.Name` only. With `Name="interface-lead"` and `BindingName="ar"`, that comparison misses.

The API resolver (`internal/api/agent_resolution.go:resolveSessionTemplateAgent`) already handles binding-qualified inputs correctly via `AgentMatchesIdentity`. This PR brings the CLI in line.

`suggestSimilar` then masks the lookup miss: levenshtein distance against the candidate `ar.interface-lead` is 0, so it gets picked as the "did you mean" hint — echoing the input back.

## Fix

1. **`cmd/gc/cmd_session.go`** — extend the qualified-only guard from `strings.Contains(input, "/")` to `strings.ContainsAny(input, "/.")`. Any input with either separator must match a qualified name exactly; no bare-name fallback. (Mirrors what the API resolver already does.)
2. **`cmd/gc/suggest.go`** — never propose a candidate equal to the input. Defense in depth: a future regression of the same shape will produce no "did you mean" line at all rather than echoing the input, which makes the underlying miss easier to spot.

## Tests

`cmd/gc/session_model_phase0_factory_namespace_spec_test.go`:
- `TestResolveSessionTemplate_BindingQualifiedExactMatch` — `ar.interface-lead` resolves.
- `TestResolveSessionTemplate_BindingQualifiedNoBareFallback` — `wrong.interface-lead` misses and does not fall through.
- `TestResolveSessionTemplate_BareNameFallbackForBoundAgent` — bare local form `interface-lead` still resolves to `ar.interface-lead`.

`cmd/gc/suggest_test.go`:
- `TestSuggestSimilarNeverEchoesInput` — same-string suggestions are skipped; close non-equal suggestions still work.

Existing `TestPhase0FactoryResolution_*` tests (V1 no-binding ambiguity) still pass — bare-name disambiguation is unchanged for V1 agents.

## Verified locally

```
# before
$ gc session new ar.interface-lead --alias '!!invalid'
gc session new: agent "ar.interface-lead" not found in city.toml; did you mean "ar.interface-lead"?

# after
$ gc session new ar.interface-lead --alias '!!invalid'
gc session new: invalid session alias: "!!invalid"   # lookup passes, downstream alias error as expected
```

Tests:
- `go test ./cmd/gc/ -run "TestPhase0|TestResolveSessionTemplate|TestSuggestSimilar|..." -count=1` → ok
- `go vet ./cmd/gc/ ./internal/config/` → clean

## Test plan

- [x] Unit: new tests for binding-qualified resolution + suggester de-dup
- [x] Unit: existing Phase 0 V1 ambiguity tests pass unchanged
- [x] Manual: original repro fixed (`gc session new ar.interface-lead` now passes lookup)
- [x] go vet clean for touched packages

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->