### PR TITLE
Release v1.1.0

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -108,7 +108,7 @@ Release tarballs are published for every tagged version. Supported platforms:
 
 ```bash
 # Set the version you want (check https://github.com/gastownhall/gascity/releases)
-VERSION=1.0.0
+VERSION=1.1.0
 
 # Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -1971,6 +1971,10 @@ exit 0
 func TestReaperScopesIssueAutoCloseToCityBeadsDir(t *testing.T) {
 	cityDir := t.TempDir()
 	writeCityBeadsMetadata(t, cityDir, "citydb")
+	canonicalCityDir, err := filepath.EvalSymlinks(cityDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(city dir): %v", err)
+	}
 	binDir := t.TempDir()
 	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
 	bdLog := filepath.Join(t.TempDir(), "bd.log")
@@ -2025,10 +2029,10 @@ exit 0
 	if !strings.Contains(bdLogText, "args=close ga-city --reason stale:auto-closed by reaper") {
 		t.Fatalf("reaper did not close city issue:\n%s", bdLogText)
 	}
-	if !strings.Contains(bdLogText, "pwd="+cityDir) {
+	if !strings.Contains(bdLogText, "pwd="+canonicalCityDir) {
 		t.Fatalf("reaper did not run bd close from city dir:\n%s", bdLogText)
 	}
-	if !strings.Contains(bdLogText, "beads="+filepath.Join(cityDir, ".beads")) {
+	if !strings.Contains(bdLogText, "beads="+filepath.Join(canonicalCityDir, ".beads")) {
 		t.Fatalf("reaper did not scope bd close to the city beads dir:\n%s", bdLogText)
 	}
 	if strings.Contains(bdLogText, "beads="+ambientBeadsDir) {


### PR DESCRIPTION
## Summary

Merge the v1.1.0 release branch back to main after the published release.

Includes:
- docs install example update for v1.1.0
- macOS reaper city path canonicalization test fix

## Release verification

- v1.1.0 tag and GitHub release are published
- GoReleaser release workflow completed and uploaded assets/SBOM
- gastownhall/homebrew-gascity tap updated to v1.1.0 and verified
- Homebrew/core PR 281261 CI is green

## Notes

The Homebrew/core PR remains under maintainer review and can proceed independently of this merge-back PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->