### PR TITLE
fix(maintenance): force UTC for BSD wisp timestamps

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4647,6 +4647,88 @@ exit 0
 	}
 }
 
+func TestWispCompactBSDDateZFallbackUsesUTC(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	bdLog := filepath.Join(t.TempDir(), "bd.log")
+	dateLog := filepath.Join(t.TempDir(), "date.log")
+
+	nearBoundary := "2033-05-17T20:33:20Z"
+	beadsJSON := fmt.Sprintf(`[
+  {"id":"ga-heartbeat","status":"open","ephemeral":true,"updated_at":"%s","comment_count":0,"labels":["wisp_type:heartbeat"]}
+]`, nearBoundary)
+
+	writeExecutable(t, filepath.Join(binDir, "bd"), fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> "$BD_LOG"
+case "$1 $2" in
+  "list --json")
+    cat <<'JSON'
+%s
+JSON
+    ;;
+esac
+exit 0
+`, beadsJSON))
+
+	writeExecutable(t, filepath.Join(binDir, "date"), fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> "$DATE_LOG"
+if [ "$1" = "+%%s" ]; then
+  echo 2000000000
+  exit 0
+fi
+if [ "$1" = "-d" ]; then
+  exit 1
+fi
+if [ "$1" = "-ju" ] && [ "$2" = "-f" ] && [ "$4" = "%s" ]; then
+  echo 1999974800
+  exit 0
+fi
+if [ "$1" = "-j" ] && [ "$2" = "-f" ] && [ "$4" = "%s" ]; then
+  echo 2000000000
+  exit 0
+fi
+exit 1
+`, nearBoundary, nearBoundary))
+
+	env := map[string]string{
+		"BD_LOG":       bdLog,
+		"DATE_LOG":     dateLog,
+		"GC_CITY":      cityDir,
+		"GC_CITY_PATH": cityDir,
+		"PATH":         binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TZ":           "America/Los_Angeles",
+	}
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "wisp-compact.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", filepath.Base(script), err, out)
+	}
+
+	want := "wisp-compact: promoted=1 deleted=0 skipped=0"
+	if !strings.Contains(string(out), want) {
+		t.Fatalf("wisp-compact should parse BSD Z timestamps as UTC at the heartbeat TTL boundary\nwant substring: %q\ngot output:\n%s", want, out)
+	}
+
+	dateData, err := os.ReadFile(dateLog)
+	if err != nil {
+		t.Fatalf("ReadFile(date log): %v", err)
+	}
+	if !strings.Contains(string(dateData), "-ju -f %Y-%m-%dT%H:%M:%SZ "+nearBoundary+" +%s") {
+		t.Fatalf("BSD Z fallback did not force UTC:\n%s", dateData)
+	}
+
+	bdData, err := os.ReadFile(bdLog)
+	if err != nil {
+		t.Fatalf("ReadFile(bd log): %v", err)
+	}
+	if !strings.Contains(string(bdData), "update ga-heartbeat --persistent") {
+		t.Fatalf("expected expired heartbeat to be promoted, got bd calls:\n%s", bdData)
+	}
+}
+
 func TestCrossRigDepsReportsNonZeroCounter(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh
@@ -57,12 +57,12 @@ while IFS= read -r bead; do
     done
 
     # Calculate age. bd emits RFC3339 timestamps with a trailing 'Z'; the
-    # second BSD `date -j -f` fallback handles that explicitly because the
-    # third (no-Z) layout rejects it. GNU `date -d` is lenient and accepts
-    # both forms via the first fallback.
+    # second BSD `date -ju -f` fallback handles that explicitly and forces
+    # UTC semantics to match GNU `date -d`. The third layout supports older
+    # no-Z timestamps without interpreting them in the local timezone.
     BEAD_TS=$(date -d "$updated_at" +%s 2>/dev/null || \
-              date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || \
-              date -j -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
+              date -ju -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null || \
+              date -ju -f "%Y-%m-%dT%H:%M:%S" "$updated_at" +%s 2>/dev/null) || continue
     AGE=$((NOW - BEAD_TS))
 
     # Skip if within TTL (unless force-promote via keep label).


### PR DESCRIPTION
Post-merge remediation for #1708.

Summary:
- Force BSD `date -j` fallbacks to UTC with `-u` for RFC3339 `Z` and no-`Z` layouts.
- Add a focused fake-`date` regression test under `TZ=America/Los_Angeles` for the heartbeat TTL boundary.

Follow-up note:
The landed #1708 diff was the BSD RFC3339 `Z` timestamp parsing fallback for `wisp-compact.sh`; the counter-preservation work referenced in the squash title/body was already present in the base branch before that merge.

Tests:
- `bash -n examples/gastown/packs/maintenance/assets/scripts/wisp-compact.sh`
- `go test ./examples/gastown -run TestWispCompact -count=1`
- `.githooks/pre-commit` during commit, including fmt check, generated schema check, lint, vet, and repository unit tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->