### PR TITLE
fix: retry invalid contracts and scope fanout fragments

### DIFF
--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
@@ -810,10 +811,9 @@ name = "test-city"
 }
 
 func TestLoadCityConfigFSAppliesFeatureFlags(t *testing.T) {
-	oldFormulaV2 := formula.IsFormulaV2Enabled()
+	formulatest.HoldV2ForTest(t)
 	oldGraphApply := molecule.IsGraphApplyEnabled()
 	t.Cleanup(func() {
-		formula.SetFormulaV2Enabled(oldFormulaV2)
 		molecule.SetGraphApplyEnabled(oldGraphApply)
 	})
 

--- a/engdocs/design/formula-v2-transient-retries.md
+++ b/engdocs/design/formula-v2-transient-retries.md
@@ -232,12 +232,14 @@ Retry-managed attempt parsing is fail-closed:
 
 1. `gc.outcome` is authoritative for pass/fail
 2. `gc.failure_class` is consulted only when `gc.outcome=fail`
-3. Any invalid or contradictory tuple is treated as:
+3. Any invalid or contradictory tuple is treated as a transient contract
+   violation so the workflow gets a bounded retry instead of immediately
+   hard-failing:
 
 ```text
 gc.outcome=fail
-gc.failure_class=hard
-gc.failure_reason=invalid_worker_result_contract
+gc.failure_class=transient
+gc.failure_reason=<specific-contract-reason>
 ```
 
 Examples of invalid tuples:
@@ -246,6 +248,26 @@ Examples of invalid tuples:
 - `gc.outcome=pass` with any `gc.failure_class`
 - `gc.outcome=pass` with any `gc.failure_reason`
 - unknown `gc.failure_class`
+- unknown `gc.outcome` value
+
+Current reason tokens are:
+
+- `missing_outcome`
+- `pass_with_failure_metadata`
+- `unknown_failure_class`
+- `invalid_outcome_value`
+
+### Expansion fanout `scope_ref`
+
+Graph v2 expansion fanouts can provide `scope_ref` from two places:
+
+- live fanout control metadata (`gc.scope_ref`)
+- static fanout bond vars (`gc.bond_vars.scope_ref`)
+
+At runtime, the live fanout `gc.scope_ref` wins. The dispatcher injects the
+current fanout scope into expansion vars after materializing `gc.bond_vars`,
+so iteration-scoped fanouts always compile child fragments against the active
+scope even if `bond_vars.scope_ref` is stale or omitted.
 
 ### Reason taxonomy
 
@@ -257,7 +279,10 @@ V0 should standardize on short machine-readable reasons, for example:
 - `prompt_too_large`
 - `missing_input`
 - `invalid_repo_state`
-- `invalid_worker_result_contract`
+- `missing_outcome`
+- `pass_with_failure_metadata`
+- `unknown_failure_class`
+- `invalid_outcome_value`
 
 The runtime does not need to interpret these in v0; they are for
 observability and future policy. `gc.failure_reason` should be a short
@@ -599,8 +624,9 @@ Add store-driven tests similar to the existing Ralph and scope tests:
 2. transient fail to exhausted budget -> hard fail
 3. transient fail to exhausted budget with `on_exhausted=soft_fail`
 4. explicit hard failure -> logical fail
-5. malformed worker result contract -> hard fail with
-   `invalid_worker_result_contract`
+5. malformed worker result contract -> transient retry with one of
+   `missing_outcome`, `pass_with_failure_metadata`,
+   `unknown_failure_class`, or `invalid_outcome_value`
 6. stale `eval.n` cannot close a logical step already closed by attempt
    `n+1`
 7. pooled transient failure recycles the current session and leaves the

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
+	"github.com/gastownhall/gascity/internal/formulatest"
 	"github.com/gastownhall/gascity/internal/molecule"
 )
 
