### PR TITLE
Fix post-merge Dolt drift review findings

### DIFF
--- a/cmd/gc/cmd_doctor_drift.go
+++ b/cmd/gc/cmd_doctor_drift.go
@@ -71,18 +71,19 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 			continue
 		}
 
-		livePID, infoExists, pidOK := rigLocalDoltPIDFromSQLServerInfo(rig.Path)
+		livePID, livePort, infoExists, liveRigLocal := rigLocalDoltPIDFromSQLServerInfo(rig.Path)
 
 		// Case A: rig is inherited_city but has a live rig-local Dolt.
-		if pidOK {
+		if liveRigLocal {
 			errors = append(errors, fmt.Sprintf(
-				"rig %q endpoint_origin=inherited_city but rig-local Dolt pid %d is live (.dolt/sql-server.info); run `gc rig set-endpoint %s --inherit` to rejoin the city or stop the rig-local server",
-				rig.Name, livePID, rig.Name,
+				"rig %q endpoint_origin=inherited_city but rig-local Dolt pid %d is listening on port %d (.dolt/sql-server.info); stop the rig-local server or acknowledge it with `gc rig set-endpoint %s --self --port %d --force`",
+				rig.Name, livePID, livePort, rig.Name, livePort,
 			))
 		} else if infoExists {
-			// Case C: stale rig-local sql-server.info (file present, PID not alive).
+			// Case C: stale rig-local sql-server.info (file present, but the
+			// recorded PID is not serving the recorded port).
 			warnings = append(warnings, fmt.Sprintf(
-				"rig %q has stale .dolt/sql-server.info (pid %d not alive); safe to delete",
+				"rig %q has stale .dolt/sql-server.info (pid %d is not a live Dolt listener for the recorded port); safe to delete after confirming no rig-local server is running",
 				rig.Name, livePID,
 			))
 		}
@@ -115,7 +116,7 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 		}
 		r.Message = fmt.Sprintf("%d drift issue%s between rig-local Dolt state and managed city topology", len(errors), plural)
 		r.Details = append(append([]string{}, errors...), warnings...)
-		r.FixHint = "use `gc rig set-endpoint <rig> --inherit` (rejoin city) or --external (pin explicit endpoint); remove stale .dolt/sql-server.info files"
+		r.FixHint = "stop the rig-local Dolt server, or acknowledge explicit rig-local ownership with `gc rig set-endpoint <rig> --self --port <port> --force`; use --external for non-local servers; remove stale .dolt/sql-server.info files"
 		return r
 	}
 	plural := ""
@@ -125,7 +126,7 @@ func (c *doltDriftCheck) Run(_ *doctor.CheckContext) *doctor.CheckResult {
 	r.Status = doctor.StatusWarning
 	r.Message = fmt.Sprintf("%d stale rig-local Dolt state file%s", len(warnings), plural)
 	r.Details = warnings
-	r.FixHint = "remove stale .dolt/sql-server.info files whose PID is not alive"
+	r.FixHint = "remove stale .dolt/sql-server.info files whose PID is not serving the recorded port"
 	return r
 }
 
@@ -135,22 +136,33 @@ func (c *doltDriftCheck) Fix(_ *doctor.CheckContext) error { return nil }
 
 // rigLocalDoltPIDFromSQLServerInfo reads the colon-separated PID:PORT:UUID
 // content of rigPath/.dolt/sql-server.info (written by dolt sql-server). It
-// returns the PID parsed from the file, whether the file exists at all, and
-// whether that PID is currently alive. When the file is missing the PID is
-// zero and both bools are false.
-func rigLocalDoltPIDFromSQLServerInfo(rigPath string) (pid int, infoExists bool, pidAliveNow bool) {
+// returns the PID and port parsed from the file, whether the file exists at
+// all, and whether that PID is currently alive and listening on the recorded
+// port. When the file is missing the PID and port are zero and both bools are
+// false.
+func rigLocalDoltPIDFromSQLServerInfo(rigPath string) (pid int, port int, infoExists bool, pidAliveNow bool) {
 	path := filepath.Join(rigPath, ".dolt", "sql-server.info")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return 0, false, false
+		return 0, 0, false, false
 	}
 	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
 	if len(parts) < 1 || strings.TrimSpace(parts[0]) == "" {
-		return 0, true, false
+		return 0, 0, true, false
 	}
 	parsed, convErr := strconv.Atoi(strings.TrimSpace(parts[0]))
 	if convErr != nil || parsed <= 0 {
-		return 0, true, false
+		return 0, 0, true, false
 	}
-	return parsed, true, pidAlive(parsed)
+	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		return parsed, 0, true, false
+	}
+	parsedPort, convErr := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if convErr != nil || parsedPort <= 0 {
+		return parsed, 0, true, false
+	}
+	if !pidAlive(parsed) {
+		return parsed, parsedPort, true, false
+	}
+	return parsed, parsedPort, true, findPortHolderPID(strconv.Itoa(parsedPort)) == parsed
 }

