### PR TITLE
fix(extmsg): outbound publish falls back to group-membership authorization (#1802)

### DIFF
--- a/internal/extmsg/group_service.go
+++ b/internal/extmsg/group_service.go
@@ -434,6 +434,51 @@ func (s *groupService) ResolveInbound(ctx context.Context, event ExternalInbound
 	return &GroupRouteDecision{Match: GroupRouteNoMatch}, nil
 }
 
+// ResolveOutbound authorizes an outbound publish from sessionID against the
+// conversation's group. Unlike ResolveInbound (which routes a message to a
+// participant by handle), ResolveOutbound checks whether sessionID is itself
+// a participant of the group bound to ref. This mirrors the authorization
+// boundary established by bind-room: any session that is a group participant
+// is authorized to publish on behalf of the conversation.
+//
+// Returns a decision with Match == GroupRouteParticipantMatch and the matching
+// participant when sessionID is a participant. Returns Match == GroupRouteNoMatch
+// when no group is bound or sessionID is not a participant.
+func (s *groupService) ResolveOutbound(ctx context.Context, ref ConversationRef, sessionID string) (*GroupOutboundDecision, error) {
+	if err := checkContext(ctx); err != nil {
+		return nil, err
+	}
+	validatedRef, err := validateConversationRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, fmt.Errorf("%w: session_id required", ErrInvalidInput)
+	}
+	group, err := s.findGroupByRoot(validatedRef)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return &GroupOutboundDecision{Match: GroupRouteNoMatch}, nil
+	}
+	participants, err := s.listParticipants(group.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, participant := range participants {
+		if participant.SessionID == sessionID {
+			return &GroupOutboundDecision{
+				Match:       GroupRouteParticipantMatch,
+				GroupID:     group.ID,
+				Participant: participant,
+			}, nil
+		}
+	}
+	return &GroupOutboundDecision{Match: GroupRouteNoMatch, GroupID: group.ID}, nil
+}
+
 func (s *groupService) UpdateCursor(ctx context.Context, caller Caller, input UpdateCursorInput) error {
 	if err := checkContext(ctx); err != nil {
 		return err

--- a/internal/extmsg/outbound.go
+++ b/internal/extmsg/outbound.go
@@ -37,12 +37,20 @@ type OutboundDeps struct {
 //
 // Pipeline:
 //  1. Resolve active binding for the conversation.
-//  2. Verify the binding session matches the caller.
+//  2. If a binding exists, verify the caller session owns it. If no binding
+//     exists but the caller passed a SessionID, fall back to group routing:
+//     the publish is authorized when the SessionID is a participant of the
+//     group bound to the conversation (mirrors the inbound group fallback).
 //  3. Look up adapter by conversation ref.
 //  4. Call adapter.Publish.
 //  5. Record delivery context.
 //  6. Append outbound entry to transcript.
 //  7. Emit event for the caller to fan out peer notifications.
+//
+// On the group-fallback path the publishing session is req.SessionID and
+// BindingGeneration is zero — the group authorization model has no
+// monotonic generation concept. Downstream consumers in the producer path
+// do not compare generations against zero today.
 func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req OutboundRequest) (*OutboundResult, error) {
 	if deps.Registry == nil {
 		return nil, errors.New("adapter registry is nil")
@@ -53,15 +61,38 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 	if err != nil {
 		return nil, fmt.Errorf("resolving binding: %w", err)
 	}
-	if binding == nil {
+
+	// Step 2: Authorize the publish.
+	//
+	// publishingSession is the session we credit for the publish (delivery
+	// context owner + event subject). On the binding path this is the
+	// binding's session; on the group fallback path it is the caller's
+	// session. bindingGeneration is non-zero only on the binding path.
+	var publishingSession string
+	var bindingGeneration int64
+	switch {
+	case binding != nil:
+		if req.SessionID != "" && binding.SessionID != req.SessionID {
+			return nil, fmt.Errorf("session %q does not own binding for conversation %s/%s (bound to %s)",
+				req.SessionID, req.Conversation.Provider, req.Conversation.ConversationID, binding.SessionID)
+		}
+		publishingSession = binding.SessionID
+		bindingGeneration = binding.BindingGeneration
+	case req.SessionID == "":
+		// No binding and no caller session — preserve the historical error
+		// string so external callers that pattern-match it stay green.
 		return nil, fmt.Errorf("no active binding for conversation %s/%s",
 			req.Conversation.Provider, req.Conversation.ConversationID)
-	}
-
-	// Step 2: Verify the caller session owns the binding.
-	if req.SessionID != "" && binding.SessionID != req.SessionID {
-		return nil, fmt.Errorf("session %q does not own binding for conversation %s/%s (bound to %s)",
-			req.SessionID, req.Conversation.Provider, req.Conversation.ConversationID, binding.SessionID)
+	default:
+		decision, err := deps.Services.Groups.ResolveOutbound(ctx, req.Conversation, req.SessionID)
+		if err != nil {
+			return nil, fmt.Errorf("resolving group route: %w", err)
+		}
+		if decision == nil || decision.Match != GroupRouteParticipantMatch {
+			return nil, fmt.Errorf("no active binding for conversation %s/%s",
+				req.Conversation.Provider, req.Conversation.ConversationID)
+		}
+		publishingSession = req.SessionID
 	}
 
 	// Step 3: Look up adapter.
@@ -89,23 +120,31 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 		return result, nil
 	}
 
-	// Step 5: Record delivery context.
+	// Step 5: Record delivery context (binding path only).
+	//
+	// Delivery context tracks per-binding publish state and requires a
+	// non-zero BindingGeneration tied to an active binding — neither
+	// applies on the group fallback path. Recording is intentionally
+	// skipped there; transcript append below still runs and remains the
+	// authoritative outbound record for group flows.
 	now := time.Now()
-	dc := DeliveryContextRecord{
-		SessionID:         binding.SessionID,
-		Conversation:      req.Conversation,
-		BindingGeneration: binding.BindingGeneration,
-		LastPublishedAt:   now,
-		LastMessageID:     receipt.MessageID,
-		SourceSessionID:   req.SessionID,
-		Metadata:          req.Metadata,
-	}
-	if err := deps.Services.Delivery.Record(ctx, caller, dc); err != nil {
-		// Delivery context recording is important but not fatal.
-		// The message was already published.
-		result.DeliveryContext = nil
-	} else {
-		result.DeliveryContext = &dc
+	if binding != nil {
+		dc := DeliveryContextRecord{
+			SessionID:         publishingSession,
+			Conversation:      req.Conversation,
+			BindingGeneration: bindingGeneration,
+			LastPublishedAt:   now,
+			LastMessageID:     receipt.MessageID,
+			SourceSessionID:   req.SessionID,
+			Metadata:          req.Metadata,
+		}
+		if err := deps.Services.Delivery.Record(ctx, caller, dc); err != nil {
+			// Delivery context recording is important but not fatal.
+			// The message was already published.
+			result.DeliveryContext = nil
+		} else {
+			result.DeliveryContext = &dc
+		}
 	}
 
 	// Step 6: Append outbound transcript entry.
@@ -127,9 +166,12 @@ func HandleOutbound(ctx context.Context, deps OutboundDeps, caller Caller, req O
 	}
 
 	// Step 7: Emit event.
-	// Wake and peer fanout are handled by the caller.
+	// Wake and peer fanout are handled by the caller. The event subject is
+	// the publishing session — identical to binding.SessionID on the
+	// binding path (Step 2 enforces equality with req.SessionID), and the
+	// caller's session on the group fallback path.
 	if deps.EmitEvent != nil {
-		deps.EmitEvent(events.ExtMsgOutbound, binding.SessionID, OutboundEventPayload{
+		deps.EmitEvent(events.ExtMsgOutbound, publishingSession, OutboundEventPayload{
 			Provider:       req.Conversation.Provider,
 			ConversationID: req.Conversation.ConversationID,
 			Session:        req.SessionID,

--- a/internal/extmsg/outbound_test.go
+++ b/internal/extmsg/outbound_test.go
@@ -1,0 +1,453 @@
+package extmsg
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/events"
+)
+
+// stubAdapter is a TransportAdapter that records Publish calls and returns a
+// fixed receipt. It exists only for outbound_test.go; widen as needed.
+type stubAdapter struct {
+	mu       sync.Mutex
+	name     string
+	receipt  PublishReceipt
+	publishs []PublishRequest
+	err      error
+}
+
+func newStubAdapter(name string, ref ConversationRef) *stubAdapter {
+	return &stubAdapter{
+		name: name,
+		receipt: PublishReceipt{
+			MessageID:    "ext-msg-1",
+			Conversation: ref,
+			Delivered:    true,
+		},
+	}
+}
+
+func (a *stubAdapter) Name() string { return a.name }
+func (a *stubAdapter) Capabilities() AdapterCapabilities {
+	return AdapterCapabilities{}
+}
+
+func (a *stubAdapter) VerifyAndNormalizeInbound(_ context.Context, _ InboundPayload) (*ExternalInboundMessage, error) {
+	return nil, errors.New("stubAdapter does not implement inbound")
+}
+
+func (a *stubAdapter) Publish(_ context.Context, req PublishRequest) (*PublishReceipt, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.err != nil {
+		return nil, a.err
+	}
+	a.publishs = append(a.publishs, req)
+	receipt := a.receipt
+	receipt.Conversation = req.Conversation
+	return &receipt, nil
+}
+
+func (a *stubAdapter) EnsureChildConversation(_ context.Context, _ ConversationRef, _ string) (*ConversationRef, error) {
+	return nil, errors.New("stubAdapter does not implement child conversations")
+}
+
+type capturedEvent struct {
+	Type    string
+	Subject string
+	Payload events.Payload
+}
+
+func newOutboundTestRig(t *testing.T) (Services, *stubAdapter, *[]capturedEvent, OutboundDeps) {
+	t.Helper()
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+	adapter := newStubAdapter("stub", ref)
+	reg := NewAdapterRegistry()
+	reg.Register(AdapterKey{Provider: ref.Provider, AccountID: ref.AccountID}, adapter)
+	captured := make([]capturedEvent, 0)
+	emit := func(eventType, subject string, payload events.Payload) {
+		captured = append(captured, capturedEvent{Type: eventType, Subject: subject, Payload: payload})
+	}
+	deps := OutboundDeps{Services: fabric, Registry: reg, EmitEvent: emit}
+	return fabric, adapter, &captured, deps
+}
+
+func TestHandleOutbound_BindingPathUnchanged(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	binding, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-bound",
+		Now:          testNow(),
+	})
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	result, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-bound",
+		Conversation: ref,
+		Text:         "hello",
+	})
+	if err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+	if !result.Receipt.Delivered {
+		t.Fatalf("Receipt.Delivered = false, want true")
+	}
+	if len(adapter.publishs) != 1 {
+		t.Fatalf("adapter publishes = %d, want 1", len(adapter.publishs))
+	}
+	if result.DeliveryContext == nil {
+		t.Fatalf("DeliveryContext = nil, want recorded")
+	}
+	if result.DeliveryContext.SessionID != "sess-bound" {
+		t.Fatalf("DeliveryContext.SessionID = %q, want sess-bound", result.DeliveryContext.SessionID)
+	}
+	if result.DeliveryContext.BindingGeneration != binding.BindingGeneration {
+		t.Fatalf("DeliveryContext.BindingGeneration = %d, want %d",
+			result.DeliveryContext.BindingGeneration, binding.BindingGeneration)
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("captured events = %d, want 1", len(*captured))
+	}
+	if (*captured)[0].Type != events.ExtMsgOutbound {
+		t.Fatalf("event type = %q, want %q", (*captured)[0].Type, events.ExtMsgOutbound)
+	}
+	if (*captured)[0].Subject != "sess-bound" {
+		t.Fatalf("event subject = %q, want sess-bound", (*captured)[0].Subject)
+	}
+}
+
+func TestHandleOutbound_RoomBoundParticipantPublishes(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, _, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	group, err := fabric.Groups.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := fabric.Groups.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-room",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	result, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-room",
+		Conversation: ref,
+		Text:         "hello",
+	})
+	if err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+	if !result.Receipt.Delivered {
+		t.Fatalf("Receipt.Delivered = false, want true")
+	}
+	if len(adapter.publishs) != 1 {
+		t.Fatalf("adapter publishes = %d, want 1", len(adapter.publishs))
+	}
+	// Delivery context is binding-only; group fallback path skips it.
+	if result.DeliveryContext != nil {
+		t.Fatalf("DeliveryContext = %#v, want nil on group path", result.DeliveryContext)
+	}
+	// Transcript append remains the authoritative outbound record on the group path.
+	if result.TranscriptEntry == nil {
+		t.Fatalf("TranscriptEntry = nil, want appended")
+	}
+	if result.TranscriptEntry.SourceSessionID != "sess-room" {
+		t.Fatalf("TranscriptEntry.SourceSessionID = %q, want sess-room", result.TranscriptEntry.SourceSessionID)
+	}
+}
+
+func TestHandleOutbound_RoomBoundNonParticipantRejected(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	group, err := fabric.Groups.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := fabric.Groups.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-room",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	_, err = HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-stranger",
+		Conversation: ref,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatalf("HandleOutbound(non-participant) error = nil, want rejection")
+	}
+	// Preserve historical error contract used by API tier (422) and external callers.
+	if !strings.Contains(err.Error(), "no active binding for conversation") {
+		t.Fatalf("HandleOutbound(non-participant) error = %v, want 'no active binding for conversation' substring", err)
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("adapter publishes = %d, want 0 on rejection", len(adapter.publishs))
+	}
+	if len(*captured) != 0 {
+		t.Fatalf("captured events = %d, want 0 on rejection", len(*captured))
+	}
+}
+
+func TestHandleOutbound_NoBindingNoGroupReturnsActiveBindingError(t *testing.T) {
+	freezeTestClock(t)
+	_, adapter, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	_, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-x",
+		Conversation: ref,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatalf("HandleOutbound error = nil, want 'no active binding'")
+	}
+	if !strings.Contains(err.Error(), "no active binding for conversation") {
+		t.Fatalf("HandleOutbound error = %v, want 'no active binding for conversation' substring", err)
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("adapter publishes = %d, want 0", len(adapter.publishs))
+	}
+	if len(*captured) != 0 {
+		t.Fatalf("captured events = %d, want 0", len(*captured))
+	}
+}
+
+func TestHandleOutbound_NoBindingEmptySessionReturnsActiveBindingError(t *testing.T) {
+	freezeTestClock(t)
+	_, adapter, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	_, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "",
+		Conversation: ref,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatalf("HandleOutbound error = nil, want 'no active binding'")
+	}
+	if !strings.Contains(err.Error(), "no active binding for conversation") {
+		t.Fatalf("HandleOutbound error = %v, want 'no active binding for conversation' substring", err)
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("adapter publishes = %d, want 0", len(adapter.publishs))
+	}
+	if len(*captured) != 0 {
+		t.Fatalf("captured events = %d, want 0", len(*captured))
+	}
+}
+
+func TestHandleOutbound_GroupRouteEmitsEventOnPublishingSession(t *testing.T) {
+	freezeTestClock(t)
+	fabric, _, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	group, err := fabric.Groups.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := fabric.Groups.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-room",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	if _, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-room",
+		Conversation: ref,
+		Text:         "hello",
+	}); err != nil {
+		t.Fatalf("HandleOutbound: %v", err)
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("captured events = %d, want 1", len(*captured))
+	}
+	if (*captured)[0].Type != events.ExtMsgOutbound {
+		t.Fatalf("event type = %q, want %q", (*captured)[0].Type, events.ExtMsgOutbound)
+	}
+	// Subject is the publishing session (the participant), not a binding session.
+	if (*captured)[0].Subject != "sess-room" {
+		t.Fatalf("event subject = %q, want sess-room (publishing session)", (*captured)[0].Subject)
+	}
+}
+
+func TestHandleOutbound_BindingMismatchRejected(t *testing.T) {
+	freezeTestClock(t)
+	fabric, adapter, captured, deps := newOutboundTestRig(t)
+	ref := testConversationRef()
+
+	if _, err := fabric.Bindings.Bind(context.Background(), testControllerCaller(), BindInput{
+		Conversation: ref,
+		SessionID:    "sess-owner",
+		Now:          testNow(),
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+
+	_, err := HandleOutbound(context.Background(), deps, testControllerCaller(), OutboundRequest{
+		SessionID:    "sess-other",
+		Conversation: ref,
+		Text:         "hello",
+	})
+	if err == nil {
+		t.Fatalf("HandleOutbound(mismatched session) error = nil, want rejection")
+	}
+	if !strings.Contains(err.Error(), "does not own binding") {
+		t.Fatalf("HandleOutbound(mismatched session) error = %v, want 'does not own binding' substring", err)
+	}
+	if len(adapter.publishs) != 0 {
+		t.Fatalf("adapter publishes = %d, want 0 on rejection", len(adapter.publishs))
+	}
+	if len(*captured) != 0 {
+		t.Fatalf("captured events = %d, want 0 on rejection", len(*captured))
+	}
+}
+
+// --- ResolveOutbound unit tests ---
+
+func TestResolveOutbound_NoGroup(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+
+	decision, err := svc.ResolveOutbound(context.Background(), ref, "sess-x")
+	if err != nil {
+		t.Fatalf("ResolveOutbound: %v", err)
+	}
+	if decision == nil {
+		t.Fatal("ResolveOutbound = nil, want NoMatch decision")
+	}
+	if decision.Match != GroupRouteNoMatch {
+		t.Fatalf("decision.Match = %q, want %q", decision.Match, GroupRouteNoMatch)
+	}
+}
+
+func TestResolveOutbound_ParticipantMatch(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-a",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	decision, err := svc.ResolveOutbound(context.Background(), ref, "sess-a")
+	if err != nil {
+		t.Fatalf("ResolveOutbound: %v", err)
+	}
+	if decision == nil {
+		t.Fatal("ResolveOutbound = nil, want match decision")
+	}
+	if decision.Match != GroupRouteParticipantMatch {
+		t.Fatalf("decision.Match = %q, want %q", decision.Match, GroupRouteParticipantMatch)
+	}
+	if decision.GroupID != group.ID {
+		t.Fatalf("decision.GroupID = %q, want %q", decision.GroupID, group.ID)
+	}
+	if decision.Participant.SessionID != "sess-a" {
+		t.Fatalf("decision.Participant.SessionID = %q, want sess-a", decision.Participant.SessionID)
+	}
+	if decision.Participant.Handle != "alpha" {
+		t.Fatalf("decision.Participant.Handle = %q, want alpha", decision.Participant.Handle)
+	}
+}
+
+func TestResolveOutbound_ParticipantMiss(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+
+	group, err := svc.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := svc.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-a",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	decision, err := svc.ResolveOutbound(context.Background(), ref, "sess-stranger")
+	if err != nil {
+		t.Fatalf("ResolveOutbound: %v", err)
+	}
+	if decision == nil {
+		t.Fatal("ResolveOutbound = nil, want NoMatch decision")
+	}
+	if decision.Match != GroupRouteNoMatch {
+		t.Fatalf("decision.Match = %q, want %q", decision.Match, GroupRouteNoMatch)
+	}
+	if decision.GroupID != group.ID {
+		t.Fatalf("decision.GroupID = %q, want %q (group exists, only participant missing)", decision.GroupID, group.ID)
+	}
+}
+
+func TestResolveOutbound_EmptySessionRejected(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	svc := NewGroupService(store)
+	ref := testConversationRef()
+
+	cases := []string{"", "   ", "\t"}
+	for _, sessionID := range cases {
+		t.Run("session_"+sessionID, func(t *testing.T) {
+			_, err := svc.ResolveOutbound(context.Background(), ref, sessionID)
+			if err == nil {
+				t.Fatalf("ResolveOutbound(%q) error = nil, want ErrInvalidInput", sessionID)
+			}
+			if !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("ResolveOutbound(%q) error = %v, want ErrInvalidInput", sessionID, err)
+			}
+		})
+	}
+}

--- a/internal/extmsg/types.go
+++ b/internal/extmsg/types.go
@@ -352,6 +352,10 @@ const (
 	GroupRouteDefault GroupRouteMatch = "default"
 	// GroupRouteNoMatch means no routing match was found.
 	GroupRouteNoMatch GroupRouteMatch = "no_match"
+	// GroupRouteParticipantMatch means an outbound publish was authorized
+	// because the publishing session is a participant of the group bound
+	// to the conversation.
+	GroupRouteParticipantMatch GroupRouteMatch = "participant_match"
 )
 
 // GroupRouteDecision is the result of routing an inbound message within a group.
@@ -359,6 +363,18 @@ type GroupRouteDecision struct {
 	Match           GroupRouteMatch
 	TargetSessionID string
 	UpdateCursor    bool
+}
+
+// GroupOutboundDecision is the result of authorizing an outbound publish
+// against a conversation's group when no single-session binding exists.
+//
+// A non-nil decision with Match == GroupRouteParticipantMatch authorizes
+// the caller's session to publish on behalf of the group; any other Match
+// value (including GroupRouteNoMatch) means no authorization was found.
+type GroupOutboundDecision struct {
+	Match       GroupRouteMatch
+	GroupID     string
+	Participant ConversationGroupParticipant
 }
 
 // BindInput is the input for creating a session binding.
@@ -501,6 +517,7 @@ type GroupService interface {
 	UpsertParticipant(ctx context.Context, caller Caller, input UpsertParticipantInput) (ConversationGroupParticipant, error)
 	RemoveParticipant(ctx context.Context, caller Caller, input RemoveParticipantInput) error
 	ResolveInbound(ctx context.Context, event ExternalInboundMessage) (*GroupRouteDecision, error)
+	ResolveOutbound(ctx context.Context, ref ConversationRef, sessionID string) (*GroupOutboundDecision, error)
 	UpdateCursor(ctx context.Context, caller Caller, input UpdateCursorInput) error
 }
 


### PR DESCRIPTION
## Summary

Closes #1802. Restores symmetry between inbound and outbound binding resolution in `internal/extmsg/`: when `Bindings.ResolveByConversation` returns nil, fall back to group-membership routing on the outbound path (mirroring the existing inbound flow).

Sessions bound via `gc slack bind-room` create `gc:extmsg-group` + `gc:extmsg-membership` beads but no `gc:extmsg-binding` bead. Before this change, inbound flowed correctly but outbound returned 422 — `gc slack reply-current` and `gc slack react` both broke for room-bound sessions.

## Plan deltas (matter for review)

1. **Plan called for `HandleOutboundFile` parity (theme #13).** That function does not exist in this codebase — no `outbound_file.go`, no Slack-file upload path on `/extmsg/outbound` today. Theme #13 parity concern is moot for this PR. When/if a `HandleOutboundFile` is added, the same pattern applies.

2. **Plan said the group fallback path would write a `DeliveryContextRecord` with `BindingGeneration=0`.** The delivery service rejects `BindingGeneration<=0` AND requires a matching active binding (see `internal/extmsg/delivery_service.go:42-66`). Plan didn't catch this. Resolved by **skipping delivery context recording entirely on the group path** — it's a binding-only concern; transcript append remains the authoritative outbound record for group flows. Event subject still uses publishing session; behavior on the binding path is unchanged.

## Files touched

- `internal/extmsg/types.go` — new `GroupRouteParticipantMatch` constant + `GroupOutboundDecision` type + `ResolveOutbound` on `GroupService` interface
- `internal/extmsg/group_service.go` — `ResolveOutbound` implementation
- `internal/extmsg/outbound.go` — group fallback in `HandleOutbound` after nil binding
- `internal/api/huma_handlers_extmsg.go` — untouched; 422 contract on real error preserved

## Test plan

- [x] 7 new `HandleOutbound` tests covering binding hit, group fallback hit, group no-match (still 422), participant validation
- [x] 4 new `ResolveOutbound` tests on `groupService`
- [x] All pass with `-race`
- [x] `make check` exits 0
- [ ] Manual smoke: room-bound session `gc slack reply-current` succeeds (Stephanie to verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->