### PR TITLE
fix(supervisor): launchctl-getenv fallback for GC_DOLT_LOGLEVEL in bd lifecycle env

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,6 +24,27 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/pidutil"
 )
+
+// providerLifecycleLaunchctlGetenv reads a value from `launchctl getenv` on
+// macOS. Used by providerLifecycleProcessEnv as a fallback when an env var
+// the bd-provider script consumes (currently only GC_DOLT_LOGLEVEL) isn't
+// set in os.Environ — without this, `gc start` from a user shell silently
+// drops `launchctl setenv` values because they live in launchd's domain,
+// not the shell's env. Returns "" on non-Darwin or when the key is unset
+// or launchctl is unavailable.
+//
+// var so tests can stub without invoking real launchctl. Same pattern as
+// supervisorLaunchctlRun / supervisorLaunchdActive in cmd_supervisor_lifecycle.go.
+var providerLifecycleLaunchctlGetenv = func(key string) string {
+	if goruntime.GOOS != "darwin" {
+		return ""
+	}
+	out, err := exec.Command("launchctl", "getenv", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
 
 // cityDoltConfigs stores per-city Dolt configuration keyed by cityPath.
 // Registered by startBeadsLifecycle so env builders and isExternalDolt can
@@ -1462,6 +1484,25 @@ func providerLifecycleProcessEnv(cityPath, provider string) []string {
 		dc, _ := v.(config.DoltConfig)
 		if dc.ArchiveLevel != nil {
 			env = append(env, fmt.Sprintf("GC_DOLT_ARCHIVE_LEVEL=%d", *dc.ArchiveLevel))
+		}
+	}
+	// `gc start` runs in the user's shell, which doesn't see vars set
+	// only via `launchctl setenv` — those live in launchd's domain.
+	// Fall back to launchctl-getenv so the managed dolt server's log
+	// level honors `launchctl setenv GC_DOLT_LOGLEVEL` even when the
+	// shell hasn't `export`ed it. The supervisor's reconcile path
+	// runs the same lookup; either source delivers the value.
+	const loglevelPrefix = "GC_DOLT_LOGLEVEL="
+	loglevelInEnv := false
+	for _, entry := range env {
+		if strings.HasPrefix(entry, loglevelPrefix) {
+			loglevelInEnv = true
+			break
+		}
+	}
+	if !loglevelInEnv {
+		if val := providerLifecycleLaunchctlGetenv("GC_DOLT_LOGLEVEL"); val != "" {
+			env = append(env, loglevelPrefix+val)
 		}
 	}
 	return env

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -203,6 +203,85 @@ func TestProviderLifecycleProcessEnvOmitsArchiveLevelWhenNil(t *testing.T) {
 	}
 }
 
+func TestProviderLifecycleProcessEnvFallsBackToLaunchctlGetenvForLoglevel(t *testing.T) {
+	// `gc start` runs in the user's shell, which doesn't see `launchctl
+	// setenv` values. Without the fallback, GC_DOLT_LOGLEVEL set only via
+	// launchctl is silently dropped between the shell and gc-beads-bd.sh,
+	// so the managed dolt config gets written with `log_level: warning`.
+	t.Setenv("GC_DOLT_LOGLEVEL", "")
+	_ = os.Unsetenv("GC_DOLT_LOGLEVEL")
+
+	prev := providerLifecycleLaunchctlGetenv
+	providerLifecycleLaunchctlGetenv = func(key string) string {
+		if key == "GC_DOLT_LOGLEVEL" {
+			return "debug"
+		}
+		return ""
+	}
+	t.Cleanup(func() { providerLifecycleLaunchctlGetenv = prev })
+
+	cityPath := t.TempDir()
+	envEntries := providerLifecycleProcessEnv(cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	got := ""
+	for _, entry := range envEntries {
+		if strings.HasPrefix(entry, "GC_DOLT_LOGLEVEL=") {
+			got = strings.TrimPrefix(entry, "GC_DOLT_LOGLEVEL=")
+			break
+		}
+	}
+	if got != "debug" {
+		t.Fatalf("GC_DOLT_LOGLEVEL = %q, want %q (launchctl fallback should fire when os.Environ lacks it)", got, "debug")
+	}
+}
+
+func TestProviderLifecycleProcessEnvPrefersOSEnvOverLaunchctlForLoglevel(t *testing.T) {
+	// When a user explicitly exports GC_DOLT_LOGLEVEL in the shell, that
+	// value must win over any stale launchctl-domain value.
+	t.Setenv("GC_DOLT_LOGLEVEL", "trace")
+
+	prev := providerLifecycleLaunchctlGetenv
+	providerLifecycleLaunchctlGetenv = func(key string) string {
+		if key == "GC_DOLT_LOGLEVEL" {
+			return "debug"
+		}
+		return ""
+	}
+	t.Cleanup(func() { providerLifecycleLaunchctlGetenv = prev })
+
+	cityPath := t.TempDir()
+	envEntries := providerLifecycleProcessEnv(cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	got := ""
+	for _, entry := range envEntries {
+		if strings.HasPrefix(entry, "GC_DOLT_LOGLEVEL=") {
+			got = strings.TrimPrefix(entry, "GC_DOLT_LOGLEVEL=")
+			break
+		}
+	}
+	if got != "trace" {
+		t.Fatalf("GC_DOLT_LOGLEVEL = %q, want %q (os.Environ should win over launchctl)", got, "trace")
+	}
+}
+
+func TestProviderLifecycleProcessEnvOmitsLoglevelWhenLaunchctlEmpty(t *testing.T) {
+	// When neither os.Environ nor launchctl has GC_DOLT_LOGLEVEL, the env
+	// must not contain a synthetic empty value (which would override
+	// gc-beads-bd.sh's `${GC_DOLT_LOGLEVEL:-warning}` default to empty).
+	t.Setenv("GC_DOLT_LOGLEVEL", "")
+	_ = os.Unsetenv("GC_DOLT_LOGLEVEL")
+
+	prev := providerLifecycleLaunchctlGetenv
+	providerLifecycleLaunchctlGetenv = func(string) string { return "" }
+	t.Cleanup(func() { providerLifecycleLaunchctlGetenv = prev })
+
+	cityPath := t.TempDir()
+	envEntries := providerLifecycleProcessEnv(cityPath, "exec:"+gcBeadsBdScriptPath(cityPath))
+	for _, entry := range envEntries {
+		if strings.HasPrefix(entry, "GC_DOLT_LOGLEVEL=") {
+			t.Fatalf("GC_DOLT_LOGLEVEL should be absent when neither os.Environ nor launchctl has it, got %q", entry)
+		}
+	}
+}
+
 func TestGcBeadsBdReadOnlyFallbackDoesNotTargetLegacyProbeDatabase(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := MaterializeBuiltinPacks(cityPath); err != nil {


### PR DESCRIPTION
## Summary

Without this fix, `launchctl setenv GC_DOLT_LOGLEVEL debug` (the documented user-facing knob) is silently dropped when `gc start` runs from a user shell. The shell doesn't see launchd-domain values unless they're also `export`ed, so `providerLifecycleProcessEnv` builds the bd-provider script's env without `GC_DOLT_LOGLEVEL` — `gc-beads-bd.sh` then defaults to `warning`, `gc dolt-state start-managed` writes `log_level: warning` to the managed `dolt-config.yaml`, and dolt comes up at `L="warning"` instead of `L="debug"`.

The fix:

- Add a Darwin-only `launchctl getenv` fallback to `providerLifecycleProcessEnv` for `GC_DOLT_LOGLEVEL` when the var isn't already in the inherited env. `os.Environ` still wins when both sources have a value, preserving the existing shell-export behavior.
- Both lifecycle-call paths (shell-spawned `gc start` and the supervisor's reconcile) flow through `providerLifecycleProcessEnv`, so a single fallback closes both.
- Non-Darwin short-circuits to `""` so Linux is unchanged. The `launchctl` probe is a `var`-declared hook so tests can stub it without invoking real `launchctl`, matching the pattern of `supervisorLaunchctlRun` / `supervisorLaunchdActive` in `cmd/gc/cmd_supervisor_lifecycle.go`.

Surface: `cmd/gc/beads_provider_lifecycle.go: providerLifecycleProcessEnv` — the canonical env-construction surface for bd-store provider subprocesses; the function every gc-beads-bd.sh lifecycle op (`start`, `stop`, `health`, `recover`) flows through.

Related: PR #1861 takes the supervisor-allowlist approach to the same root issue (launchctl-domain values not visible to ambient shell). That PR's plist passthrough is correct but only fixes the supervisor's own startup env; this PR closes the user-shell-spawned `gc start` path that #1861 doesn't cover. Once both land, the launchctl probe helpers can be deduplicated in a follow-up cleanup.

## Testing

- [x] `make check` (passes; pre-commit hook ran fmt-check, lint, vet, full test suite)
- [ ] `make check-docs` (no docs touched)
- [ ] `make test-integration` (per maintenance policy: skipped — runtime behavior is exercised by the new unit tests, which stub the launchctl hook directly)

Three new tests cover:

1. `TestProviderLifecycleProcessEnvFallsBackToLaunchctlGetenvForLoglevel` — happy path: `GC_DOLT_LOGLEVEL` absent from `os.Environ`, present in launchctl; ends up in the lifecycle env.
2. `TestProviderLifecycleProcessEnvPrefersOSEnvOverLaunchctlForLoglevel` — precedence: shell-export wins when both sources have values.
3. `TestProviderLifecycleProcessEnvOmitsLoglevelWhenLaunchctlEmpty` — absence: no synthetic empty entry that would override `gc-beads-bd.sh`'s `${GC_DOLT_LOGLEVEL:-warning}` default to empty.

## Checklist

- [x] Linked an issue: tracked in our local issue tracker (private repo) as `stg-yorj`; reproduced via the post-#1861 e2e where `dolt-config.yaml` came up at `log_level: warning` despite `launchctl setenv GC_DOLT_LOGLEVEL debug`.
- [x] Added tests for the new behavior (3 cases above).
- [ ] No user-facing docs change required.
- [x] No breaking changes — only adds a fallback source for env values; pre-existing behavior (shell-export passthrough) is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->