### PR TITLE
fix(prompts): forbid wide filesystem search in shared formula-following guidance

### DIFF
--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -1108,6 +1108,26 @@ func TestLoadCityConfigRevalidatesRequiredBuiltinPackContentsAfterReadyCacheSucc
 	}
 }
 
+func TestMaterializeBuiltinPacksIncludesWorkerFilesystemSearchGuidance(t *testing.T) {
+	dir := t.TempDir()
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	for _, name := range []string{"pool-worker.md", "graph-worker.md"} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts", name)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(%s): %v", path, err)
+			}
+			if !strings.Contains(string(data), formulaFilesystemSearchGuidance) {
+				t.Fatalf("materialized %s missing filesystem search guidance", name)
+			}
+		})
+	}
+}
+
 func writeBuiltinPackLoadTestCity(dir string) error {
 	return os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test\"\n"), 0o644)
 }

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
+const formulaFilesystemSearchGuidance = "**Never use wide filesystem searches when a CLI command exists.**"
+
 func TestRenderPromptEmptyPath(t *testing.T) {
 	f := fsys.NewFake()
 	got := renderPrompt(f, "/city", "", "", PromptContext{}, "", io.Discard, nil, nil, nil)
@@ -761,6 +763,45 @@ func TestRenderPromptMaintenanceDogPromptHasRequiredSharedTemplates(t *testing.T
 	}
 	if !strings.Contains(got, "Following Your Formula") {
 		t.Fatalf("rendered prompt missing following-mol fragment:\n%s", got)
+	}
+	if !strings.Contains(got, formulaFilesystemSearchGuidance) {
+		t.Fatalf("rendered prompt missing filesystem search guidance:\n%s", got)
+	}
+}
+
+func TestFormulaFilesystemSearchGuidanceCoversPromptSources(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("filepath.Abs(repo root): %v", err)
+	}
+
+	paths := []string{
+		"examples/gastown/packs/gastown/template-fragments/following-mol.template.md",
+		"examples/gastown/packs/maintenance/template-fragments/following-mol.template.md",
+		"internal/bootstrap/packs/core/assets/prompts/pool-worker.md",
+		"internal/bootstrap/packs/core/assets/prompts/graph-worker.md",
+	}
+	for _, rel := range paths {
+		t.Run(rel, func(t *testing.T) {
+			path := filepath.Join(repoRoot, rel)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("os.ReadFile(%s): %v", path, err)
+			}
+			text := string(data)
+			for _, want := range []string{
+				formulaFilesystemSearchGuidance,
+				"`find /`",
+				"`find ~`",
+				"`find /Users`",
+				"`find $HOME`",
+				"`gc` / `bd`",
+			} {
+				if !strings.Contains(text, want) {
+					t.Fatalf("%s missing %q", rel, want)
+				}
+			}
+		})
 	}
 }
 

--- a/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
@@ -11,7 +11,7 @@ Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
 
-**Never reach for the filesystem when a CLI command exists.** Wide
+**Never use wide filesystem searches when a CLI command exists.** Wide
 traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
 TCC-protected directories on macOS — Documents, Desktop, Downloads,
 removable volumes — and trigger permission prompts that block work. If

--- a/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/following-mol.template.md
@@ -10,4 +10,12 @@ Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
+
+**Never reach for the filesystem when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
 {{ end }}

--- a/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
@@ -11,7 +11,7 @@ Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
 
-**Never reach for the filesystem when a CLI command exists.** Wide
+**Never use wide filesystem searches when a CLI command exists.** Wide
 traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
 TCC-protected directories on macOS — Documents, Desktop, Downloads,
 removable volumes — and trigger permission prompts that block work. If

--- a/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
+++ b/examples/gastown/packs/maintenance/template-fragments/following-mol.template.md
@@ -10,4 +10,12 @@ Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
+
+**Never reach for the filesystem when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
 {{ end }}

