### PR TITLE
ci: throttle RC real inference jobs

### DIFF
--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -83,10 +83,12 @@ jobs:
 
   ubuntu_acceptance_a:
     name: ubuntu / acceptance A / ${{ matrix.label }}
+    needs: ci_parity
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - label: root-1-of-8
@@ -162,10 +164,12 @@ jobs:
 
   ubuntu_acceptance_c:
     name: ubuntu / acceptance C / ${{ matrix.shard_index }} of 5
+    needs: ubuntu_acceptance_a
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         shard_index: [1, 2, 3, 4, 5]
     env:
@@ -195,10 +199,12 @@ jobs:
 
   ubuntu_integration_shards:
     name: ubuntu / integration / ${{ matrix.shard_name }}
+    needs: ubuntu_acceptance_c
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         include:
           - shard_name: packages-core-1-of-4
@@ -316,10 +322,12 @@ jobs:
 
   ubuntu_tutorial:
     name: ubuntu / tutorial goldens / ${{ matrix.shard_index }} of 6
+    needs: ubuntu_integration_shards
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 110
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         shard_index: [1, 2, 3, 4, 5, 6]
     env:

--- a/.github/workflows/scripts/test_rc_gate_policy.py
+++ b/.github/workflows/scripts/test_rc_gate_policy.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / "rc-gate.yml"
+
+
+def _job_block(workflow: str, job_name: str) -> str:
+    marker = f"  {job_name}:\n"
+    start = workflow.index(marker)
+    lines = workflow[start:].splitlines(keepends=True)
+    block = [lines[0]]
+    for line in lines[1:]:
+        if line.startswith("  ") and not line.startswith("    ") and line.strip().endswith(":"):
+            break
+        block.append(line)
+    return "".join(block)
+
+
+class RCGatePolicyTests(unittest.TestCase):
+    def test_real_inference_jobs_are_throttled_after_ci_parity(self) -> None:
+        workflow = WORKFLOW.read_text()
+
+        acceptance_a = _job_block(workflow, "ubuntu_acceptance_a")
+        self.assertIn("needs: ci_parity", acceptance_a)
+        self.assertIn("max-parallel: 2", acceptance_a)
+
+        acceptance_c = _job_block(workflow, "ubuntu_acceptance_c")
+        self.assertIn("needs: ubuntu_acceptance_a", acceptance_c)
+        self.assertIn("max-parallel: 1", acceptance_c)
+
+        integration = _job_block(workflow, "ubuntu_integration_shards")
+        self.assertIn("needs: ubuntu_acceptance_c", integration)
+        self.assertIn("max-parallel: 4", integration)
+
+        tutorial = _job_block(workflow, "ubuntu_tutorial")
+        self.assertIn("needs: ubuntu_integration_shards", tutorial)
+        self.assertIn("max-parallel: 1", tutorial)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- serialize the RC real-inference lane behind CI parity to avoid overlapping Synthetic Claude demand
- limit RC acceptance/tutorial matrices so they do not burst 429 the shared Synthetic account
- add a stdlib workflow policy test for the RC throttling contract

## RC evidence
Iteration 2 failed with multiple Synthetic Claude 429 responses while acceptance C, tutorial goldens, and CI parity real-inference jobs ran concurrently. The macOS sharder and maintenance DB filter fixes from #1748 held: mac fast jobs no longer failed immediately.

## Verification
- python3 .github/workflows/scripts/test_rc_gate_policy.py
- python3 .github/workflows/scripts/test_runner_policy.py

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->