### PR TITLE
fix(packs): use built-in task type for warrant/digest beads

### DIFF
--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -89,10 +89,10 @@ Drain-ack and exit. Next Boot tick will re-evaluate.
 
 **Clearly stuck (very stale wisp, no output, errors visible):** File a warrant:
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task \
   --title="Stuck: deacon" \
   --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot"}' \
-  --label=pool:dog
+  --label=warrant,pool:dog
 ```
 The dog pool picks up the warrant and runs the shutdown dance.
 
@@ -124,7 +124,7 @@ up your session and spawns you again next tick.
 | View deacon output | `{{ cmd }} session peek deacon --lines 30` |
 | Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
-| File stuck warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| File stuck warrant | `gc bd create --type=task --label=warrant,pool:dog --metadata '{...}'` |
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -103,10 +103,10 @@ response is always the same:
 
 1. **File a warrant bead:**
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --label=pool:dog
+  --label=warrant,pool:dog
 ```
 
 2. The dog pool picks up the warrant and runs `mol-shutdown-dance`
@@ -163,7 +163,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | List convoys | `gc convoy list` |
 | Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |
 | Convert dep type | `gc bd dep remove <id> <dep>` then `gc bd dep add <id> <dep> --type=related` |
-| File stuck-agent warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| File stuck-agent warrant | `gc bd create --type=task --label=warrant,pool:dog --metadata '{...}'` |
 | Run system diagnostics | `gc doctor` |
 | Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
 | Compact wisps | `gc bd mol wisp gc --age 24h` |

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -130,10 +130,10 @@ A long tool call is different from an infinite loop.
 for the dog pool:
 
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"witness"}' \
-  --label=pool:dog
+  --label=warrant,pool:dog
 ```
 
 The dog pool runs `mol-shutdown-dance` — a multi-stage interrogation
@@ -253,7 +253,7 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
 | Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
-| File stuck-agent warrant | `gc bd create --type=warrant --label=pool:dog --metadata '{...}'` |
+| File stuck-agent warrant | `gc bd create --type=task --label=warrant,pool:dog --metadata '{...}'` |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -159,7 +159,7 @@ something is stuck. This is exactly why an LLM does it, not Go code.
 
 **For stuck coordination agents, file a warrant:**
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task --label=warrant \
   --title="Stuck: <rig>/<role>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --set-metadata gc.routed_to={{binding_prefix}}dog
@@ -199,7 +199,7 @@ No hardcoded thresholds. Use judgment.
 
 **Step 3: For stuck utility agents, file a warrant:**
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task --label=warrant \
   --title="Stuck dog: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
   --set-metadata gc.routed_to={{binding_prefix}}dog

--- a/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-digest-generate.toml
@@ -114,7 +114,7 @@ gc bd list --label=escalation --created-after=$SINCE --json
 
 c) **Warrants filed:**
 ```bash
-gc bd list --type=warrant --created-after=$SINCE --json
+gc bd list --label=warrant --created-after=$SINCE --json
 ```
 
 Close this step when all data is collected."""
@@ -161,7 +161,7 @@ gc mail send mayor/ -s "Gas Town Digest: $DATE" -m "$DIGEST"
 
 **3. Archive as bead:**
 ```bash
-gc bd create --type=digest \
+gc bd create --type=task \
   --title="Digest: $DATE" \
   --label=digest,{{period}}
 ```

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -433,10 +433,10 @@ Do NOT kill the agent directly. File a warrant bead and let the dog pool
 handle the shutdown dance (multi-stage interrogation with due process):
 
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness"}' \
-  --label=pool:dog
+  --label=warrant,pool:dog
 ```
 
 The dog pool picks up the warrant and runs `mol-shutdown-dance`, which

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -4,10 +4,10 @@ Shutdown dance — due process for stuck agents.
 Dispatched by filing a warrant bead with `--label=pool:dog`:
 
 ```bash
-gc bd create --type=warrant \
+gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>"}' \
-  --label=pool:dog
+  --label=warrant,pool:dog
 ```
 
 The dog pool picks up the warrant and pours this formula. Each wisp is


### PR DESCRIPTION
## Summary

The gastown pack creates beads with `--type=digest` (1 site) and
`--type=warrant` (3 sites), but those custom types are not registered
in bd's `types.custom` config, so every invocation fails with
`Error: validation failed for issue : invalid issue type: digest`.

Symptom (observed 2026-05-05 in an oscar-e2e gastown city): every
`mol-digest-generate` run fails at the "Archive as bead" step; the
parent molecule then can't close because the archive child is open.
The warrant paths in `mol-deacon-patrol` and `mol-witness-patrol` are
dormant in observed cities (no stuck agent has triggered them) but
would fail identically the first time.

This swaps `--type=<digest|warrant>` for `--type=task` and adds the
type name as a `--label` so the semantic distinction (and existing
label-based filtering) survives. `mol-digest-generate`'s "warrants
filed" query is updated lockstep
(`--type=warrant` → `--label=warrant`).

The fix also touches prompt templates for `boot`, `deacon`, and
`witness`, and `maintenance/mol-shutdown-dance.toml` — they all
instruct agents to run `gc bd create --type=warrant ...`. A pure
formula-only fix would have left these silently broken on the first
real warrant.

`examples/gastown/SDK-ROADMAP.md` and `FUTURE.md` still describe
`--type=digest` / `--type=warrant` as the design shape; those are
aspirational and left untouched. If first-class pack-declared custom
types are wanted, that is a separate (and bigger) API addition — the
current pack.toml schema has no slot for it.

## Testing

- [x] `make check` (gascity pre-commit) — passes for the docsync sweep
  the hook runs. `make check` itself was run separately and reports
  the same five pre-existing macOS failures present on `origin/main`
  (none touch the files in this PR):
  - `TestBuiltinDoltDoctorBoundsVersionProbe`
  - `TestBuiltinDoltDoctorReportsTimedOutVersionProbe`
  - `TestExecCommandRunnerTimeoutKillsChildProcess`
  - `TestCityRuntimeManualReloadPanicAfterReloadKeepsReloadReplyAndClears`
    (already addressed by #1741)
  - `TestReaperScopesIssueAutoCloseToCityBeadsDir` (added in 6dd911f9
    earlier today; failure is in the new test, not regressed by this PR)
- [x] `make check-docs` — passes (`go test ./test/docsync`).
- [ ] `make test-integration` — not run; past attempts have hit the
  30-minute timeout with no saved partial output.

## Checklist

- [x] Linked an issue, or explained why one is not needed — discovered
  during a city test run; no upstream issue filed
- [ ] Added or updated tests for behavior changes — no Go behavior
  changed; the affected files are pack templates / formula prose
- [ ] Updated docs for user-facing changes — `SDK-ROADMAP.md` /
  `FUTURE.md` left untouched (see Summary)
- [ ] Called out breaking changes or migration notes — none; existing
  beads of `--type=warrant`/`--type=digest` (if any survived bd's
  validation) are still searchable by label

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->