### PR TITLE
fix: preserve pool slot identity for live sessions

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1265,10 +1265,7 @@ func discoverSessionBeadsWithRoots(
 		// but we still need the bead in desired state so the reconciler
 		// doesn't classify it as orphaned. Only skip if we can't resolve
 		// the template.
-		template := b.Metadata["template"]
-		if template == "" {
-			template = b.Metadata["common_name"]
-		}
+		template := resolvedSessionTemplate(b, cfg)
 		if template == "" {
 			continue
 		}
@@ -1303,7 +1300,7 @@ func discoverSessionBeadsWithRoots(
 			if isPoolManagedSessionBead(b) && !manualSession && !isNamedSessionBead(b) && !creating && !pendingCreate && !scaleCheckPartial {
 				continue
 			}
-			if !manualSession && !desiredHasTemplate(desired, template) && !pendingCreate && !scaleCheckPartial {
+			if !manualSession && (!creating || isStaleCreating(b)) && !desiredHasTemplate(desired, template) && !pendingCreate && !scaleCheckPartial {
 				continue
 			}
 		}
@@ -1334,7 +1331,7 @@ func discoverSessionBeadsWithRoots(
 			// inputs aligned across buildDesiredState paths. Named beads
 			// intentionally pass through with the base shape (see
 			// canonicalSessionIdentity).
-			resolveAgent, sessionQualifiedName = canonicalSessionIdentity(cfgAgent, b)
+			resolveAgent, sessionQualifiedName = canonicalSessionIdentityWithConfig(cfg, cfgAgent, b)
 		}
 		fpExtra := buildFingerprintExtra(resolveAgent)
 		tp, err := resolveTemplateForSessionBead(bp, resolveAgent, sessionQualifiedName, fpExtra, b)
@@ -1400,7 +1397,7 @@ func realizeDependencyFloors(
 			if agentInSuspendedRig(bp.cityPath, depAgent, cfg.Rigs, suspendedRigPaths) {
 				continue
 			}
-			ensureDependencyOnlyTemplate(bp, depAgent, desired, stderr)
+			ensureDependencyOnlyTemplate(bp, cfg, depAgent, desired, stderr)
 			visit(dep)
 		}
 	}
@@ -1411,6 +1408,7 @@ func realizeDependencyFloors(
 
 func ensureDependencyOnlyTemplate(
 	bp *agentBuildParams,
+	cfg *config.City,
 	cfgAgent *config.Agent,
 	desired map[string]TemplateParams,
 	stderr io.Writer,
@@ -1458,7 +1456,7 @@ func ensureDependencyOnlyTemplate(
 	// Otherwise GC_ALIAS would be the base "rig/dog" here and "rig/dog-1"
 	// on the realize path, oscillating across ticks and triggering the
 	// reconciler's config-drift drain on the live dependency-floor session.
-	resolveAgent, resolveQN := canonicalSessionIdentity(cfgAgent, sessionBead)
+	resolveAgent, resolveQN := canonicalSessionIdentityWithConfig(cfg, cfgAgent, sessionBead)
 	// Dep-floor slot-1 fallback. The guard triggers when the helper returned
 	// the BASE form — meaning no pool_slot was stamped yet. Keying off
 	// resolveQN (a stable value) rather than pointer identity keeps the
@@ -1609,6 +1607,10 @@ func resolveTemplateForSessionBead(
 //   - Instance-expanding agent without a slot stamp → (cfgAgent,
 //     cfgAgent.QualifiedName()); realize will claim and stamp later.
 func canonicalSessionIdentity(cfgAgent *config.Agent, bead beads.Bead) (*config.Agent, string) {
+	return canonicalSessionIdentityWithConfig(nil, cfgAgent, bead)
+}
+
+func canonicalSessionIdentityWithConfig(cfg *config.City, cfgAgent *config.Agent, bead beads.Bead) (*config.Agent, string) {
 	if cfgAgent == nil {
 		return nil, ""
 	}
@@ -1618,7 +1620,7 @@ func canonicalSessionIdentity(cfgAgent *config.Agent, bead beads.Bead) (*config.
 	if !cfgAgent.SupportsInstanceExpansion() {
 		return cfgAgent, cfgAgent.QualifiedName()
 	}
-	slot := existingPoolSlot(cfgAgent, bead)
+	slot := existingPoolSlotWithConfig(cfg, cfgAgent, bead)
 	if slot <= 0 {
 		return cfgAgent, cfgAgent.QualifiedName()
 	}
@@ -1717,23 +1719,139 @@ func existingPoolSlot(cfgAgent *config.Agent, sessionBead beads.Bead) int {
 			return slot
 		}
 	}
-	agentName := strings.TrimSpace(sessionBeadAgentName(sessionBead))
-	if agentName == "" || cfgAgent == nil {
+	if cfgAgent == nil {
 		return 0
 	}
-	if slot := resolvePoolSlot(agentName, cfgAgent.QualifiedName()); slot > 0 {
+	if slot := resolvePersistedPoolIdentitySlot(cfgAgent, true, sessionBeadAgentName(sessionBead), sessionBead.Metadata["alias"]); slot > 0 {
 		return slot
 	}
-	if slot := resolvePoolSlot(agentName, cfgAgent.Name); slot > 0 {
-		return slot
+	if strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && !beadOwnsPoolSessionName(sessionBead) {
+		if slot := resolvePersistedPoolIdentitySlot(cfgAgent, true, sessionBead.Metadata["session_name"]); slot > 0 {
+			return slot
+		}
 	}
-	for idx, themed := range cfgAgent.NamepoolNames {
-		if strings.TrimSpace(themed) == agentName {
-			return idx + 1
+	return 0
+}
+
+func resolvePersistedPoolIdentitySlot(cfgAgent *config.Agent, allowLocalIdentity bool, candidates ...string) int {
+	if cfgAgent == nil {
+		return 0
+	}
+	for _, name := range candidates {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
 		}
-		if cfgAgent.Dir != "" && strings.TrimSpace(cfgAgent.QualifiedInstanceName(themed)) == agentName {
-			return idx + 1
+		if slot := resolvePoolSlot(name, cfgAgent.QualifiedName()); slot > 0 {
+			return slot
 		}
+		if cfgAgent.BindingName != "" {
+			if slot := resolvePoolSlot(name, cfgAgent.BindingQualifiedName()); slot > 0 {
+				return slot
+			}
+		}
+		if cfgAgent.BindingName == "" && allowLocalIdentity {
+			if slot := resolvePoolSlot(name, cfgAgent.Name); slot > 0 {
+				return slot
+			}
+		}
+		for idx, themed := range cfgAgent.NamepoolNames {
+			themed = strings.TrimSpace(themed)
+			if themed == "" {
+				continue
+			}
+			if themed == name {
+				return idx + 1
+			}
+			if strings.TrimSpace(cfgAgent.QualifiedInstanceName(themed)) == name {
+				return idx + 1
+			}
+		}
+	}
+	return 0
+}
+
+func poolSlotHasConfiguredBound(cfgAgent *config.Agent) bool {
+	if cfgAgent == nil {
+		return false
+	}
+	if len(cfgAgent.NamepoolNames) > 0 {
+		return true
+	}
+	if maxSessions := cfgAgent.EffectiveMaxActiveSessions(); maxSessions != nil {
+		return true
+	}
+	return false
+}
+
+func inBoundsPoolSlot(cfgAgent *config.Agent, slot int) bool {
+	if cfgAgent == nil || slot <= 0 || !poolSlotHasConfiguredBound(cfgAgent) {
+		return false
+	}
+	if len(cfgAgent.NamepoolNames) > 0 && slot > len(cfgAgent.NamepoolNames) {
+		return false
+	}
+	if maxSessions := cfgAgent.EffectiveMaxActiveSessions(); maxSessions != nil && *maxSessions > 0 && slot > *maxSessions {
+		return false
+	}
+	return true
+}
+
+func existingPoolSlotWithConfig(cfg *config.City, cfgAgent *config.Agent, sessionBead beads.Bead) int {
+	if cfgAgent == nil {
+		return 0
+	}
+	storedTemplateMatches := cfg == nil || storedTemplateMatchesPoolTemplate(sessionBeadStoredTemplate(sessionBead), cfgAgent.QualifiedName(), cfg)
+	agentSlot := resolvePersistedPoolIdentitySlot(cfgAgent, storedTemplateMatches, sessionBeadAgentName(sessionBead))
+	aliasSlot := resolvePersistedPoolIdentitySlot(cfgAgent, storedTemplateMatches, sessionBead.Metadata["alias"])
+	sessionNameSlot := 0
+	if storedTemplateMatches && strings.TrimSpace(sessionBead.Metadata["alias"]) == "" && !beadOwnsPoolSessionName(sessionBead) {
+		sessionNameSlot = resolvePersistedPoolIdentitySlot(cfgAgent, true, sessionBead.Metadata["session_name"])
+	}
+	if sessionBead.Metadata["pool_slot"] != "" {
+		if slot, err := strconv.Atoi(strings.TrimSpace(sessionBead.Metadata["pool_slot"])); err == nil && slot > 0 {
+			if agentSlot > 0 && agentSlot == aliasSlot && agentSlot != slot {
+				return agentSlot
+			}
+			if !storedTemplateMatches && agentSlot == 0 && aliasSlot == 0 {
+				return 0
+			}
+			if !inBoundsPoolSlot(cfgAgent, slot) {
+				if agentSlot > 0 {
+					return agentSlot
+				}
+				if aliasSlot > 0 {
+					return aliasSlot
+				}
+				if sessionNameSlot > 0 {
+					return sessionNameSlot
+				}
+				if poolSlotHasConfiguredBound(cfgAgent) {
+					return 0
+				}
+			}
+			return slot
+		}
+	}
+	if poolSlotHasConfiguredBound(cfgAgent) {
+		if agentSlot > 0 && !inBoundsPoolSlot(cfgAgent, agentSlot) {
+			agentSlot = 0
+		}
+		if aliasSlot > 0 && !inBoundsPoolSlot(cfgAgent, aliasSlot) {
+			aliasSlot = 0
+		}
+		if sessionNameSlot > 0 && !inBoundsPoolSlot(cfgAgent, sessionNameSlot) {
+			sessionNameSlot = 0
+		}
+	}
+	if agentSlot > 0 {
+		return agentSlot
+	}
+	if aliasSlot > 0 {
+		return aliasSlot
+	}
+	if sessionNameSlot > 0 {
+		return sessionNameSlot
 	}
 	return 0
 }

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -3452,6 +3452,58 @@ func TestBuildDesiredState_StoreBackedPoolUsesQualifiedInstanceNameForBindings(t
 	}
 }
 
+func TestBuildDesiredState_RecoversPoolTemplateFromAliasOnlyBindingIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "ops furiosa",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "ops-furiosa-session",
+			"alias":        "frontend/ops.furiosa",
+			"pool_slot":    "1",
+			"pool_managed": "true",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:          "worker",
+			Dir:           "frontend",
+			BindingName:   "ops",
+			NamepoolNames: []string{"furiosa", "nux"},
+			WorkDir:       ".gc/worktrees/{{.AgentBase}}",
+			ScaleCheck:    "printf 1",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State["ops-furiosa-session"]
+	if !ok {
+		t.Fatalf("desired state missing alias-only pool session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.TemplateName != "frontend/ops.worker" {
+		t.Fatalf("TemplateName = %q, want %q", got.TemplateName, "frontend/ops.worker")
+	}
+	wantInstance := cfg.Agents[0].QualifiedInstanceName("furiosa")
+	if got.InstanceName != wantInstance {
+		t.Fatalf("InstanceName = %q, want %q", got.InstanceName, wantInstance)
+	}
+	if got.Alias != wantInstance {
+		t.Fatalf("Alias = %q, want %q", got.Alias, wantInstance)
+	}
+	if got.Env["GC_AGENT"] != wantInstance {
+		t.Fatalf("GC_AGENT = %q, want %q", got.Env["GC_AGENT"], wantInstance)
+	}
+	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "ops.furiosa")
+	if got.WorkDir != wantWorkDir {
+		t.Fatalf("WorkDir = %q, want %q", got.WorkDir, wantWorkDir)
+	}
+}
+
 func TestBuildDesiredState_PendingCreatePoolSessionUsesConcreteBeadIdentity(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
@@ -3708,6 +3760,307 @@ func TestBuildDesiredState_LegacyAliaslessEphemeralPoolSessionFallsBackToSession
 	wantWorkDir := filepath.Join(cityPath, ".gc", "worktrees", "demo", "ants", "s-gc-legacy")
 	if got.WorkDir != wantWorkDir {
 		t.Fatalf("WorkDir = %q, want %q", got.WorkDir, wantWorkDir)
+	}
+}
+
+func TestBuildDesiredState_RediscoveriesUniqueLegacyLocalPoolTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-5",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State["worker-5"]
+	if !ok {
+		t.Fatalf("desired state missing legacy local session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.TemplateName != "frontend/worker" {
+		t.Fatalf("TemplateName = %q, want %q", got.TemplateName, "frontend/worker")
+	}
+}
+
+func TestBuildDesiredState_DoesNotRediscoverAmbiguousLegacyLocalPoolTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-5",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if _, ok := dsResult.State["worker-5"]; ok {
+		t.Fatalf("desired state %#v unexpectedly rediscovered ambiguous local pool template", dsResult.State["worker-5"])
+	}
+}
+
+func TestBuildDesiredState_RecoversPoolTemplateFromAgentNameOnlyLegacyLocalIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "worker-5",
+			"session_name": "worker-5",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State["worker-5"]
+	if !ok {
+		t.Fatalf("desired state missing agent_name-only legacy session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.TemplateName != "frontend/worker" {
+		t.Fatalf("TemplateName = %q, want %q", got.TemplateName, "frontend/worker")
+	}
+}
+
+func TestBuildDesiredState_DoesNotRecoverPoolTemplateFromAmbiguousLegacyLocalAlias(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"alias":        "worker-5",
+			"session_name": "worker-5",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if _, ok := dsResult.State["worker-5"]; ok {
+		t.Fatalf("desired state %#v unexpectedly recovered ambiguous local alias identity", dsResult.State["worker-5"])
+	}
+}
+
+func TestBuildDesiredState_RediscoveriesLegacyCommonNamePoolTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"common_name":  "worker",
+			"session_name": "worker-5",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	got, ok := dsResult.State["worker-5"]
+	if !ok {
+		t.Fatalf("desired state missing legacy common_name session: keys=%v", mapKeys(dsResult.State))
+	}
+	if got.TemplateName != "frontend/worker" {
+		t.Fatalf("TemplateName = %q, want %q", got.TemplateName, "frontend/worker")
+	}
+}
+
+func TestBuildDesiredState_DoesNotRediscoverFreshCreatingOutOfBoundsQualifiedPoolIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "frontend/worker-7",
+			"session_name": "custom-worker-7",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if _, ok := dsResult.State["custom-worker-7"]; ok {
+		t.Fatalf("desired state %#v unexpectedly kept fresh out-of-bounds qualified pool identity", dsResult.State["custom-worker-7"])
+	}
+}
+
+func TestBuildDesiredState_DoesNotRediscoverZeroCapacityQualifiedPoolIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "frontend/worker-1",
+			"session_name": "custom-worker-1",
+			"state":        "creating",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(0)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if _, ok := dsResult.State["custom-worker-1"]; ok {
+		t.Fatalf("desired state %#v unexpectedly kept zero-capacity qualified pool identity", dsResult.State["custom-worker-1"])
+	}
+}
+
+func TestBuildDesiredState_DoesNotRediscoverStaleCreatingLegacyPoolTemplate(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"common_name":               "worker",
+			"session_name":              "worker-7",
+			"state":                     "creating",
+			"pending_create_started_at": time.Now().Add(-staleCreatingStateTimeout - time.Minute).UTC().Format(time.RFC3339),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if _, ok := dsResult.State["worker-7"]; ok {
+		t.Fatalf("desired state %#v unexpectedly kept stale creating legacy pool bead", dsResult.State["worker-7"])
+	}
+}
+
+func TestBuildDesiredState_DoesNotPreserveOutOfBoundsBoundedPoolSlotWithoutIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	bead := beads.Bead{
+		Metadata: map[string]string{
+			"template":  "frontend/worker",
+			"pool_slot": "99",
+		},
+	}
+
+	if slot := existingPoolSlotWithConfig(cfg, cfgAgent, bead); slot != 0 {
+		t.Fatalf("existingPoolSlotWithConfig(out-of-bounds bounded slot) = %d, want 0", slot)
+	}
+}
+
+func TestBuildDesiredState_DoesNotRecoverOutOfBoundsAliasOnlyBoundedPoolSlot(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/worker",
+			"alias":        "frontend/worker-7",
+			"session_name": "custom-worker-7",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", Provider: "test-agent", StartCommand: "true", WorkDir: ".", MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if _, ok := dsResult.State["custom-worker-7"]; ok {
+		t.Fatalf("desired state %#v unexpectedly preserved out-of-bounds alias-only pool identity", dsResult.State["custom-worker-7"])
+	}
+}
+
+func TestClaimPoolSlot_PreservesStampedOutOfBoundsLiveIdentity(t *testing.T) {
+	cfgAgent := &config.Agent{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)}
+	bead := beads.Bead{
+		Metadata: map[string]string{
+			"pool_slot":  "7",
+			"agent_name": "frontend/worker-7",
+			"alias":      "frontend/worker-7",
+		},
+	}
+
+	if slot := existingPoolSlot(cfgAgent, bead); slot != 7 {
+		t.Fatalf("existingPoolSlot(stamped live slot) = %d, want 7", slot)
+	}
+	used := map[int]bool{}
+	if slot := claimPoolSlot(cfgAgent, bead, used); slot != 7 {
+		t.Fatalf("claimPoolSlot(stamped live slot) = %d, want 7", slot)
 	}
 }
 
