### PR TITLE
docs: fix tutorial 01 gc status snapshot (dog pool, named sessions)

### DIFF
--- a/docs/tutorials/01-cities-and-rigs.md
+++ b/docs/tutorials/01-cities-and-rigs.md
@@ -173,17 +173,25 @@ To check on the status of your city, use `gc status`:
 ~/my-city
 $ gc status
 my-city  /Users/csells/my-city
-  Controller: standalone-managed (PID 83621)
-  Authority: standalone controller PID 83621
-  Next: gc stop /Users/csells/my-city && gc start /Users/csells/my-city to hand ownership to the supervisor
+  Controller: supervisor-managed (PID 83621)
+  Authority: supervisor process PID 83621
   Suspended:  no
 
 Agents:
-  mayor                   pool (min=0, max=unlimited)
-  claude                  pool (min=0, max=unlimited)
+  dog                     scaled (min=0, max=3)
+    dog-1                 stopped
+    dog-2                 stopped
+    dog-3                 stopped
 
-Sessions: 1 active, 0 suspended
+0/3 agents running
+
+Named sessions:
+  mayor                   reserved-unmaterialized (always)
 ```
+
+The `dog` pool is a background utility agent from the built-in maintenance
+pack. It handles internal housekeeping like shutdown coordination. You don't
+need to interact with it — ignore it for now.
 
 ## Adding a rig
 


### PR DESCRIPTION
## Summary

The `gc status` output shown in Tutorial 01 was stale, predating the Apr 17 Pack V2 consolidation that made the maintenance pack always-included for all city types.

**Before (what the tutorial showed):**
```
Agents:
  mayor                   pool (min=0, max=unlimited)
  claude                  pool (min=0, max=unlimited)

Sessions: 1 active, 0 suspended
```

**After (what actually appears):**
```
Agents:
  dog                     scaled (min=0, max=3)
    dog-1                 stopped
    dog-2                 stopped
    dog-3                 stopped

0/3 agents running

Named sessions:
  mayor                   reserved-unmaterialized (always)
```

## Changes

- Update the `gc status` snapshot to match actual output
- Add a short callout explaining that `dog` comes from the built-in maintenance pack and can be ignored for now (it isn't covered later in the tutorials)

## Context

As a new user following this tutorial, I ran `gc status` on a freshly `gc init`'d minimal city and saw `dog-1/2/3` pool agents and `mayor` showing as `reserved-unmaterialized` — neither of which appears in the tutorial. I wasn't sure whether I'd made a mistake during init or was doing something wrong. The code was always correct; the snapshot just needed catching up.

Git history confirms the tutorial was last touched on Apr 20 in #1062 (renaming the template to "minimal") — three days after #809 made the maintenance pack always-included on Apr 17. The `gc status` snapshot was never updated in that commit.

## Test plan

- [x] `make check-docs` passes