### PR TITLE
fix(convoy,sourceworkflow): stamp close_reason on workflow-skipped cleanup closes

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch.go
+++ b/cmd/gc/cmd_convoy_dispatch.go
@@ -768,7 +768,10 @@ func closeWorkflowMatches(matches []workflowStoreMatch) int {
 	closed := 0
 	for _, m := range matches {
 		ids := workflowBeadIDs(m.beads)
-		n, _ := m.store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
+		n, _ := m.store.CloseAll(ids, map[string]string{
+			"gc.outcome":   "skipped",
+			"close_reason": sourceworkflow.WorkflowSkippedCloseReason,
+		})
 		closed += n
 	}
 	return closed
@@ -919,7 +922,10 @@ func openSourceWorkflowStoreRef(cfg *config.City, cityPath, storeRef string) (co
 
 func applySourceWorkflowMatchCleanup(match sourceWorkflowStoreMatch, deleteBeads bool, stderr io.Writer) (closed, deleted int, incomplete bool) {
 	ids := workflowBeadIDs(match.beads)
-	n, closeErr := match.store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
+	n, closeErr := match.store.CloseAll(ids, map[string]string{
+		"gc.outcome":   "skipped",
+		"close_reason": sourceworkflow.WorkflowSkippedCloseReason,
+	})
 	closed += n
 	if closeErr != nil {
 		incomplete = true

--- a/internal/api/huma_handlers_convoys.go
+++ b/internal/api/huma_handlers_convoys.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/sourceworkflow"
 )
 
 // convoyProgress is the shared {total, closed} progress shape used by
@@ -532,7 +533,10 @@ func (s *Server) humaDeleteWorkflow(workflowID string) (*OKResponse, error) {
 			continue
 		}
 		found = true
-		info.store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"}) //nolint:errcheck
+		info.store.CloseAll(ids, map[string]string{ //nolint:errcheck
+			"gc.outcome":   "skipped",
+			"close_reason": sourceworkflow.WorkflowSkippedCloseReason,
+		})
 	}
 
 	if !found {
@@ -675,7 +679,10 @@ func (s *Server) humaHandleWorkflowDelete(_ context.Context, input *WorkflowDele
 		found = true
 
 		// Phase 1: Batch close all open beads.
-		n, closeErr := info.store.CloseAll(ids, map[string]string{"gc.outcome": "skipped"})
+		n, closeErr := info.store.CloseAll(ids, map[string]string{
+			"gc.outcome":   "skipped",
+			"close_reason": sourceworkflow.WorkflowSkippedCloseReason,
+		})
 		closed += n
 		if closeErr != nil {
 			pa.record("store "+info.scopeRef+" close", closeErr)

--- a/internal/sourceworkflow/sourceworkflow.go
+++ b/internal/sourceworkflow/sourceworkflow.go
@@ -42,6 +42,18 @@ type ConflictError struct {
 // Used by WorkflowMatchesSource to scope cross-store singleton checks.
 const SourceStoreRefMetadataKey = "gc.source_store_ref"
 
+// WorkflowSkippedCloseReason is the canonical close_reason stamped on
+// workflow-subtree beads when they are force-closed via the
+// gc.outcome=skipped cleanup path (gc convoy delete --skip, force-replace
+// flows, or workflow-cleanup HTTP endpoints). Without an explicit reason
+// of >=20 chars, bd's validation.on-close=error rejects the close, the
+// bead stays open, and the cleanup is incomplete.
+//
+// Used in tandem with the gc.outcome=skipped metadata stamp (which
+// records the workflow-level outcome): close_reason satisfies the
+// validator; gc.outcome carries the semantic.
+const WorkflowSkippedCloseReason = "workflow cleanup: subtree bead force-closed via skip directive"
+
 // IsWorkflowRoot reports whether a bead is a source-workflow root. It must
 // stay in sync with sling.IsWorkflowAttachment: roots may be marked via the
 // legacy gc.kind=workflow label, via gc.formula_contract=graph.v2, or both.
@@ -434,7 +446,10 @@ func CloseWorkflowSubtree(store beads.Store, rootID string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return store.CloseAll(ordered, map[string]string{"gc.outcome": "skipped"})
+	return store.CloseAll(ordered, map[string]string{
+		"gc.outcome":   "skipped",
+		"close_reason": WorkflowSkippedCloseReason,
+	})
 }
 
 // WorkflowBeadSnapshot captures the mutable fields of a workflow subtree

--- a/internal/sourceworkflow/sourceworkflow_test.go
+++ b/internal/sourceworkflow/sourceworkflow_test.go
@@ -558,3 +558,60 @@ func TestCloseWorkflowSubtreeHandlesParentCycles(t *testing.T) {
 		}
 	}
 }
+
+// TestCloseWorkflowSubtree_StampsCloseReason verifies that the cleanup
+// path stamps both gc.outcome=skipped (the workflow-level outcome) and
+// close_reason=WorkflowSkippedCloseReason (the validator-satisfying
+// audit string). Under bd's validation.on-close=error, omitting the
+// close_reason silently leaves cleanup beads open.
+func TestCloseWorkflowSubtree_StampsCloseReason(t *testing.T) {
+	if got := len(WorkflowSkippedCloseReason); got < 20 {
+		t.Fatalf("WorkflowSkippedCloseReason = %q (%d chars), want >=20", WorkflowSkippedCloseReason, got)
+	}
+
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{
+		Title:    "root",
+		Type:     "task",
+		Metadata: map[string]string{"gc.kind": "workflow"},
+	})
+	if err != nil {
+		t.Fatalf("Create(root): %v", err)
+	}
+	child, err := store.Create(beads.Bead{
+		Title:    "child",
+		Type:     "task",
+		ParentID: root.ID,
+		Metadata: map[string]string{"gc.root_bead_id": root.ID},
+	})
+	if err != nil {
+		t.Fatalf("Create(child): %v", err)
+	}
+	if err := store.DepAdd(child.ID, root.ID, "parent-child"); err != nil {
+		t.Fatalf("DepAdd(child): %v", err)
+	}
+
+	closed, err := CloseWorkflowSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseWorkflowSubtree: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("CloseWorkflowSubtree closed %d beads, want 2", closed)
+	}
+
+	for _, id := range []string{root.ID, child.ID} {
+		bead, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if bead.Status != "closed" {
+			t.Fatalf("bead %s status = %q, want closed", id, bead.Status)
+		}
+		if got := bead.Metadata["close_reason"]; got != WorkflowSkippedCloseReason {
+			t.Errorf("bead %s close_reason = %q, want %q", id, got, WorkflowSkippedCloseReason)
+		}
+		if got := bead.Metadata["gc.outcome"]; got != "skipped" {
+			t.Errorf("bead %s gc.outcome = %q, want skipped", id, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes the silent-fail in workflow subtree cleanup under bd's `validation.on-close=error` mode. Five call sites across `cmd/gc`, `internal/api`, and `internal/sourceworkflow` stamped only `gc.outcome=skipped` on `store.CloseAll(...)`; without an explicit `close_reason` of >=20 chars, the validator rejects each close, the beads stay open, and the cleanup is incomplete.

Same shape as #1644 / #1680 / #1683 / #1693 — extends the canonical-reason coverage to the workflow-cleanup paths.

## Sites affected

| File | Function | Context |
| --- | --- | --- |
| `cmd/gc/cmd_convoy_dispatch.go:771` | `closeWorkflowMatches` | `gc convoy delete --skip` cleanup |
| `cmd/gc/cmd_convoy_dispatch.go:922` | `applySourceWorkflowMatchCleanup` | source-workflow force-replace cleanup |
| `internal/api/huma_handlers_convoys.go:535` | workflow delete handler | HTTP API workflow delete |
| `internal/api/huma_handlers_convoys.go:678` | workflow cleanup handler | HTTP API workflow cleanup |
| `internal/sourceworkflow/sourceworkflow.go:430` | `CloseWorkflowSubtree` | subtree force-close primitive |

## Single shared constant

```go
// internal/sourceworkflow/sourceworkflow.go
const WorkflowSkippedCloseReason = "workflow cleanup: subtree bead force-closed via skip directive"
```

All five call sites consume it. The pre-existing `gc.outcome=skipped` metadata is preserved (additive change, not a replacement) so any downstream tooling that filters on workflow outcome continues to work.

## Tests

`TestCloseWorkflowSubtree_StampsCloseReason` in `internal/sourceworkflow/sourceworkflow_test.go` verifies both metadata keys land on every bead in the subtree under `MemStore.CloseAll`.

## Why this matters

Without this fix, any city running `validation.on-close=error` cannot complete `gc convoy delete --skip`, force-replace, or HTTP-driven workflow cleanup — every cleanup leaves the subtree open and the validator silently rejects each close. The pre-fix metadata churn (`gc.outcome=skipped` stamped, but the close itself fails) makes the bug invisible until you trace bd's stderr.

## Checklist

- [x] Linked to validation.on-close=error campaign
- [x] Test for the canonical-reason stamping
- [x] Backward-compatible — `gc.outcome=skipped` metadata preserved
- [x] No breaking changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->