### PR TITLE
fix(maintenance,deacon): scope gate-sweep || true to gh + align deacon gate-list (closes #1734, #1735)

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4862,11 +4862,23 @@ exit 0
 	}
 }
 
-func TestGateSweepToleratesBdFailures(t *testing.T) {
+// TestGateSweepToleratesGhGateBdFailures verifies the surviving '|| true':
+// bd failures on the gh-gate evaluation path are tolerated because fresh
+// cities without 'gh auth' would otherwise fail this order on every 30s
+// cooldown. Timer-gate failures are NOT tolerated (see
+// TestGateSweepPropagatesTimerGateBdFailures) since #1734.
+func TestGateSweepToleratesGhGateBdFailures(t *testing.T) {
 	binDir, _, env := gateSweepEnv(t)
 	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
-echo "bd: simulated failure" >&2
-exit 1
+case "$*" in
+  *--type=gh*)
+    echo "bd: simulated gh-gate failure (e.g., missing gh auth)" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
 `)
 
 	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "gate-sweep.sh")
@@ -4874,7 +4886,35 @@ exit 1
 	cmd.Env = mergeTestEnv(env)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("gate-sweep should exit 0 even when bd fails (|| true is load-bearing for fresh cities without gh auth); got %v\n%s", err, out)
+		t.Fatalf("gate-sweep should exit 0 when only the gh-gate bd call fails (|| true is load-bearing for fresh cities without gh auth); got %v\n%s", err, out)
+	}
+}
+
+// TestGateSweepPropagatesTimerGateBdFailures verifies the #1734 fix:
+// failures on the timer-gate evaluation path must propagate (no '|| true'
+// suppression) so real bd regressions surface in the controller log.
+// Timer-gate evaluation is local-only and has no auth requirement that
+// would justify swallowing errors.
+func TestGateSweepPropagatesTimerGateBdFailures(t *testing.T) {
+	binDir, _, env := gateSweepEnv(t)
+	writeExecutable(t, filepath.Join(binDir, "bd"), `#!/bin/sh
+case "$*" in
+  *--type=timer*)
+    echo "bd: simulated timer-gate failure" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`)
+
+	script := filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "gate-sweep.sh")
+	cmd := exec.Command(script)
+	cmd.Env = mergeTestEnv(env)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gate-sweep should exit non-zero when the timer-gate bd call fails (no || true suppression on that line); got success\n%s", out)
 	}
 }
 

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -17,7 +17,7 @@ that require judgment, observation, or cross-rig coordination — things the
 Go controller can't or shouldn't do.
 
 Your job:
-- Close gates when conditions are met (timers, conditions, GitHub status)
+- Close gates when conditions are met (timer, gh, gh:run, gh:pr, bead)
 - Check convoy completion (cross-rig tracked issue status)
 - Resolve cross-rig dependencies (convert satisfied `blocks` -> `related`)
 - Monitor work-layer health (witnesses and refineries making progress)
@@ -158,7 +158,8 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }}` |
 | Context exhaustion | `gc runtime request-restart` |
 | Request target restart | `gc session kill <target>` |
-| Check gates | `gc bd gate check --type=timer --escalate` |
+| Check gates (timer) | `gc bd gate check --type=timer --escalate` |
+| Check gates (gh) | `gc bd gate check --type=gh --escalate` |
 | List gate beads | `gc bd gate list --json` |
 | List convoys | `gc convoy list` |
 | Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |

--- a/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
@@ -2,16 +2,22 @@
 # gate-sweep — evaluate and close pending gates.
 #
 # Runs as an exec order (no LLM, no agent, no wisp). bd dispatches per
-# type. `|| true` is load-bearing: bd shells out to `gh` for gh:run /
-# gh:pr gates, and fresh cities without `gh auth` would otherwise fail
-# this order on every 30s cooldown. bd's combined output reaches the
-# controller log only on non-zero exit (cmd/gc/order_dispatch.go:466-475),
-# so the suppression also hides real bd errors — diagnose by hand.
+# type. The `|| true` on the gh-gate line is load-bearing: bd shells
+# out to `gh` for gh:run / gh:pr gates, and fresh cities without
+# `gh auth` would otherwise fail this order on every 30s cooldown.
+# bd's combined output reaches the controller log only on non-zero
+# exit (cmd/gc/order_dispatch.go:466-475), so suppressing gh-gate
+# errors also hides real bd errors on that line — diagnose by hand.
+#
+# Timer-gate evaluation is local-only (no `gh` shell-out, no auth
+# requirement) so its failures should propagate to the controller log.
+# `|| true` would silently mask real bd regressions in timer-gate
+# evaluation — see #1734 for the rationale.
 #
 # Bead-type gates are skipped: in beads v1.0.2, checkBeadGate is
 # hard-coded to fail because cross-rig routing was removed upstream.
 # Restore `bd gate check --type=bead --escalate` when beads adds it back.
 set -euo pipefail
 
-bd gate check --type=timer --escalate || true
+bd gate check --type=timer --escalate
 bd gate check --type=gh --escalate || true

--- a/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh
@@ -6,8 +6,9 @@
 # out to `gh` for gh:run / gh:pr gates, and fresh cities without
 # `gh auth` would otherwise fail this order on every 30s cooldown.
 # bd's combined output reaches the controller log only on non-zero
-# exit (cmd/gc/order_dispatch.go:466-475), so suppressing gh-gate
-# errors also hides real bd errors on that line — diagnose by hand.
+# exit (see the `if err != nil` branch of `dispatchOne` in
+# cmd/gc/order_dispatch.go), so suppressing gh-gate errors also
+# hides real bd errors on that line — diagnose by hand.
 #
 # Timer-gate evaluation is local-only (no `gh` shell-out, no auth
 # requirement) so its failures should propagate to the controller log.


### PR DESCRIPTION
## Summary

Bundles two related fixes from the #1661 adoption review:

- **#1734** — `examples/gastown/packs/maintenance/assets/scripts/gate-sweep.sh` suppresses non-zero exit on **both** `bd gate check` calls. The `|| true` is load-bearing only on the gh-gate line (fresh cities without `gh auth` would fail every 30s cooldown). On the timer-gate line, the suppression silently masks real bd regressions. Drop `|| true` from the timer line, expand the rationale comment to explain the asymmetry.

- **#1735** — `examples/gastown/packs/gastown/agents/deacon/prompt.template.md` describes the gate model in two stale spots:
  - Line 20 listed `(timers, conditions, GitHub status)` but `condition` is no longer a real bd gate type post-#1661. Updated to `(timer, gh, gh:run, gh:pr, bead)`.
  - Recovery-table around line 161 listed only the timer recovery command. Added the gh recovery command since gh-gate evaluation is now an active path.

Both items were surfaced together in https://github.com/gastownhall/gascity/pull/1661#issuecomment-4381972981 so they ship together.

## Test plan

- [x] `TestGateSweepToleratesGhGateBdFailures` (renamed from `TestGateSweepToleratesBdFailures`) — gh-gate failures still tolerated, fake bd selects on `--type=gh`
- [x] `TestGateSweepPropagatesTimerGateBdFailures` (NEW) — timer-gate failures propagate (no `|| true` suppression)
- [x] `go test ./examples/gastown/ -run GateSweep` — all green
- [ ] Manual smoke: in a fresh city without `gh auth`, gate-sweep cron exits 0 and gh failure surfaces only via diagnose-by-hand path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->