### PR TITLE
fix(maintenance): reaper + jsonl-export skip databases without bd schema

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2605,86 +2605,120 @@ func writeManagedRuntimeStateWithPID(t *testing.T, cityDir string, port int, pid
 	}
 }
 
-// TestReaperSkipsDatabasesWithoutWispsTable pins the schemaless-DB
-// precheck (gastownhall/gascity#1816). Reaper iterates the user
-// databases discovered by SHOW DATABASES, but a database that exists on
-// the server without bd schema (orphan CREATE DATABASE, partial migration,
-// system schemas not on the is_user_database blocklist) has nothing for
-// the reaper to do — querying its wisps table just produces spurious
-// "table not found" anomalies. Reaper now probes SHOW TABLES FROM <db>
-// LIKE 'wisps' and skips silently when the wisps table is absent.
-func TestReaperSkipsDatabasesWithoutWispsTable(t *testing.T) {
-	cityDir := t.TempDir()
-	binDir := t.TempDir()
-	stateDir := t.TempDir()
-	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
-	gcLog := filepath.Join(t.TempDir(), "gc.log")
+// TestMaintenanceDoltScriptsSkipDatabasesWithoutWispsTable pins the
+// schemaless-DB precheck (gastownhall/gascity#1816). Both reaper.sh and
+// jsonl-export.sh iterate user databases discovered by SHOW DATABASES,
+// but a database that exists on the server without bd schema (orphan
+// CREATE DATABASE, partial migration, system schemas not on the
+// is_user_database blocklist) has nothing for them to do — querying its
+// tables just produces spurious "table not found" anomalies (reaper) or
+// failed-DB summary entries (jsonl-export). Both scripts now probe
+// SHOW TABLES FROM <db> LIKE 'wisps' via the shared has_wisps_table
+// helper in dolt-target.sh and skip silently when wisps is absent.
+func TestMaintenanceDoltScriptsSkipDatabasesWithoutWispsTable(t *testing.T) {
+	tests := []struct {
+		name           string
+		script         string
+		env            map[string]string
+		forbiddenLogs  []string
+		gcLogForbidden string
+	}{
+		{
+			name:   "reaper",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "reaper.sh"),
+			env:    map[string]string{"GC_REAPER_DRY_RUN": "1"},
+			forbiddenLogs: []string{
+				"`empty_db`.wisps",
+				"`empty_db`.issues",
+				"`empty_db`.dependencies",
+			},
+			gcLogForbidden: "empty_db",
+		},
+		{
+			name:   "jsonl export",
+			script: filepath.Join("packs", "maintenance", "assets", "scripts", "jsonl-export.sh"),
+			env: map[string]string{
+				"GC_JSONL_ARCHIVE_REPO":      "archive",
+				"GC_JSONL_MAX_PUSH_FAILURES": "99",
+			},
+			forbiddenLogs: []string{
+				"`empty_db`.issues",
+			},
+			// jsonl-export reports failures via DOG_DONE summary line in
+			// the gc nudge — empty_db must not show up there.
+			gcLogForbidden: "empty_db",
+		},
+	}
 
-	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
-	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			binDir := t.TempDir()
+			stateDir := t.TempDir()
+			doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+			gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+			writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+			writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GC_CALL_LOG"
 exit 0
 `)
 
-	env := map[string]string{
-		"DOLT_ARGS_LOG":          doltLog,
-		"DOLT_DBS":               "real_beads empty_db",
-		"DOLT_DBS_WITHOUT_WISPS": "empty_db",
-		"GC_CALL_LOG":            gcLog,
-		"GC_CITY":                cityDir,
-		"GC_CITY_PATH":           cityDir,
-		"GC_PACK_STATE_DIR":      stateDir,
-		"GC_DOLT_HOST":           "127.0.0.1",
-		"GC_DOLT_PORT":           "3307",
-		"GC_DOLT_USER":           "root",
-		"GC_DOLT_PASSWORD":       "",
-		"GC_REAPER_DRY_RUN":      "1",
-		"GIT_CONFIG_GLOBAL":      filepath.Join(t.TempDir(), "gitconfig"),
-		"GIT_CONFIG_NOSYSTEM":    "1",
-		"PATH":                   binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
-	}
+			env := map[string]string{
+				"DOLT_ARGS_LOG":          doltLog,
+				"DOLT_DBS":               "real_beads empty_db",
+				"DOLT_DBS_WITHOUT_WISPS": "empty_db",
+				"GC_CALL_LOG":            gcLog,
+				"GC_CITY":                cityDir,
+				"GC_CITY_PATH":           cityDir,
+				"GC_PACK_STATE_DIR":      stateDir,
+				"GC_DOLT_HOST":           "127.0.0.1",
+				"GC_DOLT_PORT":           "3307",
+				"GC_DOLT_USER":           "root",
+				"GC_DOLT_PASSWORD":       "",
+				"GIT_CONFIG_GLOBAL":      filepath.Join(t.TempDir(), "gitconfig"),
+				"GIT_CONFIG_NOSYSTEM":    "1",
+				"PATH":                   binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			}
+			for k, v := range tt.env {
+				if k == "GC_JSONL_ARCHIVE_REPO" {
+					v = filepath.Join(cityDir, v)
+				}
+				env[k] = v
+			}
 
-	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+			runScript(t, filepath.Join(exampleDir(), tt.script), env)
 
-	logData, err := os.ReadFile(doltLog)
-	if err != nil {
-		t.Fatalf("ReadFile(dolt log): %v", err)
-	}
-	log := string(logData)
+			logData, err := os.ReadFile(doltLog)
+			if err != nil {
+				t.Fatalf("ReadFile(dolt log): %v", err)
+			}
+			log := string(logData)
 
-	// real_beads has wisps → reaper should query its wisps table.
-	if !strings.Contains(log, "`real_beads`.wisps") {
-		t.Errorf("reaper did not query real_beads.wisps; expected normal processing:\n%s", log)
-	}
+			// The precheck itself ran for empty_db. Without this
+			// assertion the test could pass via an unrelated
+			// early-skip path that never reached the precheck.
+			if !strings.Contains(log, "SHOW TABLES FROM `empty_db` LIKE 'wisps'") {
+				t.Errorf("script did not run the SHOW TABLES precheck against empty_db:\n%s", log)
+			}
 
-	// The precheck itself ran for empty_db. Without this assertion the
-	// test could pass via an unrelated early-skip path that never
-	// reached the precheck.
-	if !strings.Contains(log, "SHOW TABLES FROM `empty_db` LIKE 'wisps'") {
-		t.Errorf("reaper did not run the SHOW TABLES precheck against empty_db:\n%s", log)
-	}
+			// empty_db has no wisps → script must skip without
+			// querying its tables.
+			for _, forbidden := range tt.forbiddenLogs {
+				if strings.Contains(log, forbidden) {
+					t.Errorf("script queried schemaless DB (%s); precheck did not skip:\n%s", forbidden, log)
+				}
+			}
 
-	// empty_db has no wisps → reaper must skip without querying its
-	// wisps/issues/dependencies tables.
-	for _, forbidden := range []string{
-		"`empty_db`.wisps",
-		"`empty_db`.issues",
-		"`empty_db`.dependencies",
-	} {
-		if strings.Contains(log, forbidden) {
-			t.Errorf("reaper queried schemaless DB (%s); precheck did not skip:\n%s", forbidden, log)
-		}
-	}
-
-	// No anomaly mail should be sent for empty_db. The reaper sends a
-	// single ESCALATION mail at end-of-run if any anomaly was recorded;
-	// with empty_db skipped silently, the gc log must not contain it.
-	gcData, err := os.ReadFile(gcLog)
-	if err != nil && !os.IsNotExist(err) {
-		t.Fatalf("ReadFile(gc log): %v", err)
-	}
-	if strings.Contains(string(gcData), "empty_db") {
-		t.Errorf("reaper escalated empty_db to mayor; precheck should have suppressed:\n%s", gcData)
+			// No anomaly / failure escalation should mention empty_db.
+			gcData, err := os.ReadFile(gcLog)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatalf("ReadFile(gc log): %v", err)
+			}
+			if strings.Contains(string(gcData), tt.gcLogForbidden) {
+				t.Errorf("script surfaced empty_db to gc/mayor; precheck should have suppressed:\n%s", gcData)
+			}
+		})
 	}
 }
 
@@ -3225,6 +3259,9 @@ func writeIssuesPayloadDoltStub(t *testing.T, binDir, issuesPayload string) {
 	t.Helper()
 	body := "#!/bin/sh\n" +
 		"case \"$*\" in\n" +
+		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
+		"    printf 'Tables_in_db\\nwisps\\n'\n" +
+		"    ;;\n" +
 		"  *\"SHOW DATABASES\"*)\n" +
 		"    printf 'Database\\nbeads\\n'\n" +
 		"    ;;\n" +
@@ -3263,6 +3300,9 @@ func writeEmptyIssuesPayloadDoltStub(t *testing.T, binDir string) {
 	t.Helper()
 	body := "#!/bin/sh\n" +
 		"case \"$*\" in\n" +
+		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
+		"    printf 'Tables_in_db\\nwisps\\n'\n" +
+		"    ;;\n" +
 		"  *\"SHOW DATABASES\"*)\n" +
 		"    printf 'Database\\nbeads\\n'\n" +
 		"    ;;\n" +
@@ -3280,6 +3320,9 @@ func writeIssuesExportFailureDoltStub(t *testing.T, binDir string) {
 	t.Helper()
 	body := "#!/bin/sh\n" +
 		"case \"$*\" in\n" +
+		"  *\"SHOW TABLES FROM\"*\"LIKE 'wisps'\"*)\n" +
+		"    printf 'Tables_in_db\\nwisps\\n'\n" +
+		"    ;;\n" +
 		"  *\"SHOW DATABASES\"*)\n" +
 		"    printf 'Database\\nbeads\\n'\n" +
 		"    ;;\n" +

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -2657,6 +2657,13 @@ exit 0
 		t.Errorf("reaper did not query real_beads.wisps; expected normal processing:\n%s", log)
 	}
 
+	// The precheck itself ran for empty_db. Without this assertion the
+	// test could pass via an unrelated early-skip path that never
+	// reached the precheck.
+	if !strings.Contains(log, "SHOW TABLES FROM `empty_db` LIKE 'wisps'") {
+		t.Errorf("reaper did not run the SHOW TABLES precheck against empty_db:\n%s", log)
+	}
+
 	// empty_db has no wisps → reaper must skip without querying its
 	// wisps/issues/dependencies tables.
 	for _, forbidden := range []string{

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -926,6 +926,9 @@ func TestMaintenanceDoltScriptsSkipUnsafeDatabaseIdentifiers(t *testing.T) {
 			writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\nfoo db\n'
     ;;
@@ -1159,6 +1162,9 @@ func TestReaperClosesStaleWispChainsToFixpoint(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1246,6 +1252,9 @@ func TestReaperCountQueriesIgnoreSuccessfulStderrWarnings(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1317,6 +1326,9 @@ func TestReaperRowQueriesIgnoreSuccessfulStderrWarnings(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1388,6 +1400,9 @@ func TestReaperDoesNotCloseNonClosedWispsByAgeOnly(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1456,6 +1471,9 @@ func TestReaperClosesStaleWispsOnlyWithClosedParent(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1548,6 +1566,9 @@ func TestReaperEscalatesDoltCommitFailure(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1619,6 +1640,9 @@ func TestReaperDoesNotCountFailedPurgeAsSuccess(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1680,6 +1704,9 @@ func TestReaperCommitReportsOnlySuccessfulPurgeRows(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1771,6 +1798,9 @@ func TestReaperDoesNotCountFailedIssueCloseAsSuccess(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -1837,6 +1867,9 @@ func TestReaperAutoClosesIssuesOnlyInCityDatabase(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\nrigdb\n'
     ;;
@@ -1912,6 +1945,9 @@ func TestReaperCityDatabaseUsesGCCityPathFallback(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\n'
     ;;
@@ -1985,6 +2021,9 @@ func TestReaperScopesIssueAutoCloseToCityBeadsDir(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\n'
     ;;
@@ -2052,6 +2091,9 @@ func TestReaperSkipsIssueAutoCloseWhenConfiguredCityDatabaseDoesNotMatchMetadata
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\nwrongdb\n'
     ;;
@@ -2133,6 +2175,9 @@ func TestReaperSkipsIssueAutoCloseWhenCityMetadataIsNotJSON(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -2204,6 +2249,9 @@ func TestReaperCityDatabaseUsesShellFallbackWhenJSONParsersUnavailable(t *testin
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\ncitydb\n'
     ;;
@@ -2278,6 +2326,9 @@ func TestReaperSkipsIssueAutoCloseWhenCityMetadataIsMalformed(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -2345,6 +2396,9 @@ func TestReaperSkipsIssueAutoCloseWhenCityDatabaseUnknown(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\nrigdb\n'
     ;;
@@ -2411,6 +2465,9 @@ func TestReaperIgnoresNothingToCommitAfterMutationRace(t *testing.T) {
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 printf '%s\n' "$*" >> "$DOLT_ARGS_LOG"
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\nbeads\n'
     ;;
@@ -2545,6 +2602,82 @@ func writeManagedRuntimeStateWithPID(t *testing.T, cityDir string, port int, pid
 	}
 	if err := os.WriteFile(filepath.Join(stateDir, "dolt-state.json"), payload, 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestReaperSkipsDatabasesWithoutWispsTable pins the schemaless-DB
+// precheck (gastownhall/gascity#1816). Reaper iterates the user
+// databases discovered by SHOW DATABASES, but a database that exists on
+// the server without bd schema (orphan CREATE DATABASE, partial migration,
+// system schemas not on the is_user_database blocklist) has nothing for
+// the reaper to do — querying its wisps table just produces spurious
+// "table not found" anomalies. Reaper now probes SHOW TABLES FROM <db>
+// LIKE 'wisps' and skips silently when the wisps table is absent.
+func TestReaperSkipsDatabasesWithoutWispsTable(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	doltLog := filepath.Join(t.TempDir(), "dolt-args.log")
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+
+	writeMaintenanceDoltStub(t, filepath.Join(binDir, "dolt"))
+	writeExecutable(t, filepath.Join(binDir, "gc"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_CALL_LOG"
+exit 0
+`)
+
+	env := map[string]string{
+		"DOLT_ARGS_LOG":          doltLog,
+		"DOLT_DBS":               "real_beads empty_db",
+		"DOLT_DBS_WITHOUT_WISPS": "empty_db",
+		"GC_CALL_LOG":            gcLog,
+		"GC_CITY":                cityDir,
+		"GC_CITY_PATH":           cityDir,
+		"GC_PACK_STATE_DIR":      stateDir,
+		"GC_DOLT_HOST":           "127.0.0.1",
+		"GC_DOLT_PORT":           "3307",
+		"GC_DOLT_USER":           "root",
+		"GC_DOLT_PASSWORD":       "",
+		"GC_REAPER_DRY_RUN":      "1",
+		"GIT_CONFIG_GLOBAL":      filepath.Join(t.TempDir(), "gitconfig"),
+		"GIT_CONFIG_NOSYSTEM":    "1",
+		"PATH":                   binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "reaper.sh"), env)
+
+	logData, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("ReadFile(dolt log): %v", err)
+	}
+	log := string(logData)
+
+	// real_beads has wisps → reaper should query its wisps table.
+	if !strings.Contains(log, "`real_beads`.wisps") {
+		t.Errorf("reaper did not query real_beads.wisps; expected normal processing:\n%s", log)
+	}
+
+	// empty_db has no wisps → reaper must skip without querying its
+	// wisps/issues/dependencies tables.
+	for _, forbidden := range []string{
+		"`empty_db`.wisps",
+		"`empty_db`.issues",
+		"`empty_db`.dependencies",
+	} {
+		if strings.Contains(log, forbidden) {
+			t.Errorf("reaper queried schemaless DB (%s); precheck did not skip:\n%s", forbidden, log)
+		}
+	}
+
+	// No anomaly mail should be sent for empty_db. The reaper sends a
+	// single ESCALATION mail at end-of-run if any anomaly was recorded;
+	// with empty_db skipped silently, the gc log must not contain it.
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	if strings.Contains(string(gcData), "empty_db") {
+		t.Errorf("reaper escalated empty_db to mayor; precheck should have suppressed:\n%s", gcData)
 	}
 }
 
