### PR TITLE
fix: add allowed_origins to supervisor config for LAN dashboard access

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -846,6 +846,9 @@ func runSupervisor(stdout, stderr io.Writer) int {
 		return 1
 	}
 	apiMux := api.NewSupervisorMux(registry, cityInitSvc, readOnly, version, startedAt)
+	if len(supCfg.Supervisor.AllowedOrigins) > 0 {
+		apiMux.WithAllowedOrigins(supCfg.Supervisor.AllowedOrigins)
+	}
 
 	pprofSrv, pprofErr := api.StartPprof("")
 	if pprofErr != nil {

--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestCORSPreflightFromLocalhostDashboard locks the contract the
@@ -56,6 +57,36 @@ func TestCORSPreflightFromLocalhostDashboard(t *testing.T) {
 				if !strings.Contains(allowedMethods, want) {
 					t.Errorf("Allow-Methods %q missing %q", allowedMethods, want)
 				}
+			}
+		})
+	}
+}
+
+// TestCORSAllowsExtraOrigins verifies that WithAllowedOrigins extends CORS
+// acceptance to explicitly listed non-localhost origins.
+func TestCORSAllowsExtraOrigins(t *testing.T) {
+	state := newFakeState(t)
+	sm := NewSupervisorMux(&stateCityResolver{state: state}, nil, false, "test", time.Now())
+	sm.WithAllowedOrigins([]string{"http://192.168.1.10:8080"})
+	h := wrapTestSupervisorMiddleware(sm)
+
+	cases := []struct {
+		origin string
+		want   string
+	}{
+		{"http://192.168.1.10:8080", "http://192.168.1.10:8080"},
+		{"http://127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"http://192.168.1.99:8080", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.origin, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodOptions, "/v0/cities", nil)
+			req.Header.Set("Origin", tc.origin)
+			req.Header.Set("Access-Control-Request-Method", "GET")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != tc.want {
+				t.Errorf("origin %q: Allow-Origin = %q, want %q", tc.origin, got, tc.want)
 			}
 		})
 	}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -96,12 +96,14 @@ func withRecovery(next http.Handler) http.Handler {
 	})
 }
 
-// withCORS adds restricted CORS headers for localhost dashboard access.
-// Only allows localhost origins to prevent browser-origin attacks on mutation endpoints.
-func withCORS(next http.Handler) http.Handler {
+// withCORSAllowing adds CORS headers for localhost dashboard access plus any
+// explicitly allowed extra origins. Only allows localhost origins by default
+// to prevent browser-origin attacks on mutation endpoints.
+// extra is checked with exact string equality after the localhost check.
+func withCORSAllowing(extra []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		if isLocalhostOrigin(origin) {
+		if isLocalhostOrigin(origin) || isAllowedExtraOrigin(origin, extra) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Last-Event-ID, X-GC-Request")
@@ -120,6 +122,17 @@ func isMutationMethod(method string) bool {
 	switch method {
 	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
 		return true
+	}
+	return false
+}
+
+// isAllowedExtraOrigin reports whether origin is in the explicit allowlist.
+// Comparison is exact (case-sensitive). An empty allowlist always returns false.
+func isAllowedExtraOrigin(origin string, extra []string) bool {
+	for _, o := range extra {
+		if o == origin {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/api/supervisor.go
+++ b/internal/api/supervisor.go
@@ -104,12 +104,13 @@ type cachedCityServer struct {
 // to per-city Server.mux. Workspace services own their own HTTP
 // contracts and are explicitly excluded from the typed control plane.
 type SupervisorMux struct {
-	resolver    CityResolver
-	initializer cityInitializer
-	readOnly    bool
-	version     string
-	startedAt   time.Time
-	server      *http.Server
+	resolver       CityResolver
+	initializer    cityInitializer
+	readOnly       bool
+	version        string
+	startedAt      time.Time
+	allowedOrigins []string
+	server         *http.Server
 
 	// Single Huma API (Phase 3.5 — Topology 1). Owns every typed
 	// operation: supervisor-scope (/v0/cities, /health, /v0/readiness,
@@ -193,7 +194,15 @@ func (sm *SupervisorMux) serveCitySvcProxy(w http.ResponseWriter, r *http.Reques
 //     their own publication rules).
 func (sm *SupervisorMux) Handler() http.Handler {
 	root := http.HandlerFunc(sm.ServeHTTP)
-	return withLogging(withRecovery(withRequestID(withCORS(root))))
+	return withLogging(withRecovery(withRequestID(withCORSAllowing(sm.allowedOrigins, root))))
+}
+
+// WithAllowedOrigins sets extra CORS origins accepted beyond localhost and
+// rebuilds the internal http.Server handler. Must be called before Serve.
+func (sm *SupervisorMux) WithAllowedOrigins(origins []string) *SupervisorMux {
+	sm.allowedOrigins = origins
+	sm.server = &http.Server{Handler: sm.Handler()}
+	return sm
 }
 
 // StartPprof starts a pprof HTTP server on 127.0.0.1:<port> if GC_PPROF=1

--- a/internal/supervisor/config.go
+++ b/internal/supervisor/config.go
@@ -32,10 +32,11 @@ type Config struct {
 
 // Section holds the [supervisor] table fields.
 type Section struct {
-	Port           int    `toml:"port,omitempty"`
-	Bind           string `toml:"bind,omitempty"`
-	PatrolInterval string `toml:"patrol_interval,omitempty"`
-	AllowMutations bool   `toml:"allow_mutations,omitempty"`
+	Port           int      `toml:"port,omitempty"`
+	Bind           string   `toml:"bind,omitempty"`
+	PatrolInterval string   `toml:"patrol_interval,omitempty"`
+	AllowMutations bool     `toml:"allow_mutations,omitempty"`
+	AllowedOrigins []string `toml:"allowed_origins,omitempty"`
 }
 
 // PublicationConfig holds machine-wide publication policy for workspace


### PR DESCRIPTION
Maintainer follow-up for #1603.

This carries forward @neutmute's contribution from the original PR after the original merge surface was closed before finalization. The adopted commit preserves the contributor author and adds the LAN dashboard CORS allowlist behavior reviewed in the adoption workflow.

Original PR: https://github.com/gastownhall/gascity/pull/1603
Original title: fix: add allowed_origins to supervisor config for LAN dashboard access
Original state at finalization: CLOSED, unmerged
Configured base branch: main
Original GitHub base branch: main
Base mismatch: none

Review summary:
- Adds `[supervisor].allowed_origins` so operators can explicitly allow exact LAN dashboard origins without opening CORS to every origin.
- Wires the configured origins into `SupervisorMux` while preserving the default localhost-only behavior when no extra origins are configured.
- Includes CORS/config test coverage for the new allowlist path.

Adopted via `/adopt-pr` workflow for source bead `ga-fvdhi5`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->