### PR TITLE
fix: retry invalid contracts and scope fanout fragments

### DIFF
--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -120,13 +120,18 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	var previousSinkIDs []string
 	totalCreated := 0
 	for index, item := range items {
-		targetRef := sourceRef + ".item." + strconv.Itoa(index+1)
+		targetRef := fanoutTargetRef(source, sourceRef, index)
 		target := &formula.Step{
 			ID:          targetRef,
 			Title:       source.Title,
 			Description: source.Description,
 		}
 		itemVars := materializeFanoutVars(bondVars, item, index)
+		if _, ok := itemVars["scope_ref"]; ok {
+			if scopeRef := strings.TrimSpace(bead.Metadata["gc.scope_ref"]); scopeRef != "" {
+				itemVars["scope_ref"] = scopeRef
+			}
+		}
 		fragment, err := formula.CompileExpansionFragment(context.Background(), bead.Metadata["gc.bond"], opts.FormulaSearchPaths, target, itemVars)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: compiling fragment %d: %w", bead.ID, index+1, err)
@@ -177,6 +182,14 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		return ControlResult{}, fmt.Errorf("%s: recording fanout state: %w", bead.ID, err)
 	}
 	return ControlResult{Processed: true, Action: "fanout-spawn", Created: totalCreated}, nil
+}
+
+func fanoutTargetRef(source beads.Bead, sourceRef string, index int) string {
+	base := strings.TrimSpace(source.Metadata["gc.step_ref"])
+	if base == "" {
+		base = sourceRef
+	}
+	return base + ".item." + strconv.Itoa(index+1)
 }
 
 func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Bead, opts ProcessOptions, store beads.Store) {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -230,7 +230,7 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	switch outcome {
 	case "pass":
 		if strings.TrimSpace(subject.Metadata["gc.failure_class"]) != "" || strings.TrimSpace(subject.Metadata["gc.failure_reason"]) != "" {
-			return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+			return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 		}
 		if strings.TrimSpace(subject.Metadata["gc.output_json_required"]) == "true" && strings.TrimSpace(subject.Metadata["gc.output_json"]) == "" {
 			return retryEvalResult{Outcome: "transient", Reason: "missing_required_output_json"}
@@ -243,12 +243,12 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 		case "hard", "":
 			return retryEvalResult{Outcome: "hard", Reason: retryFailureReason(subject)}
 		default:
-			return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+			return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 		}
 	case "":
-		return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+		return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 	default:
-		return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+		return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 	}
 }
 

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -682,7 +682,7 @@ func TestProcessRetryEvalStaleAttemptFinalizesNoop(t *testing.T) {
 	}
 }
 
-func TestProcessRetryEvalRejectsInvalidWorkerResultContract(t *testing.T) {
+func TestProcessRetryEvalRetriesInvalidWorkerResultContract(t *testing.T) {
 	t.Parallel()
 
 	store := newStrictCloseStore()
@@ -739,15 +739,91 @@ func TestProcessRetryEvalRejectsInvalidWorkerResultContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessControl(retry-eval invalid contract): %v", err)
 	}
-	if !result.Processed || result.Action != "hard-fail" {
-		t.Fatalf("result = %+v, want processed hard-fail", result)
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("result = %+v, want processed retry", result)
+	}
+
+	logicalAfter := mustGetBead(t, store, logical.ID)
+	if logicalAfter.Status == "closed" {
+		t.Fatalf("logical status = closed, want open for retry")
+	}
+	if !strings.Contains(logicalAfter.Metadata["gc.failure_reason"], "invalid_worker_result_contract") {
+		t.Fatalf("logical gc.failure_reason = %q, want invalid_worker_result_contract", logicalAfter.Metadata["gc.failure_reason"])
+	}
+	if logicalAfter.Metadata["gc.retry_count"] != "1" {
+		t.Fatalf("logical gc.retry_count = %q, want 1", logicalAfter.Metadata["gc.retry_count"])
+	}
+}
+
+func TestProcessRetryEvalExhaustsInvalidWorkerResultContract(t *testing.T) {
+	t.Parallel()
+
+	store := newStrictCloseStore()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "demo.review",
+			"gc.max_attempts": "2",
+			"gc.on_exhausted": "hard_fail",
+		},
+	})
+	run2 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "review attempt 2",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-run",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "demo.review.run.2",
+			"gc.logical_bead_id": logical.ID,
+			"gc.attempt":         "2",
+			"gc.max_attempts":    "2",
+			"gc.on_exhausted":    "hard_fail",
+		},
+	})
+	eval2 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review eval 2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-eval",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "demo.review.eval.2",
+			"gc.logical_bead_id": logical.ID,
+			"gc.attempt":         "2",
+			"gc.max_attempts":    "2",
+			"gc.on_exhausted":    "hard_fail",
+		},
+	})
+	mustDepAdd(t, store, logical.ID, eval2.ID, "blocks")
+	mustDepAdd(t, store, eval2.ID, run2.ID, "blocks")
+
+	result, err := ProcessControl(store, eval2, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(retry-eval exhausted invalid contract): %v", err)
+	}
+	if !result.Processed || result.Action != "fail" {
+		t.Fatalf("result = %+v, want processed fail", result)
 	}
 
 	logicalAfter := mustGetBead(t, store, logical.ID)
 	if logicalAfter.Status != "closed" || logicalAfter.Metadata["gc.outcome"] != "fail" {
 		t.Fatalf("logical = status %q outcome %q, want closed/fail", logicalAfter.Status, logicalAfter.Metadata["gc.outcome"])
 	}
