### PR TITLE
fix: fall back to provider state when managed dolt is unpublished

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -518,14 +519,45 @@ func externalDoltEnvOverrideTarget() (contract.DoltConnectionTarget, bool) {
 	}, true
 }
 
+func currentResolvableManagedDoltPort(cityPath string) string {
+	if port := currentManagedDoltPort(cityPath); port != "" {
+		return port
+	}
+	state, err := readDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath))
+	if err != nil {
+		return ""
+	}
+	if !validDoltRuntimeState(state, cityPath) {
+		return ""
+	}
+	return strconv.Itoa(state.Port)
+}
+
 func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contract.DoltConnectionTarget, bool, error) {
 	var managedRuntimeErr error
 	if target, ok, err := canonicalScopeDoltTarget(cityPath, cityPath); err != nil {
 		if !allowRecovery || !contract.IsManagedRuntimeUnavailable(err) {
 			return contract.DoltConnectionTarget{}, false, err
 		}
+		if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+			return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
+		}
 		managedRuntimeErr = err
 	} else if ok {
+		if !target.External && strings.TrimSpace(target.Port) == "" {
+			if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+				target.Port = port
+				return target, true, nil
+			}
+			if allowRecovery {
+				if err := healthBeadsProvider(cityPath); err == nil {
+					if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+						target.Port = port
+						return target, true, nil
+					}
+				}
+			}
+		}
 		return target, true, nil
 	}
 	if host, port, ok, invalid := resolveConfiguredCityDoltTarget(cityPath); invalid {
@@ -538,12 +570,12 @@ func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contrac
 		return target, true, nil
 	}
 
