### PR TITLE
fix(config): exclude epic beads from default worker work_query (gc-udx)

### DIFF
--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -400,7 +400,7 @@ max = 5
 		t.Fatalf("stdout = %q, want GC_RIG_ROOT=%q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --json --limit=1") {
+	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool work_query args", out)
 	}
 }
@@ -715,7 +715,7 @@ max = 5
 		t.Fatalf("stdout = %q, want command to run from rig root %q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --json --limit=1") {
+	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool template work_query args", out)
 	}
 }
@@ -783,7 +783,7 @@ name = "worker"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=host-session", out)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --json --limit=1`) {
+	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }
@@ -844,7 +844,7 @@ dir = "myrig"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=%s", out, wantSession)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --json --limit=1`) {
+	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --exclude-type=epic --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2086,6 +2086,13 @@ func (a *Agent) AttachEnabled() bool {
 // Formula roots that are themselves executable must be represented as ready()
 // work (for example type=wisp); molecule containers are not routable demand.
 //
+// Parent epics are excluded from every tier (--exclude-type=epic). An epic
+// has no executable spec — its semantic is "all children done" — so a worker
+// claiming an epic does undefined work (gc-udx). Roles that legitimately
+// process epics (oversight, reviewers, closers) opt in by setting an explicit
+// work_query in their agent config; that custom query is returned unchanged
+// above.
+//
 // When the reconciler runs the query for demand detection (no session
 // context), all identity vars are empty → assignee tiers skip → only
 // the routed_to tier fires to detect new demand.
@@ -2103,13 +2110,13 @@ func (a *Agent) EffectiveWorkQuery() string {
 			// Tier 1: in_progress assigned to any of my identifiers (crash recovery)
 			`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 			`[ -z "$id" ] && continue; ` +
-			`r=$(bd list --status in_progress --assignee="$id" --json --limit=1 2>/dev/null); ` +
+			`r=$(bd list --status in_progress --assignee="$id" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
 			// Tier 2: ready assigned to any of my identifiers (pre-assigned)
 			`for id in "$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"; do ` +
 			`[ -z "$id" ] && continue; ` +
-			`r=$(bd ready --assignee="$id" --json --limit=1 2>/dev/null); ` +
+			`r=$(bd ready --assignee="$id" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`done; ` +
 			// Tier 3: ready unassigned routed to this config (shared routed queue).
@@ -2119,7 +2126,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 			`*) exit 0 ;; ` +
 			`esac; ` +
 			`r=$(bd ready --metadata-field gc.routed_to=` + target +
-			` --unassigned --json --limit=1 2>/dev/null); ` +
+			` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 			`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 			`printf "[]"'`
 	}
@@ -2132,7 +2139,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd list --status in_progress --assignee="$cand" --json --limit=1 2>/dev/null); ` +
+		`r=$(bd list --status in_progress --assignee="$cand" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
@@ -2142,7 +2149,7 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`legacy=""; case "$id" in *control-dispatcher) legacy="${id%control-dispatcher}workflow-control";; esac; ` +
 		`for cand in "$id" "$legacy"; do ` +
 		`[ -z "$cand" ] && continue; ` +
-		`r=$(bd ready --assignee="$cand" --json --limit=1 2>/dev/null); ` +
+		`r=$(bd ready --assignee="$cand" --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`done; ` +
 		`done; ` +
@@ -2154,10 +2161,10 @@ func (a *Agent) EffectiveWorkQuery() string {
 		`*) exit 0 ;; ` +
 		`esac; ` +
 		`r=$(bd ready --metadata-field gc.routed_to=` + target +
-		` --unassigned --json --limit=1 2>/dev/null); ` +
+		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null); ` +
 		`[ -n "$r" ] && [ "$r" != "[]" ] && printf "%s" "$r" && exit 0; ` +
 		`bd ready --metadata-field gc.routed_to=` + legacyTarget +
