### PR TITLE
feat(contract): add Postgres MetadataState fields with parse validation

### DIFF
--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -104,7 +104,7 @@ var postgresBackendKeys = []string{
 
 // crossBackendKeysToScrub returns the on-disk metadata keys that should be
 // removed when canonicalising for the given backend. An empty backend
-// preserves all backend-specific keys (today's behaviour for unknown-shape
+// preserves all backend-specific keys (today's behavior for unknown-shape
 // metadata).
 func crossBackendKeysToScrub(backend string) []string {
 	switch backend {

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -46,11 +46,38 @@ type ConfigState struct {
 }
 
 // MetadataState is the canonical subset of .beads/metadata.json used by GC.
+//
+// Backend determines which backend-specific fields are meaningful. When
+// returned from LoadMetadataState the populated backend-specific fields are
+// guaranteed consistent with Backend — i.e. a state with Backend == "postgres"
+// always has every Postgres field non-empty and PostgresPort already verified
+// as a TCP-port-shaped string.
 type MetadataState struct {
-	Database     string
-	Backend      string
-	DoltMode     string
-	DoltDatabase string
+	Database         string `json:"database"`
+	Backend          string `json:"backend"`
+	DoltMode         string `json:"dolt_mode,omitempty"`
+	DoltDatabase     string `json:"dolt_database,omitempty"`
+	PostgresHost     string `json:"postgres_host,omitempty"`
+	PostgresPort     string `json:"postgres_port,omitempty"`
+	PostgresUser     string `json:"postgres_user,omitempty"`
+	PostgresDatabase string `json:"postgres_database,omitempty"`
+}
+
+// MetadataParseError reports a failure to parse or validate metadata.json.
+//
+// Returned by LoadMetadataState for JSON parse failures and for every E1–E5
+// rejection in the metadata contract. Callers may use errors.As to
+// discriminate parse failures from I/O failures (which surface as plain OS
+// errors).
+type MetadataParseError struct {
+	// Path is the absolute path to the metadata.json file that failed.
+	Path string
+	// Reason is the verbatim rejection reason text (the part after `: `).
+	Reason string
+}
+
+func (e *MetadataParseError) Error() string {
+	return fmt.Sprintf("load metadata %s: %s", e.Path, e.Reason)
 }
 
 var deprecatedMetadataKeys = []string{
@@ -61,6 +88,33 @@ var deprecatedMetadataKeys = []string{
 	"dolt_server_port",
 	"dolt_server_user",
 	"dolt_port",
+}
+
+var doltBackendKeys = []string{
+	"dolt_mode",
+	"dolt_database",
+}
+
+var postgresBackendKeys = []string{
+	"postgres_host",
+	"postgres_port",
+	"postgres_user",
+	"postgres_database",
+}
+
+// crossBackendKeysToScrub returns the on-disk metadata keys that should be
+// removed when canonicalising for the given backend. An empty backend
+// preserves all backend-specific keys (today's behaviour for unknown-shape
+// metadata).
+func crossBackendKeysToScrub(backend string) []string {
+	switch backend {
+	case "dolt":
+		return postgresBackendKeys
+	case "postgres":
+		return doltBackendKeys
+	default:
+		return nil
+	}
 }
 
 var deprecatedConfigKeys = []string{
@@ -191,6 +245,127 @@ func ReadDoltDatabase(fs fsys.FS, path string) (string, bool, error) {
 	return "", false, nil
 }
 
+// LoadMetadataState parses .beads/metadata.json at path and returns the
+// canonical MetadataState if the file exists and validates.
+//
+// Returns (zero, false, nil) when the file does not exist — callers decide
+// whether absence is an error in their context (mirrors ReadIssuePrefix and
+// ReadDoltDatabase). Returns a non-nil error for read failures other than
+// ENOENT and for any of the E1–E5 rejection cases. Validation failures are
+// wrapped in *MetadataParseError; callers may use errors.As to discriminate.
+//
+// Validation order is deterministic: the operator always sees the same
+// top-most message when several things are wrong. Order is JSON parse (E1) →
+// mixed-backend (E3) → unknown backend (E2) → postgres-required (E4) →
+// postgres-port-format (E5). An empty Backend is permitted at the parse
+// layer; downstream consumers that need a backend must check
+// state.Backend != "" themselves.
+func LoadMetadataState(fs fsys.FS, path string) (MetadataState, bool, error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MetadataState{}, false, nil
+		}
+		return MetadataState{}, false, err
+	}
+
+	abs, absErr := filepath.Abs(path)
+	if absErr != nil {
+		abs = path
+	}
+
+	var state MetadataState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return MetadataState{}, false, &MetadataParseError{
+			Path:   abs,
+			Reason: fmt.Sprintf("invalid metadata.json: %v", err),
+		}
+	}
+
+	if other, ok := mixedBackendField(state); ok {
+		return MetadataState{}, false, &MetadataParseError{
+			Path:   abs,
+			Reason: fmt.Sprintf("cannot mix dolt and postgres fields in a single scope (backend=%s but %s is also set)", state.Backend, other),
+		}
+	}
+
+	switch state.Backend {
+	case "", "dolt", "postgres":
+		// allowed
+	default:
+		return MetadataState{}, false, &MetadataParseError{
+			Path:   abs,
+			Reason: fmt.Sprintf("unsupported backend %q (supported: dolt, postgres)", state.Backend),
+		}
+	}
+
+	if state.Backend == "postgres" {
+		if state.PostgresHost == "" || state.PostgresPort == "" || state.PostgresUser == "" || state.PostgresDatabase == "" {
+			return MetadataState{}, false, &MetadataParseError{
+				Path:   abs,
+				Reason: "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)",
+			}
+		}
+		port, err := strconv.Atoi(state.PostgresPort)
+		if err != nil || port < 1 || port > 65535 {
+			return MetadataState{}, false, &MetadataParseError{
+				Path:   abs,
+				Reason: fmt.Sprintf("postgres_port must be a TCP port (1..65535), got %q", state.PostgresPort),
+			}
+		}
+	}
+
+	return state, true, nil
+}
+
+// mixedBackendField reports the first populated "other-backend" field name
+// (relative to state.Backend) when both Dolt-shaped and Postgres-shaped
+// fields are populated. Returns ("", false) when the state is not mixed.
+//
+// Field-iteration order is the JSON-key declaration order on MetadataState
+// (dolt_mode, dolt_database, postgres_host, postgres_port, postgres_user,
+// postgres_database). When state.Backend is empty or unknown, the first
+// populated field across both backends wins (with dolt fields preferred per
+// declaration order).
+func mixedBackendField(state MetadataState) (string, bool) {
+	type entry struct {
+		name    string
+		value   string
+		backend string
+	}
+	fields := []entry{
+		{"dolt_mode", state.DoltMode, "dolt"},
+		{"dolt_database", state.DoltDatabase, "dolt"},
+		{"postgres_host", state.PostgresHost, "postgres"},
+		{"postgres_port", state.PostgresPort, "postgres"},
+		{"postgres_user", state.PostgresUser, "postgres"},
+		{"postgres_database", state.PostgresDatabase, "postgres"},
+	}
+	var firstDolt, firstPostgres string
+	for _, f := range fields {
+		if f.value == "" {
+			continue
+		}
+		if f.backend == "dolt" && firstDolt == "" {
+			firstDolt = f.name
+		}
+		if f.backend == "postgres" && firstPostgres == "" {
+			firstPostgres = f.name
+		}
+	}
+	if firstDolt == "" || firstPostgres == "" {
+		return "", false
+	}
+	switch state.Backend {
+	case "postgres":
+		return firstDolt, true
+	case "dolt":
+		return firstPostgres, true
+	default:
+		return firstDolt, true
+	}
+}
+
 // EnsureCanonicalConfig rewrites config.yaml into canonical GC-managed form.
 func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, error) {
 	missing := false
@@ -273,10 +448,14 @@ func EnsureCanonicalMetadata(fs fsys.FS, path string, state MetadataState) (bool
 
 	changed := false
 	defaults := map[string]string{
-		"database":      strings.TrimSpace(state.Database),
-		"backend":       strings.TrimSpace(state.Backend),
-		"dolt_mode":     strings.TrimSpace(state.DoltMode),
-		"dolt_database": strings.TrimSpace(state.DoltDatabase),
+		"database":          strings.TrimSpace(state.Database),
+		"backend":           strings.TrimSpace(state.Backend),
+		"dolt_mode":         strings.TrimSpace(state.DoltMode),
+		"dolt_database":     strings.TrimSpace(state.DoltDatabase),
+		"postgres_host":     strings.TrimSpace(state.PostgresHost),
+		"postgres_port":     strings.TrimSpace(state.PostgresPort),
+		"postgres_user":     strings.TrimSpace(state.PostgresUser),
+		"postgres_database": strings.TrimSpace(state.PostgresDatabase),
 	}
 	for key, want := range defaults {
 		if want == "" {
@@ -288,6 +467,12 @@ func EnsureCanonicalMetadata(fs fsys.FS, path string, state MetadataState) (bool
 		}
 	}
 	for _, key := range deprecatedMetadataKeys {
+		if _, ok := meta[key]; ok {
+			delete(meta, key)
+			changed = true
+		}
+	}
+	for _, key := range crossBackendKeysToScrub(strings.TrimSpace(state.Backend)) {
 		if _, ok := meta[key]; ok {
 			delete(meta, key)
 			changed = true

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -1,7 +1,10 @@
 package contract
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -604,4 +607,478 @@ func countLineOccurrences(text, needle string) int {
 		}
 	}
 	return count
+}
+
+// metadataFixturePath joins the testdata fixture directory.
+func metadataFixturePath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("testdata", "metadata", name)
+}
+
+// copyMetadataFixture copies a fixture into a temp dir and returns the
+// destination path. The fixture is read with the OS filesystem so its bytes
+// match what would land on disk in production.
+func copyMetadataFixture(t *testing.T, fs fsys.FS, name string) (dst string, original []byte) {
+	t.Helper()
+	src := metadataFixturePath(t, name)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", src, err)
+	}
+	dst = filepath.Join(t.TempDir(), "metadata.json")
+	if err := fs.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write fixture copy: %v", err)
+	}
+	return dst, data
+}
+
+func TestLoadMetadataStateReturnsZeroWhenFileMissing(t *testing.T) {
+	fs := fsys.OSFS{}
+	path := filepath.Join(t.TempDir(), "metadata.json")
+
+	state, ok, err := LoadMetadataState(fs, path)
+	if err != nil {
+		t.Fatalf("LoadMetadataState() error = %v, want nil", err)
+	}
+	if ok {
+		t.Fatal("LoadMetadataState() ok = true, want false for missing file")
+	}
+	if state != (MetadataState{}) {
+		t.Fatalf("LoadMetadataState() state = %+v, want zero value", state)
+	}
+}
+
+func TestLoadMetadataStateAcceptsEmptyObject(t *testing.T) {
+	fs := fsys.OSFS{}
+	path := filepath.Join(t.TempDir(), "metadata.json")
+	if err := fs.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, ok, err := LoadMetadataState(fs, path)
+	if err != nil {
+		t.Fatalf("LoadMetadataState({}) error = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("LoadMetadataState({}) ok = false, want true")
+	}
+	if state != (MetadataState{}) {
+		t.Fatalf("LoadMetadataState({}) state = %+v, want zero value", state)
+	}
+}
+
+func TestLoadMetadataStateValidFixtures(t *testing.T) {
+	fs := fsys.OSFS{}
+	cases := []struct {
+		name    string
+		fixture string
+		want    MetadataState
+	}{
+		{
+			name:    "dolt round-trip",
+			fixture: "valid_dolt.json",
+			want: MetadataState{
+				Database:     "dolt",
+				Backend:      "dolt",
+				DoltMode:     "server",
+				DoltDatabase: "hq",
+			},
+		},
+		{
+			name:    "postgres round-trip",
+			fixture: "valid_postgres.json",
+			want: MetadataState{
+				Database:         "beads",
+				Backend:          "postgres",
+				PostgresHost:     "db.example.com",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads_pwu",
+			},
+		},
+		{
+			name:    "postgres round-trip with unknown key",
+			fixture: "valid_postgres_with_unknown.json",
+			want: MetadataState{
+				Database:         "beads",
+				Backend:          "postgres",
+				PostgresHost:     "db.example.com",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads_pwu",
+			},
+		},
+		{
+			name:    "empty backend permitted",
+			fixture: "valid_empty_backend.json",
+			want: MetadataState{
+				Database: "beads",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, _ := copyMetadataFixture(t, fs, tc.fixture)
+			got, ok, err := LoadMetadataState(fs, path)
+			if err != nil {
+				t.Fatalf("LoadMetadataState(%s) error = %v, want nil", tc.fixture, err)
+			}
+			if !ok {
+				t.Fatalf("LoadMetadataState(%s) ok = false, want true", tc.fixture)
+			}
+			if got != tc.want {
+				t.Fatalf("LoadMetadataState(%s) = %+v, want %+v", tc.fixture, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadMetadataStateRejectFixtures(t *testing.T) {
+	fs := fsys.OSFS{}
+	cases := []struct {
+		name            string
+		fixture         string
+		wantErrContains string
+	}{
+		{
+			name:            "E1 invalid json",
+			fixture:         "reject_invalid_json.json",
+			wantErrContains: "invalid metadata.json:",
+		},
+		{
+			name:            "E2 unknown backend",
+			fixture:         "reject_unknown_backend.json",
+			wantErrContains: `unsupported backend "postgress" (supported: dolt, postgres)`,
+		},
+		{
+			name:            "E3 mixed backends fires before required-fields",
+			fixture:         "reject_mixed_backends.json",
+			wantErrContains: "cannot mix dolt and postgres fields in a single scope (backend=dolt but postgres_database is also set)",
+		},
+		{
+			name:            "E3 surfaces dolt field when backend=postgres",
+			fixture:         "reject_mixed_pg_backend_with_dolt.json",
+			wantErrContains: "cannot mix dolt and postgres fields in a single scope (backend=postgres but dolt_database is also set)",
+		},
+		{
+			name:            "E3 surfaces dolt field first when backend is empty",
+			fixture:         "reject_mixed_empty_backend.json",
+			wantErrContains: "cannot mix dolt and postgres fields in a single scope (backend= but dolt_database is also set)",
+		},
+		{
+			name:            "E4 postgres missing host",
+			fixture:         "reject_pg_missing_host.json",
+			wantErrContains: "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)",
+		},
+		{
+			name:            "E4 postgres missing all fields",
+			fixture:         "reject_pg_missing_all.json",
+			wantErrContains: "backend=postgres requires postgres_host, postgres_port, postgres_user, postgres_database (all four must be non-empty)",
+		},
+		{
+			name:            "E5 postgres_port non-numeric",
+			fixture:         "reject_pg_port_nonnumeric.json",
+			wantErrContains: `postgres_port must be a TCP port (1..65535), got "abc"`,
+		},
+		{
+			name:            "E5 postgres_port zero",
+			fixture:         "reject_pg_port_zero.json",
+			wantErrContains: `postgres_port must be a TCP port (1..65535), got "0"`,
+		},
+		{
+			name:            "E5 postgres_port too high",
+			fixture:         "reject_pg_port_too_high.json",
+			wantErrContains: `postgres_port must be a TCP port (1..65535), got "99999"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, _ := copyMetadataFixture(t, fs, tc.fixture)
+
+			state, ok, err := LoadMetadataState(fs, path)
+			if err == nil {
+				t.Fatalf("LoadMetadataState(%s) error = nil, want %q", tc.fixture, tc.wantErrContains)
+			}
+			if ok {
+				t.Fatalf("LoadMetadataState(%s) ok = true, want false on rejection", tc.fixture)
+			}
+			if state != (MetadataState{}) {
+				t.Fatalf("LoadMetadataState(%s) state = %+v, want zero value on rejection", tc.fixture, state)
+			}
+
+			var parseErr *MetadataParseError
+			if !errors.As(err, &parseErr) {
+				t.Fatalf("LoadMetadataState(%s) error %T = %v, want *MetadataParseError", tc.fixture, err, err)
+			}
+			if parseErr.Path != path {
+				t.Fatalf("MetadataParseError.Path = %q, want %q", parseErr.Path, path)
+			}
+			if !strings.Contains(parseErr.Reason, tc.wantErrContains) {
+				t.Fatalf("MetadataParseError.Reason = %q, want substring %q", parseErr.Reason, tc.wantErrContains)
+			}
+			wantWrapped := "load metadata " + path + ": " + parseErr.Reason
+			if err.Error() != wantWrapped {
+				t.Fatalf("MetadataParseError.Error() = %q, want %q", err.Error(), wantWrapped)
+			}
+		})
+	}
+}
+
+func TestLoadMetadataStateSurfacesIOErrors(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "subdir")
+	if err := fs.MkdirAll(subdir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(subdir, 0o755) })
+
+	state, ok, err := LoadMetadataState(fs, filepath.Join(subdir, "metadata.json"))
+	if err == nil {
+		t.Skip("filesystem does not enforce mode 0000 (likely running as root); cannot exercise IO error path")
+	}
+	if ok {
+		t.Fatalf("LoadMetadataState() ok = true on IO error")
+	}
+	if state != (MetadataState{}) {
+		t.Fatalf("LoadMetadataState() state = %+v on IO error, want zero", state)
+	}
+	var parseErr *MetadataParseError
+	if errors.As(err, &parseErr) {
+		t.Fatalf("LoadMetadataState() returned *MetadataParseError on IO error; want plain error: %v", err)
+	}
+}
+
+func TestEnsureCanonicalMetadataIsByteIdempotentOnValidFixtures(t *testing.T) {
+	fs := fsys.OSFS{}
+	cases := []struct {
+		name    string
+		fixture string
+		state   MetadataState
+	}{
+		{
+			name:    "dolt",
+			fixture: "valid_dolt.json",
+			state: MetadataState{
+				Database:     "dolt",
+				Backend:      "dolt",
+				DoltMode:     "server",
+				DoltDatabase: "hq",
+			},
+		},
+		{
+			name:    "postgres",
+			fixture: "valid_postgres.json",
+			state: MetadataState{
+				Database:         "beads",
+				Backend:          "postgres",
+				PostgresHost:     "db.example.com",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads_pwu",
+			},
+		},
+		{
+			name:    "postgres with unknown key",
+			fixture: "valid_postgres_with_unknown.json",
+			state: MetadataState{
+				Database:         "beads",
+				Backend:          "postgres",
+				PostgresHost:     "db.example.com",
+				PostgresPort:     "5432",
+				PostgresUser:     "bd",
+				PostgresDatabase: "beads_pwu",
+			},
+		},
+		{
+			name:    "empty backend",
+			fixture: "valid_empty_backend.json",
+			state: MetadataState{
+				Database: "beads",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, original := copyMetadataFixture(t, fs, tc.fixture)
+
+			changed, err := EnsureCanonicalMetadata(fs, path, tc.state)
+			if err != nil {
+				t.Fatalf("EnsureCanonicalMetadata() error = %v", err)
+			}
+			if changed {
+				got, readErr := fs.ReadFile(path)
+				if readErr != nil {
+					t.Fatalf("read after canonicalise: %v", readErr)
+				}
+				t.Fatalf("EnsureCanonicalMetadata() reported changes for canonical fixture %s\nbefore: %s\nafter:  %s", tc.fixture, original, got)
+			}
+
+			got, err := fs.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read after no-op canonicalise: %v", err)
+			}
+			if !bytes.Equal(got, original) {
+				t.Fatalf("EnsureCanonicalMetadata() rewrote bytes for canonical fixture %s\nbefore: %s\nafter:  %s", tc.fixture, original, got)
+			}
+		})
+	}
+}
+
+func TestEnsureCanonicalMetadataPreservesExistingPostgresHostWhenStateOmitsIt(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+	input := `{"backend":"postgres","database":"beads","postgres_host":"db.example.com","postgres_port":"5432","postgres_user":"bd","postgres_database":"beads_pwu","custom":"keep"}`
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database:         "beads",
+		Backend:          "postgres",
+		PostgresPort:     "5432",
+		PostgresUser:     "bd",
+		PostgresDatabase: "beads_pwu",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata() error = %v", err)
+	}
+	if changed {
+		t.Fatal("EnsureCanonicalMetadata() should preserve existing postgres_host when state omits it")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if got := trimmedString(meta["postgres_host"]); got != "db.example.com" {
+		t.Fatalf("postgres_host = %q, want %q", got, "db.example.com")
+	}
+	if got := trimmedString(meta["custom"]); got != "keep" {
+		t.Fatalf("custom = %q, want %q", got, "keep")
+	}
+}
+
+func TestEnsureCanonicalMetadataScrubsPostgresKeysOnDoltCanonicalise(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+	input := `{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"hq","postgres_host":"stale.example.com","postgres_port":"5432","postgres_user":"stale","postgres_database":"stale","custom":"keep"}`
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: "hq",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalMetadata() should scrub postgres_* keys when canonicalising for backend=dolt")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	for _, key := range []string{"postgres_host", "postgres_port", "postgres_user", "postgres_database"} {
+		if _, ok := meta[key]; ok {
+			t.Fatalf("metadata should scrub %q on backend=dolt: %s", key, data)
+		}
+	}
+	if got := trimmedString(meta["custom"]); got != "keep" {
+		t.Fatalf("custom = %q, want %q", got, "keep")
+	}
+	if got := trimmedString(meta["dolt_database"]); got != "hq" {
+		t.Fatalf("dolt_database = %q, want %q", got, "hq")
+	}
+}
+
+func TestEnsureCanonicalMetadataScrubsDoltKeysOnPostgresCanonicalise(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+	input := `{"backend":"postgres","database":"beads","dolt_mode":"server","dolt_database":"stale","postgres_host":"db.example.com","postgres_port":"5432","postgres_user":"bd","postgres_database":"beads_pwu"}`
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database:         "beads",
+		Backend:          "postgres",
+		PostgresHost:     "db.example.com",
+		PostgresPort:     "5432",
+		PostgresUser:     "bd",
+		PostgresDatabase: "beads_pwu",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalMetadata() should scrub dolt_* keys when canonicalising for backend=postgres")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	for _, key := range []string{"dolt_mode", "dolt_database"} {
+		if _, ok := meta[key]; ok {
+			t.Fatalf("metadata should scrub %q on backend=postgres: %s", key, data)
+		}
+	}
+	if got := trimmedString(meta["postgres_host"]); got != "db.example.com" {
+		t.Fatalf("postgres_host = %q, want %q", got, "db.example.com")
+	}
+}
+
+func TestEnsureCanonicalMetadataPreservesAllKeysOnEmptyBackend(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metadata.json")
+	input := `{"database":"beads","backend":"","dolt_mode":"server","dolt_database":"hq","postgres_host":"db.example.com","custom":"keep"}`
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalMetadata(fs, path, MetadataState{
+		Database: "beads",
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalMetadata() error = %v", err)
+	}
+	if changed {
+		t.Fatal("EnsureCanonicalMetadata() should be a no-op for backend=\"\" with all unknowns preserved")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	for _, key := range []string{"dolt_mode", "dolt_database", "postgres_host", "custom"} {
+		if _, ok := meta[key]; !ok {
+			t.Fatalf("metadata should preserve %q when backend is empty: %s", key, data)
+		}
+	}
 }

--- a/internal/beads/contract/testdata/metadata/reject_invalid_json.json
+++ b/internal/beads/contract/testdata/metadata/reject_invalid_json.json
@@ -1,0 +1,3 @@
+{
+  "database": "beads",
+  "backend": "postgres",

--- a/internal/beads/contract/testdata/metadata/reject_mixed_backends.json
+++ b/internal/beads/contract/testdata/metadata/reject_mixed_backends.json
@@ -1,0 +1,6 @@
+{
+  "database": "beads",
+  "backend": "dolt",
+  "dolt_database": "hq",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_mixed_empty_backend.json
+++ b/internal/beads/contract/testdata/metadata/reject_mixed_empty_backend.json
@@ -1,0 +1,6 @@
+{
+  "database": "beads",
+  "backend": "",
+  "dolt_database": "hq",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_mixed_pg_backend_with_dolt.json
+++ b/internal/beads/contract/testdata/metadata/reject_mixed_pg_backend_with_dolt.json
@@ -1,0 +1,9 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "dolt_database": "stale",
+  "postgres_host": "db.example.com",
+  "postgres_port": "5432",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_missing_all.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_missing_all.json
@@ -1,0 +1,8 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "",
+  "postgres_port": "",
+  "postgres_user": "",
+  "postgres_database": ""
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_missing_host.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_missing_host.json
@@ -1,0 +1,8 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "",
+  "postgres_port": "5432",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_port_nonnumeric.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_port_nonnumeric.json
@@ -1,0 +1,8 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "db.example.com",
+  "postgres_port": "abc",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_port_too_high.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_port_too_high.json
@@ -1,0 +1,8 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "db.example.com",
+  "postgres_port": "99999",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_pg_port_zero.json
+++ b/internal/beads/contract/testdata/metadata/reject_pg_port_zero.json
@@ -1,0 +1,8 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "db.example.com",
+  "postgres_port": "0",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/reject_unknown_backend.json
+++ b/internal/beads/contract/testdata/metadata/reject_unknown_backend.json
@@ -1,0 +1,4 @@
+{
+  "database": "beads",
+  "backend": "postgress"
+}

--- a/internal/beads/contract/testdata/metadata/valid_dolt.json
+++ b/internal/beads/contract/testdata/metadata/valid_dolt.json
@@ -1,0 +1,6 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "hq"
+}

--- a/internal/beads/contract/testdata/metadata/valid_empty_backend.json
+++ b/internal/beads/contract/testdata/metadata/valid_empty_backend.json
@@ -1,0 +1,4 @@
+{
+  "database": "beads",
+  "backend": ""
+}

--- a/internal/beads/contract/testdata/metadata/valid_postgres.json
+++ b/internal/beads/contract/testdata/metadata/valid_postgres.json
@@ -1,0 +1,8 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "db.example.com",
+  "postgres_port": "5432",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu"
+}

--- a/internal/beads/contract/testdata/metadata/valid_postgres_with_unknown.json
+++ b/internal/beads/contract/testdata/metadata/valid_postgres_with_unknown.json
@@ -1,0 +1,9 @@
+{
+  "database": "beads",
+  "backend": "postgres",
+  "postgres_host": "db.example.com",
+  "postgres_port": "5432",
+  "postgres_user": "bd",
+  "postgres_database": "beads_pwu",
+  "custom_unknown": "preserved-as-is"
+}


### PR DESCRIPTION
## Summary

Slice 1/4 of the PG-auth design (`ga-dga2`). Foundation for slices 2-4
(`ga-3hay`, `ga-4qvs`, `ga-5c4x`).

- Extend `MetadataState` with `PostgresHost`, `PostgresPort`, `PostgresUser`,
  `PostgresDatabase` plus JSON tags on all eight fields. Existing Dolt scopes
  round-trip with no diff (`omitempty` on every backend-specific field).
- Add `LoadMetadataState(fs, path) -> (state, ok, err)` with the deterministic
  short-circuit specified by the design (E1 → E3 → E2 → E4 → E5). Validation
  failures are wrapped in `*MetadataParseError` so slice 4 can discriminate
  parse vs IO errors via `errors.As`.
- Extend `EnsureCanonicalMetadata` with the four PG keys in defaults and a
  backend-discriminated cross-backend scrub (dolt drops `postgres_*`,
  postgres drops `dolt_*`, empty backend preserves both).
- 14 fixtures under `internal/beads/contract/testdata/metadata/` cover every
  valid and rejected case plus the three `mixedBackendField` selector branches.

## Test plan

- [x] `go test ./internal/beads/contract/...` passes
- [x] `go vet ./internal/beads/contract/...` clean
- [ ] Reviewer confirms verbatim error wording matches designer §4
- [ ] Reviewer confirms validation reading order matches designer §5

Bead: ga-pnqg
Design: ga-0nmb
Architecture: ga-dga2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->