### PR TITLE
fix(pool): suppress death hooks for managed stops

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2059,13 +2059,10 @@ func selectOrCreateDependencyPoolSessionBead(
 	template string,
 ) (beads.Bead, error) {
 	for _, bead := range bp.sessionBeads.Open() {
-		if bead.Status == "closed" || isManualSessionBead(bead) {
+		if isManualSessionBead(bead) {
 			continue
 		}
-		if isDrainedSessionBead(bead) {
-			continue
-		}
-		if isFailedCreateSessionBead(bead) {
+		if !poolSessionBeadReusableForNewDemand(bead) {
 			continue
 		}
 		if isNamedSessionBead(bead) {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2022,11 +2022,12 @@ func poolSessionBeadReusableForNewDemand(bead beads.Bead) bool {
 		return false
 	}
 	switch strings.TrimSpace(bead.Metadata["state"]) {
-	case "active", "awake", "creating":
+	case "", "active", "awake", "creating":
 		return true
 	}
 	return false
 }
+
 func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
 	for _, wb := range workBeads {
 		assignee := strings.TrimSpace(wb.Assignee)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1931,9 +1931,6 @@ func selectOrCreatePoolSessionBead(
 	// states: fresh scale demand must not resurrect a stopped/drained/swept
 	// lifecycle record that is no longer a live worker identity.
 	for _, bead := range bp.sessionBeads.Open() {
-		if bead.Status == "closed" {
-			continue
-		}
 		if !poolSessionBeadReusableForNewDemand(bead) {
 			continue
 		}
@@ -2037,6 +2034,35 @@ func poolSessionBeadReusableForNewDemand(bead beads.Bead) bool {
 	return false
 }
 
+func dependencyPoolSessionBeadReusableForDemand(bead beads.Bead) bool {
+	if strings.TrimSpace(bead.Status) == "closed" {
+		return false
+	}
+	if isDrainedSessionBead(bead) {
+		return false
+	}
+	if isFailedCreateSessionBead(bead) {
+		return false
+	}
+	switch strings.TrimSpace(bead.Metadata["state"]) {
+	case "",
+		string(session.StateActive),
+		string(session.StateAwake),
+		string(session.StateCreating),
+		string(session.StateAsleep),
+		string(session.StateSuspended),
+		string(session.StateArchived),
+		string(session.StateQuarantined):
+		return true
+	case string(session.BaseStateStopped), sessionStateGCSwept, string(session.BaseStateOrphaned):
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata["close_reason"]) != "" || strings.TrimSpace(bead.Metadata["closed_at"]) != "" {
+		return false
+	}
+	return false
+}
+
 func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
 	for _, wb := range workBeads {
 		assignee := strings.TrimSpace(wb.Assignee)
@@ -2062,7 +2088,7 @@ func selectOrCreateDependencyPoolSessionBead(
 		if isManualSessionBead(bead) {
 			continue
 		}
-		if !poolSessionBeadReusableForNewDemand(bead) {
+		if !dependencyPoolSessionBeadReusableForDemand(bead) {
 			continue
 		}
 		if isNamedSessionBead(bead) {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1927,20 +1927,14 @@ func selectOrCreatePoolSessionBead(
 		slot := claimPoolSlot(cfgAgent, *preferred, usedSlots)
 		return *preferred, slot, nil
 	}
-	// Reuse an existing active/creating session bead. Skip drained, closed,
-	// and asleep — asleep ephemerals are not restarted; a fresh session is
-	// created instead. The reconciler closes orphaned asleep beads.
+	// Reuse an existing active/creating session bead. Skip terminal or parked
+	// states: fresh scale demand must not resurrect a stopped/drained/swept
+	// lifecycle record that is no longer a live worker identity.
 	for _, bead := range bp.sessionBeads.Open() {
 		if bead.Status == "closed" {
 			continue
 		}
-		if isDrainedSessionBead(bead) {
-			continue
-		}
-		if isFailedCreateSessionBead(bead) {
-			continue
-		}
-		if bead.Metadata["state"] == "asleep" {
+		if !poolSessionBeadReusableForNewDemand(bead) {
 			continue
 		}
 		if isManualSessionBeadForAgent(bead, cfgAgent) {
@@ -2017,6 +2011,22 @@ func isFailedCreateSessionBead(bead beads.Bead) bool {
 	return strings.TrimSpace(bead.Metadata["state"]) == string(session.StateFailedCreate)
 }
 
+func poolSessionBeadReusableForNewDemand(bead beads.Bead) bool {
+	if isDrainedSessionBead(bead) {
+		return false
+	}
+	if isFailedCreateSessionBead(bead) {
+		return false
+	}
+	if strings.TrimSpace(bead.Metadata["close_reason"]) != "" || strings.TrimSpace(bead.Metadata["closed_at"]) != "" {
+		return false
+	}
+	switch strings.TrimSpace(bead.Metadata["state"]) {
+	case "active", "awake", "creating":
+		return true
+	}
+	return false
+}
 func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
 	for _, wb := range workBeads {
 		assignee := strings.TrimSpace(wb.Assignee)

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2012,17 +2012,26 @@ func isFailedCreateSessionBead(bead beads.Bead) bool {
 }
 
 func poolSessionBeadReusableForNewDemand(bead beads.Bead) bool {
+	if strings.TrimSpace(bead.Status) == "closed" {
+		return false
+	}
 	if isDrainedSessionBead(bead) {
 		return false
 	}
 	if isFailedCreateSessionBead(bead) {
 		return false
 	}
+	switch strings.TrimSpace(bead.Metadata["state"]) {
+	case string(session.StateActive), string(session.StateAwake), string(session.StateCreating):
+		// syncSessionBeads clears stale close metadata on the next tick. Until
+		// that lands, keep the live slot/bead identity reusable so new demand
+		// does not allocate a duplicate pool worker for the same slot.
+		return true
+	}
 	if strings.TrimSpace(bead.Metadata["close_reason"]) != "" || strings.TrimSpace(bead.Metadata["closed_at"]) != "" {
 		return false
 	}
-	switch strings.TrimSpace(bead.Metadata["state"]) {
-	case "", "active", "awake", "creating":
+	if strings.TrimSpace(bead.Metadata["state"]) == "" {
 		return true
 	}
 	return false

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2044,6 +2044,10 @@ func dependencyPoolSessionBeadReusableForDemand(bead beads.Bead) bool {
 	if isFailedCreateSessionBead(bead) {
 		return false
 	}
+	// Dependency-floor demand intentionally differs from fresh tier demand:
+	// parked identities (asleep/suspended/archived/quarantined) can be reused
+	// to preserve their concrete session slot, but draining/terminal states
+	// must never absorb new demand because they are already leaving service.
 	switch strings.TrimSpace(bead.Metadata["state"]) {
 	case "",
 		string(session.StateActive),
@@ -2054,10 +2058,10 @@ func dependencyPoolSessionBeadReusableForDemand(bead beads.Bead) bool {
 		string(session.StateArchived),
 		string(session.StateQuarantined):
 		return true
-	case string(session.BaseStateStopped), sessionStateGCSwept, string(session.BaseStateOrphaned):
-		return false
-	}
-	if strings.TrimSpace(bead.Metadata["close_reason"]) != "" || strings.TrimSpace(bead.Metadata["closed_at"]) != "" {
+	case string(session.StateDraining),
+		string(session.BaseStateStopped),
+		sessionStateGCSwept,
+		string(session.BaseStateOrphaned):
 		return false
 	}
 	return false

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -2044,24 +2044,26 @@ func dependencyPoolSessionBeadReusableForDemand(bead beads.Bead) bool {
 	if isFailedCreateSessionBead(bead) {
 		return false
 	}
+	state := strings.TrimSpace(bead.Metadata["state"])
+	hasCloseMetadata := strings.TrimSpace(bead.Metadata["close_reason"]) != "" ||
+		strings.TrimSpace(bead.Metadata["closed_at"]) != ""
 	// Dependency-floor demand intentionally differs from fresh tier demand:
-	// parked identities (asleep/suspended/archived/quarantined) can be reused
-	// to preserve their concrete session slot, but draining/terminal states
-	// must never absorb new demand because they are already leaving service.
-	switch strings.TrimSpace(bead.Metadata["state"]) {
-	case "",
-		string(session.StateActive),
-		string(session.StateAwake),
-		string(session.StateCreating),
-		string(session.StateAsleep),
-		string(session.StateSuspended),
-		string(session.StateArchived),
-		string(session.StateQuarantined):
+	// parked identities (asleep/suspended/archived) can be reused to preserve
+	// their concrete session slot, but crash-recovery holds, stale close
+	// metadata, and draining/terminal states must never absorb new demand.
+	switch state {
+	case string(session.StateActive), string(session.StateAwake), string(session.StateCreating):
 		return true
+	case "", string(session.StateAsleep), string(session.StateSuspended), string(session.StateArchived):
+		return !hasCloseMetadata
 	case string(session.StateDraining),
+		string(session.StateQuarantined),
 		string(session.BaseStateStopped),
 		sessionStateGCSwept,
 		string(session.BaseStateOrphaned):
+		return false
+	}
+	if hasCloseMetadata {
 		return false
 	}
 	return false

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5146,6 +5146,55 @@ func TestSelectOrCreateDependencyPoolSessionBead_DefersAliasWhenConcreteAliasTak
 	}
 }
 
+func TestSelectOrCreateDependencyPoolSessionBead_SkipsTerminalBeadsForNewDemand(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state string
+	}{
+		{name: "stopped", state: "stopped"},
+		{name: "gc-swept", state: "gc_swept"},
+		{name: "orphaned", state: "orphaned"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			bead, err := store.Create(beads.Bead{
+				Title:  "claude",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"template":        "claude",
+					"agent_name":      "claude",
+					"session_name":    "claude-dependency-terminal",
+					"state":           tc.state,
+					"dependency_only": "true",
+					"pool_managed":    "true",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot := &sessionBeadSnapshot{}
+			snapshot.add(bead)
+			cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+			bp := &agentBuildParams{
+				beadStore:    store,
+				sessionBeads: snapshot,
+				agents:       []config.Agent{cfgAgent},
+			}
+
+			result, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "claude")
+			if err != nil {
+				t.Fatalf("selectOrCreateDependencyPoolSessionBead: %v", err)
+			}
+			if result.ID == bead.ID {
+				t.Fatalf("terminal dependency bead in state=%q should not be reused", tc.state)
+			}
+		})
+	}
+}
+
 func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 	store := beads.NewMemStore()
 	// Existing awake session bead without assigned work — should be reused

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5205,11 +5205,12 @@ func TestDependencyPoolSessionBeadReusableForDemand_Contract(t *testing.T) {
 		{name: "asleep", meta: map[string]string{"state": string(sessionpkg.StateAsleep)}, want: true},
 		{name: "suspended", meta: map[string]string{"state": string(sessionpkg.StateSuspended)}, want: true},
 		{name: "archived", meta: map[string]string{"state": string(sessionpkg.StateArchived)}, want: true},
-		{name: "quarantined", meta: map[string]string{"state": string(sessionpkg.StateQuarantined)}, want: true},
+		{name: "empty-stale-close-metadata", meta: map[string]string{"close_reason": "orphaned", "closed_at": "2026-05-10T00:00:00Z"}, want: false},
 		{name: "draining", meta: map[string]string{"state": string(sessionpkg.StateDraining)}, want: false},
 		{name: "drained", meta: map[string]string{"state": string(sessionpkg.StateAsleep), "sleep_reason": "drained"}, want: false},
 		{name: "failed-create", meta: map[string]string{"state": string(sessionpkg.StateFailedCreate)}, want: false},
 		{name: "stopped", meta: map[string]string{"state": string(sessionpkg.BaseStateStopped)}, want: false},
+		{name: "quarantined", meta: map[string]string{"state": string(sessionpkg.StateQuarantined)}, want: false},
 		{name: "gc-swept", meta: map[string]string{"state": sessionStateGCSwept}, want: false},
 		{name: "orphaned", meta: map[string]string{"state": string(sessionpkg.BaseStateOrphaned)}, want: false},
 	}
@@ -5245,7 +5246,6 @@ func TestSelectOrCreateDependencyPoolSessionBead_ReusesParkedReusableBeads(t *te
 		{name: "asleep", state: string(sessionpkg.StateAsleep)},
 		{name: "suspended", state: string(sessionpkg.StateSuspended)},
 		{name: "archived", state: string(sessionpkg.StateArchived)},
-		{name: "quarantined", state: string(sessionpkg.StateQuarantined)},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4829,6 +4829,79 @@ func TestSelectOrCreatePoolSessionBead_ReusesPreferredDrained(t *testing.T) {
 	}
 }
 
+func TestSelectOrCreatePoolSessionBead_SkipsTerminalPoolBeadsForNewTier(t *testing.T) {
+	testCases := []struct {
+		name string
+		meta map[string]string
+	}{
+		{
+			name: "failed create",
+			meta: map[string]string{"state": string(sessionpkg.StateFailedCreate)},
+		},
+		{
+			name: "stopped",
+			meta: map[string]string{"state": "stopped"},
+		},
+		{
+			name: "gc swept",
+			meta: map[string]string{
+				"state":        "gc_swept",
+				"close_reason": "gc_swept",
+				"closed_at":    "2026-05-08T17:09:11Z",
+			},
+		},
+		{
+			name: "orphan close metadata",
+			meta: map[string]string{
+				"state":        "orphaned",
+				"close_reason": "orphaned",
+				"closed_at":    "2026-05-08T17:08:18Z",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			meta := map[string]string{
+				"template":     "claude",
+				"agent_name":   "claude",
+				"session_name": "claude-terminal",
+				"pool_managed": "true",
+				"pool_slot":    "1",
+			}
+			for key, value := range tc.meta {
+				meta[key] = value
+			}
+			terminal, err := store.Create(beads.Bead{
+				Title:    "claude",
+				Type:     sessionBeadType,
+				Labels:   []string{sessionBeadLabel},
+				Metadata: meta,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot := &sessionBeadSnapshot{}
+			snapshot.add(terminal)
+			cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+			bp := &agentBuildParams{
+				beadStore:    store,
+				sessionBeads: snapshot,
+				agents:       []config.Agent{cfgAgent},
+			}
+
+			result, _, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
+			if err != nil {
+				t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+			}
+			if result.ID == terminal.ID {
+				t.Fatalf("terminal pool bead state=%q close_reason=%q was reused for new-tier demand", terminal.Metadata["state"], terminal.Metadata["close_reason"])
+			}
+		})
+	}
+}
+
 func TestSelectOrCreateDependencyPoolSessionBead_SkipsDrained(t *testing.T) {
 	store := beads.NewMemStore()
 	drained, err := store.Create(beads.Bead{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4959,17 +4959,31 @@ func TestPoolSessionBeadReusableForNewDemand_StateContract(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "close-reason",
+			name: "active-stale-close-reason",
 			meta: map[string]string{
 				"state":        string(sessionpkg.StateActive),
+				"close_reason": "orphaned",
+			},
+			want: true,
+		},
+		{
+			name: "active-stale-closed-at",
+			meta: map[string]string{
+				"state":     string(sessionpkg.StateActive),
+				"closed_at": "2026-05-08T17:08:18Z",
+			},
+			want: true,
+		},
+		{
+			name: "empty-close-reason",
+			meta: map[string]string{
 				"close_reason": "orphaned",
 			},
 			want: false,
 		},
 		{
-			name: "closed-at",
+			name: "empty-closed-at",
 			meta: map[string]string{
-				"state":     string(sessionpkg.StateActive),
 				"closed_at": "2026-05-08T17:08:18Z",
 			},
 			want: false,
@@ -4995,6 +5009,47 @@ func TestPoolSessionBeadReusableForNewDemand_StateContract(t *testing.T) {
 					bead.Metadata["state"], bead.Metadata["close_reason"], bead.Metadata["closed_at"], got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSelectOrCreatePoolSessionBead_ReusesActivePoolBeadWithStaleCloseMetadata(t *testing.T) {
+	store := beads.NewMemStore()
+	active, err := store.Create(beads.Bead{
+		Title:  "claude",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":     "claude",
+			"agent_name":   "claude",
+			"session_name": "claude-slot-1",
+			"state":        string(sessionpkg.StateActive),
+			"pool_slot":    "1",
+			"pool_managed": "true",
+			"close_reason": "orphaned",
+			"closed_at":    "2026-05-08T17:08:18Z",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.add(active)
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	bp := &agentBuildParams{
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	result, slot, err := selectOrCreatePoolSessionBead(bp, &cfgAgent, "claude", nil, map[string]bool{}, map[int]bool{})
+	if err != nil {
+		t.Fatalf("selectOrCreatePoolSessionBead: %v", err)
+	}
+	if result.ID != active.ID {
+		t.Fatalf("expected live pool bead with stale close metadata to be reused, got %s want %s", result.ID, active.ID)
+	}
+	if slot != 1 {
+		t.Fatalf("slot = %d, want 1", slot)
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5195,6 +5195,98 @@ func TestSelectOrCreateDependencyPoolSessionBead_SkipsTerminalBeadsForNewDemand(
 	}
 }
 
+func TestDependencyPoolSessionBeadReusableForDemand_Contract(t *testing.T) {
+	testCases := []struct {
+		name string
+		meta map[string]string
+		want bool
+	}{
+		{name: "active", meta: map[string]string{"state": string(sessionpkg.StateActive)}, want: true},
+		{name: "asleep", meta: map[string]string{"state": string(sessionpkg.StateAsleep)}, want: true},
+		{name: "suspended", meta: map[string]string{"state": string(sessionpkg.StateSuspended)}, want: true},
+		{name: "archived", meta: map[string]string{"state": string(sessionpkg.StateArchived)}, want: true},
+		{name: "quarantined", meta: map[string]string{"state": string(sessionpkg.StateQuarantined)}, want: true},
+		{name: "drained", meta: map[string]string{"state": string(sessionpkg.StateAsleep), "sleep_reason": "drained"}, want: false},
+		{name: "failed-create", meta: map[string]string{"state": string(sessionpkg.StateFailedCreate)}, want: false},
+		{name: "stopped", meta: map[string]string{"state": string(sessionpkg.BaseStateStopped)}, want: false},
+		{name: "gc-swept", meta: map[string]string{"state": sessionStateGCSwept}, want: false},
+		{name: "orphaned", meta: map[string]string{"state": string(sessionpkg.BaseStateOrphaned)}, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bead := beads.Bead{
+				Metadata: map[string]string{
+					"template":        "claude",
+					"agent_name":      "claude-1",
+					"session_name":    "claude-dependency",
+					"dependency_only": "true",
+					"pool_managed":    "true",
+					"pool_slot":       "1",
+				},
+			}
+			for key, value := range tc.meta {
+				bead.Metadata[key] = value
+			}
+			if got := dependencyPoolSessionBeadReusableForDemand(bead); got != tc.want {
+				t.Fatalf("dependencyPoolSessionBeadReusableForDemand(state=%q sleep_reason=%q) = %v, want %v",
+					bead.Metadata["state"], bead.Metadata["sleep_reason"], got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectOrCreateDependencyPoolSessionBead_ReusesParkedReusableBeads(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state string
+	}{
+		{name: "asleep", state: string(sessionpkg.StateAsleep)},
+		{name: "suspended", state: string(sessionpkg.StateSuspended)},
+		{name: "archived", state: string(sessionpkg.StateArchived)},
+		{name: "quarantined", state: string(sessionpkg.StateQuarantined)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			bead, err := store.Create(beads.Bead{
+				Title:  "claude",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel},
+				Metadata: map[string]string{
+					"template":        "claude",
+					"agent_name":      "claude-1",
+					"session_name":    "claude-dependency-1",
+					"state":           tc.state,
+					"dependency_only": "true",
+					"pool_managed":    "true",
+					"pool_slot":       "1",
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot := &sessionBeadSnapshot{}
+			snapshot.add(bead)
+			cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+			bp := &agentBuildParams{
+				beadStore:    store,
+				sessionBeads: snapshot,
+				agents:       []config.Agent{cfgAgent},
+			}
+
+			result, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "claude")
+			if err != nil {
+				t.Fatalf("selectOrCreateDependencyPoolSessionBead: %v", err)
+			}
+			if result.ID != bead.ID {
+				t.Fatalf("state=%q should reuse parked dependency bead, got %s want %s", tc.state, result.ID, bead.ID)
+			}
+		})
+	}
+}
+
 func TestSelectOrCreatePoolSessionBead_ReusesAvailableForNewTier(t *testing.T) {
 	store := beads.NewMemStore()
 	// Existing awake session bead without assigned work — should be reused

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -5206,6 +5206,7 @@ func TestDependencyPoolSessionBeadReusableForDemand_Contract(t *testing.T) {
 		{name: "suspended", meta: map[string]string{"state": string(sessionpkg.StateSuspended)}, want: true},
 		{name: "archived", meta: map[string]string{"state": string(sessionpkg.StateArchived)}, want: true},
 		{name: "quarantined", meta: map[string]string{"state": string(sessionpkg.StateQuarantined)}, want: true},
+		{name: "draining", meta: map[string]string{"state": string(sessionpkg.StateDraining)}, want: false},
 		{name: "drained", meta: map[string]string{"state": string(sessionpkg.StateAsleep), "sleep_reason": "drained"}, want: false},
 		{name: "failed-create", meta: map[string]string{"state": string(sessionpkg.StateFailedCreate)}, want: false},
 		{name: "stopped", meta: map[string]string{"state": string(sessionpkg.BaseStateStopped)}, want: false},
@@ -5284,6 +5285,43 @@ func TestSelectOrCreateDependencyPoolSessionBead_ReusesParkedReusableBeads(t *te
 				t.Fatalf("state=%q should reuse parked dependency bead, got %s want %s", tc.state, result.ID, bead.ID)
 			}
 		})
+	}
+}
+
+func TestSelectOrCreateDependencyPoolSessionBead_SkipsDrainingBeadsForNewDemand(t *testing.T) {
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "claude",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"template":        "claude",
+			"agent_name":      "claude-1",
+			"session_name":    "claude-dependency-draining",
+			"state":           string(sessionpkg.StateDraining),
+			"dependency_only": "true",
+			"pool_managed":    "true",
+			"pool_slot":       "1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &sessionBeadSnapshot{}
+	snapshot.add(bead)
+	cfgAgent := config.Agent{Name: "claude", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5)}
+	bp := &agentBuildParams{
+		beadStore:    store,
+		sessionBeads: snapshot,
+		agents:       []config.Agent{cfgAgent},
+	}
+
+	result, err := selectOrCreateDependencyPoolSessionBead(bp, &cfgAgent, "claude")
+	if err != nil {
+		t.Fatalf("selectOrCreateDependencyPoolSessionBead: %v", err)
+	}
+	if result.ID == bead.ID {
+		t.Fatal("draining dependency bead should not be reused for new demand")
 	}
 }
 

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4902,6 +4902,97 @@ func TestSelectOrCreatePoolSessionBead_SkipsTerminalPoolBeadsForNewTier(t *testi
 	}
 }
 
+func TestPoolSessionBeadReusableForNewDemand_StateContract(t *testing.T) {
+	testCases := []struct {
+		name string
+		meta map[string]string
+		want bool
+	}{
+		{
+			name: "active",
+			meta: map[string]string{"state": string(sessionpkg.StateActive)},
+			want: true,
+		},
+		{
+			name: "awake",
+			meta: map[string]string{"state": string(sessionpkg.StateAwake)},
+			want: true,
+		},
+		{
+			name: "creating",
+			meta: map[string]string{"state": string(sessionpkg.StateCreating)},
+			want: true,
+		},
+		{
+			name: "drained",
+			meta: map[string]string{"state": "drained"},
+			want: false,
+		},
+		{
+			name: "asleep",
+			meta: map[string]string{"state": string(sessionpkg.StateAsleep)},
+			want: false,
+		},
+		{
+			name: "suspended",
+			meta: map[string]string{"state": string(sessionpkg.StateSuspended)},
+			want: false,
+		},
+		{
+			name: "failed-create",
+			meta: map[string]string{"state": string(sessionpkg.StateFailedCreate)},
+			want: false,
+		},
+		{
+			name: "archived",
+			meta: map[string]string{"state": string(sessionpkg.StateArchived)},
+			want: false,
+		},
+		{
+			name: "quarantined",
+			meta: map[string]string{"state": string(sessionpkg.StateQuarantined)},
+			want: false,
+		},
+		{
+			name: "close-reason",
+			meta: map[string]string{
+				"state":        string(sessionpkg.StateActive),
+				"close_reason": "orphaned",
+			},
+			want: false,
+		},
+		{
+			name: "closed-at",
+			meta: map[string]string{
+				"state":     string(sessionpkg.StateActive),
+				"closed_at": "2026-05-08T17:08:18Z",
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bead := beads.Bead{
+				Metadata: map[string]string{
+					"template":     "claude",
+					"agent_name":   "claude",
+					"session_name": "claude-terminal",
+					"pool_managed": "true",
+					"pool_slot":    "1",
+				},
+			}
+			for key, value := range tc.meta {
+				bead.Metadata[key] = value
+			}
+			if got := poolSessionBeadReusableForNewDemand(bead); got != tc.want {
+				t.Fatalf("poolSessionBeadReusableForNewDemand(state=%q close_reason=%q closed_at=%q) = %v, want %v",
+					bead.Metadata["state"], bead.Metadata["close_reason"], bead.Metadata["closed_at"], got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSelectOrCreateDependencyPoolSessionBead_SkipsDrained(t *testing.T) {
 	store := beads.NewMemStore()
 	drained, err := store.Create(beads.Bead{

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -4909,6 +4909,11 @@ func TestPoolSessionBeadReusableForNewDemand_StateContract(t *testing.T) {
 		want bool
 	}{
 		{
+			name: "empty state",
+			meta: map[string]string{},
+			want: true,
+		},
+		{
 			name: "active",
 			meta: map[string]string{"state": string(sessionpkg.StateActive)},
 			want: true,

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -999,32 +999,51 @@ func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTrac
 	if len(matches) == 0 {
 		return beads.Bead{}, false
 	}
-	newestOwner, hasOwner := newestPoolManagedStopSuppressionOwner(matches)
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor(matches)
 	winner := matches[0]
 	for _, bead := range matches[1:] {
-		winner = betterPoolManagedStopSuppressionBead(winner, bead, newestOwner, hasOwner, dt)
+		winner = betterPoolManagedStopSuppressionBead(winner, bead, anchor, hasAnchor, dt)
 	}
 	return winner, true
 }
 
-func newestPoolManagedStopSuppressionOwner(matches []beads.Bead) (beads.Bead, bool) {
-	var owner beads.Bead
-	hasOwner := false
+func newestPoolManagedStopSuppressionAnchor(matches []beads.Bead) (beads.Bead, bool) {
+	var (
+		owner       beads.Bead
+		hasOwner    bool
+		fallback    beads.Bead
+		hasFallback bool
+	)
 	for _, bead := range matches {
-		if !beadOwnsPoolSessionName(bead) {
-			continue
+		if !poolDeathHookSuppressedByManagedStopState(bead) {
+			if !hasFallback || bead.CreatedAt.After(fallback.CreatedAt) || (bead.CreatedAt.Equal(fallback.CreatedAt) && strings.TrimSpace(bead.ID) > strings.TrimSpace(fallback.ID)) {
+				fallback = bead
+				hasFallback = true
+			}
 		}
-		if !hasOwner || bead.CreatedAt.After(owner.CreatedAt) || (bead.CreatedAt.Equal(owner.CreatedAt) && strings.TrimSpace(bead.ID) > strings.TrimSpace(owner.ID)) {
-			owner = bead
-			hasOwner = true
+		if beadOwnsPoolSessionName(bead) {
+			if !hasOwner || bead.CreatedAt.After(owner.CreatedAt) || (bead.CreatedAt.Equal(owner.CreatedAt) && strings.TrimSpace(bead.ID) > strings.TrimSpace(owner.ID)) {
+				owner = bead
+				hasOwner = true
+			}
 		}
 	}
-	return owner, hasOwner
+	if hasOwner {
+		return owner, true
+	}
+	// Alias-backed and legacy pool identities still need a fail-open authority
+	// anchor. When no bead owns the persisted session_name, use the newest
+	// non-suppressed candidate so an older managed-stop duplicate cannot
+	// swallow crash recovery for the live worker.
+	if hasFallback {
+		return fallback, true
+	}
+	return beads.Bead{}, false
 }
 
-func betterPoolManagedStopSuppressionBead(incumbent, candidate, newestOwner beads.Bead, hasOwner bool, dt *drainTracker) beads.Bead {
-	incumbentRank := poolManagedStopSuppressionRank(incumbent, newestOwner, hasOwner, dt)
-	candidateRank := poolManagedStopSuppressionRank(candidate, newestOwner, hasOwner, dt)
+func betterPoolManagedStopSuppressionBead(incumbent, candidate, anchor beads.Bead, hasAnchor bool, dt *drainTracker) beads.Bead {
+	incumbentRank := poolManagedStopSuppressionRank(incumbent, anchor, hasAnchor, dt)
+	candidateRank := poolManagedStopSuppressionRank(candidate, anchor, hasAnchor, dt)
 	switch {
 	case candidateRank > incumbentRank:
 		return candidate
@@ -1048,28 +1067,28 @@ func drainTrackerHasBead(dt *drainTracker, beadID string) bool {
 	return dt.get(beadID) != nil
 }
 
-func poolManagedStopSuppressionRank(bead, newestOwner beads.Bead, hasOwner bool, dt *drainTracker) int {
+func poolManagedStopSuppressionRank(bead, anchor beads.Bead, hasAnchor bool, dt *drainTracker) int {
 	suppressed := poolDeathHookSuppressedByManagedStopState(bead)
-	ownsName := beadOwnsPoolSessionName(bead)
 	tracked := drainTrackerHasBead(dt, bead.ID)
-	ownerIsNewer := hasOwner && strings.TrimSpace(newestOwner.ID) != "" && strings.TrimSpace(newestOwner.ID) != strings.TrimSpace(bead.ID) &&
-		newestOwner.CreatedAt.After(bead.CreatedAt)
+	isAnchor := hasAnchor && strings.TrimSpace(anchor.ID) != "" && strings.TrimSpace(anchor.ID) == strings.TrimSpace(bead.ID)
+	anchorIsNewer := hasAnchor && strings.TrimSpace(anchor.ID) != "" && strings.TrimSpace(anchor.ID) != strings.TrimSpace(bead.ID) &&
+		anchor.CreatedAt.After(bead.CreatedAt)
 
 	switch {
-	case suppressed && tracked && !ownerIsNewer:
+	case suppressed && tracked && !anchorIsNewer:
 		// Live drain-tracker intent wins while it still points at the newest
 		// managed-stop candidate. If the tracked duplicate is older than the
-		// current canonical owner, treat the tracker as stale and fall back to
+		// current authority anchor, treat the tracker as stale and fall back to
 		// bead-backed authority.
 		return 5
-	case suppressed && ownsName:
+	case suppressed && isAnchor:
 		return 4
-	case suppressed && hasOwner && strings.TrimSpace(newestOwner.ID) != strings.TrimSpace(bead.ID) && bead.CreatedAt.After(newestOwner.CreatedAt):
+	case suppressed && hasAnchor && !isAnchor && bead.CreatedAt.After(anchor.CreatedAt):
 		// After a controller restart, drainTracker state is gone. A newer
-		// managed-stop duplicate still needs to beat an older active owner so
+		// managed-stop duplicate still needs to beat an older active anchor so
 		// death-hook suppression survives restart.
 		return 3
-	case ownsName:
+	case isAnchor:
 		return 2
 	case suppressed:
 		return 1
@@ -1082,12 +1101,16 @@ func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
 	switch strings.TrimSpace(bead.Metadata["state"]) {
 	case string(sessionpkg.StateDraining), string(sessionpkg.StateDrained),
 		string(sessionpkg.StateArchived), string(sessionpkg.StateSuspended),
-		string(sessionpkg.StateFailedCreate), "gc_swept", "orphaned":
+		"gc_swept", "orphaned":
 		return true
 	case string(sessionpkg.StateCreating):
 		// Keep creating fail-open. Async-start cleanup can stop a runtime while
 		// the bead is still creating, and those disappearances should preserve
 		// crash recovery until the lifecycle reaches a deliberate terminal state.
+		return false
+	case string(sessionpkg.StateFailedCreate):
+		// failed-create still projects as a missing runtime that can need
+		// crash recovery. Do not swallow on_death for that state.
 		return false
 	case string(sessionpkg.StateAsleep), "stopped":
 		return isDeliberateSleepReason(bead.Metadata["sleep_reason"])

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -960,25 +960,7 @@ func (cr *CityRuntime) poolDeathHookSuppressedByManagedStop(sessionName string) 
 	if err != nil || !found {
 		return beads.Bead{}, false, err
 	}
-	// beginSessionDrain records the controller's stop intent in-memory before the
-	// provider kill lands and before any later metadata flush can persist
-	// state=draining/asleep/closed. Consult the drain tracker first so a pool
-	// death observed in that gap still suppresses the on_death hook.
-	if cr.poolDeathHookSuppressedByDrainTracker(bead) {
-		return bead, true, nil
-	}
 	return bead, poolDeathHookSuppressedByManagedStopState(bead), nil
-}
-
-func (cr *CityRuntime) poolDeathHookSuppressedByDrainTracker(bead beads.Bead) bool {
-	if cr == nil || cr.sessionDrains == nil {
-		return false
-	}
-	id := strings.TrimSpace(bead.ID)
-	if id == "" {
-		return false
-	}
-	return cr.sessionDrains.get(id) != nil
 }
 
 func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads.Bead, bool, error) {
@@ -1049,15 +1031,6 @@ func betterPoolManagedStopSuppressionBead(incumbent, candidate beads.Bead, dt *d
 	case candidateSuppressed && !incumbentSuppressed:
 		return candidate
 	case incumbentSuppressed && !candidateSuppressed:
-		return incumbent
-	}
-
-	incumbentClosed := strings.TrimSpace(incumbent.Status) == "closed"
-	candidateClosed := strings.TrimSpace(candidate.Status) == "closed"
-	switch {
-	case candidateClosed && !incumbentClosed:
-		return candidate
-	case incumbentClosed && !candidateClosed:
 		return incumbent
 	}
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -999,38 +999,36 @@ func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTrac
 	if len(matches) == 0 {
 		return beads.Bead{}, false
 	}
+	newestOwner, hasOwner := newestPoolManagedStopSuppressionOwner(matches)
 	winner := matches[0]
 	for _, bead := range matches[1:] {
-		winner = betterPoolManagedStopSuppressionBead(winner, bead, dt)
+		winner = betterPoolManagedStopSuppressionBead(winner, bead, newestOwner, hasOwner, dt)
 	}
 	return winner, true
 }
 
-func betterPoolManagedStopSuppressionBead(incumbent, candidate beads.Bead, dt *drainTracker) beads.Bead {
-	incumbentTracked := drainTrackerHasBead(dt, incumbent.ID)
-	candidateTracked := drainTrackerHasBead(dt, candidate.ID)
-	switch {
-	case candidateTracked && !incumbentTracked:
-		return candidate
-	case incumbentTracked && !candidateTracked:
-		return incumbent
+func newestPoolManagedStopSuppressionOwner(matches []beads.Bead) (beads.Bead, bool) {
+	var owner beads.Bead
+	hasOwner := false
+	for _, bead := range matches {
+		if !beadOwnsPoolSessionName(bead) {
+			continue
+		}
+		if !hasOwner || bead.CreatedAt.After(owner.CreatedAt) || (bead.CreatedAt.Equal(owner.CreatedAt) && strings.TrimSpace(bead.ID) > strings.TrimSpace(owner.ID)) {
+			owner = bead
+			hasOwner = true
+		}
 	}
+	return owner, hasOwner
+}
 
-	incumbentOwnsName := beadOwnsPoolSessionName(incumbent)
-	candidateOwnsName := beadOwnsPoolSessionName(candidate)
+func betterPoolManagedStopSuppressionBead(incumbent, candidate, newestOwner beads.Bead, hasOwner bool, dt *drainTracker) beads.Bead {
+	incumbentRank := poolManagedStopSuppressionRank(incumbent, newestOwner, hasOwner, dt)
+	candidateRank := poolManagedStopSuppressionRank(candidate, newestOwner, hasOwner, dt)
 	switch {
-	case candidateOwnsName && !incumbentOwnsName:
+	case candidateRank > incumbentRank:
 		return candidate
-	case incumbentOwnsName && !candidateOwnsName:
-		return incumbent
-	}
-
-	incumbentSuppressed := poolDeathHookSuppressedByManagedStopState(incumbent)
-	candidateSuppressed := poolDeathHookSuppressedByManagedStopState(candidate)
-	switch {
-	case candidateSuppressed && !incumbentSuppressed:
-		return candidate
-	case incumbentSuppressed && !candidateSuppressed:
+	case incumbentRank > candidateRank:
 		return incumbent
 	}
 
@@ -1050,12 +1048,47 @@ func drainTrackerHasBead(dt *drainTracker, beadID string) bool {
 	return dt.get(beadID) != nil
 }
 
+func poolManagedStopSuppressionRank(bead, newestOwner beads.Bead, hasOwner bool, dt *drainTracker) int {
+	suppressed := poolDeathHookSuppressedByManagedStopState(bead)
+	ownsName := beadOwnsPoolSessionName(bead)
+	tracked := drainTrackerHasBead(dt, bead.ID)
+	ownerIsNewer := hasOwner && strings.TrimSpace(newestOwner.ID) != "" && strings.TrimSpace(newestOwner.ID) != strings.TrimSpace(bead.ID) &&
+		newestOwner.CreatedAt.After(bead.CreatedAt)
+
+	switch {
+	case suppressed && tracked && !ownerIsNewer:
+		// Live drain-tracker intent wins while it still points at the newest
+		// managed-stop candidate. If the tracked duplicate is older than the
+		// current canonical owner, treat the tracker as stale and fall back to
+		// bead-backed authority.
+		return 5
+	case suppressed && ownsName:
+		return 4
+	case suppressed && hasOwner && strings.TrimSpace(newestOwner.ID) != strings.TrimSpace(bead.ID) && bead.CreatedAt.After(newestOwner.CreatedAt):
+		// After a controller restart, drainTracker state is gone. A newer
+		// managed-stop duplicate still needs to beat an older active owner so
+		// death-hook suppression survives restart.
+		return 3
+	case ownsName:
+		return 2
+	case suppressed:
+		return 1
+	default:
+		return 0
+	}
+}
+
 func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
 	switch strings.TrimSpace(bead.Metadata["state"]) {
 	case string(sessionpkg.StateDraining), string(sessionpkg.StateDrained),
 		string(sessionpkg.StateArchived), string(sessionpkg.StateSuspended),
 		string(sessionpkg.StateFailedCreate), "gc_swept", "orphaned":
 		return true
+	case string(sessionpkg.StateCreating):
+		// Keep creating fail-open. Async-start cleanup can stop a runtime while
+		// the bead is still creating, and those disappearances should preserve
+		// crash recovery until the lifecycle reaches a deliberate terminal state.
+		return false
 	case string(sessionpkg.StateAsleep), "stopped":
 		return isDeliberateSleepReason(bead.Metadata["sleep_reason"])
 	case string(sessionpkg.StateQuarantined):

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -976,8 +976,7 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 	if err != nil {
 		return beads.Bead{}, false, err
 	}
-	var openMatches []beads.Bead
-	var closedMatches []beads.Bead
+	var poolMatches []beads.Bead
 	for _, bead := range matches {
 		if !isPoolManagedSessionBead(bead) {
 			continue
@@ -985,16 +984,12 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 		if strings.TrimSpace(bead.Metadata["session_name"]) != sessionName {
 			continue
 		}
-		if bead.Status == "closed" {
-			closedMatches = append(closedMatches, bead)
-			continue
-		}
-		openMatches = append(openMatches, bead)
+		poolMatches = append(poolMatches, bead)
 	}
-	if bead, ok := canonicalPoolManagedStopSuppressionBead(openMatches); ok {
-		return bead, true, nil
-	}
-	if bead, ok := canonicalPoolManagedStopSuppressionBead(closedMatches); ok {
+	// Canonicalize across open and closed beads together. Once the provider has
+	// already reported the runtime session missing, an "active" duplicate is only
+	// stale metadata; the bead that owns the session name remains authoritative.
+	if bead, ok := canonicalPoolManagedStopSuppressionBead(poolMatches); ok {
 		return bead, true, nil
 	}
 	return beads.Bead{}, false, nil
@@ -1012,11 +1007,14 @@ func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead) (beads.Bead, 
 }
 
 func poolDeathHookSuppressedByManagedStop(bead beads.Bead) bool {
-	switch sessionpkg.State(strings.TrimSpace(bead.Metadata["state"])) {
-	case "", sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateCreating:
-		return false
-	default:
+	switch strings.TrimSpace(bead.Metadata["state"]) {
+	case string(sessionpkg.StateDraining), "drained", string(sessionpkg.StateArchived),
+		string(sessionpkg.StateSuspended), string(sessionpkg.StateFailedCreate):
 		return true
+	case string(sessionpkg.StateAsleep), "stopped":
+		return isDeliberateSleepReason(bead.Metadata["sleep_reason"])
+	default:
+		return false
 	}
 }
 

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1025,21 +1025,21 @@ func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTrac
 }
 
 func betterPoolManagedStopSuppressionBead(incumbent, candidate beads.Bead, dt *drainTracker) beads.Bead {
-	incumbentOwnsName := beadOwnsPoolSessionName(incumbent)
-	candidateOwnsName := beadOwnsPoolSessionName(candidate)
-	switch {
-	case candidateOwnsName && !incumbentOwnsName:
-		return candidate
-	case incumbentOwnsName && !candidateOwnsName:
-		return incumbent
-	}
-
 	incumbentTracked := drainTrackerHasBead(dt, incumbent.ID)
 	candidateTracked := drainTrackerHasBead(dt, candidate.ID)
 	switch {
 	case candidateTracked && !incumbentTracked:
 		return candidate
 	case incumbentTracked && !candidateTracked:
+		return incumbent
+	}
+
+	incumbentOwnsName := beadOwnsPoolSessionName(incumbent)
+	candidateOwnsName := beadOwnsPoolSessionName(candidate)
+	switch {
+	case candidateOwnsName && !incumbentOwnsName:
+		return candidate
+	case incumbentOwnsName && !candidateOwnsName:
 		return incumbent
 	}
 
@@ -1078,9 +1078,6 @@ func drainTrackerHasBead(dt *drainTracker, beadID string) bool {
 }
 
 func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
-	if strings.TrimSpace(bead.Status) == "closed" {
-		return true
-	}
 	switch strings.TrimSpace(bead.Metadata["state"]) {
 	case string(sessionpkg.StateDraining), string(sessionpkg.StateDrained),
 		string(sessionpkg.StateArchived), string(sessionpkg.StateSuspended),

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -965,7 +965,7 @@ func (cr *CityRuntime) poolDeathHookSuppressedByManagedStop(sessionName string) 
 	if err != nil || !found {
 		return beads.Bead{}, false, err
 	}
-	return bead, poolDeathHookSuppressedByManagedStopState(bead), nil
+	return bead, poolDeathHookSuppressedByManagedStop(bead, cr.sessionDrains), nil
 }
 
 func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads.Bead, bool, error) {
@@ -1010,7 +1010,7 @@ func (cr *CityRuntime) legacyPoolManagedStopSuppressionCandidates(store beads.St
 	if store == nil || cr.cfg == nil {
 		return nil, nil
 	}
-	all, err := store.List(beads.ListQuery{Label: sessionBeadLabel})
+	all, err := store.List(beads.ListQuery{Label: sessionBeadLabel, IncludeClosed: true})
 	if err != nil {
 		return nil, err
 	}
@@ -1034,7 +1034,7 @@ func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTrac
 	if len(matches) == 0 {
 		return beads.Bead{}, false
 	}
-	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor(matches)
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor(matches, dt)
 	winner := matches[0]
 	for _, bead := range matches[1:] {
 		winner = betterPoolManagedStopSuppressionBead(winner, bead, anchor, hasAnchor, dt)
@@ -1042,7 +1042,7 @@ func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTrac
 	return winner, true
 }
 
-func newestPoolManagedStopSuppressionAnchor(matches []beads.Bead) (beads.Bead, bool) {
+func newestPoolManagedStopSuppressionAnchor(matches []beads.Bead, dt *drainTracker) (beads.Bead, bool) {
 	var (
 		owner       beads.Bead
 		hasOwner    bool
@@ -1050,7 +1050,7 @@ func newestPoolManagedStopSuppressionAnchor(matches []beads.Bead) (beads.Bead, b
 		hasFallback bool
 	)
 	for _, bead := range matches {
-		if !poolDeathHookSuppressedByManagedStopState(bead) {
+		if !poolDeathHookSuppressedByManagedStop(bead, dt) {
 			if !hasFallback || bead.CreatedAt.After(fallback.CreatedAt) || (bead.CreatedAt.Equal(fallback.CreatedAt) && strings.TrimSpace(bead.ID) > strings.TrimSpace(fallback.ID)) {
 				fallback = bead
 				hasFallback = true
@@ -1143,7 +1143,7 @@ func poolManagedStopMatchesLegacyRuntimeSessionName(cfg *config.City, cityName s
 }
 
 func poolManagedStopSuppressionRank(bead, anchor beads.Bead, hasAnchor bool, dt *drainTracker) int {
-	suppressed := poolDeathHookSuppressedByManagedStopState(bead)
+	suppressed := poolDeathHookSuppressedByManagedStop(bead, dt)
 	tracked := drainTrackerHasBead(dt, bead.ID)
 	isAnchor := hasAnchor && strings.TrimSpace(anchor.ID) != "" && strings.TrimSpace(anchor.ID) == strings.TrimSpace(bead.ID)
 	anchorDominates := hasAnchor && strings.TrimSpace(anchor.ID) != "" &&
@@ -1171,6 +1171,22 @@ func poolManagedStopSuppressionRank(bead, anchor beads.Bead, hasAnchor bool, dt 
 	default:
 		return 0
 	}
+}
+
+func poolDeathHookSuppressedByManagedStop(bead beads.Bead, dt *drainTracker) bool {
+	return poolDeathHookSuppressedByManagedStopState(bead) ||
+		poolDeathHookSuppressedByManagedStopDrainTracker(dt, bead.ID)
+}
+
+func poolDeathHookSuppressedByManagedStopDrainTracker(dt *drainTracker, beadID string) bool {
+	if dt == nil || strings.TrimSpace(beadID) == "" {
+		return false
+	}
+	ds := dt.get(beadID)
+	if ds == nil || !ds.ackSet {
+		return false
+	}
+	return isDeliberateSleepReason(ds.reason)
 }
 
 func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -676,13 +676,19 @@ func (cr *CityRuntime) tick(
 			if *prevPoolRunning != nil {
 				for sn, info := range cr.poolDeathHandlers {
 					if (*prevPoolRunning)[sn] && !currentSet[sn] {
-						skipHook, err := cr.skipPoolDeathHookForManagedStop(sn)
+						suppressionBead, found, err := cr.poolManagedStopSuppressionBead(sn)
 						if err != nil {
-							fmt.Fprintf(cr.stderr, "%s: on_death %s skipped while checking session lifecycle: %v\n", cr.logPrefix, sn, err) //nolint:errcheck // best-effort stderr
-							continue
-						}
-						if skipHook {
-							fmt.Fprintf(cr.stderr, "%s: on_death %s skipped for managed session stop\n", cr.logPrefix, sn) //nolint:errcheck // best-effort stderr
+							fmt.Fprintf(cr.stderr, "%s: on_death %s proceeding because session lifecycle lookup failed: %v\n", cr.logPrefix, sn, err) //nolint:errcheck // best-effort stderr
+						} else if found && poolDeathHookSuppressedByManagedStop(suppressionBead) {
+							_, _ = fmt.Fprintf(
+								cr.stderr,
+								"%s: on_death %s skipped for managed session stop (bead=%s status=%s state=%s)\n",
+								cr.logPrefix,
+								sn,
+								strings.TrimSpace(suppressionBead.ID),
+								strings.TrimSpace(suppressionBead.Status),
+								strings.TrimSpace(suppressionBead.Metadata["state"]),
+							)
 							continue
 						}
 						if _, err := shellRunHook(info.Command, info.Dir, info.Env); err != nil {
@@ -950,32 +956,75 @@ func (cr *CityRuntime) applyStartupConfigReload(
 }
 
 func (cr *CityRuntime) skipPoolDeathHookForManagedStop(sessionName string) (bool, error) {
+	bead, found, err := cr.poolManagedStopSuppressionBead(sessionName)
+	if err != nil || !found {
+		return false, err
+	}
+	return poolDeathHookSuppressedByManagedStop(bead), nil
+}
+
+func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads.Bead, bool, error) {
 	sessionName = strings.TrimSpace(sessionName)
 	if sessionName == "" {
-		return false, nil
+		return beads.Bead{}, false, nil
 	}
 	store := cr.cityBeadStore()
 	if store == nil {
-		return false, nil
+		return beads.Bead{}, false, nil
 	}
-	matches, err := sessionpkg.ExactMetadataSessionCandidates(store, false, map[string]string{"session_name": sessionName})
+	matches, err := sessionpkg.ExactMetadataSessionCandidates(store, true, map[string]string{"session_name": sessionName})
 	if err != nil {
-		return true, err
+		return beads.Bead{}, false, err
 	}
+	var (
+		poolMatches []beads.Bead
+		owner       beads.Bead
+		ownerCount  int
+	)
 	for _, bead := range matches {
 		if !isPoolManagedSessionBead(bead) {
 			continue
 		}
-		switch sessionpkg.State(strings.TrimSpace(bead.Metadata["state"])) {
-		case sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateCreating:
+		if strings.TrimSpace(bead.Metadata["session_name"]) != sessionName {
 			continue
-		case "":
-			continue
-		default:
-			return true, nil
+		}
+		poolMatches = append(poolMatches, bead)
+		if beadOwnsPoolSessionName(bead) {
+			owner = bead
+			ownerCount++
 		}
 	}
-	return false, nil
+	switch {
+	case ownerCount == 1:
+		return owner, true, nil
+	case ownerCount > 1:
+		ids := make([]string, 0, len(poolMatches))
+		for _, bead := range poolMatches {
+			if beadOwnsPoolSessionName(bead) {
+				ids = append(ids, bead.ID)
+			}
+		}
+		return beads.Bead{}, false, fmt.Errorf("multiple canonical pool session beads matched %q: %s", sessionName, strings.Join(ids, ", "))
+	case len(poolMatches) == 0:
+		return beads.Bead{}, false, nil
+	case len(poolMatches) == 1:
+		return poolMatches[0], true, nil
+	default:
+		ids := make([]string, 0, len(poolMatches))
+		for _, bead := range poolMatches {
+			ids = append(ids, bead.ID)
+		}
+		return beads.Bead{}, false, fmt.Errorf("ambiguous pool session beads matched %q without a canonical owner: %s", sessionName, strings.Join(ids, ", "))
+	}
+}
+
+func poolDeathHookSuppressedByManagedStop(bead beads.Bead) bool {
+	switch sessionpkg.State(strings.TrimSpace(bead.Metadata["state"])) {
+	case "", sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateCreating:
+		return false
+	default:
+		return true
+	}
 }
 
 func (cr *CityRuntime) reloadConfigTraced(

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -676,10 +676,10 @@ func (cr *CityRuntime) tick(
 			if *prevPoolRunning != nil {
 				for sn, info := range cr.poolDeathHandlers {
 					if (*prevPoolRunning)[sn] && !currentSet[sn] {
-						suppressionBead, found, err := cr.poolManagedStopSuppressionBead(sn)
+						suppressionBead, suppressed, err := cr.poolDeathHookSuppressedByManagedStop(sn)
 						if err != nil {
 							fmt.Fprintf(cr.stderr, "%s: on_death %s proceeding because session lifecycle lookup failed: %v\n", cr.logPrefix, sn, err) //nolint:errcheck // best-effort stderr
-						} else if found && poolDeathHookSuppressedByManagedStop(suppressionBead) {
+						} else if suppressed {
 							_, _ = fmt.Fprintf(
 								cr.stderr,
 								"%s: on_death %s skipped for managed session stop (bead=%s status=%s state=%s)\n",
@@ -955,12 +955,30 @@ func (cr *CityRuntime) applyStartupConfigReload(
 	}
 }
 
-func (cr *CityRuntime) skipPoolDeathHookForManagedStop(sessionName string) (bool, error) {
+func (cr *CityRuntime) poolDeathHookSuppressedByManagedStop(sessionName string) (beads.Bead, bool, error) {
 	bead, found, err := cr.poolManagedStopSuppressionBead(sessionName)
 	if err != nil || !found {
-		return false, err
+		return beads.Bead{}, false, err
 	}
-	return poolDeathHookSuppressedByManagedStop(bead), nil
+	// beginSessionDrain records the controller's stop intent in-memory before the
+	// provider kill lands and before any later metadata flush can persist
+	// state=draining/asleep/closed. Consult the drain tracker first so a pool
+	// death observed in that gap still suppresses the on_death hook.
+	if cr.poolDeathHookSuppressedByDrainTracker(bead) {
+		return bead, true, nil
+	}
+	return bead, poolDeathHookSuppressedByManagedStopState(bead), nil
+}
+
+func (cr *CityRuntime) poolDeathHookSuppressedByDrainTracker(bead beads.Bead) bool {
+	if cr == nil || cr.sessionDrains == nil {
+		return false
+	}
+	id := strings.TrimSpace(bead.ID)
+	if id == "" {
+		return false
+	}
+	return cr.sessionDrains.get(id) != nil
 }
 
 func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads.Bead, bool, error) {
@@ -989,30 +1007,91 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 	// Canonicalize across open and closed beads together. Once the provider has
 	// already reported the runtime session missing, an "active" duplicate is only
 	// stale metadata; the bead that owns the session name remains authoritative.
-	if bead, ok := canonicalPoolManagedStopSuppressionBead(poolMatches); ok {
+	if bead, ok := canonicalPoolManagedStopSuppressionBead(poolMatches, cr.sessionDrains); ok {
 		return bead, true, nil
 	}
 	return beads.Bead{}, false, nil
 }
 
-func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead) (beads.Bead, bool) {
+func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTracker) (beads.Bead, bool) {
 	if len(matches) == 0 {
 		return beads.Bead{}, false
 	}
 	winner := matches[0]
 	for _, bead := range matches[1:] {
-		winner = canonicalDuplicateSessionBead(winner, bead)
+		winner = betterPoolManagedStopSuppressionBead(winner, bead, dt)
 	}
 	return winner, true
 }
 
-func poolDeathHookSuppressedByManagedStop(bead beads.Bead) bool {
+func betterPoolManagedStopSuppressionBead(incumbent, candidate beads.Bead, dt *drainTracker) beads.Bead {
+	incumbentOwnsName := beadOwnsPoolSessionName(incumbent)
+	candidateOwnsName := beadOwnsPoolSessionName(candidate)
+	switch {
+	case candidateOwnsName && !incumbentOwnsName:
+		return candidate
+	case incumbentOwnsName && !candidateOwnsName:
+		return incumbent
+	}
+
+	incumbentTracked := drainTrackerHasBead(dt, incumbent.ID)
+	candidateTracked := drainTrackerHasBead(dt, candidate.ID)
+	switch {
+	case candidateTracked && !incumbentTracked:
+		return candidate
+	case incumbentTracked && !candidateTracked:
+		return incumbent
+	}
+
+	incumbentSuppressed := poolDeathHookSuppressedByManagedStopState(incumbent)
+	candidateSuppressed := poolDeathHookSuppressedByManagedStopState(candidate)
+	switch {
+	case candidateSuppressed && !incumbentSuppressed:
+		return candidate
+	case incumbentSuppressed && !candidateSuppressed:
+		return incumbent
+	}
+
+	incumbentClosed := strings.TrimSpace(incumbent.Status) == "closed"
+	candidateClosed := strings.TrimSpace(candidate.Status) == "closed"
+	switch {
+	case candidateClosed && !incumbentClosed:
+		return candidate
+	case incumbentClosed && !candidateClosed:
+		return incumbent
+	}
+
+	if candidate.CreatedAt.After(incumbent.CreatedAt) {
+		return candidate
+	}
+	if candidate.CreatedAt.Equal(incumbent.CreatedAt) && strings.TrimSpace(candidate.ID) > strings.TrimSpace(incumbent.ID) {
+		return candidate
+	}
+	return incumbent
+}
+
+func drainTrackerHasBead(dt *drainTracker, beadID string) bool {
+	if dt == nil || strings.TrimSpace(beadID) == "" {
+		return false
+	}
+	return dt.get(beadID) != nil
+}
+
+func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
+	if strings.TrimSpace(bead.Status) == "closed" {
+		return true
+	}
 	switch strings.TrimSpace(bead.Metadata["state"]) {
-	case string(sessionpkg.StateDraining), "drained", string(sessionpkg.StateArchived),
-		string(sessionpkg.StateSuspended), string(sessionpkg.StateFailedCreate):
+	case string(sessionpkg.StateDraining), string(sessionpkg.StateDrained),
+		string(sessionpkg.StateArchived), string(sessionpkg.StateSuspended),
+		string(sessionpkg.StateFailedCreate), "gc_swept", "orphaned":
 		return true
 	case string(sessionpkg.StateAsleep), "stopped":
 		return isDeliberateSleepReason(bead.Metadata["sleep_reason"])
+	case string(sessionpkg.StateQuarantined):
+		// Quarantine is a crash-recovery hold after an unexpected death, not a
+		// controller-managed stop that should swallow on_death recovery.
+		return false
 	default:
 		return false
 	}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/gastownhall/gascity/internal/telemetry"
 	"github.com/gastownhall/gascity/internal/workspacesvc"
@@ -675,6 +676,15 @@ func (cr *CityRuntime) tick(
 			if *prevPoolRunning != nil {
 				for sn, info := range cr.poolDeathHandlers {
 					if (*prevPoolRunning)[sn] && !currentSet[sn] {
+						skipHook, err := cr.skipPoolDeathHookForManagedStop(sn)
+						if err != nil {
+							fmt.Fprintf(cr.stderr, "%s: on_death %s skipped while checking session lifecycle: %v\n", cr.logPrefix, sn, err) //nolint:errcheck // best-effort stderr
+							continue
+						}
+						if skipHook {
+							fmt.Fprintf(cr.stderr, "%s: on_death %s skipped for managed session stop\n", cr.logPrefix, sn) //nolint:errcheck // best-effort stderr
+							continue
+						}
 						if _, err := shellRunHook(info.Command, info.Dir, info.Env); err != nil {
 							fmt.Fprintf(cr.stderr, "on_death %s: %v\n", sn, err) //nolint:errcheck // best-effort stderr
 						}
@@ -937,6 +947,35 @@ func (cr *CityRuntime) applyStartupConfigReload(
 	if reply.Outcome == reloadOutcomeFailed && dirty != nil {
 		dirty.Store(true)
 	}
+}
+
+func (cr *CityRuntime) skipPoolDeathHookForManagedStop(sessionName string) (bool, error) {
+	sessionName = strings.TrimSpace(sessionName)
+	if sessionName == "" {
+		return false, nil
+	}
+	store := cr.cityBeadStore()
+	if store == nil {
+		return false, nil
+	}
+	matches, err := sessionpkg.ExactMetadataSessionCandidates(store, false, map[string]string{"session_name": sessionName})
+	if err != nil {
+		return true, err
+	}
+	for _, bead := range matches {
+		if !isPoolManagedSessionBead(bead) {
+			continue
+		}
+		switch sessionpkg.State(strings.TrimSpace(bead.Metadata["state"])) {
+		case sessionpkg.StateActive, sessionpkg.StateAwake, sessionpkg.StateCreating:
+			continue
+		case "":
+			continue
+		default:
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (cr *CityRuntime) reloadConfigTraced(

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -36,6 +37,8 @@ import (
 // beads are still compensated by the next startup sweep if shutdown also
 // cannot wait long enough.
 const reloadOrderDrainTimeout = 1 * time.Second
+
+const sessionStateGCSwept = "gc_swept"
 
 // CityRuntime holds all running state for a single city's reconciliation
 // loop. It encapsulates the per-city lifecycle that was previously spread
@@ -682,12 +685,14 @@ func (cr *CityRuntime) tick(
 						} else if suppressed {
 							_, _ = fmt.Fprintf(
 								cr.stderr,
-								"%s: on_death %s skipped for managed session stop (bead=%s status=%s state=%s)\n",
+								"%s: on_death %s skipped for managed session stop (bead=%s status=%s state=%s state_reason=%s close_reason=%s)\n",
 								cr.logPrefix,
 								sn,
 								strings.TrimSpace(suppressionBead.ID),
 								strings.TrimSpace(suppressionBead.Status),
 								strings.TrimSpace(suppressionBead.Metadata["state"]),
+								strings.TrimSpace(suppressionBead.Metadata["state_reason"]),
+								strings.TrimSpace(suppressionBead.Metadata["close_reason"]),
 							)
 							continue
 						}
@@ -986,6 +991,12 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 		}
 		poolMatches = append(poolMatches, bead)
 	}
+	if len(poolMatches) == 0 {
+		poolMatches, err = cr.legacyPoolManagedStopSuppressionCandidates(store, sessionName)
+		if err != nil {
+			return beads.Bead{}, false, err
+		}
+	}
 	// Canonicalize across open and closed beads together. Once the provider has
 	// already reported the runtime session missing, an "active" duplicate is only
 	// stale metadata; the bead that owns the session name remains authoritative.
@@ -993,6 +1004,30 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 		return bead, true, nil
 	}
 	return beads.Bead{}, false, nil
+}
+
+func (cr *CityRuntime) legacyPoolManagedStopSuppressionCandidates(store beads.Store, sessionName string) ([]beads.Bead, error) {
+	if store == nil || cr.cfg == nil {
+		return nil, nil
+	}
+	all, err := store.List(beads.ListQuery{Label: sessionBeadLabel})
+	if err != nil {
+		return nil, err
+	}
+	var matches []beads.Bead
+	for _, bead := range all {
+		if !sessionpkg.IsSessionBeadOrRepairable(bead) {
+			continue
+		}
+		if !isPoolManagedSessionBead(bead) {
+			continue
+		}
+		if !poolManagedStopMatchesLegacyRuntimeSessionName(cr.cfg, cr.cityName, bead, sessionName) {
+			continue
+		}
+		matches = append(matches, bead)
+	}
+	return matches, nil
 }
 
 func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead, dt *drainTracker) (beads.Bead, bool) {
@@ -1060,6 +1095,14 @@ func betterPoolManagedStopSuppressionBead(incumbent, candidate, anchor beads.Bea
 	return incumbent
 }
 
+func poolManagedStopBeadIsNewer(candidate, incumbent beads.Bead) bool {
+	if candidate.CreatedAt.After(incumbent.CreatedAt) {
+		return true
+	}
+	return candidate.CreatedAt.Equal(incumbent.CreatedAt) &&
+		strings.TrimSpace(candidate.ID) > strings.TrimSpace(incumbent.ID)
+}
+
 func drainTrackerHasBead(dt *drainTracker, beadID string) bool {
 	if dt == nil || strings.TrimSpace(beadID) == "" {
 		return false
@@ -1067,15 +1110,48 @@ func drainTrackerHasBead(dt *drainTracker, beadID string) bool {
 	return dt.get(beadID) != nil
 }
 
+func poolManagedStopMatchesLegacyRuntimeSessionName(cfg *config.City, cityName string, bead beads.Bead, sessionName string) bool {
+	sessionName = strings.TrimSpace(sessionName)
+	if cfg == nil || cityName == "" || sessionName == "" {
+		return false
+	}
+	template := normalizedSessionTemplate(bead, cfg)
+	cfgAgent := findAgentByTemplate(cfg, template)
+	if cfgAgent == nil || !cfgAgent.SupportsInstanceExpansion() {
+		return false
+	}
+	identities := make(map[string]struct{})
+	addIdentity := func(identity string) {
+		identity = strings.TrimSpace(identity)
+		if identity == "" {
+			return
+		}
+		identities[identity] = struct{}{}
+	}
+	addIdentity(sessionBeadAgentName(bead))
+	addIdentity(bead.Metadata["alias"])
+	if slot, err := strconv.Atoi(strings.TrimSpace(bead.Metadata["pool_slot"])); err == nil && slot > 0 {
+		instanceName := poolInstanceName(cfgAgent.Name, slot, cfgAgent)
+		addIdentity(cfgAgent.QualifiedInstanceName(instanceName))
+	}
+	for identity := range identities {
+		if startupSessionName(cityName, identity, cfg.Workspace.SessionTemplate) == sessionName {
+			return true
+		}
+	}
+	return false
+}
+
 func poolManagedStopSuppressionRank(bead, anchor beads.Bead, hasAnchor bool, dt *drainTracker) int {
 	suppressed := poolDeathHookSuppressedByManagedStopState(bead)
 	tracked := drainTrackerHasBead(dt, bead.ID)
 	isAnchor := hasAnchor && strings.TrimSpace(anchor.ID) != "" && strings.TrimSpace(anchor.ID) == strings.TrimSpace(bead.ID)
-	anchorIsNewer := hasAnchor && strings.TrimSpace(anchor.ID) != "" && strings.TrimSpace(anchor.ID) != strings.TrimSpace(bead.ID) &&
-		anchor.CreatedAt.After(bead.CreatedAt)
+	anchorDominates := hasAnchor && strings.TrimSpace(anchor.ID) != "" &&
+		strings.TrimSpace(anchor.ID) != strings.TrimSpace(bead.ID) &&
+		poolManagedStopBeadIsNewer(anchor, bead)
 
 	switch {
-	case suppressed && tracked && !anchorIsNewer:
+	case suppressed && tracked && !anchorDominates:
 		// Live drain-tracker intent wins while it still points at the newest
 		// managed-stop candidate. If the tracked duplicate is older than the
 		// current authority anchor, treat the tracker as stale and fall back to
@@ -1083,7 +1159,7 @@ func poolManagedStopSuppressionRank(bead, anchor beads.Bead, hasAnchor bool, dt 
 		return 5
 	case suppressed && isAnchor:
 		return 4
-	case suppressed && hasAnchor && !isAnchor && bead.CreatedAt.After(anchor.CreatedAt):
+	case suppressed && hasAnchor && !isAnchor && poolManagedStopBeadIsNewer(bead, anchor):
 		// After a controller restart, drainTracker state is gone. A newer
 		// managed-stop duplicate still needs to beat an older active anchor so
 		// death-hook suppression survives restart.
@@ -1101,7 +1177,7 @@ func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
 	switch strings.TrimSpace(bead.Metadata["state"]) {
 	case string(sessionpkg.StateDraining), string(sessionpkg.StateDrained),
 		string(sessionpkg.StateArchived), string(sessionpkg.StateSuspended),
-		"gc_swept", "orphaned":
+		sessionStateGCSwept, string(sessionpkg.BaseStateOrphaned):
 		return true
 	case string(sessionpkg.StateCreating):
 		// Keep creating fail-open. Async-start cleanup can stop a runtime while
@@ -1112,7 +1188,7 @@ func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
 		// failed-create still projects as a missing runtime that can need
 		// crash recovery. Do not swallow on_death for that state.
 		return false
-	case string(sessionpkg.StateAsleep), "stopped":
+	case string(sessionpkg.StateAsleep), string(sessionpkg.BaseStateStopped):
 		return isDeliberateSleepReason(bead.Metadata["sleep_reason"])
 	case string(sessionpkg.StateQuarantined):
 		// Quarantine is a crash-recovery hold after an unexpected death, not a

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1191,10 +1191,15 @@ func poolDeathHookSuppressedByManagedStopDrainTracker(dt *drainTracker, beadID s
 
 func poolDeathHookSuppressedByManagedStopState(bead beads.Bead) bool {
 	switch strings.TrimSpace(bead.Metadata["state"]) {
-	case string(sessionpkg.StateDraining), string(sessionpkg.StateDrained),
-		string(sessionpkg.StateArchived), string(sessionpkg.StateSuspended),
+	case string(sessionpkg.StateDrained), string(sessionpkg.StateArchived),
+		string(sessionpkg.StateSuspended),
 		sessionStateGCSwept, string(sessionpkg.BaseStateOrphaned):
 		return true
+	case string(sessionpkg.StateDraining):
+		// Persisted draining state only proves a deliberate stop once the bead
+		// has already been closed. Live draining sessions preserve crash
+		// recovery until the controller's explicit stop signal is acknowledged.
+		return strings.TrimSpace(bead.Status) == "closed"
 	case string(sessionpkg.StateCreating):
 		// Keep creating fail-open. Async-start cleanup can stop a runtime while
 		// the bead is still creating, and those disappearances should preserve

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -976,11 +976,8 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 	if err != nil {
 		return beads.Bead{}, false, err
 	}
-	var (
-		poolMatches []beads.Bead
-		owner       beads.Bead
-		ownerCount  int
-	)
+	var openMatches []beads.Bead
+	var closedMatches []beads.Bead
 	for _, bead := range matches {
 		if !isPoolManagedSessionBead(bead) {
 			continue
@@ -988,34 +985,30 @@ func (cr *CityRuntime) poolManagedStopSuppressionBead(sessionName string) (beads
 		if strings.TrimSpace(bead.Metadata["session_name"]) != sessionName {
 			continue
 		}
-		poolMatches = append(poolMatches, bead)
-		if beadOwnsPoolSessionName(bead) {
-			owner = bead
-			ownerCount++
+		if bead.Status == "closed" {
+			closedMatches = append(closedMatches, bead)
+			continue
 		}
+		openMatches = append(openMatches, bead)
 	}
-	switch {
-	case ownerCount == 1:
-		return owner, true, nil
-	case ownerCount > 1:
-		ids := make([]string, 0, len(poolMatches))
-		for _, bead := range poolMatches {
-			if beadOwnsPoolSessionName(bead) {
-				ids = append(ids, bead.ID)
-			}
-		}
-		return beads.Bead{}, false, fmt.Errorf("multiple canonical pool session beads matched %q: %s", sessionName, strings.Join(ids, ", "))
-	case len(poolMatches) == 0:
-		return beads.Bead{}, false, nil
-	case len(poolMatches) == 1:
-		return poolMatches[0], true, nil
-	default:
-		ids := make([]string, 0, len(poolMatches))
-		for _, bead := range poolMatches {
-			ids = append(ids, bead.ID)
-		}
-		return beads.Bead{}, false, fmt.Errorf("ambiguous pool session beads matched %q without a canonical owner: %s", sessionName, strings.Join(ids, ", "))
+	if bead, ok := canonicalPoolManagedStopSuppressionBead(openMatches); ok {
+		return bead, true, nil
 	}
+	if bead, ok := canonicalPoolManagedStopSuppressionBead(closedMatches); ok {
+		return bead, true, nil
+	}
+	return beads.Bead{}, false, nil
+}
+
+func canonicalPoolManagedStopSuppressionBead(matches []beads.Bead) (beads.Bead, bool) {
+	if len(matches) == 0 {
+		return beads.Bead{}, false
+	}
+	winner := matches[0]
+	for _, bead := range matches[1:] {
+		winner = canonicalDuplicateSessionBead(winner, bead)
+	}
+	return winner, true
 }
 
 func poolDeathHookSuppressedByManagedStop(bead beads.Bead) bool {

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2383,50 +2383,29 @@ func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
 	}
 }
 
-func TestCityRuntimeTickRunsOnDeathWhenCanonicalPoolBeadIsActive(t *testing.T) {
-	cityPath := t.TempDir()
-	outFile := filepath.Join(cityPath, "on-death.txt")
-	store := beads.NewMemStore()
-	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
-	mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDraining), "")
-
-	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
-	var stderr bytes.Buffer
-	cr := &CityRuntime{
-		cityPath:            cityPath,
-		cityName:            "my-city",
-		logPrefix:           "gc start",
-		cfg:                 &config.City{},
-		sp:                  runtime.NewFake(),
-		standaloneCityStore: store,
-		sessionDrains:       newDrainTracker(),
-		poolDeathHandlers: map[string]poolDeathInfo{
-			owner.Metadata["session_name"]: {
-				Command: "printf fired > " + shellQuotePath(outFile),
-				Dir:     cityPath,
-			},
-		},
-		rec:    events.Discard,
-		stdout: io.Discard,
-		stderr: &stderr,
-		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
-			return DesiredStateResult{State: map[string]TemplateParams{}}
+func TestBetterPoolManagedStopSuppressionBead_NewerActiveOwnerBeatsOlderManagedDuplicate(t *testing.T) {
+	owner := beads.Bead{
+		ID:        "gc-2",
+		CreatedAt: time.Unix(20, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": PoolSessionName("worker", "gc-2"),
+			"state":        string(sessionpkg.StateActive),
 		},
 	}
-
-	dirty := &atomic.Bool{}
-	var lastProviderName string
-	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
-
-	data, err := os.ReadFile(outFile)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	olderDraining := beads.Bead{
+		ID:        "gc-1",
+		CreatedAt: time.Unix(10, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": owner.Metadata["session_name"],
+			"state":        string(sessionpkg.StateDraining),
+		},
 	}
-	if got := strings.TrimSpace(string(data)); got != "fired" {
-		t.Fatalf("on_death output = %q, want %q", got, "fired")
-	}
-	if strings.Contains(stderr.String(), "skipped for managed session stop") {
-		t.Fatalf("stderr = %q, want canonical active bead to keep on_death enabled", stderr.String())
+	newestOwner, hasOwner := newestPoolManagedStopSuppressionOwner([]beads.Bead{olderDraining, owner})
+
+	if got := betterPoolManagedStopSuppressionBead(olderDraining, owner, newestOwner, hasOwner, nil); got.ID != owner.ID {
+		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
 	}
 }
 
@@ -2612,6 +2591,98 @@ func TestCityRuntimeTickSkipsOnDeathForDrainTrackedDuplicateWhenOwnerStillMatche
 	}
 }
 
+func TestCityRuntimeTickSkipsOnDeathForUntrackedNewerManagedDuplicateAfterRestart(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
+	draining := mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDraining), "")
+
+	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			owner.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if strings.Contains(stderr.String(), "bead="+owner.ID) {
+		t.Fatalf("stderr = %q, want newer managed duplicate to beat stale owner after restart", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), draining.ID) || !strings.Contains(stderr.String(), "state=draining") {
+		t.Fatalf("stderr = %q, want newer managed duplicate context for managed-stop skip", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickRunsOnDeathForCreatingPoolSession(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateCreating), "")
+
+	prevPoolRunning := map[string]bool{bead.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			bead.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	}
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want %q", got, "fired")
+	}
+	if strings.Contains(stderr.String(), "skipped for managed session stop") {
+		t.Fatalf("stderr = %q, want creating state to preserve on_death recovery", stderr.String())
+	}
+}
+
 func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepReason(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
@@ -2726,8 +2797,36 @@ func TestBetterPoolManagedStopSuppressionBead_SameSuppressionFallsBackToRecency(
 		},
 	}
 
-	if got := betterPoolManagedStopSuppressionBead(olderClosed, newerOpen, nil); got.ID != newerOpen.ID {
+	if got := betterPoolManagedStopSuppressionBead(olderClosed, newerOpen, beads.Bead{}, false, nil); got.ID != newerOpen.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, newerOpen.ID)
+	}
+}
+
+func TestBetterPoolManagedStopSuppressionBead_TrackedOlderManagedDuplicateDoesNotBeatNewerOwner(t *testing.T) {
+	owner := beads.Bead{
+		ID:        "gc-2",
+		CreatedAt: time.Unix(20, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": PoolSessionName("worker", "gc-2"),
+			"state":        string(sessionpkg.StateActive),
+		},
+	}
+	trackedOlder := beads.Bead{
+		ID:        "gc-1",
+		CreatedAt: time.Unix(10, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": owner.Metadata["session_name"],
+			"state":        string(sessionpkg.StateDraining),
+		},
+	}
+	drains := newDrainTracker()
+	drains.set(trackedOlder.ID, &drainState{reason: "config-drift"})
+	newestOwner, hasOwner := newestPoolManagedStopSuppressionOwner([]beads.Bead{trackedOlder, owner})
+
+	if got := betterPoolManagedStopSuppressionBead(trackedOlder, owner, newestOwner, hasOwner, drains); got.ID != owner.ID {
+		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2402,9 +2402,9 @@ func TestBetterPoolManagedStopSuppressionBead_NewerActiveOwnerBeatsOlderManagedD
 			"state":        string(sessionpkg.StateDraining),
 		},
 	}
-	newestOwner, hasOwner := newestPoolManagedStopSuppressionOwner([]beads.Bead{olderDraining, owner})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{olderDraining, owner})
 
-	if got := betterPoolManagedStopSuppressionBead(olderDraining, owner, newestOwner, hasOwner, nil); got.ID != owner.ID {
+	if got := betterPoolManagedStopSuppressionBead(olderDraining, owner, anchor, hasAnchor, nil); got.ID != owner.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
 	}
 }
@@ -2683,6 +2683,52 @@ func TestCityRuntimeTickRunsOnDeathForCreatingPoolSession(t *testing.T) {
 	}
 }
 
+func TestCityRuntimeTickRunsOnDeathForFailedCreatePoolSession(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateFailedCreate), "")
+
+	prevPoolRunning := map[string]bool{bead.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			bead.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	}
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want %q", got, "fired")
+	}
+	if strings.Contains(stderr.String(), "skipped for managed session stop") {
+		t.Fatalf("stderr = %q, want failed-create state to preserve on_death recovery", stderr.String())
+	}
+}
+
 func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepReason(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
@@ -2823,10 +2869,37 @@ func TestBetterPoolManagedStopSuppressionBead_TrackedOlderManagedDuplicateDoesNo
 	}
 	drains := newDrainTracker()
 	drains.set(trackedOlder.ID, &drainState{reason: "config-drift"})
-	newestOwner, hasOwner := newestPoolManagedStopSuppressionOwner([]beads.Bead{trackedOlder, owner})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedOlder, owner})
 
-	if got := betterPoolManagedStopSuppressionBead(trackedOlder, owner, newestOwner, hasOwner, drains); got.ID != owner.ID {
+	if got := betterPoolManagedStopSuppressionBead(trackedOlder, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
+	}
+}
+
+func TestBetterPoolManagedStopSuppressionBead_NonCanonicalActiveAnchorBeatsOlderManagedDuplicate(t *testing.T) {
+	activeAliasBead := beads.Bead{
+		ID:        "gc-2",
+		CreatedAt: time.Unix(20, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"alias":        "crew/worker-1",
+			"session_name": "crew-worker-1",
+			"state":        string(sessionpkg.StateActive),
+		},
+	}
+	olderDraining := beads.Bead{
+		ID:        "gc-1",
+		CreatedAt: time.Unix(10, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": activeAliasBead.Metadata["session_name"],
+			"state":        string(sessionpkg.StateDraining),
+		},
+	}
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{olderDraining, activeAliasBead})
+
+	if got := betterPoolManagedStopSuppressionBead(olderDraining, activeAliasBead, anchor, hasAnchor, nil); got.ID != activeAliasBead.ID {
+		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, activeAliasBead.ID)
 	}
 }
 
@@ -2932,12 +3005,12 @@ func TestPoolDeathHookSuppressedByManagedStopState_Contract(t *testing.T) {
 		{name: "active", state: string(sessionpkg.StateActive), want: false},
 		{name: "awake", state: string(sessionpkg.StateAwake), want: false},
 		{name: "creating", state: string(sessionpkg.StateCreating), want: false},
+		{name: "failed-create", state: string(sessionpkg.StateFailedCreate), want: false},
 		{name: "empty", state: "", want: false},
 		{name: "empty-closed", state: "", status: "closed", want: false},
 		{name: "asleep-empty", state: string(sessionpkg.StateAsleep), want: false},
 		{name: "asleep-idle", state: string(sessionpkg.StateAsleep), sleepReason: "idle", want: true},
 		{name: "suspended", state: string(sessionpkg.StateSuspended), want: true},
-		{name: "failed-create", state: string(sessionpkg.StateFailedCreate), want: true},
 		{name: "draining", state: string(sessionpkg.StateDraining), want: true},
 		{name: "drained", state: string(sessionpkg.StateDrained), want: true},
 		{name: "active-closed", state: string(sessionpkg.StateActive), status: "closed", want: false},

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2658,7 +2658,7 @@ func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepRe
 	}
 }
 
-func TestCityRuntimeTickSkipsOnDeathWhileManagedDrainTrackerEntryIsActive(t *testing.T) {
+func TestCityRuntimeTickRunsOnDeathWhileManagedDrainTrackerEntryIsActive(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
 	store := beads.NewMemStore()
@@ -2694,11 +2694,40 @@ func TestCityRuntimeTickSkipsOnDeathWhileManagedDrainTrackerEntryIsActive(t *tes
 	var lastProviderName string
 	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
 
-	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state=active") {
-		t.Fatalf("stderr = %q, want drain-tracked bead context for managed-stop skip", stderr.String())
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want %q", got, "fired")
+	}
+	if strings.Contains(stderr.String(), "skipped for managed session stop") {
+		t.Fatalf("stderr = %q, want active drain-tracked bead to keep on_death enabled", stderr.String())
+	}
+}
+
+func TestBetterPoolManagedStopSuppressionBead_SameSuppressionFallsBackToRecency(t *testing.T) {
+	olderClosed := beads.Bead{
+		ID:        "gc-1",
+		Status:    "closed",
+		CreatedAt: time.Unix(10, 0).UTC(),
+		Metadata: map[string]string{
+			"session_name": "worker-legacy",
+			"state":        string(sessionpkg.StateActive),
+		},
+	}
+	newerOpen := beads.Bead{
+		ID:        "gc-2",
+		Status:    "open",
+		CreatedAt: time.Unix(20, 0).UTC(),
+		Metadata: map[string]string{
+			"session_name": "worker-legacy",
+			"state":        string(sessionpkg.StateActive),
+		},
+	}
+
+	if got := betterPoolManagedStopSuppressionBead(olderClosed, newerOpen, nil); got.ID != newerOpen.ID {
+		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, newerOpen.ID)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2472,7 +2472,7 @@ func TestCityRuntimeTickSkipsOnDeathForClosedCanonicalControllerDrainingSession(
 	}
 }
 
-func TestCityRuntimeTickRunsOnDeathWhenOpenDuplicatePoolBeadIsActive(t *testing.T) {
+func TestCityRuntimeTickSkipsOnDeathWhenClosedCanonicalPoolBeadOwnsSessionName(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
 	store := beads.NewMemStore()
@@ -2507,15 +2507,14 @@ func TestCityRuntimeTickRunsOnDeathWhenOpenDuplicatePoolBeadIsActive(t *testing.
 	var lastProviderName string
 	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
 
-	data, err := os.ReadFile(outFile)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
 	}
-	if got := strings.TrimSpace(string(data)); got != "fired" {
-		t.Fatalf("on_death output = %q, want fired", got)
+	if strings.Contains(stderr.String(), activeDuplicate.ID) {
+		t.Fatalf("stderr = %q, want canonical closed owner to beat stale open duplicate", stderr.String())
 	}
-	if strings.Contains(stderr.String(), activeDuplicate.ID) || strings.Contains(stderr.String(), closedOwner.ID) {
-		t.Fatalf("stderr = %q, want managed-stop suppression to stay disabled when an open duplicate is still active", stderr.String())
+	if !strings.Contains(stderr.String(), closedOwner.ID) || !strings.Contains(stderr.String(), "state=draining") {
+		t.Fatalf("stderr = %q, want closed canonical bead context", stderr.String())
 	}
 }
 
@@ -2560,6 +2559,52 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(
 	}
 	if !strings.Contains(stderr.String(), draining.ID) || !strings.Contains(stderr.String(), "state=draining") {
 		t.Fatalf("stderr = %q, want latest legacy duplicate bead context for managed-stop skip", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepReason(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead := mustCreatePoolManagedSessionBead(t, store, "", "stopped", "")
+
+	prevPoolRunning := map[string]bool{bead.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			bead.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	}
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want %q", got, "fired")
+	}
+	if strings.Contains(stderr.String(), "skipped for managed session stop") {
+		t.Fatalf("stderr = %q, want generic stopped state to keep on_death enabled", stderr.String())
 	}
 }
 
@@ -2614,27 +2659,40 @@ func TestCityRuntimeTickRunsOnDeathWhenManagedStopLookupFails(t *testing.T) {
 
 func TestSkipPoolDeathHookForManagedStop_StateContract(t *testing.T) {
 	testCases := []struct {
-		name   string
-		state  string
-		status string
-		want   bool
+		name        string
+		state       string
+		status      string
+		sleepReason string
+		want        bool
 	}{
 		{name: "active", state: string(sessionpkg.StateActive), want: false},
 		{name: "awake", state: string(sessionpkg.StateAwake), want: false},
 		{name: "creating", state: string(sessionpkg.StateCreating), want: false},
 		{name: "empty", state: "", want: false},
-		{name: "asleep", state: string(sessionpkg.StateAsleep), want: true},
+		{name: "asleep-empty", state: string(sessionpkg.StateAsleep), want: false},
+		{name: "asleep-idle", state: string(sessionpkg.StateAsleep), sleepReason: "idle", want: true},
 		{name: "suspended", state: string(sessionpkg.StateSuspended), want: true},
 		{name: "failed-create", state: string(sessionpkg.StateFailedCreate), want: true},
 		{name: "draining", state: string(sessionpkg.StateDraining), want: true},
 		{name: "archived-closed", state: string(sessionpkg.StateArchived), status: "closed", want: true},
-		{name: "quarantined", state: string(sessionpkg.StateQuarantined), want: true},
+		{name: "stopped-empty", state: "stopped", want: false},
+		{name: "stopped-city-stop", state: "stopped", sleepReason: sleepReasonCityStop, want: true},
+		{name: "quarantined", state: string(sessionpkg.StateQuarantined), want: false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			store := beads.NewMemStore()
 			bead := mustCreatePoolManagedSessionBead(t, store, "", tc.state, tc.status)
+			if tc.sleepReason != "" {
+				if err := store.SetMetadata(bead.ID, "sleep_reason", tc.sleepReason); err != nil {
+					t.Fatalf("SetMetadata(%s, sleep_reason): %v", bead.ID, err)
+				}
+			}
+			bead, err := store.Get(bead.ID)
+			if err != nil {
+				t.Fatalf("Get(%s): %v", bead.ID, err)
+			}
 			cr := &CityRuntime{standaloneCityStore: store}
 
 			skipHook, err := cr.skipPoolDeathHookForManagedStop(bead.Metadata["session_name"])

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2346,6 +2346,8 @@ func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create(session bead): %v", err)
 	}
+	drains := newDrainTracker()
+	drains.set(bead.ID, &drainState{reason: "config-drift", ackSet: true})
 
 	prevPoolRunning := map[string]bool{sessionName: true}
 	var stderr bytes.Buffer
@@ -2356,7 +2358,7 @@ func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
 		cfg:                 &config.City{},
 		sp:                  runtime.NewFake(),
 		standaloneCityStore: store,
-		sessionDrains:       newDrainTracker(),
+		sessionDrains:       drains,
 		poolDeathHandlers: map[string]poolDeathInfo{
 			sessionName: {
 				Command: "printf fired > " + shellQuotePath(outFile),
@@ -2505,7 +2507,7 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(
 	mustCreatePoolManagedSessionBead(t, store, sessionName, string(sessionpkg.StateActive), "")
 	draining := mustCreatePoolManagedSessionBead(t, store, sessionName, string(sessionpkg.StateDraining), "")
 	drains := newDrainTracker()
-	drains.set(draining.ID, &drainState{reason: "config-drift"})
+	drains.set(draining.ID, &drainState{reason: "config-drift", ackSet: true})
 
 	prevPoolRunning := map[string]bool{sessionName: true}
 	var stderr bytes.Buffer
@@ -2571,6 +2573,8 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyHandlerKeyAgainstCanonicalPoolSessi
 	if err != nil {
 		t.Fatalf("Get(%s): %v", bead.ID, err)
 	}
+	drains := newDrainTracker()
+	drains.set(bead.ID, &drainState{reason: "config-drift", ackSet: true})
 
 	legacyHandlerKey := startupSessionName("my-city", "worker-1", "")
 	prevPoolRunning := map[string]bool{legacyHandlerKey: true}
@@ -2584,7 +2588,7 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyHandlerKeyAgainstCanonicalPoolSessi
 		},
 		sp:                  runtime.NewFake(),
 		standaloneCityStore: store,
-		sessionDrains:       newDrainTracker(),
+		sessionDrains:       drains,
 		poolDeathHandlers: map[string]poolDeathInfo{
 			legacyHandlerKey: {
 				Command: "printf fired > " + shellQuotePath(outFile),
@@ -2691,7 +2695,7 @@ func TestCityRuntimeTickSkipsOnDeathForDrainTrackedDuplicateWhenOwnerStillMatche
 	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
 	draining := mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDraining), "")
 	drains := newDrainTracker()
-	drains.set(draining.ID, &drainState{reason: "config-drift"})
+	drains.set(draining.ID, &drainState{reason: "config-drift", ackSet: true})
 
 	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
 	var stderr bytes.Buffer
@@ -2737,7 +2741,7 @@ func TestCityRuntimeTickSkipsOnDeathForUntrackedNewerManagedDuplicateAfterRestar
 	outFile := filepath.Join(cityPath, "on-death.txt")
 	store := beads.NewMemStore()
 	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
-	draining := mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDraining), "")
+	draining := mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDrained), "")
 
 	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
 	var stderr bytes.Buffer
@@ -2773,7 +2777,7 @@ func TestCityRuntimeTickSkipsOnDeathForUntrackedNewerManagedDuplicateAfterRestar
 	if strings.Contains(stderr.String(), "bead="+owner.ID) {
 		t.Fatalf("stderr = %q, want newer managed duplicate to beat stale owner after restart", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), draining.ID) || !strings.Contains(stderr.String(), "state=draining") {
+	if !strings.Contains(stderr.String(), draining.ID) || !strings.Contains(stderr.String(), "state=drained") {
 		t.Fatalf("stderr = %q, want newer managed duplicate context for managed-stop skip", stderr.String())
 	}
 }
@@ -3053,7 +3057,7 @@ func TestBetterPoolManagedStopSuppressionBead_TrackedOlderManagedDuplicateDoesNo
 		},
 	}
 	drains := newDrainTracker()
-	drains.set(trackedOlder.ID, &drainState{reason: "config-drift"})
+	drains.set(trackedOlder.ID, &drainState{reason: "config-drift", ackSet: true})
 	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedOlder, owner}, drains)
 
 	if got := betterPoolManagedStopSuppressionBead(trackedOlder, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
@@ -3081,7 +3085,7 @@ func TestBetterPoolManagedStopSuppressionBead_AnchorTieBreakBeatsTrackedDuplicat
 		},
 	}
 	drains := newDrainTracker()
-	drains.set(trackedDuplicate.ID, &drainState{reason: "config-drift"})
+	drains.set(trackedDuplicate.ID, &drainState{reason: "config-drift", ackSet: true})
 	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedDuplicate, owner}, drains)
 
 	if got := betterPoolManagedStopSuppressionBead(trackedDuplicate, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
@@ -3224,7 +3228,8 @@ func TestPoolDeathHookSuppressedByManagedStopState_Contract(t *testing.T) {
 		{name: "asleep-empty", state: string(sessionpkg.StateAsleep), want: false},
 		{name: "asleep-idle", state: string(sessionpkg.StateAsleep), sleepReason: "idle", want: true},
 		{name: "suspended", state: string(sessionpkg.StateSuspended), want: true},
-		{name: "draining", state: string(sessionpkg.StateDraining), want: true},
+		{name: "draining-open", state: string(sessionpkg.StateDraining), want: false},
+		{name: "draining-closed", state: string(sessionpkg.StateDraining), status: "closed", want: true},
 		{name: "drained", state: string(sessionpkg.StateDrained), want: true},
 		{name: "active-closed", state: string(sessionpkg.StateActive), status: "closed", want: false},
 		{name: "archived-closed", state: string(sessionpkg.StateArchived), status: "closed", want: true},

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionauto "github.com/gastownhall/gascity/internal/runtime/auto"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
@@ -2270,6 +2271,60 @@ func TestCityRuntimeTickRunsOnDeathWithCanonicalRigEnv(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(data)); got != "3308|rig-user|rig-secret" {
 		t.Fatalf("on_death env = %q, want %q", got, "3308|rig-user|rig-secret")
+	}
+}
+
+func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	sessionName := "worker-gc-1"
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker"},
+		Metadata: map[string]string{
+			"session_name":         sessionName,
+			"template":             "worker",
+			"agent_name":           "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                string(sessionpkg.StateDraining),
+			"state_reason":         "config-drift",
+		},
+	}); err != nil {
+		t.Fatalf("Create(session bead): %v", err)
+	}
+
+	prevPoolRunning := map[string]bool{sessionName: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			sessionName: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2435,7 +2435,6 @@ func TestCityRuntimeTickSkipsOnDeathForClosedCanonicalControllerDrainingSession(
 	outFile := filepath.Join(cityPath, "on-death.txt")
 	store := beads.NewMemStore()
 	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateDraining), "closed")
-	mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateActive), "")
 
 	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
 	var stderr bytes.Buffer
@@ -2470,6 +2469,97 @@ func TestCityRuntimeTickSkipsOnDeathForClosedCanonicalControllerDrainingSession(
 	}
 	if !strings.Contains(stderr.String(), owner.ID) || !strings.Contains(stderr.String(), "status=closed") {
 		t.Fatalf("stderr = %q, want closed canonical bead context", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickRunsOnDeathWhenOpenDuplicatePoolBeadIsActive(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	closedOwner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateDraining), "closed")
+	activeDuplicate := mustCreatePoolManagedSessionBead(t, store, closedOwner.Metadata["session_name"], string(sessionpkg.StateActive), "")
+
+	prevPoolRunning := map[string]bool{closedOwner.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			closedOwner.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	}
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want fired", got)
+	}
+	if strings.Contains(stderr.String(), activeDuplicate.ID) || strings.Contains(stderr.String(), closedOwner.ID) {
+		t.Fatalf("stderr = %q, want managed-stop suppression to stay disabled when an open duplicate is still active", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	const sessionName = "worker-legacy"
+	mustCreatePoolManagedSessionBead(t, store, sessionName, string(sessionpkg.StateActive), "")
+	draining := mustCreatePoolManagedSessionBead(t, store, sessionName, string(sessionpkg.StateDraining), "")
+
+	prevPoolRunning := map[string]bool{sessionName: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			sessionName: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), draining.ID) || !strings.Contains(stderr.String(), "state=draining") {
+		t.Fatalf("stderr = %q, want latest legacy duplicate bead context for managed-stop skip", stderr.String())
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2525,6 +2525,8 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(
 	const sessionName = "worker-legacy"
 	mustCreatePoolManagedSessionBead(t, store, sessionName, string(sessionpkg.StateActive), "")
 	draining := mustCreatePoolManagedSessionBead(t, store, sessionName, string(sessionpkg.StateDraining), "")
+	drains := newDrainTracker()
+	drains.set(draining.ID, &drainState{reason: "config-drift"})
 
 	prevPoolRunning := map[string]bool{sessionName: true}
 	var stderr bytes.Buffer
@@ -2535,7 +2537,7 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(
 		cfg:                 &config.City{},
 		sp:                  runtime.NewFake(),
 		standaloneCityStore: store,
-		sessionDrains:       newDrainTracker(),
+		sessionDrains:       drains,
 		poolDeathHandlers: map[string]poolDeathInfo{
 			sessionName: {
 				Command: "printf fired > " + shellQuotePath(outFile),
@@ -2608,6 +2610,92 @@ func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepRe
 	}
 }
 
+func TestCityRuntimeTickSkipsOnDeathWhileManagedDrainTrackerEntryIsActive(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
+	drains := newDrainTracker()
+	drains.set(bead.ID, &drainState{reason: "config-drift"})
+
+	prevPoolRunning := map[string]bool{bead.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       drains,
+		poolDeathHandlers: map[string]poolDeathInfo{
+			bead.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state=active") {
+		t.Fatalf("stderr = %q, want drain-tracked bead context for managed-stop skip", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickSkipsOnDeathForClosedGCSweptPoolSession(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead := mustCreatePoolManagedSessionBead(t, store, "", "gc_swept", "closed")
+
+	prevPoolRunning := map[string]bool{bead.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			bead.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state=gc_swept") {
+		t.Fatalf("stderr = %q, want terminal close bead context for managed-stop skip", stderr.String())
+	}
+}
+
 func TestCityRuntimeTickRunsOnDeathWhenManagedStopLookupFails(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
@@ -2657,7 +2745,7 @@ func TestCityRuntimeTickRunsOnDeathWhenManagedStopLookupFails(t *testing.T) {
 	}
 }
 
-func TestSkipPoolDeathHookForManagedStop_StateContract(t *testing.T) {
+func TestPoolDeathHookSuppressedByManagedStopState_Contract(t *testing.T) {
 	testCases := []struct {
 		name        string
 		state       string
@@ -2674,33 +2762,31 @@ func TestSkipPoolDeathHookForManagedStop_StateContract(t *testing.T) {
 		{name: "suspended", state: string(sessionpkg.StateSuspended), want: true},
 		{name: "failed-create", state: string(sessionpkg.StateFailedCreate), want: true},
 		{name: "draining", state: string(sessionpkg.StateDraining), want: true},
+		{name: "drained", state: string(sessionpkg.StateDrained), want: true},
 		{name: "archived-closed", state: string(sessionpkg.StateArchived), status: "closed", want: true},
 		{name: "stopped-empty", state: "stopped", want: false},
 		{name: "stopped-city-stop", state: "stopped", sleepReason: sleepReasonCityStop, want: true},
 		{name: "quarantined", state: string(sessionpkg.StateQuarantined), want: false},
+		{name: "gc-swept", state: "gc_swept", status: "closed", want: true},
+		{name: "orphaned", state: "orphaned", status: "closed", want: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			store := beads.NewMemStore()
-			bead := mustCreatePoolManagedSessionBead(t, store, "", tc.state, tc.status)
+			bead := beads.Bead{
+				Status: tc.status,
+				Metadata: map[string]string{
+					"state": tc.state,
+				},
+			}
 			if tc.sleepReason != "" {
-				if err := store.SetMetadata(bead.ID, "sleep_reason", tc.sleepReason); err != nil {
-					t.Fatalf("SetMetadata(%s, sleep_reason): %v", bead.ID, err)
-				}
+				bead.Metadata["sleep_reason"] = tc.sleepReason
 			}
-			bead, err := store.Get(bead.ID)
-			if err != nil {
-				t.Fatalf("Get(%s): %v", bead.ID, err)
+			if bead.Status == "" {
+				bead.Status = "open"
 			}
-			cr := &CityRuntime{standaloneCityStore: store}
-
-			skipHook, err := cr.skipPoolDeathHookForManagedStop(bead.Metadata["session_name"])
-			if err != nil {
-				t.Fatalf("skipPoolDeathHookForManagedStop(%q): %v", bead.Metadata["session_name"], err)
-			}
-			if skipHook != tc.want {
-				t.Fatalf("skipPoolDeathHookForManagedStop(%q) = %v, want %v", tc.name, skipHook, tc.want)
+			if got := poolDeathHookSuppressedByManagedStopState(bead); got != tc.want {
+				t.Fatalf("poolDeathHookSuppressedByManagedStopState(%q) = %v, want %v", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2402,7 +2402,7 @@ func TestBetterPoolManagedStopSuppressionBead_NewerActiveOwnerBeatsOlderManagedD
 			"state":        string(sessionpkg.StateDraining),
 		},
 	}
-	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{olderDraining, owner})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{olderDraining, owner}, nil)
 
 	if got := betterPoolManagedStopSuppressionBead(olderDraining, owner, anchor, hasAnchor, nil); got.ID != owner.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
@@ -2608,6 +2608,79 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyHandlerKeyAgainstCanonicalPoolSessi
 	}
 	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state_reason=config-drift") {
 		t.Fatalf("stderr = %q, want legacy handler key to resolve managed-stop bead context", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickSkipsOnDeathForClosedLegacyHandlerKeyAgainstCanonicalPoolSessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker-1"},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"agent_name":           "worker-1",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                string(sessionpkg.StateArchived),
+			"state_reason":         "config-drift",
+			"close_reason":         "config-drift",
+			"closed_at":            "2026-05-10T00:00:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session bead): %v", err)
+	}
+	sessionName := PoolSessionName("worker", bead.ID)
+	if err := store.SetMetadata(bead.ID, "session_name", sessionName); err != nil {
+		t.Fatalf("SetMetadata(session_name): %v", err)
+	}
+	if err := store.Close(bead.ID); err != nil {
+		t.Fatalf("Close(%s): %v", bead.ID, err)
+	}
+	bead, err = store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", bead.ID, err)
+	}
+
+	legacyHandlerKey := startupSessionName("my-city", "worker-1", "")
+	prevPoolRunning := map[string]bool{legacyHandlerKey: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:  cityPath,
+		cityName:  "my-city",
+		logPrefix: "gc start",
+		cfg: &config.City{
+			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			legacyHandlerKey: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state=archived") {
+		t.Fatalf("stderr = %q, want closed legacy handler key to resolve managed-stop bead context", stderr.String())
 	}
 }
 
@@ -2843,6 +2916,50 @@ func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepRe
 	}
 }
 
+func TestCityRuntimeTickSkipsOnDeathForAckedManagedDrainTrackerEntryWhileStateIsActive(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
+	drains := newDrainTracker()
+	drains.set(bead.ID, &drainState{reason: "config-drift", ackSet: true})
+
+	prevPoolRunning := map[string]bool{bead.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       drains,
+		poolDeathHandlers: map[string]poolDeathInfo{
+			bead.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state=active") {
+		t.Fatalf("stderr = %q, want acked managed drain tracker to suppress on_death while bead is still active", stderr.String())
+	}
+}
+
 func TestCityRuntimeTickRunsOnDeathWhileManagedDrainTrackerEntryIsActive(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
@@ -2937,7 +3054,7 @@ func TestBetterPoolManagedStopSuppressionBead_TrackedOlderManagedDuplicateDoesNo
 	}
 	drains := newDrainTracker()
 	drains.set(trackedOlder.ID, &drainState{reason: "config-drift"})
-	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedOlder, owner})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedOlder, owner}, drains)
 
 	if got := betterPoolManagedStopSuppressionBead(trackedOlder, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
@@ -2965,7 +3082,7 @@ func TestBetterPoolManagedStopSuppressionBead_AnchorTieBreakBeatsTrackedDuplicat
 	}
 	drains := newDrainTracker()
 	drains.set(trackedDuplicate.ID, &drainState{reason: "config-drift"})
-	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedDuplicate, owner})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedDuplicate, owner}, drains)
 
 	if got := betterPoolManagedStopSuppressionBead(trackedDuplicate, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
@@ -2992,7 +3109,7 @@ func TestBetterPoolManagedStopSuppressionBead_NonCanonicalActiveAnchorBeatsOlder
 			"state":        string(sessionpkg.StateDraining),
 		},
 	}
-	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{olderDraining, activeAliasBead})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{olderDraining, activeAliasBead}, nil)
 
 	if got := betterPoolManagedStopSuppressionBead(olderDraining, activeAliasBead, anchor, hasAnchor, nil); got.ID != activeAliasBead.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, activeAliasBead.ID)

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -147,6 +147,57 @@ func (s sessionSnapshotListFailStore) List(query beads.ListQuery) ([]beads.Bead,
 	return s.Store.List(query)
 }
 
+type managedStopLookupErrorStore struct {
+	*beads.MemStore
+	sessionName string
+}
+
+func (s *managedStopLookupErrorStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.TrimSpace(query.Metadata["session_name"]) == s.sessionName {
+		return nil, errors.New("session lifecycle lookup failed")
+	}
+	return s.MemStore.List(query)
+}
+
+func mustCreatePoolManagedSessionBead(t *testing.T, store beads.Store, sessionName, state, status string) beads.Bead {
+	t.Helper()
+
+	const template = "worker"
+	meta := map[string]string{
+		"template":             template,
+		"agent_name":           template,
+		poolManagedMetadataKey: boolMetadata(true),
+	}
+	if strings.TrimSpace(state) != "" {
+		meta["state"] = state
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    template,
+		Type:     sessionBeadType,
+		Labels:   []string{sessionBeadLabel},
+		Metadata: meta,
+	})
+	if err != nil {
+		t.Fatalf("Create(pool session bead): %v", err)
+	}
+	if strings.TrimSpace(sessionName) == "" {
+		sessionName = PoolSessionName(template, bead.ID)
+	}
+	if err := store.SetMetadata(bead.ID, "session_name", sessionName); err != nil {
+		t.Fatalf("SetMetadata(session_name): %v", err)
+	}
+	if strings.TrimSpace(status) == "closed" {
+		if err := store.Close(bead.ID); err != nil {
+			t.Fatalf("Close(%s): %v", bead.ID, err)
+		}
+	}
+	bead, err = store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", bead.ID, err)
+	}
+	return bead
+}
+
 func TestCityRuntimeRequestDeferredDrainFollowUpTick_PokesOnce(t *testing.T) {
 	cr := &CityRuntime{
 		sessionDrains: newDrainTracker(),
@@ -2279,7 +2330,7 @@ func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
 	outFile := filepath.Join(cityPath, "on-death.txt")
 	sessionName := "worker-gc-1"
 	store := beads.NewMemStore()
-	if _, err := store.Create(beads.Bead{
+	bead, err := store.Create(beads.Bead{
 		Title:  "worker",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:worker"},
@@ -2291,7 +2342,8 @@ func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
 			"state":                string(sessionpkg.StateDraining),
 			"state_reason":         "config-drift",
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Create(session bead): %v", err)
 	}
 
@@ -2325,6 +2377,184 @@ func TestCityRuntimeTickSkipsOnDeathForControllerDrainingSession(t *testing.T) {
 
 	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state=draining") {
+		t.Fatalf("stderr = %q, want bead and state context for managed-stop skip", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickRunsOnDeathWhenCanonicalPoolBeadIsActive(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
+	mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDraining), "")
+
+	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			owner.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	}
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want %q", got, "fired")
+	}
+	if strings.Contains(stderr.String(), "skipped for managed session stop") {
+		t.Fatalf("stderr = %q, want canonical active bead to keep on_death enabled", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickSkipsOnDeathForClosedCanonicalControllerDrainingSession(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateDraining), "closed")
+	mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateActive), "")
+
+	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			owner.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), owner.ID) || !strings.Contains(stderr.String(), "status=closed") {
+		t.Fatalf("stderr = %q, want closed canonical bead context", stderr.String())
+	}
+}
+
+func TestCityRuntimeTickRunsOnDeathWhenManagedStopLookupFails(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	sessionName := "worker-gc-1"
+	store := &managedStopLookupErrorStore{
+		MemStore:    beads.NewMemStore(),
+		sessionName: sessionName,
+	}
+
+	prevPoolRunning := map[string]bool{sessionName: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			sessionName: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v\nstderr=%s", outFile, err, stderr.String())
+	}
+	if got := strings.TrimSpace(string(data)); got != "fired" {
+		t.Fatalf("on_death output = %q, want %q", got, "fired")
+	}
+	if !strings.Contains(stderr.String(), "proceeding because session lifecycle lookup failed") {
+		t.Fatalf("stderr = %q, want fail-open lifecycle lookup warning", stderr.String())
+	}
+}
+
+func TestSkipPoolDeathHookForManagedStop_StateContract(t *testing.T) {
+	testCases := []struct {
+		name   string
+		state  string
+		status string
+		want   bool
+	}{
+		{name: "active", state: string(sessionpkg.StateActive), want: false},
+		{name: "awake", state: string(sessionpkg.StateAwake), want: false},
+		{name: "creating", state: string(sessionpkg.StateCreating), want: false},
+		{name: "empty", state: "", want: false},
+		{name: "asleep", state: string(sessionpkg.StateAsleep), want: true},
+		{name: "suspended", state: string(sessionpkg.StateSuspended), want: true},
+		{name: "failed-create", state: string(sessionpkg.StateFailedCreate), want: true},
+		{name: "draining", state: string(sessionpkg.StateDraining), want: true},
+		{name: "archived-closed", state: string(sessionpkg.StateArchived), status: "closed", want: true},
+		{name: "quarantined", state: string(sessionpkg.StateQuarantined), want: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			bead := mustCreatePoolManagedSessionBead(t, store, "", tc.state, tc.status)
+			cr := &CityRuntime{standaloneCityStore: store}
+
+			skipHook, err := cr.skipPoolDeathHookForManagedStop(bead.Metadata["session_name"])
+			if err != nil {
+				t.Fatalf("skipPoolDeathHookForManagedStop(%q): %v", bead.Metadata["session_name"], err)
+			}
+			if skipHook != tc.want {
+				t.Fatalf("skipPoolDeathHookForManagedStop(%q) = %v, want %v", tc.name, skipHook, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2543,6 +2543,74 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(
 	}
 }
 
+func TestCityRuntimeTickSkipsOnDeathForLegacyHandlerKeyAgainstCanonicalPoolSessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	bead, err := store.Create(beads.Bead{
+		Title:  "worker-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:worker-1"},
+		Metadata: map[string]string{
+			"template":             "worker",
+			"agent_name":           "worker-1",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"state":                string(sessionpkg.StateDraining),
+			"state_reason":         "config-drift",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session bead): %v", err)
+	}
+	sessionName := PoolSessionName("worker", bead.ID)
+	if err := store.SetMetadata(bead.ID, "session_name", sessionName); err != nil {
+		t.Fatalf("SetMetadata(session_name): %v", err)
+	}
+	bead, err = store.Get(bead.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", bead.ID, err)
+	}
+
+	legacyHandlerKey := startupSessionName("my-city", "worker-1", "")
+	prevPoolRunning := map[string]bool{legacyHandlerKey: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:  cityPath,
+		cityName:  "my-city",
+		logPrefix: "gc start",
+		cfg: &config.City{
+			Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}},
+		},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       newDrainTracker(),
+		poolDeathHandlers: map[string]poolDeathInfo{
+			legacyHandlerKey: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if !strings.Contains(stderr.String(), bead.ID) || !strings.Contains(stderr.String(), "state_reason=config-drift") {
+		t.Fatalf("stderr = %q, want legacy handler key to resolve managed-stop bead context", stderr.String())
+	}
+}
+
 func TestCityRuntimeTickSkipsOnDeathForDrainTrackedDuplicateWhenOwnerStillMatchesSessionName(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
@@ -2872,6 +2940,34 @@ func TestBetterPoolManagedStopSuppressionBead_TrackedOlderManagedDuplicateDoesNo
 	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedOlder, owner})
 
 	if got := betterPoolManagedStopSuppressionBead(trackedOlder, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
+		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
+	}
+}
+
+func TestBetterPoolManagedStopSuppressionBead_AnchorTieBreakBeatsTrackedDuplicate(t *testing.T) {
+	owner := beads.Bead{
+		ID:        "gc-2",
+		CreatedAt: time.Unix(20, 0).UTC(),
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": PoolSessionName("worker", "gc-2"),
+			"state":        string(sessionpkg.StateActive),
+		},
+	}
+	trackedDuplicate := beads.Bead{
+		ID:        "gc-1",
+		CreatedAt: owner.CreatedAt,
+		Metadata: map[string]string{
+			"template":     "worker",
+			"session_name": owner.Metadata["session_name"],
+			"state":        string(sessionpkg.StateDraining),
+		},
+	}
+	drains := newDrainTracker()
+	drains.set(trackedDuplicate.ID, &drainState{reason: "config-drift"})
+	anchor, hasAnchor := newestPoolManagedStopSuppressionAnchor([]beads.Bead{trackedDuplicate, owner})
+
+	if got := betterPoolManagedStopSuppressionBead(trackedDuplicate, owner, anchor, hasAnchor, drains); got.ID != owner.ID {
 		t.Fatalf("betterPoolManagedStopSuppressionBead() winner = %s, want %s", got.ID, owner.ID)
 	}
 }

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -2564,6 +2564,54 @@ func TestCityRuntimeTickSkipsOnDeathForLegacyDuplicateControllerDrainingSession(
 	}
 }
 
+func TestCityRuntimeTickSkipsOnDeathForDrainTrackedDuplicateWhenOwnerStillMatchesSessionName(t *testing.T) {
+	cityPath := t.TempDir()
+	outFile := filepath.Join(cityPath, "on-death.txt")
+	store := beads.NewMemStore()
+	owner := mustCreatePoolManagedSessionBead(t, store, "", string(sessionpkg.StateActive), "")
+	draining := mustCreatePoolManagedSessionBead(t, store, owner.Metadata["session_name"], string(sessionpkg.StateDraining), "")
+	drains := newDrainTracker()
+	drains.set(draining.ID, &drainState{reason: "config-drift"})
+
+	prevPoolRunning := map[string]bool{owner.Metadata["session_name"]: true}
+	var stderr bytes.Buffer
+	cr := &CityRuntime{
+		cityPath:            cityPath,
+		cityName:            "my-city",
+		logPrefix:           "gc start",
+		cfg:                 &config.City{},
+		sp:                  runtime.NewFake(),
+		standaloneCityStore: store,
+		sessionDrains:       drains,
+		poolDeathHandlers: map[string]poolDeathInfo{
+			owner.Metadata["session_name"]: {
+				Command: "printf fired > " + shellQuotePath(outFile),
+				Dir:     cityPath,
+			},
+		},
+		rec:    events.Discard,
+		stdout: io.Discard,
+		stderr: &stderr,
+		buildFnWithSessionBeads: func(_ *config.City, _ runtime.Provider, _ beads.Store, _ map[string]beads.Store, _ *sessionBeadSnapshot, _ *sessionReconcilerTraceCycle) DesiredStateResult {
+			return DesiredStateResult{State: map[string]TemplateParams{}}
+		},
+	}
+
+	dirty := &atomic.Bool{}
+	var lastProviderName string
+	cr.tick(context.Background(), dirty, &lastProviderName, cityPath, &prevPoolRunning, "test")
+
+	if _, err := os.Stat(outFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("on_death output err = %v, want no hook execution", err)
+	}
+	if strings.Contains(stderr.String(), "bead="+owner.ID) {
+		t.Fatalf("stderr = %q, want tracked draining duplicate to beat stale owner bead", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), draining.ID) || !strings.Contains(stderr.String(), "state=draining") {
+		t.Fatalf("stderr = %q, want tracked draining duplicate context for managed-stop skip", stderr.String())
+	}
+}
+
 func TestCityRuntimeTickRunsOnDeathForStoppedPoolSessionWithoutDeliberateSleepReason(t *testing.T) {
 	cityPath := t.TempDir()
 	outFile := filepath.Join(cityPath, "on-death.txt")
@@ -2757,16 +2805,19 @@ func TestPoolDeathHookSuppressedByManagedStopState_Contract(t *testing.T) {
 		{name: "awake", state: string(sessionpkg.StateAwake), want: false},
 		{name: "creating", state: string(sessionpkg.StateCreating), want: false},
 		{name: "empty", state: "", want: false},
+		{name: "empty-closed", state: "", status: "closed", want: false},
 		{name: "asleep-empty", state: string(sessionpkg.StateAsleep), want: false},
 		{name: "asleep-idle", state: string(sessionpkg.StateAsleep), sleepReason: "idle", want: true},
 		{name: "suspended", state: string(sessionpkg.StateSuspended), want: true},
 		{name: "failed-create", state: string(sessionpkg.StateFailedCreate), want: true},
 		{name: "draining", state: string(sessionpkg.StateDraining), want: true},
 		{name: "drained", state: string(sessionpkg.StateDrained), want: true},
+		{name: "active-closed", state: string(sessionpkg.StateActive), status: "closed", want: false},
 		{name: "archived-closed", state: string(sessionpkg.StateArchived), status: "closed", want: true},
 		{name: "stopped-empty", state: "stopped", want: false},
 		{name: "stopped-city-stop", state: "stopped", sleepReason: sleepReasonCityStop, want: true},
 		{name: "quarantined", state: string(sessionpkg.StateQuarantined), want: false},
+		{name: "quarantined-closed", state: string(sessionpkg.StateQuarantined), status: "closed", want: false},
 		{name: "gc-swept", state: "gc_swept", status: "closed", want: true},
 		{name: "orphaned", state: "orphaned", status: "closed", want: true},
 	}


### PR DESCRIPTION
## Summary
- suppress pool on_death hooks when the controller has already marked the matching pool session bead as a managed non-running state
- keep crash recovery behavior for sessions still recorded as active/awake/creating
- avoid reusing terminal pool session beads for new demand

## RCA
A controller-managed config-drift drain stopped pool sessions that still had assigned work. The city runtime then saw the tmux/provider session disappear and treated it as an unexpected death, running the configured on_death hook. That hook reopened and unassigned the in-progress beads, which made them claimable by unrelated sessions.

## Tests
- go test ./cmd/gc -run 'TestCityRuntimeTick(RunsOnDeathWithCanonicalRigEnv|SkipsOnDeathForControllerDrainingSession|SkipsOnDeathWhenSessionListingIsPartial)|TestSelectOrCreatePoolSessionBead_(SkipsTerminalPoolBeadsForNewTier|SkipsDrained|ReusesPreferredDrained)|TestComputePoolDesiredStates|TestReconcileSessionBeads_(DrainAckUsesLiveStoreQuery|AsleepIdlePoolBeadFreesSlot|OrphanDrainSkippedWithLiveAssignedWork|AssignedWorkCancelsOrphanDrainAckBeforeStop)' -count=1\n- pre-commit full observable Go unit gate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->