### PR TITLE
fix: keep assigned sessions out of new demand

### DIFF
--- a/cmd/gc/agent_build_params.go
+++ b/cmd/gc/agent_build_params.go
@@ -44,6 +44,11 @@ type agentBuildParams struct {
 	// desired-state build so per-agent resolution does not rescan the store.
 	sessionBeads *sessionBeadSnapshot
 
+	// assignedWorkBeads is the actionable assigned-work snapshot for this
+	// build. Pool new-tier materialization uses it to avoid treating sessions
+	// that already own work as available generic capacity.
+	assignedWorkBeads []beads.Bead
+
 	// beadNames caches qualifiedName → session_name mappings resolved
 	// during this build cycle. Populated lazily by resolveSessionName.
 	beadNames map[string]string

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -349,6 +349,7 @@ func buildDesiredStateWithSessionBeads(
 			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed for %s, retaining affected sessions\n", strings.Join(sortedBoolMapKeys(scaleCheckPartialTemplates), ",")) //nolint:errcheck
 		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
+		bp.assignedWorkBeads = poolWorkBeads
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)
 		for _, poolState := range poolDesiredStates {
 			cfgAgent := findAgentByTemplate(cfg, poolState.Template)
@@ -1898,6 +1899,9 @@ func selectOrCreatePoolSessionBead(
 		if isNamedSessionBead(bead) {
 			continue
 		}
+		if sessionBeadHasAssignedWork(bp.assignedWorkBeads, bead) {
+			continue
+		}
 		if used[bead.ID] {
 			continue
 		}
@@ -1909,6 +1913,22 @@ func selectOrCreatePoolSessionBead(
 		}
 	}
 	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp))
+}
+
+func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
+	for _, wb := range workBeads {
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
+			continue
+		}
+		if assignee == sessionBead.ID || assignee == strings.TrimSpace(sessionBead.Metadata["session_name"]) {
+			return true
+		}
+		if namedIdentity := strings.TrimSpace(sessionBead.Metadata["configured_named_identity"]); namedIdentity != "" && assignee == namedIdentity {
+			return true
+		}
+	}
+	return false
 }
 
 func selectOrCreateDependencyPoolSessionBead(

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4572,6 +4572,46 @@ func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 	}
 }
 