@@ -47,12 +48,10 @@ func TestNewSyncsFormulaV2FeatureFlags(t *testing.T) {
 	state := newFakeMutatorState(t)
 	state.cfg.Daemon.FormulaV2 = true
 
-	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	formulatest.SetV2ForTest(t, false)
 	prevGraphApply := molecule.IsGraphApplyEnabled()
-	formula.SetFormulaV2Enabled(false)
 	molecule.SetGraphApplyEnabled(false)
 	t.Cleanup(func() {
-		formula.SetFormulaV2Enabled(prevFormulaV2)
 		molecule.SetGraphApplyEnabled(prevGraphApply)
 	})
 
@@ -574,19 +573,19 @@ func TestSlingConflictReturns409ForExistingLiveWorkflow(t *testing.T) {
 	//      which is default-false out of newFakeMutatorState.
 	//   2. We then set state.cfg.Daemon.FormulaV2 = true for reads that go
 	//      through config (handler-level checks).
-	//   3. The global flag is what formula compile calls, so we call
-	//      formula.SetFormulaV2Enabled(true) AFTER newSlingTestServer so
-	//      New()'s syncFeatureFlags doesn't stomp it back to false.
-	prevFormulaV2 := formula.IsFormulaV2Enabled()
+	//   3. The compile-time flag is process-global, so this test holds the
+	//      shared formulatest guard and flips it to true AFTER
+	//      newSlingTestServer so New()'s syncFeatureFlags doesn't stomp it
+	//      back to false.
+	setFormulaV2 := formulatest.LockV2ForTest(t)
 	prevGraphApply := molecule.IsGraphApplyEnabled()
 	t.Cleanup(func() {
-		formula.SetFormulaV2Enabled(prevFormulaV2)
 		molecule.SetGraphApplyEnabled(prevGraphApply)
 	})
 
 	srv, state := newSlingTestServer(t)
 	state.cfg.Daemon.FormulaV2 = true
-	formula.SetFormulaV2Enabled(true)
+	setFormulaV2(true)
 	molecule.SetGraphApplyEnabled(true)
 	formulaDir := t.TempDir()
 	state.cfg.FormulaLayers.City = []string{formulaDir}

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -309,6 +309,110 @@ func TestProcessRetryControlSoftFailOnExhaustion(t *testing.T) {
 	}
 }
 
+func TestProcessRetryControlRetriesInvalidWorkerResultContract(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		attemptMeta map[string]string
+		wantReason  string
+	}{
+		{
+			name: "pass with failure metadata",
+			attemptMeta: map[string]string{
+				"gc.outcome":        "pass",
+				"gc.failure_class":  "transient",
+				"gc.failure_reason": "rate_limited",
+			},
+			wantReason: "pass_with_failure_metadata",
+		},
+		{
+			name: "missing outcome",
+			attemptMeta: map[string]string{
+				"gc.failure_class":  "transient",
+				"gc.failure_reason": "rate_limited",
+			},
+			wantReason: "missing_outcome",
+		},
+		{
+			name: "unknown failure class",
+			attemptMeta: map[string]string{
+				"gc.outcome":       "fail",
+				"gc.failure_class": "mystery",
+			},
+			wantReason: "unknown_failure_class",
+		},
+		{
+			name: "invalid outcome value",
+			attemptMeta: map[string]string{
+				"gc.outcome":       "mystery",
+				"gc.failure_class": "transient",
+			},
+			wantReason: "invalid_outcome_value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+
+			root := mustCreate(t, store, beads.Bead{
+				Title:    "workflow",
+				Metadata: map[string]string{"gc.kind": "workflow"},
+			})
+			control := mustCreate(t, store, beads.Bead{
+				Title: "review",
+				Metadata: map[string]string{
+					"gc.kind":             "retry",
+					"gc.root_bead_id":     root.ID,
+					"gc.step_ref":         "mol-test.review",
+					"gc.step_id":          "review",
+					"gc.max_attempts":     "2",
+					"gc.on_exhausted":     "hard_fail",
+					"gc.source_step_spec": `{"id":"review","title":"Review","type":"task","retry":{"max_attempts":2}}`,
+					"gc.control_epoch":    "1",
+				},
+			})
+			attemptMeta := map[string]string{
+				"gc.root_bead_id": root.ID,
+				"gc.step_ref":     "mol-test.review.attempt.1",
+				"gc.attempt":      "1",
+			}
+			for key, value := range tt.attemptMeta {
+				attemptMeta[key] = value
+			}
+			attempt1 := mustCreate(t, store, beads.Bead{
+				Title:    "review attempt 1",
+				Metadata: attemptMeta,
+			})
+			mustClose(t, store, attempt1.ID)
+			mustDep(t, store, control.ID, attempt1.ID, "blocks")
+
+			result, err := processRetryControl(store, mustGet(t, store, control.ID), ProcessOptions{})
+			if err != nil {
+				t.Fatalf("processRetryControl: %v", err)
+			}
+			if result.Action != "retry" {
+				t.Fatalf("action = %q, want retry", result.Action)
+			}
+
+			after := mustGet(t, store, control.ID)
+			if after.Status != "open" {
+				t.Fatalf("control status = %q, want open", after.Status)
+			}
+			if after.Metadata["gc.failure_reason"] != "" {
+				t.Fatalf("control gc.failure_reason = %q, want unset before exhaustion", after.Metadata["gc.failure_reason"])
+			}
+			var log []map[string]string
+			if err := json.Unmarshal([]byte(after.Metadata["gc.attempt_log"]), &log); err != nil {
+				t.Fatalf("unmarshal attempt_log: %v", err)
+			}
+			if len(log) != 1 || log[0]["reason"] != tt.wantReason {
+				t.Fatalf("attempt_log = %v, want reason %q", log, tt.wantReason)
+			}
+		})
+	}
+}
+
 func TestProcessRetryControlClosesEnclosingScopeOnFailure(t *testing.T) {
 	t.Parallel()
 	store := beads.NewMemStore()

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -120,13 +120,18 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	var previousSinkIDs []string
 	totalCreated := 0
 	for index, item := range items {
-		targetRef := sourceRef + ".item." + strconv.Itoa(index+1)
+		targetRef := fanoutTargetRef(source, sourceRef, index)
 		target := &formula.Step{
 			ID:          targetRef,
 			Title:       source.Title,
 			Description: source.Description,
 		}
 		itemVars := materializeFanoutVars(bondVars, item, index)
+		if _, ok := itemVars["scope_ref"]; ok {
+			if scopeRef := strings.TrimSpace(bead.Metadata["gc.scope_ref"]); scopeRef != "" {
+				itemVars["scope_ref"] = scopeRef
+			}
+		}
 		fragment, err := formula.CompileExpansionFragment(context.Background(), bead.Metadata["gc.bond"], opts.FormulaSearchPaths, target, itemVars)
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: compiling fragment %d: %w", bead.ID, index+1, err)
@@ -177,6 +182,14 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		return ControlResult{}, fmt.Errorf("%s: recording fanout state: %w", bead.ID, err)
 	}
 	return ControlResult{Processed: true, Action: "fanout-spawn", Created: totalCreated}, nil
+}
+
+func fanoutTargetRef(source beads.Bead, sourceRef string, index int) string {
+	base := strings.TrimSpace(source.Metadata["gc.step_ref"])
+	if base == "" {
+		base = sourceRef
+	}
+	return base + ".item." + strconv.Itoa(index+1)
 }
 
 func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Bead, opts ProcessOptions, store beads.Store) {

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -62,7 +62,11 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	if sourceRef == "" {
 		return ControlResult{}, fmt.Errorf("%s: missing gc.control_for", bead.ID)
 	}
-	source, err := resolveWorkflowStepByRefFromBeads(workflowBeads, rootID, sourceRef)
+	blockerIDs, err := controlBlockerIDs(store, bead.ID)
+	if err != nil {
+		return ControlResult{}, fmt.Errorf("%s: loading control blockers: %w", bead.ID, err)
+	}
+	source, err := resolveWorkflowStepByRefFromBeads(workflowBeads, rootID, sourceRef, workflowStepMatchOptions{PreferredIDs: blockerIDs})
 	if err != nil {
 		return ControlResult{}, fmt.Errorf("%s: resolving source step %q: %w", bead.ID, sourceRef, err)
 	}
@@ -111,11 +115,12 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 	if mode == "" {
 		mode = "parallel"
 	}
-	if bead.Metadata["gc.fanout_state"] == "" {
+	if strings.TrimSpace(bead.Metadata["gc.fanout_state"]) == "" {
 		if err := store.SetMetadataBatch(bead.ID, map[string]string{"gc.fanout_state": "spawning"}); err != nil {
 			return ControlResult{}, fmt.Errorf("%s: recording fanout spawn start: %w", bead.ID, err)
 		}
 	}
+	fanoutSinkBlockers := fanoutSinkBlockerIDs(blockerIDs, source.ID)
 
 	var previousSinkIDs []string
 	totalCreated := 0
@@ -127,10 +132,11 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 			Description: source.Description,
 		}
 		itemVars := materializeFanoutVars(bondVars, item, index)
-		if _, ok := itemVars["scope_ref"]; ok {
-			if scopeRef := strings.TrimSpace(bead.Metadata["gc.scope_ref"]); scopeRef != "" {
-				itemVars["scope_ref"] = scopeRef
+		if scopeRef := strings.TrimSpace(bead.Metadata["gc.scope_ref"]); scopeRef != "" {
+			if itemVars == nil {
+				itemVars = make(map[string]string, 1)
 			}
+			itemVars["scope_ref"] = scopeRef
 		}
 		fragment, err := formula.CompileExpansionFragment(context.Background(), bead.Metadata["gc.bond"], opts.FormulaSearchPaths, target, itemVars)
 		if err != nil {
@@ -143,7 +149,11 @@ func processFanout(store beads.Store, bead beads.Bead, opts ProcessOptions) (Con
 		}
 		routeFanoutFragmentSteps(fragment, bead, opts, store)
 		externalDeps := expectedFragmentExternalDeps(fragment, mode, previousSinkIDs)
-		existingMapping, err := resolveExistingFragmentInstanceFromBeads(store, workflowBeads, rootID, fragment, externalDeps)
+		existingMapping, err := resolveExistingFragmentInstanceFromBeads(store, workflowBeads, rootID, fragment, externalDeps, fragmentResumeMatchOptions{
+			StepRefAliases:     fanoutLegacyStepAliases(fragment, targetRef, sourceRef, index),
+			AliasScopeRef:      strings.TrimSpace(bead.Metadata["gc.scope_ref"]),
+			FanoutSinkBlockers: fanoutSinkBlockers,
+		})
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: resuming fragment %d: %w", bead.ID, index+1, err)
 		}
@@ -190,6 +200,76 @@ func fanoutTargetRef(source beads.Bead, sourceRef string, index int) string {
 		base = sourceRef
 	}
 	return base + ".item." + strconv.Itoa(index+1)
+}
+
+func controlBlockerIDs(store beads.Store, controlID string) (map[string]struct{}, error) {
+	deps, err := store.DepList(controlID, "down")
+	if err != nil {
+		return nil, err
+	}
+	blockers := make(map[string]struct{}, len(deps))
+	for _, dep := range deps {
+		if dep.Type != "blocks" || dep.DependsOnID == "" {
+			continue
+		}
+		blockers[dep.DependsOnID] = struct{}{}
+	}
+	if len(blockers) == 0 {
+		return nil, nil
+	}
+	return blockers, nil
+}
+
+func fanoutSinkBlockerIDs(blockers map[string]struct{}, sourceID string) map[string]struct{} {
+	if len(blockers) == 0 {
+		return nil
+	}
+	sinks := make(map[string]struct{}, len(blockers))
+	for blockerID := range blockers {
+		if blockerID == sourceID {
+			continue
+		}
+		sinks[blockerID] = struct{}{}
+	}
+	if len(sinks) == 0 {
+		return nil
+	}
+	return sinks
+}
+
+func fanoutLegacyStepAliases(fragment *formula.FragmentRecipe, targetRef, sourceRef string, index int) map[string]string {
+	if fragment == nil {
+		return nil
+	}
+	legacyBase := strings.TrimSpace(sourceRef)
+	if legacyBase == "" {
+		return nil
+	}
+	legacyTargetRef := legacyBase + ".item." + strconv.Itoa(index+1)
+	if legacyTargetRef == targetRef {
+		return nil
+	}
+
+	aliases := make(map[string]string, len(fragment.Steps))
+	for _, step := range fragment.Steps {
+		if strings.Count(step.ID, targetRef) != 1 {
+			continue
+		}
+		legacyID := strings.Replace(step.ID, targetRef, legacyTargetRef, 1)
+		if legacyID != step.ID {
+			aliases[step.ID] = legacyID
+		}
+	}
+	if len(aliases) == 0 {
+		return nil
+	}
+	return aliases
+}
+
+type fragmentResumeMatchOptions struct {
+	StepRefAliases     map[string]string
+	AliasScopeRef      string
+	FanoutSinkBlockers map[string]struct{}
 }
 
 func routeFanoutFragmentSteps(fragment *formula.FragmentRecipe, control beads.Bead, opts ProcessOptions, store beads.Store) {
@@ -246,18 +326,24 @@ func fanoutFragmentStepHasRoute(step formula.RecipeStep) bool {
 	return strings.TrimSpace(step.Assignee) != ""
 }
 
-func resolveExistingFragmentInstanceFromBeads(store beads.Store, all []beads.Bead, _ string, fragment *formula.FragmentRecipe, externalDeps []molecule.ExternalDep) (map[string]string, error) {
+func resolveExistingFragmentInstanceFromBeads(store beads.Store, all []beads.Bead, _ string, fragment *formula.FragmentRecipe, externalDeps []molecule.ExternalDep, opts fragmentResumeMatchOptions) (map[string]string, error) {
 	if fragment == nil || len(fragment.Steps) == 0 {
 		return nil, nil
 	}
 
 	expected := make(map[string]struct{}, len(fragment.Steps))
+	aliasToExpected := make(map[string]string, len(opts.StepRefAliases))
 	for _, step := range fragment.Steps {
 		expected[step.ID] = struct{}{}
+		if alias := strings.TrimSpace(opts.StepRefAliases[step.ID]); alias != "" && alias != step.ID {
+			aliasToExpected[alias] = step.ID
+		}
 	}
 
 	mapping := make(map[string]string, len(fragment.Steps))
 	partial := make(map[string]beads.Bead, len(fragment.Steps))
+	rejectedAlias := make(map[string]beads.Bead)
+	usedAlias := false
 	for _, bead := range all {
 		if bead.Metadata["gc.partial_fragment"] == "true" {
 			continue
@@ -266,37 +352,130 @@ func resolveExistingFragmentInstanceFromBeads(store beads.Store, all []beads.Bea
 		if stepRef == "" {
 			continue
 		}
-		if _, ok := expected[stepRef]; !ok {
+		matchID := stepRef
+		aliasMatch := false
+		if _, ok := expected[matchID]; !ok {
+			matchID = aliasToExpected[stepRef]
+			aliasMatch = matchID != ""
+		}
+		if matchID == "" {
 			continue
 		}
-		if existing := mapping[stepRef]; existing != "" && existing != bead.ID {
-			return nil, fmt.Errorf("duplicate fragment bead for %s (%s, %s)", stepRef, existing, bead.ID)
+		if aliasMatch {
+			scopeOwned := false
+			if opts.AliasScopeRef != "" {
+				beadScopeRef := strings.TrimSpace(bead.Metadata["gc.scope_ref"])
+				if beadScopeRef != "" {
+					if beadScopeRef != opts.AliasScopeRef {
+						continue
+					}
+					scopeOwned = true
+				}
+			}
+			blockerOwned := len(opts.FanoutSinkBlockers) > 0
+			// Legacy aliases are only safe to reuse once current-iteration
+			// ownership is proven. Without a matching scope_ref or already-wired
+			// sink blockers, an open legacy fragment could still belong to an
+			// older iteration that shared the same logical target.
+			if !scopeOwned && !blockerOwned {
+				if bead.Status != "closed" {
+					rejectedAlias[bead.ID] = bead
+				}
+				continue
+			}
+			usedAlias = true
 		}
-		mapping[stepRef] = bead.ID
+		if existing := mapping[matchID]; existing != "" && existing != bead.ID {
+			return nil, fmt.Errorf("duplicate fragment bead for %s (%s, %s)", matchID, existing, bead.ID)
+		}
+		mapping[matchID] = bead.ID
 		partial[bead.ID] = bead
 	}
 
 	switch {
 	case len(mapping) == 0:
+		if err := discardFragmentCandidates(store, fragment.Name, rejectedAlias); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	case len(mapping) != len(expected):
-		if err := discardPartialFragmentInstance(store, partial); err != nil {
-			return nil, fmt.Errorf("recovering partial fragment instance for %s: %w", fragment.Name, err)
+		if err := discardFragmentCandidates(store, fragment.Name, partial, rejectedAlias); err != nil {
+			return nil, err
 		}
 		return nil, nil
 	default:
+		if usedAlias && !fragmentAliasMatchesExistingBlockers(fragment, mapping, opts.FanoutSinkBlockers) {
+			if err := discardFragmentCandidates(store, fragment.Name, openFragmentBeads(partial), rejectedAlias); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
+		if len(rejectedAlias) > 0 {
+			if err := discardFragmentCandidates(store, fragment.Name, rejectedAlias); err != nil {
+				return nil, err
+			}
+		}
 		complete, err := fragmentInstanceComplete(store, fragment, mapping, externalDeps)
 		if err != nil {
 			return nil, err
 		}
 		if !complete {
-			if err := discardPartialFragmentInstance(store, partial); err != nil {
-				return nil, fmt.Errorf("recovering incompletely wired fragment instance for %s: %w", fragment.Name, err)
+			if err := discardFragmentCandidates(store, fragment.Name, partial); err != nil {
+				return nil, err
 			}
 			return nil, nil
 		}
 		return mapping, nil
 	}
+}
+
+func fragmentAliasMatchesExistingBlockers(fragment *formula.FragmentRecipe, mapping map[string]string, blockers map[string]struct{}) bool {
+	if len(blockers) == 0 {
+		return true
+	}
+	sinkIDs := mapStepIDs(fragment.Sinks, mapping)
+	if len(sinkIDs) == 0 {
+		return false
+	}
+	for _, sinkID := range sinkIDs {
+		if _, ok := blockers[sinkID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func discardFragmentCandidates(store beads.Store, fragmentName string, groups ...map[string]beads.Bead) error {
+	candidates := make(map[string]beads.Bead)
+	for _, group := range groups {
+		for id, bead := range group {
+			candidates[id] = bead
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	if err := discardPartialFragmentInstance(store, candidates); err != nil {
+		return fmt.Errorf("recovering partial fragment instance for %s: %w", fragmentName, err)
+	}
+	return nil
+}
+
+func openFragmentBeads(group map[string]beads.Bead) map[string]beads.Bead {
+	if len(group) == 0 {
+		return nil
+	}
+	openOnly := make(map[string]beads.Bead)
+	for id, bead := range group {
+		if bead.Status == "closed" {
+			continue
+		}
+		openOnly[id] = bead
+	}
+	if len(openOnly) == 0 {
+		return nil
+	}
+	return openOnly
 }
 
 func fragmentInstanceComplete(store beads.Store, fragment *formula.FragmentRecipe, mapping map[string]string, externalDeps []molecule.ExternalDep) (bool, error) {
@@ -535,12 +714,33 @@ func detachIncomingDeps(store beads.Store, beadID string) error {
 	return nil
 }
 
-func resolveWorkflowStepByRefFromBeads(all []beads.Bead, rootID, stepRef string) (beads.Bead, error) {
+type workflowStepMatchOptions struct {
+	PreferredIDs map[string]struct{}
+}
+
+func resolveWorkflowStepByRefFromBeads(all []beads.Bead, rootID, stepRef string, opts workflowStepMatchOptions) (beads.Bead, error) {
+	if len(opts.PreferredIDs) > 0 {
+		if match, ok := findWorkflowStepByRef(all, stepRef, opts.PreferredIDs); ok {
+			return match, nil
+		}
+	}
+	if match, ok := findWorkflowStepByRef(all, stepRef, nil); ok {
+		return match, nil
+	}
+	return beads.Bead{}, fmt.Errorf("step ref %q not found under root %s", stepRef, rootID)
+}
+
+func findWorkflowStepByRef(all []beads.Bead, stepRef string, allowedIDs map[string]struct{}) (beads.Bead, bool) {
 	var suffixMatch *beads.Bead
 	for _, bead := range all {
+		if len(allowedIDs) > 0 {
+			if _, ok := allowedIDs[bead.ID]; !ok {
+				continue
+			}
+		}
 		ref := bead.Metadata["gc.step_ref"]
 		if ref == stepRef {
-			return bead, nil
+			return bead, true
 		}
 		if suffixMatch == nil && strings.HasSuffix(ref, "."+stepRef) {
 			match := bead
@@ -548,9 +748,9 @@ func resolveWorkflowStepByRefFromBeads(all []beads.Bead, rootID, stepRef string)
 		}
 	}
 	if suffixMatch != nil {
-		return *suffixMatch, nil
+		return *suffixMatch, true
 	}
-	return beads.Bead{}, fmt.Errorf("step ref %q not found under root %s", stepRef, rootID)
+	return beads.Bead{}, false
 }
 
 func resolveFanoutItems(source beads.Bead, forEach string) ([]interface{}, error) {

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -230,7 +230,7 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	switch outcome {
 	case "pass":
 		if strings.TrimSpace(subject.Metadata["gc.failure_class"]) != "" || strings.TrimSpace(subject.Metadata["gc.failure_reason"]) != "" {
-			return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+			return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 		}
 		if strings.TrimSpace(subject.Metadata["gc.output_json_required"]) == "true" && strings.TrimSpace(subject.Metadata["gc.output_json"]) == "" {
 			return retryEvalResult{Outcome: "transient", Reason: "missing_required_output_json"}
@@ -243,12 +243,12 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 		case "hard", "":
 			return retryEvalResult{Outcome: "hard", Reason: retryFailureReason(subject)}
 		default:
-			return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+			return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 		}
 	case "":
-		return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+		return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 	default:
-		return retryEvalResult{Outcome: "hard", Reason: "invalid_worker_result_contract"}
+		return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
 	}
 }
 

--- a/internal/dispatch/retry.go
+++ b/internal/dispatch/retry.go
@@ -230,7 +230,7 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 	switch outcome {
 	case "pass":
 		if strings.TrimSpace(subject.Metadata["gc.failure_class"]) != "" || strings.TrimSpace(subject.Metadata["gc.failure_reason"]) != "" {
-			return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
+			return retryEvalResult{Outcome: "transient", Reason: "pass_with_failure_metadata"}
 		}
 		if strings.TrimSpace(subject.Metadata["gc.output_json_required"]) == "true" && strings.TrimSpace(subject.Metadata["gc.output_json"]) == "" {
 			return retryEvalResult{Outcome: "transient", Reason: "missing_required_output_json"}
@@ -243,12 +243,12 @@ func classifyRetryAttempt(subject beads.Bead) retryEvalResult {
 		case "hard", "":
 			return retryEvalResult{Outcome: "hard", Reason: retryFailureReason(subject)}
 		default:
-			return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
+			return retryEvalResult{Outcome: "transient", Reason: "unknown_failure_class"}
 		}
 	case "":
-		return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
+		return retryEvalResult{Outcome: "transient", Reason: "missing_outcome"}
 	default:
-		return retryEvalResult{Outcome: "transient", Reason: "invalid_worker_result_contract"}
+		return retryEvalResult{Outcome: "transient", Reason: "invalid_outcome_value"}
 	}
 }
 

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -682,7 +682,7 @@ func TestProcessRetryEvalStaleAttemptFinalizesNoop(t *testing.T) {
 	}
 }
 
-func TestProcessRetryEvalRejectsInvalidWorkerResultContract(t *testing.T) {
+func TestProcessRetryEvalRetriesInvalidWorkerResultContract(t *testing.T) {
 	t.Parallel()
 
 	store := newStrictCloseStore()
@@ -739,15 +739,91 @@ func TestProcessRetryEvalRejectsInvalidWorkerResultContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessControl(retry-eval invalid contract): %v", err)
 	}
-	if !result.Processed || result.Action != "hard-fail" {
-		t.Fatalf("result = %+v, want processed hard-fail", result)
+	if !result.Processed || result.Action != "retry" {
+		t.Fatalf("result = %+v, want processed retry", result)
+	}
+
+	logicalAfter := mustGetBead(t, store, logical.ID)
+	if logicalAfter.Status == "closed" {
+		t.Fatalf("logical status = closed, want open for retry")
+	}
+	if !strings.Contains(logicalAfter.Metadata["gc.failure_reason"], "invalid_worker_result_contract") {
+		t.Fatalf("logical gc.failure_reason = %q, want invalid_worker_result_contract", logicalAfter.Metadata["gc.failure_reason"])
+	}
+	if logicalAfter.Metadata["gc.retry_count"] != "1" {
+		t.Fatalf("logical gc.retry_count = %q, want 1", logicalAfter.Metadata["gc.retry_count"])
+	}
+}
+
+func TestProcessRetryEvalExhaustsInvalidWorkerResultContract(t *testing.T) {
+	t.Parallel()
+
+	store := newStrictCloseStore()
+	root := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "retry",
+			"gc.root_bead_id": root.ID,
+			"gc.step_ref":     "demo.review",
+			"gc.max_attempts": "2",
+			"gc.on_exhausted": "hard_fail",
+		},
+	})
+	run2 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "review attempt 2",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-run",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "demo.review.run.2",
+			"gc.logical_bead_id": logical.ID,
+			"gc.attempt":         "2",
+			"gc.max_attempts":    "2",
+			"gc.on_exhausted":    "hard_fail",
+		},
+	})
+	eval2 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review eval 2",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "retry-eval",
+			"gc.root_bead_id":    root.ID,
+			"gc.step_ref":        "demo.review.eval.2",
+			"gc.logical_bead_id": logical.ID,
+			"gc.attempt":         "2",
+			"gc.max_attempts":    "2",
+			"gc.on_exhausted":    "hard_fail",
+		},
+	})
+	mustDepAdd(t, store, logical.ID, eval2.ID, "blocks")
+	mustDepAdd(t, store, eval2.ID, run2.ID, "blocks")
+
+	result, err := ProcessControl(store, eval2, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("ProcessControl(retry-eval exhausted invalid contract): %v", err)
+	}
+	if !result.Processed || result.Action != "fail" {
+		t.Fatalf("result = %+v, want processed fail", result)
 	}
 
 	logicalAfter := mustGetBead(t, store, logical.ID)
 	if logicalAfter.Status != "closed" || logicalAfter.Metadata["gc.outcome"] != "fail" {
 		t.Fatalf("logical = status %q outcome %q, want closed/fail", logicalAfter.Status, logicalAfter.Metadata["gc.outcome"])
 	}
-	if !strings.Contains(logicalAfter.Metadata["gc.failure_reason"], "invalid_worker_result_contract") {
+	if logicalAfter.Metadata["gc.failure_class"] != "transient" {
+		t.Fatalf("logical gc.failure_class = %q, want transient", logicalAfter.Metadata["gc.failure_class"])
+	}
+	if logicalAfter.Metadata["gc.failure_reason"] != "invalid_worker_result_contract" {
 		t.Fatalf("logical gc.failure_reason = %q, want invalid_worker_result_contract", logicalAfter.Metadata["gc.failure_reason"])
 	}
 }

--- a/internal/dispatch/retry_test.go
+++ b/internal/dispatch/retry_test.go
@@ -1,7 +1,6 @@
 package dispatch
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -747,8 +746,8 @@ func TestProcessRetryEvalRetriesInvalidWorkerResultContract(t *testing.T) {
 	if logicalAfter.Status == "closed" {
 		t.Fatalf("logical status = closed, want open for retry")
 	}
-	if !strings.Contains(logicalAfter.Metadata["gc.failure_reason"], "invalid_worker_result_contract") {
-		t.Fatalf("logical gc.failure_reason = %q, want invalid_worker_result_contract", logicalAfter.Metadata["gc.failure_reason"])
+	if logicalAfter.Metadata["gc.failure_reason"] != "missing_outcome" {
+		t.Fatalf("logical gc.failure_reason = %q, want missing_outcome", logicalAfter.Metadata["gc.failure_reason"])
 	}
 	if logicalAfter.Metadata["gc.retry_count"] != "1" {
 		t.Fatalf("logical gc.retry_count = %q, want 1", logicalAfter.Metadata["gc.retry_count"])
@@ -823,8 +822,117 @@ func TestProcessRetryEvalExhaustsInvalidWorkerResultContract(t *testing.T) {
 	if logicalAfter.Metadata["gc.failure_class"] != "transient" {
 		t.Fatalf("logical gc.failure_class = %q, want transient", logicalAfter.Metadata["gc.failure_class"])
 	}
-	if logicalAfter.Metadata["gc.failure_reason"] != "invalid_worker_result_contract" {
-		t.Fatalf("logical gc.failure_reason = %q, want invalid_worker_result_contract", logicalAfter.Metadata["gc.failure_reason"])
+	if logicalAfter.Metadata["gc.failure_reason"] != "missing_outcome" {
+		t.Fatalf("logical gc.failure_reason = %q, want missing_outcome", logicalAfter.Metadata["gc.failure_reason"])
+	}
+}
+
+func TestProcessRetryEvalRetriesDistinctInvalidWorkerResultContracts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		meta   map[string]string
+		reason string
+	}{
+		{
+			name: "pass with failure metadata",
+			meta: map[string]string{
+				"gc.outcome":        "pass",
+				"gc.failure_class":  "transient",
+				"gc.failure_reason": "rate_limited",
+			},
+			reason: "pass_with_failure_metadata",
+		},
+		{
+			name: "fail with unknown failure class",
+			meta: map[string]string{
+				"gc.outcome":        "fail",
+				"gc.failure_class":  "mystery",
+				"gc.failure_reason": "weird",
+			},
+			reason: "unknown_failure_class",
+		},
+		{
+			name: "unknown outcome value",
+			meta: map[string]string{
+				"gc.outcome": "maybe",
+			},
+			reason: "invalid_outcome_value",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newStrictCloseStore()
+			root := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title: "workflow",
+				Type:  "task",
+				Metadata: map[string]string{
+					"gc.kind":             "workflow",
+					"gc.formula_contract": "graph.v2",
+				},
+			})
+			logical := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title: "review",
+				Type:  "task",
+				Metadata: map[string]string{
+					"gc.kind":         "retry",
+					"gc.root_bead_id": root.ID,
+					"gc.step_ref":     "demo.review",
+					"gc.max_attempts": "3",
+					"gc.on_exhausted": "hard_fail",
+				},
+			})
+			run1Meta := map[string]string{
+				"gc.kind":            "retry-run",
+				"gc.root_bead_id":    root.ID,
+				"gc.step_ref":        "demo.review.run.1",
+				"gc.logical_bead_id": logical.ID,
+				"gc.attempt":         "1",
+				"gc.max_attempts":    "3",
+				"gc.on_exhausted":    "hard_fail",
+			}
+			for key, value := range tc.meta {
+				run1Meta[key] = value
+			}
+			run1 := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title:    "review attempt 1",
+				Type:     "task",
+				Status:   "closed",
+				Metadata: run1Meta,
+			})
+			eval1 := mustCreateWorkflowBead(t, store, beads.Bead{
+				Title: "review eval 1",
+				Type:  "task",
+				Metadata: map[string]string{
+					"gc.kind":            "retry-eval",
+					"gc.root_bead_id":    root.ID,
+					"gc.step_ref":        "demo.review.eval.1",
+					"gc.logical_bead_id": logical.ID,
+					"gc.attempt":         "1",
+					"gc.max_attempts":    "3",
+					"gc.on_exhausted":    "hard_fail",
+				},
+			})
+			mustDepAdd(t, store, logical.ID, eval1.ID, "blocks")
+			mustDepAdd(t, store, eval1.ID, run1.ID, "blocks")
+
+			result, err := ProcessControl(store, eval1, ProcessOptions{})
+			if err != nil {
+				t.Fatalf("ProcessControl(retry-eval %s): %v", tc.name, err)
+			}
+			if !result.Processed || result.Action != "retry" {
+				t.Fatalf("result = %+v, want processed retry", result)
+			}
+
+			logicalAfter := mustGetBead(t, store, logical.ID)
+			if logicalAfter.Metadata["gc.failure_reason"] != tc.reason {
+				t.Fatalf("logical gc.failure_reason = %q, want %q", logicalAfter.Metadata["gc.failure_reason"], tc.reason)
+			}
+		})
 	}
 }
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3721,6 +3721,233 @@ on_exhausted = "hard_fail"
 	}
 }
 
+func TestProcessFanoutUsesResolvedSourceStepRefForIterationScopedFragments(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[vars.scope_ref]
+default = "body"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+metadata = { "gc.scope_ref" = "{scope_ref}" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.2.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.2",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}","scope_ref":"body"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("spawn result = %+v, want processed fanout-spawn", result)
+	}
+
+	child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.2.design-review.prepare-review-items.item.1.review")
+	if child.ID == "" {
+		t.Fatal("missing iteration-qualified fanout child")
+	}
+	if got := child.Metadata["gc.scope_ref"]; got != "mol.review-loop.iteration.2" {
+		t.Fatalf("child gc.scope_ref = %q, want live fanout scope", got)
+	}
+	if stale := findAttemptByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review"); stale.ID != "" {
+		t.Fatalf("spawned stale logical child ref %q; want iteration-qualified source step ref", stale.Metadata["gc.step_ref"])
+	}
+}
+
+func TestProcessFanoutDoesNotReusePriorIterationFragments(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	_ = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "old review",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "expansion-review.design-review.prepare-review-items.item.1.review",
+			"gc.outcome":      "pass",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.3.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.3",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if result.Created == 0 {
+		t.Fatalf("fanout reused a prior-iteration fragment; created=%d", result.Created)
+	}
+	if child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.3.design-review.prepare-review-items.item.1.review"); child.ID == "" {
+		t.Fatal("missing new iteration-qualified review child")
+	}
+}
+
+func TestProcessFanoutUsesControlForWhenSourceStepRefIsLogical(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	if _, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}}); err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if child := findAttemptByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review"); child.ID == "" {
+		t.Fatal("missing logical source child")
+	}
+}
+
 func TestProcessFanoutRecreatesExistingFragmentWithStaleRouteMetadata(t *testing.T) {
 	formulatest.EnableV2ForTest(t)
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3162,9 +3162,13 @@ type = "expansion"
 version = 2
 contract = "graph.v2"
 
+[vars.scope_ref]
+default = ""
+
 [[template]]
 id = "{target}.review"
 title = "Review {reviewer}"
+metadata = { "gc.scope_ref" = "{scope_ref}" }
 
 [[template]]
 id = "{target}.synth"
@@ -3756,6 +3760,17 @@ metadata = { "gc.scope_ref" = "{scope_ref}" }
 			"gc.formula_contract": "graph.v2",
 		},
 	})
