### PR TITLE
fix(reconciler): recognize failed-create as known pool session state

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -1259,6 +1259,9 @@ func discoverSessionBeadsWithRoots(
 		if sn == "" {
 			continue
 		}
+		if isFailedCreateSessionBead(b) {
+			continue
+		}
 		// Skip beads already in desired state (from config iteration).
 		if _, exists := desired[sn]; exists {
 			continue
@@ -1920,7 +1923,7 @@ func selectOrCreatePoolSessionBead(
 		return beads.Bead{}, 0, fmt.Errorf("pool template %q has no configured agent", template)
 	}
 	// Resume tier: reuse the session that has in-progress work assigned.
-	if preferred != nil && preferred.ID != "" && !used[preferred.ID] {
+	if preferred != nil && preferred.ID != "" && !used[preferred.ID] && !isFailedCreateSessionBead(*preferred) {
 		slot := claimPoolSlot(cfgAgent, *preferred, usedSlots)
 		return *preferred, slot, nil
 	}
@@ -1932,6 +1935,9 @@ func selectOrCreatePoolSessionBead(
 			continue
 		}
 		if isDrainedSessionBead(bead) {
+			continue
+		}
+		if isFailedCreateSessionBead(bead) {
 			continue
 		}
 		if bead.Metadata["state"] == "asleep" {
@@ -2007,6 +2013,10 @@ func createPoolSessionBeadWithGuardedAlias(
 	return createPoolSessionBead(bp.beadStore, template, bp.sessionBeads, poolSessionCreateStartedAt(bp), identity)
 }
 
+func isFailedCreateSessionBead(bead beads.Bead) bool {
+	return strings.TrimSpace(bead.Metadata["state"]) == string(session.StateFailedCreate)
+}
+
 func sessionBeadHasAssignedWork(workBeads []beads.Bead, sessionBead beads.Bead) bool {
 	for _, wb := range workBeads {
 		assignee := strings.TrimSpace(wb.Assignee)
@@ -2033,6 +2043,9 @@ func selectOrCreateDependencyPoolSessionBead(
 			continue
 		}
 		if isDrainedSessionBead(bead) {
+			continue
+		}
+		if isFailedCreateSessionBead(bead) {
 			continue
 		}
 		if isNamedSessionBead(bead) {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 type listFailStore struct {
@@ -5405,6 +5406,88 @@ func TestEnsureDependencyOnlyTemplate_StoreBackedUsesInstanceIdentity(t *testing
 	}
 	if template := tp.Env["GC_TEMPLATE"]; template != "gascity/db" {
 		t.Fatalf("store-backed dep-floor GC_TEMPLATE = %q, want base %q", template, "gascity/db")
+	}
+}
+
+func TestBuildDesiredState_DependencyFloorSkipsFailedCreate(t *testing.T) {
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{
+				Name:              "db",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+			},
+			{
+				Name:              "api",
+				Dir:               "gascity",
+				StartCommand:      "true",
+				MinActiveSessions: intPtr(0),
+				MaxActiveSessions: intPtr(3),
+				ScaleCheck:        "printf 0",
+				DependsOn:         []string{"gascity/db"},
+			},
+		},
+	}
+
+	store := beads.NewMemStore()
+	if _, err := store.Create(beads.Bead{
+		Title:  "api",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/api"},
+		Metadata: map[string]string{
+			"template":     "gascity/api",
+			"agent_name":   "gascity/api",
+			"session_name": "s-api-root",
+			"state":        "active",
+			"pool_managed": "true",
+			"pool_slot":    "1",
+		},
+	}); err != nil {
+		t.Fatalf("seed api root bead: %v", err)
+	}
+	failed, err := store.Create(beads.Bead{
+		Title:  "db failed create",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "template:gascity/db"},
+		Metadata: map[string]string{
+			"template":             "gascity/db",
+			"agent_name":           "gascity/db-failed",
+			"session_name":         "s-db-failed",
+			"state":                string(sessionpkg.StateFailedCreate),
+			"dependency_only":      "true",
+			"pool_managed":         "true",
+			"pool_slot":            "1",
+			"pending_create_claim": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed failed-create dependency bead: %v", err)
+	}
+
+	dsResult := buildDesiredState("test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(), store, io.Discard)
+
+	var tp TemplateParams
+	var found bool
+	for _, entry := range dsResult.State {
+		if entry.TemplateName == "gascity/db" && entry.DependencyOnly {
+			tp = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("store-backed dependency floor for db not found: %+v", dsResult.State)
+	}
+	if tp.SessionName == failed.Metadata["session_name"] {
+		t.Fatalf("dependency floor reused failed-create bead %s with session %q", failed.ID, tp.SessionName)
+	}
+	if tp.SessionName == "" {
+		t.Fatal("dependency floor session name is empty")
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
@@ -1807,6 +1808,55 @@ func TestLookupPoolSessionNames_PrefersActiveStampedBeadOverCreatingScoreTie(t *
 	}
 	if got["frontend/worker-5"] != "z-active-worker-5" {
 		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want active stamped bead to beat creating duplicate", got)
+	}
+}
+
+func TestLookupPoolSessionNames_IgnoresFailedCreateIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "worker", Dir: "frontend", MaxActiveSessions: intPtr(5)},
+		},
+	}
+	cfgAgent := &cfg.Agents[0]
+	for _, bead := range []beads.Bead{
+		{
+			Title:  "failed create worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "stale-worker-1",
+				"agent_name":   "frontend/worker-1",
+				"alias":        "frontend/worker-1",
+				"pool_slot":    "1",
+				"state":        string(sessionpkg.StateFailedCreate),
+			},
+		},
+		{
+			Title:  "fresh worker",
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel},
+			Metadata: map[string]string{
+				"template":     "frontend/worker",
+				"session_name": "fresh-worker-1",
+				"agent_name":   "frontend/worker-1",
+				"pool_slot":    "1",
+				"state":        "creating",
+			},
+		},
+	} {
+		if _, err := store.Create(bead); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := lookupPoolSessionNames(store, cfg, cfgAgent)
+	if err != nil {
+		t.Fatalf("lookupPoolSessionNames: %v", err)
+	}
+	if got["frontend/worker-1"] != "fresh-worker-1" {
+		t.Fatalf("lookupPoolSessionNames(frontend/worker) = %#v, want failed-create identity ignored", got)
 	}
 }
 

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -764,10 +764,19 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 	// Index by session_name for O(1) lookup. Skip closed beads — a closed
 	// bead is a completed lifecycle record, not a live session. If an agent
 	// restarts after its bead was closed, we create a fresh bead.
+	now := clk.Now().UTC()
 	bySessionName := make(map[string]beads.Bead, len(existing))
 	indexBySessionName := make(map[string]int, len(existing))
 	openBeads := make([]beads.Bead, len(existing))
 	copy(openBeads, existing)
+	for i, b := range openBeads {
+		if b.Status == "closed" || !isNamedSessionBead(b) || !isFailedCreateSessionBead(b) {
+			continue
+		}
+		if closeFailedCreateBead(store, b.ID, now, stderr) {
+			openBeads[i].Status = "closed"
+		}
+	}
 	for i, b := range openBeads {
 		if b.Status == "closed" {
 			continue
@@ -813,7 +822,6 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 		desiredNames[sn] = true
 	}
 
-	now := clk.Now().UTC()
 	cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))
 	var (
 		visibleBySessionName map[string]beads.Bead
@@ -1780,6 +1788,9 @@ func closeSessionBeadIfRuntimeStoppedAndUnassigned(
 	}
 	if hasAssignedWork {
 		return false
+	}
+	if isFailedCreateSessionBead(b) {
+		return closeFailedCreateBead(store, b.ID, now, stderr)
 	}
 	return closeBead(store, b.ID, closeReason, now, stderr)
 }

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -249,7 +249,7 @@ func preserveConfiguredNamedSessionBead(b beads.Bead, cfg *config.City, cityName
 			}
 		}
 		return false
-	case "failed-create":
+	case string(session.StateFailedCreate):
 		// rollbackPendingCreate sets state="failed-create" only with
 		// Status=closed atomically. A Status=open + state="failed-create"
 		// combination means a write failed mid-rollback — release the
@@ -1581,7 +1581,7 @@ func setMetaBatch(store beads.Store, id string, batch map[string]string, stderr 
 }
 
 func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr io.Writer) bool {
-	patch := session.ClosePatch(now.UTC(), "failed-create")
+	patch := session.ClosePatch(now.UTC(), string(session.StateFailedCreate))
 	patch["pending_create_claim"] = ""
 	patch["pending_create_started_at"] = ""
 	if setMetaBatch(store, id, patch, stderr) != nil {

--- a/cmd/gc/session_lifecycle_chaos_test.go
+++ b/cmd/gc/session_lifecycle_chaos_test.go
@@ -26,6 +26,20 @@ func TestSessionLifecycleChaos(t *testing.T) {
 	runSessionLifecycleChaos(t, sessionChaosOptions{})
 }
 
+func TestSessionLifecycleChaosInvariantsAllowFailedCreatePendingClaim(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260510)
+	h.createSessionIntent()
+	b := h.mustBead()
+	if err := h.env.store.SetMetadataBatch(b.ID, map[string]string{
+		"state":                string(sessionpkg.StateFailedCreate),
+		"pending_create_claim": "true",
+	}); err != nil {
+		t.Fatalf("SetMetadataBatch(failed-create): %v", err)
+	}
+
+	h.assertInvariants()
+}
+
 func TestSessionLifecycleChaosPendingInteractionDoesNotOverrideOrphanDrain(t *testing.T) {
 	h := newSessionChaosHarness(t, 20260415)
 	h.createSessionIntent()
@@ -1321,7 +1335,10 @@ func (h *sessionChaosHarness) assertInvariants() {
 	if state == string(sessionpkg.StateArchived) && b.Metadata["continuity_eligible"] != "true" && running {
 		h.failf("continuity-ineligible archive still running runtime %q", runtimeName)
 	}
-	if b.Status != "closed" && strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true" && state != string(sessionpkg.StateCreating) {
+	if b.Status != "closed" &&
+		strings.TrimSpace(b.Metadata["pending_create_claim"]) == "true" &&
+		state != string(sessionpkg.StateCreating) &&
+		state != string(sessionpkg.StateFailedCreate) {
 		h.failf("pending_create_claim=true with state=%q", state)
 	}
 }
@@ -1358,6 +1375,7 @@ func knownChaosLifecycleState(state string) bool {
 		sessionpkg.BaseStateDraining,
 		sessionpkg.BaseStateDrained,
 		sessionpkg.BaseStateArchived,
+		sessionpkg.BaseStateFailedCreate,
 		sessionpkg.BaseStateOrphaned,
 		sessionpkg.BaseStateClosed,
 		sessionpkg.BaseStateClosing,

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1544,7 +1544,7 @@ func rollbackPendingCreate(session *beads.Bead, store beads.Store, now time.Time
 			session.Metadata["session_name"] = ""
 		}
 	}
-	closeBead(store, session.ID, "failed-create", now, stderr)
+	closeBead(store, session.ID, string(sessionpkg.StateFailedCreate), now, stderr)
 }
 
 func executePlannedStarts(

--- a/cmd/gc/session_name_lookup.go
+++ b/cmd/gc/session_name_lookup.go
@@ -402,6 +402,9 @@ func lookupPoolSessionNameCandidates(store beads.Store, template string, cfg *co
 		if b.Status == "closed" {
 			continue
 		}
+		if isFailedCreateSessionBead(b) {
+			continue
+		}
 		if isNamedSessionBead(b) || isManualSessionBeadForAgent(b, cfgAgent) {
 			continue
 		}

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1095,18 +1095,18 @@ func topoOrder(sessions []beads.Bead, deps map[string][]string) []beads.Bead {
 // during reconciliation to allow forward-compatible rollback from newer
 // versions that add states like "draining" or "archived".
 var knownSessionStates = map[string]bool{
-	"active":        true,
-	"asleep":        true,
-	"awake":         true,
-	"stopped":       true,
-	"suspended":     true,
-	"orphaned":      true,
-	"closed":        true,
-	"quarantined":   true,
-	"creating":      true,
-	"drained":       true,
-	"failed-create": true, // mid-rollback failure: Status=open + state=failed-create releases the alias
-	"":              true, // empty state is valid (legacy beads)
+	"active":                             true,
+	"asleep":                             true,
+	"awake":                              true,
+	"stopped":                            true,
+	"suspended":                          true,
+	"orphaned":                           true,
+	"closed":                             true,
+	"quarantined":                        true,
+	"creating":                           true,
+	"drained":                            true,
+	string(sessionpkg.StateFailedCreate): true, // Status=open + failed-create releases the alias
+	"":                                   true, // empty state is valid (legacy beads)
 }
 
 // isKnownState returns true if the bead's metadata state is recognized by

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1105,7 +1105,7 @@ var knownSessionStates = map[string]bool{
 	"quarantined":                        true,
 	"creating":                           true,
 	"drained":                            true,
-	string(sessionpkg.StateFailedCreate): true, // Status=open + failed-create releases the alias
+	string(sessionpkg.StateFailedCreate): true, // processed so skip/orphan-close can release the slot
 	"":                                   true, // empty state is valid (legacy beads)
 }
 

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -1095,17 +1095,18 @@ func topoOrder(sessions []beads.Bead, deps map[string][]string) []beads.Bead {
 // during reconciliation to allow forward-compatible rollback from newer
 // versions that add states like "draining" or "archived".
 var knownSessionStates = map[string]bool{
-	"active":      true,
-	"asleep":      true,
-	"awake":       true,
-	"stopped":     true,
-	"suspended":   true,
-	"orphaned":    true,
-	"closed":      true,
-	"quarantined": true,
-	"creating":    true,
-	"drained":     true,
-	"":            true, // empty state is valid (legacy beads)
+	"active":        true,
+	"asleep":        true,
+	"awake":         true,
+	"stopped":       true,
+	"suspended":     true,
+	"orphaned":      true,
+	"closed":        true,
+	"quarantined":   true,
+	"creating":      true,
+	"drained":       true,
+	"failed-create": true, // mid-rollback failure: Status=open + state=failed-create releases the alias
+	"":              true, // empty state is valid (legacy beads)
 }
 
 // isKnownState returns true if the bead's metadata state is recognized by

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // testStore wraps a bead slice for SetMetadata tracking in tests.
@@ -1965,7 +1966,7 @@ func TestFindAgentByTemplate(t *testing.T) {
 func TestIsKnownState_KnownStates(t *testing.T) {
 	known := []string{
 		"active", "asleep", "awake", "stopped", "suspended",
-		"orphaned", "closed", "quarantined", "creating", "failed-create", "",
+		"orphaned", "closed", "quarantined", "creating", string(sessionpkg.StateFailedCreate), "",
 	}
 	for _, state := range known {
 		session := makeBead("b1", map[string]string{"state": state})
@@ -2008,13 +2009,10 @@ func TestForwardCompatibility_UnknownState(t *testing.T) {
 	}
 }
 
-// TestReconcileSessionBeads_FailedCreateSlotUnblocked verifies that a pool
-// slot stuck with state=failed-create (mid-rollback write failure) is not
-// silently skipped by the reconciler. Before the fix, failed-create was not
-// in knownSessionStates so the reconciler logged "unknown state" and left the
-// slot blocked indefinitely. After the fix the slot is processed, healed, and
-// a fresh session is started.
-func TestReconcileSessionBeads_FailedCreateSlotUnblocked(t *testing.T) {
+// TestReconcileSessionBeads_FailedCreateDesiredTargetNotStarted verifies that
+// state=failed-create cannot reach the provider start path even if a stale
+// desired-state entry points at that session_name.
+func TestReconcileSessionBeads_FailedCreateDesiredTargetNotStarted(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
 	env.addDesired("worker", "worker", false)
@@ -2028,17 +2026,17 @@ func TestReconcileSessionBeads_FailedCreateSlotUnblocked(t *testing.T) {
 	// the reconciler processes it.
 	session := env.createSessionBead("worker", "worker")
 	env.setSessionMetadata(&session, map[string]string{
-		"state":                "failed-create",
+		"state":                string(sessionpkg.StateFailedCreate),
 		"pending_create_claim": "true",
 	})
 
 	woken := env.reconcile([]beads.Bead{session})
 
-	if woken != 1 {
-		t.Errorf("expected reconciler to unblock failed-create slot and start a session, got woken=%d", woken)
+	if woken != 0 {
+		t.Errorf("expected failed-create desired target not to start, got woken=%d", woken)
 	}
-	if !env.sp.IsRunning("worker") {
-		t.Error("expected session to be started via Provider after failed-create slot is unblocked")
+	if env.sp.IsRunning("worker") {
+		t.Error("failed-create session was started via Provider")
 	}
 }
 

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1965,7 +1965,7 @@ func TestFindAgentByTemplate(t *testing.T) {
 func TestIsKnownState_KnownStates(t *testing.T) {
 	known := []string{
 		"active", "asleep", "awake", "stopped", "suspended",
-		"orphaned", "closed", "quarantined", "creating", "",
+		"orphaned", "closed", "quarantined", "creating", "failed-create", "",
 	}
 	for _, state := range known {
 		session := makeBead("b1", map[string]string{"state": state})
@@ -2005,6 +2005,40 @@ func TestForwardCompatibility_UnknownState(t *testing.T) {
 	// The warning should appear in stderr.
 	if !strings.Contains(env.stderr.String(), "unknown state") {
 		t.Errorf("expected warning about unknown state in stderr, got: %s", env.stderr.String())
+	}
+}
+
+// TestReconcileSessionBeads_FailedCreateSlotUnblocked verifies that a pool
+// slot stuck with state=failed-create (mid-rollback write failure) is not
+// silently skipped by the reconciler. Before the fix, failed-create was not
+// in knownSessionStates so the reconciler logged "unknown state" and left the
+// slot blocked indefinitely. After the fix the slot is processed, healed, and
+// a fresh session is started.
+func TestReconcileSessionBeads_FailedCreateSlotUnblocked(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addDesired("worker", "worker", false)
+
+	// Simulate the mid-rollback failure: rollbackPendingCreate writes
+	// state=failed-create via ClosePatch, then tries to set Status=closed.
+	// If that Status write fails the bead is left with Status=open,
+	// state=failed-create, and pending_create_claim still "true" — ClosePatch
+	// does not clear pending_create_claim, and clearPendingStartInFlightLease
+	// only clears last_woke_at. The combination blocks the pool slot until
+	// the reconciler processes it.
+	session := env.createSessionBead("worker", "worker")
+	env.setSessionMetadata(&session, map[string]string{
+		"state":                "failed-create",
+		"pending_create_claim": "true",
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+
+	if woken != 1 {
+		t.Errorf("expected reconciler to unblock failed-create slot and start a session, got woken=%d", woken)
+	}
+	if !env.sp.IsRunning("worker") {
+		t.Error("expected session to be started via Provider after failed-create slot is unblocked")
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1390,6 +1390,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		if shouldWake && !target.alive {
 			// Session should be awake but isn't — wake it.
+			if isFailedCreateSessionBead(*target.session) {
+				if trace != nil {
+					trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "failed_create", traceRecordPayload{
+						"pending_create_claim": strings.TrimSpace(target.session.Metadata["pending_create_claim"]),
+					}, nil, "")
+				}
+				continue
+			}
 			if sessionIsQuarantined(*target.session, clk) {
 				continue // crash-loop protection
 			}

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5996,7 +5996,7 @@ func TestDrainedIsKnownState(t *testing.T) {
 }
 
 func TestFailedCreateIsKnownState(t *testing.T) {
-	if !knownSessionStates["failed-create"] {
+	if !knownSessionStates[string(sessionpkg.StateFailedCreate)] {
 		t.Fatal("failed-create must be a known session state")
 	}
 }
@@ -6042,7 +6042,7 @@ func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *
 					"session_name":              "worker-1",
 					"agent_name":                "worker-1",
 					"template":                  "worker",
-					"state":                     "failed-create",
+					"state":                     string(sessionpkg.StateFailedCreate),
 					"pool_slot":                 "1",
 					"pending_create_claim":      boolMetadata(true),
 					"pending_create_started_at": pendingCreateStartedAtNow(tc.startedAt),
@@ -6124,6 +6124,109 @@ func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *
 	}
 }
 
+func TestReconcileSessionBeads_SyncReplacesFailedCreateNamedSession(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cityPath := t.TempDir()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              "worker",
+			StartCommand:      "true",
+			MaxActiveSessions: intPtr(1),
+		}},
+		NamedSessions: []config.NamedSession{{
+			Name:     "primary",
+			Template: "worker",
+			Mode:     "always",
+		}},
+	}
+	identity := "primary"
+	sessionName := config.NamedSessionRuntimeName(cfg.EffectiveCityName(), cfg.Workspace, identity)
+	failedBead, err := store.Create(beads.Bead{
+		Title:  sessionName,
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:" + identity},
+		Metadata: map[string]string{
+			"session_name":               sessionName,
+			"alias":                      identity,
+			"agent_name":                 identity,
+			"template":                   "worker",
+			"state":                      string(sessionpkg.StateFailedCreate),
+			"pending_create_claim":       boolMetadata(true),
+			"pending_create_started_at":  pendingCreateStartedAtNow(clk.Now()),
+			"live_hash":                  runtime.LiveFingerprint(runtime.Config{Command: "true"}),
+			"generation":                 "1",
+			"instance_token":             "failed-token",
+			namedSessionMetadataKey:      boolMetadata(true),
+			namedSessionIdentityMetadata: identity,
+			namedSessionModeMetadata:     "always",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create failed-create named bead: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	dsResult := buildDesiredState(cfg.EffectiveCityName(), cityPath, clk.Now().UTC(), cfg, sp, store, &stderr)
+	if _, ok := dsResult.State[sessionName]; !ok {
+		t.Fatalf("desired state missing configured named session %q; state=%#v stderr:\n%s", sessionName, dsResult.State, stderr.String())
+	}
+	cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
+	syncSessionBeads(cityPath, store, dsResult.State, sp, cfgNames, cfg, clk, &stderr, true)
+
+	gotFailed, err := store.Get(failedBead.ID)
+	if err != nil {
+		t.Fatalf("Get failed-create named bead: %v", err)
+	}
+	if gotFailed.Status != "closed" {
+		t.Fatalf("failed-create named bead status = %q, want closed; stderr:\n%s", gotFailed.Status, stderr.String())
+	}
+	if gotFailed.Metadata["close_reason"] != string(sessionpkg.StateFailedCreate) {
+		t.Fatalf("failed-create named bead close_reason = %q, want %q", gotFailed.Metadata["close_reason"], sessionpkg.StateFailedCreate)
+	}
+	if gotFailed.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("failed-create named bead pending_create_claim = %q, want cleared", gotFailed.Metadata["pending_create_claim"])
+	}
+
+	sessions, err := loadSessionBeads(store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	var fresh beads.Bead
+	for _, b := range sessions {
+		if b.ID != failedBead.ID && b.Metadata["session_name"] == sessionName {
+			fresh = b
+			break
+		}
+	}
+	if fresh.ID == "" {
+		t.Fatalf("sync did not create a fresh named-session bead; open sessions=%#v stderr:\n%s", sessions, stderr.String())
+	}
+	if fresh.Metadata["state"] != string(sessionpkg.StateCreating) {
+		t.Fatalf("fresh named-session state = %q, want creating", fresh.Metadata["state"])
+	}
+
+	poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessions, dsResult.ScaleCheckCounts))
+	if poolDesired == nil {
+		poolDesired = make(map[string]int)
+	}
+	mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+	woken := reconcileSessionBeads(
+		context.Background(), sessions, dsResult.State, cfgNames,
+		cfg, sp, store, nil, dsResult.AssignedWorkBeads, nil, newDrainTracker(), poolDesired,
+		dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1 for fresh named session; stdout:\n%s\nstderr:\n%s", woken, stdout.String(), stderr.String())
+	}
+	if !sp.IsRunning(sessionName) {
+		t.Fatalf("fresh named session %q is not running after reconcile; stdout:\n%s\nstderr:\n%s", sessionName, stdout.String(), stderr.String())
+	}
+}
+
 // TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot verifies
 // the post-lease-expiry close path for a pool session bead whose close call
 // failed after failed-create metadata was written.
@@ -6134,20 +6237,20 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
 		Agents: []config.Agent{
-			{Name: "polecat", StartCommand: "true", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3)},
+			{Name: "worker", StartCommand: "true", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3)},
 		},
 	}
 
 	// Simulate the close retry after a stale failed-create lease has expired.
 	failedBead, err := store.Create(beads.Bead{
-		Title:  "polecat-1",
+		Title:  "worker-1",
 		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel, "agent:polecat-1"},
+		Labels: []string{sessionBeadLabel, "agent:worker-1"},
 		Metadata: map[string]string{
-			"session_name":              "polecat-1",
-			"agent_name":                "polecat-1",
-			"template":                  "polecat",
-			"state":                     "failed-create",
+			"session_name":              "worker-1",
+			"agent_name":                "worker-1",
+			"template":                  "worker",
+			"state":                     string(sessionpkg.StateFailedCreate),
 			"pool_slot":                 "1",
 			"pending_create_claim":      boolMetadata(true),
 			"pending_create_started_at": pendingCreateStartedAtNow(clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second))),
@@ -6163,13 +6266,13 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 
 	// Fresh pool session bead: what buildDesiredState allocates for the pending demand.
 	freshBead, err := store.Create(beads.Bead{
-		Title:  "polecat-2",
+		Title:  "worker-2",
 		Type:   sessionBeadType,
-		Labels: []string{sessionBeadLabel, "agent:polecat-2"},
+		Labels: []string{sessionBeadLabel, "agent:worker-2"},
 		Metadata: map[string]string{
-			"session_name":         "polecat-2",
-			"agent_name":           "polecat-2",
-			"template":             "polecat",
+			"session_name":         "worker-2",
+			"agent_name":           "worker-2",
+			"template":             "worker",
 			"state":                "creating",
 			"pool_slot":            "2",
 			"pending_create_claim": boolMetadata(true),
@@ -6185,9 +6288,9 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 
 	// desired: only the fresh bead; the failed-create bead is not desired.
 	ds := map[string]TemplateParams{
-		"polecat-2": {
-			TemplateName: "polecat",
-			InstanceName: "polecat-2",
+		"worker-2": {
+			TemplateName: "worker",
+			InstanceName: "worker-2",
 			Command:      "true",
 			PoolSlot:     2,
 		},
@@ -6195,7 +6298,7 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 
 	sessions, _ := loadSessionBeads(store)
 	cfgNames := configuredSessionNames(cfg, "", store)
-	poolDesired := map[string]int{"polecat": 1}
+	poolDesired := map[string]int{"worker": 1}
 	var stdout, stderr bytes.Buffer
 	woken := reconcileSessionBeads(
 		context.Background(), sessions, ds, cfgNames,
@@ -6210,6 +6313,13 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 	}
 	if got.Status != "closed" {
 		t.Fatalf("failed-create bead status = %q, want closed", got.Status)
+	}
+	if got.Metadata["close_reason"] != string(sessionpkg.StateFailedCreate) {
+		t.Fatalf("failed-create bead close_reason = %q, want %q", got.Metadata["close_reason"], sessionpkg.StateFailedCreate)
+	}
+	if got.Metadata["pending_create_claim"] != "" || got.Metadata["pending_create_started_at"] != "" {
+		t.Fatalf("failed-create pending metadata = claim %q started_at %q, want cleared",
+			got.Metadata["pending_create_claim"], got.Metadata["pending_create_started_at"])
 	}
 	if strings.Contains(stderr.String(), "unknown state") {
 		t.Errorf("reconciler logged unknown state for failed-create bead: %s", stderr.String())

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -5994,6 +5994,110 @@ func TestDrainedIsKnownState(t *testing.T) {
 	}
 }
 
+func TestFailedCreateIsKnownState(t *testing.T) {
+	if !knownSessionStates["failed-create"] {
+		t.Fatal("failed-create must be a known session state")
+	}
+}
+
+// TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot is §5-T1:
+// a pool session bead whose close call failed mid-rollback (Status=open,
+// state=failed-create) must be recognized as a known state and closed by the
+// reconciler within one pass so the freed slot can be filled by a fresh session.
+func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing.T) {
+	store := beads.NewMemStore()
+	clk := &clock.Fake{Time: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{
+			{Name: "polecat", StartCommand: "true", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(3)},
+		},
+	}
+
+	// Simulate a mid-rollback failure: metadata was written (state=failed-create,
+	// pending_create_claim cleared) but store.Close failed, leaving Status=open.
+	failedBead, err := store.Create(beads.Bead{
+		Title:  "polecat-1",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:polecat-1"},
+		Metadata: map[string]string{
+			"session_name":         "polecat-1",
+			"agent_name":           "polecat-1",
+			"template":             "polecat",
+			"state":                "failed-create",
+			"pool_slot":            "1",
+			poolManagedMetadataKey: boolMetadata(true),
+			"live_hash":            runtime.LiveFingerprint(runtime.Config{Command: "true"}),
+			"generation":           "1",
+			"instance_token":       "failed-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create failed-create bead: %v", err)
+	}
+
+	// Fresh pool session bead: what buildDesiredState allocates for the pending demand.
+	freshBead, err := store.Create(beads.Bead{
+		Title:  "polecat-2",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel, "agent:polecat-2"},
+		Metadata: map[string]string{
+			"session_name":         "polecat-2",
+			"agent_name":           "polecat-2",
+			"template":             "polecat",
+			"state":                "creating",
+			"pool_slot":            "2",
+			"pending_create_claim": boolMetadata(true),
+			poolManagedMetadataKey: boolMetadata(true),
+			"live_hash":            runtime.LiveFingerprint(runtime.Config{Command: "true"}),
+			"generation":           "1",
+			"instance_token":       "new-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create fresh bead: %v", err)
+	}
+
+	// desired: only the fresh bead; the failed-create bead is not desired.
+	ds := map[string]TemplateParams{
+		"polecat-2": {
+			TemplateName: "polecat",
+			InstanceName: "polecat-2",
+			Command:      "true",
+			PoolSlot:     2,
+		},
+	}
+
+	sessions, _ := loadSessionBeads(store)
+	cfgNames := configuredSessionNames(cfg, "", store)
+	poolDesired := map[string]int{"polecat": 1}
+	var stdout, stderr bytes.Buffer
+	woken := reconcileSessionBeads(
+		context.Background(), sessions, ds, cfgNames,
+		cfg, sp, store, nil, nil, nil, newDrainTracker(), poolDesired, false, nil, "test-city",
+		nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+	)
+
+	// The failed-create bead must be closed, not silently skipped as unknown state.
+	got, err := store.Get(failedBead.ID)
+	if err != nil {
+		t.Fatalf("Get failed-create bead: %v", err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("failed-create bead status = %q, want closed", got.Status)
+	}
+	if strings.Contains(stderr.String(), "unknown state") {
+		t.Errorf("reconciler logged unknown state for failed-create bead: %s", stderr.String())
+	}
+
+	// A fresh session must be started in the freed slot.
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1 (fresh pool session should be started)", woken)
+	}
+	_ = freshBead
+}
+
 // TODO(pool-consolidation): This test validates that poolDesired gates wake
 // decisions. Needs updating when pool_slot is removed — the slot-based gate
 // will be replaced with count-based ordering.

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gastownhall/gascity/internal/events"
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
 )
 
 // fakeIdleTracker is a test double for idleTracker.
@@ -6000,10 +6001,132 @@ func TestFailedCreateIsKnownState(t *testing.T) {
 	}
 }
 
-// TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot is §5-T1:
-// a pool session bead whose close call failed mid-rollback (Status=open,
-// state=failed-create) must be recognized as a known state and closed by the
-// reconciler within one pass so the freed slot can be filled by a fresh session.
+func TestReconcileSessionBeads_BuildDesiredStateSkipsFailedCreatePoolSession(t *testing.T) {
+	cases := []struct {
+		name             string
+		startedAt        time.Time
+		wantFailedStatus string
+	}{
+		{
+			name:             "fresh pending lease waits for expiry",
+			startedAt:        time.Date(2026, 4, 1, 11, 59, 0, 0, time.UTC),
+			wantFailedStatus: "open",
+		},
+		{
+			name:             "stale pending lease closes",
+			startedAt:        time.Date(2026, 4, 1, 11, 49, 59, 0, time.UTC),
+			wantFailedStatus: "closed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := beads.NewMemStore()
+			clk := &clock.Fake{Time: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)}
+			sp := runtime.NewFake()
+			cfg := &config.City{
+				Workspace: config.Workspace{Name: "test-city"},
+				Agents: []config.Agent{{
+					Name:              "worker",
+					StartCommand:      "true",
+					MaxActiveSessions: intPtr(3),
+					ScaleCheck:        "printf 1",
+				}},
+			}
+
+			failedBead, err := store.Create(beads.Bead{
+				Title:  "worker-1",
+				Type:   sessionBeadType,
+				Labels: []string{sessionBeadLabel, "agent:worker-1"},
+				Metadata: map[string]string{
+					"session_name":              "worker-1",
+					"agent_name":                "worker-1",
+					"template":                  "worker",
+					"state":                     "failed-create",
+					"pool_slot":                 "1",
+					"pending_create_claim":      boolMetadata(true),
+					"pending_create_started_at": pendingCreateStartedAtNow(tc.startedAt),
+					poolManagedMetadataKey:      boolMetadata(true),
+					"live_hash":                 runtime.LiveFingerprint(runtime.Config{Command: "true"}),
+					"generation":                "1",
+					"instance_token":            "failed-token",
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create failed-create bead: %v", err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			dsResult := buildDesiredState(cfg.EffectiveCityName(), t.TempDir(), clk.Now().UTC(), cfg, sp, store, &stderr)
+			if _, ok := dsResult.State[failedBead.Metadata["session_name"]]; ok {
+				t.Fatalf("desired state reused failed-create bead %s; state=%#v", failedBead.ID, dsResult.State)
+			}
+
+			var fresh TemplateParams
+			for _, tp := range dsResult.State {
+				if tp.TemplateName == "worker" {
+					fresh = tp
+					break
+				}
+			}
+			if fresh.SessionName == "" {
+				t.Fatalf("desired state did not allocate a fresh worker session; state=%#v stderr:\n%s", dsResult.State, stderr.String())
+			}
+			if fresh.SessionName == failedBead.Metadata["session_name"] {
+				t.Fatalf("fresh session name = %q, want different from failed-create bead", fresh.SessionName)
+			}
+
+			sessions, err := loadSessionBeads(store)
+			if err != nil {
+				t.Fatalf("loadSessionBeads: %v", err)
+			}
+			cfgNames := configuredSessionNames(cfg, cfg.EffectiveCityName(), store)
+			poolDesired := PoolDesiredCounts(ComputePoolDesiredStates(cfg, dsResult.AssignedWorkBeads, sessions, dsResult.ScaleCheckCounts))
+			if poolDesired == nil {
+				poolDesired = make(map[string]int)
+			}
+			mergeNamedSessionDemand(poolDesired, dsResult.NamedSessionDemand, cfg)
+
+			woken := reconcileSessionBeads(
+				context.Background(), sessions, dsResult.State, cfgNames,
+				cfg, sp, store, nil, dsResult.AssignedWorkBeads, nil, newDrainTracker(), poolDesired,
+				dsResult.StoreQueryPartial, nil, cfg.EffectiveCityName(),
+				nil, clk, events.Discard, 0, 0, &stdout, &stderr,
+			)
+			if woken != 1 {
+				t.Fatalf("woken = %d, want 1 for fresh replacement session; stdout:\n%s\nstderr:\n%s", woken, stdout.String(), stderr.String())
+			}
+			if !sp.IsRunning(fresh.SessionName) {
+				t.Fatalf("fresh session %q is not running after reconcile; stdout:\n%s\nstderr:\n%s", fresh.SessionName, stdout.String(), stderr.String())
+			}
+
+			gotFailed, err := store.Get(failedBead.ID)
+			if err != nil {
+				t.Fatalf("Get failed-create bead: %v", err)
+			}
+			if gotFailed.Status != tc.wantFailedStatus {
+				t.Fatalf("failed-create bead status = %q, want %q", gotFailed.Status, tc.wantFailedStatus)
+			}
+			if gotFailed.Status == "open" && gotFailed.Metadata["state"] != string(sessionpkg.StateFailedCreate) {
+				t.Fatalf("open failed-create bead state = %q, want %q", gotFailed.Metadata["state"], sessionpkg.StateFailedCreate)
+			}
+			if gotFailed.Status == "open" {
+				var secondTickStderr bytes.Buffer
+				secondTick := buildDesiredState(cfg.EffectiveCityName(), t.TempDir(), clk.Now().UTC(), cfg, sp, store, &secondTickStderr)
+				if _, ok := secondTick.State[failedBead.Metadata["session_name"]]; ok {
+					t.Fatalf("second tick reused failed-create bead %s; state=%#v stderr:\n%s", failedBead.ID, secondTick.State, secondTickStderr.String())
+				}
+			}
+			if strings.Contains(stderr.String(), "unknown state") {
+				t.Errorf("reconciler logged unknown state for failed-create bead: %s", stderr.String())
+			}
+		})
+	}
+}
+
+// TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot verifies
+// the post-lease-expiry close path for a pool session bead whose close call
+// failed after failed-create metadata was written.
 func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing.T) {
 	store := beads.NewMemStore()
 	clk := &clock.Fake{Time: time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)}
@@ -6015,22 +6138,23 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 		},
 	}
 
-	// Simulate a mid-rollback failure: metadata was written (state=failed-create,
-	// pending_create_claim cleared) but store.Close failed, leaving Status=open.
+	// Simulate the close retry after a stale failed-create lease has expired.
 	failedBead, err := store.Create(beads.Bead{
 		Title:  "polecat-1",
 		Type:   sessionBeadType,
 		Labels: []string{sessionBeadLabel, "agent:polecat-1"},
 		Metadata: map[string]string{
-			"session_name":         "polecat-1",
-			"agent_name":           "polecat-1",
-			"template":             "polecat",
-			"state":                "failed-create",
-			"pool_slot":            "1",
-			poolManagedMetadataKey: boolMetadata(true),
-			"live_hash":            runtime.LiveFingerprint(runtime.Config{Command: "true"}),
-			"generation":           "1",
-			"instance_token":       "failed-token",
+			"session_name":              "polecat-1",
+			"agent_name":                "polecat-1",
+			"template":                  "polecat",
+			"state":                     "failed-create",
+			"pool_slot":                 "1",
+			"pending_create_claim":      boolMetadata(true),
+			"pending_create_started_at": pendingCreateStartedAtNow(clk.Now().Add(-(pendingCreateNeverStartedTimeout + time.Second))),
+			poolManagedMetadataKey:      boolMetadata(true),
+			"live_hash":                 runtime.LiveFingerprint(runtime.Config{Command: "true"}),
+			"generation":                "1",
+			"instance_token":            "failed-token",
 		},
 	})
 	if err != nil {
@@ -6095,7 +6219,9 @@ func TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot(t *testing
 	if woken != 1 {
 		t.Fatalf("woken = %d, want 1 (fresh pool session should be started)", woken)
 	}
-	_ = freshBead
+	if !sp.IsRunning(freshBead.Metadata["session_name"]) {
+		t.Fatalf("fresh session %q is not running after stale failed-create cleanup", freshBead.Metadata["session_name"])
+	}
 }
 
 // TODO(pool-consolidation): This test validates that poolDesired gates wake

--- a/cmd/gc/session_work_guard.go
+++ b/cmd/gc/session_work_guard.go
@@ -40,6 +40,9 @@ func closeSessionBeadIfUnassigned(
 	if hasAssignedWork {
 		return false
 	}
+	if isFailedCreateSessionBead(session) {
+		return closeFailedCreateBead(store, session.ID, now, stderr)
+	}
 	return closeBead(store, session.ID, reason, now, stderr)
 }
 
@@ -67,6 +70,9 @@ func closeSessionBeadIfReachableStoreUnassigned(
 	}
 	if hasAssignedWork {
 		return false
+	}
+	if isFailedCreateSessionBead(session) {
+		return closeFailedCreateBead(store, session.ID, now, stderr)
 	}
 	return closeBead(store, session.ID, reason, now, stderr)
 }

--- a/examples/dolt/assets/scripts/mol-dog-backup.sh
+++ b/examples/dolt/assets/scripts/mol-dog-backup.sh
@@ -15,7 +15,7 @@ HOST="${GC_DOLT_HOST:-127.0.0.1}"
 USER="${GC_DOLT_USER:-root}"
 OFFSITE_PATH="${GC_BACKUP_OFFSITE_PATH:-}"
 BACKUP_ARTIFACT_DIR="${GC_BACKUP_ARTIFACT_DIR:-$GC_CITY_PATH/.dolt-backup}"
-SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$\|^performance_schema$\|^sys$"
+SYSTEM_DBS="^(information_schema|mysql|dolt_cluster|__gc_probe|performance_schema|sys)$"
 MIN_DOLT_BACKUP_VERSION="1.86.2"
 
 dolt_sql() {
@@ -93,7 +93,7 @@ if [ -n "${GC_BACKUP_DATABASES:-}" ]; then
 else
     # Auto-discover: find databases that have a named Dolt backup <db>-backup.
     ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 | \
-        grep -vi "$SYSTEM_DBS" || true)
+        grep -viE "$SYSTEM_DBS" || true)
     DATABASES=""
     for db in $ALL_DBS; do
         db_dir="$DOLT_DATA_DIR/$db"

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -106,8 +106,8 @@ DISK_USAGE=$(du -sh "$DOLT_DATA_DIR" 2>/dev/null | cut -f1 || echo "unknown")
 # Orphan database detection.
 ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 || true)
 ORPHAN_PATTERNS="^testdb_\|^beads_t\|^beads_pt\|^beads_vr\|^doctest_\|^doctortest_"
-SYSTEM_DBS="^information_schema$\|^mysql$\|^dolt_cluster$\|^__gc_probe$\|^performance_schema$\|^sys$"
-USER_DBS=$(printf '%s\n' "$ALL_DBS" | grep -vi "$SYSTEM_DBS" || true)
+SYSTEM_DBS="^information_schema$|^mysql$|^dolt_cluster$|^__gc_probe$|^performance_schema$|^sys$"
+USER_DBS=$(printf '%s\n' "$ALL_DBS" | grep -viE "$SYSTEM_DBS" || true)
 ORPHANS=$(printf '%s\n' "$USER_DBS" | grep -i "$ORPHAN_PATTERNS" || true)
 ORPHAN_COUNT=$(printf '%s\n' "$ORPHANS" | awk 'NF {count++} END {print count + 0}')
 ORPHAN_WARN=""

--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -105,10 +105,10 @@ DISK_USAGE=$(du -sh "$DOLT_DATA_DIR" 2>/dev/null | cut -f1 || echo "unknown")
 
 # Orphan database detection.
 ALL_DBS=$(dolt_sql -r csv -q "SHOW DATABASES" 2>/dev/null | tail -n +2 || true)
-ORPHAN_PATTERNS="^testdb_\|^beads_t\|^beads_pt\|^beads_vr\|^doctest_\|^doctortest_"
-SYSTEM_DBS="^information_schema$|^mysql$|^dolt_cluster$|^__gc_probe$|^performance_schema$|^sys$"
+ORPHAN_PATTERNS="^(testdb_|beads_t|beads_pt|beads_vr|doctest_|doctortest_)"
+SYSTEM_DBS="^(information_schema|mysql|dolt_cluster|__gc_probe|performance_schema|sys)$"
 USER_DBS=$(printf '%s\n' "$ALL_DBS" | grep -viE "$SYSTEM_DBS" || true)
-ORPHANS=$(printf '%s\n' "$USER_DBS" | grep -i "$ORPHAN_PATTERNS" || true)
+ORPHANS=$(printf '%s\n' "$USER_DBS" | grep -iE "$ORPHAN_PATTERNS" || true)
 ORPHAN_COUNT=$(printf '%s\n' "$ORPHANS" | awk 'NF {count++} END {print count + 0}')
 ORPHAN_WARN=""
 if [ "${ORPHAN_COUNT:-0}" -gt 0 ]; then

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -848,6 +848,27 @@ exit 0
 	return logPath
 }
 
+func writeBSDLikeGrep(t *testing.T, binDir string) {
+	t.Helper()
+	realGrep, err := exec.LookPath("grep")
+	if err != nil {
+		t.Fatalf("find grep: %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "grep"), fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+bre_alternation='\|'
+if [ "$#" -ge 2 ] && { [ "$1" = "-vi" ] || [ "$1" = "-i" ]; } && [[ "$2" == *"$bre_alternation"* ]]; then
+  if [ "$1" = "-vi" ]; then
+    shift 2
+    cat "$@"
+    exit 0
+  fi
+  exit 1
+fi
+exec %s "$@"
+`, shellQuote(realGrep)))
+}
+
 func TestBackupScriptSkipsOldDoltBeforeSync(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")
@@ -936,6 +957,34 @@ func TestBackupScriptDiscoversNamedBackupsAndSyncsArtifactsOffsite(t *testing.T)
 	}
 	if strings.Contains(string(rsyncLog), dataDir+"/") {
 		t.Fatalf("rsync must not use live data dir, log:\n%s", rsyncLog)
+	}
+}
+
+func TestBackupScriptIgnoresDocumentedSystemSchemasForAutoDiscoveryWithBSDGrep(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	for _, db := range []string{"prod", "performance_schema", "sys"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
+	}
+	binDir := t.TempDir()
+	_ = writeDogFakeGC(t, binDir)
+	writeBSDLikeGrep(t, binDir)
+	doltLogPath := writeBackupFakeDolt(t, binDir, "1.86.2", 0, "prod", "performance_schema", "sys")
+
+	out := runDogScript(t, "mol-dog-backup.sh", binDir, cityPath, dataDir)
+	if !strings.Contains(out, "synced: 1/1") {
+		t.Fatalf("unexpected backup summary:\n%s", out)
+	}
+	doltLog, err := os.ReadFile(doltLogPath)
+	if err != nil {
+		t.Fatalf("read dolt log: %v", err)
+	}
+	for _, systemDB := range []string{"performance_schema", "sys"} {
+		if strings.Contains(string(doltLog), "backup sync "+systemDB+"-backup") {
+			t.Fatalf("backup auto-discovery should ignore %s, log:\n%s", systemDB, doltLog)
+		}
 	}
 }
 
@@ -1064,6 +1113,48 @@ exit 0
 		if strings.Contains(string(gcLog), systemDB) {
 			t.Fatalf("doctor should ignore %s for backup freshness, log:\n%s", systemDB, gcLog)
 		}
+	}
+}
+
+func TestDoctorScriptDetectsDoctestOrphansWithBSDGrep(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeBSDLikeGrep(t, binDir)
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n1\n'
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\ndoctest_leftover\ndoctortest_leftover\n'
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, "GC_DOCTOR_BACKUP_STALE_S=1")
+	if !strings.Contains(out, "orphans: 2") {
+		t.Fatalf("doctor should report doctest/doctortest orphan databases, output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if !strings.Contains(string(gcLog), "Orphan DBs: 2") {
+		t.Fatalf("doctor advisory should report orphan count, log:\n%s", gcLog)
 	}
 }
 

--- a/internal/session/lifecycle_projection.go
+++ b/internal/session/lifecycle_projection.go
@@ -21,6 +21,10 @@ const (
 	BaseStateAsleep BaseState = "asleep"
 	// BaseStateSuspended means config or policy has suspended the session.
 	BaseStateSuspended BaseState = "suspended"
+	// BaseStateFailedCreate means create rollback metadata landed but close did not.
+	// Runtime projection preserves it so pending create metadata cannot retry
+	// the rolled-back identity as a normal creating session.
+	BaseStateFailedCreate BaseState = "failed-create"
 	// BaseStateDraining means the session is waiting to stop cleanly.
 	BaseStateDraining BaseState = "draining"
 	// BaseStateDrained means the session completed its drain and is stopped.
@@ -363,6 +367,8 @@ func projectBaseState(status, storedState, sleepReason string) BaseState {
 		return BaseStateAsleep
 	case string(StateSuspended):
 		return BaseStateSuspended
+	case string(StateFailedCreate):
+		return BaseStateFailedCreate
 	case string(StateDraining):
 		return BaseStateDraining
 	case "drained":
@@ -394,6 +400,8 @@ func compatStateForBase(base BaseState) State {
 		return StateAsleep
 	case BaseStateSuspended:
 		return StateSuspended
+	case BaseStateFailedCreate:
+		return StateFailedCreate
 	case BaseStateDraining:
 		return StateDraining
 	case BaseStateArchived:
@@ -500,6 +508,9 @@ func projectRuntimeProjection(input LifecycleInput, base BaseState, compat State
 			return RuntimeProjectionFreshCreating, StateCreating, false
 		}
 		return RuntimeProjectionStaleCreating, StateAsleep, shouldResetContinuation(base, input.Metadata, sleepReason)
+	}
+	if base == BaseStateFailedCreate {
+		return RuntimeProjectionMissing, StateFailedCreate, false
 	}
 	if hasWakeCause(wakeCauses, WakeCausePendingCreate) {
 		return RuntimeProjectionStartRequested, StateCreating, false

--- a/internal/session/lifecycle_projection_test.go
+++ b/internal/session/lifecycle_projection_test.go
@@ -37,6 +37,15 @@ func TestProjectLifecycleNormalizesCompatibilityStates(t *testing.T) {
 			wantState: StateAsleep,
 		},
 		{
+			name: "failed-create projects as typed cleanup state",
+			metadata: map[string]string{
+				"state":        string(StateFailedCreate),
+				"session_name": "s-worker",
+			},
+			wantBase:  BaseStateFailedCreate,
+			wantState: StateFailedCreate,
+		},
+		{
 			name: "asleep with drained sleep reason projects as drained",
 			metadata: map[string]string{
 				"state":        "asleep",
@@ -461,6 +470,23 @@ func TestProjectLifecycleRuntimeLivenessProjection(t *testing.T) {
 			},
 			wantRuntime:         RuntimeProjectionStartRequested,
 			wantReconciledState: StateCreating,
+		},
+		{
+			name: "failed-create with pending_create_claim stays failed-create",
+			input: LifecycleInput{
+				Status: "open",
+				Metadata: map[string]string{
+					"state":                string(StateFailedCreate),
+					"session_name":         "s-worker",
+					"pending_create_claim": "true",
+				},
+				Runtime:            RuntimeFacts{Observed: true, Alive: false},
+				CreatedAt:          now.Add(-30 * time.Second),
+				StaleCreatingAfter: time.Minute,
+				Now:                now,
+			},
+			wantRuntime:         RuntimeProjectionMissing,
+			wantReconciledState: StateFailedCreate,
 		},
 		{
 			name: "non-creating pending_create_claim remains start requested",

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -32,6 +32,9 @@ const (
 	// StateCreating means the session bead has been written but the runtime
 	// process has not yet been confirmed alive. Counts against pool occupancy.
 	StateCreating State = "creating"
+	// StateFailedCreate means create rollback wrote terminal metadata but the
+	// bead status close did not complete. It is eligible for cleanup/replacement.
+	StateFailedCreate State = "failed-create"
 	// StateDraining means the session is being gracefully stopped (in-flight
 	// work completing). The pool routing label has been removed so no new
 	// work is routed to this session.

--- a/internal/session/named_config.go
+++ b/internal/session/named_config.go
@@ -193,7 +193,7 @@ func NamedSessionContinuityEligible(b beads.Bead) bool {
 	switch strings.TrimSpace(b.Metadata["state"]) {
 	case "archived":
 		return continuity == "true"
-	case "closing", "closed":
+	case "closing", "closed", string(StateFailedCreate):
 		return false
 	default:
 		return true
@@ -481,11 +481,11 @@ func closedNamedSessionReopenEligible(b beads.Bead) bool {
 		return false
 	}
 	switch strings.TrimSpace(b.Metadata["close_reason"]) {
-	case "duplicate", "duplicate-repair", "gc_swept", "orphaned", "reconfigured", "stale-session":
+	case "duplicate", "duplicate-repair", "gc_swept", "orphaned", "reconfigured", "stale-session", string(StateFailedCreate):
 		return false
 	}
 	switch strings.TrimSpace(b.Metadata["state"]) {
-	case "duplicate", "duplicate-repair", "gc_swept", "orphaned", "reconfigured", "stale-session":
+	case "duplicate", "duplicate-repair", "gc_swept", "orphaned", "reconfigured", "stale-session", string(StateFailedCreate):
 		return false
 	}
 	return true

--- a/internal/session/named_config_test.go
+++ b/internal/session/named_config_test.go
@@ -46,6 +46,13 @@ func TestNamedSessionContinuityEligible_ArchivedRequiresExplicitContinuity(t *te
 			want: false,
 		},
 		{
+			name: "failed create releases continuity",
+			meta: map[string]string{
+				"state": string(StateFailedCreate),
+			},
+			want: false,
+		},
+		{
 			name: "asleep missing continuity",
 			meta: map[string]string{
 				"state": "asleep",
@@ -61,6 +68,30 @@ func TestNamedSessionContinuityEligible_ArchivedRequiresExplicitContinuity(t *te
 				t.Fatalf("NamedSessionContinuityEligible() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFindCanonicalNamedSessionBead_SkipsFailedCreate(t *testing.T) {
+	spec := NamedSessionSpec{
+		Identity:    "mayor",
+		SessionName: "test-city--mayor",
+	}
+	candidates := []beads.Bead{
+		{
+			ID:     "failed",
+			Type:   BeadType,
+			Status: "open",
+			Metadata: map[string]string{
+				NamedSessionMetadataKey:      "true",
+				NamedSessionIdentityMetadata: spec.Identity,
+				"session_name":               spec.SessionName,
+				"state":                      string(StateFailedCreate),
+			},
+		},
+	}
+
+	if got, ok := FindCanonicalNamedSessionBead(candidates, spec); ok {
+		t.Fatalf("FindCanonicalNamedSessionBead() = %q, want no canonical failed-create bead", got.ID)
 	}
 }
 
@@ -191,6 +222,35 @@ func TestFindClosedNamedSessionBeadForSessionName_SkipsTerminalRetiredCandidate(
 	}
 	if ok {
 		t.Fatalf("FindClosedNamedSessionBeadForSessionName returned %q, want no reusable bead", found.ID)
+	}
+}
+
+func TestFindClosedNamedSessionBeadForSessionName_SkipsFailedCreateCandidate(t *testing.T) {
+	store := beads.NewMemStore()
+	failed, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name":               "test-city--mayor",
+			"close_reason":               string(StateFailedCreate),
+			"state":                      string(StateFailedCreate),
+			NamedSessionMetadataKey:      "true",
+			NamedSessionIdentityMetadata: "mayor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(failed-create): %v", err)
+	}
+	if err := store.Close(failed.ID); err != nil {
+		t.Fatalf("Close(failed-create): %v", err)
+	}
+
+	found, ok, err := FindClosedNamedSessionBeadForSessionName(store, "mayor", "test-city--mayor")
+	if err != nil {
+		t.Fatalf("FindClosedNamedSessionBeadForSessionName: %v", err)
+	}
+	if ok {
+		t.Fatalf("FindClosedNamedSessionBeadForSessionName returned %q, want no reusable failed-create bead", found.ID)
 	}
 }
 

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -342,6 +342,9 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 		if b.ID == selfID {
 			continue
 		}
+		if failedCreateIdentityReleased(b) {
+			continue
+		}
 		// Explicit session names are permanent identities; once claimed by any
 		// session bead, including a closed one, they are never reused.
 		//
@@ -387,6 +390,10 @@ func ensureSessionNameAvailableForSelfAndOwner(store beads.Store, name, selfID, 
 		}
 	}
 	return nil
+}
+
+func failedCreateIdentityReleased(b beads.Bead) bool {
+	return strings.TrimSpace(b.Metadata["state"]) == string(StateFailedCreate)
 }
 
 func continuityIneligibleConfiguredOwner(b beads.Bead, selfOwner string) bool {
@@ -532,6 +539,9 @@ func noLiveSessionNameCollisions(store beads.Store, name, selfID, selfOwner stri
 		if !IsSessionBeadOrRepairable(b) || b.ID == selfID {
 			continue
 		}
+		if failedCreateIdentityReleased(b) {
+			continue
+		}
 		// A live bead holding the name as session_name blocks.
 		if strings.TrimSpace(b.Metadata["session_name"]) == name && b.Status != "closed" {
 			return false
@@ -581,6 +591,9 @@ func ensureSessionAliasAvailable(store beads.Store, cfg *config.City, alias, sel
 	}
 	for _, b := range all {
 		if !IsSessionBeadOrRepairable(b) || b.ID == selfID {
+			continue
+		}
+		if failedCreateIdentityReleased(b) {
 			continue
 		}
 		if b.Status == "closed" {

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -366,6 +366,48 @@ func TestEnsureAliasAvailable_RejectsLiveSessionNameCollision(t *testing.T) {
 	}
 }
 
+func TestEnsureAliasAvailable_AllowsFailedCreateIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	_, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"alias":        "worker-1",
+			"agent_name":   "worker-1",
+			"state":        string(StateFailedCreate),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := EnsureAliasAvailable(store, "worker-1", ""); err != nil {
+		t.Fatalf("EnsureAliasAvailable(failed-create identity) = %v, want nil", err)
+	}
+}
+
+func TestEnsureSessionNameAvailable_AllowsFailedCreateIdentity(t *testing.T) {
+	store := beads.NewMemStore()
+	_, err := store.Create(beads.Bead{
+		Type:   BeadType,
+		Labels: []string{LabelSession},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"alias":        "worker-1",
+			"agent_name":   "worker-1",
+			"state":        string(StateFailedCreate),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := ensureSessionNameAvailable(store, "worker-1"); err != nil {
+		t.Fatalf("ensureSessionNameAvailable(failed-create identity) = %v, want nil", err)
+	}
+}
+
 func TestEnsureAliasAvailableWithConfig_RejectsConfiguredSingletonAlias(t *testing.T) {
 	store := beads.NewMemStore()
 	cfg := &config.City{


### PR DESCRIPTION
## Problem

When a pool session's \`store.Close\` fails mid-rollback (the bead metadata
was written with \`state=failed-create\` but the close call errored), the
bead is left with \`Status=open\` and \`state=failed-create\`. The
reconciler's forward-compat gate (\`isKnownState\`) skipped it on every tick
because \`"failed-create"\` was not registered, permanently blocking the pool
slot.

Fixes #1902

## Changes

**\`cmd/gc/session_reconcile.go\`** — add \`"failed-create": true\` to
\`knownSessionStates\`. The reconciler now processes these beads normally:
they are not in the desired set, not alive, so
\`closeSessionBeadIfReachableStoreUnassigned\` closes them and frees the
slot within one pass.

**\`cmd/gc/session_reconcile_test.go\`** — add \`"failed-create"\` to the
\`TestIsKnownState_KnownStates\` table.

**\`cmd/gc/session_reconciler_test.go\`** — two new tests:
- \`TestFailedCreateIsKnownState\` — direct map assertion
- \`TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot\` (§5-T1) — end-to-end: a failed-create bead is closed and a fresh pool session is woken in the same reconciler pass

**\`examples/dolt/assets/scripts/mol-dog-doctor.sh\`** — fix a pre-existing
macOS BRE alternation bug: BSD grep silently stops matching the 5th+
alternative when \`\|\` is used in a variable-passed pattern; switch
\`SYSTEM_DBS\` filter to \`grep -viE\` with plain \`|\` (ERE). Fixes
\`TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness\` which
was failing on macOS before this PR.

## Test plan

- [x] \`TestIsKnownState_KnownStates\` — failed-create added to known list
- [x] \`TestFailedCreateIsKnownState\` — direct knownSessionStates lookup
- [x] \`TestReconcileSessionBeads_ClosesOrphanedFailedCreateAndFreesSlot\` — reconciler closes orphaned failed-create bead and wakes fresh slot in one pass
- [x] \`TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness\` — passes after grep -E fix

```
go test ./cmd/gc/... ./examples/dolt/...
ok  github.com/gastownhall/gascity/cmd/gc        337s
ok  github.com/gastownhall/gascity/cmd/gc/dashboard  0.3s
ok  github.com/gastownhall/gascity/examples/dolt  29s
```