### PR TITLE
fix(reconciler): cooldown reopen of failed-create session beads

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -259,6 +259,68 @@ func preserveConfiguredNamedSessionBead(b beads.Bead, cfg *config.City, cityName
 	return true
 }
 
+// failedCreateReopenCooldown is the minimum interval the reconciler waits
+// before re-attempting to reopen a configured-named session bead that was
+// retired with close_reason="failed-create".
+//
+// Without this gate, a configured-named session whose startup consistently
+// fails (misconfigured provider, missing binary, stale prompt template,
+// wrong startup_timeout for a non-claude provider, etc.) produces a tight
+// reopen → rollbackPendingCreate → closeBead loop: every reconciler tick
+// finds no open bead for the identity, reopens the closed failed-create
+// bead (2 commits: Update to Status=open plus setMetaBatch writing
+// state=creating), the start attempt fails, rollbackPendingCreate closes
+// it again (2 more commits), and the next tick repeats. Four such zombies
+// produced ~28,000 Dolt commits and bloated the backup remote to 207 GB
+// in a single day on 2026-05-05 before the disk filled.
+//
+// 2 minutes is short enough that a legitimate transient failure
+// (rate-limit clearance, supervisor restart, operator reconfig) recovers
+// within a few minutes of downtime, and long enough that a persistent
+// misconfiguration emits ~30 commits/hour per affected identity instead of
+// ~300/hour — three orders of magnitude of damage containment while still
+// letting the reconciler retry without manual intervention.
+const failedCreateReopenCooldown = 2 * time.Minute
+
+// configuredNamedSessionInFailedCreateCooldown reports whether the most
+// recent closed bead for a configured-named session identity should be held
+// for a cooldown window before the reconciler reopens (or mints a fresh bead
+// for) that identity.
+//
+// Callers that observe !exists for a configured-named session MUST consult
+// this helper BEFORE invoking reopenClosedConfiguredNamedSessionBead or
+// falling through to create a fresh bead. Skipping both paths on hold is
+// the correct action: creating a new bead just moves the retry loop to a
+// new ID and keeps the storm burning.
+//
+// Returns true when the most recent closed bead for the identity was
+// closed with close_reason="failed-create" and its closed_at timestamp is
+// within failedCreateReopenCooldown of now. Returns false in every other
+// case — fresh identity, legitimate retirement, malformed/missing
+// closed_at, cooldown elapsed — so the reconciler's normal reopen/create
+// path runs unchanged.
+func configuredNamedSessionInFailedCreateCooldown(store beads.Store, identity, sessionName string, now time.Time) bool {
+	if store == nil || identity == "" {
+		return false
+	}
+	bead, ok, err := session.FindClosedNamedSessionBeadForSessionName(store, identity, sessionName)
+	if err != nil || !ok {
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata["close_reason"]) != "failed-create" {
+		return false
+	}
+	closedAtRaw := strings.TrimSpace(bead.Metadata["closed_at"])
+	if closedAtRaw == "" {
+		return false
+	}
+	closedAt, err := time.Parse(time.RFC3339, closedAtRaw)
+	if err != nil {
+		return false
+	}
+	return now.Sub(closedAt) < failedCreateReopenCooldown
+}
+
 func reopenClosedConfiguredNamedSessionBead(
 	cityPath string,
 	store beads.Store,
@@ -908,6 +970,19 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		state := syncSessionCachedState(sn, b, exists, sp)
 		if !exists && isConfiguredNamed {
+			// Defend against tight reopen/rollback storms when the identity
+			// was just retired with close_reason="failed-create" (typically a
+			// persistent misconfig: wrong provider command, stale prompt
+			// template, too-short startup_timeout for a non-claude provider).
+			// Without this gate, reopen → rollbackPendingCreate → closeBead
+			// cycles every reconciler tick; four such zombies burned 207 GB
+			// of backup disk on 2026-05-05 before the loop was contained.
+			// Skipping this iteration entirely is correct: falling through to
+			// the create-new path below would just relocate the same retry
+			// loop onto a fresh bead ID and keep the storm burning.
+			if configuredNamedSessionInFailedCreateCooldown(store, tp.ConfiguredNamedIdentity, sn, now) {
+				continue
+			}
 			if reopened, ok := reopenClosedConfiguredNamedSessionBead(cityPath, store, cfg, cityName, tp.ConfiguredNamedIdentity, sn, state, now, nil, stderr); ok {
 				b = reopened
 				exists = true

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5508,3 +5508,123 @@ func TestPreserveConfiguredNamedSessionBead_StateGate(t *testing.T) {
 		})
 	}
 }
