### PR TITLE
fix(nudge): forward stamped close reasons

### DIFF
--- a/cmd/gc/cmd_nudge.go
+++ b/cmd/gc/cmd_nudge.go
@@ -1259,15 +1259,16 @@ func enqueueQueuedNudgeWithStore(cityPath string, store beads.Store, item queued
 		return nil
 	})
 	if err != nil && created && store != nil && beadID != "" {
-		// Stamp metadata.close_reason before Close so BdStore.Close (per
-		// #1644) can forward it as `bd close --reason` and satisfy the
-		// validator under validation.on-close=error. Both writes are
-		// best-effort: failures here would only swap one symptom (leaked
-		// open bead) for another (leaked open bead with mismatched
-		// metadata) and the original enqueue error is the one the caller
-		// actually needs to see.
-		_ = store.SetMetadata(beadID, "close_reason", nudgeEnqueueRollbackCloseReason)
-		_ = store.Close(beadID)
+		// Stamp metadata.close_reason before Close so BdStore.Close can forward
+		// it as `bd close --reason` and satisfy validation.on-close=error.
+		// Preserve the original enqueue error, but return rollback failures too
+		// so leaked open nudge beads are diagnosable.
+		if setErr := store.SetMetadata(beadID, "close_reason", nudgeEnqueueRollbackCloseReason); setErr != nil {
+			err = errors.Join(err, fmt.Errorf("stamping rollback nudge bead %q close reason: %w", beadID, setErr))
+		}
+		if closeErr := store.Close(beadID); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("closing rollback nudge bead %q: %w", beadID, closeErr))
+		}
 	}
 	return err
 }

