### PR TITLE
fix(prompts): name canonical formula-show command + forbid wide filesystem search

### DIFF
--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -69,14 +69,15 @@ NEW_WISP=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ 
 gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Read the formula recipe — these are the steps to execute
-# (Use 'gc bd formula show' for the recipe on disk; 'gc bd mol show' is
-#  for poured molecule instances, not formulas, and will say 'not found'.)
-gc bd formula show mol-deacon-patrol
+# (Use 'gc bd formula show --full' for the recipe with step descriptions;
+#  'gc bd mol show' is for poured molecule instances, not formulas, and
+#  will say 'not found'.)
+gc bd formula show mol-deacon-patrol --full
 
 # Step 5: Execute — work through the steps in order
 ```
 
-**Hook -> Read formula steps (`gc bd formula show <name>`) -> Follow in order -> pour next iteration.**
+**Hook -> Read formula steps (`gc bd formula show <name> --full`) -> Follow in order -> pour next iteration.**
 
 ## Context Exhaustion
 

--- a/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
@@ -3,11 +3,20 @@
 
 Your formula defines your work as a sequence of steps. Steps are NOT
 materialized as individual beads — they exist in the formula definition.
-Read the step descriptions and work through them in order.
+Read your formula's step descriptions with `gc bd formula show <name>
+--full` and work through them in order.
 
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
+
+**Never reach for the filesystem when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
 {{ end }}

--- a/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
+++ b/examples/gastown/packs/maintenance/agents/dog/prompt.template.md
@@ -34,13 +34,12 @@ Additional formulas available from included packs (e.g. dolt).
 
 If your wisp names a formula not listed above (one that an included
 pack provides, or one the daemon assigned), read its recipe with
-`gc bd formula show <formula-name>`. **Never** locate formula files
-with whole-filesystem searches (`find /`, `find ~`) — they trigger
-macOS TCC permission prompts on protected directories (Documents,
-Desktop, Downloads, removable volumes, network mounts) and produce
-no useful signal a `gc` introspection command can't already provide.
-If `gc bd formula show` returns "formula not found", the wisp is
-mis-routed — close the bead with that reason and exit; do not hunt.
+`gc bd formula show <formula-name> --full`. If the command returns
+"formula not found", the wisp is mis-routed — close the bead with that
+reason and exit; do not hunt for the file. (The shared "Following Your
+Formula" section forbids wide filesystem searches generally; this row
+is the dog-specific reason: a missing formula means the wisp lied, not
+that the file is hidden somewhere on disk.)
 
 ---
 
@@ -119,7 +118,7 @@ gc session nudge {{"{{requester}}"}}/ "DOG_DONE: <target> — <outcome>"
 | Want to... | Correct command |
 |------------|----------------|
 | Read formula steps | `gc bd show <wisp-id>` (shows formula ref) |
-| Read formula recipe | `gc bd formula show <formula-name>` (NOT `find /`) |
+| Read formula recipe | `gc bd formula show <formula-name> --full` |
 | Find pool work | `{{ .WorkQuery }}` |
 | Claim pool work | `gc bd update <id> --claim` |
 | View work details | `gc bd show <id> --json` |

--- a/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
@@ -3,11 +3,20 @@
 
 Your formula defines your work as a sequence of steps. Steps are NOT
 materialized as individual beads — they exist in the formula definition.
-Read the step descriptions and work through them in order.
+Read your formula's step descriptions with `gc bd formula show <name>
+--full` and work through them in order.
 
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
+
+**Never reach for the filesystem when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
 {{ end }}

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -42,13 +42,22 @@ that bead; run `gc hook` again or drain if no valid work is available.
 
 Your formula defines your work as a sequence of steps. Steps are NOT
 materialized as individual beads — they exist in the formula definition.
-Read the step descriptions and work through them in order.
+Read your formula's step descriptions with `gc bd formula show <name>
+--full` and work through them in order.
 
 **THE RULE**: Execute one step at a time. Verify completion. Move to next.
 Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
+
+**Never reach for the filesystem when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
 
 ## Molecules — STOP, check BEFORE you start working
 


### PR DESCRIPTION
## Summary

Closes a systemic gap: formula-driven agents do wide filesystem
searches (`find /Users/eric -maxdepth 4 -name ".dolt-data"` and
similar) when the canonical introspection command is missing or
insufficient. Forensic dog-1 transcripts captured 2026-05-08 show
this triggers macOS TCC permission prompts on Documents, Desktop,
Downloads, and removable volumes — blocking work.

The "Following Your Formula" prompt fragment told agents to "Read
the step descriptions and work through them in order" without
naming the canonical command. Witness, refinery, and pool-worker
have no such command named anywhere in their prompts; deacon and
dog name `gc bd formula show` without `--full` (today's command is
summary-only). When the named command is missing or insufficient,
the LLM falls back to filesystem search.

This PR updates the shared `following-mol` template fragment (gastown
+ maintenance copies) and the inline copy in core's `pool-worker.md`
to:

- Name `gc bd formula show <name> --full` as the canonical command
  for reading step descriptions.
- Forbid wide filesystem traversals generally (not just for formula
  files): `find /`, `find ~`, `find /Users`, `find $HOME` are out;
  the answer to "where is X?" is a `gc` / `bd` introspection command,
  and if no such command exists, file a bead.

The deacon and dog per-agent prompts also gain `--full` at the call
sites that already named `gc bd formula show`. Dog's post-#1785
narrow prohibition is replaced by a pointer to the shared fragment
plus the dog-specific reason ("formula not found means the wisp is
mis-routed, close and exit").

**Surface:** read a formula's step descriptions via
`gc bd formula show <name> --full` (the abstractions-map row #1
canonical surface). Not the wrong-way variant of reading
`.beads/formulas/<name>.formula.toml` directly from each agent
prompt (rejected as #1845; lesson recorded as the
`fix-the-abstraction-not-around-it` rule).

**Depends on gastownhall/beads#3832** — that PR adds the `--full`
flag to `bd formula show`. This PR's prompts reference `--full`,
so it should land *after* beads#3832 merges. (Without that, agents
following these prompts will get "unknown flag: --full" until they
update their `bd` binary.)

## Testing

- [x] `make check`
- [x] `make check-docs`
- [ ] `make test-integration` (per CONTRIBUTING; this is a prose-only
  prompt change, no runtime/controller behavior touched)

`cmd/gc/prompt_test.go:694` asserts the rendered prompt contains the
"Following Your Formula" header — header text is unchanged, test
still passes.

Three open EXPECT-FAIL beads (`stg-bz3` TestStartLongSocketPathUsesShortSocketName,
`stg-f6o2` TestCityRuntimeWatchReloadPanicRestoresDirty, `stg-i7z3`
TestProjectIdentity/B10) are parallel-load flakes — none surfaced
in this run.

## Checklist

- [x] Linked an issue, or explained why one is not needed: this
  closes the systemic find-/ pattern documented internally; the
  upstream-visible artifact is the closing comment on #1845
  ("extend `gc bd formula show` to emit step descriptions") which
  named exactly this fix shape.
- [x] Added or updated tests for behavior changes: prose-only prompt
  change, no Go behavior added; existing `TestRenderMaintenancePrompt`
  / following-mol header presence checks still pass.
- [x] Updated docs for user-facing changes: prompt templates updated
  in place.
- [x] Called out breaking changes or migration notes: see "Depends on"
  above — this PR's prompts reference `--full`, which only exists in
  `bd` once beads#3832 merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->