### PR TITLE
fix(pool): create sessions with concrete identity

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1528,7 +1528,7 @@ func realizePoolDesiredSessions(
 				prefer = &bead
 			}
 		}
-		sessionBead, err := selectOrCreatePoolSessionBead(bp, qualifiedName, prefer, used)
+		sessionBead, slot, err := selectOrCreatePoolSessionBead(bp, cfgAgent, qualifiedName, prefer, used, usedSlots)
 		if err != nil {
 			fmt.Fprintf(stderr, "buildDesiredState: pool %q request: %v (skipping)\n", qualifiedName, err) //nolint:errcheck
 			continue
@@ -1537,7 +1537,6 @@ func realizePoolDesiredSessions(
 			continue
 		}
 		used[sessionBead.ID] = true
-		slot := claimPoolSlot(cfgAgent, sessionBead, usedSlots)
 		instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
 		qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
 		instanceAgent := deepCopyAgent(cfgAgent, instanceName, cfgAgent.Dir)
@@ -1871,14 +1870,23 @@ func findOpenSessionBeadByID(sessionBeads *sessionBeadSnapshot, id string) (bead
 
 func selectOrCreatePoolSessionBead(
 	bp *agentBuildParams,
+	cfgAgent *config.Agent,
 	template string,
 	preferred *beads.Bead,
 	used map[string]bool,
-) (beads.Bead, error) {
-	cfgAgent := findAgentByTemplate(&config.City{Agents: bp.agents}, template)
+	usedSlots map[int]bool,
+) (beads.Bead, int, error) {
+	if cfgAgent == nil {
+		cfgAgent = findAgentByTemplate(&config.City{Agents: bp.agents}, template)
+	}
+	if cfgAgent == nil {
+		bead, err := createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{})
+		return bead, 0, err
+	}
 	// Resume tier: reuse the session that has in-progress work assigned.
 	if preferred != nil && preferred.ID != "" && !used[preferred.ID] {
-		return *preferred, nil
+		slot := claimPoolSlot(cfgAgent, *preferred, usedSlots)
+		return *preferred, slot, nil
 	}
 	// Reuse an existing active/creating session bead. Skip drained, closed,
 	// and asleep — asleep ephemerals are not restarted; a fresh session is
@@ -1909,10 +1917,19 @@ func selectOrCreatePoolSessionBead(
 			continue
 		}
 		if desiredName := strings.TrimSpace(bead.Metadata["session_name"]); desiredName != "" {
-			return bead, nil
+			slot := claimPoolSlot(cfgAgent, bead, usedSlots)
+			return bead, slot, nil
 		}
 	}
-	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp))
+	slot := claimPoolSlot(cfgAgent, beads.Bead{}, usedSlots)
+	instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
+	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
+	bead, err := createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{
+		AgentName: qualifiedInstance,
+		Alias:     qualifiedInstance,
+		Slot:      slot,
+	})
+	return bead, slot, err
 }
 
 func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
