### PR TITLE
fix(examples): add gastown default rig import

### DIFF
--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1396,6 +1396,49 @@ source = "packs/a-pack"
 	}
 }
 
+func TestDoRigAdd_RealGastownExampleRootPackDefaultRigImport(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	examplePath, err := filepath.Abs(filepath.Join("..", "..", "examples", "gastown"))
+	if err != nil {
+		t.Fatalf("resolving examples/gastown: %v", err)
+	}
+	cityPath := filepath.Join(t.TempDir(), "city")
+
+	var initStdout, initStderr bytes.Buffer
+	code := doInitFromDirWithOptions(examplePath, cityPath, "", &initStdout, &initStderr, true)
+	if code != 0 {
+		t.Fatalf("doInitFromDirWithOptions = %d, want 0; stderr: %s", code, initStderr.String())
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "my-project")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code = doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d, stderr: %s", code, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "Import: gastown=packs/gastown (default)") {
+		t.Fatalf("output missing gastown default import: %s", stdout.String())
+	}
+	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Rigs) != 1 {
+		t.Fatalf("len(Rigs) = %d, want 1", len(cfg.Rigs))
+	}
+	if got := cfg.Rigs[0].Imports["gastown"].Source; got != "packs/gastown" {
+		t.Fatalf("rig gastown import source = %q, want %q", got, "packs/gastown")
+	}
+}
+
 func TestDoRigAdd_ExplicitIncludeOverridesDefault(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {

--- a/docs/getting-started/coming-from-gastown.md
+++ b/docs/getting-started/coming-from-gastown.md
@@ -526,9 +526,11 @@ in Gas City:
    formulas are resolved by Gas City but executed by the configured beads
    backend.
 5. Look at [examples/gastown/city.toml](https://github.com/gastownhall/gascity/blob/main/examples/gastown/city.toml)
-   first, then [examples/gastown/packs/gastown/pack.toml](https://github.com/gastownhall/gascity/blob/main/examples/gastown/packs/gastown/pack.toml).
-   The city file is the normal starting point; the pack defines the reusable
-   defaults behind it.
+   first, then [examples/gastown/pack.toml](https://github.com/gastownhall/gascity/blob/main/examples/gastown/pack.toml),
+   then [examples/gastown/packs/gastown/pack.toml](https://github.com/gastownhall/gascity/blob/main/examples/gastown/packs/gastown/pack.toml).
+   The city file is the normal starting point; the root pack wires the
+   copyable example and default rig binding; the nested pack defines the
+   reusable defaults behind it.
 
 If you keep those five points straight, most of the Gas Town to Gas City ramp
 goes quickly.

--- a/examples/gastown/city.toml
+++ b/examples/gastown/city.toml
@@ -16,6 +16,8 @@
 # fallback dog shape and shared dog formulas/prompts that gastown reuses.
 # Rig-scoped agents (witness, refinery, polecat) are stamped per-rig.
 #
+# The sibling pack.toml owns the Gastown import and default rig binding.
+#
 # To use: gc start examples/gastown/
 # Requires rigs to be registered: gc rig add <path>
 

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -107,6 +107,13 @@ func TestCityPackTomlParses(t *testing.T) {
 	if gastownImp.Source != "packs/gastown" {
 		t.Errorf("pack.toml imports[\"gastown\"].Source = %q, want %q", gastownImp.Source, "packs/gastown")
 	}
+	gastownDefault, ok := tc.Defaults.Rig.Imports["gastown"]
+	if !ok {
+		t.Fatalf("pack.toml defaults.rig.imports = %v, want entry for \"gastown\"", tc.Defaults.Rig.Imports)
+	}
+	if gastownDefault.Source != "packs/gastown" {
+		t.Errorf("pack.toml defaults.rig.imports[\"gastown\"].Source = %q, want %q", gastownDefault.Source, "packs/gastown")
+	}
 }
 
 func TestCityTomlValidates(t *testing.T) {
@@ -1344,8 +1351,13 @@ func TestDaemonConfig(t *testing.T) {
 
 // packFileConfig mirrors the pack.toml structure for test parsing.
 type packFileConfig struct {
-	Pack    config.PackMeta          `toml:"pack"`
-	Imports map[string]config.Import `toml:"imports"`
+	Pack     config.PackMeta          `toml:"pack"`
+	Imports  map[string]config.Import `toml:"imports"`
+	Defaults struct {
+		Rig struct {
+			Imports map[string]config.Import `toml:"imports"`
+		} `toml:"rig"`
+	} `toml:"defaults"`
 }
 
 func discoverPackAgents(t *testing.T, rel string) []config.Agent {

--- a/examples/gastown/pack.toml
+++ b/examples/gastown/pack.toml
@@ -9,3 +9,6 @@ schema = 2
 
 [imports.gastown]
 source = "packs/gastown"
+
+[defaults.rig.imports.gastown]
+source = "packs/gastown"


### PR DESCRIPTION
## Summary
- add the root Gastown example default rig import so copied cities apply `packs/gastown` to newly added rigs
- cover the real `examples/gastown` init -> plain `gc rig add` path
- document the root pack as the portable example wiring point

Fixes #1814.

## Tests
- `go test ./examples/gastown`
- `go test ./cmd/gc -run 'TestDoRigAdd_RealGastownExampleRootPackDefaultRigImport|TestInitFromPreservesCopiedPackDefaultRigImportOrder|TestDoRigAdd_RootPackDefaultRigImports'`\n- pre-commit hook: `go vet ./...`, `GC_FAST_UNIT=1 scripts/go-test-observable test -- -p=4 -count=1 ./...`, `go test ./test/docsync`