### PR TITLE
test: harden gc session peek packlint

### DIFF
--- a/test/packlint/gc_session_peek_form_test.go
+++ b/test/packlint/gc_session_peek_form_test.go
@@ -11,36 +11,56 @@ import (
 	"testing"
 )
 
-var positionalSessionPeekLineCountRE = regexp.MustCompile(`\bgc\s+session\s+peek\s+(?:\{\{[^}]+\}\}\S*|\S+)\s+[0-9]+(?:\s|$)`)
+var positionalSessionPeekLineCountRE = regexp.MustCompile(`(?:\bgc|\{\{[^}]+\}\})\s+session\s+peek\s+(?:\{\{[^}]+\}\}\S*|\S+)\s+[0-9]+(?:\D|$)`)
+
+var sessionPeekScanDirs = []string{
+	"examples",
+	"internal/bootstrap/packs",
+	"docs",
+}
+
+var sessionPeekScanExts = map[string]bool{
+	".toml": true,
+	".md":   true,
+	".sh":   true,
+}
+
+var sessionPeekAllowlistFiles = map[string]bool{}
 
 func TestGcSessionPeekLineCountUsesFlag(t *testing.T) {
 	root := repoRoot()
 	var violations []string
-	err := filepath.WalkDir(filepath.Join(root, "examples"), func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, _ := filepath.Rel(root, path)
-		rel = filepath.ToSlash(rel)
-		if !isPackPromptOrFormula(rel) {
-			return nil
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("reading %s: %w", path, err)
-		}
-		for lineNum, line := range strings.Split(string(data), "\n") {
-			if positionalSessionPeekLineCountRE.MatchString(line) {
-				violations = append(violations, rel+":"+strconv.Itoa(lineNum+1)+": "+strings.TrimSpace(line))
+	for _, dir := range sessionPeekScanDirs {
+		abs := filepath.Join(root, dir)
+		err := filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
 			}
+			if d.IsDir() {
+				return nil
+			}
+			if !sessionPeekScanExts[filepath.Ext(path)] {
+				return nil
+			}
+			rel, _ := filepath.Rel(root, path)
+			rel = filepath.ToSlash(rel)
+			if sessionPeekAllowlistFiles[rel] {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+			for lineNum, line := range strings.Split(string(data), "\n") {
+				if positionalSessionPeekLineCountRE.MatchString(line) {
+					violations = append(violations, rel+":"+strconv.Itoa(lineNum+1)+": "+strings.TrimSpace(line))
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", dir, err)
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking examples: %v", err)
 	}
 	if len(violations) > 0 {
 		t.Errorf("gc session peek line counts must use `--lines <n>` instead of a second positional argument.\n"+
@@ -58,8 +78,14 @@ func TestPositionalSessionPeekLineCountPattern(t *testing.T) {
 		{name: "positional target and line count", line: `gc session peek <target> 50`, violation: true},
 		{name: "template target and line count", line: `gc session peek {{target}} 1`, violation: true},
 		{name: "spaced template target and line count", line: `gc session peek {{ .RigName }}/<polecat-name> 50`, violation: true},
+		{name: "semicolon delimiter", line: `gc session peek deacon 50; echo done`, violation: true},
+		{name: "pipe delimiter", line: `gc session peek deacon 50 | sed -n '1p'`, violation: true},
+		{name: "closing paren delimiter", line: `$(gc session peek deacon 50)`, violation: true},
+		{name: "backtick delimiter", line: "`gc session peek deacon 50`", violation: true},
+		{name: "templated command prefix", line: `{{ cmd }} session peek deacon 30`, violation: true},
 		{name: "line count flag", line: `gc session peek <target> --lines 50`, violation: false},
 		{name: "default line count", line: `gc session peek <target>`, violation: false},
+		{name: "templated command prefix with flag", line: `{{ cmd }} session peek deacon --lines 30`, violation: false},
 		{name: "other command", line: `gc session nudge <target> "message"`, violation: false},
 	}
 	for _, tc := range cases {
@@ -70,9 +96,4 @@ func TestPositionalSessionPeekLineCountPattern(t *testing.T) {
 			}
 		})
 	}
-}
-
-func isPackPromptOrFormula(rel string) bool {
-	return (strings.Contains(rel, "/agents/") && strings.HasSuffix(rel, "/prompt.template.md")) ||
-		(strings.Contains(rel, "/formulas/") && strings.HasSuffix(rel, ".toml"))
 }


### PR DESCRIPTION
Follow-up to #1779 post-merge review.

## Summary
- expand `gc session peek` packlint coverage to examples, bundled bootstrap packs, and docs
- catch shell-delimited positional line counts and templated command prefixes
- add regression cases while preserving `--lines` and default-count forms

## Test
- `go test ./test/packlint -count=1`
- pre-commit hook (`lint-changed`, generated docs/schema check, `go vet ./...`, fast `go test ./...`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->