### PR TITLE
fix(beads): honor configured bd metadata backend

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -149,7 +149,7 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 		clearCityDoltConfig(cityPath)
 	}
 	skipLocalDolt := false
-	if cityUsesBdStoreContract(cityPath) {
+	if cityUsesManagedDoltBackend(cityPath) {
 		owned, err := managedDoltLifecycleOwned(cityPath)
 		if err != nil {
 			return err
@@ -199,7 +199,7 @@ func startBeadsLifecycle(cityPath, _ string, cfg *config.City, stderr io.Writer)
 // skipped init — the caller should tell the user it's deferred to gc start.
 func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 	provider := beadsProvider(cityPath)
-	if cityUsesBdStoreContract(cityPath) {
+	if cityUsesManagedDoltBackend(cityPath) {
 		if gcDoltSkip() {
 			// Defer to controller/startup without forcing a new dolt_database:
 			// preserve existing metadata identity when present.
@@ -235,7 +235,7 @@ func initDirIfReady(cityPath, dir, prefix string) (deferred bool, err error) {
 	if strings.HasPrefix(provider, "exec:") {
 		script := strings.TrimPrefix(provider, "exec:")
 		if !runProviderProbe(script, cityPath, provider) {
-			if cityUsesBdStoreContract(cityPath) {
+			if cityUsesManagedDoltBackend(cityPath) {
 				if err := seedDeferredManagedBeadsErr(cityPath, dir, prefix, ""); err != nil {
 					return false, err
 				}
@@ -445,7 +445,7 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 	if err := normalizeCanonicalBdScopeFilesForInit(cityPath, dir, prefix, doltDatabase); err != nil {
 		return err
 	}
-	if cityUsesBdStoreContract(cityPath) && currentResolvableManagedDoltPort(cityPath) != "" {
+	if cityUsesManagedDoltBackend(cityPath) && currentResolvableManagedDoltPort(cityPath) != "" {
 		if err := syncManagedDoltPortMirrors(cityPath); err != nil {
 			return fmt.Errorf("sync managed dolt port mirrors after init: %w", err)
 		}
@@ -623,7 +623,7 @@ func resolveRigPaths(cityPath string, rigs []config.Rig) {
 // Acquires a per-city semaphore to prevent concurrent start operations
 // from causing spawn storms.
 func ensureBeadsProvider(cityPath string) error {
-	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
+	if cityUsesManagedDoltBackend(cityPath) && gcDoltSkip() {
 		return nil
 	}
 	provider := beadsProvider(cityPath)
@@ -665,7 +665,7 @@ func ensureBeadsProvider(cityPath string) error {
 // Called by gc stop after agents have been terminated.
 // For exec providers, fires "stop". For file providers, always available.
 func shutdownBeadsProvider(cityPath string) error {
-	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
+	if cityUsesManagedDoltBackend(cityPath) && gcDoltSkip() {
 		return clearManagedDoltRuntimeStateUnlessPostgres(cityPath)
 	}
 	provider := beadsProvider(cityPath)
@@ -705,7 +705,7 @@ func shutdownBeadsProvider(cityPath string) error {
 // providers that run bd init elsewhere (for example gc-beads-k8s inside the
 // pod) must set it in their own wrapper before invoking bd init.
 func initBeadsForDir(cityPath, dir, prefix, doltDatabase string) error {
-	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
+	if cityUsesManagedDoltBackend(cityPath) && gcDoltSkip() {
 		if err := seedDeferredManagedBeadsErr(cityPath, dir, prefix, doltDatabase); err != nil {
 			return err
 		}
@@ -894,7 +894,7 @@ func initFileStoreForDir(cityPath, dir string) error {
 // Acquires a per-city semaphore to prevent concurrent health/recovery
 // operations from causing a thundering herd when dolt bounces.
 func healthBeadsProvider(cityPath string) error {
-	if cityUsesBdStoreContract(cityPath) && gcDoltSkip() {
+	if cityUsesManagedDoltBackend(cityPath) && gcDoltSkip() {
 		return nil
 	}
 	provider := beadsProvider(cityPath)
@@ -1245,9 +1245,11 @@ func isLegacyManagedDoltProbeDatabase(name string) bool {
 	return strings.EqualFold(strings.TrimSpace(name), managedDoltProbeDatabase)
 }
 
-func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, preserveExisting bool) error {
+func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, state contract.MetadataState, preserveExisting bool) error {
 	path := filepath.Join(scopeRoot, ".beads", "metadata.json")
 	preserveReservedExisting := false
+	metadataBackend := normalizedBeadsMetadataBackend(state.Backend)
+	managedDoltMetadata := strings.EqualFold(metadataBackend, "dolt")
 	if preserveExisting {
 		if existing, ok, err := contract.LoadMetadataState(fs, path); err != nil {
 			if !allowLegacyDoltMetadataRepair(fs, path, err) {
@@ -1258,7 +1260,7 @@ func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, pr
 		}
 		if existing, ok, err := contract.ReadDoltDatabase(fs, path); err != nil {
 			return err
-		} else if ok && strings.TrimSpace(existing) != "" {
+		} else if managedDoltMetadata && ok && strings.TrimSpace(existing) != "" {
 			doltDatabase = strings.TrimSpace(existing)
 			if isReservedManagedDoltDatabase(doltDatabase) {
 				// New init paths reject this reserved name, but existing metadata
@@ -1270,7 +1272,7 @@ func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, pr
 		}
 	}
 	var err error
-	if !preserveReservedExisting {
+	if managedDoltMetadata && !preserveReservedExisting {
 		if doltDatabase, err = validateManagedDoltDatabaseName(path, doltDatabase); err != nil {
 			return err
 		}
@@ -1278,23 +1280,42 @@ func ensureCanonicalScopeMetadata(fs fsys.FS, scopeRoot, doltDatabase string, pr
 	if err := ensureBeadsDir(fs, filepath.Dir(path)); err != nil {
 		return err
 	}
-	_, err = contract.EnsureCanonicalMetadata(fs, path, contract.MetadataState{
-		Database:     "dolt",
-		Backend:      "dolt",
-		DoltMode:     "server",
-		DoltDatabase: doltDatabase,
-	})
+	state.Backend = metadataBackend
+	if strings.TrimSpace(state.Database) == "" {
+		state.Database = metadataBackend
+	}
+	if managedDoltMetadata {
+		state.DoltMode = "server"
+		state.DoltDatabase = doltDatabase
+	}
+	_, err = contract.EnsureCanonicalMetadata(fs, path, state)
 	return err
 }
 
 //nolint:unparam // keep fs seam for future testable FS injection
 func ensureCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase string) error {
-	return ensureCanonicalScopeMetadata(fs, scopeRoot, doltDatabase, true)
+	return ensureCanonicalScopeMetadata(fs, scopeRoot, doltDatabase, contract.MetadataState{Database: "dolt", Backend: "dolt"}, true)
 }
 
 //nolint:unparam // keep fs seam for future testable FS injection
 func enforceCanonicalScopeMetadataForInit(fs fsys.FS, scopeRoot, doltDatabase string) error {
-	return ensureCanonicalScopeMetadata(fs, scopeRoot, doltDatabase, false)
+	return ensureCanonicalScopeMetadata(fs, scopeRoot, doltDatabase, contract.MetadataState{Database: "dolt", Backend: "dolt"}, false)
+}
+
+func configuredBeadsMetadataState(cfg *config.City) contract.MetadataState {
+	state := contract.MetadataState{Database: "dolt", Backend: "dolt"}
+	if cfg == nil {
+		return state
+	}
+	backend := strings.TrimSpace(cfg.Beads.Backend)
+	database := strings.TrimSpace(cfg.Beads.Database)
+	if backend != "" {
+		state.Backend = backend
+	}
+	if database != "" {
+		state.Database = database
+	}
+	return state
 }
 
 // normalizeCanonicalBdScopeFiles reconciles canonical bd metadata/config/port
@@ -1314,11 +1335,15 @@ func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City, warns ...
 		warn = io.Discard
 	}
 	resolveRigPaths(cityPath, cfg.Rigs)
+	metadataState := configuredBeadsMetadataState(cfg)
+	metadataBackend := normalizedBeadsMetadataBackend(metadataState.Backend)
 	if scopeUsesManagedBdStoreContract(cityPath, cityPath) {
-		if usesPostgres, err := scopeUsesPostgresBackendForInit(cityPath, cityPath); err != nil {
+		usesPostgres, err := scopeUsesPostgresBackendForInit(cityPath, cityPath)
+		if err != nil {
 			return fmt.Errorf("classifying city backend: %w", err)
-		} else if !usesPostgres {
-			if err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, cityPath, defaultScopeDoltDatabase(cityPath, cityPath, config.EffectiveHQPrefix(cfg))); err != nil {
+		}
+		if !usesPostgres || !strings.EqualFold(metadataBackend, "dolt") {
+			if err := ensureCanonicalScopeMetadata(fsys.OSFS{}, cityPath, defaultScopeDoltDatabase(cityPath, cityPath, config.EffectiveHQPrefix(cfg)), metadataState, true); err != nil {
 				return fmt.Errorf("canonicalizing city metadata: %w", err)
 			}
 		}
@@ -1327,13 +1352,19 @@ func normalizeCanonicalBdScopeFiles(cityPath string, cfg *config.City, warns ...
 		if !rigUsesManagedBdStoreContract(cityPath, cfg.Rigs[i]) {
 			continue
 		}
-		if usesPostgres, err := scopeUsesPostgresBackendForInit(cityPath, cfg.Rigs[i].Path); err != nil {
+		usesPostgres, err := scopeUsesPostgresBackendForInit(cityPath, cfg.Rigs[i].Path)
+		if err != nil {
 			return fmt.Errorf("classifying rig %q backend: %w", cfg.Rigs[i].Name, err)
-		} else if !usesPostgres {
-			if err := ensureCanonicalScopeMetadataForInit(fsys.OSFS{}, cfg.Rigs[i].Path, defaultScopeDoltDatabase(cityPath, cfg.Rigs[i].Path, cfg.Rigs[i].EffectivePrefix())); err != nil {
-				return fmt.Errorf("canonicalizing rig %q metadata: %w", cfg.Rigs[i].Name, err)
-			}
 		}
+		if usesPostgres && strings.EqualFold(metadataBackend, "dolt") {
+			continue
+		}
+		if err := ensureCanonicalScopeMetadata(fsys.OSFS{}, cfg.Rigs[i].Path, defaultScopeDoltDatabase(cityPath, cfg.Rigs[i].Path, cfg.Rigs[i].EffectivePrefix()), metadataState, true); err != nil {
+			return fmt.Errorf("canonicalizing rig %q metadata: %w", cfg.Rigs[i].Name, err)
+		}
+	}
+	if !strings.EqualFold(metadataBackend, "dolt") {
+		return nil
 	}
 	if err := syncConfiguredDoltPortFiles(cityPath, cfg.Dolt, config.EffectiveHQPrefix(cfg), cfg.Rigs, warn); err != nil {
 		return fmt.Errorf("syncing canonical dolt config: %w", err)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -492,6 +492,61 @@ func TestNormalizeCanonicalBdScopeFilesRejectsExistingManagedSystemDatabase(t *t
 	}
 }
 
+func TestNormalizeCanonicalBdScopeFilesUsesConfiguredNonDoltBackend(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "frontend")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"fr"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "dolt-server.port"), []byte("3306\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "dogfood-city"},
+		Beads:     config.BeadsConfig{Provider: "bd", Backend: "postgres"},
+		Rigs:      []config.Rig{{Name: "frontend", Path: rigPath, Prefix: "fr"}},
+	}
+	if err := normalizeCanonicalBdScopeFiles(cityPath, cfg, io.Discard); err != nil {
+		t.Fatalf("normalizeCanonicalBdScopeFiles: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(cityPath, ".beads", "metadata.json"),
+		filepath.Join(rigPath, ".beads", "metadata.json"),
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var meta map[string]any
+		if err := json.Unmarshal(data, &meta); err != nil {
+			t.Fatalf("metadata %s: %v", path, err)
+		}
+		if got := strings.TrimSpace(fmt.Sprint(meta["backend"])); got != "postgres" {
+			t.Fatalf("%s backend = %q, want postgres; metadata=%s", path, got, data)
+		}
+		if got := strings.TrimSpace(fmt.Sprint(meta["database"])); got != "dolt" {
+			t.Fatalf("%s database = %q, want dolt; metadata=%s", path, got, data)
+		}
+	}
+
+	if data, err := os.ReadFile(filepath.Join(cityPath, ".beads", "dolt-server.port")); err != nil {
+		t.Fatal(err)
+	} else if got := strings.TrimSpace(string(data)); got != "3306" {
+		t.Fatalf("dolt-server.port = %q, want untouched 3306", got)
+	}
+}
+
 func TestNormalizeCanonicalBdScopeFilesForInitPreservesExistingManagedProbeDatabase(t *testing.T) {
 	cityPath := t.TempDir()
 	metadataPath := filepath.Join(cityPath, ".beads", "metadata.json")

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -281,6 +281,24 @@ func peekBeadsProvider(tomlPath string) string {
 	return peek.Beads.Provider
 }
 
+// peekBeadsMetadataBackend reads just the beads.backend field from a city.toml
+// without doing full config parsing. Returns "" if not set or on error.
+func peekBeadsMetadataBackend(tomlPath string) string {
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		return ""
+	}
+	var peek struct {
+		Beads struct {
+			Backend string `toml:"backend"`
+		} `toml:"beads"`
+	}
+	if _, err := toml.Decode(string(data), &peek); err != nil {
+		return ""
+	}
+	return peek.Beads.Backend
+}
+
 // peekEventsProvider reads just the events.provider field from a city.toml
 // without doing full config parsing. Returns "" if not set or on error.
 //

--- a/cmd/gc/providers.go
+++ b/cmd/gc/providers.go
@@ -454,6 +454,13 @@ func configuredBeadsProviderValue(cityPath string) string {
 	return strings.TrimSpace(peekBeadsProvider(filepath.Join(cityPath, "city.toml")))
 }
 
+func configuredBeadsMetadataBackendValue(cityPath string) string {
+	if v := strings.TrimSpace(os.Getenv("GC_BEADS_BACKEND")); v != "" {
+		return v
+	}
+	return strings.TrimSpace(peekBeadsMetadataBackend(filepath.Join(cityPath, "city.toml")))
+}
+
 func scopedBeadsProviderOverride(cityPath, scopeRoot string) (string, bool) {
 	provider := strings.TrimSpace(os.Getenv("GC_BEADS"))
 	if provider == "" {
@@ -517,6 +524,26 @@ func providerUsesBdStoreContract(provider string) bool {
 
 func cityUsesBdStoreContract(cityPath string) bool {
 	return providerUsesBdStoreContract(rawBeadsProvider(cityPath))
+}
+
+func normalizedBeadsMetadataBackend(backend string) string {
+	backend = strings.TrimSpace(backend)
+	if backend == "" {
+		return "dolt"
+	}
+	return backend
+}
+
+func rawBeadsMetadataBackend(cityPath string) string {
+	return normalizedBeadsMetadataBackend(configuredBeadsMetadataBackendValue(cityPath))
+}
+
+func providerUsesManagedDoltBackend(provider, backend string) bool {
+	return providerUsesBdStoreContract(provider) && strings.EqualFold(normalizedBeadsMetadataBackend(backend), "dolt")
+}
+
+func cityUsesManagedDoltBackend(cityPath string) bool {
+	return providerUsesManagedDoltBackend(rawBeadsProvider(cityPath), rawBeadsMetadataBackend(cityPath))
 }
 
 func rawBeadsProviderForScope(scopeRoot, cityPath string) string {
@@ -619,7 +646,7 @@ func bdProviderMismatchHint(scopeRoot, resolvedProvider string) string {
 //     operations. Used by testscript and integration tests.
 func beadsProvider(cityPath string) string {
 	raw := rawBeadsProvider(cityPath)
-	if raw == "bd" {
+	if raw == "bd" && cityUsesManagedDoltBackend(cityPath) {
 		return "exec:" + gcBeadsBdScriptPath(cityPath)
 	}
 	return raw

--- a/cmd/gc/providers_test.go
+++ b/cmd/gc/providers_test.go
@@ -162,6 +162,32 @@ provider = "file"
 	}
 }
 
+func TestBeadsProviderLeavesBdDirectForNonDoltMetadataBackend(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+
+[beads]
+provider = "bd"
+backend = "postgres"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := rawBeadsProvider(cityDir); got != "bd" {
+		t.Fatalf("rawBeadsProvider() = %q, want bd", got)
+	}
+	if got := rawBeadsMetadataBackend(cityDir); got != "postgres" {
+		t.Fatalf("rawBeadsMetadataBackend() = %q, want postgres", got)
+	}
+	if got := beadsProvider(cityDir); got != "bd" {
+		t.Fatalf("beadsProvider() = %q, want direct bd for non-Dolt metadata backend", got)
+	}
+	if cityUsesManagedDoltBackend(cityDir) {
+		t.Fatal("cityUsesManagedDoltBackend() = true, want false for backend=postgres")
+	}
+}
+
 func TestRawBeadsProviderForScopeIgnoresConfigYamlWithoutMetadata(t *testing.T) {
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "frontend")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1251,7 +1251,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -240,6 +240,8 @@ BeadsConfig holds bead store settings.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `provider` | string |  | `bd` | Provider selects the bead store backend: "bd" (default), "file", or "exec:&lt;script&gt;" for a user-supplied script. |
+| `database` | string |  | `dolt` | Database selects the bd metadata database family written to .beads/metadata.json. Defaults to "dolt". |
+| `backend` | string |  | `dolt` | Backend selects the bd storage backend written to .beads/metadata.json. Defaults to "dolt". Non-Dolt values disable GC's managed Dolt lifecycle while still allowing the bd CLI provider to manage beads. |
 
 ## ChatSessionsConfig
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -883,6 +883,16 @@
           "type": "string",
           "description": "Provider selects the bead store backend: \"bd\" (default), \"file\",\nor \"exec:\u003cscript\u003e\" for a user-supplied script.",
           "default": "bd"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database selects the bd metadata database family written to\n.beads/metadata.json. Defaults to \"dolt\".",
+          "default": "dolt"
+        },
+        "backend": {
+          "type": "string",
+          "description": "Backend selects the bd storage backend written to .beads/metadata.json.\nDefaults to \"dolt\". Non-Dolt values disable GC's managed Dolt lifecycle\nwhile still allowing the bd CLI provider to manage beads.",
+          "default": "dolt"
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -883,6 +883,16 @@
           "type": "string",
           "description": "Provider selects the bead store backend: \"bd\" (default), \"file\",\nor \"exec:\u003cscript\u003e\" for a user-supplied script.",
           "default": "bd"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database selects the bd metadata database family written to\n.beads/metadata.json. Defaults to \"dolt\".",
+          "default": "dolt"
+        },
+        "backend": {
+          "type": "string",
+          "description": "Backend selects the bd storage backend written to .beads/metadata.json.\nDefaults to \"dolt\". Non-Dolt values disable GC's managed Dolt lifecycle\nwhile still allowing the bd CLI provider to manage beads.",
+          "default": "dolt"
         }
       },
       "additionalProperties": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1116,6 +1116,13 @@ type BeadsConfig struct {
 	// Provider selects the bead store backend: "bd" (default), "file",
 	// or "exec:<script>" for a user-supplied script.
 	Provider string `toml:"provider,omitempty" jsonschema:"default=bd"`
+	// Database selects the bd metadata database family written to
+	// .beads/metadata.json. Defaults to "dolt".
+	Database string `toml:"database,omitempty" jsonschema:"default=dolt"`
+	// Backend selects the bd storage backend written to .beads/metadata.json.
+	// Defaults to "dolt". Non-Dolt values disable GC's managed Dolt lifecycle
+	// while still allowing the bd CLI provider to manage beads.
+	Backend string `toml:"backend,omitempty" jsonschema:"default=dolt"`
 }
 
 // SessionConfig holds session provider settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -446,6 +446,8 @@ name = "test-city"
 
 [beads]
 provider = "file"
+backend = "postgres"
+database = "postgres"
 
 [[agent]]
 name = "mayor"
@@ -456,6 +458,12 @@ name = "mayor"
 	}
 	if cfg.Beads.Provider != "file" {
 		t.Errorf("Beads.Provider = %q, want %q", cfg.Beads.Provider, "file")
+	}
+	if cfg.Beads.Backend != "postgres" {
+		t.Errorf("Beads.Backend = %q, want %q", cfg.Beads.Backend, "postgres")
+	}
+	if cfg.Beads.Database != "postgres" {
+		t.Errorf("Beads.Database = %q, want %q", cfg.Beads.Database, "postgres")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add [beads].backend and [beads].database config fields for bd metadata
- keep bd as a direct provider and skip managed Dolt lifecycle when backend is non-Dolt
- normalize canonical metadata using configured backend/database instead of hardcoded dolt
- regenerate config docs/schema

## Tests
- go test ./internal/config ./cmd/gc
- go test ./test/docsync

## Notes
For basically everyone today, this does _nothing_ and setting these things to anything other than "dolt" will just break beads (sqlite is no longer supported). I'm working on adding postgres as a provider, so i'm going to need these settings soon

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->