### PR TITLE
fix(hooks): canonicalize managed JSON writes

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -154,6 +154,11 @@ func installOverlayManaged(fs fsys.FS, workDir, provider string) error {
 		if provider == "codex" && rel == path.Join(".codex", "hooks.json") {
 			return writeCodexHooksManaged(fs, dst, data)
 		}
+		if overlay.IsMergeablePath(filepath.FromSlash(rel)) {
+			if normalized, normErr := overlay.CanonicalJSON(data); normErr == nil {
+				data = normalized
+			}
+		}
 		return writeEmbeddedManaged(fs, dst, data, overlayManagedNeedsUpgrade(provider, rel))
 	})
 }
@@ -387,11 +392,10 @@ func upgradeCodexHooks(existing, desired []byte) ([]byte, bool, error) {
 	if addCodexPreCompactHook(root, desired) {
 		changed = true
 	}
-	data, err := json.MarshalIndent(root, "", "  ")
+	data, err := overlay.MarshalCanonicalJSON(root)
 	if err != nil {
 		return nil, false, err
 	}
-	data = append(data, '\n')
 	if hasManagedCommand && !needsPreCompact && !bytes.Equal(data, existing) {
 		changed = true
 	}
@@ -405,11 +409,10 @@ func normalizeCodexHookCommands(existing []byte) ([]byte, bool, error) {
 	}
 	hasManagedCommand := codexHookValueHasManagedCommand(root)
 	changed := upgradeCodexHookValue(root)
-	data, err := json.MarshalIndent(root, "", "  ")
+	data, err := overlay.MarshalCanonicalJSON(root)
 	if err != nil {
 		return nil, false, err
 	}
-	data = append(data, '\n')
 	if hasManagedCommand && !bytes.Equal(data, existing) {
 		changed = true
 	}
@@ -574,6 +577,9 @@ func desiredCodexPreCompactHook(desired []byte) any {
 }
 
 func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFilePolicy) error {
+	if normalized, err := overlay.CanonicalJSON(data); err == nil {
+		data = normalized
+	}
 	existing, readErr := fs.ReadFile(dst)
 	if readErr == nil && bytes.Equal(existing, data) {
 		return nil

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1090,6 +1090,25 @@ func TestInstallMultipleProviders(t *testing.T) {
 	}
 }
 
+func TestInstallCodexWritesCanonicalJSON(t *testing.T) {
+	fs := fsys.NewFake()
+
+	if err := Install(fs, "/city", "/work", []string{"codex"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data := fs.Files["/work/.codex/hooks.json"]
+	if bytes.Contains(data, []byte(`\u0026`)) {
+		t.Fatalf("codex hook escaped command operator:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte(` && gc prime`)) {
+		t.Fatalf("codex hook missing literal command operator:\n%s", data)
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Fatalf("codex hook missing trailing newline:\n%s", data)
+	}
+}
+
 func TestInstallIdempotent(t *testing.T) {
 	fs := fsys.NewFake()
 	// Pre-populate with a legacy hook file that carries a custom key. Under

--- a/internal/overlay/merge.go
+++ b/internal/overlay/merge.go
@@ -2,6 +2,7 @@
 package overlay
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -63,12 +64,35 @@ func MergeSettingsJSON(base, overlay []byte) ([]byte, error) {
 		}
 	}
 
-	out, err := json.MarshalIndent(result, "", "  ")
+	out, err := MarshalCanonicalJSON(result)
 	if err != nil {
 		return nil, fmt.Errorf("merge: marshaling result: %w", err)
 	}
-	out = append(out, '\n')
 	return out, nil
+}
+
+// CanonicalJSON parses and re-emits a JSON document with stable formatting.
+func CanonicalJSON(data []byte) ([]byte, error) {
+	var doc any
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&doc); err != nil {
+		return nil, err
+	}
+	return MarshalCanonicalJSON(doc)
+}
+
+// MarshalCanonicalJSON emits JSON with deterministic indentation, no HTML
+// escaping, and a trailing newline.
+func MarshalCanonicalJSON(doc any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // mergeHooksMap unions hook categories from base and overlay.

--- a/internal/overlay/merge_test.go
+++ b/internal/overlay/merge_test.go
@@ -1,6 +1,7 @@
 package overlay
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -58,6 +59,23 @@ func TestMergeSettingsJSON_UnionHookCategories(t *testing.T) {
 		if _, ok := hooks[cat]; !ok {
 			t.Errorf("missing hook category %q after merge", cat)
 		}
+	}
+}
+
+func TestMergeSettingsJSON_CanonicalizesCommandsWithoutHTMLEscaping(t *testing.T) {
+	base := `{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"export PATH=\"$HOME/bin:$PATH\" && gc prime"}]}]}}`
+	over := `{}`
+
+	result, err := MergeSettingsJSON([]byte(base), []byte(over))
+	if err != nil {
+		t.Fatalf("MergeSettingsJSON: %v", err)
+	}
+
+	if bytes.Contains(result, []byte(`\u0026`)) {
+		t.Fatalf("merged JSON escaped command operator:\n%s", result)
+	}
+	if !bytes.Contains(result, []byte(` && gc prime`)) {
+		t.Fatalf("merged JSON missing literal command operator:\n%s", result)
 	}
 }
 

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -4,6 +4,7 @@ package overlay
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -253,16 +254,17 @@ func copyOrMergeFile(src, dst string, merge bool) error {
 	// Only merge if destination already exists.
 	dstInfo, dstErr := os.Stat(dst)
 	if dstErr != nil {
-		// Destination doesn't exist or can't be stat'd — plain copy.
-		return copyFile(src, dst)
+		// Destination doesn't exist or can't be stat'd — canonicalize the
+		// mergeable source JSON before creating it.
+		return copyCanonicalJSONFile(src, dst, 0)
 	}
 	dstData, err := os.ReadFile(dst)
 	if err != nil {
-		return copyFile(src, dst)
+		return copyCanonicalJSONFile(src, dst, 0)
 	}
 	srcData, err := os.ReadFile(src)
 	if err != nil {
-		return copyFile(src, dst)
+		return copyCanonicalJSONFile(src, dst, 0)
 	}
 	merged, err := MergeSettingsJSON(dstData, srcData)
 	if err != nil {
@@ -275,6 +277,28 @@ func copyOrMergeFile(src, dst string, merge bool) error {
 	}
 	// Preserve the destination file's permissions.
 	return os.WriteFile(dst, merged, dstInfo.Mode().Perm())
+}
+
+func copyCanonicalJSONFile(src, dst string, mode fs.FileMode) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return copyFile(src, dst)
+	}
+	canonical, err := CanonicalJSON(data)
+	if err != nil {
+		return copyFile(src, dst)
+	}
+	if mode == 0 {
+		info, err := os.Stat(src)
+		if err != nil {
+			return copyFile(src, dst)
+		}
+		mode = info.Mode()
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("creating parent for %q: %w", dst, err)
+	}
+	return os.WriteFile(dst, canonical, mode.Perm())
 }
 
 // copyFile copies a single file preserving permissions.

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -313,7 +313,43 @@ func TestCopyDir_MergeableNewFile(t *testing.T) {
 		t.Fatalf("CopyDir: %v", err)
 	}
 
-	assertFileContent(t, filepath.Join(dst, ".claude", "settings.json"), overJSON)
+	data, err := os.ReadFile(filepath.Join(dst, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("reading copied settings: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal copied settings: %v", err)
+	}
+	if !bytes.Contains(data, []byte("\n  ")) {
+		t.Fatalf("copied mergeable JSON was not canonicalized:\n%s", data)
+	}
+}
+
+func TestCopyDir_MergeableNewFileCanonicalizesJSON(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	writeFile(t, filepath.Join(src, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"gc prime && gc hook"}]}]}}`)
+
+	var stderr bytes.Buffer
+	if err := CopyDir(src, dst, &stderr); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dst, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("reading copied hooks: %v", err)
+	}
+	if bytes.Contains(data, []byte(`\u0026`)) {
+		t.Fatalf("copied mergeable JSON escaped command operator:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte("\n  ")) {
+		t.Fatalf("copied mergeable JSON was not pretty canonicalized:\n%s", data)
+	}
+	if !bytes.HasSuffix(data, []byte("\n")) {
+		t.Fatalf("copied mergeable JSON missing trailing newline:\n%s", data)
+	}
 }
 
 func TestCopyDir_MergeInvalidJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- canonicalize managed provider JSON before writing copied, merged, installed, or upgraded hook/settings files
- preserve semantic JSON while making bytes deterministic with stable indentation, no HTML escaping, and trailing newlines
- add coverage for equivalent hook/settings JSON that previously drifted due to formatting or escaped shell commands

## RCA
Fingerprint drift storms were coming from managed provider JSON paths such as .codex/hooks.json and .gemini/settings.json being written through different code paths with different byte encodings. Equivalent JSON could hash differently because some paths copied raw/minified JSON while others used json.MarshalIndent, which also HTML-escaped shell operators like && into \u0026\u0026. The content hash is byte-based, so those semantically equivalent files looked like real drift.

## Tests
- go test ./internal/overlay ./internal/hooks
- commit hook ran the full fast Go gate before the integrated-branch commit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->