### PR TITLE
fix(codex): canonicalize managed hook bytes

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -350,13 +350,17 @@ func readClaudeSettingsCandidate(fs fsys.FS, path string) (claudeCandidateState,
 
 func writeCodexHooksManaged(fs fsys.FS, dst string, data []byte) error {
 	if existing, err := fs.ReadFile(dst); err == nil {
-		upgraded, changed, upgradeErr := upgradeCodexHookCommands(existing)
+		upgraded, changed, upgradeErr := normalizeCodexHookCommands(existing)
 		if upgradeErr != nil || !changed {
 			return nil
 		}
 		return writeManagedData(fs, dst, upgraded)
 	} else if _, statErr := fs.Stat(dst); statErr == nil {
 		return nil
+	}
+	normalized, _, err := normalizeCodexHookCommands(data)
+	if err == nil {
+		data = normalized
 	}
 	return writeManagedData(fs, dst, data)
 }
@@ -372,19 +376,21 @@ func writeManagedData(fs fsys.FS, dst string, data []byte) error {
 	return nil
 }
 
-func upgradeCodexHookCommands(existing []byte) ([]byte, bool, error) {
+func normalizeCodexHookCommands(existing []byte) ([]byte, bool, error) {
 	var root any
 	if err := json.Unmarshal(existing, &root); err != nil {
 		return nil, false, err
 	}
-	if !upgradeCodexHookValue(root) {
-		return nil, false, nil
-	}
+	changed := upgradeCodexHookValue(root)
 	data, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return nil, false, err
 	}
-	return append(data, '\n'), true, nil
+	data = append(data, '\n')
+	if !bytes.Equal(data, existing) {
+		changed = true
+	}
+	return data, changed, nil
 }
 
 func upgradeCodexHookValue(v any) bool {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -277,6 +278,22 @@ func TestInstallCodexUpgradesGeneratedFileMissingHookFormat(t *testing.T) {
 	got := string(fs.Files["/work/.codex/hooks.json"])
 	if !strings.Contains(got, "--hook-format codex") {
 		t.Errorf("upgraded codex hooks missing Codex hook output format:\n%s", got)
+	}
+}
+
+func TestInstallCodexWritesCanonicalHookBytes(t *testing.T) {
+	fs := fsys.NewFake()
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got := fs.Files["/work/.codex/hooks.json"]
+	normalized, changed, err := normalizeCodexHookCommands(got)
+	if err != nil {
+		t.Fatalf("normalizeCodexHookCommands: %v", err)
+	}
+	if changed || !bytes.Equal(normalized, got) {
+		t.Fatalf("codex hook install should write canonical bytes")
 	}
 }
 


### PR DESCRIPTION
## Summary
- canonicalize managed Codex hook JSON before writing it
- keep existing hook upgrade behavior while treating formatting drift as a managed change
- add regression coverage that installed Codex hooks are already in canonical byte form

## Verification
- docker run --rm -v /tmp/gascity-src:/src -w /src golang:1.25.9-bookworm bash -lc 'export PATH=/usr/local/go/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/tudorsaitoc/.codex/tmp/arg0/codex-arg088KpuO:/Users/tudorsaitoc/.pyenv/shims:/Users/tudorsaitoc/.pyenv/bin:/Users/tudorsaitoc/bin:/Users/tudorsaitoc/.local/bin:/Applications/Ghostty.app/Contents/MacOS; go test ./internal/hooks ./internal/runtime ./cmd/gc -run "TestInstallCodexWritesCanonicalHookBytes|TestInstallCodexUpgradesGeneratedFileMissingHookFormat|TestInstallOverlayManagedProviders|TestConfigFingerprintIncludesCopyFiles|TestLogCoreFingerprintDriftCopyFiles|TestParseDriftDrainTimeout"'

## Context
This fixes the CopyFiles fingerprint drift observed on desktop3080saitoc where the Codex hook installer wrote raw embedded JSON, then session startup rewrote the same JSON through MarshalIndent. The bytes changed even though the hook semantics did not, causing config-drift drains.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->