### PR TITLE
feat(k8s): add pod scheduling fields to K8sConfig and Provider

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1077,6 +1077,56 @@ type K8sConfig struct {
 	// Prebaked skips init container staging and EmptyDir volumes when true.
 	// Use with images built by `gc build-image` that have city content baked in.
 	Prebaked bool `toml:"prebaked,omitempty"`
+	// NodeSelector constrains agent pod scheduling to nodes with matching labels.
+	// Set via GC_K8S_NODE_SELECTOR env (JSON) or TOML node_selector.
+	NodeSelector map[string]string `toml:"node_selector,omitempty"`
+	// Tolerations allows agent pods to be scheduled on tainted nodes.
+	// Set via GC_K8S_TOLERATIONS env (JSON array) or TOML toleration array.
+	Tolerations []K8sToleration `toml:"toleration,omitempty"`
+	// Affinity specifies advanced node/pod affinity rules for agent pods.
+	// Set via GC_K8S_AFFINITY env (JSON) or TOML affinity block.
+	Affinity *K8sAffinity `toml:"affinity,omitempty"`
+	// PriorityClassName sets the priority class for agent pods.
+	// Set via GC_K8S_PRIORITY_CLASS_NAME env or TOML priority_class_name.
+	PriorityClassName string `toml:"priority_class_name,omitempty"`
+}
+
+// K8sToleration mirrors corev1.Toleration for TOML serialization.
+type K8sToleration struct {
+	Key               string `toml:"key,omitempty"`
+	Operator          string `toml:"operator,omitempty"` // "Equal" or "Exists"
+	Value             string `toml:"value,omitempty"`
+	Effect            string `toml:"effect,omitempty"` // "NoSchedule", "PreferNoSchedule", "NoExecute"
+	TolerationSeconds *int64 `toml:"toleration_seconds,omitempty"`
+}
+
+// K8sAffinity mirrors the subset of corev1.Affinity used for pod placement.
+type K8sAffinity struct {
+	NodeAffinity *K8sNodeAffinity `toml:"node_affinity,omitempty"`
+}
+
+// K8sNodeAffinity mirrors corev1.NodeAffinity for TOML.
+type K8sNodeAffinity struct {
+	// Required is the hard node affinity requirement
+	// (RequiredDuringSchedulingIgnoredDuringExecution).
+	Required *K8sNodeSelector `toml:"required,omitempty"`
+}
+
+// K8sNodeSelector mirrors corev1.NodeSelector for TOML.
+type K8sNodeSelector struct {
+	NodeSelectorTerms []K8sNodeSelectorTerm `toml:"node_selector_term,omitempty"`
+}
+
+// K8sNodeSelectorTerm mirrors corev1.NodeSelectorTerm for TOML.
+type K8sNodeSelectorTerm struct {
+	MatchExpressions []K8sNodeSelectorRequirement `toml:"match_expression,omitempty"`
+}
+
+// K8sNodeSelectorRequirement mirrors corev1.NodeSelectorRequirement for TOML.
+type K8sNodeSelectorRequirement struct {
+	Key      string   `toml:"key"`
+	Operator string   `toml:"operator"` // "In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"
+	Values   []string `toml:"values,omitempty"`
 }
 
 // MailConfig holds mail provider settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1077,56 +1077,6 @@ type K8sConfig struct {
 	// Prebaked skips init container staging and EmptyDir volumes when true.
 	// Use with images built by `gc build-image` that have city content baked in.
 	Prebaked bool `toml:"prebaked,omitempty"`
