### PR TITLE
test: cover pending-create pool capacity demand

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3281,6 +3281,76 @@ func TestBuildDesiredState_PendingCreatePoolSessionStaysDesiredWithoutScaleDeman
 	}
 }
 
+func TestBuildDesiredState_PendingCreatePoolSessionCountsTowardScaleDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "worker"
+	sessionName := "worker-mc-starting"
+	for i := 0; i < 2; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  fmt.Sprintf("queued work %d", i+1),
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": template,
+			},
+		}); err != nil {
+			t.Fatalf("create queued work: %v", err)
+		}
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  template,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker-1"},
+		Metadata: map[string]string{
+			"template":                  template,
+			"session_name":              sessionName,
+			"agent_name":                "worker-1",
+			"session_origin":            "ephemeral",
+			"pool_managed":              boolMetadata(true),
+			"pool_slot":                 "1",
+			"pending_create_claim":      boolMetadata(true),
+			"pending_create_started_at": time.Now().UTC().Format(time.RFC3339),
+			"state":                     "creating",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              template,
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if got := dsResult.ScaleCheckCounts[template]; got != 2 {
+		t.Fatalf("ScaleCheckCounts[%s] = %d, want 2", template, got)
+	}
+
+	var templateCount int
+	existing, ok := dsResult.State[sessionName]
+	if !ok {
+		t.Fatalf("desired state missing pending-create pool session: keys=%v", mapKeys(dsResult.State))
+	}
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == template {
+			templateCount++
+		}
+	}
+	if templateCount != 2 {
+		t.Fatalf("desired %s sessions = %d, want 2; keys=%v", template, templateCount, mapKeys(dsResult.State))
+	}
+	if existing.InstanceName != "worker-1" {
+		t.Fatalf("existing InstanceName = %q, want worker-1", existing.InstanceName)
+	}
+	if existing.PoolSlot != 1 {
+		t.Fatalf("existing PoolSlot = %d, want 1", existing.PoolSlot)
+	}
+}
+
 func TestBuildDesiredState_LegacyAliaslessEphemeralPoolSessionFallsBackToSessionNameIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3324,10 +3324,36 @@ func TestBuildDesiredState_PendingCreatePoolSessionCountsTowardScaleDemand(t *te
 			MaxActiveSessions: intPtr(5),
 		}},
 	}
+	sessionSnapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("load session snapshot: %v", err)
+	}
 
-	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	trace := newPoolDesiredStateTestTrace(template)
+	var stderr strings.Builder
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		store, nil, sessionSnapshot, trace, &stderr,
+	)
 	if got := dsResult.ScaleCheckCounts[template]; got != 2 {
 		t.Fatalf("ScaleCheckCounts[%s] = %d, want 2", template, got)
+	}
+	// The trace pins the buildDesiredState integration point: the pending
+	// create consumes one scale-demand slot before anonymous new requests are
+	// materialized.
+	if got := trace.decisionCounts[string(TraceSitePoolInFlightReuse)]; got != 1 {
+		t.Fatalf("in-flight reuse trace decisions = %d, want 1; stderr:\n%s", got, stderr.String())
+	}
+	rec := poolTraceDecision(t, trace, TraceSitePoolInFlightReuse)
+	for key, want := range map[string]int{
+		"scale_check":   2,
+		"in_flight":     1,
+		"reused":        1,
+		"anonymous_new": 1,
+	} {
+		if got := poolTraceFieldInt(t, rec.Fields, key); got != want {
+			t.Fatalf("%s = %d, want %d", key, got, want)
+		}
 	}
 
 	var templateCount int
@@ -3343,11 +3369,25 @@ func TestBuildDesiredState_PendingCreatePoolSessionCountsTowardScaleDemand(t *te
 	if templateCount != 2 {
 		t.Fatalf("desired %s sessions = %d, want 2; keys=%v", template, templateCount, mapKeys(dsResult.State))
 	}
+	var anonymousNew *TemplateParams
+	for name, tp := range dsResult.State {
+		if tp.TemplateName == template && name != sessionName {
+			tpCopy := tp
+			anonymousNew = &tpCopy
+			break
+		}
+	}
+	if anonymousNew == nil {
+		t.Fatalf("desired state missing anonymous new pool session: keys=%v", mapKeys(dsResult.State))
+	}
 	if existing.InstanceName != "worker-1" {
 		t.Fatalf("existing InstanceName = %q, want worker-1", existing.InstanceName)
 	}
 	if existing.PoolSlot != 1 {
 		t.Fatalf("existing PoolSlot = %d, want 1", existing.PoolSlot)
+	}
+	if anonymousNew.PoolSlot != 2 {
+		t.Fatalf("anonymous new PoolSlot = %d, want 2", anonymousNew.PoolSlot)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a regression test adapted from the intent of #1228
- verifies pending-create pool sessions count toward current scale demand through buildDesiredState
- verifies the existing pending-create session keeps its concrete pool identity while desired state materializes only the demanded total

## Attribution
Based on the contribution and bug analysis in #1228 by @thejosephstevens. The commit includes a Co-authored-by trailer for the original author.

## Tests
- go test ./cmd/gc -run TestBuildDesiredState_PendingCreatePoolSessionCountsTowardScaleDemand -count=1
- go test ./cmd/gc -run 'TestBuildDesiredState_PendingCreatePoolSession(CountsTowardScaleDemand|StaysDesiredWithoutScaleDemand|UsesConcreteBeadIdentity)|TestBuildDesiredState_PoolInFlightSessionsPreservePartialScaleDemand|TestSelectOrCreatePoolSessionBead_ReusesCreatingBeforeCreatingNew' -count=1
- pre-commit hook: golangci-lint, go vet, observable go test ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->