### PR TITLE
fix(sling): resolve agent.Dir to rig name before formula SearchPaths lookup (closes #1801)

### DIFF
--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -763,11 +763,51 @@ func BeadMetadataTarget(store beads.Store, beadID string) string {
 
 // SlingFormulaSearchPaths returns the formula search paths for the current
 // sling context.
+//
+// FormulaLayers.SearchPaths is keyed by rig NAME, but agent.Dir may be
+// either a rig name OR a filesystem path (the docs/examples allow both).
+// Resolve to the rig name first so pack-imported formula layers (under
+// fl.Rigs[<name>]) are reachable when an agent is configured with a path
+// instead of a name. Without this resolution the lookup silently falls
+// back to fl.City and pack-imported formulas appear "not found in search
+// paths" even though `gc formula list` discovers them via the cooked
+// dolt store. See gastownhall/gascity#1801.
 func SlingFormulaSearchPaths(deps SlingDeps, a config.Agent) []string {
 	if deps.Cfg == nil {
 		return nil
 	}
-	return deps.Cfg.FormulaLayers.SearchPaths(a.Dir)
+	rigName := rigNameForAgent(deps.Cfg, a)
+	return deps.Cfg.FormulaLayers.SearchPaths(rigName)
+}
+
+// rigNameForAgent returns the rig name for an agent. Handles both
+// configuration shapes:
+//   - a.Dir is a rig name (`dir = "gascity"`) — return as-is after a
+//     defensive existence check against cfg.Rigs.
+//   - a.Dir is a filesystem path (`dir = "/home/ds/gascity"`) — find the
+//     rig whose Path matches and return its Name.
+//
+// Returns "" when the agent is city-scoped (a.Dir empty) or no rig
+// matches; SearchPaths handles "" by returning city-level layers.
+func rigNameForAgent(cfg *config.City, a config.Agent) string {
+	dir := strings.TrimSpace(a.Dir)
+	if dir == "" {
+		return ""
+	}
+	for _, r := range cfg.Rigs {
+		if r.Name == dir {
+			return r.Name
+		}
+	}
+	for _, r := range cfg.Rigs {
+		if strings.TrimSpace(r.Path) == "" {
+			continue
+		}
+		if r.Path == dir {
+			return r.Name
+		}
+	}
+	return ""
 }
 
 // SlingFormulaUsesBaseBranch reports whether the formula conventionally

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/molecule"
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/shellquote"
 	workdirutil "github.com/gastownhall/gascity/internal/workdir"
@@ -770,8 +771,9 @@ func BeadMetadataTarget(store beads.Store, beadID string) string {
 // fl.Rigs[<name>]) are reachable when an agent is configured with a path
 // instead of a name. Without this resolution the lookup silently falls
 // back to fl.City and pack-imported formulas appear "not found in search
-// paths" even though `gc formula list` discovers them via the cooked
-// dolt store. See gastownhall/gascity#1801.
+// paths" — `gc formula list` would still find them by scanning every
+// configured search path (city + every rig), so the lookup-versus-list
+// asymmetry is the surface symptom. See gastownhall/gascity#1801.
 func SlingFormulaSearchPaths(deps SlingDeps, a config.Agent) []string {
 	if deps.Cfg == nil {
 		return nil
@@ -785,7 +787,8 @@ func SlingFormulaSearchPaths(deps SlingDeps, a config.Agent) []string {
 //   - a.Dir is a rig name (`dir = "gascity"`) — return as-is after a
 //     defensive existence check against cfg.Rigs.
 //   - a.Dir is a filesystem path (`dir = "/home/ds/gascity"`) — find the
-//     rig whose Path matches and return its Name.
+//     rig whose Path matches (after symlink resolution + normalization)
+//     and return its Name.
 //
 // Returns "" when the agent is city-scoped (a.Dir empty) or no rig
 // matches; SearchPaths handles "" by returning city-level layers.
@@ -803,7 +806,12 @@ func rigNameForAgent(cfg *config.City, a config.Agent) string {
 		if strings.TrimSpace(r.Path) == "" {
 			continue
 		}
-		if r.Path == dir {
+		// Use SamePath so paths that differ only by trailing slashes,
+		// symlink resolution (/tmp vs /private/tmp on macOS), or other
+		// normalization quirks still match. Strict string equality
+		// would re-introduce the #1801 fall-through under those
+		// conditions.
+		if pathutil.SamePath(r.Path, dir) {
 			return r.Name
 		}
 	}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -2969,3 +2969,102 @@ func TestDoSlingForceSkipsCrossRig(t *testing.T) {
 		t.Fatalf("DoSling with --force should not error on cross-rig: %v", err)
 	}
 }
+
+// TestSlingFormulaSearchPaths_RigNameKey: agent.Dir = rig name should
+// resolve to the rig-specific FormulaLayers entry. This is the legacy
+// shape and was already working pre-#1801.
+func TestSlingFormulaSearchPaths_RigNameKey(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "gascity", Path: "/home/ds/gascity"},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"gascity": {"/rig/formulas", "/pack/formulas"},
+			},
+		},
+	}
+	a := config.Agent{Name: "polecat", Dir: "gascity"}
+	deps := SlingDeps{Cfg: cfg}
+
+	got := SlingFormulaSearchPaths(deps, a)
+	want := []string{"/rig/formulas", "/pack/formulas"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("SlingFormulaSearchPaths(rig-name agent) = %v, want %v", got, want)
+	}
+}
+
+// TestSlingFormulaSearchPaths_RigPathKey: agent.Dir = filesystem path
+// should ALSO resolve to the rig-specific FormulaLayers entry by mapping
+// the path to the rig name. Prior to #1801 this fell through to
+// fl.City silently, which made every pack-imported formula appear
+// "not found in search paths" when sling tried to instantiate it.
+func TestSlingFormulaSearchPaths_RigPathKey(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "gascity", Path: "/home/ds/gascity"},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"gascity": {"/rig/formulas", "/pack/formulas"},
+			},
+		},
+	}
+	a := config.Agent{Name: "polecat", Dir: "/home/ds/gascity"}
+	deps := SlingDeps{Cfg: cfg}
+
+	got := SlingFormulaSearchPaths(deps, a)
+	want := []string{"/rig/formulas", "/pack/formulas"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("SlingFormulaSearchPaths(rig-path agent) = %v, want %v (regression of #1801)", got, want)
+	}
+}
+
+// TestSlingFormulaSearchPaths_CityScoped: agent with empty Dir should
+// fall back to fl.City layers. Verifies the city-scoped path remains
+// untouched by the #1801 fix.
+func TestSlingFormulaSearchPaths_CityScoped(t *testing.T) {
+	cfg := &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"gascity": {"/rig/formulas"},
+			},
+		},
+	}
+	a := config.Agent{Name: "mayor", Dir: ""}
+	deps := SlingDeps{Cfg: cfg}
+
+	got := SlingFormulaSearchPaths(deps, a)
+	want := []string{"/city/formulas"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("SlingFormulaSearchPaths(city-scoped) = %v, want %v", got, want)
+	}
+}
+
+// TestSlingFormulaSearchPaths_UnknownDir: agent.Dir matching neither a
+// rig name nor a rig path should fall back to fl.City (the existing
+// SearchPaths fallback when the rig key is absent).
+func TestSlingFormulaSearchPaths_UnknownDir(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "gascity", Path: "/home/ds/gascity"},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"gascity": {"/rig/formulas"},
+			},
+		},
+	}
+	a := config.Agent{Name: "mystery", Dir: "/some/other/place"}
+	deps := SlingDeps{Cfg: cfg}
+
+	got := SlingFormulaSearchPaths(deps, a)
+	want := []string{"/city/formulas"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("SlingFormulaSearchPaths(unknown dir) = %v, want %v", got, want)
+	}
+}

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -3044,6 +3044,33 @@ func TestSlingFormulaSearchPaths_CityScoped(t *testing.T) {
 	}
 }
 
