### PR TITLE
fix(polecat): release pool slot on submit — delete local branch and remove worktree

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -391,7 +391,7 @@ func TestPolecatFormulaSignalsRefineryAfterReassign(t *testing.T) {
 	nudge := `gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true`
 
 	assertContainsInOrder(t, body,
-		"**5. Reassign to refinery:**",
+		"**4. Reassign to refinery:**",
 		refineryTarget,
 		`gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"`,
 		"**6. Signal refinery to check for work immediately",
@@ -431,6 +431,77 @@ func TestPolecatPromptDoneSequenceSignalsRefinery(t *testing.T) {
 	)
 	if !strings.Contains(body, "Done sequence (push, set metadata, reassign, wake refinery, nudge refinery, `gc runtime drain-ack`, exit)") {
 		t.Fatalf("polecat quick reference must include the refinery wake+nudge handoff")
+	}
+}
+
+// TestPolecatReleasesPoolSlotOnSubmit guards against the regression
+// where the polecat agent's done sequence left its branch and worktree
+// behind. Pool slots are bounded; a stale per-polecat worktree pinned
+// to a dead branch is counted as occupied by the reconciler — under
+// fan-out the next sling either reuses a stale workspace or never
+// spawns a polecat at all (the L5b "3rd fan-out child stuck
+// unassigned" symptom).
+//
+// The fix lives in two places that must stay in sync:
+//
+//  1. The polecat prompt template's FINAL REMINDER done sequence —
+//     this is what the agent actually follows; the formula's step
+//     descriptions are read only when the agent re-pours from the
+//     wisp, which is not the common path.
+//  2. The mol-polecat-work formula's submit-and-exit step — kept in
+//     sync with the prompt template so anyone reading the formula
+//     directly gets the same instruction.
+//
+// Both must `cd "$GC_RIG_ROOT"` before `git worktree remove`, since
+// you can't remove the worktree the agent is currently sitting in,
+// and `$GC_RIG_ROOT` is the canonical rig checkout that gascity sets
+// in the polecat session env.
+func TestPolecatReleasesPoolSlotOnSubmit(t *testing.T) {
+	dir := exampleDir()
+
+	promptPath := filepath.Join(dir, "packs", "gastown", "agents", "polecat", "prompt.template.md")
+	promptData, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("reading polecat prompt: %v", err)
+	}
+	prompt := string(promptData)
+
+	// Prompt's done sequence must capture the worktree path BEFORE
+	// cd-ing out, then delete the local branch and remove the worktree
+	// while running from $GC_RIG_ROOT.
+	assertContainsInOrder(t, prompt,
+		`gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET"`,
+		`WORKTREE_PATH=$(pwd)`,
+		`BRANCH=$(git branch --show-current)`,
+		`cd "$GC_RIG_ROOT"`,
+		`git branch -D "$BRANCH"`,
+		`git worktree remove --force "$WORKTREE_PATH"`,
+		`gc runtime drain-ack`,
+	)
+
+	formulaPath := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")
+	formulaData, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Fatalf("reading polecat formula: %v", err)
+	}
+	formula := string(formulaData)
+
+	// Same chained shape in the formula's submit-and-exit step.
+	assertContainsInOrder(t, formula,
+		`Reassign to refinery`,
+		`WORKTREE_PATH=$(pwd)`,
+		`cd "$GC_RIG_ROOT"`,
+		`git branch -D "$BRANCH"`,
+		`git worktree remove --force "$WORKTREE_PATH"`,
+		`gc runtime drain-ack`,
+	)
+
+	// Guard against the prior shape where cleanup happened inside the
+	// worktree (`git checkout --detach && git branch -D`) without
+	// removing the worktree itself — that's the bug this test exists
+	// to prevent recurring.
+	if strings.Contains(formula, "git checkout --detach") {
+		t.Fatalf("polecat formula still uses `git checkout --detach` cleanup shape; switch to `cd \"$GC_RIG_ROOT\" && git worktree remove --force` so the pool slot is fully released")
 	}
 }
 

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -213,6 +213,18 @@ REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
 gc bd update <work-bead> --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"
 gc session wake "$REFINERY_TARGET" || true
 gc session nudge "$REFINERY_TARGET" "Run 'gc prime' to check merge queue and begin processing." || true
