### PR TITLE
fix(dolt): address adoption review findings for #1874

### DIFF
--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1022,7 +1022,7 @@ cleanup_stale_locks() {
 # Overwritten on each server start. Without read/write timeouts, CLOSE_WAIT connections
 # accumulate and the server enters unrecoverable read-only mode.
 write_config_yaml() {
-    local archive_level gc_bin wait_timeout_line
+    local archive_level gc_bin raw_wait_timeout wait_timeout_line
     archive_level=${GC_DOLT_ARCHIVE_LEVEL:-0}
     case "$archive_level" in
         ''|*[!0-9]*)
@@ -1041,11 +1041,23 @@ write_config_yaml() {
         return 0
     fi
     wait_timeout_line='  wait_timeout: "30"'
-    case "${GC_DOLT_WAIT_TIMEOUT:-}" in
-        -*) wait_timeout_line="" ;;
+    raw_wait_timeout=${GC_DOLT_WAIT_TIMEOUT:-}
+    case "$raw_wait_timeout" in
         '' ) ;;
+        -*)
+            case "${raw_wait_timeout#-}" in
+                ''|*[!0-9]* ) ;;
+                * ) wait_timeout_line="" ;;
+            esac
+            ;;
         *[!0-9]* ) ;;
-        * ) wait_timeout_line="  wait_timeout: \"${GC_DOLT_WAIT_TIMEOUT}\"" ;;
+        * )
+            if [ "$raw_wait_timeout" -gt 0 ] 2>/dev/null; then
+                wait_timeout_line="  wait_timeout: \"$raw_wait_timeout\""
+            else
+                wait_timeout_line=""
+            fi
+            ;;
     esac
     local tmp
     tmp=$(mktemp "$CONFIG_FILE.tmp.XXXXXX")

--- a/examples/dolt/commands/pull/run.sh
+++ b/examples/dolt/commands/pull/run.sh
@@ -3,6 +3,7 @@
 #
 # Uses the live Dolt SQL server when reachable so pull does not contend with
 # active databases. Falls back to CLI mode only when no server is running.
+# Pulls the configured remote's `main` branch in both SQL and CLI modes.
 #
 # Environment: GC_CITY_PATH, GC_DOLT_PORT, GC_DOLT_USER, GC_DOLT_PASSWORD
 set -e
