### PR TITLE
fix: apply gofumpt to convergence close reasons

### DIFF
--- a/internal/convergence/handler.go
+++ b/internal/convergence/handler.go
@@ -44,14 +44,14 @@ func ParseIterationFromKey(key string) (int, bool) {
 // <20 chars) accepts the close. The reason also lands in the closed
 // bead's metadata for audit.
 const (
-	CloseReasonCreateRollback   = "convergence: bead-create rollback after error"
-	CloseReasonRetryRollback    = "convergence: retry-create rollback after error"
-	CloseReasonManualApprove    = "convergence: iteration closed by manual approve"
-	CloseReasonManualSupersede  = "convergence: active wisp superseded during manual stop"
-	CloseReasonManualStop       = "convergence: iteration closed by manual stop"
-	CloseReasonReconcileDone    = "convergence reconcile: terminated-state bead closed"
-	CloseReasonHandlerCleanup   = "convergence: terminated state observed; closing root"
-	CloseReasonHandlerRoot      = "convergence: workflow handler closing root after terminate"
+	CloseReasonCreateRollback  = "convergence: bead-create rollback after error"
+	CloseReasonRetryRollback   = "convergence: retry-create rollback after error"
+	CloseReasonManualApprove   = "convergence: iteration closed by manual approve"
+	CloseReasonManualSupersede = "convergence: active wisp superseded during manual stop"
+	CloseReasonManualStop      = "convergence: iteration closed by manual stop"
+	CloseReasonReconcileDone   = "convergence reconcile: terminated-state bead closed"
+	CloseReasonHandlerCleanup  = "convergence: terminated state observed; closing root"
+	CloseReasonHandlerRoot     = "convergence: workflow handler closing root after terminate"
 )
 
 // BeadInfo holds the minimal bead information needed by the handler.


### PR DESCRIPTION
## Summary
- apply gofumpt formatting to convergence close reason constants

## Verification
- make lint
- make fmt-check
- go test -count=1 ./internal/convergence
- pre-commit hook: lint, vet, make test

Bead: ga-kkt17t

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->