@@ -2918,6 +3051,19 @@ case "$*" in
     printf 'beads\n'
   fi
   ;;
+*"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+  # Schemaless-DB precheck (gastownhall/gascity#1816). By default, every
+  # test DB is treated as having wisps so existing tests are unaffected.
+  # Tests that exercise the precheck set DOLT_DBS_WITHOUT_WISPS to a
+  # space-separated list of DB names that should report no wisps row.
+  printf 'Tables_in_db\n'
+  for skip in ${DOLT_DBS_WITHOUT_WISPS:-}; do
+    case "$*" in
+    *"FROM"*"$skip"*"LIKE 'wisps'"*) exit 0 ;;
+    esac
+  done
+  printf 'wisps\n'
+  ;;
 *"SELECT *"*)
   printf '{"id":"ga-1","title":"sample"}\n'
   ;;
@@ -3095,6 +3241,9 @@ func writeNoUserDatabasesDoltStub(t *testing.T, binDir string) {
 	t.Helper()
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/bin/sh
 case "$*" in
+  *"SHOW TABLES FROM"*"LIKE 'wisps'"*)
+    printf 'Tables_in_db\nwisps\n'
+    ;;
   *"SHOW DATABASES"*)
     printf 'Database\n'
     ;;

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -181,11 +181,10 @@ dolt_sql() {
 # the caller falls through to its normal queries; those will fail in the
 # same way and surface the dolt-side problem through the script's regular
 # error-handling path.
-has_wisps_table() {
-    local db="$1"
-    local output
+has_wisps_table() (
+    db="$1"
     if ! output=$(dolt_sql -r csv -q "SHOW TABLES FROM \`$db\` LIKE 'wisps'" 2>/dev/null); then
         return 0
     fi
     [ "$(printf '%s\n' "$output" | tail -n +2 | head -1 | tr -d '\r')" = "wisps" ]
-}
+)

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -165,3 +165,27 @@ DOLT_USER="${GC_DOLT_USER:-root}"
 dolt_sql() {
     DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}" dolt --host "$DOLT_HOST" --port "$DOLT_PORT" --user "$DOLT_USER" --no-tls sql "$@"
 }
