### PR TITLE
fix(lint): repair pre-existing main lint findings (ga-dw39)

### DIFF
--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -202,7 +202,7 @@ func TestCityStatusUsesStatusSnapshotToRouteACPDrainMetadata(t *testing.T) {
 
 	defaultSP := runtime.NewFake()
 	acpSP := runtime.NewFake()
-	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+	buildSessionProviderByName = func(name string, _ config.SessionConfig, _, _ string) (runtime.Provider, error) {
 		if name == "acp" {
 			return acpSP, nil
 		}

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -94,8 +94,7 @@ func doRigStatus(
 	dops drainOps,
 	rig config.Rig,
 	agents []config.Agent,
-	cityPath, cityName, sessionTemplate string,
-	cfg *config.City,
+	cityPath string,
 	stdout, stderr io.Writer,
 ) int {
 	_ = stderr // reserved for future error reporting
@@ -105,7 +104,7 @@ func doRigStatus(
 			store = opened
 		}
 	}
-	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, cityName, sessionTemplate, cfg, store, loadStatusSessionSnapshot(store), stdout, stderr)
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, "city", "", nil, store, loadStatusSessionSnapshot(store), stdout, stderr)
 }
 
 func doRigStatusWithStoreAndSnapshot(

--- a/cmd/gc/cmd_status_test.go
+++ b/cmd/gc/cmd_status_test.go
@@ -32,7 +32,7 @@ func TestDoRigStatus(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -67,7 +67,7 @@ func TestDoRigStatusSuspendedRig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -91,7 +91,7 @@ func TestDoRigStatusWithDraining(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -113,7 +113,7 @@ func TestDoRigStatusSuspendedAgent(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -140,7 +140,7 @@ func TestDoRigStatusReportsObservationErrors(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "/tmp/city", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "/tmp/city", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -726,7 +726,7 @@ func TestStatusSessionProviderUsesProvidedSnapshotToWrapObservedACPSessions(t *t
 
 	defaultSP := runtime.NewFake()
 	acpSP := runtime.NewFake()
-	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+	buildSessionProviderByName = func(name string, _ config.SessionConfig, _, _ string) (runtime.Provider, error) {
 		if name == "acp" {
 			return acpSP, nil
 		}


### PR DESCRIPTION
## Summary

`golangci-lint v2.9.0` (the version pinned by Makefile) reports four
findings against `origin/main` (b26a1310) that block every PR's
`Preflight / lint and smoke` job. None of them are introduced by an
in-flight PR.

| File | Linter | Finding |
|------|--------|---------|
| `cmd/gc/city_status_snapshot_test.go:205` | revive | unused-parameter `sc` |
| `cmd/gc/providers_test.go:729` | revive | unused-parameter `sc` |
| `cmd/gc/cmd_status.go:97` | unparam | `doRigStatus.cityName` always receives `"city"` |
| `cmd/gc/cmd_status.go:98` | unparam | `doRigStatus.cfg` always receives `nil` |

## Resolution

- **Test fakes for `buildSessionProviderByName`:** rename the unused
  `config.SessionConfig`, `cityName`, and `cityPath` parameters to `_`
  in the two flagged test fakes. The production signature stays
  unchanged (the var assignment is type-compatible).
- **`doRigStatus`:** drop the dead `cityName`, `cfg`, and (cascading)
  `sessionTemplate` parameters. `doRigStatus` is a test-only wrapper
  around `doRigStatusWithStoreAndSnapshot`; production code already
  calls the inner function directly with the real values, and all
  five test callers pass identical constants. The wrapper still
  passes `"city"`, `nil`, and `""` through to the inner function.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` (pinned v2.9.0) reports `0 issues.`
- [x] `go test -run 'TestDoRigStatus|TestStatusSessionProvider|TestCityStatusUsesStatusSnapshot' ./cmd/gc/` passes

## Unblocks

- PR #1727 (ga-pnqg slice 1/4 PG-auth) — held on this + F1 typo (now also pushed as `ce979ff5`)
- PR #1728 (ga-t0pm session-bead snapshot benchmarks) — held on this

Bead: ga-dw39
Reviewer: gascity/reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->