### PR TITLE
docs(prompts): direct formula-driven agents to read formula source for step descriptions

### DIFF
--- a/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
@@ -2,8 +2,13 @@
 ## Following Your Formula
 
 Your formula defines your work as a sequence of steps. Steps are NOT
-materialized as individual beads — they exist in the formula definition.
-Read the step descriptions and work through them in order.
+materialized as individual beads — they exist in the formula source on
+disk at `.beads/formulas/<your-formula>.formula.toml`. Read that file
+once to load the step descriptions, then work through them in order.
+
+`gc bd formula show <name>` lists step IDs and titles in a summary tree
+and is useful for confirming a formula is registered, but it does NOT
+emit the step descriptions you need to execute — read the source.
 
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.

--- a/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
@@ -2,8 +2,13 @@
 ## Following Your Formula
 
 Your formula defines your work as a sequence of steps. Steps are NOT
-materialized as individual beads — they exist in the formula definition.
-Read the step descriptions and work through them in order.
+materialized as individual beads — they exist in the formula source on
+disk at `.beads/formulas/<your-formula>.formula.toml`. Read that file
+once to load the step descriptions, then work through them in order.
+
+`gc bd formula show <name>` lists step IDs and titles in a summary tree
+and is useful for confirming a formula is registered, but it does NOT
+emit the step descriptions you need to execute — read the source.
 
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -41,8 +41,13 @@ that bead; run `gc hook` again or drain if no valid work is available.
 ## Following Your Formula
 
 Your formula defines your work as a sequence of steps. Steps are NOT
-materialized as individual beads — they exist in the formula definition.
-Read the step descriptions and work through them in order.
+materialized as individual beads — they exist in the formula source on
+disk at `.beads/formulas/<your-formula>.formula.toml`. Read that file
+once to load the step descriptions, then work through them in order.
+
+`gc bd formula show <name>` lists step IDs and titles in a summary tree
+and is useful for confirming a formula is registered, but it does NOT
+emit the step descriptions you need to execute — read the source.
 
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.


### PR DESCRIPTION
## Summary

The "Following Your Formula" prompt fragment instructs formula-driven agents
(deacon, witness, refinery, pool-worker) to "Read the step descriptions and
work through them in order" without naming where the descriptions live.
Agents improvise: in observed deacon transcripts, a single first wake spent
2–3 redundant turns paginating `gc bd formula show` and then `Read`-ing the
`.toml` source.

`gc bd formula show <name>` (cmd/gc/cmd_formula.go:200-232) prints a summary
tree of step IDs and titles only — it does **not** emit the step descriptions.
The descriptions live in the formula source on disk at
`.beads/formulas/<formula>.formula.toml`. Direct the agent there once and the
extra turns disappear.

This PR updates the three prompt locations that share the "Following Your
Formula" copy:

- `examples/gastown/packs/gastown/template-fragments/following-mol.template.md`
  (used by deacon, witness, refinery)
- `examples/gastown/packs/maintenance/template-fragments/following-mol.template.md`
  (maintenance pack copy)
- `internal/bootstrap/packs/core/assets/prompts/pool-worker.md`
  (core pool-worker prompt)

The new wording names the canonical source path, says to Read it once, and
clarifies that `gc bd formula show` is a summary-only confirmation tool.

## Background

Measured on a 2026-05-07 perf run (gastown city, fresh init): on first wake,
the deacon agent ran `gc bd formula show mol-deacon-patrol`, then `| head -200`,
then `| tail -400`, then `Read /path/to/mol-deacon-patrol.formula.toml`,
because the `formula show` output kept missing the step descriptions it needed
to execute. Estimated savings of this fix: 1 redundant turn per wake (~5–10s
of LLM inference). Small per wake, but every patrol-cycle restart pays it.

This is independent of #1744 (which redirects `gc bd mol show` → `gc bd formula
show` for a different failure mode); the two PRs touch overlapping prompt areas
but address different symptoms. Either order can land first; rebase is a
trivial one-line resolution.

## Testing

- [x] `make check`
- [x] `make check-docs`
- [x] `git diff --check`
- [ ] `make test-integration` — not run (per CONTRIBUTING; this is a
  prose-only prompt change, no runtime/controller behavior touched)

`cmd/gc/prompt_test.go:694` asserts the rendered prompt contains the
"Following Your Formula" header — header text is unchanged, test still passes.

## Checklist

- [x] Linked an issue, or explained why one is not needed: prose-only fix
  surfaced from internal investigation; no public issue.
- [x] Added or updated tests for behavior changes: no Go behavior change;
  existing render-presence test (`cmd/gc/prompt_test.go:694`) covers it.
- [x] Updated docs for user-facing changes: prompt templates updated directly.
- [x] Called out breaking changes or migration notes: none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->