-	// NodeSelector constrains agent pod scheduling to nodes with matching labels.
-	// Set via GC_K8S_NODE_SELECTOR env (JSON) or TOML node_selector.
-	NodeSelector map[string]string `toml:"node_selector,omitempty"`
-	// Tolerations allows agent pods to be scheduled on tainted nodes.
-	// Set via GC_K8S_TOLERATIONS env (JSON array) or TOML toleration array.
-	Tolerations []K8sToleration `toml:"toleration,omitempty"`
-	// Affinity specifies advanced node/pod affinity rules for agent pods.
-	// Set via GC_K8S_AFFINITY env (JSON) or TOML affinity block.
-	Affinity *K8sAffinity `toml:"affinity,omitempty"`
-	// PriorityClassName sets the priority class for agent pods.
-	// Set via GC_K8S_PRIORITY_CLASS_NAME env or TOML priority_class_name.
-	PriorityClassName string `toml:"priority_class_name,omitempty"`
-}
-
-// K8sToleration mirrors corev1.Toleration for TOML serialization.
-type K8sToleration struct {
-	Key               string `toml:"key,omitempty"`
-	Operator          string `toml:"operator,omitempty"` // "Equal" or "Exists"
-	Value             string `toml:"value,omitempty"`
-	Effect            string `toml:"effect,omitempty"` // "NoSchedule", "PreferNoSchedule", "NoExecute"
-	TolerationSeconds *int64 `toml:"toleration_seconds,omitempty"`
-}
-
-// K8sAffinity mirrors the subset of corev1.Affinity used for pod placement.
-type K8sAffinity struct {
-	NodeAffinity *K8sNodeAffinity `toml:"node_affinity,omitempty"`
-}
-
-// K8sNodeAffinity mirrors corev1.NodeAffinity for TOML.
-type K8sNodeAffinity struct {
-	// Required is the hard node affinity requirement
-	// (RequiredDuringSchedulingIgnoredDuringExecution).
-	Required *K8sNodeSelector `toml:"required,omitempty"`
-}
-
-// K8sNodeSelector mirrors corev1.NodeSelector for TOML.
-type K8sNodeSelector struct {
-	NodeSelectorTerms []K8sNodeSelectorTerm `toml:"node_selector_term,omitempty"`
-}
-
-// K8sNodeSelectorTerm mirrors corev1.NodeSelectorTerm for TOML.
-type K8sNodeSelectorTerm struct {
-	MatchExpressions []K8sNodeSelectorRequirement `toml:"match_expression,omitempty"`
-}
-
-// K8sNodeSelectorRequirement mirrors corev1.NodeSelectorRequirement for TOML.
-type K8sNodeSelectorRequirement struct {
-	Key      string   `toml:"key"`
-	Operator string   `toml:"operator"` // "In", "NotIn", "Exists", "DoesNotExist", "Gt", "Lt"
-	Values   []string `toml:"values,omitempty"`
 }
 
 // MailConfig holds mail provider settings.

--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -323,9 +324,11 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 	}
 
 	// Apply optional scheduling fields.
-	pod.Spec.NodeSelector = p.nodeSelector
-	pod.Spec.Tolerations = p.tolerations
-	pod.Spec.Affinity = p.affinity
+	pod.Spec.NodeSelector = maps.Clone(p.nodeSelector)
+	pod.Spec.Tolerations = cloneTolerations(p.tolerations)
+	if p.affinity != nil {
+		pod.Spec.Affinity = p.affinity.DeepCopy()
+	}
 	pod.Spec.PriorityClassName = p.priorityClassName
 
 	// Add init container when staging is needed (skip when prebaked).
@@ -348,6 +351,20 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 	}
 
 	return pod, nil
+}
+
+func cloneTolerations(in []corev1.Toleration) []corev1.Toleration {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([]corev1.Toleration(nil), in...)
+	for i := range out {
+		if in[i].TolerationSeconds != nil {
+			seconds := *in[i].TolerationSeconds
+			out[i].TolerationSeconds = &seconds
+		}
+	}
+	return out
 }
 
 // agentSecurityContext returns a container security context.

--- a/internal/runtime/k8s/pod.go
+++ b/internal/runtime/k8s/pod.go
@@ -322,6 +322,12 @@ func buildPod(name string, cfg runtime.Config, p *Provider) (*corev1.Pod, error)
 		},
 	}
 
