### PR TITLE
test(dashboard/crew): widen waitFor budget to absorb slow CI runners (ga-2z81)

### DIFF
--- a/cmd/gc/dashboard/web/src/panels/crew.test.ts
+++ b/cmd/gc/dashboard/web/src/panels/crew.test.ts
@@ -140,10 +140,17 @@ describe("crew empty states", () => {
   });
 });
 
+// Slow Blacksmith CI runs have shown the openLogDrawer + loadTranscript
+// chain take ~1.3s while passing runs finish in ~100ms — same VM class,
+// same code. The 1s budget here was missing those slow runs by a few
+// hundred ms even though the chain ultimately completed (the
+// `[crew] Transcript loaded` debug log fires *after* the assertion times
+// out). Five seconds keeps the local cost negligible and absorbs the
+// observed CI variance.
 async function waitFor(assertion: () => void): Promise<void> {
   const started = Date.now();
   let lastError: unknown;
-  while (Date.now() - started < 1000) {
+  while (Date.now() - started < 5000) {
     try {
       assertion();
       return;


### PR DESCRIPTION
## Summary

The `loads older transcript pages without losing the drawer loading sentinel` test in `cmd/gc/dashboard/web/src/panels/crew.test.ts` fails intermittently on Blacksmith's `Dashboard SPA` job — about half of recent runs fail, half pass, on the same code.

## Root cause

The local `waitFor` helper in this test polls for up to **1000 ms**. On Blacksmith CI the entire `openLogDrawer` → `loadTranscript` chain has been observed to take **~1.3 s** on slow runs (vs ~100 ms on fast ones — same VM class, same code). When the runner is in the slow tail, the chain ultimately completes — the CI log shows the `[crew] Transcript loaded` debug message firing **after** the assertion has already timed out — but the test has already given up.

The bead's original hypothesis (`PR #1698 introduced a regression in crew code`) is not the cause: PR #1698 only touched auto-generated dashboard SDK files (`schema.d.ts`, `sdk.gen.ts`); it did not modify `crew.ts` or its helpers.

## Evidence

- Failing run: [job 74521385425](https://github.com/gastownhall/gascity/actions/runs/25407163608/job/74521385425) — crew.test.ts took **1339 ms**, second test failed at the waitFor.
- Passing run on the same workflow ~50 minutes later: [job 74525787419](https://github.com/gastownhall/gascity/actions/runs/25408509735/job/74525787419) — crew.test.ts took **107 ms**.
- Local: 60+ runs (single-test, full-suite, with and without isolation, under CPU load) — all pass, ~50ms each.

## Fix

Bump the local `waitFor` ceiling from 1000 ms → 5000 ms with a comment explaining the observed CI variance. The new ceiling absorbs the slow tail without changing the test contract, the mocked API, or any production code. Locally the cost stays in the tens of milliseconds because waitFor still returns on the first successful poll.

## Test plan

- [x] `npm test` (vitest 22/22 passes locally)
- [x] `npm run typecheck` (clean)
- [ ] Confirm the Blacksmith `Dashboard SPA` job is green on this PR
- [ ] Re-run a few times (the failure is flaky — one passing run is necessary, several are reassuring)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->