### PR TITLE
fix(reaper): exclude 'dolt' built-in system DB from database discovery

### DIFF
--- a/cmd/gc/dashboard/web/public/dashboard.css
+++ b/cmd/gc/dashboard/web/public/dashboard.css
@@ -2219,6 +2219,7 @@
         .scope-stat-value {
             font-size: 0.85rem;
             font-weight: 500;
+            white-space: nowrap;
         }
 
         .scope-stat-value.active {

--- a/cmd/gc/dashboard/web/src/panels/status.test.ts
+++ b/cmd/gc/dashboard/web/src/panels/status.test.ts
@@ -252,6 +252,34 @@ describe("status panel scope rendering", () => {
     });
   });
 
+  it("renders all five scope stats when no overseer session exists", async () => {
+    window.history.pushState({}, "", "/dashboard?city=alpha");
+    apiGet.mockImplementation((path: string) => {
+      if (path.includes("/status")) {
+        return Promise.resolve(ok({
+          agents: { running: 0 },
+          mail: { unread: 0 },
+          work: { in_progress: 0, open: 0 },
+        }));
+      }
+      if (path.includes("/sessions")) return Promise.resolve(ok({ items: [] }));
+      if (path.includes("/beads")) return Promise.resolve(ok({ items: [] }));
+      if (path.includes("/convoys")) return Promise.resolve(ok({ items: [] }));
+      return Promise.resolve(ok({}));
+    });
+
+    const { renderStatus } = await import("./status");
+    await renderStatus();
+
+    const stats = scopeStats();
+    expect(Object.keys(stats)).toHaveLength(5);
+    expect(stats["City"]).toBe("alpha");
+    expect(stats["Session"]).toBe("—");
+    expect(stats["Activity"]).toBe("—");
+    expect(stats["Terminal"]).toBe("—");
+    expect(stats["State"]).toBe("—");
+  });
+
   it("keeps terminal attachment separate from the city scope badge", async () => {
     window.history.pushState({}, "", "/dashboard?city=alpha");
     const now = new Date().toISOString();

--- a/cmd/gc/dashboard/web/src/panels/status.ts
+++ b/cmd/gc/dashboard/web/src/panels/status.ts
@@ -250,22 +250,21 @@ function renderCityScopeBanner(city: string, sessions: SessionSummary[]): void {
     sessions.find((s) => s.configured_named_session && !s.rig) ??
     sessions.find((s) => !s.rig && !s.pool);
 
-  if (!overseer) {
-    banner.classList.remove("attached", "detached");
-    badge.className = "badge badge-cyan";
-    badge.textContent = "City";
-    clear(status);
-    status.append(
-      scopeStat("City", city),
-      scopeStat("Session", "none"),
-    );
-    return;
-  }
-
   banner.classList.remove("attached", "detached");
   badge.className = "badge badge-cyan";
   badge.textContent = "City";
   clear(status);
+
+  if (!overseer) {
+    status.append(
+      scopeStat("City", city),
+      scopeStat("Session", "—"),
+      scopeStat("Activity", "—"),
+      scopeStat("Terminal", "—"),
+      scopeStat("State", "—"),
+    );
+    return;
+  }
 
   const active = overseer.last_active
     ? Date.now() - new Date(overseer.last_active).getTime() < ACTIVE_WINDOW_MS

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -75,7 +75,7 @@ PY
 
 is_user_database() {
     case "$1" in
-        information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*)
+        dolt|information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|benchdb|testdb_*|beads_pt*|beads_vr*|doctest_*|doctortest_*)
             return 1
             ;;
         beads_t*)


### PR DESCRIPTION
## Summary

- Dolt SQL server exposes a built-in `dolt` system schema via `SHOW DATABASES`
- `is_user_database()` excluded other system schemas (`mysql`, `dolt_cluster`, etc.) but missed `dolt`
- Reaper iterated `dolt` as a user database, queried `dolt.wisps`, hit table-not-found (Error 1146), and mailed spurious ESCALATION anomalies to mayor on every run

## Fix

Add `dolt` to the exclusion pattern in `is_user_database()`:

```bash
dolt|information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe|...
```

## Test plan

- [ ] `dolt` excluded from `is_user_database()` — verified by code change
- [ ] User DBs (`hq`, `td_core`) still processed — exclusion is pattern-matched, not a broad filter
- [ ] Reaper dry-run: no anomaly for `dolt` DB

Closes core-0ozp / tc-zlpa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->