### PR TITLE
Add Codex PreCompact handoff hooks

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -148,6 +148,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		d.Register(doctor.NewDurationRangeCheck(cfg))
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
+		d.Register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
 		d.Register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))
 		d.Register(newMCPSharedTargetDoctorCheck(cityPath, cfg, exec.LookPath))
 	}

--- a/cmd/gc/cmd_handoff.go
+++ b/cmd/gc/cmd_handoff.go
@@ -18,6 +18,7 @@ import (
 func newHandoffCmd(stdout, stderr io.Writer) *cobra.Command {
 	var target string
 	var auto bool
+	var hookFormat string
 	cmd := &cobra.Command{
 		Use:   "handoff [subject] [message]",
 		Short: "Send handoff mail and restart controller-managed sessions",
@@ -58,7 +59,7 @@ or ID. Subject is required unless --auto is set.`,
 			return cobra.RangeArgs(1, 2)(cmd, args)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			if cmdHandoff(args, target, auto, stdout, stderr) != 0 {
+			if cmdHandoff(args, target, auto, hookFormat, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
@@ -66,10 +67,11 @@ or ID. Subject is required unless --auto is set.`,
 	}
 	cmd.Flags().StringVar(&target, "target", "", "Remote session alias or ID to handoff (kills only controller-restartable sessions)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Send handoff mail without requesting restart (for PreCompact hooks)")
+	cmd.Flags().StringVar(&hookFormat, "hook-format", "", "format hook output for a provider")
 	return cmd
 }
 
-func cmdHandoff(args []string, target string, auto bool, stdout, stderr io.Writer) int {
+func cmdHandoff(args []string, target string, auto bool, hookFormat string, stdout, stderr io.Writer) int {
 	if target != "" {
 		if auto {
 			fmt.Fprintln(stderr, "gc handoff: --auto cannot be used with --target") //nolint:errcheck // best-effort stderr
@@ -92,7 +94,7 @@ func cmdHandoff(args []string, target string, auto bool, stdout, stderr io.Write
 	}
 	rec := openCityRecorderAt(current.cityPath, stderr)
 	if auto {
-		return doHandoffAuto(store, rec, current.display, args, stdout, stderr)
+		return doHandoffAuto(store, rec, current.display, args, hookFormat, stdout, stderr)
 	}
 
 	sp := newSessionProvider()
@@ -212,12 +214,16 @@ func doHandoffWithOutcome(store beads.Store, rec events.Recorder, dops drainOps,
 }
 
 // doHandoffAuto sends handoff mail to self without requesting restart.
-func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string, args []string, stdout, stderr io.Writer) int {
+func doHandoffAuto(store beads.Store, rec events.Recorder, sessionAddress string, args []string, hookFormat string, stdout, stderr io.Writer) int {
 	b, ok := createHandoffMail(store, rec, sessionAddress, sessionAddress, args, "context cycle", stderr)
 	if !ok {
 		return 1
 	}
-	fmt.Fprintf(stdout, "Handoff: sent auto mail %s (restart skipped).\n", b.ID) //nolint:errcheck // best-effort stdout
+	message := fmt.Sprintf("Handoff: sent auto mail %s (restart skipped).\n", b.ID)
+	if err := writeProviderHookContextForEvent(stdout, hookFormat, "PreCompact", message); err != nil {
+		fmt.Fprintf(stderr, "gc handoff: writing hook output: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	return 0
 }
 

--- a/cmd/gc/cmd_handoff_test.go
+++ b/cmd/gc/cmd_handoff_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -121,6 +122,44 @@ func TestCmdHandoffAutoSendsMailWithoutBlocking(t *testing.T) {
 	}
 }
 
+func TestCmdHandoffAutoHookFormatCodex(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+	t.Setenv("GC_CITY", cityDir)
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_ALIAS", "mayor")
+	t.Setenv("GC_SESSION_NAME", "mayor")
+
+	var stdout, stderr bytes.Buffer
+	cmd := newHandoffCmd(&stdout, &stderr)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--auto", "--hook-format", "codex", "context cycle"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("gc handoff --auto --hook-format codex failed: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not Codex hook JSON: %v\n%s", err, stdout.String())
+	}
+	if got, want := payload.HookSpecificOutput.HookEventName, "PreCompact"; got != want {
+		t.Fatalf("hookEventName = %q, want %q", got, want)
+	}
+	if !strings.Contains(payload.HookSpecificOutput.AdditionalContext, "Handoff: sent auto mail") {
+		t.Fatalf("additionalContext = %q, want handoff confirmation", payload.HookSpecificOutput.AdditionalContext)
+	}
+}
+
 func TestCmdHandoffAutoUsesDefaultSubject(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"demo\"\n"), 0o644); err != nil {
@@ -160,7 +199,7 @@ func TestCmdHandoffAutoUsesDefaultSubject(t *testing.T) {
 
 func TestCmdHandoffAutoRejectsTarget(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if code := cmdHandoff([]string{"context cycle"}, "mayor", true, &stdout, &stderr); code == 0 {
+	if code := cmdHandoff([]string{"context cycle"}, "mayor", true, "", &stdout, &stderr); code == 0 {
 		t.Fatal("cmdHandoff returned 0 for --auto with --target")
 	}
 	if !strings.Contains(stderr.String(), "--auto cannot be used with --target") {
@@ -402,7 +441,7 @@ func TestCmdHandoff_Regression744_NamedSessionReturnsWithoutBlocking(t *testing.
 	var stdout, stderr bytes.Buffer
 	done := make(chan int, 1)
 	go func() {
-		done <- cmdHandoff([]string{"HANDOFF: context full"}, "", false, &stdout, &stderr)
+		done <- cmdHandoff([]string{"HANDOFF: context full"}, "", false, "", &stdout, &stderr)
 	}()
 
 	select {

--- a/cmd/gc/doctor_codex_hooks.go
+++ b/cmd/gc/doctor_codex_hooks.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/doctor"
+	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/hooks"
+)
+
+type codexHooksDriftCheck struct {
+	dirs []string
+}
+
+func newCodexHooksDriftCheck(dirs []string) *codexHooksDriftCheck {
+	seen := map[string]struct{}{}
+	var cleaned []string
+	for _, dir := range dirs {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		dir = filepath.Clean(dir)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		cleaned = append(cleaned, dir)
+	}
+	sort.Strings(cleaned)
+	return &codexHooksDriftCheck{dirs: cleaned}
+}
+
+func codexHookWorkDirs(cityPath string, cfg *config.City) []string {
+	dirs := []string{cityPath}
+	if cfg == nil {
+		return dirs
+	}
+	for _, rig := range cfg.Rigs {
+		if rig.Suspended || strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		dirs = append(dirs, rig.Path)
+	}
+	return dirs
+}
+
+func (c *codexHooksDriftCheck) Name() string { return "codex-hooks-drift" }
+
+func (c *codexHooksDriftCheck) CanFix() bool { return true }
+
+func (c *codexHooksDriftCheck) Fix(_ *doctor.CheckContext) error {
+	for _, dir := range c.dirs {
+		if !codexHooksMissingPreCompact(filepath.Join(dir, ".codex", "hooks.json")) {
+			continue
+		}
+		if err := hooks.Install(fsys.OSFS{}, dir, dir, []string{"codex"}); err != nil {
+			return fmt.Errorf("upgrading Codex hooks in %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func (c *codexHooksDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
+	var stale []string
+	for _, dir := range c.dirs {
+		path := filepath.Join(dir, ".codex", "hooks.json")
+		if codexHooksMissingPreCompact(path) {
+			stale = append(stale, path)
+		}
+	}
+	if len(stale) == 0 {
+		return okCheck(c.Name(), "Codex hooks are current or user-owned")
+	}
+	return warnCheck(c.Name(),
+		fmt.Sprintf("%d managed Codex hook file(s) missing PreCompact handoff", len(stale)),
+		"run `gc doctor --fix` or restart the city to upgrade managed Codex hooks",
+		stale)
+}
+
+func codexHooksMissingPreCompact(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return false
+	}
+	hooksMap, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if _, ok := hooksMap["PreCompact"]; ok {
+		return false
+	}
+	return codexHookDocHasManagedCommand(doc)
+}
+
+func codexHookDocHasManagedCommand(v any) bool {
+	switch node := v.(type) {
+	case map[string]any:
+		if command, ok := node["command"].(string); ok && codexHookCommandLooksManaged(command) {
+			return true
+		}
+		for _, val := range node {
+			if codexHookDocHasManagedCommand(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, val := range node {
+			if codexHookDocHasManagedCommand(val) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func codexHookCommandLooksManaged(command string) bool {
+	for _, needle := range []string{
+		"gc prime --hook",
+		"gc nudge drain --inject",
+		"gc mail check --inject",
+		"gc hook --inject",
+		"gc handoff --auto",
+	} {
+		if strings.Contains(command, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gc/doctor_codex_hooks_test.go
+++ b/cmd/gc/doctor_codex_hooks_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/doctor"
+)
+
+func TestCodexHooksDriftCheckReportsManagedMissingPreCompact(t *testing.T) {
+	dir := t.TempDir()
+	writeCodexHooksForDoctorTest(t, dir, `{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck([]string{dir})
+	result := check.Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusWarning {
+		t.Fatalf("status = %v, want warning; message=%s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "missing PreCompact") {
+		t.Fatalf("message = %q, want missing PreCompact", result.Message)
+	}
+}
+
+func TestCodexHooksDriftCheckPassesCurrentHooks(t *testing.T) {
+	dir := t.TempDir()
+	writeCodexHooksForDoctorTest(t, dir, `{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+      }]
+    }],
+    "PreCompact": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto --hook-format codex \"context cycle\""
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck([]string{dir})
+	result := check.Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok; message=%s", result.Status, result.Message)
+	}
+}
+
+func TestCodexHooksDriftCheckIgnoresCustomHooks(t *testing.T) {
+	dir := t.TempDir()
+	writeCodexHooksForDoctorTest(t, dir, `{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "hooks": [{
+        "type": "command",
+        "command": "printf custom-codex-hook"
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck([]string{dir})
+	result := check.Run(&doctor.CheckContext{})
+
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status = %v, want ok for user-owned hooks; message=%s", result.Status, result.Message)
+	}
+}
+
+func TestCodexHooksDriftCheckFixUpgradesManagedHooks(t *testing.T) {
+	dir := t.TempDir()
+	writeCodexHooksForDoctorTest(t, dir, `{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	check := newCodexHooksDriftCheck([]string{dir})
+	if err := check.Fix(&doctor.CheckContext{}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	result := check.Run(&doctor.CheckContext{})
+	if result.Status != doctor.StatusOK {
+		t.Fatalf("status after fix = %v, want ok; message=%s", result.Status, result.Message)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	if !strings.Contains(string(data), "PreCompact") {
+		t.Fatalf("fixed hooks missing PreCompact:\n%s", string(data))
+	}
+}
+
+func writeCodexHooksForDoctorTest(t *testing.T, dir, data string) {
+	t.Helper()
+	hookDir := filepath.Join(dir, ".codex")
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hookDir, "hooks.json"), []byte(data), 0o644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1173,6 +1173,7 @@ gc handoff [subject] [message] [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--auto` | bool |  | Send handoff mail without requesting restart (for PreCompact hooks) |
+| `--hook-format` | string |  | format hook output for a provider |
 | `--target` | string |  | Remote session alias or ID to handoff (kills only controller-restartable sessions) |
 
 ## gc help

--- a/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/codex/.codex/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto --hook-format codex \"context cycle\""
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "",

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -350,7 +350,7 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 
 func writeCodexHooksManaged(fs fsys.FS, dst string, data []byte) error {
 	if existing, err := fs.ReadFile(dst); err == nil {
-		upgraded, changed, upgradeErr := upgradeCodexHookCommands(existing)
+		upgraded, changed, upgradeErr := upgradeCodexHooks(existing, data)
 		if upgradeErr != nil || !changed {
 			return nil
 		}
@@ -372,12 +372,16 @@ func writeManagedData(fs fsys.FS, dst string, data []byte) error {
 	return nil
 }
 
-func upgradeCodexHookCommands(existing []byte) ([]byte, bool, error) {
+func upgradeCodexHooks(existing, desired []byte) ([]byte, bool, error) {
 	var root any
 	if err := json.Unmarshal(existing, &root); err != nil {
 		return nil, false, err
 	}
-	if !upgradeCodexHookValue(root) {
+	changed := upgradeCodexHookValue(root)
+	if addCodexPreCompactHook(root, desired) {
+		changed = true
+	}
+	if !changed {
 		return nil, false, nil
 	}
 	data, err := json.MarshalIndent(root, "", "  ")
@@ -434,6 +438,84 @@ func upgradeCodexHookCommand(command string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func addCodexPreCompactHook(root any, desired []byte) bool {
+	doc, ok := root.(map[string]any)
+	if !ok || !codexHookDocLooksManaged(doc) {
+		return false
+	}
+	hooksMap, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if _, exists := hooksMap["PreCompact"]; exists {
+		return false
+	}
+	preCompact := desiredCodexPreCompactHook(desired)
+	if preCompact == nil {
+		return false
+	}
+	hooksMap["PreCompact"] = preCompact
+	return true
+}
+
+func codexHookDocLooksManaged(doc map[string]any) bool {
+	var found bool
+	var walk func(any)
+	walk = func(v any) {
+		if found {
+			return
+		}
+		switch node := v.(type) {
+		case map[string]any:
+			if command, ok := node["command"].(string); ok && isManagedCodexHookCommand(command) {
+				found = true
+				return
+			}
+			for _, val := range node {
+				walk(val)
+			}
+		case []any:
+			for _, val := range node {
+				walk(val)
+			}
+		}
+	}
+	walk(doc)
+	return found
+}
+
+func isManagedCodexHookCommand(command string) bool {
+	for _, needle := range []string{
+		`gc prime --hook`,
+		`gc nudge drain --inject`,
+		`gc mail check --inject`,
+		`gc hook --inject`,
+		`gc handoff --auto`,
+	} {
+		if strings.Contains(command, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func desiredCodexPreCompactHook(desired []byte) any {
+	if len(desired) == 0 {
+		var err error
+		desired, err = iofs.ReadFile(core.PackFS, path.Join("overlay", "per-provider", "codex", ".codex", "hooks.json"))
+		if err != nil {
+			return nil
+		}
+	}
+	var doc struct {
+		Hooks map[string]any `json:"hooks"`
+	}
+	if err := json.Unmarshal(desired, &doc); err != nil {
+		return nil
+	}
+	return doc.Hooks["PreCompact"]
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -278,6 +278,44 @@ func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
 	if !strings.Contains(got, "--hook-format codex") {
 		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
 	}
+	if !strings.Contains(got, `"PreCompact"`) {
+		t.Errorf("upgraded codex hooks missing PreCompact:\n%s", got)
+	}
+	if !strings.Contains(got, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+		t.Errorf("upgraded codex PreCompact missing auto handoff command:\n%s", got)
+	}
+}
+
+func TestInstallCodexUpgradesManagedFileMissingPreCompact(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/work/.codex/hooks.json"] = []byte(`{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc prime --hook --hook-format codex"
+      }]
+    }],
+    "UserPromptSubmit": [{
+      "hooks": [{
+        "type": "command",
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc mail check --inject --hook-format codex"
+      }]
+    }]
+  }
+}`)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := string(fs.Files["/work/.codex/hooks.json"])
+	if !strings.Contains(got, `"PreCompact"`) {
+		t.Errorf("upgraded codex hooks missing PreCompact:\n%s", got)
+	}
+	if !strings.Contains(got, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+		t.Errorf("upgraded codex PreCompact missing auto handoff command:\n%s", got)
+	}
 }
 
 func TestInstallCodexUpgradePreservesCustomHooks(t *testing.T) {
@@ -309,6 +347,66 @@ func TestInstallCodexUpgradePreservesCustomHooks(t *testing.T) {
 	}
 	if !strings.Contains(got, "printf custom-codex-hook") {
 		t.Errorf("custom codex hook was not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, `"PreCompact"`) {
+		t.Errorf("managed codex upgrade should add PreCompact while preserving custom hooks:\n%s", got)
+	}
+}
+
+func TestInstallCodexPreservesFullyCustomHooks(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := []byte(`{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "hooks": [{
+        "type": "command",
+        "command": "printf custom-codex-hook"
+      }]
+    }]
+  }
+}`)
+	fs.Files["/work/.codex/hooks.json"] = custom
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if got := string(fs.Files["/work/.codex/hooks.json"]); got != string(custom) {
+		t.Fatalf("fully custom codex hooks were overwritten:\n%s", got)
+	}
+}
+
+func TestInstallCodexPreservesUnreadableExistingHooks(t *testing.T) {
+	workDir := t.TempDir()
+	hookDir := filepath.Join(workDir, ".codex")
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	hookPath := filepath.Join(hookDir, "hooks.json")
+	custom := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"printf custom"}]}]}}`)
+	if err := os.WriteFile(hookPath, custom, 0o644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+	if err := os.Chmod(hookPath, 0); err != nil {
+		t.Fatalf("chmod hooks unreadable: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(hookPath, 0o644)
+	})
+
+	if err := Install(fsys.OSFS{}, "/city", workDir, []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if err := os.Chmod(hookPath, 0o644); err != nil {
+		t.Fatalf("restore hooks mode: %v", err)
+	}
+	got, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("unreadable codex hooks were overwritten:\n%s", string(got))
 	}
 }
 
@@ -768,6 +866,12 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	codexHooks := string(fs.Files["/work/.codex/hooks.json"])
 	if !strings.Contains(codexHooks, "--hook-format codex") {
 		t.Error("codex hooks should request Codex hook output format")
+	}
+	if !strings.Contains(codexHooks, `"PreCompact"`) {
+		t.Error("codex hooks should include PreCompact")
+	}
+	if !strings.Contains(codexHooks, `gc handoff --auto --hook-format codex \"context cycle\"`) {
+		t.Error("codex PreCompact should use auto handoff with Codex hook output format")
 	}
 	for _, rel := range []string{
 		"/work/.codex/hooks.json",


### PR DESCRIPTION
## Summary

- Add `gc handoff --hook-format codex` so PreCompact auto handoff emits Codex hook JSON.
- Add Codex managed `PreCompact` hook template for `gc handoff --auto --hook-format codex "context cycle"`.
- Safely upgrade managed/stale Codex hooks, preserve custom hooks, and add `gc doctor` drift detection/fix coverage.

## Verification

After rebasing `feature/gc-oiq` onto current `upstream/main` (`262866a3`), head `ffa81ed0` passed:

- `go test ./internal/hooks -run 'TestInstallCodex|TestInstallOverlayManagedProviders' -count=1`\n- `go test ./cmd/gc -run 'Test(CmdHandoffAutoHookFormatCodex|CodexHooksDriftCheckReportsManagedMissingPreCompact|CodexHooksDriftCheckPassesCurrentHooks|CodexHooksDriftCheckIgnoresCustomHooks|CodexHooksDriftCheckFixUpgradesManagedHooks|GenDocProducesMarkdown)' -count=1`\n- `go test ./internal/docgen -count=1`\n- `go vet ./...`\n- `git diff --check`\n\nEarlier targeted checks before rebase also passed:\n\n- `go test ./internal/hooks`\n- `go test ./cmd/gc -run 'Test(CmdHandoffAuto|CodexHooksDrift|WriteProviderHookContext)' -count=1`\n- `go test ./cmd/gc -run TestGenDocProducesMarkdown -count=1`\n\n## Known Local Gate Result\n\n- `.githooks/pre-commit` was run and failed in the broad `go test ./...` phase on existing unrelated local failures:\n  - `internal/api` order history timestamp tests reject local `+09:00` formatting without `T`.\n  - `internal/beads` timeout test failed.\n  - `cmd/gc` Dolt/GCBin managed tests failed in the same environment where `flock` is not installed.\n  - failure reporting also hit `scripts/go-test-observable: line 33: mapfile: command not found`.\n\nThe targeted tests for this change pass on the rebased branch. The PR remains draft for human finalization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->