### PR TITLE
fix(packs): replace removed gc agent peek/list/drain in templates

### DIFF
--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -36,7 +36,7 @@ Narrow scope makes restarts cheap. The controller manages your lifecycle.
 ### Step 1: Check if deacon session exists
 
 ```bash
-{{ cmd }} agent peek deacon 1
+{{ cmd }} session peek deacon 1
 ```
 
 If the deacon session doesn't exist: do nothing and exit. The controller
@@ -46,7 +46,7 @@ detects dead agents and restarts them — that's its job, not yours.
 
 ```bash
 # Recent pane output — is the deacon actively working?
-{{ cmd }} agent peek deacon 30
+{{ cmd }} session peek deacon 30
 
 # Deacon's current patrol wisp — how fresh is it?
 gc bd list --assignee=deacon --status=in_progress --json --limit=5
@@ -121,11 +121,11 @@ up your session and spawns you again next tick.
 
 | Want to... | Correct command |
 |------------|----------------|
-| View deacon output | `{{ cmd }} agent peek deacon 30` |
+| View deacon output | `{{ cmd }} session peek deacon 30` |
 | Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
 | File stuck warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
-| Check agents | `{{ cmd }} agent list` |
+| Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}
 Formula: none (ephemeral triage, no patrol loop)

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -36,7 +36,7 @@ Narrow scope makes restarts cheap. The controller manages your lifecycle.
 ### Step 1: Check if deacon session exists
 
 ```bash
-{{ cmd }} session peek deacon 1
+{{ cmd }} session peek deacon --lines 1
 ```
 
 If the deacon session doesn't exist: do nothing and exit. The controller
@@ -46,7 +46,7 @@ detects dead agents and restarts them — that's its job, not yours.
 
 ```bash
 # Recent pane output — is the deacon actively working?
-{{ cmd }} session peek deacon 30
+{{ cmd }} session peek deacon --lines 30
 
 # Deacon's current patrol wisp — how fresh is it?
 gc bd list --assignee=deacon --status=in_progress --json --limit=5
@@ -121,7 +121,7 @@ up your session and spawns you again next tick.
 
 | Want to... | Correct command |
 |------------|----------------|
-| View deacon output | `{{ cmd }} session peek deacon 30` |
+| View deacon output | `{{ cmd }} session peek deacon --lines 30` |
 | Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
 | File stuck warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -202,7 +202,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 {{ cmd }} mail read <id>                              # Read a specific message
 {{ cmd }} mail send <addr> -s "Subject" -m "Message"  # Send mail
 {{ cmd }} session nudge <target> "message"            # Wake an agent
-{{ cmd }} agent list                                  # List all agents
+{{ cmd }} session list                                # List active sessions
 {{ cmd }} rig list                                    # List all rigs
 ```
 
@@ -217,7 +217,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
 | Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
-| Drain stuck polecat | `{{ cmd }} agent drain <name>` | ~~gc polecat kill~~ (not a command) |
+| Drain stuck polecat | `{{ cmd }} runtime drain <name>` | ~~gc polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |
 | Create convoy for batch work | `{{ cmd }} convoy create "name" <issues>` | |

--- a/examples/gastown/packs/gastown/assets/prompts/crew.template.md
+++ b/examples/gastown/packs/gastown/assets/prompts/crew.template.md
@@ -400,7 +400,7 @@ See `{{ .CityRoot }}/docs/AGENT-ERGONOMICS.md` for the full philosophy.
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
 | Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
-| Stop my session | `{{ cmd }} agent drain {{ basename .AgentName }}` | ~~gc rig stop~~ (stops rig agents, not crew) |
+| Stop my session | `{{ cmd }} runtime drain {{ basename .AgentName }}` | ~~gc rig stop~~ (stops rig agents, not crew) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |
 

--- a/examples/swarm/packs/swarm/agents/deacon/prompt.template.md
+++ b/examples/swarm/packs/swarm/agents/deacon/prompt.template.md
@@ -20,7 +20,7 @@ Check that agents are responsive:
 
 - Verify tmux sessions exist for expected agents
 - Report stalls or unresponsive agents to the mayor
-- Restart agents that have crashed (via `gc agent restart`)
+- Note crashed agents — the reconciler auto-restarts dead sessions
 
 ## Communication
 


### PR DESCRIPTION
## Summary

The `gc agent` subcommand tree dropped peek/list/kill/etc when those runtime operations moved to `gc session` and `gc runtime` (commit d3210cd75). Several pack prompts still reference the old names, so fresh agent sessions burn 3–5 tool calls per tick rediscovering the CLI shape via `--help` — measured at 21+ "unknown subcommand" errors per 10 minutes of normal boot ticks in real city transcripts.

This patch sweeps the remaining stale references in pack prompts:

- `gc agent peek <name>` → `gc session peek <name>` (boot prompt, 3 sites)
- `gc agent list` → `gc session list` (boot + mayor prompts, 2 sites)
- `gc agent drain <name>` → `gc runtime drain <name>` (mayor + crew templates, 2 sites). The deprecation shim in `cmd/gc/cmd_agent.go` points users at `gc runtime drain`, which preserves the original graceful-drain semantics.
- swarm/deacon: drop the "via `gc agent restart`" parenthetical. That command never existed; the reconciler auto-restarts dead sessions, so the bullet now reads `Note crashed agents — the reconciler auto-restarts dead sessions.`

Pure template-prose edits; no code changes.

## Testing

- [x] `make check` clean for the changes in this PR. Pre-commit hook (`go test ./test/docsync`) passed. Full `go test ./...` shows the documented pre-existing macOS failures (`TestBuiltinDoltDoctor*`, `TestExecCommandRunnerTimeoutKillsChildProcess`, `TestMaintenanceDoltScriptsSkipTestPatternDatabases`) which exist on plain `origin/main` and are unrelated to this prose-only change.
- [ ] `make check-docs` (no docs/navigation/link changes — prompt prose only)
- [ ] `make test-integration` (no runtime/controller/workflow behavior changes; deferred — past attempts have timed out on macOS without saving partial output)

## Checklist

- [ ] Linked an issue, or explained why one is not needed
  - Tracked locally; symptom + repro recorded in transcript scans (21+ unknown-subcommand errors/10min).
- [ ] Added or updated tests for behavior changes (no behavior change — prose-only)
- [ ] Updated docs for user-facing changes (these *are* the docs being updated)
- [x] Called out breaking changes or migration notes — none; the deprecation shims in `cmd/gc/cmd_agent.go` already cover existing references.