### PR TITLE
fix(maintenance): jsonl-export treats missing origin remote as local-only

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -335,6 +335,16 @@ push_archive_main() {
         return 1
     }
 
+    # Local-only mode: no `origin` remote means the operator has chosen to
+    # keep the archive on disk only. Clear any pending push state and return
+    # success so the failure counter doesn't climb and the escalation never
+    # fires. Configure an `origin` remote to opt back in.
+    if ! git remote get-url origin >/dev/null 2>&1; then
+        set_consecutive_push_failures "0"
+        clear_pending_archive_push
+        return 0
+    fi
+
     if ! refresh_archive_remote_main; then
         if git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1; then
             record_archive_push_failure "jsonl-export: fetching origin/main failed"
@@ -482,7 +492,7 @@ fi
 # Build scrub filter for the issues table.
 SCRUB_FILTER=""
 if [ "$SCRUB" = "true" ]; then
-    SCRUB_FILTER="WHERE type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%'"
+    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%'"
 fi
 
 TOTAL_EXPORTED=0


### PR DESCRIPTION
## Summary

Two related fixes for `examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh`:

1. **`SCRUB_FILTER` referenced a nonexistent column.** The `bd` issues schema has `issue_type` (not `type`), so every per-database export query errored with `Error 1105 (HY000): column "type" could not be found in any table in scope`. The error path is masked by `2>/dev/null`, so the only operator-visible symptom was `DOG_DONE: jsonl — exported 0/N, records: 0, push: skipped, failed: <db>...` every cycle. The reaper's stale-issue query in the same pack already uses `issue_type` correctly — single-site bug. Filed as #1837.

2. **Missing `origin` remote should be local-only mode, not a push failure.** When the archive repo has no `origin` remote configured (operator chose disk-only retention, or just hasn't wired one up yet), `git push origin main` fails, increments `consecutive_push_failures`, and once the threshold trips it mails `ESCALATION: JSONL push failed [HIGH]` to mayor every cycle thereafter — false alarm forever. Now we detect a missing `origin` at the top of `push_archive_main`, clear pending-push state, and return success. Configuring an `origin` remote opts back in.

## Verification

Against a live `bd`-managed Dolt cluster (4 databases, ~9k records):

```
Before: DOG_DONE: jsonl — exported 0/4, records: 0, push: skipped, failed: ga gol hq pl
After:  DOG_DONE: jsonl — exported 4/4, records: 9313, push: ok
```

State file: `consecutive_push_failures: 0`, no `pending_archive_push`.

## Notes

- I have not added a Go test for the schema-mirroring repro. `examples/gastown/maintenance_scripts_test.go` stubs return shapes that don't exercise the column reference, which is presumably how this slipped through. Happy to add a targeted stub mirroring the real `bd` `issues` schema in a follow-up if reviewers want — flagged as a separate concern in #1837.
- The local-only mode change only activates when `git remote get-url origin` returns non-zero. Existing deployments with a configured `origin` see no behavioral change.

Refs #1837.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->