### PR TITLE
feat(beads/contract): canonical worker_dir + artifact_dir metadata keys (Shift C C1 phase 1, refs #1251)

### DIFF
--- a/internal/beads/contract/metadata.go
+++ b/internal/beads/contract/metadata.go
@@ -1,0 +1,100 @@
+package contract
+
+import "strings"
+
+// Canonical bead-metadata keys for the worker-path / artifact-path split
+// (gastownhall/gascity#1251 Shift C, phase 1).
+//
+// The legacy `work_dir` key was overloaded: it meant "agent process cwd"
+// when written on session beads and "work artifact directory" when
+// written on task/molecule beads. resolveTaskWorkDir in
+// cmd/gc/session_reconciler.go silently bridged the two semantics. The
+// new keys split the meaning:
+//
+//   WorkerDirKey ("worker_dir")     — agent process cwd. Session beads.
+//   ArtifactDirKey ("artifact_dir") — work artifact directory.
+//                                     Task / molecule beads.
+//
+// LegacyWorkDirKey is the old name. It MUST be kept readable on session
+// beads via WorkerDirFromMetadata so existing data does not regress
+// during the rollout. New writes should use WorkerDirKey.
+const (
+	// WorkerDirKey is the canonical session-bead metadata key for the
+	// agent process working directory.
+	WorkerDirKey = "worker_dir"
+
+	// ArtifactDirKey is the canonical task/molecule-bead metadata key
+	// for the work artifact directory. Distinct from WorkerDirKey to
+	// stop conflating "where the agent runs" with "where artifacts
+	// land" (#1101, originally #1094 — already fixed by #1169).
+	ArtifactDirKey = "artifact_dir"
+
+	// LegacyWorkDirKey is the deprecated metadata key that overloaded
+	// the worker-cwd and artifact-dir semantics on different bead
+	// types. Reads still fall back to it via WorkerDirFromMetadata so
+	// existing session beads keep working during the rollout. New
+	// writes should not use this key — a future CI lint will flag any
+	// new writes outside the alias-shim path.
+	LegacyWorkDirKey = "work_dir"
+)
+
+// WorkerDirFromMetadata returns the agent process working directory
+// recorded on a session bead. Reads the canonical WorkerDirKey first
+// and falls back to the legacy work_dir key when the canonical key is
+// absent or empty. Empty result means "no worker dir recorded."
+//
+// Whitespace-only values are normalized to empty so callers do not
+// have to TrimSpace at every read site.
+func WorkerDirFromMetadata(meta map[string]string) string {
+	if meta == nil {
+		return ""
+	}
+	if v := strings.TrimSpace(meta[WorkerDirKey]); v != "" {
+		return v
+	}
+	return strings.TrimSpace(meta[LegacyWorkDirKey])
+}
+
+// ArtifactDirFromMetadata returns the work artifact directory recorded
+// on a task or molecule bead. NO fallback to legacy work_dir on this
+// key path — task/molecule beads that wrote work_dir under the old
+// semantics were storing artifact paths, but the C1 rollout treats the
+// artifact-dir reading as new behavior driven by GC_ARTIFACT_DIR
+// projection (#1169) rather than bead-stored convention. Migration of
+// existing task-bead work_dir values is out of scope for this phase.
+//
+// Empty result means "no artifact dir recorded on this bead."
+func ArtifactDirFromMetadata(meta map[string]string) string {
+	if meta == nil {
+		return ""
+	}
+	return strings.TrimSpace(meta[ArtifactDirKey])
+}
+
+// SetWorkerDir writes the canonical WorkerDirKey on a metadata map,
+// creating the map if nil. Returns the (possibly newly allocated) map
+// so call sites can use a fluent style:
+//
+//   meta = contract.SetWorkerDir(meta, "/home/ds/gascity")
+//
+// Empty values are passed through (allowing callers to clear the key
+// by passing ""). Does not touch LegacyWorkDirKey — coexistence with
+// the deprecated key is the reader's responsibility via
+// WorkerDirFromMetadata.
+func SetWorkerDir(meta map[string]string, dir string) map[string]string {
+	if meta == nil {
+		meta = make(map[string]string, 1)
+	}
+	meta[WorkerDirKey] = dir
+	return meta
+}
+
+// SetArtifactDir writes the canonical ArtifactDirKey on a metadata
+// map, creating the map if nil. Mirrors SetWorkerDir.
+func SetArtifactDir(meta map[string]string, dir string) map[string]string {
+	if meta == nil {
+		meta = make(map[string]string, 1)
+	}
+	meta[ArtifactDirKey] = dir
+	return meta
+}

--- a/internal/beads/contract/metadata.go
+++ b/internal/beads/contract/metadata.go
@@ -11,9 +11,9 @@ import "strings"
 // cmd/gc/session_reconciler.go silently bridged the two semantics. The
 // new keys split the meaning:
 //
-//   WorkerDirKey ("worker_dir")     — agent process cwd. Session beads.
-//   ArtifactDirKey ("artifact_dir") — work artifact directory.
-//                                     Task / molecule beads.
+//	WorkerDirKey ("worker_dir")     — agent process cwd. Session beads.
+//	ArtifactDirKey ("artifact_dir") — work artifact directory.
+//	                                  Task / molecule beads.
 //
 // LegacyWorkDirKey is the old name. It MUST be kept readable on session
 // beads via WorkerDirFromMetadata so existing data does not regress
@@ -75,7 +75,7 @@ func ArtifactDirFromMetadata(meta map[string]string) string {
 // creating the map if nil. Returns the (possibly newly allocated) map
 // so call sites can use a fluent style:
 //
-//   meta = contract.SetWorkerDir(meta, "/home/ds/gascity")
+//	meta = contract.SetWorkerDir(meta, "/home/ds/gascity")
 //
 // Empty values are passed through (allowing callers to clear the key
 // by passing ""). Does not touch LegacyWorkDirKey — coexistence with

--- a/internal/beads/contract/metadata_test.go
+++ b/internal/beads/contract/metadata_test.go
@@ -1,0 +1,137 @@
+package contract
+
+import "testing"
+
+func TestWorkerDirFromMetadata_ReadsCanonicalKey(t *testing.T) {
+	got := WorkerDirFromMetadata(map[string]string{
+		WorkerDirKey: "/home/ds/gascity",
+	})
+	if got != "/home/ds/gascity" {
+		t.Fatalf("WorkerDirFromMetadata = %q, want %q", got, "/home/ds/gascity")
+	}
+}
+
+func TestWorkerDirFromMetadata_FallsBackToLegacyKey(t *testing.T) {
+	// Existing session beads written before C1 only have work_dir.
+	// Reads must keep working without rewriting the bead.
+	got := WorkerDirFromMetadata(map[string]string{
+		LegacyWorkDirKey: "/legacy/path",
+	})
+	if got != "/legacy/path" {
+		t.Fatalf("WorkerDirFromMetadata = %q, want %q (legacy fallback)", got, "/legacy/path")
+	}
+}
+
+func TestWorkerDirFromMetadata_CanonicalWinsOverLegacy(t *testing.T) {
+	// During the rollout a bead may carry both keys (writer started
+	// emitting worker_dir but the old work_dir was never cleared).
+	// Canonical key takes precedence.
+	got := WorkerDirFromMetadata(map[string]string{
+		WorkerDirKey:     "/canonical",
+		LegacyWorkDirKey: "/legacy",
+	})
+	if got != "/canonical" {
+		t.Fatalf("WorkerDirFromMetadata = %q, want %q (canonical wins)", got, "/canonical")
+	}
+}
+
+func TestWorkerDirFromMetadata_EmptyCanonicalFallsToLegacy(t *testing.T) {
+	// Edge case: canonical key present but blank string. Treat as
+	// "not set" and fall through to legacy.
+	got := WorkerDirFromMetadata(map[string]string{
+		WorkerDirKey:     "",
+		LegacyWorkDirKey: "/legacy",
+	})
+	if got != "/legacy" {
+		t.Fatalf("WorkerDirFromMetadata = %q, want %q (empty canonical → legacy)", got, "/legacy")
+	}
+}
+
+func TestWorkerDirFromMetadata_WhitespaceNormalized(t *testing.T) {
+	got := WorkerDirFromMetadata(map[string]string{
+		WorkerDirKey: "  /trimmed  ",
+	})
+	if got != "/trimmed" {
+		t.Fatalf("WorkerDirFromMetadata = %q, want %q (whitespace normalized)", got, "/trimmed")
+	}
+}
+
+func TestWorkerDirFromMetadata_NilMap(t *testing.T) {
+	if got := WorkerDirFromMetadata(nil); got != "" {
+		t.Fatalf("WorkerDirFromMetadata(nil) = %q, want empty", got)
+	}
+}
+
+func TestWorkerDirFromMetadata_AllEmpty(t *testing.T) {
+	got := WorkerDirFromMetadata(map[string]string{
+		WorkerDirKey:     "",
+		LegacyWorkDirKey: "   ",
+	})
+	if got != "" {
+		t.Fatalf("WorkerDirFromMetadata(all-empty) = %q, want empty", got)
+	}
+}
+
+func TestArtifactDirFromMetadata_ReadsCanonicalKey(t *testing.T) {
+	got := ArtifactDirFromMetadata(map[string]string{
+		ArtifactDirKey: "/artifacts/bead-1",
+	})
+	if got != "/artifacts/bead-1" {
+		t.Fatalf("ArtifactDirFromMetadata = %q, want %q", got, "/artifacts/bead-1")
+	}
+}
+
+func TestArtifactDirFromMetadata_NoLegacyFallback(t *testing.T) {
+	// ArtifactDir does NOT fall back to work_dir. Old task beads that
+	// wrote work_dir under the conflated semantics were storing
+	// artifact paths, but C1 explicitly does not migrate those —
+	// GC_ARTIFACT_DIR projection from #1169 is the new source of truth.
+	got := ArtifactDirFromMetadata(map[string]string{
+		LegacyWorkDirKey: "/legacy/artifact",
+	})
+	if got != "" {
+		t.Fatalf("ArtifactDirFromMetadata = %q, want empty (no legacy fallback)", got)
+	}
+}
+
+func TestArtifactDirFromMetadata_NilMap(t *testing.T) {
+	if got := ArtifactDirFromMetadata(nil); got != "" {
+		t.Fatalf("ArtifactDirFromMetadata(nil) = %q, want empty", got)
+	}
+}
+
+func TestSetWorkerDir_AllocatesNilMap(t *testing.T) {
+	got := SetWorkerDir(nil, "/home/ds/gascity")
+	if got == nil {
+		t.Fatal("SetWorkerDir(nil) returned nil map; should allocate")
+	}
+	if got[WorkerDirKey] != "/home/ds/gascity" {
+		t.Fatalf("SetWorkerDir result[%q] = %q, want %q", WorkerDirKey, got[WorkerDirKey], "/home/ds/gascity")
+	}
+}
+
+func TestSetWorkerDir_PreservesOtherKeys(t *testing.T) {
+	got := SetWorkerDir(map[string]string{
+		"other":          "kept",
+		LegacyWorkDirKey: "/legacy",
+	}, "/canonical")
+	if got["other"] != "kept" {
+		t.Fatalf("SetWorkerDir clobbered other keys: %v", got)
+	}
+	if got[LegacyWorkDirKey] != "/legacy" {
+		t.Fatalf("SetWorkerDir cleared legacy key: %v (caller's responsibility to clear if desired)", got)
+	}
+	if got[WorkerDirKey] != "/canonical" {
+		t.Fatalf("SetWorkerDir result[%q] = %q, want %q", WorkerDirKey, got[WorkerDirKey], "/canonical")
+	}
+}
+
+func TestSetArtifactDir_AllocatesNilMap(t *testing.T) {
+	got := SetArtifactDir(nil, "/artifacts/bead-1")
+	if got == nil {
+		t.Fatal("SetArtifactDir(nil) returned nil map; should allocate")
+	}
+	if got[ArtifactDirKey] != "/artifacts/bead-1" {
+		t.Fatalf("SetArtifactDir result[%q] = %q", ArtifactDirKey, got[ArtifactDirKey])
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of **Shift C** (#1251). **Additive foundation only** — no call sites are rewritten yet; this PR establishes the convention and the alias-fallback read path so phase 2 has a target.

`#1251` was re-scoped today: C2 (artifact-dir re-anchor on molecule ID) is dropped because merged #1169 already addresses its primary motivation. C1 (rename + alias + doctor) remains valuable as a code-clarity improvement and to close #1101.

## What this PR adds

`internal/beads/contract/metadata.go`:

| Key | Constant | Read helper | Write helper |
|---|---|---|---|
| `worker_dir` | `WorkerDirKey` | `WorkerDirFromMetadata` (with legacy fallback) | `SetWorkerDir` |
| `artifact_dir` | `ArtifactDirKey` | `ArtifactDirFromMetadata` (no legacy fallback) | `SetArtifactDir` |
| `work_dir` | `LegacyWorkDirKey` | (used internally as fallback by `WorkerDirFromMetadata`) | none — deprecated |

### Design notes

- **`WorkerDirFromMetadata` falls back to legacy `work_dir`** so existing session beads keep working without rewrite. Canonical key wins when both are present. Whitespace normalized. Nil-map safe.
- **`ArtifactDirFromMetadata` does NOT fall back to `work_dir`**. Old task-bead `work_dir` values stored artifact paths under the conflated semantics, but `GC_ARTIFACT_DIR` projection from #1169 is the new source of truth, and migration of old task-bead `work_dir` values is explicitly out of scope (per the re-scoped #1251 issue body).
- **Set helpers preserve other keys**, including `LegacyWorkDirKey` — coexistence with the deprecated key is the reader's responsibility via the alias fallback.

## What this PR does NOT do (deferred to phase 2 / phase 3)

- Rewrite call sites (`internal/session/manager.go`, `internal/session/chat.go`, `cmd/gc/session_reconciler.go`, `cmd/gc/session_beads.go`, `cmd/gc/cmd_session_logs.go`) to read via `WorkerDirFromMetadata`. **Phase 2.**
- Add `gc session doctor` for cwd-vs-city drift detection. **Phase 3.**
- CI lint flagging new `work_dir` writes outside the alias shim. **Phase 3.**
- Validate-at-creation for cwd outside the registered city tree. **Phase 3.**

## Test plan

- [x] `TestWorkerDirFromMetadata_ReadsCanonicalKey`
- [x] `TestWorkerDirFromMetadata_FallsBackToLegacyKey`
- [x] `TestWorkerDirFromMetadata_CanonicalWinsOverLegacy`
- [x] `TestWorkerDirFromMetadata_EmptyCanonicalFallsToLegacy`
- [x] `TestWorkerDirFromMetadata_WhitespaceNormalized`
- [x] `TestWorkerDirFromMetadata_NilMap`
- [x] `TestWorkerDirFromMetadata_AllEmpty`
- [x] `TestArtifactDirFromMetadata_ReadsCanonicalKey`
- [x] `TestArtifactDirFromMetadata_NoLegacyFallback`
- [x] `TestArtifactDirFromMetadata_NilMap`
- [x] `TestSetWorkerDir_AllocatesNilMap`
- [x] `TestSetWorkerDir_PreservesOtherKeys`
- [x] `TestSetArtifactDir_AllocatesNilMap`
- [x] `go test ./internal/beads/contract/` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->