+
+# has_wisps_table reports whether $1 contains a `wisps` table. Maintenance
+# scripts that iterate user databases use this as a proxy for "is this DB
+# bd-managed?" — every bd-managed schema has a wisps table. Databases that
+# exist on the server without bd schema (orphan CREATE DATABASEs, system
+# schemas not on the is_user_database blocklist, partial migrations) have
+# nothing for the maintenance scripts to do, and querying their tables just
+# produces spurious "table not found" anomalies / failure-summary entries.
+# See gastownhall/gascity#1816.
+#
+# Caller must have already validated $1 via valid_database_identifier — this
+# helper does not re-quote against injection. On probe failure (dolt
+# unreachable, connection dropped, etc.) returns 0 (success/has-wisps) so
+# the caller falls through to its normal queries; those will fail in the
+# same way and surface the dolt-side problem through the script's regular
+# error-handling path.
+has_wisps_table() {
+    local db="$1"
+    local output
+    if ! output=$(dolt_sql -r csv -q "SHOW TABLES FROM \`$db\` LIKE 'wisps'" 2>/dev/null); then
+        return 0
+    fi
+    [ "$(printf '%s\n' "$output" | tail -n +2 | head -1 | tr -d '\r')" = "wisps" ]
+}

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -517,6 +517,14 @@ while IFS= read -r DB; do
 "
         continue
     fi
