### PR TITLE
feat(doctor): add pre-start-scripts check for missing pack scripts

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -144,6 +144,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		}
 		d.Register(doctor.NewConfigValidCheck(cfg))
 		d.Register(doctor.NewConfigRefsCheck(cfg, cityPath))
+		d.Register(doctor.NewPreStartScriptsCheck(cfg))
 		d.Register(doctor.NewBuiltinPackFamilyCheck(cfg, cityPath))
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		d.Register(doctor.NewDurationRangeCheck(cfg))

--- a/internal/doctor/pre_start_scripts_check.go
+++ b/internal/doctor/pre_start_scripts_check.go
@@ -1,0 +1,111 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// PreStartScriptsCheck verifies that script paths referenced via
+// {{.ConfigDir}} in any agent's pre_start command exist on disk.
+// Missing scripts cause "exit status 127" at runtime when the
+// reconciler tries to start the agent. Only checks resolvable static
+// references — commands without {{.ConfigDir}}, or whose first token
+// still contains other unresolved templates after substitution, are
+// skipped because they require runtime context to evaluate.
+type PreStartScriptsCheck struct {
+	cfg *config.City
+}
+
+// NewPreStartScriptsCheck creates a check that validates pre_start
+// script references for every pack-shipped agent in cfg.
+func NewPreStartScriptsCheck(cfg *config.City) *PreStartScriptsCheck {
+	return &PreStartScriptsCheck{cfg: cfg}
+}
+
+// Name returns the check identifier.
+func (c *PreStartScriptsCheck) Name() string { return "pre-start-scripts" }
+
+// CanFix returns false — missing scripts must be authored by the user
+// or shipped with the pack.
+func (c *PreStartScriptsCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *PreStartScriptsCheck) Fix(_ *CheckContext) error { return nil }
+
+// Run iterates each pack agent's pre_start commands and warns when a
+// {{.ConfigDir}}-relative script is missing on disk.
+func (c *PreStartScriptsCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		r.Status = StatusOK
+		r.Message = "no city config loaded"
+		return r
+	}
+	var issues []string
+	for _, a := range c.cfg.Agents {
+		// Inline (city.toml) agents have no SourceDir to resolve
+		// {{.ConfigDir}} against — skip them.
+		if a.SourceDir == "" {
+			continue
+		}
+		for _, cmd := range a.PreStart {
+			scriptPath, ok := resolvePreStartScript(cmd, a.SourceDir)
+			if !ok {
+				continue
+			}
+			if _, err := os.Stat(scriptPath); err == nil {
+				continue
+			} else if !os.IsNotExist(err) {
+				continue
+			}
+			rel, relErr := filepath.Rel(a.SourceDir, scriptPath)
+			if relErr != nil {
+				rel = scriptPath
+			}
+			issues = append(issues, fmt.Sprintf("agent %q: pre_start script %q not found", a.QualifiedName(), rel))
+		}
+	}
+	if len(issues) == 0 {
+		r.Status = StatusOK
+		r.Message = "all pre_start scripts referenced via {{.ConfigDir}} exist"
+		return r
+	}
+	sort.Strings(issues)
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("%d pre_start script(s) missing on disk", len(issues))
+	r.FixHint = "ship the missing script with the pack, or remove the pre_start reference"
+	r.Details = issues
+	return r
+}
+
+// resolvePreStartScript extracts the absolute script path from a
+// pre_start command if it references {{.ConfigDir}} cleanly. Returns
+// (path, true) when the first whitespace-separated token resolves to
+// an absolute path with no remaining template placeholders. Otherwise
+// returns ("", false) so the caller can skip the command — either it
+// is not a {{.ConfigDir}} reference, or it depends on runtime context
+// (rig, work_dir, agent identity) that doctor cannot statically
+// resolve.
+func resolvePreStartScript(cmd, sourceDir string) (string, bool) {
+	if !strings.Contains(cmd, "{{.ConfigDir}}") {
+		return "", false
+	}
+	expanded := strings.ReplaceAll(cmd, "{{.ConfigDir}}", sourceDir)
+	fields := strings.Fields(expanded)
+	if len(fields) == 0 {
+		return "", false
+	}
+	first := fields[0]
+	if strings.Contains(first, "{{") {
+		return "", false
+	}
+	if !filepath.IsAbs(first) {
+		return "", false
+	}
+	return filepath.Clean(first), true
+}

