### PR TITLE
test: refresh fresh init spawned session bead

### DIFF
--- a/test/acceptance/tier_c/fresh_install_spawn_test.go
+++ b/test/acceptance/tier_c/fresh_install_spawn_test.go
@@ -61,7 +61,9 @@ func TestFreshInit_ClaudeUnrestricted(t *testing.T) {
 	}
 
 	result := runFreshInitSlingClaudeWork(t, "Write the current time to permission-check.txt", "permission-check.txt")
-	command := metaString(result.SpawnedSessionBead.Metadata, "command")
+	spawnedSessionBead, err := showBeadJSON(result.CityDir, result.SpawnedSessionBead.ID)
+	require.NoError(t, err, "refresh spawned session bead %s", result.SpawnedSessionBead.ID)
+	command := metaString(spawnedSessionBead.Metadata, "command")
 	require.NotEmpty(t, command, "spawned worker should persist the resolved launch command")
 	require.Contains(t, command, "--dangerously-skip-permissions", "fresh claude worker should launch unrestricted")
 	require.NotContains(t, command, "--permission-mode auto-edit", "fresh claude worker should not launch in auto-edit mode")


### PR DESCRIPTION
## Summary
- Refetch the spawned session bead before asserting persisted launch command metadata in the fresh-init Tier C test.
- Avoid asserting against the stale bead snapshot captured before session metadata is fully committed.

## Test plan
- go test -tags acceptance_c -run 'TestTierCEnvAuthDoesNotMirrorAuthTokenIntoAPIKey' -count=1 ./test/acceptance/tier_c
- pre-commit fast unit loop

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->