+    if ! has_wisps_table "$DB"; then
+        # Not a bd-managed bead store. Decrement the count we just
+        # bumped — schemaless DBs aren't part of the export universe
+        # and shouldn't appear in TOTAL_DBS or FAILED_DBS summaries.
+        # See dolt-target.sh:has_wisps_table and gastownhall/gascity#1816.
+        TOTAL_DBS=$((TOTAL_DBS - 1))
+        continue
+    fi
 
     DB_DIR="$ARCHIVE_REPO/$DB"
     mkdir -p "$DB_DIR"

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -306,7 +306,13 @@ has_wisps_table() {
     local db="$1"
     local output
     if ! output=$(dolt_sql -r csv -q "SHOW TABLES FROM \`$db\` LIKE 'wisps'" 2>/dev/null); then
-        return 1
+        # Probe failed (dolt unreachable, connection dropped, etc.).
+        # Fall through to normal processing rather than silently
+        # skipping a real bead store on a transient error — the
+        # subsequent get_sql_count calls will fail in the same way
+        # and record proper anomalies, which is the right behavior
+        # for "dolt is broken" vs "this DB has no schema."
+        return 0
     fi
     [ "$(printf '%s\n' "$output" | tail -n +2 | head -1 | tr -d '\r')" = "wisps" ]
 }

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -294,29 +294,6 @@ SELECT ROW_COUNT();
     return 0
 }
 
