### PR TITLE
docs(deacon): point at "gc bd formula show" for reading recipes

### DIFF
--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -128,7 +128,7 @@ gc bd create --type=warrant \
 gc mail send mayor/ -s "Subject" -m "Message"       # Escalate to mayor
 gc mail send <rig>/witness -s "Subject" -m "..."     # Witness questions
 gc session nudge <target> "message"                  # Nudge an agent
-gc session peek <target> 50                              # View agent output
+gc session peek <target> --lines 50                      # View agent output
 ```
 
 ### Deacon Communication Rules

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -68,10 +68,15 @@ gc mail inbox
 NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
 gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
-# Step 4: Execute — read formula steps and work through them in order
+# Step 4: Read the formula recipe — these are the steps to execute
+# (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
+#  for poured molecule instances, not formulas, and will say 'not found'.)
+gc bd formula show mol-deacon-patrol
+
+# Step 5: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps -> Follow in order -> pour next iteration.**
+**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration.**
 
 ## Context Exhaustion
 
@@ -156,6 +161,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | Want to... | Correct command |
 |------------|----------------|
 | Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }}` |
+| Read formula recipe | `gc bd formula show mol-deacon-patrol` (NOT `gc bd mol show` — that's for poured instances) |
 | Context exhaustion | `gc runtime request-restart` |
 | Request target restart | `gc session kill <target>` |
 | Check gates | `gc bd gate check --type=timer --escalate` |


### PR DESCRIPTION
## Summary

The deacon agent's startup protocol tells it to "read formula steps and work through them in order" but doesn't say which command does that. Without explicit guidance the deacon improvises:

- `gc bd mol show mol-deacon-patrol` → `molecule not found`
- `gc bd mol steps mol-deacon-patrol` → unknown subcommand

These are honest mistakes. `bd mol show` is for poured molecule *instances* (issue store lookup); the recipe on disk is `bd formula show`. Two intentionally distinct commands. The deacon's primary `mol wisp` call works fine — only the human-readable recipe view is mis-routed. Real cities show 21+ `molecule not found` errors per 10 minutes of normal deacon ticks until the agent self-heals via `--help`.

This patch teaches the deacon prompt the right command:

- **Startup protocol**: split "Step 4: Execute — read formula steps" into an explicit `Step 4: gc bd formula show mol-deacon-patrol` followed by `Step 5: work through the steps in order`. Adds a brief comment noting that `mol show` is for instances, not recipes.
- **Hook line**: surface the command inline (`Hook → Read formula steps (gc bd formula show <name>) → Follow in order → pour next iteration`).
- **Command Quick-Reference**: new row for the recipe lookup, with the same "NOT `mol show`" annotation.

No code changes in bd or gascity.

## Testing

- [x] `make check` clean for the changes in this PR. Pre-commit hook (`go test ./test/docsync`) passed. Full `go test ./...` shows the documented pre-existing macOS failures (`TestBuiltinDoltDoctor*`, `TestExecCommandRunnerTimeoutKillsChildProcess`, `TestMaintenanceDoltScriptsSkipTestPatternDatabases`) which exist on plain `origin/main` and are unrelated to this prose-only change.
- [ ] `make check-docs` (no docs/navigation/link changes — prompt prose only)
- [ ] `make test-integration` (no runtime/controller/workflow behavior changes; deferred — past attempts have timed out on macOS without saving partial output)

## Checklist

- [ ] Linked an issue, or explained why one is not needed
  - Tracked locally; symptom and reproduction recorded in transcript scans (21+ `molecule not found` errors per 10 min in deacon transcripts).
- [ ] Added or updated tests for behavior changes (no behavior change — prose-only)
- [ ] Updated docs for user-facing changes (these *are* the docs being updated)
- [x] Called out breaking changes or migration notes — none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->