### PR TITLE
fix(session): roll back canceled pending creates

### DIFF
--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -245,7 +245,7 @@ func markCityStopSessionSleepReason(store beads.Store, stderr io.Writer) {
 	}
 	for _, session := range sessions {
 		state := sessionMetadataState(session)
-		if state != "active" && state != "creating" {
+		if state != "active" {
 			continue
 		}
 		if strings.TrimSpace(session.Metadata["sleep_reason"]) != "" {

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -447,6 +447,52 @@ func TestStopCityManagedBeadsProviderIfRunningStopsDefaultBD(t *testing.T) {
 	}
 }
 
+func TestMarkCityStopSessionSleepReasonSkipsCreatingSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	active, err := store.Create(beads.Bead{
+		Title:  "active",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"state":        "active",
+			"session_name": "active",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	creating, err := store.Create(beads.Bead{
+		Title:  "creating",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"state":                "creating",
+			"session_name":         "creating",
+			"pending_create_claim": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	markCityStopSessionSleepReason(store, ioDiscard{})
+
+	activeUpdated, err := store.Get(active.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := activeUpdated.Metadata["sleep_reason"]; got != sleepReasonCityStop {
+		t.Fatalf("active sleep_reason = %q, want %q", got, sleepReasonCityStop)
+	}
+	creatingUpdated, err := store.Get(creating.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := creatingUpdated.Metadata["sleep_reason"]; got != "" {
+		t.Fatalf("creating sleep_reason = %q, want empty because create rollback owns this state", got)
+	}
+}
+
 func TestCmdStopUsesTargetCitySessionProviderOutsideCityDir(t *testing.T) {
 	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1059,7 +1059,7 @@ func commitAsyncStartResultWithContext(
 		}
 		if refreshed.err == nil && shouldRollbackPendingCreate(refreshed.prepared.candidate.session) {
 			stopStaleAsyncStartRuntime(refreshed, sp, stderr)
-			clearPendingStartInFlightLease(refreshed.prepared.candidate.session, store, stderr)
+			rollbackPendingCreate(refreshed.prepared.candidate.session, store, clk.Now().UTC(), stderr)
 		}
 		logLifecycleOutcome(stderr, "start", wave, name, template, "context_canceled", refreshed.started, time.Now(), ctx.Err())
 		return false

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -3170,11 +3170,8 @@ func TestCommitAsyncStartResultWithContext_SkipsCanceledCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := updated.Metadata["state"]; got != "creating" {
-		t.Fatalf("state = %q, want creating", got)
-	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true", got)
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed so canceled create cannot strand a creating bead", updated.Status)
 	}
 }
 
@@ -3240,6 +3237,9 @@ func TestCommitAsyncStartResultWithContext_StopsCanceledSuccessfulPendingCreateR
 	if err != nil {
 		t.Fatal(err)
 	}
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed so canceled create cannot strand a creating bead", updated.Status)
+	}
 	if got := updated.Metadata["last_woke_at"]; got != "" {
 		t.Fatalf("last_woke_at = %q, want cleared so the next controller can retry", got)
 	}
@@ -3297,6 +3297,64 @@ func TestCommitAsyncStartResultWithContext_RollsBackCanceledPendingCreateError(t
 	}
 	if updated.Status != "closed" {
 		t.Fatalf("status = %q, want closed so pending-create can be retried by replacement bead", updated.Status)
+	}
+}
+
+func TestCommitAsyncStartResultWithContext_RollsBackCanceledPendingCreateSuccess(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 7, 4, 17, 11, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-control",
+		Title:  "control",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "control",
+			"template":             "control",
+			"generation":           "2",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-control",
+			"pending_create_claim": "true",
+			"last_woke_at":         clk.Now().Format(time.RFC3339),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := startResult{
+		prepared: preparedStart{
+			candidate: startCandidate{
+				session: &session,
+				tp: TemplateParams{
+					Command:      "control",
+					SessionName:  "control",
+					TemplateName: "control",
+				},
+			},
+		},
+		outcome:         "success",
+		started:         clk.Now(),
+		finished:        clk.Now(),
+		rollbackPending: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if commitAsyncStartResultWithContext(ctx, result, nil, store, clk, events.Discard, 0, ioDiscard{}, ioDiscard{}, nil) {
+		t.Fatal("canceled async success commit should report not committed")
+	}
+	updated, err := store.Get(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != "closed" {
+		t.Fatalf("status = %q, want closed so canceled create cannot strand a creating bead", updated.Status)
+	}
+	if got := updated.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim = %q, want preserved on closed failed-create bead for audit", got)
+	}
+	if pendingCreateStartInFlight(updated, clk, 0) {
+		t.Fatal("canceled async success left the pending-create bead leased")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Roll back pending-create session beads when an async start succeeds but the controller context is canceled before commit.
- Avoid stamping city-stop sleep metadata onto creating sessions; create rollback owns that state.

## Tests
- go test ./cmd/gc -run 'TestMarkCityStopSessionSleepReasonSkipsCreatingSessions|TestCommitAsyncStartResultWithContext_(SkipsCanceledCommit|StopsCanceledSuccessfulPendingCreateRuntime|RollsBackCanceledPendingCreateSuccess|RollsBackCanceledPendingCreateError)' -count=1
- pre-commit hook: go test -json -p=4 -count=1 ./...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->