+// TestSlingFormulaSearchPaths_RigPathKey_TrailingSlash: agent.Dir with a
+// trailing slash should match the rig path after normalization. Strict
+// string equality (which the first version of this fix used) re-introduces
+// the #1801 fall-through whenever the operator writes `dir =
+// "/home/ds/gascity/"` in agent.toml.
+func TestSlingFormulaSearchPaths_RigPathKey_TrailingSlash(t *testing.T) {
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{Name: "gascity", Path: "/home/ds/gascity"},
+		},
+		FormulaLayers: config.FormulaLayers{
+			City: []string{"/city/formulas"},
+			Rigs: map[string][]string{
+				"gascity": {"/rig/formulas"},
+			},
+		},
+	}
+	a := config.Agent{Name: "polecat", Dir: "/home/ds/gascity/"}
+	deps := SlingDeps{Cfg: cfg}
+
+	got := SlingFormulaSearchPaths(deps, a)
+	want := []string{"/rig/formulas"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("SlingFormulaSearchPaths(trailing-slash dir) = %v, want %v", got, want)
+	}
+}
+
 // TestSlingFormulaSearchPaths_UnknownDir: agent.Dir matching neither a
 // rig name nor a rig path should fall back to fl.City (the existing
 // SearchPaths fallback when the rig key is absent).


