### PR TITLE
fix: treat scale check failures as partial demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -43,11 +43,11 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
-	// StoreQueryPartial is true when one or more bead store queries failed
-	// during assigned-work snapshot collection. When set, the reconciler must NOT
-	// drain sessions based on the (incomplete) desired state — a transient
-	// store failure would cause running sessions to be falsely orphaned
-	// and interrupted via Ctrl-C.
+	// StoreQueryPartial is true when one or more bead store queries or
+	// bead-backed scale checks failed. When set, the reconciler must NOT drain
+	// sessions based on the incomplete desired state — a transient failure
+	// would cause running sessions to be falsely orphaned and interrupted via
+	// Ctrl-C.
 	StoreQueryPartial bool
 	// SessionQueryPartial is true when session-bead snapshot loading failed.
 	// Orphan-release and drain decisions must treat this like an incomplete
@@ -81,7 +81,7 @@ func evaluatePendingPools(
 	pendingPools []poolEvalWork,
 	stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
-) []int {
+) ([]int, bool) {
 	type poolEvalResult struct {
 		desired int
 		err     error
@@ -135,9 +135,11 @@ func evaluatePendingPools(
 	wg.Wait()
 
 	counts := make([]int, len(pendingPools))
+	partial := false
 	for j, pw := range pendingPools {
 		pr := evalResults[j]
 		if pr.err != nil {
+			partial = true
 			if pw.newDemand {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", pr.err) //nolint:errcheck
 			} else {
@@ -146,7 +148,7 @@ func evaluatePendingPools(
 		}
 		counts[j] = pr.desired
 	}
-	return counts
+	return counts, partial
 }
 
 // evaluatePendingPoolsMap is like evaluatePendingPools but returns a map from
@@ -158,13 +160,13 @@ func evaluatePendingPoolsMap(
 	pendingPools []poolEvalWork,
 	stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
-) map[string]int {
-	counts := evaluatePendingPools(cfg, pendingPools, stderr, trace)
+) (map[string]int, bool) {
+	counts, partial := evaluatePendingPools(cfg, pendingPools, stderr, trace)
 	m := make(map[string]int, len(counts))
 	for j, pw := range pendingPools {
 		m[cfg.Agents[pw.agentIdx].QualifiedName()] = counts[j]
 	}
-	return m
+	return m, partial
 }
 
 // buildDesiredState computes the desired session state from config,
@@ -294,6 +296,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkStoreRefs []string
 	var storePartial bool
 	var scaleCheckCounts map[string]int
+	var scaleCheckPartial bool
 	var namedDefaultDemand map[string]bool
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
@@ -308,11 +311,14 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
-		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		scaleCheckCounts, scaleCheckPartial = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		if len(defaultScaleTargets) > 0 {
 			defaultCounts, errs := defaultScaleCheckCounts(defaultScaleTargets)
 			for _, err := range errs {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", err) //nolint:errcheck
+			}
+			if len(errs) > 0 {
+				scaleCheckPartial = true
 			}
 			for template, count := range defaultCounts {
 				scaleCheckCounts[template] = count
@@ -324,6 +330,13 @@ func buildDesiredStateWithSessionBeads(
 			for _, err := range namedErrs {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using named demand=false)\n", err) //nolint:errcheck
 			}
+			if len(namedErrs) > 0 {
+				scaleCheckPartial = true
+			}
+		}
+		if scaleCheckPartial {
+			storePartial = true
+			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed, drain decisions suppressed\n") //nolint:errcheck
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
@@ -340,7 +353,7 @@ func buildDesiredStateWithSessionBeads(
 		}
 	} else {
 		// No store — use scale_check counts directly.
-		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		scaleCheckCounts, _ = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		for _, pw := range pendingPools {
 			desiredCount := scaleCheckCounts[cfg.Agents[pw.agentIdx].QualifiedName()]
 			for slot := 1; slot <= desiredCount; slot++ {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2792,6 +2792,30 @@ func TestBuildDesiredState_ManualImplicitPoolSessionsStayDesired(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredState_ScaleCheckErrorMarksStoreQueryPartial(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "echo",
+			ScaleCheck:        "exit 42",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+
+	var stderr strings.Builder
+	result := buildDesiredStateWithSessionBeads("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, nil, nil, nil, &stderr)
+
+	if !result.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = false, want true when bead-backed scale_check fails; stderr=%s", stderr.String())
+	}
+	if got := result.ScaleCheckCounts["worker"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[worker] = %d, want 0 on failed new-demand probe", got)
+	}
+}
+
 func TestBuildDesiredState_DrainedPoolManagedSessionIsNotRediscovered(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -202,7 +202,7 @@ func TestCityStatusUsesStatusSnapshotToRouteACPDrainMetadata(t *testing.T) {
 
 	defaultSP := runtime.NewFake()
 	acpSP := runtime.NewFake()
-	buildSessionProviderByName = func(name string, sc config.SessionConfig, cityName, cityPath string) (runtime.Provider, error) {
+	buildSessionProviderByName = func(name string, _ config.SessionConfig, _, _ string) (runtime.Provider, error) {
 		if name == "acp" {
 			return acpSP, nil
 		}

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -94,8 +94,7 @@ func doRigStatus(
 	dops drainOps,
 	rig config.Rig,
 	agents []config.Agent,
-	cityPath, cityName, sessionTemplate string,
-	cfg *config.City,
+	cityPath string,
 	stdout, stderr io.Writer,
 ) int {
 	_ = stderr // reserved for future error reporting
@@ -105,7 +104,7 @@ func doRigStatus(
 			store = opened
 		}
 	}
-	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, cityName, sessionTemplate, cfg, store, loadStatusSessionSnapshot(store), stdout, stderr)
+	return doRigStatusWithStoreAndSnapshot(sp, dops, rig, agents, cityPath, "city", "", nil, store, loadStatusSessionSnapshot(store), stdout, stderr)
 }
 
 func doRigStatusWithStoreAndSnapshot(

--- a/cmd/gc/cmd_status_test.go
+++ b/cmd/gc/cmd_status_test.go
@@ -32,7 +32,7 @@ func TestDoRigStatus(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -67,7 +67,7 @@ func TestDoRigStatusSuspendedRig(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -91,7 +91,7 @@ func TestDoRigStatusWithDraining(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -113,7 +113,7 @@ func TestDoRigStatusSuspendedAgent(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0", code)
 	}
@@ -140,7 +140,7 @@ func TestDoRigStatusReportsObservationErrors(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := doRigStatus(sp, dops, rig, agents, "/tmp/city", "city", "", nil, &stdout, &stderr)
+	code := doRigStatus(sp, dops, rig, agents, "/tmp/city", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2085,9 +2085,8 @@ func (a *Agent) EffectiveScaleCheck() string {
 		return a.ScaleCheck
 	}
 	template := a.QualifiedName()
-	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
-		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`echo "${ready:-0}" || echo 0`
+	return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1644,8 +1644,11 @@ func TestEffectiveScaleCheckUsesReadyOnly(t *testing.T) {
 		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 
-	if !strings.Contains(check, "${ready:-0}") {
-		t.Errorf("missing ${ready:-0} in arithmetic sum")
+	if !strings.Contains(check, "--limit 0") {
+		t.Errorf("missing --limit 0 for complete ready count")
+	}
+	if strings.Contains(check, "2>/dev/null") || strings.Contains(check, "${ready:-0}") || strings.Contains(check, "|| echo 0") {
+		t.Errorf("default scale_check masks bd ready failures as zero: %q", check)
 	}
 	if strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("unexpected ${molecules:-0} in arithmetic sum")


### PR DESCRIPTION
## Summary
- stop the default shell scale_check from converting bd/jq failures into demand=0
- propagate explicit/default bead-backed scale_check errors into StoreQueryPartial
- add regressions so failed demand snapshots suppress drain/orphan decisions

## Tests
- go test -count=1 ./internal/config -run 'TestEffectiveScaleCheckUsesReadyOnly|TestEffectiveScaleCheckDefaults|TestDefaultPoolCheckUsesBdReady' -v
- go test -count=1 ./cmd/gc -run 'TestBuildDesiredState_ScaleCheckErrorMarksStoreQueryPartial|TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPoolSessionUntilRecoveryTick' -v

Note: pre-commit hook was run and reached lint, but failed on unrelated existing lint in cmd/gc/city_status_snapshot_test.go, cmd/gc/providers_test.go, and cmd/gc/cmd_status.go.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->