### PR TITLE
fix(city-discovery): find a city installed at the discovery ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pack import cache validation now requires commit abbreviations in
   `packs.lock` to be at least seven characters long. Shorter abbreviations
   should be refreshed with `gc import install`.
+- City discovery now treats a `city.toml` at `$HOME` or an explicit
+  `GC_CEILING_DIRECTORIES` entry as a valid city. The ceiling directory is
+  searched but never crossed, so existing stray `$HOME/city.toml` files may now
+  be discovered from subdirectories where they were previously ignored.
 - ACP, subprocess, and Kubernetes session staging now apply pack and agent
   overlays through the provider-aware `per-provider/<provider>/` contract.
   Custom ACP overlays that previously expected a literal `per-provider/`

--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -27,23 +27,8 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 		return "", err
 	}
 
-	// Always check the starting directory itself, even when it is also the
-	// discovery ceiling. The ceiling is still included in upward discovery,
-	// but it is the final directory searched before traversal stops.
-	if citylayout.HasCityConfig(dir) {
-		return dir, nil
-	}
 	var legacy string
-	if citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
-		legacy = dir
-	}
-
 	for {
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
 		if citylayout.HasCityConfig(dir) {
 			return dir, nil
 		}
@@ -53,6 +38,11 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 		if isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
 			break
 		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
 	}
 	if legacy != "" {
 		return legacy, nil

--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -27,19 +27,33 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 		return "", err
 	}
 
+	// Always check the starting directory itself — even if it sits at the
+	// discovery ceiling (e.g. cwd == $HOME). The ceiling exists to bound
+	// upward resolution to an unrelated ancestor; a city the user is
+	// standing directly inside should still be found.
+	if citylayout.HasCityConfig(dir) {
+		return dir, nil
+	}
 	var legacy string
-	for !isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
+	if citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
+		legacy = dir
+	}
+
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+		if isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
+			break
+		}
 		if citylayout.HasCityConfig(dir) {
 			return dir, nil
 		}
 		if legacy == "" && citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
 			legacy = dir
 		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
 	}
 	if legacy != "" {
 		return legacy, nil

--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -27,10 +27,9 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 		return "", err
 	}
 
-	// Always check the starting directory itself — even if it sits at the
-	// discovery ceiling (e.g. cwd == $HOME). The ceiling exists to bound
-	// upward resolution to an unrelated ancestor; a city the user is
-	// standing directly inside should still be found.
+	// Always check the starting directory itself, even when it is also the
+	// discovery ceiling. The ceiling is still included in upward discovery,
+	// but it is the final directory searched before traversal stops.
 	if citylayout.HasCityConfig(dir) {
 		return dir, nil
 	}
@@ -45,14 +44,14 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 			break
 		}
 		dir = parent
-		if isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
-			break
-		}
 		if citylayout.HasCityConfig(dir) {
 			return dir, nil
 		}
 		if legacy == "" && citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
 			legacy = dir
+		}
+		if isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
+			break
 		}
 	}
 	if legacy != "" {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -398,7 +398,7 @@ func TestFindCity(t *testing.T) {
 		}
 	})
 
