### PR TITLE
fix(gastown): publish PRs without gh

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -86,6 +86,63 @@ func assertCurrentWispBurnsGuarded(t *testing.T, name, body string) {
 	}
 }
 
+func refineryMergePushDescription(t *testing.T) string {
+	t.Helper()
+	parser := formula.NewParser(gastownFormulaSearchPaths()...)
+	f, err := parser.ParseFile(filepath.Join(exampleDir(), "packs", "gastown", "formulas", "mol-refinery-patrol.toml"))
+	if err != nil {
+		t.Fatalf("parsing refinery formula: %v", err)
+	}
+	for _, step := range f.Steps {
+		if step.ID == "merge-push" {
+			return step.Description
+		}
+	}
+	t.Fatal("refinery formula missing merge-push step")
+	return ""
+}
+
+func extractBetween(t *testing.T, body, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(body, startMarker)
+	if start == -1 {
+		t.Fatalf("missing start marker %q", startMarker)
+	}
+	end := strings.Index(body[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("missing end marker %q after %q", endMarker, startMarker)
+	}
+	return body[start : start+end]
+}
+
+func refineryPRHelpers(t *testing.T) string {
+	t.Helper()
+	return extractBetween(t, refineryMergePushDescription(t), "pr_lookup_missing() {", "\nif [ \"$MERGE_STRATEGY\" = \"mr\" ]")
+}
+
+func refineryPRSetupHelpers(t *testing.T) string {
+	t.Helper()
+	return extractBetween(t, refineryMergePushDescription(t), "block_existing_pr() {", "\nif [ \"$MERGE_STRATEGY\" = \"mr\" ]")
+}
+
+func refineryExistingPRValidationBlock(t *testing.T) string {
+	t.Helper()
+	return extractBetween(t, refineryMergePushDescription(t), `if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then`, "\n```\n\n**If MERGE_STRATEGY")
+}
+
+func linkTestCommands(t *testing.T, binDir string, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			t.Fatalf("finding %s: %v", name, err)
+		}
+		if err := os.Symlink(path, filepath.Join(binDir, name)); err != nil {
+			t.Fatalf("linking %s: %v", name, err)
+		}
+	}
+}
+
 func assertCurrentWispBurnsRequireSuccessor(t *testing.T, name, body string) {
 	t.Helper()
 	lines := strings.Split(body, "\n")
@@ -590,8 +647,11 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 	body := string(data)
 	for _, want := range []string{
 		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')`,
-		`ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)`,
+		`if command -v gh >/dev/null 2>&1; then`,
+		`ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>&1)`,
+		`ORIGIN_REPO_ERROR="gh repo view failed while resolving origin repository: $ORIGIN_REPO"`,
 		`ORIGIN_REPO=$(printf '%s\n' "$ORIGIN_URL"`,
+		`GitHub REST fallback supports only github.com origin remotes`,
 		`metadata.existing_pr requires pull-request handoff; using merge_strategy=mr`,
 		`block_existing_pr()`,
 		`--assignee=""`,
@@ -604,9 +664,17 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 		`if [ -n "$CURRENT_WISP" ]; then`,
 		`gc bd mol burn "$CURRENT_WISP" --force`,
 		`pr_lookup_missing()`,
+		`pr_lookup_repo_mismatch()`,
+		`resolve_github_token()`,
+		`TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-${GIT_TOKEN:-}}}"`,
+		`init_github_rest()`,
+		`curl_gh_api()`,
+		`-H "Content-Type: application/json"`,
+		`lookup_pr_info()`,
 		`EXISTING_PR_ERR=$(mktemp)`,
-		`EXISTING_PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$EXISTING_PR" 2>"$EXISTING_PR_ERR")`,
+		`EXISTING_PR_INFO=$(lookup_pr_info "$EXISTING_PR" "$EXISTING_PR_ERR")`,
 		`EXISTING_PR_STATUS=$?`,
+		`if pr_lookup_repo_mismatch "$EXISTING_PR_ERROR"; then`,
 		`if pr_lookup_missing "$EXISTING_PR_ERROR"; then`,
 		`Existing PR $EXISTING_PR was not found or is not accessible.`,
 		`Could not resolve existing PR $EXISTING_PR. STOP. Debug and retry without mutating bead state.`,
@@ -627,8 +695,11 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 		`command -v gh >/dev/null 2>&1`,
 		`printf 'protocol=https\nhost=github.com\n\n'`,
 		`git credential fill 2>/dev/null`,
+		`PR_NUMBER=$(printf '%s\n' "$ref" | sed -nE`,
 		`--data-urlencode "head=$OWNER:$BRANCH"`,
 		`-X POST "$API/pulls"`,
+		`PR_NUMBER=$(printf '%s\n' "$CREATED" | jq -r '.number // empty')`,
+		`GitHub API request failed while creating a PR for $BRANCH.`,
 		`state:(.state | ascii_upcase)`,
 		`headRepositoryOwner:{login:.head.repo.owner.login}`,
 		`PR_REPO=$(printf '%s\n' "$PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')`,
@@ -641,10 +712,327 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 	}
 	assertContainsInOrder(t, body,
 		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')`,
-		`EXISTING_PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$EXISTING_PR" 2>"$EXISTING_PR_ERR")`,
+		`EXISTING_PR_INFO=$(lookup_pr_info "$EXISTING_PR" "$EXISTING_PR_ERR")`,
 		`git push origin HEAD:$BRANCH --force-with-lease`,
 		`gh pr create`,
+		`PR_INFO=$(lookup_pr_info "$PR_REF" "$PR_ERR")`,
 	)
+}
+
+func TestRefineryFormulaExistingPRNoGhUsesSharedRESTLookup(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		`lookup_pr_info() {`,
+		`if command -v gh >/dev/null 2>&1; then`,
+		`gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$ref"`,
+		`if ! init_github_rest 2>"$err_file"; then`,
+		`PR_NUMBER=$(printf '%s\n' "$ref" | sed -nE`,
+		`--data-urlencode "head=$OWNER:$ref"`,
+		`PR_RAW=$(curl_gh_api "$err_file" "$API/pulls/$PR_NUMBER") || return 1`,
+		`jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}'`,
+	)
+	assertContainsInOrder(t, body,
+		`if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then`,
+		`EXISTING_PR_INFO=$(lookup_pr_info "$EXISTING_PR" "$EXISTING_PR_ERR")`,
+		`git push origin HEAD:$BRANCH --force-with-lease`,
+		`PR_INFO=$(lookup_pr_info "$PR_REF" "$PR_ERR")`,
+	)
+	if strings.Contains(body, `EXISTING_PR_INFO=$(gh pr view`) {
+		t.Fatal("existing_pr validation must go through lookup_pr_info so the no-gh REST fallback is reachable")
+	}
+	if strings.Contains(body, `eval value=`) {
+		t.Fatal("GitHub token discovery should avoid eval-based env indirection")
+	}
+}
+
+func TestRefineryFormulaExistingPRNoGhRejectsCrossRepoFullURL(t *testing.T) {
+	helpers := refineryPRHelpers(t)
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("creating bin dir: %v", err)
+	}
+	linkTestCommands(t, binDir, "cat", "grep", "head", "jq", "sed")
+	curlPath := filepath.Join(binDir, "curl")
+	curlStub := `#!/bin/sh
+case "$*" in
+  *"/repos/origin/repo/pulls/42"*)
+    cat <<'JSON'
+{"html_url":"https://github.com/origin/repo/pull/42","number":42,"state":"open","head":{"ref":"feature","repo":{"owner":{"login":"origin"},"name":"repo"}},"base":{"ref":"main"}}
+JSON
+    ;;
+  *)
+    echo "unexpected curl arguments: $*" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(curlPath, []byte(curlStub), 0o755); err != nil {
+		t.Fatalf("writing curl stub: %v", err)
+	}
+
+	script := `set -eu
+ORIGIN_REPO="origin/repo"
+ORIGIN_REPO_ERROR=""
+GH_TOKEN="test-token"
+TARGET="main"
+` + helpers + `
+err_file="$PWD/lookup.err"
+if out=$(lookup_pr_info "https://github.com/other/repo/pull/42" "$err_file"); then
+  echo "lookup_pr_info unexpectedly resolved cross-repo URL: $out"
+  exit 1
+fi
+if ! grep -q "belongs to repo other/repo, want origin/repo" "$err_file"; then
+  cat "$err_file"
+  exit 1
+fi
+`
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = []string{"PATH=" + binDir, "HOME=" + tmp}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cross-repo full URL lookup should fail before origin REST lookup: %v\n%s", err, out)
+	}
+}
+
+func TestRefineryFormulaNoGhRESTLookupExecutesNumberAndBranchPaths(t *testing.T) {
+	helpers := refineryPRHelpers(t)
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("creating bin dir: %v", err)
+	}
+	linkTestCommands(t, binDir, "cat", "head", "jq", "sed")
+	curlPath := filepath.Join(binDir, "curl")
+	curlStub := `#!/bin/sh
+case "$*" in
+  *"/repos/origin/repo/pulls/42"*)
+    cat <<'JSON'
+{"html_url":"https://github.com/origin/repo/pull/42","number":42,"state":"open","head":{"ref":"feature","repo":{"owner":{"login":"origin"},"name":"repo"}},"base":{"ref":"main"}}
+JSON
+    ;;
+  *"--get https://api.github.com/repos/origin/repo/pulls"*head=origin:feature*base=main*)
+    cat <<'JSON'
+[{"number":43}]
+JSON
+    ;;
+  *"/repos/origin/repo/pulls/43"*)
+    cat <<'JSON'
+{"html_url":"https://github.com/origin/repo/pull/43","number":43,"state":"open","head":{"ref":"feature","repo":{"owner":{"login":"origin"},"name":"repo"}},"base":{"ref":"main"}}
+JSON
+    ;;
+  *)
+    echo "unexpected curl arguments: $*" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(curlPath, []byte(curlStub), 0o755); err != nil {
+		t.Fatalf("writing curl stub: %v", err)
+	}
+
+	script := `set -eu
+ORIGIN_REPO="origin/repo"
+ORIGIN_REPO_ERROR=""
+GH_TOKEN="test-token"
+TARGET="main"
+` + helpers + `
+err_file="$PWD/lookup.err"
+number_out=$(lookup_pr_info "42" "$err_file")
+printf '%s\n' "$number_out" | jq -e '.url == "https://github.com/origin/repo/pull/42" and .state == "OPEN"' >/dev/null
+branch_out=$(lookup_pr_info "feature" "$err_file")
+printf '%s\n' "$branch_out" | jq -e '.url == "https://github.com/origin/repo/pull/43" and .headRefName == "feature"' >/dev/null
+`
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = []string{"PATH=" + binDir, "HOME=" + tmp}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("REST lookup should resolve numeric and branch refs: %v\n%s", err, out)
+	}
+}
+
+func TestRefineryFormulaNoGhPRCreateSendsJSONContentType(t *testing.T) {
+	helpers := refineryPRHelpers(t)
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("creating bin dir: %v", err)
+	}
+	linkTestCommands(t, binDir, "cat", "head", "jq", "sed")
+	curlPath := filepath.Join(binDir, "curl")
+	curlStub := `#!/bin/sh
+saw_content_type=0
+for arg in "$@"; do
+  if [ "$arg" = "Content-Type: application/json" ]; then
+    saw_content_type=1
+  fi
+done
+if [ "$saw_content_type" -ne 1 ]; then
+  echo "missing JSON content type: $*" >&2
+  exit 2
+fi
+case "$*" in
+  *"-X POST https://api.github.com/repos/origin/repo/pulls"*)
+    cat <<'JSON'
+{"number":44}
+JSON
+    ;;
+  *)
+    echo "unexpected curl arguments: $*" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(curlPath, []byte(curlStub), 0o755); err != nil {
+		t.Fatalf("writing curl stub: %v", err)
+	}
+
+	script := `set -eu
+ORIGIN_REPO="origin/repo"
+ORIGIN_REPO_ERROR=""
+GH_TOKEN="test-token"
+TARGET="main"
+` + helpers + `
+err_file="$PWD/create.err"
+init_github_rest 2>"$err_file"
+CREATE_PAYLOAD=$(jq -n \
+  --arg title "Demo (ga-test)" \
+  --arg head "feature" \
+  --arg base "main" \
+  --arg body "body" \
+  '{title:$title, head:$head, base:$base, body:$body}')
+created=$(curl_gh_api "$err_file" -X POST "$API/pulls" -d "$CREATE_PAYLOAD")
+[ "$(printf '%s\n' "$created" | jq -r '.number')" = "44" ]
+`
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = []string{"PATH=" + binDir, "HOME=" + tmp}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("REST create should send JSON content type: %v\n%s", err, out)
+	}
+}
+
+func TestRefineryFormulaResolveGithubTokenUsesNonInteractiveCredentialFill(t *testing.T) {
+	helpers := refineryPRHelpers(t)
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("creating bin dir: %v", err)
+	}
+	linkTestCommands(t, binDir, "cat", "head", "sed")
+	gitPath := filepath.Join(binDir, "git")
+	gitStub := `#!/bin/sh
+if [ "$1" != "credential" ] || [ "$2" != "fill" ]; then
+  echo "unexpected git arguments: $*" >&2
+  exit 2
+fi
+if [ "${GIT_TERMINAL_PROMPT:-}" != "0" ]; then
+  echo "GIT_TERMINAL_PROMPT was not disabled" >&2
+  exit 2
+fi
+input=$(cat)
+case "$input" in
+  *"protocol=https"*host=github.com*)
+    printf 'protocol=https\nhost=github.com\nusername=test\npassword=credential-token\n\n'
+    ;;
+  *)
+    echo "unexpected credential input: $input" >&2
+    exit 2
+    ;;
+esac
+`
+	if err := os.WriteFile(gitPath, []byte(gitStub), 0o755); err != nil {
+		t.Fatalf("writing git stub: %v", err)
+	}
+
+	script := `set -eu
+ORIGIN_REPO="origin/repo"
+ORIGIN_REPO_ERROR=""
+TARGET="main"
+unset GH_TOKEN GITHUB_TOKEN GIT_TOKEN
+` + helpers + `
+[ "$(resolve_github_token)" = "credential-token" ]
+`
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = []string{"PATH=" + binDir, "HOME=" + tmp}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("credential fallback should be non-interactive: %v\n%s", err, out)
+	}
+}
+
+func TestRefineryFormulaExistingPRNoGhCrossRepoEscalatesToHuman(t *testing.T) {
+	helpers := refineryPRSetupHelpers(t)
+	existingPRBlock := refineryExistingPRValidationBlock(t)
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("creating bin dir: %v", err)
+	}
+	linkTestCommands(t, binDir, "cat", "grep", "head", "jq", "mktemp", "rm", "sed")
+	gcPath := filepath.Join(binDir, "gc")
+	gcStub := `#!/bin/sh
+printf '%s\n' "$*" >> "$GC_LOG"
+if [ "$1" = "bd" ] && [ "$2" = "mol" ] && [ "$3" = "wisp" ]; then
+  printf '{"new_epic_id":"next-wisp"}\n'
+fi
+exit 0
+`
+	if err := os.WriteFile(gcPath, []byte(gcStub), 0o755); err != nil {
+		t.Fatalf("writing gc stub: %v", err)
+	}
+	curlPath := filepath.Join(binDir, "curl")
+	if err := os.WriteFile(curlPath, []byte("#!/bin/sh\necho unexpected curl >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatalf("writing curl stub: %v", err)
+	}
+
+	script := `set +e
+ORIGIN_REPO="origin/repo"
+ORIGIN_REPO_ERROR=""
+GH_TOKEN="test-token"
+TARGET="main"
+BRANCH="feature"
+MERGE_STRATEGY="mr"
+EXISTING_PR="https://github.com/other/repo/pull/42"
+WORK="ga-work"
+GC_AGENT="refinery-agent"
+GC_BEAD_ID="current-wisp"
+` + helpers + `
+(
+` + existingPRBlock + `
+)
+status=$?
+if [ "$status" -eq 0 ]; then
+  echo "expected validation block to stop after human escalation"
+  exit 1
+fi
+grep -q -- "--set-metadata gc.routed_to=human" "$GC_LOG" || exit 1
+grep -q -- "ESCALATION: invalid existing_pr" "$GC_LOG" || exit 1
+grep -q -- "runtime drain-ack" "$GC_LOG" || exit 1
+`
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Dir = tmp
+	cmd.Env = []string{"PATH=" + binDir, "HOME=" + tmp, "GC_LOG=" + filepath.Join(tmp, "gc.log")}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cross-repo existing_pr should route to human on no-gh hosts: %v\n%s", err, out)
+	}
 }
 
 func TestWorktreeSetupKeepsIgnoresLocal(t *testing.T) {

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -324,6 +324,8 @@ func TestRefineryFormulaSupportsMergeStrategies(t *testing.T) {
 	for _, want := range []string{
 		".metadata.merge_strategy // \"direct\"",
 		"gh pr create",
+		"git credential fill",
+		"https://api.github.com/repos/$OWNER/$REPO",
 		"Pull request ready:",
 		"merge_strategy=local",
 	} {
@@ -588,7 +590,8 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 	body := string(data)
 	for _, want := range []string{
 		`EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')`,
