### PR TITLE
mol-witness-patrol: clarify --timeout makes gc events --watch self-terminating

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -483,6 +483,8 @@ gc events --watch --type=bead.updated \
   --after=$SEQ --timeout {{event_timeout}}s
 ```
 
+`--timeout` makes this command self-terminating — it exits on its own when an event arrives or the timeout fires. Do not add `&`, pipe to another command, or wrap in a background process.
+
 On event: proceed immediately.
 On timeout: double the timeout (cap 300s) and proceed anyway.
 


### PR DESCRIPTION
## Summary

- Adds one clarifying sentence to the `next-iteration` step of `mol-witness-patrol.toml`, immediately after the `gc events --watch --timeout` bash block.
- The sentence makes explicit that `--timeout` is self-terminating: the command exits on its own when an event arrives or the timeout fires, so agents must not add `&`, pipe to another command, or wrap in a background process.

**Motivation:** During an L5c convoy run (stg-iu2k), the witness agent constructed background-process scaffolding around `gc events --watch --timeout` as "insurance" that the command would terminate. It piped output to `head -20`, which forced backgrounding, which triggered a `kill` that hit the permission wall. Root cause: the formula didn't make the self-terminating behavior explicit. This one sentence prevents the deviation pattern without changing any behavior.

Surface confirmation: formula step description only — no runtime behavior changed.

## Testing

- [x] `make check` — passes (one pre-existing failure: `TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness`, tracked as EXPECT-FAIL with no fix yet)
- [ ] `make check-docs` — not applicable (formula TOML, not Markdown docs)
- [ ] `make test-integration` — not applicable (no runtime/controller/workflow behavior changed)

## Checklist

- [x] Linked an issue, or explained why one is not needed — driven by internal bead stg-nqwn; no public issue
- [x] Added or updated tests for behavior changes — N/A (doc-only addition)
- [x] Updated docs for user-facing changes — N/A
- [x] Called out breaking changes or migration notes — none (purely additive)