### PR TITLE
fix(gastown): route dog warrants with binding prefix

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -697,7 +697,11 @@ func TestGastownRoutedToTargetsUseBindingPrefix(t *testing.T) {
 		rel  string
 		want string
 	}{
-		{"packs/gastown/formulas/mol-deacon-patrol.toml", "gc.routed_to={{binding_prefix}}dog"},
+		{"packs/gastown/formulas/mol-deacon-patrol.toml", `"gc.routed_to":"{{binding_prefix}}dog"`},
+		{"packs/gastown/formulas/mol-witness-patrol.toml", `"gc.routed_to":"{{binding_prefix}}dog"`},
+		{"packs/gastown/agents/boot/prompt.template.md", `"gc.routed_to":"{{ .BindingPrefix }}dog"`},
+		{"packs/gastown/agents/deacon/prompt.template.md", `"gc.routed_to":"{{ .BindingPrefix }}dog"`},
+		{"packs/gastown/agents/witness/prompt.template.md", `"gc.routed_to":"{{ .BindingPrefix }}dog"`},
 		{"packs/gastown/formulas/mol-polecat-work.toml", `${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery`},
 		{"packs/gastown/formulas/mol-refinery-patrol.toml", `${GC_RIG:+$GC_RIG/}{{binding_prefix}}polecat`},
 		{"packs/gastown/formulas/mol-idea-to-plan.toml", "$GC_RIG/{{binding_prefix}}polecat"},
@@ -727,6 +731,39 @@ func TestGastownRoutedToTargetsUseBindingPrefix(t *testing.T) {
 		} {
 			if strings.Contains(body, bad) {
 				t.Errorf("%s still contains short-form route %q", check.rel, bad)
+			}
+		}
+	}
+}
+
+func TestGastownWarrantCreateCommandsUseCreateMetadata(t *testing.T) {
+	dir := exampleDir()
+	files := []string{
+		"packs/gastown/agents/boot/prompt.template.md",
+		"packs/gastown/agents/deacon/prompt.template.md",
+		"packs/gastown/agents/witness/prompt.template.md",
+		"packs/gastown/formulas/mol-deacon-patrol.toml",
+		"packs/gastown/formulas/mol-witness-patrol.toml",
+		"packs/maintenance/formulas/mol-shutdown-dance.toml",
+	}
+	for _, rel := range files {
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		inCreate := false
+		for lineNo, line := range strings.Split(string(data), "\n") {
+			if strings.Contains(line, "bd create") {
+				inCreate = true
+			}
+			if !inCreate {
+				continue
+			}
+			if strings.Contains(line, "--set-metadata") {
+				t.Errorf("%s:%d bd create command uses update-only --set-metadata:\n%s", rel, lineNo+1, line)
+			}
+			if !strings.HasSuffix(strings.TrimSpace(line), "\\") {
+				inCreate = false
 			}
 		}
 	}

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -880,6 +880,16 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 			formula: "mol-refinery-patrol",
 			vars:    []string{"--var target_branch=", "--var rig_name=", "--var binding_prefix="},
 		},