--- a/internal/doctor/pre_start_scripts_check_test.go
+++ b/internal/doctor/pre_start_scripts_check_test.go
@@ -1,0 +1,201 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestPreStartScriptsCheck_NoCfg(t *testing.T) {
+	c := NewPreStartScriptsCheck(nil)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK", r.Status)
+	}
+}
+
+func TestPreStartScriptsCheck_NoAgents(t *testing.T) {
+	c := NewPreStartScriptsCheck(&config.City{})
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK", r.Status)
+	}
+}
+
+func TestPreStartScriptsCheck_ScriptExists(t *testing.T) {
+	pack := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pack, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pack, "scripts", "setup.sh"), []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "builder",
+				SourceDir: pack,
+				PreStart:  []string{"{{.ConfigDir}}/scripts/setup.sh {{.RigRoot}} {{.WorkDir}}"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("status = %d, want OK; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+}
+
+func TestPreStartScriptsCheck_ScriptMissing(t *testing.T) {
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "wren-runner",
+				SourceDir: pack,
+				PreStart:  []string{"{{.ConfigDir}}/scripts/missing.sh args"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning; msg = %s; details = %v", r.Status, r.Message, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("expected 1 issue, got %d: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], "wren-runner") || !strings.Contains(r.Details[0], "scripts/missing.sh") {
+		t.Errorf("detail = %q; want to mention agent + missing path", r.Details[0])
+	}
+	if r.FixHint == "" {
+		t.Error("expected FixHint to be set on warning")
+	}
+}
+
+func TestPreStartScriptsCheck_InlineAgentSkipped(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "inline",
+				SourceDir: "",
+				PreStart:  []string{"{{.ConfigDir}}/scripts/whatever.sh"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("inline agents should be skipped; status = %d, msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestPreStartScriptsCheck_NoConfigDirReference(t *testing.T) {
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "agent",
+				SourceDir: pack,
+				PreStart:  []string{"mkdir -p {{.WorkDir}}/foo", "echo hello"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("commands without {{.ConfigDir}} should be skipped; status = %d, details = %v", r.Status, r.Details)
+	}
+}
+
+func TestPreStartScriptsCheck_OtherTemplateInScriptPath(t *testing.T) {
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "agent",
+				SourceDir: pack,
+				PreStart:  []string{"{{.ConfigDir}}/{{.AgentBase}}/foo.sh"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("script paths with unresolved templates should be skipped; status = %d, details = %v", r.Status, r.Details)
+	}
+}
+
+func TestPreStartScriptsCheck_MultipleAgentsSortedOutput(t *testing.T) {
+	packA := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packA, "ok.sh"), []byte("#!/bin/sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	packB := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "agent-a", SourceDir: packA, PreStart: []string{"{{.ConfigDir}}/ok.sh"}},
+			{Name: "agent-b", SourceDir: packB, PreStart: []string{"{{.ConfigDir}}/missing-z.sh", "{{.ConfigDir}}/missing-a.sh"}},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	if len(r.Details) != 2 {
+		t.Fatalf("expected 2 issues, got %d: %v", len(r.Details), r.Details)
+	}
+	for i := 1; i < len(r.Details); i++ {
+		if r.Details[i-1] > r.Details[i] {
+			t.Errorf("details not sorted: %v", r.Details)
+		}
+	}
+}
+
+func TestPreStartScriptsCheck_RelativeScriptPathSkipped(t *testing.T) {
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:      "agent",
+				SourceDir: pack,
+				PreStart:  []string{"scripts/setup.sh"}, // no ConfigDir, relative — runtime resolves CWD
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("relative paths without {{.ConfigDir}} should be skipped; status = %d, details = %v", r.Status, r.Details)
+	}
+}
+
+func TestPreStartScriptsCheck_QualifiedNameInDetail(t *testing.T) {
+	pack := t.TempDir()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{
+				Name:        "runner",
+				BindingName: "wren",
+				SourceDir:   pack,
+				PreStart:    []string{"{{.ConfigDir}}/scripts/missing.sh"},
+			},
+		},
+	}
+	c := NewPreStartScriptsCheck(cfg)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("status = %d, want Warning", r.Status)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(r.Details))
+	}
+	want := "wren.runner"
+	if !strings.Contains(r.Details[0], want) {
+		t.Errorf("detail = %q; want it to contain qualified name %q", r.Details[0], want)
+	}
+}

