### PR TITLE
fix: preserve explicit rig credentials fallback

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -164,7 +164,11 @@ func applyCanonicalDoltAuthEnv(env map[string]string, cityPath, scopeRoot string
 	if env == nil {
 		return
 	}
-	applyResolvedDoltAuthEnv(env, doltauth.AuthScopeRoot(cityPath, scopeRoot, target), strings.TrimSpace(target.User))
+	authScopeRoot := doltauth.AuthScopeRoot(cityPath, scopeRoot, target)
+	if !samePath(authScopeRoot, cityPath) {
+		clearProjectedDoltPasswordEnv(env)
+	}
+	applyResolvedDoltAuthEnv(env, authScopeRoot, strings.TrimSpace(target.User))
 }
 
 func applyCanonicalScopeDoltEnv(env map[string]string, cityPath, scopeRoot string) (bool, error) {
@@ -265,6 +269,11 @@ func clearProjectedDoltEnv(env map[string]string) {
 	for _, key := range projectedDoltEnvKeys {
 		delete(env, key)
 	}
+}
+
+func clearProjectedDoltPasswordEnv(env map[string]string) {
+	delete(env, "GC_DOLT_PASSWORD")
+	delete(env, "BEADS_DOLT_PASSWORD")
 }
 
 func managedLocalDoltHost(host string) bool {
@@ -445,6 +454,7 @@ func applyResolvedRigDoltEnv(env map[string]string, cityPath, rigPath string, ex
 	}
 	if explicitRig != nil && (explicitRig.DoltHost != "" || explicitRig.DoltPort != "") {
 		applyLegacyRigExternalTarget(env, *explicitRig)
+		clearProjectedDoltPasswordEnv(env)
 		applyResolvedDoltAuthEnv(env, rigPath, "")
 		mirrorBeadsDoltEnv(env)
 		return nil

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2185,6 +2185,7 @@ func TestSessionDoltEnvExplicitRigUsesRigStorePassword(t *testing.T) {
 	t.Setenv("GC_DOLT_PORT", "")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 	t.Setenv("BEADS_CREDENTIALS_FILE", "")
 
 	cityPath := t.TempDir()
@@ -2230,6 +2231,115 @@ dolt.user: rig-user
 	}
 }
 
+func TestBdRuntimeEnvForExplicitRigUsesCredentialsFileWhenRigStoreSecretMissing(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "")
+	t.Setenv("GC_DOLT_PORT", "")
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
+
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "repo")
+	for _, dir := range []string{cityPath, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: city_canonical
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: city-db.example.com
+dolt.port: 3307
+dolt.user: city-user
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", ".env"), []byte("BEADS_DOLT_PASSWORD=city-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(t.TempDir(), "credentials")
+	if err := os.WriteFile(credentialsPath, []byte("[rig-db.example.com:3308]\npassword=rig-credentials-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
+
+	env := bdRuntimeEnvForRig(cityPath, &config.City{Rigs: []config.Rig{{
+		Name:     "repo",
+		Path:     rigDir,
+		DoltHost: "rig-db.example.com",
+		DoltPort: "3308",
+	}}}, rigDir)
+	if got := env["GC_DOLT_PASSWORD"]; got != "rig-credentials-secret" {
+		t.Fatalf("GC_DOLT_PASSWORD = %q, want %q", got, "rig-credentials-secret")
+	}
+	if got := env["BEADS_DOLT_PASSWORD"]; got != "rig-credentials-secret" {
+		t.Fatalf("BEADS_DOLT_PASSWORD = %q, want %q", got, "rig-credentials-secret")
+	}
+}
+
+func TestBdRuntimeEnvForCanonicalExplicitRigUsesCredentialsFileWhenRigStoreSecretMissing(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "")
+	t.Setenv("GC_DOLT_PORT", "")
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
+
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "repo")
+	for _, dir := range []string{cityPath, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "config.yaml"), []byte(`issue_prefix: demo
+gc.endpoint_origin: city_canonical
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: city-db.example.com
+dolt.port: 3307
+dolt.user: city-user
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", ".env"), []byte("BEADS_DOLT_PASSWORD=city-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "config.yaml"), []byte(`issue_prefix: repo
+gc.endpoint_origin: explicit
+gc.endpoint_status: verified
+dolt.auto-start: false
+dolt.host: rig-db.example.com
+dolt.port: 3308
+dolt.user: rig-user
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath := filepath.Join(t.TempDir(), "credentials")
+	if err := os.WriteFile(credentialsPath, []byte("[rig-db.example.com:3308]\npassword=rig-credentials-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
+
+	env := bdRuntimeEnvForRig(cityPath, &config.City{Rigs: []config.Rig{{
+		Name: "repo",
+		Path: rigDir,
+	}}}, rigDir)
+	if got := env["GC_DOLT_HOST"]; got != "rig-db.example.com" {
+		t.Fatalf("GC_DOLT_HOST = %q, want %q", got, "rig-db.example.com")
+	}
+	if got := env["GC_DOLT_PASSWORD"]; got != "rig-credentials-secret" {
+		t.Fatalf("GC_DOLT_PASSWORD = %q, want %q", got, "rig-credentials-secret")
+	}
+	if got := env["BEADS_DOLT_PASSWORD"]; got != "rig-credentials-secret" {
+		t.Fatalf("BEADS_DOLT_PASSWORD = %q, want %q", got, "rig-credentials-secret")
+	}
+}
+
 func TestCityRuntimeProcessEnvForwardsBeadsCredentialsFile(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
@@ -2237,6 +2347,7 @@ func TestCityRuntimeProcessEnvForwardsBeadsCredentialsFile(t *testing.T) {
 	t.Setenv("GC_DOLT_PORT", "")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o700); err != nil {

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -2175,6 +2175,65 @@ func TestOrderExecManagedDoltFallbackSkipsInheritedExternalCity(t *testing.T) {
 	}
 }
 
+func TestApplyOrderExecCanonicalDoltEnvClearsProjectedPasswordForExplicitRig(t *testing.T) {
+	t.Setenv("GC_DOLT_HOST", "")
+	t.Setenv("GC_DOLT_PORT", "")
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "frontend")
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cityDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: ct",
+		"gc.endpoint_origin: city_canonical",
+		"gc.endpoint_status: verified",
+		"dolt.host: city-db.example.com",
+		"dolt.port: 4406",
+		"dolt.user: city-user",
+		"",
+	}, "\n"))
+	writeFile(t, filepath.Join(cityDir, ".beads", ".env"), "BEADS_DOLT_PASSWORD=city-secret\n")
+	writeFile(t, filepath.Join(rigDir, ".beads", "config.yaml"), strings.Join([]string{
+		"issue_prefix: fe",
+		"gc.endpoint_origin: explicit",
+		"gc.endpoint_status: verified",
+		"dolt.host: rig-db.example.com",
+		"dolt.port: 5506",
+		"dolt.user: rig-user",
+		"",
+	}, "\n"))
+	credentialsPath := filepath.Join(t.TempDir(), "credentials")
+	if err := os.WriteFile(credentialsPath, []byte("[rig-db.example.com:5506]\npassword=rig-credentials-secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
+
+	env := map[string]string{
+		"GC_DOLT_HOST":           "city-db.example.com",
+		"GC_DOLT_PORT":           "4406",
+		"GC_DOLT_PASSWORD":       "city-secret",
+		"BEADS_DOLT_PASSWORD":    "city-secret",
+		"BEADS_CREDENTIALS_FILE": credentialsPath,
+	}
+	applyOrderExecCanonicalDoltEnv(cityDir, rigDir, env)
+	if got := env["GC_DOLT_HOST"]; got != "rig-db.example.com" {
+		t.Fatalf("GC_DOLT_HOST = %q, want %q", got, "rig-db.example.com")
+	}
+	if got := env["GC_DOLT_PASSWORD"]; got != "rig-credentials-secret" {
+		t.Fatalf("GC_DOLT_PASSWORD = %q, want %q", got, "rig-credentials-secret")
+	}
+	if got := env["BEADS_DOLT_PASSWORD"]; got != "rig-credentials-secret" {
+		t.Fatalf("BEADS_DOLT_PASSWORD = %q, want %q", got, "rig-credentials-secret")
+	}
+}
+
 func TestOrderDispatchExecTimeout(t *testing.T) {
 	store := beads.NewMemStore()
 	var rec memRecorder

--- a/cmd/gc/order_store.go
+++ b/cmd/gc/order_store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gastownhall/gascity/internal/beads/contract"
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/doltauth"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 )
@@ -167,7 +166,7 @@ func applyOrderExecCanonicalDoltEnv(cityPath, scopeRoot string, env map[string]s
 		return
 	}
 	applyCanonicalDoltTargetEnv(env, target)
-	applyResolvedDoltAuthEnv(env, doltauth.AuthScopeRoot(cityPath, scopeRoot, target), strings.TrimSpace(target.User))
+	applyCanonicalDoltAuthEnv(env, cityPath, scopeRoot, target)
 	if target.External {
 		env["GC_DOLT_MANAGED_LOCAL"] = "0"
 		clearManagedDoltRuntimeLayoutEnv(env, cityPath)
@@ -206,8 +205,11 @@ func applyOrderExecManagedDoltFallback(cityPath, scopeRoot string, env map[strin
 	}
 	env["GC_DOLT_MANAGED_LOCAL"] = "1"
 	applyManagedDoltRuntimeLayoutEnv(env, cityPath)
-	target := contract.DoltConnectionTarget{EndpointOrigin: resolved.State.EndpointOrigin}
-	applyResolvedDoltAuthEnv(env, doltauth.AuthScopeRoot(cityPath, scopeRoot, target), strings.TrimSpace(resolved.State.DoltUser))
+	target := contract.DoltConnectionTarget{
+		User:           strings.TrimSpace(resolved.State.DoltUser),
+		EndpointOrigin: resolved.State.EndpointOrigin,
+	}
+	applyCanonicalDoltAuthEnv(env, cityPath, scopeRoot, target)
 	mirrorBeadsDoltEnv(env)
 	return true
 }

--- a/cmd/gc/test_password_leak_test.go
+++ b/cmd/gc/test_password_leak_test.go
@@ -9,6 +9,7 @@ import (
 func TestBdRuntimeEnvDoesNotTreatCityEnvPasswordAsCanonicalAuth(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o700); err != nil {
@@ -20,6 +21,7 @@ func TestBdRuntimeEnvDoesNotTreatCityEnvPasswordAsCanonicalAuth(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`
 [workspace.env]
 GC_DOLT_PASSWORD = "secret_from_toml"
+BEADS_DOLT_PASSWORD = "beads_secret_from_toml"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/convoy_sql_test.go
+++ b/internal/api/convoy_sql_test.go
@@ -261,7 +261,7 @@ func TestBuildDoltDSNUsesResolvedUserAndPassword(t *testing.T) {
 
 func clearDoltAuthEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{"GC_DOLT_USER", "GC_DOLT_PASSWORD", "BEADS_CREDENTIALS_FILE"} {
+	for _, key := range []string{"GC_DOLT_USER", "GC_DOLT_PASSWORD", "BEADS_DOLT_PASSWORD", "BEADS_CREDENTIALS_FILE"} {
 		t.Setenv(key, "")
 	}
 }

--- a/internal/doltauth/auth.go
+++ b/internal/doltauth/auth.go
@@ -31,6 +31,8 @@ func AuthScopeRoot(cityRoot, scopeRoot string, target contract.DoltConnectionTar
 }
 
 // Resolve returns the effective Dolt auth for a scope and target.
+// Ambient BEADS_DOLT_PASSWORD is an intentional fallback for operators and
+// non-bd callers, after scope-local .beads/.env and before credentials files.
 func Resolve(scopeRoot, fallbackUser, host string, port int) Resolved {
 	overridePath := strings.TrimSpace(os.Getenv("BEADS_CREDENTIALS_FILE"))
 	return Resolved{
@@ -41,6 +43,8 @@ func Resolve(scopeRoot, fallbackUser, host string, port int) Resolved {
 }
 
 // ResolveFromEnv returns effective Dolt auth using projected environment values.
+// Projected BEADS_DOLT_PASSWORD is treated like an already-resolved fallback;
+// callers that switch auth scopes must clear stale projected passwords first.
 func ResolveFromEnv(scopeRoot, fallbackUser string, env map[string]string) Resolved {
 	host := strings.TrimSpace(env["GC_DOLT_HOST"])
 	port, ok := projectedPort(env)

--- a/internal/doltauth/auth_test.go
+++ b/internal/doltauth/auth_test.go
@@ -36,6 +36,7 @@ func TestResolvePrefersProcessOverrides(t *testing.T) {
 	credentialsPath := writeCredentialsFile(t, "db.example.com", 3307, "credentials-secret")
 	t.Setenv("GC_DOLT_USER", "override-user")
 	t.Setenv("GC_DOLT_PASSWORD", "override-secret")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
 
 	resolved := Resolve(scopeRoot, "fallback-user", "db.example.com", 3307)
@@ -55,6 +56,7 @@ func TestResolveUsesStoreLocalPasswordBeforeCredentialsFile(t *testing.T) {
 	writeStorePassword(t, scopeRoot, "store-secret")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 	t.Setenv("BEADS_CREDENTIALS_FILE", writeCredentialsFile(t, "db.example.com", 3307, "credentials-secret"))
 
 	resolved := Resolve(scopeRoot, "fallback-user", "db.example.com", 3307)
@@ -71,6 +73,7 @@ func TestResolveUsesCredentialsFileFallback(t *testing.T) {
 	credentialsPath := writeCredentialsFile(t, "db.example.com", 3307, "credentials-secret")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
 
 	resolved := Resolve(scopeRoot, "fallback-user", "db.example.com", 3307)
@@ -84,6 +87,7 @@ func TestResolveReturnsNoCredentialsPasswordWithoutHostOrPort(t *testing.T) {
 	credentialsPath := writeCredentialsFile(t, "db.example.com", 3307, "credentials-secret")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
 
 	resolved := Resolve(scopeRoot, "fallback-user", "", 0)
@@ -97,11 +101,56 @@ func TestResolveFromEnvDefaultsLoopbackHostWhenOnlyPortIsPresent(t *testing.T) {
 	credentialsPath := writeCredentialsFile(t, "127.0.0.1", 3307, "loopback-secret")
 	t.Setenv("GC_DOLT_USER", "")
 	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
 	t.Setenv("BEADS_CREDENTIALS_FILE", credentialsPath)
 
 	resolved := ResolveFromEnv(scopeRoot, "fallback-user", map[string]string{"GC_DOLT_PORT": "3307"})
 	if resolved.Password != "loopback-secret" {
 		t.Fatalf("Password = %q, want loopback-secret", resolved.Password)
+	}
+}
+
+func TestResolveFromEnvUsesAmbientBeadsDoltPassword(t *testing.T) {
+	scopeRoot := t.TempDir()
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "operator-secret")
+	t.Setenv("BEADS_CREDENTIALS_FILE", "")
+
+	resolved := ResolveFromEnv(scopeRoot, "fallback-user", map[string]string{})
+	if resolved.Password != "operator-secret" {
+		t.Fatalf("Password = %q, want operator-secret", resolved.Password)
+	}
+}
+
+func TestResolveFromEnvUsesProjectedBeadsDoltPassword(t *testing.T) {
+	scopeRoot := t.TempDir()
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_CREDENTIALS_FILE", "")
+
+	resolved := ResolveFromEnv(scopeRoot, "fallback-user", map[string]string{
+		"BEADS_DOLT_PASSWORD": "projected-secret",
+	})
+	if resolved.Password != "projected-secret" {
+		t.Fatalf("Password = %q, want projected-secret", resolved.Password)
+	}
+}
+
+func TestResolveFromEnvPrefersStoreLocalPasswordOverProjectedPassword(t *testing.T) {
+	scopeRoot := t.TempDir()
+	writeStorePassword(t, scopeRoot, "rig-secret")
+	t.Setenv("GC_DOLT_USER", "")
+	t.Setenv("GC_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_DOLT_PASSWORD", "")
+	t.Setenv("BEADS_CREDENTIALS_FILE", "")
+
+	resolved := ResolveFromEnv(scopeRoot, "fallback-user", map[string]string{
+		"BEADS_DOLT_PASSWORD": "projected-city-secret",
+	})
+	if resolved.Password != "rig-secret" {
+		t.Fatalf("Password = %q, want rig-secret", resolved.Password)
 	}
 }
 


### PR DESCRIPTION
## Summary

Maintainer follow-up for #1720 after the original PR was merged before the adoption workflow could push its local review fixup.

This keeps the contributor's merged work intact and carries forward only the maintainer-side fix from the reviewed adopted branch:

- clear projected city auth before canonical explicit-rig credential resolution
- cover canonical explicit-rig credentials-file fallback when the rig has no local `.beads/.env`
- route managed order-exec fallback through the canonical auth helper
- harden tests against ambient `BEADS_DOLT_PASSWORD` leakage

## Original PR Context

- Original PR: https://github.com/gastownhall/gascity/pull/1720
- Original title: fix(doltauth): resolve BEADS_DOLT_PASSWORD in gc bd subprocess env
- Original state at finalization: MERGED
- Configured base branch: main
- Original GitHub base branch: main
- Base mismatch: none
- Adopt workflow source bead: ga-ofzmgg

## Test plan

- [x] `git diff --check refs/adopt-pr/ga-ofzmgg/latest-base..HEAD`
- [x] `go test ./internal/doltauth -count=1`
- [x] `go test ./internal/api -run TestBuildDoltDSNUsesResolvedUserAndPassword -count=1`
- [x] `go test ./cmd/gc -run 'Test(BdRuntimeEnvForCanonicalExplicitRigUsesCredentialsFileWhenRigStoreSecretMissing|BdRuntimeEnvForExplicitRigUsesCredentialsFileWhenRigStoreSecretMissing|ApplyOrderExecCanonicalDoltEnvClearsProjectedPasswordForExplicitRig|BdRuntimeEnvDoesNotTreatCityEnvPasswordAsCanonicalAuth|SessionDoltEnvExplicitRigUsesRigStorePassword|SessionDoltEnvInheritedRigUsesCityStorePassword|BdRuntimeEnvUsesStoreLocalBeadsEnvPassword|BdRuntimeEnvUsesCredentialsFilePasswordWhenStoreSecretMissing|CityRuntimeProcessEnvForwardsBeadsCredentialsFile|SessionDoltEnvCompatRigOverrideUsesRigStorePassword|SessionDoltEnvCompatCityFallbackUsesCityStorePassword)$' -count=1`

---
Adopted via `/adopt-pr` workflow. Original contributor commits were preserved in #1720; this PR contains only maintainer follow-up fixes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->