--- a/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/graph-worker.md
@@ -74,6 +74,14 @@ gc runtime drain-ack
    ```
 11. If more work exists, go to step 2. If not, poll briefly (see below).
 
+**Never use wide filesystem searches when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
+
 ## Continuation Group — Session Affinity
 
 When you claim a bead, check its `gc.continuation_group` metadata. If set,

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -50,7 +50,7 @@ Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
 
-**Never reach for the filesystem when a CLI command exists.** Wide
+**Never use wide filesystem searches when a CLI command exists.** Wide
 traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
 TCC-protected directories on macOS — Documents, Desktop, Downloads,
 removable volumes — and trigger permission prompts that block work. If

--- a/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
+++ b/internal/bootstrap/packs/core/assets/prompts/pool-worker.md
@@ -50,6 +50,14 @@ Do NOT skip ahead. Do NOT claim steps done without actually doing them.
 On crash or restart, re-read your formula steps and determine where you
 left off from context (last completed action, git state, bead state).
 
+**Never reach for the filesystem when a CLI command exists.** Wide
+traversals (`find /`, `find ~`, `find /Users`, `find $HOME`) walk
+TCC-protected directories on macOS — Documents, Desktop, Downloads,
+removable volumes — and trigger permission prompts that block work. If
+you don't know how to locate a formula, recipe, bead, mail, or Dolt
+state, the answer is a `gc` / `bd` introspection command, not a
+filesystem search. If no command exists for what you need, file a bead.
+
 ## Molecules — STOP, check BEFORE you start working
 
 **CRITICAL:** When you run `bd show` in step 4, look at the METADATA


### PR DESCRIPTION
## Summary

When an agent's first lookup hypothesis fails, the fallback should be another `gc` / `bd` introspection command, not a filesystem search. Wide traversals rooted at `/`, `~`, `/Users`, or `$HOME` walk macOS TCC-protected directories (Documents, Desktop, Downloads, removable volumes), trigger permission prompts that block work, and produce no signal a CLI command can't already provide.

#1785 added this prohibition to the dog prompt narrowly. Forensic transcripts from a 2026-05-08 fresh-init city show agents in other roles falling back to filesystem search for non-formula targets too — e.g. dog-1 ran `find /Users/eric -maxdepth 4 -name ".dolt-data"` looking for a Dolt directory layout. The narrow #1785 fix only addressed `find /` for formula files; it did not deter `find /Users` for other artifacts.

The shared "Following Your Formula" section is the right home for the broader rule — every formula-following agent reads it, the guidance applies to formula-shaped and non-formula-shaped lookups alike, and dog's existing language stays put as a role-specific reminder.

Touches three parallel mirror locations of the same content:
- `examples/gastown/packs/gastown/template-fragments/following-mol.template.md`
- `examples/gastown/packs/maintenance/template-fragments/following-mol.template.md`
- `internal/bootstrap/packs/core/assets/prompts/pool-worker.md`

Prose-only edit (+24 lines, no Go code, no API changes).

Surface: agent fallback behavior when first lookup fails, via prose in the shared `following-mol` fragment + `pool-worker.md`; not extending `gc bd formula show` and not telling agents to bypass `gc bd` via `find` (the very pattern this PR forbids).

## Testing

- [x] `make check` — clean on macOS, no new failures. EXPECT-FAIL beads on origin/main (`stg-bz3` / `stg-f6o2` / `stg-i7z3`, all flakes under parallel load) did not surface in this run.
- [x] Anecdotal verification — fresh-init city under `~/tmp/qb4m-test/` brought up via `gc init` + `gc supervisor start` + `gc start` from a worktree binary. New prose verified to render into agent system prompts (deacon, dog-1, dog-2, dog-3 all show the new paragraph). Across ~700 cumulative transcript lines from 6 agents (boot, deacon, dog x3, mayor), zero matches for `find /`, `find ~`, `find $HOME`, or bare `find /Users`. The single `find` invocation observed (`find /Users/eric/tmp/qb4m-test/.beads -maxdepth 3`) is scoped to the city's own `.beads/` dir — not a TCC-triggering wide traversal. Anecdotal — one run is not proof, agent behavior is non-deterministic — but a meaningful signal where the original symptom previously appeared.
- [ ] `make check-docs` — n/a (no `docs/` / `engdocs/` / navigation / links touched).
- [ ] `make test-integration` — not run (no runtime/controller/workflow change; this is prose-only prompt content).

## Checklist

- [x] Linked an issue, or explained why one is not needed — see Summary; reproducer is the dog-1 transcript captured in `~/.claude/projects/-Users-eric-cities-test-bed--gc-agents-dogs-gastown-dog-1/` from a 2026-05-08 fresh-init run.
- [x] Added or updated tests for behavior changes — n/a, prose-only prompt edit. The existing `cmd/gc/prompt_test.go` test that asserts "Following Your Formula" renders into the maintenance prompt continues to pass.
- [x] Updated docs for user-facing changes — the prompt itself is the user-facing artifact.
- [x] Called out breaking changes or migration notes — none; additive guidance only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->