### PR TITLE
feat(beads): deterministic reconciler stagger via FNV-32a(agent_id)

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -154,7 +154,7 @@ func wrapWithCachingStore(ctx context.Context, store beads.Store, ep events.Prov
 		if ctx.Err() != nil {
 			return
 		}
-		cs.StartReconciler(ctx)
+		cs.StartReconciler(ctx, beads.WithStaggerAuto(), os.Getenv("GC_AGENT"))
 	}()
 	return cs
 }

--- a/internal/beads/caching_store.go
+++ b/internal/beads/caching_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"strings"
 	"sync"
@@ -76,6 +77,10 @@ type CacheStats struct {
 	LastProblemAt           time.Time
 	LastProblem             string
 	State                   string
+	// StaggerOffsetMs is the one-shot startup delay applied between Prime
+	// and the first reconciler tick, in milliseconds. Set once when
+	// StartReconciler runs; zero if stagger is disabled.
+	StaggerOffsetMs int64
 }
 
 const (
@@ -85,6 +90,69 @@ const (
 	cacheReconcileIntervalMedium = 60 * time.Second
 	cacheReconcileIntervalLarge  = 120 * time.Second
 )
+
+// StaggerOption configures the deterministic startup stagger applied
+// between Prime and the first reconciler tick. N agents starting in
+// lockstep would otherwise hit the shared dolt server simultaneously;
+// the stagger spreads first-tick load across a 0–30 s window.
+//
+// Construct one via WithStaggerAuto, WithStaggerOff, or
+// WithStaggerFixed at the call site for self-documenting intent. The
+// zero value is equivalent to WithStaggerOff().
+type StaggerOption struct {
+	auto     bool
+	fixed    bool
+	explicit time.Duration
+}
+
+// WithStaggerAuto enables a deterministic per-agent stagger derived
+// from FNV-32a(agentID) mod cacheReconcileIntervalSmall. The stagger
+// is reproducible across runs given the same agent ID.
+func WithStaggerAuto() StaggerOption {
+	return StaggerOption{auto: true}
+}
+
+// WithStaggerOff disables stagger; the reconciler enters its loop with
+// no startup delay. This is the default for tests so existing behavior
+// is preserved.
+func WithStaggerOff() StaggerOption {
+	return StaggerOption{}
+}
+
+// WithStaggerFixed sets an explicit stagger duration regardless of
+// agentID. Negative durations clamp to zero.
+func WithStaggerFixed(d time.Duration) StaggerOption {
+	if d < 0 {
+		d = 0
+	}
+	return StaggerOption{fixed: true, explicit: d}
+}
+
+// resolve returns the concrete stagger duration for this option.
+// agentID is consulted only when the option is WithStaggerAuto.
+func (o StaggerOption) resolve(agentID string) time.Duration {
+	switch {
+	case o.fixed:
+		return o.explicit
+	case o.auto:
+		return computeAutoStagger(agentID)
+	}
+	return 0
+}
+
+// computeAutoStagger hashes agentID with FNV-32a and reduces it modulo
+// cacheReconcileIntervalSmall (in milliseconds). The result lies in
+// [0, cacheReconcileIntervalSmall) and is fully deterministic — no
+// time-seeding — so test runs reproduce.
+func computeAutoStagger(agentID string) time.Duration {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(agentID))
+	modMs := cacheReconcileIntervalSmall.Milliseconds()
+	if modMs <= 0 {
+		return 0
+	}
+	return time.Duration(int64(h.Sum32())%modMs) * time.Millisecond
+}
 
 // NewCachingStore wraps a BdStore with an in-memory read cache.
 // Call Prime() before serving reads, then StartReconciler() for
@@ -357,10 +425,24 @@ func (c *CachingStore) Prime(_ context.Context) error {
 }
 
 // StartReconciler launches watchdog reconciliation. Cancel ctx to stop.