+	// Apply optional scheduling fields.
+	pod.Spec.NodeSelector = p.nodeSelector
+	pod.Spec.Tolerations = p.tolerations
+	pod.Spec.Affinity = p.affinity
+	pod.Spec.PriorityClassName = p.priorityClassName
+
 	// Add init container when staging is needed (skip when prebaked).
 	if !p.prebaked && needsStaging(cfg, ctrlCity) {
 		initVolMounts := []corev1.VolumeMount{

--- a/internal/runtime/k8s/pod_test.go
+++ b/internal/runtime/k8s/pod_test.go
@@ -60,6 +60,10 @@ func TestBuildPod_Affinity(t *testing.T) {
 	if pod.Spec.Affinity.NodeAffinity == nil {
 		t.Fatal("NodeAffinity is nil")
 	}
+	expressions := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+	if expressions[0].Values[0] != "gpu" {
+		t.Fatalf("affinity value = %q, want gpu", expressions[0].Values[0])
+	}
 }
 
 func TestBuildPod_PriorityClassName(t *testing.T) {
@@ -92,5 +96,48 @@ func TestBuildPod_NoSchedulingFields_NoBehaviorChange(t *testing.T) {
 	}
 	if pod.Spec.PriorityClassName != "" {
 		t.Errorf("PriorityClassName should be empty when not set")
+	}
+}
+
+func TestBuildPod_ClonesSchedulingFields(t *testing.T) {
+	seconds := int64(30)
+	p := newProviderWithOps(newFakeK8sOps())
+	p.nodeSelector = map[string]string{"workload": "gc-agents"}
+	p.tolerations = []corev1.Toleration{{
+		Key:               "gc-agents",
+		Operator:          corev1.TolerationOpExists,
+		Effect:            corev1.TaintEffectNoSchedule,
+		TolerationSeconds: &seconds,
+	}}
+	p.affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "node-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"gpu"},
+					}},
+				}},
+			},
+		},
+	}
+
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+
+	pod.Spec.NodeSelector["workload"] = "changed"
+	pod.Spec.Tolerations[0].Key = "changed"
+	pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values[0] = "changed"
+
+	if p.nodeSelector["workload"] != "gc-agents" {
+		t.Fatalf("provider nodeSelector mutated to %q", p.nodeSelector["workload"])
+	}
+	if p.tolerations[0].Key != "gc-agents" {
+		t.Fatalf("provider toleration key mutated to %q", p.tolerations[0].Key)
+	}
+	values := p.affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values
+	if values[0] != "gpu" {
+		t.Fatalf("provider affinity value mutated to %q", values[0])
 	}
 }