--- a/cmd/gc/cmd_nudge_test.go
+++ b/cmd/gc/cmd_nudge_test.go
@@ -71,6 +71,15 @@ func (s *unrelatedNotFoundNudgeBeadStore) SetMetadataBatch(id string, kvs map[st
 	return s.MemStore.SetMetadataBatch(id, kvs)
 }
 
+type rollbackCloseFailStore struct {
+	*beads.MemStore
+	closeErr error
+}
+
+func (s *rollbackCloseFailStore) Close(string) error {
+	return s.closeErr
+}
+
 func TestMarkQueuedNudgeTerminalFallsBackWhenStoredBeadIDEmpty(t *testing.T) {
 	store := beads.NewMemStore()
 	item := queuedNudge{
@@ -2044,12 +2053,12 @@ func TestListQueuedNudges_CategorizesPendingAndDead(t *testing.T) {
 
 // TestMarkQueuedNudgeTerminalStampsCloseReason verifies that
 // markQueuedNudgeTerminal stamps a canonical close_reason on the nudge
-// bead's metadata before invoking store.Close. BdStore.Close (per #1644)
-// forwards metadata.close_reason as `bd close --reason ...`; without
-// this stamp, cities running with validation.on-close=error reject the
-// close, the withNudgeQueueState transaction rolls back, and the nudge
-// bounces between Pending and InFlight forever — generating a
-// bead.updated event per claim attempt for every wedged nudge.
+// bead's metadata before invoking store.Close. BdStore.Close forwards
+// metadata.close_reason as `bd close --reason ...`; without this stamp,
+// cities running with validation.on-close=error reject the close, the
+// withNudgeQueueState transaction rolls back, and the nudge bounces
+// between Pending and InFlight forever, generating a bead.updated event
+// per claim attempt for every wedged nudge.
 //
 // This test pins the contract that the close_reason metadata flows
 // through every state markQueuedNudgeTerminal handles. The
@@ -2142,8 +2151,8 @@ func TestNudgeCanonicalCloseReasonMeetsValidatorThreshold(t *testing.T) {
 	}
 	// Empty input also yields a >=20 char fallback (avoids accidental
 	// short close_reason if a caller passes "").
-	if got := nudgeCanonicalCloseReason(""); len(got) < 20 {
-		t.Errorf("empty-code fallback = %q (%d chars), want >=20", got, len(got))
+	if got := strings.TrimSpace(nudgeCanonicalCloseReason("")); len(got) < 20 {
+		t.Errorf("trimmed empty-code fallback = %q (%d chars), want >=20", got, len(got))
 	}
 	// Codes already >=20 characters pass through unchanged.
 	const long = "a-very-long-state-code-already-sufficient"
@@ -2155,10 +2164,10 @@ func TestNudgeCanonicalCloseReasonMeetsValidatorThreshold(t *testing.T) {
 // TestEnqueueQueuedNudgeWithStore_RollbackStampsCloseReason verifies that
 // enqueueQueuedNudgeWithStore's rollback path stamps a canonical
 // metadata.close_reason on the partially-created nudge bead before
-// invoking store.Close. Without the stamp, BdStore.Close (per #1644)
-// has no metadata.close_reason to forward, the validator (under
-// validation.on-close=error) rejects the close, and the rollback
-// silently leaks an OPEN nudge bead with metadata.state="queued".
+// invoking store.Close. Without the stamp, BdStore.Close has no
+// metadata.close_reason to forward, the validator (under
+// validation.on-close=error) rejects the close, and the rollback leaks
+// an OPEN nudge bead with metadata.state="queued".
 //
 // Triggers the rollback by writing corrupt JSON to the queue state
 // file before the call, which fails LoadState inside withNudgeQueueState
@@ -2204,5 +2213,37 @@ func TestEnqueueQueuedNudgeWithStore_RollbackStampsCloseReason(t *testing.T) {
 	// floor. If someone shortens it without thinking, this guard fires.
 	if got := nudgeEnqueueRollbackCloseReason; len(got) < 20 {
 		t.Errorf("nudgeEnqueueRollbackCloseReason = %q (%d chars), want >=20 to satisfy validation.on-close=error", got, len(got))
+	}
+}
+
+func TestEnqueueQueuedNudgeWithStore_RollbackReturnsCloseFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	statePath := nudgequeue.StatePath(dir)
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(statePath, []byte("{not-valid-json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	closeErr := errors.New("rollback close failed")
+	store := &rollbackCloseFailStore{
+		MemStore: beads.NewMemStore(),
+		closeErr: closeErr,
+	}
+	item := newQueuedNudgeWithOptions("worker", "rollback close failure", "session", time.Now(), queuedNudgeOptions{
+		ID: "nudge-rollback-close-failure",
+	})
+
+	err := enqueueQueuedNudgeWithStore(dir, store, item)
+	if err == nil {
+		t.Fatal("enqueueQueuedNudgeWithStore: expected error from corrupt queue state and rollback close failure")
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("error = %v, want joined rollback close failure", err)
+	}
+	if !strings.Contains(err.Error(), "rollback nudge bead") {
+		t.Fatalf("error = %q, want rollback context", err)
 	}
 }

--- a/cmd/gc/nudge_beads.go
+++ b/cmd/gc/nudge_beads.go
@@ -19,10 +19,10 @@ const (
 	// stamped on partially-created nudge beads when enqueueQueuedNudgeWithStore's
 	// withNudgeQueueState transaction returns an error after the backing
 	// bead was successfully created. The rollback path closes the bead to
-	// avoid leaking it; the close goes through BdStore.Close (per #1644)
-	// which forwards metadata.close_reason as `bd close --reason`. Without
-	// this stamp, cities running with validation.on-close=error reject the
-	// rollback close and the bead leaks open with metadata.state="queued".
+	// avoid leaking it; BdStore.Close forwards metadata.close_reason as
+	// `bd close --reason`. Without this stamp, cities running with
+	// validation.on-close=error reject the rollback close and the bead leaks
+	// open with metadata.state="queued".
 	// The 42-character form satisfies the >=20 char validator floor.
 	nudgeEnqueueRollbackCloseReason = "nudge rollback: enqueue transaction failed"
 )
@@ -186,18 +186,18 @@ func markQueuedNudgeTerminal(store beads.Store, item queuedNudge, state, reason,
 // use as `bd close --reason` under validation.on-close=error.
 //
 // markQueuedNudgeTerminal stamps the result in metadata.close_reason
-// before invoking store.Close. BdStore.Close (per #1644) forwards
-// metadata.close_reason as the --reason argument, which is what allows
-// cities running with validation.on-close=error to accept the close.
+// before invoking store.Close. BdStore.Close and CloseAll forward
+// metadata.close_reason as the --reason argument, which allows cities
+// running with validation.on-close=error to accept the close.
 // Without the canonical reason, the validator rejects close calls with
 // reason <20 chars, the close fails, the entire withNudgeQueueState
 // transaction rolls back, and the nudge bounces between InFlight and
 // Pending forever (one bead.updated event per claim attempt) until
 // expires_at cuts in.
 //
-// Unknown codes fall back to "nudge terminated: <code>" which is always
-// >=20 characters for non-empty short codes. Codes already 20+ chars
-// pass through unchanged.
+// Unknown codes fall back to a descriptive phrase that remains >=20
+// characters after bd's validator trims whitespace. Codes already 20+
+// chars pass through unchanged.
 func nudgeCanonicalCloseReason(stateCode string) string {
 	switch stateCode {
 	case "failed":
@@ -214,8 +214,9 @@ func nudgeCanonicalCloseReason(stateCode string) string {
 	if len(stateCode) >= 20 {
 		return stateCode
 	}
-	// Prefix is exactly 20 chars so that the empty-code fallback meets
-	// the validator threshold and any non-empty addition exceeds it.
+	if stateCode == "" {
+		return "nudge terminalized: unknown-state"
+	}
 	return "nudge terminalized: " + stateCode
 }
 

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -870,10 +870,15 @@ func (s *BdStore) CloseAll(ids []string, metadata map[string]string) (int, error
 	return len(ids), nil
 }
 
-// Close sets a bead's status to closed via bd close.
+// Close sets a bead's status to closed via bd close. If the bead already has
+// metadata.close_reason, the trimmed value is forwarded as bd close --reason.
 // Idempotent: closing an already-closed bead returns nil.
 func (s *BdStore) Close(id string) error {
-	return s.close(id, "")
+	reason := ""
+	if b, err := s.Get(id); err == nil {
+		reason = strings.TrimSpace(b.Metadata["close_reason"])
+	}
+	return s.close(id, reason)
 }
 
 func bdCloseArgs(reason string, ids ...string) []string {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -330,6 +330,35 @@ func TestBdStoreClose(t *testing.T) {
 	}
 }
 
+func TestBdStoreCloseForwardsStampedCloseReason(t *testing.T) {
+	const reason = "nudge failed: queue terminalization rejected delivery"
+	var closeArgs []string
+	runner := func(_, name string, args ...string) ([]byte, error) {
+		if name != "bd" {
+			return nil, fmt.Errorf("unexpected command name: %s", name)
+		}
+		switch strings.Join(args, " ") {
+		case "show --json bd-abc-123":
+			return []byte(`[{"id":"bd-abc-123","title":"test","status":"open","issue_type":"task","created_at":"2025-01-15T10:30:00Z","metadata":{"close_reason":"` + reason + `"}}]`), nil
+		case "close --force --json --reason " + reason + " bd-abc-123":
+			closeArgs = append([]string(nil), args...)
+			return []byte(`[{"id":"bd-abc-123","title":"test","status":"closed","issue_type":"task","created_at":"2025-01-15T10:30:00Z"}]`), nil
+		default:
+			return nil, fmt.Errorf("unexpected command: bd %s", strings.Join(args, " "))
+		}
+	}
+
+	s := beads.NewBdStore("/city", runner)
+	if err := s.Close("bd-abc-123"); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"close", "--force", "--json", "--reason", reason, "bd-abc-123"}
+	if got := fmt.Sprint(closeArgs); got != fmt.Sprint(want) {
+		t.Fatalf("close args = %v, want %v", closeArgs, want)
+	}
+}
+
 func TestBdStoreReopenUsesReopenCommand(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte


### PR DESCRIPTION
Follow-up for the post-merge review of #1693.

## Summary
- Forward stamped `metadata.close_reason` through `BdStore.Close` as `bd close --reason`.
- Return rollback close/stamp failures so leaked nudge beads are diagnosable.
- Keep empty nudge terminal fallback reasons above the validator threshold after trimming.

## Tests
- `.githooks/pre-commit` full observable Go unit run
- `GC_FAST_UNIT=1 go test ./internal/beads ./cmd/gc -run 'Test(BdStoreClose|BdStoreCloseForwardsStampedCloseReason|MarkQueuedNudgeTerminalStampsCloseReason|NudgeCanonicalCloseReasonMeetsValidatorThreshold|EnqueueQueuedNudgeWithStore_RollbackStampsCloseReason|EnqueueQueuedNudgeWithStore_RollbackReturnsCloseFailure)$'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->