### PR TITLE
fixup: apply gc bd review feedback

### DIFF
--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -66,9 +66,7 @@ func bdCommandEnv(cityPath string, cfg *config.City, target execStoreTarget) []s
 	overrides["GC_STORE_ROOT"] = target.ScopeRoot
 	overrides["GC_STORE_SCOPE"] = target.ScopeKind
 	overrides["GC_BEADS_PREFIX"] = target.Prefix
-	// GC owns the Dolt-backed beads lifecycle; bd's git auto-export can run
-	// after command output and wedge the wrapper on git staging failures.
-	overrides["BD_EXPORT_AUTO"] = "false"
+	applyControlBdEnv(overrides)
 	return mergeRuntimeEnv(os.Environ(), overrides)
 }
 

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -468,7 +468,7 @@ set -eu
 	}
 }
 
-func TestGcBdSuppressesBdAutoExportForJsonShowAndUpdate(t *testing.T) {
+func TestGcBdSuppressesBdAutoExportInChildEnv(t *testing.T) {
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag
 	defer func() {


### PR DESCRIPTION
Follow-up for #1671.

Original PR: https://github.com/gastownhall/gascity/pull/1671
Original title: fix: suppress bd auto-export in gc bd wrapper
Original state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none; configured base and GitHub base are both main.

This follow-up carries the maintainer-side review fixes after the original PR merged. It keeps the already-merged contribution intact and adds the small cleanup needed from the adoption review:

- Reuses applyControlBdEnv(overrides) in bdCommandEnv so the BD_EXPORT_AUTO=false policy stays centralized.
- Renames the regression test to describe the wrapper-wide child environment guarantee.
- Preserves the gc bd help text that explains the wrapper suppresses bd auto-export and that direct bd invocation remains available when auto-export behavior is needed.

Base refresh: the adopted branch was refreshed from 3a6bcea5aafe6c249a0b77cfba5b86204f1f299f to 0782fbff7d102333f38c4426cc43e00c544f3122 with the patch-id preserved.

Validation:

- go test ./cmd/gc -run TestGcBdSuppressesBdAutoExportInChildEnv -count=1

_Adopted via /adopt-pr workflow. Original contributor commits from #1671 are already preserved in main._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->