+		{
+			rel:     "packs/gastown/agents/witness/prompt.template.md",
+			formula: "mol-witness-patrol",
+			vars:    []string{"--var binding_prefix="},
+		},
+		{
+			rel:     "packs/gastown/formulas/mol-witness-patrol.toml",
+			formula: "mol-witness-patrol",
+			vars:    []string{"--var binding_prefix="},
+		},
 	}
 	for _, check := range checks {
 		data, err := os.ReadFile(filepath.Join(dir, check.rel))
@@ -906,6 +916,7 @@ func TestGastownPatrolWispCommandsPropagateRoutingNamespace(t *testing.T) {
 	for _, rel := range []string{
 		"packs/gastown/formulas/mol-deacon-patrol.toml",
 		"packs/gastown/formulas/mol-refinery-patrol.toml",
+		"packs/gastown/formulas/mol-witness-patrol.toml",
 	} {
 		data, err := os.ReadFile(filepath.Join(dir, rel))
 		if err != nil {

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -96,9 +96,8 @@ Drain-ack and exit. Next Boot wake will re-evaluate.
 ```bash
 gc bd create --type=task \
   --title="Stuck: deacon" \
-  --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot"}' \
-  --label=warrant \
-  --set-metadata gc.routed_to={{ .BindingPrefix }}dog
+  --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
+  --label=warrant
 ```
 The dog pool picks up the warrant and runs the shutdown dance.
 
@@ -131,7 +130,7 @@ with a fresh provider context.
 | View deacon output | `{{ cmd }} session peek deacon --lines 30` |
 | Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
-| File stuck warrant | `gc bd create --type=task --label=warrant --set-metadata gc.routed_to={{ .BindingPrefix }}dog --metadata '{...}'` |
+| File stuck warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"deacon","reason":"...","requester":"boot","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/boot/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/boot/prompt.template.md
@@ -97,7 +97,8 @@ Drain-ack and exit. Next Boot wake will re-evaluate.
 gc bd create --type=task \
   --title="Stuck: deacon" \
   --metadata '{"target":"deacon","reason":"Stale patrol wisp, no activity","requester":"boot"}' \
-  --label=warrant,pool:dog
+  --label=warrant \
+  --set-metadata gc.routed_to={{ .BindingPrefix }}dog
 ```
 The dog pool picks up the warrant and runs the shutdown dance.
 
@@ -130,7 +131,7 @@ with a fresh provider context.
 | View deacon output | `{{ cmd }} session peek deacon --lines 30` |
 | Check deacon work | `gc bd list --assignee=deacon --status=in_progress --json` |
 | Nudge deacon | `{{ cmd }} session nudge deacon "message"` |
-| File stuck warrant | `gc bd create --type=task --label=warrant,pool:dog --metadata '{...}'` |
+| File stuck warrant | `gc bd create --type=task --label=warrant --set-metadata gc.routed_to={{ .BindingPrefix }}dog --metadata '{...}'` |
 | Check active sessions | `{{ cmd }} session list` |
 
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -111,7 +111,8 @@ response is always the same:
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --label=warrant,pool:dog
+  --label=warrant \
+  --set-metadata gc.routed_to={{ .BindingPrefix }}dog
 ```
 
 2. The dog pool picks up the warrant and runs `mol-shutdown-dance`
@@ -170,7 +171,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | List convoys | `gc convoy list` |
 | Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |
 | Convert dep type | `gc bd dep remove <id> <dep>` then `gc bd dep add <id> <dep> --type=related` |
-| File stuck-agent warrant | `gc bd create --type=task --label=warrant,pool:dog --metadata '{...}'` |
+| File stuck-agent warrant | `gc bd create --type=task --label=warrant --set-metadata gc.routed_to={{ .BindingPrefix }}dog --metadata '{...}'` |
 | Run system diagnostics | `gc doctor` |
 | Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
 | Compact wisps | `gc bd mol wisp gc --age 24h` |

--- a/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/deacon/prompt.template.md
@@ -110,9 +110,8 @@ response is always the same:
 ```bash
 gc bd create --type=task \
   --title="Stuck: <agent>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --label=warrant \
-  --set-metadata gc.routed_to={{ .BindingPrefix }}dog
+  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
+  --label=warrant
 ```
 
 2. The dog pool picks up the warrant and runs `mol-shutdown-dance`
@@ -161,7 +160,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{ .BindingPrefix }}` |
+| Pour next wisp | `gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}'` |
 | Read formula recipe | `gc bd formula show mol-deacon-patrol` (NOT `gc bd mol show` — that's for poured instances) |
 | Context exhaustion | `gc runtime request-restart` |
 | Request target restart | `gc session kill <target>` |
@@ -171,7 +170,7 @@ Individual stuck agents don't need escalation — the warrant system handles the
 | List convoys | `gc convoy list` |
 | Find cross-rig deps | `gc bd dep list <id> --direction=up --type=blocks --json` |
 | Convert dep type | `gc bd dep remove <id> <dep>` then `gc bd dep add <id> <dep> --type=related` |
-| File stuck-agent warrant | `gc bd create --type=task --label=warrant --set-metadata gc.routed_to={{ .BindingPrefix }}dog --metadata '{...}'` |
+| File stuck-agent warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 | Run system diagnostics | `gc doctor` |
 | Compact wisps (dry run) | `gc bd mol wisp gc --age 24h --dry-run` |
 | Compact wisps | `gc bd mol wisp gc --age 24h` |

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -132,9 +132,8 @@ for the dog pool:
 ```bash
 gc bd create --type=task \
   --title="Stuck: <agent>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"witness"}' \
-  --label=warrant \
-  --set-metadata gc.routed_to={{ .BindingPrefix }}dog
+  --metadata '{"target":"<session>","reason":"<reason>","requester":"witness","gc.routed_to":"{{ .BindingPrefix }}dog"}' \
+  --label=warrant
 ```
 
 The dog pool runs `mol-shutdown-dance` — a multi-stage interrogation
@@ -161,7 +160,7 @@ gc bd list --assignee="$GC_ALIAS" --status=in_progress
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
+NEW_WISP=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}' --json | jq -r '.new_epic_id')
 gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
@@ -248,13 +247,13 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{ .BindingPrefix }}` |
+| Pour next wisp | `gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{ .BindingPrefix }}'` |
 | Context exhaustion | `gc runtime request-restart` |
 | Recover orphaned bead | `gc workflow delete-source <id> --apply && gc workflow reopen-source <id>` |
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
 | Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
