### PR TITLE
test(cmd/gc): add requireNoLeakedDoltAfter helper for dolt-leak detection

### DIFF
--- a/release-gates/ga-ytbdp8-dolt-leak-helper-gate.md
+++ b/release-gates/ga-ytbdp8-dolt-leak-helper-gate.md
@@ -1,0 +1,37 @@
+# Release gate — requireNoLeakedDoltAfter test helper (ga-ytbdp8 / ga-de27g)
+
+**Verdict:** PASS
+
+- Bead: `ga-ytbdp8` (review of `ga-de27g`, closed)
+- Branch: `quad341:builder/ga-b4gug-1`
+- HEAD: `79b3e64a` (stacked on slice 3 `5cbf1d75` of identity contract chain)
+- Diff: 2 files, +63 / 0 (test-only)
+
+## Stack note
+
+Stacked on PR #1794 (slice 3 lint guard). The dolt-leak helper is
+**not semantically dependent** on the identity contract chain — the
+builder happened to author both on the same branch. While #1794 / #1793
+/ #1791 are open, this PR will show four commits.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `79b3e64a` (per gm-k19yck). |
+| 2 | Acceptance criteria met | PASS | Helper added, applied via `writeCityRuntimeConfig*` writers (14 callers auto-covered); failure-mode test deferred to follow-up `ga-vux42u` (role boundary — builders don't author new tests). |
+| 3 | Tests pass on final branch | PASS | `go test ./cmd/gc/ -run '^TestCityRuntimeReload' -count=1` — PASS (13/13). |
+| 4 | No high-severity review findings open | PASS | No findings in routing message. |
+| 5 | Working tree clean | PASS | `git status` clean before gate-file commit. |
+| 6 | Branch diverges cleanly from main | PASS | 4 commits ahead, 0 behind. Stacked relationship. |
+
+## Validation (deployer re-run on `deploy/ga-ytbdp8` at HEAD `79b3e64a`)
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `golangci-lint run ./cmd/gc/` — 0 issues
+- `go test ./cmd/gc/ -run '^TestCityRuntimeReload' -count=1` — PASS (13/13 in 2.96s)
+
+## Push target
+
+Pushing to fork (`quad341/gascity`); PR cross-repo. Stacked on PR #1794.

--- a/release-gates/ga-ytbdp8-dolt-leak-helper-gate.md
+++ b/release-gates/ga-ytbdp8-dolt-leak-helper-gate.md
@@ -3,35 +3,48 @@
 **Verdict:** PASS
 
 - Bead: `ga-ytbdp8` (review of `ga-de27g`, closed)
-- Branch: `quad341:builder/ga-b4gug-1`
-- HEAD: `79b3e64a` (stacked on slice 3 `5cbf1d75` of identity contract chain)
-- Diff: 2 files, +63 / 0 (test-only)
+- Branch: `quad341:builder/ga-b4gug-2` (post-rebase adopted PR head)
+- Replayed gate artifact commit: `28c0b031d` (artifact commit replayed from
+  `472674043` onto `main` base `e26cdef5d`)
+- Original helper HEAD: `79b3e64a` on `quad341:builder/ga-b4gug-1`
+- Artifact-commit diff: 1 file, +37 / 0 (release-gate artifact only)
+- Original helper diff: 2 files, +63 / 0 (test-only)
 
 ## Stack note
 
-Stacked on PR #1794 (slice 3 lint guard). The dolt-leak helper is
-**not semantically dependent** on the identity contract chain — the
-builder happened to author both on the same branch. While #1794 / #1793
-/ #1791 are open, this PR will show four commits.
+This PR was originally stacked on PR #1794 (slice 3 lint guard), with lower
+slices in PR #1793 and PR #1791. Those identity-chain slices, plus the
+`requireNoLeakedDoltAfter` helper, have since reached `main` through separate
+PR cycles. The adopted post-rebase branch now carries only this gate artifact.
+
+Rebase repair summary from the source bead: skipped duplicate identity/helper
+commits already present on the upstream base; replayed only release-gate
+artifact `472674043` onto `e26cdef5d` as `28c0b031d`.
 
 ## Criteria
 
 | # | Criterion | Verdict | Evidence |
 |---|-----------|---------|----------|
 | 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `79b3e64a` (per gm-k19yck). |
-| 2 | Acceptance criteria met | PASS | Helper added, applied via `writeCityRuntimeConfig*` writers (14 callers auto-covered); failure-mode test deferred to follow-up `ga-vux42u` (role boundary — builders don't author new tests). |
-| 3 | Tests pass on final branch | PASS | `go test ./cmd/gc/ -run '^TestCityRuntimeReload' -count=1` — PASS (13/13). |
+| 2 | Acceptance criteria met | PASS | Helper added and applied via `writeCityRuntimeConfig*` writers in the original helper branch; the helper code is already present on `main`, so this PR now records the release gate only. |
+| 3 | Tests pass on final branch | PASS | Original helper validation passed `go test ./cmd/gc/ -run '^TestCityRuntimeReload' -count=1` (13/13); post-rebase artifact validation passed `go test ./test/docsync/...`. |
 | 4 | No high-severity review findings open | PASS | No findings in routing message. |
 | 5 | Working tree clean | PASS | `git status` clean before gate-file commit. |
-| 6 | Branch diverges cleanly from main | PASS | 4 commits ahead, 0 behind. Stacked relationship. |
+| 6 | Branch diverges cleanly from main | PASS | Post-rebase review head carries the replayed artifact commit plus maintainer provenance fixup on current `main`; the original helper and identity-chain commits are already in `main`. |
 
-## Validation (deployer re-run on `deploy/ga-ytbdp8` at HEAD `79b3e64a`)
+## Original validation (deployer re-run on `deploy/ga-ytbdp8` at helper HEAD `79b3e64a`)
 
 - `go build ./...` — clean
 - `go vet ./...` — clean
 - `golangci-lint run ./cmd/gc/` — 0 issues
 - `go test ./cmd/gc/ -run '^TestCityRuntimeReload' -count=1` — PASS (13/13 in 2.96s)
 
+## Post-rebase artifact validation
+
+- `git diff --check refs/adopt-pr/ga-3t12vc/upstream-base..HEAD` — clean
+- `go test ./test/docsync/...` — PASS
+
 ## Push target
 
-Pushing to fork (`quad341/gascity`); PR cross-repo. Stacked on PR #1794.
+Pushing to fork (`quad341/gascity`); PR cross-repo. No longer stacked after
+the duplicate helper and lower identity-chain commits reached `main`.


### PR DESCRIPTION
## What this changes

Adds a test-only `requireNoLeakedDoltAfter` helper that snapshots live
`dolt sql-server` PIDs (via `/proc`) at registration time and re-scans
in `t.Cleanup`. Any new PID present at cleanup is reported via
`t.Errorf` with PID + argv, surfacing the dolt-leak class of bugs that
have repeatedly caused OOMs and identity-drift incidents in the past
(see parent `ga-de27g`, related `ga-3ski1`).

The helper is wired into `writeCityRuntimeConfig*` writers in
`city_runtime_test.go`, so all 14 callers — including the 13
`TestCityRuntimeReload*` tests — get auto-coverage without the bead
having to enumerate them.

> ⚠️ **Stacked on the identity contract chain** (PR #1791 → #1793 →
> #1794 → this). The dolt-leak helper itself is not semantically
> dependent on the identity work — the builder happened to author both
> on the same branch. Will show four commits while the lower three PRs
> are open.

## Review notes

- Test-only diff: `cmd/gc/path_helpers_test.go` (+59) and
  `cmd/gc/city_runtime_test.go` (+4) for the writer integration.
- The helper is package-private to `cmd/gc` — no public API.
- `clearInheritedBeadsEnv` gap filled in
  `writeCityRuntimeConfigWithShutdownTimeout`; this was uncovered
  during integration.
- The failure-mode test (synthetic-leak injection) is deferred to
  follow-up `ga-vux42u` (validator's responsibility per role boundary
  — builders don't author new tests against tests they wrote).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./cmd/gc/` clean.
- [x] `go test ./cmd/gc/ -run '^TestCityRuntimeReload' -count=1` PASS (13/13 in 2.96s).
- [x] Release gate: [`release-gates/ga-ytbdp8-dolt-leak-helper-gate.md`](release-gates/ga-ytbdp8-dolt-leak-helper-gate.md)

🤖 Deployed by actual-factory (stacked on #1794)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->