### PR TITLE
fix(runtime): handle Claude resume selector

### DIFF
--- a/internal/runtime/dialog.go
+++ b/internal/runtime/dialog.go
@@ -30,10 +30,11 @@ func StartupDialogTimeout() time.Duration {
 
 // AcceptStartupDialogs dismisses startup dialogs that can block automated
 // sessions. Handles (in order):
-//  1. Codex update dialog ("Update available") — requires Down+Enter to skip
-//  2. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
-//  3. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
-//  4. Claude custom API key confirmation — requires Up+Enter to select "Yes"
+//  1. Claude resume selector — requires Down+Enter to resume the full session
+//  2. Codex update dialog ("Update available") — requires Down+Enter to skip
+//  3. Workspace trust dialog (Claude "Quick safety check", Codex "Do you trust the contents of this directory?")
+//  4. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
+//  5. Claude custom API key confirmation — requires Up+Enter to select "Yes"
 //
 // The peek function should return the last N lines of the session's terminal output.
 // The sendKeys function should send bare tmux-style keystrokes (e.g., "Enter", "Down").
@@ -76,7 +77,18 @@ func AcceptStartupDialogsFromStreamWithStatus(
 		return sendKeys(keys...)
 	}
 
-	phaseObserved, err := acceptCodexUpdateDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	phaseObserved, err := acceptClaudeResumeDialogFromStream(ctx, timeout, stream, trackingSendKeys)
+	if err != nil {
+		return observed, fmt.Errorf("claude resume dialog: %w", err)
+	}
+	observed = observed || phaseObserved
+	if !phaseObserved && !observed {
+		return false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return observed, err
+	}
+	phaseObserved, err = acceptCodexUpdateDialogFromStream(ctx, timeout, stream, trackingSendKeys)
 	if err != nil {
 		return observed, fmt.Errorf("codex update dialog: %w", err)
 	}
@@ -148,6 +160,12 @@ func AcceptStartupDialogsWithTimeout(
 	peek func(lines int) (string, error),
 	sendKeys func(keys ...string) error,
 ) error {
+	if err := acceptClaudeResumeDialog(ctx, timeout, peek, sendKeys); err != nil {
+		return fmt.Errorf("claude resume dialog: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := acceptCodexUpdateDialog(ctx, timeout, peek, sendKeys); err != nil {
 		return fmt.Errorf("codex update dialog: %w", err)
 	}
@@ -176,6 +194,78 @@ func AcceptStartupDialogsWithTimeout(
 		return fmt.Errorf("rate limit dialog: %w", err)
 	}
 	return nil
+}
+
+// acceptClaudeResumeDialog dismisses Claude's high-token/old-session resume
+// selector. The menu cursor uses the same ❯ prefix as the normal input prompt,
+// so this must run before generic prompt detection. Choose "Resume full session
+// as-is" to preserve the in-flight workflow context instead of summarizing it.
+func acceptClaudeResumeDialog(
+	ctx context.Context,
+	timeout time.Duration,
+	peek func(lines int) (string, error),
+	sendKeys func(keys ...string) error,
+) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		content, err := peek(startupDialogPeekLines)
+		if err != nil {
+			return err
+		}
+
+		if containsClaudeResumeDialog(content) {
+			if err := sendKeys("Down"); err != nil {
+				return err
+			}
+			sleep(ctx, bypassDialogConfirmDelay)
+			return sendKeys("Enter")
+		}
+
+		if containsPromptIndicator(content) ||
+			containsCodexUpdateDialog(content) ||
+			containsWorkspaceTrustDialog(content) ||
+			strings.Contains(content, "Bypass Permissions mode") ||
+			containsCustomAPIKeyDialog(content) ||
+			ContainsRateLimitDialog(content) {
+			return nil
+		}
+
+		sleep(ctx, dialogPollInterval)
+	}
+	return nil
+}
+
+func containsClaudeResumeDialog(content string) bool {
+	return strings.Contains(content, "Resume from summary") &&
+		strings.Contains(content, "Resume full session as-is") &&
+		strings.Contains(content, "Enter to confirm")
+}
+
+func acceptClaudeResumeDialogFromStream(
+	ctx context.Context,
+	timeout time.Duration,
+	snapshots *replayableSnapshotCursor,
+	sendKeys func(keys ...string) error,
+) (bool, error) {
+	return acceptDialogFromStream(ctx, timeout, snapshots, sendKeys, streamDialogSpec{
+		match:       containsClaudeResumeDialog,
+		matchKeys:   []string{"Down", "Enter"},
+		matchDelay:  bypassDialogConfirmDelay,
+		ready:       containsPromptIndicator,
+		readyOrNext: containsPostClaudeResumeStartupDialog,
+	})
+}
+
+func containsPostClaudeResumeStartupDialog(content string) bool {
+	return containsCodexUpdateDialog(content) ||
+		containsWorkspaceTrustDialog(content) ||
+		strings.Contains(content, "Bypass Permissions mode") ||
+		containsCustomAPIKeyDialog(content) ||
+		ContainsRateLimitDialog(content)
 }
 
 // acceptCodexUpdateDialog skips Codex's interactive update prompt. The default

