### PR TITLE
Speed up local golangci-lint flow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,7 @@ if [ -n "$staged_go_files" ]; then
   golangci-lint fmt ./... 2>/dev/null
   echo "$staged_go_files" | xargs git add
 
-  golangci-lint run --new-from-rev=HEAD --fix || exit 1
+  make lint-changed LINT_CHANGED_SCOPE=staged LINT_FLAGS="--new-from-rev=HEAD --whole-files --fix" || exit 1
   echo "$staged_go_files" | xargs git add
 
   # Regenerate the OpenAPI spec from the live Huma API and stage both
@@ -32,7 +32,6 @@ if [ -n "$staged_go_files" ]; then
   go run ./cmd/genschema
   git add docs/schema/city-schema.json docs/schema/city-schema.txt docs/reference/config.md docs/reference/cli.md
 
-  make lint
   make vet
   make test
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,16 @@ jobs:
           install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
+      - name: Restore golangci-lint cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml', 'Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-
       - name: Lint
+        env:
+          GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
         run: make lint
       - name: Format
         run: make fmt-check

--- a/.github/workflows/mac-regression.yml
+++ b/.github/workflows/mac-regression.yml
@@ -108,7 +108,16 @@ jobs:
           install-claude-cli: "false"
       - name: Install tools
         run: make install-tools
+      - name: Restore golangci-lint cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml', 'Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-
       - name: Lint
+        env:
+          GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
         run: make lint
       - name: Format
         run: make fmt-check

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.commit=$(COMMIT) \
            -X main.date=$(BUILD_TIME)
 
-.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
+.PHONY: build check check-all check-bd check-docker check-docs check-dolt check-version-tag lint lint-full lint-new lint-changed fmt-check fmt vet test test-fast-parallel test-fsys-darwin-compile test-cmd-gc-process test-cmd-gc-process-shard test-cmd-gc-process-parallel test-worker-core test-worker-core-phase2 test-worker-core-phase2-real-transport setup-worker-inference test-worker-inference test-worker-inference-phase3 test-acceptance test-acceptance-b test-acceptance-c test-acceptance-all test-tutorial-goldens test-tutorial-regression test-tutorial test-integration test-integration-shards test-integration-shards-parallel test-integration-shards-cover test-integration-packages test-integration-packages-cover test-integration-review-formulas test-integration-review-formulas-cover test-integration-review-formulas-basic test-integration-review-formulas-basic-cover test-integration-review-formulas-retries test-integration-review-formulas-retries-cover test-integration-review-formulas-recovery test-integration-review-formulas-recovery-cover test-integration-bdstore test-integration-bdstore-cover test-integration-rest test-integration-rest-cover test-integration-rest-smoke test-integration-rest-smoke-cover test-integration-rest-full test-integration-rest-full-cover test-local-full-parallel test-mcp-mail test-docker test-k8s test-cover cover install install-tools install-buildx setup clean generate check-schema docker-base docker-agent docker-controller docs-dev dashboard-smoke
 
 ## build: compile gc binary with version metadata
 build:
@@ -108,9 +108,57 @@ check-version-tag:
 ## check-all: run all quality gates including integration tests (CI)
 check-all: fmt-check lint vet check-bd check-dolt check-docker test-integration check-docs
 
-## lint: run golangci-lint
-lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run ./...
+LINT_BASE ?= origin/main
+LINT_CHANGED_REF ?= HEAD
+LINT_CHANGED_SCOPE ?= worktree
+LINT_FLAGS ?=
+
+## lint: run full-repo golangci-lint
+lint: lint-full
+
+## lint-full: run golangci-lint across all packages
+lint-full: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run $(LINT_FLAGS) ./...
+
+## lint-new: run golangci-lint for issues introduced since LINT_BASE
+lint-new: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run $(LINT_FLAGS) --new-from-merge-base=$(LINT_BASE) --whole-files ./...
+
+## lint-changed: run golangci-lint only for packages touched by changed Go files
+lint-changed: $(GOLANGCI_LINT)
+	@case "$(LINT_CHANGED_SCOPE)" in \
+		staged) \
+			files="$$(git diff --cached --name-only --diff-filter=ACMRT -- '*.go')"; \
+			;; \
+		tracked) \
+			files="$$(git diff --name-only --diff-filter=ACMRT "$(LINT_CHANGED_REF)" -- '*.go')"; \
+			;; \
+		worktree) \
+			files="$$( \
+				git diff --name-only --diff-filter=ACMRT "$(LINT_CHANGED_REF)" -- '*.go'; \
+				git diff --cached --name-only --diff-filter=ACMRT -- '*.go'; \
+				git ls-files --others --exclude-standard -- '*.go'; \
+			)"; \
+			;; \
+		*) \
+			echo "unknown LINT_CHANGED_SCOPE=$(LINT_CHANGED_SCOPE); expected staged, tracked, or worktree" >&2; \
+			exit 2; \
+			;; \
+	esac; \
+	if [ -z "$$files" ]; then \
+		echo "lint-changed: no changed Go files"; \
+		exit 0; \
+	fi; \
+	pkgs="$$(printf '%s\n' "$$files" | sed '/^$$/d' | sort -u | while IFS= read -r file; do dirname "$$file"; done | sort -u | while IFS= read -r dir; do \
+		if [ "$$dir" = "." ]; then pkg="."; else pkg="./$$dir"; fi; \
+		if go list "$$pkg" >/dev/null 2>&1; then printf '%s\n' "$$pkg"; fi; \
+	done | sort -u)"; \
+	if [ -z "$$pkgs" ]; then \
+		echo "lint-changed: no lintable Go packages"; \
+		exit 0; \
+	fi; \
+	echo "lint-changed: $$(printf '%s\n' "$$pkgs" | tr '\n' ' ')"; \
+	$(GOLANGCI_LINT) run $(LINT_FLAGS) $$pkgs
 
 ## fmt-check: fail if formatting would change files
 fmt-check: $(GOLANGCI_LINT)


### PR DESCRIPTION
## Summary

- add `lint-full`, `lint-new`, and `lint-changed` Makefile targets while keeping `make lint` as the full-repo lint target
- switch the pre-commit hook from full-repo lint to changed-package lint for staged Go files
- cache the golangci-lint run cache in Linux and macOS CI lint steps while preserving full CI lint coverage

## Verification

- `make lint-changed`
- `GOLANGCI_LINT_CACHE=/data/tmp/golangci-lint-cache-fast-flow make lint`
- `GOLANGCI_LINT_CACHE=/data/tmp/golangci-lint-cache-fast-flow make lint-new`
- `make lint-changed LINT_CHANGED_SCOPE=staged LINT_FLAGS="--new-from-rev=HEAD --whole-files --fix"`
- `make fmt-check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml .github/workflows/mac-regression.yml`
- `make test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->