### PR TITLE
test(api): cover positive-offset order history cursors

### DIFF
--- a/internal/api/handler_orders_test.go
+++ b/internal/api/handler_orders_test.go
@@ -779,6 +779,15 @@ func (s *cachedOnlyOrderHistoryStore) List(query beads.ListQuery) ([]beads.Bead,
 	return s.Store.List(query)
 }
 
+type fixedOrderHistoryStore struct {
+	beads.Store
+	rows []beads.Bead
+}
+
+func (s *fixedOrderHistoryStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	return beads.ApplyListQuery(s.rows, query), nil
+}
+
 func TestHandleOrderCheckUsesCachedHistoryWhenAvailable(t *testing.T) {
 	fs := newFakeState(t)
 	run := beads.Bead{
@@ -1134,6 +1143,76 @@ func TestHandleOrderHistoryBeforeUsesBufferedBoundedFetch(t *testing.T) {
 	}
 	if resp.Entries[0].BeadID != oldRun.ID {
 		t.Fatalf("bead_id = %q, want older run %q", resp.Entries[0].BeadID, oldRun.ID)
+	}
+}
+
+func TestHandleOrderHistoryBeforeRequiresEscapedPositiveOffsetCursor(t *testing.T) {
+	fs := newFakeState(t)
+	fs.autos = []orders.Order{
+		{Name: "nightly-review", Formula: "mol-adopt-pr-v2"},
+	}
+
+	plusTwo := time.FixedZone("plus-two", 2*60*60)
+	oldCreatedAt := time.Date(2026, 5, 9, 10, 0, 0, 123456789, plusTwo)
+	cursorCreatedAt := oldCreatedAt.Add(time.Minute)
+	newCreatedAt := cursorCreatedAt.Add(time.Minute)
+	fs.cityBeadStore = &fixedOrderHistoryStore{
+		Store: beads.NewMemStore(),
+		rows: []beads.Bead{
+			{
+				ID:        "old-run",
+				Title:     "old nightly-review",
+				Status:    "closed",
+				CreatedAt: oldCreatedAt,
+				Labels:    []string{"order-run:nightly-review", "wisp"},
+			},
+			{
+				ID:        "cursor-run",
+				Title:     "cursor nightly-review",
+				Status:    "closed",
+				CreatedAt: cursorCreatedAt,
+				Labels:    []string{"order-run:nightly-review", "wisp"},
+			},
+			{
+				ID:        "new-run",
+				Title:     "new nightly-review",
+				Status:    "closed",
+				CreatedAt: newCreatedAt,
+				Labels:    []string{"order-run:nightly-review", "wisp"},
+			},
+		},
+	}
+
+	h := newTestCityHandler(t, fs)
+	before := cursorCreatedAt.Format(time.RFC3339Nano)
+
+	rawReq := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+before), nil)
+	rawW := httptest.NewRecorder()
+	h.ServeHTTP(rawW, rawReq)
+	if rawW.Code != http.StatusBadRequest {
+		t.Fatalf("raw status = %d, want %d; body = %s", rawW.Code, http.StatusBadRequest, rawW.Body.String())
+	}
+
+	escapedReq := httptest.NewRequest(http.MethodGet, cityURL(fs, "/orders/history?scoped_name=nightly-review&limit=1&before="+url.QueryEscape(before)), nil)
+	escapedW := httptest.NewRecorder()
+	h.ServeHTTP(escapedW, escapedReq)
+	if escapedW.Code != http.StatusOK {
+		t.Fatalf("escaped status = %d, want %d; body = %s", escapedW.Code, http.StatusOK, escapedW.Body.String())
+	}
+
+	var resp struct {
+		Entries []struct {
+			BeadID string `json:"bead_id"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(escapedW.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1: %+v", len(resp.Entries), resp.Entries)
+	}
+	if resp.Entries[0].BeadID != "old-run" {
+		t.Fatalf("bead_id = %q, want old-run", resp.Entries[0].BeadID)
 	}
 }
 


### PR DESCRIPTION
Post-merge follow-up for #1180.

This adds a deterministic order-history regression test with a fixed `+02:00` RFC3339 cursor. The test verifies that raw query-string concatenation is rejected and the escaped cursor succeeds.

Tests:
- `go test ./internal/api -run 'TestHandleOrderHistoryBefore' -count=1`\n- pre-commit hook (`scripts/go-test-observable test -- -p=4 -count=1 ./...`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->