-	if port := currentManagedDoltPort(cityPath); port != "" {
+	if port := currentResolvableManagedDoltPort(cityPath); port != "" {
 		return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 	}
 	if allowRecovery {
 		if err := healthBeadsProvider(cityPath); err == nil {
-			if port := currentManagedDoltPort(cityPath); port != "" {
+			if port := currentResolvableManagedDoltPort(cityPath); port != "" {
 				return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 			}
 		}

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -519,45 +519,89 @@ func externalDoltEnvOverrideTarget() (contract.DoltConnectionTarget, bool) {
 	}, true
 }
 
+// currentResolvableManagedDoltPort returns a live managed Dolt port from the
+// published runtime state, or from provider state when publication has not
+// caught up yet. Provider fallback uses validDoltRuntimeState instead of the
+// contract package's lighter published-state validation because callers may
+// mirror or publish this value into user-visible runtime files.
 func currentResolvableManagedDoltPort(cityPath string) string {
 	if port := currentManagedDoltPort(cityPath); port != "" {
 		return port
 	}
-	state, err := readDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath))
-	if err != nil {
-		return ""
-	}
-	if !validDoltRuntimeState(state, cityPath) {
+	state, ok := readValidProviderManagedDoltState(cityPath)
+	if !ok {
 		return ""
 	}
 	return strconv.Itoa(state.Port)
 }
 
+func readValidProviderManagedDoltState(cityPath string) (doltRuntimeState, bool) {
+	state, err := readDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath))
+	if err != nil {
+		return doltRuntimeState{}, false
+	}
+	if !validDoltRuntimeState(state, cityPath) {
+		return doltRuntimeState{}, false
+	}
+	return state, true
+}
+
+func currentPublishedOrRecoveredManagedDoltPort(cityPath string, allowRecovery bool) (string, error) {
+	if port := currentManagedDoltPort(cityPath); port != "" {
+		return port, nil
+	}
+	if !allowRecovery {
+		return "", nil
+	}
+	state, ok := readValidProviderManagedDoltState(cityPath)
+	if !ok {
+		return "", nil
+	}
+	published, err := publishManagedDoltRuntimeStateIfOwnedResultFromState(cityPath, state)
+	if err != nil {
+		return "", fmt.Errorf("publish managed dolt runtime state from provider state: %w", err)
+	}
+	port := currentManagedDoltPort(cityPath)
+	if port == "" {
+		if !published {
+			return "", fmt.Errorf("publish managed dolt runtime state from provider state: managed dolt lifecycle is not owned and published state is absent")
+		}
+		return "", fmt.Errorf("publish managed dolt runtime state from provider state: published state is not valid")
+	}
+	return port, nil
+}
+
 func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contract.DoltConnectionTarget, bool, error) {
 	var managedRuntimeErr error
+	var recoveryErr error
+	recoveryChecked := false
+	recoveryPort := ""
+	recoveredManagedDoltPort := func() string {
+		if recoveryChecked {
+			return recoveryPort
+		}
+		recoveryChecked = true
+		port, err := currentPublishedOrRecoveredManagedDoltPort(cityPath, allowRecovery)
+		if err != nil {
+			recoveryErr = err
+			return ""
+		}
+		recoveryPort = port
+		return port
+	}
+	resetRecoveryCache := func() {
+		recoveryChecked = false
+		recoveryPort = ""
+	}
 	if target, ok, err := canonicalScopeDoltTarget(cityPath, cityPath); err != nil {
 		if !allowRecovery || !contract.IsManagedRuntimeUnavailable(err) {
 			return contract.DoltConnectionTarget{}, false, err
 		}
-		if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+		if port := recoveredManagedDoltPort(); port != "" {
 			return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 		}
 		managedRuntimeErr = err
 	} else if ok {
-		if !target.External && strings.TrimSpace(target.Port) == "" {
-			if port := currentResolvableManagedDoltPort(cityPath); port != "" {
-				target.Port = port
-				return target, true, nil
-			}
-			if allowRecovery {
-				if err := healthBeadsProvider(cityPath); err == nil {
-					if port := currentResolvableManagedDoltPort(cityPath); port != "" {
-						target.Port = port
-						return target, true, nil
-					}
-				}
-			}
-		}
 		return target, true, nil
 	}
 	if host, port, ok, invalid := resolveConfiguredCityDoltTarget(cityPath); invalid {
@@ -570,15 +614,19 @@ func resolvedRuntimeCityDoltTarget(cityPath string, allowRecovery bool) (contrac
 		return target, true, nil
 	}
 
-	if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+	if port := recoveredManagedDoltPort(); port != "" {
 		return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 	}
 	if allowRecovery {
 		if err := healthBeadsProvider(cityPath); err == nil {
-			if port := currentResolvableManagedDoltPort(cityPath); port != "" {
+			resetRecoveryCache()
+			if port := recoveredManagedDoltPort(); port != "" {
 				return contract.DoltConnectionTarget{Host: defaultManagedDoltHost, Port: port}, true, nil
 			}
 		}
+	}
+	if recoveryErr != nil {
+		return contract.DoltConnectionTarget{}, false, recoveryErr
 	}
 	if managedRuntimeErr != nil {
 		return contract.DoltConnectionTarget{}, false, managedRuntimeErr

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -443,18 +443,11 @@ dolt.auto-start: false
 	if got := currentResolvableManagedDoltPort(cityPath); got != strconv.Itoa(port) {
 		t.Fatalf("currentResolvableManagedDoltPort() = %q, want %d", got, port)
 	}
-	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, true)
-	if err != nil {
-		t.Fatalf("resolvedRuntimeCityDoltTarget() error = %v", err)
-	}
-	if !ok {
-		t.Fatal("resolvedRuntimeCityDoltTarget() ok = false, want true")
-	}
-	if got := target.Port; got != strconv.Itoa(port) {
-		t.Fatalf("resolvedRuntimeCityDoltTarget().Port = %q, want %d", got, port)
-	}
 
-	env := mustBdRuntimeEnv(t, cityPath)
+	env, err := bdRuntimeEnvWithError(cityPath)
+	if err != nil {
+		t.Fatalf("bdRuntimeEnvWithError() error = %v", err)
+	}
 	want := strconv.Itoa(port)
 	if got := env["GC_DOLT_PORT"]; got != want {
 		t.Fatalf("GC_DOLT_PORT = %q, want provider-state port %q", got, want)
@@ -465,6 +458,137 @@ dolt.auto-start: false
 	if got := env["GC_DOLT_HOST"]; got != "" {
 		t.Fatalf("GC_DOLT_HOST = %q, want empty for managed provider-state target", got)
 	}
+
+	publishedState, err := readDoltRuntimeStateFile(managedDoltStatePath(cityPath))
+	if err != nil {
+		t.Fatalf("read published state: %v", err)
+	}
+	if publishedState.Port != port || publishedState.PID != listener.Process.Pid {
+		t.Fatalf("published state = %+v, want pid %d port %d", publishedState, listener.Process.Pid, port)
+	}
+	mirror, err := os.ReadFile(filepath.Join(cityPath, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("read port mirror: %v", err)
+	}
+	if got := strings.TrimSpace(string(mirror)); got != strconv.Itoa(port) {
+		t.Fatalf("port mirror = %q, want %d", got, port)
+	}
+}
+
+func TestResolvedRuntimeCityDoltTargetWithoutRecoveryDoesNotPublishProviderState(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "")
+	_ = os.Unsetenv("GC_DOLT_HOST")
+	t.Setenv("GC_DOLT_PORT", "")
+	_ = os.Unsetenv("GC_DOLT_PORT")
+
+	cityPath := t.TempDir()
+	writeMinimalCityToml(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	port := writeReachableProviderManagedDoltState(t, cityPath)
+
+	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, false)
+	if err == nil || !contract.IsManagedRuntimeUnavailable(err) {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() error = %v, want managed runtime unavailable", err)
+	}
+	if ok {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() ok = true with target %+v, want no fallback target", target)
+	}
+	if got := currentResolvableManagedDoltPort(cityPath); got != strconv.Itoa(port) {
+		t.Fatalf("currentResolvableManagedDoltPort() = %q, want %d", got, port)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityPath)); !os.IsNotExist(err) {
+		t.Fatalf("published state should remain absent when recovery is disabled, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityPath, ".beads", "dolt-server.port")); !os.IsNotExist(err) {
+		t.Fatalf("port mirror should remain absent when recovery is disabled, stat err = %v", err)
+	}
+}
+
+func TestResolvedRuntimeCityDoltTargetFallsBackToEnvWhenProviderStateIsNotOwned(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "external-db.example.com")
+	t.Setenv("GC_DOLT_PORT", "3307")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeReachableProviderManagedDoltState(t, cityPath)
+
+	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, true)
+	if err != nil {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() error = %v, want env fallback", err)
+	}
+	if !ok {
+		t.Fatal("resolvedRuntimeCityDoltTarget() ok = false, want env fallback")
+	}
+	if target.Host != "external-db.example.com" || target.Port != "3307" || !target.External {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() = %+v, want external env target", target)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityPath)); !os.IsNotExist(err) {
+		t.Fatalf("published state should remain absent for not-owned recovery, stat err = %v", err)
+	}
+}
+
+func TestResolvedRuntimeCityDoltTargetSurfacesNotOwnedProviderStateWhenNoFallbackResolves(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("GC_DOLT_HOST")
+	_ = os.Unsetenv("GC_DOLT_PORT")
+
+	cityPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeReachableProviderManagedDoltState(t, cityPath)
+
+	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, true)
+	if err == nil {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() error = nil with ok=%v target=%+v, want not-owned recovery error", ok, target)
+	}
+	requireErrorContains(t, err, "managed dolt lifecycle is not owned")
 }
 
 func TestResolvedRuntimeCityDoltTargetDoesNotMaskInvalidCanonicalConfigWithProviderState(t *testing.T) {

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/beads/contract"
@@ -386,6 +387,127 @@ dolt.auto-start: false
 	if got := env["BEADS_DOLT_SERVER_PORT"]; got != "" {
 		t.Fatalf("BEADS_DOLT_SERVER_PORT = %q, want empty without managed runtime state", got)
 	}
+}
+
+func TestBdRuntimeEnvUsesValidProviderStateWhenPublishedStateIsMissing(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "")
+	_ = os.Unsetenv("GC_DOLT_HOST")
+	t.Setenv("GC_DOLT_PORT", "")
+	_ = os.Unsetenv("GC_DOLT_PORT")
+	t.Setenv("GC_DOLT_USER", "")
+	_ = os.Unsetenv("GC_DOLT_USER")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	_ = os.Unsetenv("GC_DOLT_PASSWORD")
+
+	cityPath := t.TempDir()
+	writeMinimalCityToml(t, cityPath)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: managed_city
+gc.endpoint_status: verified
+dolt.auto-start: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, filepath.Join(cityPath, ".beads", "dolt"))
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	state := doltRuntimeState{
+		Running:   true,
+		PID:       listener.Process.Pid,
+		Port:      port,
+		DataDir:   filepath.Join(cityPath, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath), state); err != nil {
+		t.Fatalf("write provider state: %v", err)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityPath)); !os.IsNotExist(err) {
+		t.Fatalf("published state should be absent before fallback test, stat err = %v", err)
+	}
+	if got := currentResolvableManagedDoltPort(cityPath); got != strconv.Itoa(port) {
+		t.Fatalf("currentResolvableManagedDoltPort() = %q, want %d", got, port)
+	}
+	target, ok, err := resolvedRuntimeCityDoltTarget(cityPath, true)
+	if err != nil {
+		t.Fatalf("resolvedRuntimeCityDoltTarget() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("resolvedRuntimeCityDoltTarget() ok = false, want true")
+	}
+	if got := target.Port; got != strconv.Itoa(port) {
+		t.Fatalf("resolvedRuntimeCityDoltTarget().Port = %q, want %d", got, port)
+	}
+
+	env := mustBdRuntimeEnv(t, cityPath)
+	want := strconv.Itoa(port)
+	if got := env["GC_DOLT_PORT"]; got != want {
+		t.Fatalf("GC_DOLT_PORT = %q, want provider-state port %q", got, want)
+	}
+	if got := env["BEADS_DOLT_SERVER_PORT"]; got != want {
+		t.Fatalf("BEADS_DOLT_SERVER_PORT = %q, want provider-state port %q", got, want)
+	}
+	if got := env["GC_DOLT_HOST"]; got != "" {
+		t.Fatalf("GC_DOLT_HOST = %q, want empty for managed provider-state target", got)
+	}
+}
+
+func TestResolvedRuntimeCityDoltTargetDoesNotMaskInvalidCanonicalConfigWithProviderState(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	_ = os.Unsetenv("GC_DOLT_HOST")
+	_ = os.Unsetenv("GC_DOLT_PORT")
+	_ = os.Unsetenv("GC_DOLT_USER")
+	_ = os.Unsetenv("GC_DOLT_PASSWORD")
+
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: city_canonical
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: canonical-db.example.com
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	port := reserveRandomTCPPort(t)
+	listener := startTCPListenerProcessInDir(t, port, filepath.Join(cityPath, ".beads", "dolt"))
+	defer func() {
+		_ = listener.Process.Kill()
+		_ = listener.Wait()
+	}()
+
+	state := doltRuntimeState{
+		Running:   true,
+		PID:       listener.Process.Pid,
+		Port:      port,
+		DataDir:   filepath.Join(cityPath, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath), state); err != nil {
+		t.Fatalf("write provider state: %v", err)
+	}
+
+	_, _, err := resolvedRuntimeCityDoltTarget(cityPath, true)
+	requireErrorContains(t, err, "city_canonical config requires dolt.port")
 }
 
 func TestBdRuntimeEnvInvalidCanonicalConfigDoesNotFallbackToCompatRegistration(t *testing.T) {

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -434,7 +434,7 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 	if err := normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase); err != nil {
 		return err
 	}
