### PR TITLE
fix(test): canonicalize cityDir to make reaper scope test pass on macOS

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1970,6 +1970,13 @@ exit 0
 
 func TestReaperScopesIssueAutoCloseToCityBeadsDir(t *testing.T) {
 	cityDir := t.TempDir()
+	// reaper.sh canonicalizes its CITY arg via `pwd -P`, so on macOS
+	// (where t.TempDir is under /var/folders -> /private/var/folders)
+	// the logged $PWD will be the resolved form. Resolve here so the
+	// assertions below compare apples to apples on every OS.
+	if resolved, err := filepath.EvalSymlinks(cityDir); err == nil {
+		cityDir = resolved
+	}
 	writeCityBeadsMetadata(t, cityDir, "citydb")
 	binDir := t.TempDir()
 	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")


### PR DESCRIPTION
## Summary

`TestReaperScopesIssueAutoCloseToCityBeadsDir` in
`examples/gastown/maintenance_scripts_test.go` fails deterministically on
macOS. `reaper.sh` canonicalizes its `CITY` argument via `pwd -P` (line 14
of `examples/gastown/packs/maintenance/assets/scripts/reaper.sh`), so on
macOS the `bd`-call log records `pwd=/private/var/folders/...` while the
test asserts against the unresolved `t.TempDir()` value
(`/var/folders/...`).

Resolve `cityDir` once via `filepath.EvalSymlinks` before using it. On
Linux the call is identity for non-symlinked paths, so the change is a
no-op there. Pattern matches the existing usage at
`test/acceptance/worker_inference/worker_inference_test.go:4971`.

## Testing

- [x] `make check` — `examples/gastown` package passes (was failing
  deterministically before this change). 4 unrelated pre-existing macOS
  failures still present (none in the touched package):
  - `TestBuiltinDoltDoctorBoundsVersionProbe` (cmd/gc) — tracked by #1729
  - `TestBuiltinDoltDoctorReportsTimedOutVersionProbe` (cmd/gc) — tracked by #1729
  - `TestExecCommandRunnerTimeoutKillsChildProcess` (internal/beads) — tracked by #1729
  - `TestStartLongSocketPathUsesShortSocketName` (internal/runtime/acp) —
    pre-existing parallel-load flake; passes 5/5 in isolation on `main`,
    flakes only under `make check`'s `-p=4`.
- [x] Targeted: `go test -count=3 -run '^TestReaperScopesIssueAutoCloseToCityBeadsDir$' ./examples/gastown/` — passes consistently (was failing every run before).
- [ ] `make check-docs` — no docs touched.
- [ ] `make test-integration` — not run.

Used `--no-verify` on commit per the `#1729` workaround for the broken
macOS pre-commit hook.

## Checklist

- [x] Linked an issue, or explained why one is not needed — internal tracker bead `stg-ize`.
- [x] Added or updated tests for behavior changes — the existing test is the regression coverage.
- [ ] Updated docs for user-facing changes — none.
- [ ] Called out breaking changes or migration notes — none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->