### PR TITLE
Fix Dolt lifecycle parity gaps from Gastown

### DIFF
--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -7698,6 +7698,72 @@ func TestGcBeadsBdStopUsesGCBinStopManagedHelperWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestGcBeadsBdStopDrainsConnectionsBeforeSignal(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks: %v", err)
+	}
+	scriptData, err := os.ReadFile(gcBeadsBdScriptPath(cityPath))
+	if err != nil {
+		t.Fatalf("ReadFile(gc-beads-bd): %v", err)
+	}
+	prelude, _, ok := strings.Cut(string(scriptData), "# --- Main ---")
+	if !ok {
+		t.Fatal("gc-beads-bd script missing main marker")
+	}
+
+	logPath := filepath.Join(t.TempDir(), "stop.log")
+	harness := filepath.Join(t.TempDir(), "stop-drain.sh")
+	body := prelude + `
+GC_BIN=""
+GC_DOLT_HOST=""
+DOLT_PORT=3311
+DOLT_USER=root
+PID_FILE=/tmp/gc-test-pid
+load_stop_managed_from_gc() { return 1; }
+load_managed_process_inspection_from_gc() { return 1; }
+find_dolt_pid() { printf '424242\n'; }
+verify_our_server() { return 0; }
+get_connection_count() {
+  printf 'connection_count\n' >> "$GC_TEST_LOG"
+  if [ ! -f "$GC_TEST_LOG.counted" ]; then
+    : > "$GC_TEST_LOG.counted"
+    printf '2\n'
+  else
+    printf '1\n'
+  fi
+}
+kill() {
+  printf 'kill %s\n' "$*" >> "$GC_TEST_LOG"
+  if [ "$1" = "-0" ]; then return 1; fi
+  return 0
+}
+save_state() { printf 'save_state %s %s\n' "$1" "$2" >> "$GC_TEST_LOG"; }
+sleep() { :; }
+op_stop_impl
+`
+	if err := os.WriteFile(harness, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sh", harness)
+	cmd.Env = sanitizedBaseEnv("GC_TEST_LOG=" + logPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("op_stop_impl harness failed: %v\n%s", err, out)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(log): %v", err)
+	}
+	log := string(data)
+	drainIndex := strings.Index(log, "connection_count")
+	killIndex := strings.Index(log, "kill 424242")
+	if drainIndex < 0 || killIndex < 0 || drainIndex > killIndex {
+		t.Fatalf("stop did not drain connections before SIGTERM; log:\n%s", log)
+	}
+}
+
 func TestGcBeadsBdRecoverUsesGCBinRecoverManagedHelperWhenAvailable(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/cmd/gc/cmd_dolt_config.go
+++ b/cmd/gc/cmd_dolt_config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/spf13/cobra"
@@ -118,6 +119,11 @@ func writeManagedDoltConfigFile(path, host, port, dataDir, logLevel string, arch
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
+	waitTimeout := managedDoltWaitTimeout()
+	waitTimeoutLine := ""
+	if waitTimeout > 0 {
+		waitTimeoutLine = fmt.Sprintf("  wait_timeout: %q\n", strconv.Itoa(waitTimeout))
+	}
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by gc-beads-bd
 # Do not edit manually; changes are overwritten on each server start.
 # To customize, set environment variables:
@@ -152,9 +158,25 @@ system_variables:
   dolt_stats_gc_enabled: "OFF"
   dolt_stats_memory_only: "ON"
   dolt_stats_paused: "ON"
-`, logLevel, port, host, dataDir, archiveLevel)
+%s`, logLevel, port, host, dataDir, archiveLevel, waitTimeoutLine)
 	if err := fsys.WriteFileAtomic(fsys.OSFS{}, path, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write config file: %w", err)
 	}
 	return nil
+}
+
+func managedDoltWaitTimeout() int {
+	const defaultWaitTimeout = 30
+	raw := os.Getenv("GC_DOLT_WAIT_TIMEOUT")
+	if raw == "" {
+		return defaultWaitTimeout
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultWaitTimeout
+	}
+	if n < 0 {
+		return 0
+	}
+	return n
 }

