### PR TITLE
Follow-up for #1136: accept Claude setup-token OAuth in readiness probe

### DIFF
--- a/cmd/gc/init_provider_readiness.go
+++ b/cmd/gc/init_provider_readiness.go
@@ -342,7 +342,7 @@ func providerStatusFixHint(probeName, status string) string {
 		case api.ProbeStatusNotInstalled:
 			return "install Claude Code"
 		case api.ProbeStatusInvalidConfiguration:
-			return "use first-party Claude Code login (`claude.ai` / `firstParty`)"
+			return "use first-party Claude Code login (`claude.ai` or `oauth_token` / `firstParty`)"
 		case api.ProbeStatusProbeError:
 			return "run `claude auth status --json` and fix the local Claude setup"
 		}

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -54,6 +54,15 @@ func TestMaybePrintWizardProviderGuidanceNeedsAuth(t *testing.T) {
 	}
 }
 
+func TestProviderStatusFixHintIncludesClaudeOAuthToken(t *testing.T) {
+	got := providerStatusFixHint("claude", api.ProbeStatusInvalidConfiguration)
+	for _, want := range []string{"`claude.ai`", "`oauth_token`", "`firstParty`"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("providerStatusFixHint = %q, want %s", got, want)
+		}
+	}
+}
+
 func TestFinalizeInitBlocksProviderReadinessBeforeSupervisorRegistration(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_DOLT", "skip")

--- a/internal/api/handler_provider_readiness.go
+++ b/internal/api/handler_provider_readiness.go
@@ -333,7 +333,7 @@ func probeClaude(ctx context.Context, homeDir string) providerProbeResult {
 		return providerProbeResult{status: probeStatusNotInstalled, detail: "claude executable not found in probe PATH"}
 	}
 
-	stdout, _, err := runProbeCommand(ctx, homeDir, 5*time.Second, path, "auth", "status", "--json")
+	stdout, _, err := runProbeCommandWithEnv(ctx, homeDir, 5*time.Second, claudeProbeCommandEnv(), path, "auth", "status", "--json")
 	if err != nil && strings.TrimSpace(stdout) == "" {
 		return providerProbeResult{status: probeStatusProbeError, detail: "claude auth status failed before returning JSON"}
 	}
@@ -490,10 +490,11 @@ func githubCLITokenConfigured() bool {
 }
 
 func probeGitHubCLIAuthStatus(ctx context.Context, homeDir, ghPath string) providerProbeResult {
-	stdout, stderr, err := runProbeCommand(
+	stdout, stderr, err := runProbeCommandWithEnv(
 		ctx,
 		homeDir,
 		5*time.Second,
+		gitHubCLIProbeCommandEnv(),
 		ghPath,
 		"auth",
 		"status",
@@ -540,10 +541,11 @@ func providerProbeSearchPath(homeDir string) string {
 	return searchpath.ExpandPath(homeDir, providerProbeGOOS, providerProbePathEnv)
 }
 
-func runProbeCommand(
+func runProbeCommandWithEnv(
 	ctx context.Context,
 	homeDir string,
 	timeout time.Duration,
+	extraEnv []string,
 	path string,
 	args ...string,
 ) (string, string, error) {
@@ -552,7 +554,7 @@ func runProbeCommand(
 
 	cmd := providerProbeCommandContext(ctx, path, args...)
 	cmd.Dir = homeDir
-	cmd.Env = probeCommandEnv(homeDir)
+	cmd.Env = append(probeCommandEnv(homeDir), extraEnv...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -588,27 +590,30 @@ func probeCommandEnv(homeDir string) []string {
 	} else {
 		env = append(env, "XDG_STATE_HOME="+filepath.Join(homeDir, ".local", "state"))
 	}
-	if configDir := strings.TrimSpace(os.Getenv("GH_CONFIG_DIR")); configDir != "" {
-		env = append(env, "GH_CONFIG_DIR="+configDir)
-	}
-	for _, key := range []string{
+	return env
+}
+
+func claudeProbeCommandEnv() []string {
+	return probeEnvVars("CLAUDE_CONFIG_DIR", "CLAUDE_CODE_OAUTH_TOKEN")
+}
+
+func gitHubCLIProbeCommandEnv() []string {
+	return probeEnvVars(
+		"GH_CONFIG_DIR",
 		"GH_HOST",
 		"GH_TOKEN",
 		"GITHUB_TOKEN",
 		"GH_ENTERPRISE_TOKEN",
 		"GITHUB_ENTERPRISE_TOKEN",
-	} {
+	)
+}
+
+func probeEnvVars(keys ...string) []string {
+	env := make([]string, 0, len(keys))
+	for _, key := range keys {
 		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 			env = append(env, key+"="+value)
 		}
-	}
-	// CLAUDE_CODE_OAUTH_TOKEN holds the long-lived first-party token from
-	// `claude setup-token`. In headless / containerised deployments it is
-	// the only authentication signal available, so it must be forwarded
-	// into the probe subprocess — otherwise `claude auth status --json`
-	// reports loggedIn: false and readiness falls through to needs_auth.
-	if value := strings.TrimSpace(os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")); value != "" {
-		env = append(env, "CLAUDE_CODE_OAUTH_TOKEN="+value)
 	}
 	return env
 }

--- a/internal/api/handler_provider_readiness_test.go
+++ b/internal/api/handler_provider_readiness_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -52,29 +53,7 @@ func TestReadinessRegistrySync(t *testing.T) {
 	}
 }
 
-func TestProbeCommandEnvForwardsClaudeCodeOAuthToken(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test")
-
-	env := probeCommandEnv(homeDir)
-	if !slices.Contains(env, "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-test") {
-		t.Fatalf("probeCommandEnv missing CLAUDE_CODE_OAUTH_TOKEN forwarding: %v", env)
-	}
-}
-
-func TestProbeCommandEnvOmitsUnsetClaudeCodeOAuthToken(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
-
-	env := probeCommandEnv(homeDir)
-	for _, entry := range env {
-		if strings.HasPrefix(entry, "CLAUDE_CODE_OAUTH_TOKEN=") {
-			t.Fatalf("probeCommandEnv forwarded unset CLAUDE_CODE_OAUTH_TOKEN: %q", entry)
-		}
-	}
-}
-
-func TestProbeCommandEnvPreservesXDGOverridesWhenGHConfigDirIsSet(t *testing.T) {
+func TestProbeCommandEnvPreservesXDGOverridesWithoutProviderSpecificEnv(t *testing.T) {
 	homeDir := t.TempDir()
 	xdgConfigHome := filepath.Join(homeDir, "xdg-config")
 	xdgStateHome := filepath.Join(homeDir, "xdg-state")
@@ -90,9 +69,31 @@ func TestProbeCommandEnvPreservesXDGOverridesWhenGHConfigDirIsSet(t *testing.T) 
 	if !slices.Contains(env, "XDG_STATE_HOME="+xdgStateHome) {
 		t.Fatalf("probeCommandEnv missing XDG_STATE_HOME override: %v", env)
 	}
-	if !slices.Contains(env, "GH_CONFIG_DIR="+ghConfigDir) {
-		t.Fatalf("probeCommandEnv missing GH_CONFIG_DIR override: %v", env)
+	assertEnvOmitsPrefix(t, env, "GH_CONFIG_DIR=")
+}
+
+func TestClaudeProbeCommandEnvForwardsConfigDirAndOAuthToken(t *testing.T) {
+	homeDir := t.TempDir()
+	configDir := filepath.Join(homeDir, "custom-claude")
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test")
+
+	env := claudeProbeCommandEnv()
+	if !slices.Contains(env, "CLAUDE_CONFIG_DIR="+configDir) {
+		t.Fatalf("claudeProbeCommandEnv missing CLAUDE_CONFIG_DIR forwarding: %v", env)
 	}
+	if !slices.Contains(env, "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-test") {
+		t.Fatalf("claudeProbeCommandEnv missing CLAUDE_CODE_OAUTH_TOKEN forwarding: %v", env)
+	}
+}
+
+func TestClaudeProbeCommandEnvOmitsUnsetValues(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+
+	env := claudeProbeCommandEnv()
+	assertEnvOmitsPrefix(t, env, "CLAUDE_CONFIG_DIR=")
+	assertEnvOmitsPrefix(t, env, "CLAUDE_CODE_OAUTH_TOKEN=")
 }
 
 func TestProviderProbeSearchDirsIncludesUserLocalAndLinuxDefaults(t *testing.T) {
@@ -572,6 +573,41 @@ func TestHandleProviderReadinessReturnsConfiguredForClaudeOAuthToken(t *testing.
 printf '%s\n' '{"loggedIn":true,"authMethod":"oauth_token","apiProvider":"firstParty"}'
 `)
 
+	t.Setenv("HOME", homeDir)
+	originalPathEnv := providerProbePathEnv
+	originalCommandContext := providerProbeCommandContext
+	providerProbePathEnv = binDir
+	providerProbeCommandContext = exec.CommandContext
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+		providerProbeCommandContext = originalCommandContext
+	}()
+
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+	assertProviderStatus(t, h, state, "/provider-readiness?providers=claude&fresh=1", "claude", probeStatusConfigured)
+}
+
+func TestHandleProviderReadinessForwardsClaudeOnlyEnvToClaudeProbe(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	writeExecutable(t, binDir, "claude", `#!/bin/sh
+if [ "$CLAUDE_CONFIG_DIR" != "$HOME/custom-claude" ]; then
+	echo "missing CLAUDE_CONFIG_DIR" >&2
+	exit 1
+fi
+if [ "$CLAUDE_CODE_OAUTH_TOKEN" != "sk-ant-oat-test" ]; then
+	echo "missing CLAUDE_CODE_OAUTH_TOKEN" >&2
+	exit 1
+fi
+printf '%s\n' '{"loggedIn":true,"authMethod":"oauth_token","apiProvider":"firstParty"}'
+`)
+
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(homeDir, "custom-claude"))
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test")
 	t.Setenv("HOME", homeDir)
 	originalPathEnv := providerProbePathEnv
 	originalCommandContext := providerProbeCommandContext
@@ -1077,6 +1113,47 @@ func TestHandleReadinessReturnsNeedsAuthForGitHubCLIWithoutStoredTokens(t *testi
 	assertGitHubCLIReadinessStatus(t, h, state, probeStatusNeedsAuth)
 }
 
+func TestHandleReadinessDoesNotForwardClaudeTokenToGitHubCLIProbe(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	writeExecutable(t, binDir, "gh", `#!/bin/sh
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+	: > "$HOME/gh-saw-claude-token"
+fi
+echo "not logged in" >&2
+exit 1
+`)
+	if err := os.MkdirAll(filepath.Join(homeDir, ".config", "gh"), 0o755); err != nil {
+		t.Fatalf("mkdir gh config dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(homeDir, ".config", "gh", "hosts.yml"),
+		[]byte("github.com:\n    user: octocat\n    git_protocol: https\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write gh hosts: %v", err)
+	}
+	unsetGitHubCLITokenEnv(t)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-test")
+	t.Setenv("HOME", homeDir)
+
+	originalPathEnv := providerProbePathEnv
+	providerProbePathEnv = binDir
+	defer func() {
+		providerProbePathEnv = originalPathEnv
+	}()
+
+	state := newFakeState(t)
+	h := newTestCityHandler(t, state)
+	assertGitHubCLIReadinessStatus(t, h, state, probeStatusNeedsAuth)
+	if _, err := os.Stat(filepath.Join(homeDir, "gh-saw-claude-token")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("github CLI probe received CLAUDE_CODE_OAUTH_TOKEN")
+	}
+}
+
 func TestHandleReadinessReturnsConfiguredForGitHubCLIAuthStatusFallback(t *testing.T) {
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, "bin")
@@ -1144,6 +1221,15 @@ func writeExecutable(t *testing.T, dir, name, body string) {
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func assertEnvOmitsPrefix(t *testing.T, env []string, prefix string) {
+	t.Helper()
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			t.Fatalf("env contains %s entry: %q", prefix, entry)
+		}
 	}
 }
 


### PR DESCRIPTION
Maintainer follow-up for #1136.

Original PR: https://github.com/gastownhall/gascity/pull/1136
Original title: feat(api): accept `claude setup-token` OAuth in provider readiness probe
Original state at adoption: OPEN
Configured base: main
Original GitHub base: main
Base mismatch: none

The adoption workflow could not safely update the original fork branch: GitHub rejected the maintainer push to `GoIncremental/gascity:feat/claude-oauth-token-auth` with HTTP 403 for the available token. This follow-up carries the reviewed change set on a maintainer branch in `gastownhall/gascity`.

This branch preserves the contributor-authored commits and adds one maintainer fixup commit:

- `9e6d91bd2` feat(api): accept claude setup-token OAuth for provider readiness
- `c9f2b0d25` feat(api): forward CLAUDE_CODE_OAUTH_TOKEN into readiness probe env
- `d52c33d62` fix: isolate provider readiness probe env

The maintainer fixup keeps the provider-neutral subprocess environment from leaking Claude credentials to non-Claude probes, forwards Claude-specific env only to the Claude readiness probe, and updates coverage for the OAuth/config-dir readiness paths.

Adopted via `/adopt-pr` workflow. Original contributor commits preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->