### PR TITLE
feat(cmd/gc): split session start_call into provider+recovery sub-phases (gc-9ha)

### DIFF
--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -167,6 +167,44 @@ type startResult struct {
 	finished        time.Time
 	rollbackPending bool
 	rateLimitScreen bool
+	// phases captures sub-phase wall-clock so the lifecycle log can pinpoint
+	// where a slow start spent its time. See gc-67o for context.
+	phases startPhaseTimings
+}
+
+// startPhaseTimings breaks down a start operation into the discrete
+// sub-phases visible from runPreparedStartCandidate +
+// commitAsyncStartResultWithContext. Each duration is wall-clock; zero
+// means the phase did not execute (e.g. PostStartObserve only runs when
+// session_key is set, CommitRefresh only on the async path).
+type startPhaseTimings struct {
+	StartCall         time.Duration // startPreparedStartCandidate total (provider Start + any ErrStateSync recovery)
+	StateSyncRecovery time.Duration // workerSessionTargetRunningWithConfig branch when provider Start returned ErrStateSync (subset of StartCall; gc-9ha)
+	PostStartObserve  time.Duration // staleKeyDetectDelay + workerObserveSessionTarget when session_key present
+	CommitRefresh     time.Duration // refreshAsyncStartResult bead reload (async path only)
+}
+
+// formatLog returns the trailing segment to append to a lifecycle log
+// line, or "" when no phase ran. Zero phases are elided so a healthy
+// start without session_key remains a single phase=N field.
+func (p startPhaseTimings) formatLog() string {
+	if p.StartCall == 0 && p.StateSyncRecovery == 0 && p.PostStartObserve == 0 && p.CommitRefresh == 0 {
+		return ""
+	}
+	var parts []string
+	if p.StartCall > 0 {
+		parts = append(parts, fmt.Sprintf("start_call=%s", p.StartCall.Round(time.Millisecond)))
+	}
+	if p.StateSyncRecovery > 0 {
+		parts = append(parts, fmt.Sprintf("state_sync_recovery=%s", p.StateSyncRecovery.Round(time.Millisecond)))
+	}
+	if p.PostStartObserve > 0 {
+		parts = append(parts, fmt.Sprintf("post_start_observe=%s", p.PostStartObserve.Round(time.Millisecond)))
+	}
+	if p.CommitRefresh > 0 {
+		parts = append(parts, fmt.Sprintf("commit_refresh=%s", p.CommitRefresh.Round(time.Millisecond)))
+	}
+	return " phases=[" + strings.Join(parts, " ") + "]"
 }
 
 type startExecutionOptions struct {
@@ -314,6 +352,11 @@ type stopResult struct {
 	finished time.Time
 }
 
+// logLifecycleOutcome writes one structured "session lifecycle" line.
+// The trailing variadic phases parameter is honored when exactly one
+// startPhaseTimings is passed (more than one is a programmer error and
+// is silently ignored). Existing callers that don't care about phases
+// pass none.
 func logLifecycleOutcome(
 	w io.Writer,
 	op string,
@@ -321,6 +364,7 @@ func logLifecycleOutcome(
 	name, template, outcome string,
 	started, finished time.Time,
 	err error,
+	phases ...startPhaseTimings,
 ) {
 	if w == nil {
 		return
@@ -328,6 +372,9 @@ func logLifecycleOutcome(
 	msg := fmt.Sprintf("session lifecycle: op=%s wave=%d session=%s template=%s outcome=%s", op, wave, name, template, outcome)
 	if !started.IsZero() && !finished.IsZero() {
 		msg += fmt.Sprintf(" duration=%s", finished.Sub(started).Round(time.Millisecond))
+	}
+	if len(phases) == 1 {
+		msg += phases[0].formatLog()
 	}
 	if err != nil {
 		msg += fmt.Sprintf(" err=%s", formatLifecycleError(err))
@@ -835,20 +882,31 @@ func runPreparedStartCandidate(
 		startCtx, cancel = context.WithTimeout(ctx, startupTimeout)
 	}
 	defer cancel()
+	var phases startPhaseTimings
+	startCallBegin := time.Now()
 	_, err := startPreparedStartCandidate(startCtx, item, cityPath, store, sp, cfg)
 	startCtxErr := startCtx.Err()
+	// Split start_call into provider.Start and the ErrStateSync recovery
+	// branch (gc-9ha). The recovery branch hits the worker observation
+	// API which can dominate start_call when the runtime is wedged.
+	// state_sync_recovery only fires when err==ErrStateSync, so it stays
+	// zero on the happy path.
 	if err != nil && errors.Is(err, sessionpkg.ErrStateSync) {
+		recoveryBegin := time.Now()
 		running, runningErr := workerSessionTargetRunningWithConfig(cityPath, store, sp, cfg, item.candidate.name())
+		phases.StateSyncRecovery = time.Since(recoveryBegin)
 		if runningErr == nil && running {
 			err = nil
 		}
 	}
+	phases.StartCall = time.Since(startCallBegin)
 	// Stale session key detection: if the session was started
 	// with a resume flag but dies immediately, the session key
 	// likely references a conversation that no longer exists
 	// (e.g., "No conversation found"). Report as a failure so
 	// recordWakeFailure clears the key for the next attempt.
 	if err == nil && item.candidate.session != nil && item.candidate.session.Metadata["session_key"] != "" {
+		postStartBegin := time.Now()
 		time.Sleep(staleKeyDetectDelay)
 		running := false
 		alive := false
@@ -864,6 +922,7 @@ func runPreparedStartCandidate(
 		if err != nil || !running || !alive {
 			err = fmt.Errorf("session %q died during startup", item.candidate.name())
 		}
+		phases.PostStartObserve = time.Since(postStartBegin)
 	}
 	finished := time.Now()
 	rollbackPending := err != nil && shouldRollbackPendingCreate(item.candidate.session)
@@ -876,6 +935,7 @@ func runPreparedStartCandidate(
 			started:         started,
 			finished:        finished,
 			rollbackPending: false,
+			phases:          phases,
 		}
 	}
 	var outcome string
@@ -921,6 +981,7 @@ func runPreparedStartCandidate(
 		finished:        finished,
 		rollbackPending: rollbackPending,
 		rateLimitScreen: rateLimitScreen,
+		phases:          phases,
 	}
 }
 
@@ -1035,8 +1096,20 @@ func commitAsyncStartResultWithContext(
 		}
 	}()
 
+	refreshBegin := time.Now()
 	refreshed, ok, cleanupRuntime, releaseInFlight := refreshAsyncStartResult(result, store, stderr)
+	commitRefreshElapsed := time.Since(refreshBegin)
+	// Carry the per-phase timings forward: refresh's elapsed time is
+	// commit-side, distinct from the start phases captured in
+	// runPreparedStartCandidate. Both flow into the lifecycle log.
+	refreshed.phases.CommitRefresh = commitRefreshElapsed
 	if !ok {
+		// refreshAsyncStartResult does not always carry the original
+		// phases through on the !ok path; restore them so a stale
+		// commit still reports start_call / post_start_observe along
+		// with the now-known commit_refresh.
+		refreshed.phases.StartCall = result.phases.StartCall
+		refreshed.phases.PostStartObserve = result.phases.PostStartObserve
 		if cleanupRuntime {
 			stopStaleAsyncStartRuntime(result, sp, stderr)
 		}
@@ -1045,7 +1118,7 @@ func commitAsyncStartResultWithContext(
 			clearPendingStartInFlightLease(result.prepared.candidate.session, store, stderr)
 			outcome = "async_start_refresh_failed"
 		}
-		logLifecycleOutcome(stderr, "start", wave, name, template, outcome, result.started, time.Now(), nil)
+		logLifecycleOutcome(stderr, "start", wave, name, template, outcome, result.started, time.Now(), nil, refreshed.phases)
 		return false
 	}
 	if refreshed.err != nil && refreshed.rollbackPending && runningSessionMatchesPendingCreate(refreshed.prepared.candidate.session, refreshed.prepared.candidate.name(), sp) {
@@ -1061,7 +1134,7 @@ func commitAsyncStartResultWithContext(
 			stopStaleAsyncStartRuntime(refreshed, sp, stderr)
 			rollbackPendingCreate(refreshed.prepared.candidate.session, store, clk.Now().UTC(), stderr)
 		}
-		logLifecycleOutcome(stderr, "start", wave, name, template, "context_canceled", refreshed.started, time.Now(), ctx.Err())
+		logLifecycleOutcome(stderr, "start", wave, name, template, "context_canceled", refreshed.started, time.Now(), ctx.Err(), refreshed.phases)
 		return false
 	}
 	if sp != nil && refreshed.err == nil && refreshed.outcome != "session_initializing" {
@@ -1287,7 +1360,7 @@ func commitStartResultTraced(
 	// The reconciler will retry on the next patrol tick.
 	if result.outcome == "session_initializing" {
 		clearPendingStartInFlightLease(session, store, stderr)
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil, result.phases)
 		return false
 	}
 	if result.err != nil {
@@ -1319,7 +1392,7 @@ func commitStartResultTraced(
 				}, "")
 			}
 			rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
-			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
+			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 			return false
 		}
 		if err := store.SetMetadata(session.ID, "last_woke_at", ""); err != nil {
@@ -1333,7 +1406,7 @@ func commitStartResultTraced(
 				"error": formatLifecycleError(result.err),
 			}, "")
 		}
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 		return false
 	}
 	fmt.Fprintf(stdout, "Woke session '%s'\n", tp.DisplayName()) //nolint:errcheck
@@ -1366,7 +1439,7 @@ func commitStartResultTraced(
 	if err != nil {
 		clearPendingStartInFlightLease(session, store, stderr)
 		fmt.Fprintf(stderr, "session reconciler: encoding MCP snapshot for %s: %v\n", name, err) //nolint:errcheck
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "metadata_encode_failed", result.started, result.finished, err)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "metadata_encode_failed", result.started, result.finished, err, result.phases)
 		return false
 	}
 	if storedMCPSnapshot != "" || session.Metadata[sessionpkg.MCPServersSnapshotMetadataKey] != "" {
@@ -1375,7 +1448,7 @@ func commitStartResultTraced(
 	if err := sessionpkg.PersistRuntimeMCPServersSnapshot(result.prepared.cfg.Env["GC_CITY_PATH"], session.ID, result.prepared.cfg.MCPServers); err != nil {
 		clearPendingStartInFlightLease(session, store, stderr)
 		fmt.Fprintf(stderr, "session reconciler: storing runtime MCP snapshot for %s: %v\n", name, err) //nolint:errcheck
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "runtime_mcp_snapshot_failed", result.started, result.finished, err)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "runtime_mcp_snapshot_failed", result.started, result.finished, err, result.phases)
 		return false
 	}
 	if result.prepared.candidate.tp.IsACP ||
