### PR TITLE
fix(reviewquorum): align durable quorum contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   synthesis-created changes, lane mutation deltas remain under their lane
   records, lane-scoped finalizer failures use
   `lane=<lane_id> reason=<stable_reason>` entries, and unknown lane verdict
-  values are hard contract failures.
+  values are hard contract failures. Reviewer lane prompts now require durable
+  `lane_id`, `provider`, and `model` fields, and the finalizer rejects blank
+  lane IDs without merging contract-invalid lane findings, evidence, or usage
+  into the synthesized summary.
 - `[[orders.overrides]]` rig matching is stricter and clearer. A rigless
   override (`rig` unset) still matches **only** city-level orders; if the
   named order exists only as per-rig instances, the error now names every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Custom ACP overlays that previously expected a literal `per-provider/`
   subtree in the session workdir should move provider-specific files under the
   matching provider slot so they are flattened at launch.
+- The review-quorum durable contract now documents that synthesized
+  `findings_count` is deduplicated, top-level `mutations_delta` is reserved for
+  synthesis-created changes, lane mutation deltas remain under their lane
+  records, lane-scoped finalizer failures use
+  `lane=<lane_id> reason=<stable_reason>` entries, and unknown lane verdict
+  values are hard contract failures.
 - `[[orders.overrides]]` rig matching is stricter and clearer. A rigless
   override (`rig` unset) still matches **only** city-level orders; if the
   named order exists only as per-rig instances, the error now names every

--- a/docs/reference/formula.md
+++ b/docs/reference/formula.md
@@ -90,6 +90,12 @@ automation. The lane output contract includes `verdict`, `summary`,
 `findings_count`, `findings`, `evidence`, `usage`,
 `read_only_enforcement`, `mutations_delta`, `failure_class`, and
 `failure_reason`.
+The summary output keeps reviewer mutation deltas under each lane and reserves
+top-level `mutations_delta` for synthesis-created changes. Summary
+`findings_count` is the deduplicated finding count. When the Go finalizer
+emits lane-scoped failures, `failure_reason` uses
+`lane=<lane_id> reason=<stable_reason>` entries joined by `; `; unknown lane
+verdict values are hard contract failures.
 
 Read-only enforcement is baseline-relative: reviewers compare the after state
 against the mutation baseline they recorded before review with

--- a/docs/reference/formula.md
+++ b/docs/reference/formula.md
@@ -86,8 +86,8 @@ Reviewer lanes use retry semantics with
 continue with degraded coverage when one lane exhausts its retry budget.
 
 Reviewer and synthesis steps must persist structured JSON state for future
-automation. The lane output contract includes `verdict`, `summary`,
-`findings_count`, `findings`, `evidence`, `usage`,
+automation. The lane output contract includes `lane_id`, `provider`, `model`,
+`verdict`, `summary`, `findings_count`, `findings`, `evidence`, `usage`,
 `read_only_enforcement`, `mutations_delta`, `failure_class`, and
 `failure_reason`.
 The summary output keeps reviewer mutation deltas under each lane and reserves

--- a/engdocs/architecture/formulas.md
+++ b/engdocs/architecture/formulas.md
@@ -83,9 +83,10 @@ coverage instead of failing the whole formula. The synthesis step is hard-fail
 because it is responsible for persisting the final durable state.
 
 Reviewer output is structured for future automation. Lanes must write
-`verdict`, `summary`, `findings_count`, `findings`, `evidence`, `usage`,
-`read_only_enforcement`, `mutations_delta`, `failure_class`, and
-`failure_reason`; synthesis preserves lane provenance and writes a
+`lane_id`, `provider`, `model`, `verdict`, `summary`, `findings_count`,
+`findings`, `evidence`, `usage`, `read_only_enforcement`, `mutations_delta`,
+`failure_class`, and `failure_reason`; synthesis preserves lane provenance and
+writes a
 `review-quorum.summary.v1` output. `internal/reviewquorum` defines the durable
 Go contract and finalizer, but the current formula synthesis step is
 agent-executed and does not call `reviewquorum.Finalize` directly. Future

--- a/engdocs/architecture/formulas.md
+++ b/engdocs/architecture/formulas.md
@@ -91,6 +91,11 @@ Go contract and finalizer, but the current formula synthesis step is
 agent-executed and does not call `reviewquorum.Finalize` directly. Future
 `dx-review summarize` compatibility can consume that state, but `dx-review` is
 not the lifecycle owner.
+The summary `findings_count` is deduplicated, top-level `mutations_delta` is
+reserved for synthesis-created changes, and reviewer mutation deltas stay under
+the corresponding lane. Go finalizer lane failures use
+`lane=<lane_id> reason=<stable_reason>` entries joined by `; `; unknown lane
+verdict values are hard contract failures.
 
 Read-only enforcement is defined as a mutation baseline delta. A reviewer must
 record the workspace state before review with `git status --porcelain=v1 -z`

--- a/internal/bootstrap/packs/core/formulas/mol-review-quorum.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-review-quorum.toml
@@ -162,14 +162,16 @@ The synthesis output must preserve lane provenance and include:
   failure reasons, read-only enforcement, and mutation deltas
 - `verdict`: combined quorum verdict
 - `summary`: combined summary
-- `findings_count`: total actionable findings
+- `findings_count`: total deduplicated actionable findings
 - `findings`: deduplicated findings with lane evidence
 - `evidence`: lane outputs and any synthesis-only checks
 - `usage`: aggregate usage if available
 - `read_only_enforcement`: synthesis baseline/after delta and lane deltas
 - `mutations_delta`: synthesis-created delta only; empty if none
 - `failure_class`: `none`, `transient`, or `hard`
-- `failure_reason`: stable reason string or empty
+- `failure_reason`: stable reason string or empty. Go finalizer failures use
+  `lane=<lane_id> reason=<stable_reason>` entries joined by `; ` when a lane
+  is responsible. Unknown lane verdict values are hard contract failures.
 
 Propagate this JSON through `gc.output_json` when available, or store it in the
 bead notes/metadata exactly enough for future `dx-review summarize` ingestion.

--- a/internal/bootstrap/packs/core/formulas/mol-review-quorum.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-review-quorum.toml
@@ -78,6 +78,9 @@ reviewer-created mutations.
 Persist durable structured output compatible with a future `dx-review
 summarize` consumer. The output must include these keys:
 
+- `lane_id`: `{{lane_one_id}}`
+- `provider`: `{{lane_one_provider}}`
+- `model`: `{{lane_one_model}}`
 - `verdict`: one of `pass`, `pass_with_findings`, `fail`, or `blocked`
 - `summary`: concise review summary
 - `findings_count`: integer count of findings
@@ -121,6 +124,9 @@ reviewer-created mutations.
 Persist durable structured output compatible with a future `dx-review
 summarize` consumer. The output must include these keys:
 
