### PR TITLE
fix(beadmail): stamp close_reason on Archive and ArchiveMany closes

### DIFF
--- a/internal/mail/beadmail/beadmail.go
+++ b/internal/mail/beadmail/beadmail.go
@@ -219,6 +219,13 @@ func (p *Provider) MarkUnread(id string) error {
 	})
 }
 
+// MailArchivedCloseReason is the canonical close_reason stamped on
+// message beads when they are archived (or deleted, which has the same
+// storage semantics — see DeleteMany). Without an explicit reason of
+// >=20 chars, bd's validation.on-close=error rejects the close, the
+// message stays open, and the archive operation silently fails.
+const MailArchivedCloseReason = "beadmail: message archived without read"
+
 // Archive closes a message bead without reading it.
 func (p *Provider) Archive(id string) error {
 	b, err := p.store.Get(id)
@@ -231,6 +238,11 @@ func (p *Provider) Archive(id string) error {
 	if b.Status == "closed" {
 		return mail.ErrAlreadyArchived
 	}
+	// Stamp close_reason before Close so validation.on-close=error sees
+	// it on the close that follows. Best-effort: an error here is not
+	// fatal — Close still proceeds and any pre-existing close_reason is
+	// preserved.
+	_ = p.store.SetMetadata(id, "close_reason", MailArchivedCloseReason)
 	if err := p.store.Close(id); err != nil {
 		return fmt.Errorf("beadmail archive: %w", err)
 	}
@@ -277,8 +289,13 @@ func (p *Provider) ArchiveMany(ids []string) ([]mail.ArchiveResult, error) {
 	if len(openIDs) == 0 {
 		return results, nil
 	}
-	if _, err := p.store.CloseAll(openIDs, nil); err != nil {
+	if _, err := p.store.CloseAll(openIDs, map[string]string{
+		"close_reason": MailArchivedCloseReason,
+	}); err != nil {
 		for k, id := range openIDs {
+			// Per-id fallback also stamps the canonical reason so the
+			// retry path is validation-safe under on-close=error.
+			_ = p.store.SetMetadata(id, "close_reason", MailArchivedCloseReason)
 			if closeErr := p.store.Close(id); closeErr != nil {
 				results[openIdx[k]].Err = fmt.Errorf("beadmail archive: %w", closeErr)
 			}

--- a/internal/mail/beadmail/beadmail_test.go
+++ b/internal/mail/beadmail/beadmail_test.go
@@ -686,6 +686,73 @@ func TestArchiveNotFound(t *testing.T) {
 	}
 }
 
+// TestArchiveStampsCloseReason verifies that Archive stamps
+// close_reason=MailArchivedCloseReason on the closed message bead.
+// Without this, bd's validation.on-close=error rejects the close and
+// leaves the message open silently.
+func TestArchiveStampsCloseReason(t *testing.T) {
+	if got := len(MailArchivedCloseReason); got < 20 {
+		t.Fatalf("MailArchivedCloseReason = %q (%d chars), want >=20", MailArchivedCloseReason, got)
+	}
+
+	store := beads.NewMemStore()
+	p := New(store)
+
+	sent, err := p.Send("human", "mayor", "", "dismiss me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Archive(sent.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	b, err := store.Get(sent.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := b.Metadata["close_reason"]; got != MailArchivedCloseReason {
+		t.Errorf("close_reason = %q, want %q", got, MailArchivedCloseReason)
+	}
+}
+
+// TestArchiveManyStampsCloseReason verifies the batch-archive path also
+// stamps close_reason on every closed bead.
+func TestArchiveManyStampsCloseReason(t *testing.T) {
+	store := beads.NewMemStore()
+	p := New(store)
+
+	a, err := p.Send("human", "mayor", "", "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := p.Send("human", "mayor", "", "second")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := p.ArchiveMany([]string{a.ID, b.ID})
+	if err != nil {
+		t.Fatalf("ArchiveMany: %v", err)
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Errorf("ArchiveMany[%d].Err = %v", i, r.Err)
+		}
+	}
+	for _, id := range []string{a.ID, b.ID} {
+		got, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("store.Get(%s): %v", id, err)
+		}
+		if got.Status != "closed" {
+			t.Errorf("bead %s status = %q, want closed", id, got.Status)
+		}
+		if reason := got.Metadata["close_reason"]; reason != MailArchivedCloseReason {
+			t.Errorf("bead %s close_reason = %q, want %q", id, reason, MailArchivedCloseReason)
+		}
+	}
+}
+
 // --- Delete ---
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Closes the silent-fail in beadmail's archive paths under bd's `validation.on-close=error` mode. Both `Archive` (single) and `ArchiveMany` (batch) called `Close`/`CloseAll` without stamping a `close_reason`; under `on-close=error`, the validator rejects every close, the message bead stays open, and `Archive` returns success while the message remains in the inbox.

## Sites affected

| Function | Pre-fix | Post-fix |
| --- | --- | --- |
| `Archive(id)` | `p.store.Close(id)` (no metadata channel) | `SetMetadata(id, "close_reason", ...)` then `Close(id)` |
| `ArchiveMany(ids)` | `p.store.CloseAll(openIDs, nil)` | `CloseAll(openIDs, {"close_reason": ...})`; per-id fallback also stamps before `Close` |

## Single new constant

```go
const MailArchivedCloseReason = "beadmail: message archived without read"
```

## Tests

- `TestArchiveStampsCloseReason` — single-archive path verifies the metadata key lands on the closed bead.
- `TestArchiveManyStampsCloseReason` — batch path verifies the metadata key lands on every bead in the batch.

## Same shape as

#1644 / #1680 / #1683 / #1693 / convoy-cleanup PR — extends canonical-reason coverage to the beadmail close paths.

## Checklist

- [x] Linked to validation.on-close=error campaign
- [x] Tests for both paths
- [x] Backward-compatible — no behavior change when `validation.on-close=error` is off
- [x] No breaking changes; pre-existing message metadata preserved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->