### PR TITLE
fix(refinery): chain merge metadata write into close to prevent skip under fan-out

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -178,6 +178,46 @@ func TestRefineryFormulaSupportsMergeStrategies(t *testing.T) {
 	}
 }
 
+// TestRefineryFormulaChainsMergeMetadataWithClose guards against the
+// regression observed during concurrent fan-out (3 polecats, 3 work
+// beads, one refinery): when the formula presented `gc bd update
+// --set-metadata` and `gc bd close` as two separate commands in the
+// same code block, the refinery agent skipped the metadata write and
+// jumped straight to the close, leaving `merged_sha` and
+// `merged_target` NULL on every closed bead. Forensic context tracing
+// a closed bead to its merge commit is then lost.
+//
+// The fix chains both commands with `&&` so a refinery agent cannot
+// honor `gc bd close` without also honoring the preceding metadata
+// write. Both the direct-merge path and the mr/pr handoff path use
+// the same chained shape.
+func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+
+	// Direct-merge path: metadata write must be chained into the close.
+	assertContainsInOrder(t, body,
+		"--set-metadata merge_result=merged",
+		"--set-metadata merged_sha=$MERGED_SHA",
+		"--set-metadata merged_target=$TARGET &&",
+		`gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"`,
+	)
+
+	// mr/pr handoff path: same chained shape, different metadata fields.
+	assertContainsInOrder(t, body,
+		"--set-metadata merge_result=pull_request",
+		`--set-metadata pr_url="$PR_URL"`,
+		`--set-metadata pr_number="$PR_NUMBER"`,
+		`--set-metadata merged_target="$TARGET" &&`,
+		`gc bd close $WORK --reason "Pull request ready: $PR_URL"`,
+	)
+}
+
 func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -393,12 +393,21 @@ REMOTE=$(git rev-parse origin/$TARGET)
 If SHAs differ: STOP. Debug and retry. Do NOT continue.
 
 **3. Record merge metadata and close work bead:**
+
+Run as a single chained command so the metadata write cannot be skipped
+when the close-reason already names the SHA. Both the `--set-metadata`
+write and the `gc bd close` are required — `merged_sha` and
+`merged_target` are the only forensic breadcrumbs tying a closed bead
+to its merge commit on `$TARGET`.
+
 ```bash
+MERGED_SHA=$(git rev-parse HEAD) && \
+MERGED_SHORT=$(git rev-parse --short HEAD) && \
 gc bd update $WORK \
   --set-metadata merge_result=merged \
-  --set-metadata merged_sha=$(git rev-parse HEAD) \
-  --set-metadata merged_target=$TARGET
-gc bd close $WORK --reason "Merged to $TARGET at $(git rev-parse --short HEAD)"
+  --set-metadata merged_sha=$MERGED_SHA \
+  --set-metadata merged_target=$TARGET && \
+gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"
 ```
 
 **4. Cleanup:**
@@ -521,12 +530,19 @@ fi
 If this command fails or prints empty output: STOP. Debug and retry. Do NOT continue.
 
 **4. Record PR metadata and close the work bead:**
+
+Run as a single chained command so the metadata write cannot be skipped
+when the close-reason already names the PR. Both the `--set-metadata`
+write and the `gc bd close` are required — `pr_url` and `pr_number`
+are the only forensic breadcrumbs tying a closed bead to its pull
+request.
+
 ```bash
 gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \
   --set-metadata pr_number="$PR_NUMBER" \
-  --set-metadata merged_target="$TARGET"
+  --set-metadata merged_target="$TARGET" && \
 gc bd close $WORK --reason "Pull request ready: $PR_URL"
 ```
 


### PR DESCRIPTION
## Summary

The `mol-refinery-patrol` formula presented `gc bd update --set-metadata` and `gc bd close` as two separate commands in the same code block. Under concurrent fan-out load (3 polecats merging through one refinery), the refinery agent was observed to skip the metadata write and run only `gc bd close $WORK --reason "Merged to ..."` — the close-reason already names the SHA, so the agent treated the separate metadata write as redundant and dropped it. Result: every closed work bead under fan-out had `merged_sha` and `merged_target` set to NULL, losing the only forensic breadcrumb tying a closed bead to its merge commit on `$TARGET`.

Under sequential load (one work bead at a time) the same agent had been chaining both writes with `&&` voluntarily, so the regression appeared only when the agent was processing multiple work beads in rapid succession.

## What changed

- `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml` — direct-merge path: chained `gc bd update --set-metadata` + `gc bd close` into one `&&`-chained command so the metadata write cannot be skipped when the close-reason already names the SHA. Added a one-paragraph preamble naming the regression and stating both writes are required.
- Same file, mr/pr handoff path: same chained shape applied for `pr_url` / `pr_number` / `merged_target`.
- `examples/gastown/gastown_test.go` — new test `TestRefineryFormulaChainsMergeMetadataWithClose` asserts the chained shape on both paths via `assertContainsInOrder`. Guards against accidentally splitting the commands again.

Surface: refinery merge-then-close metadata write via `mol-refinery-patrol` formula step prompt; not `gc bd close` flag, not gascity Go code.

## Out of scope

A `--set-metadata` flag on `gc bd close` to atomically write metadata and close in one CLI invocation. That would be a feature addition (solution-shape #5) and crosses into API surface. The prompt-only fix closes the regression at solution-shape #1 (instruction change).

## Testing

- [x] `make build` — clean
- [x] `make check` — full Go test suite passes
- [x] `go test ./examples/gastown/ -run TestRefineryFormula -count=1 -v` — new and existing refinery formula tests pass
- [ ] `make check-docs` — not run (no docs files touched)
- [ ] `make test-integration` — not run (per CONTRIBUTING; this is a prompt-only formula edit, no runtime/controller behavior touched)

## Checklist

- [x] Linked an issue, or explained why one is not needed: prompt-edit fix surfaced from internal investigation; no public issue.
- [x] Added or updated tests for behavior changes: `TestRefineryFormulaChainsMergeMetadataWithClose` covers both the direct-merge and mr/pr paths.
- [x] Updated docs for user-facing changes: formula prompt updated directly; the chained shape and the rationale preamble are the user-visible change.
- [x] Called out breaking changes or migration notes: none — the prompt is what the LLM agent reads each cycle, no runtime contract change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->