### PR TITLE
fix(packs): use --lines flag for gc session peek (dog template)

### DIFF
--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -76,7 +76,7 @@ and the pool can't recycle your slot.
 
 ```bash
 gc session nudge <target> "message"                # Nudge an agent
-gc session peek <target> 50                        # View agent output
+gc session peek <target> --lines 50                # View agent output
 gc session list                                    # Check agent status
 ```
 


### PR DESCRIPTION
## Summary

- Replace `gc session peek <target> 50` with `gc session peek <target> --lines 50` in `examples/gastown/packs/maintenance/agents/dog/prompt.template.md` line 79.
- Same bug class as the boot/deacon fixes in #1743 / #1744: the line-count is now a flag, not a positional. Without `--lines`, runtime fails with `accepts 1 arg(s), received 2`.
- Dog agents peek at target sessions to assess state during warrant processing and shutdown dances; every dog warrant currently burns a tool call on this error before falling back to `--help` discovery.
- Filed separately from #1743 / #1744 because this prompt lives in a different pack file (`packs/maintenance/...` vs `packs/gastown/...`) and bundling would have stretched those PRs' titles.

Verified the new syntax against `gc session peek --help`:
```
Flags:
  -h, --help        help for peek
      --lines int   number of lines to capture (default 50)
```

## Testing

- [x] `make check` — pre-existing macOS test failures (none caused by this change; verified two passing on main with this edit stashed):
  - `TestBuiltinDoltDoctorBoundsVersionProbe` (documented in cities CLAUDE.md)
  - `TestBuiltinDoltDoctorReportsTimedOutVersionProbe` (documented in cities CLAUDE.md)
  - `TestExecCommandRunnerTimeoutKillsChildProcess` (documented in cities CLAUDE.md)
  - `TestCityRuntimeManualReloadPanicAfterReloadKeepsReloadReplyAndClears` — ~10% macOS flake fixed by my open #1741 (commit 564cb96c, *cancel dispatched orders before t.TempDir cleanup*)
  - `TestReaperScopesIssueAutoCloseToCityBeadsDir` — macOS `/var → /private/var` path-resolution flake; pre-existing, not yet documented (will file follow-up)
- [ ] `make check-docs` — not applicable (no docs/ changes)
- [ ] `make test-integration` — not run (per cities CLAUDE.md, deferred while the suite times out without saving partial output)

## Checklist

- [x] Linked an issue, or explained why one is not needed — internal bead stg-7n9 (cities)
- [ ] Added or updated tests for behavior changes — not applicable (one-line prompt-template fix, same class as #1743 / #1744 which also added no tests)
- [x] Updated docs for user-facing changes — the prompt template *is* the user-facing artifact
- [ ] Called out breaking changes or migration notes — none (the broken syntax was already failing at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->