### PR TITLE
fix(prompt): mayor dispatch instructions use gc sling instead of raw bd commands

### DIFF
--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -216,7 +216,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc sling <rig>/polecat <bead>` | ~~gc bd update --label=pool:...~~ (labels don't trigger scale_check) |
+| Dispatch work to polecat | `gc sling <rig>/{{ .BindingPrefix }}polecat <bead>` | ~~gc bd update --label=pool:...~~ (labels don't trigger scale_check); plain `<rig>/polecat` won't match binding-prefixed polecats imported via PackV2 |
 | Drain stuck polecat | `{{ cmd }} runtime drain <name>` | ~~gc polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |

--- a/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/mayor/prompt.template.md
@@ -23,7 +23,7 @@ When you file a bead, default to immediately dispatching it to a polecat:
 gc bd create "Fix the auth timeout bug" -t task --json   # file it
 TARGET_RIG="${GC_RIG:-}"  # set to the target rig, or leave empty in an HQ-only city
 POLECAT_TARGET="${TARGET_RIG:+$TARGET_RIG/}{{ .BindingPrefix }}polecat"
-gc bd update <bead-id> --set-metadata gc.routed_to="$POLECAT_TARGET"  # dispatch to polecat pool (pool reconciler picks up routed metadata)
+gc sling "$POLECAT_TARGET" <bead-id>                     # dispatch to polecat pool (sets gc.routed_to metadata for controller scale_check)
 ```
 
 **Why this is the default:**
@@ -216,7 +216,7 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
-| Dispatch work to polecat | `gc bd update <bead> --label=pool:<rig>/polecat` | ~~gc polecat spawn~~ / ~~--assignee=<rig>/polecat~~ |
+| Dispatch work to polecat | `gc sling <rig>/polecat <bead>` | ~~gc bd update --label=pool:...~~ (labels don't trigger scale_check) |
 | Drain stuck polecat | `{{ cmd }} runtime drain <name>` | ~~gc polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig suspend <rig>` | ~~gc rig stop~~ (daemon will restart it) |
 | Re-enable suspended rig | `{{ cmd }} rig resume <rig>` | |


### PR DESCRIPTION
## Summary

Two prompt-template instructions in `examples/gastown/packs/gastown/agents/mayor/prompt.template.md` told the mayor to dispatch via `gc bd update --set-metadata gc.routed_to=...` (or `--label=pool:...`). Neither path triggers the controller's `scale_check`, so beads sit unclaimed against warm-idle pools. The canonical dispatch path is `gc sling <target> <bead>`, which sets the routed metadata AND wakes the pool reconciler.

This PR replaces both instructions with `gc sling`, matching the actual behavior we want from mayor sessions.

## Provenance

This is a rebased version of @zook-bot's #1754 (authored by @johnzook). That PR went `DIRTY` after a recent main update touched the same prompt-template table (an `agent drain` → `runtime drain` refactor landed on main while #1754 was open). Rebase carries through cleanly: take #1754's `gc sling` row, take main's `runtime drain` row, drop the now-stale `agent drain` text. Original commit authorship is preserved (`John Zook <johnzook@users.noreply.github.com>`).

Closing #1754 in favor of this PR.

## Test plan

- [x] Rebased onto current main with conflict resolved correctly (verified by re-reading the resulting prompt-template diff)
- [ ] CI green

Co-Authored-By: John Zook <johnzook@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->