### PR TITLE
fix(bd): name the actually-missing dolt identity field

### DIFF
--- a/cmd/gc/gc_beads_bd_identity_test.go
+++ b/cmd/gc/gc_beads_bd_identity_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestEnsureDoltIdentityErrorMessages exercises the ensure_dolt_identity
+// helper from examples/bd/assets/scripts/gc-beads-bd.sh against stub `dolt`
+// and `git` binaries on PATH. The bug being guarded against: when a user
+// has set ONLY `dolt config --global --add user.name`, the previous
+// implementation reported "git user.name not available" and told the user
+// to set user.name (which they already had). The corrected helper reports
+// the field that is actually missing — user.email.
+func TestEnsureDoltIdentityErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available; skipping shell-function test")
+	}
+
+	root := repoRootForLint(t)
+	scriptPath := filepath.Join(root, "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	fnSrc := extractShellFunction(t, string(scriptBytes), "ensure_dolt_identity")
+
+	type fakeStore struct {
+		name  string
+		email string
+	}
+	type wantOutcome struct {
+		exitOK             bool
+		mustContain        []string
+		mustNotContain     []string
+		expectDoltNameSet  string
+		expectDoltEmailSet string
+	}
+	cases := []struct {
+		name string
+		dolt fakeStore
+		git  fakeStore
+		want wantOutcome
+	}{
+		{
+			name: "dolt_has_both_returns_ok",
+			dolt: fakeStore{name: "Roger", email: "roger@example.com"},
+			want: wantOutcome{exitOK: true},
+		},
+		{
+			name: "dolt_only_name_git_empty_reports_email_missing_not_name",
+			dolt: fakeStore{name: "Roger"},
+			want: wantOutcome{
+				exitOK:         false,
+				mustContain:    []string{"user.email"},
+				mustNotContain: []string{`add user.name "Your Name"`},
+			},
+		},
+		{
+			name: "dolt_only_email_git_empty_reports_name_missing_not_email",
+			dolt: fakeStore{email: "roger@example.com"},
+			want: wantOutcome{
+				exitOK:         false,
+				mustContain:    []string{"user.name"},
+				mustNotContain: []string{`add user.email "you@example.com"`},
+			},
+		},
+		{
+			name: "dolt_empty_git_empty_reports_both_missing",
+			want: wantOutcome{
+				exitOK:      false,
+				mustContain: []string{"user.name", "user.email"},
+			},
+		},
+		{
+			name: "dolt_empty_git_has_both_backfills_dolt",
+			git:  fakeStore{name: "Roger", email: "roger@example.com"},
+			want: wantOutcome{
+				exitOK:             true,
+				expectDoltNameSet:  "Roger",
+				expectDoltEmailSet: "roger@example.com",
+			},
+		},
+		{
+			name: "dolt_name_git_email_backfills_only_email",
+			dolt: fakeStore{name: "Roger"},
+			git:  fakeStore{email: "roger@example.com"},
+			want: wantOutcome{
+				exitOK:             true,
+				expectDoltEmailSet: "roger@example.com",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			writeFakeDolt(t, binDir, tc.dolt.name, tc.dolt.email)
+			writeFakeGit(t, binDir, tc.git.name, tc.git.email)
+
+			doltLog := filepath.Join(binDir, "dolt-set.log")
+			origPath := os.Getenv("PATH")
+
+			script := fnSrc + "\n" +
+				"die() { printf '%s\\n' \"$*\" >&2; exit 1; }\n" +
+				"ensure_dolt_identity\n"
+
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+string(os.PathListSeparator)+origPath,
+				"FAKE_DOLT_LOG="+doltLog,
+			)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			runErr := cmd.Run()
+
+			if tc.want.exitOK {
+				if runErr != nil {
+					t.Fatalf("expected success, got %v\nstderr:\n%s", runErr, stderr.String())
+				}
+			} else {
+				if runErr == nil {
+					t.Fatalf("expected non-zero exit, got success\nstderr:\n%s", stderr.String())
+				}
+			}
+			out := stderr.String()
+			for _, frag := range tc.want.mustContain {
+				if !strings.Contains(out, frag) {
+					t.Errorf("stderr missing %q:\n%s", frag, out)
+				}
+			}
+			for _, frag := range tc.want.mustNotContain {
+				if strings.Contains(out, frag) {
+					t.Errorf("stderr should not contain %q (it is misleading guidance):\n%s", frag, out)
+				}
+			}
+			if tc.want.expectDoltNameSet != "" {
+				if !logContains(doltLog, "set user.name "+tc.want.expectDoltNameSet) {
+					t.Errorf("expected dolt user.name to be set to %q; log:\n%s",
+						tc.want.expectDoltNameSet, readFile(doltLog))
+				}
+			}
+			if tc.want.expectDoltEmailSet != "" {
+				if !logContains(doltLog, "set user.email "+tc.want.expectDoltEmailSet) {
+					t.Errorf("expected dolt user.email to be set to %q; log:\n%s",
+						tc.want.expectDoltEmailSet, readFile(doltLog))
+				}
+			}
+		})
+	}
+}
+
+func extractShellFunction(t *testing.T, script, name string) string {
+	t.Helper()
+	// Match the function header and capture lines until the matching
+	// closing brace at column 0. The script uses the conventional
+	// `name() {` ... `\n}` shape.
+	pattern := regexp.MustCompile(`(?ms)^` + regexp.QuoteMeta(name) + `\(\)\s*\{.*?\n\}`)
+	loc := pattern.FindStringIndex(script)
+	if loc == nil {
+		t.Fatalf("could not find shell function %q in script", name)
+	}
+	return script[loc[0]:loc[1]]
+}
+
+func writeFakeDolt(t *testing.T, dir, name, email string) {
+	t.Helper()
+	body := `#!/usr/bin/env bash
+# Stub: only handles "config --global --get|--add user.name|user.email".
+set -e
+log_file=${FAKE_DOLT_LOG:-/dev/null}
+case "$1 $2" in
+  "config --global")
+    case "$3" in
+      --get)
+        case "$4" in
+          user.name)
+` + emitGetIf(name) + `
+            ;;
+          user.email)
+` + emitGetIf(email) + `
+            ;;
+        esac
+        ;;
+      --add)
+        echo "set $4 $5" >> "$log_file"
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+`
+	writeExecutable(t, filepath.Join(dir, "dolt"), body)
+}
+
+func writeFakeGit(t *testing.T, dir, name, email string) {
+	t.Helper()
+	body := `#!/usr/bin/env bash
+set -e
+case "$1 $2" in
+  "config --global")
+    case "$3" in
+      user.name)
+` + emitGetIf(name) + `
+        ;;
+      user.email)
+` + emitGetIf(email) + `
+        ;;
+    esac
+    ;;
+esac
+exit 0
+`
+	writeExecutable(t, filepath.Join(dir, "git"), body)
+}
+
+func emitGetIf(value string) string {
+	if value == "" {
+		return "            exit 1"
+	}
+	return "            echo " + value + "; exit 0"
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func logContains(path, want string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), want)
+}
+
+func readFile(path string) string {
+	data, _ := os.ReadFile(path)
+	return string(data)
+}

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -1614,31 +1614,66 @@ ensure_beads_role() {
 }
 
 # ensure_dolt_identity ensures dolt has user.name and user.email configured.