--- a/internal/runtime/k8s/pod_test.go
+++ b/internal/runtime/k8s/pod_test.go
@@ -1,0 +1,96 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestBuildPod_NodeSelector(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.nodeSelector = map[string]string{"workload": "gc-agents"}
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if pod.Spec.NodeSelector["workload"] != "gc-agents" {
+		t.Errorf("NodeSelector[workload] = %q, want \"gc-agents\"", pod.Spec.NodeSelector["workload"])
+	}
+}
+
+func TestBuildPod_Tolerations(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.tolerations = []corev1.Toleration{{
+		Key: "gc-agents", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule,
+	}}
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if len(pod.Spec.Tolerations) != 1 {
+		t.Fatalf("len(Tolerations) = %d, want 1", len(pod.Spec.Tolerations))
+	}
+	if pod.Spec.Tolerations[0].Key != "gc-agents" {
+		t.Errorf("Toleration.Key = %q, want \"gc-agents\"", pod.Spec.Tolerations[0].Key)
+	}
+}
+
+func TestBuildPod_Affinity(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "node-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"gpu"},
+					}},
+				}},
+			},
+		},
+	}
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if pod.Spec.Affinity == nil {
+		t.Fatal("Affinity is nil")
+	}
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		t.Fatal("NodeAffinity is nil")
+	}
+}
+
+func TestBuildPod_PriorityClassName(t *testing.T) {
+	p := newProviderWithOps(newFakeK8sOps())
+	p.priorityClassName = "gc-agent-high"
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if pod.Spec.PriorityClassName != "gc-agent-high" {
+		t.Errorf("PriorityClassName = %q, want \"gc-agent-high\"", pod.Spec.PriorityClassName)
+	}
+}
+
+func TestBuildPod_NoSchedulingFields_NoBehaviorChange(t *testing.T) {
+	// Zero-value scheduling fields must not alter default pod behavior.
+	p := newProviderWithOps(newFakeK8sOps())
+	pod, err := buildPod("test-session", runtime.Config{Command: "/bin/bash"}, p)
+	if err != nil {
+		t.Fatalf("buildPod: %v", err)
+	}
+	if pod.Spec.NodeSelector != nil {
+		t.Errorf("NodeSelector should be nil when not set")
+	}
+	if len(pod.Spec.Tolerations) != 0 {
+		t.Errorf("Tolerations should be empty when not set")
+	}
+	if pod.Spec.Affinity != nil {
+		t.Errorf("Affinity should be nil when not set")
+	}
+	if pod.Spec.PriorityClassName != "" {
+		t.Errorf("PriorityClassName should be empty when not set")
+	}
+}

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -37,14 +37,21 @@ type Provider struct {
 	memRequest         string
 	cpuLimit           string
 	memLimit           string
-	serviceAccount     string        // pod service account name (GC_K8S_SERVICE_ACCOUNT)
-	prebaked           bool          // skip staging + init container for prebaked images
+	serviceAccount     string              // pod service account name (GC_K8S_SERVICE_ACCOUNT)
+	prebaked           bool                // skip staging + init container for prebaked images
 	nodeSelector       map[string]string   // GC_K8S_NODE_SELECTOR (JSON)
 	tolerations        []corev1.Toleration // GC_K8S_TOLERATIONS (JSON)
 	affinity           *corev1.Affinity    // GC_K8S_AFFINITY (JSON)
 	priorityClassName  string              // GC_K8S_PRIORITY_CLASS_NAME
-	postStartSettle    time.Duration // settle time before post-start liveness check
-	stderr             io.Writer     // warning output (default os.Stderr)
+	postStartSettle    time.Duration       // settle time before post-start liveness check
+	stderr             io.Writer           // warning output (default os.Stderr)
+}
+
+type schedulingFields struct {
+	nodeSelector      map[string]string
+	tolerations       []corev1.Toleration
+	affinity          *corev1.Affinity
+	priorityClassName string
 }
 
 // NewProvider creates a K8s session provider.
@@ -83,26 +90,11 @@ func NewProvider() (*Provider, error) {
 		return nil, err
 	}
 
