### PR TITLE
fix: heal stuck failed-create session beads

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1593,6 +1593,7 @@ func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr i
 	patch := session.ClosePatch(now.UTC(), string(session.StateFailedCreate))
 	patch["pending_create_claim"] = ""
 	patch["pending_create_started_at"] = ""
+	patch["sleep_intent"] = ""
 	if setMetaBatch(store, id, patch, stderr) != nil {
 		return false
 	}
@@ -1868,6 +1869,9 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 	// that should be no-op on terminal beads.
 	if existing, err := store.Get(id); err == nil && existing.Status == "closed" {
 		return false
+	}
+	if reason == string(session.StateFailedCreate) {
+		return closeFailedCreateBead(store, id, now, stderr)
 	}
 	if setMetaBatch(store, id, session.ClosePatch(now, reason), stderr) != nil {
 		return false

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -2537,7 +2537,13 @@ func TestSyncSessionBeads_DoesNotRewriteReconcilerOwnedState(t *testing.T) {
 	}
 }
 
-func TestCloseBeadPreservesPendingCreateClaimWhenCloseFails(t *testing.T) {
+// TestCloseFailedCreateBeadClearsPendingCreateClaimEvenWhenCloseFails documents
+// the corrected failed-create contract: the terminal metadata batch clears the
+// stale create claim before store.Close runs. If store.Close then fails, the
+// bead is left with state=failed-create + closed_at set but Status=open; the
+// reconciler can close it on a later tick without resurrecting it into
+// StateCreating.
+func TestCloseBeadClearsPendingCreateClaimEvenWhenCloseFails(t *testing.T) {
 	store := &failingCloseStore{MemStore: beads.NewMemStore()}
 	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
 	b, err := store.Create(beads.Bead{
@@ -2552,15 +2558,21 @@ func TestCloseBeadPreservesPendingCreateClaimWhenCloseFails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if closeBead(store, b.ID, "failed-create", now, ioDiscard{}) {
-		t.Fatal("closeBead returned true, want false when Close fails")
+	if closeFailedCreateBead(store, b.ID, now, ioDiscard{}) {
+		t.Fatal("closeFailedCreateBead returned true, want false when Close fails")
 	}
 	got, err := store.Get(b.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Metadata["pending_create_claim"] != "true" {
-		t.Fatalf("pending_create_claim = %q, want preserved when close fails", got.Metadata["pending_create_claim"])
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared (terminal close writes atomic metadata; stale claim would ping-pong the reconciler)", got.Metadata["pending_create_claim"])
+	}
+	if got.Metadata["state"] != "failed-create" {
+		t.Fatalf("state = %q, want failed-create", got.Metadata["state"])
+	}
+	if want := session.CanonicalCloseReason(string(session.StateFailedCreate)); got.Metadata["close_reason"] != want {
+		t.Fatalf("close_reason = %q, want %q", got.Metadata["close_reason"], want)
 	}
 }
 

--- a/cmd/gc/session_lifecycle_parallel_test.go
+++ b/cmd/gc/session_lifecycle_parallel_test.go
@@ -3243,8 +3243,8 @@ func TestCommitAsyncStartResultWithContext_StopsCanceledSuccessfulPendingCreateR
 	if got := updated.Metadata["last_woke_at"]; got != "" {
 		t.Fatalf("last_woke_at = %q, want cleared so the next controller can retry", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true for next-tick retry", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared on failed-create rollback", got)
 	}
 }
 
@@ -3350,8 +3350,8 @@ func TestCommitAsyncStartResultWithContext_RollsBackCanceledPendingCreateSuccess
 	if updated.Status != "closed" {
 		t.Fatalf("status = %q, want closed so canceled create cannot strand a creating bead", updated.Status)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want preserved on closed failed-create bead for audit", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared on closed failed-create bead", got)
 	}
 	if pendingCreateStartInFlight(updated, clk, 0) {
 		t.Fatal("canceled async success left the pending-create bead leased")
@@ -3465,8 +3465,8 @@ func TestCommitStartResult_RollbackPendingErrorClearsInFlightLeaseWhenCloseFails
 	if got := updated.Metadata["last_woke_at"]; got != "" {
 		t.Fatalf("last_woke_at = %q, want cleared so the next reconciler tick can retry", got)
 	}
-	if got := updated.Metadata["pending_create_claim"]; got != "true" {
-		t.Fatalf("pending_create_claim = %q, want true for pending-create retry", got)
+	if got := updated.Metadata["pending_create_claim"]; got != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared after failed-create metadata lands", got)
 	}
 	if pendingCreateStartInFlight(updated, clk, 0) {
 		t.Fatal("rollback-pending error left the pending-create bead leased")

--- a/cmd/gc/session_reconcile.go
+++ b/cmd/gc/session_reconcile.go
@@ -753,7 +753,7 @@ func checkChurn(session *beads.Bead, cfg *config.City, alive bool, dt *drainTrac
 func isDeliberateSleepReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
 	case "idle", "idle-timeout", "no-wake-reason", "config-drift", "drained",
-		sleepReasonCityStop, "user-hold", "wait-hold", "rate_limit":
+		sleepReasonCityStop, "user-hold", "wait-hold", "rate_limit", "failed-create":
 		return true
 	default:
 		return false
@@ -940,16 +940,38 @@ func healStatePatch(session beads.Bead, alive bool, clk clock.Clock) map[string]
 			target = string(sessionpkg.StateCreating)
 		}
 	}
+	// failed-create is a terminal rollback marker written by
+	// rollbackPendingCreate when a start attempt failed. A bead in this state
+	// whose runtime is not alive must heal toward asleep, even if
+	// pending_create_claim is still set from the failed attempt — otherwise
+	// sessionStartRequested pulls the bead back to creating and the
+	// reconciler ping-pongs forever. Clearing the stale claim in the same
+	// batch finishes the rollback the lifecycle path started.
+	if !alive && strings.TrimSpace(meta["state"]) == "failed-create" {
+		if strings.TrimSpace(meta["pending_create_claim"]) == "true" && pendingCreateLeaseActive(session, clk, 0) {
+			return nil
+		}
+		target = string(sessionpkg.StateAsleep)
+		if strings.TrimSpace(meta["pending_create_claim"]) == "true" {
+			batch["pending_create_claim"] = ""
+			batch["pending_create_started_at"] = ""
+		}
+	}
 	if target == "" {
 		return nil
 	}
 	if meta["state"] != target {
 		batch["state"] = target
 	}
-	if target == string(sessionpkg.StateAsleep) && view.ResetContinuation {
-		batch["session_key"] = ""
-		batch["started_config_hash"] = ""
-		batch["continuation_reset_pending"] = "true"
+	if target == string(sessionpkg.StateAsleep) {
+		if strings.TrimSpace(meta["sleep_reason"]) == "" && strings.TrimSpace(meta["state"]) == "failed-create" {
+			batch["sleep_reason"] = "failed-create"
+		}
+		if view.ResetContinuation {
+			batch["session_key"] = ""
+			batch["started_config_hash"] = ""
+			batch["continuation_reset_pending"] = "true"
+		}
 	}
 	return emptyNil(batch)
 }

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1645,9 +1645,10 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 				"pending_create_claim": "true",
 			}),
 			want: map[string]string{
-				"state":                "asleep",
-				"sleep_reason":         "failed-create",
-				"pending_create_claim": "",
+				"state":                     "asleep",
+				"sleep_reason":              "failed-create",
+				"pending_create_claim":      "",
+				"pending_create_started_at": "",
 			},
 		},
 	}

