### PR TITLE
fix(api): match bounded pool instances with binding prefix in findAgent

### DIFF
--- a/internal/api/handler_agents.go
+++ b/internal/api/handler_agents.go
@@ -252,7 +252,14 @@ func findAgent(cfg *config.City, name string) (config.Agent, bool) {
 			}
 			for i := 1; i <= poolMax; i++ {
 				memberName := poolInstanceNameForAPI(a.Name, i, a)
+				// V2 agents address instances with the binding prefix
+				// (matching Agent.QualifiedInstanceName), so accept both
+				// the bare and binding-qualified forms — same shape the
+				// unlimited path applies above.
 				if memberName == baseName {
+					return a, true
+				}
+				if a.BindingName != "" && a.BindingName+"."+memberName == baseName {
 					return a, true
 				}
 			}

--- a/internal/api/handler_agents_test.go
+++ b/internal/api/handler_agents_test.go
@@ -253,6 +253,115 @@ func TestFindAgentUnlimitedPoolMember(t *testing.T) {
 	}
 }
 
+// TestFindAgentBoundedPoolMember covers bounded multi-session pools — both
+// V1 (no BindingName) and V2 (with BindingName), with and without
+// NamepoolNames. The V2 cases regressed silently because the bounded
+// path enumerated raw member names without applying the binding prefix
+// the listing endpoint adds via Agent.QualifiedInstanceName, so detail
+// lookups for those instances 404'd while the listing happily emitted
+// them. The unlimited path already handled this correctly.
+func TestFindAgentBoundedPoolMember(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    config.Agent
+		query    string
+		wantOK   bool
+		wantName string
+	}{
+		{
+			name: "v1 numeric in rig",
+			agent: config.Agent{
+				Name:              "polecat",
+				Dir:               "myrig",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+			},
+			query: "myrig/polecat-1", wantOK: true, wantName: "polecat",
+		},
+		{
+			name: "v1 namepool in rig",
+			agent: config.Agent{
+				Name:              "polecat",
+				Dir:               "myrig",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+				NamepoolNames: []string{"alpha", "bravo", "charlie"},
+			},
+			query: "myrig/bravo", wantOK: true, wantName: "polecat",
+		},
+		{
+			name: "v2 numeric city-scoped",
+			agent: config.Agent{
+				Name:              "dog",
+				BindingName:       "gastown",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+			},
+			query: "gastown.dog-1", wantOK: true, wantName: "dog",
+		},
+		{
+			name: "v2 numeric in rig",
+			agent: config.Agent{
+				Name:              "polecat",
+				Dir:               "myrig",
+				BindingName:       "gastown",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+			},
+			query: "myrig/gastown.polecat-2", wantOK: true, wantName: "polecat",
+		},
+		{
+			name: "v2 namepool in rig",
+			agent: config.Agent{
+				Name:              "polecat",
+				Dir:               "nextlex-legal-rag",
+				BindingName:       "gastown",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(5),
+				NamepoolNames: []string{"furiosa", "nux", "slit", "rictus", "capable"},
+			},
+			query: "nextlex-legal-rag/gastown.furiosa", wantOK: true, wantName: "polecat",
+		},
+		{
+			name: "v2 namepool city-scoped",
+			agent: config.Agent{
+				Name:              "polecat",
+				BindingName:       "gastown",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2),
+				NamepoolNames: []string{"furiosa", "nux"},
+			},
+			query: "gastown.nux", wantOK: true, wantName: "polecat",
+		},
+		{
+			name: "v2 unknown instance does not match",
+			agent: config.Agent{
+				Name:              "dog",
+				BindingName:       "gastown",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3),
+			},
+			query: "gastown.dog-99", wantOK: false,
+		},
+		{
+			name: "v2 namepool unknown member does not match",
+			agent: config.Agent{
+				Name:              "polecat",
+				BindingName:       "gastown",
+				MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2),
+				NamepoolNames: []string{"furiosa", "nux"},
+			},
+			query: "gastown.unknown", wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.City{Agents: []config.Agent{tt.agent}}
+			a, ok := findAgent(cfg, tt.query)
+			if ok != tt.wantOK {
+				t.Fatalf("findAgent(%q) ok = %v, want %v", tt.query, ok, tt.wantOK)
+			}
+			if tt.wantOK && a.Name != tt.wantName {
+				t.Errorf("findAgent(%q).Name = %q, want %q", tt.query, a.Name, tt.wantName)
+			}
+		})
+	}
+}
+
 func TestAgentListFilterByRig(t *testing.T) {
 	state := newFakeState(t)
 	state.cfg.Agents = []config.Agent{


### PR DESCRIPTION
## Summary

`findAgent` (in `internal/api/handler_agents.go`) silently 404s every member of a **V2 bounded pool** (an agent with `BindingName != ""` and a finite `MaxActiveSessions`).

Repro against a live supervisor with a city that imports a binding-qualified pool — e.g. `gastown.dog` (max=3, no namepool) and `nextlex-legal-rag/gastown.polecat` (max=5, `namepool = ["furiosa", "nux", ...]`):

```
GET /v0/city/X/agents
  → 200, lists "gastown.dog-1", "gastown.dog-2", "gastown.dog-3",
         "nextlex-legal-rag/gastown.furiosa", ...

GET /v0/city/X/agent/gastown.dog-1
  → 404 "agent gastown.dog-1 not found"

GET /v0/city/X/agent/nextlex-legal-rag/gastown.furiosa
  → 404 "agent nextlex-legal-rag/gastown.furiosa not found"
```

Every endpoint that resolves through `findAgent` inherits the 404: detail GET, PATCH, DELETE, POST suspend/resume, GET output, GET output/stream.

### Root cause

The bounded path of `findAgent` compares `baseName` against the bare instance name returned by `poolInstanceNameForAPI` (e.g. `dog-1` or `furiosa`), but the listing path emits each instance through `Agent.QualifiedInstanceName`, which prepends the `BindingName` for V2 agents (`gastown.dog-1`, `gastown.furiosa`). Bare-vs-prefixed shape never matches.

The **unlimited** path in the same function already handles this — it builds `prefixes := []string{a.Name + "-"}` and prepends `a.BindingName + "." + a.Name + "-"` when a binding exists (lines 229-232 in this file, pre-fix). The bounded path was simply missing the equivalent guard.

### Fix

Mirror the unlimited path's binding awareness on the bounded path: try both `memberName == baseName` and `a.BindingName + "." + memberName == baseName`. Five-line change.

## Testing

- [x] `go test ./internal/api/...` (added table-driven `TestFindAgentBoundedPoolMember` covering V1+V2, numeric+namepool, plus negative cases for unknown members)
- [x] `go vet ./internal/api/...`
- [x] `golangci-lint run --new-from-rev=upstream/main ./internal/api/...` (0 issues after `golangci-lint fmt`)
- [x] Live curl validation against a supervisor running the patched binary: previously-404 endpoints now return 200 with the expected pool-derived `agentResponse`.
- [ ] `make check` — declined locally (test suite ~50s; race detector flags a pre-existing race in `TestStreamSessionPeekAcceptsPeekCapability` on `upstream/main` unrelated to this change). Trusting CI.
- [ ] `make check-docs` — no docs touched.
- [ ] `make test-integration` — runtime/controller behavior unchanged; this is an address-resolution fix.

## Checklist

- [x] No linked issue — couldn't find one in the repo for this specific bug. Happy to file one if the maintainers prefer that workflow.
- [x] Added tests for behavior change (`TestFindAgentBoundedPoolMember`, 8 sub-cases).
- [ ] No user-facing docs changes — bug fix restores expected behavior of an existing endpoint.
- [x] No breaking changes. Strict superset of previous matching behavior; existing passing inputs continue to pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->