--- a/internal/runtime/dialog_test.go
+++ b/internal/runtime/dialog_test.go
@@ -126,6 +126,74 @@ func TestAcceptStartupDialogsAcceptsGeminiTrustDialog(t *testing.T) {
 	}
 }
 
+func TestAcceptStartupDialogsSelectsClaudeResumeAsIs(t *testing.T) {
+	withZeroDialogTimings(t)
+	dialogPollTimeout = time.Second
+
+	var sent []string
+	err := AcceptStartupDialogs(
+		context.Background(),
+		func(_ int) (string, error) {
+			if len(sent) == 0 {
+				return strings.Join([]string{
+					"This session is 1h 55m old and 212.7k tokens.",
+					"",
+					"❯ 1. Resume from summary (recommended)",
+					"  2. Resume full session as-is",
+					"  3. Don't ask me again",
+					"",
+					"Enter to confirm · Esc to cancel",
+				}, "\n"), nil
+			}
+			return "❯ ", nil
+		},
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogs() error = %v", err)
+	}
+	if !reflect.DeepEqual(sent, []string{"Down", "Enter"}) {
+		t.Fatalf("sent keys = %v, want [Down Enter]", sent)
+	}
+}
+
+func TestAcceptStartupDialogsFromStreamSelectsClaudeResumeAsIs(t *testing.T) {
+	withZeroDialogTimings(t)
+
+	snapshots := make(chan string, 2)
+	snapshots <- strings.Join([]string{
+		"This session is 1h 55m old and 212.7k tokens.",
+		"",
+		"❯ 1. Resume from summary (recommended)",
+		"  2. Resume full session as-is",
+		"  3. Don't ask me again",
+		"",
+		"Enter to confirm · Esc to cancel",
+	}, "\n")
+	snapshots <- "❯ "
+	close(snapshots)
+
+	var sent []string
+	err := AcceptStartupDialogsFromStream(
+		context.Background(),
+		time.Second,
+		snapshots,
+		func(keys ...string) error {
+			sent = append(sent, keys...)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("AcceptStartupDialogsFromStream() error = %v", err)
+	}
+	if !reflect.DeepEqual(sent, []string{"Down", "Enter"}) {
+		t.Fatalf("sent keys = %v, want [Down Enter]", sent)
+	}
+}
+
 func TestAcceptStartupDialogsPeeksDeepEnoughForLateTrustDialog(t *testing.T) {
 	withZeroDialogTimings(t)
 	dialogPollTimeout = time.Second

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -1112,26 +1112,47 @@ func liveContractHTTPRequest(baseURL, method, path string, body any) (*http.Requ
 
 func assertLiveContractStreamOpens(t *testing.T, baseURL, path string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
-	if err != nil {
-		t.Fatalf("build stream request %s: %v", path, err)
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET %s stream: %v", path, err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode != http.StatusOK {
+	deadline := time.Now().Add(30 * time.Second)
+	var lastStatus int
+	var lastBody string
+	var lastContentType string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+		if err != nil {
+			cancel()
+			t.Fatalf("build stream request %s: %v", path, err)
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			cancel()
+			lastErr = err
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		lastErr = nil
+		lastStatus = resp.StatusCode
+		lastContentType = resp.Header.Get("Content-Type")
+		if resp.StatusCode == http.StatusOK {
+			_ = resp.Body.Close()
+			cancel()
+			if !strings.Contains(lastContentType, "text/event-stream") {
+				t.Fatalf("GET %s stream content-type = %q, want text/event-stream", path, lastContentType)
+			}
+			return
+		}
 		raw, _ := io.ReadAll(resp.Body)
-		t.Fatalf("GET %s stream status = %d, want 200; body: %s", path, resp.StatusCode, string(raw))
+		_ = resp.Body.Close()
+		cancel()
+		lastBody = string(raw)
+		time.Sleep(250 * time.Millisecond)
 	}
-	contentType := resp.Header.Get("Content-Type")
-	if !strings.Contains(contentType, "text/event-stream") {
-		t.Fatalf("GET %s stream content-type = %q, want text/event-stream", path, contentType)
+	if lastErr != nil {
+		t.Fatalf("GET %s stream: %v", path, lastErr)
 	}
+	t.Fatalf("GET %s stream status = %d, want 200; body: %s", path, lastStatus, lastBody)
 }
 
 func validateLiveContractResponse(t *testing.T, v openapivalidator.Validator, req *http.Request, resp *http.Response, raw []byte) {


### PR DESCRIPTION
## Summary
- detect Claude's old/high-token resume selector before generic prompt readiness
- select "Resume full session as-is" so resumed workflow sessions keep context
- cover both peek-based and stream-based startup dialog handlers

## Tests
- go test ./internal/runtime ./internal/runtime/tmux -count=1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->