### PR TITLE
fix: preserve dispatcher trace runtime root

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -261,7 +261,11 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	// wins over both passthroughEnv and the uniform city default seeded by
 	// cityRuntimeEnvMapForCity above.
 	if cfgAgent.Name == config.ControlDispatcherAgentName {
-		agentEnv["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"] = citylayout.ControlDispatcherTraceDefaultPathFor(p.cityPath, qualifiedName)
+		agentEnv["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"] = citylayout.ControlDispatcherTraceDefaultPathForRuntimeDirAndName(
+			p.cityPath,
+			agentEnv["GC_CITY_RUNTIME_DIR"],
+			qualifiedName,
+		)
 	}
 	agentEnv["GC_BEADS"] = rawBeadsProviderForScope(rigRoot, p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {

--- a/cmd/gc/template_resolve_env_test.go
+++ b/cmd/gc/template_resolve_env_test.go
@@ -135,6 +135,41 @@ func TestResolveTemplateUsesTrustedRuntimeRootForControlTraceDefault(t *testing.
 	}
 }
 
+func TestResolveTemplateUsesTrustedRuntimeRootForControlDispatcherTraceDefault(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	customRuntimeDir := filepath.Join(t.TempDir(), "runtime-root")
+	t.Setenv("GC_CITY_PATH", cityPath)
+	t.Setenv("GC_CITY_RUNTIME_DIR", customRuntimeDir)
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	qualifiedName := "app/" + config.ControlDispatcherAgentName
+	agent := &config.Agent{Name: config.ControlDispatcherAgentName, Dir: "app"}
+	tp, err := resolveTemplate(params, agent, qualifiedName, nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_CITY_RUNTIME_DIR"]; got != customRuntimeDir {
+		t.Fatalf("GC_CITY_RUNTIME_DIR = %q, want %q", got, customRuntimeDir)
+	}
+	wantTraceDefault := filepath.Join(customRuntimeDir, "app--control-dispatcher-trace.log")
+	if got := tp.Env["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"]; got != wantTraceDefault {
+		t.Fatalf("GC_CONTROL_DISPATCHER_TRACE_DEFAULT = %q, want %q", got, wantTraceDefault)
+	}
+}
+
 // TestResolveTemplateInjectsPerDispatcherTraceDefault asserts that
 // resolveTemplate produces a per-dispatcher GC_CONTROL_DISPATCHER_TRACE_DEFAULT
 // in agentEnv for control-dispatcher agents (closes #1650). The override


### PR DESCRIPTION
Maintainer follow-up for #1695 after the adoption review.

Original PR: https://github.com/gastownhall/gascity/pull/1695
Original title: fix(dispatch): per-dispatcher trace logs in .gc/runtime/ (#1650)
Original state: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none

#1695 already merged the contributor's per-dispatcher trace-log work. The adoption review found one remaining runtime-root issue: control-dispatcher trace defaults still ignored a trusted `GC_CITY_RUNTIME_DIR`, so dispatchers launched with an external runtime root could fall back under the city directory.

This follow-up contains only the maintainer-side fix from the adoption loop. It preserves the seeded runtime root when computing `GC_CONTROL_DISPATCHER_TRACE_DEFAULT` for control-dispatcher agents and adds regression coverage for an external runtime root.

Validation from the adoption workflow:

- Review attempt 2 approved the fix with no required changes.
- Local diff is `2 files changed, 40 insertions(+), 1 deletion(-)`.
- The branch was refreshed onto current `main` and the patch ID was preserved before push.
