### PR TITLE
deps: bump GitPython to 3.1.50 (GHSA-mv93-w799-cj2w HIGH)

### DIFF
--- a/.github/requirements/mcp-agent-mail.in
+++ b/.github/requirements/mcp-agent-mail.in
@@ -1,3 +1,9 @@
 # PyPI is still at 0.1.0; pin the v0.3.2 release commit until upstream
 # publishes current wheel/sdist assets.
 mcp-agent-mail @ https://github.com/Dicklesworthstone/mcp_agent_mail/archive/32783f6848bd63c425c4b5004cee3350016635fb.tar.gz
+
+# Security floor: GitPython 3.1.49 has GHSA-mv93-w799-cj2w (HIGH).
+# Pinning floor at 3.1.50 to ensure the resolver picks the patched version
+# even if mcp-agent-mail's transitive constraint allows older. Drop this
+# line once mcp-agent-mail upstream pins GitPython>=3.1.50 itself.
+gitpython>=3.1.50

--- a/.github/requirements/mcp-agent-mail.txt
+++ b/.github/requirements/mcp-agent-mail.txt
@@ -742,10 +742,12 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.49 \
-    --hash=sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c \
-    --hash=sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1
-    # via mcp-agent-mail
+gitpython==3.1.50 \
+    --hash=sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc \
+    --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
+    # via
+    #   -r .github/requirements/mcp-agent-mail.in
+    #   mcp-agent-mail
 greenlet==3.5.0 \
     --hash=sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846 \
     --hash=sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4 \


### PR DESCRIPTION
## Summary

Container Scan was failing on every PR with a HIGH-severity Trivy finding for GitPython 3.1.49 (GHSA-mv93-w799-cj2w). Fixed in 3.1.50.

## Cause

GitPython is a transitive dep pulled via `mcp-agent-mail`. The version that resolves with the current `mcp-agent-mail.in` is 3.1.49.

## Fix

Add an explicit floor in `mcp-agent-mail.in`:

```
gitpython>=3.1.50
```

…so the uv resolver picks the patched version regardless of mcp-agent-mail's own constraint. Then regenerated `mcp-agent-mail.txt` with the documented uv command:

```
uv pip compile .github/requirements/mcp-agent-mail.in --generate-hashes --python-version 3.12 --python-platform linux --output-file .github/requirements/mcp-agent-mail.txt
```

## Verification

`gitpython==3.1.50` in the regenerated lock file. Build green.

## Cleanup

The floor line in `mcp-agent-mail.in` is self-documenting — drop it once `mcp-agent-mail` upstream pins GitPython>=3.1.50 itself.

## Why this PR exists

Spotted while merging contributor PR #1636 (kenhorn / quickstart docs fix) — the Image vulnerabilities check blocked merge despite the change being doc-only. Confirmed via Copilot diagnosis that the failure is global, not PR-specific. Unblocking #1636 once this lands.