-		`ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')`,
+		`ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)`,
+		`ORIGIN_REPO=$(printf '%s\n' "$ORIGIN_URL"`,
 		`metadata.existing_pr requires pull-request handoff; using merge_strategy=mr`,
 		`block_existing_pr()`,
 		`--assignee=""`,
@@ -621,6 +624,13 @@ func TestRefineryFormulaRespectsExistingPRMetadata(t *testing.T) {
 		`PR_REF="$EXISTING_PR"`,
 		`PR_STATUS=$?`,
 		`if [ -n "$EXISTING_PR" ] && pr_lookup_missing "$PR_ERROR"; then`,
+		`command -v gh >/dev/null 2>&1`,
+		`printf 'protocol=https\nhost=github.com\n\n'`,
+		`git credential fill 2>/dev/null`,
+		`--data-urlencode "head=$OWNER:$BRANCH"`,
+		`-X POST "$API/pulls"`,
+		`state:(.state | ascii_upcase)`,
+		`headRepositoryOwner:{login:.head.repo.owner.login}`,
 		`PR_REPO=$(printf '%s\n' "$PR_URL" | sed -E 's#^https://github.com/([^/]+/[^/]+)/pull/[0-9]+$#\\1#')`,
 		`Existing PR $EXISTING_PR belongs to repo $PR_REPO, want $ORIGIN_REPO`,
 		`if [ -n "$EXISTING_PR" ]; then`,

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -379,11 +379,23 @@ BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
 TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
 EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
-ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
-if [ -z "$ORIGIN_REPO" ]; then
+ORIGIN_REPO_ERROR=""
+if command -v gh >/dev/null 2>&1; then
+  if ! ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>&1); then
+    ORIGIN_REPO_ERROR="gh repo view failed while resolving origin repository: $ORIGIN_REPO"
+    ORIGIN_REPO=""
+  fi
+else
   ORIGIN_URL=$(git remote get-url origin)