-# has_wisps_table reports whether $1 contains a `wisps` table. Reaper
-# operates exclusively on bd-managed schemas; databases that exist on the
-# server without bd schema (orphan CREATE DATABASEs, system schemas not
-# on the is_user_database blocklist, partial migrations) have nothing
-# for the reaper to do, and querying their wisps table just produces
-# spurious "table not found" anomalies. Caller must have already
-# validated $1 via valid_database_identifier — this helper does not
-# re-quote against injection.
-has_wisps_table() {
-    local db="$1"
-    local output
-    if ! output=$(dolt_sql -r csv -q "SHOW TABLES FROM \`$db\` LIKE 'wisps'" 2>/dev/null); then
-        # Probe failed (dolt unreachable, connection dropped, etc.).
-        # Fall through to normal processing rather than silently
-        # skipping a real bead store on a transient error — the
-        # subsequent get_sql_count calls will fail in the same way
-        # and record proper anomalies, which is the right behavior
-        # for "dolt is broken" vs "this DB has no schema."
-        return 0
-    fi
-    [ "$(printf '%s\n' "$output" | tail -n +2 | head -1 | tr -d '\r')" = "wisps" ]
-}
-
 while IFS= read -r DB; do
     [ -z "$DB" ] && continue
     if ! valid_database_identifier "$DB"; then

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -294,10 +294,35 @@ SELECT ROW_COUNT();
     return 0
 }
 