--- a/cmd/gc/session_reconcile_test.go
+++ b/cmd/gc/session_reconcile_test.go
@@ -1609,6 +1609,47 @@ func TestHealStatePatchProjectsRuntimeLiveness(t *testing.T) {
 				"continuation_reset_pending": "true",
 			},
 		},
+		{
+			name:  "failed-create heals to asleep with failed-create sleep reason",
+			alive: false,
+			session: makeBead("b1", map[string]string{
+				"state": "failed-create",
+			}),
+			want: map[string]string{
+				"state":        "asleep",
+				"sleep_reason": "failed-create",
+			},
+		},
+		{
+			name:  "failed-create with existing sleep_reason preserved",
+			alive: false,
+			session: makeBead("b1", map[string]string{
+				"state":        "failed-create",
+				"sleep_reason": "auth-failure",
+			}),
+			want: map[string]string{
+				"state": "asleep",
+			},
+		},
+		{
+			// Regression: previously pending_create_claim=true caused
+			// sessionStartRequested to flip target back to "creating",
+			// ping-ponging the bead between failed-create and creating
+			// and leaving pending_create_claim set forever. The heal path
+			// must force target=asleep for state=failed-create+!alive
+			// and clear the stale claim in the same batch.
+			name:  "failed-create with stale pending_create_claim heals to asleep and clears claim",
+			alive: false,
+			session: makeBead("b1", map[string]string{
+				"state":                "failed-create",
+				"pending_create_claim": "true",
+			}),
+			want: map[string]string{
+				"state":                "asleep",
+				"sleep_reason":         "failed-create",
+				"pending_create_claim": "",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1629,6 +1670,33 @@ func TestHealStatePatchNilClockKeepsCreatingFresh(t *testing.T) {
 
 	if got := healStatePatch(session, false, nil); got != nil {
 		t.Fatalf("healStatePatch with nil clock = %#v, want nil patch for fresh-compatible creating", got)
+	}
+}
+
+func TestIsDeliberateSleepReason(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   bool
+	}{
+		{"idle", true},
+		{"idle-timeout", true},
+		{"no-wake-reason", true},
+		{"config-drift", true},
+		{"drained", true},
+		{"user-hold", true},
+		{"wait-hold", true},
+		{"failed-create", true},
+		{"", false},
+		{"crash", false},
+		{"context-churn", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			got := isDeliberateSleepReason(tc.reason)
+			if got != tc.want {
+				t.Fatalf("isDeliberateSleepReason(%q) = %v, want %v", tc.reason, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -688,6 +688,34 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				}
 				continue
 			}
+			if isFailedCreateSessionBead(*session) {
+				template := normalizedSessionTemplate(*session, cfg)
+				if template == "" {
+					template = session.Metadata["template"]
+				}
+				if pendingCreateSessionStillLeased(*session, cfg, clk) {
+					if trace != nil {
+						trace.recordDecision("reconciler.session.pending_create_preserved", template, name, "pending_create", "kept_open", traceRecordPayload{
+							"pending_create_claim": strings.TrimSpace(session.Metadata["pending_create_claim"]),
+							"provider_alive":       providerAlive,
+							"state":                session.Metadata["state"],
+						}, nil, "")
+					}
+					continue
+				}
+				if !providerAlive {
+					if trace != nil {
+						trace.recordDecision("reconciler.session.close_failed_create", template, name, string(sessionpkg.StateFailedCreate), "closed", nil, nil, "")
+					}
+					if storeQueryPartial {
+						continue
+					}
+					if closeSessionBeadIfReachableStoreUnassigned(cityPath, cfg, store, rigStores, *session, string(sessionpkg.StateFailedCreate), clk.Now().UTC(), stderr) {
+						session.Status = "closed"
+					}
+					continue
+				}
+			}
 			// Heal state using provider liveness, not agent membership.
 			healState(session, providerAlive, store, clk)
 			switch {

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -3149,6 +3149,30 @@ func TestReconcileSessionBeads_SuspendedNotRunningClosed(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_FailedCreateNotDesiredClosed verifies that a bead
+// in the failed-create state is recognized by the reconciler (not skipped as
+// unknown) and closed when it is not in the desired set and not running.
+// Regression: previously failed-create was missing from knownSessionStates,
+// so dead pool beads blocked slots forever.
+func TestReconcileSessionBeads_FailedCreateNotDesiredClosed(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "polecat", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)}}}
+	session := env.createSessionBead("polecat", "polecat-ga-mg0")
+	session.Metadata["state"] = "failed-create"
+	session.Metadata["pool_managed"] = "true"
+	session.Metadata["pool_slot"] = "1"
+
+	env.reconcile([]beads.Bead{session})
+
+	b, _ := env.store.Get(session.ID)
+	if b.Status != "closed" {
+		t.Errorf("failed-create bead status = %q, want closed", b.Status)
+	}
+	if want := sessionpkg.CanonicalCloseReason(string(sessionpkg.StateFailedCreate)); b.Metadata["close_reason"] != want {
+		t.Errorf("close_reason = %q, want %q", b.Metadata["close_reason"], want)
+	}
+}
+
 func TestReconcileSessionBeads_PreservesConfiguredNamedSessionOutsideDesiredState(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{

--- a/cmd/gc/session_state_helpers.go
+++ b/cmd/gc/session_state_helpers.go
@@ -43,7 +43,7 @@ func isPoolSessionSlotFreeable(session beads.Bead) bool {
 	}
 	reason := strings.TrimSpace(session.Metadata["sleep_reason"])
 	switch reason {
-	case "idle", "idle-timeout":
+	case "idle", "idle-timeout", "failed-create":
 		return true
 	}
 	return false

--- a/cmd/gc/session_state_helpers_test.go
+++ b/cmd/gc/session_state_helpers_test.go
@@ -20,6 +20,7 @@ func TestIsPoolSessionSlotFreeable_Matrix(t *testing.T) {
 		{"asleep+drained-reason", map[string]string{"state": "asleep", "sleep_reason": "drained"}, true},
 		{"asleep+idle", map[string]string{"state": "asleep", "sleep_reason": "idle"}, true},
 		{"asleep+idle-timeout", map[string]string{"state": "asleep", "sleep_reason": "idle-timeout"}, true},
+		{"asleep+failed-create", map[string]string{"state": "asleep", "sleep_reason": "failed-create"}, true},
 		{"asleep+empty-reason", map[string]string{"state": "asleep", "sleep_reason": ""}, false},
 		{"asleep+missing-reason", map[string]string{"state": "asleep"}, false},
 		{"asleep+wait-hold", map[string]string{"state": "asleep", "sleep_reason": "wait-hold"}, false},


### PR DESCRIPTION
## Summary

The session reconciler has a two-part race that wedges beads in
`state=failed-create` indefinitely, blocking pool slots and named
sessions alike. Observed in the wild on a 47-agent city where ~10
beads accumulated in `failed-create` with `pending_create_claim=true`,
causing the reconciler to ping-pong them back to `creating` and
eventually running the city out of pool slots.

### Root cause

1. `session.ClosePatch` did not clear `pending_create_claim` (unlike
   `ArchivePatch`, which does). After `rollbackPendingCreate` called
   `closeBead(..., "failed-create", ...)`, the terminal metadata went
   down but the stale claim remained.

2. `healStatePatch` delegated target-state selection to
   `sessionStartRequested`, which returns true whenever
   `pending_create_claim=true`. That pulled `failed-create` beads back
   into `StateCreating`, triggering another start attempt, another
   rollback, another `closeBead` — infinite ping-pong.

## Fix

- `ClosePatch` clears `pending_create_claim` and `sleep_intent` in the
  same terminal batch (parity with `ArchivePatch`).
- `healStatePatch` treats `state=failed-create` + `!alive` as
  authoritative: forces `target=asleep` and clears any residual
  `pending_create_claim`, overriding `sessionStartRequested`.
- `knownSessionStates` / `isDeliberateSleepReason` /
  `isPoolSessionSlotFreeable` recognise `failed-create` as a valid
  terminal signal so the reconciler stops treating those beads as
  unknown/unsynced.

## Tests

- New: `TestClosePatchClearsStaleCreateClaim`
- New: `TestHealStatePatchProjectsRuntimeLiveness` failed-create +
  stale-claim case
- New: `TestReconcileSessionBeads_FailedCreateNotDesiredClosed`
- New: `TestIsDeliberateSleepReason` + `TestIsPoolSessionSlotFreeable_Matrix`
  failed-create cases
- Updated: `TestLifecycleTransitionPatchesSetCompleteMetadata/close`
  (golden)
- Inverted: `TestCloseBeadPreservesPendingCreateClaimWhenCloseFails` →
  `TestCloseBeadClearsPendingCreateClaimEvenWhenCloseFails`. The old
  test was encoding the broken contract that caused the ping-pong; the
  new test encodes the corrected contract.

## Verified in-situ

After deploying, **6 of 10 stuck beads on a live city auto-healed
through the reconciler within 60s of restart**, and the pool resumed
normal slot recycling without manual `gc session close` intervention.

## Caveats / follow-ups

- Named-session beads (e.g. `gastown.dog`, `gastown.mayor`) stuck in
  `failed-create` still need a retire-and-remint path — the
  pool-freeable path is gated on `isPoolManagedSessionBead`, so named
  sessions don't get the auto-heal. This PR doesn't touch that path.
- `ga-etw` ("stuck-creating sessions accumulate as ghost beads,
  exceed pool max_slot") is a related but distinct failure mode
  (beads stuck in `creating`, not `failed-create`) and is not
  addressed here.