### PR TITLE
fix(workspacesvc): Tick retries proxy_process services that failed initial construction (closes #1774)

### DIFF
--- a/internal/workspacesvc/manager.go
+++ b/internal/workspacesvc/manager.go
@@ -44,6 +44,14 @@ type entry struct {
 	spec   config.Service
 	status Status
 	inst   Instance
+	// nextConstructionRetry is the earliest time Tick may re-attempt
+	// construction for this entry when inst is nil. Set by Reload (and
+	// failed Tick retries) for proxy_process services whose initial
+	// construction failed; ignored when inst is non-nil. Without this
+	// retry path, a transient construction failure (e.g. dependency
+	// endpoint not yet reachable at boot) leaves the service permanently
+	// dead until manual Restart. See gastownhall/gascity#1774.
+	nextConstructionRetry time.Time
 }
 
 type closeTarget struct {
@@ -166,7 +174,9 @@ func (m *Manager) Reload() error {
 				base.State = "degraded"
 				base.LocalState = "config_error"
 				base.Reason = err.Error()
-				next[svc.Name] = &entry{spec: svc, status: base}
+				// Schedule a Tick retry rather than leaving the entry
+				// permanently nil-inst (gastownhall/gascity#1774).
+				next[svc.Name] = &entry{spec: svc, status: base, nextConstructionRetry: now.Add(proxyProcessRestartBackoff)}
 				continue
 			}
 			base = mergeStatus(base, inst.Status())
@@ -216,6 +226,47 @@ func (m *Manager) Tick(ctx context.Context, now time.Time) {
 	refs := m.currentPublicationRefs()
 	for _, e := range entries {
 		if e.inst == nil {
+			// proxy_process services whose initial construction failed
+			// get retried here; without this, a transient boot-order
+			// failure (e.g. city not yet running when the proxy tries
+			// to register) leaves the service dead until manual
+			// Restart. See gastownhall/gascity#1774.
+			if e.spec.KindOrDefault() != "proxy_process" {
+				continue
+			}
+			if !e.nextConstructionRetry.IsZero() && now.Before(e.nextConstructionRetry) {
+				continue
+			}
+			base := baseStatus(m.rt.Config(), m.rt.PublicationConfig(), refs, e.spec, now)
+			inst, err := newProxyProcessInstance(m.rt, e.spec, base)
+			if err != nil {
+				m.mu.Lock()
+				if cur, ok := m.entries[e.spec.Name]; ok && cur.inst == nil {
+					base.State = "degraded"
+					base.LocalState = "config_error"
+					base.Reason = err.Error()
+					cur.status = base
+					cur.nextConstructionRetry = now.Add(proxyProcessRestartBackoff)
+				}
+				m.mu.Unlock()
+				continue
+			}
+			m.mu.Lock()
+			cur, ok := m.entries[e.spec.Name]
+			if ok && cur.inst == nil {
+				cur.inst = inst
+				cur.status = mergeStatus(base, inst.Status())
+				cur.nextConstructionRetry = time.Time{}
+			}
+			m.mu.Unlock()
+			if !ok || cur.inst != inst {
+				// Race: entry was Reloaded out from under us, or another
+				// Tick installed an inst first. Close the orphan we just
+				// constructed so it doesn't leak.
+				if err := inst.Close(); err != nil {
+					log.Printf("workspacesvc: close orphan proxy process %s after retry race: %v", e.spec.Name, err)
+				}
+			}
 			continue
 		}
 		base := baseStatus(m.rt.Config(), m.rt.PublicationConfig(), refs, e.spec, now)

--- a/internal/workspacesvc/proxy_process_test.go
+++ b/internal/workspacesvc/proxy_process_test.go
@@ -845,3 +845,152 @@ func TestProxyProcessSwapAndCloseCleanUpSocketFiles(t *testing.T) {
 		t.Fatalf("socket still exists after close: %v", err)
 	}
 }
+
+// TestManagerReloadProxyProcess_ConstructionFailureSchedulesRetry verifies
+// the #1774 fix: when proxy_process construction fails during Reload,
+// the entry is stored with inst=nil but nextConstructionRetry is set
+// to a time in the future. Without this scheduling, Tick would skip
+// the entry forever and the service would stay dead until manual
+// Restart.
+func TestManagerReloadProxyProcess_ConstructionFailureSchedulesRetry(t *testing.T) {
+	rt := &testRuntime{
+		cityPath: t.TempDir(),
+		cityName: "test-city",
+		cfg: &config.City{
+			Services: []config.Service{{
+				Name: "doomed",
+				Kind: "proxy_process",
+				Process: config.ServiceProcessConfig{
+					Command:    []string{"/this/binary/does/not/exist"},
+					HealthPath: "/healthz",
+				},
+			}},
+		},
+		sp:    runtime.NewFake(),
+		store: beads.NewMemStore(),
+	}
+	mgr := NewManager(rt)
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup
+
+	before := time.Now().UTC()
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	mgr.mu.RLock()
+	e, ok := mgr.entries["doomed"]
+	mgr.mu.RUnlock()
+	if !ok {
+		t.Fatal("entry missing after Reload")
+	}
+	if e.inst != nil {
+		t.Fatalf("inst should be nil after construction failure; got %T", e.inst)
+	}
+	if e.status.LocalState != "config_error" {
+		t.Fatalf("LocalState = %q, want config_error", e.status.LocalState)
+	}
+	if e.nextConstructionRetry.IsZero() {
+		t.Fatal("nextConstructionRetry should be set; got zero (would prevent Tick from ever retrying)")
+	}
+	if !e.nextConstructionRetry.After(before) {
+		t.Fatalf("nextConstructionRetry = %v, want > %v", e.nextConstructionRetry, before)
+	}
+}
+
+// TestManagerTickProxyProcess_RetriesAfterDeadline verifies the #1774
+// fix: Tick re-attempts construction on a nil-inst proxy_process entry
+// once nextConstructionRetry has elapsed. The retry still fails (the
+// binary is still missing) so we assert the deadline was bumped — the
+// key invariant is "Tick is willing to retry" rather than success.
+func TestManagerTickProxyProcess_RetriesAfterDeadline(t *testing.T) {
+	rt := &testRuntime{
+		cityPath: t.TempDir(),
+		cityName: "test-city",
+		cfg: &config.City{
+			Services: []config.Service{{
+				Name: "doomed",
+				Kind: "proxy_process",
+				Process: config.ServiceProcessConfig{
+					Command:    []string{"/this/binary/does/not/exist"},
+					HealthPath: "/healthz",
+				},
+			}},
+		},
+		sp:    runtime.NewFake(),
+		store: beads.NewMemStore(),
+	}
+	mgr := NewManager(rt)
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	mgr.mu.Lock()
+	e := mgr.entries["doomed"]
+	originalDeadline := e.nextConstructionRetry
+	// Simulate sufficient time having passed without sleeping the test.
+	e.nextConstructionRetry = time.Time{}
+	mgr.mu.Unlock()
+
+	mgr.Tick(context.Background(), time.Now().UTC().Add(time.Hour))
+
+	mgr.mu.RLock()
+	e = mgr.entries["doomed"]
+	mgr.mu.RUnlock()
+	if e == nil {
+		t.Fatal("entry vanished after Tick")
+	}
+	if e.inst != nil {
+		t.Fatalf("inst should still be nil (binary still missing); got %T", e.inst)
+	}
+	if e.nextConstructionRetry.IsZero() {
+		t.Fatal("nextConstructionRetry should be re-armed after a failed retry; got zero")
+	}
+	// Deadline should have moved forward — i.e. not still equal to original.
+	// We can't assert exact value because the test uses Tick's own clock.
+	if e.nextConstructionRetry.Equal(originalDeadline) {
+		t.Fatalf("nextConstructionRetry = %v unchanged; should have been bumped", e.nextConstructionRetry)
+	}
+}
+
+// TestManagerTickProxyProcess_RetryRespectsDeadline verifies that Tick
+// does NOT re-attempt construction before nextConstructionRetry has
+// elapsed. Bypassing the deadline would spam the supervisor with
+// per-Tick retry attempts when the precondition is permanently broken.
+func TestManagerTickProxyProcess_RetryRespectsDeadline(t *testing.T) {
+	rt := &testRuntime{
+		cityPath: t.TempDir(),
+		cityName: "test-city",
+		cfg: &config.City{
+			Services: []config.Service{{
+				Name: "doomed",
+				Kind: "proxy_process",
+				Process: config.ServiceProcessConfig{
+					Command:    []string{"/this/binary/does/not/exist"},
+					HealthPath: "/healthz",
+				},
+			}},
+		},
+		sp:    runtime.NewFake(),
+		store: beads.NewMemStore(),
+	}
+	mgr := NewManager(rt)
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	mgr.mu.Lock()
+	originalDeadline := mgr.entries["doomed"].nextConstructionRetry
+	mgr.mu.Unlock()
+
+	// Tick at a time well before the deadline.
+	mgr.Tick(context.Background(), originalDeadline.Add(-1*time.Second))
+
+	mgr.mu.RLock()
+	deadlineAfter := mgr.entries["doomed"].nextConstructionRetry
+	mgr.mu.RUnlock()
+	if !deadlineAfter.Equal(originalDeadline) {
+		t.Fatalf("nextConstructionRetry changed before deadline elapsed: %v -> %v", originalDeadline, deadlineAfter)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1774. `Manager.Tick` previously skipped every entry whose `inst` was nil (`internal/workspacesvc/manager.go:218`), which left `proxy_process` services dead forever when their initial Reload-time construction failed on a transient precondition (e.g. a subprocess that wants to register against a city HTTP endpoint that 404s for the first ~30s after supervisor boot).

Recovery before this fix required a manual `POST /v0/city/<name>/service/<name>/restart`. Stephanie hit this four times across `gc-mode dogfood`/`stable` flips during pack development on 2026-05-06.

## Implementation

Per issue's recommendation A:

- Added `nextConstructionRetry time.Time` to `entry`.
- `Reload`'s proxy_process construction-failure path now stamps `nextConstructionRetry = now + proxyProcessRestartBackoff`.
- `Tick`'s nil-inst loop now re-attempts construction for `proxy_process` entries whose `nextConstructionRetry` has elapsed. On success the `inst` slot is filled and the deadline cleared; on failure the deadline is bumped by another backoff interval.
- Race-safe: the retry path holds `m.mu` when swapping `inst`, double-checks `cur.inst==nil` to avoid stomping a Reload-installed inst, and `Closes` the freshly-built instance if a concurrent Reload raced ahead.

`workflow` services intentionally still skip in `Tick` — their construction errors (unsupported contract, factory-level config errors) don't fit the same transient-retry pattern. Issue's option B (generalized `pendingRetry` across all kinds) is the structural follow-up.

## Test plan

- [x] `TestManagerReloadProxyProcess_ConstructionFailureSchedulesRetry` — Reload sets `nextConstructionRetry > now` when construction fails
- [x] `TestManagerTickProxyProcess_RetriesAfterDeadline` — Tick re-attempts after deadline elapses (still fails on nonexistent binary, but deadline bumps)
- [x] `TestManagerTickProxyProcess_RetryRespectsDeadline` — Tick does NOT retry before deadline elapses (prevents per-Tick retry spam)
- [x] `go test ./internal/workspacesvc/` — all green
- [ ] Manual smoke: configure a proxy_process service whose subprocess registers against the city HTTP endpoint; restart supervisor; verify subprocess self-recovers within `proxyProcessRestartBackoff` of the city flipping to `running:true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->