@@ -69,8 +70,8 @@ dolt_sql() {
 
 find_remote_sql() {
   db="$1"
-  dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1" \
-    | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
+  remote_csv=$(dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1") || return 1
+  printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
 }
 
 pull_database_sql() {
@@ -95,7 +96,7 @@ pull_database_sql() {
     return 1
   fi
 
-  if dolt_sql "USE \`$name\`; CALL DOLT_PULL('$remote_name')" >/dev/null 2>&1; then
+  if dolt_sql "USE \`$name\`; CALL DOLT_PULL('$remote_name', 'main')" >/dev/null 2>&1; then
     echo "  $name: pulled from $remote_url"
     return 0
   fi

--- a/examples/dolt/commands/start/run.sh
+++ b/examples/dolt/commands/start/run.sh
@@ -2,7 +2,8 @@
 # gc dolt start — Start the Dolt server if not already running.
 #
 # Delegates to the gc-beads-bd exec: provider's start operation.
-# Used by the dolt-health order to restart after crashes.
+# Operator command for explicit lifecycle recovery; the dolt-health order is
+# diagnostic-only and does not restart the server automatically.
 #
 # Environment: GC_CITY_PATH
 set -e

--- a/examples/dolt/commands/status/run.sh
+++ b/examples/dolt/commands/status/run.sh
@@ -2,7 +2,8 @@
 # gc dolt status — Check if the Dolt server is running.
 #
 # Exits 0 if the server is reachable, 1 otherwise.
-# Used by the dolt-health order to detect crashes.
+# Lightweight status probe for manual checks and scripts; the dolt-health order
+# uses structured `gc dolt health --json | gc dolt health-check` diagnostics.
 #
 # Environment: GC_CITY_PATH
 set -e

--- a/examples/dolt/commands/sync/run.sh
+++ b/examples/dolt/commands/sync/run.sh
@@ -3,6 +3,8 @@
 #
 # Uses the live Dolt SQL server when reachable so sync does not restart
 # active databases. Falls back to CLI mode only when no server is running.
+# Pushes committed `main` branch state only; it does not auto-commit working
+# changes before pushing.
 # Use --gc to purge closed ephemeral beads before syncing.
 # Use --dry-run to preview without pushing.
 #
@@ -108,8 +110,8 @@ dolt_sql() {
 
 find_remote_sql() {
   db="$1"
-  dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1" \
-    | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
+  remote_csv=$(dolt_sql "USE \`$db\`; SELECT name, url FROM dolt_remotes LIMIT 1") || return 1
+  printf '%s\n' "$remote_csv" | awk -F, 'NR > 1 && $1 != "" {print $1 "|" $2; exit}'
 }
 
 sync_database_sql() {
@@ -139,9 +141,6 @@ sync_database_sql() {
     return 0
   fi
 
-  dolt_sql "USE \`$name\`; CALL DOLT_ADD('-A')" >/dev/null 2>&1 || true
-  dolt_sql "USE \`$name\`; CALL DOLT_COMMIT('-m', 'gc dolt sync: auto-commit working changes', '--allow-empty', '--author', 'Gas City Sync <sync@gascity.local>')" >/dev/null 2>&1 || true
-
   if [ "$force" = true ]; then
     push_query="USE \`$name\`; CALL DOLT_PUSH('--force', '$remote_name', 'main')"
   else
@@ -161,14 +160,21 @@ sync_database_cli() {
   name="$2"
 
   # Check for remote.
+  remote_name=""
   remote=""
   if [ -f "$d/.dolt/remotes.json" ]; then
+    remote_name=$(grep -o '"name":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"name":"//;s/"//' || true)
     remote=$(grep -o '"url":"[^"]*"' "$d/.dolt/remotes.json" 2>/dev/null | head -1 | sed 's/"url":"//;s/"//' || true)
   fi
+  [ -z "$remote_name" ] && remote_name="origin"
 
   if [ -z "$remote" ]; then
     echo "  $name: skipped (no remote)"
     return 0
+  fi
+  if ! valid_remote_name "$remote_name"; then
+    echo "  $name: ERROR: invalid remote name: $remote_name" >&2
+    return 1
   fi
 
   if [ "$dry_run" = true ]; then
@@ -176,10 +182,12 @@ sync_database_cli() {
     return 0
   fi
 
-  push_args="push"
-  [ "$force" = true ] && push_args="push --force"
-
-  if (cd "$d" && dolt $push_args 2>&1); then
+  if [ "$force" = true ]; then
+    if (cd "$d" && dolt push --force "$remote_name" main 2>&1); then
+      echo "  $name: pushed to $remote"
+      return 0
+    fi
+  elif (cd "$d" && dolt push "$remote_name" main 2>&1); then
     echo "  $name: pushed to $remote"
     return 0
   fi

--- a/examples/dolt/orders/dolt-health.toml
+++ b/examples/dolt/orders/dolt-health.toml
@@ -1,5 +1,5 @@
 [order]
-description = "Check dolt server health"
+description = "Check dolt server health without restarting it"
 trigger = "cooldown"
 interval = "30s"
 exec = "gc dolt health --json | gc dolt health-check"

--- a/examples/dolt/pull_test.go
+++ b/examples/dolt/pull_test.go
@@ -57,10 +57,64 @@ func TestPullUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 	log := string(data)
 	for _, want := range []string{
 		"SELECT name, url FROM dolt_remotes LIMIT 1",
-		"CALL DOLT_PULL('origin')",
+		"CALL DOLT_PULL('origin', 'main')",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("dolt log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
 		}
+	}
+}
+
+func TestPullReportsLiveSQLRemoteLookupFailure(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, pullScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltRemoteLookupFailure(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc dolt pull succeeded despite remote lookup failure:\n%s", out)
+	}
+	if !strings.Contains(string(out), "app: ERROR: failed to query remotes") {
+		t.Fatalf("output missing remote lookup failure:\n%s", out)
+	}
+	if strings.Contains(string(out), "skipped (no remote)") {
+		t.Fatalf("remote lookup failure should not be reported as no remote:\n%s", out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "SELECT name, url FROM dolt_remotes LIMIT 1") {
+		t.Fatalf("dolt log missing remote lookup:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PULL") {
+		t.Fatalf("pull should not run after remote lookup failure:\n%s", log)
 	}
 }

--- a/examples/dolt/sync_test.go
+++ b/examples/dolt/sync_test.go
@@ -54,6 +54,25 @@ exit 0
 	return logPath
 }
 
+func writeSyncFakeDoltRemoteLookupFailure(t *testing.T, dir string) string {
+	t.Helper()
+	logPath := filepath.Join(dir, "dolt.log")
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$*" in
+  *"SELECT name, url FROM dolt_remotes LIMIT 1"*)
+    printf 'sql lookup failed\n' >&2
+    exit 7
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "dolt"), []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	return logPath
+}
+
 func writeSyncFakeBeadsBD(t *testing.T, cityPath string) string {
 	t.Helper()
 	scriptDir := filepath.Join(cityPath, ".gc", "system", "packs", "bd", "assets", "scripts")
@@ -117,12 +136,18 @@ func TestSyncUsesLiveSQLWhenManagedServerReachable(t *testing.T) {
 	log := string(data)
 	for _, want := range []string{
 		"SELECT name, url FROM dolt_remotes LIMIT 1",
-		"CALL DOLT_ADD('-A')",
-		"CALL DOLT_COMMIT",
 		"CALL DOLT_PUSH('origin', 'main')",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("dolt log missing %q\nlog:\n%s\noutput:\n%s", want, log, out)
+		}
+	}
+	for _, unwanted := range []string{
+		"CALL DOLT_ADD",
+		"CALL DOLT_COMMIT",
+	} {
+		if strings.Contains(log, unwanted) {
+			t.Fatalf("sync should not auto-commit working changes via SQL; found %q\nlog:\n%s", unwanted, log)
 		}
 	}
 }
@@ -171,5 +196,106 @@ func TestSyncSkipsDatabasesWithNoSyncMarker(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "app: skipped (.no-sync)") {
 		t.Fatalf("output missing .no-sync skip:\n%s", out)
+	}
+}
+
+func TestSyncReportsLiveSQLRemoteLookupFailure(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	port, cleanup := startReachableTCPListener(t)
+	defer cleanup()
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "app", ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDoltRemoteLookupFailure(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		fmt.Sprintf("GC_DOLT_PORT=%d", port),
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gc dolt sync succeeded despite remote lookup failure:\n%s", out)
+	}
+	if !strings.Contains(string(out), "app: ERROR: failed to query remotes") {
+		t.Fatalf("output missing remote lookup failure:\n%s", out)
+	}
+	if strings.Contains(string(out), "skipped (no remote)") {
+		t.Fatalf("remote lookup failure should not be reported as no remote:\n%s", out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "SELECT name, url FROM dolt_remotes LIMIT 1") {
+		t.Fatalf("dolt log missing remote lookup:\n%s", log)
+	}
+	if strings.Contains(log, "DOLT_PUSH") {
+		t.Fatalf("sync should not push after remote lookup failure:\n%s", log)
+	}
+}
+
+func TestSyncCLIFallbackPushesOriginMain(t *testing.T) {
+	root := repoRoot(t)
+	script := filepath.Join(root, syncScript)
+
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "data")
+	dbDir := filepath.Join(dataDir, "app")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir db: %v", err)
+	}
+	remotes := `{"remotes":[{"name":"origin","url":"https://example.invalid/repo"}]}`
+	if err := os.WriteFile(filepath.Join(dbDir, ".dolt", "remotes.json"), []byte(remotes), 0o644); err != nil {
+		t.Fatalf("write remotes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	doltLog := writeSyncFakeDolt(t, binDir)
+	_ = writeSyncFakeBeadsBD(t, cityPath)
+
+	cmd := exec.Command("sh", script, "--db", "app")
+	cmd.Env = append(filteredEnv(
+		"PATH", "GC_DOLT_HOST", "GC_DOLT_PORT", "GC_DOLT_USER",
+		"GC_DOLT_PASSWORD", "GC_DOLT_DATA_DIR", "GC_CITY_PATH", "GC_PACK_DIR",
+	),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_DATA_DIR="+dataDir,
+		"GC_DOLT_PORT=1",
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gc dolt sync failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(doltLog)
+	if err != nil {
+		t.Fatalf("read fake dolt log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "push origin main") {
+		t.Fatalf("CLI fallback should push explicit origin main\nlog:\n%s\noutput:\n%s", log, out)
 	}
 }

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -2387,11 +2387,12 @@ type DoltConfigExpectedValue struct {
 //
 // This is intentionally a contract subset, not a byte-for-byte mirror of
 // writeManagedDoltConfigFile in cmd/gc/cmd_dolt_config.go. It covers the keys
-// whose drift would change managed runtime behavior materially. Dynamic values
-// such as data_dir are checked by DoltConfigCheck because they depend on the
-// inspected city path.
+// whose drift would change managed runtime behavior materially. wait_timeout
+// follows the same GC_DOLT_WAIT_TIMEOUT environment override as config
+// generation. Dynamic values such as data_dir are checked by DoltConfigCheck
+// because they depend on the inspected city path.
 func DoltConfigExpectedValues() []DoltConfigExpectedValue {
-	return []DoltConfigExpectedValue{
+	values := []DoltConfigExpectedValue{
 		{"behavior.auto_gc_behavior.enable", false},
 		{"behavior.auto_gc_behavior.archive_level", 0},
 		{"system_variables.dolt_auto_gc_enabled", "OFF"},
@@ -2399,13 +2400,35 @@ func DoltConfigExpectedValues() []DoltConfigExpectedValue {
 		{"system_variables.dolt_stats_gc_enabled", "OFF"},
 		{"system_variables.dolt_stats_memory_only", "ON"},
 		{"system_variables.dolt_stats_paused", "ON"},
-		{"system_variables.wait_timeout", "30"},
 		{"listener.read_timeout_millis", 300000},
 		{"listener.write_timeout_millis", 300000},
 		{"listener.max_connections", 1000},
 		{"listener.back_log", 50},
 		{"listener.max_connections_timeout_millis", 5000},
 	}
+	if waitTimeout := managedDoltConfigExpectedWaitTimeout(); waitTimeout > 0 {
+		values = append(values, DoltConfigExpectedValue{
+			Path:  "system_variables.wait_timeout",
+			Value: strconv.Itoa(waitTimeout),
+		})
+	}
+	return values
+}
+
+func managedDoltConfigExpectedWaitTimeout() int {
+	const defaultWaitTimeout = 30
+	raw := os.Getenv("GC_DOLT_WAIT_TIMEOUT")
+	if raw == "" {
+		return defaultWaitTimeout
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultWaitTimeout
+	}
+	if n < 0 {
+		return 0
+	}
+	return n
 }
 
 // lookupYAMLPath walks a dotted key path through a decoded YAML map and

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -3083,6 +3083,32 @@ func TestDoltConfigCheck_OK(t *testing.T) {
 	}
 }
 
+func TestDoltConfigCheck_AcceptsConfiguredWaitTimeout(t *testing.T) {
+	t.Setenv("GC_DOLT_WAIT_TIMEOUT", "60")
+	dir := setupManagedDoltCity(t)
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"system_variables.wait_timeout": "60",
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK for configured wait_timeout; msg = %s", r.Status, r.Message)
+	}
+}
+
+func TestDoltConfigCheck_AcceptsDisabledWaitTimeout(t *testing.T) {
+	t.Setenv("GC_DOLT_WAIT_TIMEOUT", "-1")
+	dir := setupManagedDoltCity(t)
+	writeDoctorManagedDoltConfig(t, dir, map[string]any{
+		"system_variables.wait_timeout": "__missing__",
+	})
+	c := NewDoltConfigCheck(dir, false)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("status = %d, want OK for disabled wait_timeout; msg = %s", r.Status, r.Message)
+	}
+}
+
 func TestDoltConfigCheck_AcceptsLegacyArchiveLevelOne(t *testing.T) {
 	dir := setupManagedDoltCity(t)
 	writeDoctorManagedDoltConfig(t, dir, map[string]any{


### PR DESCRIPTION
Maintainer follow-up for #1874 because the original PR was already merged before the adopted maintainer fixup could be carried through a new merge surface.

Original PR: https://github.com/gastownhall/gascity/pull/1874
Original title: Fix Dolt lifecycle parity gaps from Gastown
Original state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up is based on current `main` and contains only the reviewed maintainer fixup commit from the adoption workflow:

- `bd4fa866f fix(dolt): address review findings`

## Maintainer Changes

- Preserve live-SQL remote lookup failures in Dolt sync and pull instead of reporting them as `skipped (no remote)`.
- Remove SQL sync auto-commit behavior so SQL and CLI sync both push committed `main` state.
- Surface add/commit and remote-query failures instead of reporting success for a previous clean state.
- Align `gc doctor` wait-timeout expectations with supported generated config overrides.
- Clarify the Dolt health order as diagnostic-only and keep branch selection consistent with the documented contract.

## Review Status

The adoption review found the Dolt lifecycle parity fixes valuable, then identified gaps around SQL sync semantics, hidden failure handling, doctor config drift, and stale health-order wording. The follow-up commit resolves those findings, and the latest adoption review approved the resulting patch with no remaining gating issues.

Remaining non-gating follow-up notes from review:

- SQL-mode push/pull failures still do not include the underlying Dolt diagnostic output.
- CLI fallback remote-name parsing can silently default to `origin` if `remotes.json` formatting changes.

## Local Validation

- `go test ./examples/dolt ./internal/doctor` under a clean environment
- `go test ./cmd/gc -run 'TestSyncConfiguredDoltPortFilesSkipsNonBDProviders|TestInitBeadsForDirExecSetsBEADSDIR|TestInitBeadsForDirExecPreventsStrayGitInit|TestInitBeadsForDirBdMaterializedScriptPreservesCityPath|TestInitBeadsForDirBdMaterializedScriptIgnoresAmbientCityRuntimeEnv|TestGcBeadsBdInitRetriesRootStoreVerification'` under a clean environment

_Adopted via `/adopt-pr` workflow. Original contributor commits are already preserved in #1874; this PR carries only the maintainer-side fixup._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->