### PR TITLE
fix(orders): synchronize m.stderr writes from parallel dispatch goroutines

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -82,6 +82,28 @@ func logDispatchError(stderr io.Writer, format string, args ...any) {
 	}
 }
 
+// lockedWriter serializes Write calls so concurrent dispatchOne goroutines
+// logging via logDispatchError(m.stderr, ...) do not interleave bytes.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (lw *lockedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.w.Write(p)
+}
+
+// lockedStderr wraps w for storage on memoryOrderDispatcher.stderr. Returns
+// nil unchanged so logDispatchError's nil-guard keeps its original semantics.
+func lockedStderr(w io.Writer) io.Writer {
+	if w == nil {
+		return nil
+	}
+	return &lockedWriter{w: w}
+}
+
 type orderStoreFunc func(execStoreTarget) (beads.Store, error)
 
 // memoryOrderDispatcher is the production implementation.
@@ -160,7 +182,7 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 		ep:             ep,
 		execRun:        shellExecRunner,
 		rec:            rec,
-		stderr:         stderr,
+		stderr:         lockedStderr(stderr),
 		maxTimeout:     cfg.Orders.MaxTimeoutDuration(),
 		cfg:            cfg,
 		cityName:       loadedCityName(cfg, cityPath),

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2788,7 +2789,7 @@ func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep e
 		ep:             ep,
 		execRun:        execRun,
 		rec:            rec,
-		stderr:         &bytes.Buffer{},
+		stderr:         lockedStderr(&bytes.Buffer{}),
 		cfg:            cfg,
 		dispatchCtx:    dispatchCtx,
 		dispatchCancel: dispatchCancel,
@@ -4226,5 +4227,55 @@ func TestOrderDispatcherCancelTerminatesInFlight(t *testing.T) {
 	case <-drainDone:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("drain did not return promptly after cancel()")
+	}
+}
+
+// lockedWriter must serialize concurrent Write calls so log lines emitted
+// from parallel dispatchOne goroutines do not interleave. Run under -race
+// to also catch the underlying data race on the shared writer.
+func TestLockedWriterSerializesConcurrentWrites(t *testing.T) {
+	var buf bytes.Buffer
+	lw := &lockedWriter{w: &buf}
+	const goroutines = 16
+	const writesPerG = 100
+	line := []byte("dispatch err line\n")
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < writesPerG; j++ {
+				if _, err := lw.Write(line); err != nil {
+					t.Errorf("Write: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	wantBytes := goroutines * writesPerG * len(line)
+	if got := buf.Len(); got != wantBytes {
+		t.Fatalf("buffer length: got %d, want %d (suggests torn or lost writes)", got, wantBytes)
+	}
+	wantLine := bytes.TrimRight(line, "\n")
+	for i, l := range bytes.Split(bytes.TrimRight(buf.Bytes(), "\n"), []byte{'\n'}) {
+		if !bytes.Equal(l, wantLine) {
+			t.Fatalf("line %d: got %q, want %q (interleaved bytes)", i, l, wantLine)
+		}
+	}
+}
+
+func TestLockedStderrPreservesNil(t *testing.T) {
+	if got := lockedStderr(nil); got != nil {
+		t.Fatalf("lockedStderr(nil): got %v, want nil", got)
+	}
+}
+
+func TestLockedStderrWrapsNonNil(t *testing.T) {
+	var buf bytes.Buffer
+	w := lockedStderr(&buf)
+	if _, ok := w.(*lockedWriter); !ok {
+		t.Fatalf("lockedStderr(non-nil): got %T, want *lockedWriter", w)
 	}
 }


### PR DESCRIPTION
## Summary

`memoryOrderDispatcher.dispatch` spawns one `dispatchOne` goroutine per due order. Each goroutine may call `logDispatchError(m.stderr, …)` if its order errors out — but `m.stderr` is unsynchronized. `go test -race` flags concurrent writes on `bytes.Buffer.Write` (test fakes); production writes to `os.Stderr` are also undefined per Go docs (atomic per-`write(2)` for small payloads, unspecified inter-call ordering).

Wrap `stderr` in a small mutex-guarded writer at construction time so the call sites stay unchanged. Both construction paths get the wrap:
- `buildOrderDispatcher` (production)
- `buildOrderDispatcherFromListExec` (test helper that constructs `memoryOrderDispatcher` directly)

`lockedStderr` returns `nil` for `nil` input so `logDispatchError`'s existing nil-guard keeps its semantics.

## Testing

- [x] `make check` — 5 pre-existing failures, all documented EXPECT-FAIL on macOS, none introduced by this PR (verified by stashing the change and re-running the same tests in isolation):
  - `TestExecCommandRunnerTimeoutKillsChildProcess` — fixed by #1729
  - `TestBuiltinDoltDoctorReportsTimedOutVersionProbe` — fixed by #1729
  - `TestBuiltinDoltDoctorBoundsVersionProbe` — fixed by #1729
  - `TestCityRuntimeManualReloadPanicAfterReloadKeepsReloadReplyAndClears` — fixed by #1741
  - `TestCityRuntimeWatchReloadPanicRestoresDirty` — sibling of the above (TempDir cleanup race under parallel load); pre-existing flake under `make check`, no fix-PR yet
- [x] `go test -race -count=3 -run '^TestCityRuntimeManualReloadPanicAfterReloadKeepsReloadReplyAndClears$' ./cmd/gc/` — race gone (was flagged by the race detector before this change)
- [x] `go test -race -count=1 -run '^TestLockedWriter|^TestLockedStderr' ./cmd/gc/` — green
- [x] `go test -race -count=1 -run 'OrderDispatch|CityRuntimeShutdown|TestSweep|CityRuntimeManualReload|TestLockedWriter|TestLockedStderr' -skip '^TestOrderDispatchRejectsAmbiguousPackPool$' ./cmd/gc/` — green
- [ ] `make check-docs` — no docs changed, skipped
- [ ] `make test-integration` — not run; past attempts have hit the 30-min timeout with no saved partial output

### Note: separate pre-existing race observed

`TestOrderDispatchRejectsAmbiguousPackPool` trips a different race under `-race`: the test fake `memRecorder` is read from the test goroutine while `dispatchOne` is still writing to it. Different surface (test fake field, not `m.stderr`), pre-existing on origin/main, **out of scope for this PR**. Skipped via `-skip` in the broader race check above.

## Checklist

- [ ] Linked an issue, or explained why one is not needed — internal stg-fxm; this is the externally-tracked half
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes — none, internal synchronization
- [ ] Called out breaking changes or migration notes — none

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->