-	if !strings.Contains(logicalAfter.Metadata["gc.failure_reason"], "invalid_worker_result_contract") {
+	if logicalAfter.Metadata["gc.failure_class"] != "transient" {
+		t.Fatalf("logical gc.failure_class = %q, want transient", logicalAfter.Metadata["gc.failure_class"])
+	}
+	if logicalAfter.Metadata["gc.failure_reason"] != "invalid_worker_result_contract" {
 		t.Fatalf("logical gc.failure_reason = %q, want invalid_worker_result_contract", logicalAfter.Metadata["gc.failure_reason"])
 	}
 }

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3721,6 +3721,233 @@ on_exhausted = "hard_fail"
 	}
 }
 
+func TestProcessFanoutUsesResolvedSourceStepRefForIterationScopedFragments(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[vars.scope_ref]
+default = "body"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+metadata = { "gc.scope_ref" = "{scope_ref}" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.2.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.2",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}","scope_ref":"body"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("spawn result = %+v, want processed fanout-spawn", result)
+	}
+
+	child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.2.design-review.prepare-review-items.item.1.review")
+	if child.ID == "" {
+		t.Fatal("missing iteration-qualified fanout child")
+	}
+	if got := child.Metadata["gc.scope_ref"]; got != "mol.review-loop.iteration.2" {
+		t.Fatalf("child gc.scope_ref = %q, want live fanout scope", got)
+	}
+	if stale := findAttemptByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review"); stale.ID != "" {
+		t.Fatalf("spawned stale logical child ref %q; want iteration-qualified source step ref", stale.Metadata["gc.step_ref"])
+	}
+}
+
+func TestProcessFanoutDoesNotReusePriorIterationFragments(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	_ = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "old review",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "expansion-review.design-review.prepare-review-items.item.1.review",
+			"gc.outcome":      "pass",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.3.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.3",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if result.Created == 0 {
+		t.Fatalf("fanout reused a prior-iteration fragment; created=%d", result.Created)
+	}
+	if child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.3.design-review.prepare-review-items.item.1.review"); child.ID == "" {
+		t.Fatal("missing new iteration-qualified review child")
+	}
+}
+
+func TestProcessFanoutUsesControlForWhenSourceStepRefIsLogical(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	if _, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if child := findAttemptByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review"); child.ID == "" {
+		t.Fatal("missing logical source child")
+	}
+}
+
 func TestProcessFanoutRecreatesExistingFragmentWithStaleRouteMetadata(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 

--- a/internal/formulatest/v2.go
+++ b/internal/formulatest/v2.go
@@ -3,18 +3,36 @@
 package formulatest
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
+var (
+	v2Mu          sync.Mutex
+	v2EnableCount int
+	v2SavedValue  bool
+)
+
 // EnableV2ForTest enables graph.v2 formula compilation for the duration of the
-// test, restoring the previous value on cleanup. Callers must not use it in
-// tests that run in parallel with other formula-v2 flag mutations because the
-// flag is process-global.
+// test, restoring the previous value after the last concurrent enable cleanup.
 func EnableV2ForTest(tb testing.TB) {
 	tb.Helper()
-	prev := formula.IsFormulaV2Enabled()
+	v2Mu.Lock()
+	if v2EnableCount == 0 {
+		v2SavedValue = formula.IsFormulaV2Enabled()
+	}
+	v2EnableCount++
 	formula.SetFormulaV2Enabled(true)
-	tb.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
+	v2Mu.Unlock()
+
+	tb.Cleanup(func() {
+		v2Mu.Lock()
+		defer v2Mu.Unlock()
+		v2EnableCount--
+		if v2EnableCount == 0 {
+			formula.SetFormulaV2Enabled(v2SavedValue)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- retry invalid worker result contracts instead of hard-failing the whole workflow immediately
- scope fanout expansion fragments to the resolved source bead `gc.step_ref` so retry/Ralph iterations do not reuse stale prior-iteration children
- pass the live fanout `scope_ref` into graph.v2 expansion vars and make the graph.v2 test helper safe for parallel tests

## Tests
- `go test -count=10 ./internal/dispatch`
- `go test -count=1 ./internal/dispatch ./internal/formula ./internal/formulatest ./internal/sling`
- pre-commit hook: `make lint`, `go vet`, `GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...`

## Local verification
- built and installed local `gc`
- restarted `/data/projects/maintainer-city`
- repaired the stuck bugflow fanout state and verified the corrected iteration-qualified fanout branch spawned workers