--- a/cmd/gc/cmd_doctor_drift_test.go
+++ b/cmd/gc/cmd_doctor_drift_test.go
@@ -105,19 +105,51 @@ func TestDoltDriftCheckCleanManagedCityIsOK(t *testing.T) {
 
 func TestDoltDriftCheckDetectsLiveRigLocalDolt(t *testing.T) {
 	cityDir, rigDir, _, cfg := managedCityDriftFixture(t, "runner")
-	// Write sql-server.info with our own PID (definitely alive).
-	writeSQLServerInfo(t, rigDir, os.Getpid(), 28232)
+	ln := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = ln.Close() })
+	rigLocalPort := ln.Addr().(*net.TCPAddr).Port
+	// Write sql-server.info with our own PID and a port held by this process.
+	writeSQLServerInfo(t, rigDir, os.Getpid(), rigLocalPort)
 
 	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
 	if r.Status != doctor.StatusError {
 		t.Fatalf("Run() status = %v, want StatusError; message=%q details=%v", r.Status, r.Message, r.Details)
 	}
-	joined := r.Message + " " + strings.Join(r.Details, " ")
+	joined := r.Message + " " + strings.Join(r.Details, " ") + " " + r.FixHint
 	if !strings.Contains(joined, "runner") {
 		t.Errorf("want rig name in message/details, got:\n%s", joined)
 	}
 	if !strings.Contains(joined, "rig-local Dolt") && !strings.Contains(joined, "sql-server.info") {
 		t.Errorf("want rig-local Dolt mention in details, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--self --port") || !strings.Contains(joined, "--force") {
+		t.Errorf("want explicit --self --port --force remediation, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "--inherit") {
+		t.Errorf("want no --inherit no-op remediation for inherited rig, got:\n%s", joined)
+	}
+}
+
+func TestDoltDriftCheckTreatsLivePIDWithoutMatchingPortAsStale(t *testing.T) {
+	cityDir, rigDir, _, cfg := managedCityDriftFixture(t, "reused")
+	unusedPort := reserveRandomTCPPort(t)
+	// The PID is live, but it is not the process listening on the recorded
+	// sql-server.info port. Treat it as stale instead of a live rig-local Dolt.
+	writeSQLServerInfo(t, rigDir, os.Getpid(), unusedPort)
+
+	r := newDoltDriftCheck(cityDir, cfg).Run(&doctor.CheckContext{CityPath: cityDir})
+	if r.Status != doctor.StatusWarning {
+		t.Fatalf("Run() status = %v, want StatusWarning; message=%q details=%v", r.Status, r.Message, r.Details)
+	}
+	joined := r.Message + " " + strings.Join(r.Details, " ") + " " + r.FixHint
+	if !strings.Contains(joined, "stale") {
+		t.Errorf("want stale classification, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "endpoint_origin=inherited_city") {
+		t.Errorf("want no live rig-local error for reused PID, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "PID is not alive") {
+		t.Errorf("want stale hint to account for live PID with mismatched port, got:\n%s", joined)
 	}
 }
 
@@ -134,8 +166,8 @@ func TestDoltDriftCheckDetectsStaleRigLocalInfo(t *testing.T) {
 	if !strings.Contains(joined, "stale") {
 		t.Errorf("want 'stale' in result, got:\n%s", joined)
 	}
-	if !strings.Contains(joined, "stale") {
-		t.Errorf("want stale file mention, got:\n%s", joined)
+	if !strings.Contains(joined, "pid 2147483640") {
+		t.Errorf("want stale PID detail, got:\n%s", joined)
 	}
 }
 
@@ -173,26 +205,34 @@ func TestDoltDriftCheckNoRigsIsOK(t *testing.T) {
 
 func TestRigLocalDoltPIDFromSQLServerInfoParsesColonFormat(t *testing.T) {
 	dir := t.TempDir()
-	writeSQLServerInfo(t, dir, 12345, 28232)
-	pid, exists, alive := rigLocalDoltPIDFromSQLServerInfo(dir)
+	const parsedPID = 2147483639
+	writeSQLServerInfo(t, dir, parsedPID, 28232)
+	pid, port, exists, alive := rigLocalDoltPIDFromSQLServerInfo(dir)
 	if !exists {
 		t.Fatalf("infoExists = false, want true")
 	}
-	if pid != 12345 {
-		t.Errorf("pid = %d, want 12345", pid)
+	if pid != parsedPID {
+		t.Errorf("pid = %d, want %d", pid, parsedPID)
 	}
-	// alive depends on whether pid 12345 happens to be live; don't assert.
-	_ = alive
+	if port != 28232 {
+		t.Errorf("port = %d, want 28232", port)
+	}
+	if alive {
+		t.Errorf("pidAliveNow = true, want false when recorded PID is not tied to the port")
+	}
 }
 
 func TestRigLocalDoltPIDFromSQLServerInfoMissingFile(t *testing.T) {
 	dir := t.TempDir()
-	pid, exists, alive := rigLocalDoltPIDFromSQLServerInfo(dir)
+	pid, port, exists, alive := rigLocalDoltPIDFromSQLServerInfo(dir)
 	if exists {
 		t.Errorf("infoExists = true, want false when file is absent")
 	}
 	if pid != 0 {
 		t.Errorf("pid = %d, want 0", pid)
+	}
+	if port != 0 {
+		t.Errorf("port = %d, want 0", port)
 	}
 	if alive {
 		t.Errorf("pidAliveNow = true, want false when file absent")

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -120,6 +120,10 @@ func TestDoRigSetEndpointSelfWithForceSucceeds(t *testing.T) {
 		EndpointOrigin: contract.EndpointOriginInheritedCity,
 		EndpointStatus: contract.EndpointStatusVerified,
 	})
+	rigPortFile := filepath.Join(rigDir, ".beads", "dolt-server.port")
+	if err := os.WriteFile(rigPortFile, []byte("3311\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	origVerify := verifyRigExternalEndpoint
 	defer func() { verifyRigExternalEndpoint = origVerify }()
@@ -147,6 +151,9 @@ func TestDoRigSetEndpointSelfWithForceSucceeds(t *testing.T) {
 	}
 	if state.DoltPort != "28232" {
 		t.Fatalf("DoltPort = %q, want 28232", state.DoltPort)
+	}
+	if _, err := os.Stat(rigPortFile); !os.IsNotExist(err) {
+		t.Fatalf("rig port file after --self --force: err = %v, want not exist", err)
 	}
 }
 


### PR DESCRIPTION
Post-merge follow-up for #1156, authored as a maintainer remediation PR after reviewing the landed range `baa657ec..df807de7`.

Original PR author: @quad341.

Changes:
- Validate stale rig-local `.dolt/sql-server.info` by checking the recorded port holder PID before treating it as live drift.
- Update `gc doctor` remediation text to point operators at stopping the rig-local server or explicitly acknowledging it with `gc rig set-endpoint <rig> --self --port <port> --force`.
- Replace the duplicated stale-info assertion with a PID-detail assertion.
- Assert `--self --force` removes the managed rig `.beads/dolt-server.port` mirror.

Tests:
- `go test ./cmd/gc -run 'TestDoltDriftCheck|TestRigLocalDoltPIDFromSQLServerInfo|TestSyncConfiguredDoltPortFilesWarnsOnRigPortFileRewrite|TestSyncConfiguredDoltPortFilesSilentOnNoChange|TestValidateRigEndpointOptions(Self|Force|RejectsMultipleModes)|TestDoRigSetEndpointSelf' -count=1`

Self-review:
- Verified the diff is limited to the post-merge findings and focused test coverage.
- No unrelated cleanup or optional nit fixes were included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->