+#
+# Resolution order per field, in order of precedence:
+#   1. dolt config --global (returned as-is if already set)
+#   2. git config --global  (copied into dolt config)
+#
+# If a field is missing from BOTH dolt and git, fail with an error that
+# names the specific field(s) the user must set — never instruct the user
+# to set a value they have already configured. Historically this function
+# would report "user.name not available" whenever EITHER field was missing
+# (because the dolt-side guard required both), which left users running
+# `dolt config --add user.name` over and over while the real culprit was
+# user.email.
 ensure_dolt_identity() {
-    # Check if already configured.
-    if dolt config --global --get user.name >/dev/null 2>&1 && \
-       dolt config --global --get user.email >/dev/null 2>&1; then
+    # Use dolt's exit code as the canonical "is this field configured?"
+    # signal. Real dolt returns 0 with the value on stdout when the field
+    # is set, non-zero otherwise; some tests stub dolt to return 0 with
+    # empty stdout for any `config` invocation, and we treat that as
+    # configured too (matches historical behavior of this helper).
+    local dolt_has_name=0 dolt_has_email=0
+    local dolt_name="" dolt_email="" git_name git_email
+    if dolt config --global --get user.name >/dev/null 2>&1; then
+        dolt_has_name=1
+        dolt_name=$(dolt config --global --get user.name 2>/dev/null || true)
+    fi
+    if dolt config --global --get user.email >/dev/null 2>&1; then
+        dolt_has_email=1
+        dolt_email=$(dolt config --global --get user.email 2>/dev/null || true)
+    fi
+    if [ "$dolt_has_name" -eq 1 ] && [ "$dolt_has_email" -eq 1 ]; then
         return 0
     fi
 
-    # Copy from git config.
-    local name email
-    name=$(git config --global user.name 2>/dev/null || true)
-    email=$(git config --global user.email 2>/dev/null || true)
+    git_name=$(git config --global user.name 2>/dev/null || true)
+    git_email=$(git config --global user.email 2>/dev/null || true)
 
-    if [ -z "$name" ]; then
-        die "dolt identity not configured and git user.name not available; run: dolt config --global --add user.name \"Your Name\""
+    # Accumulate missing-field hints in a semicolon-joined string rather
+    # than a bash array so this stays runnable under POSIX /bin/sh
+    # (matches the script's shebang). Each branch reports only the field
+    # that is truly missing from BOTH dolt and git — never instruct the
+    # user to set a value they have already configured.
+    local missing=""
+    if [ "$dolt_has_name" -ne 1 ] && [ -z "$git_name" ]; then
+        missing='dolt config --global --add user.name "Your Name"'
     fi
-    if [ -z "$email" ]; then
-        die "dolt identity not configured and git user.email not available; run: dolt config --global --add user.email \"you@example.com\""
+    if [ "$dolt_has_email" -ne 1 ] && [ -z "$git_email" ]; then
+        if [ -n "$missing" ]; then
+            missing="$missing; "
+        fi
+        missing="${missing}dolt config --global --add user.email \"you@example.com\""
+    fi
+    if [ -n "$missing" ]; then
+        die "dolt identity incomplete; run: $missing"
     fi
 
-    # Set missing fields.
-    if ! dolt config --global --get user.name >/dev/null 2>&1; then
-        dolt config --global --add user.name "$name" || die "failed to set dolt user.name"
+    # Backfill missing dolt fields from git.
+    if [ "$dolt_has_name" -ne 1 ]; then
+        dolt config --global --add user.name "$git_name" || die "failed to set dolt user.name"
     fi
-    if ! dolt config --global --get user.email >/dev/null 2>&1; then
-        dolt config --global --add user.email "$email" || die "failed to set dolt user.email"
+    if [ "$dolt_has_email" -ne 1 ]; then
+        dolt config --global --add user.email "$git_email" || die "failed to set dolt user.email"
     fi
 }
 