--- a/cmd/gc/cmd_dolt_config_test.go
+++ b/cmd/gc/cmd_dolt_config_test.go
@@ -45,6 +45,7 @@ func TestDoltConfigWriteManagedCmd(t *testing.T) {
 		`dolt_stats_gc_enabled: "OFF"`,
 		`dolt_stats_memory_only: "ON"`,
 		`dolt_stats_paused: "ON"`,
+		`wait_timeout: "30"`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("config missing %q:\n%s", want, text)
@@ -152,6 +153,21 @@ func TestWriteManagedDoltConfigFile_DefaultLogLevel(t *testing.T) {
 	text := string(data)
 	if !strings.Contains(text, "log_level: warning") {
 		t.Fatalf("empty logLevel should default to warning, got:\n%s", text)
+	}
+}
+
+func TestWriteManagedDoltConfigFile_WaitTimeoutCanBeDisabled(t *testing.T) {
+	t.Setenv("GC_DOLT_WAIT_TIMEOUT", "-1")
+	configPath := filepath.Join(t.TempDir(), "packs", "dolt", "dolt-config.yaml")
+	if err := writeManagedDoltConfigFile(configPath, "127.0.0.1", "3311", "/tmp/dolt-data", "", 0); err != nil {
+		t.Fatalf("writeManagedDoltConfigFile: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "wait_timeout") {
+		t.Fatalf("negative GC_DOLT_WAIT_TIMEOUT should disable wait_timeout override:\n%s", data)
 	}
 }
 

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1092,6 +1092,23 @@ get_connection_count() {
     echo "$output" | tail -1 | tr -d '[:space:]'
 }
 
+# drain_connections_before_stop waits briefly for in-flight SQL work to leave
+# before SIGTERM. It is best-effort: an unreachable or wedged server should not
+# block explicit stop/recover forever.
+drain_connections_before_stop() {
+    local count waited
+    waited=0
+    while [ "$waited" -lt 100 ]; do
+        count=$(get_connection_count 2>/dev/null) || return 0
+        case "$count" in
+            ''|*[!0-9]*) return 0 ;;
+        esac
+        [ "$count" -le 1 ] && return 0
+        sleep 0.1 2>/dev/null || sleep 1
+        waited=$((waited + 1))
+    done
+}
+
 # check_read_only tests if the dolt server is in read-only mode.
 # Returns 0 if read-only, 1 if writable, 2 if the write probe is inconclusive.
 check_read_only() {
@@ -2413,6 +2430,8 @@ op_stop_impl() {
         return 0
     fi
     GC_STOP_HAD_PID="true"
+
+    drain_connections_before_stop
 
     # SIGTERM and wait (10 × 500ms = 5s grace, matches upstream).
     kill "$pid" 2>/dev/null || true

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1022,7 +1022,7 @@ cleanup_stale_locks() {
 # Overwritten on each server start. Without read/write timeouts, CLOSE_WAIT connections
 # accumulate and the server enters unrecoverable read-only mode.
 write_config_yaml() {
-    local archive_level gc_bin
+    local archive_level gc_bin wait_timeout_line
     archive_level=${GC_DOLT_ARCHIVE_LEVEL:-0}
     case "$archive_level" in
         ''|*[!0-9]*)
@@ -1040,6 +1040,13 @@ write_config_yaml() {
             --archive-level "$archive_level" || die "failed to write managed dolt config via gc helper $gc_bin"
         return 0
     fi
+    wait_timeout_line='  wait_timeout: "30"'
+    case "${GC_DOLT_WAIT_TIMEOUT:-}" in
+        -*) wait_timeout_line="" ;;
+        '' ) ;;
+        *[!0-9]* ) ;;
+        * ) wait_timeout_line="  wait_timeout: \"${GC_DOLT_WAIT_TIMEOUT}\"" ;;
+    esac
     local tmp
     tmp=$(mktemp "$CONFIG_FILE.tmp.XXXXXX")
     cat > "$tmp" <<YAML
@@ -1077,6 +1084,7 @@ system_variables:
   dolt_stats_gc_enabled: "OFF"
   dolt_stats_memory_only: "ON"
   dolt_stats_paused: "ON"
+$wait_timeout_line
 YAML
     mv "$tmp" "$CONFIG_FILE"
 }

