### PR TITLE
fix(reconciler): preserve assigned-work drain recovery

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -159,6 +159,7 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 		}
 		evals[bead.ID] = wakeEvaluation{
 			Reasons:          reasons,
+			Reason:           d.Reason,
 			ConfigSuppressed: d.Reason == "idle-sleep",
 		}
 	}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -83,6 +83,26 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 	}
 }
 
+func TestAwakeSetToWakeEvalsPreservesDecisionReason(t *testing.T) {
+	evals := awakeSetToWakeEvals(
+		map[string]AwakeDecision{
+			"s-worker": {ShouldWake: true, Reason: "assigned-work"},
+		},
+		[]AwakeSessionBead{{
+			ID:          "mc-session-1",
+			SessionName: "s-worker",
+		}},
+	)
+
+	got := evals["mc-session-1"]
+	if got.Reason != "assigned-work" {
+		t.Fatalf("Reason = %q, want assigned-work", got.Reason)
+	}
+	if !containsWakeReason(got.Reasons, WakeWork) {
+		t.Fatalf("Reasons = %v, want WakeWork", got.Reasons)
+	}
+}
+
 func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &config.City{

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -29,6 +29,7 @@ import (
 
 type wakeEvaluation struct {
 	Reasons          []WakeReason
+	Reason           string
 	Policy           resolvedSessionSleepPolicy
 	ConfigSuppressed bool
 }

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -232,6 +232,12 @@ func cancelSessionDrainForPending(session beads.Bead, sp runtime.Provider, dt *d
 	return cancelSessionDrainIf(session, sp, dt, pendingDrainReasonCancelable)
 }
 
+func cancelOrphanedSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
+	return cancelSessionDrainIf(session, sp, dt, func(reason string) bool {
+		return reason == "orphaned"
+	})
+}
+
 func cancelSessionConfigDriftDrain(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
 	if dt == nil {
 		return false
@@ -453,6 +459,18 @@ func advanceSessionDrainsWithSessionsTraced(
 			if cancelSessionDrainForPending(*session, sp, dt) {
 				if trace != nil {
 					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplate(*session, cfg), name, ds.reason, "cancel_pending", nil, nil, "")
+				}
+				continue
+			}
+		}
+
+		if eval, ok := wakeEvals[session.ID]; ok &&
+			eval.Reason == "assigned-work" &&
+			containsWakeReason(eval.Reasons, WakeWork) &&
+			ds.reason == "orphaned" {
+			if cancelOrphanedSessionDrainForAssignedWork(*session, sp, dt) {
+				if trace != nil {
+					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplate(*session, cfg), name, ds.reason, "cancel_assigned_work", nil, nil, "")
 				}
 				continue
 			}

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -1022,6 +1022,81 @@ func TestAdvanceSessionDrains_DeferredInterrupt_CanceledBeforeSignal(t *testing.
 	}
 }
 
+func TestAdvanceSessionDrains_OrphanedDrainCanceledForAssignedWork(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	dt := newDrainTracker()
+
+	if err := sp.Start(context.Background(), "test-session", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := sp.SetMeta("test-session", "GC_DRAIN_ACK", "1"); err != nil {
+		t.Fatalf("SetMeta(GC_DRAIN_ACK): %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Title:  "test",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "test-session",
+			"template":     "worker",
+			"provider":     "claude",
+			"work_dir":     t.TempDir(),
+			"generation":   "3",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	dt.set(b.ID, &drainState{
+		startedAt:  now.Add(-10 * time.Second),
+		deadline:   now.Add(20 * time.Second),
+		reason:     "orphaned",
+		generation: 3,
+		ackSet:     true,
+	})
+	advanceSessionDrainsWithSessions(
+		dt,
+		sp,
+		store,
+		func(id string) *beads.Bead {
+			got, _ := store.Get(id)
+			return &got
+		},
+		[]beads.Bead{b},
+		map[string]wakeEvaluation{
+			b.ID: {
+				Reasons: []WakeReason{WakeWork},
+				Reason:  "assigned-work",
+			},
+		},
+		&config.City{Agents: []config.Agent{{Name: "worker"}}},
+		nil,
+		nil,
+		nil,
+		clk,
+	)
+
+	if ds := dt.get(b.ID); ds != nil {
+		t.Fatalf("drain = %+v, want canceled for assigned work", ds)
+	}
+	if ack, _ := sp.GetMeta("test-session", "GC_DRAIN_ACK"); ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want cleared after assigned-work cancellation", ack)
+	}
+	if !sp.IsRunning("test-session") {
+		t.Fatal("session should stay running after assigned-work cancellation")
+	}
+	for _, call := range sp.Calls {
+		if call.Method == "Interrupt" || call.Method == "Stop" {
+			t.Fatalf("runtime call %s should not happen after assigned-work cancellation; calls=%#v", call.Method, sp.Calls)
+		}
+	}
+}
+
 func TestAdvanceSessionDrains_DeferredInterrupt_CancelableNoSignal(t *testing.T) {
 	// For cancelable drains (no-wake-reason, idle), verify the drain is
 	// canceled before the deferred interrupt fires.


### PR DESCRIPTION
## Summary
- supersedes #1518 with a minimal rewrite on current origin/main
- carries awake decision reasons through the awake-set bridge so drain handling can distinguish concrete assigned work from generic work-query wakeups
- cancels an orphaned session drain when the same session has assigned work again, clearing the reconciler drain ack without interrupting or stopping the running session
- leaves the worker/session handle boundary and cached demand snapshot paths as-is because those parts of the original PR are already present on main

## Verification
- go test ./cmd/gc -run 'TestAwakeSetToWakeEvalsPreservesDecisionReason|TestAdvanceSessionDrains_OrphanedDrainCanceledForAssignedWork'\n- go test ./cmd/gc -run 'TestAwakeSetToWakeEvalsPreservesDecisionReason|TestAdvanceSessionDrains_OrphanedDrainCanceledForAssignedWork|TestAdvanceSessionDrains_DeferredInterrupt_CanceledBeforeSignal|TestGCNonTestFilesStayOnWorkerBoundary|TestExecutePreparedStartWaveUsesWorkerBoundaryForKnownSession|TestStartPreparedStartCandidateUsesWorkerBoundaryForRuntimeOnlyTarget'\n- GC_FAST_UNIT=1 go test ./cmd/gc\n- make test\n- pre-commit hook during commit\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->