-  ORIGIN_REPO=$(printf '%s\n' "$ORIGIN_URL" \
-    | sed -E 's#^git@github.com:##; s#^https://github.com/##; s#\.git$##')
+  case "$ORIGIN_URL" in
+    git@github.com:*|https://github.com/*)
+      ORIGIN_REPO=$(printf '%s\n' "$ORIGIN_URL" \
+        | sed -E 's#^git@github.com:##; s#^https://github.com/##; s#\\.git$##')
+      ;;
+    *)
+      ORIGIN_REPO_ERROR="GitHub REST fallback supports only github.com origin remotes; install gh for $ORIGIN_URL."
+      ;;
+  esac
 fi
 if [ "$MERGE_STRATEGY" = "pr" ]; then
   MERGE_STRATEGY="mr"
@@ -444,9 +456,98 @@ Target: $TARGET"
 
 pr_lookup_missing() {
   case "$1" in
-    *"Could not resolve to a PullRequest"*|*"could not resolve to a PullRequest"*|*"no pull requests found"*|*"Not Found"*|*"not found"*) return 0 ;;
+    *"Could not resolve to a PullRequest"*|*"could not resolve to a PullRequest"*|*"no pull requests found"*|*"Not Found"*|*"not found"*|*"404"*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+pr_lookup_repo_mismatch() {
+  case "$1" in
+    *" belongs to repo "*", want "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_github_token() {
+  TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-${GIT_TOKEN:-}}}"
+  if [ -n "$TOKEN" ]; then
+    printf '%s\n' "$TOKEN"
+    return
+  fi
+  printf 'protocol=https\nhost=github.com\n\n' \
+    | GIT_TERMINAL_PROMPT=0 git credential fill 2>/dev/null \
+    | sed -n 's/^password=//p' \
+    | head -n 1
+}
+
+init_github_rest() {
+  if [ -n "${API:-}" ] && [ -n "${TOKEN:-}" ]; then
+    return 0
+  fi
+  if [ -n "$ORIGIN_REPO_ERROR" ]; then
+    echo "$ORIGIN_REPO_ERROR" >&2
+    return 1
+  fi
+  TOKEN=$(resolve_github_token)
+  if [ -z "$TOKEN" ]; then
+    echo "GitHub PR mode requires gh or a GitHub token available from env/git credential fill." >&2
+    return 1
+  fi
+  case "$ORIGIN_REPO" in
+    */*)
+      OWNER=${ORIGIN_REPO%%/*}
+      REPO=${ORIGIN_REPO#*/}
+      ;;
+    *)
+      echo "Could not resolve standard github.com origin repository for REST fallback." >&2
+      return 1
+      ;;
+  esac
+  API="https://api.github.com/repos/$OWNER/$REPO"
+}
+
+curl_gh_api() {
+  err_file="$1"
+  shift
+  curl -fsS \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@" 2>"$err_file"
+}
+
+lookup_pr_info() {
+  ref="$1"
+  err_file="$2"
+  if command -v gh >/dev/null 2>&1; then
+    gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$ref" 2>"$err_file"
+    return $?
+  fi
+  if ! init_github_rest 2>"$err_file"; then
+    return 1
+  fi
+  PR_REF_REPO=$(printf '%s\n' "$ref" | sed -nE 's#^[Hh][Tt][Tt][Pp][Ss]://github.com/([^/]+/[^/]+)/pull/[0-9]+/?$#\\1#p' | head -n 1)
+  if [ -n "$PR_REF_REPO" ] && [ "$PR_REF_REPO" != "$ORIGIN_REPO" ]; then
+    echo "Pull request $ref belongs to repo $PR_REF_REPO, want $ORIGIN_REPO." >"$err_file"
+    return 1
+  fi
+  PR_NUMBER=$(printf '%s\n' "$ref" | sed -nE 's#^[Hh][Tt][Tt][Pp][Ss]://github.com/[^/]+/[^/]+/pull/([0-9]+)/?$#\\1#p; s|^#([0-9]+)$|\\1|p; s|^([0-9]+)$|\\1|p' | head -n 1)
+  if [ -z "$PR_NUMBER" ]; then
+    PR_MATCHES=$(curl_gh_api "$err_file" \
+      --get "$API/pulls" \
+      --data-urlencode "state=open" \
+      --data-urlencode "head=$OWNER:$ref" \
+      --data-urlencode "base=$TARGET") || return 1
+    PR_NUMBER=$(printf '%s\n' "$PR_MATCHES" | jq -r '.[0].number // empty')
+  fi
+  if [ -z "$PR_NUMBER" ]; then
+    echo "Pull request $ref was not found." >"$err_file"
+    return 1
+  fi
+  PR_RAW=$(curl_gh_api "$err_file" "$API/pulls/$PR_NUMBER") || return 1
+  printf '%s\n' "$PR_RAW" \
+    | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}'
 }
 
 if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
