### PR TITLE
gastown: fix refinery patrol merge-push worktree conflict and find-work race

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -233,7 +233,18 @@ merge, and close the bead. If there's a conflict, the refinery puts the
 bead back in the pool with `rejection_reason` metadata — a new polecat
 picks it up and resumes from the existing branch.
 
-**6. Signal reconciler and exit.**
+**6. Nudge the refinery (belt-and-suspenders):**
+```bash
+gc session nudge "$REFINERY_TARGET" 2>/dev/null || true
+```
+
+The `gc bd update` in step 5 already generates a `bead.updated` event that
+the refinery's event-watch will see, but the nudge wakes the refinery
+session immediately — before the next event-loop tick — so it does not
+idle for up to `event_timeout` seconds waiting for the watch to fire.
+Failure is non-fatal: the refinery finds the work on its next poll.
+
+**7. Signal reconciler and exit.**
 ```bash
 gc runtime drain-ack
 exit
@@ -243,4 +254,4 @@ exit
 reconciler only restarts you if the pool check command finds more work.
 You are GONE. Done means gone. There is no idle state.
 
-**Exit criteria:** Branch pushed, metadata set, bead reassigned, drain acknowledged, session exited."""
+**Exit criteria:** Branch pushed, metadata set, bead reassigned, refinery nudged, drain acknowledged, session exited."""

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -122,9 +122,20 @@ gc bd show $WORK --json | jq '.[0].metadata'
 The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
 
-If NO work found: wait for assignment:
+If NO work found: wait for assignment.
+
+Capture SEQ **before** the final list check so any bead routed during
+the window between check and watch is covered by the subscription:
 ```bash
 SEQ=$(gc events --seq)
+WORK=$(gc bd list --assignee=$GC_AGENT --status=open \
+  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
+```
+
+If WORK is now non-empty (routed in the gap): proceed as if found above.
+
+Otherwise watch:
+```bash
 gc events --watch --type=bead.updated \
   --after=$SEQ --timeout {{event_timeout}}s
 ```
@@ -376,10 +387,17 @@ fi
 
 **If MERGE_STRATEGY = "direct" (default):**
 
-**1. Merge and push target branch:**
+**1. Advance target branch and push:**
+
+Use `git update-ref` instead of `checkout + merge` so the branch
+pointer advances regardless of which branch any worktree has checked
+out. A `git checkout $TARGET` in an environment where a worktree
+is already on a different branch silently merges into that worktree's
+HEAD instead of $TARGET.
+
 ```bash
-git checkout $TARGET
-git merge --ff-only temp
+NEW_SHA=$(git rev-parse temp)
+git update-ref refs/heads/$TARGET "$NEW_SHA"
 git push origin $TARGET
 ```
 

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -395,7 +395,17 @@ out. A `git checkout $TARGET` in an environment where a worktree
 is already on a different branch silently merges into that worktree's
 HEAD instead of $TARGET.
 
+The `merge-base --is-ancestor` check below restores the
+fast-forward safety that `git merge --ff-only` provided: if `temp`
+is not an ancestor of `origin/$TARGET` (i.e. `$TARGET` has moved on
+remotely since the polecat branched), abort before `update-ref`
+silently rewinds the local pointer. The push would fail-safe at the
+remote either way; this guard fails earlier and at the right layer.
+
 ```bash
+git fetch origin $TARGET
+git merge-base --is-ancestor "origin/$TARGET" temp \
+  || { echo "non-FF: refinery aborts" >&2; exit 1; }
 NEW_SHA=$(git rev-parse temp)
 git update-ref refs/heads/$TARGET "$NEW_SHA"
 git push origin $TARGET

--- a/examples/gastown/packs/gastown/template-fragments/patrol-next-work.template.md
+++ b/examples/gastown/packs/gastown/template-fragments/patrol-next-work.template.md
@@ -1,0 +1,44 @@
+{{ define "patrol-next-work" }}
+## Finding the Next Work Bead (Race-Free)
+
+The event-watch loop has a window: if a bead is routed between the list
+check and the `gc events --watch` call, the assignment event arrives before
+the subscription starts and is silently missed. The refinery then idles for
+up to `event_timeout` seconds before the next poll.
+
+Fix: capture `SEQ` **before** the list check, not after. Any event that
+fires during the list→watch gap is already within the subscribed range.
+
+```bash
+SEQ=$(gc events --seq)
+WORK=$(gc bd list --assignee=$GC_AGENT --status=open \
+  --exclude-type=epic --limit=1 --json | jq -r '.[0].id // empty')
+
+if [ -n "$WORK" ]; then
+  # Work was already assigned (possibly in the SEQ-to-list gap).
+  # Proceed to next step.
+  :
+else
+  gc events --watch --type=bead.updated \
+    --after=$SEQ --timeout ${EVENT_TIMEOUT:-30}s
+  # On event or timeout: re-run the list check.
+fi
+```
+
+**Why the order matters:**
+
+```
+timeline ──────────────────────────────────────────────────────►
+  [wrong order]   list-check ─── SEQ-capture ─── watch-start
+                                  ↑ polecat routes bead here → MISSED
+
+  [correct order] SEQ-capture ─── list-check ─── watch-start
+                                   ↑ polecat routes bead here → CAUGHT
+                                     (event falls within the subscribed range)
+```
+
+**Belt-and-suspenders:** the polecat's `submit-and-exit` step sends
+`gc session nudge` to the refinery immediately after reassigning the bead.
+This wakes the refinery from its event-watch before the next event loop
+even fires.
+{{ end }}


### PR DESCRIPTION
## Summary

Two bugs in `mol-refinery-patrol.toml` and `mol-polecat-work.toml`
found during T5 round-trip testing (stg-wwl7, stg-b0oi).

**Fix 1 — merge-push: replace `checkout + ff-merge` with `git update-ref`**

`git checkout $TARGET && git merge --ff-only` merges into whatever branch
the rig worktree has checked out, not `$TARGET`. In multi-worktree cities
where the rig is on a feature branch, `main` (or the target branch) never
advances. Subsequent beads see a stale base and conflicts go undetected.

`git update-ref refs/heads/$TARGET "$NEW_SHA"` is ref surgery — it advances
the branch pointer regardless of which branch any worktree has checked out.
No checkout needed.

**Fix 2 — find-work: race-free SEQ → list → watch**

Refinery captured `SEQ` after the list check. If a bead was routed during
the list→watch gap, the assignment event arrived before the subscription
started and was silently missed. Refinery then idled for up to
`event_timeout` seconds.

Fix: capture `SEQ` before the final list check. Any event that fires in the
gap falls within the subscribed range. Also adds a gap re-check immediately
before entering `gc events --watch`.

Extracted the race-free idiom to
`template-fragments/patrol-next-work.template.md` for future patrol agents.

**Belt-and-suspenders: polecat nudge**

Added `gc session nudge "$REFINERY_TARGET"` to `mol-polecat-work`
`submit-and-exit` step so the refinery session wakes immediately on
reassignment rather than waiting for the next event-watch tick.

## Testing

- [x] `make check` — skipped (pre-existing failures in `examples/dolt`
  unrelated to this PR; see stg-7s03 / stg-3xr3)
- [ ] `make check-docs` — no doc nav changes
- [ ] `make test-integration` — formula changes, not runtime behavior

## Checklist

- [x] Linked issues: stg-5956, stg-wwl7, stg-b0oi
- [x] No new tests needed — formula/template changes only (no Go code)
- [x] No user-facing doc changes
- [x] No breaking changes