### PR TITLE
fix(maintenance): jsonl-export auto-detects archive mode instead of silently escalating on unconfigured remote

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -227,6 +227,11 @@ cd ~/my-city
 `gc init` registers the city with the supervisor and starts it automatically.
 See the [Quickstart](/getting-started/quickstart) for a complete walkthrough.
 
+Gas City ships a JSONL archive that snapshots every bead database for
+disaster recovery. By default it runs in local-only mode and keeps commits
+on this host. To enable off-box backup, see
+[JSONL archive push failures](/getting-started/troubleshooting#jsonl-archive-push-failures).
+
 ## Docs preview
 
 The docs site uses [Mintlify](https://mintlify.com). Preview locally from the

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -160,6 +160,108 @@ of a clean version string, upgrade to Gas City v0.13.4 or later. This was a
 bug where remote pack fetches wrote git sideband output to the terminal,
 fixed in [PR #141](https://github.com/gastownhall/gascity/pull/141).
 
+## JSONL Archive Push Failures
+
+The maintenance pack runs `jsonl-export` every 15 minutes to dump each bead
+database to a text-diffable JSONL snapshot inside a local git repository
+(the "JSONL archive"). The archive serves as a disaster-recovery backup:
+if the live Dolt server loses data, the last-known-good bead graph can be
+reconstructed from the archive's commit history.
+
+### Local-only vs push mode
+
+The archive operates in one of two modes, detected from the state of its
+git remotes on every run:
+
+- **Local-only (default).** No `origin` remote is configured. Commits are
+  created and retained on the host but never leave the machine. This mode
+  is safe to run indefinitely; its only limitation is that the archive is
+  not backed up off-box, so a disk failure on this host loses the archive
+  alongside the live Dolt data.
+- **Push.** An `origin` remote is configured. Each run rebases onto
+  `origin/main` and pushes new commits so the archive survives a host
+  loss.
+
+On each run `jsonl-export` logs the active mode to stderr on transitions
+(e.g. after you add or remove `origin`) and re-logs it at least weekly so
+that an operator reading the log file can always find the current mode.
+
+### Enabling off-box backup
+
+Pick a repository that only this host will push to (the archive contains
+bead content and should not be shared across cities). Then:
+
+```bash
+# Create a private repo on your git host (example: GitHub via gh)
+gh repo create my-city-jsonl-archive --private
+
+# Point the archive at it
+ARCHIVE=$(gc config get state_dir)/packs/maintenance/jsonl-archive
+git -C "$ARCHIVE" remote add origin git@github.com:<you>/my-city-jsonl-archive.git
+
+# Seed the remote with the existing local history
+git -C "$ARCHIVE" push -u origin main
+```
+
+On the next 15-minute tick, `jsonl-export` detects the new `origin`,
+logs `archive running in push mode`, and resumes pushing every run.
+
+### Switching back to local-only
+
+Remove the remote:
+
+```bash
+git -C "$ARCHIVE" remote remove origin
+```
+
+Re-detection is automatic on the next run — no state-file edits are
+required. The next log line will read `archive running in local-only
+mode`.
+
+### Reading a `JSONL push failed [HIGH]` escalation
+
+When push mode is active and `git push` fails `GC_JSONL_MAX_PUSH_FAILURES`
+times in a row (default: 3), the mayor's inbox receives an
+`ESCALATION: JSONL push failed [HIGH]` message with a body shaped like:
+
+```
+Order: mol-dog-jsonl
+Archive: /path/to/archive
+Consecutive failures: 3 (threshold: 3)
+
+Last git push stderr:
+<last ~20 lines of captured stderr from fetch / rebase / push>
+
+Remediation:
+- Check remote: git -C <archive> remote -v
+- Verify remote is reachable and credentials are valid
+- Temporarily suppress: export GC_JSONL_MAX_PUSH_FAILURES=99
+- See docs/getting-started/troubleshooting.md#jsonl-archive-push-failures
+```
+
+Common root causes, in rough order of frequency:
+
+- **Credentials rotated or expired.** SSH key removed from the remote
+  host, HTTPS token expired. The captured stderr usually reads
+  `Permission denied (publickey)` or `remote: Invalid username or
+  password`.
+- **Remote URL typo or deleted repo.** stderr reads `does not appear to
+  be a git repository` or `repository not found`.
+- **Network partition.** stderr reads `Could not resolve host` or a
+  connection-timeout message. If the host is also firewalled from the
+  rest of the internet, this will recover once connectivity returns.
+- **Diverged history.** Very unusual — the archive rebases onto
+  `origin/main` automatically — but if the remote was force-pushed from
+  another host, rebase may fail with a conflict. Inspecting the archive
+  and resolving manually is the only option.
+
+If the underlying problem cannot be fixed immediately (e.g., the remote
+host is down for scheduled maintenance), set
+`GC_JSONL_MAX_PUSH_FAILURES=99` in the maintenance pack's environment and
+restart the city with `gc restart`. That bumps the escalation threshold
+from 3 to 99, which at the current 15-minute tick rate is ~24 hours of
+silence.
+
 ## WSL (Windows Subsystem for Linux)
 
 Gas City works under WSL 2 with a standard Ubuntu or Debian distribution.

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3457,14 +3457,13 @@ func initEmptyArchiveRemote(t *testing.T, archiveRepo string, prevCount int) str
 // Used by tests that specifically exercise the push-failure recovery paths:
 // push mode is active (so `should_attempt_push` returns true) but the remote
 // cannot be reached.
-func initSeedArchiveWithUnreachableRemote(t *testing.T, archiveRepo string, prevCount int) string {
+func initSeedArchiveWithUnreachableRemote(t *testing.T, archiveRepo string, prevCount int) {
 	t.Helper()
-	head := initSeedArchive(t, archiveRepo, prevCount)
+	initSeedArchive(t, archiveRepo, prevCount)
 	unreachable := filepath.Join(t.TempDir(), "nonexistent-remote.git")
 	if out, err := exec.Command("git", "-C", archiveRepo, "remote", "add", "origin", unreachable).CombinedOutput(); err != nil {
 		t.Fatalf("git remote add origin: %v\n%s", err, out)
 	}
-	return head
 }
 
 func advanceArchiveRemoteMain(t *testing.T, remoteRepo string) string {

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4915,6 +4915,79 @@ func TestJsonlExportPushModeAttemptsPushWhenOriginConfigured(t *testing.T) {
 	}
 }
 
+// TestJsonlExportLocalOnlyTransitionClearsStalePushFailureState covers the
+// push→local-only transition: when the operator removes origin after
+// push-failure state has accumulated, the next run must clear
+// consecutive_push_failures so a later push→local-only→push round-trip
+// starts from a clean counter (not from the stale value, which could trigger
+// a premature HIGH escalation on the very first failure after origin
+// returns). pending_archive_push is intentionally retained — it tracks that
+// local commits still need to be pushed once origin returns.
+func TestJsonlExportLocalOnlyTransitionClearsStalePushFailureState(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	initSeedArchive(t, archiveRepo, 3)
+	writeMultiRecordDoltStub(t, binDir, 5)
+	writeJsonlExportGCStub(t, binDir)
+
+	if err := os.MkdirAll(filepath.Dir(stateFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll(state dir): %v", err)
+	}
+	// Seed state: push mode was active, two push failures accumulated, the
+	// pending-push flag is set. Then operator removed origin (no remote on
+	// archive). Next tick should detect the transition and reset both fields.
+	priorState := `{"last_logged_mode":"push","last_logged_at":"2026-05-01T00:00:00Z","consecutive_push_failures":2,"pending_archive_push":true}` + "\n"
+	if err := os.WriteFile(stateFile, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state file): %v", err)
+	}
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	delete(env, "GC_JSONL_MAX_PUSH_FAILURES")
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "archive running in local-only mode") {
+		t.Fatalf("expected local-only transition log, got:\n%s", out)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["last_logged_mode"]; got != "local-only" {
+		t.Fatalf("last_logged_mode = %v, want local-only\nstate: %s", got, stateData)
+	}
+	// consecutive_push_failures must be cleared (json.Unmarshal decodes
+	// numbers as float64).
+	if got, ok := state["consecutive_push_failures"].(float64); !ok || got != 0 {
+		t.Fatalf("consecutive_push_failures = %v, want 0\nstate: %s", state["consecutive_push_failures"], stateData)
+	}
+	// pending_archive_push is retained — local commits still need to be
+	// pushed when origin returns. Verify it's present and true.
+	if got, ok := state["pending_archive_push"].(bool); !ok || !got {
+		t.Fatalf("pending_archive_push must remain true to track deferred push\nstate: %s", stateData)
+	}
+
+	// No HIGH escalation should have fired during the transition itself.
+	mailContents, err := os.ReadFile(mailLog)
+	if err == nil && strings.Contains(string(mailContents), "ESCALATION: JSONL push failed [HIGH]") {
+		t.Fatalf("local-only transition must not escalate; mail log:\n%s", mailContents)
+	}
+}
+
 // TestJsonlExportModeTransitionFromPushToLocalOnlyRelogs covers the operator
 // who previously had origin configured, ran the archive (so state already
 // carries last_logged_mode=push), then removed origin. The next run must log

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4806,6 +4806,210 @@ func TestJsonlExportHaltMailFailurePreservesExistingPendingAlerts(t *testing.T) 
 	}
 }
 
+// TestJsonlExportLocalOnlyModeSkipsPushAndLogsMode covers the default setup
+// where no `origin` remote has been configured on the archive. The script
+// must log the mode, skip the push path entirely, and leave push-failure
+// state untouched.
+func TestJsonlExportLocalOnlyModeSkipsPushAndLogsMode(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	writeMultiRecordDoltStub(t, binDir, 3)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	delete(env, "GC_JSONL_MAX_PUSH_FAILURES")
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "archive running in local-only mode") {
+		t.Fatalf("expected local-only mode log, got:\n%s", out)
+	}
+	if !strings.Contains(string(out), "push: skipped (local-only)") {
+		t.Fatalf("expected push: skipped (local-only) summary, got:\n%s", out)
+	}
+
+	mailData, _ := os.ReadFile(mailLog)
+	if strings.Contains(string(mailData), "JSONL push failed") {
+		t.Fatalf("local-only mode must not trigger push-failure escalation; mail log:\n%s", mailData)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["consecutive_push_failures"]; got != nil && got != float64(0) {
+		t.Fatalf("consecutive_push_failures = %v, expected unset or 0\nstate: %s", got, stateData)
+	}
+	if got := state["last_logged_mode"]; got != "local-only" {
+		t.Fatalf("last_logged_mode = %v, want local-only\nstate: %s", got, stateData)
+	}
+	if _, ok := state["last_logged_at"].(string); !ok {
+		t.Fatalf("last_logged_at missing or not a string\nstate: %s", stateData)
+	}
+}
+
+// TestJsonlExportPushModeAttemptsPushWhenOriginConfigured covers the operator
+// who has opted into off-box backup: origin is configured and reachable, so
+// the mode log reports push mode and the push actually happens.
+func TestJsonlExportPushModeAttemptsPushWhenOriginConfigured(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	remoteRepo, priorHead := initSeedArchiveWithRemote(t, archiveRepo)
+	writeMultiRecordDoltStub(t, binDir, 5)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "archive running in push mode") {
+		t.Fatalf("expected push mode log, got:\n%s", out)
+	}
+
+	remoteHeadOut, err := exec.Command("git", "--git-dir", remoteRepo, "rev-parse", "refs/heads/main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse remote main: %v\n%s", err, remoteHeadOut)
+	}
+	newRemoteHead := strings.TrimSpace(string(remoteHeadOut))
+	if newRemoteHead == priorHead {
+		t.Fatalf("expected push mode to advance the remote main: still at %s", priorHead)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["last_logged_mode"]; got != "push" {
+		t.Fatalf("last_logged_mode = %v, want push\nstate: %s", got, stateData)
+	}
+}
+
+// TestJsonlExportModeTransitionFromPushToLocalOnlyRelogs covers the operator
+// who previously had origin configured, ran the archive (so state already
+// carries last_logged_mode=push), then removed origin. The next run must log
+// the transition to local-only and update state — without escalating.
+func TestJsonlExportModeTransitionFromPushToLocalOnlyRelogs(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	initSeedArchive(t, archiveRepo, 3)
+	writeMultiRecordDoltStub(t, binDir, 5)
+	writeJsonlExportGCStub(t, binDir)
+
+	if err := os.MkdirAll(filepath.Dir(stateFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll(state dir): %v", err)
+	}
+	priorState := `{"last_logged_mode":"push","last_logged_at":"2026-05-01T00:00:00Z"}` + "\n"
+	if err := os.WriteFile(stateFile, []byte(priorState), 0o644); err != nil {
+		t.Fatalf("WriteFile(state file): %v", err)
+	}
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	delete(env, "GC_JSONL_MAX_PUSH_FAILURES")
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "archive running in local-only mode") {
+		t.Fatalf("expected transition log to local-only mode, got:\n%s", out)
+	}
+
+	mailData, _ := os.ReadFile(mailLog)
+	if strings.Contains(string(mailData), "JSONL push failed") {
+		t.Fatalf("transition to local-only must not escalate; mail log:\n%s", mailData)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["last_logged_mode"]; got != "local-only" {
+		t.Fatalf("last_logged_mode = %v, want local-only after transition\nstate: %s", got, stateData)
+	}
+	if got := state["last_logged_at"]; got == "2026-05-01T00:00:00Z" {
+		t.Fatalf("last_logged_at not refreshed after transition\nstate: %s", stateData)
+	}
+}
+
+// TestJsonlExportPushFailureEscalationBodyIncludesStderrAndRemediation
+// verifies that the enriched escalation body reaches the mayor with the
+// captured git stderr and the remediation pointer. Uses an unreachable
+// origin so push fails on the first run.
+func TestJsonlExportPushFailureEscalationBodyIncludesStderrAndRemediation(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+
+	initSeedArchiveWithUnreachableRemote(t, archiveRepo, 3)
+	writeMultiRecordDoltStub(t, binDir, 5)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["GC_JSONL_MAX_PUSH_FAILURES"] = "1"
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+
+	mailData, err := os.ReadFile(mailLog)
+	if err != nil {
+		t.Fatalf("ReadFile(mail log): %v", err)
+	}
+	body := string(mailData)
+	wants := []string{
+		"ESCALATION: JSONL push failed",
+		"Order: mol-dog-jsonl",
+		"Archive: " + archiveRepo,
+		"Consecutive failures: 1 (threshold: 1)",
+		"Last git push stderr:",
+		"Remediation:",
+		"docs/getting-started/troubleshooting.md#jsonl-archive-push-failures",
+	}
+	for _, want := range wants {
+		if !strings.Contains(body, want) {
+			t.Fatalf("escalation body missing %q:\n%s", want, body)
+		}
+	}
+}
+
 // gateSweepEnv constructs the env for a gate-sweep.sh invocation with a
 // PATH-shimmed bd stub that logs every call to BD_LOG.
 func gateSweepEnv(t *testing.T) (binDir, bdLog string, env map[string]string) {

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -3452,6 +3452,21 @@ func initEmptyArchiveRemote(t *testing.T, archiveRepo string, prevCount int) str
 	return remoteRepo
 }
 
+// initSeedArchiveWithUnreachableRemote seeds the archive and adds an `origin`
+// that points at a nonexistent path, so any `git fetch`/`git push` fails.
+// Used by tests that specifically exercise the push-failure recovery paths:
+// push mode is active (so `should_attempt_push` returns true) but the remote
+// cannot be reached.
+func initSeedArchiveWithUnreachableRemote(t *testing.T, archiveRepo string, prevCount int) string {
+	t.Helper()
+	head := initSeedArchive(t, archiveRepo, prevCount)
+	unreachable := filepath.Join(t.TempDir(), "nonexistent-remote.git")
+	if out, err := exec.Command("git", "-C", archiveRepo, "remote", "add", "origin", unreachable).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add origin: %v\n%s", err, out)
+	}
+	return head
+}
+
 func advanceArchiveRemoteMain(t *testing.T, remoteRepo string) string {
 	t.Helper()
 	worktree := t.TempDir()
@@ -4522,7 +4537,7 @@ func TestJsonlExportPushFailureRecoversFromMalformedState(t *testing.T) {
 	archiveRepo := filepath.Join(cityDir, "archive")
 	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
 
-	initSeedArchive(t, archiveRepo, 3)
+	initSeedArchiveWithUnreachableRemote(t, archiveRepo, 3)
 	writeMultiRecordDoltStub(t, binDir, 5)
 	writeJsonlExportGCStub(t, binDir)
 
@@ -4556,7 +4571,7 @@ func TestJsonlExportPushFailureRecoversFromWrongShapeState(t *testing.T) {
 	archiveRepo := filepath.Join(cityDir, "archive")
 	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
 
-	initSeedArchive(t, archiveRepo, 3)
+	initSeedArchiveWithUnreachableRemote(t, archiveRepo, 3)
 	writeMultiRecordDoltStub(t, binDir, 5)
 	writeJsonlExportGCStub(t, binDir)
 

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4877,6 +4877,12 @@ func TestJsonlExportPushModeAttemptsPushWhenOriginConfigured(t *testing.T) {
 	writeJsonlExportGCStub(t, binDir)
 
 	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	// initSeedArchiveWithRemote seeds 100 prev rows; the multi-record stub
+	// returns 5. The default 20% spike threshold would flag this 95% drop and
+	// route the run through the HALT path, which suppresses the push. This
+	// test is scoped to push behavior, not spike detection — raise MIN_PREV
+	// above 100 so the percent check is skipped here.
+	env["GC_JSONL_MIN_PREV_FOR_SPIKE"] = "1000"
 
 	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
 	if err != nil {

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -383,9 +383,24 @@ retry_pending_spike_alert() {
 
 push_archive_main() {
     local consecutive
+    local fetch_err
+    local rebase_err
+    local push_err
+
+    # Retain only the last ~20 lines of stderr so an extremely chatty failure
+    # doesn't drown the escalation body.
+    truncate_stderr_context() {
+        local raw="$1"
+
+        [ -z "$raw" ] && return 0
+        printf '%s\n' "$raw" | tail -n 20
+    }
 
     record_archive_push_failure() {
         local message="$1"
+        local stderr_context="$2"
+        local body
+        local stderr_display
 
         echo "$message" >&2
         consecutive=$(read_state_json | jq -r '.consecutive_push_failures // 0' || echo "0")
@@ -394,17 +409,39 @@ push_archive_main() {
         set_pending_archive_push
 
         if [ "$consecutive" -ge "$MAX_PUSH_FAILURES" ]; then
+            stderr_display=$(truncate_stderr_context "$stderr_context")
+            if [ -z "$stderr_display" ]; then
+                stderr_display="(no stderr captured)"
+            fi
+            body=$(cat <<ESCALATION
+Order: mol-dog-jsonl
+Archive: $ARCHIVE_REPO
+Consecutive failures: $consecutive (threshold: $MAX_PUSH_FAILURES)
+
+Last git push stderr:
+$stderr_display
+
+Remediation:
+- Check remote: git -C $ARCHIVE_REPO remote -v
+- Verify remote is reachable and credentials are valid
+- Temporarily suppress: export GC_JSONL_MAX_PUSH_FAILURES=99
+- See docs/getting-started/troubleshooting.md#jsonl-archive-push-failures
+ESCALATION
+)
             gc mail send mayor/ -s "ESCALATION: JSONL push failed [HIGH]" \
-                -m "Consecutive failures: $consecutive (threshold: $MAX_PUSH_FAILURES)" \
+                -m "$body" \
                 2>/dev/null || true
         fi
 
         return 1
     }
 
-    if ! refresh_archive_remote_main; then
+    fetch_err=$(git fetch origin main -q 2>&1 >/dev/null) || true
+    if [ -n "$fetch_err" ] || ! git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
         if git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
-            record_archive_push_failure "jsonl-export: fetching origin/main failed"
+            record_archive_push_failure \
+                "jsonl-export: fetching origin/main failed" \
+                "$fetch_err"
             return 1
         fi
         echo "jsonl-export: origin/main missing; attempting initial push bootstrap" >&2
@@ -412,11 +449,13 @@ push_archive_main() {
 
     if git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
         if ! git merge-base --is-ancestor refs/remotes/origin/main HEAD >/dev/null 2>&1; then
-            if ! git rebase refs/remotes/origin/main >/dev/null 2>&1; then
+            rebase_err=$(git rebase refs/remotes/origin/main 2>&1 >/dev/null) || {
                 git rebase --abort >/dev/null 2>&1 || true
-                record_archive_push_failure "jsonl-export: rebase onto origin/main failed during archive push recovery"
+                record_archive_push_failure \
+                    "jsonl-export: rebase onto origin/main failed during archive push recovery" \
+                    "$rebase_err"
                 return 1
-            fi
+            }
         fi
         if ! archive_has_local_only_commits_from_tracking; then
             set_consecutive_push_failures "0"
@@ -425,13 +464,16 @@ push_archive_main() {
         fi
     fi
 
-    if git push origin main -q 2>/dev/null; then
-        set_consecutive_push_failures "0"
-        clear_pending_archive_push
-        return 0
-    fi
+    push_err=$(git push origin main -q 2>&1 >/dev/null) || {
+        record_archive_push_failure \
+            "jsonl-export: pushing archive main failed" \
+            "$push_err"
+        return 1
+    }
 
-    record_archive_push_failure "jsonl-export: pushing archive main failed"
+    set_consecutive_push_failures "0"
+    clear_pending_archive_push
+    return 0
 }
 
 commit_archive_snapshot() {

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -256,10 +256,22 @@ log_archive_mode_if_needed() {
     fi
     echo "$message" >&2
 
+    # On entering local-only mode, clear consecutive_push_failures so a later
+    # return to push mode starts from a clean counter. Without this, a
+    # push→local-only→push round-trip (operator removes then re-adds origin)
+    # would carry the old failure count forward and could trigger a premature
+    # HIGH escalation on the very first failure after origin returns.
+    # pending_archive_push is intentionally NOT cleared here — it correctly
+    # tracks that local commits still need to be pushed once origin returns.
+    # shellcheck disable=SC2016  # $mode/$at are jq variables, not bash
+    local jq_filter='.last_logged_mode = $mode | .last_logged_at = $at'
+    if [ "$current_mode" = "local-only" ]; then
+        jq_filter="$jq_filter | .consecutive_push_failures = 0"
+    fi
+
     write_state_json "$(
         printf '%s\n' "$state_json" \
-            | jq -c --arg mode "$current_mode" --arg at "$now" \
-                '.last_logged_mode = $mode | .last_logged_at = $at'
+            | jq -c --arg mode "$current_mode" --arg at "$now" "$jq_filter"
     )"
 }
 
@@ -436,8 +448,11 @@ ESCALATION
         return 1
     }
 
-    fetch_err=$(git fetch origin main -q 2>&1 >/dev/null) || true
-    if [ -n "$fetch_err" ] || ! git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
+    # Branch on the actual git exit status, not on whether stderr is non-empty.
+    # Successful git commands can emit benign stderr (e.g. "warning: redirecting
+    # to https://...", credential-helper notes, protocol upgrade hints) which
+    # would otherwise misclassify the run as a failure and falsely escalate.
+    if ! fetch_err=$(git fetch origin main -q 2>&1 >/dev/null); then
         if git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
             record_archive_push_failure \
                 "jsonl-export: fetching origin/main failed" \
@@ -449,13 +464,13 @@ ESCALATION
 
     if git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
         if ! git merge-base --is-ancestor refs/remotes/origin/main HEAD >/dev/null 2>&1; then
-            rebase_err=$(git rebase refs/remotes/origin/main 2>&1 >/dev/null) || {
+            if ! rebase_err=$(git rebase refs/remotes/origin/main 2>&1 >/dev/null); then
                 git rebase --abort >/dev/null 2>&1 || true
                 record_archive_push_failure \
                     "jsonl-export: rebase onto origin/main failed during archive push recovery" \
                     "$rebase_err"
                 return 1
-            }
+            fi
         fi
         if ! archive_has_local_only_commits_from_tracking; then
             set_consecutive_push_failures "0"
@@ -464,12 +479,12 @@ ESCALATION
         fi
     fi
 
-    push_err=$(git push origin main -q 2>&1 >/dev/null) || {
+    if ! push_err=$(git push origin main -q 2>&1 >/dev/null); then
         record_archive_push_failure \
             "jsonl-export: pushing archive main failed" \
             "$push_err"
         return 1
-    }
+    fi
 
     set_consecutive_push_failures "0"
     clear_pending_archive_push

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -196,6 +196,73 @@ archive_has_local_only_commits() {
     return 1
 }
 
+# Detect the archive's push mode from the live state of its remotes rather
+# than from a cached state field. Operators opt into off-box backup by adding
+# an `origin` remote; removing it reverts to local-only on the next run with
+# no extra command.
+get_archive_mode() {
+    if [ -d "$ARCHIVE_REPO/.git" ] \
+        && git -C "$ARCHIVE_REPO" remote get-url origin >/dev/null 2>&1; then
+        echo "push"
+    else
+        echo "local-only"
+    fi
+}
+
+should_attempt_push() {
+    [ "$(get_archive_mode)" = "push" ]
+}
+
+# Log the archive mode on transitions and re-log weekly so operators who
+# missed the first line still see the current configuration. State fields
+# last_logged_mode and last_logged_at drive the re-log interval.
+log_archive_mode_if_needed() {
+    local current_mode
+    local state_json
+    local last_logged_mode
+    local last_logged_at
+    local now
+    local now_ts
+    local last_ts
+    local should_log=0
+    local message
+
+    current_mode=$(get_archive_mode)
+    state_json=$(read_state_json)
+    last_logged_mode=$(printf '%s\n' "$state_json" | jq -r '.last_logged_mode // empty')
+    last_logged_at=$(printf '%s\n' "$state_json" | jq -r '.last_logged_at // empty')
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    now_ts=$(date -u +%s)
+
+    if [ "$current_mode" != "$last_logged_mode" ]; then
+        should_log=1
+    elif [ -z "$last_logged_at" ]; then
+        should_log=1
+    else
+        last_ts=$(jq -n -r --arg ts "$last_logged_at" '$ts | try fromdateiso8601 catch 0')
+        if [ "$last_ts" = "0" ] || [ "$((now_ts - last_ts))" -gt 604800 ]; then
+            should_log=1
+        fi
+    fi
+
+    if [ "$should_log" -eq 0 ]; then
+        return 0
+    fi
+
+    if [ "$current_mode" = "push" ]; then
+        message="jsonl-export: archive running in push mode (origin configured; will push commits to remote)"
+    else
+        message="jsonl-export: archive running in local-only mode (no origin remote; commits stay on this host — off-box backup disabled)"
+    fi
+    echo "$message" >&2
+
+    write_state_json "$(
+        printf '%s\n' "$state_json" \
+            | jq -c --arg mode "$current_mode" --arg at "$now" \
+                '.last_logged_mode = $mode | .last_logged_at = $at'
+    )"
+}
+
 set_pending_spike_alert() {
     local db="$1"
     local prev_count="$2"
@@ -425,6 +492,7 @@ fi
 STATE_FILE_BACKUP="${STATE_FILE}.bak"
 mkdir -p "$(dirname "$STATE_FILE")"
 
+log_archive_mode_if_needed
 retry_pending_spike_alert
 
 is_user_database() {

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -529,9 +529,13 @@ if [ -z "$DATABASES" ]; then
     if [ -d "$ARCHIVE_REPO/.git" ]; then
         cd "$ARCHIVE_REPO"
         if has_pending_archive_push || archive_has_local_only_commits; then
-            PUSH_STATUS="ok"
-            if ! push_archive_main; then
-                PUSH_STATUS="failed"
+            if should_attempt_push; then
+                PUSH_STATUS="ok"
+                if ! push_archive_main; then
+                    PUSH_STATUS="failed"
+                fi
+            else
+                PUSH_STATUS="skipped (local-only)"
             fi
             SUMMARY="jsonl — no user databases, push: $PUSH_STATUS"
             gc session nudge deacon/ "DOG_DONE: $SUMMARY" 2>/dev/null || true
@@ -746,9 +750,13 @@ fi
 
 if git diff --cached --quiet 2>/dev/null; then
     if has_pending_archive_push || archive_has_local_only_commits; then
-        PUSH_STATUS="ok"
-        if ! push_archive_main; then
-            PUSH_STATUS="failed"
+        if should_attempt_push; then
+            PUSH_STATUS="ok"
+            if ! push_archive_main; then
+                PUSH_STATUS="failed"
+            fi
+        else
+            PUSH_STATUS="skipped (local-only)"
         fi
         if [ -n "$FAILED_DBS" ]; then
             EXPORTED_DBS=$((TOTAL_DBS - FAILED_DB_COUNT))
@@ -781,9 +789,13 @@ commit_archive_snapshot \
 }
 set_pending_archive_push
 
-PUSH_STATUS="ok"
-if ! push_archive_main; then
-    PUSH_STATUS="failed"
+if should_attempt_push; then
+    PUSH_STATUS="ok"
+    if ! push_archive_main; then
+        PUSH_STATUS="failed"
+    fi
+else
+    PUSH_STATUS="skipped (local-only)"
 fi
 
 SUMMARY="jsonl — exported $EXPORTED_DBS/$TOTAL_DBS, records: $TOTAL_EXPORTED, push: $PUSH_STATUS"


### PR DESCRIPTION
## Summary

Fixes #1275. Today the `jsonl-export` maintenance script unconditionally runs
`git push origin main` against the bead JSONL archive. On a fresh install
the archive has no `origin` remote, so every 15-minute tick the push fails,
`consecutive_push_failures` climbs, and after three ticks the mayor's inbox
gets a `HIGH` escalation for an archive the operator never asked to back
up off-box.

This PR reworks the archive to detect its push mode on every run from
the live state of its git remotes:

- **Local-only** (no `origin`): commits are created locally and retained;
  push is skipped; no escalation ever fires.
- **Push** (`origin` configured): fetch/rebase/push runs as before; real
  push failures still escalate.

Mode transitions (operator adds or removes `origin`) are logged to stderr,
and the mode is re-logged weekly so an operator who missed the transition
line can still find the current mode by reading the log.

When push mode is active and push genuinely fails, the escalation body is
now enriched so an on-call operator can act without reading the script:

```
Order: mol-dog-jsonl
Archive: <path>
Consecutive failures: N (threshold: M)

Last git push stderr:
<last ~20 lines from fetch / rebase / push>

Remediation:
- Check remote: git -C <archive> remote -v
- Verify remote is reachable and credentials are valid
- Temporarily suppress: export GC_JSONL_MAX_PUSH_FAILURES=99
- See docs/getting-started/troubleshooting.md#jsonl-archive-push-failures
```

A new troubleshooting section covers the archive's purpose, the two modes,
the recipe to enable off-box backup, and how to read the enriched escalation.

## Behavioral diff

Before:

- Fresh install + 15-minute tick → silent `git push` → `push failed`
  summary → after 3 ticks, `ESCALATION: JSONL push failed [HIGH]` with a
  body that says only `Consecutive failures: 3 (threshold: 3)`.
- No documented way to opt into off-box backup.

After:

- Fresh install + 15-minute tick → `archive running in local-only mode`
  log → `push: skipped (local-only)` summary → no escalation.
- Operator runs `git remote add origin <url>` → next tick logs
  `archive running in push mode` and resumes pushing.
- Real push failures escalate with a body pointing at the specific
  remote URL, the captured git stderr, and a link to the new
  troubleshooting section.

## Commits

1. `maintenance: detect jsonl-export archive mode per run` — adds
   `get_archive_mode` / `should_attempt_push` / transition-plus-weekly
   mode logging. No behavior change to push paths.
2. `maintenance: skip jsonl-export push when in local-only mode` —
   wraps the three `push_archive_main` call sites with the new guard;
   surfaces `push: skipped (local-only)` in the summary; updates two
   tests whose previous behavior relied on "no origin" implicitly
   failing the push.
3. `maintenance: enrich jsonl-export push-failure escalation body` —
   captures stderr from `git fetch` / `git rebase` / `git push` and
   threads it through `record_archive_push_failure` into the mayor
   mail body along with Order/Archive/Remediation fields.
4. `docs: document jsonl archive modes and push-failure troubleshooting` —
   new `#jsonl-archive-push-failures` anchor referenced by the
   escalation body, plus a short pointer in `installation.md`.
5. `test(maintenance): cover jsonl-export mode detection and enriched escalation` —
   four new Go tests covering local-only default, reachable-origin push
   mode, push→local-only transition, and the enriched escalation body.

## Test plan

- [x] `bash -n examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh` on each commit
- [x] Manual run: temp archive with no origin → local-only log, push skipped, exit 0
- [x] Manual run: `git remote add origin <unreachable>` → push mode log, push fails, enriched body delivered to mail
- [x] Manual run: origin removed mid-lifecycle → transition log back to local-only, no escalation
- [x] Manual run: second run within a week → no re-log (transitions only)
- [ ] CI: `make check` + `make check-docs` (this sandbox has no network so golangci-lint / deps could not be fetched locally; relying on upstream CI)

Follow-up tracked in #1798 — a `gc doctor` check that warns on accumulated local-only commits without an origin remote. Out of scope for this PR.

Out of scope here: `mol-dog-backup` sibling formula, `city.toml` schema changes, Go-side changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->