### PR TITLE
bd-npxnm.10.10: Fix provider lifecycle process cleanup on timeout

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -63,6 +63,8 @@ var resolveProviderLifecycleGCBinary = func() string {
 	return ""
 }
 
+var providerProbeTimeout = 10 * time.Second
+
 var (
 	initDirIfReadyEnsureBeadsProvider = ensureBeadsProvider
 	initDirIfReadyInitAndHookDir      = initAndHookDir
@@ -1367,11 +1369,12 @@ func normalizeScopeDoltConfig(dir string, state contract.ConfigState) error {
 // available (exit 2) or on any error. Unlike runProviderOp, exit 2 means
 // "not running" rather than "not needed."
 func runProviderProbe(script, cityPath, provider string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), providerProbeTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, script, "probe")
 	cmd.WaitDelay = 2 * time.Second
+	prepareProviderOpCommand(cmd)
 	if cityPath != "" {
 		cmd.Env = providerLifecycleProcessEnv(cityPath, provider)
 	}
@@ -1469,7 +1472,7 @@ func acquireProviderSemaphoreForOp(cityPath, op string) (func(), error) {
 // operation. The "start" and "recover" operations get a longer timeout
 // because dolt server startup can take 30+ seconds for large data dirs.
 // All other operations use 30s.
-func providerOpTimeout(op string) time.Duration {
+var providerOpTimeout = func(op string) time.Duration {
 	switch op {
 	case "start", "recover":
 		return 120 * time.Second
@@ -1500,6 +1503,7 @@ func runProviderOpWithEnv(script string, environ []string, args ...string) error
 
 	cmd := exec.CommandContext(ctx, script, args...)
 	cmd.WaitDelay = 2 * time.Second
+	prepareProviderOpCommand(cmd)
 	if len(environ) > 0 {
 		cmd.Env = environ
 	}

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3116,6 +3116,98 @@ func TestRunProviderOpSanitizesInheritedRuntimeEnv(t *testing.T) {
 	}
 }
 
+func TestRunProviderOpKillsProcessGroupOnTimeout(t *testing.T) {
+	oldProviderOpTimeout := providerOpTimeout
+	providerOpTimeout = func(string) time.Duration {
+		return 300 * time.Millisecond
+	}
+	t.Cleanup(func() {
+		providerOpTimeout = oldProviderOpTimeout
+	})
+
+	dir := t.TempDir()
+	childPIDFile := filepath.Join(dir, "child.pid")
+	script := filepath.Join(dir, "provider-op.sh")
+	content := `#!/bin/sh
+sh -c 'echo $$ > "$GC_TEST_CHILD_PID"; while :; do sleep 1; done' &
+wait
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runProviderOpWithEnv(script, append(os.Environ(), "GC_TEST_CHILD_PID="+childPIDFile), "health")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	pidBytes, readErr := os.ReadFile(childPIDFile)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if convErr != nil {
+		t.Fatalf("parse child pid: %v", convErr)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("provider child pid %d survived provider op timeout", pid)
+}
+
+func TestRunProviderProbeKillsProcessGroupOnTimeout(t *testing.T) {
+	oldProviderProbeTimeout := providerProbeTimeout
+	providerProbeTimeout = 300 * time.Millisecond
+	t.Cleanup(func() {
+		providerProbeTimeout = oldProviderProbeTimeout
+	})
+
+	dir := t.TempDir()
+	childPIDFile := filepath.Join(dir, "child.pid")
+	script := filepath.Join(dir, "provider-probe.sh")
+	content := `#!/bin/sh
+sh -c 'echo $$ > "$GC_TEST_CHILD_PID"; while :; do sleep 1; done' &
+wait
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_TEST_CHILD_PID", childPIDFile)
+
+	if ok := runProviderProbe(script, "", ""); ok {
+		t.Fatal("expected timeout probe to return false")
+	}
+
+	pidBytes, readErr := os.ReadFile(childPIDFile)
+	if readErr != nil {
+		t.Fatalf("read child pid: %v", readErr)
+	}
+	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if convErr != nil {
+		t.Fatalf("parse child pid: %v", convErr)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("provider child pid %d survived provider probe timeout", pid)
+}
+
 func TestStartBeadsLifecycleDoesNotMutateProcessDoltEnv(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")

--- a/cmd/gc/provider_op_process_unix.go
+++ b/cmd/gc/provider_op_process_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareProviderOpCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd == nil || cmd.Process == nil {
+			return nil
+		}
+		pgid, err := syscall.Getpgid(cmd.Process.Pid)
+		if err == nil {
+			if killErr := syscall.Kill(-pgid, syscall.SIGKILL); killErr != nil &&
+				!errors.Is(killErr, os.ErrProcessDone) &&
+				!errors.Is(killErr, syscall.ESRCH) {
+				return killErr
+			}
+			return nil
+		}
+		if killErr := cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return killErr
+		}
+		return nil
+	}
+}

--- a/cmd/gc/provider_op_process_windows.go
+++ b/cmd/gc/provider_op_process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import "os/exec"
+
+func prepareProviderOpCommand(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd == nil || cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Kill()
+	}
+}


### PR DESCRIPTION
Agent: gascity-agent

## Summary

Fix provider lifecycle timeout cleanup so provider op/probe scripts cannot leave spawned child processes running after cancellation.

This is intentionally narrow. It does not include BD Symphony-specific docs, epyc6 production-readiness framing, BEADS_DIR convoy/autoclose behavior, or overlay chmod/umask behavior.

Closes #1714.

## What Changed

- Start provider op/probe commands in an isolated process group on Unix-like platforms.
- Override cancellation to kill the provider process group on timeout/cancel.
- Keep a Windows direct-process kill fallback without broadening scope into job-object management.
- Add focused tests proving spawned background children do not survive op/probe timeout.

## Validation

Passed:

```sh
mise exec go@1.25.9 -- go test ./cmd/gc -run 'TestRunProviderOpKillsProcessGroupOnTimeout|TestRunProviderProbeKillsProcessGroupOnTimeout|TestRunProviderOpSanitizesInheritedRuntimeEnv' -count=1 -timeout 90s
mise exec go@1.25.9 -- go vet ./cmd/gc
```

Review:

- `dx-review` Kimi + DeepSeek ran on the narrow branch with zero mutations.
- Both reviewer bodies recommended `APPROVE_NARROW_PR`.
- `dx-review summarize` still marked the review bodies unusable because the prose did not match its schema parser; raw reviewer logs are available locally under `/tmp/dx-runner/opencode/`.

Known local baseline note:

- A full local `go test ./cmd/gc -count=1` still fails on unrelated baseline issues around init-from-dir permission preservation and convoy autoclose store resolution. Those are intentionally excluded from this lifecycle-only PR.

Internal tracking: bd-npxnm.10.10

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->