### PR TITLE
fix(molecule): stamp close_reason on CloseSubtree force-close

### DIFF
--- a/internal/molecule/cleanup.go
+++ b/internal/molecule/cleanup.go
@@ -9,6 +9,14 @@ import (
 	"github.com/gastownhall/gascity/internal/beads/closeorder"
 )
 
+// SubtreeClosedReason is the canonical close_reason stamped on every
+// bead in a molecule subtree when CloseSubtree force-closes it. Without
+// an explicit reason of >=20 chars, bd's validation.on-close=error
+// rejects the close, the subtree stays open, and downstream cleanup
+// (sling.CloseAttachedSubtree, formula teardown, etc.) is silently
+// incomplete.
+const SubtreeClosedReason = "molecule cleanup: subtree force-closed by CloseSubtree"
+
 // ListSubtree returns the root bead and all transitive parent-child
 // descendants, including already-closed beads so nested open descendants are
 // still reachable through a closed intermediate node.
@@ -132,5 +140,7 @@ func CloseSubtree(store beads.Store, rootID string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return store.CloseAll(ordered, nil)
+	return store.CloseAll(ordered, map[string]string{
+		"close_reason": SubtreeClosedReason,
+	})
 }

--- a/internal/molecule/cleanup_test.go
+++ b/internal/molecule/cleanup_test.go
@@ -280,3 +280,46 @@ func TestCloseSubtreeHandlesParentCycles(t *testing.T) {
 		}
 	}
 }
+
+// TestCloseSubtree_StampsCloseReason verifies that CloseSubtree stamps
+// close_reason=SubtreeClosedReason on every bead in the closed subtree.
+// Without this, bd's validation.on-close=error rejects the close, the
+// subtree stays open, and sling.CloseAttachedSubtree (which delegates
+// here for non-workflow molecule attachments) silently leaves
+// descendants alive.
+func TestCloseSubtree_StampsCloseReason(t *testing.T) {
+	if got := len(SubtreeClosedReason); got < 20 {
+		t.Fatalf("SubtreeClosedReason = %q (%d chars), want >=20", SubtreeClosedReason, got)
+	}
+
+	store := beads.NewMemStore()
+	root, err := store.Create(beads.Bead{Title: "root", Type: "molecule"})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	child, err := store.Create(beads.Bead{Title: "child", ParentID: root.ID})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	closed, err := CloseSubtree(store, root.ID)
+	if err != nil {
+		t.Fatalf("CloseSubtree: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("CloseSubtree closed %d beads, want 2", closed)
+	}
+
+	for _, id := range []string{root.ID, child.ID} {
+		bead, err := store.Get(id)
+		if err != nil {
+			t.Fatalf("Get(%s): %v", id, err)
+		}
+		if bead.Status != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, bead.Status)
+		}
+		if got := bead.Metadata["close_reason"]; got != SubtreeClosedReason {
+			t.Errorf("%s close_reason = %q, want %q", id, got, SubtreeClosedReason)
+		}
+	}
+}


### PR DESCRIPTION
Closes the silent-fail in `molecule.CloseSubtree` under bd's `validation.on-close=error` mode. The pre-fix call passed `nil` metadata to `store.CloseAll`, so the validator (which requires `close_reason` >=20 chars) rejected every close, the subtree stayed open, and all callers — `sling.CloseAttachedSubtree` (the non-workflow attachment teardown), formula teardown, etc. — silently completed with the subtree still open.

## Single site, transitive impact

| File | Site |
| --- | --- |
| `internal/molecule/cleanup.go:125` | `CloseSubtree` body — single `store.CloseAll(ids, nil)` call |

`internal/sling/sling_attachment.go:152` (`CloseAttachedSubtree`) is the public consumer; fixing the callee fixes both.

## Single new constant

```go
const SubtreeClosedReason = "molecule cleanup: subtree force-closed by CloseSubtree"
```

## Tests

`TestCloseSubtree_StampsCloseReason` verifies the metadata key lands on every bead in the closed subtree under `MemStore.CloseAll`.

## Same shape as

#1644 / #1680 / #1683 / #1693 plus the workflow / beadmail companion PRs in this same `validation.on-close=error` campaign.

## Checklist

- [x] Linked to validation.on-close=error campaign
- [x] Test for the canonical-reason stamping
- [x] Backward-compatible — no behavior change when `validation.on-close=error` is off
- [x] No breaking changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->