-	if cityUsesBdStoreContract(cityPath) && currentManagedDoltPort(cityPath) != "" {
+	if cityUsesBdStoreContract(cityPath) && currentResolvableManagedDoltPort(cityPath) != "" {
 		if err := syncManagedDoltPortMirrors(cityPath); err != nil {
 			return fmt.Errorf("sync managed dolt port mirrors after init: %w", err)
 		}
@@ -521,14 +521,14 @@ func allowLegacyDoltMetadataRepair(fs fsys.FS, path string, err error) bool {
 // the database is found, or an actionable error otherwise.
 //
 // The function is a no-op (returns nil) when the city does not use the bd
-// store contract or when no managed Dolt port is published — the caller
+// store contract or when no managed Dolt port is resolvable — the caller
 // already gates on those conditions, but we double-check defensively so
 // the helper is safe to call from new sites without re-checking.
 var verifyManagedDoltDatabaseExistsAfterInit = func(cityPath, dir, dbName string) error {
 	if !cityUsesBdStoreContract(cityPath) {
 		return nil
 	}
-	port := currentManagedDoltPort(cityPath)
+	port := currentResolvableManagedDoltPort(cityPath)
 	if port == "" {
 		return nil
 	}
@@ -1052,11 +1052,13 @@ type doltRuntimeState struct {
 }
 
 // currentDoltPort returns the controller-managed Dolt port for the city.
-// The only managed-local authority is .gc/runtime/packs/dolt/dolt-state.json.
+// Published runtime state is preferred; valid provider state is accepted while
+// publication catches up so the raw-bd compatibility mirror does not get
+// removed during a live managed-Dolt window.
 // .beads/dolt-server.port is a compatibility mirror for raw bd, not a GC
 // control-plane input.
 func currentDoltPort(cityPath string) string {
-	if port := currentManagedDoltPort(cityPath); port != "" {
+	if port := currentResolvableManagedDoltPort(cityPath); port != "" {
 		writeDoltPortFile(cityPath, port, "", io.Discard)
 		return port
 	}

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -1228,6 +1228,29 @@ func TestCurrentDoltPortPrefersRuntimeState(t *testing.T) {
 	}
 }
 
+func TestCurrentDoltPortUsesProviderStateWhenPublishedStateIsMissing(t *testing.T) {
+	cityDir := setupBdContractCityForTest(t)
+	port := writeReachableProviderManagedDoltState(t, cityDir)
+
+	if _, err := os.Stat(managedDoltStatePath(cityDir)); !os.IsNotExist(err) {
+		t.Fatalf("published state should start absent, stat err = %v", err)
+	}
+	if got := currentDoltPort(cityDir); got != strconv.Itoa(port) {
+		t.Fatalf("currentDoltPort() = %q, want provider-state port %d", got, port)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityDir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(data)); got != strconv.Itoa(port) {
+		t.Fatalf("city port file = %q, want %d", got, port)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityDir)); !os.IsNotExist(err) {
+		t.Fatalf("currentDoltPort should not publish runtime state, stat err = %v", err)
+	}
+}
+
 func TestCurrentDoltPortIgnoresReachablePortFileWithoutManagedState(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
@@ -10059,6 +10082,34 @@ func TestVerifyManagedDoltDatabaseExistsAfterInitCatalogMatch(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("catalog listing was not reached")
+	}
+}
+
+func TestVerifyManagedDoltDatabaseExistsAfterInitUsesProviderStateWhenPublishedStateIsMissing(t *testing.T) {
+	original := verifyManagedDoltDatabaseExistsAfterInit
+	originalListDatabases := managedDoltListUserDatabasesAfterInit
+	t.Cleanup(func() { managedDoltListUserDatabasesAfterInit = originalListDatabases })
+
+	cityPath := setupBdContractCityForTest(t)
+	port := writeReachableProviderManagedDoltState(t, cityPath)
+
+	called := false
+	managedDoltListUserDatabasesAfterInit = func(gotPort string) ([]string, error) {
+		called = true
+		if gotPort != strconv.Itoa(port) {
+			t.Fatalf("managed Dolt port = %q, want provider-state port %d", gotPort, port)
+		}
+		return []string{"archive", "HQ"}, nil
+	}
+
+	if err := original(cityPath, filepath.Join(cityPath, "scope"), "hq"); err != nil {
+		t.Fatalf("catalog containing database should pass: %v", err)
+	}
+	if !called {
+		t.Fatal("catalog listing was not reached")
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityPath)); !os.IsNotExist(err) {
+		t.Fatalf("post-init verification should not publish runtime state, stat err = %v", err)
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -205,7 +205,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 	}
 	managedDoltPort := p.ManagedDoltPort
 	if managedDoltPort == nil {
-		managedDoltPort = currentManagedDoltPort
+		managedDoltPort = currentResolvableManagedDoltPort
 	}
 
 	logPrefix := p.LogPrefix
@@ -2010,7 +2010,7 @@ func (cr *CityRuntime) ensureManagedDoltPublishedForTick() {
 	}
 	portFn := cr.managedDoltPort
 	if portFn == nil {
-		portFn = currentManagedDoltPort
+		portFn = currentResolvableManagedDoltPort
 	}
 	ensureManagedDoltPublishedForRuntime(cr.cityPath, cr.stderr, cr.logPrefix, healthFn, ownedFn, portFn)
 }

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -717,6 +717,65 @@ func TestNewCityRuntimePreflightsManagedDoltPublicationBeforeStartupStoreWork(t 
 	}
 }
 
+func TestNewCityRuntimePreflightUsesResolvableProviderStateByDefault(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	healthCalls := 0
+	cityPath := t.TempDir()
+	writeReachableProviderManagedDoltState(t, cityPath)
+	sp := runtime.NewFake()
+	_ = newCityRuntime(CityRuntimeParams{
+		CityPath: cityPath,
+		CityName: "test-city",
+		Cfg:      &config.City{},
+		SP:       sp,
+		ManagedDoltHealth: func(string) error {
+			healthCalls++
+			return nil
+		},
+		ManagedDoltOwned: func(string) (bool, error) {
+			return true, nil
+		},
+		BuildFn: func(*config.City, runtime.Provider, beads.Store) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+		Dops:   newDrainOps(sp),
+		Rec:    events.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+
+	if healthCalls != 0 {
+		t.Fatalf("healthCalls = %d, want 0 when provider state is already resolvable", healthCalls)
+	}
+}
+
+func TestCityRuntimeTickPreflightUsesResolvableProviderStateByDefault(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	healthCalls := 0
+	cityPath := t.TempDir()
+	writeReachableProviderManagedDoltState(t, cityPath)
+	cr := &CityRuntime{
+		cityPath:  cityPath,
+		logPrefix: "gc test",
+		stderr:    io.Discard,
+		managedDoltHealth: func(string) error {
+			healthCalls++
+			return nil
+		},
+		managedDoltOwned: func(string) (bool, error) {
+			return true, nil
+		},
+	}
+
+	cr.ensureManagedDoltPublishedForTick()
+
+	if healthCalls != 0 {
+		t.Fatalf("healthCalls = %d, want 0 when provider state is already resolvable", healthCalls)
+	}
+}
+
 func TestCityRuntimeDemandSnapshotRetainsOnlyPoolScaleCheckPartials(t *testing.T) {
 	sessionBeads := newSessionBeadSnapshot([]beads.Bead{{
 		ID:     "session-worker",

--- a/cmd/gc/cmd_doctor_drift.go
+++ b/cmd/gc/cmd_doctor_drift.go
@@ -47,7 +47,7 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		return r
 	}
 
-	managedPort := currentManagedDoltPort(c.cityPath)
+	managedPort := currentResolvableManagedDoltPort(c.cityPath)
 
 	var errors []string
 	var warnings []string

--- a/cmd/gc/cmd_doctor_drift_test.go
+++ b/cmd/gc/cmd_doctor_drift_test.go
@@ -103,6 +103,35 @@ func TestDoltDriftCheckCleanManagedCityIsOK(t *testing.T) {
 	}
 }
 
+func TestDoltDriftCheckUsesProviderStateWhenPublishedStateIsMissing(t *testing.T) {
+	cityDir, rigDir, managedPort, cfg := managedCityDriftFixture(t, "provider")
+	state, err := readDoltRuntimeStateFile(managedDoltStatePath(cityDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityDir), state); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(managedDoltStatePath(cityDir)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "dolt-server.port"), []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusError {
+		t.Fatalf("Run() status = %v, want StatusError; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+	joined := r.Message + " " + strings.Join(r.Details, " ")
+	if !strings.Contains(joined, managedPort) {
+		t.Fatalf("drift output = %q, want managed provider-state port %s", joined, managedPort)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityDir)); !os.IsNotExist(err) {
+		t.Fatalf("drift check should not publish runtime state, stat err = %v", err)
+	}
+}
+
 func TestDoltDriftCheckDetectsLiveRigLocalDolt(t *testing.T) {
 	cityDir, rigDir, _, cfg := managedCityDriftFixture(t, "runner")
 	ln := listenOnRandomPort(t)

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -303,7 +303,7 @@ func stopCityManagedBeadsProvider(cityPath string) (bool, error) {
 	if rawBeadsProvider(cityPath) != "bd" {
 		return false, nil
 	}
-	if currentManagedDoltPort(cityPath) == "" {
+	if currentResolvableManagedDoltPort(cityPath) == "" {
 		return false, nil
 	}
 	return true, shutdownBeadsProviderForStop(cityPath)

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -661,6 +661,35 @@ func TestCmdStopInvalidConfigManagedRuntimeFailsWhenShutdownFails(t *testing.T) 
 	}
 }
 
+func TestStopCityManagedBeadsProviderUsesProviderStateWhenPublishedStateIsMissing(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
+	cityDir := t.TempDir()
+	_ = writeReachableProviderManagedDoltState(t, cityDir)
+
+	var shutdowns int
+	overrideShutdownBeadsProviderForStop(t, func(path string) error {
+		shutdowns++
+		assertSameTestPath(t, path, cityDir)
+		return nil
+	})
+
+	stopped, err := stopCityManagedBeadsProvider(cityDir)
+	if err != nil {
+		t.Fatalf("stopCityManagedBeadsProvider() error = %v", err)
+	}
+	if !stopped {
+		t.Fatal("stopCityManagedBeadsProvider() stopped = false, want true")
+	}
+	if shutdowns != 1 {
+		t.Fatalf("shutdown calls = %d, want 1", shutdowns)
+	}
+	if _, err := os.Stat(managedDoltStatePath(cityDir)); !os.IsNotExist(err) {
+		t.Fatalf("stop detection should not publish runtime state, stat err = %v", err)
+	}
+}
+
 func setupInvalidConfigManagedRuntime(t *testing.T) string {
 	t.Helper()
 

--- a/cmd/gc/dolt_runtime_publication.go
+++ b/cmd/gc/dolt_runtime_publication.go
@@ -158,6 +158,10 @@ func publishManagedDoltRuntimeState(cityPath string) error {
 		state = repaired
 	}
 
+	return publishManagedDoltRuntimeStateFromState(cityPath, state)
+}
+
+func publishManagedDoltRuntimeStateFromState(cityPath string, state doltRuntimeState) error {
 	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), state); err != nil {
 		return fmt.Errorf("write published dolt runtime state: %w", err)
 	}
@@ -178,14 +182,36 @@ func clearManagedDoltRuntimeState(cityPath string) error {
 }
 
 func publishManagedDoltRuntimeStateIfOwned(cityPath string) error {
+	_, err := publishManagedDoltRuntimeStateIfOwnedResult(cityPath)
+	return err
+}
+
+func publishManagedDoltRuntimeStateIfOwnedResult(cityPath string) (bool, error) {
 	owned, err := managedDoltLifecycleOwned(cityPath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !owned {
-		return nil
+		return false, nil
 	}
-	return publishManagedDoltRuntimeState(cityPath)
+	if err := publishManagedDoltRuntimeState(cityPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func publishManagedDoltRuntimeStateIfOwnedResultFromState(cityPath string, state doltRuntimeState) (bool, error) {
+	owned, err := managedDoltLifecycleOwned(cityPath)
+	if err != nil {
+		return false, err
+	}
+	if !owned {
+		return false, nil
+	}
+	if err := publishManagedDoltRuntimeStateFromState(cityPath, state); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func clearManagedDoltRuntimeStateIfOwned(cityPath string) error {

--- a/cmd/gc/dolt_runtime_test_helpers_test.go
+++ b/cmd/gc/dolt_runtime_test_helpers_test.go
@@ -42,6 +42,37 @@ func writeReachableManagedDoltState(t *testing.T, cityPath string) int {
 	return port
 }
 
+func writeReachableProviderManagedDoltState(t *testing.T, cityPath string) int {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(runtime dolt): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(city .beads/dolt): %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := writeDoltRuntimeStateFile(providerManagedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   filepath.Join(cityPath, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("write provider Dolt state: %v", err)
+	}
+	return port
+}
+
 func occupyManagedDoltPort(t *testing.T, port int) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

This teaches GC-managed Dolt target resolution to fall back to valid provider runtime state when the published managed-Dolt state file is still missing.

## What changed

- add `currentResolvableManagedDoltPort()` to prefer published runtime state but fall back to valid provider runtime state
- allow `resolvedRuntimeCityDoltTarget()` to use that provider-state port during recovery when the canonical managed target is still unpublished
- cover the gap with a focused regression test

## Why

There is a startup window where managed Dolt is already running and provider state is valid, but the published runtime state file is not present yet. During that window, GC-managed startup paths could still resolve a local managed target without a port and fall through to `127.0.0.1:0` failures.

This keeps the target resolution aligned with the real managed runtime state during that gap.

## Tests

- `go test ./cmd/gc -run 'TestBdRuntimeEnv(DoesNotUseStalePortFileWithoutManagedRuntimeState|UsesValidProviderStateWhenPublishedStateIsMissing)' -count=1`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->