+- `lane_id`: `{{lane_two_id}}`
+- `provider`: `{{lane_two_provider}}`
+- `model`: `{{lane_two_model}}`
 - `verdict`: one of `pass`, `pass_with_findings`, `fail`, or `blocked`
 - `summary`: concise review summary
 - `findings_count`: integer count of findings

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1170,6 +1170,9 @@ func TestCompileReviewQuorumCoreFormula(t *testing.T) {
 				t.Fatalf("%s retry on_exhausted = %q, want soft_fail", step.ID, step.Retry.OnExhausted)
 			}
 			for _, required := range []string{
+				"lane_id",
+				"provider",
+				"model",
 				"verdict",
 				"findings_count",
 				"evidence",

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1194,6 +1194,36 @@ func TestCompileReviewQuorumCoreFormula(t *testing.T) {
 	if got, want := strings.Join(reviewerLanes, ","), "{{lane_one_id}},{{lane_two_id}}"; got != want {
 		t.Fatalf("reviewer lanes = %q, want %q", got, want)
 	}
+	var synthesisPrompts int
+	for _, step := range parsed.Steps {
+		if step.Metadata["gc.review_quorum_role"] != "synthesis" {
+			continue
+		}
+		synthesisPrompts++
+		for _, required := range []string{
+			"subject",
+			"base_ref",
+			"lanes",
+			"verdict",
+			"summary",
+			"findings_count",
+			"findings",
+			"evidence",
+			"usage",
+			"read_only_enforcement",
+			"mutations_delta",
+			"failure_class",
+			"failure_reason",
+			"lane=<lane_id> reason=<stable_reason>",
+		} {
+			if !strings.Contains(step.Description, required) {
+				t.Fatalf("%s description missing synthesis contract key %q", step.ID, required)
+			}
+		}
+	}
+	if synthesisPrompts != 1 {
+		t.Fatalf("synthesis prompt count = %d, want 1", synthesisPrompts)
+	}
 	for _, name := range []string{
 		"lane_one_id",
 		"lane_one_provider",

--- a/internal/reviewquorum/classify.go
+++ b/internal/reviewquorum/classify.go
@@ -43,7 +43,7 @@ func ClassifyFailure(failureClass, failureReason string) (class, reason string) 
 	if class == "" {
 		return FailureClassHard, reason
 	}
-	return FailureClassHard, "invalid_failure_class"
+	return FailureClassHard, "invalid_failure_class_" + normalizeFailureFragment(reason, "unspecified")
 }
 
 func normalizeToken(value string) string {

--- a/internal/reviewquorum/classify.go
+++ b/internal/reviewquorum/classify.go
@@ -20,6 +20,9 @@ func IsTransientFailure(failureClass, failureReason string) bool {
 	if class == FailureClassTransient {
 		return true
 	}
+	if class != "" {
+		return false
+	}
 	_, ok := transientFailureReasons[reason]
 	return ok
 }
@@ -34,16 +37,19 @@ func ClassifyFailure(failureClass, failureReason string) (class, reason string) 
 	if reason == "" {
 		reason = "unspecified"
 	}
-	if IsTransientFailure(class, reason) {
+	switch class {
+	case FailureClassTransient:
 		return FailureClassTransient, reason
-	}
-	if class == FailureClassHard {
+	case FailureClassHard:
 		return FailureClassHard, reason
-	}
-	if class == "" {
+	case "":
+		if IsTransientFailure(class, reason) {
+			return FailureClassTransient, reason
+		}
 		return FailureClassHard, reason
+	default:
+		return FailureClassHard, "invalid_failure_class_" + normalizeFailureFragment(reason, "unspecified")
 	}
-	return FailureClassHard, "invalid_failure_class_" + normalizeFailureFragment(reason, "unspecified")
 }
 
 func normalizeToken(value string) string {

--- a/internal/reviewquorum/finalize.go
+++ b/internal/reviewquorum/finalize.go
@@ -12,7 +12,7 @@ import (
 // unknown verdict values, or explicit lane failures, transient blocked for
 // retryable lane failures, and pass/pass_with_findings otherwise.
 func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
-	lanes := append([]LaneOutput{}, outputs...)
+	lanes := cloneLaneOutputs(outputs)
 	sortLaneOutputs(lanes)
 
 	summary := Summary{
@@ -50,16 +50,21 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 	var findingOrder []string
 	var laneSummaries []string
 	var transientFailures []string
-	for i, lane := range lanes {
+	readOnlyMerged := false
+	for _, lane := range lanes {
 		laneFailures := laneContractFailures(lane)
 		for _, reason := range laneFailures {
 			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
 		}
+		if len(laneFailures) > 0 {
+			continue
+		}
 		mergeLaneFindings(findingAccumulators, &findingOrder, lane)
-		summary.Evidence = append(summary.Evidence, lane.Evidence...)
+		summary.Evidence = append(summary.Evidence, cloneEvidence(lane.Evidence)...)
 		summary.Usage = addUsage(summary.Usage, lane.Usage)
-		if i == 0 {
+		if !readOnlyMerged {
 			summary.ReadOnlyEnforcement = cloneReadOnlyEnforcement(lane.ReadOnlyEnforcement)
+			readOnlyMerged = true
 		} else {
 			summary.ReadOnlyEnforcement = mergeReadOnly(summary.ReadOnlyEnforcement, lane.ReadOnlyEnforcement)
 		}
@@ -82,9 +87,6 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 				}
 				continue
 			}
-		}
-		if len(laneFailures) > 0 {
-			continue
 		}
 		switch normalizeToken(lane.Verdict) {
 		case VerdictPass:
@@ -132,6 +134,9 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 
 func laneContractFailures(lane LaneOutput) []string {
 	var failures []string
+	if strings.TrimSpace(lane.LaneID) == "" {
+		failures = append(failures, "lane_id_missing")
+	}
 	if strings.TrimSpace(lane.Provider) == "" {
 		failures = append(failures, "provider_missing")
 	}
@@ -155,7 +160,7 @@ func mergeLaneFindings(accumulators map[string]Finding, order *[]string, lane La
 		key := findingKey(finding)
 		merged, ok := accumulators[key]
 		if !ok {
-			merged = cloneFinding(finding)
+			merged = finding
 			merged.Lanes = nil
 			merged.Evidence = nil
 			*order = append(*order, key)
@@ -182,14 +187,51 @@ func findingKey(finding Finding) string {
 	)
 }
 
-func cloneFinding(finding Finding) Finding {
-	finding.Lanes = append([]string(nil), finding.Lanes...)
-	finding.Evidence = cloneEvidence(finding.Evidence)
-	return finding
-}
-
 func cloneEvidence(evidence []Evidence) []Evidence {
 	return append([]Evidence(nil), evidence...)
+}
+
+func cloneLaneOutputs(outputs []LaneOutput) []LaneOutput {
+	lanes := make([]LaneOutput, len(outputs))
+	for i, output := range outputs {
+		lanes[i] = cloneLaneOutput(output)
+	}
+	return lanes
+}
+
+func cloneLaneOutput(output LaneOutput) LaneOutput {
+	output.Findings = cloneFindings(output.Findings)
+	output.Evidence = cloneEvidence(output.Evidence)
+	output.Usage = cloneUsage(output.Usage)
+	output.ReadOnlyEnforcement = cloneReadOnlyEnforcement(output.ReadOnlyEnforcement)
+	output.MutationsDelta = cloneMutationsDelta(output.MutationsDelta)
+	return output
+}
+
+func cloneFindings(findings []Finding) []Finding {
+	if findings == nil {
+		return nil
+	}
+	cloned := make([]Finding, len(findings))
+	for i, finding := range findings {
+		finding.Lanes = append([]string(nil), finding.Lanes...)
+		finding.Evidence = cloneEvidence(finding.Evidence)
+		cloned[i] = finding
+	}
+	return cloned
+}
+
+func cloneUsage(usage *Usage) *Usage {
+	if usage == nil {
+		return nil
+	}
+	cloned := *usage
+	return &cloned
+}
+
+func cloneMutationsDelta(delta MutationsDelta) MutationsDelta {
+	delta.Changed = append([]StatusEntry(nil), delta.Changed...)
+	return delta
 }
 
 func appendUniqueStrings(values []string, additions ...string) []string {

--- a/internal/reviewquorum/finalize.go
+++ b/internal/reviewquorum/finalize.go
@@ -7,9 +7,10 @@ import (
 
 // Finalize synthesizes durable lane outputs into a quorum summary for subject
 // relative to baseRef. The identity arguments are required durable summary
-// fields. It returns a terminal blocked summary when at least one lane output
-// exists and another lane soft-failed transiently; awaiting states are reserved
-// for zero output.
+// fields. It returns awaiting only for zero lane output, hard failure for
+// summary identity drift, lane contract violations, read-only mutations,
+// unknown verdict values, or explicit lane failures, transient blocked for
+// retryable lane failures, and pass/pass_with_findings otherwise.
 func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 	lanes := append([]LaneOutput{}, outputs...)
 	sortLaneOutputs(lanes)
@@ -57,7 +58,6 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 		mergeLaneFindings(findingAccumulators, &findingOrder, lane)
 		summary.Evidence = append(summary.Evidence, lane.Evidence...)
 		summary.Usage = addUsage(summary.Usage, lane.Usage)
-		summary.MutationsDelta = mergeMutationDeltas(summary.MutationsDelta, lane.MutationsDelta)
 		if i == 0 {
 			summary.ReadOnlyEnforcement = cloneReadOnlyEnforcement(lane.ReadOnlyEnforcement)
 		} else {
@@ -132,6 +132,12 @@ func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 
 func laneContractFailures(lane LaneOutput) []string {
 	var failures []string
+	if strings.TrimSpace(lane.Provider) == "" {
+		failures = append(failures, "provider_missing")
+	}
+	if strings.TrimSpace(lane.Model) == "" {
+		failures = append(failures, "model_missing")
+	}
 	if lane.FindingsCount != len(lane.Findings) {
 		failures = append(failures, "findings_count_mismatch")
 	}
@@ -158,7 +164,7 @@ func mergeLaneFindings(accumulators map[string]Finding, order *[]string, lane La
 		merged.Lanes = appendUniqueStrings(merged.Lanes, finding.Lanes...)
 		if len(finding.Evidence) > 0 {
 			merged.Evidence = append(merged.Evidence, cloneEvidence(finding.Evidence)...)
-		} else {
+		} else if len(merged.Evidence) == 0 {
 			merged.Evidence = append(merged.Evidence, cloneEvidence(lane.Evidence)...)
 		}
 		accumulators[key] = merged

--- a/internal/reviewquorum/finalize.go
+++ b/internal/reviewquorum/finalize.go
@@ -9,13 +9,17 @@ import (
 // a terminal blocked summary when at least one lane output exists and another
 // lane soft-failed transiently; awaiting states are reserved for zero output.
 func Finalize(outputs []LaneOutput) Summary {
-	lanes := append([]LaneOutput(nil), outputs...)
+	lanes := append([]LaneOutput{}, outputs...)
 	sortLaneOutputs(lanes)
 
 	summary := Summary{
-		Verdict: VerdictAwaitingReviewers,
-		Summary: "awaiting reviewer lane output",
-		Lanes:   lanes,
+		Verdict:       VerdictAwaitingReviewers,
+		Summary:       "awaiting reviewer lane output",
+		Findings:      []Finding{},
+		Evidence:      []Evidence{},
+		FailureClass:  FailureClassNone,
+		FailureReason: "",
+		Lanes:         lanes,
 	}
 	if len(lanes) == 0 {
 		return summary
@@ -24,26 +28,23 @@ func Finalize(outputs []LaneOutput) Summary {
 	summary.Verdict = VerdictPass
 	summary.Summary = "review quorum passed with no findings"
 
+	findingAccumulators := map[string]Finding{}
+	var findingOrder []string
 	var laneSummaries []string
 	var hardFailures []string
 	var transientFailures []string
-	var readOnlyMutated bool
 	for i, lane := range lanes {
-		count := normalizedFindingsCount(lane)
-		summary.FindingsCount += count
-		summary.Findings = append(summary.Findings, lane.Findings...)
+		mergeLaneFindings(findingAccumulators, &findingOrder, lane)
 		summary.Evidence = append(summary.Evidence, lane.Evidence...)
 		summary.Usage = addUsage(summary.Usage, lane.Usage)
 		summary.MutationsDelta = mergeMutationDeltas(summary.MutationsDelta, lane.MutationsDelta)
 		if i == 0 {
-			summary.ReadOnlyEnforcement = lane.ReadOnlyEnforcement
+			summary.ReadOnlyEnforcement = cloneReadOnlyEnforcement(lane.ReadOnlyEnforcement)
 		} else {
 			summary.ReadOnlyEnforcement = mergeReadOnly(summary.ReadOnlyEnforcement, lane.ReadOnlyEnforcement)
 		}
 		switch reason := readOnlyContractFailure(lane); reason {
 		case "":
-		case "read_only_mutation_detected":
-			readOnlyMutated = true
 		default:
 			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
 		}
@@ -76,13 +77,14 @@ func Finalize(outputs []LaneOutput) Summary {
 				hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
 			}
 		default:
-			transientFailures = append(transientFailures, formatLaneFailure(lane.LaneID, "unknown_verdict_value"))
+			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, "unknown_verdict_value"))
 		}
 	}
 
-	if readOnlyMutated {
-		hardFailures = append([]string{"read_only_mutation_detected"}, hardFailures...)
+	for _, key := range findingOrder {
+		summary.Findings = append(summary.Findings, findingAccumulators[key])
 	}
+	summary.FindingsCount = len(summary.Findings)
 
 	switch {
 	case len(hardFailures) > 0:
@@ -105,6 +107,67 @@ func Finalize(outputs []LaneOutput) Summary {
 	return summary
 }
 
+func mergeLaneFindings(accumulators map[string]Finding, order *[]string, lane LaneOutput) {
+	for _, finding := range lane.Findings {
+		key := findingKey(finding)
+		merged, ok := accumulators[key]
+		if !ok {
+			merged = cloneFinding(finding)
+			merged.Lanes = nil
+			merged.Evidence = nil
+			*order = append(*order, key)
+		}
+		merged.Lanes = appendUniqueStrings(merged.Lanes, lane.LaneID)
+		merged.Lanes = appendUniqueStrings(merged.Lanes, finding.Lanes...)
+		if len(finding.Evidence) > 0 {
+			merged.Evidence = append(merged.Evidence, cloneEvidence(finding.Evidence)...)
+		} else {
+			merged.Evidence = append(merged.Evidence, cloneEvidence(lane.Evidence)...)
+		}
+		accumulators[key] = merged
+	}
+}
+
+func findingKey(finding Finding) string {
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%d\x00%d",
+		normalizeToken(finding.Severity),
+		normalizeToken(finding.Title),
+		strings.TrimSpace(finding.Body),
+		strings.TrimSpace(finding.File),
+		finding.Start,
+		finding.End,
+	)
+}
+
+func cloneFinding(finding Finding) Finding {
+	finding.Lanes = append([]string(nil), finding.Lanes...)
+	finding.Evidence = cloneEvidence(finding.Evidence)
+	return finding
+}
+
+func cloneEvidence(evidence []Evidence) []Evidence {
+	return append([]Evidence(nil), evidence...)
+}
+
+func appendUniqueStrings(values []string, additions ...string) []string {
+	seen := make(map[string]struct{}, len(values)+len(additions))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	for _, addition := range additions {
+		addition = strings.TrimSpace(addition)
+		if addition == "" {
+			continue
+		}
+		if _, ok := seen[addition]; ok {
+			continue
+		}
+		seen[addition] = struct{}{}
+		values = append(values, addition)
+	}
+	return values
+}
+
 func readOnlyContractFailure(lane LaneOutput) string {
 	if !lane.ReadOnlyEnforcement.Observed {
 		return "read_only_enforcement_missing"
@@ -121,13 +184,29 @@ func readOnlyContractFailure(lane LaneOutput) string {
 	return ""
 }
 
-func addUsage(a, b Usage) Usage {
-	return Usage{
+func addUsage(a, b *Usage) *Usage {
+	if a == nil && b == nil {
+		return nil
+	}
+	if a == nil {
+		usage := *b
+		return &usage
+	}
+	if b == nil {
+		usage := *a
+		return &usage
+	}
+	return &Usage{
 		InputTokens:  a.InputTokens + b.InputTokens,
 		OutputTokens: a.OutputTokens + b.OutputTokens,
 		TotalTokens:  a.TotalTokens + b.TotalTokens,
 		CostUSD:      a.CostUSD + b.CostUSD,
 	}
+}
+
+func cloneReadOnlyEnforcement(value ReadOnlyEnforcement) ReadOnlyEnforcement {
+	value.Notes = append([]string(nil), value.Notes...)
+	return value
 }
 
 func mergeReadOnly(a, b ReadOnlyEnforcement) ReadOnlyEnforcement {

--- a/internal/reviewquorum/finalize.go
+++ b/internal/reviewquorum/finalize.go
@@ -5,14 +5,18 @@ import (
 	"strings"
 )
 
-// Finalize synthesizes durable lane outputs into a quorum summary. It returns
-// a terminal blocked summary when at least one lane output exists and another
-// lane soft-failed transiently; awaiting states are reserved for zero output.
-func Finalize(outputs []LaneOutput) Summary {
+// Finalize synthesizes durable lane outputs into a quorum summary for subject
+// relative to baseRef. The identity arguments are required durable summary
+// fields. It returns a terminal blocked summary when at least one lane output
+// exists and another lane soft-failed transiently; awaiting states are reserved
+// for zero output.
+func Finalize(subject, baseRef string, outputs []LaneOutput) Summary {
 	lanes := append([]LaneOutput{}, outputs...)
 	sortLaneOutputs(lanes)
 
 	summary := Summary{
+		Subject:       strings.TrimSpace(subject),
+		BaseRef:       strings.TrimSpace(baseRef),
 		Verdict:       VerdictAwaitingReviewers,
 		Summary:       "awaiting reviewer lane output",
 		Findings:      []Finding{},
@@ -21,7 +25,20 @@ func Finalize(outputs []LaneOutput) Summary {
 		FailureReason: "",
 		Lanes:         lanes,
 	}
+	var hardFailures []string
+	if summary.Subject == "" {
+		hardFailures = append(hardFailures, "summary_subject_missing")
+	}
+	if summary.BaseRef == "" {
+		hardFailures = append(hardFailures, "summary_base_ref_missing")
+	}
 	if len(lanes) == 0 {
+		if len(hardFailures) > 0 {
+			summary.Verdict = VerdictFail
+			summary.FailureClass = FailureClassHard
+			summary.FailureReason = strings.Join(hardFailures, "; ")
+			summary.Summary = "review quorum failed: " + summary.FailureReason
+		}
 		return summary
 	}
 
@@ -31,9 +48,12 @@ func Finalize(outputs []LaneOutput) Summary {
 	findingAccumulators := map[string]Finding{}
 	var findingOrder []string
 	var laneSummaries []string
-	var hardFailures []string
 	var transientFailures []string
 	for i, lane := range lanes {
+		laneFailures := laneContractFailures(lane)
+		for _, reason := range laneFailures {
+			hardFailures = append(hardFailures, formatLaneFailure(lane.LaneID, reason))
+		}
 		mergeLaneFindings(findingAccumulators, &findingOrder, lane)
 		summary.Evidence = append(summary.Evidence, lane.Evidence...)
 		summary.Usage = addUsage(summary.Usage, lane.Usage)
@@ -62,6 +82,9 @@ func Finalize(outputs []LaneOutput) Summary {
 				}
 				continue
 			}
+		}
+		if len(laneFailures) > 0 {
+			continue
 		}
 		switch normalizeToken(lane.Verdict) {
 		case VerdictPass:
@@ -105,6 +128,20 @@ func Finalize(outputs []LaneOutput) Summary {
 	}
 
 	return summary
+}
+
+func laneContractFailures(lane LaneOutput) []string {
+	var failures []string
+	if lane.FindingsCount != len(lane.Findings) {
+		failures = append(failures, "findings_count_mismatch")
+	}
+	switch normalizeToken(lane.Verdict) {
+	case VerdictPassWithFindings, VerdictFail:
+		if len(lane.Findings) == 0 {
+			failures = append(failures, "materialized_findings_missing")
+		}
+	}
+	return failures
 }
 
 func mergeLaneFindings(accumulators map[string]Finding, order *[]string, lane LaneOutput) {

--- a/internal/reviewquorum/finalize.go
+++ b/internal/reviewquorum/finalize.go
@@ -143,13 +143,39 @@ func laneContractFailures(lane LaneOutput) []string {
 	if strings.TrimSpace(lane.Model) == "" {
 		failures = append(failures, "model_missing")
 	}
+	if len(failures) > 0 {
+		return failures
+	}
 	if lane.FindingsCount != len(lane.Findings) {
 		failures = append(failures, "findings_count_mismatch")
+	}
+	switch normalizeToken(lane.Verdict) {
+	case VerdictPass, VerdictPassWithFindings:
+		switch class := normalizeToken(lane.FailureClass); class {
+		case "":
+			failures = append(failures, "failure_class_missing")
+		case FailureClassNone:
+			if strings.TrimSpace(lane.FailureReason) != "" {
+				_, reason := ClassifyFailure(lane.FailureClass, lane.FailureReason)
+				failures = append(failures, reason)
+			}
+		case FailureClassTransient, FailureClassHard:
+			failures = append(failures, "success_failure_class_not_none")
+		default:
+			_, reason := ClassifyFailure(lane.FailureClass, lane.FailureReason)
+			failures = append(failures, reason)
+		}
 	}
 	switch normalizeToken(lane.Verdict) {
 	case VerdictPassWithFindings, VerdictFail:
 		if len(lane.Findings) == 0 {
 			failures = append(failures, "materialized_findings_missing")
+		}
+	}
+	for _, finding := range lane.Findings {
+		if len(finding.Lanes) > 0 {
+			failures = append(failures, "finding_lanes_not_allowed")
+			break
 		}
 	}
 	return failures
@@ -166,7 +192,6 @@ func mergeLaneFindings(accumulators map[string]Finding, order *[]string, lane La
 			*order = append(*order, key)
 		}
 		merged.Lanes = appendUniqueStrings(merged.Lanes, lane.LaneID)
-		merged.Lanes = appendUniqueStrings(merged.Lanes, finding.Lanes...)
 		if len(finding.Evidence) > 0 {
 			merged.Evidence = append(merged.Evidence, cloneEvidence(finding.Evidence)...)
 		} else if len(merged.Evidence) == 0 {
@@ -188,6 +213,9 @@ func findingKey(finding Finding) string {
 }
 
 func cloneEvidence(evidence []Evidence) []Evidence {
+	if evidence == nil {
+		return []Evidence{}
+	}
 	return append([]Evidence(nil), evidence...)
 }
 
@@ -210,7 +238,7 @@ func cloneLaneOutput(output LaneOutput) LaneOutput {
 
 func cloneFindings(findings []Finding) []Finding {
 	if findings == nil {
-		return nil
+		return []Finding{}
 	}
 	cloned := make([]Finding, len(findings))
 	for i, finding := range findings {
@@ -259,6 +287,12 @@ func readOnlyContractFailure(lane LaneOutput) string {
 	}
 	if !lane.ReadOnlyEnforcement.Enabled {
 		return "read_only_enforcement_disabled"
+	}
+	if lane.ReadOnlyEnforcement.Passed && strings.TrimSpace(lane.ReadOnlyEnforcement.BaselineCommand) == "" {
+		return "read_only_baseline_command_missing"
+	}
+	if lane.ReadOnlyEnforcement.Passed && strings.TrimSpace(lane.ReadOnlyEnforcement.AfterCommand) == "" {
+		return "read_only_after_command_missing"
 	}
 	if len(lane.MutationsDelta.Changed) > 0 {
 		return "read_only_mutation_detected"

--- a/internal/reviewquorum/finalize_test.go
+++ b/internal/reviewquorum/finalize_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	lanePrimary   = "primary"
-	laneSecondary = "secondary"
-	reviewSubject = "gh:gastownhall/gascity#1694"
-	reviewBaseRef = "origin/main"
+	lanePrimary           = "primary"
+	laneSecondary         = "secondary"
+	reviewSubject         = "gh:gastownhall/gascity#1694"
+	reviewBaseRef         = "origin/main"
+	readOnlyStatusCommand = "git status --porcelain=v1 -z"
 )
 
 func finalize(outputs []LaneOutput) Summary {
@@ -22,6 +23,19 @@ func finalize(outputs []LaneOutput) Summary {
 		}
 		if lanes[i].Model == "" {
 			lanes[i].Model = "test-model"
+		}
+		if lanes[i].FailureClass == "" && lanes[i].FailureReason == "" {
+			lanes[i].FailureClass = FailureClassNone
+		}
+		if lanes[i].ReadOnlyEnforcement.Observed &&
+			lanes[i].ReadOnlyEnforcement.Enabled &&
+			lanes[i].ReadOnlyEnforcement.Passed {
+			if lanes[i].ReadOnlyEnforcement.BaselineCommand == "" {
+				lanes[i].ReadOnlyEnforcement.BaselineCommand = readOnlyStatusCommand
+			}
+			if lanes[i].ReadOnlyEnforcement.AfterCommand == "" {
+				lanes[i].ReadOnlyEnforcement.AfterCommand = readOnlyStatusCommand
+			}
 		}
 	}
 	return Finalize(reviewSubject, reviewBaseRef, lanes)
@@ -259,11 +273,14 @@ func TestFinalizeSkipsContractInvalidLaneDataFromSummary(t *testing.T) {
 			FindingsCount: 0,
 			Usage:         &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
 			ReadOnlyEnforcement: ReadOnlyEnforcement{
-				Observed: true,
-				Enabled:  true,
-				Passed:   true,
-				Notes:    []string{"valid lane note"},
+				Observed:        true,
+				Enabled:         true,
+				Passed:          true,
+				BaselineCommand: readOnlyStatusCommand,
+				AfterCommand:    readOnlyStatusCommand,
+				Notes:           []string{"valid lane note"},
 			},
+			FailureClass: FailureClassNone,
 		},
 	})
 
@@ -432,7 +449,6 @@ func TestFinalizeDeepCopiesLaneOutputs(t *testing.T) {
 					Title:    "finding",
 					File:     "internal/reviewquorum/finalize.go",
 					Start:    12,
-					Lanes:    []string{"reported"},
 					Evidence: []Evidence{{Kind: "file", Path: "finding.go"}},
 				},
 			},
@@ -450,7 +466,6 @@ func TestFinalizeDeepCopiesLaneOutputs(t *testing.T) {
 	got := Finalize(reviewSubject, reviewBaseRef, outputs)
 
 	outputs[0].Findings[0].Title = "mutated"
-	outputs[0].Findings[0].Lanes[0] = "mutated"
 	outputs[0].Findings[0].Evidence[0].Path = "mutated.go"
 	outputs[0].Evidence[0].Path = "mutated-lane.go"
 	outputs[0].Usage.TotalTokens = 99
@@ -460,9 +475,6 @@ func TestFinalizeDeepCopiesLaneOutputs(t *testing.T) {
 	lane := got.Lanes[0]
 	if lane.Findings[0].Title != "finding" {
 		t.Fatalf("lane finding title = %q, want copied finding", lane.Findings[0].Title)
-	}
-	if lane.Findings[0].Lanes[0] != "reported" {
-		t.Fatalf("lane finding lanes = %+v, want copied finding lanes", lane.Findings[0].Lanes)
 	}
 	if lane.Findings[0].Evidence[0].Path != "finding.go" {
 		t.Fatalf("lane finding evidence = %+v, want copied finding evidence", lane.Findings[0].Evidence)
@@ -501,6 +513,155 @@ func TestFinalizeIgnoresFailureClassNoneOnPassingLane(t *testing.T) {
 	}
 	if got.FailureClass != FailureClassNone || got.FailureReason != "" {
 		t.Fatalf("failure = %q/%q, want none/empty", got.FailureClass, got.FailureReason)
+	}
+}
+
+func TestFinalizeRejectsMissingSuccessFailureClass(t *testing.T) {
+	got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{
+		{
+			LaneID:        lanePrimary,
+			Provider:      "test-provider",
+			Model:         "test-model",
+			Verdict:       VerdictPass,
+			FindingsCount: 0,
+			ReadOnlyEnforcement: ReadOnlyEnforcement{
+				Observed:        true,
+				Enabled:         true,
+				Passed:          true,
+				BaselineCommand: readOnlyStatusCommand,
+				AfterCommand:    readOnlyStatusCommand,
+			},
+		},
+	})
+	if got.Verdict != VerdictFail {
+		t.Fatalf("Verdict = %q, want fail", got.Verdict)
+	}
+	if got.FailureClass != FailureClassHard {
+		t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
+	}
+	if got.FailureReason != "lane=primary reason=failure_class_missing" {
+		t.Fatalf("FailureReason = %q, want failure_class_missing", got.FailureReason)
+	}
+}
+
+func TestFinalizeRejectsMissingReadOnlyProofCommands(t *testing.T) {
+	tests := []struct {
+		name            string
+		baselineCommand string
+		afterCommand    string
+		reason          string
+	}{
+		{
+			name:            "missing baseline command",
+			baselineCommand: "",
+			afterCommand:    readOnlyStatusCommand,
+			reason:          "lane=primary reason=read_only_baseline_command_missing",
+		},
+		{
+			name:            "missing after command",
+			baselineCommand: readOnlyStatusCommand,
+			afterCommand:    " ",
+			reason:          "lane=primary reason=read_only_after_command_missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{
+				{
+					LaneID:        lanePrimary,
+					Provider:      "test-provider",
+					Model:         "test-model",
+					Verdict:       VerdictPass,
+					FindingsCount: 0,
+					ReadOnlyEnforcement: ReadOnlyEnforcement{
+						Observed:        true,
+						Enabled:         true,
+						Passed:          true,
+						BaselineCommand: tt.baselineCommand,
+						AfterCommand:    tt.afterCommand,
+					},
+					FailureClass: FailureClassNone,
+				},
+			})
+			if got.Verdict != VerdictFail {
+				t.Fatalf("Verdict = %q, want fail", got.Verdict)
+			}
+			if got.FailureClass != FailureClassHard {
+				t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
+			}
+			if got.FailureReason != tt.reason {
+				t.Fatalf("FailureReason = %q, want %q", got.FailureReason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestFinalizeRejectsLaneProvidedFindingProvenance(t *testing.T) {
+	got := finalize([]LaneOutput{
+		{
+			LaneID:        lanePrimary,
+			Verdict:       VerdictPassWithFindings,
+			FindingsCount: 1,
+			Findings: []Finding{
+				{
+					Title: "finding",
+					File:  "internal/reviewquorum/finalize.go",
+					Start: 12,
+					Lanes: []string{"reviewer-supplied"},
+				},
+			},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+	if got.Verdict != VerdictFail {
+		t.Fatalf("Verdict = %q, want fail", got.Verdict)
+	}
+	if got.FailureReason != "lane=primary reason=finding_lanes_not_allowed" {
+		t.Fatalf("FailureReason = %q, want finding_lanes_not_allowed", got.FailureReason)
+	}
+	if got.FindingsCount != 0 || len(got.Findings) != 0 {
+		t.Fatalf("Findings = %d/%d, want invalid lane finding excluded", got.FindingsCount, len(got.Findings))
+	}
+}
+
+func TestFinalizeNormalizesNilLaneArraysInSummaryJSON(t *testing.T) {
+	got := finalize([]LaneOutput{
+		{
+			LaneID:              lanePrimary,
+			Verdict:             VerdictPass,
+			FindingsCount:       0,
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+	if len(got.Lanes) != 1 {
+		t.Fatalf("Lanes len = %d, want 1", len(got.Lanes))
+	}
+	if got.Lanes[0].Findings == nil {
+		t.Fatal("lane Findings = nil, want empty array for durable JSON")
+	}
+	if got.Lanes[0].Evidence == nil {
+		t.Fatal("lane Evidence = nil, want empty array for durable JSON")
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var summary struct {
+		Lanes []struct {
+			Findings json.RawMessage `json:"findings"`
+			Evidence json.RawMessage `json:"evidence"`
+		} `json:"lanes"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if string(summary.Lanes[0].Findings) != "[]" {
+		t.Fatalf("lane findings JSON = %s, want []", summary.Lanes[0].Findings)
+	}
+	if string(summary.Lanes[0].Evidence) != "[]" {
+		t.Fatalf("lane evidence JSON = %s, want []", summary.Lanes[0].Evidence)
 	}
 }
 

--- a/internal/reviewquorum/finalize_test.go
+++ b/internal/reviewquorum/finalize_test.go
@@ -1,6 +1,10 @@
 package reviewquorum
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 const (
 	lanePrimary   = "primary"
@@ -26,7 +30,7 @@ func TestFinalizeSoftFailsTransientLaneWithoutAwaitingFinalize(t *testing.T) {
 			Verdict:       VerdictPass,
 			Summary:       "no issues found",
 			FindingsCount: 0,
-			Usage:         Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+			Usage:         &Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
 			ReadOnlyEnforcement: ReadOnlyEnforcement{
 				Observed: true,
 				Enabled:  true,
@@ -60,8 +64,8 @@ func TestFinalizeSoftFailsTransientLaneWithoutAwaitingFinalize(t *testing.T) {
 	if got.Summary == "awaiting_finalize" || got.Verdict == "awaiting_finalize" {
 		t.Fatalf("summary must not use ambiguous awaiting_finalize: %+v", got)
 	}
-	if got.Usage.TotalTokens != 15 {
-		t.Fatalf("Usage.TotalTokens = %d, want 15", got.Usage.TotalTokens)
+	if got.Usage == nil || got.Usage.TotalTokens != 15 {
+		t.Fatalf("Usage = %+v, want TotalTokens 15", got.Usage)
 	}
 }
 
@@ -89,6 +93,56 @@ func TestFinalizeFindingsRequestChanges(t *testing.T) {
 	}
 }
 
+func TestFinalizeDeduplicatesFindingsWithLaneEvidence(t *testing.T) {
+	got := Finalize([]LaneOutput{
+		{
+			LaneID:  lanePrimary,
+			Verdict: VerdictPassWithFindings,
+			Findings: []Finding{
+				{
+					Severity: "major",
+					Title:    "double counted finding",
+					Body:     "same issue",
+					File:     "internal/reviewquorum/finalize.go",
+					Start:    32,
+					End:      34,
+				},
+			},
+			Evidence:            []Evidence{{Kind: "file", Path: "internal/reviewquorum/finalize.go", Note: "primary"}},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+		{
+			LaneID:  laneSecondary,
+			Verdict: VerdictPassWithFindings,
+			Findings: []Finding{
+				{
+					Severity: "major",
+					Title:    "double counted finding",
+					Body:     "same issue",
+					File:     "internal/reviewquorum/finalize.go",
+					Start:    32,
+					End:      34,
+				},
+			},
+			Evidence:            []Evidence{{Kind: "file", Path: "internal/reviewquorum/finalize.go", Note: "secondary"}},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+	if got.FindingsCount != 1 {
+		t.Fatalf("FindingsCount = %d, want deduplicated count 1", got.FindingsCount)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("Findings len = %d, want 1", len(got.Findings))
+	}
+	wantLanes := []string{lanePrimary, laneSecondary}
+	if !reflect.DeepEqual(got.Findings[0].Lanes, wantLanes) {
+		t.Fatalf("Findings[0].Lanes = %+v, want %+v", got.Findings[0].Lanes, wantLanes)
+	}
+	if len(got.Findings[0].Evidence) != 2 {
+		t.Fatalf("Findings[0].Evidence len = %d, want 2", len(got.Findings[0].Evidence))
+	}
+}
+
 func TestFinalizeIgnoresFailureClassNoneOnPassingLane(t *testing.T) {
 	got := Finalize([]LaneOutput{
 		{
@@ -107,8 +161,48 @@ func TestFinalizeIgnoresFailureClassNoneOnPassingLane(t *testing.T) {
 	if got.Verdict != VerdictPass {
 		t.Fatalf("Verdict = %q, want pass", got.Verdict)
 	}
-	if got.FailureClass != "" || got.FailureReason != "" {
-		t.Fatalf("failure = %q/%q, want empty", got.FailureClass, got.FailureReason)
+	if got.FailureClass != FailureClassNone || got.FailureReason != "" {
+		t.Fatalf("failure = %q/%q, want none/empty", got.FailureClass, got.FailureReason)
+	}
+}
+
+func TestFinalizeSuccessUsesDurableNoFailureContract(t *testing.T) {
+	got := Finalize([]LaneOutput{
+		{
+			LaneID:              lanePrimary,
+			Verdict:             VerdictPass,
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+	if got.FailureClass != FailureClassNone || got.FailureReason != "" {
+		t.Fatalf("failure = %q/%q, want none/empty", got.FailureClass, got.FailureReason)
+	}
+	if got.Findings == nil {
+		t.Fatal("Findings = nil, want empty array for durable JSON")
+	}
+	if got.Evidence == nil {
+		t.Fatal("Evidence = nil, want empty array for durable JSON")
+	}
+	if got.Lanes == nil {
+		t.Fatal("Lanes = nil, want empty or populated array for durable JSON")
+	}
+
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if string(fields["failure_class"]) != `"`+FailureClassNone+`"` {
+		t.Fatalf("failure_class JSON = %s, want %q", fields["failure_class"], FailureClassNone)
+	}
+	if string(fields["findings"]) != "[]" {
+		t.Fatalf("findings JSON = %s, want []", fields["findings"])
+	}
+	if string(fields["evidence"]) != "[]" {
+		t.Fatalf("evidence JSON = %s, want []", fields["evidence"])
 	}
 }
 
@@ -173,8 +267,11 @@ func TestFinalizeReadOnlyViolationOverridesFindings(t *testing.T) {
 	if got.FailureClass != FailureClassHard {
 		t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
 	}
-	if got.FailureReason != "read_only_mutation_detected" {
-		t.Fatalf("FailureReason = %q, want read_only_mutation_detected", got.FailureReason)
+	if got.FailureReason != "lane=secondary reason=read_only_mutation_detected" {
+		t.Fatalf("FailureReason = %q, want lane=secondary reason=read_only_mutation_detected", got.FailureReason)
+	}
+	if got.FindingsCount != 1 || len(got.Findings) != 1 {
+		t.Fatalf("Findings = %d/%d, want preserved finding despite read-only failure", got.FindingsCount, len(got.Findings))
 	}
 }
 
@@ -206,12 +303,12 @@ func TestFinalizeReadOnlyViolationOverridesTransientFailure(t *testing.T) {
 	if got.FailureClass != FailureClassHard {
 		t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
 	}
-	if got.FailureReason != "read_only_mutation_detected" {
-		t.Fatalf("FailureReason = %q, want read_only_mutation_detected", got.FailureReason)
+	if got.FailureReason != "lane=secondary reason=read_only_mutation_detected" {
+		t.Fatalf("FailureReason = %q, want lane=secondary reason=read_only_mutation_detected", got.FailureReason)
 	}
 }
 
-func TestFinalizeUnknownVerdictBlocksWithContractFailure(t *testing.T) {
+func TestFinalizeUnknownVerdictFailsWithHardContractFailure(t *testing.T) {
 	got := Finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
@@ -219,11 +316,11 @@ func TestFinalizeUnknownVerdictBlocksWithContractFailure(t *testing.T) {
 			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
 		},
 	})
-	if got.Verdict != VerdictBlocked {
-		t.Fatalf("Verdict = %q, want blocked", got.Verdict)
+	if got.Verdict != VerdictFail {
+		t.Fatalf("Verdict = %q, want fail", got.Verdict)
 	}
-	if got.FailureClass != FailureClassTransient {
-		t.Fatalf("FailureClass = %q, want transient", got.FailureClass)
+	if got.FailureClass != FailureClassHard {
+		t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
 	}
 	if got.FailureReason != "lane=primary reason=unknown_verdict_value" {
 		t.Fatalf("FailureReason = %q, want lane=primary reason=unknown_verdict_value", got.FailureReason)
@@ -304,5 +401,70 @@ func TestFinalizeDisabledReadOnlyEnforcementHardFails(t *testing.T) {
 	}
 	if got.FailureReason != "lane=primary reason=read_only_enforcement_disabled" {
 		t.Fatalf("FailureReason = %q, want read_only_enforcement_disabled", got.FailureReason)
+	}
+}
+
+func TestFinalizeReadOnlyMutationFailureIdentifiesAllMutatingLanes(t *testing.T) {
+	got := Finalize([]LaneOutput{
+		{
+			LaneID:  lanePrimary,
+			Verdict: VerdictPass,
+			MutationsDelta: MutationsDelta{Changed: []StatusEntry{
+				{Path: "primary.go", Status: "M"},
+			}},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: false},
+		},
+		{
+			LaneID:  laneSecondary,
+			Verdict: VerdictPass,
+			MutationsDelta: MutationsDelta{Changed: []StatusEntry{
+				{Path: "secondary.go", Status: "M"},
+			}},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: false},
+		},
+	})
+	want := "lane=primary reason=read_only_mutation_detected; lane=secondary reason=read_only_mutation_detected"
+	if got.FailureReason != want {
+		t.Fatalf("FailureReason = %q, want %q", got.FailureReason, want)
+	}
+}
+
+func TestFinalizeCopiesFirstReadOnlyNotes(t *testing.T) {
+	notes := []string{"baseline captured"}
+	got := Finalize([]LaneOutput{
+		{
+			LaneID:              lanePrimary,
+			Verdict:             VerdictPass,
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true, Notes: notes},
+		},
+	})
+	notes[0] = "mutated after finalize"
+	if got.ReadOnlyEnforcement.Notes[0] != "baseline captured" {
+		t.Fatalf("ReadOnlyEnforcement.Notes[0] = %q, want copied note", got.ReadOnlyEnforcement.Notes[0])
+	}
+}
+
+func TestFinalizeMergesMutationsInLaneOrder(t *testing.T) {
+	got := Finalize([]LaneOutput{
+		{
+			LaneID:  laneSecondary,
+			Verdict: VerdictPass,
+			MutationsDelta: MutationsDelta{Changed: []StatusEntry{
+				{Path: "same.go", Status: "D"},
+			}},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: false},
+		},
+		{
+			LaneID:  lanePrimary,
+			Verdict: VerdictPass,
+			MutationsDelta: MutationsDelta{Changed: []StatusEntry{
+				{Path: "same.go", Status: "M"},
+			}},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: false},
+		},
+	})
+	want := MutationsDelta{Changed: []StatusEntry{{Path: "same.go", Status: "D"}}}
+	if !reflect.DeepEqual(got.MutationsDelta, want) {
+		t.Fatalf("MutationsDelta = %+v, want %+v", got.MutationsDelta, want)
 	}
 }

--- a/internal/reviewquorum/finalize_test.go
+++ b/internal/reviewquorum/finalize_test.go
@@ -9,20 +9,104 @@ import (
 const (
 	lanePrimary   = "primary"
 	laneSecondary = "secondary"
+	reviewSubject = "gh:gastownhall/gascity#1694"
+	reviewBaseRef = "origin/main"
 )
 
+func finalize(outputs []LaneOutput) Summary {
+	return Finalize(reviewSubject, reviewBaseRef, outputs)
+}
+
 func TestFinalizeReturnsAwaitingOnlyWithoutLaneOutputs(t *testing.T) {
-	got := Finalize(nil)
+	got := finalize(nil)
 	if got.Verdict != VerdictAwaitingReviewers {
 		t.Fatalf("Verdict = %q, want %q", got.Verdict, VerdictAwaitingReviewers)
+	}
+	if got.Subject != reviewSubject || got.BaseRef != reviewBaseRef {
+		t.Fatalf("identity = %q/%q, want %q/%q", got.Subject, got.BaseRef, reviewSubject, reviewBaseRef)
 	}
 	if len(got.Lanes) != 0 {
 		t.Fatalf("Lanes len = %d, want 0", len(got.Lanes))
 	}
 }
 
+func TestFinalizePropagatesReviewIdentityToSummaryJSON(t *testing.T) {
+	got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{
+		{
+			LaneID:              lanePrimary,
+			Verdict:             VerdictPass,
+			FindingsCount:       0,
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+
+	if got.Subject != reviewSubject || got.BaseRef != reviewBaseRef {
+		t.Fatalf("identity = %q/%q, want %q/%q", got.Subject, got.BaseRef, reviewSubject, reviewBaseRef)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if string(fields["subject"]) != `"`+reviewSubject+`"` || string(fields["base_ref"]) != `"`+reviewBaseRef+`"` {
+		t.Fatalf("JSON identity = %s/%s, want %q/%q", fields["subject"], fields["base_ref"], reviewSubject, reviewBaseRef)
+	}
+}
+
+func TestFinalizeRejectsFindingsCountMismatch(t *testing.T) {
+	got := finalize([]LaneOutput{
+		{
+			LaneID:        lanePrimary,
+			Verdict:       VerdictPassWithFindings,
+			FindingsCount: 2,
+			Findings: []Finding{
+				{Title: "missing peer", File: "main.go", Start: 12},
+			},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+
+	if got.Verdict != VerdictFail {
+		t.Fatalf("Verdict = %q, want fail", got.Verdict)
+	}
+	if got.FailureClass != FailureClassHard {
+		t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
+	}
+	if got.FailureReason != "lane=primary reason=findings_count_mismatch" {
+		t.Fatalf("FailureReason = %q, want findings_count_mismatch", got.FailureReason)
+	}
+}
+
+func TestFinalizeRejectsFindingsBearingVerdictsWithoutFindings(t *testing.T) {
+	for _, verdict := range []string{VerdictPassWithFindings, VerdictFail} {
+		t.Run(verdict, func(t *testing.T) {
+			got := finalize([]LaneOutput{
+				{
+					LaneID:              lanePrimary,
+					Verdict:             verdict,
+					FindingsCount:       0,
+					ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+				},
+			})
+
+			if got.Verdict != VerdictFail {
+				t.Fatalf("Verdict = %q, want fail", got.Verdict)
+			}
+			if got.FailureClass != FailureClassHard {
+				t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
+			}
+			if got.FailureReason != "lane=primary reason=materialized_findings_missing" {
+				t.Fatalf("FailureReason = %q, want materialized_findings_missing", got.FailureReason)
+			}
+		})
+	}
+}
+
 func TestFinalizeSoftFailsTransientLaneWithoutAwaitingFinalize(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:        lanePrimary,
 			Provider:      "local",
@@ -70,10 +154,11 @@ func TestFinalizeSoftFailsTransientLaneWithoutAwaitingFinalize(t *testing.T) {
 }
 
 func TestFinalizeFindingsRequestChanges(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
-			LaneID:  lanePrimary,
-			Verdict: VerdictPass,
+			LaneID:        lanePrimary,
+			Verdict:       VerdictPass,
+			FindingsCount: 1,
 			Findings: []Finding{
 				{Title: "bug", File: "main.go", Start: 12},
 			},
@@ -94,10 +179,11 @@ func TestFinalizeFindingsRequestChanges(t *testing.T) {
 }
 
 func TestFinalizeDeduplicatesFindingsWithLaneEvidence(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
-			LaneID:  lanePrimary,
-			Verdict: VerdictPassWithFindings,
+			LaneID:        lanePrimary,
+			Verdict:       VerdictPassWithFindings,
+			FindingsCount: 1,
 			Findings: []Finding{
 				{
 					Severity: "major",
@@ -112,8 +198,9 @@ func TestFinalizeDeduplicatesFindingsWithLaneEvidence(t *testing.T) {
 			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
 		},
 		{
-			LaneID:  laneSecondary,
-			Verdict: VerdictPassWithFindings,
+			LaneID:        laneSecondary,
+			Verdict:       VerdictPassWithFindings,
+			FindingsCount: 1,
 			Findings: []Finding{
 				{
 					Severity: "major",
@@ -144,7 +231,7 @@ func TestFinalizeDeduplicatesFindingsWithLaneEvidence(t *testing.T) {
 }
 
 func TestFinalizeIgnoresFailureClassNoneOnPassingLane(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
 			Verdict:             VerdictPass,
@@ -167,7 +254,7 @@ func TestFinalizeIgnoresFailureClassNoneOnPassingLane(t *testing.T) {
 }
 
 func TestFinalizeSuccessUsesDurableNoFailureContract(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
 			Verdict:             VerdictPass,
@@ -207,10 +294,12 @@ func TestFinalizeSuccessUsesDurableNoFailureContract(t *testing.T) {
 }
 
 func TestFinalizeFailureClassNoneStillHonorsLaneVerdict(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
 			Verdict:             VerdictFail,
+			FindingsCount:       1,
+			Findings:            []Finding{{Title: "blocking issue", File: "main.go", Start: 12}},
 			FailureClass:        FailureClassNone,
 			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
 		},
@@ -224,7 +313,7 @@ func TestFinalizeFailureClassNoneStillHonorsLaneVerdict(t *testing.T) {
 }
 
 func TestFinalizeMutationsRequestChanges(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:  lanePrimary,
 			Verdict: VerdictPass,
@@ -243,10 +332,11 @@ func TestFinalizeMutationsRequestChanges(t *testing.T) {
 }
 
 func TestFinalizeReadOnlyViolationOverridesFindings(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
-			LaneID:  lanePrimary,
-			Verdict: VerdictPass,
+			LaneID:        lanePrimary,
+			Verdict:       VerdictPass,
+			FindingsCount: 1,
 			Findings: []Finding{
 				{Title: "bug", File: "main.go", Start: 12},
 			},
@@ -276,7 +366,7 @@ func TestFinalizeReadOnlyViolationOverridesFindings(t *testing.T) {
 }
 
 func TestFinalizeReadOnlyViolationOverridesTransientFailure(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:        lanePrimary,
 			Verdict:       VerdictBlocked,
@@ -309,7 +399,7 @@ func TestFinalizeReadOnlyViolationOverridesTransientFailure(t *testing.T) {
 }
 
 func TestFinalizeUnknownVerdictFailsWithHardContractFailure(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
 			Verdict:             "approve",
@@ -328,10 +418,11 @@ func TestFinalizeUnknownVerdictFailsWithHardContractFailure(t *testing.T) {
 }
 
 func TestFinalizeTransientFailureOutranksFindings(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
-			LaneID:  lanePrimary,
-			Verdict: VerdictPassWithFindings,
+			LaneID:        lanePrimary,
+			Verdict:       VerdictPassWithFindings,
+			FindingsCount: 1,
 			Findings: []Finding{
 				{Title: "bug", File: "main.go", Start: 12},
 			},
@@ -361,7 +452,7 @@ func TestFinalizeTransientFailureOutranksFindings(t *testing.T) {
 }
 
 func TestFinalizeMissingReadOnlyEnforcementHardFails(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:  lanePrimary,
 			Verdict: VerdictPass,
@@ -382,7 +473,7 @@ func TestFinalizeMissingReadOnlyEnforcementHardFails(t *testing.T) {
 }
 
 func TestFinalizeDisabledReadOnlyEnforcementHardFails(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:  lanePrimary,
 			Verdict: VerdictPass,
@@ -405,7 +496,7 @@ func TestFinalizeDisabledReadOnlyEnforcementHardFails(t *testing.T) {
 }
 
 func TestFinalizeReadOnlyMutationFailureIdentifiesAllMutatingLanes(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:  lanePrimary,
 			Verdict: VerdictPass,
@@ -431,7 +522,7 @@ func TestFinalizeReadOnlyMutationFailureIdentifiesAllMutatingLanes(t *testing.T)
 
 func TestFinalizeCopiesFirstReadOnlyNotes(t *testing.T) {
 	notes := []string{"baseline captured"}
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
 			Verdict:             VerdictPass,
@@ -445,7 +536,7 @@ func TestFinalizeCopiesFirstReadOnlyNotes(t *testing.T) {
 }
 
 func TestFinalizeMergesMutationsInLaneOrder(t *testing.T) {
-	got := Finalize([]LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:  laneSecondary,
 			Verdict: VerdictPass,

--- a/internal/reviewquorum/finalize_test.go
+++ b/internal/reviewquorum/finalize_test.go
@@ -14,7 +14,16 @@ const (
 )
 
 func finalize(outputs []LaneOutput) Summary {
-	return Finalize(reviewSubject, reviewBaseRef, outputs)
+	lanes := append([]LaneOutput(nil), outputs...)
+	for i := range lanes {
+		if lanes[i].Provider == "" {
+			lanes[i].Provider = "test-provider"
+		}
+		if lanes[i].Model == "" {
+			lanes[i].Model = "test-model"
+		}
+	}
+	return Finalize(reviewSubject, reviewBaseRef, lanes)
 }
 
 func TestFinalizeReturnsAwaitingOnlyWithoutLaneOutputs(t *testing.T) {
@@ -31,7 +40,7 @@ func TestFinalizeReturnsAwaitingOnlyWithoutLaneOutputs(t *testing.T) {
 }
 
 func TestFinalizePropagatesReviewIdentityToSummaryJSON(t *testing.T) {
-	got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{
+	got := finalize([]LaneOutput{
 		{
 			LaneID:              lanePrimary,
 			Verdict:             VerdictPass,
@@ -53,6 +62,50 @@ func TestFinalizePropagatesReviewIdentityToSummaryJSON(t *testing.T) {
 	}
 	if string(fields["subject"]) != `"`+reviewSubject+`"` || string(fields["base_ref"]) != `"`+reviewBaseRef+`"` {
 		t.Fatalf("JSON identity = %s/%s, want %q/%q", fields["subject"], fields["base_ref"], reviewSubject, reviewBaseRef)
+	}
+}
+
+func TestFinalizeRejectsMissingLaneIdentityFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		lane   LaneOutput
+		reason string
+	}{
+		{
+			name: "missing provider",
+			lane: LaneOutput{
+				LaneID:              lanePrimary,
+				Model:               "model-a",
+				Verdict:             VerdictPass,
+				ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+			},
+			reason: "lane=primary reason=provider_missing",
+		},
+		{
+			name: "missing model",
+			lane: LaneOutput{
+				LaneID:              lanePrimary,
+				Provider:            "provider-a",
+				Verdict:             VerdictPass,
+				ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+			},
+			reason: "lane=primary reason=model_missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{tt.lane})
+			if got.Verdict != VerdictFail {
+				t.Fatalf("Verdict = %q, want fail", got.Verdict)
+			}
+			if got.FailureClass != FailureClassHard {
+				t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
+			}
+			if got.FailureReason != tt.reason {
+				t.Fatalf("FailureReason = %q, want %q", got.FailureReason, tt.reason)
+			}
+		})
 	}
 }
 
@@ -225,8 +278,8 @@ func TestFinalizeDeduplicatesFindingsWithLaneEvidence(t *testing.T) {
 	if !reflect.DeepEqual(got.Findings[0].Lanes, wantLanes) {
 		t.Fatalf("Findings[0].Lanes = %+v, want %+v", got.Findings[0].Lanes, wantLanes)
 	}
-	if len(got.Findings[0].Evidence) != 2 {
-		t.Fatalf("Findings[0].Evidence len = %d, want 2", len(got.Findings[0].Evidence))
+	if len(got.Findings[0].Evidence) != 1 {
+		t.Fatalf("Findings[0].Evidence len = %d, want first lane-level evidence only", len(got.Findings[0].Evidence))
 	}
 }
 
@@ -535,7 +588,7 @@ func TestFinalizeCopiesFirstReadOnlyNotes(t *testing.T) {
 	}
 }
 
-func TestFinalizeMergesMutationsInLaneOrder(t *testing.T) {
+func TestFinalizeKeepsLaneMutationsOutOfSummaryDelta(t *testing.T) {
 	got := finalize([]LaneOutput{
 		{
 			LaneID:  laneSecondary,
@@ -554,8 +607,14 @@ func TestFinalizeMergesMutationsInLaneOrder(t *testing.T) {
 			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: false},
 		},
 	})
-	want := MutationsDelta{Changed: []StatusEntry{{Path: "same.go", Status: "D"}}}
-	if !reflect.DeepEqual(got.MutationsDelta, want) {
-		t.Fatalf("MutationsDelta = %+v, want %+v", got.MutationsDelta, want)
+	if len(got.MutationsDelta.Changed) != 0 {
+		t.Fatalf("summary MutationsDelta = %+v, want synthesis-only empty delta", got.MutationsDelta)
+	}
+	if len(got.Lanes) != 2 {
+		t.Fatalf("Lanes len = %d, want 2", len(got.Lanes))
+	}
+	want := MutationsDelta{Changed: []StatusEntry{{Path: "same.go", Status: "M"}}}
+	if !reflect.DeepEqual(got.Lanes[0].MutationsDelta, want) {
+		t.Fatalf("primary lane MutationsDelta = %+v, want %+v", got.Lanes[0].MutationsDelta, want)
 	}
 }

--- a/internal/reviewquorum/finalize_test.go
+++ b/internal/reviewquorum/finalize_test.go
@@ -3,6 +3,7 @@ package reviewquorum
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -72,6 +73,16 @@ func TestFinalizeRejectsMissingLaneIdentityFields(t *testing.T) {
 		reason string
 	}{
 		{
+			name: "missing lane id",
+			lane: LaneOutput{
+				Provider:            "provider-a",
+				Model:               "model-a",
+				Verdict:             VerdictPass,
+				ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+			},
+			reason: "lane=unknown_lane reason=lane_id_missing",
+		},
+		{
 			name: "missing provider",
 			lane: LaneOutput{
 				LaneID:              lanePrimary,
@@ -96,6 +107,66 @@ func TestFinalizeRejectsMissingLaneIdentityFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{tt.lane})
+			if got.Verdict != VerdictFail {
+				t.Fatalf("Verdict = %q, want fail", got.Verdict)
+			}
+			if got.FailureClass != FailureClassHard {
+				t.Fatalf("FailureClass = %q, want hard", got.FailureClass)
+			}
+			if got.FailureReason != tt.reason {
+				t.Fatalf("FailureReason = %q, want %q", got.FailureReason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestFinalizeReportsSummaryIdentityFailuresBeforeLaneFailures(t *testing.T) {
+	got := Finalize(" ", "", []LaneOutput{
+		{
+			LaneID:              lanePrimary,
+			Provider:            "",
+			Model:               "model-a",
+			Verdict:             VerdictPass,
+			ReadOnlyEnforcement: ReadOnlyEnforcement{Observed: true, Enabled: true, Passed: true},
+		},
+	})
+
+	wantPrefix := "summary_subject_missing; summary_base_ref_missing; lane=primary reason=provider_missing"
+	if !strings.HasPrefix(got.FailureReason, wantPrefix) {
+		t.Fatalf("FailureReason = %q, want prefix %q", got.FailureReason, wantPrefix)
+	}
+}
+
+func TestFinalizeRejectsMissingSummaryIdentityWithoutLanes(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+		baseRef string
+		reason  string
+	}{
+		{
+			name:    "missing subject",
+			subject: "",
+			baseRef: reviewBaseRef,
+			reason:  "summary_subject_missing",
+		},
+		{
+			name:    "missing base ref",
+			subject: reviewSubject,
+			baseRef: " ",
+			reason:  "summary_base_ref_missing",
+		},
+		{
+			name:    "missing both",
+			subject: " ",
+			baseRef: "",
+			reason:  "summary_subject_missing; summary_base_ref_missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Finalize(tt.subject, tt.baseRef, nil)
 			if got.Verdict != VerdictFail {
 				t.Fatalf("Verdict = %q, want fail", got.Verdict)
 			}
@@ -155,6 +226,70 @@ func TestFinalizeRejectsFindingsBearingVerdictsWithoutFindings(t *testing.T) {
 				t.Fatalf("FailureReason = %q, want materialized_findings_missing", got.FailureReason)
 			}
 		})
+	}
+}
+
+func TestFinalizeSkipsContractInvalidLaneDataFromSummary(t *testing.T) {
+	got := Finalize(reviewSubject, reviewBaseRef, []LaneOutput{
+		{
+			LaneID:        lanePrimary,
+			Provider:      "",
+			Model:         "model-a",
+			Verdict:       VerdictPassWithFindings,
+			Summary:       "invalid lane summary",
+			FindingsCount: 1,
+			Findings: []Finding{
+				{Title: "must not be merged", File: "internal/reviewquorum/finalize.go", Start: 12},
+			},
+			Evidence: []Evidence{{Kind: "file", Path: "internal/reviewquorum/finalize.go"}},
+			Usage:    &Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{
+				Observed: true,
+				Enabled:  true,
+				Passed:   true,
+				Notes:    []string{"invalid lane note"},
+			},
+		},
+		{
+			LaneID:        laneSecondary,
+			Provider:      "provider-b",
+			Model:         "model-b",
+			Verdict:       VerdictPass,
+			Summary:       "valid lane summary",
+			FindingsCount: 0,
+			Usage:         &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{
+				Observed: true,
+				Enabled:  true,
+				Passed:   true,
+				Notes:    []string{"valid lane note"},
+			},
+		},
+	})
+
+	if got.Verdict != VerdictFail {
+		t.Fatalf("Verdict = %q, want fail", got.Verdict)
+	}
+	if got.FailureReason != "lane=primary reason=provider_missing" {
+		t.Fatalf("FailureReason = %q, want provider_missing", got.FailureReason)
+	}
+	if got.FindingsCount != 0 || len(got.Findings) != 0 {
+		t.Fatalf("Findings = %d/%d, want no invalid lane findings", got.FindingsCount, len(got.Findings))
+	}
+	if len(got.Evidence) != 0 {
+		t.Fatalf("Evidence len = %d, want no invalid lane evidence", len(got.Evidence))
+	}
+	if got.Usage == nil || got.Usage.TotalTokens != 3 {
+		t.Fatalf("Usage = %+v, want valid lane usage only", got.Usage)
+	}
+	if !reflect.DeepEqual(got.ReadOnlyEnforcement.Notes, []string{"valid lane note"}) {
+		t.Fatalf("ReadOnlyEnforcement.Notes = %+v, want valid lane notes only", got.ReadOnlyEnforcement.Notes)
+	}
+	if !got.ReadOnlyEnforcement.Observed || !got.ReadOnlyEnforcement.Enabled || !got.ReadOnlyEnforcement.Passed {
+		t.Fatalf("ReadOnlyEnforcement = %+v, want valid lane enforcement only", got.ReadOnlyEnforcement)
+	}
+	if len(got.Lanes) != 2 {
+		t.Fatalf("Lanes len = %d, want traceability for both lanes", len(got.Lanes))
 	}
 }
 
@@ -280,6 +415,69 @@ func TestFinalizeDeduplicatesFindingsWithLaneEvidence(t *testing.T) {
 	}
 	if len(got.Findings[0].Evidence) != 1 {
 		t.Fatalf("Findings[0].Evidence len = %d, want first lane-level evidence only", len(got.Findings[0].Evidence))
+	}
+}
+
+func TestFinalizeDeepCopiesLaneOutputs(t *testing.T) {
+	outputs := []LaneOutput{
+		{
+			LaneID:        lanePrimary,
+			Provider:      "provider-a",
+			Model:         "model-a",
+			Verdict:       VerdictPassWithFindings,
+			Summary:       "has finding",
+			FindingsCount: 1,
+			Findings: []Finding{
+				{
+					Title:    "finding",
+					File:     "internal/reviewquorum/finalize.go",
+					Start:    12,
+					Lanes:    []string{"reported"},
+					Evidence: []Evidence{{Kind: "file", Path: "finding.go"}},
+				},
+			},
+			Evidence: []Evidence{{Kind: "file", Path: "lane.go"}},
+			Usage:    &Usage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+			ReadOnlyEnforcement: ReadOnlyEnforcement{
+				Observed: true,
+				Enabled:  true,
+				Passed:   true,
+				Notes:    []string{"captured"},
+			},
+			MutationsDelta: MutationsDelta{Changed: []StatusEntry{{Path: "clean.go", Status: "M"}}},
+		},
+	}
+	got := Finalize(reviewSubject, reviewBaseRef, outputs)
+
+	outputs[0].Findings[0].Title = "mutated"
+	outputs[0].Findings[0].Lanes[0] = "mutated"
+	outputs[0].Findings[0].Evidence[0].Path = "mutated.go"
+	outputs[0].Evidence[0].Path = "mutated-lane.go"
+	outputs[0].Usage.TotalTokens = 99
+	outputs[0].ReadOnlyEnforcement.Notes[0] = "mutated"
+	outputs[0].MutationsDelta.Changed[0].Path = "mutated.go"
+
+	lane := got.Lanes[0]
+	if lane.Findings[0].Title != "finding" {
+		t.Fatalf("lane finding title = %q, want copied finding", lane.Findings[0].Title)
+	}
+	if lane.Findings[0].Lanes[0] != "reported" {
+		t.Fatalf("lane finding lanes = %+v, want copied finding lanes", lane.Findings[0].Lanes)
+	}
+	if lane.Findings[0].Evidence[0].Path != "finding.go" {
+		t.Fatalf("lane finding evidence = %+v, want copied finding evidence", lane.Findings[0].Evidence)
+	}
+	if lane.Evidence[0].Path != "lane.go" {
+		t.Fatalf("lane evidence = %+v, want copied lane evidence", lane.Evidence)
+	}
+	if lane.Usage.TotalTokens != 3 {
+		t.Fatalf("lane usage = %+v, want copied usage", lane.Usage)
+	}
+	if lane.ReadOnlyEnforcement.Notes[0] != "captured" {
+		t.Fatalf("lane notes = %+v, want copied notes", lane.ReadOnlyEnforcement.Notes)
+	}
+	if lane.MutationsDelta.Changed[0].Path != "clean.go" {
+		t.Fatalf("lane mutations = %+v, want copied mutations", lane.MutationsDelta)
 	}
 }
 

--- a/internal/reviewquorum/mutations.go
+++ b/internal/reviewquorum/mutations.go
@@ -127,20 +127,3 @@ func sortStatusEntries(entries []StatusEntry) {
 		return entries[i].Path < entries[j].Path
 	})
 }
-
-func mergeMutationDeltas(deltas ...MutationsDelta) MutationsDelta {
-	byPath := map[string]StatusEntry{}
-	for _, delta := range deltas {
-		for _, entry := range delta.Changed {
-			// Callers pass deltas in deterministic lane order; the last entry
-			// wins when lanes report the same path with different statuses.
-			byPath[entry.Path] = entry
-		}
-	}
-	merged := make([]StatusEntry, 0, len(byPath))
-	for _, entry := range byPath {
-		merged = append(merged, entry)
-	}
-	sortStatusEntries(merged)
-	return MutationsDelta{Changed: merged}
-}

--- a/internal/reviewquorum/mutations_test.go
+++ b/internal/reviewquorum/mutations_test.go
@@ -94,14 +94,3 @@ func TestParseStatusPorcelainDoesNotSplitArrowInNonRenamePath(t *testing.T) {
 		t.Fatalf("ParseStatusPorcelain() = %+v, want %+v", got, want)
 	}
 }
-
-func TestMergeMutationDeltasSamePathLastWriterWins(t *testing.T) {
-	got := mergeMutationDeltas(
-		MutationsDelta{Changed: []StatusEntry{{Path: "main.go", Status: "M"}}},
-		MutationsDelta{Changed: []StatusEntry{{Path: "main.go", Status: "D"}}},
-	)
-	want := MutationsDelta{Changed: []StatusEntry{{Path: "main.go", Status: "D"}}}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("mergeMutationDeltas() = %+v, want %+v", got, want)
-	}
-}

--- a/internal/reviewquorum/types.go
+++ b/internal/reviewquorum/types.go
@@ -66,28 +66,30 @@ func ValidateLaneConfigs(lanes []LaneConfig) error {
 // LaneOutput is the durable JSON payload produced by one reviewer lane.
 type LaneOutput struct {
 	LaneID              string              `json:"lane_id"`
-	Provider            string              `json:"provider,omitempty"`
-	Model               string              `json:"model,omitempty"`
+	Provider            string              `json:"provider"`
+	Model               string              `json:"model"`
 	Verdict             string              `json:"verdict"`
 	Summary             string              `json:"summary"`
 	FindingsCount       int                 `json:"findings_count"`
-	Findings            []Finding           `json:"findings,omitempty"`
-	Evidence            []Evidence          `json:"evidence,omitempty"`
-	Usage               Usage               `json:"usage,omitempty"`
+	Findings            []Finding           `json:"findings"`
+	Evidence            []Evidence          `json:"evidence"`
+	Usage               *Usage              `json:"usage"`
 	ReadOnlyEnforcement ReadOnlyEnforcement `json:"read_only_enforcement"`
 	MutationsDelta      MutationsDelta      `json:"mutations_delta"`
-	FailureClass        string              `json:"failure_class,omitempty"`
-	FailureReason       string              `json:"failure_reason,omitempty"`
+	FailureClass        string              `json:"failure_class"`
+	FailureReason       string              `json:"failure_reason"`
 }
 
 // Finding is a normalized reviewer finding.
 type Finding struct {
-	Title    string `json:"title,omitempty"`
-	Body     string `json:"body,omitempty"`
-	File     string `json:"file,omitempty"`
-	Start    int    `json:"start,omitempty"`
-	End      int    `json:"end,omitempty"`
-	Severity string `json:"severity,omitempty"`
+	Title    string     `json:"title,omitempty"`
+	Body     string     `json:"body,omitempty"`
+	File     string     `json:"file,omitempty"`
+	Start    int        `json:"start,omitempty"`
+	End      int        `json:"end,omitempty"`
+	Severity string     `json:"severity,omitempty"`
+	Lanes    []string   `json:"lanes,omitempty"`
+	Evidence []Evidence `json:"evidence,omitempty"`
 }
 
 // Evidence captures compact source material used by a lane or summary.
@@ -113,31 +115,26 @@ type ReadOnlyEnforcement struct {
 	Observed        bool     `json:"observed"`
 	Enabled         bool     `json:"enabled"`
 	Passed          bool     `json:"passed"`
-	BaselineCommand string   `json:"baseline_command,omitempty"`
-	AfterCommand    string   `json:"after_command,omitempty"`
+	BaselineCommand string   `json:"baseline_command"`
+	AfterCommand    string   `json:"after_command"`
 	Notes           []string `json:"notes,omitempty"`
 }
 
 // Summary is the durable synthesized review quorum result.
 type Summary struct {
+	Subject             string              `json:"subject"`
+	BaseRef             string              `json:"base_ref"`
 	Verdict             string              `json:"verdict"`
 	Summary             string              `json:"summary"`
 	FindingsCount       int                 `json:"findings_count"`
-	Findings            []Finding           `json:"findings,omitempty"`
-	Evidence            []Evidence          `json:"evidence,omitempty"`
-	Usage               Usage               `json:"usage,omitempty"`
+	Findings            []Finding           `json:"findings"`
+	Evidence            []Evidence          `json:"evidence"`
+	Usage               *Usage              `json:"usage"`
 	ReadOnlyEnforcement ReadOnlyEnforcement `json:"read_only_enforcement"`
 	MutationsDelta      MutationsDelta      `json:"mutations_delta"`
-	FailureClass        string              `json:"failure_class,omitempty"`
-	FailureReason       string              `json:"failure_reason,omitempty"`
+	FailureClass        string              `json:"failure_class"`
+	FailureReason       string              `json:"failure_reason"`
 	Lanes               []LaneOutput        `json:"lanes"`
-}
-
-func normalizedFindingsCount(out LaneOutput) int {
-	if out.FindingsCount > 0 {
-		return out.FindingsCount
-	}
-	return len(out.Findings)
 }
 
 func sortLaneOutputs(outputs []LaneOutput) {

--- a/internal/reviewquorum/types.go
+++ b/internal/reviewquorum/types.go
@@ -122,19 +122,22 @@ type ReadOnlyEnforcement struct {
 
 // Summary is the durable synthesized review quorum result.
 type Summary struct {
-	Subject             string              `json:"subject"`
-	BaseRef             string              `json:"base_ref"`
-	Verdict             string              `json:"verdict"`
-	Summary             string              `json:"summary"`
+	Subject string `json:"subject"`
+	BaseRef string `json:"base_ref"`
+	Verdict string `json:"verdict"`
+	Summary string `json:"summary"`
+	// FindingsCount is the count of deduplicated synthesized findings.
 	FindingsCount       int                 `json:"findings_count"`
 	Findings            []Finding           `json:"findings"`
 	Evidence            []Evidence          `json:"evidence"`
 	Usage               *Usage              `json:"usage"`
 	ReadOnlyEnforcement ReadOnlyEnforcement `json:"read_only_enforcement"`
-	MutationsDelta      MutationsDelta      `json:"mutations_delta"`
-	FailureClass        string              `json:"failure_class"`
-	FailureReason       string              `json:"failure_reason"`
-	Lanes               []LaneOutput        `json:"lanes"`
+	// MutationsDelta records synthesis-created mutations only; reviewer lane
+	// mutation deltas remain in Lanes.
+	MutationsDelta MutationsDelta `json:"mutations_delta"`
+	FailureClass   string         `json:"failure_class"`
+	FailureReason  string         `json:"failure_reason"`
+	Lanes          []LaneOutput   `json:"lanes"`
 }
 
 func sortLaneOutputs(outputs []LaneOutput) {

--- a/internal/reviewquorum/types_test.go
+++ b/internal/reviewquorum/types_test.go
@@ -106,6 +106,16 @@ func TestClassifyFailureInvalidClassWithTransientReasonIsHard(t *testing.T) {
 	}
 }
 
+func TestExplicitHardFailureWithTransientReasonStaysHard(t *testing.T) {
+	if IsTransientFailure(FailureClassHard, "provider_timeout") {
+		t.Fatal("IsTransientFailure(hard, provider_timeout) = true, want false")
+	}
+	class, reason := ClassifyFailure(FailureClassHard, "provider_timeout")
+	if class != FailureClassHard || reason != "provider_timeout" {
+		t.Fatalf("ClassifyFailure(hard, provider_timeout) = %q/%q, want hard/provider_timeout", class, reason)
+	}
+}
+
 func TestLaneOutputJSONMatchesFormulaRequiredKeys(t *testing.T) {
 	out := LaneOutput{
 		LaneID:        lanePrimary,

--- a/internal/reviewquorum/types_test.go
+++ b/internal/reviewquorum/types_test.go
@@ -96,6 +96,16 @@ func TestClassifyFailureInvalidClassPreservesReason(t *testing.T) {
 	}
 }
 
+func TestClassifyFailureInvalidClassWithTransientReasonIsHard(t *testing.T) {
+	if IsTransientFailure("retry_later", "provider_timeout") {
+		t.Fatal("IsTransientFailure(retry_later, provider_timeout) = true, want false")
+	}
+	class, reason := ClassifyFailure("retry_later", "provider_timeout")
+	if class != FailureClassHard || reason != "invalid_failure_class_provider_timeout" {
+		t.Fatalf("ClassifyFailure(retry_later, provider_timeout) = %q/%q, want hard/invalid_failure_class_provider_timeout", class, reason)
+	}
+}
+
 func TestLaneOutputJSONMatchesFormulaRequiredKeys(t *testing.T) {
 	out := LaneOutput{
 		LaneID:        lanePrimary,

--- a/internal/reviewquorum/types_test.go
+++ b/internal/reviewquorum/types_test.go
@@ -1,6 +1,10 @@
 package reviewquorum
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 func TestValidateLaneConfigsAcceptsConfiguredLanes(t *testing.T) {
 	lanes := []LaneConfig{
@@ -80,7 +84,96 @@ func TestClassifyFailureNoneNoFailure(t *testing.T) {
 
 func TestClassifyFailureNoneWithReasonIsHardContractFailure(t *testing.T) {
 	class, reason := ClassifyFailure(FailureClassNone, "stale_reason")
-	if class != FailureClassHard || reason != "invalid_failure_class" {
-		t.Fatalf("ClassifyFailure(none, stale_reason) = %q/%q, want hard/invalid_failure_class", class, reason)
+	if class != FailureClassHard || reason != "invalid_failure_class_stale_reason" {
+		t.Fatalf("ClassifyFailure(none, stale_reason) = %q/%q, want hard/invalid_failure_class_stale_reason", class, reason)
+	}
+}
+
+func TestClassifyFailureInvalidClassPreservesReason(t *testing.T) {
+	class, reason := ClassifyFailure("retry_later", "provider exploded")
+	if class != FailureClassHard || reason != "invalid_failure_class_provider_exploded" {
+		t.Fatalf("ClassifyFailure(retry_later, provider exploded) = %q/%q, want hard/invalid_failure_class_provider_exploded", class, reason)
+	}
+}
+
+func TestLaneOutputJSONMatchesFormulaRequiredKeys(t *testing.T) {
+	out := LaneOutput{
+		LaneID:        lanePrimary,
+		Provider:      "codex",
+		Model:         "gpt-5.5",
+		Verdict:       VerdictPass,
+		Summary:       "clean",
+		FindingsCount: 0,
+		Findings:      []Finding{},
+		Evidence:      []Evidence{},
+		Usage:         nil,
+		ReadOnlyEnforcement: ReadOnlyEnforcement{
+			Observed:        true,
+			Enabled:         true,
+			Passed:          true,
+			BaselineCommand: "git status --porcelain=v1 -z",
+			AfterCommand:    "git status --porcelain=v1 -z",
+		},
+		MutationsDelta: MutationsDelta{},
+		FailureClass:   FailureClassNone,
+		FailureReason:  "",
+	}
+
+	got, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	want := `{"lane_id":"primary","provider":"codex","model":"gpt-5.5","verdict":"pass","summary":"clean","findings_count":0,"findings":[],"evidence":[],"usage":null,"read_only_enforcement":{"observed":true,"enabled":true,"passed":true,"baseline_command":"git status --porcelain=v1 -z","after_command":"git status --porcelain=v1 -z"},"mutations_delta":{},"failure_class":"none","failure_reason":""}`
+	if string(got) != want {
+		t.Fatalf("LaneOutput JSON = %s, want %s", got, want)
+	}
+
+	var roundTripped LaneOutput
+	if err := json.Unmarshal(got, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !reflect.DeepEqual(roundTripped, out) {
+		t.Fatalf("round trip = %+v, want %+v", roundTripped, out)
+	}
+}
+
+func TestSummaryJSONMatchesFormulaRequiredKeys(t *testing.T) {
+	out := Summary{
+		Subject:       "gh:gastownhall/gascity#1694",
+		BaseRef:       "origin/main",
+		Verdict:       VerdictPass,
+		Summary:       "clean",
+		FindingsCount: 0,
+		Findings:      []Finding{},
+		Evidence:      []Evidence{},
+		Usage:         nil,
+		ReadOnlyEnforcement: ReadOnlyEnforcement{
+			Observed:        true,
+			Enabled:         true,
+			Passed:          true,
+			BaselineCommand: "git status --porcelain=v1 -z",
+			AfterCommand:    "git status --porcelain=v1 -z",
+		},
+		MutationsDelta: MutationsDelta{},
+		FailureClass:   FailureClassNone,
+		FailureReason:  "",
+		Lanes:          []LaneOutput{},
+	}
+
+	got, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	want := `{"subject":"gh:gastownhall/gascity#1694","base_ref":"origin/main","verdict":"pass","summary":"clean","findings_count":0,"findings":[],"evidence":[],"usage":null,"read_only_enforcement":{"observed":true,"enabled":true,"passed":true,"baseline_command":"git status --porcelain=v1 -z","after_command":"git status --porcelain=v1 -z"},"mutations_delta":{},"failure_class":"none","failure_reason":"","lanes":[]}`
+	if string(got) != want {
+		t.Fatalf("Summary JSON = %s, want %s", got, want)
+	}
+
+	var roundTripped Summary
+	if err := json.Unmarshal(got, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !reflect.DeepEqual(roundTripped, out) {
+		t.Fatalf("round trip = %+v, want %+v", roundTripped, out)
 	}
 }


### PR DESCRIPTION
## Summary
- align `reviewquorum` lane and summary JSON structs with the review-quorum formula contract
- deduplicate synthesized findings while preserving lane provenance and evidence
- treat unknown verdicts and malformed failure classes as hard contract failures with useful reasons
- include lane IDs in read-only mutation failures and preserve read-only notes defensively

## Tests
- `go test -count=1 ./internal/reviewquorum`
- `go test -count=1 ./internal/reviewquorum ./internal/formula ./internal/molecule ./internal/dispatch`
- `make test`
- `.githooks/pre-commit` via `git commit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->