-func (c *CachingStore) StartReconciler(ctx context.Context) {
+// The stagger applies a one-time delay between this call and the first
+// reconciler tick (see StaggerOption); agentID is consulted only when
+// stagger is WithStaggerAuto. A single "beads cache: stagger=Nms
+// agent=..." log line is emitted before the loop starts, even when the
+// resolved stagger is zero, so absence is unambiguous.
+func (c *CachingStore) StartReconciler(ctx context.Context, stagger StaggerOption, agentID string) {
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancelFn = cancel
-	go c.reconcileLoop(ctx)
+
+	offset := stagger.resolve(agentID)
+
+	c.mu.Lock()
+	c.stats.StaggerOffsetMs = offset.Milliseconds()
+	c.mu.Unlock()
+
+	log.Printf("beads cache: stagger=%dms agent=%s", offset.Milliseconds(), agentID)
+
+	go c.reconcileLoop(ctx, offset)
 }
 
 // StopReconciler cancels the background reconciler.

--- a/internal/beads/caching_store_reconcile.go
+++ b/internal/beads/caching_store_reconcile.go
@@ -7,7 +7,15 @@ import (
 	"time"
 )
 
-func (c *CachingStore) reconcileLoop(ctx context.Context) {
+func (c *CachingStore) reconcileLoop(ctx context.Context, stagger time.Duration) {
+	if stagger > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(stagger):
+		}
+	}
+
 	timer := time.NewTimer(cacheReconcilePollInterval)
 	defer timer.Stop()
 

--- a/internal/beads/caching_store_test.go
+++ b/internal/beads/caching_store_test.go
@@ -2289,7 +2289,7 @@ func TestCachingStoreReconcilerStopsOnCancel(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cs.StartReconciler(ctx)
+	cs.StartReconciler(ctx, beads.WithStaggerOff(), "")
 	time.Sleep(100 * time.Millisecond)
 	cancel()
 	time.Sleep(100 * time.Millisecond)
@@ -2484,6 +2484,123 @@ func dependencySnapshotUpdatePayload(t *testing.T, b beads.Bead, deps []beads.De
 		t.Fatalf("Marshal event payload: %v", err)
 	}
 	return payload
+}
+
+func TestStartReconcilerStaggerOff(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	cs := beads.NewCachingStoreForTest(mem, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cs.StartReconciler(ctx, beads.WithStaggerOff(), "any-agent-name")
+
+	if got := cs.Stats().StaggerOffsetMs; got != 0 {
+		t.Fatalf("StaggerOffsetMs = %d, want 0 with WithStaggerOff()", got)
+	}
+}
+
+func TestStartReconcilerStaggerFixed(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	cs := beads.NewCachingStoreForTest(mem, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cs.StartReconciler(ctx, beads.WithStaggerFixed(5*time.Second), "any-agent-name")
+
+	if got := cs.Stats().StaggerOffsetMs; got != 5000 {
+		t.Fatalf("StaggerOffsetMs = %d, want 5000 with WithStaggerFixed(5s)", got)
+	}
+}
+
+func TestStartReconcilerStaggerFixedNegativeClampsToZero(t *testing.T) {
+	t.Parallel()
+	mem := beads.NewMemStore()
+	cs := beads.NewCachingStoreForTest(mem, nil)
+	if err := cs.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cs.StartReconciler(ctx, beads.WithStaggerFixed(-1*time.Second), "")
+
+	if got := cs.Stats().StaggerOffsetMs; got != 0 {
+		t.Fatalf("StaggerOffsetMs = %d, want 0 for negative WithStaggerFixed", got)
+	}
+}
+
+func TestStartReconcilerStaggerAutoIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Acceptance criterion 2: pinned FNV-32a-derived offset for a known agent_id.
+	cases := []struct {
+		agentID      string
+		wantOffsetMs int64
+	}{
+		{"beads/builder-1", 20616},
+		{"beads/builder-2", 13473},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.agentID, func(t *testing.T) {
+			t.Parallel()
+			mem := beads.NewMemStore()
+			cs := beads.NewCachingStoreForTest(mem, nil)
+			if err := cs.Prime(context.Background()); err != nil {
+				t.Fatalf("Prime: %v", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			cs.StartReconciler(ctx, beads.WithStaggerAuto(), tc.agentID)
+
+			got := cs.Stats().StaggerOffsetMs
+			if got != tc.wantOffsetMs {
+				t.Fatalf("StaggerOffsetMs for %q = %d, want %d (FNV-32a pin)", tc.agentID, got, tc.wantOffsetMs)
+			}
+			if got < 0 || got >= 30000 {
+				t.Fatalf("StaggerOffsetMs for %q = %d outside [0, 30000) bound", tc.agentID, got)
+			}
+		})
+	}
+}
+
+func TestStartReconcilerStaggerAutoDifferentAgentsDiffer(t *testing.T) {
+	t.Parallel()
+
+	// Acceptance criterion 1: two agents started with WithStaggerAuto produce
+	// measurably different stagger offsets.
+	mem1 := beads.NewMemStore()
+	cs1 := beads.NewCachingStoreForTest(mem1, nil)
+	if err := cs1.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime cs1: %v", err)
+	}
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	cs1.StartReconciler(ctx1, beads.WithStaggerAuto(), "beads/builder-1")
+
+	mem2 := beads.NewMemStore()
+	cs2 := beads.NewCachingStoreForTest(mem2, nil)
+	if err := cs2.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime cs2: %v", err)
+	}
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	cs2.StartReconciler(ctx2, beads.WithStaggerAuto(), "beads/builder-2")
+
+	off1 := cs1.Stats().StaggerOffsetMs
+	off2 := cs2.Stats().StaggerOffsetMs
+	if off1 == off2 {
+		t.Fatalf("expected different stagger offsets for distinct agents; both got %d", off1)
+	}
 }
 
 func findTestBead(items []beads.Bead, id string) (beads.Bead, bool) {

--- a/release-gates/ga-zor1n2-reconciler-stagger-gate.md
+++ b/release-gates/ga-zor1n2-reconciler-stagger-gate.md
@@ -1,0 +1,30 @@
+# Release gate — deterministic reconciler stagger (ga-zor1n2 / ga-wzse)
+
+**Verdict:** PASS
+
+- Bead: `ga-zor1n2` (review of `ga-wzse`, closed)
+- Branch: `quad341:builder/ga-wzse-1`
+- HEAD: `fb01d7fa` (single commit off `origin/main` 5f1a686d)
+- Diff: 4 files, +212 / -5
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `fb01d7fa`; 4 INFO findings, none block. |
+| 2 | Acceptance criteria met | PASS | All 5 AC + 1 edge-case test in 1:1 alignment with `ga-wzse` design spec; reviewer confirmed FNV-32a pin (`beads/builder-1` → 20616 ms) reproduces independently. |
+| 3 | Tests pass on final branch | PASS | `go test ./internal/beads -run 'TestStartReconcilerStagger\|TestCachingStoreReconcilerStopsOnCancel' -count=1` — PASS (210ms). |
+| 4 | No high-severity review findings open | PASS | 4 INFO findings, 0 HIGH (race-clean per `go test -race`; out-of-scope items deferred to ga-7gpo/ga-70nf). |
+| 5 | Working tree clean | PASS | `git status` clean before gate-file commit. |
+| 6 | Branch diverges cleanly from main | PASS | 1 ahead / 0 behind `origin/main`. |
+
+## Validation (deployer re-run on `deploy/ga-zor1n2` at HEAD `fb01d7fa`)
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `golangci-lint run ./internal/beads/ ./cmd/gc/` — 0 issues
+- `go test ./internal/beads -run 'TestStartReconcilerStagger|TestCachingStoreReconcilerStopsOnCancel' -count=1` — PASS
+
+## Push target
+
+Pushing to fork (`quad341/gascity`); PR cross-repo.


### PR DESCRIPTION
## What this changes

When N agents start in lockstep against the same Dolt server, their
reconcilers fire on aligned ticks and the server sees a thundering
herd of identical queries every interval. This change adds a one-shot
**deterministic stagger** at the start of `reconcileLoop`, derived from
`FNV-32a(agent_id) mod 30s`. Each agent's first poll is offset by a
fixed, reproducible amount in `[0, 30s)` — no time-seeding, no random
jitter. After the stagger fires once, the existing
`cacheReconcilePollInterval` (5s) is unchanged.

API surface added: a `StaggerOption` value with three named
constructors that document intent at the call site:

- `WithStaggerAuto(agentID string)` — production default
- `WithStaggerOff()` — preserves today's behavior (used by existing tests)
- `WithStaggerFixed(d time.Duration)` — explicit override (negatives clamp to zero)

`StartReconciler` now takes the stagger option; the production caller
is `cmd/gc/api_state.go` (using `WithStaggerAuto(os.Getenv("GC_AGENT"))`).

## Review notes

- Three constructors instead of a single bool/duration is a deliberate
  call to make intent explicit at every site. The unexported fields plus
  exported constructors prevent malformed options from outside the
  package.
- `computeAutoStagger` uses stdlib `hash/fnv` (no new dep). FNV-32a
  is non-cryptographic, fine for stagger derivation; not a security
  primitive.
- `Stats().StaggerOffsetMs` is set under `c.mu.Lock()` and read by
  value-copy. No data race; verified `go test -race` clean.
- The stagger `select` (`ctx.Done()` vs `time.After(stagger)`) is
  cancel-safe — context cancellation during stagger returns immediately
  without entering the timer-driven loop.
- Designer's open question about a canonical identity getter
  (`os.Getenv("GC_AGENT")` use site) was deferred — no such helper
  exists today; consistent with `internal/telemetry/subprocess.go`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- [x] 5 AC tests + 1 edge-case test pass:
      `TestStartReconcilerStaggerAutoIsDeterministic` (FNV pin),
      `TestStartReconcilerStaggerAutoDifferentAgentsDiffer`,
      `TestStartReconcilerStaggerOff`,
      `TestStartReconcilerStaggerFixed`,
      `TestStartReconcilerStaggerFixedNegativeClampsToZero`,
      `TestCachingStoreReconcilerStopsOnCancel` (existing, updated for new signature).
- [x] `go test -race ./internal/beads/...` — clean (per reviewer).
- [x] Release gate: [`release-gates/ga-zor1n2-reconciler-stagger-gate.md`](release-gates/ga-zor1n2-reconciler-stagger-gate.md)

🤖 Deployed by actual-factory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->