### PR TITLE
fix: preserve custom-only codex hooks

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -381,16 +381,41 @@ func normalizeCodexHookCommands(existing []byte) ([]byte, bool, error) {
 	if err := json.Unmarshal(existing, &root); err != nil {
 		return nil, false, err
 	}
+	hasManagedCommand := codexHookValueHasManagedCommand(root)
 	changed := upgradeCodexHookValue(root)
 	data, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return nil, false, err
 	}
 	data = append(data, '\n')
-	if !bytes.Equal(data, existing) {
+	if hasManagedCommand && !bytes.Equal(data, existing) {
 		changed = true
 	}
 	return data, changed, nil
+}
+
+func codexHookValueHasManagedCommand(v any) bool {
+	switch node := v.(type) {
+	case map[string]any:
+		for key, val := range node {
+			if key == "command" {
+				if command, ok := val.(string); ok && isCodexManagedHookCommand(command) {
+					return true
+				}
+				continue
+			}
+			if codexHookValueHasManagedCommand(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, elem := range node {
+			if codexHookValueHasManagedCommand(elem) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func upgradeCodexHookValue(v any) bool {
@@ -425,16 +450,27 @@ func upgradeCodexHookValue(v any) bool {
 	}
 }
 
+var codexManagedHookCommandNeedles = []string{
+	`gc prime --hook`,
+	`gc nudge drain --inject`,
+	`gc mail check --inject`,
+	`gc hook --inject`,
+}
+
+func isCodexManagedHookCommand(command string) bool {
+	for _, needle := range codexManagedHookCommandNeedles {
+		if strings.Contains(command, needle) {
+			return true
+		}
+	}
+	return false
+}
+
 func upgradeCodexHookCommand(command string) (string, bool) {
 	if strings.Contains(command, `--hook-format codex`) {
 		return "", false
 	}
-	for _, needle := range []string{
-		`gc prime --hook`,
-		`gc nudge drain --inject`,
-		`gc mail check --inject`,
-		`gc hook --inject`,
-	} {
+	for _, needle := range codexManagedHookCommandNeedles {
 		if strings.Contains(command, needle) {
 			return strings.Replace(command, needle, needle+` --hook-format codex`, 1), true
 		}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -297,6 +297,36 @@ func TestInstallCodexWritesCanonicalHookBytes(t *testing.T) {
 	}
 }
 
+func TestInstallCodexIsByteStableAcrossRepeatedInstalls(t *testing.T) {
+	fs := fsys.NewFake()
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+	before := append([]byte(nil), fs.Files["/work/.codex/hooks.json"]...)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("second Install: %v", err)
+	}
+	after := fs.Files["/work/.codex/hooks.json"]
+	if !bytes.Equal(before, after) {
+		t.Fatalf("second Install rewrote codex hooks:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestInstallCodexPreservesCustomOnlyHooksByteForByte(t *testing.T) {
+	fs := fsys.NewFake()
+	custom := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"command":"printf custom-codex-hook","type":"command"}]}]}}`)
+	fs.Files["/work/.codex/hooks.json"] = append([]byte(nil), custom...)
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	got := fs.Files["/work/.codex/hooks.json"]
+	if !bytes.Equal(custom, got) {
+		t.Fatalf("custom-only codex hooks were rewritten:\nbefore:\n%s\nafter:\n%s", custom, got)
+	}
+}
+
 func TestInstallCodexUpgradePreservesCustomHooks(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/work/.codex/hooks.json"] = []byte(`{


### PR DESCRIPTION
Follow-up to #1826 (`fix(codex): canonicalize managed hook bytes`).

Original PR URL: https://github.com/gastownhall/gascity/pull/1826
Original PR title: fix(codex): canonicalize managed hook bytes
Original PR state at finalization: MERGED
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

The original contributor PR was merged before adoption finalization. The adoption review found one maintainer-side fixup that still needs to land: preserving custom-only `.codex/hooks.json` files byte-for-byte while keeping managed Codex hook installs canonical and stable.

This follow-up contains only the maintainer fixup commit:

- `fix: preserve custom-only codex hooks`

Local validation:

- `go test ./internal/hooks`

_Adopted via `/adopt-pr` workflow for #1826. Original contributor commit was preserved in the already-merged PR; this PR carries the maintainer-side fixup._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->