### PR TITLE
docs: Fix `./mint.sh dev` command instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ For the capability boundary, use the
 The docs tree is now Mintlify-based.
 
 - Config lives in `docs/docs.json`
-- Preview locally with `cd docs && ./mint.sh dev`
+- Preview locally with `./mint.sh dev`
 - Run docs checks with `make check-docs`
 
 When updating docs:


### PR DESCRIPTION
## Summary

docs: Fix `./mint.sh dev` command instruction

- Remove `cd docs` as `mint.sh` is now in root dir vs docs dir

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->