### PR TITLE
Post-merge fix: Dolt cleanup force blockers

### DIFF
--- a/cmd/gc/cmd_dolt_cleanup.go
+++ b/cmd/gc/cmd_dolt_cleanup.go
@@ -223,6 +223,19 @@ type cleanupOptions struct {
 // otherwise the report still renders with errors describing the unreachable
 // data plane.
 func runDoltCleanup(opts cleanupOptions, stdout, stderr io.Writer) int {
+	if opts.MaxOrphanDBs < 0 {
+		report := CleanupReport{Schema: CleanupSchemaVersion}
+		recordCleanupErrorKind(
+			&report,
+			"config",
+			cleanupErrorKindInvalidMaxOrphanDBs,
+			"--max-orphan-dbs",
+			fmt.Errorf("--max-orphan-dbs must be non-negative, got %d", opts.MaxOrphanDBs),
+		)
+		emitReport(report, PortResolution{}, opts, stdout, stderr)
+		return 1
+	}
+
 	resolution := cleanupPortResolution(opts)
 	opts.PortResolution = resolution
 	protections, protectionErrors := rigProtections(opts.Rigs, opts.FS)
@@ -517,7 +530,7 @@ func fatalPortResolutionAttempt(resolution PortResolution) (PortResolutionAttemp
 		if attempt.Status != "error" {
 			continue
 		}
-		if attempt.Source != "--port flag" && attempt.Source != "city config dolt.port" && !isRigPortFileSource(attempt.Source) {
+		if attempt.Source != flagDoltPortSource && attempt.Source != cityConfigDoltPortSource && !isRigPortFileSource(attempt.Source) {
 			continue
 		}
 		if attempt.Detail != "" {
@@ -614,6 +627,7 @@ func emitHumanReport(report CleanupReport, resolution PortResolution, opts clean
 	emitDroppedSection(report, stdout)
 	emitOrphansSection(report, stdout)
 	emitProtectedSection(report, stdout)
+	emitForceBlockersSection(report, stdout)
 	emitErrorsOrSummary(report, opts, stdout)
 	if !opts.Force {
 		fmt.Fprintln(stdout, "")                              //nolint:errcheck
@@ -667,6 +681,21 @@ func emitProtectedSection(report CleanupReport, stdout io.Writer) {
 	}
 	for _, pid := range report.Reaped.ProtectedPIDs {
 		fmt.Fprintf(stdout, "  PID %d (active server or non-test path)\n", pid) //nolint:errcheck
+	}
+}
+
+func emitForceBlockersSection(report CleanupReport, stdout io.Writer) {
+	if len(report.ForceBlockers) == 0 {
+		return
+	}
+	fmt.Fprintln(stdout, "")                                                //nolint:errcheck
+	fmt.Fprintf(stdout, "FORCE BLOCKERS (%d)\n", len(report.ForceBlockers)) //nolint:errcheck
+	for _, blocker := range report.ForceBlockers {
+		if blocker.Name != "" {
+			fmt.Fprintf(stdout, "  [%s] %s - %s\n", blocker.Kind, blocker.Name, blocker.Error) //nolint:errcheck
+		} else {
+			fmt.Fprintf(stdout, "  [%s] %s\n", blocker.Kind, blocker.Error) //nolint:errcheck
+		}
 	}
 }
 
@@ -800,11 +829,14 @@ and non-leading hyphens. Missing or silent rig metadata disables forced
 drop/purge because the live database name cannot be proven safe.
 
 JSON envelope schema is stable: gc.dolt.cleanup.v1. Automation that
-uses --json must inspect summary.errors_total and errors; dry-run
+uses --json must inspect summary.errors_total and errors, and must also
+refuse to invoke --force when dry-run force_blockers is non-empty.
 force_blockers reports conditions that would block forced cleanup without
-incrementing errors_total. Cleanup stage errors are reported in the
-envelope even when the command can still return successfully after
-emitting the report.`,
+incrementing errors_total. The rig-protection blocker is intentionally
+global: missing or silent rig metadata prevents forced drop/purge because
+the command cannot prove all registered rig databases are protected.
+Cleanup stage errors are reported in the envelope even when the command
+can still return successfully after emitting the report.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if maxOrphanDBs < 0 {

--- a/cmd/gc/cmd_dolt_cleanup_test.go
+++ b/cmd/gc/cmd_dolt_cleanup_test.go
@@ -77,6 +77,29 @@ func TestDoltCleanupCmdRejectsNegativeMaxOrphanDBsBeforeCityResolution(t *testin
 	}
 }
 
+func TestRunDoltCleanupRejectsNegativeMaxOrphanDBs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		JSON:         true,
+		MaxOrphanDBs: -1,
+	}
+
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("runDoltCleanup exit=0; want negative MaxOrphanDBs rejected")
+	}
+	var r CleanupReport
+	if err := json.Unmarshal(stdout.Bytes(), &r); err != nil {
+		t.Fatalf("Unmarshal: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	if r.Summary.ErrorsTotal != 1 {
+		t.Fatalf("Summary.ErrorsTotal = %d, want 1; errors=%+v", r.Summary.ErrorsTotal, r.Errors)
+	}
+	if len(r.Errors) != 1 || r.Errors[0].Kind != cleanupErrorKindInvalidMaxOrphanDBs || !strings.Contains(r.Errors[0].Error, "non-negative") {
+		t.Fatalf("Errors = %+v, want invalid max orphan validation error", r.Errors)
+	}
+}
+
 func TestRunDoltCleanup_JSONOutputsResolvedPort(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.beads/dolt-server.port"] = []byte("28231\n")

--- a/cmd/gc/dolt_cleanup_human_test.go
+++ b/cmd/gc/dolt_cleanup_human_test.go
@@ -143,6 +143,37 @@ func TestRunDoltCleanup_HumanOutputShowsErrorsSection(t *testing.T) {
 	}
 }
 
+func TestRunDoltCleanup_HumanOutputShowsForceBlockersSection(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/rigs/silent/.beads/metadata.json"] = []byte(`{"database":"sqlite"}`)
+
+	var stdout, stderr bytes.Buffer
+	opts := cleanupOptions{
+		Rigs: []resolverRig{
+			{Name: "missing", Path: "/rigs/missing"},
+			{Name: "silent", Path: "/rigs/silent"},
+		},
+		FS:                fs,
+		JSON:              false,
+		DiscoverProcesses: func() ([]DoltProcInfo, error) { return nil, nil },
+	}
+	code := runDoltCleanup(opts, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d, stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"FORCE BLOCKERS (2)",
+		"rig-protection",
+		"missing",
+		"silent",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("human output missing force-blocker detail %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestRunDoltCleanup_HumanOutputCountsPostSIGTERMGoneAsReaped(t *testing.T) {
 	discoverCalls := 0
 

--- a/cmd/gc/dolt_cleanup_port.go
+++ b/cmd/gc/dolt_cleanup_port.go
@@ -17,6 +17,8 @@ const LegacyDefaultDoltPort = 3307
 
 const maxTCPPort = 65535
 
+const flagDoltPortSource = "--port flag"
+
 const cityConfigDoltPortSource = "city config dolt.port"
 
 // PortResolverInput bundles the inputs needed for the dolt port discovery
@@ -118,7 +120,7 @@ func ResolveDoltPort(in PortResolverInput) PortResolution {
 }
 
 func tryFlagPort(flag string) (PortResolutionAttempt, int, bool) {
-	src := "--port flag"
+	src := flagDoltPortSource
 	flag = strings.TrimSpace(flag)
 	if flag == "" {
 		return PortResolutionAttempt{Source: src, Status: "not-provided"}, 0, false

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -941,11 +941,14 @@ and non-leading hyphens. Missing or silent rig metadata disables forced
 drop/purge because the live database name cannot be proven safe.
 
 JSON envelope schema is stable: gc.dolt.cleanup.v1. Automation that
-uses --json must inspect summary.errors_total and errors; dry-run
+uses --json must inspect summary.errors_total and errors, and must also
+refuse to invoke --force when dry-run force_blockers is non-empty.
 force_blockers reports conditions that would block forced cleanup without
-incrementing errors_total. Cleanup stage errors are reported in the
-envelope even when the command can still return successfully after
-emitting the report.
+incrementing errors_total. The rig-protection blocker is intentionally
+global: missing or silent rig metadata prevents forced drop/purge because
+the command cannot prove all registered rig databases are protected.
+Cleanup stage errors are reported in the envelope even when the command
+can still return successfully after emitting the report.
 
 ```
 gc dolt-cleanup [flags]

--- a/examples/dolt/formulas/mol-dog-stale-db.toml
+++ b/examples/dolt/formulas/mol-dog-stale-db.toml
@@ -138,10 +138,11 @@ DISK_BYTES=$(jq -r '.summary.bytes_freed_disk // .purge.bytes_reclaimed // 0' "$
 RSS_BYTES=$(jq -r '.summary.bytes_freed_rss // 0' "$SCAN_FILE")
 SCAN_ERRS=$(jq -r '.summary.errors_total // 0' "$SCAN_FILE")
 INVALID_DROP_SKIPS=$(jq -r '[.dropped.skipped[]? | select(.reason == "invalid-identifier")] | length' "$SCAN_FILE")
+SCAN_FORCE_BLOCKERS=$(jq -r '[.force_blockers[]?] | length' "$SCAN_FILE")
 
 run_or_warn "emit scan event" gc event emit mol-dog-stale-db.scan \
   --message "$ORPHAN_DBS orphans (${DISK_BYTES} bytes), $ORPHAN_PROCS procs (${RSS_BYTES} bytes)" \
-  --payload "$(jq -c '{dropped: .dropped.count, purge_bytes: .purge.bytes_reclaimed, procs: (.reaped.targets | length), rss_bytes: .summary.bytes_freed_rss, errors: .summary.errors_total, invalid_identifier_skips: ([.dropped.skipped[]? | select(.reason == "invalid-identifier")] | length)}' "$SCAN_FILE")"
+  --payload "$(jq -c '{dropped: .dropped.count, purge_bytes: .purge.bytes_reclaimed, procs: (.reaped.targets | length), rss_bytes: .summary.bytes_freed_rss, errors: .summary.errors_total, invalid_identifier_skips: ([.dropped.skipped[]? | select(.reason == "invalid-identifier")] | length), force_blockers: ([.force_blockers[]?] | length)}' "$SCAN_FILE")"
 
 append_report_note "scan (dry-run)" "$SCAN_FILE"
 
@@ -156,14 +157,14 @@ MISSED_PURGE_BYTES=0
 REAP_KILLED=0
 REAP_TOTAL="$ORPHAN_PROCS"
 
-if [ "$SCAN_ERRS" -gt 0 ] || [ "$INVALID_DROP_SKIPS" -gt 0 ]; then
+if [ "$SCAN_ERRS" -gt 0 ] || [ "$INVALID_DROP_SKIPS" -gt 0 ] || [ "$SCAN_FORCE_BLOCKERS" -gt 0 ]; then
   ESCALATED=1
   run_or_warn "send dry-run error escalation mail" gc mail send mayor \
-    "ESCALATION: Dolt cleanup dry-run reported ${SCAN_ERRS} error(s), ${INVALID_DROP_SKIPS} invalid stale database identifier(s)" \
+    "ESCALATION: Dolt cleanup dry-run reported ${SCAN_ERRS} error(s), ${INVALID_DROP_SKIPS} invalid stale database identifier(s), ${SCAN_FORCE_BLOCKERS} force blocker(s)" \
     "Dry-run report attached to work bead. Operator review required before forcing cleanup."
   run_or_warn "emit dry-run error escalation" gc event emit mol-dog-stale-db.escalate \
-    --message "dry-run reported ${SCAN_ERRS} error(s), ${INVALID_DROP_SKIPS} invalid stale database identifier(s); leaving work bead open"
-  fail_open_after_drain "gc dolt-cleanup dry-run reported ${SCAN_ERRS} error(s), ${INVALID_DROP_SKIPS} invalid stale database identifier(s); leaving work bead open"
+    --message "dry-run reported ${SCAN_ERRS} error(s), ${INVALID_DROP_SKIPS} invalid stale database identifier(s), ${SCAN_FORCE_BLOCKERS} force blocker(s); leaving work bead open"
+  fail_open_after_drain "gc dolt-cleanup dry-run reported ${SCAN_ERRS} error(s), ${INVALID_DROP_SKIPS} invalid stale database identifier(s), ${SCAN_FORCE_BLOCKERS} force blocker(s); leaving work bead open"
 elif [ "$ORPHAN_TOTAL" -eq 0 ] && [ "$DISK_BYTES" -le 0 ]; then
   :
 elif [ "$ORPHAN_DBS" -gt "{{max_orphans_for_sql}}" ]; then
@@ -251,10 +252,6 @@ if [ "$APPLIED" -eq 1 ] && [ "$MISSED_PURGE_BYTES" -gt 0 ]; then
   ESCALATED=1
   run_or_warn "emit missed purge escalation" gc event emit mol-dog-stale-db.escalate \
     --message "apply missed ${MISSED_PURGE_BYTES} reclaimable bytes; leaving work bead open"
-elif [ "$APPLIED" -eq 1 ] && [ "$DONE_ERRS" -gt 0 ]; then
-  ESCALATED=1
-  run_or_warn "emit apply error escalation" gc event emit mol-dog-stale-db.escalate \
-    --message "apply reported ${DONE_ERRS} error(s); leaving work bead open"
 fi
 
 if [ "$ORPHAN_TOTAL" -ge "{{warn_threshold}}" ]; then
@@ -265,10 +262,6 @@ gc session nudge deacon "DOG_DONE: stale-db - orphans: ${ORPHAN_TOTAL}, applied:
 
 if [ "$APPLIED" -eq 1 ] && [ "$MISSED_PURGE_BYTES" -gt 0 ]; then
   fail_open_after_drain "gc dolt-cleanup apply missed ${MISSED_PURGE_BYTES} reclaimable bytes; leaving work bead open"
-fi
-
-if [ "$APPLIED" -eq 1 ] && [ "$DONE_ERRS" -gt 0 ]; then
-  fail_open_after_drain "gc dolt-cleanup apply reported ${DONE_ERRS} error(s); leaving work bead open"
 fi
 
 bd close "$WORK_BEAD" --reason "Stale DB scan complete (orphans=${ORPHAN_TOTAL}, applied=${APPLIED}, escalated=${ESCALATED})"

--- a/examples/dolt/stale_db_formula_test.go
+++ b/examples/dolt/stale_db_formula_test.go
@@ -36,6 +36,7 @@ func TestStaleDBFormulaRuntimeContract(t *testing.T) {
 		`gc dolt-cleanup --json --probe --force --max-orphan-dbs "{{max_orphans_for_sql}}" > "$APPLY_FILE"`,
 		`jq -r '.dropped.count // 0'`,
 		`jq -r '[.dropped.skipped[]? | select(.reason == "invalid-identifier")] | length'`,
+		`jq -r '[.force_blockers[]?] | length'`,
 		`jq -r '.reaped.targets | length'`,
 		`gc event emit mol-dog-stale-db.scan`,
 		`gc event emit mol-dog-stale-db.drop`,
@@ -43,7 +44,7 @@ func TestStaleDBFormulaRuntimeContract(t *testing.T) {
 		`gc event emit mol-dog-stale-db.reap`,
 		`gc event emit mol-dog-stale-db.done`,
 		`gc event emit mol-dog-stale-db.escalate`,
-		`if [ "$APPLIED" -eq 1 ] && [ "$DONE_ERRS" -gt 0 ]; then`,
+		`if [ "$APPLIED" -eq 1 ] && [ "$MISSED_PURGE_BYTES" -gt 0 ]; then`,
 		`leaving work bead open`,
 		`gc session nudge deacon "WARN: $ORPHAN_TOTAL Dolt orphan(s) seen this scan`,
 		`gc session nudge deacon "DOG_DONE: stale-db - orphans: ${ORPHAN_TOTAL}, applied: ${APPLIED}, escalated: ${ESCALATED}" || true`,
@@ -633,6 +634,45 @@ func TestStaleDBFormulaExitZeroMaxOrphanRefusalLeavesWorkOpenWithoutSuccessEvent
 	}
 }
 
+func TestStaleDBFormulaDryRunForceBlockersLeaveWorkOpenBeforeApply(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not found: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq not found: %v", err)
+	}
+
+	log, out, err := runStaleDBFormulaFailureCase(t, staleDBFailureCase{
+		scanJSON: `{"schema":"gc.dolt.cleanup.v1","force_blockers":[{"kind":"rig-protection","name":"missing","error":"missing metadata"}],"dropped":{"count":1,"failed":[]},"purge":{"bytes_reclaimed":4096},"reaped":{"count":0,"targets":[]},"summary":{"bytes_freed_disk":4096,"bytes_freed_rss":0,"errors_total":0}}`,
+		wantNote: "## scan (dry-run)",
+		wantLog:  "force blocker",
+	})
+	if err == nil {
+		t.Fatalf("rendered script exited successfully; want dry-run force blockers to keep work open\nlog:\n%s\noutput:\n%s", log, out)
+	}
+	for _, want := range []string{
+		"gc event emit mol-dog-stale-db.escalate",
+		"gc mail send mayor",
+		"gc runtime drain-ack",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("force-blocker path missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
+	}
+	for _, forbidden := range []string{
+		"gc dolt-cleanup --json --probe --force",
+		"gc event emit mol-dog-stale-db.drop",
+		"gc event emit mol-dog-stale-db.purge",
+		"gc event emit mol-dog-stale-db.reap",
+		"gc event emit mol-dog-stale-db.done",
+		"bd close bead-1",
+	} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("force-blocker path logged forbidden command %q\nlog:\n%s\noutput:\n%s", forbidden, log, out)
+		}
+	}
+}
+
 type staleDBFailureCase struct {
 	scanJSON     string
 	scanExit     string
@@ -818,6 +858,7 @@ maybe_fail() {
 }
 case "${1:-} ${2:-}" in
   "dolt-cleanup "*)
+    echo "gc $*" >> "$GC_TEST_LOG"
     case " $* " in
       *" --force "*)
         cat "$GC_TEST_APPLY_JSON"


### PR DESCRIPTION
## Summary
- Block the stale DB formula from force-applying when the dry-run reports `force_blockers`.
- Render force blockers in human `gc dolt-cleanup` output and document the JSON automation contract.
- Reject negative `MaxOrphanDBs` in the core cleanup runner and centralize the port-source label.

## Verification
- `make test`
- pre-commit hook: generated docs/schema, `golangci-lint`, `go vet`, unit tests, `go test ./test/docsync`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->