### PR TITLE
fix(maintenance): orphan-sweep validates against live pool sessions (ga-nvx)

### DIFF
--- a/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh
@@ -46,9 +46,31 @@ if [ -z "$AGENTS" ]; then
     exit 0
 fi
 
+# Step 2b: Collect identities of every live (non-closed) session so that
+# pool-spawned ephemeral assignees (e.g. gastown__polekitten-gc-q9j0om) are
+# treated as known. The Go-side releaseOrphanedPoolAssignments path validates
+# these via liveOpenSessionAssignmentExists, but this shell sweep ran without
+# that guard — an ephemeral assignee whose template-stripped form did not
+# match any agent name was incorrectly reset, racing against active polekitten
+# work and producing the false-orphan loop tracked in ga-nvx.
+SESSIONS_JSON=$(gc session list --json 2>/dev/null) || SESSIONS_JSON="[]"
+LIVE_SESSION_IDS=$(echo "$SESSIONS_JSON" | jq -r '
+    .[]
+    | select(.Closed == false)
+    | [.ID, .SessionName, .Alias, .AgentName]
+    | .[]
+    | select(. != null and . != "")
+' 2>/dev/null) || LIVE_SESSION_IDS=""
+
 agent_exists() {
     local candidate="$1"
     [ -n "$candidate" ] && printf '%s\n' "$AGENTS" | grep -Fxq -- "$candidate"
+}
+
+live_session_match() {
+    local candidate="$1"
+    [ -n "$candidate" ] && [ -n "$LIVE_SESSION_IDS" ] \
+        && printf '%s\n' "$LIVE_SESSION_IDS" | grep -Fxq -- "$candidate"
 }
 
 # Step 3: Find orphaned beads (assigned to non-existent agents).
@@ -56,7 +78,7 @@ agent_exists() {
 # the template name from config.
 is_known_agent() {
     local name="$1"
-    # Direct match.
+    # Direct match against a configured agent template name.
     if agent_exists "$name"; then return 0; fi
     # Pool instance: strip trailing -<digits> and check template name.
     local base="${name%-[0-9]*}"
@@ -72,6 +94,11 @@ is_known_agent() {
         local short_base="${short%-[0-9]*}"
         if [ "$short_base" != "$short" ] && agent_exists "$short_base"; then return 0; fi
     fi
+    # Live ephemeral session names like gastown__polekitten-gc-q9j0om won't
+    # match any template form — accept them as known when a non-closed session
+    # is currently running with a matching ID, SessionName, Alias, or
+    # AgentName. Mirrors liveOpenSessionAssignmentExists in the Go path.
+    if live_session_match "$name"; then return 0; fi
     return 1
 }
 


### PR DESCRIPTION
## Summary
- Stops `orphan-sweep.sh` from clearing `bead.assignee` on healthy in-flight pool work
- Adds a `live_session_match` lookup against `gc session list --json` so ephemeral assignees like `gastown__polekitten-gc-q9j0om` are recognized
- Mirrors the validation already present in the Go path (`liveOpenSessionAssignmentExists`)

## Problem

Pool reconciler ran every 5 minutes and cleared assignees mid-flow on healthy in-progress beads when the assignee was an ephemeral pool session. Witness re-claimed; cycle repeated. Today (2026-05-08) reproduced on the cashmaster rig: `ca-pigvc` and `ca-reoah` were repeatedly orphaned while their polekittens were actively coding.

The Go reconciler path (`releaseOrphanedPoolAssignments` → `liveOpenSessionAssignmentExists`) already validates ephemeral assignees against live session beads. But `orphan-sweep.sh` runs the same intent as a separate `exec` order on a 5-minute cadence, and its `is_known_agent` only consulted `gc config explain` agent template names. Pool ephemeral session names (`<workspace>__<template>-gc-<id>`) never reduce to a configured template — wrong separator (`__` vs `.`) and wrong suffix (`-gc-<id>` vs pool-instance `-N`), so the existing strip rules can't bridge them.

## What changed

`examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh`:

1. New step **2b** snapshots live sessions via `gc session list --json` and builds a flat list of `ID | SessionName | Alias | AgentName` from non-closed sessions.
2. New `live_session_match` accepts any of those identifiers as a valid assignee.
3. `is_known_agent` falls through to `live_session_match` after the existing template strips fail; the prior template-only behavior is preserved as the first match.
4. When `gc session list` is unavailable (older binaries / broken controller), `SESSIONS_JSON` defaults to `[]` and the new check is a no-op, so the script stays correct on older deployments.

## Test plan
- [x] `bash -n examples/gastown/packs/maintenance/assets/scripts/orphan-sweep.sh`
- [x] Manual repro on cashmaster: pre-fix, ephemeral polekitten assignees were cleared every 5 min while sessions were alive; post-fix, the same assignees survive across multiple sweep cycles.

## Provenance

Tracked in cashmaster local beads as `ga-nvx`. Discovered while bringing the cashmaster rig online for a feature wave; surfaced as the false-orphan loop on `ca-pigvc` + `ca-reoah` where polekittens started work, dropped assignee, and ended up not committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->