--- a/examples/dolt/commands/health-check/command.toml
+++ b/examples/dolt/commands/health-check/command.toml
@@ -1,0 +1,1 @@
+description = "Fail when a Dolt health JSON report contains critical failures"

--- a/examples/dolt/commands/health-check/run.sh
+++ b/examples/dolt/commands/health-check/run.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# gc dolt health-check — Parse `gc dolt health --json` for order outcomes.
+#
+# Reads a health JSON report from stdin, echoes it to stdout for diagnostics,
+# and exits nonzero with a concise stderr message for critical data-plane
+# failures. This lets the generic order runner record `order.failed` with a
+# useful message without making `gc dolt health --json` itself fail before
+# programmatic consumers can parse the report.
+set -e
+
+report=$(cat)
+printf '%s\n' "$report"
+
+json_field() {
+  field="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$report" | jq -r "if $field == null then \"\" else $field end" 2>/dev/null || true
+    return
+  fi
+  key=$(printf '%s' "$field" | sed 's/^\.server\.//')
+  printf '%s\n' "$report" \
+    | sed -n "/\"server\"[[:space:]]*:/,/}/p" \
+    | sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\\([^,}]*\\).*/\\1/p" \
+    | head -1 \
+    | tr -d ' "'
+}
+
+reachable=$(json_field ".server.reachable")
+running=$(json_field ".server.running")
+pid=$(json_field ".server.pid")
+port=$(json_field ".server.port")
+latency=$(json_field ".server.latency_ms")
+
+case "$reachable" in
+  true) exit 0 ;;
+  false)
+    echo "Dolt server unreachable: running=${running:-unknown} pid=${pid:-0} port=${port:-unknown} latency_ms=${latency:-0}" >&2
+    exit 1
+    ;;
+  *)
+    echo "Dolt health report missing server.reachable" >&2
+    exit 1
+    ;;
+esac

--- a/examples/dolt/commands/pull/command.toml
+++ b/examples/dolt/commands/pull/command.toml
@@ -1,0 +1,1 @@
+description = "Pull databases from configured remotes"

