### PR TITLE
fix(extmsg): set X-GC-Request on http_adapter outbound callbacks

### DIFF
--- a/internal/extmsg/http_adapter.go
+++ b/internal/extmsg/http_adapter.go
@@ -64,6 +64,14 @@ func (a *HTTPAdapter) Publish(ctx context.Context, req PublishRequest) (*Publish
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	// Adapters often register a callback URL pointing at gc's own
+	// /svc/<service>/publish proxy (proxy_process mode). gc's CSRF gate
+	// for private-service-proxy mutations requires X-GC-Request != ""
+	// (see internal/api/handler_services.go:serviceRequestAllowed). The
+	// header is harmless when the callback is an external HTTP listener,
+	// so set it unconditionally — same convention as gc's CLI client
+	// (internal/api/client.go).
+	httpReq.Header.Set("X-GC-Request", "true")
 
 	resp, err := a.client.Do(httpReq)
 	if err != nil {
@@ -166,6 +174,8 @@ func (a *HTTPAdapter) EnsureChildConversation(ctx context.Context, ref Conversat
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	// Same /svc-proxy CSRF reasoning as Publish above.
+	httpReq.Header.Set("X-GC-Request", "true")
 
 	resp, err := a.client.Do(httpReq)
 	if err != nil {

--- a/internal/extmsg/http_adapter.go
+++ b/internal/extmsg/http_adapter.go
@@ -10,6 +10,14 @@ import (
 	"time"
 )
 
+// csrfHeaderName mirrors internal/api/city_scope.go:csrfHeaderName.
+// http_adapter's outbound requests must set it because adapters often
+// register a callback URL pointing at gc's own /svc/<service>/publish
+// proxy (proxy_process mode), which is gated by the same CSRF check
+// gc's CLI client already passes. Defined locally to avoid an import
+// cycle on internal/api.
+const csrfHeaderName = "X-GC-Request"
+
 // HTTPAdapter implements TransportAdapter by forwarding publish requests
 // to an external HTTP service at callbackURL. Used for out-of-process
 // adapters that register via the API.
@@ -64,14 +72,9 @@ func (a *HTTPAdapter) Publish(ctx context.Context, req PublishRequest) (*Publish
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	// Adapters often register a callback URL pointing at gc's own
-	// /svc/<service>/publish proxy (proxy_process mode). gc's CSRF gate
-	// for private-service-proxy mutations requires X-GC-Request != ""
-	// (see internal/api/handler_services.go:serviceRequestAllowed). The
-	// header is harmless when the callback is an external HTTP listener,
-	// so set it unconditionally — same convention as gc's CLI client
-	// (internal/api/client.go).
-	httpReq.Header.Set("X-GC-Request", "true")
+	// See csrfHeaderName above for why this is required on outbound
+	// callbacks. Harmless when callbackURL is an external HTTP listener.
+	httpReq.Header.Set(csrfHeaderName, "true")
 
 	resp, err := a.client.Do(httpReq)
 	if err != nil {
@@ -174,8 +177,7 @@ func (a *HTTPAdapter) EnsureChildConversation(ctx context.Context, ref Conversat
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	// Same /svc-proxy CSRF reasoning as Publish above.
-	httpReq.Header.Set("X-GC-Request", "true")
+	httpReq.Header.Set(csrfHeaderName, "true")
 
 	resp, err := a.client.Do(httpReq)
 	if err != nil {

--- a/internal/extmsg/http_adapter_test.go
+++ b/internal/extmsg/http_adapter_test.go
@@ -22,15 +22,19 @@ import (
 func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader string
+	var (
+		handlerCalled bool
+		gotHeader     string
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
 		if !strings.HasSuffix(r.URL.Path, "/publish") {
 			t.Errorf("expected /publish suffix, got %s", r.URL.Path)
 		}
-		gotHeader = r.Header.Get("X-GC-Request")
+		gotHeader = r.Header.Get(csrfHeaderName)
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(wirePublishReceipt{
@@ -57,13 +61,17 @@ func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
+	if !handlerCalled {
+		t.Fatalf("server handler was never invoked; request did not reach the callback URL")
+	}
 	if !receipt.Delivered {
 		t.Fatalf("expected Delivered=true, got receipt=%+v", receipt)
 	}
-	if gotHeader == "" {
-		t.Fatalf("expected X-GC-Request header on outbound request; got empty. " +
-			"This header is required by gc's /svc-proxy CSRF gate when the " +
-			"adapter callback URL points at a gc-internal proxy.")
+	if gotHeader != "true" {
+		t.Fatalf("expected %s=%q on outbound request, got %q. "+
+			"This header is required by gc's /svc-proxy CSRF gate when the "+
+			"adapter callback URL points at a gc-internal proxy.",
+			csrfHeaderName, "true", gotHeader)
 	}
 }
 
@@ -74,15 +82,19 @@ func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
 func TestHTTPAdapterEnsureChildConversationSetsCSRFHeader(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader string
+	var (
+		handlerCalled bool
+		gotHeader     string
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
 		if !strings.HasSuffix(r.URL.Path, "/child-conversation") {
 			t.Errorf("expected /child-conversation suffix, got %s", r.URL.Path)
 		}
-		gotHeader = r.Header.Get("X-GC-Request")
+		gotHeader = r.Header.Get(csrfHeaderName)
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(ConversationRef{
@@ -103,7 +115,11 @@ func TestHTTPAdapterEnsureChildConversationSetsCSRFHeader(t *testing.T) {
 	if _, err := adapter.EnsureChildConversation(context.Background(), parent, "test-label"); err != nil {
 		t.Fatalf("EnsureChildConversation: %v", err)
 	}
-	if gotHeader == "" {
-		t.Fatalf("expected X-GC-Request header on outbound child-conversation request; got empty.")
+	if !handlerCalled {
+		t.Fatalf("server handler was never invoked; request did not reach the callback URL")
+	}
+	if gotHeader != "true" {
+		t.Fatalf("expected %s=%q on outbound child-conversation request, got %q.",
+			csrfHeaderName, "true", gotHeader)
 	}
 }

--- a/internal/extmsg/http_adapter_test.go
+++ b/internal/extmsg/http_adapter_test.go
@@ -1,0 +1,109 @@
+package extmsg
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHTTPAdapterPublishSetsCSRFHeader pins that HTTPAdapter.Publish sets
+// X-GC-Request on the outbound request. When an adapter registers a
+// callback URL pointing at gc's own /svc/<service>/publish proxy
+// (proxy_process mode — the standard slack-pack registration shape), gc's
+// CSRF gate at internal/api/handler_services.go:serviceRequestAllowed
+// requires the header on private-service-proxy mutations and 403s the
+// request without it. Without the header, every Publish call silently
+// returns FailureKind=auth and the message never reaches the actual
+// adapter. See gastownhall/gascity#1817.
+func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/publish") {
+			t.Errorf("expected /publish suffix, got %s", r.URL.Path)
+		}
+		gotHeader = r.Header.Get("X-GC-Request")
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(wirePublishReceipt{
+			MessageID: "ts-100",
+			Conversation: ConversationRef{
+				Provider:       "slack",
+				ConversationID: "C123",
+				Kind:           ConversationRoom,
+			},
+			Delivered: true,
+		})
+	}))
+	defer server.Close()
+
+	adapter := NewHTTPAdapter("test", server.URL, AdapterCapabilities{})
+	receipt, err := adapter.Publish(context.Background(), PublishRequest{
+		Conversation: ConversationRef{
+			Provider:       "slack",
+			ConversationID: "C123",
+			Kind:           ConversationRoom,
+		},
+		Text: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !receipt.Delivered {
+		t.Fatalf("expected Delivered=true, got receipt=%+v", receipt)
+	}
+	if gotHeader == "" {
+		t.Fatalf("expected X-GC-Request header on outbound request; got empty. " +
+			"This header is required by gc's /svc-proxy CSRF gate when the " +
+			"adapter callback URL points at a gc-internal proxy.")
+	}
+}
+
+// TestHTTPAdapterEnsureChildConversationSetsCSRFHeader pins the same
+// header on the sibling /child-conversation callback. Same /svc-proxy
+// CSRF reasoning applies — without the header, child-conversation
+// requests against a /svc-proxy callback URL also 403 silently.
+func TestHTTPAdapterEnsureChildConversationSetsCSRFHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/child-conversation") {
+			t.Errorf("expected /child-conversation suffix, got %s", r.URL.Path)
+		}
+		gotHeader = r.Header.Get("X-GC-Request")
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ConversationRef{
+			Provider:             "slack",
+			ConversationID:       "C123-thread",
+			Kind:                 ConversationThread,
+			ParentConversationID: "C123",
+		})
+	}))
+	defer server.Close()
+
+	adapter := NewHTTPAdapter("test", server.URL, AdapterCapabilities{})
+	parent := ConversationRef{
+		Provider:       "slack",
+		ConversationID: "C123",
+		Kind:           ConversationRoom,
+	}
+	if _, err := adapter.EnsureChildConversation(context.Background(), parent, "test-label"); err != nil {
+		t.Fatalf("EnsureChildConversation: %v", err)
+	}
+	if gotHeader == "" {
+		t.Fatalf("expected X-GC-Request header on outbound child-conversation request; got empty.")
+	}
+}

--- a/internal/extmsg/http_adapter_test.go
+++ b/internal/extmsg/http_adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestHTTPAdapterPublishSetsCSRFHeader pins that HTTPAdapter.Publish sets
@@ -22,19 +23,19 @@ import (
 func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
 	t.Parallel()
 
-	var (
-		handlerCalled bool
-		gotHeader     string
-	)
+	// Pass observations from the handler goroutine to the test
+	// goroutine via a buffered channel — receiving on the channel
+	// happens-before the test's assertions, satisfying the Go memory
+	// model. A bare shared variable would race.
+	gotHeader := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handlerCalled = true
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
 		if !strings.HasSuffix(r.URL.Path, "/publish") {
 			t.Errorf("expected /publish suffix, got %s", r.URL.Path)
 		}
-		gotHeader = r.Header.Get(csrfHeaderName)
+		gotHeader <- r.Header.Get(csrfHeaderName)
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(wirePublishReceipt{
@@ -61,17 +62,19 @@ func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Publish: %v", err)
 	}
-	if !handlerCalled {
-		t.Fatalf("server handler was never invoked; request did not reach the callback URL")
-	}
 	if !receipt.Delivered {
 		t.Fatalf("expected Delivered=true, got receipt=%+v", receipt)
 	}
-	if gotHeader != "true" {
-		t.Fatalf("expected %s=%q on outbound request, got %q. "+
-			"This header is required by gc's /svc-proxy CSRF gate when the "+
-			"adapter callback URL points at a gc-internal proxy.",
-			csrfHeaderName, "true", gotHeader)
+	select {
+	case h := <-gotHeader:
+		if h != "true" {
+			t.Fatalf("expected %s=%q on outbound request, got %q. "+
+				"This header is required by gc's /svc-proxy CSRF gate when the "+
+				"adapter callback URL points at a gc-internal proxy.",
+				csrfHeaderName, "true", h)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server handler was never invoked; request did not reach the callback URL")
 	}
 }
 
@@ -82,19 +85,15 @@ func TestHTTPAdapterPublishSetsCSRFHeader(t *testing.T) {
 func TestHTTPAdapterEnsureChildConversationSetsCSRFHeader(t *testing.T) {
 	t.Parallel()
 
-	var (
-		handlerCalled bool
-		gotHeader     string
-	)
+	gotHeader := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handlerCalled = true
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
 		if !strings.HasSuffix(r.URL.Path, "/child-conversation") {
 			t.Errorf("expected /child-conversation suffix, got %s", r.URL.Path)
 		}
-		gotHeader = r.Header.Get(csrfHeaderName)
+		gotHeader <- r.Header.Get(csrfHeaderName)
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(ConversationRef{
@@ -115,11 +114,13 @@ func TestHTTPAdapterEnsureChildConversationSetsCSRFHeader(t *testing.T) {
 	if _, err := adapter.EnsureChildConversation(context.Background(), parent, "test-label"); err != nil {
 		t.Fatalf("EnsureChildConversation: %v", err)
 	}
-	if !handlerCalled {
+	select {
+	case h := <-gotHeader:
+		if h != "true" {
+			t.Fatalf("expected %s=%q on outbound child-conversation request, got %q.",
+				csrfHeaderName, "true", h)
+		}
+	case <-time.After(2 * time.Second):
 		t.Fatalf("server handler was never invoked; request did not reach the callback URL")
-	}
-	if gotHeader != "true" {
-		t.Fatalf("expected %s=%q on outbound child-conversation request, got %q.",
-			csrfHeaderName, "true", gotHeader)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1817. `internal/extmsg/http_adapter.go` did not set `X-GC-Request` on the HTTP request it sends to the registered adapter callback URL. When the callback points at gc's own `/svc/<service>/publish` proxy (the standard slack-pack `proxy_process` registration shape), gc's CSRF gate at `internal/api/handler_services.go:serviceRequestAllowed` rejects the request with 403 → http_adapter reports `FailureKind: auth` → the publish silently no-ops, regardless of whether the binding lookup succeeded. The CLI client at `internal/api/client.go:143,264` already passes the same gate by setting `X-GC-Request: "true"`; http_adapter just got missed.

## Changes

- `internal/extmsg/http_adapter.go`
  - New package-local `csrfHeaderName = "X-GC-Request"` const, mirroring `internal/api/city_scope.go:csrfHeaderName`. Defined locally because `internal/api` already imports `internal/extmsg` (e.g. `huma_handlers_extmsg.go:13`), so importing the api-side const would cycle.
  - Both `Publish` (POST `/publish`) and `EnsureChildConversation` (POST `/child-conversation`) now set `httpReq.Header.Set(csrfHeaderName, "true")` after their existing `Content-Type` line. Header is harmless when the callback is an external HTTP listener.
- `internal/extmsg/http_adapter_test.go` *(new)*
  - Two regression tests using `httptest.NewServer`: `TestHTTPAdapterPublishSetsCSRFHeader` and `TestHTTPAdapterEnsureChildConversationSetsCSRFHeader`. Each captures the inbound request, asserts the handler was actually invoked (`handlerCalled` flag — guards against the test passing on a never-hit handler), and asserts the header value equals `"true"` (more discriminating than a presence-only check).

## Verification

- `go test ./internal/extmsg/...` → PASS
- Stash-then-test sanity → both new tests fail with clear error messages without the fix; pass with it
- `make build` → clean
- `make check` (fmt + lint + vet + test) → clean (4m28s, no baseline noise)
- `go vet ./...` → clean
- `gofmt -l internal/extmsg/` → clean

Multi-model review (Claude × 3 lenses + Codex `gpt-5.4` + Copilot `gpt-5.3-codex`) converged at iteration 1 with no blocker / major / minor findings. Notably, Codex pinned the chain via existing `internal/api/handler_services_test.go:269,295` which already cover the gate's accept-with-header / reject-without-header behavior — this PR's tests pin the http_adapter side that was previously unpinned.

## Test plan

- [x] `go test ./internal/extmsg/...`
- [x] `make check`
- [x] Sanity: stash the fix, both tests fail; restore, both pass

## Out of scope

- Path-aliased session bead reassignment across supervisor restarts (separate structural issue surfaced during the same debugging session)
- The slack-pack `bind-room` `--binding-owner` flag-defaulting (separate; covered by a different fix path)
- PR #1632 (PublishRequest snake_case wire tags) — already merged; required-but-not-sufficient for end-to-end threading

Closes #1817

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->