### PR TITLE
fix(supervisor): pass launchctl-set GC_DOLT_LOGLEVEL through plist EnvironmentVariables

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -55,7 +55,8 @@ var (
 		if err != nil {
 			return ""
 		}
-		return strings.TrimSpace(string(out))
+		val := strings.TrimSuffix(string(out), "\n")
+		return strings.TrimSuffix(val, "\r")
 	}
 	supervisorSystemctlRun = func(args ...string) error {
 		return exec.Command("systemctl", args...).Run()
@@ -699,6 +700,8 @@ var supervisorServiceEnvKeys = map[string]bool{
 	"CLAUDE_CODE_SUBAGENT_MODEL":               true,
 	"CLAUDE_CONFIG_DIR":                        true,
 	"GC_DOLT_LOGLEVEL":                         true,
+	"GC_DOLT_PASSWORD":                         true,
+	"GC_DOLT_USER":                             true,
 	"HOME":                                     true,
 	"LANG":                                     true,
 	"LC_ALL":                                   true,
@@ -726,6 +729,7 @@ var supervisorServiceFixedEnvKeys = map[string]bool{
 
 func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
 	env := make(map[string]string)
+	explicitEnvKeys := supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV"))
 	for _, entry := range os.Environ() {
 		key, val, ok := strings.Cut(entry, "=")
 		if !ok || val == "" || !shouldPersistSupervisorEnv(key) {
@@ -733,25 +737,32 @@ func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
 		}
 		env[key] = val
 	}
-	for _, key := range supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV")) {
+	for _, key := range explicitEnvKeys {
 		if val := os.Getenv(key); val != "" {
 			env[key] = val
 		}
 	}
 	// Fall back to `launchctl getenv` for known-allowlisted keys and
-	// for GC_SUPERVISOR_ENV opt-ins. Without this, `launchctl setenv
-	// GC_DOLT_LOGLEVEL debug` is silently dropped: the plist's
-	// EnvironmentVariables block scopes the spawned supervisor's env,
-	// and `os.Environ()` only sees what's exported in the calling shell.
+	// for GC_SUPERVISOR_ENV opt-ins. Without this, launchctl-set
+	// documented Dolt credential/logging settings are silently dropped:
+	// the plist's EnvironmentVariables block scopes the spawned
+	// supervisor's env, and `os.Environ()` only sees what's exported in
+	// the calling shell.
+	launchctlKeys := make([]string, 0, len(supervisorServiceEnvKeys)+len(explicitEnvKeys))
+	launchctlSeen := make(map[string]bool, cap(launchctlKeys))
 	for key := range supervisorServiceEnvKeys {
-		if _, ok := env[key]; ok {
+		launchctlSeen[key] = true
+		launchctlKeys = append(launchctlKeys, key)
+	}
+	for _, key := range explicitEnvKeys {
+		if launchctlSeen[key] {
 			continue
 		}
-		if val := supervisorLaunchctlGetenv(key); val != "" {
-			env[key] = val
-		}
+		launchctlSeen[key] = true
+		launchctlKeys = append(launchctlKeys, key)
 	}
-	for _, key := range supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV")) {
+	sort.Strings(launchctlKeys)
+	for _, key := range launchctlKeys {
 		if _, ok := env[key]; ok {
 			continue
 		}

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -43,6 +43,20 @@ var (
 		out, err := exec.Command("launchctl", "print", supervisorLaunchdServiceTarget(label)).Output()
 		return err == nil && launchdPrintReportsRunning(out)
 	}
+	// supervisorLaunchctlGetenv reads a value from `launchctl getenv` on
+	// macOS so users can set per-domain env (e.g. GC_DOLT_LOGLEVEL) and
+	// have it flow into the supervisor's launchd plist. Returns "" on
+	// non-Darwin or when the key is unset / launchctl is unavailable.
+	supervisorLaunchctlGetenv = func(key string) string {
+		if supervisorRuntimeGOOS != "darwin" {
+			return ""
+		}
+		out, err := exec.Command("launchctl", "getenv", key).Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	}
 	supervisorSystemctlRun = func(args ...string) error {
 		return exec.Command("systemctl", args...).Run()
 	}
@@ -684,6 +698,7 @@ var supervisorServiceEnvKeys = map[string]bool{
 	"CLAUDE_CODE_OAUTH_TOKEN":                  true,
 	"CLAUDE_CODE_SUBAGENT_MODEL":               true,
 	"CLAUDE_CONFIG_DIR":                        true,
+	"GC_DOLT_LOGLEVEL":                         true,
 	"HOME":                                     true,
 	"LANG":                                     true,
 	"LC_ALL":                                   true,
@@ -720,6 +735,27 @@ func supervisorServiceExtraEnv() []supervisorServiceEnvVar {
 	}
 	for _, key := range supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV")) {
 		if val := os.Getenv(key); val != "" {
+			env[key] = val
+		}
+	}
+	// Fall back to `launchctl getenv` for known-allowlisted keys and
+	// for GC_SUPERVISOR_ENV opt-ins. Without this, `launchctl setenv
+	// GC_DOLT_LOGLEVEL debug` is silently dropped: the plist's
+	// EnvironmentVariables block scopes the spawned supervisor's env,
+	// and `os.Environ()` only sees what's exported in the calling shell.
+	for key := range supervisorServiceEnvKeys {
+		if _, ok := env[key]; ok {
+			continue
+		}
+		if val := supervisorLaunchctlGetenv(key); val != "" {
+			env[key] = val
+		}
+	}
+	for _, key := range supervisorServiceExplicitEnvKeys(os.Getenv("GC_SUPERVISOR_ENV")) {
+		if _, ok := env[key]; ok {
+			continue
+		}
+		if val := supervisorLaunchctlGetenv(key); val != "" {
 			env[key] = val
 		}
 	}

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -561,6 +561,88 @@ func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
 	return m
 }
 
+func TestBuildSupervisorServiceDataReadsAllowlistedKeysFromLaunchctl(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+	// Ensure GC_DOLT_LOGLEVEL is not in os.Environ so the launchctl
+	// fallback is the only source.
+	t.Setenv("GC_DOLT_LOGLEVEL", "")
+
+	stub := map[string]string{"GC_DOLT_LOGLEVEL": "debug"}
+	prev := supervisorLaunchctlGetenv
+	supervisorLaunchctlGetenv = func(key string) string { return stub[key] }
+	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	if got["GC_DOLT_LOGLEVEL"] != "debug" {
+		t.Fatalf("ExtraEnv[GC_DOLT_LOGLEVEL] = %q, want %q (all env: %#v)",
+			got["GC_DOLT_LOGLEVEL"], "debug", got)
+	}
+}
+
+func TestBuildSupervisorServiceDataPrefersOSEnvOverLaunchctl(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("GC_DOLT_LOGLEVEL", "trace")
+
+	prev := supervisorLaunchctlGetenv
+	supervisorLaunchctlGetenv = func(key string) string {
+		if key == "GC_DOLT_LOGLEVEL" {
+			return "debug"
+		}
+		return ""
+	}
+	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	if got["GC_DOLT_LOGLEVEL"] != "trace" {
+		t.Fatalf("ExtraEnv[GC_DOLT_LOGLEVEL] = %q, want %q (os.Environ should win over launchctl)",
+			got["GC_DOLT_LOGLEVEL"], "trace")
+	}
+}
+
+func TestBuildSupervisorServiceDataReadsExplicitEnvOptInFromLaunchctl(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("GC_SUPERVISOR_ENV", "GC_DOLT_DATA_DIR")
+	// GC_DOLT_DATA_DIR is not in os.Environ; only launchctl has it.
+	t.Setenv("GC_DOLT_DATA_DIR", "")
+
+	prev := supervisorLaunchctlGetenv
+	supervisorLaunchctlGetenv = func(key string) string {
+		if key == "GC_DOLT_DATA_DIR" {
+			return "/srv/gc/dolt"
+		}
+		return ""
+	}
+	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	if got["GC_DOLT_DATA_DIR"] != "/srv/gc/dolt" {
+		t.Fatalf("ExtraEnv[GC_DOLT_DATA_DIR] = %q, want %q (launchctl fallback for GC_SUPERVISOR_ENV opt-in)",
+			got["GC_DOLT_DATA_DIR"], "/srv/gc/dolt")
+	}
+}
+
 func TestBuildSupervisorServiceDataExpandsUserManagedPath(t *testing.T) {
 	homeDir := t.TempDir()
 	nvmBin := filepath.Join(homeDir, ".nvm", "versions", "node", "v22.14.0", "bin")

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -561,17 +561,25 @@ func supervisorServiceEnvMap(vars []supervisorServiceEnvVar) map[string]string {
 	return m
 }
 
-func TestBuildSupervisorServiceDataReadsAllowlistedKeysFromLaunchctl(t *testing.T) {
+func TestBuildSupervisorServiceDataReadsAllowlistedDoltCredentialKeysFromLaunchctl(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
 	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
 	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
-	// Ensure GC_DOLT_LOGLEVEL is not in os.Environ so the launchctl
-	// fallback is the only source.
-	t.Setenv("GC_DOLT_LOGLEVEL", "")
+	for _, key := range []string{
+		"GC_DOLT_USER",
+		"GC_DOLT_PASSWORD",
+		"GC_DOLT_LOGLEVEL",
+	} {
+		t.Setenv(key, "")
+	}
 
-	stub := map[string]string{"GC_DOLT_LOGLEVEL": "debug"}
+	stub := map[string]string{
+		"GC_DOLT_USER":     "gc_user",
+		"GC_DOLT_PASSWORD": "redacted-test-value",
+		"GC_DOLT_LOGLEVEL": "debug",
+	}
 	prev := supervisorLaunchctlGetenv
 	supervisorLaunchctlGetenv = func(key string) string { return stub[key] }
 	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
@@ -581,9 +589,59 @@ func TestBuildSupervisorServiceDataReadsAllowlistedKeysFromLaunchctl(t *testing.
 		t.Fatalf("buildSupervisorServiceData: %v", err)
 	}
 	got := supervisorServiceEnvMap(data.ExtraEnv)
-	if got["GC_DOLT_LOGLEVEL"] != "debug" {
-		t.Fatalf("ExtraEnv[GC_DOLT_LOGLEVEL] = %q, want %q (all env: %#v)",
-			got["GC_DOLT_LOGLEVEL"], "debug", got)
+	for key, want := range stub {
+		if got[key] != want {
+			t.Fatalf("ExtraEnv[%s] = %q, want %q (all env: %#v)", key, got[key], want, got)
+		}
+	}
+}
+
+func TestBuildSupervisorServiceDataSkipsDoltEndpointEnvUnlessExplicitlyOptedIn(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+	t.Setenv("GC_DOLT_HOST", "127.0.0.1")
+	t.Setenv("GC_DOLT_PORT", "3306")
+
+	prev := supervisorLaunchctlGetenv
+	supervisorLaunchctlGetenv = func(key string) string {
+		switch key {
+		case "GC_DOLT_HOST":
+			return "launchctl.example"
+		case "GC_DOLT_PORT":
+			return "4406"
+		default:
+			return ""
+		}
+	}
+	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	got := supervisorServiceEnvMap(data.ExtraEnv)
+	for _, key := range []string{"GC_DOLT_HOST", "GC_DOLT_PORT"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("ExtraEnv should not include default Dolt endpoint key %s (all env: %#v)", key, got)
+		}
+	}
+
+	t.Setenv("GC_SUPERVISOR_ENV", "GC_DOLT_HOST GC_DOLT_PORT")
+	data, err = buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData with explicit opt-in: %v", err)
+	}
+	got = supervisorServiceEnvMap(data.ExtraEnv)
+	for key, want := range map[string]string{
+		"GC_DOLT_HOST": "127.0.0.1",
+		"GC_DOLT_PORT": "3306",
+	} {
+		if got[key] != want {
+			t.Fatalf("ExtraEnv[%s] = %q, want %q after explicit opt-in (all env: %#v)", key, got[key], want, got)
+		}
 	}
 }
 
@@ -640,6 +698,79 @@ func TestBuildSupervisorServiceDataReadsExplicitEnvOptInFromLaunchctl(t *testing
 	if got["GC_DOLT_DATA_DIR"] != "/srv/gc/dolt" {
 		t.Fatalf("ExtraEnv[GC_DOLT_DATA_DIR] = %q, want %q (launchctl fallback for GC_SUPERVISOR_ENV opt-in)",
 			got["GC_DOLT_DATA_DIR"], "/srv/gc/dolt")
+	}
+}
+
+func TestBuildSupervisorServiceDataDeduplicatesLaunchctlFallbackProbes(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("GC_SUPERVISOR_ENV", "GC_DOLT_LOGLEVEL CUSTOM_ONLY")
+	t.Setenv("GC_DOLT_LOGLEVEL", "")
+	t.Setenv("CUSTOM_ONLY", "")
+
+	calls := map[string]int{}
+	prev := supervisorLaunchctlGetenv
+	supervisorLaunchctlGetenv = func(key string) string {
+		calls[key]++
+		return ""
+	}
+	t.Cleanup(func() { supervisorLaunchctlGetenv = prev })
+
+	if _, err := buildSupervisorServiceData(); err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	for _, key := range []string{"GC_DOLT_LOGLEVEL", "CUSTOM_ONLY"} {
+		if calls[key] != 1 {
+			t.Fatalf("launchctl getenv calls for %s = %d, want 1 (all calls: %#v)", key, calls[key], calls)
+		}
+	}
+}
+
+func TestSupervisorLaunchctlGetenvSkipsNonDarwin(t *testing.T) {
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "linux"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	binDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "launchctl.log")
+	script := filepath.Join(binDir, "launchctl")
+	content := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$GC_TEST_LAUNCHCTL_LOG\"\nprintf 'should-not-run\\n'\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", script, err)
+	}
+	t.Setenv("GC_TEST_LAUNCHCTL_LOG", logFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if got := supervisorLaunchctlGetenv("GC_DOLT_LOGLEVEL"); got != "" {
+		t.Fatalf("supervisorLaunchctlGetenv on linux = %q, want empty", got)
+	}
+	if log := readCommandLog(t, logFile); log != "" {
+		t.Fatalf("launchctl was invoked on linux: %q", log)
+	}
+}
+
+func TestSupervisorLaunchctlGetenvStripsDarwinOutputNewline(t *testing.T) {
+	oldGOOS := supervisorRuntimeGOOS
+	supervisorRuntimeGOOS = "darwin"
+	t.Cleanup(func() { supervisorRuntimeGOOS = oldGOOS })
+
+	binDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "launchctl.log")
+	script := filepath.Join(binDir, "launchctl")
+	content := "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" >> \"$GC_TEST_LAUNCHCTL_LOG\"\nif [ \"$1\" = \"getenv\" ] && [ \"$2\" = \"GC_DOLT_LOGLEVEL\" ]; then\n  printf '  debug  \\n'\n  exit 0\nfi\nexit 1\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", script, err)
+	}
+	t.Setenv("GC_TEST_LAUNCHCTL_LOG", logFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if got := supervisorLaunchctlGetenv("GC_DOLT_LOGLEVEL"); got != "  debug  " {
+		t.Fatalf("supervisorLaunchctlGetenv = %q, want %q", got, "  debug  ")
+	}
+	if log := readCommandLog(t, logFile); strings.TrimSpace(log) != "getenv GC_DOLT_LOGLEVEL" {
+		t.Fatalf("launchctl log = %q, want getenv GC_DOLT_LOGLEVEL", log)
 	}
 }
 


### PR DESCRIPTION
## Summary

When launchd spawns the supervisor, the plist's `EnvironmentVariables` block scopes the spawned process's env — values set via `launchctl setenv` do not bleed through. The plist generator at `cmd/gc/cmd_supervisor_lifecycle.go` only included shell-exported env, so the documented `launchctl setenv GC_DOLT_LOGLEVEL debug` flow silently dropped the value and dolt came up at `L="warning"` instead of `L="debug"`.

This made debug-level dolt logging unmeasurable in the launchd-spawned path, breaking Q3 (Dolt residual) e2e measurement that relies on debug logs to surface query attribution.

The fix:

- Add `GC_DOLT_LOGLEVEL` to the persisted-env allowlist (`supervisorServiceEnvKeys`).
- On macOS, fall back to `launchctl getenv` for allowlisted keys (and `GC_SUPERVISOR_ENV` opt-ins) when not present in `os.Environ`. `os.Environ` still wins when both sources have a value, so the existing shell-export path is unchanged.
- The launchctl probe is a `var`-declared hook so tests can stub it without invoking real launchctl, matching the pattern of `supervisorLaunchctlRun` / `supervisorLaunchdActive` already in the file.

Surface: Supervisor lifecycle (env passthrough on the launchd plist) via `gc supervisor`'s plist generator; not hand-edits to `~/Library/LaunchAgents/com.gascity.supervisor.plist`.

## Testing

- [x] `make check` (passes; no regressions)
- [ ] `make check-docs` (no docs touched)
- [ ] `make test-integration` (per maintenance policy: skipped — runtime behavior is exercised by the plist-rendering unit tests + the new `buildSupervisorServiceData` cases)

Three new tests cover:

1. `TestBuildSupervisorServiceDataReadsAllowlistedKeysFromLaunchctl` — happy path: allowlisted key (`GC_DOLT_LOGLEVEL`) absent from `os.Environ`, present in launchctl; ends up in `ExtraEnv`.
2. `TestBuildSupervisorServiceDataPrefersOSEnvOverLaunchctl` — precedence: shell-export wins when both sources have values.
3. `TestBuildSupervisorServiceDataReadsExplicitEnvOptInFromLaunchctl` — `GC_SUPERVISOR_ENV` opt-in path also picks up launchctl values.

The launchctl helper short-circuits on non-Darwin, so Linux CI tests exercise the same code path with the hook returning `""`.

## Checklist

- [x] Linked an issue: tracking bead `stg-cpip` in our local issue tracker (private repo); reproduced via `mol-e2e-baseline.formula.toml` step 2 prep flow.
- [x] Added tests for the new behavior (3 cases above).
- [ ] No user-facing docs change required (the existing prose at `mol-e2e-baseline` step 2 in our pack will be reconciled separately to drop the "launchctl setenv does not propagate" caveat once this lands).
- [x] No breaking changes — only adds a fallback source for env values; pre-existing behavior (shell-export passthrough) is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->