--- a/release-gates/ga-mvvitw-pre-start-scripts-doctor-gate.md
+++ b/release-gates/ga-mvvitw-pre-start-scripts-doctor-gate.md
@@ -1,0 +1,46 @@
+# Release gate — pre-start-scripts doctor check (ga-mvvitw / ga-lmy1)
+
+**Verdict:** PASS
+
+- Bead: `ga-mvvitw` (review of `ga-lmy1`, closed)
+- Branch: `quad341:builder/ga-lmy1-1`
+- HEAD: `fb001b57`
+- Base: `origin/main` at `5f1a686d` (was `75aba222` at PR creation; clean rebase, no diverge)
+- PR: [gastownhall/gascity#1778](https://github.com/gastownhall/gascity/pull/1778) — already opened by builder
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `fb001b57`; 2 INFO findings, none block. |
+| 2 | Acceptance criteria met | PASS | All 5 suggested-focus items in handoff verified by reviewer; 10/10 test cases cover the documented decision branches. |
+| 3 | Tests pass on final branch | PASS | `go test ./internal/doctor/ -run TestPreStartScriptsCheck -count=1` — 10/10 PASS in 5ms. |
+| 4 | No high-severity review findings open | PASS | Reviewer findings: 2 INFO (scope-of-detection comment opportunity, FixHint test pinning suggestion); 0 HIGH. |
+| 5 | Working tree clean | PASS | `git status` clean prior to gate-file commit. |
+| 6 | Branch diverges cleanly from main | PASS | 1 commit ahead, 0 behind `origin/main`. PR shows `MERGEABLE`. |
+
+## Validation (deployer re-run on `deploy/ga-mvvitw` at HEAD `fb001b57`)
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `golangci-lint run ./internal/doctor/ ./cmd/gc/` — 0 issues (golangci-lint v2.10.1)
+- `go test ./internal/doctor/ -run TestPreStartScriptsCheck -count=1` — PASS (10/10)
+
+## CI status (PR #1778)
+
+All required CI gates SUCCESS at HEAD `fb001b57`:
+- `CI / required` — SUCCESS
+- `Preflight / unit cover` — SUCCESS
+- `cmd/gc process / shards 1-2,3-4,5-6 of 6` — SUCCESS
+- `Integration / packages-core, packages-cmd-gc, packages-runtime-tmux` — SUCCESS
+- `Integration / rest-full-{1-2,3-4,5-6,7,8} of 8` — SUCCESS
+- `Worker core phase 2 (Claude/Codex/Gemini)` — SUCCESS
+- `CodeQL Analyze (actions/go/javascript-typescript/python)` — SUCCESS
+- `Dashboard SPA` — SUCCESS
+
+PR is `MERGEABLE`; no review decision required (post-CI-required gating).
+
+## Push target
+
+Branch already on fork (`quad341:builder/ga-lmy1-1`). Gate-file commit
+pushed to same branch; PR #1778 is updated in place.


### PR DESCRIPTION
## Summary

- Adds `pre-start-scripts` check to `gc doctor` that resolves
  `{{.ConfigDir}}` in each agent's `pre_start` against the agent's
  pack directory and warns when the referenced script is missing on
  disk.
- Catches the failure mode behind ga-lmy1: a pack declares
  `pre_start = ['{{.ConfigDir}}/scripts/worktree-setup.sh ...']` but
  ships the agent without `scripts/worktree-setup.sh`, so the
  reconciler fails to start the agent with `exit status 127`. The
  workaround was 8 manually-copied scripts; this check makes the
  next instance visible at config-load time instead of at runtime.
- Conservative scope: skips inline (city.toml) agents, commands that
  don't reference `{{.ConfigDir}}`, and commands whose first token
  still contains other unresolved templates (`{{.RigRoot}}`,
  `{{.WorkDir}}`, etc.) after substitution — those need runtime
  context to evaluate.

## Test plan

- [x] `TestPreStartScriptsCheck_*` — 10 cases covering nil cfg, no
      agents, valid script, missing script, inline-agent skip, no
      `{{.ConfigDir}}` skip, other templates in path skip, multiple
      agents with deterministic sorted output, relative-path skip,
      qualified-name format in details (binding.agent).
- [x] `go vet ./...` clean
- [x] `make lint` (golangci-lint) clean
- [x] Sibling `TestConfigRefsCheck_*` still passes (registration
      ordering preserved).

Closes ga-lmy1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->