### PR TITLE
fix(orders): honor IsEnabled() in dispatcher filter so orders.overrides enabled=false actually suppresses orders

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -126,9 +126,15 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 	}
 
 	// Filter out manual-trigger orders — they are never auto-dispatched.
+	// Also filter out disabled orders — ApplyOverrides above may have flipped
+	// Enabled=false on a scanned order whose formula default is enabled, and
+	// the dispatcher must honor that override (DECISION.md 2026-05-05:
+	// "[[orders.overrides]] enabled = false did not suppress the orders from
+	// firing"). The scanner pre-filter at scanner.go:85 only sees the formula
+	// default, so post-override re-filtering is required here.
 	var auto []orders.Order
 	for _, a := range allAA {
-		if a.Trigger != "manual" {
+		if a.Trigger != "manual" && a.IsEnabled() {
 			auto = append(auto, a)
 		}
 	}

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -168,6 +168,59 @@ func TestOrderDispatchManualFiltered(t *testing.T) {
 	}
 }
 
+// TestOrderDispatchDisabledFiltered guards against the orders.overrides
+// regression: ApplyOverrides correctly sets Enabled=false on the in-memory
+// Order, but if the dispatcher's auto-trigger filter only rejects
+// Trigger=="manual" and ignores IsEnabled(), every disabled order still
+// runs every reconciler tick. This is the bug DECISION.md (2026-05-05)
+// reported as "[[orders.overrides]] enabled = false did not suppress the
+// orders from firing". Disabled orders must not produce a dispatcher.
+func TestOrderDispatchDisabledFiltered(t *testing.T) {
+	disabled := false
+	ad := buildOrderDispatcherFromList(
+		[]orders.Order{{
+			Name:     "disabled-cooldown",
+			Trigger:  "cooldown",
+			Interval: "1m",
+			Formula:  "noop",
+			Pool:     "worker",
+			Enabled:  &disabled,
+		}},
+		beads.NewMemStore(), nil,
+	)
+	if ad != nil {
+		t.Error("expected nil dispatcher — disabled orders must be filtered out (orders.overrides enabled=false)")
+	}
+}
+
+// TestOrderDispatchEnabledFalseOverrideTakesEffect is the end-to-end
+// regression for the ApplyOverrides → buildOrderDispatcher pipeline that
+// DECISION.md flagged. A scanned order arrives Enabled=nil (meaning "use
+// formula default = enabled"); a city.toml [[orders.overrides]] with
+// enabled=false should flip it; the dispatcher's filter must respect that.
+func TestOrderDispatchEnabledFalseOverrideTakesEffect(t *testing.T) {
+	scanned := []orders.Order{{
+		Name:     "noisy-cooldown",
+		Trigger:  "cooldown",
+		Interval: "1m",
+		Formula:  "noop",
+		Pool:     "worker",
+		// Enabled deliberately nil — defaults to "enabled" per IsEnabled().
+	}}
+	disabled := false
+	overrides := []orders.Override{{Name: "noisy-cooldown", Enabled: &disabled}}
+	if err := orders.ApplyOverrides(scanned, overrides); err != nil {
+		t.Fatalf("ApplyOverrides: %v", err)
+	}
+	if scanned[0].IsEnabled() {
+		t.Fatal("ApplyOverrides did not flip Enabled to false; helper changed shape?")
+	}
+	ad := buildOrderDispatcherFromList(scanned, beads.NewMemStore(), nil)
+	if ad != nil {
+		t.Error("expected nil dispatcher after enabled=false override — buildOrderDispatcher filter ignores IsEnabled()")
+	}
+}
+
 func TestOrderDispatchCooldownDue(t *testing.T) {
 	store := beads.NewMemStore()
 
@@ -2762,7 +2815,7 @@ func buildOrderDispatcherFromListExec(aa []orders.Order, store beads.Store, ep e
 	cfg := &config.City{}
 	seenRigs := make(map[string]bool)
 	for _, a := range aa {
-		if a.Trigger != "manual" {
+		if a.Trigger != "manual" && a.IsEnabled() {
 			auto = append(auto, a)
 		}
 		if a.Rig != "" && !seenRigs[a.Rig] {

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -930,7 +930,15 @@ func TestHandleReadinessReturnsNotInstalledForGitHubCLIWithoutBinary(t *testing.
 		providerProbePathEnv = originalPathEnv
 		providerProbeGOOS = originalGOOS
 	}()
-	providerProbeGOOS = "linux"
+	// Use a sentinel GOOS so searchpath.Expand skips the unconditional
+	// platform path injection (linux: /snap/bin, /home/linuxbrew/.linuxbrew/bin;
+	// darwin: /opt/homebrew/bin, /opt/local/bin). On dev machines with brew
+	// installed, those leak into the search and let findProbeBinary find a
+	// real gh outside the sandboxed homeDir, reporting needs_auth instead of
+	// not_installed. "test" matches no case in searchpath.Expand and preserves
+	// the test's intent: when no binary is on the configured search path, the
+	// probe must report not_installed.
+	providerProbeGOOS = "test"
 
 	state := newFakeState(t)
 	h := newTestCityHandler(t, state)


### PR DESCRIPTION
## Summary

`[[orders.overrides]] enabled = false` in `city.toml` does not actually disable orders today. The override pipeline parses correctly, `ApplyOverrides` flips `Order.Enabled` from `nil` to `false`, and `Order.IsEnabled()` reports false afterward — but the dispatcher's auto-trigger filter only rejects `Trigger == "manual"` and doesn't check `IsEnabled()`. So every disabled-by-override order keeps firing on every reconciler tick. The user-visible knob is silently a no-op.

A 2026-05-05 incident report described the symptom exactly: 18 overrides written, all parsed, beads still accumulating at ~7/min over a 90-second observation window, bring-up of a quiet single-agent pack abandoned because the override mechanism does not actually override.

## What's in this PR

**Commit 1** — `test(api): use sentinel GOOS in readiness "without binary" test to avoid host PATH leaks`
Prerequisite test fix unrelated to the orders fix but required for the suite to pass deterministically on dev machines: `internal/searchpath/searchpath.go` unconditionally appends `/snap/bin` and `/home/linuxbrew/.linuxbrew/bin` for `goos=linux`, which lets `findProbeBinary("gh")` find the real linuxbrew gh outside the test sandbox and flips `not_installed` to `needs_auth`. Switching the test's GOOS to a sentinel `"test"` value preserves intent without baking in a host assumption. The deeper fix (test isolation in `searchpath.Expand`) is recommended as a separate change.

**Commit 2** — `fix(orders): honor IsEnabled() in dispatcher filter`
The actual fix. Adds `&& a.IsEnabled()` to the dispatcher's auto-trigger filter, both in production code (`cmd/gc/order_dispatch.go:buildOrderDispatcher`) and the test helper that has the same shape (`buildOrderDispatcherFromListExec`). `cmd_order.go` and `api_state.go` intentionally keep returning the post-override list AS-IS because those are listing/introspection paths where the disabled state is what callers want to see; only the dispatcher should drop disabled orders before scheduling.

## Test plan

- [x] `TestOrderDispatchDisabledFiltered`: a directly-disabled order (`Enabled=&false`) must produce a nil dispatcher. New, fails before the fix, passes after.
- [x] `TestOrderDispatchEnabledFalseOverrideTakesEffect`: end-to-end `ApplyOverrides` → `buildOrderDispatcher` pipeline; an order scanned with `Enabled=nil` that gets `enabled=false` via override must produce a nil dispatcher. New, fails before the fix, passes after.
- [x] Existing `TestOrderDispatchManualFiltered` and `TestOrderDispatchCooldownDue` still pass.
- [x] `make test` passes locally with both commits applied.
- [ ] Reviewer: confirm `cmd_order.go`/`api_state.go` callers are correctly classified as listing-path (should NOT skip disabled) vs dispatch-path (should).

## Notes

This is the first of several "ugliness" items from the same incident report. Pool-name resolution gaps (orders write `pool="dog"`, reconciler queries `pool="gastown.dog"`) and the embedded-pack auto-materialize behavior are tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->