### PR TITLE
fix(dolt): disable persistent stats for managed servers

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -6166,8 +6167,15 @@ data_dir: "$data_dir"
 
 behavior:
   auto_gc_behavior:
-    enable: true
+    enable: false
     archive_level: 0
+
+system_variables:
+  dolt_auto_gc_enabled: "OFF"
+  dolt_stats_enabled: "OFF"
+  dolt_stats_gc_enabled: "OFF"
+  dolt_stats_memory_only: "ON"
+  dolt_stats_paused: "ON"
 EOF
     ;;
   "dolt-state allocate-port")
@@ -6421,8 +6429,15 @@ data_dir: "$data_dir"
 
 behavior:
   auto_gc_behavior:
-    enable: true
+    enable: false
     archive_level: 0
+
+system_variables:
+  dolt_auto_gc_enabled: "OFF"
+  dolt_stats_enabled: "OFF"
+  dolt_stats_gc_enabled: "OFF"
+  dolt_stats_memory_only: "ON"
+  dolt_stats_paused: "ON"
 EOF
     printf '12345\n' > "$pid_file"
     printf '{"running":true,"pid":12345,"port":%%s,"data_dir":"%%s","started_at":"2026-04-14T00:00:00Z"}\n' "$port" "$data_dir" > "$state_file"
@@ -7750,7 +7765,7 @@ esac
 	shellConfigPath := filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
 	goConfig := readManagedDoltConfigForTest(t, goConfigPath)
 	shellConfig := readManagedDoltConfigForTest(t, shellConfigPath)
-	if goConfig != shellConfig {
+	if !reflect.DeepEqual(goConfig, shellConfig) {
 		t.Fatalf("managed config mismatch\nGo: %+v\nShell: %+v", goConfig, shellConfig)
 	}
 }
@@ -7773,6 +7788,7 @@ type managedDoltConfigForTest struct {
 			ArchiveLevel int  `yaml:"archive_level"`
 		} `yaml:"auto_gc_behavior"`
 	} `yaml:"behavior"`