-		` --unassigned --json --limit=1 2>/dev/null'`
+		` --unassigned --exclude-type=epic --json --limit=1 2>/dev/null'`
 }
 
 func legacyWorkflowControlQualifiedName(target string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1452,7 +1452,7 @@ func TestEffectiveWorkQueryDefault(t *testing.T) {
 	a := Agent{Name: "mayor"}
 	got := a.EffectiveWorkQuery()
 	// Tiered query: check that tier 3 (routed_to) and tier 1-2 (assignee resolution) are present.
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=mayor --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 	if !strings.Contains(got, `"$GC_SESSION_ID" "$GC_SESSION_NAME" "$GC_ALIAS"`) {
@@ -1472,7 +1472,7 @@ func TestEffectiveWorkQueryCustom(t *testing.T) {
 func TestEffectiveWorkQueryWithDir(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world"}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 }
@@ -1480,7 +1480,7 @@ func TestEffectiveWorkQueryWithDir(t *testing.T) {
 func TestEffectiveWorkQueryPoolDefault(t *testing.T) {
 	a := Agent{Name: "polecat", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/polecat --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 	if strings.Contains(got, "--type=molecule") {
@@ -1533,7 +1533,7 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 		PoolName: "hello-world/dog",
 	}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to with pool name: %q", got)
 	}
 	if strings.Contains(got, "--type=molecule") {
@@ -1544,7 +1544,7 @@ func TestEffectiveWorkQueryPoolNameOverride(t *testing.T) {
 func TestEffectiveWorkQueryPoolNoPoolName(t *testing.T) {
 	a := Agent{Name: "dog", Dir: "hello-world", MinActiveSessions: ptrInt(1), MaxActiveSessions: ptrInt(3)}
 	got := a.EffectiveWorkQuery()
-	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --json --limit=1") {
+	if !strings.Contains(got, "bd ready --metadata-field gc.routed_to=hello-world/dog --unassigned --exclude-type=epic --json --limit=1") {
 		t.Errorf("EffectiveWorkQuery() missing tier 3 routed_to: %q", got)
 	}
 }
@@ -1574,14 +1574,14 @@ func TestEffectiveWorkQueryControlDispatcherClaimsLegacyAssignedWork(t *testing.
 	}, `#!/bin/sh
 set -eu
 case "$*" in
-  "list --status in_progress --assignee=gascity--control-dispatcher --json --limit=1"|\
-  "list --status in_progress --assignee=gascity/control-dispatcher --json --limit=1"|\
-  "list --status in_progress --assignee=gascity--workflow-control --json --limit=1"|\
-  "list --status in_progress --assignee=gascity/workflow-control --json --limit=1")
+  "list --status in_progress --assignee=gascity--control-dispatcher --exclude-type=epic --json --limit=1"|\
+  "list --status in_progress --assignee=gascity/control-dispatcher --exclude-type=epic --json --limit=1"|\
+  "list --status in_progress --assignee=gascity--workflow-control --exclude-type=epic --json --limit=1"|\
+  "list --status in_progress --assignee=gascity/workflow-control --exclude-type=epic --json --limit=1")
     printf '[]'
     ;;
-  "ready --assignee=gascity--workflow-control --json --limit=1"|\
-  "ready --assignee=gascity/workflow-control --json --limit=1")
+  "ready --assignee=gascity--workflow-control --exclude-type=epic --json --limit=1"|\
+  "ready --assignee=gascity/workflow-control --exclude-type=epic --json --limit=1")
     printf '[{"id":"ga-legacy-ready"}]'
     ;;
   *)
@@ -1599,10 +1599,10 @@ func TestEffectiveWorkQueryControlDispatcherClaimsLegacyUnassignedRoute(t *testi
 	out := runEffectiveWorkQuery(t, a, nil, `#!/bin/sh
 set -eu
 case "$*" in
-  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --json --limit=1")
+  "ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json --limit=1")
     printf '[]'
     ;;
-  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --json --limit=1")
+  "ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --exclude-type=epic --json --limit=1")
     printf '[{"id":"ga-legacy-route"}]'
     ;;
   *)
@@ -1626,6 +1626,95 @@ func TestEffectiveSlingQueryPoolNameOverride(t *testing.T) {
 	want := "bd update {} --set-metadata gc.routed_to=hello-world/dog-1"
 	if got != want {
 		t.Errorf("EffectiveSlingQuery() = %q, want %q", got, want)
+	}
+}
+
+// TestEffectiveWorkQueryExcludesEpics verifies that the default work query
+// excludes parent epic beads from claimable work — regression coverage for
+// gc-udx where workers were claiming open parent epics whose only role is
+// "all children done." Workers should only see leaf work; parent epics must
+// flow through an explicit override path (a custom work_query in the
+// agent's TOML), not the default tier-1/2/3 query.
+func TestEffectiveWorkQueryExcludesEpics(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	got := a.EffectiveWorkQuery()
+	// All three tiers (in_progress assignee, ready assignee, ready routed)
+	// must structurally exclude the epic type.
+	wantSnippets := []string{
+		`bd list --status in_progress --assignee="$id" --exclude-type=epic --json`,
+		`bd ready --assignee="$id" --exclude-type=epic --json`,
+		`bd ready --metadata-field gc.routed_to=hello-world/worker --unassigned --exclude-type=epic --json`,
+	}
+	for _, want := range wantSnippets {
+		if !strings.Contains(got, want) {
+			t.Errorf("EffectiveWorkQuery() missing exclude-type=epic on tier:\n  want substring: %s\n  got: %s", want, got)
+		}
+	}
+}
+
+// TestEffectiveWorkQueryExcludesEpicsControlDispatcher verifies the
+// control-dispatcher path (which has an extra legacy workflow-control
+// route) also excludes epics on every tier.
+func TestEffectiveWorkQueryExcludesEpicsControlDispatcher(t *testing.T) {
+	a := Agent{Name: ControlDispatcherAgentName, Dir: "gascity"}
+	got := a.EffectiveWorkQuery()
+	wantSnippets := []string{
+		`bd list --status in_progress --assignee="$cand" --exclude-type=epic --json`,
+		`bd ready --assignee="$cand" --exclude-type=epic --json`,
+		`bd ready --metadata-field gc.routed_to=gascity/control-dispatcher --unassigned --exclude-type=epic --json`,
+		`bd ready --metadata-field gc.routed_to=gascity/workflow-control --unassigned --exclude-type=epic --json`,
+	}
+	for _, want := range wantSnippets {
+		if !strings.Contains(got, want) {
+			t.Errorf("EffectiveWorkQuery() missing exclude-type=epic on control-dispatcher tier:\n  want substring: %s\n  got: %s", want, got)
+		}
+	}
+}
+
+// TestEffectiveWorkQueryCustomPreservesOverride verifies that an agent
+// that explicitly opts into epic-handling (e.g. an oversight role that
+// closes epics once their children complete) can do so via a custom
+// work_query — the explicit-override path required by gc-udx.
+func TestEffectiveWorkQueryCustomPreservesOverride(t *testing.T) {
+	custom := "bd ready --type=epic --assignee=closer --json --limit=1"
+	a := Agent{Name: "closer", WorkQuery: custom}
+	if got := a.EffectiveWorkQuery(); got != custom {
+		t.Errorf("EffectiveWorkQuery() = %q, want %q (custom override must pass through unmodified)", got, custom)
+	}
+}
+
+// TestEffectiveWorkQuerySkipsEpicLeafScenario simulates the gc-udx
+// reproduction state through the runEffectiveWorkQuery harness:
+//   - parent epic is open and routed_to the worker
+//   - one open leaf child is also routed_to the worker
+//
+// The default query must return the leaf, never the epic. The fake bd
+// stub here only returns results when --exclude-type=epic is present on
+// the tier-3 routed query — i.e. it asserts the flag is on the wire.
+func TestEffectiveWorkQuerySkipsEpicLeafScenario(t *testing.T) {
+	a := Agent{Name: "worker", Dir: "hello-world"}
+	out := runEffectiveWorkQuery(t, a, map[string]string{
+		"GC_SESSION_ORIGIN": "ephemeral",
+	}, `#!/bin/sh
+set -eu
+case "$*" in
+  *"--exclude-type=epic"*"--metadata-field gc.routed_to=hello-world/worker"*|\
+  *"--metadata-field gc.routed_to=hello-world/worker"*"--exclude-type=epic"*)
+    printf '[{"id":"leaf-child","issue_type":"task"}]'
+    ;;
+  *"--metadata-field gc.routed_to=hello-world/worker"*)
+    printf '[{"id":"parent-epic","issue_type":"epic"}]'
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac
+`)
+	if !strings.Contains(out, "leaf-child") {
+		t.Fatalf("EffectiveWorkQuery() did not return the leaf child: %q", out)
+	}
+	if strings.Contains(out, "parent-epic") {
+		t.Fatalf("EffectiveWorkQuery() surfaced the parent epic to the worker: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Workers were claiming open parent epic beads via `gc hook` because the default three-tier work query in `Agent.EffectiveWorkQuery` did not filter out the `epic` issue_type. An epic has no executable spec — its semantic is "all children done" — so a worker grabbing one either closes prematurely without verifying child completion, does duplicate/invalid work, or fails-closed because there is nothing to do.

Reproduced at least twice in production with the oversight-rig pack on the ds-research workspace.

## Root cause

Missing `--exclude-type=epic` on every `bd ready` / `bd list` invocation in the default query (`internal/config/config.go`). The custom-WorkQuery path is unchanged (returns `a.WorkQuery` as-is), so roles that legitimately process epics (oversight, reviewers, closers) opt in by setting an explicit `work_query` in their agent config — the explicit-override path required by the bead.

Same flag pattern is already used in `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.formula.toml` (PR #397) for the same reason: prevent `--limit=1` from returning a non-leaf wisp/epic ahead of real work.

ZFC clean: filtering by structural `issue_type=epic` is a type-system check, not a semantic judgment. No role names appear in Go. The reconciler probe path shares `EffectiveWorkQuery` so it also stops surfacing epics as routable demand — correct, since a mis-routed epic should not spawn a session that then claims it.

## Tests

- `TestEffectiveWorkQueryExcludesEpics` — verifies `--exclude-type=epic` on all 3 tiers (in_progress assignee, ready assignee, ready routed).
- `TestEffectiveWorkQueryExcludesEpicsControlDispatcher` — same on the control-dispatcher path with its extra legacy workflow-control route (4 tiers).
- `TestEffectiveWorkQueryCustomPreservesOverride` — explicit-override path returns the custom `WorkQuery` unmodified.
- `TestEffectiveWorkQuerySkipsEpicLeafScenario` — end-to-end fake-bd scenario.

## Provenance

Cherry-picked from local maintainer branch `feat/slack-pack-px8-import` at commit `016ab2a1` (originally written 2026-05-03). Original branch is being retired as obsolete; this is one of several commits from it that's still genuinely novel against current `origin/main` and worth landing individually.

## Test plan

- [ ] `make build`
- [ ] `make check`
- [ ] `go test ./internal/config -run TestEffectiveWorkQuery -count=1`