-| File stuck-agent warrant | `gc bd create --type=task --label=warrant --set-metadata gc.routed_to={{ .BindingPrefix }}dog --metadata '{...}'` |
+| File stuck-agent warrant | `gc bd create --type=task --label=warrant --metadata '{"target":"<session>","reason":"<reason>","requester":"witness","gc.routed_to":"{{ .BindingPrefix }}dog"}'` |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/agents/witness/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/witness/prompt.template.md
@@ -133,7 +133,8 @@ for the dog pool:
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"witness"}' \
-  --label=warrant,pool:dog
+  --label=warrant \
+  --set-metadata gc.routed_to={{ .BindingPrefix }}dog
 ```
 
 The dog pool runs `mol-shutdown-dance` — a multi-stage interrogation
@@ -160,7 +161,7 @@ gc bd list --assignee="$GC_ALIAS" --status=in_progress
 gc mail inbox
 
 # Step 3: Still nothing? Create patrol wisp (root-only — no child step beads)
-NEW_WISP=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+NEW_WISP=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
 gc bd update "$NEW_WISP" --assignee="$GC_ALIAS"
 
 # Step 4: Execute — read formula steps and work through them in order
@@ -247,13 +248,13 @@ gc mail send mayor/ -s "ESCALATION: Brief description [HIGH]" -m "Details"
 
 | Want to... | Correct command |
 |------------|----------------|
-| Pour next wisp | `gc bd mol wisp mol-witness-patrol --root-only` |
+| Pour next wisp | `gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{ .BindingPrefix }}` |
 | Context exhaustion | `gc runtime request-restart` |
 | Recover orphaned bead | `gc workflow delete-source <id> --apply && gc workflow reopen-source <id>` |
 | Salvage worktree work | `git add -A && git commit && git push origin HEAD` |
 | Delete worktree | `git worktree remove <path> --force` |
 | Set branch metadata | `gc bd update <id> --set-metadata branch=<name>` |
-| File stuck-agent warrant | `gc bd create --type=task --label=warrant,pool:dog --metadata '{...}'` |
+| File stuck-agent warrant | `gc bd create --type=task --label=warrant --set-metadata gc.routed_to={{ .BindingPrefix }}dog --metadata '{...}'` |
 
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -1,7 +1,7 @@
 description = """
 Deacon patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{binding_prefix}}
+  gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}'
   gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check inbox, run town-wide coordination
@@ -161,8 +161,7 @@ something is stuck. This is exactly why an LLM does it, not Go code.
 ```bash
 gc bd create --type=task --label=warrant \
   --title="Stuck: <rig>/<role>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --set-metadata gc.routed_to={{binding_prefix}}dog
+  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
 ```
 
 The dog pool runs `mol-shutdown-dance` for due process.
@@ -201,8 +200,7 @@ No hardcoded thresholds. Use judgment.
 ```bash
 gc bd create --type=task --label=warrant \
   --title="Stuck dog: <agent>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon"}' \
-  --set-metadata gc.routed_to={{binding_prefix}}dog
+  --metadata '{"target":"<session>","reason":"<reason>","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
 ```
 
 A different dog from the pool picks up the warrant and runs the
@@ -340,7 +338,7 @@ Handle any urgent messages that arrived during patrol. Archive the rest.
 
 **3. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
+NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -1,7 +1,7 @@
 description = """
 Witness patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-witness-patrol --root-only
+  gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{binding_prefix}}
   gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, patrol, pour the next
@@ -436,7 +436,8 @@ handle the shutdown dance (multi-stage interrogation with due process):
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness"}' \
-  --label=warrant,pool:dog
+  --label=warrant \
+  --set-metadata gc.routed_to={{binding_prefix}}dog
 ```
 
 The dog pool picks up the warrant and runs `mol-shutdown-dance`, which
