### PR TITLE
fix(extmsg): notify reminder uses actual provider name (#1866)

### DIFF
--- a/internal/api/handler_extmsg.go
+++ b/internal/api/handler_extmsg.go
@@ -118,16 +118,20 @@ func (s *Server) extmsgNotifyMembers(
 
 	notifyResolved := func(sessionSelector, resolvedID string) {
 		handle := s.extmsgSessionHandleForResolvedID(resolvedID, sessionSelector)
+		// Normalize for the CLI hint — gc subcommands are lowercase. The
+		// human-facing prose uses titleCaseProvider for display.
+		providerCLI := strings.ToLower(conv.Provider)
+		providerDisplay := titleCaseProvider(providerCLI)
 		nudge := fmt.Sprintf("<system-reminder>\nNew message in shared conversation %s/%s:\n\n"+
 			"- %s (%s): %s\n\n"+
-			"To reply in Discord, write your response to a file and run:\n"+
-			"  gc discord reply-current --conversation-id %s --body-file <path>\n"+
+			"To reply in %s, write your response to a file and run:\n"+
+			"  gc %s reply-current --conversation-id %s --body-file <path>\n"+
 			"Prefix your reply with your agent handle in bold (e.g., **%s:** your message).\n"+
-			"Run 'gc transcript read --ack' after responding to mark as read.\n"+
 			"</system-reminder>",
 			conv.Provider, conv.ConversationID,
 			actorDisplayName, actorKind, text,
-			conv.ConversationID,
+			providerDisplay,
+			providerCLI, conv.ConversationID,
 			handle,
 		)
 		if err := s.sendBackgroundMessageToSession(ctx, store, resolvedID, nudge); err != nil {
@@ -174,4 +178,19 @@ func (s *Server) extmsgNotifyInboundMembers(ctx context.Context, msg extmsg.Exte
 		actorKind = "human"
 	}
 	s.extmsgNotifyMembers(ctx, msg.Conversation, msg.Actor.DisplayName, actorKind, msg.Text, "")
+}
+
+// titleCaseProvider uppercases the first ASCII byte of a provider name.
+// Used to avoid a golang.org/x/text/cases dependency just for one
+// capitalization in the inbound nudge — provider names are always
+// short lowercase ASCII identifiers (slack, discord, ...).
+func titleCaseProvider(name string) string {
+	if name == "" {
+		return ""
+	}
+	first := name[0]
+	if first >= 'a' && first <= 'z' {
+		return string(first-'a'+'A') + name[1:]
+	}
+	return name
 }

--- a/internal/api/handler_extmsg_test.go
+++ b/internal/api/handler_extmsg_test.go
@@ -307,3 +307,22 @@ func TestHandleExtMsgOutboundNotifiesDeliveredConversationMembers(t *testing.T) 
 		t.Fatalf("delivered conversation peer nudge not found; calls=%#v", fs.sp.Calls)
 	}
 }
+
+func TestTitleCaseProvider(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"slack", "Slack"},
+		{"discord", "Discord"},
+		{"", ""},
+		{"a", "A"},
+		{"Slack", "Slack"},
+		{"X", "X"},
+		{"123", "123"},
+	}
+	for _, tc := range cases {
+		if got := titleCaseProvider(tc.in); got != tc.want {
+			t.Errorf("titleCaseProvider(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1866.

## Summary

The system-reminder injected when an agent receives an extmsg inbound
hardcoded "Discord" / `gc discord reply-current` regardless of the
actual provider, causing slack-bound agents to spend tool-use turns
discovering they need `gc slack reply-current` instead. Also drops the
trailing `Run 'gc transcript read --ack'...` hint — there is no
`gc transcript` CLI subcommand on origin/main (the ack functionality
exists only as the HTTP endpoint `/v0/.../extmsg/transcript/ack`).

## Fix

`internal/api/handler_extmsg.go` `notifyResolved`: parameterize the
prose ("To reply in %s") and the CLI command (`gc %s reply-current`)
on `conv.Provider`, with a small `titleCaseProvider` helper for the
display capitalization. Drops the broken `gc transcript` hint.

Diff: ~25 LOC; one new test (`TestTitleCaseProvider`) covering the
helper.

## Test plan

- [x] `go test ./internal/api/ -count=1` passes (full api suite)
- [x] New `TestTitleCaseProvider` covers slack/discord/empty/upper/digit
- [ ] If desired, add a snapshot-style test asserting the rendered
      reminder string for slack and discord — happy to follow up.

## Sample output

Before:
```
New message in shared conversation slack/C0B25SS12CD:
- alice (human): Ping

To reply in Discord, write your response to a file and run:
  gc discord reply-current --conversation-id C0B25SS12CD --body-file <path>
...
Run 'gc transcript read --ack' after responding to mark as read.
```

After:
```
New message in shared conversation slack/C0B25SS12CD:
- alice (human): Ping

To reply in Slack, write your response to a file and run:
  gc slack reply-current --conversation-id C0B25SS12CD --body-file <path>
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->