### PR TITLE
fix(pool): guard orphan release with live state

### DIFF
--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -136,6 +136,9 @@ func releaseOrphanedPoolAssignments(
 			if assigneePreservesNamedSessionRoute(cfg, cityPath, template, assignee, workStoreRef, storeRefAware) {
 				continue
 			}
+			if liveOpenSessionAssignmentExists(store, assignee) {
+				continue
+			}
 		}
 
 		var ownerStore beads.Store
@@ -150,6 +153,9 @@ func releaseOrphanedPoolAssignments(
 			if ownerStore == nil {
 				continue
 			}
+		}
+		if !liveWorkAssignmentStillReleasable(ownerStore, wb.ID, assignee) {
+			continue
 		}
 		if !releaseOrphanedPoolAssignment(ownerStore, wb.ID) {
 			continue
@@ -261,6 +267,85 @@ func releaseOrphanedPoolAssignment(store beads.Store, id string) bool {
 		Status:   stringPtr("open"),
 	}
 	return store.Update(id, opts) == nil
+}
+
+func liveOpenSessionAssignmentExists(store beads.Store, assignee string) bool {
+	assignee = strings.TrimSpace(assignee)
+	if store == nil || assignee == "" {
+		return false
+	}
+	if liveSessionBeadExistsByIdentity(store, assignee) {
+		return true
+	}
+	sessions, err := store.List(beads.ListQuery{
+		Label: sessionBeadLabel,
+		Live:  true,
+	})
+	if err != nil {
+		log.Printf("releaseOrphanedPoolAssignments: live session validation failed for assignee %q: %v", assignee, err)
+		return true
+	}
+	for _, sb := range sessions {
+		if sb.Status == "closed" || !isSessionBead(sb) {
+			continue
+		}
+		if assignee == strings.TrimSpace(sb.ID) ||
+			assignee == strings.TrimSpace(sb.Metadata["session_name"]) ||
+			assignee == strings.TrimSpace(sb.Metadata["configured_named_identity"]) {
+			return true
+		}
+	}
+	return false
+}
+
+func liveSessionBeadExistsByIdentity(store beads.Store, assignee string) bool {
+	for _, id := range directSessionBeadIDCandidates(assignee) {
+		sb, err := store.Get(id)
+		if err != nil {
+			continue
+		}
+		if sb.Status != "closed" && isSessionBead(sb) &&
+			(assignee == strings.TrimSpace(sb.ID) ||
+				assignee == strings.TrimSpace(sb.Metadata["session_name"]) ||
+				assignee == strings.TrimSpace(sb.Metadata["configured_named_identity"])) {
+			return true
+		}
+	}
+	return false
+}
+
+func directSessionBeadIDCandidates(assignee string) []string {
+	assignee = strings.TrimSpace(assignee)
+	if assignee == "" {
+		return nil
+	}
+	candidates := []string{assignee}
+	if idx := strings.LastIndex(assignee, "-mc-"); idx >= 0 {
+		candidates = append(candidates, assignee[idx+1:])
+	}
+	return candidates
+}
+
+func liveWorkAssignmentStillReleasable(store beads.Store, id, assignee string) bool {
+	id = strings.TrimSpace(id)
+	if store == nil || id == "" {
+		return false
+	}
+	work, err := store.List(beads.ListQuery{
+		Status: "in_progress",
+		Live:   true,
+	})
+	if err != nil {
+		log.Printf("releaseOrphanedPoolAssignments: live work validation failed for %q: %v", id, err)
+		return false
+	}
+	for _, wb := range work {
+		if wb.ID != id {
+			continue
+		}
+		return strings.TrimSpace(wb.Assignee) == strings.TrimSpace(assignee)
+	}
+	return false
 }
 
 func assigneePreservesNamedSessionRoute(cfg *config.City, cityPath, template, assignee, workStoreRef string, storeRefAware bool) bool {

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -185,6 +185,192 @@ func TestReleaseOrphanedPoolAssignments_ReopensMissingPoolAssignee(t *testing.T)
 	}
 }
 