@@ -472,7 +473,7 @@ is already assigned — the new session resumes from context.
 
 **2. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --json | jq -r '.new_epic_id')
+NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -1,7 +1,7 @@
 description = """
 Witness patrol loop. Poured as a root-only wisp on startup:
 
-  gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{binding_prefix}}
+  gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}'
   gc bd update $WISP --assignee=$GC_AGENT
 
 Each wisp is ONE iteration: check for work, patrol, pour the next
@@ -435,9 +435,8 @@ handle the shutdown dance (multi-stage interrogation with due process):
 ```bash
 gc bd create --type=task \
   --title="Stuck: <agent>" \
-  --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness"}' \
-  --label=warrant \
-  --set-metadata gc.routed_to={{binding_prefix}}dog
+  --metadata '{"target":"<session-name>","reason":"No progress on <bead> for <duration>","requester":"witness","gc.routed_to":"{{binding_prefix}}dog"}' \
+  --label=warrant
 ```
 
 The dog pool picks up the warrant and runs `mol-shutdown-dance`, which
@@ -473,7 +472,7 @@ is already assigned — the new session resumes from context.
 
 **2. Pour next iteration BEFORE burning:**
 ```bash
-NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix={{binding_prefix}} --json | jq -r '.new_epic_id')
+NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{binding_prefix}}' --json | jq -r '.new_epic_id')
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -1,13 +1,14 @@
 description = """
 Shutdown dance — due process for stuck agents.
 
-Dispatched by filing a warrant bead with `--label=pool:dog`:
+Dispatched by filing a warrant bead routed to the dog pool:
 
 ```bash
 gc bd create --type=task \
   --title="Stuck: <agent>" \
   --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>"}' \
-  --label=warrant,pool:dog
+  --label=warrant \
+  --set-metadata gc.routed_to={{binding_prefix}}dog
 ```
 
 The dog pool picks up the warrant and pours this formula. Each wisp is

--- a/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
+++ b/examples/gastown/packs/maintenance/formulas/mol-shutdown-dance.toml
@@ -6,9 +6,8 @@ Dispatched by filing a warrant bead routed to the dog pool:
 ```bash
 gc bd create --type=task \
   --title="Stuck: <agent>" \
-  --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>"}' \
-  --label=warrant \
-  --set-metadata gc.routed_to={{binding_prefix}}dog
+  --metadata '{"target":"<session>","reason":"<reason>","requester":"<who>","gc.routed_to":"<binding-prefix>dog"}' \
+  --label=warrant
 ```
 
 The dog pool picks up the warrant and pours this formula. Each wisp is

--- a/examples/routing_namespace_test.go
+++ b/examples/routing_namespace_test.go
@@ -18,6 +18,7 @@ func TestShippedExamplesDoNotHardcodeShortRoutedToPools(t *testing.T) {
 		"gc.routed_to=<rig>/polecat",
 		"gc.routed_to=<rig>/refinery",
 		"gc.routed_to={{ .RigName }}/refinery",
+		"pool:dog",
 	}
 
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {


### PR DESCRIPTION
## Summary

- route Gastown dog warrant examples through `gc.routed_to` with the active binding prefix instead of bare `pool:dog` labels
- pass `binding_prefix` through witness patrol wisp startup/recurrence so nested imported packs route back to the importing rig
- harden shipped-example regression tests against bare dog pool routing

## Regression tests

- `TestShippedExamplesDoNotHardcodeShortRoutedToPools` now rejects `pool:dog` in shipped example packs
- `TestGastownPatrolWispCommandsPropagateRoutingNamespace` covers witness patrol wisp commands carrying `--var binding_prefix=`
- Existing `TestGastownRoutedToTargetsUseBindingPrefix` continues to guard the refinery handoff path

## Verification

- `go test ./examples -run TestShippedExamplesDoNotHardcodeShortRoutedToPools -count=1`
- `go test ./examples/gastown -run 'TestGastown(PatrolWispCommandsPropagateRoutingNamespace|RoutedToTargetsUseBindingPrefix)' -count=1`\n- `make test`\n- pre-commit hook: lint-changed, docs sync, `go vet ./...`, `make test`\n\nRelated: #1397, #1486, #1870

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->