### PR TITLE
fix gc-work skill: use gc bd instead of bare bd commands

### DIFF
--- a/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
+++ b/internal/bootstrap/packs/core/skills/gc-work/SKILL.md
@@ -6,7 +6,7 @@ description: Finding, creating, claiming, and closing work items (beads)
 # Work Items (Beads)
 
 Everything in Gas City is a bead — tasks, messages, molecules, convoys.
-The `bd` CLI is the primary interface for bead CRUD.
+The `gc bd` CLI is the primary interface for bead CRUD.
 
 ## Rig-scoped beads
 
@@ -25,37 +25,37 @@ Use `gc rig list` to see rig names, paths, and prefixes.
 be dispatched to a rig-scoped agent, create the bead in that agent's rig:
 
 ```
-bd create "title" --rig frontend         # Create in frontend's db (fe- prefix)
-bd create "title" --rig beads            # Create in beads db (be- prefix)
-bd create "title"                        # Create in current directory's .beads/
-bd create "title" -t bug                 # Create with type
-bd create "title" --label priority=high  # Create with labels
+gc bd create "title" --rig frontend         # Create in frontend's db (fe- prefix)
+gc bd create "title" --rig beads            # Create in beads db (be- prefix)
+gc bd create "title"                        # Create in current directory's .beads/
+gc bd create "title" -t bug                 # Create with type
+gc bd create "title" --label priority=high  # Create with labels
 ```
 
 ## Finding work
 
 ```
-bd list                                # List beads in current .beads/
-bd list --dir /path/to/rig             # List beads in a specific rig
-bd ready                               # List beads available for claiming
-bd ready --label role:worker           # Filter by label
-bd show <id>                           # Show bead details
+gc bd list                                # List beads in current .beads/
+gc bd list --rig <rigname>                # List beads in a specific rig
+gc bd ready                               # List beads available for claiming
+gc bd ready --label role:worker           # Filter by label
+gc bd show <id>                           # Show bead details
 ```
 
 ## Claiming and updating
 
 ```
-bd update <id> --claim                 # Claim a bead (sets assignee + in_progress)
-bd update <id> --status in_progress    # Update status
-bd update <id> --label <key>=<value>   # Add/update labels
-bd update <id> --note "progress..."    # Add a note
+gc bd update <id> --claim                 # Claim a bead (sets assignee + in_progress)
+gc bd update <id> --status in_progress    # Update status
+gc bd update <id> --label <key>=<value>   # Add/update labels
+gc bd update <id> --note "progress..."    # Add a note
 ```
 
 ## Closing work
 
 ```
-bd close <id>                          # Close a completed bead
-bd close <id> --reason "done"          # Close with reason
+gc bd close <id>                          # Close a completed bead
+gc bd close <id> --reason "done"          # Close with reason
 ```
 
 ## Hooks


### PR DESCRIPTION
## Summary

- Fixes #1771

## Testing

- [x] `make check`
- [x] ~`make check-docs` if docs, navigation, or links changed~ N/A
- [x] ~`make test-integration` if runtime, controller, or workflow behavior changed~ N/A

## Checklist

- [x] Linked an issue, or explained why one is not needed
- [x] ~Added or updated tests for behavior changes~ N/A
- [x] ~Updated docs for user-facing changes~ N/A
- [x] Called out breaking changes or migration notes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->