### PR TITLE
test(perf): add session-bead snapshot benchmarks (ga-t0pm)

### DIFF
--- a/cmd/gc/session_bead_snapshot_test.go
+++ b/cmd/gc/session_bead_snapshot_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+// seedSessionBeads populates a Store with the given number of open and
+// closed session beads. Open beads carry a fresh session_name and template
+// so newSessionBeadSnapshot's identity indexes get exercised the same way
+// as in production.
+func seedSessionBeads(tb testing.TB, store beads.Store, openCount, closedCount int) {
+	tb.Helper()
+	for i := 0; i < openCount; i++ {
+		bead, err := store.Create(beads.Bead{
+			Title:  fmt.Sprintf("open session %d", i),
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"session_name": fmt.Sprintf("agent-open-%d", i),
+				"template":     fmt.Sprintf("template-open-%d", i),
+			},
+		})
+		if err != nil {
+			tb.Fatalf("seed open session bead %d: %v", i, err)
+		}
+		_ = bead
+	}
+	for i := 0; i < closedCount; i++ {
+		bead, err := store.Create(beads.Bead{
+			Title:  fmt.Sprintf("closed session %d", i),
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"session_name": fmt.Sprintf("agent-closed-%d", i),
+				"template":     fmt.Sprintf("template-closed-%d", i),
+			},
+		})
+		if err != nil {
+			tb.Fatalf("seed closed session bead %d: %v", i, err)
+		}
+		if err := store.Close(bead.ID); err != nil {
+			tb.Fatalf("close session bead %d: %v", i, err)
+		}
+	}
+}
+
+// BenchmarkLoadSessionBeadSnapshot_LargeStore exercises the hot-path
+// snapshot loader against a store dominated by closed session beads. After
+// the IncludeClosed drop in loadSessionBeadSnapshot, runtime should scale
+// with the open count, not the open+closed total.
+func BenchmarkLoadSessionBeadSnapshot_LargeStore(b *testing.B) {
+	store := beads.NewMemStore()
+	seedSessionBeads(b, store, 50, 5000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		snap, err := loadSessionBeadSnapshot(store)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if got := len(snap.Open()); got != 50 {
+			b.Fatalf("Open()=%d, want 50", got)
+		}
+	}
+}
+
+// BenchmarkLoadSessionBeadSnapshot_OpenOnlyBaseline establishes a control
+// for BenchmarkLoadSessionBeadSnapshot_LargeStore: same open count, no
+// closed history. The two benchmarks should report comparable ns/op.
+func BenchmarkLoadSessionBeadSnapshot_OpenOnlyBaseline(b *testing.B) {
+	store := beads.NewMemStore()
+	seedSessionBeads(b, store, 50, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		snap, err := loadSessionBeadSnapshot(store)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if got := len(snap.Open()); got != 50 {
+			b.Fatalf("Open()=%d, want 50", got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes the regression-coverage Done-when item for **ga-t0pm**. The
spec'd snapshot/wait/doctor changes (Changes 1A, 1B, 2) already landed
in main:

- 1A + 1B in `d4046d75` (perf(reconciler): avoid broad tick-time store scans)
- 2 in #1672 (`a0323e50`, Fix gc status and doctor hangs)

This PR adds the missing benchmark to lock in the perf invariant.

## What

`cmd/gc/session_bead_snapshot_test.go`:

- `BenchmarkLoadSessionBeadSnapshot_LargeStore` — 50 open / 5000 closed.
- `BenchmarkLoadSessionBeadSnapshot_OpenOnlyBaseline` — 50 open / 0 closed (control).

Both should report identical alloc shape (181 allocs, ~105KB) since the
snapshot only retains open beads. A future re-introduction of
`IncludeClosed: true` would balloon both ns/op and alloc count at
LargeStore (snapshot would be built over 5050 beads instead of 50).

Local results on AMD Ryzen AI MAX+ 395:

```
BenchmarkLoadSessionBeadSnapshot_LargeStore-32           ~93us/op   105KB   181 allocs
BenchmarkLoadSessionBeadSnapshot_OpenOnlyBaseline-32     ~46us/op   105KB   181 allocs
```

The ~2x ns/op delta is MemStore's O(N) iteration overhead. Production
dolt filters via the labels+status indexes, so real-world LargeStore
should be closer to baseline.

## Test plan

- [x] `go vet ./cmd/gc/...` clean
- [x] `go test -run 'Test.*Snapshot|Test.*WaitWake|Test.*SessionModel|TestCloseBead' ./cmd/gc/` passes
- [x] `go test -bench='BenchmarkLoadSessionBeadSnapshot' -benchmem ./cmd/gc/` runs both benchmarks

Bead: ga-t0pm
Source design: ga-7pjf

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->