### PR TITLE
fix(dolt): export DOLT_CLI_PASSWORD unconditionally in connected branch

### DIFF
--- a/examples/dolt/commands/sql/run.sh
+++ b/examples/dolt/commands/sql/run.sh
@@ -36,9 +36,13 @@ if is_running; then
     host="127.0.0.1"
   fi
   args="--host $host --port $GC_DOLT_PORT --user $GC_DOLT_USER --no-tls"
-  if [ -n "$GC_DOLT_PASSWORD" ]; then
-    export DOLT_CLI_PASSWORD="$GC_DOLT_PASSWORD"
-  fi
+  # Always export DOLT_CLI_PASSWORD so dolt does not prompt interactively.
+  # Non-TTY contexts (agent sessions) cannot answer the prompt and fail with
+  # "Failed to parse credentials: operation not supported by device". Empty
+  # is correct because the managed Dolt server runs without auth. An
+  # externally-set DOLT_CLI_PASSWORD is preserved.
+  : "${DOLT_CLI_PASSWORD=${GC_DOLT_PASSWORD-}}"
+  export DOLT_CLI_PASSWORD
   exec dolt $args sql "$@"
 else
   # Embedded mode — find first database directory.

--- a/examples/dolt/sql_test.go
+++ b/examples/dolt/sql_test.go
@@ -7,9 +7,11 @@
 package dolt_test
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -135,5 +137,118 @@ func TestSQLScriptForwardsQueryArgs(t *testing.T) {
 	}
 	if argv[sqlIdx+1] != "-q" || argv[sqlIdx+2] != "SELECT 1" {
 		t.Fatalf("argv after `sql` = %v; want [-q, SELECT 1] (the wrapper is dropping trailing args)", argv[sqlIdx+1:])
+	}
+}
+
+// writeFakeDoltCapturingEnv installs a fake `dolt` that records argv and the
+// full env to two files under dir. Returns paths to (argvFile, envFile).
+func writeFakeDoltCapturingEnv(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	argvFile := filepath.Join(dir, "argv.log")
+	envFile := filepath.Join(dir, "env.log")
+	body := `#!/bin/sh
+for a in "$@"; do printf '%s\n' "$a"; done > "` + argvFile + `"
+env > "` + envFile + `"
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return argvFile, envFile
+}
+
+// TestSQLScriptConnectedBranchExportsPasswordEnv guards the non-TTY contract
+// from sjarmak's PR #1587 ("preserve the empty-password connected-mode
+// contract so default sessions do not prompt interactively"). Without this,
+// agents calling `gc dolt sql` from a TTY-less context fail with
+// "Failed to parse credentials: operation not supported by device" because
+// dolt prompts for a password the agent cannot answer (stg-jge).
+//
+// The original wrapper exported DOLT_CLI_PASSWORD only when GC_DOLT_PASSWORD
+// was non-empty. With the managed Dolt server (no auth, empty password), that
+// branch never fires and dolt prompts. The fix exports DOLT_CLI_PASSWORD
+// unconditionally — empty when nothing else provides one.
+func TestSQLScriptConnectedBranchExportsPasswordEnv(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, sqlScript)
+
+	// Listen on an ephemeral port so the script's is_running probe
+	// (echo > /dev/tcp/127.0.0.1/$port) succeeds and the connected
+	// branch — the one that would prompt — actually runs. No accept
+	// loop needed: the kernel queues SYN-ACKs in the listen backlog,
+	// so the probe sees a connected socket without us touching it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck // test cleanup
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	binDir := t.TempDir()
+	argvFile, envFile := writeFakeDoltCapturingEnv(t, binDir)
+	cityPath := t.TempDir() // runtime.sh requires GC_CITY_PATH
+
+	cmd := exec.Command("sh", script, "-q", "SELECT 1")
+	// Strip every Dolt-related env so the test controls the inputs.
+	// Crucially do NOT set GC_DOLT_PASSWORD or DOLT_CLI_PASSWORD —
+	// the realistic case for non-TTY agents, and the one the bug bites.
+	cmd.Env = append(filteredEnv("PATH",
+		"GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "DOLT_CLI_PASSWORD",
+		"GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+strconv.Itoa(port),
+		"GC_DOLT_USER=root",
+	)
+
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("sql.sh exited non-zero: %v\noutput: %s", runErr, out)
+	}
+
+	argv := readArgv(t, argvFile)
+	if len(argv) == 0 {
+		t.Fatalf("fake dolt was never invoked; output: %s", out)
+	}
+
+	// The connected branch must be the one that ran (--host/--port before sql,
+	// no --data-dir). If the wrapper falls through to embedded mode the env
+	// contract under test no longer applies.
+	hostIdx, sqlIdx, dataDirIdx := -1, -1, -1
+	for i, a := range argv {
+		switch a {
+		case "--host":
+			if hostIdx == -1 {
+				hostIdx = i
+			}
+		case "sql":
+			if sqlIdx == -1 {
+				sqlIdx = i
+			}
+		case "--data-dir":
+			dataDirIdx = i
+		}
+	}
+	if dataDirIdx != -1 {
+		t.Fatalf("argv exercised embedded branch (saw --data-dir): %v", argv)
+	}
+	if hostIdx == -1 || sqlIdx == -1 || hostIdx >= sqlIdx {
+		t.Fatalf("argv did not exercise connected branch (--host before sql): %v", argv)
+	}
+
+	envBody, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	// Match the start-of-line prefix to avoid false positives on
+	// names like DOLT_CLI_PASSWORD_OTHER. An empty value (bare
+	// `DOLT_CLI_PASSWORD=`) counts as present — that is exactly
+	// the prompt-suppressing contract under test.
+	if !strings.Contains("\n"+string(envBody), "\nDOLT_CLI_PASSWORD=") {
+		t.Fatalf("DOLT_CLI_PASSWORD was not exported to dolt; without it dolt prompts and non-TTY agents fail. env:\n%s", envBody)
 	}
 }


### PR DESCRIPTION
## Summary

`examples/dolt/commands/sql/run.sh` connected branch now exports `DOLT_CLI_PASSWORD` unconditionally, so `dolt` does not prompt for a password. Non-TTY contexts (agent sessions) cannot answer the prompt and currently fail with *"Failed to parse credentials: operation not supported by device"* before any SQL runs.

PR #1587 stated this contract in its commit message (*"preserve the empty-password connected-mode contract so default sessions do not prompt interactively"*) but the script kept a `[ -n "$GC_DOLT_PASSWORD" ]` guard that never fires by default — so the prompt-suppressing path never ran.

The fix:

```sh
: "${DOLT_CLI_PASSWORD=${GC_DOLT_PASSWORD-}}"
export DOLT_CLI_PASSWORD
```

- preserves an externally-set `DOLT_CLI_PASSWORD`,
- else uses `GC_DOLT_PASSWORD` (even when set to empty),
- else defaults to empty — correct for the managed Dolt server, which runs without auth.

## Testing

- [x] `make check`
- [ ] `make check-docs` (no docs changed)
- [ ] `make test-integration` (no runtime/controller behavior changed)

Same three macOS-specific pre-existing failures noted on PR #1706 fail identically on `origin/main` without this PR; unrelated to this change.

## Checklist

- [x] Linked an issue, or explained why one is not needed (internal tracker)
- [x] Added or updated tests for behavior changes (`TestSQLScriptConnectedBranchExportsPasswordEnv` opens an ephemeral `net.Listen` so the script's TCP probe succeeds, drives the connected branch via a fake `dolt` that captures argv + env, asserts `DOLT_CLI_PASSWORD` is exported)
- [ ] Updated docs for user-facing changes (n/a — pack-internal wrapper)
- [ ] Called out breaking changes or migration notes (no behavior change for users with `GC_DOLT_PASSWORD` set)