### PR TITLE
fix(contract): remediate identity L1 post-merge findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cmd/gc/.runtime/
 **/.beads/*
 !**/.beads/config.yaml
 !**/.beads/metadata.json
+!**/.beads/identity.toml
 .claude/
 !examples/gastown/packs/gastown/overlays/default/.claude/
 !examples/gastown/packs/gastown/overlays/default/.claude/settings.json

--- a/internal/beads/contract/identity_test.go
+++ b/internal/beads/contract/identity_test.go
@@ -121,6 +121,21 @@ func TestProjectIdentity(t *testing.T) {
 		}
 	})
 
+	t.Run("A6b_read_bare_project_section_treated_as_not_ok", func(t *testing.T) {
+		scope := t.TempDir()
+		writeIdentity(t, scope, "[project]\n")
+		id, ok, err := ReadProjectIdentity(fs, scope)
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if ok {
+			t.Fatalf("ok = true, want false (project.id is absent)")
+		}
+		if id != "" {
+			t.Fatalf("id = %q, want \"\"", id)
+		}
+	})
+
 	t.Run("A7_read_malformed_toml_errors", func(t *testing.T) {
 		scope := t.TempDir()
 		// Truncated section header — invalid TOML.
@@ -164,6 +179,36 @@ func TestProjectIdentity(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "name") {
 			t.Fatalf("err = %v, want message naming the unknown key %q", err, "name")
+		}
+		if ok {
+			t.Fatalf("ok = true, want false on parse error")
+		}
+	})
+
+	t.Run("A9b_read_non_string_project_id_errors", func(t *testing.T) {
+		scope := t.TempDir()
+		path := writeIdentity(t, scope, "[project]\nid = 123\n")
+		_, ok, err := ReadProjectIdentity(fs, scope)
+		if err == nil {
+			t.Fatalf("err = nil, want non-nil for non-string project.id")
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Fatalf("err = %v, want message containing path %q", err, path)
+		}
+		if ok {
+			t.Fatalf("ok = true, want false on parse error")
+		}
+	})
+
+	t.Run("A9c_read_nested_unknown_project_table_errors", func(t *testing.T) {
+		scope := t.TempDir()
+		writeIdentity(t, scope, "[project]\nid = \"gc-local-x\"\n[project.extra]\nvalue = \"unexpected\"\n")
+		_, ok, err := ReadProjectIdentity(fs, scope)
+		if err == nil {
+			t.Fatalf("err = nil, want non-nil for nested unknown project table")
+		}
+		if !strings.Contains(err.Error(), "project.extra") {
+			t.Fatalf("err = %v, want message naming the unknown nested table %q", err, "project.extra")
 		}
 		if ok {
 			t.Fatalf("ok = true, want false on parse error")

--- a/release-gates/ga-80f5v3-identity-contract-l1-reader-gate.md
+++ b/release-gates/ga-80f5v3-identity-contract-l1-reader-gate.md
@@ -4,16 +4,18 @@
 
 - Bead: `ga-80f5v3` (review of `ga-401s4`, closed)
 - Branch: `quad341:builder/ga-401s4-1`
-- HEAD: `7298aa39` (single commit off `origin/main` 5f1a686d)
-- Diff: 2 new files (`internal/beads/contract/identity.go` +83, `identity_test.go` +250)
+- Pre-gate validation HEAD: `7298aa39` (single commit off `origin/main` 5f1a686d)
+- Final landed PR: `gastownhall/gascity#1791`
+- Final landed range: `6040b07661ef1162025a49dc949fe2aa8a4a9b83..b61b12fb37e1e656fb01f261e42037f612c329e2`
+- Final landed diff: 3 new files (`internal/beads/contract/identity.go` +83, `identity_test.go` +250, this release gate +42)
 
 ## Criteria
 
 | # | Criterion | Verdict | Evidence |
 |---|-----------|---------|----------|
-| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at HEAD `7298aa39`. |
-| 2 | Acceptance criteria met | PASS | A1-A12 + C1-C2 (14/14) subtests pass; 100% patch coverage on the two new exported funcs (`ReadProjectIdentity`, errors-wrapping helpers); out-of-scope guardrails (no write path, no lint guard, no gitignore patch, no cmd/gc, no role names) verified by reviewer. |
-| 3 | Tests pass on final branch | PASS | `go test ./internal/beads/contract -count=1` — PASS (23ms). |
+| 1 | Reviewer PASS verdict in bead notes | PASS | `gascity/reviewer` PASS at pre-gate HEAD `7298aa39`; post-merge review rechecked final landed range `6040b076..b61b12f`. |
+| 2 | Acceptance criteria met | PASS | A1-A12 + C1-C2 (14/14) subtests passed pre-gate; post-merge follow-up adds strict-decode coverage for bare `[project]`, non-string `project.id`, and nested unknown `[project.*]` tables. |
+| 3 | Tests pass on final branch | PASS | `go test ./internal/beads/contract -count=1` — PASS on pre-gate branch and post-merge follow-up branch. |
 | 4 | No high-severity review findings open | PASS | Reviewer findings list: empty. |
 | 5 | Working tree clean | PASS | `git status` clean before push. |
 | 6 | Branch diverges cleanly from main | PASS | 1 ahead / 0 behind `origin/main`. |
@@ -24,6 +26,13 @@
 - `go vet ./...` — clean
 - `golangci-lint run ./internal/beads/contract` — 0 issues
 - `go test ./internal/beads/contract -count=1` — PASS
+
+## Final landed evidence
+
+- Squash merge commit: `b61b12fb37e1e656fb01f261e42037f612c329e2`
+- Base before merge: `6040b07661ef1162025a49dc949fe2aa8a4a9b83`
+- Landed diff command: `git diff --stat 6040b07661ef1162025a49dc949fe2aa8a4a9b83..b61b12fb37e1e656fb01f261e42037f612c329e2`
+- Landed diff stat: 3 files changed, 375 insertions
 
 ## Stack context
 


### PR DESCRIPTION
Remediates post-merge review findings from #1791.

Summary:
- Tracks `.beads/identity.toml` while preserving ignore behavior for other `.beads` artifacts.
- Adds strict identity.toml decode coverage for bare `[project]`, non-string `project.id`, and nested unknown project tables.
- Updates the release gate evidence to distinguish pre-gate validation from the final landed range.

Validation:
- `go test ./internal/beads/contract -count=1`
- Pre-commit hook: `golangci-lint run ./...`, `go vet ./...`, fast `go test ./...`, and doc sync checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->