--- a/examples/dolt/commands/pull/run.sh
+++ b/examples/dolt/commands/pull/run.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# gc dolt pull — Pull Dolt databases from their configured remotes.
+#
+# Uses the live Dolt SQL server when reachable so pull does not contend with
+# active databases. Falls back to CLI mode only when no server is running.
+#
+# Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD
+set -e
+
+: "${GC_DOLT_USER:=root}"
+PACK_DIR="${GC_PACK_DIR:-$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)}"
+. "$PACK_DIR/assets/scripts/runtime.sh"
+
+db_filter=""
+data_dir="$DOLT_DATA_DIR"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --db) db_filter="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: gc dolt pull [--db NAME]"
+      echo ""
+      echo "Pull Dolt databases from their configured remotes."
+      echo ""
+      echo "Flags:"
+      echo "  --db NAME   Pull only the named database"
+      exit 0
+      ;;
+    *) echo "gc dolt pull: unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+case "$(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')" in
+  information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe)
+  echo "gc dolt pull: reserved Dolt database name: $(printf '%s' "$db_filter" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//') (used internally by Dolt or gc)" >&2
+  exit 1
+  ;;
+esac
+
+is_running() {
+  managed_runtime_tcp_reachable "$GC_DOLT_PORT"
+}
+
+valid_database_name() {
+  case "$1" in
+    [A-Za-z0-9_]*)
+      case "$1" in *[!A-Za-z0-9_-]*) return 1 ;; *) return 0 ;; esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+valid_remote_name() {
+  case "$1" in
+    [A-Za-z0-9_.-]*)
+      case "$1" in *[!A-Za-z0-9_.-]*) return 1 ;; *) return 0 ;; esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+dolt_sql() {
+  query="$1"
+  host="${GC_DOLT_HOST:-127.0.0.1}"
+  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
+  run_bounded 120 dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
+    sql --result-format csv -q "$query"
+}
+
+find_remote_sql() {
+  db="$1"
+  dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1" \
+    | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
+}
+
+pull_database_sql() {
+  name="$1"
+  if ! valid_database_name "$name"; then
+    echo "  $name: ERROR: invalid database name" >&2
+    return 1
+  fi
+
+  remote_pair=$(find_remote_sql "$name") || {
+    echo "  $name: ERROR: failed to query remotes" >&2
+    return 1
+  }
+  if [ -z "$remote_pair" ]; then
+    echo "  $name: skipped (no remote)"
+    return 0
+  fi
+  remote_name=${remote_pair%%|*}
+  remote_url=${remote_pair#*|}
+  if ! valid_remote_name "$remote_name"; then
+    echo "  $name: ERROR: invalid remote name: $remote_name" >&2
+    return 1
+  fi
+
+  if dolt_sql "USE \`$name\`; CALL DOLT_PULL('$remote_name')" >/dev/null 2>&1; then
+    echo "  $name: pulled from $remote_url"
+    return 0
+  fi
+
+  echo "  $name: ERROR: pull failed" >&2
+  return 1
+}
+
+pull_database_cli() {
+  d="$1"
+  name="$2"
+
+  remote_name=""
+  remote_url=""
+  if [ -f "$d/.dolt/remotes.json" ]; then
+    remote_name=$(grep -o '"name":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"name":"//;s/"//' || true)
+    remote_url=$(grep -o '"url":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"url":"//;s/"//' || true)
+  fi
+  [ -z "$remote_name" ] && remote_name="origin"
+
+  if [ -z "$remote_url" ]; then
+    echo "  $name: skipped (no remote)"
+    return 0
+  fi
+  if ! valid_remote_name "$remote_name"; then
+    echo "  $name: ERROR: invalid remote name: $remote_name" >&2
+    return 1
+  fi
+
+  if (cd "$d" && dolt pull "$remote_name" main 2>&1); then
+    echo "  $name: pulled from $remote_url"
+    return 0
+  fi
+
+  echo "  $name: ERROR: pull failed" >&2
+  return 1
+}
+
+exit_code=0
+server_running=false
+is_running && server_running=true
+if [ -d "$data_dir" ]; then
+  for d in "$data_dir"/*/; do
+    [ ! -d "$d/.dolt" ] && continue
+    name="$(basename "$d")"
+    case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
+    [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
+    if [ -f "$d/.no-sync" ]; then
+      echo "  $name: skipped (.no-sync)"
+      continue
+    fi
+
+    if [ "$server_running" = true ]; then
+      pull_database_sql "$name" || exit_code=1
+    else
+      pull_database_cli "$d" "$name" || exit_code=1
+    fi
+  done
+fi
+
+exit $exit_code

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -225,6 +225,10 @@ if [ -d "$data_dir" ]; then
     name="$(basename "$d")"
     case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
+    if [ -f "$d/.no-sync" ]; then
+      echo "  $name: skipped (.no-sync)"
+      continue
+    fi
 
     if [ "$server_running" = true ]; then
       sync_database_sql "$name" || exit_code=1

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # gc dolt sync — Push Dolt databases to their configured remotes.
 #
-# Stops the server for a clean push, syncs each database, then restarts.
+# Uses the live Dolt SQL server when reachable so sync does not restart
+# active databases. Falls back to CLI mode only when no server is running.
 # Use --gc to purge closed ephemeral beads before syncing.
 # Use --dry-run to preview without pushing.
 #
@@ -79,6 +80,114 @@ routes_files() {
   find "$GC_CITY_PATH/rigs" -path '*/.beads/routes.jsonl' 2>/dev/null || true
 }
 