+	_ = mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "stale prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"stale"}]}`,
+		},
+	})
 	source := mustCreateWorkflowBead(t, store, beads.Bead{
 		Title:  "prepare items",
 		Type:   "task",
@@ -3800,6 +3815,85 @@ metadata = { "gc.scope_ref" = "{scope_ref}" }
 	}
 	if stale := findAttemptByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review"); stale.ID != "" {
 		t.Fatalf("spawned stale logical child ref %q; want iteration-qualified source step ref", stale.Metadata["gc.step_ref"])
+	}
+}
+
+func TestProcessFanoutPropagatesLiveScopeRefWithoutBondVarOverride(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[vars.reviewer]
+required = true
+
+[vars.scope_ref]
+default = "body"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+metadata = { "gc.scope_ref" = "{scope_ref}" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.4.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.4",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout spawn): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("spawn result = %+v, want processed fanout-spawn", result)
+	}
+
+	child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.4.design-review.prepare-review-items.item.1.review")
+	if child.ID == "" {
+		t.Fatal("missing iteration-qualified fanout child")
+	}
+	if got := child.Metadata["gc.scope_ref"]; got != "mol.review-loop.iteration.4" {
+		t.Fatalf("child gc.scope_ref = %q, want live fanout scope without bond_vars scope_ref", got)
 	}
 }
 
