### PR TITLE
Follow-up for #1695: preserve dispatcher trace runtime root

### DIFF
--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -261,7 +261,11 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 	// wins over both passthroughEnv and the uniform city default seeded by
 	// cityRuntimeEnvMapForCity above.
 	if cfgAgent.Name == config.ControlDispatcherAgentName {
-		agentEnv["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"] = citylayout.ControlDispatcherTraceDefaultPathFor(p.cityPath, qualifiedName)
+		agentEnv["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"] = citylayout.ControlDispatcherTraceDefaultPathForRuntimeDirAndName(
+			p.cityPath,
+			agentEnv["GC_CITY_RUNTIME_DIR"],
+			qualifiedName,
+		)
 	}
 	agentEnv["GC_BEADS"] = rawBeadsProviderForScope(rigRoot, p.cityPath)
 	if exe, err := os.Executable(); err == nil && exe != "" {

--- a/cmd/gc/template_resolve_env_test.go
+++ b/cmd/gc/template_resolve_env_test.go
@@ -135,6 +135,41 @@ func TestResolveTemplateUsesTrustedRuntimeRootForControlTraceDefault(t *testing.
 	}
 }
 
+func TestResolveTemplateUsesTrustedRuntimeRootForControlDispatcherTraceDefault(t *testing.T) {
+	cityPath := t.TempDir()
+	writeTemplateResolveCityConfig(t, cityPath, "file")
+	customRuntimeDir := filepath.Join(t.TempDir(), "runtime-root")
+	t.Setenv("GC_CITY_PATH", cityPath)
+	t.Setenv("GC_CITY_RUNTIME_DIR", customRuntimeDir)
+
+	params := &agentBuildParams{
+		cityName:   "city",
+		cityPath:   cityPath,
+		workspace:  &config.Workspace{Provider: "test"},
+		providers:  map[string]config.ProviderSpec{"test": {Command: "echo", PromptMode: "none"}},
+		lookPath:   func(string) (string, error) { return "/bin/echo", nil },
+		fs:         fsys.OSFS{},
+		beaconTime: time.Unix(0, 0),
+		beadNames:  make(map[string]string),
+		stderr:     io.Discard,
+	}
+
+	qualifiedName := "app/" + config.ControlDispatcherAgentName
+	agent := &config.Agent{Name: config.ControlDispatcherAgentName, Dir: "app"}
+	tp, err := resolveTemplate(params, agent, qualifiedName, nil)
+	if err != nil {
+		t.Fatalf("resolveTemplate: %v", err)
+	}
+
+	if got := tp.Env["GC_CITY_RUNTIME_DIR"]; got != customRuntimeDir {
+		t.Fatalf("GC_CITY_RUNTIME_DIR = %q, want %q", got, customRuntimeDir)
+	}
+	wantTraceDefault := filepath.Join(customRuntimeDir, "app--control-dispatcher-trace.log")
+	if got := tp.Env["GC_CONTROL_DISPATCHER_TRACE_DEFAULT"]; got != wantTraceDefault {
+		t.Fatalf("GC_CONTROL_DISPATCHER_TRACE_DEFAULT = %q, want %q", got, wantTraceDefault)
+	}
+}
+
 // TestResolveTemplateInjectsPerDispatcherTraceDefault asserts that
 // resolveTemplate produces a per-dispatcher GC_CONTROL_DISPATCHER_TRACE_DEFAULT
 // in agentEnv for control-dispatcher agents (closes #1650). The override


### PR DESCRIPTION
Maintainer follow-up for #1695 after the original PR was already merged.

Original PR: https://github.com/gastownhall/gascity/pull/1695
Original title: fix(dispatch): per-dispatcher trace logs in .gc/runtime/ (#1650)
Original state at finalization: MERGED
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up carries only the maintainer-side fix identified during adoption review. The original contribution in #1695 added per-dispatcher trace files under `.gc/runtime/`; this follow-up preserves the trusted runtime root when a dispatcher is spawned with `GC_CITY_RUNTIME_DIR` set, so custom runtime directories do not fall back to the city default. It also adds regression coverage for a rig-qualified control dispatcher using an external runtime root.

Review summary:
- Iteration 1 found that control-dispatcher trace default injection ignored the trusted `GC_CITY_RUNTIME_DIR` and lacked regression coverage for an external runtime root.
- The follow-up patch now computes `GC_CONTROL_DISPATCHER_TRACE_DEFAULT` from `agentEnv["GC_CITY_RUNTIME_DIR"]` with the runtime-dir-aware citylayout helper.
- The new regression test covers `app/control-dispatcher` with a trusted external runtime directory and verifies the dispatcher-specific trace file remains under that root.
- Iteration 2 approved the fix; remaining notes were non-gating cleanup/readability items.

Local/visible validation before opening:
- Adoption review attempt 2 approved the refreshed head.
- Base refresh replayed the patch onto latest `main` with the same stable patch ID.
- Pre-approval CI on the original merge surface was passing before this follow-up was opened.

_Opened by the `/adopt-pr` workflow finalization for rig bead `ga-5az4ms`._