@@ -4621,6 +4974,82 @@ func TestEnsureDependencyOnlyTemplate_StoreBackedUsesInstanceIdentity(t *testing
 	}
 	if template := tp.Env["GC_TEMPLATE"]; template != "gascity/db" {
 		t.Fatalf("store-backed dep-floor GC_TEMPLATE = %q, want base %q", template, "gascity/db")
+	}
+}
+
+func TestBuildDesiredState_DependencyFloorIgnoresConfigBlindLegacySlotRecovery(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "db",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+			},
+			{
+				Name:              "api",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+				DependsOn:         []string{"gascity/db"},
+			},
+		},
+	}
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "api",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/api"},
+		Metadata: map[string]string{
+			"template":     "gascity/api",
+			"agent_name":   "gascity/api",
+			"session_name": "s-api-root",
+			"state":        "active",
+			"pool_managed": "true",
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatalf("seed api root bead: %v", err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "db",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":      "db-2",
+			"session_name":    "s-db-dep-legacy",
+			"state":           "active",
+			"dependency_only": "true",
+			"pool_managed":    "true",
+		},
+	}); err != nil {
+		t.Fatalf("seed dependency-only db bead: %v", err)
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	var tp TemplateParams
+	var found bool
+	for _, entry := range dsResult.State {
+		if entry.TemplateName == "gascity/db" && entry.DependencyOnly {
+			tp = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("store-backed dependency floor for db not found: %+v", dsResult.State)
+	}
+
+	if got, want := tp.Env["GC_ALIAS"], "gascity/db-1"; got != want {
+		t.Fatalf("store-backed dep-floor GC_ALIAS = %q, want %q when legacy bead lacks matching template metadata", got, want)
 	}
 }
 

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -164,15 +164,12 @@ func doRigRestart(
 			}
 		} else {
 			// Pool agent: resolve live instances from beads first, then legacy discovery.
-			for _, ref := range resolvePoolSessionRefs(store, a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp, stderr) {
-				running, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, ref.sessionName)
-				if err != nil {
-					fmt.Fprintf(stderr, "gc rig restart: observing %s: %v\n", ref.sessionName, err) //nolint:errcheck
-					return 1
-				}
-				if !running {
-					continue
-				}
+			refs, err := selectRunningPoolSessionRefs(store, sp, cfg, resolvePoolSessionRefs(store, cfg, a.Name, a.Dir, sp0, &a, cityName, sessionTemplate, sp, stderr))
+			if err != nil {
+				fmt.Fprintf(stderr, "gc rig restart: observing %s: %v\n", a.QualifiedName(), err) //nolint:errcheck
+				return 1
+			}
+			for _, ref := range refs {
 				targets = append(targets, stopTarget{
 					name:     ref.sessionName,
 					template: a.QualifiedName(),

--- a/cmd/gc/cmd_restart_test.go
+++ b/cmd/gc/cmd_restart_test.go
@@ -253,6 +253,253 @@ func TestDoRigRestart_UsesUnlimitedPoolSessionBeadsForCustomSessionNames(t *test
 	}
 }
 
+func TestDoRigRestart_UsesBoundPoolSlotOnlySessionBeadForCustomSessionName(t *testing.T) {
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "frontend/ops.furiosa",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/ops.worker",
+			"session_name": "custom-ops-furiosa",
+			"pool_slot":    "1",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.Start(context.Background(), "custom-ops-furiosa", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := events.NewFake()
+	agents := []config.Agent{{
+		Name:              "worker",
+		Dir:               "frontend",
+		BindingName:       "ops",
+		NamepoolNames:     []string{"furiosa", "nux"},
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(2), ScaleCheck: "echo 1",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigRestart(sp, rec, store, nil, agents, "frontend", "city", "{{.Agent}}", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if sp.IsRunning("custom-ops-furiosa") {
+		t.Fatal("custom bound pool session still running after rig restart")
+	}
+	if len(rec.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Subject != "frontend/ops.furiosa" {
+		t.Fatalf("event subject = %q, want %q", rec.Events[0].Subject, "frontend/ops.furiosa")
+	}
+}
+
+func TestDoRigRestart_UsesTemplateIdentityPoolSlotSessionBeadForCustomSessionName(t *testing.T) {
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "frontend/worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/worker",
+			"agent_name":   "frontend/worker",
+			"session_name": "custom-worker-7",
+			"pool_slot":    "7",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.Start(context.Background(), "custom-worker-7", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := events.NewFake()
+	agents := []config.Agent{{
+		Name:              "worker",
+		Dir:               "frontend",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(10), ScaleCheck: "echo 1",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigRestart(sp, rec, store, nil, agents, "frontend", "city", "{{.Agent}}", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if sp.IsRunning("custom-worker-7") {
+		t.Fatal("template-identity pool session still running after rig restart")
+	}
+	if len(rec.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Subject != "frontend/worker-7" {
+		t.Fatalf("event subject = %q, want %q", rec.Events[0].Subject, "frontend/worker-7")
+	}
+}
+
+func TestDoRigRestart_DoesNotTargetOutOfBoundsAliasOnlyBoundedPoolIdentity(t *testing.T) {
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "stale out-of-bounds pool instance",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/worker",
+			"alias":        "frontend/worker-7",
+			"session_name": "custom-worker-7",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sp.Start(context.Background(), "custom-worker-7", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := events.NewFake()
+	agents := []config.Agent{{
+		Name:              "worker",
+		Dir:               "frontend",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5), ScaleCheck: "echo 1",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigRestart(sp, rec, store, nil, agents, "frontend", "city", "{{.Agent}}", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if !sp.IsRunning("custom-worker-7") {
+		t.Fatal("out-of-bounds pool session should not have been restarted")
+	}
+	if len(rec.Events) != 0 {
+		t.Fatalf("got %d events, want 0", len(rec.Events))
+	}
+}
+
+func TestDoRigRestart_PrefersLiveFallbackCandidateOncePerLogicalInstance(t *testing.T) {
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "stale duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-stale-worker-7",
+				"pool_slot":    "7",
+			},
+		},
+		{
+			Title:  "live legacy",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+				"alias":        "frontend/worker-7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := sp.Start(context.Background(), "worker-7", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := events.NewFake()
+	agents := []config.Agent{{
+		Name:              "worker",
+		Dir:               "frontend",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(10), ScaleCheck: "echo 1",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigRestart(sp, rec, store, nil, agents, "frontend", "city", "{{.Agent}}", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if sp.IsRunning("worker-7") {
+		t.Fatal("live fallback session still running after rig restart")
+	}
+	if len(rec.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(rec.Events))
+	}
+	if rec.Events[0].Subject != "frontend/worker-7" {
+		t.Fatalf("event subject = %q, want %q", rec.Events[0].Subject, "frontend/worker-7")
+	}
+}
+
+func TestDoRigRestart_StopsAllLiveCandidatesForLogicalInstance(t *testing.T) {
+	sp := runtime.NewFake()
+	store := beads.NewMemStore()
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "stale duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-stale-worker-7",
+				"pool_slot":    "7",
+			},
+		},
+		{
+			Title:  "live legacy",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+				"alias":        "frontend/worker-7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, sessionName := range []string{"s-stale-worker-7", "worker-7"} {
+		if err := sp.Start(context.Background(), sessionName, runtime.Config{Command: "echo"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := events.NewFake()
+	agents := []config.Agent{{
+		Name:              "worker",
+		Dir:               "frontend",
+		MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(10), ScaleCheck: "echo 1",
+	}}
+
+	var stdout, stderr bytes.Buffer
+	code := doRigRestart(sp, rec, store, nil, agents, "frontend", "city", "{{.Agent}}", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	for _, sessionName := range []string{"s-stale-worker-7", "worker-7"} {
+		if sp.IsRunning(sessionName) {
+			t.Fatalf("%s still running after rig restart", sessionName)
+		}
+	}
+	if len(rec.Events) != 2 {
+		t.Fatalf("got %d events, want 2", len(rec.Events))
+	}
+	for _, event := range rec.Events {
+		if event.Subject != "frontend/worker-7" {
+			t.Fatalf("event subject = %q, want %q", event.Subject, "frontend/worker-7")
+		}
+	}
+}
+
 func TestDoRigRestart_UsesLegacyPoolAgentLabelForCustomSessionNames(t *testing.T) {
 	sp := runtime.NewFake()
 	store := beads.NewMemStore()

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -98,7 +98,7 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 			desired[sn] = true
 		} else {
 			// Pool agent: resolve runtime session names from beads first, then legacy discovery.
-			for _, ref := range resolvePoolSessionRefs(store, a.Name, a.Dir, sp0, &a, cityName, st, sp, stderr) {
+			for _, ref := range resolvePoolSessionRefs(store, cfg, a.Name, a.Dir, sp0, &a, cityName, st, sp, stderr) {
 				sessionNames = append(sessionNames, ref.sessionName)
 				desired[ref.sessionName] = true
 			}

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -1349,6 +1349,12 @@ func TestFindSessionNameByTemplate_UsesLegacyAgentLabelForPoolInstance(t *testin
 
 func TestLookupPoolSessionNames_RejectsSharedPrefixSiblingTemplates(t *testing.T) {
 	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
 	for _, bead := range []beads.Bead{
 		{
 			Title:  "worker",
@@ -1376,7 +1382,7 @@ func TestLookupPoolSessionNames_RejectsSharedPrefixSiblingTemplates(t *testing.T
 		}
 	}
 
-	got, err := lookupPoolSessionNames(store, "frontend/worker")
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
 	if err != nil {
 		t.Fatalf("lookupPoolSessionNames: %v", err)
 	}
@@ -1385,6 +1391,734 @@ func TestLookupPoolSessionNames_RejectsSharedPrefixSiblingTemplates(t *testing.T
 	}
 	if _, ok := got["frontend/worker-supervisor-1"]; ok {
 		t.Fatalf("lookupPoolSessionNames(frontend/worker) wrongly matched sibling template: %#v", got)
+	}
+}
+
+func TestLookupPoolSessionNames_PreservesUniqueLegacyLocalSessionNameIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-5",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-5"] != "worker-5" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want unique local session_name to recover worker-5", got)
+	}
+}
+
+func TestLookupPoolSessionNames_DoesNotClaimAmbiguousLegacyLocalSessionNameIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": "worker-5",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want ambiguous local session_name to stay unresolved", got)
+	}
+}
+
+func TestLookupPoolSessionNames_PreservesLegacyCommonNameSessionNameIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"common_name":  "worker",
+			"session_name": "worker-5",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-5"] != "worker-5" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want common_name-only legacy session_name to recover worker-5", got)
+	}
+}
+
+func TestLookupPoolSessionNames_DoesNotRecoverSessionNameSlotWhenAliasPresent(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/worker",
+			"alias":        "stale-worker-alias",
+			"session_name": "worker-5",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want alias-bearing bead to stay unresolved", got)
+	}
+}
+
+type lookupPoolSessionNameCandidatesStore struct {
+	beads.Store
+	beads []beads.Bead
+}
+
+func (s lookupPoolSessionNameCandidatesStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	var result []beads.Bead
+	for _, bead := range s.beads {
+		if query.Label != "" {
+			matched := false
+			for _, label := range bead.Labels {
+				if label == query.Label {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		result = append(result, bead)
+	}
+	return result, nil
+}
+
+func TestLookupPoolSessionNames_DoesNotRecoverOwnedPoolSessionNameSlot(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	store := lookupPoolSessionNameCandidatesStore{
+		beads: []beads.Bead{
+			{
+				ID:     "5",
+				Title:  "worker",
+				Type:   sessionBeadType,
+				Status: "open",
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"template":     "frontend/worker",
+					"session_name": PoolSessionName("frontend/worker", "5"),
+				},
+			},
+		},
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want bead-owned pool session_name to stay unresolved", got)
+	}
+}
+
+func TestLookupPoolSessionNames_PrefersStampedBeadOverLegacyCollision(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "legacy worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+			},
+		},
+		{
+			Title:  "live worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-live-worker-7",
+				"agent_name":   "frontend/worker-7",
+				"pool_slot":    "7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-7"] != "s-live-worker-7" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want stamped bead to win the collision", got)
+	}
+}
+
+func TestLookupPoolSessionNames_DropsAmbiguousLegacyCollision(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "legacy worker a",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "legacy-worker-a",
+				"alias":        "frontend/worker-7",
+			},
+		},
+		{
+			Title:  "legacy worker b",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "legacy-worker-b",
+				"alias":        "frontend/worker-7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if _, ok := got["frontend/worker-7"]; ok {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want ambiguous legacy collision dropped", got)
+	}
+}
+
+func TestLookupPoolSessionNames_StampedBeadOverridesEarlierAmbiguousLegacyCollision(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "legacy worker a",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+			},
+		},
+		{
+			Title:  "legacy worker b",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "legacy-worker-b",
+				"alias":        "frontend/worker-7",
+			},
+		},
+		{
+			Title:  "live worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-live-worker-7",
+				"agent_name":   "frontend/worker-7",
+				"pool_slot":    "7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-7"] != "s-live-worker-7" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want stamped bead to override earlier ambiguous legacy collision", got)
+	}
+}
+
+func TestLookupPoolSessionNames_PrefersConcreteStampedBeadOverPoolSlotOnlyDuplicate(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "stale duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-stale-duplicate",
+				"pool_slot":    "7",
+			},
+		},
+		{
+			Title:  "live worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-live-worker-7",
+				"agent_name":   "frontend/worker-7",
+				"pool_slot":    "7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-7"] != "s-live-worker-7" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want concrete stamped bead to beat pool_slot-only duplicate", got)
+	}
+}
+
+func TestLookupPoolSessionNames_PrefersActiveStampedBeadOverCreatingScoreTie(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "creating duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "a-creating-worker-5",
+				"pool_slot":    "5",
+				"state":        "creating",
+			},
+		},
+		{
+			Title:  "active worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "z-active-worker-5",
+				"pool_slot":    "5",
+				"state":        "awake",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-5"] != "z-active-worker-5" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want active stamped bead to beat creating duplicate", got)
+	}
+}
+
+func TestResolvePoolSessionRefs_KeepsLowerScoredFallbackCandidate(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(10)},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "stale duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-stale-worker-7",
+				"pool_slot":    "7",
+			},
+		},
+		{
+			Title:  "live legacy",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+				"alias":        "frontend/worker-7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	refs := resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", runtime.NewFake(), io.Discard)
+	var got []string
+	for _, ref := range refs {
+		if ref.qualifiedInstance == "frontend/worker-7" {
+			got = append(got, ref.sessionName)
+		}
+	}
+	wantPrefix := []string{"s-stale-worker-7", "worker-7"}
+	if len(got) < len(wantPrefix) || !reflect.DeepEqual(got[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("resolvePoolSessionRefs(frontend/worker-7) = %v, want prefix %v", got, wantPrefix)
+	}
+}
+
+func TestSelectRunningPoolSessionRefs_PrefersLiveFallbackCandidate(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(10)},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "stale duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-stale-worker-7",
+				"pool_slot":    "7",
+			},
+		},
+		{
+			Title:  "live legacy",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+				"alias":        "frontend/worker-7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sp := runtime.NewFake()
+	if err := sp.Start(context.Background(), "worker-7", runtime.Config{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := selectRunningPoolSessionRefs(store, sp, cfg, resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", sp, io.Discard))
+	if err != nil {
+		t.Fatalf("selectRunningPoolSessionRefs: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("selectRunningPoolSessionRefs() returned %d refs, want 1: %#v", len(refs), refs)
+	}
+	if refs[0].qualifiedInstance != "frontend/worker-7" || refs[0].sessionName != "worker-7" {
+		t.Fatalf("selectRunningPoolSessionRefs() = %#v, want frontend/worker-7 -> worker-7", refs)
+	}
+}
+
+func TestSelectRunningPoolSessionRefs_ReturnsAllLiveCandidatesForLogicalInstance(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(10)},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "stale duplicate",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "s-stale-worker-7",
+				"pool_slot":    "7",
+			},
+		},
+		{
+			Title:  "live legacy",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"common_name":  "worker",
+				"session_name": "worker-7",
+				"alias":        "frontend/worker-7",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sp := runtime.NewFake()
+	for _, sessionName := range []string{"s-stale-worker-7", "worker-7"} {
+		if err := sp.Start(context.Background(), sessionName, runtime.Config{Command: "echo"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	refs, err := selectRunningPoolSessionRefs(store, sp, cfg, resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", sp, io.Discard))
+	if err != nil {
+		t.Fatalf("selectRunningPoolSessionRefs: %v", err)
+	}
+	got := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if ref.qualifiedInstance == "frontend/worker-7" {
+			got = append(got, ref.sessionName)
+		}
+	}
+	want := []string{"s-stale-worker-7", "worker-7"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selectRunningPoolSessionRefs(frontend/worker-7) = %v, want %v", got, want)
+	}
+}
+
+func TestSelectRunningPoolSessionRefs_ReportsConcreteSessionOnProbeFailure(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(10)},
+		},
+	}
+	refs := []poolSessionRef{{
+		qualifiedInstance: "frontend/worker-7",
+		sessionName:       "custom-worker-7",
+	}}
+
+	_, err := selectRunningPoolSessionRefs(nil, nil, cfg, refs)
+	if err == nil {
+		t.Fatal("selectRunningPoolSessionRefs() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "custom-worker-7") {
+		t.Fatalf("selectRunningPoolSessionRefs() error = %q, want concrete session name", err)
+	}
+}
+
+func TestResolvePoolSessionRefs_ResolvesBindingQualifiedNamepoolAlias(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:          "worker",
+				Dir:           "frontend",
+				BindingName:   "ops",
+				NamepoolNames: []string{"furiosa", "nux"},
+			},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "bound themed pool instance",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/ops.worker",
+			"session_name": "ops-furiosa-session",
+			"alias":        "frontend/ops.furiosa",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", runtime.NewFake(), io.Discard)
+	if len(refs) != 1 {
+		t.Fatalf("resolvePoolSessionRefs() returned %d refs, want 1: %#v", len(refs), refs)
+	}
+	if refs[0].qualifiedInstance != "frontend/ops.furiosa" || refs[0].sessionName != "ops-furiosa-session" {
+		t.Fatalf("resolvePoolSessionRefs() = %#v, want frontend/ops.furiosa -> ops-furiosa-session", refs)
+	}
+}
+
+func TestResolvePoolSessionRefs_UsesBoundTemplatePoolSlotForCustomSessionName(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:          "worker",
+				Dir:           "frontend",
+				BindingName:   "ops",
+				NamepoolNames: []string{"furiosa", "nux"},
+			},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "bound themed pool instance",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/ops.worker",
+			"session_name": "custom-ops-furiosa",
+			"pool_slot":    "1",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", runtime.NewFake(), io.Discard)
+	if len(refs) != 1 {
+		t.Fatalf("resolvePoolSessionRefs() returned %d refs, want 1: %#v", len(refs), refs)
+	}
+	if refs[0].qualifiedInstance != "frontend/ops.furiosa" || refs[0].sessionName != "custom-ops-furiosa" {
+		t.Fatalf("resolvePoolSessionRefs() = %#v, want frontend/ops.furiosa -> custom-ops-furiosa", refs)
+	}
+}
+
+func TestResolvePoolSessionRefs_RewritesTemplateIdentityAgentNameFromPoolSlot(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(10)},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "legacy pool instance",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/worker",
+			"agent_name":   "frontend/worker",
+			"session_name": "custom-worker-7",
+			"pool_slot":    "7",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", runtime.NewFake(), io.Discard)
+	for _, ref := range refs {
+		if ref.sessionName == "custom-worker-7" {
+			if ref.qualifiedInstance != "frontend/worker-7" {
+				t.Fatalf("resolvePoolSessionRefs() custom ref = %#v, want frontend/worker-7 -> custom-worker-7", ref)
+			}
+			return
+		}
+	}
+	t.Fatalf("resolvePoolSessionRefs() = %#v, want custom-worker-7 candidate keyed by frontend/worker-7", refs)
+}
+
+func TestResolvePoolSessionRefs_DoesNotRecoverOutOfBoundsAliasOnlyBoundedPoolIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	agentCfg := cfg.Agents[0]
+	if _, err := store.Create(beads.Bead{
+		Title:  "stale out-of-bounds pool instance",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "frontend/worker",
+			"alias":        "frontend/worker-7",
+			"session_name": "custom-worker-7",
+			"state":        "awake",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := resolvePoolSessionRefs(store, cfg, agentCfg.Name, agentCfg.Dir, scaleParamsFor(&agentCfg), &agentCfg, "test-city", "", runtime.NewFake(), io.Discard)
+	for _, ref := range refs {
+		if ref.sessionName == "custom-worker-7" {
+			t.Fatalf("resolvePoolSessionRefs() unexpectedly kept out-of-bounds ref %#v", ref)
+		}
 	}
 }
 

--- a/cmd/gc/pool.go
+++ b/cmd/gc/pool.go
@@ -428,7 +428,9 @@ func discoverPoolInstances(agentName, agentDir string, sp0 scaleParams, a *confi
 		for i := 1; i <= sp0.Max; i++ {
 			instanceName := poolInstanceName(agentName, i, a)
 			qn := instanceName
-			if agentDir != "" {
+			if a != nil {
+				qn = a.QualifiedInstanceName(instanceName)
+			} else if agentDir != "" {
 				qn = agentDir + "/" + instanceName
 			}
 			names = append(names, qn)
@@ -441,7 +443,9 @@ func discoverPoolInstances(agentName, agentDir string, sp0 scaleParams, a *confi
 	// When bead-derived session names ("s-{beadID}") are active, this prefix
 	// match will fail. Migrate to bead store query by template metadata.
 	qnPrefix := agentName + "-"
-	if agentDir != "" {
+	if a != nil {
+		qnPrefix = a.QualifiedName() + "-"
+	} else if agentDir != "" {
 		qnPrefix = agentDir + "/" + agentName + "-"
 	}
 	// Build the session name prefix to match against running sessions.
@@ -472,6 +476,7 @@ func discoverPoolInstances(agentName, agentDir string, sp0 scaleParams, a *confi
 
 func resolvePoolSessionRefs(
 	store beads.Store,
+	cfg *config.City,
 	agentName, agentDir string,
 	sp0 scaleParams, a *config.Agent,
 	cityName, sessionTemplate string,
@@ -479,12 +484,14 @@ func resolvePoolSessionRefs(
 	stderr io.Writer,
 ) []poolSessionRef {
 	template := agentName
-	if agentDir != "" {
+	if a != nil {
+		template = a.QualifiedName()
+	} else if agentDir != "" {
 		template = agentDir + "/" + agentName
 	}
 	seenSessions := make(map[string]bool)
 	var refs []poolSessionRef
-	poolSessions, err := lookupPoolSessionNames(store, template)
+	poolSessions, err := lookupPoolSessionNameCandidates(store, template, cfg, a)
 	if err != nil && stderr != nil {
 		fmt.Fprintf(stderr, "gc lifecycle: pool bead lookup for %s returned error (legacy discovery also runs): %v\n", template, err) //nolint:errcheck
 	}
@@ -494,15 +501,17 @@ func resolvePoolSessionRefs(
 	}
 	sort.Strings(poolInstances)
 	for _, qualifiedInstance := range poolInstances {
-		sessionName := poolSessions[qualifiedInstance]
-		if sessionName == "" || seenSessions[sessionName] {
-			continue
+		for _, candidate := range poolSessions[qualifiedInstance] {
+			sessionName := candidate.sessionName
+			if sessionName == "" || seenSessions[sessionName] {
+				continue
+			}
+			seenSessions[sessionName] = true
+			refs = append(refs, poolSessionRef{
+				qualifiedInstance: qualifiedInstance,
+				sessionName:       sessionName,
+			})
 		}
-		seenSessions[sessionName] = true
-		refs = append(refs, poolSessionRef{
-			qualifiedInstance: qualifiedInstance,
-			sessionName:       sessionName,
-		})
 	}
 	for _, qualifiedInstance := range discoverPoolInstances(agentName, agentDir, sp0, a, cityName, sessionTemplate, sp) {
 		sessionName := lookupSessionNameOrLegacy(store, cityName, qualifiedInstance, sessionTemplate)
@@ -516,4 +525,29 @@ func resolvePoolSessionRefs(
 		})
 	}
 	return refs
+}
+
+func selectRunningPoolSessionRefs(store beads.Store, sp runtime.Provider, cfg *config.City, refs []poolSessionRef) ([]poolSessionRef, error) {
+	grouped := make(map[string][]poolSessionRef)
+	order := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if _, ok := grouped[ref.qualifiedInstance]; !ok {
+			order = append(order, ref.qualifiedInstance)
+		}
+		grouped[ref.qualifiedInstance] = append(grouped[ref.qualifiedInstance], ref)
+	}
+
+	live := make([]poolSessionRef, 0, len(order))
+	for _, qualifiedInstance := range order {
+		for _, ref := range grouped[qualifiedInstance] {
+			running, err := workerSessionTargetRunningWithConfig("", store, sp, cfg, ref.sessionName)
+			if err != nil {
+				return nil, fmt.Errorf("observing %s: %w", ref.sessionName, err)
+			}
+			if running {
+				live = append(live, ref)
+			}
+		}
+	}
+	return live, nil
 }

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1384,7 +1384,7 @@ func syncDesiredPoolSlots(
 				continue
 			}
 			slot, _ := strconv.Atoi(openBeads[idx].Metadata["pool_slot"])
-			if slot <= 0 || slot > len(names) || usedSlots[slot] != "" {
+			if slot <= 0 || usedSlots[slot] != "" {
 				continue
 			}
 			usedSlots[slot] = sn

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -24,6 +24,12 @@ const sessionBeadLabel = "gc:session"
 // sessionBeadType is the bead type for session beads.
 const sessionBeadType = "session"
 
+const (
+	poolAliasConflictMetadataKey      = "pool_alias_conflict"
+	poolAliasConflictCountMetadataKey = "pool_alias_conflict_count"
+	poolAliasConflictAtMetadataKey    = "pool_alias_conflict_at"
+)
+
 // loadSessionBeads returns all open session beads from the store.
 func loadSessionBeads(store beads.Store) ([]beads.Bead, error) {
 	if store == nil {
@@ -1084,8 +1090,17 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		// per-key writes are expensive enough to stall unrelated reconciler
 		// work during city startup.
 		batch := map[string]string{}
+		aliasGuardedBatch := map[string]string{}
 		queueMeta := func(key, value string) {
 			batch[key] = value
+		}
+		queueAliasGuardedMeta := func(key, value string) {
+			aliasGuardedBatch[key] = value
+		}
+		mergeAliasGuardedBatch := func() {
+			for key, value := range aliasGuardedBatch {
+				queueMeta(key, value)
+			}
 		}
 
 		// Backfill template and pool_slot metadata for beads created
@@ -1112,11 +1127,16 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				queueMeta("pool_slot", "")
 			}
 		}
+		needsAliasSync := b.Metadata["alias"] != managedAlias
 		if b.Metadata["pool_slot"] == "" {
+			queuePoolSlotMeta := queueMeta
+			if needsAliasSync && isManagedPool && isPoolInstance {
+				queuePoolSlotMeta = queueAliasGuardedMeta
+			}
 			if tp.PoolSlot > 0 {
-				queueMeta("pool_slot", strconv.Itoa(tp.PoolSlot))
+				queuePoolSlotMeta("pool_slot", strconv.Itoa(tp.PoolSlot))
 			} else if slot := resolvePoolSlot(tp.InstanceName, tp.TemplateName); slot > 0 {
-				queueMeta("pool_slot", strconv.Itoa(slot))
+				queuePoolSlotMeta("pool_slot", strconv.Itoa(slot))
 			}
 		}
 		existingAgentName := strings.TrimSpace(b.Metadata["agent_name"])
@@ -1130,14 +1150,18 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				// Legacy active sessions are still running in their original
 				// work_dir. Don't repoint metadata until the session stops.
 				if !legacyNeedsConcreteIdentity || state != "active" {
-					queueMeta("work_dir", tp.WorkDir)
+					if legacyNeedsConcreteIdentity {
+						queueAliasGuardedMeta("work_dir", tp.WorkDir)
+					} else {
+						queueMeta("work_dir", tp.WorkDir)
+					}
 				}
 			case legacyNeedsConcreteIdentity && b.Metadata["work_dir"] != tp.WorkDir && state != "active":
-				queueMeta("work_dir", tp.WorkDir)
+				queueAliasGuardedMeta("work_dir", tp.WorkDir)
 			}
 		}
 		if legacyNeedsConcreteIdentity && agentName != "" {
-			queueMeta("agent_name", agentName)
+			queueAliasGuardedMeta("agent_name", agentName)
 		}
 		if b.Metadata["dependency_only"] != boolMetadata(tp.DependencyOnly) {
 			queueMeta("dependency_only", boolMetadata(tp.DependencyOnly))
@@ -1163,7 +1187,6 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				queueMeta(namedSessionModeMetadata, "")
 			}
 		}
-		needsAliasSync := b.Metadata["alias"] != managedAlias
 		if b.Metadata["wake_mode"] != tp.WakeMode {
 			queueMeta("wake_mode", tp.WakeMode)
 		}
@@ -1245,6 +1268,26 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				setMeta(store, b.ID, "synced_at", now.Format("2006-01-02T15:04:05Z07:00"), stderr) //nolint:errcheck
 			}
 		}
+		clearAliasConflict := func() {
+			if b.Metadata[poolAliasConflictMetadataKey] != "" {
+				queueMeta(poolAliasConflictMetadataKey, "")
+			}
+			if b.Metadata[poolAliasConflictCountMetadataKey] != "" {
+				queueMeta(poolAliasConflictCountMetadataKey, "")
+			}
+			if b.Metadata[poolAliasConflictAtMetadataKey] != "" {
+				queueMeta(poolAliasConflictAtMetadataKey, "")
+			}
+		}
+		recordAliasConflict := func() {
+			count := 0
+			if existing, err := strconv.Atoi(strings.TrimSpace(b.Metadata[poolAliasConflictCountMetadataKey])); err == nil && existing > 0 {
+				count = existing
+			}
+			queueMeta(poolAliasConflictMetadataKey, managedAlias)
+			queueMeta(poolAliasConflictCountMetadataKey, strconv.Itoa(count+1))
+			queueMeta(poolAliasConflictAtMetadataKey, now.Format(time.RFC3339))
+		}
 		if needsAliasSync {
 			lockAlias := managedAlias
 			if lockAlias == "" {
@@ -1259,11 +1302,14 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					err = session.EnsureAliasAvailableWithConfig(store, cfg, managedAlias, b.ID)
 				}
 				if err != nil {
+					recordAliasConflict()
 					fmt.Fprintf(stderr, "session beads: alias %q for %s unavailable: %v\n", managedAlias, agentName, err) //nolint:errcheck
 				} else {
+					clearAliasConflict()
 					for key, value := range session.UpdatedAliasMetadata(b.Metadata, managedAlias) {
 						queueMeta(key, value)
 					}
+					mergeAliasGuardedBatch()
 				}
 				applyBatch()
 				appliedWithLock = true
@@ -1275,6 +1321,10 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			if appliedWithLock {
 				continue
 			}
+		}
+		if !needsAliasSync {
+			clearAliasConflict()
+			mergeAliasGuardedBatch()
 		}
 		applyBatch()
 	}
@@ -1375,6 +1425,7 @@ func syncDesiredPoolSlots(
 	}
 
 	for template, names := range desiredByTemplate {
+		agentCfg := findAgentByTemplate(cfg, template)
 		sort.Strings(names)
 		usedSlots := make(map[int]string)
 		slotByName := make(map[string]int, len(names))
@@ -1383,7 +1434,12 @@ func syncDesiredPoolSlots(
 			if !ok {
 				continue
 			}
-			slot, _ := strconv.Atoi(openBeads[idx].Metadata["pool_slot"])
+			bead := openBeads[idx]
+			tp := desiredState[sn]
+			if tp.Alias != "" && bead.Metadata["alias"] != tp.Alias {
+				continue
+			}
+			slot := existingPoolSlotWithConfig(cfg, agentCfg, openBeads[idx])
 			if slot <= 0 || usedSlots[slot] != "" {
 				continue
 			}
@@ -1409,6 +1465,10 @@ func syncDesiredPoolSlots(
 				continue
 			}
 			bead := openBeads[idx]
+			tp := desiredState[sn]
+			if tp.Alias != "" && bead.Metadata["alias"] != tp.Alias {
+				continue
+			}
 			wantSlot := strconv.Itoa(slotByName[sn])
 			batch := map[string]string{}
 			if bead.Metadata[poolManagedMetadataKey] != boolMetadata(true) {

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2854,6 +2854,75 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_DoesNotCompactLivePoolSlotIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 5, 17, 30, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	sessionName := "pack-worker-mc-live"
+
+	live, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         sessionName,
+			"agent_name":           "pack/worker-6",
+			"alias":                "pack/worker-6",
+			"pool_slot":            "6",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		sessionName: {
+			TemplateName: template,
+			InstanceName: "pack/worker-6",
+			Alias:        "pack/worker-6",
+			PoolSlot:     6,
+		},
+		"pack-worker-mc-other": {
+			TemplateName: template,
+			InstanceName: "pack/worker-1",
+			Alias:        "pack/worker-1",
+			PoolSlot:     1,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["pool_slot"] != "6" {
+		t.Fatalf("pool_slot = %q, want live identity slot 6", got.Metadata["pool_slot"])
+	}
+	if got.Metadata["alias"] != "pack/worker-6" {
+		t.Fatalf("alias = %q, want pack/worker-6", got.Metadata["alias"])
+	}
+	if got.Metadata["agent_name"] != "pack/worker-6" {
+		t.Fatalf("agent_name = %q, want pack/worker-6", got.Metadata["agent_name"])
+	}
+}
+
 func TestCreatePoolSessionBead_MetadataFailureLeavesReachablePlaceholder(t *testing.T) {
 	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
 	template := "pack/worker"

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2923,6 +2923,308 @@ func TestSyncSessionBeads_DoesNotCompactLivePoolSlotIdentity(t *testing.T) {
 	}
 }
 
+func TestSyncSessionBeads_RewritesStalePoolSlotWhenConcreteIdentityAgrees(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	sessionName := "pack-worker-live"
+
+	live, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         sessionName,
+			"agent_name":           "pack/worker-6",
+			"alias":                "pack/worker-6",
+			"pool_slot":            "1",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		sessionName: {
+			TemplateName: template,
+			InstanceName: "pack/worker-6",
+			Alias:        "pack/worker-6",
+			PoolSlot:     6,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["pool_slot"] != "6" {
+		t.Fatalf("pool_slot = %q, want repaired slot 6", got.Metadata["pool_slot"])
+	}
+}
+
+func TestSyncSessionBeads_DoesNotRewriteOwnershipWhenAliasRepairFails(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 5, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	if _, err := store.Create(beads.Bead{
+		Title:  "incumbent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-incumbent",
+			"agent_name":           "pack/worker-2",
+			"alias":                "pack/worker-2",
+			"pool_slot":            "2",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	live, err := store.Create(beads.Bead{
+		Title:  "legacy worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-legacy",
+			"agent_name":           template,
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		"pack-worker-legacy": {
+			TemplateName: template,
+			InstanceName: "pack/worker-2",
+			Alias:        "pack/worker-2",
+			PoolSlot:     2,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["agent_name"] != template {
+		t.Fatalf("agent_name = %q, want unchanged template identity after alias conflict", got.Metadata["agent_name"])
+	}
+	if got.Metadata["pool_slot"] != "" {
+		t.Fatalf("pool_slot = %q, want unset after alias conflict", got.Metadata["pool_slot"])
+	}
+	if got.Metadata["alias"] != "" {
+		t.Fatalf("alias = %q, want unchanged empty alias after conflict", got.Metadata["alias"])
+	}
+	if got.Metadata[poolAliasConflictMetadataKey] != "pack/worker-2" {
+		t.Fatalf("pool_alias_conflict = %q, want pack/worker-2", got.Metadata[poolAliasConflictMetadataKey])
+	}
+	if got.Metadata[poolAliasConflictCountMetadataKey] != "1" {
+		t.Fatalf("pool_alias_conflict_count = %q, want 1", got.Metadata[poolAliasConflictCountMetadataKey])
+	}
+	if got.Metadata[poolAliasConflictAtMetadataKey] != "2026-05-06T02:05:00Z" {
+		t.Fatalf("pool_alias_conflict_at = %q, want 2026-05-06T02:05:00Z", got.Metadata[poolAliasConflictAtMetadataKey])
+	}
+	if !strings.Contains(stderr.String(), "unavailable") {
+		t.Fatalf("stderr %q does not mention alias conflict", stderr.String())
+	}
+}
+
+func TestSyncSessionBeads_DoesNotReservePoolSlotForAliasConflictBead(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 10, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	if _, err := store.Create(beads.Bead{
+		Title:  "alias owner",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-owner-2",
+			"agent_name":           "pack/worker-2",
+			"alias":                "pack/worker-2",
+			"pool_slot":            "2",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(beads.Bead{
+		Title:  "legacy worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-a-legacy",
+			"agent_name":           template,
+			"pool_slot":            "6",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	live, err := store.Create(beads.Bead{
+		Title:  "live worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-z-live",
+			"agent_name":           "pack/worker-6",
+			"alias":                "pack/worker-6",
+			"pool_slot":            "6",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		"pack-worker-a-legacy": {
+			TemplateName: template,
+			InstanceName: "pack/worker-2",
+			Alias:        "pack/worker-2",
+			PoolSlot:     2,
+		},
+		"pack-worker-z-live": {
+			TemplateName: template,
+			InstanceName: "pack/worker-6",
+			Alias:        "pack/worker-6",
+			PoolSlot:     6,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	if !strings.Contains(stderr.String(), "unavailable") {
+		t.Fatalf("stderr %q does not mention alias conflict", stderr.String())
+	}
+
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["pool_slot"] != "6" {
+		t.Fatalf("pool_slot = %q, want live identity slot 6 preserved", got.Metadata["pool_slot"])
+	}
+}
+
+func TestSyncSessionBeads_PreservesAliasConflictMetadataWhenAliasLockFails(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 15, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	live, err := store.Create(beads.Bead{
+		Title:  "legacy worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":                        template,
+			"session_name":                    "pack-worker-legacy",
+			"agent_name":                      template,
+			"state":                           "awake",
+			"session_origin":                  "ephemeral",
+			poolManagedMetadataKey:            boolMetadata(true),
+			poolAliasConflictMetadataKey:      "pack/worker-2",
+			poolAliasConflictCountMetadataKey: "3",
+			poolAliasConflictAtMetadataKey:    "2026-05-06T02:10:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		"pack-worker-legacy": {
+			TemplateName: template,
+			InstanceName: "pack/worker-2",
+			Alias:        "pack/worker-2",
+			PoolSlot:     2,
+		},
+	}
+
+	cityRoot := t.TempDir()
+	cityPath := filepath.Join(cityRoot, "not-a-dir")
+	if err := os.WriteFile(cityPath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads(cityPath, store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata[poolAliasConflictMetadataKey] != "pack/worker-2" {
+		t.Fatalf("pool_alias_conflict = %q, want preserved %q", got.Metadata[poolAliasConflictMetadataKey], "pack/worker-2")
+	}
+	if got.Metadata[poolAliasConflictCountMetadataKey] != "3" {
+		t.Fatalf("pool_alias_conflict_count = %q, want preserved %q", got.Metadata[poolAliasConflictCountMetadataKey], "3")
+	}
+	if got.Metadata[poolAliasConflictAtMetadataKey] != "2026-05-06T02:10:00Z" {
+		t.Fatalf("pool_alias_conflict_at = %q, want preserved %q", got.Metadata[poolAliasConflictAtMetadataKey], "2026-05-06T02:10:00Z")
+	}
+	if !strings.Contains(stderr.String(), "locking alias") {
+		t.Fatalf("stderr %q does not mention alias lock failure", stderr.String())
+	}
+}
+
 func TestCreatePoolSessionBead_MetadataFailureLeavesReachablePlaceholder(t *testing.T) {
 	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
 	template := "pack/worker"

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +23,99 @@ func isPoolManagedSessionBead(bead beads.Bead) bool {
 		return true
 	}
 	return strings.TrimSpace(bead.Metadata["pool_slot"]) != ""
+}
+
+func resolveLegacyPoolTemplate(cfg *config.City, storedTemplate string) string {
+	storedTemplate = strings.TrimSpace(storedTemplate)
+	if cfg == nil || storedTemplate == "" {
+		return ""
+	}
+	if findAgentByTemplate(cfg, storedTemplate) != nil {
+		return storedTemplate
+	}
+	match := ""
+	for i := range cfg.Agents {
+		agentCfg := &cfg.Agents[i]
+		if !agentCfg.SupportsInstanceExpansion() {
+			continue
+		}
+		_, localTemplate := config.ParseQualifiedName(agentCfg.QualifiedName())
+		if localTemplate != storedTemplate {
+			continue
+		}
+		if match != "" && match != agentCfg.QualifiedName() {
+			return ""
+		}
+		match = agentCfg.QualifiedName()
+	}
+	return match
+}
+
+func sessionBeadStoredTemplate(bead beads.Bead) string {
+	storedTemplate := strings.TrimSpace(bead.Metadata["template"])
+	if storedTemplate != "" {
+		return storedTemplate
+	}
+	return strings.TrimSpace(bead.Metadata["common_name"])
+}
+
+func resolvedTemplateForIdentity(identity string, cfg *config.City) string {
+	identity = strings.TrimSpace(identity)
+	if cfg == nil || identity == "" {
+		return ""
+	}
+	if findAgentByTemplate(cfg, identity) != nil {
+		return identity
+	}
+	if resolved := resolveLegacyPoolTemplate(cfg, identity); resolved != "" {
+		return resolved
+	}
+	match := ""
+	for i := range cfg.Agents {
+		agentCfg := &cfg.Agents[i]
+		if !agentCfg.SupportsInstanceExpansion() {
+			continue
+		}
+		slot := resolvePersistedPoolIdentitySlot(agentCfg, true, identity)
+		if slot <= 0 {
+			continue
+		}
+		if poolSlotHasConfiguredBound(agentCfg) && !inBoundsPoolSlot(agentCfg, slot) {
+			continue
+		}
+		if match != "" && match != agentCfg.QualifiedName() {
+			return ""
+		}
+		match = agentCfg.QualifiedName()
+	}
+	return match
+}
+
+func resolvedSessionTemplate(bead beads.Bead, cfg *config.City) string {
+	template := normalizedSessionTemplate(bead, cfg)
+	if template != "" && (cfg == nil || findAgentByTemplate(cfg, template) != nil) {
+		return template
+	}
+	storedTemplate := sessionBeadStoredTemplate(bead)
+	if storedTemplate == "" {
+		return ""
+	}
+	if resolved := resolveLegacyPoolTemplate(cfg, storedTemplate); resolved != "" {
+		return resolved
+	}
+	return storedTemplate
+}
+
+func storedTemplateMatchesPoolTemplate(storedTemplate, template string, cfg *config.City) bool {
+	storedTemplate = strings.TrimSpace(storedTemplate)
+	template = strings.TrimSpace(template)
+	if storedTemplate == "" || template == "" {
+		return false
+	}
+	if storedTemplate == template {
+		return true
+	}
+	return resolveLegacyPoolTemplate(cfg, storedTemplate) == template
 }
 
 func createPoolSessionBead(
@@ -132,9 +227,12 @@ func normalizedSessionTemplate(bead beads.Bead, cfg *config.City) string {
 	}
 	agentName := sessionBeadAgentName(bead)
 	if agentName != "" {
-		if resolved := resolveAgentTemplate(agentName, cfg); resolved != "" && findAgentByTemplate(cfg, resolved) != nil {
+		if resolved := resolvedTemplateForIdentity(agentName, cfg); resolved != "" {
 			return resolved
 		}
+	}
+	if resolved := resolvedTemplateForIdentity(strings.TrimSpace(bead.Metadata["alias"]), cfg); resolved != "" {
+		return resolved
 	}
 	return template
 }
@@ -242,8 +340,32 @@ func lookupSessionNameOrLegacy(store beads.Store, cityName, qualifiedName, sessi
 // under the given template-qualified agent. The result maps the logical
 // instance qualified name (for example "frontend/worker-1") to the actual
 // runtime session name.
-func lookupPoolSessionNames(store beads.Store, template string) (map[string]string, error) {
-	result := make(map[string]string)
+type poolLookupCandidate struct {
+	sessionName         string
+	score               int
+	stateRank           int
+	ownsPoolSessionName bool
+}
+
+func poolLookupCandidateStateRank(b beads.Bead) int {
+	switch sessionMetadataState(b) {
+	case "active":
+		return 2
+	case "creating":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func poolLookupCandidatesEquivalent(a, b poolLookupCandidate) bool {
+	return a.score == b.score &&
+		a.stateRank == b.stateRank &&
+		a.ownsPoolSessionName == b.ownsPoolSessionName
+}
+
+func lookupPoolSessionNameCandidates(store beads.Store, template string, cfg *config.City, cfgAgent *config.Agent) (map[string][]poolLookupCandidate, error) {
+	result := make(map[string][]poolLookupCandidate)
 	if store == nil {
 		return result, nil
 	}
@@ -257,23 +379,144 @@ func lookupPoolSessionNames(store beads.Store, template string) (map[string]stri
 		if !sessionpkg.IsSessionBeadOrRepairable(b) {
 			continue
 		}
-		if b.Status == "closed" || b.Metadata["pool_slot"] == "" {
+		if b.Status == "closed" {
 			continue
 		}
-		agentName := sessionBeadAgentName(b)
-		if b.Metadata["template"] != template && resolvePoolSlot(agentName, template) == 0 {
+		if isNamedSessionBead(b) || isManualSessionBeadForAgent(b, cfgAgent) {
 			continue
 		}
-		sessionName := b.Metadata["session_name"]
+		storedTemplateMatches := storedTemplateMatchesPoolTemplate(sessionBeadStoredTemplate(b), template, cfg)
+		resolveSlot := func(identity string) int {
+			if cfgAgent != nil {
+				return resolvePersistedPoolIdentitySlot(cfgAgent, storedTemplateMatches, identity)
+			}
+			return 0
+		}
+		qualifiedInstanceName := func(slot int) string {
+			if cfgAgent != nil {
+				return cfgAgent.QualifiedInstanceName(poolInstanceName(cfgAgent.Name, slot, cfgAgent))
+			}
+			return template + "-" + strconv.Itoa(slot)
+		}
+		agentSlot := resolveSlot(sessionBeadAgentName(b))
+		aliasSlot := resolveSlot(strings.TrimSpace(b.Metadata["alias"]))
+		sessionName := strings.TrimSpace(b.Metadata["session_name"])
+		sessionNameSlot := 0
+		if storedTemplateMatches && strings.TrimSpace(b.Metadata["alias"]) == "" && !beadOwnsPoolSessionName(b) {
+			sessionNameSlot = resolveSlot(sessionName)
+		}
+		if cfgAgent != nil && poolSlotHasConfiguredBound(cfgAgent) {
+			if agentSlot > 0 && !inBoundsPoolSlot(cfgAgent, agentSlot) {
+				agentSlot = 0
+			}
+			if aliasSlot > 0 && !inBoundsPoolSlot(cfgAgent, aliasSlot) {
+				aliasSlot = 0
+			}
+			if sessionNameSlot > 0 && !inBoundsPoolSlot(cfgAgent, sessionNameSlot) {
+				sessionNameSlot = 0
+			}
+		}
+		if !storedTemplateMatches && agentSlot == 0 && aliasSlot == 0 {
+			continue
+		}
 		if sessionName == "" {
 			continue
 		}
+		agentName := sessionBeadAgentName(b)
+		if storedTemplateMatches && (agentName == template || agentName == targetBasename(template)) {
+			agentName = ""
+		}
+		switch {
+		case agentSlot > 0:
+			agentName = qualifiedInstanceName(agentSlot)
+		case aliasSlot > 0:
+			agentName = qualifiedInstanceName(aliasSlot)
+		case sessionNameSlot > 0:
+			agentName = qualifiedInstanceName(sessionNameSlot)
+		case agentName == "" && storedTemplateMatches && strings.TrimSpace(b.Metadata["pool_slot"]) != "":
+			if slot, err := strconv.Atoi(strings.TrimSpace(b.Metadata["pool_slot"])); err == nil && slot > 0 {
+				if cfgAgent == nil || !poolSlotHasConfiguredBound(cfgAgent) || inBoundsPoolSlot(cfgAgent, slot) {
+					agentName = qualifiedInstanceName(slot)
+				}
+			}
+		}
 		if agentName == "" {
-			agentName = template + "-" + b.Metadata["pool_slot"]
+			continue
 		}
-		if agentName != "" {
-			result[agentName] = sessionName
+		score := 0
+		if strings.TrimSpace(b.Metadata["pool_slot"]) != "" {
+			score += 2
 		}
+		if strings.TrimSpace(b.Metadata["template"]) == template {
+			score++
+		}
+		if agentSlot > 0 {
+			score += 2
+		}
+		if aliasSlot > 0 {
+			score++
+		}
+		candidate := poolLookupCandidate{
+			sessionName:         sessionName,
+			score:               score,
+			stateRank:           poolLookupCandidateStateRank(b),
+			ownsPoolSessionName: beadOwnsPoolSessionName(b),
+		}
+		existing := result[agentName]
+		replaced := false
+		for idx := range existing {
+			if existing[idx].sessionName != sessionName {
+				continue
+			}
+			if candidate.score > existing[idx].score ||
+				(candidate.score == existing[idx].score && candidate.stateRank > existing[idx].stateRank) ||
+				(candidate.score == existing[idx].score && candidate.stateRank == existing[idx].stateRank && candidate.ownsPoolSessionName && !existing[idx].ownsPoolSessionName) {
+				existing[idx] = candidate
+			}
+			replaced = true
+			break
+		}
+		if !replaced {
+			existing = append(existing, candidate)
+		}
+		result[agentName] = existing
+	}
+	for agentName, candidates := range result {
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].score != candidates[j].score {
+				return candidates[i].score > candidates[j].score
+			}
+			if candidates[i].stateRank != candidates[j].stateRank {
+				return candidates[i].stateRank > candidates[j].stateRank
+			}
+			if candidates[i].ownsPoolSessionName != candidates[j].ownsPoolSessionName {
+				return candidates[i].ownsPoolSessionName
+			}
+			return candidates[i].sessionName < candidates[j].sessionName
+		})
+		result[agentName] = candidates
+	}
+	return result, nil
+}
+
+func lookupPoolSessionNames(store beads.Store, cfg *config.City, cfgAgent *config.Agent) (map[string]string, error) {
+	template := ""
+	if cfgAgent != nil {
+		template = cfgAgent.QualifiedName()
+	}
+	candidates, err := lookupPoolSessionNameCandidates(store, template, cfg, cfgAgent)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]string, len(candidates))
+	for agentName, ranked := range candidates {
+		if len(ranked) == 0 {
+			continue
+		}
+		if len(ranked) > 1 && poolLookupCandidatesEquivalent(ranked[0], ranked[1]) && ranked[0].sessionName != ranked[1].sessionName {
+			continue
+		}
+		result[agentName] = ranked[0].sessionName
 	}
 	return result, nil
 }

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
 )
 
 func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
@@ -32,5 +33,55 @@ func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
 	}
 	if got, want := stored.Metadata["pending_create_started_at"], pendingCreateStartedAtNow(now); got != want {
 		t.Fatalf("stored pending_create_started_at = %q, want %q", got, want)
+	}
+}
+
+func TestResolvedTemplateForIdentity_ResolvesUniqueInBoundsLegacyLocalPoolIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(1)},
+		},
+	}
+
+	if got := resolvedTemplateForIdentity("worker-5", cfg); got != "frontend/worker" {
+		t.Fatalf("resolvedTemplateForIdentity(worker-5) = %q, want %q", got, "frontend/worker")
+	}
+}
+
+func TestResolvedTemplateForIdentity_DoesNotResolveAmbiguousLegacyLocalPoolIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+			{Name: "worker", Dir: "backend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	if got := resolvedTemplateForIdentity("worker-7", cfg); got != "" {
+		t.Fatalf("resolvedTemplateForIdentity(worker-7) = %q, want unresolved ambiguity", got)
+	}
+}
+
+func TestResolvedTemplateForIdentity_DoesNotResolveZeroCapacityLocalIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(0)},
+		},
+	}
+
+	if got := resolvedTemplateForIdentity("worker-1", cfg); got != "" {
+		t.Fatalf("resolvedTemplateForIdentity(worker-1) = %q, want zero-capacity template to stay unresolved", got)
+	}
+}
+
+func TestResolvedTemplateForIdentity_DoesNotResolveOutOfBoundsQualifiedPoolIdentity(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+
+	if got := resolvedTemplateForIdentity("frontend/worker-7", cfg); got != "" {
+		t.Fatalf("resolvedTemplateForIdentity(frontend/worker-7) = %q, want unresolved out-of-bounds identity", got)
 	}
 }


### PR DESCRIPTION
Supersedes #1713

Credit: Original fix by @julianknutsen

## Summary

- preserve existing unique positive `pool_slot` values during desired pool-slot sync so live pool sessions are not compacted into lower-numbered aliases when desired count temporarily shrinks
- unify pool identity recovery across desired-state rediscovery, pool lookup, restart, and stop flows so stale qualified out-of-bounds identities are not revived as base templates
- make dependency-floor pool identity recovery config-aware and treat explicit `max_active_sessions = 0` as a real bound
- add regression coverage for live sparse-slot preservation, config-aware dependency floors, out-of-bounds qualified identities, and zero-capacity pool recovery

## Testing

- [x] Focused verification run
- `go vet ./cmd/gc`
- `go test ./cmd/gc -run 'Test(BuildDesiredState|LookupPoolSessionNames|ResolvePoolSessionRefs|SelectRunningPoolSessionRefs|DoRigRestart|SyncSessionBeads|ResolvedTemplateForIdentity)_' -count=1`
- [x] Added or updated tests for behavior changes
- [ ] `make check-docs` if docs, navigation, or links changed
- [ ] `make test-integration` if runtime, controller, or workflow behavior changed

## Checklist

- [x] Linked an issue, or explained why one is not needed
- Supersedes #1713; no separate issue was needed
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes
- [ ] Called out breaking changes or migration notes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->