### PR TITLE
fix(polecat): cut feature branches from origin/<base>, not stale local default

### DIFF
--- a/examples/gastown/packs/gastown/assets/scripts/worktree-setup.sh
+++ b/examples/gastown/packs/gastown/assets/scripts/worktree-setup.sh
@@ -107,6 +107,21 @@ rmdir "$WT" 2>/dev/null || true
 git -C "$RIG_ROOT" worktree prune >/dev/null 2>&1 || true
 
 BRANCH=$(branch_name)
+
+# Determine the upstream default branch ref and refresh it so the agent's
+# persistent worktree branch is always created from the remote tip, not
+# from whatever happened to be checked out locally. Without this fetch +
+# explicit start-point, the worktree branch inherits a stale local default
+# branch — across many beads, this causes the agent's local default branch
+# to drift behind origin's, and feature branches cut from it carry
+# already-merged commits that the refinery rebase rejects as spurious
+# duplicates with mismatched hashes.
+DEFAULT_REF=$(git -C "$RIG_ROOT" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)
+if [ -n "$DEFAULT_REF" ]; then
+    DEFAULT_BRANCH=${DEFAULT_REF#refs/remotes/origin/}
+    git -C "$RIG_ROOT" fetch origin "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+fi
+
 if git -C "$RIG_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
     if ! GIT_LFS_SKIP_SMUDGE=1 git -C "$RIG_ROOT" worktree add "$WT" "$BRANCH"; then
         echo "worktree-setup: failed to create worktree at $WT from $RIG_ROOT (branch $BRANCH)" >&2
@@ -114,7 +129,14 @@ if git -C "$RIG_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
         exit 1
     fi
 else
-    if ! GIT_LFS_SKIP_SMUDGE=1 git -C "$RIG_ROOT" worktree add "$WT" -b "$BRANCH"; then
+    if [ -n "$DEFAULT_REF" ]; then
+        WORKTREE_ADD="git -C $RIG_ROOT worktree add $WT -b $BRANCH $DEFAULT_REF"
+    else
+        # Fallback: no origin/HEAD configured (detached, or no remote default
+        # set). Create from current HEAD as before.
+        WORKTREE_ADD="git -C $RIG_ROOT worktree add $WT -b $BRANCH"
+    fi
+    if ! GIT_LFS_SKIP_SMUDGE=1 $WORKTREE_ADD; then
         echo "worktree-setup: failed to create worktree at $WT from $RIG_ROOT (branch $BRANCH)" >&2
         restore_stage
         exit 1

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -133,10 +133,19 @@ if [ -n "$REJECTION" ]; then
 fi
 ```
 
-**If no branch** — create one and record it:
+**If no branch** — create one and record it. Always branch from the
+freshly-fetched `origin/{{base_branch}}`, never from local
+{{base_branch}} or whatever branch happens to be checked out.
+Polecat worktrees are reused across beads, so the local copy of
+{{base_branch}} may lag the remote — branching from a stale local ref
+inherits already-merged commits with stale hashes and causes the next
+refinery rebase to reject for spurious "duplicate" conflicts.
+
 ```bash
+git fetch origin {{base_branch}}                     # ensure origin ref is current
 BRANCH="polecat/{{issue}}"
-git checkout -b "$BRANCH" origin/{{base_branch}}
+git branch -D "$BRANCH" 2>/dev/null || true          # drop any stale local branch with the same name
+git checkout -B "$BRANCH" "origin/{{base_branch}}"   # force-create from the freshly-fetched remote tip
 gc bd update {{issue}} --set-metadata branch="$BRANCH"
 ```
 


### PR DESCRIPTION
## Summary

Polecat worktrees are persistent and reused across many beads. Two paths were silently inheriting commits from the worktree's local default branch instead of the upstream tip:

1. **`assets/scripts/worktree-setup.sh`** creates the agent's persistent worktree branch with `git worktree add ... -b $BRANCH` (no start-point) — branches from current HEAD, which is the local default branch, not origin's tip.
2. **`formulas/mol-polecat-work.toml`** "no branch" path uses `git checkout -b "$BRANCH" origin/{{base_branch}}`, which is correct in principle, but only if the polecat actually ran the preceding `git fetch --prune origin` step. Across many beads, local origin/`<base_branch>` ref drifts.

When the local default branch lags origin's tip, polecat feature branches inherit already-merged commits with stale hashes. The refinery's rebase sees those commits as spurious duplicates and rejects.

Witness `gc-wisp-drz` documented the pattern across biscuit/furiosa/nux/slit in cashmaster; only the freshly-spawned oreo was clean. Multiple beads bounced back to the pool with rebase-conflict rejections (ca-86ttb, ca-40s7g.5, etc.).

## Changes

- **`worktree-setup.sh`**: detect upstream default via `git symbolic-ref refs/remotes/origin/HEAD`, fetch that branch, and create the worktree's persistent branch from the remote ref. Falls back to the previous behavior if no `origin/HEAD` is configured (detached or no remote default set).
- **`mol-polecat-work.toml`**: harden the no-branch path:
  - `git fetch origin {{base_branch}}` inline (don't rely on the upstream step having run)
  - `git branch -D "$BRANCH" 2>/dev/null || true` to drop any stale local branch with the same name
  - `git checkout -B "$BRANCH" "origin/{{base_branch}}"` to force-create from the freshly-fetched remote tip
  - Comment block explaining why local refs must not be the start-point

## Test plan

- [ ] `sh -n examples/gastown/packs/gastown/assets/scripts/worktree-setup.sh` (already passes)
- [ ] On a polecat worktree previously contaminated with merged-via-different-hash commits, run a fresh polecat session — the new feature branch should NOT carry those commits, and refinery rebase should succeed
- [ ] On a fresh polecat (oreo-equivalent), confirm the new branch is created off `origin/<default>` not local `<default>`
- [ ] `gc doctor` continues to pass

## Provenance

Filed in cashmaster local beads as `ga-3k4d` after witness reports `gc-wisp-drz` and `gc-wisp-e13`. Multiple cashmaster beads (`ca-86ttb`, `ca-40s7g.5`) were bouncing back to pool with rebase-conflict rejections. With this fix the contamination won't recur for new branches; existing contaminated worktrees still need their persistent branch reset (one-time `git fetch origin <default> && git reset --hard origin/<default>` per polecat worktree, or simply recreate them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->