@@ -455,17 +556,21 @@ if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
   fi
 
   if [ -z "$ORIGIN_REPO" ]; then
+    [ -n "$ORIGIN_REPO_ERROR" ] && echo "$ORIGIN_REPO_ERROR"
     echo "Could not resolve origin repository for existing PR validation. STOP. Debug and retry without mutating bead state."
     gc runtime drain-ack
     exit 1
   fi
 
   EXISTING_PR_ERR=$(mktemp)
-  EXISTING_PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$EXISTING_PR" 2>"$EXISTING_PR_ERR")
+  EXISTING_PR_INFO=$(lookup_pr_info "$EXISTING_PR" "$EXISTING_PR_ERR")
   EXISTING_PR_STATUS=$?
   EXISTING_PR_ERROR=$(cat "$EXISTING_PR_ERR")
   rm -f "$EXISTING_PR_ERR"
   if [ "$EXISTING_PR_STATUS" -ne 0 ] || [ -z "$EXISTING_PR_INFO" ]; then
+    if pr_lookup_repo_mismatch "$EXISTING_PR_ERROR"; then
+      block_existing_pr "Existing PR $EXISTING_PR is not in $ORIGIN_REPO. $EXISTING_PR_ERROR"
+    fi
     if pr_lookup_missing "$EXISTING_PR_ERROR"; then
       block_existing_pr "Existing PR $EXISTING_PR was not found or is not accessible."
     fi