@@ -1933,7 +1950,7 @@ func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) 
 
 func selectOrCreateDependencyPoolSessionBead(
 	bp *agentBuildParams,
-	_ *config.Agent,
+	cfgAgent *config.Agent,
 	template string,
 ) (beads.Bead, error) {
 	for _, bead := range bp.sessionBeads.Open() {
@@ -1956,7 +1973,19 @@ func selectOrCreateDependencyPoolSessionBead(
 			return bead, nil
 		}
 	}
-	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp))
+	if cfgAgent == nil {
+		cfgAgent = findAgentByTemplate(&config.City{Agents: bp.agents}, template)
+	}
+	if cfgAgent == nil {
+		return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{})
+	}
+	instanceName := poolInstanceName(cfgAgent.Name, 1, cfgAgent)
+	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
+	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{
+		AgentName: qualifiedInstance,
+		Alias:     qualifiedInstance,
+		Slot:      1,
+	})
 }
 
 func poolSessionCreateStartedAt(_ *agentBuildParams) time.Time {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/hooks"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	"github.com/gastownhall/gascity/internal/session"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
@@ -1549,10 +1550,46 @@ func realizePoolDesiredSessions(
 		tp.Alias = qualifiedInstance
 		tp.InstanceName = qualifiedInstance
 		tp.PoolSlot = slot
-		setTemplateEnvIdentity(&tp, qualifiedInstance)
+		setPoolTemplateRuntimeIdentity(&tp, qualifiedInstance, sessionBead)
 		installAgentSideEffects(bp, &instanceAgent, tp, stderr)
 		desired[tp.SessionName] = tp
 	}
+}
+
+// setPoolTemplateRuntimeIdentity stamps the pool alias unless this bead is in a
+// known deferred-alias state. Stable legacy pool beads can lack alias metadata;
+// those keep their historic instance identity until syncSessionBeads backfills.
+func setPoolTemplateRuntimeIdentity(tp *TemplateParams, desiredAlias string, sessionBead beads.Bead) {
+	if tp == nil {
+		return
+	}
+	if strings.TrimSpace(sessionBead.Metadata["alias"]) != strings.TrimSpace(desiredAlias) && poolRuntimeAliasIsDeferred(sessionBead) {
+		tp.Alias = ""
+		if tp.Env == nil {
+			tp.Env = make(map[string]string)
+		}
+		tp.Env["GC_ALIAS"] = ""
+		if tp.SessionName != "" {
+			tp.Env["GC_AGENT"] = tp.SessionName
+		}
+		tp.EnvIdentityStamped = false
+		return
+	}
+	tp.Alias = desiredAlias
+	setTemplateEnvIdentity(tp, desiredAlias)
+}
+
+func poolRuntimeAliasIsDeferred(sessionBead beads.Bead) bool {
+	if strings.TrimSpace(sessionBead.Metadata["alias"]) != "" {
+		return false
+	}
+	if strings.TrimSpace(sessionBead.Metadata[poolAliasConflictMetadataKey]) != "" {
+		return true
+	}
+	if strings.TrimSpace(sessionBead.Metadata["pending_create_claim"]) == boolMetadata(true) {
+		return true
+	}
+	return strings.TrimSpace(sessionBead.Metadata["state"]) == "creating"
 }
 
 func setTemplateEnvIdentity(tp *TemplateParams, identity string) {
@@ -1880,8 +1917,7 @@ func selectOrCreatePoolSessionBead(
 		cfgAgent = findAgentByTemplate(&config.City{Agents: bp.agents}, template)
 	}
 	if cfgAgent == nil {
-		bead, err := createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{})
-		return bead, 0, err
+		return beads.Bead{}, 0, fmt.Errorf("pool template %q has no configured agent", template)
 	}
 	// Resume tier: reuse the session that has in-progress work assigned.
 	if preferred != nil && preferred.ID != "" && !used[preferred.ID] {
@@ -1924,12 +1960,51 @@ func selectOrCreatePoolSessionBead(
 	slot := claimPoolSlot(cfgAgent, beads.Bead{}, usedSlots)
 	instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
 	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
-	bead, err := createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{
+	bead, err := createPoolSessionBeadWithGuardedAlias(bp, template, qualifiedInstance, slot)
+	if err != nil {
+		delete(usedSlots, slot)
+		return bead, 0, err
+	}
+	return bead, slot, nil
+}
+
+func createPoolSessionBeadWithGuardedAlias(
+	bp *agentBuildParams,
+	template string,
+	qualifiedInstance string,
+	slot int,
+) (beads.Bead, error) {
+	if bp == nil {
+		return beads.Bead{}, fmt.Errorf("creating pool session for %q: build params unavailable", template)
+	}
+	identity := poolSessionCreateIdentity{
 		AgentName: qualifiedInstance,
-		Alias:     qualifiedInstance,
 		Slot:      slot,
+	}
+	alias := strings.TrimSpace(qualifiedInstance)
+	if alias == "" || bp.beadStore == nil {
+		return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
+	}
+
+	var bead beads.Bead
+	createdWithLock := false
+	lockErr := session.WithCitySessionAliasLock(bp.cityPath, alias, func() error {
+		createIdentity := identity
+		if err := session.EnsureAliasAvailableWithConfig(bp.beadStore, bp.city, alias, ""); err == nil {
+			createIdentity.Alias = alias
+		}
+		var err error
+		bead, err = createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), createIdentity)
+		createdWithLock = true
+		return err
 	})
-	return bead, slot, err
+	if createdWithLock {
+		return bead, lockErr
+	}
+	if lockErr != nil && bp.stderr != nil {
+		fmt.Fprintf(bp.stderr, "createPoolSessionBeadWithGuardedAlias: locking alias %q for %s: %v; creating without alias\n", alias, template, lockErr) //nolint:errcheck
+	}
+	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
 }
 
 func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
@@ -1977,15 +2052,11 @@ func selectOrCreateDependencyPoolSessionBead(
 		cfgAgent = findAgentByTemplate(&config.City{Agents: bp.agents}, template)
 	}
 	if cfgAgent == nil {
-		return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{})
+		return beads.Bead{}, fmt.Errorf("dependency pool template %q has no configured agent", template)
 	}
 	instanceName := poolInstanceName(cfgAgent.Name, 1, cfgAgent)
 	qualifiedInstance := cfgAgent.QualifiedInstanceName(instanceName)
-	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), poolSessionCreateIdentity{
-		AgentName: qualifiedInstance,
-		Alias:     qualifiedInstance,
-		Slot:      1,
-	})
+	return createPoolSessionBeadWithGuardedAlias(bp, template, qualifiedInstance, 1)
 }
 
 func poolSessionCreateStartedAt(_ *agentBuildParams) time.Time {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1464,6 +1464,54 @@ func TestBuildDesiredState_RoutedQueueDoesNotCreateOneSessionPerBead(t *testing.
 	}
 }
 
