### PR TITLE
fix(init): materialize pack overlays before installing Claude hooks

### DIFF
--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -948,12 +948,49 @@ func applyBootstrapProfile(cfg *config.City, profile string) {
 
 // installClaudeHooks writes Claude Code hook settings for the city.
 // Delegates to hooks.Install which is idempotent (won't overwrite existing files).
+//
+// Materializes pack-overlay universal files into cityPath first so the
+// Claude override file (.claude/settings.json) is in its final state when
+// hooks.Install reads it. Without this, pack overlays are materialized
+// asynchronously by tmux/adapter.go:Provider.Start() during the first
+// session start. That late write flips .gc/settings.json content on the
+// next supervisor reconcile, drifting the CopyFiles fingerprint and
+// draining every named session — including ones that never woke. See
+// stg-wvpl.
 func installClaudeHooks(fs fsys.FS, cityPath string, stderr io.Writer) int {
+	materializeCityRootPackOverlays(fs, cityPath, stderr)
 	if err := hooks.Install(fs, cityPath, cityPath, []string{"claude"}); err != nil {
 		fmt.Fprintf(stderr, "gc init: installing claude hooks: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
 	return 0
+}
+
+// materializeCityRootPackOverlays applies pack-overlay universal files into
+// cityPath. It mirrors the universal portion of overlay.CopyDirForProviders
+// for the cityRoot WorkDir case — agents whose work_dir defaults to cityRoot
+// (mayor, deacon, boot in gastown) cause the same materialization during
+// session start. Doing it before installClaude makes the supervisor's first
+// reconcile observe a stable .gc/settings.json source.
+//
+// Per-provider overlay files remain agent-scoped (materialized at session
+// start when the agent's provider is known); Claude's settings live outside
+// per-provider/, so universal-only is sufficient for the drift bug.
+//
+// Best-effort: if pack expansion fails (e.g. cityPath has no city.toml yet
+// in some early-init paths) or an overlay copy fails, we let installClaude
+// proceed against the pre-overlay state. Pre-fix behavior is the failure
+// mode, so degrading to it is acceptable.
+func materializeCityRootPackOverlays(fs fsys.FS, cityPath string, stderr io.Writer) {
+	cfg, _, err := config.LoadWithIncludes(fs, filepath.Join(cityPath, citylayout.CityConfigFile))
+	if err != nil || cfg == nil {
+		return
+	}
+	for _, od := range cfg.PackOverlayDirs {
+		if err := overlay.CopyDirForProviders(od, cityPath, nil, stderr); err != nil {
+			fmt.Fprintf(stderr, "gc init: materializing pack overlay %s: %v\n", od, err) //nolint:errcheck // best-effort stderr
+		}
+	}
 }
 
 func shouldBootstrapScopedFileStore(cfg *config.City) bool {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3641,6 +3641,82 @@ func TestDoInitFromDirSuccess(t *testing.T) {
 	}
 }
 
+// TestDoInitFromDirMaterializesPackOverlayClaudeSettings locks the fix for
+// stg-wvpl: pack-overlay universal files (notably .claude/settings.json) must
+// be present at the city root by the end of `gc init`. Otherwise the file is
+// materialized later, during the first session's tmux/adapter.go:Start, and
+// the supervisor's reconcile sees a content drift on .gc/settings.json that
+// drains every still-waking session — including ones that never woke yet
+// (deacon).
+func TestDoInitFromDirMaterializesPackOverlayClaudeSettings(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "packs", "demo", "overlay", ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\nincludes = [\"packs/demo\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
+		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "packs", "demo", "pack.toml"),
+		[]byte("[pack]\nname = \"demo\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	overlayPayload := []byte(`{"permissions":{"allow":["Bash"]}}`)
+	overlaySrc := filepath.Join(srcDir, "packs", "demo", "overlay", ".claude", "settings.json")
+	if err := os.WriteFile(overlaySrc, overlayPayload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(dir, "city")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := doInitFromDir(srcDir, cityPath, &stdout, &stderr); code != 0 {
+		t.Fatalf("doInitFromDir = %d; stderr: %s", code, stderr.String())
+	}
+
+	overlayDst := filepath.Join(cityPath, ".claude", "settings.json")
+	got, err := os.ReadFile(overlayDst)
+	if err != nil {
+		t.Fatalf("expected %s materialized at init: %v", overlayDst, err)
+	}
+	// Compare structurally — the merge layer may re-marshal the JSON, but
+	// the overlay's content must be present.
+	var gotJSON, wantJSON map[string]any
+	if err := json.Unmarshal(got, &gotJSON); err != nil {
+		t.Fatalf("parsing materialized override: %v\n%s", err, got)
+	}
+	if err := json.Unmarshal(overlayPayload, &wantJSON); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Errorf("city .claude/settings.json = %v, want %v", gotJSON, wantJSON)
+	}
+
+	// .gc/settings.json must reflect the overlay-merged base — without the
+	// fix it would only contain embedded defaults and be re-written on the
+	// first reconcile after session-start materialization.
+	runtime, err := os.ReadFile(filepath.Join(cityPath, ".gc", "settings.json"))
+	if err != nil {
+		t.Fatalf("reading runtime settings: %v", err)
+	}
+	if !strings.Contains(string(runtime), `"Bash"`) {
+		t.Errorf("runtime .gc/settings.json missing overlay-provided permission entry, got:\n%s", runtime)
+	}
+}
+
 func TestResolveCityName(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

- Materialize each `PackOverlayDirs` entry's universal files into `cityPath` from inside `installClaudeHooks`, before `hooks.Install` runs.
- This makes `<cityRoot>/.claude/settings.json` (the override that drives `desiredClaudeSettings`) present in its final state when `installClaude` projects `.gc/settings.json`, so the CopyFiles content hash captured by the supervisor's first reconcile matches subsequent reconciles.

## Why

`installClaudeHooks` is called both at `gc init` and via `ensureInitArtifacts` (`gc start`, `gc supervisor`). It reads `<cityRoot>/.claude/settings.json` as the override input to `desiredClaudeSettings` and writes the merged result to `<cityRoot>/.gc/settings.json`. Until now, the override file was only materialized into cityRoot lazily — by `tmux/adapter.go:Provider.Start` calling `overlay.CopyDirForProviders` for agents whose `work_dir` defaults to cityRoot (mayor / deacon / boot in gastown).

That late write changes the desired Claude settings between the supervisor's first reconcile (which captures the CopyFiles content hash as `started_config_hash`) and subsequent reconciles. The fingerprint flips, every always-named session is drained as "config drift," and the slowest-to-wake session — deacon — is drained before it ever reaches `session.woke`. `mol-e2e-baseline` reports `always-sessions never woke: deacon`, `init_seconds=null` ~80 % of the time on the default 5-minute wall.

This is the same shape as the skills-materialization bug fixed in #1152 (the comment at `cmd/gc/cmd_start.go:844-848` documents that pattern), but for `.claude/settings.json` instead of `.claude/skills`. #1152's fix (`SkipFingerprint=true`) is not the right shape here — #695 deliberately left the cityDir Claude settings with `SkipFingerprint=false` plus a locking test (`TestStageHookFilesIncludesCanonicalClaudeHook`), with the rationale that "real user edits still drive drain." Pack-provided overlay content is the pre-existing baseline, not a user edit, so materializing it earlier removes a false-positive drift signal without affecting the user-edit path.

## Testing

- [x] `make check` (gascity) — passes except for the three EXPECT-FAILs documented below; my new test `TestDoInitFromDirMaterializesPackOverlayClaudeSettings` passes.
- [ ] `make check-docs` — no docs touched.
- [ ] `make test-integration` — current contributor policy; reviewer can request a run.

Pre-existing failures observed under `make check`, all already documented as EXPECT-FAIL beads against `origin/main`, none touched by this PR:

- `TestBuiltinDoltDoctorBoundsVersionProbe` and `TestBuiltinDoltDoctorReportsTimedOutVersionProbe` — fixed by #1729 (still open).
- `TestProjectIdentity/B10_write_concurrent_same_id_safe` — flake under `make check` parallel load; passes 5/5 in isolation, fires under load (no fix-PR yet).

`go test ./cmd/gc -run 'TestDoInitFromDir|TestDoInitDoesNotOverwriteExistingSettings|TestInstallClaude|TestResolveTemplateClaudeProjectsCityDotClaudeSettingsIntoRuntimeFile' -count=1` is green locally.

## Checklist

- [x] Linked an issue: stg-wvpl downstream tracking; companion to #461 / #695 / #1152.
- [x] Added or updated tests for behavior changes — `TestDoInitFromDirMaterializesPackOverlayClaudeSettings` locks the post-init invariant on cityRoot's `.claude/settings.json`.
- [ ] Updated docs for user-facing changes — none.
- [ ] Called out breaking changes or migration notes — none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->