+# has_wisps_table reports whether $1 contains a `wisps` table. Reaper
+# operates exclusively on bd-managed schemas; databases that exist on the
+# server without bd schema (orphan CREATE DATABASEs, system schemas not
+# on the is_user_database blocklist, partial migrations) have nothing
+# for the reaper to do, and querying their wisps table just produces
+# spurious "table not found" anomalies. Caller must have already
+# validated $1 via valid_database_identifier — this helper does not
+# re-quote against injection.
+has_wisps_table() {
+    local db="$1"
+    local output
+    if ! output=$(dolt_sql -r csv -q "SHOW TABLES FROM \`$db\` LIKE 'wisps'" 2>/dev/null); then
+        return 1
+    fi
+    # SHOW TABLES emits one header row plus one row per matching table.
+    # When wisps is absent, only the header is present.
+    [ "$(printf '%s\n' "$output" | tail -n +2 | head -1)" = "wisps" ]
+}
+
 while IFS= read -r DB; do
     [ -z "$DB" ] && continue
     if ! valid_database_identifier "$DB"; then
         record_anomaly "$DB" "unsafe Dolt database identifier skipped by reaper"
+        continue
+    fi
+    if ! has_wisps_table "$DB"; then
+        # Not a bd-managed bead store. Skip silently; recording an
+        # anomaly here would just turn every schemaless DB on the
+        # server into noise. See gastownhall/gascity#1816.
         continue
     fi
 

--- a/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/reaper.sh
@@ -308,9 +308,7 @@ has_wisps_table() {
     if ! output=$(dolt_sql -r csv -q "SHOW TABLES FROM \`$db\` LIKE 'wisps'" 2>/dev/null); then
         return 1
     fi
-    # SHOW TABLES emits one header row plus one row per matching table.
-    # When wisps is absent, only the header is present.
-    [ "$(printf '%s\n' "$output" | tail -n +2 | head -1)" = "wisps" ]
+    [ "$(printf '%s\n' "$output" | tail -n +2 | head -1 | tr -d '\r')" = "wisps" ]
 }
 
 while IFS= read -r DB; do


