### PR TITLE
fix(opencode): add OpenCode MCP projection support

### DIFF
--- a/cmd/gc/mcp_integration.go
+++ b/cmd/gc/mcp_integration.go
@@ -19,6 +19,7 @@ var managedMCPGitignoreEntries = []string{
 	".mcp.json",
 	filepath.ToSlash(filepath.Join(".gemini", "settings.json")),
 	filepath.ToSlash(filepath.Join(".codex", "config.toml")),
+	"opencode.json",
 }
 
 type mcpTargetSpec struct {
@@ -40,7 +41,10 @@ type resolvedMCPProjection struct {
 
 func supportsMCPProviderKind(kind string) bool {
 	switch strings.TrimSpace(kind) {
-	case materialize.MCPProviderClaude, materialize.MCPProviderCodex, materialize.MCPProviderGemini:
+	case materialize.MCPProviderClaude,
+		materialize.MCPProviderCodex,
+		materialize.MCPProviderGemini,
+		materialize.MCPProviderOpenCode:
 		return true
 	default:
 		return false

--- a/cmd/gc/template_resolve_mcp_test.go
+++ b/cmd/gc/template_resolve_mcp_test.go
@@ -132,6 +132,22 @@ args = ["notes-mcp"]
 		}
 	})
 
+	t.Run("wrapped opencode provider accepts mcp", func(t *testing.T) {
+		cityCfg.Providers["wrapped-opencode"] = config.ProviderSpec{
+			Base:       stringPtr("builtin:opencode"),
+			Command:    "echo",
+			PromptMode: "none",
+		}
+		agent := &config.Agent{Name: "worker", Scope: "city", Provider: "wrapped-opencode"}
+		tp, err := resolveTemplate(buildParams("tmux"), agent, agent.QualifiedName(), nil)
+		if err != nil {
+			t.Fatalf("resolveTemplate: %v", err)
+		}
+		if tp.FPExtra["mcp:opencode"] == "" {
+			t.Fatalf("expected opencode mcp fingerprint entry, got %+v", tp.FPExtra)
+		}
+	})
+
 	t.Run("nil city hard-errors when MCP would resolve non-empty", func(t *testing.T) {
 		// Regression guard: the prior fallback silently constructed a
 		// synthetic City that omitted imports/implicit/bootstrap layers,

--- a/internal/materialize/mcp_project.go
+++ b/internal/materialize/mcp_project.go
@@ -24,6 +24,8 @@ const (
 	MCPProviderCodex = "codex"
 	// MCPProviderGemini projects to Gemini CLI's project-native settings file.
 	MCPProviderGemini = "gemini"
+	// MCPProviderOpenCode projects to OpenCode's project-native JSON config.
+	MCPProviderOpenCode = "opencode"
 )
 
 // MCPProjection is one provider-native MCP payload for a single target file.
@@ -43,6 +45,7 @@ func BuildMCPProjection(providerKind, workdir string, servers []MCPServer) (MCPP
 	case MCPProviderClaude:
 	case MCPProviderCodex:
 	case MCPProviderGemini:
+	case MCPProviderOpenCode:
 	default:
 		return MCPProjection{}, fmt.Errorf("unsupported MCP provider %q", providerKind)
 	}
@@ -61,6 +64,8 @@ func BuildMCPProjection(providerKind, workdir string, servers []MCPServer) (MCPP
 		out.Target = filepath.Join(workdir, ".codex", "config.toml")
 	case MCPProviderGemini:
 		out.Target = filepath.Join(workdir, ".gemini", "settings.json")
+	case MCPProviderOpenCode:
+		out.Target = filepath.Join(workdir, "opencode.json")
 	}
 	return out, nil
 }
@@ -134,6 +139,8 @@ func (p MCPProjection) applyWithStderr(fs fsys.FS, stderr io.Writer) error {
 			return p.applyCodex(fs)
 		case MCPProviderGemini:
 			return p.applyGemini(fs)
+		case MCPProviderOpenCode:
+			return p.applyOpenCode(fs)
 		default:
 			return fmt.Errorf("unsupported MCP provider %q", p.Provider)
 		}
@@ -245,6 +252,39 @@ func (p MCPProjection) applyCodex(fs fsys.FS) error {
 	return p.writeManagedMarker(fs)
 }
 
+func (p MCPProjection) applyOpenCode(fs fsys.FS) error {
+	managed := p.isManaged(fs)
+	if len(p.Servers) == 0 && !managed {
+		return nil
+	}
+	doc, err := readJSONDoc(fs, p.Target)
+	if err != nil {
+		return err
+	}
+	if len(p.Servers) == 0 {
+		delete(doc, "mcp")
+		if len(doc) == 0 {
+			if err := removeManagedMCPFile(fs, p.Target); err != nil {
+				return err
+			}
+			return removeManagedMCPFile(fs, p.markerPath())
+		}
+	} else {
+		doc["mcp"] = p.opencodeServersDoc()
+	}
+	data, err := marshalJSONDoc(doc)
+	if err != nil {
+		return err
+	}
+	if err := writeManagedMCPFile(fs, p.Target, data); err != nil {
+		return err
+	}
+	if len(p.Servers) == 0 {
+		return removeManagedMCPFile(fs, p.markerPath())
+	}
+	return p.writeManagedMarker(fs)
+}
+
 func (p MCPProjection) claudeServersDoc() map[string]any {
 	out := make(map[string]any, len(p.Servers))
 	for _, server := range p.Servers {
@@ -311,6 +351,34 @@ func (p MCPProjection) codexServersDoc() map[string]any {
 			entry["url"] = server.URL
 			if len(server.Headers) > 0 {
 				entry["http_headers"] = cloneStringMap(server.Headers)
+			}
+		}
+		out[server.Name] = entry
+	}
+	return out
+}
+
+func (p MCPProjection) opencodeServersDoc() map[string]any {
+	out := make(map[string]any, len(p.Servers))
+	for _, server := range p.Servers {
+		entry := map[string]any{"enabled": true}
+		switch server.Transport {
+		case MCPTransportStdio:
+			entry["type"] = "local"
+			command := make([]string, 0, 1+len(server.Args))
+			if server.Command != "" {
+				command = append(command, server.Command)
+			}
+			command = append(command, server.Args...)
+			entry["command"] = command
+			if len(server.Env) > 0 {
+				entry["environment"] = cloneStringMap(server.Env)
+			}
+		case MCPTransportHTTP:
+			entry["type"] = "remote"
+			entry["url"] = server.URL
+			if len(server.Headers) > 0 {
+				entry["headers"] = cloneStringMap(server.Headers)
 			}
 		}
 		out[server.Name] = entry

--- a/internal/materialize/mcp_project_test.go
+++ b/internal/materialize/mcp_project_test.go
@@ -74,6 +74,14 @@ func TestBuildMCPProjectionTargetsAndStableHash(t *testing.T) {
 	if got, want := gemini.Target, filepath.Join("/work", ".gemini", "settings.json"); got != want {
 		t.Fatalf("gemini target = %q, want %q", got, want)
 	}
+
+	opencode, err := BuildMCPProjection(MCPProviderOpenCode, "/work", nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(opencode): %v", err)
+	}
+	if got, want := opencode.Target, filepath.Join("/work", "opencode.json"); got != want {
+		t.Fatalf("opencode target = %q, want %q", got, want)
+	}
 }
 
 func TestBuildMCPProjectionRejectsUnsupportedProvider(t *testing.T) {
@@ -333,6 +341,104 @@ func TestApplyMCPProjectionCodexRemovesManagedFileWhenItOnlyContainsMCP(t *testi
 	}
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		t.Fatalf("codex config should be removed, stat err = %v", err)
+	}
+}
+
+func TestApplyMCPProjectionOpenCodePreservesNonMCPConfig(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(target, []byte(`{"theme":"system","mcp":{"old":{"type":"local","command":["old"]}}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	proj, err := BuildMCPProjection(MCPProviderOpenCode, dir, []MCPServer{
+		{
+			Name:      "alpha",
+			Transport: MCPTransportStdio,
+			Command:   "uvx",
+			Args:      []string{"pkg"},
+			Env:       map[string]string{"TOKEN": "secret"},
+		},
+		{
+			Name:      "remote",
+			Transport: MCPTransportHTTP,
+			URL:       "https://mcp.example.com",
+			Headers:   map[string]string{"Authorization": "Bearer token"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildMCPProjection: %v", err)
+	}
+	if err := proj.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc struct {
+		Theme string `json:"theme"`
+		MCP   map[string]struct {
+			Type    string            `json:"type"`
+			Command []string          `json:"command"`
+			URL     string            `json:"url"`
+			Env     map[string]string `json:"environment"`
+			Headers map[string]string `json:"headers"`
+			Enabled bool              `json:"enabled"`
+		} `json:"mcp"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if doc.Theme != "system" {
+		t.Fatalf("theme = %q, want system", doc.Theme)
+	}
+	if _, ok := doc.MCP["old"]; ok {
+		t.Fatalf("old MCP entry was preserved: %+v", doc.MCP)
+	}
+	if got, want := doc.MCP["alpha"].Type, "local"; got != want {
+		t.Fatalf("alpha.type = %q, want %q", got, want)
+	}
+	if !reflect.DeepEqual(doc.MCP["alpha"].Command, []string{"uvx", "pkg"}) {
+		t.Fatalf("alpha.command = %#v, want uvx/pkg", doc.MCP["alpha"].Command)
+	}
+	if got := doc.MCP["alpha"].Env["TOKEN"]; got != "secret" {
+		t.Fatalf("alpha.environment TOKEN = %q, want secret", got)
+	}
+	if got, want := doc.MCP["remote"].Type, "remote"; got != want {
+		t.Fatalf("remote.type = %q, want %q", got, want)
+	}
+	if got, want := doc.MCP["remote"].URL, "https://mcp.example.com"; got != want {
+		t.Fatalf("remote.url = %q, want %q", got, want)
+	}
+	if got := doc.MCP["remote"].Headers["Authorization"]; got != "Bearer token" {
+		t.Fatalf("remote.headers Authorization = %q, want Bearer token", got)
+	}
+	if !doc.MCP["alpha"].Enabled || !doc.MCP["remote"].Enabled {
+		t.Fatalf("projected OpenCode MCP entries should be enabled: %+v", doc.MCP)
+	}
+
+	empty, err := BuildMCPProjection(MCPProviderOpenCode, dir, nil)
+	if err != nil {
+		t.Fatalf("BuildMCPProjection(empty): %v", err)
+	}
+	if err := empty.Apply(fsys.OSFS{}); err != nil {
+		t.Fatalf("Apply(empty): %v", err)
+	}
+	data, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile after empty apply: %v", err)
+	}
+	var after map[string]any
+	if err := json.Unmarshal(data, &after); err != nil {
+		t.Fatalf("Unmarshal after empty apply: %v", err)
+	}
+	if _, ok := after["mcp"]; ok {
+		t.Fatalf("mcp key remained after empty projection: %s", data)
+	}
+	if got := after["theme"]; got != "system" {
+		t.Fatalf("theme after empty apply = %v, want system", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`gc start` for a city with an agent using a wrapped `builtin:opencode` provider fails during init:

```
init: project MCP: agent "groktown.grokcats": effective MCP requires a supported provider family, got "opencode"
```

Gas City resolves the provider family correctly as `opencode`, but MCP projection only accepted Claude / Codex / Gemini.

This patch:

- Adds `opencode` as a supported MCP projection provider family
- Projects OpenCode MCP config into project-root `opencode.json` under the `mcp` object using OpenCode's native shape:
  - stdio servers → `type: "local"` with `command: [...]`
  - HTTP servers → `type: "remote"` with `url` and optional `headers`
- Preserves unrelated existing OpenCode config when updating or clearing the managed MCP subtree
- Adds `opencode.json` to managed MCP gitignore entries
- Adds regression coverage for OpenCode target selection / projection and wrapped `builtin:opencode` providers

## Provenance

Bundle prepared on a separate machine (commit base `66fb414f`). Patch applied cleanly here on top of `main` (`0ea311ae`). gofmt + targeted tests run before commit:

```
go test ./internal/materialize -run 'TestBuildMCPProjectionTargetsAndStableHash|TestApplyMCPProjectionOpenCodePreservesNonMCPConfig'  → ok
go test ./cmd/gc -run 'TestResolveTemplateMCPIntegration/(wrapped_opencode_provider_accepts_mcp|unsupported_provider_hard_errors_when_MCP_exists)'  → ok
```

## Test plan

- [ ] `go test ./internal/materialize ./cmd/gc` (broader coverage)
- [ ] `gc start <city>` against a city with a `builtin:opencode`-wrapped provider; confirm init succeeds and `opencode.json` is projected at project root with the configured MCP servers
- [ ] Edit a non-MCP key in `opencode.json` and re-project; confirm it is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->