+type sessionListMissStore struct {
+	beads.Store
+	directSessions map[string]beads.Bead
+}
+
+func (s sessionListMissStore) Get(id string) (beads.Bead, error) {
+	if b, ok := s.directSessions[id]; ok {
+		return b, nil
+	}
+	return s.Store.Get(id)
+}
+
+func (s sessionListMissStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if query.Live && query.Label == sessionBeadLabel {
+		return nil, nil
+	}
+	return s.Store.List(query)
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionMissingFromSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "worker-mc-live",
+			"template":             "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: sessionBead.Metadata["session_name"],
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none for live session", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want %q", got.Assignee, sessionBead.Metadata["session_name"])
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionWhenLiveSessionListMissesIt(t *testing.T) {
+	base := beads.NewMemStore()
+	sessionBead, err := base.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "worker-mc-live",
+			"template":             "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := base.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: sessionBead.Metadata["session_name"],
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := base.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = base.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+	store := sessionListMissStore{
+		Store:          base,
+		directSessions: map[string]beads.Bead{"mc-live": sessionBead},
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none for directly resolvable live session", released)
+	}
+
+	got, err := base.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != sessionBead.Metadata["session_name"] {
+		t.Fatalf("assignee = %q, want %q", got.Assignee, sessionBead.Metadata["session_name"])
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsWorkReassignedAfterCandidateSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: "worker-old",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	candidate, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload candidate work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Assignee: stringPtr("worker-new")}); err != nil {
+		t.Fatalf("Reassign work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		nil,
+		[]beads.Bead{candidate},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none for reassigned work", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != "worker-new" {
+		t.Fatalf("assignee = %q, want worker-new", got.Assignee)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_ReopensUnassignedInProgressPoolWork(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -753,6 +753,26 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if configuredNames[name] {
 						reason = "suspended"
 					}
+					hasAssignedWork, assignedErr := sessionHasOpenAssignedWork(store, rigStores, *session)
+					if assignedErr != nil {
+						fmt.Fprintf(stderr, "session reconciler: checking assigned work before %s drain for %s: %v\n", reason, name, assignedErr) //nolint:errcheck
+						continue
+					}
+					if hasAssignedWork {
+						if trace != nil {
+							template := normalizedSessionTemplate(*session, cfg)
+							if template == "" {
+								template = session.Metadata["template"]
+							}
+							trace.recordDecision("reconciler.session.orphan_or_suspended", template, name, reason, "kept_open", traceRecordPayload{
+								"store_query_partial": storeQueryPartial,
+								"provider_alive":      providerAlive,
+								"live_assigned_work":  true,
+							}, nil, "")
+						}
+						fmt.Fprintf(stdout, "Skipping drain for '%s': live assigned work found\n", name) //nolint:errcheck
+						continue
+					}
 					if beginSessionDrain(*session, sp, dt, reason, clk, defaultDrainTimeout) {
 						if trace != nil {
 							template := normalizedSessionTemplate(*session, cfg)

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2709,6 +2709,32 @@ func TestReconcileSessionBeads_OrphanSessionDrained(t *testing.T) {
 	}
 }
 
+func TestReconcileSessionBeads_OrphanDrainLiveAssignedWorkStaysOpen(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "other"}}}
+	_ = env.sp.Start(context.Background(), "orphan", runtime.Config{})
+	session := env.createSessionBead("orphan", "orphan")
+	env.markSessionActive(&session)
+
+	if _, err := env.store.Create(beads.Bead{
+		Title:    "claimed work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.Metadata["session_name"],
+	}); err != nil {
+		t.Fatalf("Create assigned work bead: %v", err)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected live assigned work to block orphan drain, got drain state %+v", ds)
+	}
+	if strings.Contains(env.stdout.String(), "Draining session 'orphan': orphaned") {
+		t.Fatalf("expected no orphan drain log, got stdout:\n%s", env.stdout.String())
+	}
+}
+
 // TestReconcileSessionBeads_OrphanDrainLogThrottled covers issue #855:
 // once a session is draining, the reconciler must not re-emit
 // "Draining session '...': orphaned" on every subsequent tick. The


### PR DESCRIPTION
## Summary
- add live session validation before orphan-release clears a pool assignment
- re-read live work state immediately before mutating the bead
- add regressions for stale session snapshots and reassigned work snapshots

## Verification
- go test ./cmd/gc -run 'TestReleaseOrphanedPoolAssignments|TestCollectAssignedWorkBeadsIncludesUnassignedInProgressPoolWorkForRecovery|TestSyncSessionBeads_(StalePoolSnapshotReusesVisibleOwner|DuplicatePoolSessionNameKeepsVisibleOwner|PoolSessionNameFailureLeavesReachableFailedCreate)|TestBeadOwnsPoolSessionName|TestCanonicalDuplicateSessionBead' -count=1\n- pre-commit hook ran full fast unit loop during commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->