### PR TITLE
fix(supervisor): pin install ExecStart to a stable on-disk gc path (#1888)

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -659,11 +659,12 @@ type supervisorServiceEnvVar struct {
 }
 
 func buildSupervisorServiceData() (*supervisorServiceData, error) {
-	gcPath, err := os.Executable()
+	gcExe, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("finding executable: %w", err)
 	}
 	homeDir, _ := os.UserHomeDir()
+	gcPath := resolveStableSupervisorBinaryPath(homeDir, stableSupervisorBinaryGopath(homeDir), gcExe)
 	home := supervisor.DefaultHome()
 	xdgRuntimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR"))
 	if supervisor.UsesIsolatedGCHomeOverride() {
@@ -679,6 +680,65 @@ func buildSupervisorServiceData() (*supervisorServiceData, error) {
 		Path:          searchpath.ExpandPath(homeDir, goruntime.GOOS, os.Getenv("PATH")),
 		ExtraEnv:      supervisorServiceExtraEnv(),
 	}, nil
+}
+
+const (
+	supervisorBinaryName       = "gc"
+	supervisorUserLocalBinPath = ".local/bin"
+	supervisorGopathBinPath    = "bin"
+)
+
+// resolveStableSupervisorBinaryPath picks a stable install path for the
+// supervisor service unit's ExecStart when one points at the same binary as
+// currentExe; otherwise it returns currentExe. This prevents `gc supervisor
+// install` from pinning the unit to a transient path (e.g. /tmp/gc) that
+// later install paths (`make install`, gcsync) never refresh.
+func resolveStableSupervisorBinaryPath(homeDir, gopath, currentExe string) string {
+	if currentExe == "" {
+		return currentExe
+	}
+	runningInfo, err := os.Stat(currentExe)
+	if err != nil {
+		return currentExe
+	}
+	for _, candidate := range stableSupervisorBinaryCandidates(homeDir, gopath) {
+		if supervisorBinaryCandidateMatches(candidate, runningInfo) {
+			return candidate
+		}
+	}
+	return currentExe
+}
+
+func stableSupervisorBinaryCandidates(homeDir, gopath string) []string {
+	var out []string
+	if homeDir != "" {
+		out = append(out, filepath.Join(homeDir, supervisorUserLocalBinPath, supervisorBinaryName))
+	}
+	if gopath != "" {
+		out = append(out, filepath.Join(gopath, supervisorGopathBinPath, supervisorBinaryName))
+	}
+	return out
+}
+
+func supervisorBinaryCandidateMatches(candidate string, runningInfo os.FileInfo) bool {
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if info.Mode()&0o111 == 0 {
+		return false
+	}
+	return os.SameFile(info, runningInfo)
+}
+
+func stableSupervisorBinaryGopath(homeDir string) string {
+	if v := strings.TrimSpace(os.Getenv("GOPATH")); v != "" {
+		return v
+	}
+	if homeDir == "" {
+		return ""
+	}
+	return filepath.Join(homeDir, "go")
 }
 
 func sanitizeServiceName(name string) string {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -4775,3 +4775,260 @@ func TestStopSupervisorWithWaitTimesOutWhenSocketKeepsAnswering(t *testing.T) {
 		t.Fatalf("stderr = %q, want timeout message", stderr.String())
 	}
 }
+
+func TestResolveStableSupervisorBinaryPath(t *testing.T) {
+	newRunningExe := func(t *testing.T) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "gc")
+		if err := os.WriteFile(path, []byte{}, 0o755); err != nil {
+			t.Fatalf("write running exe: %v", err)
+		}
+		return path
+	}
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T) (homeDir, gopath, currentExe, want string)
+	}{
+		{
+			name: "local_bin_symlink_resolves_to_running_exe",
+			setup: func(t *testing.T) (string, string, string, string) {
+				running := newRunningExe(t)
+				homeDir := t.TempDir()
+				binDir := filepath.Join(homeDir, ".local", "bin")
+				if err := os.MkdirAll(binDir, 0o755); err != nil {
+					t.Fatalf("mkdir local bin: %v", err)
+				}
+				symlink := filepath.Join(binDir, "gc")
+				if err := os.Symlink(running, symlink); err != nil {
+					t.Fatalf("symlink: %v", err)
+				}
+				return homeDir, "", running, symlink
+			},
+		},
+		{
+			name: "local_bin_hardlink_matches_running_exe_inode",
+			setup: func(t *testing.T) (string, string, string, string) {
+				running := newRunningExe(t)
+				homeDir := t.TempDir()
+				binDir := filepath.Join(homeDir, ".local", "bin")
+				if err := os.MkdirAll(binDir, 0o755); err != nil {
+					t.Fatalf("mkdir local bin: %v", err)
+				}
+				hardlink := filepath.Join(binDir, "gc")
+				if err := os.Link(running, hardlink); err != nil {
+					t.Skipf("os.Link not supported on this filesystem: %v", err)
+				}
+				return homeDir, "", running, hardlink
+			},
+		},
+		{
+			name: "only_gopath_bin_matches_running_exe",
+			setup: func(t *testing.T) (string, string, string, string) {
+				running := newRunningExe(t)
+				homeDir := t.TempDir()
+				gopath := t.TempDir()
+				binDir := filepath.Join(gopath, "bin")
+				if err := os.MkdirAll(binDir, 0o755); err != nil {
+					t.Fatalf("mkdir gopath bin: %v", err)
+				}
+				symlink := filepath.Join(binDir, "gc")
+				if err := os.Symlink(running, symlink); err != nil {
+					t.Fatalf("symlink: %v", err)
+				}
+				return homeDir, gopath, running, symlink
+			},
+		},
+		{
+			name: "candidates_point_to_different_binary_falls_through",
+			setup: func(t *testing.T) (string, string, string, string) {
+				running := newRunningExe(t)
+				other := filepath.Join(t.TempDir(), "other-gc")
+				if err := os.WriteFile(other, []byte("decoy"), 0o755); err != nil {
+					t.Fatalf("write decoy: %v", err)
+				}
+				homeDir := t.TempDir()
+				gopath := t.TempDir()
+				localBin := filepath.Join(homeDir, ".local", "bin")
+				if err := os.MkdirAll(localBin, 0o755); err != nil {
+					t.Fatalf("mkdir local bin: %v", err)
+				}
+				if err := os.Symlink(other, filepath.Join(localBin, "gc")); err != nil {
+					t.Fatalf("symlink local: %v", err)
+				}
+				gopathBin := filepath.Join(gopath, "bin")
+				if err := os.MkdirAll(gopathBin, 0o755); err != nil {
+					t.Fatalf("mkdir gopath bin: %v", err)
+				}
+				if err := os.Symlink(other, filepath.Join(gopathBin, "gc")); err != nil {
+					t.Fatalf("symlink gopath: %v", err)
+				}
+				return homeDir, gopath, running, running
+			},
+		},
+		{
+			name: "no_candidates_exist_falls_through",
+			setup: func(t *testing.T) (string, string, string, string) {
+				running := newRunningExe(t)
+				return t.TempDir(), t.TempDir(), running, running
+			},
+		},
+		{
+			name: "local_bin_not_executable_falls_through",
+			setup: func(t *testing.T) (string, string, string, string) {
+				running := newRunningExe(t)
+				homeDir := t.TempDir()
+				binDir := filepath.Join(homeDir, ".local", "bin")
+				if err := os.MkdirAll(binDir, 0o755); err != nil {
+					t.Fatalf("mkdir local bin: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(binDir, "gc"), []byte{}, 0o644); err != nil {
+					t.Fatalf("write non-executable: %v", err)
+				}
+				return homeDir, "", running, running
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			homeDir, gopath, currentExe, want := tc.setup(t)
+			got := resolveStableSupervisorBinaryPath(homeDir, gopath, currentExe)
+			if got != want {
+				t.Fatalf("resolveStableSupervisorBinaryPath(%q, %q, %q) = %q, want %q",
+					homeDir, gopath, currentExe, got, want)
+			}
+		})
+	}
+}
+
+func TestBuildSupervisorServiceDataPrefersUserLocalBinExecPath(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("symlink behavior not exercised on windows here")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp/gc-run")
+
+	runningExe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	binDir := filepath.Join(homeDir, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir local bin: %v", err)
+	}
+	stable := filepath.Join(binDir, "gc")
+	if err := os.Symlink(runningExe, stable); err != nil {
+		t.Fatalf("symlink stable path: %v", err)
+	}
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	if data.GCPath != stable {
+		t.Fatalf("GCPath = %q, want %q (stable user-local-bin path)", data.GCPath, stable)
+	}
+
+	systemdContent, err := renderSupervisorTemplate(supervisorSystemdTemplate, data)
+	if err != nil {
+		t.Fatalf("renderSupervisorTemplate: %v", err)
+	}
+	wantExec := "ExecStart=" + stable + " supervisor run"
+	if !strings.Contains(systemdContent, wantExec) {
+		t.Fatalf("systemd unit missing %q:\n%s", wantExec, systemdContent)
+	}
+}
+
+func TestInstallSupervisorSystemdRefreshesStaleTmpExecStart(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+	runningExe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	binDir := filepath.Join(homeDir, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir local bin: %v", err)
+	}
+	stable := filepath.Join(binDir, "gc")
+	if err := os.Symlink(runningExe, stable); err != nil {
+		t.Fatalf("symlink stable: %v", err)
+	}
+
+	data, err := buildSupervisorServiceData()
+	if err != nil {
+		t.Fatalf("buildSupervisorServiceData: %v", err)
+	}
+	if data.GCPath != stable {
+		t.Fatalf("GCPath = %q, want %q", data.GCPath, stable)
+	}
+
+	path := supervisorSystemdServicePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir unit dir: %v", err)
+	}
+	stale := "[Unit]\nDescription=Gas City machine supervisor\n[Service]\nExecStart=/tmp/gc supervisor run\n"
+	if err := os.WriteFile(path, []byte(stale), 0o600); err != nil {
+		t.Fatalf("write stale unit: %v", err)
+	}
+
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		call := strings.Join(args, " ")
+		calls = append(calls, call)
+		return nil
+	}
+	supervisorSystemctlActive = func(service string) bool {
+		if service != "gascity-supervisor.service" {
+			return false
+		}
+		for _, call := range calls {
+			if call == "--user kill --kill-who=main --signal=SIGTERM "+service {
+				return false
+			}
+		}
+		return true
+	}
+	stubSupervisorRunningPreserveSignalReady(t, true)
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read refreshed unit: %v", err)
+	}
+	wantExec := "ExecStart=" + stable + " supervisor run"
+	if !strings.Contains(string(contents), wantExec) {
+		t.Fatalf("refreshed unit missing %q:\n%s", wantExec, string(contents))
+	}
+	if strings.Contains(string(contents), "ExecStart=/tmp/gc ") {
+		t.Fatalf("refreshed unit still references stale /tmp/gc:\n%s", string(contents))
+	}
+	joined := strings.Join(calls, "\n")
+	for _, want := range []string{
+		"--user daemon-reload",
+		"--user kill --kill-who=main --signal=SIGTERM gascity-supervisor.service",
+		"--user start gascity-supervisor.service",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("systemctl calls = %v, want %q (warm-refresh path)", calls, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1888.

## Root cause
`os.Executable()` resolves symlinks on Linux, so the systemd unit captures whichever path the install was invoked from — pinning to `/tmp/gc` permanently if invoked once from there.

## Fix
On `gc supervisor install`, prefer `~/.local/bin/gc` → `$GOPATH/bin/gc` → `os.Executable()` as the recorded `ExecStart`. Each candidate is verified against the running binary via `os.SameFile` (inode comparison — covers symlinks AND hardlinks transparently) so the unit is guaranteed to launch the same program the operator just ran.

## Migration
Existing units with stale `/tmp/gc` ExecStart auto-refresh on the next `gc supervisor install` (warm-refresh path already present — no manual intervention needed for systemd units).

## Out of scope (called out in commit body)
- Sibling `os.Executable()` at `cmd_supervisor_lifecycle.go:379` (`gc supervisor start`) — separate code path, not driven by this fix.
- `Restart=always` not auto-reloading on binary change — orthogonal.
- Operator-side `oom-preference.conf` drop-ins matching `ExecStart=/tmp/gc` — one-time manual rewrite, will be flagged in the next operator-side audit.

## Test evidence
- `go test ./cmd/gc/ -run TestResolveStableSupervisorBinaryPath|TestBuildSupervisorServiceData|TestInstallSupervisorSystemd` — pass (5.157s)
- 257 lines of new test coverage in `cmd/gc/cmd_supervisor_test.go`
- Build, vet, lint (golangci-lint, 0 issues): green
- Full `cmd/gc` sweep: 5 unrelated baseline failures (legacy-script prune race, three missing-fixture tests, controller env-resolution invariant) — all reproduce on `origin/main` with this branch's files reverted.

## Diff size
- `cmd/gc/cmd_supervisor_lifecycle.go`: +62 / -1
- `cmd/gc/cmd_supervisor_test.go`: +257

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->