### PR TITLE
fix: scope flaky dolt leak checks

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -4286,7 +4286,7 @@ func loadCityRuntimeControllerConfig(t *testing.T, cityPath string) (*config.Cit
 func writeCityRuntimeConfigNamed(t *testing.T, tomlPath, name, provider string) {
 	t.Helper()
 	clearInheritedBeadsEnv(t)
-	requireNoLeakedDoltAfter(t)
+	requireNoLeakedDoltAfterForPaths(t, filepath.Dir(tomlPath))
 	data := []byte("[workspace]\nname = \"" + name + "\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"" + provider + "\"\n")
 	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -4296,7 +4296,7 @@ func writeCityRuntimeConfigNamed(t *testing.T, tomlPath, name, provider string) 
 func writeCityRuntimeConfigWithShutdownTimeout(t *testing.T, tomlPath, provider, timeout string) {
 	t.Helper()
 	clearInheritedBeadsEnv(t)
-	requireNoLeakedDoltAfter(t)
+	requireNoLeakedDoltAfterForPaths(t, filepath.Dir(tomlPath))
 	data := []byte("[workspace]\nname = \"test-city\"\n\n[beads]\nprovider = \"file\"\n\n[session]\nprovider = \"" + provider + "\"\n\n[daemon]\nshutdown_timeout = \"" + timeout + "\"\n")
 	if err := os.WriteFile(tomlPath, data, 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -4315,7 +4315,7 @@ func warningsContain(warnings []string, substr string) bool {
 func writeCityRuntimeConfigWithIncludes(t *testing.T, tomlPath string, includes []string) {
 	t.Helper()
 	clearInheritedBeadsEnv(t)
-	requireNoLeakedDoltAfter(t)
+	requireNoLeakedDoltAfterForPaths(t, filepath.Dir(tomlPath))
 	var quoted []string
 	for _, include := range includes {
 		quoted = append(quoted, fmt.Sprintf("%q", include))

--- a/cmd/gc/dolt_leak_helper_test.go
+++ b/cmd/gc/dolt_leak_helper_test.go
@@ -250,6 +250,49 @@ func TestRequireNoLeakedDoltAfter_NewNonTestPIDIgnored(t *testing.T) {
 	}
 }
 
+func TestRequireNoLeakedDoltAfterWithFilterIgnoresUnownedTempPID(t *testing.T) {
+	ownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "owned-city")
+	unownedRoot := filepath.Join("/tmp", "TestDoltLeakHelper", "other-city")
+	owned := DoltProcInfo{
+		PID: 1001,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(ownedRoot, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	unowned := DoltProcInfo{
+		PID: 1002,
+		Argv: []string{
+			"dolt",
+			"sql-server",
+			"--config",
+			filepath.Join(unownedRoot, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml"),
+		},
+	}
+	enumerate := scriptedDoltEnumerator(t,
+		nil,
+		[]DoltProcInfo{owned, unowned},
+	)
+	inner := &recordingTB{}
+	requireNoLeakedDoltAfterWithFilter(inner, enumerate, func(configPath string) bool {
+		return samePath(configPath, ownedRoot) || strings.HasPrefix(configPath, ownedRoot+string(filepath.Separator))
+	})
+	inner.runCleanups()
+
+	if !inner.failed() {
+		t.Fatalf("expected scoped leak Errorf for owned PID; nothing recorded")
+	}
+	msg := strings.Join(inner.errors, "\n")
+	if !strings.Contains(msg, "1001") {
+		t.Fatalf("error missing owned leaked PID 1001; got %q", msg)
+	}
+	if strings.Contains(msg, "1002") {
+		t.Fatalf("error included unowned leaked PID 1002; got %q", msg)
+	}
+}
+
 // TestSnapshotDoltProcessPIDs_EnumeratorErrorIsFatal pins that a
 // discovery error is reported via Fatalf so test runs surface
 // enumeration failures directly rather than silently treating them

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/pathutil"
 	"github.com/gastownhall/gascity/internal/testutil"
 )
 
@@ -65,9 +66,16 @@ func clearInheritedBeadsEnv(t *testing.T) {
 // (discoverDoltProcesses returns nil there). The test-config allowlist keeps
 // unrelated city/runtime dolt servers out of the diff so background activity
 // does not false-positive the cleanup check.
-func requireNoLeakedDoltAfter(t *testing.T) {
+func requireNoLeakedDoltAfterForPaths(t *testing.T, paths ...string) {
 	t.Helper()
-	requireNoLeakedDoltAfterWith(t, discoverDoltProcesses)
+	requireNoLeakedDoltAfterWithFilter(t, discoverDoltProcesses, func(configPath string) bool {
+		for _, path := range paths {
+			if path != "" && pathutil.PathWithin(path, configPath) {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 // requireNoLeakedDoltAfterWith is the testReporter+injectable-enumerator
@@ -77,9 +85,18 @@ func requireNoLeakedDoltAfter(t *testing.T) {
 // without spawning real dolt children.
 func requireNoLeakedDoltAfterWith(t testReporter, enumerate func() ([]DoltProcInfo, error)) {
 	t.Helper()
-	initial := snapshotDoltProcessPIDsWith(t, enumerate)
+	homeDir, _ := os.UserHomeDir()
+	tempDir := os.TempDir()
+	requireNoLeakedDoltAfterWithFilter(t, enumerate, func(configPath string) bool {
+		return isTestConfigPath(configPath, homeDir, tempDir)
+	})
+}
+
+func requireNoLeakedDoltAfterWithFilter(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool) {
+	t.Helper()
+	initial := snapshotDoltProcessPIDsWithFilter(t, enumerate, includeConfigPath)
 	t.Cleanup(func() {
-		leaked := snapshotDoltProcessPIDsWith(t, enumerate)
+		leaked := snapshotDoltProcessPIDsWithFilter(t, enumerate, includeConfigPath)
 		for pid := range initial {
 			delete(leaked, pid)
 		}
@@ -108,15 +125,22 @@ func requireNoLeakedDoltAfterWith(t testReporter, enumerate func() ([]DoltProcIn
 // swallowed discovery failure can never silently mask a real leak.
 func snapshotDoltProcessPIDsWith(t testReporter, enumerate func() ([]DoltProcInfo, error)) map[int]string {
 	t.Helper()
+	homeDir, _ := os.UserHomeDir()
+	tempDir := os.TempDir()
+	return snapshotDoltProcessPIDsWithFilter(t, enumerate, func(configPath string) bool {
+		return isTestConfigPath(configPath, homeDir, tempDir)
+	})
+}
+
+func snapshotDoltProcessPIDsWithFilter(t testReporter, enumerate func() ([]DoltProcInfo, error), includeConfigPath func(string) bool) map[int]string {
+	t.Helper()
 	procs, err := enumerate()
 	if err != nil {
 		t.Fatalf("discoverDoltProcesses: %v", err)
 	}
-	homeDir, _ := os.UserHomeDir()
-	tempDir := os.TempDir()
 	out := make(map[int]string, len(procs))
 	for _, p := range procs {
-		if !isTestConfigPath(extractConfigPath(p.Argv), homeDir, tempDir) {
+		if !includeConfigPath(extractConfigPath(p.Argv)) {
 			continue
 		}
 		out[p.PID] = strings.Join(p.Argv, " ")


### PR DESCRIPTION
## Summary
- scope city-runtime Dolt leak assertions to the test-owned city directory
- keep the generic leak detector behavior available behind the injectable helper
- add a regression test proving unowned temp Dolt processes are ignored while owned leaks still report

## Tests
- go test ./cmd/gc -run 'TestRequireNoLeakedDoltAfter|TestSnapshotDoltProcessPIDs|TestCityRuntimeReloadProviderSwapPreservesDrainTracker' -count=10 -v
- go test ./cmd/gc -run 'TestCityRuntimeReloadProviderSwapPreservesDrainTracker|TestRequireNoLeakedDoltAfterWithFilterIgnoresUnownedTempPID' -count=20
- git commit hook: lint-changed, generated docs/schema checks, go vet ./..., fast unit suite