### PR TITLE
fix(maintenance): use issue_type column in jsonl-export SCRUB_FILTER

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -482,7 +482,7 @@ fi
 # Build scrub filter for the issues table.
 SCRUB_FILTER=""
 if [ "$SCRUB" = "true" ]; then
-    SCRUB_FILTER="WHERE type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%'"
+    SCRUB_FILTER="WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent') AND title NOT LIKE 'gc:%'"
 fi
 
 TOTAL_EXPORTED=0


### PR DESCRIPTION
## Summary

- Fix `jsonl-export.sh:485` SCRUB_FILTER to use `issue_type` (current schema column name) instead of stale `type` reference.
- Restores backup-export functionality for all populated databases.

## Root cause

The maintenance pack's `jsonl-export.sh` runs every 15 minutes and is responsible for exporting all dolt databases to a git-versioned JSONL archive — the human-readable, git-versioned backup of all durable work product.

In gc 1.1.0 (and likely earlier), this script silently failed for every populated database. The `2>/dev/null` redirect on line 526 hid the dolt error:

```
Error 1105 (HY000): column "type" could not be found in any table in scope
```

The SCRUB_FILTER on line 485 references `type`, but the `issues` table column is `issue_type`. This appears to be a schema rename that the filter never picked up.

## Verification

**Before:** archive repo at `$PACK_STATE_DIR/jsonl-archive/` had 0 commits despite hours of every-15-min export cycles. Every cycle reported `failed: <db>`.

**After fix on a city with hq populated (1263 issues):**

```
$ git -C $PACK_STATE_DIR/jsonl-archive log --oneline
7b006dd backup 2026-05-08T16:55:10Z: exported=1/3 records=1265
$ wc -c $PACK_STATE_DIR/jsonl-archive/hq.jsonl
1133822
```

Manual verification of the corrected query:

```sql
SELECT COUNT(*) FROM `hq`.issues
WHERE issue_type NOT IN ('message', 'event', 'wisp', 'agent')
  AND title NOT LIKE 'gc:%';
-- 1261
```

## Out of scope (separate observations, not fixed here)

1. **Empty-DB export still fails.** Dolt returns `{}` for zero-row results, but `validate_exported_issues` (line 68-76) requires `{"rows": [...]}` and rejects `{}`. Affects any database with no issues. Happy to file a separate PR if there's interest.
2. **`2>/dev/null` on the dolt call** is what hid this bug for hours of every-15-min cycles. Worth considering a per-DB stderr capture for future debuggability — kept out of this PR to keep the fix focused and reviewable.

## Test plan

- [x] Manual `dolt sql` with corrected query against a populated DB returns expected rows
- [x] Full export script post-fix produces archive commit + JSONL output for the populated DB
- [ ] Maintainer verification on a city with multiple populated DBs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->