### PR DESCRIPTION
## Summary

`ensure_dolt_identity` in `examples/bd/assets/scripts/gc-beads-bd.sh` required BOTH dolt user.name AND dolt user.email; if either was unset, the function fell through to git, and if git was empty too, errored that ``"git user.name not available"`` — even when the user had already set dolt user.name and was actually missing user.email. The user then re-runs `dolt config --add user.name "..."` and hits the same error in a loop.

Reproducer (real user report):
```
$ dolt config --global --add user.name "rome"
Config successfully updated.
$ gc init
gc init: bead store: exec beads start: dolt identity not configured and git
user.name not available; run: dolt config --global --add user.name "Your Name"
$ # ...repeat the same dolt config command, same error...
```

The rewrite resolves each field independently from `dolt → git → missing`, collects every still-missing field, and reports them all in one error. The hint now points at exactly what the user has not yet set (e.g., `user.email` in the case above).

Kept POSIX-sh-friendly (no bash arrays) to match the script's `#!/bin/sh` shebang; verified runnable under dash.

## Testing

- [x] `go test -run TestEnsureDoltIdentityErrorMessages -count=1 ./cmd/gc/` passes
- [x] `go vet ./...` clean
- [x] Manual: function executed under both `bash` and `dash` produces the corrected diagnostic

New: `TestEnsureDoltIdentityErrorMessages` extracts the function from the script and execs it under bash with stub `dolt`/`git` binaries on PATH. Six scenarios:
- both dolt fields set → returns 0
- dolt name only, git empty → reports `user.email` (NOT user.name) — the bug repro
- dolt email only, git empty → reports `user.name` (NOT user.email) — symmetric
- nothing set → reports both
- dolt empty, git has both → backfills dolt
- dolt name only, git email only → backfills email only

## Checklist

- [x] Added regression test
- [x] No user-facing doc changes
- [x] No breaking changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->