+
+# Release this slot: branch is pushed and the bead is reassigned, so refinery
+# owns the work from here. Without removing the local branch and worktree,
+# every polecat session leaves the pool slot pinned to a dead branch — the
+# next dispatch sees the slot as occupied and stalls (or never spawns the
+# polecat at all under fan-out).
+WORKTREE_PATH=$(pwd)
+BRANCH=$(git branch --show-current)
+cd "$GC_RIG_ROOT"
+[ -n "$BRANCH" ] && git branch -D "$BRANCH" 2>/dev/null
+git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+
 gc runtime drain-ack
 exit
 ```
@@ -221,6 +233,13 @@ Your work is not complete until you run these commands. `gc runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the
 pool check command finds more work. Sitting idle after finishing implementation
 is the "Idle Polecat heresy."
+
+The `git branch -D` + `git worktree remove` step matters under fan-out: pool
+slots are bounded, and a stale worktree pinned to a dead branch counts as
+"occupied" to the reconciler. Skipping cleanup means the next sling routed to
+this rig either reuses a stale workspace (subtle) or never gets a polecat at
+all (visible). Run cleanup BEFORE `gc runtime drain-ack` so the session is
+still alive while git operations execute.
 
 ---
 

--- a/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-polecat-work.toml
@@ -201,14 +201,7 @@ but we never push with untracked work left behind.
 git push origin HEAD
 ```
 
-**3. Clean up local branch (prevent stale branch accumulation):**
-```bash
-BRANCH=$(git branch --show-current)
-git checkout --detach                 # Detach so we can delete the branch
-git branch -D "$BRANCH"              # Branch is pushed; refinery owns it now
-```
-
-**4. Update metadata on the work bead:**
+**3. Update metadata on the work bead:**
 ```bash
 gc bd update {{issue}} \
   --set-metadata target={{base_branch}} \
@@ -220,7 +213,7 @@ provided by the caller, `metadata.existing_pr` is preserved for refinery
 validation. The refinery records canonical `pr_url` only after verifying
 the PR is open and matches the branch, base, and origin repository.
 
-**5. Reassign to refinery:**
+**4. Reassign to refinery:**
 ```bash
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{binding_prefix}}refinery"
 gc bd update {{issue}} --status=open --assignee="$REFINERY_TARGET" --set-metadata gc.routed_to="$REFINERY_TARGET"
@@ -240,7 +233,32 @@ spawns phantom polecats that can't claim the bead.
 The refinery will pick this up, rebase onto {{base_branch}}, run tests,
 merge, and close the bead. If there's a conflict, the refinery puts the
 bead back in the pool with `rejection_reason` metadata — a new polecat
-picks it up and resumes from the existing branch.
+picks it up from the bead's `metadata.work_dir` (or creates a fresh
+worktree if step 5 below already removed it — workspace-setup handles
+both cases).
+
+**5. Release the pool slot — delete the local branch and remove the worktree:**
+```bash
+WORKTREE_PATH=$(pwd)
+BRANCH=$(git branch --show-current)
+cd "$GC_RIG_ROOT"
+[ -n "$BRANCH" ] && git branch -D "$BRANCH" 2>/dev/null   # branch is pushed; refinery owns it now
+git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+```
+
+Pool slots are bounded. A stale per-polecat branch and worktree pinned
+to a dead bead is counted as "occupied" by the reconciler — the next
+sling routed to this rig either reuses a stale workspace (subtle) or
+never gets a polecat at all (visible). Run cleanup BEFORE drain-ack so
+the session is still alive while git operations execute. Skipping this
+step (or running it inside the worktree, where `git worktree remove`
+refuses to delete the cwd) reproduces the fan-out stuck-slot symptom.
+
+The `cd "$GC_RIG_ROOT"` matters: `git worktree remove` cannot remove
+the worktree the agent is currently sitting in, and `$GC_RIG_ROOT` is
+the canonical rig checkout (the only worktree guaranteed to exist after
+this cleanup). Subsequent `gc bd` and `gc runtime` commands are
+path-agnostic; they read scope from env vars, not cwd.
 
 **6. Signal refinery to check for work immediately (belt-and-suspenders):**
 ```bash
