### PR TITLE
test(gastown): TestAllPackTomlsParse — gate every pack TOML through toml.Decode

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1268,6 +1268,52 @@ func TestAllFormulasExist(t *testing.T) {
 	}
 }
 
+// TestAllPackTomlsParse decodes every *.toml file under
+// examples/gastown/packs/ to catch malformed formulas, agent manifests,
+// orders, and pack manifests at CI time. Without this, a description
+// string with an invalid TOML escape (e.g. "\<space>" inside a """..."""
+// block) silently fails formula registration at runtime — the agent
+// running that formula falls back to memory and skips load-bearing
+// steps. The remaining string-match formula tests in this file run
+// AFTER parse, so adding this gate up front keeps their failure
+// messages meaningful (they assume valid TOML).
+//
+// The walk includes pack.toml, formulas/*.toml, orders/*.toml, and
+// agents/*/agent.toml uniformly — they all share the same TOML
+// grammar, and we want any new TOML file added under packs/ to be
+// covered automatically without remembering to update this test.
+func TestAllPackTomlsParse(t *testing.T) {
+	dir := exampleDir()
+	packsRoot := filepath.Join(dir, "packs")
+
+	var count int
+	err := filepath.Walk(packsRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".toml") {
+			return nil
+		}
+		count++
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Errorf("reading %s: %v", path, readErr)
+			return nil
+		}
+		var into map[string]any
+		if _, err := toml.Decode(string(data), &into); err != nil {
+			t.Errorf("parsing %s: %v", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", packsRoot, err)
+	}
+	if count == 0 {
+		t.Fatalf("no .toml files found under %s — directory layout changed?", packsRoot)
+	}
+}
+
 func TestAllPromptTemplatesExist(t *testing.T) {
 	var count int
 	for _, a := range discoverPackAgents(t, filepath.Join("packs", "gastown")) {


### PR DESCRIPTION
## Summary

The gastown test suite asserts string-shape on individual formula files but never `toml.Decode`s them — every existing `TestRefineryFormula*` and `TestPolecatFormula*` check uses `os.ReadFile` + `strings.Contains`. A description string with an invalid TOML escape (e.g. backslash-space inside a triple-quoted basic string) silently fails formula registration at runtime: the agent that depended on the formula falls back to generic role memory and skips load-bearing steps. The recent example: a comment placed after `&& \` in `mol-refinery-patrol`'s direct-merge close block parsed as `Unescaped '\' in a string` — the formula never registered, the refinery agent dropped the metadata write under fan-out, and 8/8 work beads in an internal L5a run closed with `merged_sha = NULL`. The follow-up fix-PR for the comment landed `make check` clean because no test parses formula TOMLs.

This PR adds `TestAllPackTomlsParse` which walks every `*.toml` under `examples/gastown/packs/` and `toml.Decode`s each. The walk is recursive so `pack.toml`, `formulas/*.toml`, `orders/*.toml`, and `agents/*/agent.toml` are all covered uniformly — any new TOML file added under `packs/` gets covered automatically without remembering to update this test.

The package comment at the top of `gastown_test.go` already states "all formulas parse" as a goal — this PR makes that statement true.

**Surface:** `examples/gastown/gastown_test.go` only. Pure additive test.

**Out of scope:** integrating a `[toml-parses]` lint as a separate CLI tool. Internal pack-authoring tooling already runs that check during edits; this Go test covers the upstream-CI side. Both safety nets matter because they catch the same bug at different stages.

## Testing

- [x] `make check` — passes (only failure is documented EXPECT-FAIL `TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness`, unrelated to this PR)
- [x] `go test ./examples/gastown/ -run TestAllPackTomlsParse -count=1 -v` — passes
- [x] Regression check: temporarily restored the buggy `mol-refinery-patrol.toml` from a prior commit that introduced an invalid `\<space>` escape; the new test fails with `invalid escape: '\ '` at the right line. Restored the good version; test passes again. Confirmed it catches the exact class of bug.
- [ ] `make check-docs` — not run (no docs files touched)
- [ ] `make test-integration` — not run (per CONTRIBUTING; pure test-code addition)

## Checklist

- [x] Linked an issue, or explained why one is not needed: defensive test surfaced from internal investigation of a TOML-parse-class regression; no public issue.
- [x] Added or updated tests for behavior changes: this IS the test addition.
- [x] Updated docs for user-facing changes: not user-facing; the package comment at the top of `gastown_test.go` already named this as a goal.
- [x] Called out breaking changes or migration notes: none — pure additive test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
