### PR TITLE
fix(refinery): add Merge Bookkeeping section binding metadata to close

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -370,6 +370,37 @@ func TestRefineryPromptSeedsTargetBranchVar(t *testing.T) {
 	}
 }
 
+// TestRefineryPromptMergeBookkeepingBindsMetadataToClose guards against
+// the regression observed in L5c v4 (2026-05-10): the refinery agent
+// merged a polecat branch (fast-forward) on a no-remote rig, then ran
+// only `gc bd close $WORK --reason "Merged to main at 055fa36..."` —
+// no `gc bd update --set-metadata merged_sha=...` ran. The closed bead
+// had `merged_sha=null` and `merged_target=null`, so downstream tools
+// could not tell the bead actually merged. The agent had also bypassed
+// the formula's `git update-ref` flow in favor of `git checkout
+// $TARGET; git merge --ff-only temp` from a worktree.
+//
+// The fix adds a "Merge Bookkeeping" section to the refinery prompt
+// that names both obligations: metadata-write before close (regardless
+// of remote / FF / merge-commit shape), and `git update-ref` over
+// `git checkout + merge --ff-only`.
+func TestRefineryPromptMergeBookkeepingBindsMetadataToClose(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "refinery", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery prompt: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		"## Merge Bookkeeping",
+		"`merged_sha` and `merged_target` MUST be written via",
+		"`gc bd update --set-metadata` BEFORE `gc bd close`",
+		"`git update-ref refs/heads/$TARGET <sha>`",
+	)
+}
+
 func TestRefineryFormulaSupportsMergeStrategies(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -263,6 +263,34 @@ If `metadata.existing_pr` is present while `merge_strategy` is unset or
 `direct`, treat the handoff as `mr`. An existing PR cannot be validated
 and then ignored by landing directly to the target branch.
 
+## Merge Bookkeeping
+
+Two non-negotiable obligations on every merge, regardless of merge
+strategy, remote presence, or merge shape (fast-forward / merge
+commit):
+
+- **`merged_sha` and `merged_target` MUST be written via
+  `gc bd update --set-metadata` BEFORE `gc bd close`.** They are the
+  only forensic breadcrumbs tying a closed bead to its merge commit on
+  `$TARGET`. Skipping the metadata write — even on a rig with no
+  remote, even when `gc bd close --reason` already names the SHA in
+  prose — leaves downstream tools with no way to verify the bead
+  actually merged. The formula chains both writes with `&&`; do not
+  split them, and do not skip the metadata write because the close
+  reason looks redundant.
+
+- **Use `git update-ref refs/heads/$TARGET <sha>` to advance the
+  target branch.** The formula's `merge-push` step uses this instead
+  of `git checkout $TARGET; git merge --ff-only temp` for a reason:
+  checking out a branch that another worktree has open silently
+  merges into the wrong worktree's HEAD instead of `$TARGET`. Follow
+  the formula's command shape verbatim — do not substitute a simpler
+  `git merge --ff-only` even when it looks equivalent.
+
+If `git push` is impossible (no remote, push-disabled rig), still run
+the metadata write and the close. The local merge happened; the bead
+records that merge.
+
 ---
 
 ## Communication


### PR DESCRIPTION
## Summary

The refinery prompt had no "Merge Flow" quick reference paralleling its "Rejection Flow" section. On a no-remote test rig (no `origin` configured), the LLM refinery agent observed the formula's `merge-push` step assumed a remote (`git fetch origin`, `git push origin $TARGET`) and bypassed it entirely — using `git merge --ff-only temp` from the refinery's worktree and then running only `gc bd close $WORK --reason "Merged to main at <sha>. No remote; no push step."`. The `gc bd update --set-metadata merged_sha=... merged_target=...` write that #1886 chained into the close was skipped along with everything else in the merge-push step. Closed work beads ended up with `merged_sha=null` and `merged_target=null`, losing the forensic breadcrumb tying a closed bead to its merge commit.

This walks back the validation on stg-a1st, which #1886 covered for L5a / L5b (every merge was a merge-commit, exercising the chained close). The L5c-shape case (one FF merge + one rejection in the same iteration, on a no-remote rig) exposed that the chain isn't sufficient when the LLM bypasses the merge-push step upstream of the chain.

Reproduced on validate-l5-20260510-v4 (gascity local/integration 4d656c14): the cleanly-merged second L5c bead `vl2vr-le9` closed with `metadata.merged_sha=null` and `metadata.merged_target=null` even though main HEAD shows the merge commit `055fa36`. Refinery transcript at `0729867d-d125-4fec-b089-0cccf108f1bd.jsonl` shows the agent ran `git merge --ff-only gc-nux-03afa35551bd` followed directly by `gc bd close ...` — no metadata write in between.

## What changed

- `examples/gastown/packs/gastown/agents/refinery/prompt.template.md` — added a new "Merge Bookkeeping" section after "Merge Strategy". Names two non-negotiable obligations on every merge:
  1. `merged_sha` / `merged_target` MUST be written via `gc bd update --set-metadata` BEFORE `gc bd close`, regardless of remote presence or merge shape (FF / merge commit). The formula chains them; do not split, do not skip the metadata write because the close-reason looks redundant.
  2. Use `git update-ref refs/heads/$TARGET <sha>` (per the formula), not `git checkout $TARGET; git merge --ff-only temp` from a worktree — checking out a branch that another worktree has open silently merges into the wrong worktree's HEAD.

  Explicitly states that on rigs without a remote, the metadata write and the close still run.

- `examples/gastown/gastown_test.go` — `TestRefineryPromptMergeBookkeepingBindsMetadataToClose` asserts the new section's load-bearing phrases (\`gc bd update --set-metadata\` BEFORE \`gc bd close\`, \`git update-ref refs/heads/\$TARGET <sha>\`) appear in order.

Surface: refinery merge metadata via \`gc bd update --set-metadata\` (canonical bd CLI), shown in canonical agent prompt template; not direct Dolt edits.

## Out of scope

- The formula-level no-remote handling (the merge-push step still calls \`git fetch origin\` etc.). The prompt-level fix asks the agent to follow the metadata-write contract regardless; rewiring the formula to support no-remote rigs cleanly is a separate concern (likely test-harness-side rather than gascity-side).
- A guard test in the formula for the FF metadata case — #1886's \`TestRefineryFormulaChainsMergeMetadataWithClose\` already covers the chain shape; this PR is upstream of that gate, in the prompt the LLM reads first.

## Testing

- [x] \`go test ./examples/gastown/... -run "TestRefineryPrompt|TestRefineryFormula|TestPolecatFormula" -count=1\` — 8/8 pass in 1s, including the new regression guard.
- [ ] \`make check\` — local pre-commit gate skipped per session-author authorization. The diff is markdown prose plus a substring-assertion test that reads the same markdown; blast radius is \`./examples/gastown/...\` only, which the targeted run above covered. The same Go test surface was exercised by the sibling PR for stg-66wz (which ran a full \`make check\` and surfaced only pre-existing flakes in unrelated packages). CI will run the full suite.
- [ ] \`make check-docs\` — not applicable (no \`docs/\` or \`engdocs/\` touched).
- [ ] \`make test-integration\` — deferred per CONTRIBUTING.

Pre-existing test flakes observed on \`origin/main\` (same set as the sibling PR for stg-66wz):
- \`TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness\` (matches local stg-7s03 EXPECT-FAIL)
- \`TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase\` (not yet filed)
- \`TestDoctorScriptDoesNotCreditSharedPrefixBackupToDatabase\` (not yet filed)
- \`TestProvider_StartUsesLongerTimeout\` (signal-killed under parallel load; not yet filed)

## Checklist

- [x] Linked an issue / explained why one is not needed: internal investigation bead stg-a1st reopened from oscar's L5c v4 findings; no public issue.
- [x] Added or updated tests for behavior changes: \`TestRefineryPromptMergeBookkeepingBindsMetadataToClose\` covers the new prompt section.
- [x] Updated docs for user-facing changes: prompt template is what the LLM agent reads; the new section is the user-visible change.
- [x] Called out breaking changes or migration notes: none — prompt content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)