### PR TITLE
fix(refinery): include gc.routed_to=polecat in prompt's Rejection Flow

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -370,6 +370,34 @@ func TestRefineryPromptSeedsTargetBranchVar(t *testing.T) {
 	}
 }
 
+// TestRefineryPromptRejectionFlowIncludesRoutedTo guards against the
+// regression observed in L5c v4 (2026-05-10): the prompt's "Rejection
+// Flow" section showed a partial bd update — `--status=open
+// --assignee="" --set-metadata rejection_reason="..."` — that omitted
+// `gc.routed_to`. The refinery agent ran exactly the partial command
+// from the prompt instead of the formula's full update, leaving the
+// rejected bead with stale `gc.routed_to=...refinery`. The pool
+// reconciler matches on `gc.routed_to`, so no polecat was ever spawned
+// to resume the bead.
+//
+// The fix shows the full bd update in the prompt and explicitly names
+// `gc.routed_to=...polecat` as load-bearing for pool spawn.
+func TestRefineryPromptRejectionFlowIncludesRoutedTo(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "refinery", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery prompt: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		"## Rejection Flow",
+		`--set-metadata rejection_reason=`,
+		`--set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat"`,
+	)
+}
+
 func TestRefineryFormulaSupportsMergeStrategies(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -216,13 +216,29 @@ Never infer a branch name. If `metadata.branch` is missing, reject the bead.
 
 ## Rejection Flow
 
-On rebase conflict or test failure:
-1. Put work bead back in pool:
-   `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."`
-2. Branch handling depends on failure type:
-   - Conflict: leave branch intact (polecat needs it for rebase)
-   - Test failure: delete branch (polecat redoes work)
-3. Pour next wisp, burn current one
+On rebase conflict or test failure, follow `mol-refinery-patrol`'s
+rebase / handle-failures step verbatim. Do not compose your own
+shorter version of the bd update — the full update is required,
+including `gc.routed_to`:
+
+```bash
+gc bd update $WORK \
+  --status=open \
+  --assignee="" \
+  --set-metadata rejection_reason="..." \
+  --set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat"
+```
+
+`gc.routed_to=...polecat` is load-bearing: the pool reconciler matches
+on `gc.routed_to`, not `rejection_reason`, so a rejected bead with the
+old `gc.routed_to=...refinery` value (set when the polecat first
+submitted) sits in the queue forever — no polecat is ever spawned.
+
+Branch handling depends on failure type:
+- Conflict: leave branch intact (polecat needs it for rebase)
+- Test failure: delete branch (polecat redoes work)
+
+Then pour the next wisp and burn the current one.
 
 A new polecat picks up the bead, sees `metadata.branch` and
 `metadata.rejection_reason`, rebases or redoes work, reassigns to refinery.


### PR DESCRIPTION
## Summary

The refinery prompt's "Rejection Flow" quick reference showed a partial `gc bd update $WORK --status=open --assignee="" --set-metadata rejection_reason="..."` that **omitted** `--set-metadata gc.routed_to=...polecat`. LLM refinery agents ran exactly that partial form verbatim instead of the formula's full update. Result: rejected work beads sat in the queue with stale `gc.routed_to=...refinery` (set when the polecat originally submitted to refinery). The pool reconciler matches on `gc.routed_to`, not `rejection_reason`, so no polecat was ever spawned to resume the bead. The convoy stalled silently.

Reproduced on a clean L5c run (validate-l5-20260510-v4, gascity local/integration 4d656c14 with #1925, #1916, #1913 in flight). The refinery merged the first of two conflicting beads as a fast-forward and correctly rejected the second — but the rejected bead's `gc.routed_to` was still `...refinery` afterwards. Verified from the rig's `.beads/issues.jsonl` and the refinery agent's full transcript at `0729867d-d125-4fec-b089-0cccf108f1bd.jsonl`. The agent's exact rejection command was:

```
gc bd update vl2vr-j4y --status=open --assignee="" \
  --set-metadata rejection_reason="rebase conflict on shared_func.go: ..."
```

— a verbatim copy of the prompt's incomplete sketch, not the formula's full update.

## What changed

- `examples/gastown/packs/gastown/agents/refinery/prompt.template.md` — rewrote the "Rejection Flow" section to show the full bd update including `--set-metadata gc.routed_to="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}polecat"`, plus a one-paragraph "why" naming the pool reconciler's match field. Pointed readers at `mol-refinery-patrol`'s `rebase` / `handle-failures` step as the canonical source.

- `examples/gastown/gastown_test.go` — `TestRefineryPromptRejectionFlowIncludesRoutedTo` asserts the prompt's Rejection Flow contains both `--set-metadata rejection_reason=` and the full `gc.routed_to=...polecat` line, in order. Guards against silently reverting to a partial bd update.

Surface: refinery rejection metadata via \`gc bd update --set-metadata\` (canonical bd CLI), shown in canonical agent prompt template (rendered by \`gc init\`); not direct Dolt edits, not inline ad-hoc metadata queries.

## Out of scope

- The v3-only metadata-pollution case (a separate slot-state cache leak when L5c follows L5a/L5b on the same rig); different root cause, separate bead.
- The `gc workflow delete-source` / `reopen-source` cleanup that the formula calls for before the bd update; the agent in v4 also skipped these, but the visible symptom (no polecat spawn) is fixed by the `gc.routed_to` correction alone.
- A `--metadata` flag on `gc bd close` or a `gc bd reject` subcommand (solution-shape #5, feature addition).

## Testing

- [x] `go test ./examples/gastown/... -run "TestRefineryPrompt|TestRefineryFormula|TestPolecatFormula" -count=1` — 7/7 pass in 1s, including the new regression guard.
- [ ] `make check` — local pre-commit gate skipped per session-author authorization (the diff is markdown prose plus a substring-assertion test reading the same markdown; blast radius is `./examples/gastown/...` only, which the targeted run above covered). CI will exercise the full suite.
- [ ] `make check-docs` — not applicable (no `docs/` or `engdocs/` touched).
- [ ] `make test-integration` — deferred per CONTRIBUTING (prompt-only pack edit, no runtime/controller behavior changes).

Pre-existing test flakes observed on `origin/main` during initial run, none touching this diff:
- `TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness` (matches local stg-7s03 EXPECT-FAIL)
- `TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase` (not yet filed)
- `TestDoctorScriptDoesNotCreditSharedPrefixBackupToDatabase` (not yet filed)
- `TestProvider_StartUsesLongerTimeout` (signal-killed under parallel load; not yet filed)

## Checklist

- [x] Linked an issue / explained why one is not needed: internal investigation bead stg-66wz; no public issue.
- [x] Added or updated tests for behavior changes: `TestRefineryPromptRejectionFlowIncludesRoutedTo` covers the partial-vs-full form regression.
- [x] Updated docs for user-facing changes: prompt template is what the LLM agent reads each cycle; the rewritten section is the user-visible change.
- [x] Called out breaking changes or migration notes: none — prompt content only, no contract or runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)