### PR TITLE
Clear stale E2E no-start reports

### DIFF
--- a/test/integration/e2e_helpers_test.go
+++ b/test/integration/e2e_helpers_test.go
@@ -480,6 +480,9 @@ func setupE2ECityNoStart(t *testing.T, city e2eCity) string {
 	if err != nil {
 		t.Fatalf("gc stop after init failed: %v\noutput: %s", err, out)
 	}
+	if err := os.RemoveAll(filepath.Join(cityDir, ".gc-reports")); err != nil {
+		t.Fatalf("removing stale reports after init stop: %v", err)
+	}
 	restartIsolatedSupervisor(t, env)
 
 	t.Cleanup(func() {

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -168,6 +168,26 @@ func TestE2E_Overlay(t *testing.T) {
 	}
 }
 
+func TestE2E_NoStartClearsReportsFromInit(t *testing.T) {
+	city := e2eCity{
+		Agents: []e2eAgent{
+			{Name: "nostart-report", StartCommand: e2eReportScript()},
+		},
+	}
+	cityDir := setupE2ECityNoStart(t, city)
+	reportDir := filepath.Join(cityDir, ".gc-reports")
+	entries, err := os.ReadDir(reportDir)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("reading report dir: %v", err)
+	}
+	if len(entries) > 0 {
+		t.Fatalf("setupE2ECityNoStart left stale report files: %v", entries)
+	}
+}
+
 // TestE2E_Hooks_Gemini verifies that install_agent_hooks=["gemini"] creates
 // .gemini/settings.json in the workdir.
 func TestE2E_Hooks_Gemini(t *testing.T) {


### PR DESCRIPTION
## Summary
- clear stale .gc-reports files after setupE2ECityNoStart stops the init-started city
- add an integration regression test that asserts no-start setup leaves no stale reports

## Verification
- go test -tags integration -timeout 4m ./test/integration -run '^(TestE2E_Overlay|TestE2E_NoStartClearsReportsFromInit)$' -count=1 -v
- ./scripts/test-integration-shard rest-full-3-of-8
- make test
- pre-commit hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->