### PR TITLE
bd-npxnm: harden provider lifecycle cleanup

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -63,6 +63,8 @@ var resolveProviderLifecycleGCBinary = func() string {
 	return ""
 }
 
+var providerProbeTimeout = 10 * time.Second
+
 var (
 	initDirIfReadyEnsureBeadsProvider = ensureBeadsProvider
 	initDirIfReadyInitAndHookDir      = initAndHookDir
@@ -1367,11 +1369,12 @@ func normalizeScopeDoltConfig(dir string, state contract.ConfigState) error {
 // available (exit 2) or on any error. Unlike runProviderOp, exit 2 means
 // "not running" rather than "not needed."
 func runProviderProbe(script, cityPath, provider string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), providerProbeTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, script, "probe")
 	cmd.WaitDelay = 2 * time.Second
+	prepareProviderOpCommand(cmd)
 	if cityPath != "" {
 		cmd.Env = providerLifecycleProcessEnv(cityPath, provider)
 	}
@@ -1469,7 +1472,7 @@ func acquireProviderSemaphoreForOp(cityPath, op string) (func(), error) {
 // operation. The "start" and "recover" operations get a longer timeout
 // because dolt server startup can take 30+ seconds for large data dirs.
 // All other operations use 30s.
-func providerOpTimeout(op string) time.Duration {
+var providerOpTimeout = func(op string) time.Duration {
 	switch op {
 	case "start", "recover":
 		return 120 * time.Second
@@ -1500,6 +1503,7 @@ func runProviderOpWithEnv(script string, environ []string, args ...string) error
 
 	cmd := exec.CommandContext(ctx, script, args...)
 	cmd.WaitDelay = 2 * time.Second
+	prepareProviderOpCommand(cmd)
 	if len(environ) > 0 {
 		cmd.Env = environ
 	}

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3116,6 +3116,98 @@ func TestRunProviderOpSanitizesInheritedRuntimeEnv(t *testing.T) {
 	}
 }
 
+func TestRunProviderOpKillsProcessGroupOnTimeout(t *testing.T) {
+	oldProviderOpTimeout := providerOpTimeout
+	providerOpTimeout = func(string) time.Duration {
+		return 300 * time.Millisecond
+	}
+	t.Cleanup(func() {
+		providerOpTimeout = oldProviderOpTimeout
+	})
+
+	dir := t.TempDir()
+	childPIDFile := filepath.Join(dir, "child.pid")
+	script := filepath.Join(dir, "provider-op.sh")
+	content := `#!/bin/sh
+sh -c 'echo $$ > "$GC_TEST_CHILD_PID"; while :; do sleep 1; done' &
+wait
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runProviderOpWithEnv(script, append(os.Environ(), "GC_TEST_CHILD_PID="+childPIDFile), "health")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	pidBytes, readErr := os.ReadFile(childPIDFile)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if convErr != nil {
+		t.Fatalf("parse child pid: %v", convErr)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("provider child pid %d survived provider op timeout", pid)
+}
+
+func TestRunProviderProbeKillsProcessGroupOnTimeout(t *testing.T) {
+	oldProviderProbeTimeout := providerProbeTimeout
+	providerProbeTimeout = 300 * time.Millisecond
+	t.Cleanup(func() {
+		providerProbeTimeout = oldProviderProbeTimeout
+	})
+
+	dir := t.TempDir()
+	childPIDFile := filepath.Join(dir, "child.pid")
+	script := filepath.Join(dir, "provider-probe.sh")
+	content := `#!/bin/sh
+sh -c 'echo $$ > "$GC_TEST_CHILD_PID"; while :; do sleep 1; done' &
+wait
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_TEST_CHILD_PID", childPIDFile)
+
+	if ok := runProviderProbe(script, "", ""); ok {
+		t.Fatal("expected timeout probe to return false")
+	}
+
+	pidBytes, readErr := os.ReadFile(childPIDFile)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if convErr != nil {
+		t.Fatalf("parse child pid: %v", convErr)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("provider child pid %d survived provider probe timeout", pid)
+}
+
 func TestStartBeadsLifecycleDoesNotMutateProcessDoltEnv(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -1125,13 +1125,27 @@ func convoyAutocloseStoreRoot(cwd string) string {
 		}
 		return filepath.Clean(root)
 	}
+	if cityPath, err := findCity(cwd); err == nil && pathIsWithin(cityPath, cwd) {
+		if beadsRoot := convoyAutocloseBeadsDirRoot(cwd); beadsRoot != "" &&
+			(samePath(beadsRoot, cityPath) || pathIsWithin(cityPath, beadsRoot)) {
+			return beadsRoot
+		}
+		return filepath.Clean(cwd)
+	}
+	if beadsRoot := convoyAutocloseBeadsDirRoot(cwd); beadsRoot != "" {
+		return beadsRoot
+	}
+	return cwd
+}
+
+func convoyAutocloseBeadsDirRoot(cwd string) string {
 	if beadsDir := strings.TrimSpace(os.Getenv("BEADS_DIR")); beadsDir != "" {
 		if !filepath.IsAbs(beadsDir) {
 			beadsDir = filepath.Join(cwd, beadsDir)
 		}
 		return filepath.Clean(filepath.Dir(beadsDir))
 	}
-	return cwd
+	return ""
 }
 
 // doConvoyAutocloseWith checks whether the closed bead's parent is a

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3328,6 +3328,9 @@ func TestDoInitFromDirPreservesPermissionsForLegacyTopLevelScripts(t *testing.T)
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hello"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	cityPath := filepath.Join(dir, "dst")
 	if err := os.MkdirAll(cityPath, 0o755); err != nil {
@@ -3370,6 +3373,9 @@ func TestDoInitFromDirPreservesRealTopLevelScriptsForPackV2Template(t *testing.T
 	}
 	scriptPath := filepath.Join(srcDir, "scripts", "run.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gc/provider_op_process_unix.go
+++ b/cmd/gc/provider_op_process_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareProviderOpCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd == nil || cmd.Process == nil {
+			return nil
+		}
+		pgid, err := syscall.Getpgid(cmd.Process.Pid)
+		if err == nil {
+			if killErr := syscall.Kill(-pgid, syscall.SIGKILL); killErr != nil &&
+				!errors.Is(killErr, os.ErrProcessDone) &&
+				!errors.Is(killErr, syscall.ESRCH) {
+				return killErr
+			}
+			return nil
+		}
+		if killErr := cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return killErr
+		}
+		return nil
+	}
+}

--- a/cmd/gc/provider_op_process_windows.go
+++ b/cmd/gc/provider_op_process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import "os/exec"
+
+func prepareProviderOpCommand(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd == nil || cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Kill()
+	}
+}

--- a/cmd/gc/provider_store_resolution_test.go
+++ b/cmd/gc/provider_store_resolution_test.go
@@ -191,6 +191,11 @@ func TestConvoyStoreCandidatesUseRigStoresForScopedFileProvider(t *testing.T) {
 func TestDoConvoyAutocloseUsesProviderAwareStore(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_STORE_ROOT", "")
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
 
 	cityDir := t.TempDir()
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
@@ -235,6 +240,54 @@ name = "demo"
 	}
 	if !strings.Contains(stdout.String(), "Auto-closed convoy") {
 		t.Fatalf("stdout = %q, want autoclose message", stdout.String())
+	}
+}
+
+func TestDoConvoyAutocloseIgnoresExternalBeadsDirWhenInCity(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	writeProviderAwareTestCity(t, cityDir, `[workspace]
+name = "demo"
+`)
+	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {
+		t.Fatal(err)
+	}
+	store, err := openScopeLocalFileStore(cityDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	convoy, err := store.Create(beads.Bead{Title: "deploy", Type: "convoy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create(beads.Bead{Title: "task", Type: "task", ParentID: convoy.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(child.ID); err != nil {
+		t.Fatal(err)
+	}
+	chdirProviderAwareTest(t, cityDir)
+	t.Setenv("BEADS_DIR", filepath.Join(t.TempDir(), ".beads"))
+
+	var stdout, stderr bytes.Buffer
+	doConvoyAutoclose(child.ID, &stdout, &stderr)
+
+	reloaded, err := openStoreAtForCity(cityDir, cityDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := reloaded.Get(convoy.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("convoy status = %q, want closed", updated.Status)
 	}
 }
 

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -305,5 +305,13 @@ func copyFile(src, dst string) error {
 		_ = closeErr
 		return fmt.Errorf("copying %q → %q: %w", src, dst, err)
 	}
-	return dstFile.Close()
+	if err := dstFile.Close(); err != nil {
+		return err
+	}
+	// OpenFile honors the process umask when creating files, so restore the
+	// source mode explicitly after the write to preserve executable scripts.
+	if err := os.Chmod(dst, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("chmod %q: %w", dst, err)
+	}
+	return nil
 }


### PR DESCRIPTION
Agent: epyc6-codex\n\n## Summary\n- Kills provider lifecycle/probe helper process groups on timeout/cancel to prevent orphaned children.\n- Fixes provider-aware convoy autoclose when ambient BEADS_DIR points outside the active city.\n- Restores copied file permissions after OpenFile so restrictive umask does not strip executable script bits, and hardens related tests.\n\n## Validation\n- timeout 90 mise exec go@1.25.9 -- go test ./cmd/gc -run 'TestRunProviderOp|TestRunProviderProbe|TestDoConvoyAutoclose|TestConvoyStoreCandidatesUseRigStoresForScopedFileProvider' -count=1\n- timeout 180 mise exec go@1.25.9 -- go test ./internal/overlay ./cmd/gc -run 'TestDoInitFromDirPreservesPermissionsForLegacyTopLevelScripts|TestDoInitFromDirPreservesRealTopLevelScriptsForPackV2Template|TestRunProviderOp|TestRunProviderProbe|TestDoConvoyAutoclose' -count=1\n- timeout 600 mise exec go@1.25.9 -- go test ./internal/formula ./internal/dispatch ./internal/worker/builtin ./internal/overlay ./cmd/gc -count=1\n- BD Symphony installed patched provider smoke evidence: /tmp/agents/bd-npxnm/evidence/20260505T145309Z-installed-patched-provider-smoke-1593900\n\nFeature-Key: bd-npxnm.3.6\nFeature-Key: bd-npxnm.9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->