### PR DESCRIPTION
## Summary

Closes #1801. `SlingFormulaSearchPaths` was passing `agent.Dir` (which can be either a rig name OR a filesystem path) directly to `FormulaLayers.SearchPaths`, which is keyed by rig **name**. When an agent is configured with `dir = "/home/ds/gascity"` (a filesystem path — a supported config shape), the lookup at `fl.Rigs[<path>]` always misses and falls back silently to `fl.City`, hiding rig-specific formula layers that include pack imports.

Result: `gc sling --on <name>` and `gc sling --formula` fail with `formula "<name>" not found in search paths` for any pack-imported formula, even though the formula file exists on disk and `bd formula list` discovers it via the cooked Dolt store. Reproduced today against `pr-pipeline` pack formulas (`mol-pr-start`, `mol-adopt-pr`); workaround was `gc formula cook <name>` followed by `gc sling <cooked-root>`, which uses `cmd_formula.go`'s correctly-keyed `resolveFormulaScope`.

## Fix

Add a `rigNameForAgent` helper that resolves `agent.Dir` to a rig name in two passes:

1. Match by rig **name** (legacy shape, already worked).
2. Match by rig **path** (the regression shape — find the rig whose `Path` matches).

Empty `agent.Dir` (city-scoped agents) returns `""` and preserves the existing `fl.City` fallback. Unknown-dir agents also fall through to city-level layers (no behavior change for that path).

`SlingFormulaSearchPaths` now calls `FormulaLayers.SearchPaths(rigNameForAgent(deps.Cfg, a))` instead of `FormulaLayers.SearchPaths(a.Dir)`.

## Test plan

- [x] `TestSlingFormulaSearchPaths_RigNameKey` — agent.Dir = rig name resolves to rig layers (regression guard for the legacy shape)
- [x] `TestSlingFormulaSearchPaths_RigPathKey` — agent.Dir = rig path resolves to rig layers (the #1801 fix)
- [x] `TestSlingFormulaSearchPaths_CityScoped` — empty Dir falls back to fl.City
- [x] `TestSlingFormulaSearchPaths_UnknownDir` — unknown Dir falls back to fl.City
- [x] `go test ./internal/sling/` — all green
- [ ] Manual smoke: `gc sling polecat <bead> --on mol-pr-start --var issue=N` from a city where the gascity rig has `dir = "/home/ds/gascity"` — should now find the formula instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->