### PR TITLE
fix(reconciler): preserve assigned-work drain recovery

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -159,6 +159,7 @@ func awakeSetToWakeEvals(decisions map[string]AwakeDecision, sessionBeads []Awak
 		}
 		evals[bead.ID] = wakeEvaluation{
 			Reasons:          reasons,
+			Reason:           d.Reason,
 			ConfigSuppressed: d.Reason == "idle-sleep",
 		}
 	}

--- a/cmd/gc/compute_awake_bridge_test.go
+++ b/cmd/gc/compute_awake_bridge_test.go
@@ -83,6 +83,26 @@ func TestBuildAwakeInputFromReconcilerPopulatesPendingInteractions(t *testing.T)
 	}
 }
 
+func TestAwakeSetToWakeEvalsPreservesDecisionReason(t *testing.T) {
+	evals := awakeSetToWakeEvals(
+		map[string]AwakeDecision{
+			"s-worker": {ShouldWake: true, Reason: "assigned-work"},
+		},
+		[]AwakeSessionBead{{
+			ID:          "mc-session-1",
+			SessionName: "s-worker",
+		}},
+	)
+
+	got := evals["mc-session-1"]
+	if got.Reason != "assigned-work" {
+		t.Fatalf("Reason = %q, want assigned-work", got.Reason)
+	}
+	if !containsWakeReason(got.Reasons, WakeWork) {
+		t.Fatalf("Reasons = %v, want WakeWork", got.Reasons)
+	}
+}
+
 func TestBuildAwakeInputFromReconcilerCarriesNamedSessionDemand(t *testing.T) {
 	now := time.Now().UTC()
 	cfg := &config.City{

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -29,6 +29,7 @@ import (
 
 type wakeEvaluation struct {
 	Reasons          []WakeReason
+	Reason           string
 	Policy           resolvedSessionSleepPolicy
 	ConfigSuppressed bool
 }

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -28,7 +28,9 @@ import (
 )
 
 type wakeEvaluation struct {
-	Reasons          []WakeReason
+	Reasons []WakeReason
+	// Reason mirrors AwakeDecision.Reason on the ComputeAwakeSet bridge path.
+	// It is only actionable when Reasons contains the matching effective wake.
 	Reason           string
 	Policy           resolvedSessionSleepPolicy
 	ConfigSuppressed bool

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -671,6 +671,26 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			default:
 				if dops != nil {
 					if acked, _ := dops.isDrainAcked(name); acked {
+						hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+						if assignedErr != nil {
+							fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
+							hasAssignedWork = true
+						}
+						if providerAlive && hasAssignedWork {
+							if cancelOrphanedSessionDrainForAssignedWork(*session, sp, dt) ||
+								cancelRecoveredOrphanedDrainForAssignedWork(*session, sp, name) {
+								_ = dops.clearDrain(name)
+								template := normalizedSessionTemplate(*session, cfg)
+								if template == "" {
+									template = session.Metadata["template"]
+								}
+								fmt.Fprintf(stdout, "Canceled drain-acked session '%s' (assigned work)\n", name) //nolint:errcheck
+								if trace != nil {
+									trace.recordDecision("reconciler.drain.cancel", template, name, "orphaned", "cancel_assigned_work", nil, nil, "")
+								}
+								continue
+							}
+						}
 						stopped := !providerAlive
 						if providerAlive {
 							if err := workerKillSessionTargetWithConfig("", store, sp, cfg, name); err != nil {
@@ -691,11 +711,6 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								Subject: template,
 								Message: "drain acknowledged by agent",
 							})
-							hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
-							if assignedErr != nil {
-								fmt.Fprintf(stderr, "session reconciler: checking assigned work for drain-acked %s: %v\n", name, assignedErr) //nolint:errcheck
-								hasAssignedWork = true
-							}
 							if hasAssignedWork {
 								batch := sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", session.Metadata["wake_mode"] == "fresh")
 								_ = store.SetMetadataBatch(session.ID, batch)
@@ -1330,6 +1345,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if !demandOverrides {
 				eval.ConfigSuppressed = true
 				eval.Reasons = nil // Clear reasons so Phase 2 does not cancel the drain.
+				eval.Reason = ""
 			}
 		}
 		wakeEvals[target.session.ID] = eval

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2739,6 +2739,210 @@ func TestReconcileSessionBeads_OrphanDrainLogThrottled(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_DrainAckedOrphanCanceledForAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{}
+	if err := env.sp.Start(context.Background(), "orphan", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := env.sp.SetMeta("orphan", "GC_DRAIN_ACK", "1"); err != nil {
+		t.Fatalf("SetMeta(GC_DRAIN_ACK): %v", err)
+	}
+	session := env.createSessionBead("orphan", "worker")
+	env.markSessionActive(&session)
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("orphan"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+	env.dt.set(session.ID, &drainState{
+		startedAt:  env.clk.Now().Add(-defaultDrainTimeout),
+		deadline:   env.clk.Now().Add(-time.Second),
+		reason:     "orphaned",
+		generation: 1,
+		ackSet:     true,
+	})
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		nil,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		env.dt,
+		map[string]int{},
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	if !env.sp.IsRunning("orphan") {
+		t.Fatal("assigned-work orphan drain should be canceled before stopping the running session")
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("drain = %+v, want canceled", ds)
+	}
+	if ack, _ := env.sp.GetMeta("orphan", "GC_DRAIN_ACK"); ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want cleared", ack)
+	}
+}
+
+func TestReconcileSessionBeads_RecoveredDrainAckedOrphanCanceledForAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{}
+	if err := env.sp.Start(context.Background(), "orphan", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session := env.createSessionBead("orphan", "worker")
+	env.markSessionActive(&session)
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := setReconcilerDrainAckMetadata(env.sp, "orphan", &drainState{
+		reason:     "orphaned",
+		generation: 1,
+		ackSet:     true,
+	}); err != nil {
+		t.Fatalf("setReconcilerDrainAckMetadata: %v", err)
+	}
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		nil,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		newDrainOps(env.sp),
+		[]beads.Bead{work},
+		nil,
+		nil,
+		env.dt,
+		map[string]int{},
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	if !env.sp.IsRunning("orphan") {
+		t.Fatal("recovered assigned-work orphan drain should be canceled before stopping the running session")
+	}
+	if ack, _ := env.sp.GetMeta("orphan", "GC_DRAIN_ACK"); ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want cleared", ack)
+	}
+	if source, _ := env.sp.GetMeta("orphan", reconcilerDrainAckSourceKey); source != "" {
+		t.Fatalf("%s = %q, want cleared", reconcilerDrainAckSourceKey, source)
+	}
+}
+
+func TestReconcileSessionBeads_DeadDrainAckedOrphanWithAssignedWorkCompletesDrain(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{}
+	session := env.createSessionBead("orphan", "worker")
+	env.markSessionActive(&session)
+	work, err := env.store.Create(beads.Bead{
+		Title:    "assigned work",
+		Type:     "task",
+		Status:   "open",
+		Assignee: session.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	dops := newFakeDrainOps()
+	if err := dops.setDrainAck("orphan"); err != nil {
+		t.Fatalf("setDrainAck: %v", err)
+	}
+	env.dt.set(session.ID, &drainState{
+		startedAt:  env.clk.Now().Add(-defaultDrainTimeout),
+		deadline:   env.clk.Now().Add(-time.Second),
+		reason:     "orphaned",
+		generation: 1,
+		ackSet:     true,
+	})
+
+	reconcileSessionBeadsAtPath(
+		context.Background(),
+		"",
+		[]beads.Bead{session},
+		nil,
+		nil,
+		env.cfg,
+		env.sp,
+		env.store,
+		dops,
+		[]beads.Bead{work},
+		nil,
+		nil,
+		env.dt,
+		map[string]int{},
+		false,
+		nil,
+		"",
+		nil,
+		env.clk,
+		env.rec,
+		0,
+		0,
+		&env.stdout,
+		&env.stderr,
+	)
+
+	if env.sp.IsRunning("orphan") {
+		t.Fatal("dead provider should not be treated as recovered")
+	}
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("drain = %+v, want completed", ds)
+	}
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", session.ID, err)
+	}
+	if got.Metadata["state"] != "asleep" {
+		t.Fatalf("state = %q, want asleep", got.Metadata["state"])
+	}
+	if got.Metadata["sleep_reason"] != "idle" {
+		t.Fatalf("sleep_reason = %q, want idle", got.Metadata["sleep_reason"])
+	}
+}
+
 func TestReconcileSessionBeads_OrphanNotRunningClosed(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "other"}}}

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -232,6 +232,12 @@ func cancelSessionDrainForPending(session beads.Bead, sp runtime.Provider, dt *d
 	return cancelSessionDrainIf(session, sp, dt, pendingDrainReasonCancelable)
 }
 
+func cancelOrphanedSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
+	return cancelSessionDrainIf(session, sp, dt, func(reason string) bool {
+		return reason == "orphaned"
+	})
+}
+
 func cancelSessionConfigDriftDrain(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
 	if dt == nil {
 		return false
@@ -453,6 +459,18 @@ func advanceSessionDrainsWithSessionsTraced(
 			if cancelSessionDrainForPending(*session, sp, dt) {
 				if trace != nil {
 					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplate(*session, cfg), name, ds.reason, "cancel_pending", nil, nil, "")
+				}
+				continue
+			}
+		}
+
+		if eval, ok := wakeEvals[session.ID]; ok &&
+			eval.Reason == "assigned-work" &&
+			containsWakeReason(eval.Reasons, WakeWork) &&
+			ds.reason == "orphaned" {
+			if cancelOrphanedSessionDrainForAssignedWork(*session, sp, dt) {
+				if trace != nil {
+					trace.recordDecision("reconciler.drain.cancel", normalizedSessionTemplate(*session, cfg), name, ds.reason, "cancel_assigned_work", nil, nil, "")
 				}
 				continue
 			}

--- a/cmd/gc/session_wake.go
+++ b/cmd/gc/session_wake.go
@@ -234,6 +234,8 @@ func cancelSessionDrainForPending(session beads.Bead, sp runtime.Provider, dt *d
 
 func cancelOrphanedSessionDrainForAssignedWork(session beads.Bead, sp runtime.Provider, dt *drainTracker) bool {
 	return cancelSessionDrainIf(session, sp, dt, func(reason string) bool {
+		// Only concrete assigned work overrides an orphan drain; generic
+		// work-query and named-demand wakeups intentionally do not.
 		return reason == "orphaned"
 	})
 }
@@ -344,6 +346,16 @@ func staleOrLegacyDrainAckBeforeStart(session beads.Bead, sp runtime.Provider, n
 func cancelRecoveredReconcilerAckedDrain(session beads.Bead, sp runtime.Provider, name string) bool {
 	reason, ok := reconcilerDrainAckMatchesSession(session, sp, name)
 	if !ok || !pendingDrainReasonCancelable(reason) {
+		return false
+	}
+	clearReconcilerDrainAckMetadata(sp, name)
+	telemetry.RecordDrainTransition(context.Background(), name, reason, "cancel")
+	return true
+}
+
+func cancelRecoveredOrphanedDrainForAssignedWork(session beads.Bead, sp runtime.Provider, name string) bool {
+	reason, ok := reconcilerDrainAckMatchesSession(session, sp, name)
+	if !ok || reason != "orphaned" {
 		return false
 	}
 	clearReconcilerDrainAckMetadata(sp, name)

--- a/cmd/gc/session_wake_test.go
+++ b/cmd/gc/session_wake_test.go
@@ -1022,6 +1022,81 @@ func TestAdvanceSessionDrains_DeferredInterrupt_CanceledBeforeSignal(t *testing.
 	}
 }
 
+func TestAdvanceSessionDrains_OrphanedDrainCanceledForAssignedWork(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)
+	clk := &clock.Fake{Time: now}
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	dt := newDrainTracker()
+
+	if err := sp.Start(context.Background(), "test-session", runtime.Config{}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := sp.SetMeta("test-session", "GC_DRAIN_ACK", "1"); err != nil {
+		t.Fatalf("SetMeta(GC_DRAIN_ACK): %v", err)
+	}
+	b, err := store.Create(beads.Bead{
+		Title:  "test",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "test-session",
+			"template":     "worker",
+			"provider":     "claude",
+			"work_dir":     t.TempDir(),
+			"generation":   "3",
+			"state":        "active",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	dt.set(b.ID, &drainState{
+		startedAt:  now.Add(-10 * time.Second),
+		deadline:   now.Add(20 * time.Second),
+		reason:     "orphaned",
+		generation: 3,
+		ackSet:     true,
+	})
+	advanceSessionDrainsWithSessions(
+		dt,
+		sp,
+		store,
+		func(id string) *beads.Bead {
+			got, _ := store.Get(id)
+			return &got
+		},
+		[]beads.Bead{b},
+		map[string]wakeEvaluation{
+			b.ID: {
+				Reasons: []WakeReason{WakeWork},
+				Reason:  "assigned-work",
+			},
+		},
+		&config.City{Agents: []config.Agent{{Name: "worker"}}},
+		nil,
+		nil,
+		nil,
+		clk,
+	)
+
+	if ds := dt.get(b.ID); ds != nil {
+		t.Fatalf("drain = %+v, want canceled for assigned work", ds)
+	}
+	if ack, _ := sp.GetMeta("test-session", "GC_DRAIN_ACK"); ack != "" {
+		t.Fatalf("GC_DRAIN_ACK = %q, want cleared after assigned-work cancellation", ack)
+	}
+	if !sp.IsRunning("test-session") {
+		t.Fatal("session should stay running after assigned-work cancellation")
+	}
+	for _, call := range sp.Calls {
+		if call.Method == "Interrupt" || call.Method == "Stop" {
+			t.Fatalf("runtime call %s should not happen after assigned-work cancellation; calls=%#v", call.Method, sp.Calls)
+		}
+	}
+}
+
 func TestAdvanceSessionDrains_DeferredInterrupt_CancelableNoSignal(t *testing.T) {
 	// For cancelable drains (no-wake-reason, idle), verify the drain is
 	// canceled before the deferred interrupt fires.


### PR DESCRIPTION
## Summary

- Supersedes #1717, which superseded #1518, by carrying awake decision reasons through the awake-set bridge so drain handling can distinguish concrete assigned work from generic wakeups.
- Preserves @julianknutsen's original fix and authorship, then adds maintainer hardening for drain-acked orphan recovery before the stop path, including recovered persisted drain-ack metadata after controller restart.
- Adds reconciler-level regression coverage for live in-memory drains, recovered persisted acks, and dead-provider fallthrough to the existing drain completion path.

Credit: Original fix by @julianknutsen (commit preserved with original authorship).

## Testing

- [x] `go test ./cmd/gc -run 'TestAwakeSetToWakeEvalsPreservesDecisionReason|TestAdvanceSessionDrains_OrphanedDrainCanceledForAssignedWork|TestReconcileSessionBeads_DrainAckedOrphanCanceledForAssignedWork|TestReconcileSessionBeads_RecoveredDrainAckedOrphanCanceledForAssignedWork|TestReconcileSessionBeads_DeadDrainAckedOrphanWithAssignedWorkCompletesDrain|TestGCNonTestFilesStayOnWorkerBoundary' -count=1`
- [x] `GC_FAST_UNIT=1 go test ./cmd/gc`
- [x] `/home/ubuntu/go/bin/golangci-lint run ./...`
- [x] `go vet ./...`
- [ ] `make check`
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed: supersedes #1717.
- [x] Added or updated tests for behavior changes.
- [x] Updated docs for user-facing changes: not applicable; internal reconciler behavior only.
- [x] Called out breaking changes or migration notes: none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->