-	t.Run("not_found_ignores_stray_home_city_toml", func(t *testing.T) {
+	t.Run("checks_home_ceiling_dir_last", func(t *testing.T) {
 		homeDir := t.TempDir()
 		t.Setenv("HOME", homeDir)
 		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
@@ -411,12 +411,12 @@ func TestFindCity(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := findCity(dir)
-		if err == nil {
-			t.Fatal("findCity() should fail when only a stray $HOME/city.toml exists")
+		got, err := findCity(dir)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", dir, err)
 		}
-		if !strings.Contains(err.Error(), "not in a city directory") {
-			t.Errorf("error = %q, want 'not in a city directory'", err)
+		if got != homeDir {
+			t.Errorf("findCity(%q) = %q, want %q", dir, got, homeDir)
 		}
 	})
 
@@ -513,7 +513,7 @@ func TestFindCity(t *testing.T) {
 		}
 	})
 
-	t.Run("respects_gc_ceiling_directories", func(t *testing.T) {
+	t.Run("checks_explicit_ceiling_dir_last", func(t *testing.T) {
 		root := t.TempDir()
 		parent := filepath.Join(root, "parent")
 		if err := os.MkdirAll(parent, 0o755); err != nil {
@@ -528,9 +528,33 @@ func TestFindCity(t *testing.T) {
 		}
 		t.Setenv("GC_CEILING_DIRECTORIES", parent)
 
+		got, err := findCity(dir)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", dir, err)
+		}
+		if got != parent {
+			t.Errorf("findCity(%q) = %q, want %q", dir, got, parent)
+		}
+	})
+
+	t.Run("does_not_search_above_explicit_ceiling_dir", func(t *testing.T) {
+		root := t.TempDir()
+		ceiling := filepath.Join(root, "ceiling")
+		if err := os.MkdirAll(ceiling, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "city.toml"), []byte("[workspace]\nname = \"root\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(ceiling, "child", "deep")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GC_CEILING_DIRECTORIES", ceiling)
+
 		_, err := findCity(dir)
 		if err == nil {
-			t.Fatal("findCity() should fail when GC_CEILING_DIRECTORIES excludes the ancestor city root")
+			t.Fatal("findCity() should fail when only an ancestor above the ceiling has city.toml")
 		}
 		if !strings.Contains(err.Error(), "not in a city directory") {
 			t.Errorf("error = %q, want 'not in a city directory'", err)

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -491,6 +491,28 @@ func TestFindCity(t *testing.T) {
 		}
 	})
 
+	t.Run("start_at_home_ceiling_does_not_search_above", func(t *testing.T) {
+		root := t.TempDir()
+		homeDir := filepath.Join(root, "home")
+		if err := os.MkdirAll(homeDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		if err := os.WriteFile(filepath.Join(root, "city.toml"), []byte("[workspace]\nname = \"root\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := findCity(homeDir)
+		if err == nil {
+			t.Fatal("findCity() should fail when only an ancestor above $HOME has city.toml")
+		}
+		if !strings.Contains(err.Error(), "not in a city directory") {
+			t.Errorf("error = %q, want 'not in a city directory'", err)
+		}
+	})
+
 	t.Run("city_at_explicit_ceiling_dir_is_found", func(t *testing.T) {
 		// Same idea as city_at_home, but for an explicit
 		// GC_CEILING_DIRECTORIES entry.
@@ -510,6 +532,26 @@ func TestFindCity(t *testing.T) {
 		}
 		if got != ceiling {
 			t.Errorf("findCity(%q) = %q, want %q", ceiling, got, ceiling)
+		}
+	})
+
+	t.Run("start_at_explicit_ceiling_dir_does_not_search_above", func(t *testing.T) {
+		root := t.TempDir()
+		ceiling := filepath.Join(root, "ceiling")
+		if err := os.MkdirAll(ceiling, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "city.toml"), []byte("[workspace]\nname = \"root\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GC_CEILING_DIRECTORIES", ceiling)
+
+		_, err := findCity(ceiling)
+		if err == nil {
+			t.Fatal("findCity() should fail when only an ancestor above the ceiling has city.toml")
+		}
+		if !strings.Contains(err.Error(), "not in a city directory") {
+			t.Errorf("error = %q, want 'not in a city directory'", err)
 		}
 	})
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -468,6 +468,51 @@ func TestFindCity(t *testing.T) {
 		}
 	})
 
+	t.Run("city_at_home_is_found", func(t *testing.T) {
+		// Repro for the bug where a city installed directly at $HOME
+		// (e.g. running as user "gc" with city at /home/gc) was reported
+		// as "not in a city directory" because the discovery ceiling
+		// fired before the starting dir was checked. The ceiling should
+		// only bound upward traversal, not the dir the user is in.
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		if err := os.WriteFile(filepath.Join(homeDir, "city.toml"), []byte("[workspace]\nname = \"home-city\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := findCity(homeDir)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", homeDir, err)
+		}
+		if got != homeDir {
+			t.Errorf("findCity(%q) = %q, want %q", homeDir, got, homeDir)
+		}
+	})
+
+	t.Run("city_at_explicit_ceiling_dir_is_found", func(t *testing.T) {
+		// Same idea as city_at_home, but for an explicit
+		// GC_CEILING_DIRECTORIES entry.
+		root := t.TempDir()
+		ceiling := filepath.Join(root, "ceiling")
+		if err := os.MkdirAll(ceiling, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(ceiling, "city.toml"), []byte("[workspace]\nname = \"ceiling-city\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("GC_CEILING_DIRECTORIES", ceiling)
+
+		got, err := findCity(ceiling)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", ceiling, err)
+		}
+		if got != ceiling {
+			t.Errorf("findCity(%q) = %q, want %q", ceiling, got, ceiling)
+		}
+	})
+
 	t.Run("respects_gc_ceiling_directories", func(t *testing.T) {
 		root := t.TempDir()
 		parent := filepath.Join(root, "parent")


### PR DESCRIPTION
## Summary

`findCity` walks upward looking for `city.toml`/`.gc/`, bounded by a discovery ceiling (typically `\$HOME`) so an unrelated ancestor is not picked up. The bound also prevented checking the **starting** directory itself when that directory was the ceiling — so a city installed directly at \$HOME (common when running `gc` as a service account whose home is the city root) reported ``"not in a city directory"`` even though `city.toml` was sitting right there.

Reproducer (real user report — running as the `gc` user with city in `/home/gc`):
```
gc@ip-…:~$ ls
agents  assets  city.toml  commands  formulas  pack.toml  ...
gc@ip-…:~$ gc doctor
gc doctor: not in a city directory (no city.toml or .gc/ found)
```

`gc start` worked because `resolveContextFromPath` calls `validateCityPath` first, but every other command flowing through `resolveCommandCity` → step 9 `findCity(cwd)` hit the ceiling guard.

Reorder: always check the starting dir for a city (or legacy runtime root) first, then enter the upward walk where the ceiling caps further ascent. The existing safeguard against accidentally resolving a stray `\$HOME/city.toml` from a deep subdir still holds — those paths now hit the ceiling on the parent step before the would-be match.

## Testing

- [x] `go test -run TestFindCity -count=1 ./cmd/gc/` passes (8 subtests, including 2 new)
- [x] `go vet ./...` clean

New subtests:
- `city_at_home_is_found` — cwd is \$HOME, \$HOME has city.toml → must find it
- `city_at_explicit_ceiling_dir_is_found` — same idea with `GC_CEILING_DIRECTORIES` instead of \$HOME

Existing subtests still pass:
- `not_found_ignores_stray_home_city_toml`
- `not_found_ignores_supervisor_home_runtime_root`
- `nested_city_below_home_boundary_still_found`
- `parent_canonical_outranks_child_legacy`
- `respects_gc_ceiling_directories`
- `canonical`, `found`, `nested`, `not_found`

## Checklist

- [x] Added regression tests
- [x] No user-facing doc changes
- [x] No breaking changes — the bound on accidental upward resolution is preserved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->