### PR TITLE
fix(dolt): avoid managed recovery for transient disconnects

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -341,24 +341,37 @@ func managedBDRecoveryAllowed(cityPath, scopeRoot string, env map[string]string)
 	return managedLocalDoltEnv(env)
 }
 
-func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
+func bdTransportErrorMatches(cityPath, scopeRoot string, env map[string]string, err error, markers []string) bool {
 	if err == nil || !providerUsesBdStoreContract(rawBeadsProviderForScope(scopeRoot, cityPath)) || !managedBDRecoveryAllowed(cityPath, scopeRoot, env) {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{
+	for _, marker := range markers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func bdTransportRetryableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
+	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, []string{
 		"server unreachable",
 		"dial tcp",
 		"connection refused",
 		"broken pipe",
 		"unexpected eof",
 		"bad connection",
-	} {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
+		"use of closed network connection",
+	})
+}
+
+func bdTransportRecoverableError(cityPath, scopeRoot string, env map[string]string, err error) bool {
+	return bdTransportErrorMatches(cityPath, scopeRoot, env, err, []string{
+		"server unreachable",
+		"dial tcp",
+		"connection refused",
+	})
 }
 
 func bdCommandRunnerWithManagedRetry(cityPath string, envFn func(dir string) map[string]string) beads.CommandRunner {
@@ -370,8 +383,10 @@ func bdCommandRunnerWithManagedRetry(cityPath string, envFn func(dir string) map
 		if name != "bd" || !bdTransportRetryableError(cityPath, dir, env, err) {
 			return out, err
 		}
-		if recErr := recoverManagedBDCommand(cityPath); recErr != nil {
-			return out, err
+		if bdTransportRecoverableError(cityPath, dir, env, err) {
+			if recErr := recoverManagedBDCommand(cityPath); recErr != nil {
+				return out, err
+			}
 		}
 		retryEnv := envFn(dir)
 		ensureProjectedDoltEnvExplicit(retryEnv)

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -2458,6 +2458,51 @@ func TestBdTransportRetryableErrorDoesNotTreatCommandTimeoutAsTransportFailure(t
 	}
 }
 
+func TestBdTransportTransientDisconnectDoesNotTriggerManagedRecovery(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+
+	origRunner := beadsExecCommandRunnerWithEnv
+	origRecover := recoverManagedBDCommand
+	t.Cleanup(func() {
+		beadsExecCommandRunnerWithEnv = origRunner
+		recoverManagedBDCommand = origRecover
+	})
+
+	attempts := 0
+	recoverCalls := 0
+	beadsExecCommandRunnerWithEnv = func(_ map[string]string) beads.CommandRunner {
+		return func(_ string, _ string, _ ...string) ([]byte, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, fmt.Errorf("bad connection: use of closed network connection")
+			}
+			return []byte("ok"), nil
+		}
+	}
+	recoverManagedBDCommand = func(_ string) error {
+		recoverCalls++
+		return nil
+	}
+
+	runner := bdCommandRunnerWithManagedRetry(t.TempDir(), func(_ string) map[string]string {
+		return map[string]string{"GC_DOLT_PORT": "3307"}
+	})
+
+	out, err := runner(t.TempDir(), "bd", "list", "--json")
+	if err != nil {
+		t.Fatalf("runner error = %v, want nil", err)
+	}
+	if string(out) != "ok" {
+		t.Fatalf("runner output = %q, want %q", out, "ok")
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if recoverCalls != 0 {
+		t.Fatalf("recoverCalls = %d, want 0", recoverCalls)
+	}
+}
+
 func TestBdTransportRetryableErrorUsesScopeProviderForMixedRig(t *testing.T) {
 	cityPath := t.TempDir()
 	_ = writeReachableManagedDoltState(t, cityPath)


### PR DESCRIPTION
## Summary
- keep transient Dolt transport disconnects retryable once
- restrict managed Dolt recovery/restart attempts to explicit unreachable endpoint failures
- add regression coverage for closed-connection/bad-connection retries that should not recover the managed server

## Testing
- go test ./cmd/gc -run 'TestBdTransport|TestBdCommandRunnerWithManagedRetry'

Installed locally with `make install` from `local/deploy-current-integrated` and restarted `gascity-supervisor.service`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->