@@ -1403,7 +1476,7 @@ func commitStartResultTraced(
 		// (including the state transition to active). Report failure so
 		// the reconciler retries on the next tick rather than leaving
 		// the session stuck in "creating" where it gets orphan-drained.
-		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "metadata_batch_failed", result.started, result.finished, err)
+		logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, "metadata_batch_failed", result.started, result.finished, err, result.phases)
 		return false
 	}
 	if session.Metadata == nil {
@@ -1417,7 +1490,7 @@ func commitStartResultTraced(
 			"wave": wave,
 		}, "")
 	}
-	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil)
+	logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, nil, result.phases)
 	return true
 }
 

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -185,24 +185,34 @@ type startPhaseTimings struct {
 }
 
 // formatLog returns the trailing segment to append to a lifecycle log
-// line, or "" when no phase ran. Zero phases are elided so a healthy
-// start without session_key remains a single phase=N field.
+// line — a single " phases=[...]" field — or "" when no phase ran or
+// every phase rounds to sub-millisecond. The lifecycle log's primary
+// duration field stays the top-level "duration=" already emitted by
+// logLifecycleOutcome; this helper only adds the per-phase breakdown
+// when there is something nonzero to report.
+//
+// Rounding happens BEFORE the include decision so a phase shorter than
+// 0.5ms doesn't print as "...=0s" (which would be misleading and
+// defeat the elision intent). Sub-ms durations are dropped entirely.
 func (p startPhaseTimings) formatLog() string {
 	if p.StartCall == 0 && p.StateSyncRecovery == 0 && p.PostStartObserve == 0 && p.CommitRefresh == 0 {
 		return ""
 	}
 	var parts []string
-	if p.StartCall > 0 {
-		parts = append(parts, fmt.Sprintf("start_call=%s", p.StartCall.Round(time.Millisecond)))
+	if r := p.StartCall.Round(time.Millisecond); r > 0 {
+		parts = append(parts, fmt.Sprintf("start_call=%s", r))
 	}
-	if p.StateSyncRecovery > 0 {
-		parts = append(parts, fmt.Sprintf("state_sync_recovery=%s", p.StateSyncRecovery.Round(time.Millisecond)))
+	if r := p.StateSyncRecovery.Round(time.Millisecond); r > 0 {
+		parts = append(parts, fmt.Sprintf("state_sync_recovery=%s", r))
 	}
-	if p.PostStartObserve > 0 {
-		parts = append(parts, fmt.Sprintf("post_start_observe=%s", p.PostStartObserve.Round(time.Millisecond)))
+	if r := p.PostStartObserve.Round(time.Millisecond); r > 0 {
+		parts = append(parts, fmt.Sprintf("post_start_observe=%s", r))
 	}
-	if p.CommitRefresh > 0 {
-		parts = append(parts, fmt.Sprintf("commit_refresh=%s", p.CommitRefresh.Round(time.Millisecond)))
+	if r := p.CommitRefresh.Round(time.Millisecond); r > 0 {
+		parts = append(parts, fmt.Sprintf("commit_refresh=%s", r))
+	}
+	if len(parts) == 0 {
+		return ""
 	}
 	return " phases=[" + strings.Join(parts, " ") + "]"
 }
@@ -1091,7 +1101,10 @@ func commitAsyncStartResultWithContext(
 			err := fmt.Errorf("panic during async start commit: %v\n%s", recovered, debug.Stack())
 			clearPendingStartInFlightLease(result.prepared.candidate.session, store, stderr)
 			fmt.Fprintf(stderr, "session reconciler: committing async start %s: %s\n", name, formatLifecycleError(err)) //nolint:errcheck
-			logLifecycleOutcome(stderr, "start", wave, name, template, "panic_recovered", result.started, time.Now(), err)
+			// Pass the pre-refresh phases so commit-time panic diagnostics
+			// still show start_call / post_start_observe timings; commit_refresh
+			// may be unset if the panic fired before refreshAsyncStartResult.
+			logLifecycleOutcome(stderr, "start", wave, name, template, "panic_recovered", result.started, time.Now(), err, result.phases)
 			committed = false
 		}
 	}()
@@ -1104,12 +1117,11 @@ func commitAsyncStartResultWithContext(
 	// runPreparedStartCandidate. Both flow into the lifecycle log.
 	refreshed.phases.CommitRefresh = commitRefreshElapsed
 	if !ok {
-		// refreshAsyncStartResult does not always carry the original
-		// phases through on the !ok path; restore them so a stale
-		// commit still reports start_call / post_start_observe along
-		// with the now-known commit_refresh.
-		refreshed.phases.StartCall = result.phases.StartCall
-		refreshed.phases.PostStartObserve = result.phases.PostStartObserve
+		// refreshAsyncStartResult returns result unchanged on every !ok
+		// branch (store.Get error, stale prepared command, stale runtime
+		// session), so refreshed.phases already carries the original
+		// start_call / post_start_observe; only commit_refresh was
+		// stamped above. No restore needed.
 		if cleanupRuntime {
 			stopStaleAsyncStartRuntime(result, sp, stderr)
 		}
@@ -1374,7 +1386,7 @@ func commitStartResultTraced(
 						"cause": err.Error(),
 					}, "")
 				}
-				logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
+				logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 				return false
 			}
 			if trace != nil {
@@ -1382,7 +1394,7 @@ func commitStartResultTraced(
 					"error": formatLifecycleError(result.err),
 				}, "")
 			}
-			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err)
+			logLifecycleOutcome(stderr, "start", wave, name, tp.TemplateName, result.outcome, result.started, result.finished, result.err, result.phases)
 			return false
 		}
 		if result.rollbackPending {

--- a/cmd/gc/session_lifecycle_phases_test.go
+++ b/cmd/gc/session_lifecycle_phases_test.go
@@ -13,9 +13,9 @@ import (
 // without session_key still produces a single duration field.
 func TestStartPhaseTimingsFormatLog(t *testing.T) {
 	cases := []struct {
-		name    string
-		phases  startPhaseTimings
-		want    string
+		name   string
+		phases startPhaseTimings
+		want   string
 	}{
 		{
 			name:   "all zero elides",
@@ -49,10 +49,10 @@ func TestStartPhaseTimingsFormatLog(t *testing.T) {
 		{
 			name: "state_sync_recovery emits when nonzero (gc-9ha)",
 			phases: startPhaseTimings{
-				StartCall:          82 * time.Second,
-				StateSyncRecovery:  2 * time.Second,
-				PostStartObserve:   2 * time.Second,
-				CommitRefresh:      1 * time.Millisecond,
+				StartCall:         82 * time.Second,
+				StateSyncRecovery: 2 * time.Second,
+				PostStartObserve:  2 * time.Second,
+				CommitRefresh:     1 * time.Millisecond,
 			},
 			want: " phases=[start_call=1m22s state_sync_recovery=2s post_start_observe=2s commit_refresh=1ms]",
 		},

--- a/cmd/gc/session_lifecycle_phases_test.go
+++ b/cmd/gc/session_lifecycle_phases_test.go
@@ -78,6 +78,38 @@ func TestStartPhaseTimingsFormatLog(t *testing.T) {
 			},
 			want: " phases=[commit_refresh=12ms]",
 		},
+		{
+			// Regression: sub-0.5ms durations previously rendered as
+			// "...=0s" because the >0 check ran on the unrounded value
+			// but the printf used the rounded value. After the fix, the
+			// rounded value drives the include decision and sub-ms is
+			// elided entirely.
+			name: "sub-millisecond phases elide (no =0s artifacts)",
+			phases: startPhaseTimings{
+				StartCall:        100 * time.Microsecond,
+				PostStartObserve: 200 * time.Microsecond,
+				CommitRefresh:    400 * time.Microsecond,
+			},
+			want: "",
+		},
+		{
+			// Mix of sub-ms and ms+ durations: sub-ms phase elides, ms+ stays.
+			name: "sub-ms phase elides while ms+ peer survives",
+			phases: startPhaseTimings{
+				StartCall:        300 * time.Microsecond, // <0.5ms → elide
+				PostStartObserve: 5 * time.Second,
+			},
+			want: " phases=[post_start_observe=5s]",
+		},
+		{
+			// Boundary: 500µs rounds to 1ms (Go's time.Duration.Round uses
+			// half-away-from-zero), so it survives.
+			name: "0.5ms boundary survives as 1ms",
+			phases: startPhaseTimings{
+				StartCall: 500 * time.Microsecond,
+			},
+			want: " phases=[start_call=1ms]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/gc/session_lifecycle_phases_test.go
+++ b/cmd/gc/session_lifecycle_phases_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStartPhaseTimingsFormatLog covers the formatLog helper that gc-67o
+// uses to emit per-phase wall-clock segments in the session lifecycle log.
+// Zero-valued phases must elide entirely so a healthy synchronous start
+// without session_key still produces a single duration field.
+func TestStartPhaseTimingsFormatLog(t *testing.T) {
+	cases := []struct {
+		name    string
+		phases  startPhaseTimings
+		want    string
+	}{
+		{
+			name:   "all zero elides",
+			phases: startPhaseTimings{},
+			want:   "",
+		},
+		{
+			name: "start_call only",
+			phases: startPhaseTimings{
+				StartCall: 5 * time.Second,
+			},
+			want: " phases=[start_call=5s]",
+		},
+		{
+			name: "start and post_start_observe",
+			phases: startPhaseTimings{
+				StartCall:        5 * time.Second,
+				PostStartObserve: 2*time.Second + 100*time.Millisecond,
+			},
+			want: " phases=[start_call=5s post_start_observe=2.1s]",
+		},
+		{
+			name: "all three phases",
+			phases: startPhaseTimings{
+				StartCall:        65 * time.Second,
+				PostStartObserve: 2 * time.Second,
+				CommitRefresh:    50 * time.Millisecond,
+			},
+			want: " phases=[start_call=1m5s post_start_observe=2s commit_refresh=50ms]",
+		},
+		{
+			name: "state_sync_recovery emits when nonzero (gc-9ha)",
+			phases: startPhaseTimings{
+				StartCall:          82 * time.Second,
+				StateSyncRecovery:  2 * time.Second,
+				PostStartObserve:   2 * time.Second,
+				CommitRefresh:      1 * time.Millisecond,
+			},
+			want: " phases=[start_call=1m22s state_sync_recovery=2s post_start_observe=2s commit_refresh=1ms]",
+		},
+		{
+			name: "state_sync_recovery zero stays elided",
+			phases: startPhaseTimings{
+				StartCall:        4 * time.Second,
+				PostStartObserve: 2 * time.Second,
+			},
+			want: " phases=[start_call=4s post_start_observe=2s]",
+		},
+		{
+			name: "rounding to milliseconds",
+			phases: startPhaseTimings{
+				StartCall: 1234567 * time.Microsecond, // ~1.234567s
+			},
+			want: " phases=[start_call=1.235s]",
+		},
+		{
+			name: "commit_refresh only (e.g. stale_async_start with no run)",
+			phases: startPhaseTimings{
+				CommitRefresh: 12 * time.Millisecond,
+			},
+			want: " phases=[commit_refresh=12ms]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.phases.formatLog()
+			if got != tc.want {
+				t.Errorf("formatLog() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogLifecycleOutcomeWithPhases verifies that logLifecycleOutcome
+// emits the phases segment when a single startPhaseTimings is supplied
+// and omits it when none is. Existing call sites pass no variadic
+// argument; this guards backward compatibility.
+func TestLogLifecycleOutcomeWithPhases(t *testing.T) {
+	started := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	finished := started.Add(7 * time.Second)
+
+	t.Run("no phases (legacy callers)", func(t *testing.T) {
+		var buf bytes.Buffer
+		logLifecycleOutcome(&buf, "start", 0, "s-cos", "oversight-rig.cos", "success", started, finished, nil)
+		got := buf.String()
+		if !strings.Contains(got, "duration=7s") {
+			t.Errorf("missing duration=7s in %q", got)
+		}
+		if strings.Contains(got, "phases=") {
+			t.Errorf("legacy call should not emit phases segment: %q", got)
+		}
+	})
+
+	t.Run("phases segment when supplied", func(t *testing.T) {
+		var buf bytes.Buffer
+		phases := startPhaseTimings{
+			StartCall:        5 * time.Second,
+			PostStartObserve: 2 * time.Second,
+		}
+		logLifecycleOutcome(&buf, "start", 0, "s-cos", "oversight-rig.cos", "success", started, finished, nil, phases)
+		got := buf.String()
+		if !strings.Contains(got, "phases=[start_call=5s post_start_observe=2s]") {
+			t.Errorf("phases segment missing or malformed: %q", got)
+		}
+		if !strings.Contains(got, "duration=7s") {
+			t.Errorf("missing duration=7s in %q", got)
+		}
+	})
+
+	t.Run("zero phases tail elided", func(t *testing.T) {
+		var buf bytes.Buffer
+		// Pass an explicit zero startPhaseTimings — formatLog returns ""
+		// so the log line should not contain a phases segment.
+		logLifecycleOutcome(&buf, "start", 0, "s-cos", "oversight-rig.cos", "success", started, finished, nil, startPhaseTimings{})
+		got := buf.String()
+		if strings.Contains(got, "phases=") {
+			t.Errorf("zero phases should not emit segment: %q", got)
+		}
+	})
+
+	t.Run("error and phases coexist", func(t *testing.T) {
+		var buf bytes.Buffer
+		phases := startPhaseTimings{StartCall: 60 * time.Second}
+		logLifecycleOutcome(&buf, "start", 0, "s-cos", "oversight-rig.cos", "deadline_exceeded", started, finished, errCtxDeadline{}, phases)
+		got := buf.String()
+		if !strings.Contains(got, "phases=[start_call=1m0s]") {
+			t.Errorf("phases segment missing: %q", got)
+		}
+		if !strings.Contains(got, "err=ctx deadline") {
+			t.Errorf("err segment missing: %q", got)
+		}
+	})
+}
+
+// errCtxDeadline is a tiny test-local error so the log-coexistence subtest
+// doesn't pull in context.DeadlineExceeded indirectly.
+type errCtxDeadline struct{}
+
+func (errCtxDeadline) Error() string { return "ctx deadline" }


### PR DESCRIPTION
## Summary

Slow session starts surfaced as a single `start_call=Xs` field in the lifecycle log, which couldn't distinguish provider.Start latency from the `ErrStateSync` recovery branch (`workerSessionTargetRunningWithConfig`). This commit splits the timing into four discrete sub-phases captured on the parallel-start fast path so operators can pinpoint where a slow start spent its time.

## Sub-phases

- `start_call` — `startPreparedStartCandidate` total (provider Start + any ErrStateSync recovery)
- `state_sync_recovery` — `workerSessionTargetRunningWithConfig` branch when provider Start returned `ErrStateSync` (subset of `start_call`)
- `post_start_observe` — `staleKeyDetectDelay` + `workerObserveSessionTarget` when `session_key` is present
- `commit_refresh` — `refreshAsyncStartResult` bead reload (async path only)

Each duration is wall-clock; zero phases are elided so a healthy start without `session_key` remains a single `phase=N` field.

Lifecycle log line shape after this change:

```
session lifecycle: op=start ... outcome=success duration=6.336s phases=[start_call=2.683s post_start_observe=3.652s commit_refresh=1ms]
```

This already-shipping format was visible in supervisor logs across multiple PRs that touched the lifecycle path; this PR makes it intentional and surfaces the recovery branch when wedged.

## Files changed

- `cmd/gc/session_lifecycle_parallel.go` — new `startPhaseTimings` struct + `formatLog()`, threaded through the start path. Coexists with the existing `rateLimitScreen` field added later on `origin/main`.
- `cmd/gc/session_lifecycle_phases_test.go` — new file, table-driven tests for each phase combination + format-log elision.

## Conflict resolution note

Cherry-pick conflicted on `session_lifecycle_parallel.go` because `origin/main` independently added `rateLimitScreen bool` to the same struct. Resolved by keeping both fields. No semantic interaction: `rateLimitScreen` is a screening signal; `phases` is timing instrumentation.

## Test plan

- [ ] `make build`
- [ ] `make check`
- [ ] `go test ./cmd/gc -run TestStartPhase -count=1`
- [ ] inspect a real `gc supervisor restart` log to verify the new phase line shape

## Provenance

Cherry-picked from local maintainer branch `feat/slack-pack-px8-import` at commit `fb132d79` (originally written 2026-05-03). Original branch is being retired as obsolete; this is one of several commits from it that's still genuinely novel against current `origin/main`.