+func TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "claude",
+			Dir:               "rig",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "printf 1",
+		}},
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+	if len(dsResult.State) != 1 {
+		t.Fatalf("desired sessions = %d, want 1", len(dsResult.State))
+	}
+
+	sessionBeads, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("load session beads: %v", err)
+	}
+	if len(sessionBeads) != 1 {
+		t.Fatalf("session beads = %d, want 1", len(sessionBeads))
+	}
+	got := sessionBeads[0]
+	if got.Metadata["agent_name"] != "rig/claude-1" {
+		t.Fatalf("agent_name = %q, want concrete slot identity", got.Metadata["agent_name"])
+	}
+	if got.Metadata["alias"] != "rig/claude-1" {
+		t.Fatalf("alias = %q, want concrete slot identity", got.Metadata["alias"])
+	}
+	if got.Metadata["pool_slot"] != "1" {
+		t.Fatalf("pool_slot = %q, want 1", got.Metadata["pool_slot"])
+	}
+	if got.Title != "rig/claude-1" {
+		t.Fatalf("title = %q, want concrete slot identity", got.Title)
+	}
+	if !containsString(got.Labels, "agent:rig/claude-1") {
+		t.Fatalf("labels = %#v, want concrete slot agent label", got.Labels)
+	}
+	if !beadOwnsPoolSessionName(got) {
+		t.Fatalf("session_name = %q should be the bead-owned pool runtime name", got.Metadata["session_name"])
+	}
+}
+
 func TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession(t *testing.T) {
 	skipSlowCmdGCTest(t, "uses real bd subprocesses for routed-work scale checks; run make test-cmd-gc-process for full coverage")
 	bdPath, err := findPreferredBinary("bd", "/home/ubuntu/.local/bin/bd")
@@ -4420,7 +4468,7 @@ func TestSelectOrCreatePoolSessionBead_SkipsDrained(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4443,7 +4491,7 @@ func TestSelectOrCreatePoolSessionBead_UsesFreshCreateTimeNotBeaconTime(t *testi
 		beaconTime:   oldBeacon,
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4489,7 +4537,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesPreferredDrained(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", &drained, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", &drained, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4563,7 +4611,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4603,7 +4651,7 @@ func TestSelectOrCreatePoolSessionBead_SkipsAssignedForNewTier(t *testing.T) {
 		}},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "claude", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4643,7 +4691,7 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepBeads(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "polecat", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4679,7 +4727,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesActiveBeforeCreatingNew(t *testing.
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "polecat", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4715,7 +4763,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesCreatingBeforeCreatingNew(t *testin
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "polecat", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
@@ -4766,7 +4814,7 @@ func TestSelectOrCreatePoolSessionBead_SkipsAsleepButReusesActive(t *testing.T) 
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, err := selectOrCreatePoolSessionBead(bp, "polecat", nil, map[string]bool{})
+	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "polecat", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,6 +66,50 @@ func (s *readyQueryRecordingStore) Ready(query ...beads.ReadyQuery) ([]beads.Bea
 		s.readyQueries = append(s.readyQueries, query[0])
 	}
 	return s.MemStore.Ready(query...)
+}
+
+type blockingPoolCreateStore struct {
+	*beads.MemStore
+	alias               string
+	mu                  sync.Mutex
+	createCount         int
+	firstCreateStarted  chan struct{}
+	secondCreateStarted chan struct{}
+	releaseFirstCreate  chan struct{}
+	releaseSecondCreate chan struct{}
+}
+
+func newBlockingPoolCreateStore(alias string) *blockingPoolCreateStore {
+	return &blockingPoolCreateStore{
+		MemStore:            beads.NewMemStore(),
+		alias:               alias,
+		firstCreateStarted:  make(chan struct{}),
+		secondCreateStarted: make(chan struct{}),
+		releaseFirstCreate:  make(chan struct{}),
+		releaseSecondCreate: make(chan struct{}),
+	}
+}
+
+func (s *blockingPoolCreateStore) Create(bead beads.Bead) (beads.Bead, error) {
+	if bead.Type == sessionBeadType && bead.Metadata["agent_name"] == s.alias {
+		s.mu.Lock()
+		s.createCount++
+		createNumber := s.createCount
+		switch createNumber {
+		case 1:
+			close(s.firstCreateStarted)
+		case 2:
+			close(s.secondCreateStarted)
+		}
+		s.mu.Unlock()
+		switch createNumber {
+		case 1:
+			<-s.releaseFirstCreate
+		case 2:
+			<-s.releaseSecondCreate
+		}
+	}
+	return s.MemStore.Create(bead)
 }
 
 type demandListCountingStore struct {
@@ -1509,6 +1555,200 @@ func TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity(t *test
 	}
 	if !beadOwnsPoolSessionName(got) {
 		t.Fatalf("session_name = %q should be the bead-owned pool runtime name", got.Metadata["session_name"])
+	}
+}
+
+func TestBuildDesiredState_NewPoolSessionBeadDefersAliasWhenConcreteAliasTaken(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+
+	if _, err := store.Create(beads.Bead{
+		Title:  "manual session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:rig/manual"},
+		Metadata: map[string]string{
+			"template":       "rig/manual",
+			"agent_name":     "rig/manual",
+			"alias":          "rig/claude-1",
+			"session_name":   "manual-rig-claude-1",
+			"state":          "awake",
+			"session_origin": "manual",
+			"manual_session": "true",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "claude",
+			Dir:               "rig",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(3),
+			ScaleCheck:        "printf 1",
+		}},
+	}
+
+	var stderr bytes.Buffer
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, &stderr)
+
+	sessionBeads, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("load session beads: %v", err)
+	}
+	var created beads.Bead
+	for _, candidate := range sessionBeads {
+		if candidate.Metadata[poolManagedMetadataKey] == boolMetadata(true) {
+			created = candidate
+			break
+		}
+	}
+	if created.ID == "" {
+		t.Fatalf("did not create a managed pool session bead; beads=%#v", sessionBeads)
+	}
+	if got := created.Metadata["agent_name"]; got != "rig/claude-1" {
+		t.Fatalf("created agent_name = %q, want concrete slot identity", got)
+	}
+	if got := created.Metadata["alias"]; got != "" {
+		t.Fatalf("created alias = %q, want deferred until alias guard accepts it", got)
+	}
+	if got := created.Metadata["pool_slot"]; got != "1" {
+		t.Fatalf("created pool_slot = %q, want 1", got)
+	}
+	tp, ok := dsResult.State[created.Metadata["session_name"]]
+	if !ok {
+		t.Fatalf("desired state missing created session %q; keys=%v", created.Metadata["session_name"], mapKeys(dsResult.State))
+	}
+	if got := tp.Alias; got != "" {
+		t.Fatalf("deferred pool TemplateParams.Alias = %q, want empty until alias is claimed", got)
+	}
+	if got := tp.Env["GC_ALIAS"]; got != "" {
+		t.Fatalf("deferred pool GC_ALIAS = %q, want empty until alias is claimed", got)
+	}
+	if got := tp.Env["GC_AGENT"]; got != tp.SessionName {
+		t.Fatalf("deferred pool GC_AGENT = %q, want bead session name %q", got, tp.SessionName)
+	}
+	if tp.EnvIdentityStamped {
+		t.Fatal("deferred pool EnvIdentityStamped = true, want false until alias is claimed")
+	}
+
+	clk := &clock.Fake{Time: time.Date(2026, 5, 7, 15, 10, 0, 0, time.UTC)}
+	var syncStderr bytes.Buffer
+	syncSessionBeads(cityPath, store, dsResult.State, runtime.NewFake(), allConfiguredDS(dsResult.State), cfg, clk, &syncStderr, false)
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["alias"] != "" {
+		t.Fatalf("synced alias = %q, want still deferred after conflict", got.Metadata["alias"])
+	}
+	if got.Metadata[poolAliasConflictMetadataKey] != "rig/claude-1" {
+		t.Fatalf("pool_alias_conflict = %q, want rig/claude-1", got.Metadata[poolAliasConflictMetadataKey])
+	}
+	if !strings.Contains(syncStderr.String(), "unavailable") {
+		t.Fatalf("sync stderr %q does not mention alias conflict", syncStderr.String())
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_SerializesAliasCheckAndCreate(t *testing.T) {
+	store := newBlockingPoolCreateStore("claude-1")
+	cityPath := t.TempDir()
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	newBuildParams := func() *agentBuildParams {
+		return &agentBuildParams{
+			cityPath:     cityPath,
+			beadStore:    store,
+			sessionBeads: &sessionBeadSnapshot{},
+			agents:       []config.Agent{cfgAgent},
+		}
+	}
+
+	type createResult struct {
+		bead beads.Bead
+		slot int
+		err  error
+	}
+	results := make(chan createResult, 2)
+	create := func() {
+		bead, slot, err := selectOrCreatePoolSessionBead(newBuildParams(), &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
+		results <- createResult{bead: bead, slot: slot, err: err}
+	}
+	go create()
+	go create()
+
+	select {
+	case <-store.firstCreateStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first pool create did not start")
+	}
+
+	select {
+	case <-store.secondCreateStarted:
+		close(store.releaseFirstCreate)
+		close(store.releaseSecondCreate)
+		t.Fatal("second pool create reached the store before first create finished; alias lock did not serialize create")
+	case <-time.After(150 * time.Millisecond):
+		close(store.releaseFirstCreate)
+		select {
+		case <-store.secondCreateStarted:
+			close(store.releaseSecondCreate)
+		case <-time.After(time.Second):
+			t.Fatal("second pool create did not start after first create completed")
+		}
+	}
+
+	for i := 0; i < 2; i++ {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("selectOrCreatePoolSessionBead result %d: %v", i+1, result.err)
+		}
+		if result.bead.ID == "" {
+			t.Fatalf("selectOrCreatePoolSessionBead result %d returned empty bead", i+1)
+		}
+		if result.slot != 1 {
+			t.Fatalf("selectOrCreatePoolSessionBead result %d slot = %d, want 1", i+1, result.slot)
+		}
+	}
+
+	sessionBeads, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("load session beads: %v", err)
+	}
+	aliasOwners := 0
+	for _, bead := range sessionBeads {
+		if bead.Metadata["alias"] == "claude-1" {
+			aliasOwners++
+		}
+	}
+	if aliasOwners != 1 {
+		t.Fatalf("pool alias owners = %d, want exactly one; beads=%#v", aliasOwners, sessionBeads)
+	}
+}
+
+func TestCreatePoolSessionBeadWithGuardedAlias_LogsAliasLockSetupFailure(t *testing.T) {
+	store := beads.NewMemStore()
+	cityPath := filepath.Join(t.TempDir(), "city-file")
+	if err := os.WriteFile(cityPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	bp := &agentBuildParams{
+		cityPath:     cityPath,
+		beadStore:    store,
+		sessionBeads: &sessionBeadSnapshot{},
+		stderr:       &stderr,
+	}
+
+	bead, err := createPoolSessionBeadWithGuardedAlias(bp, "claude", "claude-1", 1)
+	if err != nil {
+		t.Fatalf("createPoolSessionBeadWithGuardedAlias: %v", err)
+	}
+	if got := bead.Metadata["alias"]; got != "" {
+		t.Fatalf("alias = %q, want empty fallback when alias lock setup fails", got)
+	}
+	if !strings.Contains(stderr.String(), "locking alias \"claude-1\"") || !strings.Contains(stderr.String(), "creating without alias") {
+		t.Fatalf("stderr = %q, want alias-lock setup failure and unaliased fallback", stderr.String())
 	}
 }
 
@@ -4468,12 +4708,50 @@ func TestSelectOrCreatePoolSessionBead_SkipsDrained(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
+	result, slot, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
 	if result.ID == drained.ID {
 		t.Fatal("should not reuse drained session bead for new-tier request")
+	}
+	if slot != 1 {
+		t.Fatalf("fresh create slot = %d, want 1", slot)
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_DoesNotReserveFreshSlotOnCreateError(t *testing.T) {
+	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
+	snapshot := &sessionBeadSnapshot{}
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	usedSlots := map[int]bool{}
+	bp := &agentBuildParams{
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	if _, slot, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, usedSlots); err == nil {
+		t.Fatal("selectOrCreatePoolSessionBead returned nil error, want create failure")
+	} else if slot != 0 {
+		t.Fatalf("slot on create error = %d, want 0", slot)
+	}
+	if usedSlots[1] {
+		t.Fatalf("usedSlots[1] = true after create error, want released")
+	}
+
+	successStore := beads.NewMemStore()
+	bp.beadStore = successStore
+	bp.sessionBeads = &sessionBeadSnapshot{}
+	result, slot, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, usedSlots)
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead after failure: %v", err)
+	}
+	if slot != 1 {
+		t.Fatalf("slot after previous create error = %d, want 1", slot)
+	}
+	if result.Metadata["pool_slot"] != "1" {
+		t.Fatalf("pool_slot after previous create error = %q, want 1", result.Metadata["pool_slot"])
 	}
 }
 
@@ -4522,6 +4800,7 @@ func TestSelectOrCreatePoolSessionBead_ReusesPreferredDrained(t *testing.T) {
 			"agent_name":   "claude",
 			"session_name": "claude-drained",
 			"state":        "drained",
+			"pool_slot":    "4",
 			"pool_managed": "true",
 		},
 	})
@@ -4537,12 +4816,15 @@ func TestSelectOrCreatePoolSessionBead_ReusesPreferredDrained(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", &drained, map[string]bool{}, map[int]bool{})
+	result, slot, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", &drained, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
 	if result.ID != drained.ID {
 		t.Fatal("resume tier should reuse preferred drained session bead")
+	}
+	if slot != 4 {
+		t.Fatalf("preferred reuse slot = %d, want 4", slot)
 	}
 }
 
@@ -4581,6 +4863,62 @@ func TestSelectOrCreateDependencyPoolSessionBead_SkipsDrained(t *testing.T) {
 	if result.ID == drained.ID {
 		t.Fatal("should not reuse drained dependency session bead for generic dependency demand")
 	}
+	if got := result.Metadata["agent_name"]; got != "claude-1" {
+		t.Fatalf("dependency agent_name = %q, want claude-1", got)
+	}
+	if got := result.Metadata["alias"]; got != "claude-1" {
+		t.Fatalf("dependency alias = %q, want claude-1", got)
+	}
+	if got := result.Metadata["pool_slot"]; got != "1" {
+		t.Fatalf("dependency pool_slot = %q, want 1", got)
+	}
+	if got := result.Title; got != "claude-1" {
+		t.Fatalf("dependency title = %q, want claude-1", got)
+	}
+	if !containsString(result.Labels, "agent:claude-1") {
+		t.Fatalf("dependency labels = %#v, want concrete slot agent label", result.Labels)
+	}
+}
+
+func TestSelectOrCreateDependencyPoolSessionBead_DefersAliasWhenConcreteAliasTaken(t *testing.T) {
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "manual session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:manual"},
+		Metadata: map[string]string{
+			"template":       "manual",
+			"agent_name":     "manual",
+			"alias":          "claude-1",
+			"session_name":   "manual-claude-1",
+			"state":          "awake",
+			"session_origin": "manual",
+			"manual_session": "true",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	bp := &agentBuildParams{
+		cityPath:     t.TempDir(),
+		beadStore:    store,
+		sessionBeads: &sessionBeadSnapshot{},
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	result, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "claude")
+	if err != nil {
+		t.Fatalf("selectOrCreateDependencyPoolSessionBead: %v", err)
+	}
+	if got := result.Metadata["agent_name"]; got != "claude-1" {
+		t.Fatalf("dependency agent_name = %q, want claude-1", got)
+	}
+	if got := result.Metadata["alias"]; got != "" {
+		t.Fatalf("dependency alias = %q, want deferred until alias guard accepts it", got)
+	}
+	if got := result.Metadata["pool_slot"]; got != "1" {
+		t.Fatalf("dependency pool_slot = %q, want 1", got)
+	}
 }
 
 func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
@@ -4593,9 +4931,11 @@ func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 		Labels: []string{sessionBeadLabel},
 		Metadata: map[string]string{
 			"template":     "claude",
-			"agent_name":   "claude",
+			"agent_name":   "claude-3",
+			"alias":        "claude-3",
 			"session_name": "claude-awake",
 			"state":        "awake",
+			"pool_slot":    "3",
 			"pool_managed": "true",
 		},
 	})
