### PR TITLE
fix(codex): harden managed SessionStart hooks

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -145,6 +145,9 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	if len(args) > 0 {
 		agentName = args[0]
 	}
+	if hookMode && strings.TrimSpace(agentName) == "" {
+		agentName = primeHookAgentFromWorkDir()
+	}
 
 	hookContext := primeHookContext{}
 	suppressHookPrompt := false
@@ -318,7 +321,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	// when the agent has no prompt_template and doesn't match a builtin
 	// worker prompt — a supported config shape, so the default prompt is
 	// the correct output even under --strict.
-	writePrimePromptWithFormat(stdout, "", agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
+	writePrimePromptWithFormat(stdout, cityName, agentName, defaultPrimePrompt, hookMode, hookFormat, suppressHookPrompt)
 	return 0
 }
 
@@ -364,6 +367,21 @@ func primeHookSessionTemplate(cityPath string) string {
 		return template
 	}
 	return strings.TrimSpace(sessionBead.Metadata["common_name"])
+}
+
+func primeHookAgentFromWorkDir() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	clean := filepath.Clean(cwd)
+	parts := strings.Split(clean, string(os.PathSeparator))
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] == ".gc" && parts[i+1] == "agents" {
+			return parts[i+2]
+		}
+	}
+	return ""
 }
 
 func prependHookBeacon(cityName, agentName, prompt string) string {

--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -145,10 +145,6 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	if len(args) > 0 {
 		agentName = args[0]
 	}
-	if hookMode && strings.TrimSpace(agentName) == "" {
-		agentName = primeHookAgentFromWorkDir()
-	}
-
 	hookContext := primeHookContext{}
 	suppressHookPrompt := false
 	if hookMode {
@@ -203,6 +199,9 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 	}
 
 	cityName := loadedCityName(cfg, cityPath)
+	if hookMode && strings.TrimSpace(agentName) == "" {
+		agentName = primeHookAgentFromWorkDir(cfg)
+	}
 
 	// Look up agent in config. First try qualified identity resolution
 	// (handles "rig/agent" and rig-context matching), then fall back to
@@ -369,19 +368,40 @@ func primeHookSessionTemplate(cityPath string) string {
 	return strings.TrimSpace(sessionBead.Metadata["common_name"])
 }
 
-func primeHookAgentFromWorkDir() string {
+func primeHookAgentFromWorkDir(cfg *config.City) string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
 	}
-	clean := filepath.Clean(cwd)
+	candidates := primeHookAgentCandidatesFromPath(cwd)
+	if cfg != nil {
+		rigContext := currentRigContext(cfg)
+		for _, candidate := range candidates {
+			if a, ok := resolveAgentIdentity(cfg, candidate, rigContext); ok {
+				return a.QualifiedName()
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[len(candidates)-1]
+}
+
+func primeHookAgentCandidatesFromPath(path string) []string {
+	clean := filepath.Clean(path)
 	parts := strings.Split(clean, string(os.PathSeparator))
 	for i := 0; i+2 < len(parts); i++ {
 		if parts[i] == ".gc" && parts[i+1] == "agents" {
-			return parts[i+2]
+			remaining := parts[i+2:]
+			candidates := make([]string, 0, len(remaining))
+			for end := len(remaining); end >= 1; end-- {
+				candidates = append(candidates, strings.Join(remaining[:end], "/"))
+			}
+			return candidates
 		}
 	}
-	return ""
+	return nil
 }
 
 func prependHookBeacon(cityName, agentName, prompt string) string {

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -564,70 +565,102 @@ prompt_template = "prompts/worker.md"
 }
 
 func TestDoPrimeWithHook_CodexJSONFormatInfersAgentFromWorkDir(t *testing.T) {
-	clearGCEnv(t)
-	t.Setenv("GC_TEMPLATE", "")
-	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
-	withPrimeHookStdin(t)
+	for _, tt := range []struct {
+		name        string
+		identity    string
+		agentDir    string
+		agentName   string
+		promptFile  string
+		promptText  string
+		beaconAgent string
+	}{
+		{
+			name:        "city scoped",
+			identity:    "mayor",
+			agentName:   "mayor",
+			promptFile:  "prompts/mayor.md",
+			promptText:  "mayor startup prompt\n",
+			beaconAgent: "mayor",
+		},
+		{
+			name:        "rig scoped",
+			identity:    "hello-world/witness",
+			agentDir:    "hello-world",
+			agentName:   "witness",
+			promptFile:  "prompts/witness.md",
+			promptText:  "witness startup prompt\n",
+			beaconAgent: "hello-world/witness",
+		},
+		{
+			name:        "workflow style",
+			identity:    "gascity/workflows.codex-max",
+			agentDir:    "gascity",
+			agentName:   "workflows.codex-max",
+			promptFile:  "prompts/codex-max.md",
+			promptText:  "codex-max startup prompt\n",
+			beaconAgent: "gascity/workflows.codex-max",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clearGCEnv(t)
+			clearInheritedCityRoutingEnv(t)
+			t.Setenv("GC_TEMPLATE", "")
+			t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+			withPrimeHookStdin(t)
 
-	cityDir := t.TempDir()
-	agentDir := filepath.Join(cityDir, ".gc", "agents", "mayor")
-	promptDir := filepath.Join(cityDir, "prompts")
-	if err := os.MkdirAll(agentDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(agentDir): %v", err)
-	}
-	if err := os.MkdirAll(promptDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(promptDir): %v", err)
-	}
-	const promptContent = "mayor startup prompt\n"
-	if err := os.WriteFile(filepath.Join(promptDir, "mayor.md"), []byte(promptContent), 0o644); err != nil {
-		t.Fatalf("WriteFile(prompt): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+			cityDir := t.TempDir()
+			agentWorkDirParts := append([]string{cityDir, ".gc", "agents"}, strings.Split(tt.identity, "/")...)
+			agentWorkDir := filepath.Join(agentWorkDirParts...)
+			if err := os.MkdirAll(agentWorkDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll(agentWorkDir): %v", err)
+			}
+			promptPath := filepath.Join(cityDir, tt.promptFile)
+			if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(prompt dir): %v", err)
+			}
+			if err := os.WriteFile(promptPath, []byte(tt.promptText), 0o644); err != nil {
+				t.Fatalf("WriteFile(prompt): %v", err)
+			}
+			cityTOML := fmt.Sprintf(`
 [workspace]
 name = "gastown"
 
 [[agent]]
-name = "mayor"
-prompt_template = "prompts/mayor.md"
-`), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
+name = %q
+dir = %q
+prompt_template = %q
+`, tt.agentName, tt.agentDir, tt.promptFile)
+			if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityTOML), 0o644); err != nil {
+				t.Fatalf("WriteFile(city.toml): %v", err)
+			}
+			t.Chdir(agentWorkDir)
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	if err := os.Chdir(agentDir); err != nil {
-		t.Fatalf("Chdir(agentDir): %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(cwd)
-	})
+			var stdout, stderr bytes.Buffer
+			code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false)
+			if code != 0 {
+				t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+			}
 
-	var stdout, stderr bytes.Buffer
-	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false)
-	if code != 0 {
-		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
-	}
-
-	var got struct {
-		HookSpecificOutput struct {
-			HookEventName     string `json:"hookEventName"`
-			AdditionalContext string `json:"additionalContext"`
-		} `json:"hookSpecificOutput"`
-	}
-	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
-		t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
-	}
-	if got.HookSpecificOutput.HookEventName != "SessionStart" {
-		t.Fatalf("hookEventName = %q, want SessionStart", got.HookSpecificOutput.HookEventName)
-	}
-	context := got.HookSpecificOutput.AdditionalContext
-	if !strings.Contains(context, strings.TrimSpace(promptContent)) {
-		t.Fatalf("additionalContext = %q, want mayor prompt", context)
-	}
-	if !strings.Contains(context, "[gastown] mayor") {
-		t.Fatalf("additionalContext = %q, want hook beacon", context)
+			var got struct {
+				HookSpecificOutput struct {
+					HookEventName     string `json:"hookEventName"`
+					AdditionalContext string `json:"additionalContext"`
+				} `json:"hookSpecificOutput"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
+			}
+			if got.HookSpecificOutput.HookEventName != "SessionStart" {
+				t.Fatalf("hookEventName = %q, want SessionStart", got.HookSpecificOutput.HookEventName)
+			}
+			context := got.HookSpecificOutput.AdditionalContext
+			if !strings.Contains(context, strings.TrimSpace(tt.promptText)) {
+				t.Fatalf("additionalContext = %q, want prompt %q", context, strings.TrimSpace(tt.promptText))
+			}
+			if !strings.Contains(context, "[gastown] "+tt.beaconAgent) {
+				t.Fatalf("additionalContext = %q, want hook beacon for %s", context, tt.beaconAgent)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -388,7 +388,7 @@ prompt_template = "prompts/worker.md"
 		{name: "unset source not delivered", wantPromptInHook: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			withPrimeHookStdin(t, nil)
+			withPrimeHookStdin(t)
 			t.Setenv("GC_CITY", cityDir)
 			t.Setenv("GC_AGENT", "worker")
 			t.Setenv("GC_ALIAS", "worker")
@@ -450,7 +450,7 @@ prompt_template = "prompts/worker.md"
 	t.Setenv("GC_HOOK_SOURCE", "startup")
 	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
 	t.Setenv(startupPromptDeliveredEnv, "1")
-	withPrimeHookStdin(t, nil)
+	withPrimeHookStdin(t)
 
 	var stdout, stderr bytes.Buffer
 	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatGemini, false)
@@ -503,17 +503,140 @@ func TestDoPrimeWithHookFormat_FormatsDefaultFallback(t *testing.T) {
 	}
 }
 
-func withPrimeHookStdin(t *testing.T, payload map[string]string) {
+func TestDoPrimeWithHook_DeliveredStartupPromptCodexJSONHookFormat(t *testing.T) {
+	cityDir := t.TempDir()
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	const promptContent = "launch-only startup prompt\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "worker.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_AGENT", "worker")
+	t.Setenv("GC_ALIAS", "worker")
+	t.Setenv("GC_TEMPLATE", "worker")
+	t.Setenv("GC_SESSION_NAME", "gastown--worker")
+	t.Setenv("GC_SESSION_ID", "sess-777")
+	t.Setenv(managedSessionHookEnv, "1")
+	t.Setenv("GC_HOOK_SOURCE", "startup")
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+	t.Setenv(startupPromptDeliveredEnv, "1")
+	withPrimeHookStdin(t)
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, "codex", false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var got struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
+	}
+	if got.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Fatalf("hookEventName = %q, want SessionStart", got.HookSpecificOutput.HookEventName)
+	}
+	context := got.HookSpecificOutput.AdditionalContext
+	if strings.Contains(context, promptContent) {
+		t.Fatalf("additionalContext = %q, want no repeated startup prompt", context)
+	}
+	if !strings.Contains(context, "[gastown] worker") {
+		t.Fatalf("additionalContext = %q, want hook beacon", context)
+	}
+}
+
+func TestDoPrimeWithHook_CodexJSONFormatInfersAgentFromWorkDir(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_TEMPLATE", "")
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+	withPrimeHookStdin(t)
+
+	cityDir := t.TempDir()
+	agentDir := filepath.Join(cityDir, ".gc", "agents", "mayor")
+	promptDir := filepath.Join(cityDir, "prompts")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agentDir): %v", err)
+	}
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir): %v", err)
+	}
+	const promptContent = "mayor startup prompt\n"
+	if err := os.WriteFile(filepath.Join(promptDir, "mayor.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`
+[workspace]
+name = "gastown"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(city.toml): %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(agentDir); err != nil {
+		t.Fatalf("Chdir(agentDir): %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := doPrimeWithHookFormat(nil, &stdout, &stderr, true, hookOutputFormatCodex, false)
+	if code != 0 {
+		t.Fatalf("doPrimeWithHookFormat() = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	var got struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("hook output is not JSON: %v; stdout=%q", err, stdout.String())
+	}
+	if got.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Fatalf("hookEventName = %q, want SessionStart", got.HookSpecificOutput.HookEventName)
+	}
+	context := got.HookSpecificOutput.AdditionalContext
+	if !strings.Contains(context, strings.TrimSpace(promptContent)) {
+		t.Fatalf("additionalContext = %q, want mayor prompt", context)
+	}
+	if !strings.Contains(context, "[gastown] mayor") {
+		t.Fatalf("additionalContext = %q, want hook beacon", context)
+	}
+}
+
+func withPrimeHookStdin(t *testing.T) {
 	t.Helper()
 
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
-	}
-	if payload != nil {
-		if err := json.NewEncoder(writer).Encode(payload); err != nil {
-			t.Fatal(err)
-		}
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatal(err)

--- a/cmd/gc/hook_output.go
+++ b/cmd/gc/hook_output.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"os"
 	"strings"
 )
 
@@ -40,7 +41,10 @@ func codexHookOutput(eventName, content string) map[string]any {
 }
 
 func codexHookAdditionalContext(eventName, content string) map[string]any {
-	if eventName == "" {
+	if strings.TrimSpace(eventName) == "" {
+		eventName = strings.TrimSpace(os.Getenv("GC_HOOK_EVENT_NAME"))
+	}
+	if strings.TrimSpace(eventName) == "" {
 		eventName = "SessionStart"
 	}
 	return map[string]any{

--- a/cmd/gc/hook_output_test.go
+++ b/cmd/gc/hook_output_test.go
@@ -72,6 +72,32 @@ func TestWriteProviderHookContextCodexAdditionalContext(t *testing.T) {
 	}
 }
 
+func TestWriteProviderHookContextCodexDefaultsSessionStartFromEnv(t *testing.T) {
+	t.Setenv("GC_HOOK_EVENT_NAME", "SessionStart")
+
+	var out bytes.Buffer
+	err := writeProviderHookContext(&out, "codex", "<system-reminder>\nhello\n</system-reminder>\n")
+	if err != nil {
+		t.Fatalf("writeProviderHookContext: %v", err)
+	}
+
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out.String())
+	}
+	if got, want := payload.HookSpecificOutput.HookEventName, "SessionStart"; got != want {
+		t.Fatalf("hookEventName = %q, want %q", got, want)
+	}
+	if got, want := payload.HookSpecificOutput.AdditionalContext, "<system-reminder>\nhello\n</system-reminder>"; got != want {
+		t.Fatalf("additionalContext = %q, want %q", got, want)
+	}
+}
+
 func TestWriteProviderHookContextPlain(t *testing.T) {
 	var out bytes.Buffer
 	err := writeProviderHookContext(&out, "", "<system-reminder>\nhello\n</system-reminder>\n")

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
           }
         ]
       }

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
           }
         ]
       }