@@ -4175,6 +4269,455 @@ needs = ["{target}.review"]
 	fanoutAfter := mustGetBead(t, store, fanout.ID)
 	if got := fanoutAfter.Metadata["gc.fanout_state"]; got != "spawned" {
 		t.Fatalf("fanout state after resume = %q, want spawned", got)
+	}
+}
+
+func TestProcessFanoutResumesLegacyIterationFragmentsWithoutDuplicates(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+
+[[template]]
+id = "{target}.synth"
+title = "Synthesize {reviewer}"
+needs = ["{target}.review"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.5.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.5",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+			"gc.fanout_state": "spawning",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	legacyFragment, err := formula.CompileExpansionFragment(context.Background(), "expansion-review", []string{dir}, &formula.Step{
+		ID:          "design-review.prepare-review-items.item.1",
+		Title:       source.Title,
+		Description: source.Description,
+	}, map[string]string{
+		"reviewer":  "claude",
+		"scope_ref": "mol.review-loop.iteration.5",
+	})
+	if err != nil {
+		t.Fatalf("CompileExpansionFragment(legacy): %v", err)
+	}
+	legacyInst, err := molecule.InstantiateFragment(context.Background(), store, legacyFragment, molecule.FragmentOptions{RootID: workflow.ID})
+	if err != nil {
+		t.Fatalf("InstantiateFragment(legacy): %v", err)
+	}
+	for _, sinkID := range mapStepIDs(legacyFragment.Sinks, legacyInst.IDMapping) {
+		mustDepAdd(t, store, fanout.ID, sinkID, "blocks")
+	}
+
+	before, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("store.List before: %v", err)
+	}
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout legacy resume): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("result = %+v, want processed fanout-spawn", result)
+	}
+	if result.Created != 0 {
+		t.Fatalf("result.Created = %d, want legacy fragment reuse without duplication", result.Created)
+	}
+
+	after, err := store.ListOpen()
+	if err != nil {
+		t.Fatalf("store.List after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("open bead count after legacy resume = %d, want unchanged %d", len(after), len(before))
+	}
+
+	if reused := findAttemptByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review"); reused.ID == "" {
+		t.Fatal("missing reused legacy fragment bead")
+	}
+	if duplicated := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.5.design-review.prepare-review-items.item.1.review"); duplicated.ID != "" {
+		t.Fatalf("created duplicate iteration-qualified fragment %q instead of reusing legacy fragment", duplicated.ID)
+	}
+}
+
+func TestProcessFanoutBlankStateRecreatesLegacyFragmentsWithoutOwnershipProof(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+
+[[template]]
+id = "{target}.synth"
+title = "Synthesize {reviewer}"
+needs = ["{target}.review"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.6.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.6",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	legacyFragment, err := formula.CompileExpansionFragment(context.Background(), "expansion-review", []string{dir}, &formula.Step{
+		ID:          "design-review.prepare-review-items.item.1",
+		Title:       source.Title,
+		Description: source.Description,
+	}, map[string]string{"reviewer": "claude"})
+	if err != nil {
+		t.Fatalf("CompileExpansionFragment(legacy): %v", err)
+	}
+	if _, err := molecule.InstantiateFragment(context.Background(), store, legacyFragment, molecule.FragmentOptions{RootID: workflow.ID}); err != nil {
+		t.Fatalf("InstantiateFragment(legacy): %v", err)
+	}
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout blank-state legacy recreate): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("result = %+v, want processed fanout-spawn", result)
+	}
+	if result.Created == 0 {
+		t.Fatal("expected blank-state fanout to recreate a current fragment when legacy ownership is unproven")
+	}
+
+	fanoutAfter := mustGetBead(t, store, fanout.ID)
+	if got := fanoutAfter.Metadata["gc.fanout_state"]; got != "spawned" {
+		t.Fatalf("fanout gc.fanout_state = %q, want spawned", got)
+	}
+	if child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.6.design-review.prepare-review-items.item.1.review"); child.ID == "" {
+		t.Fatal("missing new iteration-qualified review child")
+	}
+	legacyReview := findWorkflowBeadByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review")
+	legacySynth := findWorkflowBeadByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.synth")
+	for _, legacy := range []beads.Bead{legacyReview, legacySynth} {
+		if legacy.ID == "" {
+			t.Fatal("missing retired legacy fragment bead")
+		}
+		if legacy.Status != "closed" {
+			t.Fatalf("legacy bead %s status = %q, want closed", legacy.ID, legacy.Status)
+		}
+		if legacy.Metadata["gc.partial_fragment"] != "true" {
+			t.Fatalf("legacy bead %s gc.partial_fragment = %q, want true", legacy.ID, legacy.Metadata["gc.partial_fragment"])
+		}
+		if mustReadyContains(t, store, legacy.ID) {
+			t.Fatalf("legacy bead %s should no longer be ready/open", legacy.ID)
+		}
+	}
+}
+
+func TestProcessFanoutDoesNotReuseOpenLegacyFragmentsWithoutOwnershipProof(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+
+[[template]]
+id = "{target}.synth"
+title = "Synthesize {reviewer}"
+needs = ["{target}.review"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.7.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.7",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+			"gc.fanout_state": "spawning",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	legacyFragment, err := formula.CompileExpansionFragment(context.Background(), "expansion-review", []string{dir}, &formula.Step{
+		ID:          "design-review.prepare-review-items.item.1",
+		Title:       source.Title,
+		Description: source.Description,
+	}, map[string]string{"reviewer": "claude"})
+	if err != nil {
+		t.Fatalf("CompileExpansionFragment(legacy): %v", err)
+	}
+	if _, err := molecule.InstantiateFragment(context.Background(), store, legacyFragment, molecule.FragmentOptions{RootID: workflow.ID}); err != nil {
+		t.Fatalf("InstantiateFragment(legacy): %v", err)
+	}
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout legacy resume): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("result = %+v, want processed fanout-spawn", result)
+	}
+	if result.Created == 0 {
+		t.Fatal("expected a new iteration-qualified fragment when legacy ownership is unproven")
+	}
+
+	if child := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.7.design-review.prepare-review-items.item.1.review"); child.ID == "" {
+		t.Fatal("missing new iteration-qualified review child")
+	}
+	legacyReview := findWorkflowBeadByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.review")
+	legacySynth := findWorkflowBeadByRef(t, store, workflow.ID, "expansion-review.design-review.prepare-review-items.item.1.synth")
+	for _, legacy := range []beads.Bead{legacyReview, legacySynth} {
+		if legacy.ID == "" {
+			t.Fatal("missing retired legacy fragment bead")
+		}
+		if legacy.Status != "closed" {
+			t.Fatalf("legacy bead %s status = %q, want closed", legacy.ID, legacy.Status)
+		}
+		if legacy.Metadata["gc.partial_fragment"] != "true" {
+			t.Fatalf("legacy bead %s gc.partial_fragment = %q, want true", legacy.ID, legacy.Metadata["gc.partial_fragment"])
+		}
+		if mustReadyContains(t, store, legacy.ID) {
+			t.Fatalf("legacy bead %s should no longer be ready/open", legacy.ID)
+		}
+	}
+}
+
+func TestProcessFanoutDoesNotReuseClosedLegacyFragmentsFromPriorIteration(t *testing.T) {
+	t.Parallel()
+	formulatest.EnableV2ForTest(t)
+
+	dir := t.TempDir()
+	expansion := `
+formula = "expansion-review"
+type = "expansion"
+version = 2
+contract = "graph.v2"
+
+[[template]]
+id = "{target}.review"
+title = "Review {reviewer}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "expansion-review.toml"), []byte(expansion), 0o644); err != nil {
+		t.Fatalf("write expansion formula: %v", err)
+	}
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "prepare items",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "mol.review-loop.iteration.7.design-review.prepare-review-items",
+			"gc.outcome":      "pass",
+			"gc.output_json":  `{"items":[{"name":"claude"}]}`,
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for prepare items",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "fanout",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "mol.review-loop.iteration.7",
+			"gc.control_for":  "design-review.prepare-review-items",
+			"gc.for_each":     "output.items",
+			"gc.bond":         "expansion-review",
+			"gc.bond_vars":    `{"reviewer":"{item.name}"}`,
+			"gc.fanout_mode":  "parallel",
+			"gc.fanout_state": "spawning",
+		},
+	})
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+
+	legacyRef := "expansion-review.design-review.prepare-review-items.item.1.review"
+	legacyFragment, err := formula.CompileExpansionFragment(context.Background(), "expansion-review", []string{dir}, &formula.Step{
+		ID:          "design-review.prepare-review-items.item.1",
+		Title:       source.Title,
+		Description: source.Description,
+	}, map[string]string{"reviewer": "claude"})
+	if err != nil {
+		t.Fatalf("CompileExpansionFragment(legacy): %v", err)
+	}
+	if _, err := molecule.InstantiateFragment(context.Background(), store, legacyFragment, molecule.FragmentOptions{RootID: workflow.ID}); err != nil {
+		t.Fatalf("InstantiateFragment(legacy): %v", err)
+	}
+
+	legacy := findAttemptByRef(t, store, workflow.ID, legacyRef)
+	if legacy.ID == "" {
+		t.Fatal("missing legacy fragment bead")
+	}
+	if err := store.SetMetadataBatch(legacy.ID, map[string]string{"gc.outcome": "pass"}); err != nil {
+		t.Fatalf("mark legacy fragment pass: %v", err)
+	}
+	if err := store.Close(legacy.ID); err != nil {
+		t.Fatalf("close legacy fragment: %v", err)
+	}
+
+	result, err := ProcessControl(store, fanout, ProcessOptions{FormulaSearchPaths: []string{dir}})
+	if err != nil {
+		t.Fatalf("ProcessControl(fanout closed legacy resume): %v", err)
+	}
+	if !result.Processed || result.Action != "fanout-spawn" {
+		t.Fatalf("result = %+v, want processed fanout-spawn", result)
+	}
+	if result.Created == 0 {
+		t.Fatalf("result.Created = %d, want a new iteration-qualified fragment instead of closed legacy reuse", result.Created)
+	}
+
+	current := findAttemptByRef(t, store, workflow.ID, "expansion-review.mol.review-loop.iteration.7.design-review.prepare-review-items.item.1.review")
+	if current.ID == "" {
+		t.Fatal("missing new iteration-qualified fragment bead")
+	}
+	if current.ID == legacy.ID {
+		t.Fatalf("reused closed legacy fragment %q for current iteration", current.ID)
+	}
+
+	all, err := store.ListByMetadata(map[string]string{"gc.root_bead_id": workflow.ID}, 0, beads.IncludeClosed)
+	if err != nil {
+		t.Fatalf("ListByMetadata(root): %v", err)
+	}
+	var legacyAfter beads.Bead
+	for _, bead := range all {
+		if bead.Metadata["gc.step_ref"] == legacyRef {
+			legacyAfter = bead
+			break
+		}
+	}
+	if legacyAfter.ID == "" {
+		t.Fatal("missing closed legacy fragment after resume")
+	}
+	if legacyAfter.Status != "closed" {
+		t.Fatalf("legacy fragment status = %q, want closed", legacyAfter.Status)
+	}
+	if got := legacyAfter.Metadata["gc.partial_fragment"]; got != "" {
+		t.Fatalf("legacy fragment gc.partial_fragment = %q, want preserved historical bead", got)
+	}
+	if got := legacyAfter.Metadata["gc.outcome"]; got != "pass" {
+		t.Fatalf("legacy fragment gc.outcome = %q, want preserved pass outcome", got)
 	}
 }
 
@@ -4838,12 +5381,32 @@ func TestResolveWorkflowStepByRefFromBeadsPrefersExactMatch(t *testing.T) {
 	exact := beads.Bead{ID: "exact", Metadata: map[string]string{"gc.step_ref": "demo.survey"}}
 	suffix := beads.Bead{ID: "suffix", Metadata: map[string]string{"gc.step_ref": "other.demo.survey"}}
 
-	got, err := resolveWorkflowStepByRefFromBeads([]beads.Bead{suffix, exact}, "wf-1", "demo.survey")
+	got, err := resolveWorkflowStepByRefFromBeads([]beads.Bead{suffix, exact}, "wf-1", "demo.survey", workflowStepMatchOptions{})
 	if err != nil {
 		t.Fatalf("resolveWorkflowStepByRefFromBeads: %v", err)
 	}
 	if got.ID != exact.ID {
 		t.Fatalf("matched bead %s, want exact match %s", got.ID, exact.ID)
+	}
+}
+
+func TestResolveWorkflowStepByRefFromBeadsPrefersCurrentBlockerMatch(t *testing.T) {
+	t.Parallel()
+
+	exact := beads.Bead{ID: "exact", Metadata: map[string]string{"gc.step_ref": "demo.survey"}}
+	current := beads.Bead{ID: "current", Metadata: map[string]string{"gc.step_ref": "mol.iteration.2.demo.survey"}}
+
+	got, err := resolveWorkflowStepByRefFromBeads(
+		[]beads.Bead{exact, current},
+		"wf-1",
+		"demo.survey",
+		workflowStepMatchOptions{PreferredIDs: map[string]struct{}{current.ID: {}}},
+	)
+	if err != nil {
+		t.Fatalf("resolveWorkflowStepByRefFromBeads: %v", err)
+	}
+	if got.ID != current.ID {
+		t.Fatalf("matched bead %s, want current blocker %s", got.ID, current.ID)
 	}
 }
 
@@ -5575,6 +6138,20 @@ func mustGetBead(t *testing.T, store beads.Store, beadID string) beads.Bead {
 		t.Fatalf("get bead %s: %v", beadID, err)
 	}
 	return bead
+}
+
+func findWorkflowBeadByRef(t *testing.T, store beads.Store, rootID, stepRef string) beads.Bead {
+	t.Helper()
+	all, err := listByWorkflowRoot(store, rootID)
+	if err != nil {
+		t.Fatalf("list workflow beads: %v", err)
+	}
+	for _, bead := range all {
+		if bead.Metadata["gc.step_ref"] == stepRef {
+			return bead
+		}
+	}
+	return beads.Bead{}
 }
 
 type ralphPassOrderStore struct {

--- a/internal/formulatest/v2.go
+++ b/internal/formulatest/v2.go
@@ -9,30 +9,41 @@ import (
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
-var (
-	v2Mu          sync.Mutex
-	v2EnableCount int
-	v2SavedValue  bool
-)
+var v2Mu sync.Mutex
 
-// EnableV2ForTest enables graph.v2 formula compilation for the duration of the
-// test, restoring the previous value after the last concurrent enable cleanup.
-func EnableV2ForTest(tb testing.TB) {
+// LockV2ForTest acquires exclusive access to the process-global formula_v2
+// flag for the duration of the test and returns a setter for in-test updates.
+// It is non-reentrant: call it at most once per test goroutine.
+func LockV2ForTest(tb testing.TB) func(enabled bool) {
 	tb.Helper()
 	v2Mu.Lock()
-	if v2EnableCount == 0 {
-		v2SavedValue = formula.IsFormulaV2Enabled()
-	}
-	v2EnableCount++
-	formula.SetFormulaV2Enabled(true)
-	v2Mu.Unlock()
-
+	prev := formula.IsFormulaV2Enabled()
 	tb.Cleanup(func() {
-		v2Mu.Lock()
 		defer v2Mu.Unlock()
-		v2EnableCount--
-		if v2EnableCount == 0 {
-			formula.SetFormulaV2Enabled(v2SavedValue)
-		}
+		formula.SetFormulaV2Enabled(prev)
 	})
+	return func(enabled bool) {
+		formula.SetFormulaV2Enabled(enabled)
+	}
+}
+
+// HoldV2ForTest serializes a test against other formula_v2 mutators while
+// preserving the current flag value.
+func HoldV2ForTest(tb testing.TB) {
+	tb.Helper()
+	_ = LockV2ForTest(tb)
+}
+
+// SetV2ForTest sets graph.v2 formula compilation for the duration of the test,
+// restoring the previous value during cleanup.
+func SetV2ForTest(tb testing.TB, enabled bool) {
+	tb.Helper()
+	LockV2ForTest(tb)(enabled)
+}
+
+// EnableV2ForTest enables graph.v2 formula compilation for the duration of the
+// test, restoring the previous value during cleanup.
+func EnableV2ForTest(tb testing.TB) {
+	tb.Helper()
+	SetV2ForTest(tb, true)
 }

--- a/internal/formulatest/v2.go
+++ b/internal/formulatest/v2.go
@@ -3,18 +3,36 @@
 package formulatest
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/formula"
 )
 
+var (
+	v2Mu          sync.Mutex
+	v2EnableCount int
+	v2SavedValue  bool
+)
+
 // EnableV2ForTest enables graph.v2 formula compilation for the duration of the
-// test, restoring the previous value on cleanup. Callers must not use it in
-// tests that run in parallel with other formula-v2 flag mutations because the
-// flag is process-global.
+// test, restoring the previous value after the last concurrent enable cleanup.
 func EnableV2ForTest(tb testing.TB) {
 	tb.Helper()
-	prev := formula.IsFormulaV2Enabled()
+	v2Mu.Lock()
+	if v2EnableCount == 0 {
+		v2SavedValue = formula.IsFormulaV2Enabled()
+	}
+	v2EnableCount++
 	formula.SetFormulaV2Enabled(true)
-	tb.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
+	v2Mu.Unlock()
+
+	tb.Cleanup(func() {
+		v2Mu.Lock()
+		defer v2Mu.Unlock()
+		v2EnableCount--
+		if v2EnableCount == 0 {
+			formula.SetFormulaV2Enabled(v2SavedValue)
+		}
+	})
 }

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -21,9 +21,7 @@ import (
 // graph will be missing the dep — which is exactly what we saw in
 // production.
 func TestBuildRecipeApplyPlanBugReportFlowV2(t *testing.T) {
-	prev := formula.IsFormulaV2Enabled()
-	formula.SetFormulaV2Enabled(true)
-	t.Cleanup(func() { formula.SetFormulaV2Enabled(prev) })
+	formulatest.EnableV2ForTest(t)
 
 	const toolingPath = "/home/ubuntu/tooling/formulas"
 	if _, err := os.Stat(filepath.Join(toolingPath, "mol-bug-report-flow-v2.formula.toml")); err != nil {
@@ -85,9 +83,7 @@ func TestBuildRecipeApplyPlanBugReportFlowV2(t *testing.T) {
 // soon as its non-attempt blockers (body scope) close, trips the
 // "latest attempt ... is open, not closed" invariant, and crash-loops.
 func TestCookTeardownRetryBlocksOnAttempt(t *testing.T) {
-	prevFormulaV2 := formula.IsFormulaV2Enabled()
-	formula.SetFormulaV2Enabled(true)
-	t.Cleanup(func() { formula.SetFormulaV2Enabled(prevFormulaV2) })
+	formulatest.EnableV2ForTest(t)
 	prevGraphApply := IsGraphApplyEnabled()
 	SetGraphApplyEnabled(true)
 	t.Cleanup(func() { SetGraphApplyEnabled(prevGraphApply) })


### PR DESCRIPTION
## Summary

- Supersedes #1742.
- Credit: Original fix by @julianknutsen.
- Preserve the original fix to retry malformed worker-result contracts, bind fanout fragments to the resolved source bead `gc.step_ref`, and inject the live fanout `scope_ref` into graph.v2 expansion vars.
- Add maintainer fixups for legacy fanout resume ownership checks, broader malformed-contract retry coverage across controller and retry paths, parallel-safe formula-v2 test helpers, and design-doc updates.
- Migration note: exhausted invalid worker-result contracts now close with `gc.failure_class=transient` plus specific `gc.failure_reason` tokens (`pass_with_failure_metadata`, `missing_outcome`, `unknown_failure_class`, `invalid_outcome_value`).

## Testing

- [x] `make check`
- [x] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] Added or updated tests for behavior changes
- [x] Updated docs for user-facing changes
- [x] Called out breaking changes or migration notes

No separate issue is needed; this PR supersedes #1742.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->