@@ -497,6 +602,13 @@ if [ "$MERGE_STRATEGY" = "mr" ] && [ -n "$EXISTING_PR" ]; then
   if [ "$EXISTING_PR_HEAD_REPO" != "$ORIGIN_REPO" ]; then
     block_existing_pr "Existing PR $EXISTING_PR head repo $EXISTING_PR_HEAD_REPO, want $ORIGIN_REPO."
   fi
+fi
+
+if [ "$MERGE_STRATEGY" = "mr" ] && [ -z "$ORIGIN_REPO" ]; then
+  [ -n "$ORIGIN_REPO_ERROR" ] && echo "$ORIGIN_REPO_ERROR"
+  echo "Could not resolve origin repository for pull-request handoff. STOP. Debug and retry without mutating bead state."
+  gc runtime drain-ack
+  exit 1
 fi
 ```
 
@@ -589,32 +701,27 @@ else
       PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
     fi
   else
-    TOKEN=$(
-      for key in GH_TOKEN GITHUB_TOKEN GIT_TOKEN; do
-        eval value=\${$key:-}
-        if [ -n "$value" ]; then printf '%s\n' "$value"; exit 0; fi
-      done
-      printf 'protocol=https\nhost=github.com\n\n' \
-        | git credential fill 2>/dev/null \
-        | sed -n 's/^password=//p' \
-        | head -n 1
-    )
-    if [ -z "$TOKEN" ]; then
-      echo "GitHub PR mode requires gh or a GitHub token available from env/git credential fill."
+    PR_ERR=$(mktemp)
+    if ! init_github_rest 2>"$PR_ERR"; then
+      cat "$PR_ERR"
+      rm -f "$PR_ERR"
       gc runtime drain-ack
       exit 1
     fi
-    OWNER=${ORIGIN_REPO%%/*}
-    REPO=${ORIGIN_REPO#*/}
-    API="https://api.github.com/repos/$OWNER/$REPO"
-    EXISTING=$(curl -fsS \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer $TOKEN" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
+    EXISTING=$(curl_gh_api "$PR_ERR" \
       --get "$API/pulls" \
       --data-urlencode "state=open" \
       --data-urlencode "head=$OWNER:$BRANCH" \
       --data-urlencode "base=$TARGET")
+    PR_STATUS=$?
+    PR_ERROR=$(cat "$PR_ERR")
+    if [ "$PR_STATUS" -ne 0 ]; then
+      echo "GitHub API request failed while checking for an existing PR for $BRANCH."
+      [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
+      rm -f "$PR_ERR"
+      gc runtime drain-ack
+      exit 1
+    fi
     PR_NUMBER=$(printf '%s\n' "$EXISTING" | jq -r '.[0].number // empty')
     if [ -z "$PR_NUMBER" ]; then
       CREATE_PAYLOAD=$(jq -n \
@@ -623,19 +730,37 @@ else
         --arg base "$TARGET" \
         --arg body "$PR_BODY" \
         '{title:$title, head:$head, base:$base, body:$body}')
-      CREATED=$(curl -fsS \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
+      CREATED=$(curl_gh_api "$PR_ERR" \
         -X POST "$API/pulls" \
         -d "$CREATE_PAYLOAD")
-      PR_NUMBER=$(printf '%s\n' "$CREATED" | jq -r '.number')
+      PR_STATUS=$?
+      PR_ERROR=$(cat "$PR_ERR")
+      if [ "$PR_STATUS" -ne 0 ]; then
+        echo "GitHub API request failed while creating a PR for $BRANCH."
+        [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
+        rm -f "$PR_ERR"
+        gc runtime drain-ack
+        exit 1
+      fi
+      PR_NUMBER=$(printf '%s\n' "$CREATED" | jq -r '.number // empty')
+      if [ -z "$PR_NUMBER" ]; then
+        echo "GitHub API response did not include a pull request number."
+        rm -f "$PR_ERR"
+        gc runtime drain-ack
+        exit 1
+      fi
     fi
-    PR_URL=$(curl -fsS \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer $TOKEN" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      "$API/pulls/$PR_NUMBER" | jq -r '.html_url')
+    PR_RAW=$(curl_gh_api "$PR_ERR" "$API/pulls/$PR_NUMBER")
+    PR_STATUS=$?
+    PR_ERROR=$(cat "$PR_ERR")
+    rm -f "$PR_ERR"
+    if [ "$PR_STATUS" -ne 0 ]; then
+      echo "GitHub API request failed while reading PR $PR_NUMBER."
+      [ -n "$PR_ERROR" ] && echo "$PR_ERROR"
+      gc runtime drain-ack
+      exit 1
+    fi
+    PR_URL=$(printf '%s\n' "$PR_RAW" | jq -r '.html_url // empty')
   fi
   PR_REF="$BRANCH"
 fi
@@ -644,57 +769,9 @@ fi
 **3. Verify the pull request exists:**
 ```bash
 PR_ERR=$(mktemp)
