### PR TITLE
feat(gitignore): negate .beads/identity.toml in city + rig templates

### DIFF
--- a/cmd/gc/gitignore.go
+++ b/cmd/gc/gitignore.go
@@ -8,11 +8,11 @@ import (
 )
 
 // cityGitignoreEntries are the paths that gc init writes into .gitignore.
-var cityGitignoreEntries = []string{".gc/", ".beads/*", "!.beads/config.yaml", "!.beads/metadata.json", "hooks/", ".runtime/"}
+var cityGitignoreEntries = []string{".gc/", ".beads/*", "!.beads/config.yaml", "!.beads/metadata.json", "!.beads/identity.toml", "hooks/", ".runtime/"}
 
 // rigGitignoreEntries are the paths that gc rig add writes into
 // the rig-scoped .gitignore.
-var rigGitignoreEntries = []string{".beads/*", "!.beads/config.yaml", "!.beads/metadata.json"}
+var rigGitignoreEntries = []string{".beads/*", "!.beads/config.yaml", "!.beads/metadata.json", "!.beads/identity.toml"}
 
 func usesCanonicalBeadsEntries(entries []string) bool {
 	for _, entry := range entries {

--- a/cmd/gc/gitignore_test.go
+++ b/cmd/gc/gitignore_test.go
@@ -98,7 +98,7 @@ func TestEnsureGitignoreEntries_Idempotent(t *testing.T) {
 
 func TestEnsureGitignoreEntries_NoOpWhenAllPresent(t *testing.T) {
 	f := fsys.NewFake()
-	original := ".gc/\n.beads/*\n!.beads/config.yaml\n!.beads/metadata.json\nhooks/\n.runtime/\n"
+	original := ".gc/\n.beads/*\n!.beads/config.yaml\n!.beads/metadata.json\n!.beads/identity.toml\nhooks/\n.runtime/\n"
 	f.Files[filepath.Join("/city", ".gitignore")] = []byte(original)
 
 	if err := ensureGitignoreEntries(f, "/city", cityGitignoreEntries); err != nil {
@@ -152,6 +152,68 @@ func TestDoInit_GitignoreIdempotent(t *testing.T) {
 	second := string(f.Files[filepath.Join("/bright-lights", ".gitignore")])
 	if first != second {
 		t.Errorf("gitignore changed on second pass;\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+// TestEnsureGitignoreEntries_IdentityTomlNegationPresent locks designer §6:
+// both city- and rig-rendered .gitignore must contain
+// "!.beads/identity.toml" so the identity file is committed alongside
+// .beads/config.yaml and .beads/metadata.json.
+func TestEnsureGitignoreEntries_IdentityTomlNegationPresent(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dir     string
+		entries []string
+	}{
+		{"city", "/city", cityGitignoreEntries},
+		{"rig", "/rig", rigGitignoreEntries},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := fsys.NewFake()
+			if err := ensureGitignoreEntries(f, tc.dir, tc.entries); err != nil {
+				t.Fatalf("ensureGitignoreEntries: %v", err)
+			}
+			got := string(f.Files[filepath.Join(tc.dir, ".gitignore")])
+			if !strings.Contains(got, "!.beads/identity.toml") {
+				t.Errorf("%s .gitignore missing %q; got:\n%s", tc.name, "!.beads/identity.toml", got)
+			}
+		})
+	}
+}
+
+// TestEnsureGitignoreEntries_IdentityTomlNegationAfterGlob locks the
+// ordering invariant: "!.beads/identity.toml" must appear AFTER
+// ".beads/*" in the rendered output, otherwise the negation is inert.
+// This catches the most common regression — alphabetical reorders of
+// the slice.
+func TestEnsureGitignoreEntries_IdentityTomlNegationAfterGlob(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dir     string
+		entries []string
+	}{
+		{"city", "/city", cityGitignoreEntries},
+		{"rig", "/rig", rigGitignoreEntries},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := fsys.NewFake()
+			if err := ensureGitignoreEntries(f, tc.dir, tc.entries); err != nil {
+				t.Fatalf("ensureGitignoreEntries: %v", err)
+			}
+			got := string(f.Files[filepath.Join(tc.dir, ".gitignore")])
+			globIdx := strings.Index(got, ".beads/*")
+			negIdx := strings.Index(got, "!.beads/identity.toml")
+			if globIdx < 0 {
+				t.Fatalf("%s .gitignore missing %q; got:\n%s", tc.name, ".beads/*", got)
+			}
+			if negIdx < 0 {
+				t.Fatalf("%s .gitignore missing %q; got:\n%s", tc.name, "!.beads/identity.toml", got)
+			}
+			if negIdx < globIdx {
+				t.Errorf("%s .gitignore: %q must appear AFTER %q (negation requires it); got:\n%s",
+					tc.name, "!.beads/identity.toml", ".beads/*", got)
+			}
+		})
 	}
 }
 

--- a/release-gates/ga-lwac5s-gitignore-identity-toml-gate.md
+++ b/release-gates/ga-lwac5s-gitignore-identity-toml-gate.md
@@ -1,0 +1,30 @@
+# Release gate — gitignore .beads/identity.toml negation (ga-lwac5s / ga-4tg3j)
+
+**Verdict:** PASS
+
+- Bead: `ga-lwac5s` (review of `ga-4tg3j`, closed)
+- Branch: `quad341:builder/ga-4tg3j-1`
+- HEAD: `5b1ed763` (single commit off `origin/main` 5f1a686d)
+- Diff: 2 files (`cmd/gc/gitignore.go` +2/-2, `cmd/gc/gitignore_test.go` +62/-2)
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `5b1ed763`. |
+| 2 | Acceptance criteria met | PASS | `!.beads/identity.toml` added to both `cityGitignoreEntries` and `rigGitignoreEntries` after the `.beads/*` glob (ordering matters); 4 new sub-tests + 1 fixture extension lock presence and ordering. |
+| 3 | Tests pass on final branch | PASS | `go test ./cmd/gc -run 'TestEnsureGitignoreEntries\|TestGitignore' -count=1` — PASS. |
+| 4 | No high-severity review findings open | PASS | Reviewer findings list: empty. |
+| 5 | Working tree clean | PASS | `git status` clean prior to gate-file commit. |
+| 6 | Branch diverges cleanly from main | PASS | 1 ahead / 0 behind `origin/main`. |
+
+## Validation (deployer re-run on `deploy/ga-lwac5s` at HEAD `5b1ed763`)
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `golangci-lint run ./cmd/gc/` — 0 issues
+- `go test ./cmd/gc -run 'TestEnsureGitignoreEntries|TestGitignore' -count=1` — PASS (48ms)
+
+## Push target
+
+Pushing to fork (`quad341/gascity`); PR is cross-repo.


### PR DESCRIPTION
## What this changes

Adds `!.beads/identity.toml` to both the city and rig gitignore
templates, immediately after the `.beads/*` ignore glob. This makes
the new contract-level identity file (`internal/beads/contract`,
landing in parallel) visible to git so a city's project identity
travels with the repo, while everything else under `.beads/` remains
untracked.

The negation must come **after** `.beads/*` to take effect; the test
suite locks both presence and ordering so a future reorder can't
silently drop the negation.

## Review notes

- `cmd/gc/gitignore.go` is the only production change — 2 string
  literals added, one to each of `cityGitignoreEntries` and
  `rigGitignoreEntries`.
- All callers of those slices (`ensureGitignoreEntries` in
  `cmd_init.go` and `cmd_rig.go`) consume the slice as-is; no
  copies, no other call sites need updating.
- Existing test fixtures with partial slice literals (`gitignore_test.go`
  general-helper tests) intentionally remain unchanged — they cover
  helper behavior with subsets, not the canonical list shape.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- [x] New tests: presence + post-glob-ordering + negation-after-`.beads/*`.
- [x] Existing `usesCanonicalBeadsEntries` and `isLegacyWholeBeadsIgnore`
      checks still pass against the extended canonical list.
- [x] Release gate: [`release-gates/ga-lwac5s-gitignore-identity-toml-gate.md`](release-gates/ga-lwac5s-gitignore-identity-toml-gate.md)

🤖 Deployed by actual-factory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->