### PR TITLE
test(integration): slack mock scaffold for slack-pack E2E tests (gc-3ccr step 1)

### DIFF
--- a/test/integration/slack_mock_selftest_test.go
+++ b/test/integration/slack_mock_selftest_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestSlackMock_CapturesPostMessage exercises the mock in isolation —
+// no slack-pack adapter, no e2eCity. This pins the mock's contract so a
+// later refactor that breaks capture semantics fails here, where the
+// failure is unambiguous, instead of in the higher-level e2e tests
+// where the failure could look like a slack-pack bug.
+func TestSlackMock_CapturesPostMessage(t *testing.T) {
+	t.Parallel()
+
+	mock := newSlackMock(t)
+
+	body := `{"channel":"C123","text":"hello","thread_ts":"1700000000.000100","idempotency_key":"k-1"}`
+	req, err := http.NewRequest(http.MethodPost, mock.URL()+"/api/chat.postMessage", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GC-Request", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var decoded map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if ok, _ := decoded["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true in response, got %#v", decoded)
+	}
+	if ts, _ := decoded["ts"].(string); ts == "" {
+		t.Fatalf("expected non-empty ts in response, got %#v", decoded)
+	}
+
+	calls := mock.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 captured call, got %d", len(calls))
+	}
+	c := calls[0]
+	if c.Channel != "C123" {
+		t.Errorf("Channel = %q, want %q", c.Channel, "C123")
+	}
+	if c.Text != "hello" {
+		t.Errorf("Text = %q, want %q", c.Text, "hello")
+	}
+	if c.ThreadTS != "1700000000.000100" {
+		t.Errorf("ThreadTS = %q, want %q", c.ThreadTS, "1700000000.000100")
+	}
+	if c.IdempotencyKey != "k-1" {
+		t.Errorf("IdempotencyKey = %q, want %q", c.IdempotencyKey, "k-1")
+	}
+	if c.GCRequest != "true" {
+		t.Errorf("GCRequest = %q, want %q", c.GCRequest, "true")
+	}
+}
+
+// TestSlackMock_CSRFGateRejectsMissingHeader pins the regression for
+// gastownhall/gascity#1817 — when requireGCRequest() is enabled the
+// mock returns 403 on /api/chat.* POSTs missing X-GC-Request: true.
+// A regression that drops the header in HTTPAdapter.Publish would
+// silently fail in production; this test makes that failure loud.
+func TestSlackMock_CSRFGateRejectsMissingHeader(t *testing.T) {
+	t.Parallel()
+
+	mock := newSlackMock(t)
+	mock.requireGCRequest()
+
+	resp, err := http.DefaultClient.Post(
+		mock.URL()+"/api/chat.postMessage",
+		"application/json",
+		strings.NewReader(`{"channel":"C1","text":"x"}`),
+	)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 without X-GC-Request, got %d", resp.StatusCode)
+	}
+	if calls := mock.Calls(); len(calls) != 0 {
+		t.Errorf("CSRF-gated request should not have been recorded, got %d call(s)", len(calls))
+	}
+}
+
+// TestSlackMock_EmitInboundEvent verifies that the mock can synthesize
+// an inbound Slack event and POST it at a callback URL the test
+// supplies. This is the Slack → adapter leg the higher-level e2e tests
+// will use.
+func TestSlackMock_EmitInboundEvent(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotBody    []byte
+		gotHeaders http.Header
+		hits       atomic.Int32
+	)
+	callback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(r.Body)
+		gotBody = buf.Bytes()
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(callback.Close)
+
+	mock := newSlackMock(t)
+	mock.emitInboundEvent(t, callback.URL, "C1", "U1", "hi", "1700000000.000200", "")
+
+	if hits.Load() != 1 {
+		t.Fatalf("expected callback to fire exactly once, got %d", hits.Load())
+	}
+
+	var env map[string]any
+	if err := json.Unmarshal(gotBody, &env); err != nil {
+		t.Fatalf("decode envelope: %v\nbody=%s", err, gotBody)
+	}
+	if env["type"] != "event_callback" {
+		t.Errorf("envelope type = %v, want event_callback", env["type"])
+	}
+	ev, _ := env["event"].(map[string]any)
+	if ev == nil {
+		t.Fatalf("envelope had no event field; body=%s", gotBody)
+	}
+	if ev["channel"] != "C1" || ev["user"] != "U1" || ev["text"] != "hi" {
+		t.Errorf("event payload mismatch: %#v", ev)
+	}
+	if got := gotHeaders.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/test/integration/slack_mock_test.go
+++ b/test/integration/slack_mock_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slackMock is an httptest.Server that stands in for the Slack Web API
+// during E2E tests. It captures every chat.postMessage call (and a small
+// set of related verbs) so tests can assert on what the slack-pack
+// adapter actually sent across the wire, and it can synthesize inbound
+// Slack events targeting an adapter callback URL supplied by the test.
+//
+// The mock deliberately implements the minimum surface needed to cover
+// the slack-pack pipeline. It is not a fidelity reimplementation of the
+// Slack Web API.
+//
+// CSRF gate: when requireGCRequestHeader is true, the mock returns 403
+// on any /api/chat.* POST that lacks the X-GC-Request header. This pins
+// the fix from gastownhall/gascity#1817 — the slack-pack adapter callback
+// URL points at gc's own /svc/<service>/publish proxy, which gates
+// private-service-proxy mutations on that header. A regression that
+// drops the header silently fails delivery in production; this mock
+// makes it fail the test.
+type slackMock struct {
+	t      *testing.T
+	server *httptest.Server
+
+	mu    sync.Mutex
+	calls []slackCall
+
+	tsCounter atomic.Int64
+
+	// requireGCRequestHeader, when true, makes the mock return 403 on
+	// /api/chat.* POSTs missing X-GC-Request: true. Off by default;
+	// regression tests for #1817 turn it on.
+	requireGCRequestHeader bool
+}
+
+// slackCall captures a single Slack Web API call as it arrived at the
+// mock. text/thread_ts/blocks are pulled from the JSON body for the
+// scenarios we need; less-used fields are kept in raw for tests that
+// want to assert on specifics without growing the struct.
+type slackCall struct {
+	Method         string
+	Channel        string
+	ThreadTS       string
+	Text           string
+	Blocks         json.RawMessage
+	IdempotencyKey string
+	GCRequest      string
+	Raw            json.RawMessage
+	At             time.Time
+}
+
+func newSlackMock(t *testing.T) *slackMock {
+	t.Helper()
+	m := &slackMock{t: t}
+	m.server = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+// URL returns the base URL of the mock — point the slack-pack adapter's
+// outbound HTTP client at this when wiring the e2eCity.
+func (m *slackMock) URL() string { return m.server.URL }
+
+// requireGCRequest enables the CSRF gate for #1817 regression.
+func (m *slackMock) requireGCRequest() { m.requireGCRequestHeader = true }
+
+// Calls returns a snapshot of every captured Slack API call so far.
+// Returned slice is safe for the caller to inspect without holding the
+// mock's lock.
+func (m *slackMock) Calls() []slackCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]slackCall, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// nextTS returns a deterministic message timestamp shaped like a real
+// Slack ts (seconds.microseconds). Monotonically increasing per mock
+// instance so ordering assertions are stable.
+func (m *slackMock) nextTS() string {
+	n := m.tsCounter.Add(1)
+	return fmt.Sprintf("17000000%02d.0001%02d", n%100, n%100)
+}
+
+func (m *slackMock) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	gcReq := r.Header.Get("X-GC-Request")
+	if m.requireGCRequestHeader && gcReq != "true" {
+		http.Error(w, "missing X-GC-Request: true", http.StatusForbidden)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var parsed map[string]json.RawMessage
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			http.Error(w, "invalid json: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	call := slackCall{
+		Method:    r.URL.Path,
+		Raw:       json.RawMessage(body),
+		GCRequest: gcReq,
+		At:        time.Now(),
+	}
+	if v, ok := parsed["channel"]; ok {
+		_ = json.Unmarshal(v, &call.Channel)
+	}
+	if v, ok := parsed["thread_ts"]; ok {
+		_ = json.Unmarshal(v, &call.ThreadTS)
+	}
+	if v, ok := parsed["text"]; ok {
+		_ = json.Unmarshal(v, &call.Text)
+	}
+	if v, ok := parsed["blocks"]; ok {
+		call.Blocks = v
+	}
+	if v, ok := parsed["idempotency_key"]; ok {
+		_ = json.Unmarshal(v, &call.IdempotencyKey)
+	}
+
+	m.mu.Lock()
+	m.calls = append(m.calls, call)
+	m.mu.Unlock()
+
+	ts := m.nextTS()
+	w.Header().Set("Content-Type", "application/json")
+	resp := map[string]any{
+		"ok":      true,
+		"ts":      ts,
+		"channel": call.Channel,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// emitInboundEvent POSTs a synthetic Slack event payload at the adapter
+// callback URL the caller provides — modeling the Slack → adapter leg
+// that real production traffic flows over. The shape mirrors the
+// `event_callback` envelope Slack sends.
+func (m *slackMock) emitInboundEvent(t *testing.T, callbackURL, channel, user, text, ts, threadTS string) {
+	t.Helper()
+	event := map[string]any{
+		"type":    "event_callback",
+		"team_id": "T0TESTWS",
+		"event": map[string]any{
+			"type":      "message",
+			"channel":   channel,
+			"user":      user,
+			"text":      text,
+			"ts":        ts,
+			"thread_ts": threadTS,
+		},
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal inbound event: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, callbackURL, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build inbound request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("emit inbound event: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("adapter rejected inbound event: status=%d body=%s", resp.StatusCode, respBody)
+	}
+}


### PR DESCRIPTION
## Summary

First commit of gc-3ccr — adds a reusable Slack Web API mock for `test/integration/` so future commits can build the missing slack-pack E2E coverage on top.

- `test/integration/slack_mock_test.go` — `slackMock` type backed by `httptest.Server`. Captures `/api/chat.*` POSTs (channel, thread_ts, text, blocks, idempotency_key, X-GC-Request) and synthesizes inbound Slack `event_callback` envelopes against an adapter callback URL the test supplies.
- `test/integration/slack_mock_selftest_test.go` — three tests pinning the mock's contract: happy-path capture, CSRF gate rejection (#1817 regression), inbound event emission.
- `requireGCRequest()` enables a CSRF gate: when on, the mock 403s any `/api/chat.*` POST missing `X-GC-Request: true`. This mirrors gc's `/svc-proxy` gate so a future regression that drops the header in `HTTPAdapter.Publish` fails the test instead of silently failing delivery in production.

Both files are tagged `//go:build integration`; they run under `make test-integration`.

## Why this PR exists

Today's slack-pack coverage is unit-only:

- `internal/extmsg/*_test.go` covers binding/group/transcript services and the HTTPAdapter Publish CSRF check (#1817 fix) but with httptest stand-ins, not a real round-trip.
- `examples/slack-pack/tests/*.py` mocks the HTTP layer in Python; no real gc binary is involved.
- `test/integration/` has the `setupE2ECity` + `gc(...)` pattern but zero slack/extmsg/adapter-prefixed files.

#1817 (http_adapter CSRF gap) and #1802 (extmsg group fallback) both shipped to production before tests caught them. An end-to-end layer would have caught both.

## Status — DRAFT

This PR lands the mock + self-tests only. The remaining pieces from gc-3ccr are the next commits / follow-on PRs:

- `slack_pack_helpers_test.go` — wires the slack-pack adapter into an `e2eCity` and points its outbound at the mock.
- `slack_pack_e2e_test.go` — first scenario test (`TestE2E_SlackPack_BindRoomReplyRoundTrip`) covering bind-room → inbound event → session reminder → `gc slack reply-current` → mock receives correct payload, plus regression sub-tests for #1817 and #1802.

Stays in draft until at least one end-to-end scenario lands on top.

## Test plan

- [x] `go test -tags integration -run "TestSlackMock_" -count=1 ./test/integration/` passes locally (3 tests, ~0.01s wall time)
- [x] `golangci-lint run --build-tags integration ./test/integration/...` reports no new issues
- [x] `golangci-lint fmt --diff ./test/integration/...` clean
- [x] `go vet -tags integration ./test/integration/...` clean
- [ ] CI's full integration suite green

Bead reference: gc-3ccr (gascity rig).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->