### PR TITLE
fix(maintenance): preserve counters across jq pipe in wisp-compact + cross-rig-deps

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
@@ -56,8 +56,13 @@ while IFS= read -r bead; do
         esac
     done
 
-    # Calculate age.
-    BEAD_TS=$(date -d "$updated_at" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
+    # Calculate age. bd emits RFC3339 timestamps with a trailing 'Z'; the
+    # second BSD `date -j -f` fallback handles that explicitly because the
+    # third (no-Z) layout rejects it. GNU `date -d` is lenient and accepts
+    # both forms via the first fallback.
+    BEAD_TS=$(date -d "$updated_at" +%s 2>/dev/null || \
+              date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || \
+              date -j -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
     AGE=$((NOW - BEAD_TS))
 
     # Skip if within TTL (unless force-promote via keep label).


### PR DESCRIPTION
## Summary

Both `wisp-compact.sh` and `cross-rig-deps.sh` piped `jq` output through `|` into a `while read` loop. The pipe puts the loop body in a subshell, so `PROMOTED`/`DELETED`/`SKIPPED` (wisp-compact) and `RESOLVED` (cross-rig-deps) were lost when the subshell exited. The summary `echo` at the end of each script is gated on those counters being non-zero, so under any normal load both scripts ran silently — silent broken telemetry on every maintenance run, even though the side-effect `bd` calls inside the loop (`delete`, `--persistent`, `dep remove`/`add`) still fired correctly.

`cross-rig-deps.sh` had the anti-pattern at both the outer loop (over closed beads) and the nested inner loop (over external deps); both needed fixing because the inner pipe also discarded `RESOLVED`.

Follow-up to the body-coverage review on #1662 — that PR added tests for these two scripts but didn't assert on counter values, which is why the bug went undetected.

## Approach

Capture `jq` output into a variable first, then loop in the parent shell via a here-string:

```bash
LINES=$(producer)        # set -e + pipefail still catches jq failure
while ... done <<< "\$LINES"
```

This both:

1. Preserves the original fail-loud-on-jq-failure behavior under `set -euo pipefail`. Process substitution (`< <(producer)`) was considered first but silently swallows producer exit codes, which would have been a regression vs. the original pipeline form where `pipefail` propagated `jq`'s non-zero exit.
2. Keeps the loop body in the parent shell so the counters survive to the summary echo.

The `cross-rig-deps` inner loop's `select(...)` filter may legitimately yield zero matches (closed beads with only-internal deps). `<<< ""` would otherwise produce one bogus iteration with `dep_id=""`, so an explicit `if [ -z "\$EXTERNAL_DEPS" ]; then continue; fi` guards that case.

## Test coverage

New body-level tests in `examples/gastown/maintenance_scripts_test.go`:

- `TestWispCompactReportsNonZeroCounters` — drives the script with 2 closed-past-TTL + 1 open-past-TTL + 1 within-TTL ephemerals; asserts the exact summary line `wisp-compact: promoted=1 deleted=2 skipped=1`.
- `TestCrossRigDepsReportsNonZeroCounter` — drives the script with 2 closed beads × 2 external deps each (`RESOLVED`=4) plus 1 closed bead with only-internal deps (`RESOLVED` unchanged); asserts the exact summary `cross-rig-deps: resolved 4 cross-rig dependencies` AND the absence of any `bd dep remove ""` call (locks in the empty-filter guard).

Both tests fail on the pre-fix scripts (side effects observed in the bd stub log, summary echo missing) and pass after the fix.

## Test plan

- [x] `make build` — clean
- [x] `make lint` (golangci-lint with revive) — 0 issues
- [x] `make fmt-check` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — 0 failures across all packages
- [x] Verified RED→GREEN: reverting the script changes makes both new tests fail with the targeted assertion message
- [x] Verified empty-filter guard: removing `if [ -z "\$EXTERNAL_DEPS" ]` makes the test fail with `dep remove ""` observed in the bd log
- [x] Sibling sweep across all 9 maintenance scripts: only `wisp-compact.sh` and `cross-rig-deps.sh` had the buggy `echo | jq | while + counter` pattern; others use `<<<` here-strings, `for`, or `\$()` capture which are all parent-shell-safe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->