### PR TITLE
fix(maintenance): skip jsonl-export push when no origin remote configured

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4549,8 +4549,8 @@ func TestJsonlExportPushFailureRecoversFromMalformedState(t *testing.T) {
 	if err := json.Unmarshal(stateData, &state); err != nil {
 		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
 	}
-	if got := state["consecutive_push_failures"]; got != float64(1) {
-		t.Fatalf("consecutive_push_failures = %v, want 1\nstate: %s", got, stateData)
+	if got := state["consecutive_push_failures"]; got != float64(0) {
+		t.Fatalf("consecutive_push_failures = %v, want 0\nstate: %s", got, stateData)
 	}
 }
 
@@ -4583,8 +4583,46 @@ func TestJsonlExportPushFailureRecoversFromWrongShapeState(t *testing.T) {
 	if err := json.Unmarshal(stateData, &state); err != nil {
 		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
 	}
-	if got := state["consecutive_push_failures"]; got != float64(1) {
-		t.Fatalf("consecutive_push_failures = %v, want 1\nstate: %s", got, stateData)
+	if got := state["consecutive_push_failures"]; got != float64(0) {
+		t.Fatalf("consecutive_push_failures = %v, want 0\nstate: %s", got, stateData)
+	}
+}
+
+func TestJsonlExportSkipsPushWhenNoOriginRemoteAndResetsCounter(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+
+	initSeedArchive(t, archiveRepo, 3)
+	writeMultiRecordDoltStub(t, binDir, 5)
+	writeJsonlExportGCStub(t, binDir)
+
+	initial := `{"consecutive_push_failures":2,"pending_archive_push":true}`
+	if err := os.WriteFile(stateFile, []byte(initial+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(state file): %v", err)
+	}
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["consecutive_push_failures"]; got != float64(0) {
+		t.Fatalf("consecutive_push_failures = %v, want 0 (no-origin skip resets counter)\nstate: %s", got, stateData)
+	}
+	if _, ok := state["pending_archive_push"]; ok {
+		t.Fatalf("pending_archive_push should be cleared when origin is missing\nstate: %s", stateData)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -317,6 +317,13 @@ retry_pending_spike_alert() {
 push_archive_main() {
     local consecutive
 
+    if ! git remote get-url origin >/dev/null 2>&1; then
+        echo "jsonl-export: no origin remote configured; skipping push" >&2
+        set_consecutive_push_failures "0"
+        clear_pending_archive_push
+        return 0
+    fi
+
     record_archive_push_failure() {
         local message="$1"
 


### PR DESCRIPTION
## Summary

- `push_archive_main()` in `jsonl-export.sh` calls `git push origin main` unconditionally. When no origin remote is configured (e.g. a test city with a local-only archive repo), the push returns exit 128, `record_archive_push_failure` increments `consecutive_push_failures`, and after three failures the script mails a HIGH escalation to the mayor — even though no data was lost and no action is possible.
- Add a guard at the top of `push_archive_main()` using `git remote get-url origin` to detect the missing remote. When absent: print a diagnostic to stderr, reset `consecutive_push_failures` to 0 (healing any pre-existing spurious count), clear the pending archive push flag, and return 0.
- Update two existing tests whose assertions reflected the old behavior (push attempt fails → counter increments). Add a new test `TestJsonlExportSkipsPushWhenNoOriginRemoteAndResetsCounter` that directly exercises the guard path.

Surface: `examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh`. The parallel copy at `cmd/gc/.gc/system/packs/maintenance/assets/scripts/jsonl-export.sh` has schema differences and is not changed by this PR.

## Testing

- [x] `make check`
- [x] All `TestJsonlExport*` tests pass: `go test ./examples/gastown/... -run TestJsonlExport -count=1`
- Note: `TestStartLongSocketPathUsesShortSocketName` fails intermittently under full-suite parallel load (passes in isolation); pre-existing flake on `origin/main`, unrelated to this change.

## Checklist

- [x] Linked an issue: closes gastownhall-dev#stg-urqy
- [x] Added or updated tests for behavior changes
- [ ] Updated docs for user-facing changes (none)
- [ ] Called out breaking changes or migration notes (none)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->