--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
           }
         ]
       }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -587,6 +587,15 @@ func isCodexManagedHookCommand(command string) bool {
 }
 
 func upgradeCodexHookCommand(command string) (string, bool) {
+	body := commandBodyAfterCanonicalPrefix(command)
+	if equalsLegacyCommandBody(body, `gc prime --hook`) ||
+		equalsLegacyCommandBody(body, `gc prime --hook --hook-format codex`) ||
+		equalsLegacyCommandBody(body, `GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`) ||
+		equalsLegacyCommandBody(body, `GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`) ||
+		equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) {
+		prefix := strings.TrimSuffix(command, body)
+		return prefix + sessionStartCurrentFormBody, true
+	}
 	if strings.Contains(command, `--hook-format codex`) {
 		return "", false
 	}
@@ -859,6 +868,7 @@ func isLegacyGCManagedCommand(event, command string) bool {
 	case "SessionStart":
 		return equalsLegacyCommandBody(body, "gc prime --hook") ||
 			equalsLegacyCommandBody(body, "gc prime --hook --hook-format codex") ||
+			equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) ||
 			equalsLegacyCommandBody(body, sessionStartCurrentFormBody)
 	}
 	return false
@@ -873,6 +883,8 @@ func isLegacyGCManagedCommand(event, command string) bool {
 // with additional arguments, update this constant alongside the
 // emission site so legacy detection remains tight.
 const sessionStartCurrentFormBody = `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`
+
+const sessionStartPreviousManagedFormBody = `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`
 
 // equalsLegacyCommandBody reports whether the command body is exactly the
 // legacy token. gc historically emitted these tokens as the complete
@@ -923,7 +935,8 @@ func upgradeClaudeHookCommand(event, command string) (string, bool) {
 		// GC_MANAGED_SESSION_HOOK / GC_HOOK_EVENT_NAME env vars the
 		// current managed form expects.
 		if equalsLegacyCommandBody(body, `gc prime --hook`) ||
-			equalsLegacyCommandBody(body, `gc prime --hook --hook-format codex`) {
+			equalsLegacyCommandBody(body, `gc prime --hook --hook-format codex`) ||
+			equalsLegacyCommandBody(body, sessionStartPreviousManagedFormBody) {
 			prefix := strings.TrimSuffix(command, body)
 			return prefix + sessionStartCurrentFormBody, true
 		}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -858,6 +858,7 @@ func isLegacyGCManagedCommand(event, command string) bool {
 			equalsLegacyCommandBody(body, `gc handoff --auto "context cycle"`)
 	case "SessionStart":
 		return equalsLegacyCommandBody(body, "gc prime --hook") ||
+			equalsLegacyCommandBody(body, "gc prime --hook --hook-format codex") ||
 			equalsLegacyCommandBody(body, sessionStartCurrentFormBody)
 	}
 	return false
@@ -871,7 +872,7 @@ func isLegacyGCManagedCommand(event, command string) bool {
 // full env-var preamble. If gc ever extends the current-form command
 // with additional arguments, update this constant alongside the
 // emission site so legacy detection remains tight.
-const sessionStartCurrentFormBody = `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`
+const sessionStartCurrentFormBody = `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`
 
 // equalsLegacyCommandBody reports whether the command body is exactly the
 // legacy token. gc historically emitted these tokens as the complete
@@ -921,8 +922,10 @@ func upgradeClaudeHookCommand(event, command string) (string, bool) {
 		// Legacy: bare `gc prime --hook` without the
 		// GC_MANAGED_SESSION_HOOK / GC_HOOK_EVENT_NAME env vars the
 		// current managed form expects.
-		if equalsLegacyCommandBody(body, `gc prime --hook`) {
-			return strings.Replace(command, `gc prime --hook`, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, 1), true
+		if equalsLegacyCommandBody(body, `gc prime --hook`) ||
+			equalsLegacyCommandBody(body, `gc prime --hook --hook-format codex`) {
+			prefix := strings.TrimSuffix(command, body)
+			return prefix + sessionStartCurrentFormBody, true
 		}
 	}
 	return "", false

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -246,6 +246,34 @@ func TestInstallClaudeUpgradesGeneratedFileMissingManagedSessionMarkers(t *testi
 	}
 }
 
+func TestInstallClaudeUpgradesPreviousCanonicalSessionStart(t *testing.T) {
+	fs := fsys.NewFake()
+	current, err := readEmbedded("config/claude.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	stale := strings.Replace(string(current), sessionStartCurrentFormBody, sessionStartPreviousManagedFormBody, 1)
+	if stale == string(current) {
+		t.Fatal("stale fixture did not diverge from current embedded config — check previous SessionStart pattern")
+	}
+	fs.Files["/city/hooks/claude.json"] = []byte(stale)
+	fs.Files["/city/.gc/settings.json"] = []byte(stale)
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	hookData := fs.Files["/city/hooks/claude.json"]
+	runtimeData := fs.Files["/city/.gc/settings.json"]
+	sessionStartCommand := claudeHookCommand(t, hookData, "SessionStart")
+	if got := commandBodyAfterCanonicalPrefix(sessionStartCommand); got != sessionStartCurrentFormBody {
+		t.Fatalf("upgraded SessionStart body = %q, want %q", got, sessionStartCurrentFormBody)
+	}
+	if string(runtimeData) != string(hookData) {
+		t.Fatalf("runtime Claude settings should mirror upgraded hook settings:\n%s", string(runtimeData))
+	}
+}
+
 func TestInstallClaudeUpgradesGeneratedFileSessionStartMatcher(t *testing.T) {
 	fs := fsys.NewFake()
 	current, err := readEmbedded("config/claude.json")
@@ -299,11 +327,46 @@ func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
 	if !strings.Contains(got, "--hook-format codex") {
 		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
 	}
+	if !strings.Contains(got, "GC_MANAGED_SESSION_HOOK=1") {
+		t.Errorf("upgraded codex hooks missing managed SessionStart marker:\n%s", got)
+	}
+	if !strings.Contains(got, "GC_HOOK_EVENT_NAME=SessionStart") {
+		t.Errorf("upgraded codex hooks missing SessionStart event marker:\n%s", got)
+	}
 	if !strings.Contains(got, `"PreCompact"`) {
 		t.Errorf("upgraded codex hooks missing PreCompact:\n%s", got)
 	}
 	if !strings.Contains(got, `gc handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Errorf("upgraded codex PreCompact missing auto handoff command:\n%s", got)
+	}
+}
+
+func TestInstallCodexUpgradesSessionStartMissingManagedMarker(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	sessionStartCommand := codexHookCommand(t, fs.Files["/work/.codex/hooks.json"], "SessionStart")
+	if !strings.Contains(sessionStartCommand, "GC_MANAGED_SESSION_HOOK=1") {
+		t.Fatalf("upgraded codex SessionStart missing managed marker: %s", sessionStartCommand)
+	}
+	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
+		t.Fatalf("upgraded codex SessionStart missing event marker: %s", sessionStartCommand)
+	}
+	if !strings.Contains(sessionStartCommand, "gc prime --hook --hook-format codex") {
+		t.Fatalf("upgraded codex SessionStart missing hook format: %s", sessionStartCommand)
 	}
 }
 
@@ -449,7 +512,7 @@ func TestUpgradeCodexHooksSkipsWhenDesiredPreCompactUnavailable(t *testing.T) {
     "SessionStart": [{
       "hooks": [{
         "type": "command",
-        "command": "gc prime --hook --hook-format codex"
+        "command": "GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex"
       }]
     }]
   }
@@ -1324,6 +1387,9 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
 		t.Fatalf("codex SessionStart hook command = %q, want GC_HOOK_EVENT_NAME=SessionStart", sessionStartCommand)
 	}
+	if !strings.Contains(sessionStartCommand, "GC_MANAGED_SESSION_HOOK=1") {
+		t.Fatalf("codex SessionStart hook command = %q, want GC_MANAGED_SESSION_HOOK=1", sessionStartCommand)
+	}
 	if !strings.Contains(codexHooksText, `"PreCompact"`) {
 		t.Error("codex hooks should include PreCompact")
 	}
@@ -1562,7 +1628,7 @@ func TestInstallCodexWritesCanonicalJSON(t *testing.T) {
 	if bytes.Contains(data, []byte(`\u0026`)) {
 		t.Fatalf("codex hook escaped command operator:\n%s", data)
 	}
-	if !bytes.Contains(data, []byte(` && GC_HOOK_EVENT_NAME=SessionStart gc prime`)) {
+	if !bytes.Contains(data, []byte(` && GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime`)) {
 		t.Fatalf("codex hook missing literal command operator:\n%s", data)
 	}
 	if !bytes.HasSuffix(data, []byte("\n")) {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -40,6 +40,15 @@ func claudeHookEntries(t *testing.T, data []byte, event string) []claudeHookEntr
 	return cfg.Hooks[event]
 }
 
+func codexHookCommand(t *testing.T, data []byte, event string) string {
+	t.Helper()
+	entries := claudeHookEntries(t, data, event)
+	if len(entries) == 0 || len(entries[0].Hooks) == 0 {
+		t.Fatalf("missing codex hook for %s", event)
+	}
+	return entries[0].Hooks[0].Command
+}
+
 func TestSupportedProviders(t *testing.T) {
 	got := SupportedProviders()
 	want := map[string]bool{
@@ -113,8 +122,8 @@ func TestInstallClaude(t *testing.T) {
 		t.Error("claude settings should contain SessionStart hook")
 	}
 	sessionStartCommand := claudeHookCommand(t, runtimeData, "SessionStart")
-	if !strings.Contains(sessionStartCommand, "gc prime --hook") {
-		t.Error("claude SessionStart hook should contain gc prime --hook")
+	if !strings.Contains(sessionStartCommand, "gc prime --hook --hook-format codex") {
+		t.Error("claude SessionStart hook should contain gc prime --hook --hook-format codex")
 	}
 	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
 		t.Error("claude SessionStart hook should mark managed hook event")
@@ -212,7 +221,7 @@ func TestInstallClaudeUpgradesGeneratedFileMissingManagedSessionMarkers(t *testi
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}
-	stale := strings.Replace(string(current), `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
+	stale := strings.Replace(string(current), `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`, `gc prime --hook`, 1)
 	if stale == string(current) {
 		t.Fatal("stale fixture did not diverge from current embedded config — check SessionStart marker pattern")
 	}
@@ -534,7 +543,7 @@ func TestInstallClaudeUpgradesGeneratedFileWithCombinedKnownDrift(t *testing.T) 
 	if err != nil {
 		t.Fatalf("readEmbedded: %v", err)
 	}
-	stale := strings.Replace(string(current), `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
+	stale := strings.Replace(string(current), `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`, `gc prime --hook`, 1)
 	stale = strings.Replace(stale, `"matcher": "startup"`, `"matcher": ""`, 1)
 	if stale == string(current) {
 		t.Fatal("stale fixture did not diverge from current embedded config — check combined SessionStart drift pattern")
@@ -575,7 +584,7 @@ func TestInstallClaudeUpgradesGeneratedFileWithAllKnownDrift(t *testing.T) {
 		t.Fatalf("readEmbedded: %v", err)
 	}
 	stale := strings.Replace(string(current), `gc handoff --auto \"context cycle\"`, `gc prime --hook`, 1)
-	stale = strings.Replace(stale, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
+	stale = strings.Replace(stale, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook --hook-format codex`, `gc prime --hook --hook-format codex`, 1)
 	stale = strings.Replace(stale, `"matcher": "startup"`, `"matcher": ""`, 1)
 	if stale == string(current) {
 		t.Fatal("stale fixture did not diverge from current embedded config — check all known Claude drift patterns")
@@ -1306,14 +1315,19 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 			t.Errorf("expected overlay-managed provider file %s to be written", rel)
 		}
 	}
-	codexHooks := string(fs.Files["/work/.codex/hooks.json"])
-	if !strings.Contains(codexHooks, "--hook-format codex") {
-		t.Error("codex hooks should request Codex hook output format")
+	codexHooks := fs.Files["/work/.codex/hooks.json"]
+	codexHooksText := string(codexHooks)
+	sessionStartCommand := codexHookCommand(t, codexHooks, "SessionStart")
+	if !strings.Contains(sessionStartCommand, "gc prime --hook --hook-format codex") {
+		t.Fatalf("codex SessionStart hook command = %q, want gc prime --hook --hook-format codex", sessionStartCommand)
 	}
-	if !strings.Contains(codexHooks, `"PreCompact"`) {
+	if !strings.Contains(sessionStartCommand, "GC_HOOK_EVENT_NAME=SessionStart") {
+		t.Fatalf("codex SessionStart hook command = %q, want GC_HOOK_EVENT_NAME=SessionStart", sessionStartCommand)
+	}
+	if !strings.Contains(codexHooksText, `"PreCompact"`) {
 		t.Error("codex hooks should include PreCompact")
 	}
-	if !strings.Contains(codexHooks, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+	if !strings.Contains(codexHooksText, `gc handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Error("codex PreCompact should use auto handoff with Codex hook output format")
 	}
 	// Copilot CLI documents preCompact (camelCase). The hook fires before
@@ -1548,7 +1562,7 @@ func TestInstallCodexWritesCanonicalJSON(t *testing.T) {
 	if bytes.Contains(data, []byte(`\u0026`)) {
 		t.Fatalf("codex hook escaped command operator:\n%s", data)
 	}
-	if !bytes.Contains(data, []byte(` && gc prime`)) {
+	if !bytes.Contains(data, []byte(` && GC_HOOK_EVENT_NAME=SessionStart gc prime`)) {
 		t.Fatalf("codex hook missing literal command operator:\n%s", data)
 	}
 	if !bytes.HasSuffix(data, []byte("\n")) {


### PR DESCRIPTION
## Summary
- harden managed Codex SessionStart hook output for controller-installed startup paths
- ensure managed hook templates/install paths keep the Codex hook format and SessionStart event marker
- add regression coverage for Codex hook JSON output, startup prompt delivery, and managed hook upgrades

## Testing
- go test ./cmd/gc ./internal/hooks -run 'TestWriteProviderHookContextCodex|TestWriteProviderHookContextCodexDefaultsSessionStartFromEnv|TestDoPrimeWithHook_DeliveredStartupPromptCodexJSONHookFormat|TestDoPrimeWithHook_CodexJSONFormatInfersAgentFromWorkDir|TestInstallClaudeUpgradesGeneratedFileWithAllKnownDrift|TestInstallClaudeUpgradesGeneratedFileMissingManagedSessionMarkers|TestInstallClaudeUpgradesGeneratedFileWithCombinedKnownDrift|TestInstallOverlayManagedProviders'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->