### PR TITLE
fix(supervisor): opt-out for persisting provider creds in service file

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -192,6 +192,15 @@ const (
 
 const supervisorPreserveSessionsOnSignalEnv = "GC_SUPERVISOR_PRESERVE_SESSIONS_ON_SIGNAL"
 
+// supervisorOmitProviderCredsEnv, when set to "1" at the time the supervisor
+// service file is generated, causes provider-credential env vars
+// (ANTHROPIC_*, GEMINI_*, GOOGLE_*, OPENAI_*) to be excluded from the
+// generated launchd plist or systemd unit. Default behavior is unchanged.
+// When opted out, the user is responsible for delivering provider creds to
+// the supervisor's environment via some other mechanism (e.g. a wrapper
+// around `gc supervisor run` that sources a credentials file).
+const supervisorOmitProviderCredsEnv = "GC_SUPERVISOR_OMIT_PROVIDER_CREDS"
+
 var supervisorShutdownSettleDelay = 50 * time.Millisecond
 
 var supervisorSignalNotify = signal.Notify

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -743,7 +743,10 @@ func shouldPersistSupervisorEnv(key string) bool {
 	if supervisorServiceEnvKeys[key] {
 		return true
 	}
-	return isProviderCredentialEnv(key)
+	if isProviderCredentialEnv(key) {
+		return os.Getenv(supervisorOmitProviderCredsEnv) != "1"
+	}
+	return false
 }
 
 func isProviderCredentialEnv(key string) bool {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -509,6 +509,50 @@ func TestBuildSupervisorServiceDataIncludesProviderEnv(t *testing.T) {
 	}
 }
 
+func TestBuildSupervisorServiceDataOmitsProviderEnvWhenOptedOut(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-123")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://anthropic.example.test")
+	t.Setenv("OPENAI_API_KEY", "sk-openai-123")
+	t.Setenv("GEMINI_API_KEY", "gemini-123")
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "gc-project")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(homeDir, ".claude"))
+	t.Setenv("GC_SUPERVISOR_ENV", "CUSTOM_PROVIDER_TOKEN")
+	t.Setenv("CUSTOM_PROVIDER_TOKEN", "custom-token")
+	t.Setenv(supervisorOmitProviderCredsEnv, "1")
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for _, key := range []string{
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_BASE_URL",
+		"OPENAI_API_KEY",
+		"GEMINI_API_KEY",
+		"GOOGLE_CLOUD_PROJECT",
+	} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("ExtraEnv should not include provider key %s when %s=1: %#v",
+				key, supervisorOmitProviderCredsEnv, got)
+		}
+	}
+	for key, want := range map[string]string{
+		"CLAUDE_CONFIG_DIR":     filepath.Join(homeDir, ".claude"),
+		"CUSTOM_PROVIDER_TOKEN": "custom-token",
+	} {
+		if got[key] != want {
+			t.Fatalf("ExtraEnv[%s] = %q, want %q (all env: %#v)", key, got[key], want, got)
+		}
+	}
+}
+
 func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
 	m := make(map[string]string, len(vars))
 	for _, item := range vars {


### PR DESCRIPTION
## Summary

Adds an opt-out env var, `GC_SUPERVISOR_OMIT_PROVIDER_CREDS`. When set to `"1"`
at the time the supervisor service file is generated, provider-credential env
vars (`ANTHROPIC_*`, `GEMINI_*`, `GOOGLE_*`, `OPENAI_*`) are excluded from the
generated launchd plist / systemd unit. Default behavior is unchanged.

Background — provider creds are persisted in plaintext (mode 0600) into the
service file by design (#1198) so launchd/systemd-spawned supervisors can
deliver creds to agent sessions. The opt-out gives users who'd prefer to avoid
the on-disk plaintext (Time Machine backup posture, crash dumps, regression
surface) a way to disable persistence and deliver creds to the supervisor by
another mechanism (e.g. a wrapper around `gc supervisor run`).

This is the smallest concrete proposal in #1786; happy to take a different
direction if preferred (e.g. credentials-file loading at supervisor start,
Keychain).

## Testing

- [x] `make check` — passes locally except for documented pre-existing
  failures on `origin/main` (none related to this change):
  - `TestBuiltinDoltDoctorBoundsVersionProbe` — fixed by #1729 (open)
  - `TestBuiltinDoltDoctorReportsTimedOutVersionProbe` — fixed by #1729 (open)
  - `TestExecCommandRunnerTimeoutKillsChildProcess` — fixed by #1729 (open)
- [ ] `make check-docs` — no docs touched
- [ ] `make test-integration` — not run
- [x] `go test ./cmd/gc -run 'TestBuildSupervisorServiceData' -count=1` — green,
  including the new `TestBuildSupervisorServiceDataOmitsProviderEnvWhenOptedOut`

## Checklist

- [x] Linked an issue: #1786
- [x] Added tests for behavior change
- [ ] Updated docs — no user-facing docs changed; the opt-out is documented
  inline at the const declaration
- [x] No breaking changes; default behavior is unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->