@@ -265,4 +283,6 @@ exit
 reconciler only restarts you if the pool check command finds more work.
 You are GONE. Done means gone. There is no idle state.
 
-**Exit criteria:** Branch pushed, metadata set, bead reassigned, refinery signaled, drain acknowledged, session exited."""
+**Exit criteria:** Branch pushed, metadata set, bead reassigned, local
+branch and worktree removed, refinery signaled, drain acknowledged,
+session exited."""


### PR DESCRIPTION
## Summary

Polecat slots are bounded; a stale per-polecat branch and worktree pinned to a dead bead is counted as "occupied" by the reconciler. Under fan-out the next sling either reuses a stale workspace (subtle) or never spawns a polecat at all (visible — the stuck "3rd fan-out child unassigned" symptom). The polecat formula's `submit-and-exit` step had a `git checkout --detach && git branch -D` fragment that deleted the local branch but left the worktree on detached HEAD; nothing removed the worktree. Worse, the agent prompt template's FINAL REMINDER done sequence — which is what the agent actually follows during a session, since polecat sessions don't re-pour the formula — had no cleanup at all. Result: every polecat session across L4 / L5a / L5b / L5c left its worktree behind, and the reconciler counted those slots as in-use.

This PR adds a worktree+branch cleanup sequence to BOTH the polecat agent prompt template's FINAL REMINDER and the `mol-polecat-work` formula's submit-and-exit step. The cleanup runs before `gc runtime drain-ack` so git operations execute while the session is still alive, and it `cd`s out of the worktree first because `git worktree remove` refuses to delete the cwd. `$GC_RIG_ROOT` is the canonical rig checkout (the only worktree guaranteed to exist after this cleanup); subsequent `gc bd` and `gc runtime` commands are path-agnostic so the cd has no other side effects.

A new `TestPolecatReleasesPoolSlotOnSubmit` asserts the chained shape in both files in sync (so partial reverts fail the test) and explicitly rejects the prior `git checkout --detach` shape.

**Surface:** polecat agent prompt template + `mol-polecat-work` formula step prompt; not gascity Go code, not the runtime.

**Out of scope:** a runtime-level worktree janitor (gc reconciler that prunes worktrees of closed beads as defense-in-depth) — would be a Go behavior change with larger surface. Prompt-only fix closes the observed regression.

**Runtime-verification debt (full disclosure):** this is an agent-prompt change; per the maintenance-fixer "runtime exercise" rule it should be A/B-tested across N≥3 polecat trials before claiming the fix takes effect. That gate has not been crossed. The CLAIM ("polecat agents will run `git branch -D` + `git worktree remove` after the new prompt") is plausible but unverified. Posting now so reviewers can flag concerns; the next L5 run will exercise the new prompt and produce real-world evidence.

## Testing

- [x] `make check` — full suite passes (only failure is the documented EXPECT-FAIL `TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness`, unrelated to this PR)
- [x] `go test ./examples/gastown/ -run TestPolecatReleasesPoolSlotOnSubmit -count=1 -v` — passes
- [ ] `make check-docs` — not run (no docs files touched)
- [ ] `make test-integration` — not run (per CONTRIBUTING; prompt-only formula edit, no runtime/controller behavior touched)

## Checklist

- [x] Linked an issue, or explained why one is not needed: prompt-only fix surfaced from internal L5 fan-out testing; no public issue.
- [x] Added or updated tests for behavior changes: `TestPolecatReleasesPoolSlotOnSubmit` covers both files in sync.
- [x] Updated docs for user-facing changes: formula prompt + agent prompt updated directly; the new shape and the rationale prose are the user-visible change.
- [x] Called out breaking changes or migration notes: none — the prompt is what the LLM agent reads each cycle; no runtime contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