### PR DESCRIPTION
## Summary

Fixes #1816. Both `reaper.sh` and `jsonl-export.sh` iterate user databases discovered via `SHOW DATABASES` and run per-DB queries (`<db>.wisps` / `<db>.issues` / `<db>.dependencies`) without checking whether the database actually has bd schema. Any database that exists on the server without bd schema (orphan `CREATE DATABASE`, partial migration, system schemas not on the `is_user_database` blocklist) produces `Error 1146: table not found` on every query — which becomes spurious `ESCALATION: Reaper anomalies detected` mail (4 anomalies × N orphan DBs per cycle, every 30 minutes) and inflated `failed: <db>` entries in the `jsonl-export` summary.

## Changes

- **`examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh`**
  - New `has_wisps_table()` helper that probes `SHOW TABLES FROM \`<db>\` LIKE 'wisps'` and reports whether the database is bd-managed. Wisps acts as a proxy for bd schema; every bd-managed schema has a wisps table.
  - Fail-closed-toward-processing on probe error: if the SHOW TABLES call itself errors (dolt unreachable, connection dropped), the helper returns success so the caller falls through to its normal queries — those will fail in the same way and surface the dolt-side problem through the script's regular error-handling path. This matches the rest of the script's error semantics rather than silently skipping a real bead store on a transient blip.
- **`examples/gastown/packs/maintenance/assets/scripts/reaper.sh`**
  - Per-DB iteration loop calls `has_wisps_table` right after the existing `valid_database_identifier` guard. Schemaless DB → `continue` silently, no anomaly recorded.
- **`examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh`**
  - Same precheck applied. `TOTAL_DBS=$((TOTAL_DBS - 1))` decrement on skip so the DOG_DONE summary's `exported N/M` denominator reflects only bd-managed databases.
- **`examples/gastown/maintenance_scripts_test.go`**
  - New `TestMaintenanceDoltScriptsSkipDatabasesWithoutWispsTable` (table-driven over both scripts). Asserts (a) the SHOW TABLES precheck actually ran for `empty_db`, (b) no `empty_db` table queries were issued, (c) no escalation surfaces `empty_db` to gc/mayor.
  - New `DOLT_DBS_WITHOUT_WISPS` env var on the shared `writeMaintenanceDoltStub` helper — space-separated DB names that report no wisps row. Defaults to empty (every DB has wisps), preserving backward compatibility with all 16+ existing tests that use this stub.
  - 17 inline raw-string dolt stubs and 3 Go-string-concatenated stubs (`writeIssuesPayloadDoltStub` and siblings) get a one-line SHOW TABLES case prepended so the new precheck doesn't spuriously skip their target DBs.

## Verification

- `make build` clean
- `make check` clean (~4m28s, fmt + lint + vet + test)
- `go test ./examples/gastown/...` clean (13.6s, all maintenance tests green)
- Sanity-verified: each script's precheck disabled independently makes the corresponding subtest of `TestMaintenanceDoltScriptsSkipDatabasesWithoutWispsTable` fail, with clear error messages naming the un-skipped query
- `gofmt -l` clean, `go vet ./...` clean

## Multi-model review

5-reviewer panel (Claude × 3 lenses + Codex `gpt-5.4` + Copilot `gpt-5.3-codex`) iterated twice:
- Iteration 1 flagged `jsonl-export.sh` as a major sibling-site bug (Codex + Copilot agreed independently). Addressed.
- Iteration 2 clean across all reviewers; Codex independently sanity-verified the fix by removing each precheck and confirming subtest failure.

## Out of scope

- "Why are orphan databases being created in the first place" — separate investigation. The `gascity_packs` orphan I observed was created today during normal city operation with no trace in supervisor.log, suggesting a different bug worth tracking down.
- The `is_user_database()` blocklist itself — left unchanged. The precheck is additive, handles both system schemas and orphans uniformly, and is self-healing for future cases.
- PR #1812 partially overlaps (adds `dolt` to the `is_user_database` blocklist). This PR's `SHOW TABLES` precheck strictly subsumes that change — `dolt` lacks a `wisps` table and would be skipped silently regardless. Maintainer's call which to land first.

Closes #1816

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->