### PR TITLE
fix: treat scale check failures as partial demand

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -24,12 +24,18 @@ import (
 // can pass ScaleCheckCounts to ComputePoolDesiredStates without re-running
 // scale_check commands.
 type DesiredStateResult struct {
-	State             map[string]TemplateParams
-	BaseState         map[string]TemplateParams
-	ScaleCheckCounts  map[string]int // nil when store is nil or scale_check not run
-	PoolDesiredCounts map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
-	WorkSet           map[string]bool
-	AssignedWorkBeads []beads.Bead // actionable assigned work, plus stranded pool work that needs release
+	State            map[string]TemplateParams
+	BaseState        map[string]TemplateParams
+	ScaleCheckCounts map[string]int // nil when store is nil or scale_check not run
+	// ScaleCheckPartialTemplates records all templates whose bead-backed demand
+	// probe failed. PoolScaleCheckPartialTemplates drives generic pool retention;
+	// NamedScaleCheckPartialTemplates only protects configured named sessions.
+	ScaleCheckPartialTemplates      map[string]bool
+	PoolScaleCheckPartialTemplates  map[string]bool
+	NamedScaleCheckPartialTemplates map[string]bool
+	PoolDesiredCounts               map[string]int // runtime-owned demand snapshot; reused on stable patrol ticks when still fresh
+	WorkSet                         map[string]bool
+	AssignedWorkBeads               []beads.Bead // actionable assigned work, plus stranded pool work that needs release
 	// AssignedWorkStores is aligned by index with AssignedWorkBeads, so later
 	// mutation paths update rig-owned work in the right store even when
 	// independent stores produce overlapping bead IDs.
@@ -43,11 +49,10 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
-	// StoreQueryPartial is true when one or more bead store queries or
-	// bead-backed scale checks failed. When set, the reconciler must NOT drain
-	// sessions based on the incomplete desired state — a transient failure
-	// would cause running sessions to be falsely orphaned and interrupted via
-	// Ctrl-C.
+	// StoreQueryPartial is true when one or more bead store work queries
+	// failed. When set, the reconciler must NOT drain sessions based on the
+	// incomplete desired state — a transient failure would cause running
+	// sessions to be falsely orphaned and interrupted via Ctrl-C.
 	StoreQueryPartial bool
 	// SessionQueryPartial is true when session-bead snapshot loading failed.
 	// Orphan-release and drain decisions must treat this like an incomplete
@@ -81,7 +86,7 @@ func evaluatePendingPools(
 	pendingPools []poolEvalWork,
 	stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
-) ([]int, bool) {
+) ([]int, []bool) {
 	type poolEvalResult struct {
 		desired int
 		err     error
@@ -135,11 +140,11 @@ func evaluatePendingPools(
 	wg.Wait()
 
 	counts := make([]int, len(pendingPools))
-	partial := false
+	partials := make([]bool, len(pendingPools))
 	for j, pw := range pendingPools {
 		pr := evalResults[j]
 		if pr.err != nil {
-			partial = true
+			partials[j] = true
 			if pw.newDemand {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", pr.err) //nolint:errcheck
 			} else {
@@ -148,7 +153,7 @@ func evaluatePendingPools(
 		}
 		counts[j] = pr.desired
 	}
-	return counts, partial
+	return counts, partials
 }
 
 // evaluatePendingPoolsMap is like evaluatePendingPools but returns a map from
@@ -160,13 +165,18 @@ func evaluatePendingPoolsMap(
 	pendingPools []poolEvalWork,
 	stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
-) (map[string]int, bool) {
-	counts, partial := evaluatePendingPools(cfg, pendingPools, stderr, trace)
+) (map[string]int, map[string]bool) {
+	counts, partials := evaluatePendingPools(cfg, pendingPools, stderr, trace)
 	m := make(map[string]int, len(counts))
+	var partialTemplates map[string]bool
 	for j, pw := range pendingPools {
-		m[cfg.Agents[pw.agentIdx].QualifiedName()] = counts[j]
+		template := cfg.Agents[pw.agentIdx].QualifiedName()
+		m[template] = counts[j]
+		if partials[j] {
+			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
+		}
 	}
-	return m, partial
+	return m, partialTemplates
 }
 
 // buildDesiredState computes the desired session state from config,
@@ -296,7 +306,9 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkStoreRefs []string
 	var storePartial bool
 	var scaleCheckCounts map[string]int
-	var scaleCheckPartial bool
+	var poolScaleCheckPartialTemplates map[string]bool
+	var namedScaleCheckPartialTemplates map[string]bool
+	var scaleCheckPartialTemplates map[string]bool
 	var namedDefaultDemand map[string]bool
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
@@ -311,32 +323,30 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
-		scaleCheckCounts, scaleCheckPartial = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		scaleCheckCounts, poolScaleCheckPartialTemplates = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		if len(defaultScaleTargets) > 0 {
-			defaultCounts, errs := defaultScaleCheckCounts(defaultScaleTargets)
+			defaultCounts, partialTemplates, errs := defaultScaleCheckCounts(defaultScaleTargets)
 			for _, err := range errs {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", err) //nolint:errcheck
 			}
-			if len(errs) > 0 {
-				scaleCheckPartial = true
-			}
+			poolScaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(poolScaleCheckPartialTemplates, partialTemplates)
 			for template, count := range defaultCounts {
 				scaleCheckCounts[template] = count
 			}
 		}
 		if len(defaultNamedScaleTargets) > 0 {
 			var namedErrs []error
-			namedDefaultDemand, namedErrs = defaultNamedSessionDemand(defaultNamedScaleTargets, cfg, cityName)
+			var partialTemplates map[string]bool
+			namedDefaultDemand, partialTemplates, namedErrs = defaultNamedSessionDemand(defaultNamedScaleTargets, cfg, cityName)
 			for _, err := range namedErrs {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using named demand=false)\n", err) //nolint:errcheck
 			}
-			if len(namedErrs) > 0 {
-				scaleCheckPartial = true
-			}
+			namedScaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(namedScaleCheckPartialTemplates, partialTemplates)
 		}
-		if scaleCheckPartial {
-			storePartial = true
-			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed, drain decisions suppressed\n") //nolint:errcheck
+		scaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(scaleCheckPartialTemplates, poolScaleCheckPartialTemplates)
+		scaleCheckPartialTemplates = mergeScaleCheckPartialTemplates(scaleCheckPartialTemplates, namedScaleCheckPartialTemplates)
+		if len(scaleCheckPartialTemplates) > 0 {
+			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed for %s, retaining affected sessions\n", strings.Join(sortedBoolMapKeys(scaleCheckPartialTemplates), ",")) //nolint:errcheck
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
@@ -473,18 +483,21 @@ func buildDesiredStateWithSessionBeads(
 	// Phase 2: discover session beads created outside config iteration
 	// (e.g., by "gc session new"). Include them in desired state if they
 	// have a valid template and are not held/closed.
-	applySessionBeadDesiredOverlay(bp, cfg, desired, suspendedRigPaths, stderr)
+	applySessionBeadDesiredOverlay(bp, cfg, desired, suspendedRigPaths, poolScaleCheckPartialTemplates, namedScaleCheckPartialTemplates, stderr)
 
 	return DesiredStateResult{
-		State:                 desired,
-		BaseState:             baseDesired,
-		ScaleCheckCounts:      scaleCheckCounts,
-		AssignedWorkBeads:     assignedWorkBeads,
-		AssignedWorkStores:    assignedWorkStores,
-		AssignedWorkStoreRefs: assignedWorkStoreRefs,
-		NamedSessionDemand:    namedWorkReady,
-		StoreQueryPartial:     storePartial,
-		BeaconTime:            beaconTime,
+		State:                           desired,
+		BaseState:                       baseDesired,
+		ScaleCheckCounts:                scaleCheckCounts,
+		ScaleCheckPartialTemplates:      scaleCheckPartialTemplates,
+		PoolScaleCheckPartialTemplates:  poolScaleCheckPartialTemplates,
+		NamedScaleCheckPartialTemplates: namedScaleCheckPartialTemplates,
+		AssignedWorkBeads:               assignedWorkBeads,
+		AssignedWorkStores:              assignedWorkStores,
+		AssignedWorkStoreRefs:           assignedWorkStoreRefs,
+		NamedSessionDemand:              namedWorkReady,
+		StoreQueryPartial:               storePartial,
+		BeaconTime:                      beaconTime,
 	}
 }
 
@@ -517,9 +530,11 @@ func applySessionBeadDesiredOverlay(
 	cfg *config.City,
 	desired map[string]TemplateParams,
 	suspendedRigPaths map[string]bool,
+	poolScaleCheckPartialTemplates map[string]bool,
+	namedScaleCheckPartialTemplates map[string]bool,
 	stderr io.Writer,
 ) {
-	realizedRoots := discoverSessionBeadsWithRoots(bp, cfg, desired, suspendedRigPaths, stderr)
+	realizedRoots := discoverSessionBeadsWithRoots(bp, cfg, desired, suspendedRigPaths, poolScaleCheckPartialTemplates, namedScaleCheckPartialTemplates, stderr)
 	realizeDependencyFloors(bp, cfg, desired, realizedRoots, suspendedRigPaths, stderr)
 }
 
@@ -548,7 +563,7 @@ func refreshDesiredStateWithSessionBeads(
 
 	bp := newAgentBuildParams(cityName, cityPath, cfg, sp, result.BeaconTime, store, stderr)
 	bp.sessionBeads = sessionBeads
-	applySessionBeadDesiredOverlay(bp, cfg, refreshed.State, buildSuspendedRigPaths(cfg), stderr)
+	applySessionBeadDesiredOverlay(bp, cfg, refreshed.State, buildSuspendedRigPaths(cfg), result.PoolScaleCheckPartialTemplates, result.NamedScaleCheckPartialTemplates, stderr)
 	return refreshed
 }
 
@@ -807,10 +822,10 @@ func defaultScaleCheckTargetForAgent(
 	return target
 }
 
-func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int, []error) {
+func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int, map[string]bool, []error) {
 	counts := make(map[string]int, len(targets))
 	if len(targets) == 0 {
-		return counts, nil
+		return counts, nil, nil
 	}
 
 	type scaleStoreGroup struct {
@@ -819,6 +834,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 	}
 	groups := make(map[string]*scaleStoreGroup)
 	var errs []error
+	var partialTemplates map[string]bool
 	for _, target := range targets {
 		template := strings.TrimSpace(target.template)
 		if template == "" {
@@ -827,11 +843,13 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		counts[template] = 0
 		if target.err != nil {
 			errs = append(errs, target.err)
+			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
 		}
 		if target.store == nil {
 			if target.err == nil {
 				errs = append(errs, fmt.Errorf("default scale_check %s: store unavailable", template))
 			}
+			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
 			continue
 		}
 		key := strings.TrimSpace(target.storeKey)
@@ -850,6 +868,7 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		ready, err := readyForControllerDemand(group.store)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
+			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
 			if !beads.IsPartialResult(err) || len(ready) == 0 {
 				continue
 			}
@@ -864,13 +883,13 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			}
 		}
 	}
-	return counts, errs
+	return counts, partialTemplates, errs
 }
 
-func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.City, cityName string) (map[string]bool, []error) {
+func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.City, cityName string) (map[string]bool, map[string]bool, []error) {
 	demand := make(map[string]bool)
 	if len(targets) == 0 || cfg == nil {
-		return demand, nil
+		return demand, nil, nil
 	}
 
 	type scaleStoreGroup struct {
@@ -879,6 +898,7 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 	}
 	groups := make(map[string]*scaleStoreGroup)
 	var errs []error
+	var partialTemplates map[string]bool
 	for _, target := range targets {
 		template := strings.TrimSpace(target.template)
 		if template == "" {
@@ -886,11 +906,13 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 		}
 		if target.err != nil {
 			errs = append(errs, target.err)
+			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
 		}
 		if target.store == nil {
 			if target.err == nil {
 				errs = append(errs, fmt.Errorf("default scale_check %s: store unavailable", template))
 			}
+			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
 			continue
 		}
 		key := strings.TrimSpace(target.storeKey)
@@ -925,6 +947,7 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 		ready, err := readyForControllerDemand(group.store)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
+			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
 			if !beads.IsPartialResult(err) || len(ready) == 0 {
 				continue
 			}
@@ -953,7 +976,92 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 			}
 		}
 	}
-	return demand, errs
+	return demand, partialTemplates, errs
+}
+
+func markScaleCheckPartialTemplate(partials map[string]bool, template string) map[string]bool {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return partials
+	}
+	if partials == nil {
+		partials = make(map[string]bool)
+	}
+	partials[template] = true
+	return partials
+}
+
+func markScaleCheckPartialSet(partials map[string]bool, templates map[string]struct{}) map[string]bool {
+	for template := range templates {
+		partials = markScaleCheckPartialTemplate(partials, template)
+	}
+	return partials
+}
+
+func mergeScaleCheckPartialTemplates(dst, src map[string]bool) map[string]bool {
+	for template, partial := range src {
+		if partial {
+			dst = markScaleCheckPartialTemplate(dst, template)
+		}
+	}
+	return dst
+}
+
+func sortedBoolMapKeys(values map[string]bool) []string {
+	out := make([]string, 0, len(values))
+	for value, include := range values {
+		if include {
+			out = append(out, value)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func retainScaleCheckPartialPoolDesired(counts map[string]int, sessionBeads *sessionBeadSnapshot, partialTemplates map[string]bool) map[string]int {
+	if len(partialTemplates) == 0 || sessionBeads == nil {
+		return counts
+	}
+	retained := make(map[string]int)
+	for _, b := range sessionBeads.Open() {
+		template := strings.TrimSpace(b.Metadata["template"])
+		if !partialTemplates[template] || !isPoolManagedSessionBead(b) || !scaleCheckPartialSessionRetainable(b) {
+			continue
+		}
+		retained[template]++
+	}
+	if len(retained) == 0 {
+		return counts
+	}
+	if counts == nil {
+		counts = make(map[string]int)
+	}
+	for template, count := range retained {
+		if counts[template] < count {
+			counts[template] = count
+		}
+	}
+	return counts
+}
+
+// Preserve dormant affected-template beads during transient scale_check
+// failures, but do not count them as awake demand.
+func scaleCheckPartialSessionPreservable(b beads.Bead) bool {
+	switch strings.TrimSpace(b.Metadata["state"]) {
+	case "", "active", "awake", "creating", "asleep", "stopped", "suspended", "quarantined", "draining", "drained", "archived":
+		return true
+	default:
+		return isPendingPoolCreate(b)
+	}
+}
+
+func scaleCheckPartialSessionRetainable(b beads.Bead) bool {
+	switch strings.TrimSpace(b.Metadata["state"]) {
+	case "active", "awake", "creating":
+		return true
+	default:
+		return isPendingPoolCreate(b)
+	}
 }
 
 func sortedStringSet(values map[string]struct{}) []string {
@@ -1116,7 +1224,7 @@ func discoverSessionBeads(
 	desired map[string]TemplateParams,
 	stderr io.Writer,
 ) {
-	discoverSessionBeadsWithRoots(bp, cfg, desired, nil, stderr)
+	discoverSessionBeadsWithRoots(bp, cfg, desired, nil, nil, nil, stderr)
 }
 
 func discoverSessionBeadsWithRoots(
@@ -1124,6 +1232,8 @@ func discoverSessionBeadsWithRoots(
 	cfg *config.City,
 	desired map[string]TemplateParams,
 	suspendedRigPaths map[string]bool,
+	poolScaleCheckPartialTemplates map[string]bool,
+	namedScaleCheckPartialTemplates map[string]bool,
 	stderr io.Writer,
 ) map[string]bool {
 	sessionBeads := bp.sessionBeads
@@ -1162,6 +1272,9 @@ func discoverSessionBeadsWithRoots(
 		if template == "" {
 			continue
 		}
+		poolScaleCheckPartial := poolScaleCheckPartialTemplates[template]
+		namedScaleCheckPartial := namedScaleCheckPartialTemplates[template] && isNamedSessionBead(b)
+		scaleCheckPartial := scaleCheckPartialSessionPreservable(b) && (poolScaleCheckPartial || namedScaleCheckPartial)
 		// Find the config agent for this template.
 		cfgAgent := findAgentByTemplate(cfg, template)
 		if cfgAgent == nil {
@@ -1187,10 +1300,10 @@ func discoverSessionBeadsWithRoots(
 			manualSession := isManualSessionBeadForAgent(b, cfgAgent)
 			creating := b.Metadata["state"] == "creating"
 			pendingCreate := isPendingPoolCreate(b)
-			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating && !pendingCreate {
+			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating && !pendingCreate && !scaleCheckPartial {
 				continue
 			}
-			if !manualSession && !desiredHasTemplate(desired, template) && !pendingCreate {
+			if !manualSession && !desiredHasTemplate(desired, template) && !pendingCreate && !scaleCheckPartial {
 				continue
 			}
 		}

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -43,11 +43,11 @@ type DesiredStateResult struct {
 	// direct assignee demand (Assignee == identity). The reconciler merges this
 	// into poolDesired so that on-demand named sessions remain config-eligible.
 	NamedSessionDemand map[string]bool
-	// StoreQueryPartial is true when one or more bead store queries failed
-	// during assigned-work snapshot collection. When set, the reconciler must NOT
-	// drain sessions based on the (incomplete) desired state — a transient
-	// store failure would cause running sessions to be falsely orphaned
-	// and interrupted via Ctrl-C.
+	// StoreQueryPartial is true when one or more bead store queries or
+	// bead-backed scale checks failed. When set, the reconciler must NOT drain
+	// sessions based on the incomplete desired state — a transient failure
+	// would cause running sessions to be falsely orphaned and interrupted via
+	// Ctrl-C.
 	StoreQueryPartial bool
 	// SessionQueryPartial is true when session-bead snapshot loading failed.
 	// Orphan-release and drain decisions must treat this like an incomplete
@@ -81,7 +81,7 @@ func evaluatePendingPools(
 	pendingPools []poolEvalWork,
 	stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
-) []int {
+) ([]int, bool) {
 	type poolEvalResult struct {
 		desired int
 		err     error
@@ -135,9 +135,11 @@ func evaluatePendingPools(
 	wg.Wait()
 
 	counts := make([]int, len(pendingPools))
+	partial := false
 	for j, pw := range pendingPools {
 		pr := evalResults[j]
 		if pr.err != nil {
+			partial = true
 			if pw.newDemand {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", pr.err) //nolint:errcheck
 			} else {
@@ -146,7 +148,7 @@ func evaluatePendingPools(
 		}
 		counts[j] = pr.desired
 	}
-	return counts
+	return counts, partial
 }
 
 // evaluatePendingPoolsMap is like evaluatePendingPools but returns a map from
@@ -158,13 +160,13 @@ func evaluatePendingPoolsMap(
 	pendingPools []poolEvalWork,
 	stderr io.Writer,
 	trace *sessionReconcilerTraceCycle,
-) map[string]int {
-	counts := evaluatePendingPools(cfg, pendingPools, stderr, trace)
+) (map[string]int, bool) {
+	counts, partial := evaluatePendingPools(cfg, pendingPools, stderr, trace)
 	m := make(map[string]int, len(counts))
 	for j, pw := range pendingPools {
 		m[cfg.Agents[pw.agentIdx].QualifiedName()] = counts[j]
 	}
-	return m
+	return m, partial
 }
 
 // buildDesiredState computes the desired session state from config,
@@ -294,6 +296,7 @@ func buildDesiredStateWithSessionBeads(
 	var assignedWorkStoreRefs []string
 	var storePartial bool
 	var scaleCheckCounts map[string]int
+	var scaleCheckPartial bool
 	var namedDefaultDemand map[string]bool
 	if store != nil {
 		assignedWorkBeads, assignedWorkStores, assignedWorkStoreRefs, storePartial = collectAssignedWorkBeadsWithStores(cfg, store, rigStores, suspendedRigPaths, sessionBeads)
@@ -308,11 +311,14 @@ func buildDesiredStateWithSessionBeads(
 		} else {
 			fmt.Fprintf(stderr, "assignedWorkBeads: 0 beads (rigStores=%d)\n", len(rigStores)) //nolint:errcheck
 		}
-		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		scaleCheckCounts, scaleCheckPartial = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		if len(defaultScaleTargets) > 0 {
 			defaultCounts, errs := defaultScaleCheckCounts(defaultScaleTargets)
 			for _, err := range errs {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using new demand=0)\n", err) //nolint:errcheck
+			}
+			if len(errs) > 0 {
+				scaleCheckPartial = true
 			}
 			for template, count := range defaultCounts {
 				scaleCheckCounts[template] = count
@@ -324,6 +330,13 @@ func buildDesiredStateWithSessionBeads(
 			for _, err := range namedErrs {
 				fmt.Fprintf(stderr, "buildDesiredState: %v (using named demand=false)\n", err) //nolint:errcheck
 			}
+			if len(namedErrs) > 0 {
+				scaleCheckPartial = true
+			}
+		}
+		if scaleCheckPartial {
+			storePartial = true
+			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed, drain decisions suppressed\n") //nolint:errcheck
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
@@ -340,7 +353,7 @@ func buildDesiredStateWithSessionBeads(
 		}
 	} else {
 		// No store — use scale_check counts directly.
-		scaleCheckCounts = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
+		scaleCheckCounts, _ = evaluatePendingPoolsMap(cfg, pendingPools, stderr, trace)
 		for _, pw := range pendingPools {
 			desiredCount := scaleCheckCounts[cfg.Agents[pw.agentIdx].QualifiedName()]
 			for slot := 1; slot <= desiredCount; slot++ {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -2792,6 +2792,30 @@ func TestBuildDesiredState_ManualImplicitPoolSessionsStayDesired(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredState_ScaleCheckErrorMarksStoreQueryPartial(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "echo",
+			ScaleCheck:        "exit 42",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(3),
+		}},
+	}
+
+	var stderr strings.Builder
+	result := buildDesiredStateWithSessionBeads("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, nil, nil, nil, &stderr)
+
+	if !result.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = false, want true when bead-backed scale_check fails; stderr=%s", stderr.String())
+	}
+	if got := result.ScaleCheckCounts["worker"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[worker] = %d, want 0 on failed new-demand probe", got)
+	}
+}
+
 func TestBuildDesiredState_DrainedPoolManagedSessionIsNotRediscovered(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -109,6 +109,21 @@ type partialAssignedWorkStore struct {
 	partialReady      bool
 }
 
+type controllerDemandPartialStore struct {
+	*beads.MemStore
+}
+
+func (s *controllerDemandPartialStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	rows, err := s.MemStore.Ready(query...)
+	if err != nil {
+		return nil, err
+	}
+	if len(query) == 0 {
+		return rows, &beads.PartialResultError{Op: "bd ready", Err: errors.New("skipped corrupt controller demand bead")}
+	}
+	return rows, nil
+}
+
 type acpOnlyDesiredStateProvider struct {
 	*runtime.Fake
 }
@@ -306,7 +321,7 @@ func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
 		t.Fatalf("PrimeActive: %v", err)
 	}
 
-	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
 		template: "gascity/workflows.codex-min",
 		storeKey: "rig:gascity",
 		store:    cache,
@@ -339,7 +354,7 @@ func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 		t.Fatalf("PrimeActive: %v", err)
 	}
 
-	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
 		template: "gascity/workflows.codex-min",
 		storeKey: "rig:gascity",
 		store:    cache,
@@ -384,7 +399,7 @@ func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.
 		t.Fatalf("DepAdd: %v", err)
 	}
 
-	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
 		template: "gascity/workflows.codex-max",
 		storeKey: "rig:gascity",
 		store:    cache,
@@ -419,7 +434,7 @@ func TestDefaultScaleCheckCountsFallsBackWhenCachedEventDepsUnknown(t *testing.T
 	}
 	cache.ApplyEvent("bead.created", []byte(`{"id":"gc-blocked","status":"open","metadata":{"gc.routed_to":"gascity/workflows.codex-max"}}`))
 
-	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
 		template: "gascity/workflows.codex-max",
 		storeKey: "rig:gascity",
 		store:    cache,
@@ -448,7 +463,7 @@ func TestDefaultScaleCheckCountsUsesPartialReadyRows(t *testing.T) {
 		t.Fatalf("create routed bead: %v", err)
 	}
 
-	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+	counts, partialTemplates, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
 		template: "gascity/workflows.codex-max",
 		storeKey: "rig:gascity",
 		store:    store,
@@ -459,12 +474,15 @@ func TestDefaultScaleCheckCountsUsesPartialReadyRows(t *testing.T) {
 	if len(errs) != 1 || !beads.IsPartialResult(errs[0]) {
 		t.Fatalf("defaultScaleCheckCounts errs = %v, want partial-result diagnostic", errs)
 	}
+	if !partialTemplates["gascity/workflows.codex-max"] {
+		t.Fatalf("partialTemplates = %v, want affected template marked partial", partialTemplates)
+	}
 }
 
 func TestDefaultScaleCheckCountsReadyErrorNamesAffectedTemplates(t *testing.T) {
 	store := &readyFailStore{Store: beads.NewMemStore()}
 
-	_, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{
+	_, partialTemplates, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{
 		{template: "gascity/workflows.codex-min", storeKey: "rig:gascity", store: store},
 		{template: "gascity/workflows.codex-max", storeKey: "rig:gascity", store: store},
 	})
@@ -475,6 +493,11 @@ func TestDefaultScaleCheckCountsReadyErrorNamesAffectedTemplates(t *testing.T) {
 	for _, want := range []string{"rig:gascity", "gascity/workflows.codex-min", "gascity/workflows.codex-max"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("defaultScaleCheckCounts err = %q, want affected template %q", msg, want)
+		}
+	}
+	for _, want := range []string{"gascity/workflows.codex-min", "gascity/workflows.codex-max"} {
+		if !partialTemplates[want] {
+			t.Fatalf("partialTemplates = %v, want %q marked partial", partialTemplates, want)
 		}
 	}
 }
@@ -503,7 +526,7 @@ func TestDefaultNamedSessionDemandUsesPartialReadyRows(t *testing.T) {
 		}},
 	}
 
-	demand, errs := defaultNamedSessionDemand([]defaultScaleCheckTarget{{
+	demand, partialTemplates, errs := defaultNamedSessionDemand([]defaultScaleCheckTarget{{
 		template: "worker",
 		storeKey: "rig:gascity",
 		store:    store,
@@ -519,6 +542,9 @@ func TestDefaultNamedSessionDemandUsesPartialReadyRows(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("defaultNamedSessionDemand err = %q, want affected template %q", msg, want)
 		}
+	}
+	if !partialTemplates["worker"] {
+		t.Fatalf("partialTemplates = %v, want worker marked partial", partialTemplates)
 	}
 }
 
@@ -544,7 +570,7 @@ func TestDefaultScaleCheckCountsReportsMissingRigStore(t *testing.T) {
 	}
 	target := defaultScaleCheckTargetForAgent(cityPath, cfg, agent, cityStore, nil)
 
-	counts, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{target})
+	counts, partialTemplates, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{target})
 	if got := counts["repos/repo/worker"]; got != 0 {
 		t.Fatalf("defaultScaleCheckCounts = %d, want 0", got)
 	}
@@ -553,6 +579,9 @@ func TestDefaultScaleCheckCountsReportsMissingRigStore(t *testing.T) {
 	}
 	if !strings.Contains(errs[0].Error(), `rig store "repo" unavailable`) {
 		t.Fatalf("defaultScaleCheckCounts err = %v, want missing rig-store diagnostic", errs[0])
+	}
+	if !partialTemplates["repos/repo/worker"] {
+		t.Fatalf("partialTemplates = %v, want missing rig-store template marked partial", partialTemplates)
 	}
 }
 
@@ -588,6 +617,12 @@ func TestBuildDesiredStateDefaultScaleCheckMissingRigStoreReportsZeroDemand(t *t
 	got := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, &stderr)
 	if demand := got.ScaleCheckCounts["repos/repo/worker"]; demand != 0 {
 		t.Fatalf("ScaleCheckCounts[repos/repo/worker] = %d, want 0 without rig store", demand)
+	}
+	if got.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = true, want false for scoped default scale_check failure")
+	}
+	if !got.ScaleCheckPartialTemplates["repos/repo/worker"] {
+		t.Fatalf("ScaleCheckPartialTemplates = %v, want missing rig-store template marked partial", got.ScaleCheckPartialTemplates)
 	}
 	if len(got.State) != 0 {
 		t.Fatalf("desired sessions = %d, want none without rig store demand", len(got.State))
@@ -2792,27 +2827,243 @@ func TestBuildDesiredState_ManualImplicitPoolSessionsStayDesired(t *testing.T) {
 	}
 }
 
-func TestBuildDesiredState_ScaleCheckErrorMarksStoreQueryPartial(t *testing.T) {
+func TestBuildDesiredState_ScaleCheckErrorRetainsOnlyAffectedPoolSessions(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
+	workerSession := beads.Bead{
+		ID:     "session-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "template:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+		},
+	}
+	helperSession := beads.Bead{
+		ID:     "session-helper",
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "template:helper"},
+		Metadata: map[string]string{
+			"session_name":         "helper-bd-123",
+			"template":             "helper",
+			"agent_name":           "helper",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+		},
+	}
 	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "worker",
+				StartCommand:      "echo",
+				ScaleCheck:        "exit 42",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+			{
+				Name:              "helper",
+				StartCommand:      "echo",
+				ScaleCheck:        "printf 0",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+		},
+	}
+
+	var stderr strings.Builder
+	result := buildDesiredStateWithSessionBeads(
+		"test-city",
+		cityPath,
+		time.Now().UTC(),
+		cfg,
+		runtime.NewFake(),
+		store,
+		nil,
+		newSessionBeadSnapshot([]beads.Bead{workerSession, helperSession}),
+		nil,
+		&stderr,
+	)
+
+	if result.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = true, want false for scoped scale_check failure; stderr=%s", stderr.String())
+	}
+	if !result.ScaleCheckPartialTemplates["worker"] {
+		t.Fatalf("ScaleCheckPartialTemplates[worker] = false, want true; templates=%v stderr=%s", result.ScaleCheckPartialTemplates, stderr.String())
+	}
+	if !result.PoolScaleCheckPartialTemplates["worker"] {
+		t.Fatalf("PoolScaleCheckPartialTemplates[worker] = false, want true; templates=%v", result.PoolScaleCheckPartialTemplates)
+	}
+	if result.ScaleCheckPartialTemplates["helper"] {
+		t.Fatalf("ScaleCheckPartialTemplates[helper] = true, want false; templates=%v", result.ScaleCheckPartialTemplates)
+	}
+	if _, ok := result.State["worker-bd-123"]; !ok {
+		t.Fatalf("affected worker session not retained in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+	}
+	if _, ok := result.State["helper-bd-123"]; ok {
+		t.Fatalf("unaffected helper session retained despite clean zero demand: keys=%v", mapKeys(result.State))
+	}
+	if got := result.ScaleCheckCounts["worker"]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[worker] = %d, want 0 on failed new-demand probe", got)
+	}
+}
+
+func TestBuildDesiredState_ScaleCheckErrorPreservesDormantAffectedPoolSessionWithoutWakeDemand(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	workerSession := beads.Bead{
+		ID:     "session-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "template:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "asleep",
+		},
+	}
+	helperSession := beads.Bead{
+		ID:     "session-helper",
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "template:helper"},
+		Metadata: map[string]string{
+			"session_name":         "helper-bd-123",
+			"template":             "helper",
+			"agent_name":           "helper",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "asleep",
+		},
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:              "worker",
+				StartCommand:      "echo",
+				ScaleCheck:        "exit 42",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+			{
+				Name:              "helper",
+				StartCommand:      "echo",
+				ScaleCheck:        "printf 0",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+			},
+		},
+	}
+	snapshot := newSessionBeadSnapshot([]beads.Bead{workerSession, helperSession})
+
+	var stderr strings.Builder
+	result := buildDesiredStateWithSessionBeads(
+		"test-city",
+		cityPath,
+		time.Now().UTC(),
+		cfg,
+		runtime.NewFake(),
+		store,
+		nil,
+		snapshot,
+		nil,
+		&stderr,
+	)
+
+	if result.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = true, want false for scoped scale_check failure; stderr=%s", stderr.String())
+	}
+	if _, ok := result.State["worker-bd-123"]; !ok {
+		t.Fatalf("dormant affected worker session not preserved in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+	}
+	if _, ok := result.State["helper-bd-123"]; ok {
+		t.Fatalf("unaffected dormant helper session retained despite clean zero demand: keys=%v", mapKeys(result.State))
+	}
+
+	poolDesired := retainScaleCheckPartialPoolDesired(
+		PoolDesiredCounts(ComputePoolDesiredStates(cfg, nil, snapshot.Open(), result.ScaleCheckCounts)),
+		snapshot,
+		result.PoolScaleCheckPartialTemplates,
+	)
+	if got := poolDesired["worker"]; got != 0 {
+		t.Fatalf("poolDesired[worker] = %d, want dormant preservation without wake demand", got)
+	}
+}
+
+func TestBuildDesiredState_NamedScaleCheckPartialDoesNotRetainGenericPoolSession(t *testing.T) {
+	cityPath := t.TempDir()
+	store := &controllerDemandPartialStore{MemStore: beads.NewMemStore()}
+	poolSession := beads.Bead{
+		ID:     "session-worker-pool",
+		Title:  "worker pool",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "template:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+		},
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{{
 			Name:              "worker",
 			StartCommand:      "echo",
-			ScaleCheck:        "exit 42",
 			MinActiveSessions: intPtr(0),
 			MaxActiveSessions: intPtr(3),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "worker",
+			Mode:     "on_demand",
 		}},
 	}
 
 	var stderr strings.Builder
-	result := buildDesiredStateWithSessionBeads("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, nil, nil, nil, &stderr)
+	result := buildDesiredStateWithSessionBeads(
+		"test-city",
+		cityPath,
+		time.Now().UTC(),
+		cfg,
+		runtime.NewFake(),
+		store,
+		nil,
+		newSessionBeadSnapshot([]beads.Bead{poolSession}),
+		nil,
+		&stderr,
+	)
 
-	if !result.StoreQueryPartial {
-		t.Fatalf("StoreQueryPartial = false, want true when bead-backed scale_check fails; stderr=%s", stderr.String())
+	if result.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = true, want false for scoped named scale_check failure; stderr=%s", stderr.String())
 	}
-	if got := result.ScaleCheckCounts["worker"]; got != 0 {
-		t.Fatalf("ScaleCheckCounts[worker] = %d, want 0 on failed new-demand probe", got)
+	if !result.ScaleCheckPartialTemplates["worker"] {
+		t.Fatalf("ScaleCheckPartialTemplates[worker] = false, want named-session partial recorded; templates=%v stderr=%s", result.ScaleCheckPartialTemplates, stderr.String())
+	}
+	if result.PoolScaleCheckPartialTemplates["worker"] {
+		t.Fatalf("PoolScaleCheckPartialTemplates[worker] = true, want false for named-session partial; templates=%v", result.PoolScaleCheckPartialTemplates)
+	}
+	if !result.NamedScaleCheckPartialTemplates["worker"] {
+		t.Fatalf("NamedScaleCheckPartialTemplates[worker] = false, want true; templates=%v", result.NamedScaleCheckPartialTemplates)
+	}
+	if _, ok := result.State["worker-bd-123"]; ok {
+		t.Fatalf("generic pool session retained by named-session partial: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1265,8 +1265,12 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	poolDesired := result.PoolDesiredCounts
 	if poolDesired == nil {
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
-		poolDesired = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-			cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace))
+		poolDesired = retainScaleCheckPartialPoolDesired(
+			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
+				cr.cfg, poolWorkBeads, sessionBeads.Open(), result.ScaleCheckCounts, trace)),
+			sessionBeads,
+			result.PoolScaleCheckPartialTemplates,
+		)
 	}
 	// Merge named-session assignee demand so on-demand named sessions with
 	// direct work (Assignee match, no gc.routed_to) stay config-eligible.
@@ -1358,15 +1362,19 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 			})
 		}
 		trace.RecordCycleInputSnapshot(map[string]any{
-			"desired_session_count":  len(desiredState),
-			"open_session_count":     len(open),
-			"scale_check_counts":     result.ScaleCheckCounts,
-			"pool_desired":           poolDesired,
-			"ready_wait_count":       len(readyWaitSet),
-			"work_set_count":         len(workSet),
-			"store_query_partial":    result.StoreQueryPartial,
-			"session_query_partial":  result.SessionQueryPartial,
-			"snapshot_query_partial": result.snapshotQueryPartial(),
+			"desired_session_count":               len(desiredState),
+			"open_session_count":                  len(open),
+			"scale_check_counts":                  result.ScaleCheckCounts,
+			"pool_desired":                        poolDesired,
+			"ready_wait_count":                    len(readyWaitSet),
+			"work_set_count":                      len(workSet),
+			"store_query_partial":                 result.StoreQueryPartial,
+			"scale_check_query_partial":           len(result.ScaleCheckPartialTemplates) > 0,
+			"scale_check_partial_templates":       sortedBoolMapKeys(result.ScaleCheckPartialTemplates),
+			"pool_scale_check_partial_templates":  sortedBoolMapKeys(result.PoolScaleCheckPartialTemplates),
+			"named_scale_check_partial_templates": sortedBoolMapKeys(result.NamedScaleCheckPartialTemplates),
+			"session_query_partial":               result.SessionQueryPartial,
+			"snapshot_query_partial":              result.snapshotQueryPartial(),
 		})
 		for _, agent := range cr.cfg.Agents {
 			template := agent.QualifiedName()
@@ -1719,8 +1727,12 @@ func (cr *CityRuntime) controlDispatcherTick(ctx context.Context) {
 	)
 	open := filterSessionBeadsByName(updated, cfgNames)
 	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(filteredCfg, cr.cityPath, open, wfcResult.AssignedWorkBeads, wfcResult.AssignedWorkStoreRefs)
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
-		filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts))
+	poolDesired := retainScaleCheckPartialPoolDesired(
+		PoolDesiredCounts(ComputePoolDesiredStates(
+			filteredCfg, poolWorkBeads, open, wfcResult.ScaleCheckCounts)),
+		newSessionBeadSnapshot(open),
+		wfcResult.PoolScaleCheckPartialTemplates,
+	)
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}
@@ -1837,8 +1849,12 @@ func (cr *CityRuntime) loadDemandSnapshot(
 			openSessionBeads = sessionBeads.Open()
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cr.cfg, cr.cityPath, openSessionBeads, result.AssignedWorkBeads, result.AssignedWorkStoreRefs)
-		result.PoolDesiredCounts = PoolDesiredCounts(ComputePoolDesiredStatesTraced(
-			cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace))
+		result.PoolDesiredCounts = retainScaleCheckPartialPoolDesired(
+			PoolDesiredCounts(ComputePoolDesiredStatesTraced(
+				cr.cfg, poolWorkBeads, openSessionBeads, result.ScaleCheckCounts, trace)),
+			sessionBeads,
+			result.PoolScaleCheckPartialTemplates,
+		)
 		if result.PoolDesiredCounts == nil {
 			result.PoolDesiredCounts = make(map[string]int)
 		}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -255,6 +255,78 @@ func TestCityRuntimeDemandSnapshotReusesStablePatrolDemand(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeDemandSnapshotRetainsOnlyPoolScaleCheckPartials(t *testing.T) {
+	sessionBeads := newSessionBeadSnapshot([]beads.Bead{{
+		ID:     "session-worker",
+		Status: "open",
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+		},
+	}})
+
+	tests := []struct {
+		name   string
+		result DesiredStateResult
+		want   int
+	}{
+		{
+			name: "pool partial retains awake pool session",
+			result: DesiredStateResult{
+				State:                          map[string]TemplateParams{},
+				ScaleCheckCounts:               map[string]int{"worker": 0},
+				ScaleCheckPartialTemplates:     map[string]bool{"worker": true},
+				PoolScaleCheckPartialTemplates: map[string]bool{"worker": true},
+			},
+			want: 1,
+		},
+		{
+			name: "named partial does not retain generic pool session",
+			result: DesiredStateResult{
+				State:                           map[string]TemplateParams{},
+				ScaleCheckCounts:                map[string]int{"worker": 0},
+				ScaleCheckPartialTemplates:      map[string]bool{"worker": true},
+				NamedScaleCheckPartialTemplates: map[string]bool{"worker": true},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := &CityRuntime{
+				cityName: "test-city",
+				cityPath: t.TempDir(),
+				cfg: &config.City{
+					Workspace: config.Workspace{Name: "test-city"},
+					Agents: []config.Agent{{
+						Name:              "worker",
+						MinActiveSessions: intPtr(0),
+						MaxActiveSessions: intPtr(5),
+					}},
+				},
+				cs: &controllerState{
+					eventProv: events.NewFake(),
+				},
+				stderr: io.Discard,
+			}
+			cr.buildFnWithSessionBeads = func(*config.City, runtime.Provider, beads.Store, map[string]beads.Store, *sessionBeadSnapshot, *sessionReconcilerTraceCycle) DesiredStateResult {
+				return tc.result
+			}
+
+			snapshot := cr.loadDemandSnapshot(sessionBeads, nil, "poke", false)
+
+			if got := snapshot.result.PoolDesiredCounts["worker"]; got != tc.want {
+				t.Fatalf("PoolDesiredCounts[worker] = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCityRuntimeAsyncStartLimiterUsesMaxWakesPerTick(t *testing.T) {
 	maxWakes := 7
 	cfg := &config.City{Daemon: config.DaemonConfig{MaxWakesPerTick: &maxWakes}}
@@ -1462,6 +1534,178 @@ func TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPool
 	}
 	if !sp.IsRunning("worker-bd-123") {
 		t.Fatal("recovered tick should keep the worker running")
+	}
+}
+
+func TestCityRuntimeBeadReconcileTick_ScaleCheckPartialKeepsOnlyAffectedPoolSession(t *testing.T) {
+	store := beads.NewMemStore()
+	worker, err := store.Create(beads.Bead{
+		ID:     "session-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create worker session: %v", err)
+	}
+	helper, err := store.Create(beads.Bead{
+		ID:     "session-helper",
+		Title:  "helper",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:helper"},
+		Metadata: map[string]string{
+			"session_name":         "helper-bd-123",
+			"template":             "helper",
+			"agent_name":           "helper",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "awake",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create helper session: %v", err)
+	}
+
+	sp := runtime.NewFake()
+	for _, name := range []string{"worker-bd-123", "helper-bd-123"} {
+		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+			t.Fatalf("Start(%s): %v", name, err)
+		}
+	}
+
+	cityPath := t.TempDir()
+	cfg := &config.City{Agents: []config.Agent{
+		{
+			Name:              "worker",
+			StartCommand:      "echo",
+			ScaleCheck:        "exit 42",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		},
+		{
+			Name:              "helper",
+			StartCommand:      "echo",
+			ScaleCheck:        "printf 0",
+			MinActiveSessions: intPtr(0),
+			MaxActiveSessions: intPtr(5),
+		},
+	}}
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "maintainer-city",
+		cfg:                 cfg,
+		sp:                  sp,
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{worker, helper})
+	var stderr strings.Builder
+	result := buildDesiredStateWithSessionBeads("maintainer-city", cityPath, time.Now().UTC(), cfg, sp, store, nil, snapshot, nil, &stderr)
+	if result.StoreQueryPartial {
+		t.Fatalf("StoreQueryPartial = true, want false for scoped scale_check failure; stderr=%s", stderr.String())
+	}
+	if !result.ScaleCheckPartialTemplates["worker"] || result.ScaleCheckPartialTemplates["helper"] {
+		t.Fatalf("ScaleCheckPartialTemplates = %v, want only worker", result.ScaleCheckPartialTemplates)
+	}
+	cr.beadReconcileTick(context.Background(), result, snapshot, nil)
+
+	if drain := cr.sessionDrains.get(worker.ID); drain != nil {
+		t.Fatalf("affected worker session was scheduled for drain: reason=%s", drain.reason)
+	}
+	if cr.sessionDrains.get(helper.ID) == nil {
+		t.Fatal("unaffected helper session was not scheduled for drain")
+	}
+	if !sp.IsRunning("worker-bd-123") {
+		t.Fatal("affected worker session should remain running")
+	}
+	if !sp.IsRunning("helper-bd-123") {
+		t.Fatal("helper drain should be asynchronous and not stop immediately")
+	}
+}
+
+func TestCityRuntimeBeadReconcileTick_ScaleCheckPartialPreservesDormantAffectedPoolSessionWithoutDrain(t *testing.T) {
+	store := beads.NewMemStore()
+	worker, err := store.Create(beads.Bead{
+		ID:     "session-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         "worker-bd-123",
+			"template":             "worker",
+			"agent_name":           "worker",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "asleep",
+			"generation":           "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create worker session: %v", err)
+	}
+
+	sp := runtime.NewFake()
+	cityPath := t.TempDir()
+	cfg := &config.City{Agents: []config.Agent{{
+		Name:              "worker",
+		StartCommand:      "echo",
+		ScaleCheck:        "exit 42",
+		MinActiveSessions: intPtr(0),
+		MaxActiveSessions: intPtr(5),
+	}}}
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "maintainer-city",
+		cfg:                 cfg,
+		sp:                  sp,
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		rec:                 events.Discard,
+		stdout:              io.Discard,
+		stderr:              io.Discard,
+	}
+
+	snapshot := newSessionBeadSnapshot([]beads.Bead{worker})
+	var stderr strings.Builder
+	result := buildDesiredStateWithSessionBeads("maintainer-city", cityPath, time.Now().UTC(), cfg, sp, store, nil, snapshot, nil, &stderr)
+	if _, ok := result.State["worker-bd-123"]; !ok {
+		t.Fatalf("affected dormant worker session not preserved in desired state: keys=%v stderr=%s", mapKeys(result.State), stderr.String())
+	}
+
+	cr.beadReconcileTick(context.Background(), result, snapshot, nil)
+
+	if drain := cr.sessionDrains.get(worker.ID); drain != nil {
+		t.Fatalf("affected dormant worker session was scheduled for drain: reason=%s", drain.reason)
+	}
+	got, err := store.Get(worker.ID)
+	if err != nil {
+		t.Fatalf("Get worker session: %v", err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("affected dormant worker session was closed: %+v", got)
+	}
+	if state := got.Metadata["state"]; state != "asleep" {
+		t.Fatalf("affected dormant worker state = %q, want asleep", state)
+	}
+	if sp.IsRunning("worker-bd-123") {
+		t.Fatal("affected dormant worker should not be woken by scale_check retention")
 	}
 }
 

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -616,8 +616,12 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 
 	dt := newDrainTracker()
 	poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, open, dsResult.AssignedWorkBeads, dsResult.AssignedWorkStoreRefs)
-	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(
-		cfg, poolWorkBeads, open, dsResult.ScaleCheckCounts))
+	poolDesired := retainScaleCheckPartialPoolDesired(
+		PoolDesiredCounts(ComputePoolDesiredStates(
+			cfg, poolWorkBeads, open, dsResult.ScaleCheckCounts)),
+		sessionBeads,
+		dsResult.PoolScaleCheckPartialTemplates,
+	)
 	if poolDesired == nil {
 		poolDesired = make(map[string]int)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2111,9 +2111,8 @@ func (a *Agent) EffectiveScaleCheck() string {
 		return a.ScaleCheck
 	}
 	template := a.QualifiedName()
-	return `ready=$(bd ready --metadata-field gc.routed_to=` + template +
-		` --unassigned --json 2>/dev/null | jq 'length' 2>/dev/null); ` +
-		`echo "${ready:-0}" || echo 0`
+	return `ready_json=$(bd ready --metadata-field gc.routed_to=` + template +
+		` --unassigned --limit 0 --json) && printf '%s\n' "$ready_json" | jq 'length'`
 }
 
 // EffectiveMaxActiveSessions returns the agent's max active sessions.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1645,8 +1645,11 @@ func TestEffectiveScaleCheckUsesReadyOnly(t *testing.T) {
 		t.Errorf("EffectiveScaleCheck = %q, should not count in-progress work as new demand", check)
 	}
 
-	if !strings.Contains(check, "${ready:-0}") {
-		t.Errorf("missing ${ready:-0} in arithmetic sum")
+	if !strings.Contains(check, "--limit 0") {
+		t.Errorf("missing --limit 0 for complete ready count")
+	}
+	if strings.Contains(check, "2>/dev/null") || strings.Contains(check, "${ready:-0}") || strings.Contains(check, "|| echo 0") {
+		t.Errorf("default scale_check masks bd ready failures as zero: %q", check)
 	}
 	if strings.Contains(check, "${molecules:-0}") {
 		t.Errorf("unexpected ${molecules:-0} in arithmetic sum")


### PR DESCRIPTION
## Summary
- Supersedes #1732.
- Credit: Original fix by @julianknutsen (commit preserved with original authorship).
- Stop default shell `scale_check` failures from collapsing demand to zero.
- Preserve only affected pool sessions during partial `scale_check` demand snapshots, and split pool vs named-session partial retention so named demand cannot keep unrelated generic pool sessions alive.
- Add regression coverage for scale-check partial demand, named-vs-pool scoping, demand snapshot retention, and dormant session preservation.

## Tests
- `go test -count=1 ./internal/config ./cmd/gc -run 'TestEffectiveScaleCheckUsesReadyOnly|TestEffectiveScaleCheckDefaults|TestDefaultPoolCheckUsesBdReady|TestBuildDesiredState_ScaleCheckErrorMarksStoreQueryPartial|TestBuildDesiredState_NamedScaleCheckPartialDoesNotRetainGenericPoolSession|TestCityRuntimeDemandSnapshotRetainsOnlyPoolScaleCheckPartials|TestCityRuntimeBeadReconcileTick_TransientStoreQueryPartialKeepsRunningPoolSessionUntilRecoveryTick|TestCityRuntimeBeadReconcileTick_ScaleCheckPartialKeepsOnlyAffectedPoolSession|TestCityRuntimeBeadReconcileTick_ScaleCheckPartialPreservesDormantAffectedPoolSessionWithoutDrain' -v`
- Pre-commit hook on the adopted branch completed: `golangci-lint run ./...`, `go vet ./...`, and `GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...`
- Dual adoption review approved: `/tmp/review-pr/20260506T005908Z-b840368d/outputs/synthesis.md`

## Adoption Notes
This replacement PR includes the original contribution from #1732 plus maintainer fixups from the adoption review. A replacement PR is used because the original PR branch does not allow maintainer edits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->