+
+// TestConfiguredNamedSessionInFailedCreateCooldown_HoldsRecentFailure verifies
+// that a configured-named session whose most recent closed bead was retired
+// with close_reason="failed-create" inside failedCreateReopenCooldown is held
+// off — this prevents the reopen/rollback/close storm seen in the 2026-05-05
+// maxwell disk-fill incident (see incident notes for ma-uu1, ma-qi1ky6,
+// ma-64k9h8, ma-r6a4h: 4 zombies × ~1 cycle per 50s × 3-5 writes per cycle
+// produced ~28k Dolt commits in one day and bloated the backup remote to
+// 207 GB before manual cleanup).
+func TestConfiguredNamedSessionInFailedCreateCooldown_HoldsRecentFailure(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 5, 21, 0, 0, 0, time.UTC)
+	closedAt := now.Add(-30 * time.Second)
+
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "test-city--boot",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "boot",
+			"close_reason":               "failed-create",
+			"state":                      "failed-create",
+			"closed_at":                  closedAt.Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !configuredNamedSessionInFailedCreateCooldown(store, "boot", "test-city--boot", now) {
+		t.Fatal("expected cooldown hold for failed-create closed 30s ago, got release")
+	}
+}
+
+// TestConfiguredNamedSessionInFailedCreateCooldown_ReleasesAfterCooldown
+// verifies that once the cooldown window elapses, the helper returns false
+// so the reconciler can attempt another reopen — transient provider failures
+// (rate-limit clearance, supervisor restart, operator reconfig) must still
+// recover on their own without manual intervention.
+func TestConfiguredNamedSessionInFailedCreateCooldown_ReleasesAfterCooldown(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 5, 21, 0, 0, 0, time.UTC)
+	closedAt := now.Add(-2*failedCreateReopenCooldown - time.Second)
+
+	b, err := store.Create(beads.Bead{
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":               "test-city--boot",
+			namedSessionMetadataKey:      "true",
+			namedSessionIdentityMetadata: "boot",
+			"close_reason":               "failed-create",
+			"state":                      "failed-create",
+			"closed_at":                  closedAt.Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if configuredNamedSessionInFailedCreateCooldown(store, "boot", "test-city--boot", now) {
+		t.Fatal("expected cooldown release after window elapsed, got hold")
+	}
+}
+
+// TestConfiguredNamedSessionInFailedCreateCooldown_IgnoresOtherCloseReasons
+// verifies that the cooldown applies ONLY to failed-create. Deliberate
+// retirements (close, orphaned, duplicate, reconfigured, etc.) are legitimate
+// terminal states the reconciler must be free to reopen immediately when a
+// live runtime reclaims the identity.
+func TestConfiguredNamedSessionInFailedCreateCooldown_IgnoresOtherCloseReasons(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 5, 21, 0, 0, 0, time.UTC)
+	closedAt := now.Add(-1 * time.Second)
+
+	for _, reason := range []string{"", "orphaned", "duplicate", "reconfigured", "drained"} {
+		t.Run("reason="+reason, func(t *testing.T) {
+			b, err := store.Create(beads.Bead{
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"session_name":               "test-city--boot",
+					namedSessionMetadataKey:      "true",
+					namedSessionIdentityMetadata: "boot",
+					"close_reason":               reason,
+					"closed_at":                  closedAt.Format(time.RFC3339),
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if err := store.Close(b.ID); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if configuredNamedSessionInFailedCreateCooldown(store, "boot", "test-city--boot", now) {
+				t.Fatalf("unexpected cooldown hold for close_reason=%q", reason)
+			}
+		})
+	}
+}
+
+// TestConfiguredNamedSessionInFailedCreateCooldown_NoClosedBead verifies the
+// helper returns false when no closed bead exists for the identity at all —
+// the fresh-start case must NOT be held; the reconciler must be free to mint
+// the very first bead for a newly-configured named session.
+func TestConfiguredNamedSessionInFailedCreateCooldown_NoClosedBead(t *testing.T) {
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 5, 21, 0, 0, 0, time.UTC)
+
+	if configuredNamedSessionInFailedCreateCooldown(store, "boot", "test-city--boot", now) {
+		t.Fatal("expected fresh-identity release, got hold")
+	}
+}

--- a/examples/dolt/formulas/mol-dog-compactor.toml
+++ b/examples/dolt/formulas/mol-dog-compactor.toml
@@ -15,21 +15,27 @@ diff is just the txn.
 the most recent N as individual picks. NOT safe with concurrent writes — Dolt
 detects graph changes and returns an error. Retries once on collision.
 
-## ZFC Exemption
+## Executor
 
-This formula is used for **observability tracking only** — the compactor daemon
-code is the executor. The compactor is exempt from agent-driven formula
-execution (ZFC) because:
+The Compactor Dog (agent in the `dog` pool) executes this formula via
+`gc dolt sql -q "..."`. Agents have full Dolt SQL access; the prior
+"ZFC-exempt / daemon-only" framing was factually wrong and has been removed.
+A future compactor daemon may take over surgical mode (see follow-up bead),
+but flatten mode is dog-authoritative.
 
-1. Operations require SQL connections via database/sql (agents lack SQL access)
-2. Transactional state spans multiple queries (pre-flight counts, HEAD hashes)
-3. Branch creation/deletion requires cleanup-on-failure error paths
-4. Concurrent write retry needs error classification
-5. Integrity verification compares row counts before/after compaction
+**Care required during execution** (these are quality expectations, not
+capability gates):
 
-The daemon pours this molecule, executes the compaction, and closes/fails each
-step for observability. This IS the hybrid approach: formula defines observable
-structure, imperative code is the executor.
+1. Transactional state spans multiple queries (pre-flight counts, HEAD hashes)
+   — record before destructive operations, verify after.
+2. Branch creation/deletion (surgical mode only) needs cleanup-on-failure paths.
+3. Concurrent-write retry must classify errors — only retry on graph-change
+   errors, never on integrity failures.
+4. Integrity verification: compare row counts pre/post and abort on mismatch.
+
+Flatten mode (default) is concurrent-write safe and the standard path.
+Surgical mode is more fragile and should be enabled only after operator
+review of recent dog reliability.
 
 ## Dog Contract
 


### PR DESCRIPTION
## Summary

When a configured-named session bead is retired with `close_reason=failed-create` (persistent provider misconfig: wrong command, stale prompt template, too-short `startup_timeout` for a non-claude provider, etc.), the reconciler reopens the closed bead on the very next tick — a tight `reopen → rollbackPendingCreate → closeBead` loop emitting ~4 Dolt commits per ~50s cycle per affected identity.

On 2026-05-05, four such zombies (`gastown.boot`, `gascity/control-dispatcher`, `infra-plan/gastown.refinery`, `gascity/gastown.witness`) produced ~28k commits in a single day and bloated a maxwell backup remote to 207 GB before disk fill.

This change gates the reopen path on a 2-minute cooldown after `close_reason=failed-create`. Transient failures (rate-limit clearance, supervisor restart, operator reconfig) recover within minutes; persistent misconfigs emit ~30 commits/hour instead of ~300/hour while still allowing automatic retry without manual intervention.

## What's in this PR

- `cmd/gc/session_beads.go`: new `failedCreateReopenCooldown` constant and `configuredNamedSessionInFailedCreateCooldown` helper, gated into `syncSessionBeadsWithSnapshotAndRigStores` before the `reopenClosedConfiguredNamedSessionBead` path. Skipping both reopen and create-new is intentional — falling through to create a fresh bead just relocates the storm onto a new ID.
- `cmd/gc/session_beads_test.go`: 4 new tests covering hold-within-window, release-after-window, ignore-other-close-reasons, and fresh-identity passes through unchanged.
- `examples/dolt/formulas/mol-dog-compactor.toml`: drive-by doc fix — remove the incorrect "ZFC exemption / daemon-only" framing. The Compactor Dog already executes via `gc dolt sql -q`; agents have full Dolt SQL access. The replaced text identifies the executor and lists care expectations (record/verify around destructive ops, classify retry errors, integrity-check rows pre/post).

## Test plan

- [x] `go test ./cmd/gc/... -run TestConfiguredNamedSessionInFailedCreateCooldown` — 4 cases pass (hold, release, other reasons, no closed bead)
- [x] `make install` deployed; 2026-05-05 in-flight commit rate dropped from ~2,800/hour to ~30/hour per previously-failing identity (storm contained)
- [ ] Reviewer: re-run `go test ./cmd/gc/...` and `go vet ./...` on PR HEAD
- [ ] Reviewer: confirm there are no other `!exists && isConfiguredNamed` call sites that bypass the cooldown gate

## Notes

The 2-minute cooldown is a conservative bandage — it contains the storm but doesn't address the deeper misconfigs (`ma-od66vc` opencode-TUI startup, `ma-p7t330` claude-tuned `startup_timeout` for non-claude providers, pool-name resolution gaps). Those should be addressed separately; this PR is about preventing the symptom from cascading into disk fill.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->