-PR_STATUS=""
-if command -v gh >/dev/null 2>&1; then
-  PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$PR_REF" 2>"$PR_ERR")
-  PR_STATUS=$?
-  PR_ERROR=$(cat "$PR_ERR")
-else
-  TOKEN=$(
-    for key in GH_TOKEN GITHUB_TOKEN GIT_TOKEN; do
-      eval value=\${$key:-}
-      if [ -n "$value" ]; then printf '%s\n' "$value"; exit 0; fi
-    done
-    printf 'protocol=https\nhost=github.com\n\n' \
-      | git credential fill 2>/dev/null \
-      | sed -n 's/^password=//p' \
-      | head -n 1
-  )
-  OWNER=${ORIGIN_REPO%%/*}
-  REPO=${ORIGIN_REPO#*/}
-  API="https://api.github.com/repos/$OWNER/$REPO"
-  if [ -z "$TOKEN" ]; then
-    PR_INFO=""
-    PR_STATUS=1
-    PR_ERROR="GitHub PR mode requires gh or a GitHub token available from env/git credential fill."
-  elif [ -n "$EXISTING_PR" ]; then
-    PR_NUMBER=$(printf '%s\n' "$EXISTING_PR" | sed -E 's|^.*/pull/([0-9]+)$|\1|; s|^#([0-9]+)$|\1|')
-  else
-    PR_NUMBER=$(curl -fsS \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer $TOKEN" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      --get "$API/pulls" \
-      --data-urlencode "state=open" \
-      --data-urlencode "head=$OWNER:$BRANCH" \
-      --data-urlencode "base=$TARGET" \
-      | jq -r '.[0].number // empty')
-  fi
-  if [ -z "$PR_STATUS" ] && [ -z "$PR_NUMBER" ]; then
-    PR_INFO=""
-    PR_STATUS=1
-    PR_ERROR="Pull request $PR_REF was not found."
-  elif [ -z "$PR_STATUS" ]; then
-    PR_INFO=$(curl -fsS \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer $TOKEN" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      "$API/pulls/$PR_NUMBER" 2>"$PR_ERR" \
-      | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}')
-    PR_STATUS=$?
-    PR_ERROR=$(cat "$PR_ERR")
-  fi
-fi
+PR_INFO=$(lookup_pr_info "$PR_REF" "$PR_ERR")
+PR_STATUS=$?
+PR_ERROR=$(cat "$PR_ERR")
 rm -f "$PR_ERR"
 if [ "$PR_STATUS" -ne 0 ] || [ -z "$PR_INFO" ]; then
   if [ -n "$EXISTING_PR" ] && pr_lookup_missing "$PR_ERROR"; then

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -379,7 +379,12 @@ BRANCH=$(gc bd show $WORK --json | jq -r '.[0].metadata.branch')
 TARGET=$(gc bd show $WORK --json | jq -r '.[0].metadata.target // "{{target_branch}}"')
 MERGE_STRATEGY=$(gc bd show $WORK --json | jq -r '.[0].metadata.merge_strategy // "direct"')
 EXISTING_PR=$(gc bd show $WORK --json | jq -r '.[0].metadata.existing_pr // empty')
-ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+ORIGIN_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
+if [ -z "$ORIGIN_REPO" ]; then
+  ORIGIN_URL=$(git remote get-url origin)
+  ORIGIN_REPO=$(printf '%s\n' "$ORIGIN_URL" \
+    | sed -E 's#^git@github.com:##; s#^https://github.com/##; s#\.git$##')
+fi
 if [ "$MERGE_STRATEGY" = "pr" ]; then
   MERGE_STRATEGY="mr"
 fi
@@ -573,14 +578,64 @@ EOF
 if [ -n "$EXISTING_PR" ]; then
   PR_REF="$EXISTING_PR"
 else
-  PR_URL=$(gh pr create \
-    --base "$TARGET" \
-    --head "$BRANCH" \
-    --title "$ISSUE_TITLE ($WORK)" \
-    --body "$PR_BODY" 2>/dev/null || true)
+  if command -v gh >/dev/null 2>&1; then
+    PR_URL=$(gh pr create \
+      --base "$TARGET" \
+      --head "$BRANCH" \
+      --title "$ISSUE_TITLE ($WORK)" \
+      --body "$PR_BODY" 2>/dev/null || true)
 
-  if [ -z "$PR_URL" ]; then
-    PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
+    if [ -z "$PR_URL" ]; then
+      PR_URL=$(gh pr view "$BRANCH" --json url -q '.url')
+    fi
+  else
+    TOKEN=$(
+      for key in GH_TOKEN GITHUB_TOKEN GIT_TOKEN; do
+        eval value=\${$key:-}
+        if [ -n "$value" ]; then printf '%s\n' "$value"; exit 0; fi
+      done
+      printf 'protocol=https\nhost=github.com\n\n' \
+        | git credential fill 2>/dev/null \
+        | sed -n 's/^password=//p' \
+        | head -n 1
+    )
+    if [ -z "$TOKEN" ]; then
+      echo "GitHub PR mode requires gh or a GitHub token available from env/git credential fill."
+      gc runtime drain-ack
+      exit 1
+    fi
+    OWNER=${ORIGIN_REPO%%/*}
+    REPO=${ORIGIN_REPO#*/}
+    API="https://api.github.com/repos/$OWNER/$REPO"
+    EXISTING=$(curl -fsS \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      --get "$API/pulls" \
+      --data-urlencode "state=open" \
+      --data-urlencode "head=$OWNER:$BRANCH" \
+      --data-urlencode "base=$TARGET")
+    PR_NUMBER=$(printf '%s\n' "$EXISTING" | jq -r '.[0].number // empty')
+    if [ -z "$PR_NUMBER" ]; then
+      CREATE_PAYLOAD=$(jq -n \
+        --arg title "$ISSUE_TITLE ($WORK)" \
+        --arg head "$BRANCH" \
+        --arg base "$TARGET" \
+        --arg body "$PR_BODY" \
+        '{title:$title, head:$head, base:$base, body:$body}')
+      CREATED=$(curl -fsS \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -X POST "$API/pulls" \
+        -d "$CREATE_PAYLOAD")
+      PR_NUMBER=$(printf '%s\n' "$CREATED" | jq -r '.number')
+    fi
+    PR_URL=$(curl -fsS \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "$API/pulls/$PR_NUMBER" | jq -r '.html_url')
   fi
   PR_REF="$BRANCH"
 fi
@@ -589,9 +644,57 @@ fi
 **3. Verify the pull request exists:**
 ```bash
 PR_ERR=$(mktemp)
-PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$PR_REF" 2>"$PR_ERR")
-PR_STATUS=$?
-PR_ERROR=$(cat "$PR_ERR")
+PR_STATUS=""
+if command -v gh >/dev/null 2>&1; then
+  PR_INFO=$(gh pr view --json url,number,state,headRefName,baseRefName,headRepositoryOwner,headRepository -- "$PR_REF" 2>"$PR_ERR")
+  PR_STATUS=$?
+  PR_ERROR=$(cat "$PR_ERR")
+else
+  TOKEN=$(
+    for key in GH_TOKEN GITHUB_TOKEN GIT_TOKEN; do
+      eval value=\${$key:-}
+      if [ -n "$value" ]; then printf '%s\n' "$value"; exit 0; fi
+    done
+    printf 'protocol=https\nhost=github.com\n\n' \
+      | git credential fill 2>/dev/null \
+      | sed -n 's/^password=//p' \
+      | head -n 1
+  )
+  OWNER=${ORIGIN_REPO%%/*}
+  REPO=${ORIGIN_REPO#*/}
+  API="https://api.github.com/repos/$OWNER/$REPO"
+  if [ -z "$TOKEN" ]; then
+    PR_INFO=""
+    PR_STATUS=1
+    PR_ERROR="GitHub PR mode requires gh or a GitHub token available from env/git credential fill."
+  elif [ -n "$EXISTING_PR" ]; then
+    PR_NUMBER=$(printf '%s\n' "$EXISTING_PR" | sed -E 's|^.*/pull/([0-9]+)$|\1|; s|^#([0-9]+)$|\1|')
+  else
+    PR_NUMBER=$(curl -fsS \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      --get "$API/pulls" \
+      --data-urlencode "state=open" \
+      --data-urlencode "head=$OWNER:$BRANCH" \
+      --data-urlencode "base=$TARGET" \
+      | jq -r '.[0].number // empty')
+  fi
+  if [ -z "$PR_STATUS" ] && [ -z "$PR_NUMBER" ]; then
+    PR_INFO=""
+    PR_STATUS=1
+    PR_ERROR="Pull request $PR_REF was not found."
+  elif [ -z "$PR_STATUS" ]; then
+    PR_INFO=$(curl -fsS \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "$API/pulls/$PR_NUMBER" 2>"$PR_ERR" \
+      | jq '{url:.html_url, number, state:(.state | ascii_upcase), headRefName:.head.ref, baseRefName:.base.ref, headRepositoryOwner:{login:.head.repo.owner.login}, headRepository:{name:.head.repo.name}}')
+    PR_STATUS=$?
+    PR_ERROR=$(cat "$PR_ERR")
+  fi
+fi
 rm -f "$PR_ERR"
 if [ "$PR_STATUS" -ne 0 ] || [ -z "$PR_INFO" ]; then
   if [ -n "$EXISTING_PR" ] && pr_lookup_missing "$PR_ERROR"; then


### PR DESCRIPTION
## Summary
- keep GitHub CLI as the preferred refinery PR path
- add a GitHub REST fallback that uses env tokens or `git credential fill` when `gh` is missing
- verify API-created/discovered PRs against branch, base, and same-repo ownership before closing the work bead

## Verification
- docker run --rm -v /tmp/gascity-src:/src -w /src golang:1.25.9-bookworm bash -lc 'export PATH=/usr/local/go/bin:$PATH; gofmt -w examples/gastown/gastown_test.go && go test ./examples/gastown -run "TestRefineryFormulaSupportsMergeStrategies|TestRefineryFormulaRespectsExistingPRMetadata"'\n- docker run --rm -v /tmp/gascity-src:/src -w /src golang:1.25.9-bookworm bash -lc 'apt-get update >/dev/null && apt-get install -y jq >/dev/null && export PATH=/usr/local/go/bin:$PATH; go test ./examples/gastown'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->