+	SystemVariables map[string]string `yaml:"system_variables"`
 }
 
 func readManagedDoltConfigForTest(t *testing.T, path string) managedDoltConfigForTest {

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -138,8 +138,20 @@ data_dir: %q
 
 behavior:
   auto_gc_behavior:
-    enable: true
+    enable: false
     archive_level: %d
+
+# Managed Gas City workloads generate short-lived probe and metadata queries.
+# Dolt's persistent stats worker can make those tiny databases grow large
+# stats stores and burn CPU, especially on macOS endpoint-managed machines.
+# Keep stats disabled for managed servers; use explicit gc dolt maintenance
+# commands for storage cleanup instead of background workers.
+system_variables:
+  dolt_auto_gc_enabled: "OFF"
+  dolt_stats_enabled: "OFF"
+  dolt_stats_gc_enabled: "OFF"
+  dolt_stats_memory_only: "ON"
+  dolt_stats_paused: "ON"
 `, logLevel, port, host, dataDir, archiveLevel)
 	if err := fsys.WriteFileAtomic(fsys.OSFS{}, path, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write config file: %w", err)

--- a/cmd/gc/cmd_dolt_config_test.go
+++ b/cmd/gc/cmd_dolt_config_test.go
@@ -37,8 +37,14 @@ func TestDoltConfigWriteManagedCmd(t *testing.T) {
 		"host: 127.0.0.1",
 		`data_dir: "/tmp/city/.beads/dolt"`,
 		"archive_level: 0",
+		"enable: false",
 		"back_log: 50",
 		"max_connections_timeout_millis: 5000",
+		`dolt_auto_gc_enabled: "OFF"`,
+		`dolt_stats_enabled: "OFF"`,
+		`dolt_stats_gc_enabled: "OFF"`,
+		`dolt_stats_memory_only: "ON"`,
+		`dolt_stats_paused: "ON"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("config missing %q:\n%s", want, text)

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1063,8 +1063,20 @@ data_dir: "$DATA_DIR"
 
 behavior:
   auto_gc_behavior:
-    enable: true
+    enable: false
     archive_level: $archive_level
+
+# Managed Gas City workloads generate short-lived probe and metadata queries.
+# Dolt's persistent stats worker can make those tiny databases grow large
+# stats stores and burn CPU, especially on macOS endpoint-managed machines.
+# Keep stats disabled for managed servers; use explicit gc dolt maintenance
+# commands for storage cleanup instead of background workers.
+system_variables:
+  dolt_auto_gc_enabled: "OFF"
+  dolt_stats_enabled: "OFF"
+  dolt_stats_gc_enabled: "OFF"
+  dolt_stats_memory_only: "ON"
+  dolt_stats_paused: "ON"
 YAML
     mv "$tmp" "$CONFIG_FILE"
 }

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2392,8 +2392,13 @@ type DoltConfigExpectedValue struct {
 // inspected city path.
 func DoltConfigExpectedValues() []DoltConfigExpectedValue {
 	return []DoltConfigExpectedValue{
-		{"behavior.auto_gc_behavior.enable", true},
+		{"behavior.auto_gc_behavior.enable", false},
 		{"behavior.auto_gc_behavior.archive_level", 0},
+		{"system_variables.dolt_auto_gc_enabled", "OFF"},
+		{"system_variables.dolt_stats_enabled", "OFF"},
+		{"system_variables.dolt_stats_gc_enabled", "OFF"},
+		{"system_variables.dolt_stats_memory_only", "ON"},
+		{"system_variables.dolt_stats_paused", "ON"},
 		{"listener.read_timeout_millis", 300000},
 		{"listener.write_timeout_millis", 300000},
 		{"listener.max_connections", 1000},

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -2949,9 +2949,16 @@ func writeDoctorManagedDoltConfig(t *testing.T, cityPath string, overrides map[s
 		"data_dir": filepath.Join(cityPath, ".beads", "dolt"),
 		"behavior": map[string]any{
 			"auto_gc_behavior": map[string]any{
-				"enable":        true,
+				"enable":        false,
 				"archive_level": 0,
 			},
+		},
+		"system_variables": map[string]any{
+			"dolt_auto_gc_enabled":   "OFF",
+			"dolt_stats_enabled":     "OFF",
+			"dolt_stats_gc_enabled":  "OFF",
+			"dolt_stats_memory_only": "ON",
+			"dolt_stats_paused":      "ON",
 		},
 	}
 	for k, v := range overrides {
@@ -3194,10 +3201,10 @@ func TestDoltConfigCheck_WrongDataDir(t *testing.T) {
 	}
 }
 
-func TestDoltConfigCheck_AutoGCDisabled(t *testing.T) {
+func TestDoltConfigCheck_AutoGCEnabled(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, map[string]any{
-		"behavior.auto_gc_behavior.enable": false,
+		"behavior.auto_gc_behavior.enable": true,
 	})
 	c := NewDoltConfigCheck(dir, false)
 	r := c.Run(&CheckContext{})
@@ -3206,6 +3213,21 @@ func TestDoltConfigCheck_AutoGCDisabled(t *testing.T) {
 	}
 	if !strings.Contains(r.Message, "auto_gc_behavior.enable") {
 		t.Errorf("message = %q, want auto_gc_behavior.enable mention", r.Message)
+	}
+}
+
+func TestDoltConfigCheck_StatsEnabled(t *testing.T) {
+	dir := setupManagedDoltCity(t)
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"system_variables.dolt_stats_enabled": "ON",
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s", r.Status, r.Message)
+	}
+	if !strings.Contains(r.Message, "dolt_stats_enabled") {
+		t.Errorf("message = %q, want dolt_stats_enabled mention", r.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

On macOS endpoint-managed laptops, the managed Dolt server is repeatedly CPU-hot and Dolt-backed Gas City commands run slow or hang. The strongest local evidence pointed at Dolt's persistent stats worker:

- Dolt was CPU-hot while `SHOW PROCESSLIST` showed no long-running query
- Managed Dolt vars had stats enabled by default (`dolt_stats_enabled=ON`, `dolt_stats_gc_enabled=ON`, `dolt_stats_job_interval=30`)
- `__gc_probe` contained almost no real data, but its persistent stats store had grown to ~300 MB on disk

Managed Gas City workloads generate short-lived probe and metadata queries. Dolt's persistent stats worker turns those tiny databases into large stats stores and burns CPU. Manual maintenance remains available via explicit `gc dolt` commands.

This change makes new managed servers start with:

- `behavior.auto_gc_behavior.enable: false`
- `system_variables.dolt_auto_gc_enabled: "OFF"`
- `system_variables.dolt_stats_enabled: "OFF"`
- `system_variables.dolt_stats_gc_enabled: "OFF"`
- `system_variables.dolt_stats_memory_only: "ON"`
- `system_variables.dolt_stats_paused: "ON"`

Updates: Go config writer (`cmd/gc/cmd_dolt_config.go`), shell fallback writer (`examples/bd/assets/scripts/gc-beads-bd.sh`), doctor expected config values (`internal/doctor/checks.go`), tests/fixtures covering the managed config contract.

## Provenance

Bundle prepared on a separate machine for commit base `66fb414f`. Patch needed manual conflict resolution on `main` (`0ea311ae`) due to drift in surrounding context (notably `archive_level` is now 0 not 1). Substantive intent matches the original patch; the test that previously asserted `enable=false` triggers a warning was inverted (renamed `_AutoGCDisabled` → `_AutoGCEnabled`) and a new `_StatsEnabled` test was added.

Targeted tests pass:

```
go test ./cmd/gc -run 'TestDoltConfig|TestManagedDoltConfig'  → ok
go test ./internal/doctor -run 'TestDoltConfigCheck'  → ok
```

## Optional local remediation after merge

After deploying a `gc` with this patch, restart the managed Dolt server so it regenerates `dolt-config.yaml`. For a machine already affected by a bloated `__gc_probe` stats store, preserve diagnostics first, stop Dolt cleanly, then move the probe stats directory aside (don't `rm -rf`):

```bash
gc dolt stop
mv <city>/.beads/dolt/__gc_probe/.dolt/stats <city>/.beads/dolt/__gc_probe/.dolt/stats.disabled.$(date +%s)
gc dolt start
```

## Test plan

- [ ] `go test ./cmd/gc -run 'TestDoltConfig|TestManagedDoltConfig'`
- [ ] `go test ./internal/doctor -run 'TestDoltConfigCheck'`
- [ ] Restart a managed Dolt server, verify `dolt-config.yaml` includes the new `system_variables` block
- [ ] `gc doctor` reports the new keys without warning when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->