+func TestSelectOrCreatePoolSessionBead_SkipsAssignedForNewTier(t *testing.T) {
+	store := beads.NewMemStore()
+	assigned, err := store.Create(beads.Bead{
+		Title:  "claude",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "claude",
+			"agent_name":   "claude",
+			"session_name": "claude-assigned",
+			"state":        "active",
+			"pool_managed": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.add(assigned)
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	bp := &agentBuildParams{
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+		assignedWorkBeads: []beads.Bead{{
+			ID:       "w-assigned",
+			Status:   "in_progress",
+			Assignee: assigned.ID,
+		}},
+	}
+
+	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+	}
+	if result.ID == assigned.ID {
+		t.Fatal("new-tier should not reuse a session bead that has assigned work")
+	}
+}
+
 func TestSelectOrCreatePoolSessionBead_SkipsAsleepBeads(t *testing.T) {
 	// An asleep pool session should NOT be reused for new demand.
 	// The reconciler should create a fresh session instead.

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -157,17 +157,24 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			continue
 		}
 		active := collectActiveBeads(input.SessionBeads, template)
-		for i, bead := range active {
-			if i >= count {
+		filled := 0
+		for _, bead := range active {
+			if filled >= count {
 				break
 			}
+			if sessionHasConcreteAssignedWork(input.WorkBeads, bead) {
+				continue
+			}
 			desired[bead.SessionName] = "scaled:demand"
+			filled++
 		}
 		creating := collectCreatingBeads(input.SessionBeads, template)
-		filled := len(active)
 		for _, bead := range creating {
 			if filled >= count {
 				break
+			}
+			if sessionHasConcreteAssignedWork(input.WorkBeads, bead) {
+				continue
 			}
 			desired[bead.SessionName] = "scaled:creating"
 			filled++
@@ -381,6 +388,19 @@ func collectActiveBeads(beads []AwakeSessionBead, template string) []AwakeSessio
 		}
 	}
 	return result
+}
+
+func sessionHasConcreteAssignedWork(workBeads []AwakeWorkBead, bead AwakeSessionBead) bool {
+	for _, wb := range workBeads {
+		assignee := strings.TrimSpace(wb.Assignee)
+		if assignee == "" || (wb.Status != "open" && wb.Status != "in_progress") {
+			continue
+		}
+		if assignee == bead.ID || assignee == bead.SessionName {
+			return true
+		}
+	}
+	return false
 }
 
 func isOnDemandSession(named []AwakeNamedSession, bead AwakeSessionBead) bool {

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -341,6 +342,48 @@ func TestScaled_Demand2_OneActive(t *testing.T) {
 	})
 	assertAwake(t, result, "polecat-mc-1")
 	assertAsleep(t, result, "polecat-mc-2") // asleep ephemerals not reused
+}
+
+func TestScaled_NewDemandDoesNotUseActiveAssignedSessions(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/polecat"}},
+		SessionBeads: []AwakeSessionBead{
+			{ID: "mc-assigned-1", SessionName: "polecat-assigned-1", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-assigned-2", SessionName: "polecat-assigned-2", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-assigned-3", SessionName: "polecat-assigned-3", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-assigned-4", SessionName: "polecat-assigned-4", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-assigned-5", SessionName: "polecat-assigned-5", Template: "hello-world/polecat", State: "active"},
+			{ID: "mc-new-1", SessionName: "polecat-new-1", Template: "hello-world/polecat", State: "creating"},
+			{ID: "mc-new-2", SessionName: "polecat-new-2", Template: "hello-world/polecat", State: "creating"},
+			{ID: "mc-new-3", SessionName: "polecat-new-3", Template: "hello-world/polecat", State: "creating"},
+			{ID: "mc-new-4", SessionName: "polecat-new-4", Template: "hello-world/polecat", State: "creating"},
+			{ID: "mc-new-5", SessionName: "polecat-new-5", Template: "hello-world/polecat", State: "creating"},
+		},
+		WorkBeads: []AwakeWorkBead{
+			{ID: "w-assigned-1", Assignee: "mc-assigned-1", Status: "in_progress"},
+			{ID: "w-assigned-2", Assignee: "mc-assigned-2", Status: "in_progress"},
+			{ID: "w-assigned-3", Assignee: "mc-assigned-3", Status: "in_progress"},
+			{ID: "w-assigned-4", Assignee: "mc-assigned-4", Status: "in_progress"},
+			{ID: "w-assigned-5", Assignee: "mc-assigned-5", Status: "in_progress"},
+		},
+		ScaleCheckCounts: map[string]int{"hello-world/polecat": 5},
+		RunningSessions: map[string]bool{
+			"polecat-assigned-1": true,
+			"polecat-assigned-2": true,
+			"polecat-assigned-3": true,
+			"polecat-assigned-4": true,
+			"polecat-assigned-5": true,
+		},
+		Now: now,
+	})
+
+	for i := 1; i <= 5; i++ {
+		suffix := strconv.Itoa(i)
+		assertAwake(t, result, "polecat-assigned-"+suffix)
+		assertReason(t, result, "polecat-assigned-"+suffix, "assigned-work")
+		assertAwake(t, result, "polecat-new-"+suffix)
+		assertReason(t, result, "polecat-new-"+suffix, "scaled:creating")
+	}
 }
 
 func TestScaled_Demand1_TwoActive(t *testing.T) {

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -624,6 +625,42 @@ func TestComputePoolDesiredStates_ScaleCheckAndResumeAddUp(t *testing.T) {
 	}
 	if resumeCount != 1 || newCount != 2 {
 		t.Errorf("resume=%d new=%d, want resume=1 new=2", resumeCount, newCount)
+	}
+}
+
+func TestComputePoolDesiredStates_AssignedSessionsDoNotConsumeNewDemand(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "", intPtr(20), 0)},
+	}
+	var work []beads.Bead
+	var sessions []beads.Bead
+	for i := 1; i <= 5; i++ {
+		suffix := strconv.Itoa(i)
+		sessionID := "sess-" + suffix
+		work = append(work, workBead("w"+suffix, "claude", sessionID, "in_progress", 0))
+		sessions = append(sessions, sessionBead(sessionID, "open"))
+	}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, map[string]int{"claude": 5})
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if got := len(result[0].Requests); got != 10 {
+		t.Fatalf("len(requests) = %d, want 10 (5 assigned resume + 5 new ready)", got)
+	}
+	resumeCount := 0
+	newCount := 0
+	for _, request := range result[0].Requests {
+		switch request.Tier {
+		case "resume":
+			resumeCount++
+		case "new":
+			newCount++
+		}
+	}
+	if resumeCount != 5 || newCount != 5 {
+		t.Fatalf("request tiers = resume:%d new:%d, want resume:5 new:5", resumeCount, newCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep active sessions with concrete assigned work out of new pool-demand capacity accounting
- skip assigned session beads when materializing new-tier pool demand
- add regression coverage for assigned sessions plus fresh ready demand producing total desired capacity

## Tests
- go test ./cmd/gc -run 'TestSelectOrCreatePoolSessionBead_SkipsAssignedForNewTier|TestComputePoolDesiredStates_AssignedSessionsDoNotConsumeNewDemand|TestScaled_NewDemandDoesNotUseActiveAssignedSessions|TestComputePoolDesiredStates_InFlightNewSessionsConsumeScaleDemand|TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier'\n- go test ./cmd/gc -run 'TestComputePoolDesiredStates_|TestScaled_|TestSelectOrCreatePoolSessionBead_'\n- pre-commit hook: GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->