### PR TITLE
fix(stop): bound subprocess + per-target timeouts so gc stop can't hang

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1544,9 +1544,9 @@ func (cr *CityRuntime) requestAsyncStartFollowUpTick() {
 	}
 }
 
-func (cr *CityRuntime) waitForAsyncStarts() {
+func (cr *CityRuntime) waitForAsyncStarts() bool {
 	if cr == nil {
-		return
+		return true
 	}
 	timeout := time.Duration(0)
 	if cr.cfg != nil {
@@ -1555,9 +1555,17 @@ func (cr *CityRuntime) waitForAsyncStarts() {
 	if timeout <= 0 {
 		timeout = 5 * time.Second
 	}
-	if !cr.asyncStarts.wait(timeout) && cr.stderr != nil {
-		fmt.Fprintf(cr.stderr, "%s: async session starts still running after %s; continuing shutdown\n", cr.logPrefix, timeout) //nolint:errcheck // best-effort stderr
+	// A force stop may leave provider Start calls to finish after shutdown has
+	// stopped waiting. That favors bounded shutdown; the next controller start
+	// re-lists live runtime sessions after the first stop pass so late-created
+	// sessions do not survive the shutdown that abandoned the async wait.
+	if !cr.asyncStarts.waitUntil(timeout, cr.forceStopRequested) {
+		if cr.stderr != nil && !cr.forceStopRequested() {
+			fmt.Fprintf(cr.stderr, "%s: async session starts still running after %s; continuing shutdown\n", cr.logPrefix, timeout) //nolint:errcheck // best-effort stderr
+		}
+		return false
 	}
+	return true
 }
 
 func sweepUndesiredPoolSessionBeads(
@@ -2099,7 +2107,7 @@ func (cr *CityRuntime) recordPreservedShutdownTrace() {
 // normal shutdown) — only the first call takes effect.
 func (cr *CityRuntime) shutdown() {
 	cr.shutdownOnce.Do(func() {
-		cr.waitForAsyncStarts()
+		asyncStartsDrained := cr.waitForAsyncStarts()
 		preserveSessions := cr.preserveSessionsShutdown.Load()
 		if preserveSessions {
 			cr.recordPreservedShutdownTrace()
@@ -2127,11 +2135,14 @@ func (cr *CityRuntime) shutdown() {
 		// sweepOrphanedOrderTrackingRetry on next start.
 		total := cr.cfg.Daemon.ShutdownTimeoutDuration()
 		gracefulTimeout := total
-		if cr.forceStopShutdown != nil && cr.forceStopShutdown.Load() {
+		if cr.forceStopRequested() {
 			gracefulTimeout = 0
 		}
 		if cr.od != nil || len(cr.retiredOrderDispatchers) > 0 {
 			drainTimeout := orderShutdownDrainTimeout(total)
+			if cr.forceStopRequested() {
+				drainTimeout = 0
+			}
 			drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
 			cr.drainOrderDispatchers(drainCtx)
 			drainCancel()
@@ -2146,10 +2157,28 @@ func (cr *CityRuntime) shutdown() {
 		}
 		store := cr.cityBeadStore()
 		markCityStopSessionSleepReason(store, cr.stderr)
-		gracefulStopAll(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr)
+		gracefulStopAllWithForceSignal(running, cr.sp, gracefulTimeout, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
+		if !asyncStartsDrained && cr.forceStopRequested() {
+			lateRunning, lateListErr := cr.sp.ListRunning("")
+			if lateListErr != nil {
+				if runtime.IsPartialListError(lateListErr) {
+					fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing partially failed; stopping %d visible agent(s): %v\n", cr.logPrefix, len(lateRunning), lateListErr) //nolint:errcheck // best-effort stderr
+				} else {
+					fmt.Fprintf(cr.stderr, "%s: force shutdown late async-start listing failed: %v\n", cr.logPrefix, lateListErr) //nolint:errcheck // best-effort stderr
+				}
+			}
+			if len(lateRunning) > 0 {
+				markCityStopSessionSleepReason(store, cr.stderr)
+				gracefulStopAllWithForceSignal(lateRunning, cr.sp, 0, cr.rec, cr.cfg, store, cr.stdout, cr.stderr, cr.forceStopRequested)
+			}
+		}
 	})
 }
 
 func (cr *CityRuntime) preserveSessionsOnShutdown() {
 	cr.preserveSessionsShutdown.Store(true)
+}
+
+func (cr *CityRuntime) forceStopRequested() bool {
+	return cr != nil && cr.forceStopShutdown != nil && cr.forceStopShutdown.Load()
 }

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -98,6 +98,7 @@ type CityRuntime struct {
 
 	shutdownOnce             sync.Once
 	preserveSessionsShutdown atomic.Bool
+	forceStopShutdown        *atomic.Bool
 	logPrefix                string // "gc start" or "gc supervisor"
 	stdout, stderr           io.Writer
 }
@@ -132,6 +133,7 @@ type CityRuntimeParams struct {
 
 	PoolSessions      map[string]time.Duration
 	PoolDeathHandlers map[string]poolDeathInfo
+	ForceStopShutdown *atomic.Bool
 
 	ConvergenceReqCh    chan convergenceRequest // may be nil
 	ReloadReqCh         chan reloadRequest      // may be nil; receives structured reload commands
@@ -219,6 +221,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 		rec:                     p.Rec,
 		poolSessions:            p.PoolSessions,
 		poolDeathHandlers:       p.PoolDeathHandlers,
+		forceStopShutdown:       p.ForceStopShutdown,
 		suspendedNames:          suspendedNames,
 		asyncStartLimiter:       newAsyncStartLimiter(maxParallelStartsPerTick(p.Cfg)),
 		convergenceReqCh:        p.ConvergenceReqCh,
@@ -2124,6 +2127,9 @@ func (cr *CityRuntime) shutdown() {
 		// sweepOrphanedOrderTrackingRetry on next start.
 		total := cr.cfg.Daemon.ShutdownTimeoutDuration()
 		gracefulTimeout := total
+		if cr.forceStopShutdown != nil && cr.forceStopShutdown.Load() {
+			gracefulTimeout = 0
+		}
 		if cr.od != nil || len(cr.retiredOrderDispatchers) > 0 {
 			drainTimeout := orderShutdownDrainTimeout(total)
 			drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)

--- a/cmd/gc/cmd_register.go
+++ b/cmd/gc/cmd_register.go
@@ -120,7 +120,7 @@ func doUnregister(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc unregister: %v\n", err) //nolint:errcheck
 		return 1
 	}
-	_, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc unregister")
+	_, code := unregisterCityFromSupervisor(cityPath, stdout, stderr)
 	return code
 }
 

--- a/cmd/gc/cmd_restart.go
+++ b/cmd/gc/cmd_restart.go
@@ -38,7 +38,7 @@ func cmdRestart(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc restart: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if code := cmdStop(args, stdout, stderr); code != 0 {
+	if code := cmdStop(args, stdout, stderr, 0, false); code != 0 {
 		return code
 	}
 	return doStartWithNameOverride(args, false /*controllerMode*/, stdout, stderr, nameOverride)

--- a/cmd/gc/cmd_session_reset_test.go
+++ b/cmd/gc/cmd_session_reset_test.go
@@ -74,6 +74,7 @@ func TestCmdSessionReset_ClearsCircuitBreaker(t *testing.T) {
 		cityDir,
 		func() {},
 		nil,
+		nil,
 		make(chan reloadRequest),
 		make(chan convergenceRequest, 1),
 		make(chan struct{}, 1),

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -17,6 +17,8 @@ import (
 )
 
 func newStopCmd(stdout, stderr io.Writer) *cobra.Command {
+	var wallClockTimeout time.Duration
+	var force bool
 	cmd := &cobra.Command{
 		Use:   "stop [path]",
 		Short: "Stop all agent sessions in the city",
@@ -25,15 +27,22 @@ func newStopCmd(stdout, stderr io.Writer) *cobra.Command {
 Sends interrupt signals to running agents, waits for the configured
 shutdown timeout, then force-kills any remaining sessions. Also stops
 the Dolt server and cleans up orphan sessions. If a controller is
-running, delegates shutdown to it.`,
+running, delegates shutdown to it.
+
+Use --timeout=DURATION to cap the wall-clock time gc stop will spend
+before giving up; the default derives from the configured shutdown
+grace times a fudge factor. Use --force to skip the interrupt grace
+period and go straight to kill.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdStop(args, stdout, stderr) != 0 {
+			if cmdStop(args, stdout, stderr, wallClockTimeout, force) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
+	cmd.Flags().DurationVar(&wallClockTimeout, "timeout", 0, "wall-clock cap for the stop sequence (0 = derive from city config)")
+	cmd.Flags().BoolVar(&force, "force", false, "skip the interrupt grace period and force-kill all sessions immediately")
 	return cmd
 }
 
@@ -43,7 +52,12 @@ const sleepReasonCityStop = "city-stop"
 
 // cmdStop stops the city by terminating all configured agent sessions.
 // If a path is given, operates there; otherwise uses cwd.
-func cmdStop(args []string, stdout, stderr io.Writer) int {
+//
+// wallClockTimeout caps how long cmdStop will wait for the shutdown
+// sequence; if 0, a default derived from cfg.Daemon.ShutdownTimeoutDuration
+// is used. force=true skips the interrupt grace period (gracefulStopAll
+// runs with timeout=0, going straight to kill).
+func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Duration, force bool) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -54,6 +68,44 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+
+	wallClockCap := wallClockTimeout
+	if wallClockCap <= 0 {
+		wallClockCap = defaultStopWallClockTimeout(cfg)
+	}
+
+	type stopOutcome struct{ code int }
+	doneCh := make(chan stopOutcome, 1)
+	go func() {
+		doneCh <- stopOutcome{code: cmdStopBody(cityPath, cfg, force, stdout, stderr)}
+	}()
+
+	select {
+	case out := <-doneCh:
+		return out.code
+	case <-time.After(wallClockCap):
+		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — try gc stop --force\n", wallClockCap) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+}
+
+// defaultStopWallClockTimeout returns the wall-clock cap used by cmdStop
+// when --timeout is not set: a multiple of the configured shutdown grace,
+// padded enough to absorb the interrupt wave + per-target stop timeout
+// for every session in serial worst-case.
+func defaultStopWallClockTimeout(cfg *config.City) time.Duration {
+	base := 5 * time.Second
+	if cfg != nil {
+		if d := cfg.Daemon.ShutdownTimeoutDuration(); d > 0 {
+			base = d
+		}
+	}
+	return base*4 + stopPerTargetTimeoutDefault
+}
+
+// cmdStopBody contains the original cmdStop flow, factored out so cmdStop
+// can apply a wall-clock cap by running it in a goroutine.
+func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr io.Writer) int {
 	cityName := loadedCityName(cfg, cityPath)
 
 	if handled, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc stop"); handled {
@@ -110,11 +162,17 @@ func cmdStop(args []string, stdout, stderr io.Writer) int {
 		recorder = fr
 	}
 
-	code := doStop(sessionNames, sp, cfg, store, cfg.Daemon.ShutdownTimeoutDuration(), recorder, stdout, stderr)
+	graceTimeout := cfg.Daemon.ShutdownTimeoutDuration()
+	if force {
+		// gracefulStopAll treats timeout=0 as "skip interrupt pass, kill immediately".
+		graceTimeout = 0
+	}
+
+	code := doStop(sessionNames, sp, cfg, store, graceTimeout, recorder, stdout, stderr)
 
 	// Clean up orphan sessions (sessions with the city prefix that are
 	// not in the current config).
-	stopOrphans(sp, desired, cfg, store, cfg.Daemon.ShutdownTimeoutDuration(), recorder, stdout, stderr)
+	stopOrphans(sp, desired, cfg, store, graceTimeout, recorder, stdout, stderr)
 
 	// Stop bead store's backing service after agents.
 	if err := shutdownBeadsProvider(cityPath); err != nil {

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -30,9 +30,10 @@ the Dolt server and cleans up orphan sessions. If a controller is
 running, delegates shutdown to it.
 
 Use --timeout=DURATION to cap the wall-clock time gc stop will spend
-before giving up; the default derives from the configured shutdown
-grace times a fudge factor. Use --force to skip the interrupt grace
-period and go straight to kill.`,
+before giving up; the default budgets configured session interrupt and
+stop waves, the configured shutdown grace wait, and a second orphan
+cleanup pass. Use --force to skip the interrupt grace period and go
+straight to kill.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			if cmdStop(args, stdout, stderr, wallClockTimeout, force) != 0 {
@@ -84,15 +85,16 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 	case out := <-doneCh:
 		return out.code
 	case <-time.After(wallClockCap):
-		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — try gc stop --force\n", wallClockCap) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — try gc stop --force --timeout=<longer-duration>\n", wallClockCap) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 }
 
 // defaultStopWallClockTimeout returns the wall-clock cap used by cmdStop
-// when --timeout is not set: a multiple of the configured shutdown grace,
-// padded enough to absorb the interrupt wave + per-target stop timeout
-// for every session in serial worst-case.
+// when --timeout is not set. It budgets a full configured-session stop and a
+// second full orphan cleanup pass using the same bounded wave sizes as the
+// stop implementation. Unknown extra live pool sessions or orphans can still
+// require an explicit --timeout from the operator.
 func defaultStopWallClockTimeout(cfg *config.City) time.Duration {
 	base := 5 * time.Second
 	if cfg != nil {
@@ -100,7 +102,55 @@ func defaultStopWallClockTimeout(cfg *config.City) time.Duration {
 			base = d
 		}
 	}
-	return base*4 + stopPerTargetTimeoutDefault
+	targets := estimatedConfiguredStopTargets(cfg)
+	interruptWaves := ceilDiv(targets, defaultMaxParallelInterrupts)
+	stopWaves := ceilDiv(targets, defaultMaxParallelStopsPerWave)
+	onePass := time.Duration(interruptWaves)*interruptPerTargetTimeout(cfg) +
+		base +
+		time.Duration(stopWaves)*stopPerTargetTimeoutDefault
+	return 2*onePass + stopPerTargetTimeoutDefault
+}
+
+func estimatedConfiguredStopTargets(cfg *config.City) int {
+	if cfg == nil || len(cfg.Agents) == 0 {
+		return 1
+	}
+	total := 0
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if len(agent.NamepoolNames) > 0 {
+			total += len(agent.NamepoolNames)
+			continue
+		}
+		if maxSessions := agent.EffectiveMaxActiveSessions(); maxSessions != nil {
+			switch {
+			case *maxSessions == 0:
+				continue
+			case *maxSessions > 0:
+				total += *maxSessions
+				continue
+			}
+		}
+		if minSessions := agent.EffectiveMinActiveSessions(); minSessions > 1 {
+			total += minSessions
+			continue
+		}
+		total++
+	}
+	if total < 1 {
+		return 1
+	}
+	return total
+}
+
+func ceilDiv(n, d int) int {
+	if n <= 0 {
+		return 0
+	}
+	if d <= 0 {
+		return n
+	}
+	return (n + d - 1) / d
 }
 
 // cmdStopBody contains the original cmdStop flow, factored out so cmdStop
@@ -108,7 +158,7 @@ func defaultStopWallClockTimeout(cfg *config.City) time.Duration {
 func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr io.Writer) int {
 	cityName := loadedCityName(cfg, cityPath)
 
-	if handled, code := unregisterCityFromSupervisor(cityPath, stdout, stderr, "gc stop"); handled {
+	if handled, code := unregisterCityFromSupervisorWithForce(cityPath, stdout, stderr, "gc stop", force); handled {
 		if code != 0 {
 			return code
 		}
@@ -123,7 +173,7 @@ func cmdStopBody(cityPath string, cfg *config.City, force bool, stdout, stderr i
 	markCityStopSessionSleepReason(store, stderr)
 
 	// If a controller is running, ask it to shut down (it stops agents).
-	if tryStopController(cityPath, stdout) {
+	if tryStopControllerWithForce(cityPath, stdout, force) {
 		if err := waitForStandaloneControllerStop(cityPath, cfg.Daemon.ShutdownTimeoutDuration()+15*time.Second); err != nil {
 			fmt.Fprintf(stderr, "gc stop: %v\n", err) //nolint:errcheck // best-effort stderr
 			return 1
@@ -247,13 +297,21 @@ func stopOrphans(sp runtime.Provider, desired map[string]bool, cfg *config.City,
 // Returns true if a controller acknowledged the shutdown. If no controller
 // is running (socket doesn't exist or connection refused), returns false.
 func tryStopController(cityPath string, stdout io.Writer) bool {
+	return tryStopControllerWithForce(cityPath, stdout, false)
+}
+
+func tryStopControllerWithForce(cityPath string, stdout io.Writer, force bool) bool {
 	sockPath := controllerSocketPath(cityPath)
 	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
 	if err != nil {
 		return false
 	}
-	defer conn.Close()                                     //nolint:errcheck // best-effort cleanup
-	conn.Write([]byte("stop\n"))                           //nolint:errcheck // best-effort
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	command := "stop\n"
+	if force {
+		command = "stop-force\n"
+	}
+	conn.Write([]byte(command))                            //nolint:errcheck // best-effort
 	conn.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck // best-effort
 	buf := make([]byte, 64)
 	n, readErr := conn.Read(buf)

--- a/cmd/gc/cmd_stop.go
+++ b/cmd/gc/cmd_stop.go
@@ -85,16 +85,17 @@ func cmdStop(args []string, stdout, stderr io.Writer, wallClockTimeout time.Dura
 	case out := <-doneCh:
 		return out.code
 	case <-time.After(wallClockCap):
-		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — try gc stop --force --timeout=<longer-duration>\n", wallClockCap) //nolint:errcheck // best-effort stderr
+		fmt.Fprintf(stderr, "gc stop: timed out after %s; some sessions may not have stopped — retry with --force if stop is wedged, or raise --timeout for large stop sets\n", wallClockCap) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 }
 
 // defaultStopWallClockTimeout returns the wall-clock cap used by cmdStop
-// when --timeout is not set. It budgets a full configured-session stop and a
-// second full orphan cleanup pass using the same bounded wave sizes as the
-// stop implementation. Unknown extra live pool sessions or orphans can still
-// require an explicit --timeout from the operator.
+// when --timeout is not set. Each pass budgets three sequential phases:
+// interrupt provider dispatch, the configured post-interrupt grace wait, and
+// bounded force-stop waves. A second pass covers orphan cleanup. Unknown extra
+// live pool sessions or orphans can still require an explicit --timeout from
+// the operator.
 func defaultStopWallClockTimeout(cfg *config.City) time.Duration {
 	base := 5 * time.Second
 	if cfg != nil {

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -79,7 +80,7 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 	}
 	const seededSession = "seeded-session"
 
-	var controllerStdout, controllerStderr bytes.Buffer
+	var controllerStdout, controllerStderr lockedBuffer
 	done := make(chan struct{})
 	go func() {
 		runController(dir, tomlPath, cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
@@ -97,12 +98,12 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 		}
 	})
 
-	waitForControllerAvailable(t, dir, 15*time.Second)
+	waitForControllerAvailable(t, dir)
 	if err := sp.Start(context.Background(), seededSession, runtime.Config{}); err != nil {
 		t.Fatal(err)
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 	stopDone := make(chan int, 1)
 	go func() {
 		stopDone <- cmdStop([]string{dir}, &stdout, &stderr, 0, false)
@@ -145,7 +146,7 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 	if !strings.Contains(stdout.String(), "City stopped.") {
 		t.Fatalf("stdout missing city stopped message: %q", stdout.String())
 	}
-	if stderr.Len() != 0 {
+	if stderr.String() != "" {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
 	}
 }
@@ -227,7 +228,7 @@ func TestCmdStopForceDelegatesImmediateControllerStop(t *testing.T) {
 		return DesiredStateResult{State: map[string]TemplateParams{}}
 	}
 
-	var controllerStdout, controllerStderr bytes.Buffer
+	var controllerStdout, controllerStderr lockedBuffer
 	done := make(chan struct{})
 	go func() {
 		runController(dir, tomlPath, cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
@@ -241,13 +242,13 @@ func TestCmdStopForceDelegatesImmediateControllerStop(t *testing.T) {
 		}
 	})
 
-	waitForControllerAvailable(t, dir, 15*time.Second)
+	waitForControllerAvailable(t, dir)
 	const sess = "force-stop-session"
 	if err := sp.Start(context.Background(), sess, runtime.Config{}); err != nil {
 		t.Fatal(err)
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 	stopDone := make(chan int, 1)
 	go func() {
 		stopDone <- cmdStop([]string{dir}, &stdout, &stderr, 2*time.Second, true)
@@ -274,6 +275,98 @@ func TestCmdStopForceDelegatesImmediateControllerStop(t *testing.T) {
 	}
 }
 
+func TestCmdStopForceEscalatesInProgressControllerStop(t *testing.T) {
+	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
+
+	dir := shortSocketTempDir(t, "gc-force-escalate-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "force-escalate-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "5s"},
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := filepath.Join(dir, "city.toml")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := newGatedStopProvider()
+	buildFn := func(_ *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	var controllerStdout, controllerStderr lockedBuffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, tomlPath, cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		tryStopControllerWithForce(dir, io.Discard, true)
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForControllerAvailable(t, dir)
+	const sess = "force-escalate-session"
+	if err := sp.Start(context.Background(), sess, runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var normalStdout, normalStderr lockedBuffer
+	normalDone := make(chan int, 1)
+	go func() {
+		normalDone <- cmdStop([]string{dir}, &normalStdout, &normalStderr, 10*time.Second, false)
+	}()
+
+	interrupted := sp.waitForInterrupts(t, 1)
+	if interrupted[0] != sess {
+		t.Fatalf("interrupted = %q, want %q", interrupted[0], sess)
+	}
+
+	var forceStdout, forceStderr lockedBuffer
+	forceDone := make(chan int, 1)
+	go func() {
+		forceDone <- cmdStop([]string{dir}, &forceStdout, &forceStderr, 10*time.Second, true)
+	}()
+
+	stopped := sp.waitForStops(t, 1)
+	if stopped[0] != sess {
+		t.Fatalf("stopped = %q, want %q", stopped[0], sess)
+	}
+	sp.release(stopped[0])
+	sp.releaseInterrupt(interrupted[0])
+
+	for _, result := range []struct {
+		name string
+		ch   <-chan int
+		out  *lockedBuffer
+		err  *lockedBuffer
+	}{
+		{name: "normal stop", ch: normalDone, out: &normalStdout, err: &normalStderr},
+		{name: "force stop", ch: forceDone, out: &forceStdout, err: &forceStderr},
+	} {
+		select {
+		case code := <-result.ch:
+			if code != 0 {
+				t.Fatalf("%s code = %d, want 0; stdout=%q stderr=%q controller stderr=%q",
+					result.name, code, result.out.String(), result.err.String(), controllerStderr.String())
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s did not finish after force escalation", result.name)
+		}
+	}
+}
+
 func TestDefaultStopWallClockTimeoutScalesWithConfiguredStopTargets(t *testing.T) {
 	origStop := stopPerTargetTimeoutDefault
 	origMargin := interruptPerTargetTimeoutMargin
@@ -292,6 +385,9 @@ func TestDefaultStopWallClockTimeoutScalesWithConfiguredStopTargets(t *testing.T
 	}
 
 	got := defaultStopWallClockTimeout(cfg)
+	// One stop pass budgets a 3s interrupt-dispatch cap, 2s graceful-exit
+	// wait, and three 10s stop waves. The default cap allows two passes plus
+	// one extra orphan-cleanup stop wave: 2*(3s+2s+30s)+10s.
 	want := 80 * time.Second
 	if got != want {
 		t.Fatalf("defaultStopWallClockTimeout() = %s, want %s", got, want)
@@ -340,9 +436,9 @@ func TestStopCityManagedBeadsProviderIfRunningStopsDefaultBD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var stderr bytes.Buffer
+	var stderr lockedBuffer
 	stopCityManagedBeadsProviderIfRunning(cityDir, &stderr)
-	if stderr.Len() != 0 {
+	if stderr.String() != "" {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
 	}
 	ops := readOpLog(t, logFile)
@@ -399,7 +495,7 @@ func TestCmdStopUsesTargetCitySessionProviderOutsideCityDir(t *testing.T) {
 		return runtime.NewFake()
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 	code := cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
 	if code != 0 {
 		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
@@ -445,7 +541,7 @@ func TestCmdStopMarginExhaustion(t *testing.T) {
 		return DesiredStateResult{State: map[string]TemplateParams{}}
 	}
 
-	var controllerStdout, controllerStderr bytes.Buffer
+	var controllerStdout, controllerStderr lockedBuffer
 	done := make(chan struct{})
 	go func() {
 		runController(dir, filepath.Join(dir, "city.toml"), cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
@@ -463,7 +559,7 @@ func TestCmdStopMarginExhaustion(t *testing.T) {
 		}
 	})
 
-	waitForControllerAvailable(t, dir, 15*time.Second)
+	waitForControllerAvailable(t, dir)
 
 	const sess = "margin-session"
 	if err := sp.Start(context.Background(), sess, runtime.Config{}); err != nil {
@@ -475,7 +571,7 @@ func TestCmdStopMarginExhaustion(t *testing.T) {
 		sp.releaseInterrupt(sess)
 	}()
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr lockedBuffer
 	stopDone := make(chan int, 1)
 	go func() {
 		stopDone <- cmdStop([]string{dir}, &stdout, &stderr, 0, false)
@@ -513,9 +609,9 @@ func TestCmdStopMarginExhaustion(t *testing.T) {
 	}
 }
 
-func waitForControllerAvailable(t *testing.T, dir string, timeout time.Duration) {
+func waitForControllerAvailable(t *testing.T, dir string) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
+	deadline := time.Now().Add(15 * time.Second)
 	for {
 		if controllerAcceptsPing(dir, 100*time.Millisecond) {
 			return

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -80,7 +80,7 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	stopDone := make(chan int, 1)
 	go func() {
-		stopDone <- cmdStop([]string{dir}, &stdout, &stderr)
+		stopDone <- cmdStop([]string{dir}, &stdout, &stderr, 0, false)
 	}()
 
 	stopped := sp.waitForStops(t, 1)
@@ -227,7 +227,7 @@ func TestCmdStopUsesTargetCitySessionProviderOutsideCityDir(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := cmdStop([]string{cityDir}, &stdout, &stderr)
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 0, false)
 	if code != 0 {
 		t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
@@ -305,7 +305,7 @@ func TestCmdStopMarginExhaustion(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	stopDone := make(chan int, 1)
 	go func() {
-		stopDone <- cmdStop([]string{dir}, &stdout, &stderr)
+		stopDone <- cmdStop([]string{dir}, &stdout, &stderr, 0, false)
 	}()
 
 	stopped := sp.waitForStops(t, 1)

--- a/cmd/gc/cmd_stop_test.go
+++ b/cmd/gc/cmd_stop_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -16,6 +17,30 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 )
+
+type recordingStopProvider struct {
+	*runtime.Fake
+	stops      chan string
+	interrupts chan string
+}
+
+func newRecordingStopProvider() *recordingStopProvider {
+	return &recordingStopProvider{
+		Fake:       runtime.NewFake(),
+		stops:      make(chan string, 8),
+		interrupts: make(chan string, 8),
+	}
+}
+
+func (p *recordingStopProvider) Stop(name string) error {
+	p.stops <- name
+	return p.Fake.Stop(name)
+}
+
+func (p *recordingStopProvider) Interrupt(name string) error {
+	p.interrupts <- name
+	return p.Fake.Interrupt(name)
+}
 
 func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
@@ -122,6 +147,154 @@ func TestCmdStopWaitsForStandaloneControllerExit(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestCmdStopWallClockTimeoutBoundsDirectStop(t *testing.T) {
+	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
+
+	cityDir := shortSocketTempDir(t, "gc-stop-timeout-")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "timeout-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "0s"},
+		Agents: []config.Agent{
+			{Name: "worker", StartCommand: "sleep 1"},
+		},
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := newHangingProvider()
+	t.Cleanup(sp.release)
+	sessionName := lookupSessionNameOrLegacy(nil, loadedCityName(cfg, cityDir), cfg.Agents[0].QualifiedName(), cfg.Workspace.SessionTemplate)
+	if err := sp.Start(context.Background(), sessionName, runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldFactory := sessionProviderForStopCity
+	t.Cleanup(func() { sessionProviderForStopCity = oldFactory })
+	sessionProviderForStopCity = func(*config.City, string) runtime.Provider {
+		return sp
+	}
+
+	var stdout, stderr lockedBuffer
+	started := time.Now()
+	code := cmdStop([]string{cityDir}, &stdout, &stderr, 100*time.Millisecond, false)
+	if code != 1 {
+		t.Fatalf("cmdStop() = %d, want timeout code 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("cmdStop returned after %s, want wall-clock cap near 100ms", elapsed)
+	}
+	if !strings.Contains(stderr.String(), "timed out after 100ms") {
+		t.Fatalf("stderr = %q, want wall-clock timeout message", stderr.String())
+	}
+}
+
+func TestCmdStopForceDelegatesImmediateControllerStop(t *testing.T) {
+	t.Setenv("GC_HOME", shortSocketTempDir(t, "gc-home-"))
+
+	dir := shortSocketTempDir(t, "gc-force-stop-")
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "force-stop-city"},
+		Beads:     config.BeadsConfig{Provider: "file"},
+		Daemon:    config.DaemonConfig{ShutdownTimeout: "250ms"},
+	}
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := filepath.Join(dir, "city.toml")
+	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := newRecordingStopProvider()
+	buildFn := func(_ *config.City, _ runtime.Provider, _ beads.Store) DesiredStateResult {
+		return DesiredStateResult{State: map[string]TemplateParams{}}
+	}
+
+	var controllerStdout, controllerStderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		runController(dir, tomlPath, cfg, "", buildFn, nil, sp, nil, nil, nil, nil, events.Discard, nil, &controllerStdout, &controllerStderr)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		tryStopController(dir, &bytes.Buffer{})
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	waitForControllerAvailable(t, dir, 15*time.Second)
+	const sess = "force-stop-session"
+	if err := sp.Start(context.Background(), sess, runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	stopDone := make(chan int, 1)
+	go func() {
+		stopDone <- cmdStop([]string{dir}, &stdout, &stderr, 2*time.Second, true)
+	}()
+
+	select {
+	case interrupted := <-sp.interrupts:
+		t.Fatalf("gc stop --force delegated interrupt for %q; want immediate stop", interrupted)
+	case stopped := <-sp.stops:
+		if stopped != sess {
+			t.Fatalf("stopped = %q, want %q", stopped, sess)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delegated force stop")
+	}
+
+	select {
+	case code := <-stopDone:
+		if code != 0 {
+			t.Fatalf("cmdStop = %d, want 0; stdout=%q stderr=%q controller stderr=%q", code, stdout.String(), stderr.String(), controllerStderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cmdStop did not finish after delegated force stop")
+	}
+}
+
+func TestDefaultStopWallClockTimeoutScalesWithConfiguredStopTargets(t *testing.T) {
+	origStop := stopPerTargetTimeoutDefault
+	origMargin := interruptPerTargetTimeoutMargin
+	stopPerTargetTimeoutDefault = 10 * time.Second
+	interruptPerTargetTimeoutMargin = time.Second
+	t.Cleanup(func() {
+		stopPerTargetTimeoutDefault = origStop
+		interruptPerTargetTimeoutMargin = origMargin
+	})
+
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{ShutdownTimeout: "2s"},
+	}
+	for i := 0; i < 7; i++ {
+		cfg.Agents = append(cfg.Agents, config.Agent{Name: fmt.Sprintf("worker-%d", i+1)})
+	}
+
+	got := defaultStopWallClockTimeout(cfg)
+	want := 80 * time.Second
+	if got != want {
+		t.Fatalf("defaultStopWallClockTimeout() = %s, want %s", got, want)
 	}
 }
 

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -1445,6 +1445,7 @@ func reconcileCities(
 		configRev := config.Revision(fsys.OSFS{}, prov, cfg, path)
 		pokeCh := make(chan struct{}, 1)
 		configDirty := &atomic.Bool{}
+		forceShutdown := &atomic.Bool{}
 		reloadReqCh := make(chan reloadRequest)
 		cityCtx, cityCancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
@@ -1471,6 +1472,7 @@ func reconcileCities(
 				Rec:                     rec,
 				PoolSessions:            poolSessions,
 				PoolDeathHandlers:       poolDeathHandlers,
+				ForceStopShutdown:       forceShutdown,
 				ReloadReqCh:             reloadReqCh,
 				ConvergenceReqCh:        convergenceReqCh,
 				PokeCh:                  pokeCh,
@@ -1572,7 +1574,7 @@ func reconcileCities(
 		// Start controller socket AFTER the alreadyRunning check so we
 		// never destroy a live city's socket or leak a listener.
 		sockPath := filepath.Join(path, ".gc", "controller.sock")
-		lis, lisErr := startControllerSocket(path, cityCancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
+		lis, lisErr := startControllerSocket(path, cityCancel, forceShutdown, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		if lisErr != nil {
 			fmt.Fprintf(stderr, "gc supervisor: city '%s': controller socket: %v\n", cityName, lisErr) //nolint:errcheck
 			lock.Close()                                                                               //nolint:errcheck // no socket to race with

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -434,7 +434,11 @@ func statusDisplayText(status string) string {
 	}
 }
 
-func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer, commandName string) (bool, int) {
+func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer) (bool, int) {
+	return unregisterCityFromSupervisorWithForce(cityPath, stdout, stderr, "gc unregister", false)
+}
+
+func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Writer, commandName string, force bool) (bool, int) {
 	cityPath = normalizePathForCompare(cityPath)
 	entry, registered, err := registeredCityEntry(cityPath)
 	if err != nil {
@@ -452,6 +456,10 @@ func unregisterCityFromSupervisor(cityPath string, stdout, stderr io.Writer, com
 	}
 
 	fmt.Fprintf(stdout, "Unregistered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
+
+	if force && supervisorAliveHook() != 0 {
+		tryStopControllerWithForce(cityPath, io.Discard, true)
+	}
 
 	// If the city directory is gone, there's nothing to wait on or restore.
 	// Skip the supervisor-side probes that would otherwise spew

--- a/cmd/gc/cmd_supervisor_city.go
+++ b/cmd/gc/cmd_supervisor_city.go
@@ -450,16 +450,15 @@ func unregisterCityFromSupervisorWithForce(cityPath string, stdout, stderr io.Wr
 	}
 
 	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if force && supervisorAliveHook() != 0 {
+		tryStopControllerWithForce(cityPath, io.Discard, true)
+	}
 	if err := reg.Unregister(cityPath); err != nil {
 		fmt.Fprintf(stderr, "%s: %v\n", commandName, err) //nolint:errcheck // best-effort stderr
 		return true, 1
 	}
 
 	fmt.Fprintf(stdout, "Unregistered city '%s' (%s)\n", entry.EffectiveName(), entry.Path) //nolint:errcheck // best-effort stdout
-
-	if force && supervisorAliveHook() != 0 {
-		tryStopControllerWithForce(cityPath, io.Discard, true)
-	}
 
 	// If the city directory is gone, there's nothing to wait on or restore.
 	// Skip the supervisor-side probes that would otherwise spew

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -940,7 +940,7 @@ func TestUnregisterCityFromSupervisorRestoresRegistrationOnReloadFailure(t *test
 	)
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr)
 	if !handled || code != 1 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 1)", handled, code)
 	}
@@ -996,7 +996,7 @@ func TestUnregisterCityFromSupervisorWaitsForControllerStop(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr)
 	if !handled || code != 0 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 0)", handled, code)
 	}
@@ -1005,6 +1005,70 @@ func TestUnregisterCityFromSupervisorWaitsForControllerStop(t *testing.T) {
 	}
 	if waitedTimeout != supervisorCityStopTimeout(cityPath) {
 		t.Fatalf("wait timeout = %s, want %s", waitedTimeout, supervisorCityStopTimeout(cityPath))
+	}
+}
+
+func TestUnregisterCityFromSupervisorWithForceSendsForceStop(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+
+	cityPath := filepath.Join(t.TempDir(), "force-city")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"force-city\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := supervisor.NewRegistry(supervisor.RegistryPath())
+	if err := reg.Register(cityPath, "force-city"); err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := net.Listen("unix", controllerSocketPath(cityPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()                               //nolint:errcheck
+	defer os.Remove(controllerSocketPath(cityPath)) //nolint:errcheck
+
+	commands := make(chan string, 1)
+	go func() {
+		conn, acceptErr := lis.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+		buf := make([]byte, 64)
+		n, _ := conn.Read(buf)
+		commands <- strings.TrimSpace(string(buf[:n]))
+		conn.Write([]byte("ok\n")) //nolint:errcheck
+	}()
+
+	withSupervisorTestHooks(
+		t,
+		func(_, _ io.Writer) int { return 0 },
+		func(_, _ io.Writer) int { return 0 },
+		func() int { return 4242 },
+		func(string) (bool, string, bool) { return false, "", false },
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	waitForSupervisorControllerStopHook = func(string, time.Duration) error { return nil }
+
+	var stdout, stderr bytes.Buffer
+	handled, code := unregisterCityFromSupervisorWithForce(cityPath, &stdout, &stderr, "gc stop", true)
+	if !handled || code != 0 {
+		t.Fatalf("unregisterCityFromSupervisorWithForce = (%t, %d), want (true, 0); stderr=%q", handled, code, stderr.String())
+	}
+
+	select {
+	case got := <-commands:
+		if got != "stop-force" {
+			t.Fatalf("controller command = %q, want stop-force", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for force controller command")
 	}
 }
 
@@ -1053,7 +1117,7 @@ func TestUnregisterCityFromSupervisorSkipsProbesWhenCityDirMissing(t *testing.T)
 	}
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr)
 	if !handled || code != 0 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 0)", handled, code)
 	}
@@ -1118,7 +1182,7 @@ func TestUnregisterCityFromSupervisorReturnsReloadFailureWhenCityDirMissing(t *t
 	}
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr)
 	if !handled || code != 1 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 1)", handled, code)
 	}
@@ -1344,7 +1408,7 @@ func TestUnregisterCityFromSupervisorRestoresRegistrationWhenControllerStopWaitF
 	}
 
 	var stdout, stderr bytes.Buffer
-	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr, "gc unregister")
+	handled, code := unregisterCityFromSupervisor(cityPath, &stdout, &stderr)
 	if !handled || code != 1 {
 		t.Fatalf("unregisterCityFromSupervisor = (%t, %d), want (true, 1)", handled, code)
 	}

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -1480,7 +1480,7 @@ func TestCmdStopSupervisorManagedCityReliesOnSupervisorCleanup(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	code := cmdStop([]string{cityPath}, &stdout, &stderr)
+	code := cmdStop([]string{cityPath}, &stdout, &stderr, 0, false)
 	if code != 0 {
 		t.Fatalf("cmdStop code = %d, want 0: %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_supervisor_city_test.go
+++ b/cmd/gc/cmd_supervisor_city_test.go
@@ -1025,14 +1025,22 @@ func TestUnregisterCityFromSupervisorWithForceSendsForceStop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lis, err := net.Listen("unix", controllerSocketPath(cityPath))
+	sockPath := controllerSocketPath(cityPath)
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lis, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer lis.Close()                               //nolint:errcheck
-	defer os.Remove(controllerSocketPath(cityPath)) //nolint:errcheck
+	defer lis.Close()         //nolint:errcheck
+	defer os.Remove(sockPath) //nolint:errcheck
 
-	commands := make(chan string, 1)
+	type observedForceCommand struct {
+		command                 string
+		registeredBeforeCommand bool
+	}
+	commands := make(chan observedForceCommand, 1)
 	go func() {
 		conn, acceptErr := lis.Accept()
 		if acceptErr != nil {
@@ -1041,7 +1049,15 @@ func TestUnregisterCityFromSupervisorWithForceSendsForceStop(t *testing.T) {
 		defer conn.Close() //nolint:errcheck
 		buf := make([]byte, 64)
 		n, _ := conn.Read(buf)
-		commands <- strings.TrimSpace(string(buf[:n]))
+		entries, listErr := reg.List()
+		if listErr != nil {
+			commands <- observedForceCommand{command: "list-error:" + listErr.Error()}
+		} else {
+			commands <- observedForceCommand{
+				command:                 strings.TrimSpace(string(buf[:n])),
+				registeredBeforeCommand: len(entries) == 1 && samePath(entries[0].Path, cityPath),
+			}
+		}
 		conn.Write([]byte("ok\n")) //nolint:errcheck
 	}()
 
@@ -1064,8 +1080,11 @@ func TestUnregisterCityFromSupervisorWithForceSendsForceStop(t *testing.T) {
 
 	select {
 	case got := <-commands:
-		if got != "stop-force" {
-			t.Fatalf("controller command = %q, want stop-force", got)
+		if got.command != "stop-force" {
+			t.Fatalf("controller command = %q, want stop-force", got.command)
+		}
+		if !got.registeredBeforeCommand {
+			t.Fatal("force stop reached controller after supervisor registry entry was removed")
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for force controller command")

--- a/cmd/gc/cmd_trace_test.go
+++ b/cmd/gc/cmd_trace_test.go
@@ -150,7 +150,7 @@ func TestTraceControllerSocketInvalidRequestDoesNotPoke(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 
@@ -228,7 +228,7 @@ func sendTraceSocketCommand(t *testing.T, cityDir, command string, req traceCont
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 
@@ -259,7 +259,7 @@ func sendTraceStatusSocketCommand(t *testing.T, cityDir string, pokeCh chan stru
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityDir, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityDir, func() {}, nil, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 

--- a/cmd/gc/command_context_test.go
+++ b/cmd/gc/command_context_test.go
@@ -174,7 +174,7 @@ func TestRigAnywhere_CmdStopFromRigDir(t *testing.T) {
 			setCwd(t, fx.workDir)
 
 			var stdout, stderr bytes.Buffer
-			code := cmdStop(nil, &stdout, &stderr)
+			code := cmdStop(nil, &stdout, &stderr, 0, false)
 			if code != 0 {
 				t.Fatalf("cmdStop() = %d, want 0; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 			}

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -122,6 +122,7 @@ func acquireControllerLock(cityPath string) (*os.File, error) {
 func startControllerSocket(
 	cityPath string,
 	cancelFn context.CancelFunc,
+	forceShutdown *atomic.Bool,
 	dirty *atomic.Bool,
 	reloadReqCh chan reloadRequest,
 	convergenceReqCh chan convergenceRequest,
@@ -144,19 +145,21 @@ func startControllerSocket(
 			if err != nil {
 				return // listener closed
 			}
-			go handleControllerConn(conn, cityPath, cancelFn, dirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
+			go handleControllerConn(conn, cityPath, cancelFn, forceShutdown, dirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 		}
 	}()
 	return lis, nil
 }
 
 // handleControllerConn reads from a connection and dispatches commands.
-// Supported commands: "stop" (shutdown), "ping" (liveness check, returns PID),
-// "converge:{json}" (convergence commands routed to event loop).
+// Supported commands: "stop" (shutdown), "stop-force" (shutdown without
+// interrupt grace), "ping" (liveness check, returns PID), "converge:{json}"
+// (convergence commands routed to event loop).
 func handleControllerConn(
 	conn net.Conn,
 	cityPath string,
 	cancelFn context.CancelFunc,
+	forceShutdown *atomic.Bool,
 	dirty *atomic.Bool,
 	reloadReqCh chan reloadRequest,
 	convergenceReqCh chan convergenceRequest,
@@ -172,6 +175,12 @@ func handleControllerConn(
 		line := scanner.Text()
 		switch {
 		case line == "stop":
+			cancelFn()
+			conn.Write([]byte("ok\n")) //nolint:errcheck // best-effort ack
+		case line == "stop-force":
+			if forceShutdown != nil {
+				forceShutdown.Store(true)
+			}
 			cancelFn()
 			conn.Write([]byte("ok\n")) //nolint:errcheck // best-effort ack
 		case line == "ping":
@@ -1198,7 +1207,8 @@ func runController(
 	configDirty := &atomic.Bool{}
 
 	sockPath := controllerSocketPath(cityPath)
-	lis, err := startControllerSocket(cityPath, cancel, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
+	forceShutdown := &atomic.Bool{}
+	lis, err := startControllerSocket(cityPath, cancel, forceShutdown, configDirty, reloadReqCh, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc start: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1245,6 +1255,7 @@ func runController(
 		Rec:                     rec,
 		PoolSessions:            poolSessions,
 		PoolDeathHandlers:       poolDeathHandlers,
+		ForceStopShutdown:       forceShutdown,
 		ReloadReqCh:             reloadReqCh,
 		ConvergenceReqCh:        convergenceReqCh,
 		PokeCh:                  pokeCh,

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -961,7 +961,20 @@ func gracefulStopAll(
 	store beads.Store,
 	stdout, stderr io.Writer,
 ) {
-	if timeout <= 0 || len(names) == 0 {
+	gracefulStopAllWithForceSignal(names, sp, timeout, rec, cfg, store, stdout, stderr, nil)
+}
+
+func gracefulStopAllWithForceSignal(
+	names []string,
+	sp runtime.Provider,
+	timeout time.Duration,
+	rec events.Recorder,
+	cfg *config.City,
+	store beads.Store,
+	stdout, stderr io.Writer,
+	forceStopRequested func() bool,
+) {
+	if timeout <= 0 || len(names) == 0 || stopForceRequested(forceStopRequested) {
 		// Immediate kill (no grace period).
 		stopTargetsBounded(stopTargetsForNames(names, cfg, store, stderr), cfg, store, sp, rec, "gc", stdout, stderr)
 		return
@@ -978,14 +991,20 @@ func gracefulStopAll(
 	// The configured timeout is the post-dispatch grace window; dispatch
 	// latency is intentionally outside that budget so every interrupted
 	// session still gets the full graceful-exit wait once nudged.
-	sent := interruptTargetsBounded(targets, cfg, store, sp, stderr)
+	sent := interruptTargetsBoundedWithForceSignal(targets, cfg, store, sp, stderr, forceStopRequested)
 	fmt.Fprintf(stdout, "Sent interrupt to %d/%d agent(s), waiting %s...\n", //nolint:errcheck // best-effort stdout
 		sent, len(names), timeout)
 
 	// Poll until all agents exit or timeout expires (avoid sleeping full duration).
 	pollInterval := 500 * time.Millisecond
+	if forceStopRequested != nil {
+		pollInterval = 50 * time.Millisecond
+	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		if stopForceRequested(forceStopRequested) {
+			break
+		}
 		allExited := true
 		if runningSet, ok := runningSessionSet(sp, names); ok {
 			allExited = len(runningSet) == 0
@@ -1002,6 +1021,9 @@ func gracefulStopAll(
 			break
 		}
 		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
 		if remaining < pollInterval {
 			time.Sleep(remaining)
 		} else {
@@ -1039,6 +1061,10 @@ func gracefulStopAll(
 		survivors = append(survivors, name)
 	}
 	stopTargetsBounded(filterStopTargets(targets, survivors), cfg, store, sp, rec, "gc", stdout, stderr)
+}
+
+func stopForceRequested(forceStopRequested func() bool) bool {
+	return forceStopRequested != nil && forceStopRequested()
 }
 
 func runningSessionSet(sp runtime.Provider, names []string) (map[string]bool, bool) {

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -244,7 +244,7 @@ func TestControllerSocketFallbackUsesShortPathForLongCityPath(t *testing.T) {
 	pokeCh := make(chan struct{}, 1)
 	controlDispatcherCh := make(chan struct{}, 1)
 	configDirty := &atomic.Bool{}
-	lis, err := startControllerSocket(cityPath, cancel, configDirty, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+	lis, err := startControllerSocket(cityPath, cancel, nil, configDirty, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 	if err != nil {
 		t.Fatalf("startControllerSocket: %v", err)
 	}
@@ -1288,7 +1288,7 @@ func TestHandleControllerConnControlDispatcher(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		handleControllerConn(server, cityPath, func() {}, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
+		handleControllerConn(server, cityPath, func() {}, nil, nil, nil, convergenceReqCh, pokeCh, controlDispatcherCh)
 		close(done)
 	}()
 

--- a/cmd/gc/session_lifecycle_hang_test.go
+++ b/cmd/gc/session_lifecycle_hang_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// hangingProvider's Stop and Interrupt block until released, simulating a
+// wedged tmux subprocess or unresponsive runtime.
+type hangingProvider struct {
+	*runtime.Fake
+	mu       sync.Mutex
+	released bool
+	releaseC chan struct{}
+}
+
+func newHangingProvider() *hangingProvider {
+	return &hangingProvider{
+		Fake:     runtime.NewFake(),
+		releaseC: make(chan struct{}),
+	}
+}
+
+func (p *hangingProvider) Stop(name string) error {
+	<-p.releaseC
+	return p.Fake.Stop(name)
+}
+
+func (p *hangingProvider) Interrupt(name string) error {
+	<-p.releaseC
+	return p.Fake.Interrupt(name)
+}
+
+func (p *hangingProvider) release() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.released {
+		p.released = true
+		close(p.releaseC)
+	}
+}
+
+// TestExecuteTargetWave_BoundedByPerTargetTimeout verifies that
+// executeTargetWave returns within roughly perTargetTimeout when one target's
+// run() blocks; the blocked target's result records outcome="timed_out" while
+// the other target still completes successfully.
+func TestExecuteTargetWave_BoundedByPerTargetTimeout(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+
+	targets := []stopTarget{
+		{name: "blocked", template: "worker", resolved: true},
+		{name: "fast", template: "worker", resolved: true},
+	}
+
+	done := make(chan []stopResult, 1)
+	go func() {
+		done <- executeTargetWave(targets, 2, 100*time.Millisecond, func(target stopTarget) error {
+			if target.name == "blocked" {
+				<-block
+			}
+			return nil
+		})
+	}()
+
+	select {
+	case results := <-done:
+		if len(results) != 2 {
+			t.Fatalf("len(results) = %d, want 2", len(results))
+		}
+		var blocked, fast stopResult
+		for _, r := range results {
+			switch r.target.name {
+			case "blocked":
+				blocked = r
+			case "fast":
+				fast = r
+			}
+		}
+		if blocked.outcome != "timed_out" {
+			t.Fatalf("blocked.outcome = %q, want timed_out", blocked.outcome)
+		}
+		if blocked.err == nil {
+			t.Fatalf("blocked.err = nil, want non-nil timeout error")
+		}
+		if fast.outcome != "success" {
+			t.Fatalf("fast.outcome = %q, want success", fast.outcome)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("executeTargetWave did not return within 2s — perTargetTimeout regression")
+	}
+}
+
+// TestGracefulStopAll_HangingProviderDoesNotWedge verifies that gracefulStopAll
+// returns within a bounded time when the provider's Stop and Interrupt block
+// forever. Without per-target timeouts the goroutines that run them never
+// signal completion and the wave drainer hangs indefinitely.
+func TestGracefulStopAll_HangingProviderDoesNotWedge(t *testing.T) {
+	origStop := stopPerTargetTimeoutDefault
+	stopPerTargetTimeoutDefault = 200 * time.Millisecond
+	t.Cleanup(func() { stopPerTargetTimeoutDefault = origStop })
+
+	sp := newHangingProvider()
+	t.Cleanup(sp.release)
+
+	for _, name := range []string{"alpha", "bravo", "charlie"} {
+		if err := sp.Start(context.Background(), name, runtime.Config{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{ShutdownTimeout: "50ms"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		gracefulStopAll(
+			[]string{"alpha", "bravo", "charlie"},
+			sp,
+			cfg.Daemon.ShutdownTimeoutDuration(),
+			events.Discard,
+			cfg,
+			nil,
+			&stdout,
+			&stderr,
+		)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gracefulStopAll did not return within 5s — unbounded wait regression")
+	}
+}

--- a/cmd/gc/session_lifecycle_hang_test.go
+++ b/cmd/gc/session_lifecycle_hang_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
@@ -139,5 +141,55 @@ func TestGracefulStopAll_HangingProviderDoesNotWedge(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("gracefulStopAll did not return within 5s — unbounded wait regression")
+	}
+}
+
+// TestInterruptTargetsBounded_PoolManagedStopDoesNotWedge verifies that
+// pool-managed sessions are stopped through the same bounded worker boundary as
+// normal stop targets. Pool-managed sessions bypass the interrupt prompt, so an
+// inline stop here would wedge the whole interrupt pass.
+func TestInterruptTargetsBounded_PoolManagedStopDoesNotWedge(t *testing.T) {
+	origStop := stopPerTargetTimeoutDefault
+	stopPerTargetTimeoutDefault = 100 * time.Millisecond
+	t.Cleanup(func() { stopPerTargetTimeoutDefault = origStop })
+
+	sp := newHangingProvider()
+	t.Cleanup(sp.release)
+	if err := sp.Start(context.Background(), "pool-worker", runtime.Config{}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "pool-worker session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "pool-worker",
+			"template":             "pool",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                "active",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := []stopTarget{{name: "pool-worker", template: "pool", resolved: true, poolManaged: true}}
+	var stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- interruptTargetsBounded(targets, nil, store, sp, &stderr)
+	}()
+
+	select {
+	case sent := <-done:
+		if sent != 0 {
+			t.Fatalf("sent = %d, want 0 for pool-managed stop-only target", sent)
+		}
+		if !strings.Contains(stderr.String(), "outcome=timed_out") {
+			t.Fatalf("stderr = %q, want timed_out lifecycle outcome", stderr.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool-managed stop wedged interruptTargetsBounded")
 	}
 }

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -2111,22 +2111,35 @@ func interruptTargetsBounded(targets []stopTarget, cfg *config.City, store beads
 	// interactive "What should Claude do instead?" prompt would hang
 	// them forever. Stop them immediately instead of interrupting —
 	// no metadata to go stale if shutdown is aborted.
+	poolManaged := make([]stopTarget, 0, len(targets))
 	interruptable := make([]stopTarget, 0, len(targets))
 	for _, t := range targets {
 		if t.poolManaged {
-			started := time.Now()
-			err := stopTargetThroughWorkerBoundary(t, store, sp, cfg)
-			outcome := "stopped_pool_managed"
-			if err != nil {
-				outcome = "stop_failed"
-			}
-			logLifecycleOutcome(stderr, "interrupt", 0, t.name, t.template, outcome, started, time.Now(), err)
+			poolManaged = append(poolManaged, t)
 			continue
 		}
 		interruptable = append(interruptable, t)
 	}
 
+	if len(poolManaged) > 0 {
+		waveStarted := time.Now()
+		results := executeTargetWave(poolManaged, defaultMaxParallelStopsPerWave, stopPerTargetTimeoutDefault, func(target stopTarget) error {
+			return stopTargetThroughWorkerBoundary(target, store, sp, cfg)
+		})
+		for _, result := range results {
+			outcome := result.outcome
+			if result.err == nil && outcome == "success" {
+				outcome = "stopped_pool_managed"
+			}
+			logLifecycleOutcome(stderr, "interrupt", 0, result.target.name, result.target.template, outcome, result.started, result.finished, result.err)
+		}
+		logLifecycleWave(stderr, "interrupt", 0, waveStarted, len(poolManaged))
+	}
+
 	sent := 0
+	if len(interruptable) == 0 {
+		return sent
+	}
 	waveStarted := time.Now()
 	results := executeTargetWave(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), func(target stopTarget) error {
 		targetID := strings.TrimSpace(target.sessionID)

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -121,6 +121,18 @@ func asyncStartBatchNeedsFollowUp(candidates []startCandidate, cfg *config.City)
 	return false
 }
 
+// stopPerTargetTimeoutDefault caps the wall-clock time stopTargetsBounded
+// will wait for any single target's lifecycle op (worker Stop/Interrupt
+// boundary). The cap is intentionally wider than KillSessionWithProcesses'
+// 4s SIGTERM-then-SIGKILL grace. Test-overridable; production value is 30s.
+var stopPerTargetTimeoutDefault = 30 * time.Second
+
+// interruptPerTargetTimeoutMargin is the headroom added on top of
+// cfg.Daemon.ShutdownTimeoutDuration() when computing the interrupt wave's
+// per-target timeout. The base shutdown grace is the post-interrupt wait;
+// this margin covers dispatch/tmux latency for the interrupt itself.
+var interruptPerTargetTimeoutMargin = 2 * time.Second
+
 type startCandidate struct {
 	session *beads.Bead
 	tp      TemplateParams
@@ -1817,11 +1829,20 @@ func reachableSelectedDependencies(
 	return reachable
 }
 
+// executeTargetWave runs each target's run() under a bounded-parallelism
+// semaphore and returns a stopResult per target. perTargetTimeout caps the
+// wall-clock each goroutine waits for run() to return; on expiry, that
+// target's outcome is "timed_out" and the inner goroutine is intentionally
+// leaked (it will return when the bounded subprocess deadline kicks in or
+// the process exits). perTargetTimeout <= 0 means no timeout (legacy
+// behavior, used only by tests that exercise unrelated paths).
 func executeTargetWave(
 	targets []stopTarget,
 	maxParallel int,
+	perTargetTimeout time.Duration,
 	run func(stopTarget) error,
 ) []stopResult {
+	_ = perTargetTimeout // RED stub: parameter accepted but not yet honored.
 	if len(targets) == 0 {
 		return nil
 	}
@@ -2043,6 +2064,21 @@ func markCityStopSessionAsAsleep(store beads.Store, sessionID string, stderr io.
 	}
 }
 
+// interruptPerTargetTimeout returns the wall-clock cap an interrupt-wave
+// goroutine waits before declaring its target timed out. It composes the
+// configured shutdown grace (which is the post-interrupt wait the caller
+// itself imposes) with a small dispatch margin for the interrupt syscalls
+// themselves.
+func interruptPerTargetTimeout(cfg *config.City) time.Duration {
+	base := 5 * time.Second
+	if cfg != nil {
+		if d := cfg.Daemon.ShutdownTimeoutDuration(); d > 0 {
+			base = d
+		}
+	}
+	return base + interruptPerTargetTimeoutMargin
+}
+
 func interruptTargetsBounded(targets []stopTarget, cfg *config.City, store beads.Store, sp runtime.Provider, stderr io.Writer) int {
 	targets = hydrateStopTargets(targets, cfg, store, stderr)
 	// Pool-managed sessions have no human user, so Claude Code's
@@ -2066,7 +2102,7 @@ func interruptTargetsBounded(targets []stopTarget, cfg *config.City, store beads
 
 	sent := 0
 	waveStarted := time.Now()
-	results := executeTargetWave(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), func(target stopTarget) error {
+	results := executeTargetWave(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), func(target stopTarget) error {
 		targetID := strings.TrimSpace(target.sessionID)
 		if targetID == "" {
 			targetID = strings.TrimSpace(target.name)
@@ -2105,7 +2141,7 @@ func stopTargetsBounded(
 			stopped := 0
 			for wave, target := range targets {
 				waveStarted := time.Now()
-				results := executeTargetWave([]stopTarget{target}, 1, func(target stopTarget) error {
+				results := executeTargetWave([]stopTarget{target}, 1, stopPerTargetTimeoutDefault, func(target stopTarget) error {
 					return stopTargetThroughWorkerBoundary(target, store, sp, cfg)
 				})
 				for _, result := range results {
@@ -2147,7 +2183,7 @@ func stopTargetsBounded(
 				waveTargets = append(waveTargets, target)
 			}
 		}
-		results := executeTargetWave(waveTargets, defaultMaxParallelStopsPerWave, func(target stopTarget) error {
+		results := executeTargetWave(waveTargets, defaultMaxParallelStopsPerWave, stopPerTargetTimeoutDefault, func(target stopTarget) error {
 			return stopTargetThroughWorkerBoundary(target, store, sp, cfg)
 		})
 		for _, result := range results {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -129,8 +129,9 @@ var stopPerTargetTimeoutDefault = 30 * time.Second
 
 // interruptPerTargetTimeoutMargin is the headroom added on top of
 // cfg.Daemon.ShutdownTimeoutDuration() when computing the interrupt wave's
-// per-target timeout. The base shutdown grace is the post-interrupt wait;
-// this margin covers dispatch/tmux latency for the interrupt itself.
+// per-target dispatch timeout. defaultStopWallClockTimeout budgets this
+// dispatch cap separately from the post-interrupt grace wait because a blocked
+// provider Interrupt call and a graceful process exit are sequential phases.
 var interruptPerTargetTimeoutMargin = 2 * time.Second
 
 type startCandidate struct {
@@ -221,15 +222,22 @@ func (t *asyncStartTracker) start() (func(), bool) {
 }
 
 func (t *asyncStartTracker) wait(timeout time.Duration) bool {
+	return t.waitUntil(timeout, nil)
+}
+
+func (t *asyncStartTracker) waitUntil(timeout time.Duration, shouldStop func() bool) bool {
 	if t == nil {
 		return true
 	}
 	t.mu.Lock()
 	t.stopping = true
 	t.mu.Unlock()
-	if timeout < 0 {
+	if shouldStop == nil && timeout < 0 {
 		t.wg.Wait()
 		return true
+	}
+	if shouldStop != nil && shouldStop() {
+		return false
 	}
 	done := make(chan struct{})
 	go func() {
@@ -244,11 +252,41 @@ func (t *asyncStartTracker) wait(timeout time.Duration) bool {
 			return false
 		}
 	}
-	select {
-	case <-done:
-		return true
-	case <-time.After(timeout):
-		return false
+	if shouldStop == nil {
+		select {
+		case <-done:
+			return true
+		case <-time.After(timeout):
+			return false
+		}
+	}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	if timeout < 0 {
+		for {
+			select {
+			case <-done:
+				return true
+			case <-ticker.C:
+				if shouldStop() {
+					return false
+				}
+			}
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-done:
+			return true
+		case <-timer.C:
+			return false
+		case <-ticker.C:
+			if shouldStop() {
+				return false
+			}
+		}
 	}
 }
 
@@ -1833,15 +1871,25 @@ func reachableSelectedDependencies(
 // semaphore and returns a stopResult per target. perTargetTimeout caps the
 // wall-clock each goroutine waits for run() to return; on expiry, that
 // target's outcome is "timed_out" and the inner goroutine is intentionally
-// leaked. The leak is acceptable because the only caller is the stop path,
-// which Layer 2 (tmux.tmuxSubprocessTimeout) bounds at the subprocess level
-// — leaked goroutines return when their tmux subprocess is SIGKILL'd at
-// the deadline, or when the process exits. perTargetTimeout <= 0 means no
+// leaked. Callers must only pass run functions that are wall-clock bounded by
+// their provider implementation; tmux satisfies this with its subprocess
+// timeout. Non-tmux providers must enforce an equivalent bound before using
+// this helper on long-lived controller paths. perTargetTimeout <= 0 means no
 // timeout (legacy behavior; useful only for tests that bypass the timeout).
 func executeTargetWave(
 	targets []stopTarget,
 	maxParallel int,
 	perTargetTimeout time.Duration,
+	run func(stopTarget) error,
+) []stopResult {
+	return executeTargetWaveUntil(targets, maxParallel, perTargetTimeout, nil, run)
+}
+
+func executeTargetWaveUntil(
+	targets []stopTarget,
+	maxParallel int,
+	perTargetTimeout time.Duration,
+	shouldStop func() bool,
 	run func(stopTarget) error,
 ) []stopResult {
 	if len(targets) == 0 {
@@ -1853,9 +1901,43 @@ func executeTargetWave(
 	results := make([]stopResult, len(targets))
 	sem := make(chan struct{}, maxParallel)
 	done := make(chan int, len(targets))
+	stopCh, stopWatchDone := lifecycleStopSignal(shouldStop)
+	defer stopWatchDone()
+	launched := 0
+	forceResult := func(target stopTarget) stopResult {
+		now := time.Now()
+		return stopResult{
+			target:   target,
+			err:      errors.New("target lifecycle op abandoned after force request"),
+			outcome:  "force_requested",
+			started:  now,
+			finished: now,
+		}
+	}
+	fillRemaining := func(from int) {
+		for j := from; j < len(targets); j++ {
+			results[j] = forceResult(targets[j])
+		}
+	}
+launchLoop:
 	for i, target := range targets {
 		i, target := i, target
-		sem <- struct{}{}
+		if lifecycleStopRequested(stopCh) {
+			fillRemaining(i)
+			break launchLoop
+		}
+		select {
+		case sem <- struct{}{}:
+		case <-stopCh:
+			fillRemaining(i)
+			break launchLoop
+		}
+		if lifecycleStopRequested(stopCh) {
+			<-sem
+			fillRemaining(i)
+			break launchLoop
+		}
+		launched++
 		go func() {
 			started := time.Now()
 			defer func() {
@@ -1899,9 +1981,23 @@ func executeTargetWave(
 						finished: time.Now(),
 						outcome:  "timed_out",
 					}
+				case <-stopCh:
+					rr = runResult{
+						err:      errors.New("target lifecycle op abandoned after force request"),
+						finished: time.Now(),
+						outcome:  "force_requested",
+					}
 				}
 			} else {
-				rr = <-inner
+				select {
+				case rr = <-inner:
+				case <-stopCh:
+					rr = runResult{
+						err:      errors.New("target lifecycle op abandoned after force request"),
+						finished: time.Now(),
+						outcome:  "force_requested",
+					}
+				}
 			}
 			results[i] = stopResult{
 				target:   target,
@@ -1912,10 +2008,58 @@ func executeTargetWave(
 			}
 		}()
 	}
-	for range targets {
+	for completed := 0; completed < launched; completed++ {
 		<-done
 	}
 	return results
+}
+
+func lifecycleStopSignal(shouldStop func() bool) (<-chan struct{}, func()) {
+	if shouldStop == nil {
+		return nil, func() {}
+	}
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	var stopOnce sync.Once
+	closeStop := func() {
+		stopOnce.Do(func() {
+			close(stopCh)
+		})
+	}
+	if shouldStop() {
+		closeStop()
+		return stopCh, func() {}
+	}
+	go func() {
+		ticker := time.NewTicker(25 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if shouldStop() {
+					closeStop()
+					return
+				}
+			}
+		}
+	}()
+	return stopCh, func() {
+		close(done)
+	}
+}
+
+func lifecycleStopRequested(stopCh <-chan struct{}) bool {
+	if stopCh == nil {
+		return false
+	}
+	select {
+	case <-stopCh:
+		return true
+	default:
+		return false
+	}
 }
 
 func stopTargetsForNames(names []string, cfg *config.City, store beads.Store, stderr io.Writer) []stopTarget {
@@ -2091,10 +2235,10 @@ func markCityStopSessionAsAsleep(store beads.Store, sessionID string, stderr io.
 }
 
 // interruptPerTargetTimeout returns the wall-clock cap an interrupt-wave
-// goroutine waits before declaring its target timed out. It composes the
-// configured shutdown grace (which is the post-interrupt wait the caller
-// itself imposes) with a small dispatch margin for the interrupt syscalls
-// themselves.
+// goroutine waits before declaring its target timed out. It deliberately tracks
+// the configured shutdown grace plus a small margin: if the provider's
+// Interrupt call itself wedges, that dispatch attempt can consume up to one
+// grace-sized budget before the post-dispatch graceful-exit wait begins.
 func interruptPerTargetTimeout(cfg *config.City) time.Duration {
 	base := 5 * time.Second
 	if cfg != nil {
@@ -2106,6 +2250,10 @@ func interruptPerTargetTimeout(cfg *config.City) time.Duration {
 }
 
 func interruptTargetsBounded(targets []stopTarget, cfg *config.City, store beads.Store, sp runtime.Provider, stderr io.Writer) int {
+	return interruptTargetsBoundedWithForceSignal(targets, cfg, store, sp, stderr, nil)
+}
+
+func interruptTargetsBoundedWithForceSignal(targets []stopTarget, cfg *config.City, store beads.Store, sp runtime.Provider, stderr io.Writer, shouldStop func() bool) int {
 	targets = hydrateStopTargets(targets, cfg, store, stderr)
 	// Pool-managed sessions have no human user, so Claude Code's
 	// interactive "What should Claude do instead?" prompt would hang
@@ -2141,7 +2289,7 @@ func interruptTargetsBounded(targets []stopTarget, cfg *config.City, store beads
 		return sent
 	}
 	waveStarted := time.Now()
-	results := executeTargetWave(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), func(target stopTarget) error {
+	results := executeTargetWaveUntil(interruptable, min(len(interruptable), defaultMaxParallelInterrupts), interruptPerTargetTimeout(cfg), shouldStop, func(target stopTarget) error {
 		targetID := strings.TrimSpace(target.sessionID)
 		if targetID == "" {
 			targetID = strings.TrimSpace(target.name)

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1833,16 +1833,17 @@ func reachableSelectedDependencies(
 // semaphore and returns a stopResult per target. perTargetTimeout caps the
 // wall-clock each goroutine waits for run() to return; on expiry, that
 // target's outcome is "timed_out" and the inner goroutine is intentionally
-// leaked (it will return when the bounded subprocess deadline kicks in or
-// the process exits). perTargetTimeout <= 0 means no timeout (legacy
-// behavior, used only by tests that exercise unrelated paths).
+// leaked. The leak is acceptable because the only caller is the stop path,
+// which Layer 2 (tmux.tmuxSubprocessTimeout) bounds at the subprocess level
+// — leaked goroutines return when their tmux subprocess is SIGKILL'd at
+// the deadline, or when the process exits. perTargetTimeout <= 0 means no
+// timeout (legacy behavior; useful only for tests that bypass the timeout).
 func executeTargetWave(
 	targets []stopTarget,
 	maxParallel int,
 	perTargetTimeout time.Duration,
 	run func(stopTarget) error,
 ) []stopResult {
-	_ = perTargetTimeout // RED stub: parameter accepted but not yet honored.
 	if len(targets) == 0 {
 		return nil
 	}
@@ -1858,31 +1859,56 @@ func executeTargetWave(
 		go func() {
 			started := time.Now()
 			defer func() {
-				if recovered := recover(); recovered != nil {
-					stack := debug.Stack()
-					results[i] = stopResult{
-						target:   target,
-						err:      fmt.Errorf("panic during lifecycle op: %v\n%s", recovered, stack),
-						outcome:  "panic_recovered",
-						started:  started,
-						finished: time.Now(),
-					}
-				}
 				<-sem
 				done <- i
 			}()
-			err := run(target)
-			finished := time.Now()
-			outcome := "success"
-			if err != nil {
-				outcome = "provider_error"
+
+			type runResult struct {
+				err      error
+				finished time.Time
+				outcome  string
+			}
+			inner := make(chan runResult, 1)
+			go func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						stack := debug.Stack()
+						inner <- runResult{
+							err:      fmt.Errorf("panic during lifecycle op: %v\n%s", recovered, stack),
+							finished: time.Now(),
+							outcome:  "panic_recovered",
+						}
+					}
+				}()
+				err := run(target)
+				finished := time.Now()
+				outcome := "success"
+				if err != nil {
+					outcome = "provider_error"
+				}
+				inner <- runResult{err: err, finished: finished, outcome: outcome}
+			}()
+
+			var rr runResult
+			if perTargetTimeout > 0 {
+				select {
+				case rr = <-inner:
+				case <-time.After(perTargetTimeout):
+					rr = runResult{
+						err:      fmt.Errorf("target lifecycle op did not return within %s", perTargetTimeout),
+						finished: time.Now(),
+						outcome:  "timed_out",
+					}
+				}
+			} else {
+				rr = <-inner
 			}
 			results[i] = stopResult{
 				target:   target,
-				err:      err,
-				outcome:  outcome,
+				err:      rr.err,
+				outcome:  rr.outcome,
 				started:  started,
-				finished: finished,
+				finished: rr.finished,
 			}
 		}()
 	}

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -4508,7 +4508,7 @@ func TestExecutePreparedStartWave_PanicIncludesStackTrace(t *testing.T) {
 }
 
 func TestExecuteTargetWave_PanicIncludesStackTrace(t *testing.T) {
-	results := executeTargetWave([]stopTarget{{name: "worker"}}, 1, func(stopTarget) error {
+	results := executeTargetWave([]stopTarget{{name: "worker"}}, 1, time.Second, func(stopTarget) error {
 		panic("boom")
 	})
 	if len(results) != 1 {

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -212,6 +213,34 @@ func newShutdownWaitProvider() *shutdownWaitProvider {
 func (p *shutdownWaitProvider) ListRunning(prefix string) ([]string, error) {
 	p.listOnce.Do(func() { close(p.listCalled) })
 	return p.Fake.ListRunning(prefix)
+}
+
+type lateAsyncStartListProvider struct {
+	*gatedStartProvider
+	listCalls int
+}
+
+func newLateAsyncStartListProvider() *lateAsyncStartListProvider {
+	return &lateAsyncStartListProvider{
+		gatedStartProvider: newGatedStartProvider(),
+	}
+}
+
+func (p *lateAsyncStartListProvider) ListRunning(prefix string) ([]string, error) {
+	p.mu.Lock()
+	p.listCalls++
+	call := p.listCalls
+	p.mu.Unlock()
+
+	running, err := p.Fake.ListRunning(prefix)
+	if call == 1 {
+		p.release("worker")
+		deadline := time.Now().Add(2 * time.Second)
+		for !p.IsRunning("worker") && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	return running, err
 }
 
 func creatingMeta(meta map[string]string) map[string]string {
@@ -1874,6 +1903,78 @@ func TestCityRuntimeShutdownWaitsForTrackedAsyncStartsBeforeStopSnapshot(t *test
 	}
 	if sp.IsRunning("worker") {
 		t.Fatal("shutdown should stop the runtime that the async start created")
+	}
+}
+
+func TestCityRuntimeForceShutdownRelistsLateAsyncStart(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 26, 12, 1, 26, 0, time.UTC)}
+	session, err := store.Create(beads.Bead{
+		ID:     "gc-worker",
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: creatingMeta(map[string]string{
+			"session_name":         "worker",
+			"template":             "worker",
+			"generation":           "1",
+			"continuation_epoch":   "1",
+			"instance_token":       "tok-worker",
+			"pending_create_claim": "true",
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := newLateAsyncStartListProvider()
+	cfg := &config.City{
+		Daemon: config.DaemonConfig{ShutdownTimeout: "500ms"},
+		Agents: []config.Agent{{Name: "worker"}},
+	}
+	forceStop := &atomic.Bool{}
+	forceStop.Store(true)
+	cr := &CityRuntime{
+		cfg:                 cfg,
+		sp:                  sp,
+		rec:                 events.Discard,
+		standaloneCityStore: store,
+		asyncStartLimiter:   newAsyncStartLimiter(maxParallelStartsPerTick(cfg)),
+		forceStopShutdown:   forceStop,
+		logPrefix:           "gc test",
+		stdout:              ioDiscard{},
+		stderr:              ioDiscard{},
+	}
+	tp := TemplateParams{Command: "worker", SessionName: "worker", TemplateName: "worker"}
+	if got := executePlannedStartsTraced(
+		context.Background(),
+		[]startCandidate{{session: &session, tp: tp}},
+		cfg,
+		map[string]TemplateParams{"worker": tp},
+		sp,
+		store,
+		"test-city",
+		"",
+		clk,
+		events.Discard,
+		time.Minute,
+		ioDiscard{},
+		ioDiscard{},
+		nil,
+		withAsyncStartExecution(),
+		withAsyncStartLimiter(cr.ensureAsyncStartLimiter()),
+		withAsyncStartTracker(&cr.asyncStarts),
+	); got != 1 {
+		t.Fatalf("woken = %d, want 1", got)
+	}
+	sp.waitForStarts(t, 1)
+
+	cr.shutdown()
+
+	if sp.IsRunning("worker") {
+		t.Fatal("force shutdown missed late async-started runtime")
+	}
+	if sp.listCalls < 2 {
+		t.Fatalf("ListRunning calls = %d, want a second snapshot for force async-start cleanup", sp.listCalls)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2650,9 +2650,20 @@ shutdown timeout, then force-kills any remaining sessions. Also stops
 the Dolt server and cleans up orphan sessions. If a controller is
 running, delegates shutdown to it.
 
+Use --timeout=DURATION to cap the wall-clock time gc stop will spend
+before giving up; the default budgets configured session interrupt and
+stop waves, the configured shutdown grace wait, and a second orphan
+cleanup pass. Use --force to skip the interrupt grace period and go
+straight to kill.
+
 ```
-gc stop [path]
+gc stop [path] [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--force` | bool |  | skip the interrupt grace period and force-kill all sessions immediately |
+| `--timeout` | duration | `0s` | wall-clock cap for the stop sequence (0 = derive from city config) |
 
 ## gc supervisor
 

--- a/internal/runtime/tmux/executor_test.go
+++ b/internal/runtime/tmux/executor_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -113,6 +114,65 @@ func (p *promptFooterExecutor) execute(args []string) (string, error) {
 
 func (p *promptFooterExecutor) executeCtx(_ context.Context, args []string) (string, error) {
 	return p.execute(args)
+}
+
+// ctxBlockingExecutor blocks executeCtx until ctx is canceled. Used to
+// verify that callers honor a wall-clock deadline on the subprocess.
+type ctxBlockingExecutor struct {
+	calls [][]string
+}
+
+func (b *ctxBlockingExecutor) execute(args []string) (string, error) {
+	cp := make([]string, len(args))
+	copy(cp, args)
+	b.calls = append(b.calls, cp)
+	return "", nil
+}
+
+func (b *ctxBlockingExecutor) executeCtx(ctx context.Context, args []string) (string, error) {
+	cp := make([]string, len(args))
+	copy(cp, args)
+	b.calls = append(b.calls, cp)
+	<-ctx.Done()
+	return "", ctx.Err()
+}
+
+// TestRunBoundsByTmuxSubprocessTimeout verifies that Tmux.run applies a
+// wall-clock cap to subprocess invocations. A wedged tmux subprocess must
+// not be able to hang the shutdown path indefinitely.
+func TestRunBoundsByTmuxSubprocessTimeout(t *testing.T) {
+	orig := tmuxSubprocessTimeout
+	tmuxSubprocessTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { tmuxSubprocessTimeout = orig })
+
+	bx := &ctxBlockingExecutor{}
+	tm := &Tmux{cfg: DefaultConfig(), exec: bx}
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		_, err := tm.run("list-sessions")
+		done <- result{err: err}
+	}()
+
+	select {
+	case r := <-done:
+		elapsed := time.Since(start)
+		if r.err == nil {
+			t.Fatalf("err = nil after %s, want context.DeadlineExceeded", elapsed)
+		}
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want context.DeadlineExceeded chain", r.err)
+		}
+		if elapsed > 500*time.Millisecond {
+			t.Fatalf("elapsed = %s, want < 500ms", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("tm.run did not return within 2s — tmuxSubprocessTimeout not applied")
+	}
 }
 
 func TestRunInjectsSocketFlag(t *testing.T) {

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -128,6 +128,12 @@ const (
 	hiddenAttachPollInterval = 50 * time.Millisecond
 )
 
+// tmuxSubprocessTimeout caps the wall-clock time any single tmux subprocess
+// invocation may run before the kernel SIGKILLs it. Bounds the shutdown path
+// against wedged tmux servers and FD/inode-exhausted hosts where fork()
+// blocks. Test-overridable; production value is 30s.
+var tmuxSubprocessTimeout = 30 * time.Second
+
 // validateSessionName checks that a session name contains only safe characters.
 // Returns ErrInvalidSessionName if the name contains dots, colons, or other
 // characters that cause tmux to silently fail or produce cryptic errors.

--- a/internal/runtime/tmux/tmux.go
+++ b/internal/runtime/tmux/tmux.go
@@ -212,8 +212,13 @@ func (t *Tmux) approvalDedup() *approvalDedup {
 	return t.interactionDedup
 }
 
-// runCtx executes a tmux command with a context (for timeout/cancellation).
+// runCtx executes a tmux command with a context. The caller-supplied
+// context is composed with tmuxSubprocessTimeout so a wedged tmux server
+// or fork-blocked host cannot hang the call indefinitely. When the parent
+// already has an earlier deadline, that earlier deadline wins.
 func (t *Tmux) runCtx(ctx context.Context, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, tmuxSubprocessTimeout)
+	defer cancel()
 	allArgs := []string{"-u"}
 	if t.cfg.SocketName != "" {
 		allArgs = append(allArgs, "-L", t.cfg.SocketName)
@@ -222,18 +227,12 @@ func (t *Tmux) runCtx(ctx context.Context, args ...string) (string, error) {
 	return t.exec.executeCtx(ctx, allArgs)
 }
 
-// run executes a tmux command and returns stdout.
-// All commands include -u flag for UTF-8 support regardless of locale settings.
-// When SocketName is configured, -L <socket> is injected after -u.
-// See: https://github.com/steveyegge/gastown/issues/1219
+// run executes a tmux command and returns stdout. All commands include -u
+// for UTF-8 regardless of locale; when SocketName is set, -L <socket> is
+// injected after -u (see https://github.com/steveyegge/gastown/issues/1219).
+// Every invocation is bounded by tmuxSubprocessTimeout via runCtx.
 func (t *Tmux) run(args ...string) (string, error) {
-	allArgs := []string{"-u"}
-	if t.cfg.SocketName != "" {
-		allArgs = append(allArgs, "-L", t.cfg.SocketName)
-	}
-	allArgs = append(allArgs, args...)
-
-	return t.exec.execute(allArgs)
+	return t.runCtx(context.Background(), args...)
 }
 
 // wrapError wraps tmux errors with context.

--- a/release-gates/ga-co7mdp-gc-stop-hang-fix-gate.md
+++ b/release-gates/ga-co7mdp-gc-stop-hang-fix-gate.md
@@ -1,0 +1,56 @@
+# Release gate — gc stop hang fix (ga-co7mdp / ga-me9g)
+
+**Verdict:** PASS
+
+- Bead: `ga-co7mdp` (review of `ga-me9g`, closed at `3493fa5b`)
+- Branch: `fork/builder/ga-me9g-2` → re-pushed as deploy branch
+- Base: `origin/main` at `5f1a686d`
+- Branch shape: 2 commits ahead, 0 behind main (TDD red→green)
+  - `5b41f442` — `test(stop): red — bound subprocess + per-target timeouts`
+  - `3493fa5b` — `fix(stop): bound subprocess + per-target timeouts so gc stop can't hang`
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `3493fa5b`; 3 INFO findings, none block. |
+| 2 | Acceptance criteria met | PASS | All 7 acceptance criteria from `ga-me9g` checked off in bead description; verified by reviewer re-run. |
+| 3 | Tests pass on final branch | PASS | Targeted regression suites green (see Validation); cmd/gc baseline failures are pre-existing on `origin/main` (see "Pre-existing test environment"). |
+| 4 | No high-severity review findings open | PASS | Reviewer findings list: 3 INFO, 0 HIGH. |
+| 5 | Working tree clean | PASS | `git status` reports nothing to commit on the deploy branch prior to the gate-file commit. |
+| 6 | Branch diverges cleanly from main | PASS | 2 ahead / 0 behind `origin/main`. No conflicts. |
+
+## Validation (deployer re-run on `deploy/ga-co7mdp` at HEAD `3493fa5b`)
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `golangci-lint run ./cmd/gc/ ./internal/runtime/tmux/` — 0 issues (golangci-lint v2.10.1)
+- `go test ./cmd/gc -run '^(TestExecuteTargetWave|TestGracefulStopAll|TestCmdStop|TestSessionLifecycle|TestRunBoundsByTmuxSubprocess)' -count=1` — PASS (4.77s)
+- `go test ./internal/runtime/tmux -count=1` — PASS (1.05s)
+
+## Pre-existing test environment
+
+`make test` on this machine reports a large number of failing tests in
+`./cmd/gc/...` that are **independent of this change**. To verify, the
+deployer re-ran the same suite directly on `origin/main` (`5f1a686d`)
+in the same environment:
+
+| Branch | `cmd/gc` failures |
+|---|---|
+| `origin/main` (5f1a686d) | 121 |
+| `deploy/ga-co7mdp` (3493fa5b) | 60 |
+
+The set difference (failed-on-deploy-but-not-on-main) is **empty** —
+ga-co7mdp introduces zero new test regressions. The branch in fact
+exhibits fewer environmental flakes than main, which the deployer
+attributes to the bounded-timeout improvements making test cleanup
+more deterministic on a busy host.
+
+The remaining cmd/gc instability on origin/main affects every
+in-flight deploy and is being tracked outside this gate.
+
+## Push target
+
+Pushing to fork (`quad341/gascity`) since origin (`gastownhall/gascity`)
+is upstream-only for this rig. PR is cross-repo with `--head
+quad341:builder/ga-me9g-2`.


### PR DESCRIPTION
## What this changes

`gc stop` previously could hang indefinitely on stuck-creating sessions
because the per-target wait, the tmux subprocess invocations, and the
overall command had no wall-clock bound. This change adds three
defense-in-depth layers:

1. **Per-target timeout** in `executeTargetWave` so an individual
   session that won't shut down can't wedge the wave.
2. **30s subprocess wall-clock cap** on every `tmux` invocation
   (`internal/runtime/tmux/tmux.go`) so a wedged tmux server can't pin
   the goroutine.
3. **Operator escape hatches** on `gc stop`: `--timeout=DURATION` lets
   you raise/lower the wall-clock cap, `--force` skips the per-target
   wait entirely.

The defaults compose conservatively: `gc stop` defaults to
`4 * shutdown_grace + 30s`. With no flags, a normal stop is unaffected;
only a hang now produces a deterministic fail-out.

## Review notes

- `executeTargetWave` leaks its inner goroutine on timeout. This is
  intentional — Layer 2 SIGKILLs the underlying tmux subprocess and the
  goroutine returns when its child exits. Comment on the function
  documents this.
- `interruptPerTargetTimeout` falls back to a 5s base when `cfg` is nil
  or `ShutdownTimeoutDuration` is 0 — preserves existing test behavior.
- `tmuxSubprocessTimeout` is 30s. Generous on purpose: the goal is a
  wedged-server bound, not a hot-path latency cap.
- Visibility logic in `cmd_stop.go` is unchanged; only the new flag
  plumbing was added. The wall-clock-cap default composition is worth a
  careful read.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run …` clean.
- [x] Targeted suites pass: `TestExecuteTargetWave_BoundedByPerTargetTimeout`,
      `TestGracefulStopAll_HangingProviderDoesNotWedge`,
      `TestExecuteTargetWave_PanicIncludesStackTrace`,
      `TestRunBoundsByTmuxSubprocessTimeout`.
- [x] No new test regressions vs `origin/main`. (Pre-existing cmd/gc
      env flakes affect every PR on this repo; not introduced here.)
- [x] Release gate: [`release-gates/ga-co7mdp-gc-stop-hang-fix-gate.md`](release-gates/ga-co7mdp-gc-stop-hang-fix-gate.md)

🤖 Deployed by actual-factory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->