-	var nodeSelector map[string]string
-	if v := os.Getenv("GC_K8S_NODE_SELECTOR"); v != "" {
-		if err := json.Unmarshal([]byte(v), &nodeSelector); err != nil {
-			return nil, fmt.Errorf("parsing GC_K8S_NODE_SELECTOR: %w", err)
-		}
+	scheduling, err := parseSchedulingEnv()
+	if err != nil {
+		return nil, err
 	}
-	var tolerations []corev1.Toleration
-	if v := os.Getenv("GC_K8S_TOLERATIONS"); v != "" {
-		if err := json.Unmarshal([]byte(v), &tolerations); err != nil {
-			return nil, fmt.Errorf("parsing GC_K8S_TOLERATIONS: %w", err)
-		}
-	}
-	var affinity *corev1.Affinity
-	if v := os.Getenv("GC_K8S_AFFINITY"); v != "" {
-		affinity = &corev1.Affinity{}
-		if err := json.Unmarshal([]byte(v), affinity); err != nil {
-			return nil, fmt.Errorf("parsing GC_K8S_AFFINITY: %w", err)
-		}
-	}
-	priorityClassName := os.Getenv("GC_K8S_PRIORITY_CLASS_NAME")
+
 	return &Provider{
 		ops: &realK8sOps{
 			clientset:  clientset,
@@ -122,11 +114,32 @@ func NewProvider() (*Provider, error) {
 		prebaked:           os.Getenv("GC_K8S_PREBAKED") == "true",
 		postStartSettle:    3 * time.Second,
 		stderr:             os.Stderr,
-		nodeSelector:       nodeSelector,
-		tolerations:        tolerations,
-		affinity:           affinity,
-		priorityClassName:  priorityClassName,
+		nodeSelector:       scheduling.nodeSelector,
+		tolerations:        scheduling.tolerations,
+		affinity:           scheduling.affinity,
+		priorityClassName:  scheduling.priorityClassName,
 	}, nil
+}
+
+func parseSchedulingEnv() (schedulingFields, error) {
+	var scheduling schedulingFields
+	if v := os.Getenv("GC_K8S_NODE_SELECTOR"); v != "" {
+		if err := json.Unmarshal([]byte(v), &scheduling.nodeSelector); err != nil {
+			return schedulingFields{}, fmt.Errorf("parsing GC_K8S_NODE_SELECTOR: %w", err)
+		}
+	}
+	if v := os.Getenv("GC_K8S_TOLERATIONS"); v != "" {
+		if err := json.Unmarshal([]byte(v), &scheduling.tolerations); err != nil {
+			return schedulingFields{}, fmt.Errorf("parsing GC_K8S_TOLERATIONS: %w", err)
+		}
+	}
+	if v := os.Getenv("GC_K8S_AFFINITY"); v != "" {
+		if err := json.Unmarshal([]byte(v), &scheduling.affinity); err != nil {
+			return schedulingFields{}, fmt.Errorf("parsing GC_K8S_AFFINITY: %w", err)
+		}
+	}
+	scheduling.priorityClassName = os.Getenv("GC_K8S_PRIORITY_CLASS_NAME")
+	return scheduling, nil
 }
 
 // newProviderWithOps creates a provider with a custom k8sOps (for testing).

--- a/internal/runtime/k8s/provider.go
+++ b/internal/runtime/k8s/provider.go
@@ -39,6 +39,10 @@ type Provider struct {
 	memLimit           string
 	serviceAccount     string        // pod service account name (GC_K8S_SERVICE_ACCOUNT)
 	prebaked           bool          // skip staging + init container for prebaked images
+	nodeSelector       map[string]string   // GC_K8S_NODE_SELECTOR (JSON)
+	tolerations        []corev1.Toleration // GC_K8S_TOLERATIONS (JSON)
+	affinity           *corev1.Affinity    // GC_K8S_AFFINITY (JSON)
+	priorityClassName  string              // GC_K8S_PRIORITY_CLASS_NAME
 	postStartSettle    time.Duration // settle time before post-start liveness check
 	stderr             io.Writer     // warning output (default os.Stderr)
 }
@@ -79,6 +83,26 @@ func NewProvider() (*Provider, error) {
 		return nil, err
 	}
 
+	var nodeSelector map[string]string
+	if v := os.Getenv("GC_K8S_NODE_SELECTOR"); v != "" {
+		if err := json.Unmarshal([]byte(v), &nodeSelector); err != nil {
+			return nil, fmt.Errorf("parsing GC_K8S_NODE_SELECTOR: %w", err)
+		}
+	}
+	var tolerations []corev1.Toleration
+	if v := os.Getenv("GC_K8S_TOLERATIONS"); v != "" {
+		if err := json.Unmarshal([]byte(v), &tolerations); err != nil {
+			return nil, fmt.Errorf("parsing GC_K8S_TOLERATIONS: %w", err)
+		}
+	}
+	var affinity *corev1.Affinity
+	if v := os.Getenv("GC_K8S_AFFINITY"); v != "" {
+		affinity = &corev1.Affinity{}
+		if err := json.Unmarshal([]byte(v), affinity); err != nil {
+			return nil, fmt.Errorf("parsing GC_K8S_AFFINITY: %w", err)
+		}
+	}
+	priorityClassName := os.Getenv("GC_K8S_PRIORITY_CLASS_NAME")
 	return &Provider{
 		ops: &realK8sOps{
 			clientset:  clientset,
@@ -98,6 +122,10 @@ func NewProvider() (*Provider, error) {
 		prebaked:           os.Getenv("GC_K8S_PREBAKED") == "true",
 		postStartSettle:    3 * time.Second,
 		stderr:             os.Stderr,
+		nodeSelector:       nodeSelector,
+		tolerations:        tolerations,
+		affinity:           affinity,
+		priorityClassName:  priorityClassName,
 	}, nil
 }
 

--- a/internal/runtime/k8s/provider_test.go
+++ b/internal/runtime/k8s/provider_test.go
@@ -66,6 +66,124 @@ func TestManagedServiceAliasRejectsPartialCompatOverride(t *testing.T) {
 	}
 }
 
+func TestParseSchedulingEnvHappyPath(t *testing.T) {
+	clearSchedulingEnv(t)
+	t.Setenv("GC_K8S_NODE_SELECTOR", `{"workload":"gc-agents"}`)
+	t.Setenv("GC_K8S_TOLERATIONS", `[{"key":"gc-agents","operator":"Exists","effect":"NoSchedule","tolerationSeconds":60}]`)
+	t.Setenv("GC_K8S_AFFINITY", `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node-type","operator":"In","values":["gpu"]}]}]}}}`)
+	t.Setenv("GC_K8S_PRIORITY_CLASS_NAME", "gc-agent-high")
+
+	scheduling, err := parseSchedulingEnv()
+	if err != nil {
+		t.Fatalf("parseSchedulingEnv: %v", err)
+	}
+	if scheduling.nodeSelector["workload"] != "gc-agents" {
+		t.Fatalf("nodeSelector[workload] = %q, want gc-agents", scheduling.nodeSelector["workload"])
+	}
+	if len(scheduling.tolerations) != 1 {
+		t.Fatalf("len(tolerations) = %d, want 1", len(scheduling.tolerations))
+	}
+	if scheduling.tolerations[0].TolerationSeconds == nil || *scheduling.tolerations[0].TolerationSeconds != 60 {
+		t.Fatalf("tolerationSeconds = %v, want 60", scheduling.tolerations[0].TolerationSeconds)
+	}
+	if scheduling.affinity == nil ||
+		scheduling.affinity.NodeAffinity == nil ||
+		scheduling.affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("affinity did not parse required node affinity: %#v", scheduling.affinity)
+	}
+	if got := scheduling.priorityClassName; got != "gc-agent-high" {
+		t.Fatalf("priorityClassName = %q, want gc-agent-high", got)
+	}
+}
+
+func TestParseSchedulingEnvRejectsMalformedJSON(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+	}{
+		{name: "node selector", key: "GC_K8S_NODE_SELECTOR"},
+		{name: "tolerations", key: "GC_K8S_TOLERATIONS"},
+		{name: "affinity", key: "GC_K8S_AFFINITY"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearSchedulingEnv(t)
+			t.Setenv(tc.key, "{")
+
+			_, err := parseSchedulingEnv()
+			if err == nil {
+				t.Fatal("expected malformed JSON to fail")
+			}
+			if !strings.Contains(err.Error(), tc.key) {
+				t.Fatalf("error = %q, want to mention %s", err, tc.key)
+			}
+		})
+	}
+}
+
+func TestParseSchedulingEnvEmptyAndNullAffinitySemantics(t *testing.T) {
+	t.Run("empty strings are unset", func(t *testing.T) {
+		clearSchedulingEnv(t)
+
+		scheduling, err := parseSchedulingEnv()
+		if err != nil {
+			t.Fatalf("parseSchedulingEnv: %v", err)
+		}
+		if scheduling.nodeSelector != nil {
+			t.Fatalf("nodeSelector = %#v, want nil", scheduling.nodeSelector)
+		}
+		if len(scheduling.tolerations) != 0 {
+			t.Fatalf("len(tolerations) = %d, want 0", len(scheduling.tolerations))
+		}
+		if scheduling.affinity != nil {
+			t.Fatalf("affinity = %#v, want nil", scheduling.affinity)
+		}
+		if scheduling.priorityClassName != "" {
+			t.Fatalf("priorityClassName = %q, want empty", scheduling.priorityClassName)
+		}
+	})
+
+	t.Run("affinity null is unset", func(t *testing.T) {
+		clearSchedulingEnv(t)
+		t.Setenv("GC_K8S_AFFINITY", "null")
+
+		scheduling, err := parseSchedulingEnv()
+		if err != nil {
+			t.Fatalf("parseSchedulingEnv: %v", err)
+		}
+		if scheduling.affinity != nil {
+			t.Fatalf("affinity = %#v, want nil", scheduling.affinity)
+		}
+	})
+
+	t.Run("affinity empty object is explicit empty", func(t *testing.T) {
+		clearSchedulingEnv(t)
+		t.Setenv("GC_K8S_AFFINITY", "{}")
+
+		scheduling, err := parseSchedulingEnv()
+		if err != nil {
+			t.Fatalf("parseSchedulingEnv: %v", err)
+		}
+		if scheduling.affinity == nil {
+			t.Fatal("affinity = nil, want explicit empty affinity")
+		}
+		if scheduling.affinity.NodeAffinity != nil {
+			t.Fatalf("NodeAffinity = %#v, want nil", scheduling.affinity.NodeAffinity)
+		}
+	})
+}
+
+func clearSchedulingEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GC_K8S_NODE_SELECTOR",
+		"GC_K8S_TOLERATIONS",
+		"GC_K8S_AFFINITY",
+		"GC_K8S_PRIORITY_CLASS_NAME",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestProjectedPodStoreRootPrefersGCStoreRoot(t *testing.T) {
 	cfg := runtime.Config{
 		WorkDir: "/host/city/workspaces/agent",


### PR DESCRIPTION
## Summary

Extends the Kubernetes session provider with four pod scheduling fields, enabling operators to constrain agent pod placement without modifying Go code.

## Changes

### `internal/config/config.go`
Adds four fields to `K8sConfig`:
- `NodeSelector map[string]string` — TOML `node_selector`, env `GC_K8S_NODE_SELECTOR` (JSON)
- `Tolerations []K8sToleration` — TOML `toleration`, env `GC_K8S_TOLERATIONS` (JSON array)
- `Affinity *K8sAffinity` — TOML `affinity`, env `GC_K8S_AFFINITY` (JSON)
- `PriorityClassName string` — TOML `priority_class_name`, env `GC_K8S_PRIORITY_CLASS_NAME`

Six new TOML-serializable mirror types avoid a direct `corev1` dependency in the config package.

### `internal/runtime/k8s/provider.go`
`NewProvider` reads and JSON-unmarshals the three composite env vars; invalid JSON is rejected with a wrapped error.

### `internal/runtime/k8s/pod.go`
`buildPod` sets `pod.Spec.NodeSelector`, `Tolerations`, `Affinity`, and `PriorityClassName` from provider fields. Nil/empty zero values are no-ops on the pod spec.

### `internal/runtime/k8s/pod_test.go` (new)
Five tests: one per scheduling field plus a zero-value no-op invariant test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->