### PR TITLE
fix(dog): forbid filesystem-wide formula searches

### DIFF
--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -32,6 +32,16 @@ queued formula.
 
 Additional formulas available from included packs (e.g. dolt).
 
+If your wisp names a formula not listed above (one that an included
+pack provides, or one the daemon assigned), read its recipe with
+`gc bd formula show <formula-name>`. **Never** locate formula files
+with whole-filesystem searches (`find /`, `find ~`) — they trigger
+macOS TCC permission prompts on protected directories (Documents,
+Desktop, Downloads, removable volumes, network mounts) and produce
+no useful signal a `gc` introspection command can't already provide.
+If `gc bd formula show` returns "formula not found", the wisp is
+mis-routed — close the bead with that reason and exit; do not hunt.
+
 ---
 
 ## The Shutdown Dance
@@ -109,6 +119,7 @@ gc session nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 | Want to... | Correct command |
 |------------|----------------|
 | Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
+| Read formula recipe | `gc bd formula show <formula-name>` (NOT `find /`) |
 | Find pool work | `{{ .WorkQuery }}` |
 | Claim pool work | `gc bd update <id> --claim` |
 | View work details | `gc bd show <id> --json` |


### PR DESCRIPTION
## Summary

- When a dog is assigned a wisp whose formula isn't in its built-in list (an included pack's formula, or one routed by the daemon), the dog's prompt previously gave no guidance on how to read the recipe. Dogs filled the gap with `find / -name "mol-*"` to locate the file, which on macOS triggers TCC permission prompts on protected directories (Documents, Desktop, Downloads, removable volumes, network mounts) — interrupting the user with prompts the dog has no business asking.
- Add explicit prompt guidance: read formula recipes with `gc bd formula show <formula-name>` (matching the existing convention in the deacon prompt), and never run whole-filesystem searches. If the formula isn't found, the wisp is mis-routed — close the bead with that reason and exit.
- Prose-only edit to `examples/gastown/packs/maintenance/agents/dog/prompt.template.md` (11 lines added). No Go code changes.

## Testing

- [x] `make check` — passes the same as `origin/main` on macOS. Pre-existing failures (unchanged by this PR): `TestBuiltinDoltDoctorBoundsVersionProbe`, `TestBuiltinDoltDoctorReportsTimedOutVersionProbe`, `TestExecCommandRunnerTimeoutKillsChildProcess` — all three are macOS-specific and tracked as fixed by #1729.
- [ ] `make check-docs` — n/a (no docs/, navigation/, or links touched).
- [ ] `make test-integration` — not run (no runtime/controller/workflow change; this is prose-only prompt content).

## Checklist

- [x] Linked an issue, or explained why one is not needed — see Summary; reproducer transcript captured at `~/.claude/projects/-Users-eric-cities-e2e-stg-lkg1-v2--gc-agents-dogs-gastown-dog-1/2af78333-b2d2-4c7f-b5ab-6e26a0881ce6.jsonl` (the `find /` invocation that triggered the popups).
- [x] Added or updated tests for behavior changes — n/a, prose-only prompt edit.
- [x] Updated docs for user-facing changes — the prompt itself is the user-facing artifact.
- [x] Called out breaking changes or migration notes — none; additive guidance only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->