### PR TITLE
fix: treat {} as zero rows in validate_exported_issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tmux and runtime provider-overlay staging now surface nonfatal preservation
   warnings on stderr, including the Kiro `AGENTS.md` preservation notice when
   project instructions already exist.
+- `jsonl-export.sh` no longer mis-classifies a bead database with an empty
+  `issues` table as a failed export. `dolt sql -r json` returns `{}` (not
+  `{"rows":[]}`) when a queried table is empty; `validate_exported_issues` now
+  treats the bare-object form as zero rows so the database lands in the
+  success path with an `issues.jsonl` committed to the archive instead of
+  appearing in the `failed:` summary.
 - The built-in `control-dispatcher` trace now defaults to
   `${GC_CITY_RUNTIME_DIR}/control-dispatcher-trace.log` (falling back to
   `${GC_CITY}/.gc/runtime/control-dispatcher-trace.log`) instead of writing at

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4534,6 +4534,54 @@ func TestJsonlExportEmptyIssuesPayloadDoesNotCommitBrokenOutputs(t *testing.T) {
 	}
 }
 
+// TestJsonlExportEmptyDatabaseDoesNotAppearInFailedSummary is the regression
+// test for #1898: an empty `issues` table in dolt produces `{}` (not
+// `{"rows":[]}`) from `dolt sql -r json`. Before the fix in
+// validate_exported_issues, that bare-object payload was rejected as malformed
+// JSON and the database was logged in `failed:` even though nothing was wrong
+// with it. After widening the type check (`.rows? // [] | type == "array"`),
+// `{}` is treated as zero rows and the DB lands in the success path with an
+// `issues.jsonl` committed to the archive.
+func TestJsonlExportEmptyDatabaseDoesNotAppearInFailedSummary(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+
+	initSeedArchive(t, archiveRepo, 0)
+	// `{}` is the dolt-empty-result encoding the validator must accept.
+	writeIssuesPayloadDoltStub(t, binDir, `{}`)
+	writeJsonlExportGCStub(t, binDir)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+
+	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+
+	gcData, err := os.ReadFile(gcLog)
+	if err != nil {
+		t.Fatalf("ReadFile(gc log): %v", err)
+	}
+	log := string(gcData)
+	if strings.Contains(log, "failed: beads") {
+		t.Fatalf("empty issues table must not land in failed: summary; gc log:\n%s", log)
+	}
+	if !strings.Contains(log, "DOG_DONE: jsonl — exported 1/1") {
+		t.Fatalf("expected success summary `exported 1/1`, got:\n%s", log)
+	}
+
+	// The DB should have an issues.jsonl committed in the archive, even though
+	// the payload is the empty `{}` form.
+	committed, err := exec.Command("git", "-C", archiveRepo, "show", "HEAD:beads/issues.jsonl").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git show HEAD:beads/issues.jsonl: %v\n%s", err, committed)
+	}
+	if len(strings.TrimSpace(string(committed))) == 0 {
+		t.Fatalf("expected issues.jsonl to be committed (even if empty rows), got empty file")
+	}
+}
+
 func TestJsonlExportPushFailureRecoversFromMalformedState(t *testing.T) {
 	cityDir := t.TempDir()
 	binDir := t.TempDir()

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -67,7 +67,7 @@ scrub_exported_issues() {
 
 validate_exported_issues() {
     jq -e -c '
-        if (type == "object") and ((.rows? | type) == "array") then
+        if (type == "object") and ((.rows? // [] | type) == "array") then
             .
         else
             error("issues export must be a JSON object with a rows array")


### PR DESCRIPTION
Fixes gastownhall/gascity#1898

## What

`validate_exported_issues` rejected `{}` (dolt's empty-result encoding for empty databases) because it required `.rows` to be present. Every export from an empty `bd` database would fail validation.

## Fix

Apply `.rows? // []` in the type check, matching the existing pattern in `count_jsonl_rows`:

```diff
-        if (type == "object") and ((.rows? | type) == "array") then
+        if (type == "object") and ((.rows? // [] | type) == "array") then
```

`{}` now passes as a zero-row result; malformed objects (`.rows` present but not an array) still fail.

## Testing

- `{}` → passes (zero rows)
- `{"rows":[]}` → passes
- `{"rows":[{"id":"x"}]}` → passes
- `[]` → rejected (not an object)
- `{"rows":"bad"}` → rejected (rows is not an array)

No regression to #1848 (column rename) or #1819 (schemaless skip) — both operate on the `.rows` array contents, unaffected by this guard-clause change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gascity/pr/1908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->