@@ -4611,12 +4951,15 @@ func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 		agents:       []config.Agent{cfgAgent},
 	}
 
-	result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
+	result, slot, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
 	if err != nil {
 		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
 	}
 	if result.ID != awake.ID {
 		t.Fatal("new-tier should reuse available (non-drained) session bead")
+	}
+	if slot != 3 {
+		t.Fatalf("available reuse slot = %d, want 3", slot)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -3235,6 +3235,9 @@ func TestCityRuntimeManualReloadReplyWaitsForTickCompletion(t *testing.T) {
 		Stdout: &stdout,
 		Stderr: io.Discard,
 	})
+	// This test asserts reload reply timing only; order subprocesses add
+	// unrelated tempdir cleanup races after the tick has completed.
+	cr.od = nil
 	cr.activeReload = &reloadRequest{doneCh: doneCh}
 	lastProviderName := "fake"
 	var prevPoolRunning map[string]bool

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -861,7 +861,6 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	for sn, tp := range desiredState {
 		agentCfg := templateParamsToConfig(tp)
 		liveHash := runtime.LiveFingerprint(agentCfg)
-		managedAlias := strings.TrimSpace(tp.Alias)
 		isConfiguredNamed := strings.TrimSpace(tp.ConfiguredNamedIdentity) != ""
 		if isConfiguredNamed && blockedReconfiguredNamedIdentities[strings.TrimSpace(tp.ConfiguredNamedIdentity)] {
 			continue
@@ -881,6 +880,10 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		}
 		isManagedPool := origin == "ephemeral"
 		isPoolInstance := poolSlot > 0
+		managedAlias := strings.TrimSpace(tp.Alias)
+		if managedAlias == "" && isManagedPool && isPoolInstance {
+			managedAlias = strings.TrimSpace(tp.InstanceName)
+		}
 
 		b, exists := bySessionName[sn]
 		if !exists && isPoolInstance {
@@ -1288,7 +1291,12 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			queueMeta(poolAliasConflictCountMetadataKey, strconv.Itoa(count+1))
 			queueMeta(poolAliasConflictAtMetadataKey, now.Format(time.RFC3339))
 		}
-		if needsAliasSync {
+		// Stable managed pool aliases are intentionally revalidated every sync
+		// tick. Pool create holds the alias lock through persistence, but manual
+		// sessions and legacy/pre-stamped beads can still introduce conflicts
+		// outside that path; this O(pool sessions) check is the recovery point.
+		needsManagedPoolAliasValidation := !needsAliasSync && managedAlias != "" && isManagedPool && isPoolInstance
+		if needsAliasSync || needsManagedPoolAliasValidation {
 			lockAlias := managedAlias
 			if lockAlias == "" {
 				lockAlias = strings.TrimSpace(b.Metadata["alias"])
@@ -1303,11 +1311,16 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				}
 				if err != nil {
 					recordAliasConflict()
+					if needsManagedPoolAliasValidation {
+						queueMeta("alias", "")
+					}
 					fmt.Fprintf(stderr, "session beads: alias %q for %s unavailable: %v\n", managedAlias, agentName, err) //nolint:errcheck
 				} else {
 					clearAliasConflict()
-					for key, value := range session.UpdatedAliasMetadata(b.Metadata, managedAlias) {
-						queueMeta(key, value)
+					if needsAliasSync {
+						for key, value := range session.UpdatedAliasMetadata(b.Metadata, managedAlias) {
+							queueMeta(key, value)
+						}
 					}
 					mergeAliasGuardedBatch()
 				}
@@ -1319,6 +1332,10 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				fmt.Fprintf(stderr, "session beads: locking alias %q for %s: %v\n", lockAlias, agentName, lockErr) //nolint:errcheck
 			}
 			if appliedWithLock {
+				continue
+			}
+			if needsManagedPoolAliasValidation {
+				applyBatch()
 				continue
 			}
 		}

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2803,7 +2803,7 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 	sp := runtime.NewFake()
 	template := "pack/worker"
 
-	owner, err := createPoolSessionBead(store, template, nil, clk.Now())
+	owner, err := createPoolSessionBead(store, template, nil, clk.Now(), poolSessionCreateIdentity{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3229,7 +3229,7 @@ func TestCreatePoolSessionBead_MetadataFailureLeavesReachablePlaceholder(t *test
 	store := &failingPoolSessionNameStore{MemStore: beads.NewMemStore()}
 	template := "pack/worker"
 
-	if _, err := createPoolSessionBead(store, template, nil, time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)); err == nil {
+	if _, err := createPoolSessionBead(store, template, nil, time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC), poolSessionCreateIdentity{}); err == nil {
 		t.Fatal("createPoolSessionBead returned nil error, want session_name metadata failure")
 	}
 

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -3158,7 +3158,149 @@ func TestSyncSessionBeads_DoesNotReservePoolSlotForAliasConflictBead(t *testing.
 	}
 }
 
-func TestSyncSessionBeads_PreservesAliasConflictMetadataWhenAliasLockFails(t *testing.T) {
+func TestSyncSessionBeads_ValidatesPreStampedPoolAlias(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 12, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	if _, err := store.Create(beads.Bead{
+		Title:  "manual alias owner",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:pack/manual"},
+		Metadata: map[string]string{
+			"template":       "pack/manual",
+			"session_name":   "manual-pack-worker-2",
+			"agent_name":     "pack/manual",
+			"alias":          "pack/worker-2",
+			"state":          "awake",
+			"session_origin": "manual",
+			"manual_session": "true",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	live, err := store.Create(beads.Bead{
+		Title:  "pre-stamped worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-live",
+			"agent_name":           "pack/worker-2",
+			"alias":                "pack/worker-2",
+			"pool_slot":            "2",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		"pack-worker-live": {
+			TemplateName: template,
+			InstanceName: "pack/worker-2",
+			Alias:        "pack/worker-2",
+			PoolSlot:     2,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["alias"] != "" {
+		t.Fatalf("alias = %q, want cleared after conflict", got.Metadata["alias"])
+	}
+	if got.Metadata[poolAliasConflictMetadataKey] != "pack/worker-2" {
+		t.Fatalf("pool_alias_conflict = %q, want pack/worker-2", got.Metadata[poolAliasConflictMetadataKey])
+	}
+	if got.Metadata[poolAliasConflictCountMetadataKey] != "1" {
+		t.Fatalf("pool_alias_conflict_count = %q, want 1", got.Metadata[poolAliasConflictCountMetadataKey])
+	}
+	if got.Metadata[poolAliasConflictAtMetadataKey] != "2026-05-06T02:12:00Z" {
+		t.Fatalf("pool_alias_conflict_at = %q, want 2026-05-06T02:12:00Z", got.Metadata[poolAliasConflictAtMetadataKey])
+	}
+	if !strings.Contains(stderr.String(), "unavailable") {
+		t.Fatalf("stderr %q does not mention alias conflict", stderr.String())
+	}
+}
+
+func TestSyncSessionBeads_ManagedPoolAliasValidationKeepsCleanAlias(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 14, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:              "worker",
+			Dir:               "pack",
+			MaxActiveSessions: intPtr(10),
+		}},
+	}
+	template := "pack/worker"
+	live, err := store.Create(beads.Bead{
+		Title:  "pre-stamped worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + template},
+		Metadata: map[string]string{
+			"template":             template,
+			"session_name":         "pack-worker-live",
+			"agent_name":           "pack/worker-2",
+			"alias":                "pack/worker-2",
+			"pool_slot":            "2",
+			"state":                "awake",
+			"session_origin":       "ephemeral",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]TemplateParams{
+		"pack-worker-live": {
+			TemplateName: template,
+			InstanceName: "pack/worker-2",
+			Alias:        "pack/worker-2",
+			PoolSlot:     2,
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads("", store, desired, sp, allConfiguredDS(desired), cfg, clk, &stderr, false)
+	got, err := store.Get(live.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Metadata["alias"] != "pack/worker-2" {
+		t.Fatalf("alias = %q, want clean managed alias preserved", got.Metadata["alias"])
+	}
+	if got.Metadata[poolAliasConflictMetadataKey] != "" {
+		t.Fatalf("pool_alias_conflict = %q, want empty", got.Metadata[poolAliasConflictMetadataKey])
+	}
+	if got.Metadata[poolAliasConflictCountMetadataKey] != "" {
+		t.Fatalf("pool_alias_conflict_count = %q, want empty", got.Metadata[poolAliasConflictCountMetadataKey])
+	}
+	if got.Metadata[poolAliasConflictAtMetadataKey] != "" {
+		t.Fatalf("pool_alias_conflict_at = %q, want empty", got.Metadata[poolAliasConflictAtMetadataKey])
+	}
+	if strings.Contains(stderr.String(), "unavailable") {
+		t.Fatalf("stderr %q unexpectedly mentions alias conflict", stderr.String())
+	}
+}
+
+func TestSyncSessionBeads_PreservesStablePoolAliasConflictMetadataWhenAliasLockFails(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 5, 6, 2, 15, 0, 0, time.UTC)}
 	sp := runtime.NewFake()
@@ -3171,13 +3313,15 @@ func TestSyncSessionBeads_PreservesAliasConflictMetadataWhenAliasLockFails(t *te
 	}
 	template := "pack/worker"
 	live, err := store.Create(beads.Bead{
-		Title:  "legacy worker",
+		Title:  "stable worker",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:" + template},
 		Metadata: map[string]string{
 			"template":                        template,
-			"session_name":                    "pack-worker-legacy",
-			"agent_name":                      template,
+			"session_name":                    "pack-worker-live",
+			"agent_name":                      "pack/worker-2",
+			"alias":                           "pack/worker-2",
+			"pool_slot":                       "2",
 			"state":                           "awake",
 			"session_origin":                  "ephemeral",
 			poolManagedMetadataKey:            boolMetadata(true),
@@ -3191,7 +3335,7 @@ func TestSyncSessionBeads_PreservesAliasConflictMetadataWhenAliasLockFails(t *te
 	}
 
 	desired := map[string]TemplateParams{
-		"pack-worker-legacy": {
+		"pack-worker-live": {
 			TemplateName: template,
 			InstanceName: "pack/worker-2",
 			Alias:        "pack/worker-2",

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -691,16 +691,6 @@ func buildPreparedStart(
 		continuationEpoch,
 		instanceToken,
 	)
-	// When the bead has no alias but the template was identity-stamped
-	// (pool workers and dependency floors via setTemplateEnvIdentity),
-	// don't let mergeEnv's override-wins semantics clobber the stamped
-	// GC_ALIAS with the runtime's empty value. For ordinary sessions the
-	// resolver-stamped GC_ALIAS is left to be overwritten by the empty
-	// runtime value so the tmux runtime emits `env -u GC_ALIAS` and scrubs
-	// any inherited GC_ALIAS from the tmux server.
-	if beadAlias == "" && tp.EnvIdentityStamped {
-		delete(runtimeEnv, "GC_ALIAS")
-	}
 	agentCfg.Env = mergeEnv(agentCfg.Env, runtimeEnv)
 	if gcProvider := sessionProviderFamily(*session); gcProvider != "" {
 		agentCfg.Env = mergeEnv(agentCfg.Env, map[string]string{"GC_PROVIDER": gcProvider})

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -5187,15 +5187,20 @@ func TestPrepareStartCandidateUsesBuiltinAncestorForGCProviderEnv(t *testing.T) 
 	}
 }
 
-func TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias(t *testing.T) {
+func TestPrepareStartCandidate_EmptyPoolBeadAliasScrubsStampedTemplateIdentity(t *testing.T) {
 	store := beads.NewMemStore()
 	bead, err := store.Create(beads.Bead{
 		Title: "ants-ant-1",
 		Type:  "task",
 		Metadata: map[string]string{
-			"session_name": "ants-ant-1",
-			"provider":     "claude",
-			"state":        "creating",
+			"session_name":        "ants-pool-gc123",
+			"provider":            "claude",
+			"state":               "creating",
+			"template":            "ants",
+			"session_origin":      "ephemeral",
+			"pool_managed":        "true",
+			"pool_slot":           "1",
+			"pool_alias_conflict": "ants-ant-1",
 		},
 	})
 	if err != nil {
@@ -5204,11 +5209,12 @@ func TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias(t *testing
 
 	tp := TemplateParams{
 		Command: "claude",
-		// Shape matches setTemplateEnvIdentity output (GC_ALIAS+GC_AGENT stamped)
-		// plus an unrelated template key to verify the merge preserves it.
+		// Shape matches a stale setTemplateEnvIdentity output from an earlier
+		// build. The persisted bead alias is authoritative; an empty alias must
+		// scrub this contested template identity before runtime launch.
 		Env:                map[string]string{"GC_ALIAS": "ants-ant-1", "GC_AGENT": "ants-ant-1", "TEMPLATE_KEY": "keep"},
 		WorkDir:            t.TempDir(),
-		SessionName:        "ants-ant-1",
+		SessionName:        "ants-pool-gc123",
 		InstanceName:       "ants-ant-1",
 		PoolSlot:           1,
 		EnvIdentityStamped: true,
@@ -5226,11 +5232,13 @@ func TestPrepareStartCandidate_EmptyBeadAliasPreservesTemplateGCAlias(t *testing
 		t.Fatalf("prepareStartCandidate: %v", err)
 	}
 
-	if got := prepared.cfg.Env["GC_ALIAS"]; got != "ants-ant-1" {
-		t.Fatalf("GC_ALIAS = %q, want %q (template value must survive merge when bead alias is empty)", got, "ants-ant-1")
+	if got, ok := prepared.cfg.Env["GC_ALIAS"]; !ok {
+		t.Fatalf("GC_ALIAS should be present with empty value so tmux emits `env -u GC_ALIAS`; got absent")
+	} else if got != "" {
+		t.Fatalf("GC_ALIAS = %q, want empty because the pool alias is deferred", got)
 	}
-	if got := prepared.cfg.Env["GC_AGENT"]; got != "ants-ant-1" {
-		t.Fatalf("GC_AGENT = %q, want %q (companion identity key must also survive)", got, "ants-ant-1")
+	if got := prepared.cfg.Env["GC_AGENT"]; got != "ants-pool-gc123" {
+		t.Fatalf("GC_AGENT = %q, want non-conflicting session name %q", got, "ants-pool-gc123")
 	}
 	if got := prepared.cfg.Env["TEMPLATE_KEY"]; got != "keep" {
 		t.Fatalf("TEMPLATE_KEY = %q, want %q (unrelated template env must survive merge)", got, "keep")

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -15,6 +15,12 @@ import (
 
 const poolManagedMetadataKey = "pool_managed"
 
+type poolSessionCreateIdentity struct {
+	AgentName string
+	Alias     string
+	Slot      int
+}
+
 func isPoolManagedSessionBead(bead beads.Bead) bool {
 	if isEphemeralSessionBead(bead) {
 		return true
@@ -123,14 +129,22 @@ func createPoolSessionBead(
 	template string,
 	sessionBeads *sessionBeadSnapshot,
 	now time.Time,
+	identity poolSessionCreateIdentity,
 ) (beads.Bead, error) {
 	if store == nil {
 		return beads.Bead{}, fmt.Errorf("session store unavailable for pool template %q", template)
 	}
 	instanceToken := sessionpkg.NewInstanceToken()
+	agentName := strings.TrimSpace(identity.AgentName)
+	title := targetBasename(template)
+	if agentName == "" {
+		agentName = template
+	} else {
+		title = agentName
+	}
 	meta := map[string]string{
 		"template":                  template,
-		"agent_name":                template,
+		"agent_name":                agentName,
 		"state":                     "creating",
 		"pending_create_claim":      "true",
 		"pending_create_started_at": pendingCreateStartedAtNow(now),
@@ -141,10 +155,16 @@ func createPoolSessionBead(
 		"session_name":              pendingPoolSessionName(template, instanceToken),
 		poolManagedMetadataKey:      boolMetadata(true),
 	}
+	if alias := strings.TrimSpace(identity.Alias); alias != "" {
+		meta["alias"] = alias
+	}
+	if identity.Slot > 0 {
+		meta["pool_slot"] = strconv.Itoa(identity.Slot)
+	}
 	bead, err := store.Create(beads.Bead{
-		Title:    targetBasename(template),
+		Title:    title,
 		Type:     sessionBeadType,
-		Labels:   []string{sessionBeadLabel, "agent:" + template},
+		Labels:   []string{sessionBeadLabel, "agent:" + agentName},
 		Metadata: meta,
 	})
 	if err != nil {

--- a/cmd/gc/session_name_lookup_test.go
+++ b/cmd/gc/session_name_lookup_test.go
@@ -12,7 +12,7 @@ func TestCreatePoolSessionBead_SetsPendingCreateClaim(t *testing.T) {
 	store := beads.NewMemStore()
 	now := time.Date(2026, 5, 1, 9, 15, 0, 0, time.UTC)
 
-	bead, err := createPoolSessionBead(store, "gascity/claude", nil, now)
+	bead, err := createPoolSessionBead(store, "gascity/claude", nil, now, poolSessionCreateIdentity{})
 	if err != nil {
 		t.Fatalf("createPoolSessionBead: %v", err)
 	}


### PR DESCRIPTION
## Summary
- create new pool session beads with their concrete slot identity immediately
- stamp agent_name, alias, pool_slot, title, and agent label consistently at creation time
- keep existing fallback behavior for callers that do not know a concrete pool identity

## Tests
- go test ./cmd/gc -run 'TestBuildDesiredState_NewPoolSessionBeadCreatedWithConcreteIdentity|TestBuildDesiredState_RoutedQueueDoesNotCreateOneSessionPerBead|TestSelectOrCreatePoolSessionBead|TestSelectOrCreateDependencyPoolSessionBead|TestPoolSessionName|TestCreatePoolSessionBead' -count=1
- go test ./cmd/gc -count=1
- pre-commit quality gate during commit: lint, vet, observable go test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->