### PR TITLE
fix(dispatch): keep scope checks retryable during closeout

### DIFF
--- a/internal/dispatch/runtime.go
+++ b/internal/dispatch/runtime.go
@@ -176,11 +176,6 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 	}
 
 	if isRetryAttemptSubject(subject) {
-		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
-			return setOutcomeAndClose(store, bead.ID, "pass")
-		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: completing retry-attempt control bead: %w", bead.ID, err)
-		}
 		remainingOpen, err := tracePhase(opts, bead.ID, "check-open-members", func() (bool, error) {
 			return hasOpenScopeMembers(store, rootID, scopeRef, bead.ID)
 		})
@@ -219,7 +214,17 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 					return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
 				}
 			}
+			if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
+				return setOutcomeAndClose(store, bead.ID, "pass")
+			}); err != nil {
+				return ControlResult{}, fmt.Errorf("%s: completing retry-attempt control bead: %w", bead.ID, err)
+			}
 			return ControlResult{Processed: true, Action: "scope-pass"}, nil
+		}
+		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
+			return setOutcomeAndClose(store, bead.ID, "pass")
+		}); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: completing retry-attempt control bead: %w", bead.ID, err)
 		}
 		return ControlResult{Processed: true, Action: "continue"}, nil
 	}
@@ -244,11 +249,6 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 		if err != nil {
 			return ControlResult{}, fmt.Errorf("%s: aborting scope: %w", bead.ID, err)
 		}
-		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
-			return setOutcomeAndClose(store, bead.ID, "pass")
-		}); err != nil {
-			return ControlResult{}, fmt.Errorf("%s: completing control bead: %w", bead.ID, err)
-		}
 		if body.Status != "closed" {
 			if err := tracePhaseErr(opts, bead.ID, "close-body-fail", func() error {
 				return setOutcomeAndClose(store, body.ID, "fail")
@@ -256,13 +256,12 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 				return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
 			}
 		}
+		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
+			return setOutcomeAndClose(store, bead.ID, "pass")
+		}); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: completing control bead: %w", bead.ID, err)
+		}
 		return ControlResult{Processed: true, Action: "scope-fail", Skipped: skipped}, nil
-	}
-
-	if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
-		return setOutcomeAndClose(store, bead.ID, "pass")
-	}); err != nil {
-		return ControlResult{}, fmt.Errorf("%s: completing control bead: %w", bead.ID, err)
 	}
 
 	remainingOpen, err := tracePhase(opts, bead.ID, "check-open-members", func() (bool, error) {
@@ -311,7 +310,17 @@ func processScopeCheck(store beads.Store, bead beads.Bead, opts ProcessOptions) 
 				return ControlResult{}, fmt.Errorf("%s: completing scope body: %w", body.ID, err)
 			}
 		}
+		if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
+			return setOutcomeAndClose(store, bead.ID, "pass")
+		}); err != nil {
+			return ControlResult{}, fmt.Errorf("%s: completing control bead: %w", bead.ID, err)
+		}
 		return ControlResult{Processed: true, Action: "scope-pass"}, nil
+	}
+	if err := tracePhaseErr(opts, bead.ID, "close-control", func() error {
+		return setOutcomeAndClose(store, bead.ID, "pass")
+	}); err != nil {
+		return ControlResult{}, fmt.Errorf("%s: completing control bead: %w", bead.ID, err)
 	}
 
 	return ControlResult{Processed: true, Action: "continue"}, nil

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -261,6 +261,70 @@ func TestProcessScopeCheckPassWithRemainingOpenAvoidsClosedSnapshot(t *testing.T
 	}
 }
 
+func TestProcessScopeCheckKeepsControlOpenIfBodyCloseoutFails(t *testing.T) {
+	t.Parallel()
+
+	base := beads.NewMemStore()
+	store := &failBodyMetadataStore{Store: base}
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	body := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "body",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope",
+			"gc.scope_role":   "body",
+			"gc.root_bead_id": workflow.ID,
+			"gc.step_ref":     "body",
+		},
+	})
+	store.failID = body.ID
+	step := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title:  "apply fixes",
+		Type:   "task",
+		Status: "closed",
+		Metadata: map[string]string{
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "member",
+			"gc.outcome":      "pass",
+			"review.verdict":  "done",
+		},
+	})
+	control := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Finalize scope for apply fixes",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "scope-check",
+			"gc.root_bead_id": workflow.ID,
+			"gc.scope_ref":    "body",
+			"gc.scope_role":   "control",
+		},
+	})
+	mustDepAdd(t, store, control.ID, step.ID, "blocks")
+	mustDepAdd(t, store, body.ID, control.ID, "blocks")
+
+	_, err := ProcessControl(store, mustGetBead(t, store, control.ID), ProcessOptions{})
+	if err == nil {
+		t.Fatal("ProcessControl(scope-check) succeeded, want injected closeout error")
+	}
+
+	controlAfter := mustGetBead(t, store, control.ID)
+	if controlAfter.Status != "open" {
+		t.Fatalf("control status = %q, want open so dispatcher can retry body closeout", controlAfter.Status)
+	}
+	bodyAfter := mustGetBead(t, store, body.ID)
+	if bodyAfter.Status != "open" {
+		t.Fatalf("body status = %q, want open after failed closeout", bodyAfter.Status)
+	}
+}
+
 func TestProcessScopeCheckAbortsScopeOnFailure(t *testing.T) {
 	t.Parallel()
 
@@ -737,6 +801,18 @@ func (s *scopeSnapshotQueryGuardStore) List(query beads.ListQuery) ([]beads.Bead
 		}
 	}
 	return s.Store.List(query)
+}
+
+type failBodyMetadataStore struct {
+	beads.Store
+	failID string
+}
+
+func (s *failBodyMetadataStore) SetMetadataBatch(id string, kvs map[string]string) error {
+	if id == s.failID && kvs["review.verdict"] != "" {
+		return errors.New("injected body metadata failure")
+	}
+	return s.Store.SetMetadataBatch(id, kvs)
 }
 
 func newStrictCloseStore() *strictCloseStore {


### PR DESCRIPTION
## Summary

- keep scope-check control beads open until terminal body closeout succeeds, so interrupted closeout can retry
- add a regression test for body metadata/closeout failure keeping the control bead open

## RCA

Two stuck PR-review scope checks had closed their control bead before closing the scope body. If the dispatcher stopped after that early close, the control bead was no longer eligible to retry and the body stayed open, leaving the parent workflow pending.

## Test

- go test ./internal/dispatch -count=1
- full pre-commit hook: make check / observable go test passed during commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->