### PR TITLE
fix(extmsg): close residual memberships when retiring a session bead (#1865)

### DIFF
--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -548,7 +548,7 @@ func CloseSessionBindings(ctx context.Context, store beads.Store, sessionID stri
 	return closeSessionMemberships(ctx, svc, caller, sessionID, now)
 }
 
-// closeSessionParticipants closes every gc:extmsg-participant bead labelled
+// closeSessionParticipants closes every gc:extmsg-participant bead labeled
 // for sessionID by delegating to RemoveParticipant, which also cleans up the
 // group-owned portion of the corresponding membership.
 func closeSessionParticipants(ctx context.Context, store beads.Store, svc Services, caller Caller, sessionID string) error {

--- a/internal/extmsg/binding_service.go
+++ b/internal/extmsg/binding_service.go
@@ -2,6 +2,7 @@ package extmsg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -512,7 +513,16 @@ func ReassignSessionBindings(ctx context.Context, store beads.Store, oldSessionI
 	return nil
 }
 
-// CloseSessionBindings terminates active bindings for a retired session bead ID.
+// CloseSessionBindings terminates active bindings, group participants, AND any
+// residual conversation memberships for a retired session bead ID.
+//
+// The Unbind cascade only closes memberships through the binding seed loop, so
+// a session whose only extmsg state is a participant-driven membership (e.g.
+// created via POST /extmsg/participants by gc slack bind-room, with no
+// corresponding gc:extmsg-binding bead) is left as a zombie. Worse, the
+// gc:extmsg-participant beads themselves stay open and remain visible to
+// ResolveInbound / ResolveOutbound, so group routing can still target the
+// dead session. Sweep both explicitly.
 func CloseSessionBindings(ctx context.Context, store beads.Store, sessionID string, now time.Time) error {
 	if err := checkContext(ctx); err != nil {
 		return err
@@ -524,11 +534,94 @@ func CloseSessionBindings(ctx context.Context, store beads.Store, sessionID stri
 	if sessionID == "" {
 		return nil
 	}
-	_, err := NewServices(store).Bindings.Unbind(ctx, Caller{Kind: CallerController, ID: "session-retirement"}, UnbindInput{
+	caller := Caller{Kind: CallerController, ID: "session-retirement"}
+	svc := NewServices(store)
+	if _, err := svc.Bindings.Unbind(ctx, caller, UnbindInput{
 		SessionID: sessionID,
 		Now:       now,
-	})
-	return err
+	}); err != nil {
+		return err
+	}
+	if err := closeSessionParticipants(ctx, store, svc, caller, sessionID); err != nil {
+		return err
+	}
+	return closeSessionMemberships(ctx, svc, caller, sessionID, now)
+}
+
+// closeSessionParticipants closes every gc:extmsg-participant bead labelled
+// for sessionID by delegating to RemoveParticipant, which also cleans up the
+// group-owned portion of the corresponding membership.
+func closeSessionParticipants(ctx context.Context, store beads.Store, svc Services, caller Caller, sessionID string) error {
+	items, err := store.List(beads.ListQuery{Label: groupParticipantSessionLabel(sessionID)})
+	if err != nil {
+		return fmt.Errorf("list residual participants for retired session %s: %w", sessionID, err)
+	}
+	type pair struct {
+		groupID string
+		handle  string
+	}
+	seen := make(map[pair]struct{}, len(items))
+	for _, item := range items {
+		if !hasLabel(item, "gc:extmsg-participant") || item.Status == "closed" {
+			continue
+		}
+		record, decodeErr := decodeParticipantBead(item)
+		if decodeErr != nil {
+			return fmt.Errorf("decode residual participant %s: %w", item.ID, decodeErr)
+		}
+		if record.SessionID != sessionID {
+			continue
+		}
+		key := pair{groupID: record.GroupID, handle: record.Handle}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		removeErr := svc.Groups.RemoveParticipant(ctx, caller, RemoveParticipantInput{
+			GroupID: record.GroupID,
+			Handle:  record.Handle,
+		})
+		if removeErr == nil || errors.Is(removeErr, ErrGroupRouteNotFound) {
+			continue
+		}
+		return fmt.Errorf("remove residual participant %s (group=%s handle=%s) for retired session %s: %w", record.ID, record.GroupID, record.Handle, sessionID, removeErr)
+	}
+	return nil
+}
+
+// closeSessionMemberships closes any membership bead still listing sessionID
+// after the binding and participant sweeps. Catches binding-owned memberships
+// whose binding bead never existed (legacy data) and any other orphan paths.
+func closeSessionMemberships(ctx context.Context, svc Services, caller Caller, sessionID string, now time.Time) error {
+	memberships, err := svc.Transcript.ListConversationsBySession(ctx, caller, sessionID)
+	if err != nil {
+		return fmt.Errorf("list residual memberships for retired session %s: %w", sessionID, err)
+	}
+	for _, m := range memberships {
+		// Iterate stored owners so removeMembershipLocked decrements the
+		// owners slice to empty and closes the bead. Legacy beads with
+		// empty owners still need closing; passing any single owner
+		// triggers removeMembershipLocked's empty-owners substitution
+		// path (transcript_service.go) which closes the bead in one call.
+		owners := m.Owners
+		if len(owners) == 0 {
+			owners = []MembershipOwner{MembershipOwnerManual}
+		}
+		for _, owner := range owners {
+			removeErr := svc.Transcript.RemoveMembership(ctx, RemoveMembershipInput{
+				Caller:       caller,
+				Conversation: m.Conversation,
+				SessionID:    sessionID,
+				Owner:        owner,
+				Now:          now,
+			})
+			if removeErr == nil || errors.Is(removeErr, ErrMembershipNotFound) {
+				continue
+			}
+			return fmt.Errorf("remove residual membership %s (owner=%s) for retired session %s: %w", m.ID, owner, sessionID, removeErr)
+		}
+	}
+	return nil
 }
 
 func activeBindingExistsForSession(store beads.Store, ref ConversationRef, currentID, sessionID string) (bool, error) {

--- a/internal/extmsg/extmsg_test.go
+++ b/internal/extmsg/extmsg_test.go
@@ -2210,3 +2210,83 @@ func (f *flakyTranscriptService) MarkHydrationFailed(context.Context, Caller, Co
 func (f *flakyTranscriptService) State(context.Context, Caller, ConversationRef) (*ConversationTranscriptStateRecord, error) {
 	panic("unexpected State call")
 }
+
+func TestCloseSessionBindingsClosesGroupOwnedMembership(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+
+	group, err := fabric.Groups.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := fabric.Groups.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-a",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	if got := membershipSessionIDs(t, fabric.Transcript, ref); len(got) != 1 || got[0] != "sess-a" {
+		t.Fatalf("memberships(after participant upsert) = %#v, want [sess-a]", got)
+	}
+
+	if err := CloseSessionBindings(context.Background(), store, "sess-a", testNow().Add(time.Minute)); err != nil {
+		t.Fatalf("CloseSessionBindings: %v", err)
+	}
+
+	if got := membershipSessionIDs(t, fabric.Transcript, ref); len(got) != 0 {
+		t.Fatalf("memberships(after CloseSessionBindings) = %#v, want []", got)
+	}
+}
+
+func TestCloseSessionBindingsClosesGroupParticipants(t *testing.T) {
+	freezeTestClock(t)
+	store := beads.NewMemStore()
+	fabric := NewServices(store)
+	ref := testConversationRef()
+
+	group, err := fabric.Groups.EnsureGroup(context.Background(), testControllerCaller(), EnsureGroupInput{
+		RootConversation: ref,
+		Mode:             GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := fabric.Groups.UpsertParticipant(context.Background(), testControllerCaller(), UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "alpha",
+		SessionID: "sess-a",
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	openParticipants := func() []string {
+		t.Helper()
+		items, err := store.ListByLabel(groupParticipantSessionLabel("sess-a"), 0)
+		if err != nil {
+			t.Fatalf("ListByLabel: %v", err)
+		}
+		open := make([]string, 0, len(items))
+		for _, item := range items {
+			if hasLabel(item, "gc:extmsg-participant") && item.Status != "closed" {
+				open = append(open, item.ID)
+			}
+		}
+		return open
+	}
+	if got := openParticipants(); len(got) != 1 {
+		t.Fatalf("open participants(after upsert) = %#v, want 1", got)
+	}
+
+	if err := CloseSessionBindings(context.Background(), store, "sess-a", testNow().Add(time.Minute)); err != nil {
+		t.Fatalf("CloseSessionBindings: %v", err)
+	}
+
+	if got := openParticipants(); len(got) != 0 {
+		t.Fatalf("open participants(after CloseSessionBindings) = %#v, want []", got)
+	}
+}


### PR DESCRIPTION
Closes #1865.

## Summary

`CloseSessionBindings` only cascaded membership cleanup through the
`Bindings.Unbind` seed loop, which iterates `gc:extmsg-binding` beads.
Memberships created via the participant-only flow (POST `/extmsg/participants`,
e.g. by `gc slack bind-room`) have no corresponding binding bead, so the
cascade never fired and they leaked as zombies referencing closed sessions.

This triggered visible failures during routine session respawns: the
notify path kept emitting `extmsg: notify <closed-id> failed: session is
closed` per inbound, and downstream sessions (e.g. `gascity-maintenance-pl`)
were either never reached or refused to act because they saw stale
peer-membership state.

## Fix

After the existing `Unbind` call, enumerate any remaining memberships
for the session via `ListConversationsBySession` and call
`RemoveMembership` for each `(Owner, Conversation, SessionID)` tuple so
the membership fully closes regardless of which owner kinds (group,
binding, manual) created it. The cleanup primitive
(`removeMembershipLocked`) already existed; the session-close path just
wasn't using it.

Diff: `internal/extmsg/binding_service.go`, ~30 LOC added; one
regression test (`TestCloseSessionBindingsClosesGroupOwnedMembership`)
covering the participant-only → CloseSessionBindings → no-residual path.

## Test plan

- [x] `go test ./internal/extmsg/ -count=1` passes (full extmsg suite)
- [x] New regression test passes
- [ ] Maintainer eyes on the cleanup loop's error handling — currently
      bails on first failure; alternative is collect-then-aggregate. Open
      to changing if preferred.

## Validation in production

After applying this fix locally to clean up the leak from issue #1865:

- POST `/extmsg/unbind` for the closed session ID `gc-140884` cleared
  membership `gc-140912` cleanly.
- Subsequent slack inbounds to room `C0B25SS12CD` routed correctly to
  the live maintenance-pl session.
- `gc slack reply-current` returned `Delivered: true` end-to-end (the
  reply path that was originally 422'ing pre-#1818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->