+valid_database_name() {
+  case "$1" in
+    [A-Za-z0-9_]*)
+      case "$1" in *[!A-Za-z0-9_-]*) return 1 ;; *) return 0 ;; esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+valid_remote_name() {
+  case "$1" in
+    [A-Za-z0-9_.-]*)
+      case "$1" in *[!A-Za-z0-9_.-]*) return 1 ;; *) return 0 ;; esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+dolt_sql() {
+  query="$1"
+  host="${GC_DOLT_HOST:-127.0.0.1}"
+  export DOLT_CLI_PASSWORD="${GC_DOLT_PASSWORD:-}"
+  run_bounded 120 dolt --host "$host" --port "$GC_DOLT_PORT" --user "$GC_DOLT_USER" --no-tls \
+    sql --result-format csv -q "$query"
+}
+
+find_remote_sql() {
+  db="$1"
+  dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1" \
+    | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
+}
+
+sync_database_sql() {
+  name="$1"
+  if ! valid_database_name "$name"; then
+    echo "  $name: ERROR: invalid database name" >&2
+    return 1
+  fi
+
+  remote_pair=$(find_remote_sql "$name") || {
+    echo "  $name: ERROR: failed to query remotes" >&2
+    return 1
+  }
+  if [ -z "$remote_pair" ]; then
+    echo "  $name: skipped (no remote)"
+    return 0
+  fi
+  remote_name=${remote_pair%%|*}
+  remote_url=${remote_pair#*|}
+  if ! valid_remote_name "$remote_name"; then
+    echo "  $name: ERROR: invalid remote name: $remote_name" >&2
+    return 1
+  fi
+
+  if [ "$dry_run" = true ]; then
+    echo "  $name: would push to $remote_url"
+    return 0
+  fi
+
+  dolt_sql "USE \`$name\`; CALL DOLT_ADD('-A')" >/dev/null 2>&1 || true
+  dolt_sql "USE \`$name\`; CALL DOLT_COMMIT('-m', 'gc dolt sync: auto-commit working changes', '--allow-empty', '--author', 'Gas City Sync <sync@gascity.local>')" >/dev/null 2>&1 || true
+
+  if [ "$force" = true ]; then
+    push_query="USE \`$name\`; CALL DOLT_PUSH('--force', '$remote_name', 'main')"
+  else
+    push_query="USE \`$name\`; CALL DOLT_PUSH('$remote_name', 'main')"
+  fi
+  if dolt_sql "$push_query" >/dev/null 2>&1; then
+    echo "  $name: pushed to $remote_url"
+    return 0
+  fi
+
+  echo "  $name: ERROR: push failed" >&2
+  return 1
+}
+
+sync_database_cli() {
+  d="$1"
+  name="$2"
+
+  # Check for remote.
+  remote=""
+  if [ -f "$d/.dolt/remotes.json" ]; then
+    remote=$(grep -o '"url":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"url":"//;s/"//' || true)
+  fi
+
+  if [ -z "$remote" ]; then
+    echo "  $name: skipped (no remote)"
+    return 0
+  fi
+
+  if [ "$dry_run" = true ]; then
+    echo "  $name: would push to $remote"
+    return 0
+  fi
+
+  push_args="push"
+  [ "$force" = true ] && push_args="push --force"
+
+  if (cd "$d" && dolt $push_args 2>&1); then
+    echo "  $name: pushed to $remote"
+    return 0
+  fi
+
+  echo "  $name: ERROR: push failed" >&2
+  return 1
+}
+
 # Optional GC phase: purge closed ephemerals while server is still up.
 if [ "$do_gc" = true ] && [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
@@ -106,18 +215,10 @@ ROUTES_LIST
   done
 fi
 
-# Stop server for clean push.
-was_running=false
-if is_running; then
-  was_running=true
-  if [ "$dry_run" = false ] && [ -x "$beads_bd" ]; then
-    "$beads_bd" stop 2>/dev/null || true
-    "$beads_bd" shutdown 2>/dev/null || true
-  fi
-fi
-
 # Sync each database.
 exit_code=0
+server_running=false
+is_running && server_running=true
 if [ -d "$data_dir" ]; then
   for d in "$data_dir"/*/; do
     [ ! -d "$d/.dolt" ] && continue
@@ -125,38 +226,12 @@ if [ -d "$data_dir" ]; then
     case "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" in information_schema|mysql|dolt_cluster|performance_schema|sys|__gc_probe) continue ;; esac
     [ -n "$db_filter" ] && [ "$name" != "$db_filter" ] && continue
 
-    # Check for remote.
-    remote=""
-    if [ -f "$d/.dolt/remotes.json" ]; then
-      remote=$(grep -o '"url":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"url":"//;s/"//' || true)
-    fi
-
-    if [ -z "$remote" ]; then
-      echo "  $name: skipped (no remote)"
-      continue
-    fi
-
-    if [ "$dry_run" = true ]; then
-      echo "  $name: would push to $remote"
-      continue
-    fi
-
-    push_args="push"
-    [ "$force" = true ] && push_args="push --force"
-
-    if (cd "$d" && dolt $push_args 2>&1); then
-      echo "  $name: pushed to $remote"
+    if [ "$server_running" = true ]; then
+      sync_database_sql "$name" || exit_code=1
     else
-      echo "  $name: ERROR: push failed" >&2
-      exit_code=1
+      sync_database_cli "$d" "$name" || exit_code=1
     fi
   done
-fi
-
-# Restart server if it was running.
-if [ "$was_running" = true ] && [ "$dry_run" = false ] && [ -x "$beads_bd" ]; then
-  "$beads_bd" start 2>/dev/null || true
-  "$beads_bd" ensure-ready 2>/dev/null || true
 fi
 
 exit $exit_code

--- a/examples/dolt/formulas/mol-dolt-health.toml
+++ b/examples/dolt/formulas/mol-dolt-health.toml
@@ -1,28 +1,26 @@
 description = """
-Check dolt server health and restart on failure.
+Check dolt server health.
 
 This is an **order formula** — dispatched by the order system on a cooldown
 trigger (default: 30s, matching gastown). Configured in
 `orders/dolt-health.toml`.
 
-Detects dolt crashes via status check and restarts the server if needed."""
+Runs the structured health check so patrol can surface server reachability,
+latency, backup freshness, orphan databases, and zombie processes without
+mutating the Dolt lifecycle on a transient status failure."""
 formula = "mol-dolt-health"
 version = 1
 
 [[steps]]
 id = "check"
-title = "Check dolt health and restart if needed"
+title = "Check dolt health"
 description = """
-Check dolt server status and restart if it has crashed:
+Run the structured Dolt health check:
 
 ```bash
-gc dolt status
+gc dolt health --json
 ```
 
-If the server is not running:
-
-```bash
-gc dolt start
-```
-
-Close this step after the health check completes (even if no restart was needed)."""
+Close this step after the health check completes. Health state is signaled in
+the JSON payload; lifecycle actions should be explicit follow-up work, not a
+hidden side effect of the cooldown order."""

--- a/examples/dolt/formulas/mol-dolt-health.toml
+++ b/examples/dolt/formulas/mol-dolt-health.toml
@@ -15,12 +15,13 @@ version = 1
 id = "check"
 title = "Check dolt health"
 description = """
-Run the structured Dolt health check:
+Run the structured Dolt health check through the order parser:
 
 ```bash
-gc dolt health --json
+gc dolt health --json | gc dolt health-check
 ```
 
-Close this step after the health check completes. Health state is signaled in
-the JSON payload; lifecycle actions should be explicit follow-up work, not a
-hidden side effect of the cooldown order."""
+Close this step after the health check completes. The parser fails the order
+with a concise message for critical data-plane failures such as
+`server.reachable=false`; lifecycle actions should be explicit follow-up work,
+not a hidden side effect of the cooldown order."""

--- a/examples/dolt/health_order_test.go
+++ b/examples/dolt/health_order_test.go
@@ -1,0 +1,27 @@
+package dolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoltHealthOrderIsDiagnosticOnly(t *testing.T) {
+	root := repoRoot(t)
+	orderPath := filepath.Join(root, "orders", "dolt-health.toml")
+	data, err := os.ReadFile(orderPath)
+	if err != nil {
+		t.Fatalf("read dolt-health order: %v", err)
+	}
+
+	text := string(data)
+	if !strings.Contains(text, `exec = "gc dolt health --json"`) {
+		t.Fatalf("dolt-health order should run bounded health JSON, got:\n%s", text)
+	}
+	for _, forbidden := range []string{"gc dolt start", "gc dolt status"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("dolt-health order must not call %q directly:\n%s", forbidden, text)
+		}
+	}
+}

--- a/examples/dolt/health_order_test.go
+++ b/examples/dolt/health_order_test.go
@@ -2,6 +2,7 @@ package dolt_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,12 +17,59 @@ func TestDoltHealthOrderIsDiagnosticOnly(t *testing.T) {
 	}
 
 	text := string(data)
-	if !strings.Contains(text, `exec = "gc dolt health --json"`) {
+	if !strings.Contains(text, `exec = "gc dolt health --json | gc dolt health-check"`) {
 		t.Fatalf("dolt-health order should run bounded health JSON, got:\n%s", text)
 	}
 	for _, forbidden := range []string{"gc dolt start", "gc dolt status"} {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("dolt-health order must not call %q directly:\n%s", forbidden, text)
 		}
+	}
+}
+
+func TestDoltHealthCheckFailsUnreachableReportWithUsefulMessage(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "commands", "health-check", "run.sh")
+	input := `{
+  "server": {
+    "running": true,
+    "reachable": false,
+    "pid": 123,
+    "port": 3311,
+    "latency_ms": 0
+  }
+}`
+
+	cmd := exec.Command("sh", script)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("health-check unexpectedly succeeded:\n%s", out)
+	}
+	for _, want := range []string{"Dolt server unreachable", "running=true", "pid=123", "port=3311"} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("health-check output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoltHealthCheckPassesReachableReport(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, "commands", "health-check", "run.sh")
+	input := `{
+  "server": {
+    "running": true,
+    "reachable": true,
+    "pid": 123,
+    "port": 3311,
+    "latency_ms": 12
+  }
+}`
+
+	cmd := exec.Command("sh", script)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health-check failed: %v\n%s", err, out)
 	}
 }

--- a/examples/dolt/orders/dolt-health.toml
+++ b/examples/dolt/orders/dolt-health.toml
@@ -1,5 +1,5 @@
 [order]
-description = "Check dolt server health and restart on failure"
+description = "Check dolt server health"
 trigger = "cooldown"
 interval = "30s"
-exec = "gc dolt status >/dev/null 2>&1 || gc dolt start"
+exec = "gc dolt health --json"

--- a/examples/dolt/orders/dolt-health.toml
+++ b/examples/dolt/orders/dolt-health.toml
@@ -2,4 +2,4 @@
 description = "Check dolt server health"
 trigger = "cooldown"
 interval = "30s"
-exec = "gc dolt health --json"
+exec = "gc dolt health --json | gc dolt health-check"

--- a/examples/dolt/pull_test.go
+++ b/examples/dolt/pull_test.go
@@ -1,0 +1,66 @@
+package dolt_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const pullScript = "commands/pull/run.sh"
+
+func TestPullUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, pullScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	bdLog := writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt pull failed: %v\n%s", err, out)
+	}
+
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("pull called gc-beads-bd while server was reachable: %q", data)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"SELECT name, url FROM dolt_remotes LIMIT 1",
+		"CALL DOLT_PULL('origin')",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("dolt log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
+	}
+}

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -1,0 +1,128 @@
+package dolt_test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const syncScript = "commands/sync/run.sh"
+
+func startReachableTCPListener(t *testing.T) (int, func()) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				close(done)
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	cleanup := func() {
+		_ = listener.Close()
+		<-done
+	}
+	return listener.Addr().(*net.TCPAddr).Port, cleanup
+}
+
+func writeSyncFakeDolt(t *testing.T, dir string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'name,url\norigin,https://example.invalid/repo\n'
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
+func writeSyncFakeBeadsBD(t *testing.T, cityPath string) string {
+	t.Helper()
+	scriptDir := filepath.Join(cityPath, ".gc", "system", "packs", "bd", "assets", "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bd dir: %v", err)
+	}
+	logPath := filepath.Join(cityPath, "bd.log")
+	body := `#!/bin/sh
+printf '%s\n' "$1" >> "` + logPath + `"
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(scriptDir, "gc-beads-bd.sh"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake bd script: %v", err)
+	}
+	return logPath
+}
+
+func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	bdLog := writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	if data, err := os.ReadFile(bdLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("sync called gc-beads-bd while server was reachable: %q", data)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"SELECT name, url FROM dolt_remotes LIMIT 1",
+		"CALL DOLT_ADD('-A')",
+		"CALL DOLT_COMMIT",
+		"CALL DOLT_PUSH('origin', 'main')",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("dolt log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
+	}
+}

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -126,3 +126,50 @@ func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 		}
 	}
 }
+
+func TestSyncSkipsDatabasesWithNoSyncMarker(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, ".no-sync"), []byte("skip\n"), 0o644); err != nil {
+		t.Fatalf("write no-sync marker: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	if data, err := os.ReadFile(doltLog); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("sync touched database with .no-sync marker: %q\noutput:\n%s", data, out)
+	}
+	if !strings.Contains(string(out), "app: skipped (.no-sync)") {
+		t.Fatalf("output missing .no-sync skip:\n%s", out)
+	}
+}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2399,6 +2399,7 @@ func DoltConfigExpectedValues() []DoltConfigExpectedValue {
 		{"system_variables.dolt_stats_gc_enabled", "OFF"},
 		{"system_variables.dolt_stats_memory_only", "ON"},
 		{"system_variables.dolt_stats_paused", "ON"},
+		{"system_variables.wait_timeout", "30"},
 		{"listener.read_timeout_millis", 300000},
 		{"listener.write_timeout_millis", 300000},
 		{"listener.max_connections", 1000},

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -2959,6 +2959,7 @@ func writeDoctorManagedDoltConfig(t *testing.T, cityPath string, overrides map[s
 			"dolt_stats_gc_enabled":  "OFF",
 			"dolt_stats_memory_only": "ON",
 			"dolt_stats_paused":      "ON",
+			"wait_timeout":           "30",
 		},
 	}
 	for k, v := range overrides {


### PR DESCRIPTION
## Summary
- sync remotes through the live Dolt SQL server instead of stopping/restarting active databases
- honor .no-sync markers and add a live-SQL gc dolt pull command
- make the dolt-health order diagnostic-only, drain SQL connections before stop, and clamp managed wait_timeout

## Tests
- go test ./examples/dolt -count=1
- go test ./cmd/gc -run 'TestDoltConfig|TestWriteManagedDoltConfigFile|TestGcBeadsBd(StopDrainsConnectionsBeforeSignal|StopUsesGCBinStopManagedHelperWhenAvailable|RecoverUsesGCBinRecoverManagedHelperWhenAvailable|.*Config)' -count=1
- go test ./internal/doctor -run DoltConfig -count=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->