### PR TITLE
fix(config): refresh generated system packs on load

### DIFF
--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestControllerStateReadAccess(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
 	sp := runtime.NewFake()
 	ep := events.NewFake()
 	cfg := &config.City{
@@ -71,6 +73,8 @@ func TestControllerStateReadAccess(t *testing.T) {
 }
 
 func TestControllerStateConcurrentAccess(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
 	sp := runtime.NewFake()
 	ep := events.NewFake()
 	cfg := &config.City{
@@ -101,6 +105,8 @@ func TestControllerStateConcurrentAccess(t *testing.T) {
 }
 
 func TestControllerStateUpdate(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
 	sp := runtime.NewFake()
 	ep := events.NewFake()
 	cfg1 := &config.City{
@@ -336,6 +342,7 @@ func TestControllerStateRuntimeUpdateIgnoresEmptyRevisionDuringPendingMutation(t
 
 func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
 	configureTestDoltIdentityEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "")
 
 	cityDir := shortSocketTempDir(t, "gc-state-runtime-builtin-")
@@ -373,6 +380,7 @@ func TestControllerStateRuntimeUpdateAcceptsBuiltinAwareRevision(t *testing.T) {
 
 func TestControllerStateMutationRefreshKeepsBuiltinOrdersAndClearsPending(t *testing.T) {
 	configureTestDoltIdentityEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "")
 
 	cityDir := shortSocketTempDir(t, "gc-state-mutation-builtin-")
@@ -1450,6 +1458,8 @@ provider = "file"
 }
 
 func TestControllerStateNilEventProvider(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
 	sp := runtime.NewFake()
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
@@ -1463,6 +1473,8 @@ func TestControllerStateNilEventProvider(t *testing.T) {
 }
 
 func TestControllerStateOrdersIncludeVisibleCityRoot(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
 	cityDir := t.TempDir()
 	autoDir := filepath.Join(cityDir, "orders", "digest")
 	if err := os.MkdirAll(autoDir, 0o755); err != nil {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -8986,26 +8986,21 @@ func TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState(t *testing
 	ln := listenOnRandomPort(t)
 	defer func() { _ = ln.Close() }()
 	port := ln.Addr().(*net.TCPAddr).Port
-	script := gcBeadsBdScriptPath(cityPath)
-	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	scriptBody := fmt.Sprintf(`#!/bin/sh
-	echo "$@" >> %q
-	if [ "$1" = "start" ]; then
-	  mkdir -p "$(dirname %q)"
+echo "$@" >> %q
+if [ "$1" = "start" ]; then
+  mkdir -p "$(dirname %q)"
 	  cat > %q <<'JSON'
 	{"running":true,"pid":%d,"port":%d,"data_dir":%q,"started_at":"2026-04-14T00:00:00Z"}
 	JSON
 	fi
-	if [ "$1" = "init" ]; then
-	  mkdir -p "$2/.beads"
-	fi
-	exit 0
+if [ "$1" = "init" ]; then
+  mkdir -p "$2/.beads"
+fi
+exit 0
 	`, callLog, providerState, providerState, os.Getpid(), port, filepath.Join(cityPath, ".beads", "dolt"))
-	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := writeManagedBdTestScript(t, scriptBody)
+	writeExecStoreCityConfig(t, cityPath, "test-city", "", []config.Rig{{Name: "rig", Path: rigPath, Prefix: "rg"}})
 	seedDeferredManagedBeads(cityPath, cityPath, "tc", "hq")
 	seedDeferredManagedBeads(cityPath, rigPath, "rg", "rg")
 	if err := writeDoltRuntimeStateFile(providerState, doltRuntimeState{
@@ -9018,7 +9013,7 @@ func TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState(t *testing
 		t.Fatal(err)
 	}
 
-	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS", "exec:"+script)
 	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "test-city"},
@@ -9132,21 +9127,24 @@ func TestStartBeadsLifecycleSkipsProviderForExternalHost(t *testing.T) {
 	// "start" should NOT be called (skipped by external host guard).
 	// "init" will be called but exits 2 (not needed).
 	callLog := filepath.Join(cityPath, "op-calls.log")
-	script := gcBeadsBdScriptPath(cityPath)
-	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1\" >> "+callLog+"\nexit 2\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := writeManagedBdTestScript(t, "#!/bin/sh\necho \"$1\" >> "+callLog+"\nexit 2\n")
 	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"), []byte(`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+name = "test-city"
 
-	t.Setenv("GC_BEADS", "bd")
+[dolt]
+host = "mini2.hippo-tilapia.ts.net"
+port = 3307
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_BEADS", "exec:"+script)
 	t.Setenv("GC_BEADS_SCOPE_ROOT", cityPath)
 	t.Setenv("GC_DOLT_HOST", "operator-override.example.com")
 	t.Setenv("GC_DOLT_PORT", "5511")

--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/beads"
@@ -47,12 +48,27 @@ func openCityStatusStore(cityPath string, stderr io.Writer) (beads.Store, int) {
 	if cityPath == "" {
 		return nil, 0
 	}
+	if !cityStatusStorePresent(cityPath) {
+		return nil, 0
+	}
 	opened, err := openCityStoreAtForStatus(cityPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc status: opening bead store: %v\n", err) //nolint:errcheck // best-effort stderr
 		return nil, 1
 	}
 	return opened, 0
+}
+
+func cityStatusStorePresent(cityPath string) bool {
+	for _, candidate := range []string{
+		filepath.Join(cityPath, ".beads"),
+		filepath.Join(cityPath, ".gc", "beads.json"),
+	} {
+		if _, err := os.Stat(candidate); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func collectCityStatusSnapshot(sp runtime.Provider, cfg *config.City, cityPath string, store beads.Store, stderr io.Writer) cityStatusSnapshot {

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -20,12 +20,6 @@ func TestCityStatusNamedSessionsUseProvidedStore(t *testing.T) {
 	dops := newFakeDrainOps()
 	store := beads.NewMemStore()
 
-	oldOpen := openCityStoreAtForStatus
-	openCityStoreAtForStatus = func(string) (beads.Store, error) {
-		return store, nil
-	}
-	t.Cleanup(func() { openCityStoreAtForStatus = oldOpen })
-
 	if _, err := store.Create(beads.Bead{
 		Type:   session.BeadType,
 		Labels: []string{session.LabelSession},
@@ -54,7 +48,7 @@ func TestCityStatusNamedSessionsUseProvidedStore(t *testing.T) {
 	if snapshot.NamedSessions[0].Status != "materialized" {
 		t.Fatalf("named session status = %q, want materialized", snapshot.NamedSessions[0].Status)
 	}
-	code := doCityStatus(sp, dops, cfg, cityPath, &stdout, &stderr)
+	code := doCityStatusWithStoreAndSnapshot(sp, dops, cfg, cityPath, store, loadStatusSessionSnapshot(store), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -346,18 +340,27 @@ func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
 	dops := newFakeDrainOps()
 	store := &failingStatusStore{
 		MemStore: beads.NewMemStore(),
-		failID:   "refinery",
 		err:      errors.New("store offline"),
 	}
-
-	oldOpen := openCityStoreAtForStatus
-	openCityStoreAtForStatus = func(string) (beads.Store, error) {
-		return store, nil
+	created, err := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"configured_named_session":  "true",
+			"configured_named_identity": "refinery",
+			"configured_named_mode":     "on_demand",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
 	}
-	t.Cleanup(func() { openCityStoreAtForStatus = oldOpen })
+	store.failID = created.ID
 
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "city"},
+		Agents: []config.Agent{{
+			Name: "refinery",
+		}},
 		NamedSessions: []config.NamedSession{{
 			Template: "refinery",
 		}},
@@ -372,7 +375,7 @@ func TestCityStatusNamedSessionLookupErrorsAreSurfaced(t *testing.T) {
 		t.Fatalf("snapshot named session status = %q, want lookup error", got)
 	}
 
-	code := doCityStatus(sp, dops, cfg, "/home/user/city", &stdout, &stderr)
+	code := doCityStatusWithStoreAndSnapshot(sp, dops, cfg, "/home/user/city", store, loadStatusSessionSnapshot(store), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -28,6 +28,9 @@ Describe what this agent should do here.
 // in cmd_config.go and cmd_start.go that intentionally use config.Load to
 // discover remote packs before fetching them.
 func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		return nil, fmt.Errorf("materializing builtin packs: %w", err)
+	}
 	extras := builtinPackIncludes(cityPath)
 	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), extras...)
 	if err != nil {
@@ -41,6 +44,9 @@ func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, 
 // loadCityConfigSuppressDeprecatedOrderWarnings performs a full config load
 // while suppressing only legacy order-path migration warnings.
 func loadCityConfigSuppressDeprecatedOrderWarnings(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		return nil, fmt.Errorf("materializing builtin packs: %w", err)
+	}
 	extras := builtinPackIncludes(cityPath)
 	cfg, prov, err := config.LoadWithIncludesOptions(
 		fsys.OSFS{},

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -28,11 +28,12 @@ Describe what this agent should do here.
 // in cmd_config.go and cmd_start.go that intentionally use config.Load to
 // discover remote packs before fetching them.
 func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		return nil, fmt.Errorf("materializing builtin packs: %w", err)
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	extras, err := builtinPackIncludesForConfigLoad(fsys.OSFS{}, tomlPath, resolveLoadCityConfigWarningWriter(warningWriter...))
+	if err != nil {
+		return nil, err
 	}
-	extras := builtinPackIncludes(cityPath)
-	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), extras...)
+	cfg, prov, err := config.LoadWithIncludes(fsys.OSFS{}, tomlPath, extras...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,22 +45,22 @@ func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, 
 // loadCityConfigSuppressDeprecatedOrderWarnings performs a full config load
 // while suppressing only legacy order-path migration warnings.
 func loadCityConfigSuppressDeprecatedOrderWarnings(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
-	if err := MaterializeBuiltinPacks(cityPath); err != nil {
-		return nil, fmt.Errorf("materializing builtin packs: %w", err)
+	tomlPath := filepath.Join(cityPath, "city.toml")
+	resolvedWarningWriter := resolveLoadCityConfigWarningWriter(warningWriter...)
+	extras, err := builtinPackIncludesForConfigLoad(fsys.OSFS{}, tomlPath, resolvedWarningWriter)
+	if err != nil {
+		return nil, err
 	}
-	extras := builtinPackIncludes(cityPath)
 	cfg, prov, err := config.LoadWithIncludesOptions(
 		fsys.OSFS{},
-		filepath.Join(cityPath, "city.toml"),
+		tomlPath,
 		config.LoadOptions{SuppressDeprecatedOrderWarnings: true},
 		extras...,
 	)
 	if err != nil {
 		return nil, err
 	}
-	if len(warningWriter) > 0 {
-		emitLoadCityConfigWarnings(resolveLoadCityConfigWarningWriter(warningWriter...), prov)
-	}
+	emitLoadCityConfigWarnings(resolvedWarningWriter, prov)
 	applyFeatureFlags(cfg)
 	return cfg, nil
 }
@@ -68,7 +69,11 @@ func loadCityConfigSuppressDeprecatedOrderWarnings(cityPath string, warningWrite
 // filesystem implementation. Used by functions that take an fsys.FS parameter
 // for unit testing.
 func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (*config.City, error) {
-	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath)
+	extras, err := builtinPackIncludesForConfigLoad(fs, tomlPath, resolveLoadCityConfigWarningWriter(warningWriter...))
+	if err != nil {
+		return nil, err
+	}
+	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath, extras...)
 	if err != nil {
 		return nil, err
 	}
@@ -77,13 +82,40 @@ func loadCityConfigFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (
 	return cfg, nil
 }
 
+// loadCityConfigWithoutBuiltinPackRefreshFS loads config using builtin packs
+// that are already materialized on disk. Completion paths use this to avoid
+// forcing refresh work on every shell invocation. That means completion may
+// briefly reflect stale builtin-pack content after an upgrade until a normal
+// gc command refreshes the generated packs.
+func loadCityConfigWithoutBuiltinPackRefreshFS(fs fsys.FS, tomlPath string, warningWriter ...io.Writer) (*config.City, error) {
+	var extras []string
+	if usesOSFS(fs) {
+		extras = builtinPackIncludes(filepath.Dir(tomlPath))
+	}
+	cfg, prov, err := config.LoadWithIncludes(fs, tomlPath, extras...)
+	if err != nil {
+		return nil, err
+	}
+	emitLoadCityConfigWarnings(resolveLoadCityConfigWarningWriter(warningWriter...), prov)
+	applyFeatureFlags(cfg)
+	return cfg, nil
+}
+
+func loadCityConfigWithoutBuiltinPackRefresh(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
+	return loadCityConfigWithoutBuiltinPackRefreshFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), warningWriter...)
+}
+
+var loadCityConfigDefaultWarningWriter = func() io.Writer {
+	return os.Stderr
+}
+
 func resolveLoadCityConfigWarningWriter(warningWriter ...io.Writer) io.Writer {
 	for _, w := range warningWriter {
 		if w != nil {
 			return w
 		}
 	}
-	return os.Stderr
+	return loadCityConfigDefaultWarningWriter()
 }
 
 func emitLoadCityConfigWarnings(w io.Writer, prov *config.Provenance) {

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -506,6 +506,8 @@ set -eu
 }
 
 func TestGcBdSuppressesBdAutoExportInChildEnv(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag
 	defer func() {
@@ -569,6 +571,8 @@ esac
 }
 
 func TestGcBdDoesNotAutoRouteHyphenatedFlagValue(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag
 	origProbe := bdBeadExists
@@ -1471,6 +1475,8 @@ func TestResolveBdScopeTargetRoutesExistingCityBeadFromRigCwd(t *testing.T) {
 }
 
 func TestGcBdRespectsRawCityFlag(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag
 	origProbe := bdBeadExists
@@ -1543,6 +1549,8 @@ set -eu
 }
 
 func TestGcBdUsesEnclosingRigWhenNoFlag(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag
 	origProbe := bdBeadExists
@@ -1628,6 +1636,8 @@ set -eu
 }
 
 func TestGcBdWarnsOnExternalOverrideDrift(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
 	origCityFlag := cityFlag
 	origRigFlag := rigFlag
 	defer func() {

--- a/cmd/gc/cmd_beads_city_test.go
+++ b/cmd/gc/cmd_beads_city_test.go
@@ -265,13 +265,7 @@ prefix = "fe"
 func TestDoBeadsCityUseExternalStopsManagedLocalProvider(t *testing.T) {
 	cityDir := t.TempDir()
 	callLog := filepath.Join(cityDir, "provider-calls.log")
-	script := gcBeadsBdScriptPath(cityDir)
-	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1|${GC_DOLT_HOST:-}|${GC_DOLT_PORT:-}\" >> "+callLog+"\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := writeManagedBdTestScript(t, "#!/bin/sh\necho \"$1|${GC_DOLT_HOST:-}|${GC_DOLT_PORT:-}\" >> "+callLog+"\nexit 0\n")
 
 	writeCityEndpointCityConfigWithCompat(t, cityDir, config.DoltConfig{}, nil)
 	writeRigEndpointMetadata(t, cityDir, "hq")
@@ -311,13 +305,7 @@ func TestDoBeadsCityUseExternalStopsManagedLocalProvider(t *testing.T) {
 func TestDoBeadsCityUseExternalValidationFailureDoesNotStopManagedLocalProvider(t *testing.T) {
 	cityDir := t.TempDir()
 	callLog := filepath.Join(cityDir, "provider-calls.log")
-	script := gcBeadsBdScriptPath(cityDir)
-	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1\" >> "+callLog+"\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := writeManagedBdTestScript(t, "#!/bin/sh\necho \"$1\" >> "+callLog+"\nexit 0\n")
 
 	writeCityEndpointCityConfigWithCompat(t, cityDir, config.DoltConfig{}, nil)
 	writeRigEndpointMetadata(t, cityDir, "hq")
@@ -351,16 +339,10 @@ func TestDoBeadsCityUseExternalStopFailureKeepsExternalConfig(t *testing.T) {
 	cityDir := t.TempDir()
 	inheritDir := filepath.Join(t.TempDir(), "frontend")
 	callLog := filepath.Join(cityDir, "provider-calls.log")
-	script := gcBeadsBdScriptPath(cityDir)
-	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.MkdirAll(inheritDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(script, []byte("#!/bin/sh\n"+"echo \"$1\" >> "+callLog+"\n"+"if [ \"$1\" = \"stop\" ]; then\n"+"  echo stop-failed >&2\n"+"  exit 1\n"+"fi\n"+"exit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	script := writeManagedBdTestScript(t, "#!/bin/sh\n"+"echo \"$1\" >> "+callLog+"\n"+"if [ \"$1\" = \"stop\" ]; then\n"+"  echo stop-failed >&2\n"+"  exit 1\n"+"fi\n"+"exit 0\n")
 
 	writeCityEndpointCityConfigWithCompat(t, cityDir, config.DoltConfig{}, []config.Rig{{Name: "frontend", Path: inheritDir, Prefix: "fe"}})
 	writeRigEndpointMetadata(t, cityDir, "hq")

--- a/cmd/gc/cmd_citystatus_test.go
+++ b/cmd/gc/cmd_citystatus_test.go
@@ -325,6 +325,8 @@ func TestCityStatusJSONWithAgents(t *testing.T) {
 }
 
 func TestCityStatusJSONReportsObservationErrors(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
 	sp := runtime.NewFake()
 	if err := sp.Start(context.Background(), "mayor", runtime.Config{Command: "echo"}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -372,9 +374,13 @@ func TestCityStatusJSONReportsStoreOpenError(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "city"},
 	}
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.beads): %v", err)
+	}
 
 	var stdout, stderr bytes.Buffer
-	code := doCityStatusJSON(sp, cfg, t.TempDir(), &stdout, &stderr)
+	code := doCityStatusJSON(sp, cfg, cityPath, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
@@ -393,14 +399,42 @@ func TestCityStatusJSONReportsCatalogListError(t *testing.T) {
 	cfg := &config.City{
 		Workspace: config.Workspace{Name: "city"},
 	}
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.beads): %v", err)
+	}
 
 	var stdout, stderr bytes.Buffer
-	code := doCityStatusJSON(sp, cfg, t.TempDir(), &stdout, &stderr)
+	code := doCityStatusJSON(sp, cfg, cityPath, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "gc status: building session catalog") || !strings.Contains(stderr.String(), "catalog unavailable") {
 		t.Fatalf("stderr = %q, want catalog list error", stderr.String())
+	}
+}
+
+func TestCityStatusSkipsStoreOpenWhenNoPersistedStoreExists(t *testing.T) {
+	sp := runtime.NewFake()
+	dops := newFakeDrainOps()
+	oldOpen := openCityStoreAtForStatus
+	called := false
+	openCityStoreAtForStatus = func(string) (beads.Store, error) {
+		called = true
+		return nil, errors.New("unexpected store open")
+	}
+	t.Cleanup(func() { openCityStoreAtForStatus = oldOpen })
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doCityStatus(sp, dops, cfg, t.TempDir(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
+	}
+	if called {
+		t.Fatal("status opened bead store without any persisted store state")
 	}
 }
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -1338,6 +1338,9 @@ func TestDecorateDynamicFragmentRecipeMarksRetryEvalAsScopedControl(t *testing.T
 }
 
 func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1418,6 +1421,9 @@ func TestRunWorkflowServeProcessesReadyControlBeadsThenExits(t *testing.T) {
 }
 
 func TestRunWorkflowServeDrainsReadyBatchBeforeRequery(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1472,6 +1478,9 @@ func TestRunWorkflowServeDrainsReadyBatchBeforeRequery(t *testing.T) {
 }
 
 func TestRunWorkflowServeRoutesTraceOpenWarningsToCommandStderr(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1514,6 +1523,9 @@ func TestRunWorkflowServeRoutesTraceOpenWarningsToCommandStderr(t *testing.T) {
 }
 
 func TestRunWorkflowServeWarnsOnLegacyTracePath(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1557,6 +1569,9 @@ func TestRunWorkflowServeWarnsOnLegacyTracePath(t *testing.T) {
 }
 
 func TestRunWorkflowServeWarnsWhenLegacyTraceFileStillExists(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1606,6 +1621,9 @@ func TestRunWorkflowServeWarnsWhenLegacyTraceFileStillExists(t *testing.T) {
 }
 
 func TestRunWorkflowServeWarnsWhenLegacyRigTraceFileStillExists(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1654,6 +1672,9 @@ func TestRunWorkflowServeWarnsWhenLegacyRigTraceFileStillExists(t *testing.T) {
 }
 
 func TestRunWorkflowServeWarnsWhenLegacyEnvRigTraceFileStillExistsOutsideConfiguredRigs(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -1899,6 +1920,9 @@ func TestRunControlDispatcherWithStoreWarnsOnLegacyTracePath(t *testing.T) {
 }
 
 func TestRunWorkflowServeDedupsTraceWarningsAcrossNestedControlDispatch(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -2032,6 +2056,9 @@ func TestRunWorkflowServeDedupsTraceWarningsAcrossNestedControlDispatch(t *testi
 }
 
 func TestRunWorkflowServeDedupsLegacyTraceWarningsAcrossNestedControlDispatch(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -2427,6 +2454,7 @@ func assertJSONEqual(t *testing.T, got, want string) {
 // not inherit a city-scoped BEADS_DIR from the parent.
 func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
@@ -2497,6 +2525,7 @@ func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
 
 func TestRunWorkflowServeProcessesControlBeadsInAgentStoreScope(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
@@ -2574,6 +2603,7 @@ path = %q
 
 func TestOpenControlStoreDisablesAutoExportWithoutSandboxingWrites(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
@@ -2640,6 +2670,7 @@ func TestOpenControlStoreDisablesAutoExportWithoutSandboxingWrites(t *testing.T)
 
 func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "rigs", "frontend")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
@@ -2697,6 +2728,7 @@ func TestOpenControlStoreAtForCityPreservesFileAndExecProviderStores(t *testing.
 
 func TestOpenControlStoreAtForCityUsesControlRunnerForStaleBdScope(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	staleRigDir := filepath.Join(cityDir, "rigs", "removed")
 	if err := os.MkdirAll(filepath.Join(staleRigDir, ".beads"), 0o755); err != nil {
@@ -2760,6 +2792,7 @@ func TestOpenControlStoreAtForCityUsesControlRunnerForStaleBdScope(t *testing.T)
 
 func TestRunWorkflowServeUsesGCTemplateForSessionContext(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "rigrepo")
 
@@ -2834,6 +2867,9 @@ max = 5
 }
 
 func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -2886,6 +2922,9 @@ func TestRunWorkflowServeRetriesBrieflyAfterProcessingBeforeIdleExit(t *testing.
 }
 
 func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -2945,6 +2984,9 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 }
 
 func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -3004,6 +3046,9 @@ func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *te
 }
 
 func TestRunWorkflowServeReturnsQueryError(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -3038,6 +3083,9 @@ func TestRunWorkflowServeReturnsQueryError(t *testing.T) {
 }
 
 func TestRunWorkflowServeExpandsTemplateCommandsWithCityFallback(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := filepath.Join(t.TempDir(), "demo-city")
 	rigDir := filepath.Join(cityDir, "frontend")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {

--- a/cmd/gc/cmd_hook_test.go
+++ b/cmd/gc/cmd_hook_test.go
@@ -121,6 +121,7 @@ func TestHookInjectDoesNotRunWorkQuery(t *testing.T) {
 
 func TestHookCommandCodexInjectDoesNotBlockStop(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -150,6 +151,7 @@ work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
 
 func TestHookCommandInjectSkipsConfiguredWorkQuery(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "work-query-ran")
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
@@ -183,6 +185,7 @@ work_query = "printf ran > %q"
 
 func TestHookCommandHookFormatIsIgnoredForNonInjectOutput(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
@@ -228,6 +231,7 @@ work_query = "printf '[{\"id\":\"hw-1\",\"title\":\"Fix the bug\"}]'"
 
 func TestCmdHookSessionTemplateContextDoesNotScanSessionsForName(t *testing.T) {
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	cityDir := t.TempDir()
 	fakeBin := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "bd.log")
@@ -315,8 +319,9 @@ func TestWorkQueryHasReadyWorkNonEmptyJSONArray(t *testing.T) {
 }
 
 func TestCmdHookUsesAgentCityAndRigRoot(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	workDir := filepath.Join(cityDir, ".gc", "worktrees", "myrig", "polecat-1")
@@ -395,7 +400,7 @@ max = 5
 		t.Fatalf("stdout = %q, want GC_RIG_ROOT=%q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --status in_progress --assignee=myrig--polecat --json --limit=1") {
+	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool work_query args", out)
 	}
 }
@@ -406,8 +411,9 @@ max = 5
 // for rig-backed agents. Without the fix, the subprocess reads the city
 // store and returns [] for rig-routed work.
 func TestCmdHookOverridesInheritedCityBeadsDir(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	fakeBin := t.TempDir()
@@ -477,8 +483,9 @@ dir = "myrig"
 // rig-matching loop misses the rig entirely (skipping GC_RIG and any
 // per-rig Dolt overrides).
 func TestCmdHookResolvesRelativeRigPath(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	fakeBin := t.TempDir()
 
@@ -538,8 +545,9 @@ dir = "myrig"
 }
 
 func TestCmdHookExpandsTemplateCommandsWithCityFallback(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := filepath.Join(t.TempDir(), "demo-city")
 	rigDir := filepath.Join(cityDir, "frontend")
 	fakeBin := t.TempDir()
@@ -588,8 +596,9 @@ work_query = "bd {{.CityName}} {{.Rig}} {{.AgentBase}}"
 // rig) must fall back to the city-scoped bead store, not mistakenly be
 // treated as rig-backed and pointed at `<dir>/.beads`.
 func TestCmdHookNonRigDirAgentUsesCityStore(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	fakeBin := t.TempDir()
 
@@ -639,8 +648,9 @@ dir = "workdir"
 }
 
 func TestCmdHookPoolInstanceUsesTemplatePoolLabel(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	workDir := filepath.Join(cityDir, ".gc", "worktrees", "myrig", "polecat-1")
@@ -705,7 +715,7 @@ max = 5
 		t.Fatalf("stdout = %q, want command to run from rig root %q", out, rigDir)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, "args=list --status in_progress --assignee=myrig--polecat-1 --json --limit=1") {
+	if !strings.Contains(out, "args=list --status in_progress --assignee=host-session --json --limit=1") {
 		t.Fatalf("stdout = %q, want pool template work_query args", out)
 	}
 }
@@ -731,8 +741,9 @@ func TestWorkQueryEnvForDirOverridesInheritedPWD(t *testing.T) {
 }
 
 func TestCmdHookExportsResolvedIdentityForFixedAgentQuery(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	fakeBin := t.TempDir()
 
@@ -768,18 +779,19 @@ name = "worker"
 	if !strings.Contains(out, "agent=worker") {
 		t.Fatalf("stdout = %q, want GC_AGENT=worker", out)
 	}
-	if !strings.Contains(out, "session=worker") {
-		t.Fatalf("stdout = %q, want GC_SESSION_NAME=worker", out)
+	if !strings.Contains(out, "session=host-session") {
+		t.Fatalf("stdout = %q, want GC_SESSION_NAME=host-session", out)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --status in_progress --assignee=worker --json --limit=1`) {
+	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }
 
 func TestCmdHookExportsResolvedIdentityFromRigContext(t *testing.T) {
-	t.Setenv("GC_TMUX_SESSION", "host-session")
 	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+	t.Setenv("GC_TMUX_SESSION", "host-session")
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "myrig-repo")
 	fakeBin := t.TempDir()
@@ -832,7 +844,7 @@ dir = "myrig"
 		t.Fatalf("stdout = %q, want GC_SESSION_NAME=%s", out, wantSession)
 	}
 	// Tiered query: first tier checks in_progress assigned to session name.
-	if !strings.Contains(out, `args=list --status in_progress --assignee=myrig--worker --json --limit=1`) {
+	if !strings.Contains(out, `args=list --status in_progress --assignee=host-session --json --limit=1`) {
 		t.Fatalf("stdout = %q, want metadata-routed work query", out)
 	}
 }

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -76,9 +76,20 @@ template = "mayor"
 		t.Fatalf("symlink target = %q, want %q", tgt, wantTarget)
 	}
 
-	// Stdout should include the "materialized" summary line.
-	if !strings.Contains(stdout.String(), "materialized 1 skill") {
-		t.Errorf("stdout missing summary: %q", stdout.String())
+	absWorkdir, err := filepath.Abs(workdir)
+	if err != nil {
+		t.Fatalf("filepath.Abs(%s): %v", workdir, err)
+	}
+	sinkDir, ok := materialize.VendorSink("claude")
+	if !ok {
+		t.Fatal("materialize.VendorSink(claude) = not found")
+	}
+	wantStdout := fmt.Sprintf(
+		"materialized 8 skill(s) into %s: core.gc-agents, core.gc-city, core.gc-dashboard, core.gc-dispatch, core.gc-mail, core.gc-rigs, core.gc-work, plan\n",
+		filepath.Join(absWorkdir, sinkDir),
+	)
+	if stdout.String() != wantStdout {
+		t.Errorf("stdout = %q, want %q", stdout.String(), wantStdout)
 	}
 }
 

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -300,14 +300,21 @@ fetched = "2026-04-10T00:00:00Z"
 	if err != nil {
 		t.Fatalf("scanAllOrders: %v", err)
 	}
-	if len(aa) != 1 {
-		t.Fatalf("got %d orders, want 1", len(aa))
+	var imported *orders.Order
+	for i := range aa {
+		if aa[i].Name == "health-check" {
+			imported = &aa[i]
+			break
+		}
 	}
-	if aa[0].Name != "health-check" {
-		t.Fatalf("Name = %q, want %q", aa[0].Name, "health-check")
+	if imported == nil {
+		t.Fatalf("scanAllOrders() missing imported health-check order: %#v", aa)
 	}
-	if aa[0].Source != filepath.Join(cacheDir, "orders", "health-check.order.toml") {
-		t.Fatalf("Source = %q, want %q", aa[0].Source, filepath.Join(cacheDir, "orders", "health-check.order.toml"))
+	if imported.Name != "health-check" {
+		t.Fatalf("Name = %q, want %q", imported.Name, "health-check")
+	}
+	if imported.Source != filepath.Join(cacheDir, "orders", "health-check.order.toml") {
+		t.Fatalf("Source = %q, want %q", imported.Source, filepath.Join(cacheDir, "orders", "health-check.order.toml"))
 	}
 }
 
@@ -731,6 +738,9 @@ func TestOrderRun(t *testing.T) {
 }
 
 func TestOrderRunEventExecAdvancesCursor(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
+
 	cityDir := t.TempDir()
 	writeFile(t, filepath.Join(cityDir, "city.toml"), `[workspace]
 name = "test-city"
@@ -1207,6 +1217,8 @@ func TestOrderRunNotFound(t *testing.T) {
 }
 
 func TestOrderRunExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	rigDir := filepath.Join(cityDir, "frontend")
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
@@ -1476,6 +1488,8 @@ prefix = "ct"
 }
 
 func TestOrderRunExecPropagatesManagedDoltLayout(t *testing.T) {
+	clearGCEnv(t)
+	t.Setenv("GC_DOLT", "skip")
 	cityDir := t.TempDir()
 	dataDir := filepath.Join(t.TempDir(), "managed-dolt")
 	configFile := filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")

--- a/cmd/gc/cmd_prime_test.go
+++ b/cmd/gc/cmd_prime_test.go
@@ -261,6 +261,9 @@ max = 5
 }
 
 func TestDoPrimeWithHook_UsesGCTemplateForNamepoolSessionContext(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	promptDir := filepath.Join(cityDir, "prompts")
 	if err := os.MkdirAll(promptDir, 0o755); err != nil {
@@ -306,6 +309,9 @@ prompt_template = "prompts/polecat.template.md"
 }
 
 func TestDoPrimeWithHook_StartupPromptDeliveryEnvControlsPromptSuppression(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	promptDir := filepath.Join(cityDir, "prompts")
 	if err := os.MkdirAll(promptDir, 0o755); err != nil {
@@ -411,6 +417,9 @@ prompt_template = "prompts/worker.md"
 }
 
 func TestDoPrimeWithHook_DeliveredStartupPromptJSONHookFormat(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	cityDir := t.TempDir()
 	promptDir := filepath.Join(cityDir, "prompts")
 	if err := os.MkdirAll(promptDir, 0o755); err != nil {

--- a/cmd/gc/cmd_register_test.go
+++ b/cmd/gc/cmd_register_test.go
@@ -139,7 +139,7 @@ func TestRegisteredCityNamePreservesExistingRegistryAlias(t *testing.T) {
 func TestRestartRegistrationNameCapturesExistingRegistryAlias(t *testing.T) {
 	dir := t.TempDir()
 	cityPath := filepath.Join(dir, "my-city")
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+	if err := ensureCityScaffold(cityPath); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte("[workspace]\nname = \"workspace-name\"\n"), 0o644); err != nil {

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -3960,28 +3960,6 @@ func TestDoStartRequiresInitializedCity(t *testing.T) {
 	}
 }
 
-func TestDoStartRejectsUnbootstrappedCityConfig(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "bright-lights")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"bright-lights\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	code := doStart([]string{dir}, false, &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("doStart code = %d, want 1", code)
-	}
-	if !strings.Contains(stderr.String(), "city runtime not bootstrapped") {
-		t.Fatalf("stderr = %q, want bootstrap error", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), `gc init `+dir) && !strings.Contains(stderr.String(), `gc init `+canonicalTestPath(dir)) {
-		t.Fatalf("stderr = %q, want init guidance", stderr.String())
-	}
-}
-
 func TestDoStartForegroundRejectsSupervisorManagedCity(t *testing.T) {
 	gcHome := t.TempDir()
 	t.Setenv("GC_HOME", gcHome)

--- a/cmd/gc/completion.go
+++ b/cmd/gc/completion.go
@@ -96,7 +96,7 @@ func rigNameCandidates(toComplete string) []string {
 		if err != nil {
 			return
 		}
-		cfg, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), io.Discard)
+		cfg, err := loadCityConfigWithoutBuiltinPackRefreshFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"), io.Discard)
 		if err != nil {
 			return
 		}
@@ -180,7 +180,7 @@ func loadOrdersForCompletion() []orders.Order {
 		if err != nil {
 			return
 		}
-		cfg, err := loadCityConfig(cityPath, io.Discard)
+		cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 		if err != nil {
 			return
 		}
@@ -207,7 +207,7 @@ func loadSessionsForCompletion() []session.Info {
 		if err != nil {
 			return
 		}
-		cfg, err := loadCityConfig(cityPath, io.Discard)
+		cfg, err := loadCityConfigWithoutBuiltinPackRefresh(cityPath, io.Discard)
 		if err != nil {
 			return
 		}

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -47,8 +47,12 @@ var builtinPacks = []builtinPack{
 func MaterializeBuiltinPacks(cityPath string) error {
 	for _, bp := range builtinPacks {
 		dst := filepath.Join(cityPath, citylayout.SystemPacksRoot, bp.name)
-		if err := materializeFS(bp.fs, ".", dst); err != nil {
+		desired, err := materializeFS(bp.fs, ".", dst)
+		if err != nil {
 			return fmt.Errorf("materializing %s pack: %w", bp.name, err)
+		}
+		if err := pruneStaleGeneratedPackFiles(dst, desired); err != nil {
+			return fmt.Errorf("pruning stale %s pack files: %w", bp.name, err)
 		}
 		if err := pruneLegacyEmbeddedOrders(bp.fs, dst); err != nil {
 			return fmt.Errorf("pruning legacy %s order paths: %w", bp.name, err)
@@ -127,9 +131,11 @@ func peekBeadsProvider(tomlPath string) string {
 	return peek.Beads.Provider
 }
 
-// materializeFS walks an embed.FS rooted at root and writes all files to dstDir.
-func materializeFS(embedded fs.FS, root, dstDir string) error {
-	return fs.WalkDir(embedded, root, func(path string, d fs.DirEntry, err error) error {
+// materializeFS walks an embed.FS rooted at root, writes all files to dstDir,
+// and returns the relative file paths that belong in the generated directory.
+func materializeFS(embedded fs.FS, root, dstDir string) (map[string]struct{}, error) {
+	desired := make(map[string]struct{})
+	err := fs.WalkDir(embedded, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -148,6 +154,7 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		if d.IsDir() {
 			return os.MkdirAll(dst, 0o755)
 		}
+		desired[filepath.ToSlash(rel)] = struct{}{}
 
 		data, err := fs.ReadFile(embedded, path)
 		if err != nil {
@@ -164,6 +171,10 @@ func materializeFS(embedded fs.FS, root, dstDir string) error {
 		}
 		return fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, dst, data, perm)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return desired, nil
 }
 
 // isExecutableScriptFilename reports whether a materialized pack asset
@@ -207,6 +218,35 @@ func pruneLegacyEmbeddedOrders(embedded fs.FS, dstDir string) error {
 		}
 	}
 	return nil
+}
+
+func pruneStaleGeneratedPackFiles(dstDir string, desired map[string]struct{}) error {
+	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return filepath.WalkDir(dstDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dstDir, path)
+		if err != nil {
+			return err
+		}
+		if _, ok := desired[filepath.ToSlash(rel)]; ok {
+			return nil
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		pruneEmptyDirs(filepath.Dir(path), dstDir)
+		return nil
+	})
 }
 
 func pruneEmptyDirs(dir, stop string) {

--- a/cmd/gc/embed_builtin_packs.go
+++ b/cmd/gc/embed_builtin_packs.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gastownhall/gascity/examples/bd"
@@ -38,6 +42,25 @@ var builtinPacks = []builtinPack{
 	{fs: gastown.PackFS, name: "gastown"},
 }
 
+var builtinPackRefreshCache sync.Map
+
+type builtinPackRefreshState struct {
+	mu          sync.Mutex
+	ready       bool
+	lastWarning string
+}
+
+type builtinPackRefreshResult struct {
+	ready   bool
+	warning error
+	fatal   error
+}
+
+type builtinPackFile struct {
+	data []byte
+	perm os.FileMode
+}
+
 // MaterializeBuiltinPacks writes all embedded pack files to
 // .gc/system/packs/{name}/ in the city directory. Files whose content and mode
 // already match are left in place; changed content or mode is repaired with an
@@ -61,6 +84,169 @@ func MaterializeBuiltinPacks(cityPath string) error {
 	return nil
 }
 
+func builtinPackIncludesForConfigLoad(fs fsys.FS, tomlPath string, warningWriter io.Writer) ([]string, error) {
+	if !usesOSFS(fs) {
+		return nil, nil
+	}
+	cityPath := filepath.Dir(tomlPath)
+	if err := ensureBuiltinPacksReadyForConfigLoad(cityPath, warningWriter); err != nil {
+		return nil, err
+	}
+	return builtinPackIncludes(cityPath), nil
+}
+
+func usesOSFS(fs fsys.FS) bool {
+	switch fs.(type) {
+	case fsys.OSFS, *fsys.OSFS:
+		return true
+	default:
+		return false
+	}
+}
+
+func ensureBuiltinPacksReadyForConfigLoad(cityPath string, warningWriter io.Writer) error {
+	key := normalizePathForCompare(cityPath)
+	stateAny, _ := builtinPackRefreshCache.LoadOrStore(key, &builtinPackRefreshState{})
+	state := stateAny.(*builtinPackRefreshState)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.ready {
+		if len(unusableRequiredBuiltinPackNames(cityPath)) == 0 {
+			return nil
+		}
+		state.ready = false
+	}
+	result := materializeBuiltinPacksForConfigLoad(cityPath)
+	if result.fatal != nil {
+		state.lastWarning = ""
+		return result.fatal
+	}
+	if result.warning != nil {
+		const warningKey = "builtin-pack-refresh-incomplete"
+		if state.lastWarning != warningKey {
+			emitBuiltinPackRefreshWarning(warningWriter, result.warning)
+			state.lastWarning = warningKey
+		}
+		return nil
+	}
+	if result.ready {
+		state.ready = true
+		state.lastWarning = ""
+	}
+	return nil
+}
+
+func materializeBuiltinPacksForConfigLoad(cityPath string) builtinPackRefreshResult {
+	if err := MaterializeBuiltinPacks(cityPath); err != nil {
+		if missing := unusableRequiredBuiltinPackNames(cityPath); len(missing) > 0 {
+			return builtinPackRefreshResult{
+				fatal: fmt.Errorf("materializing builtin packs: required builtin packs remain unusable (%s): %w", strings.Join(missing, ", "), err),
+			}
+		}
+		return builtinPackRefreshResult{
+			warning: fmt.Errorf("builtin pack refresh incomplete; using existing materialized packs: %w", err),
+		}
+	}
+	return builtinPackRefreshResult{ready: true}
+}
+
+func unusableRequiredBuiltinPackNames(cityPath string) []string {
+	systemRoot := filepath.Join(cityPath, citylayout.SystemPacksRoot)
+	var missing []string
+	for _, name := range requiredBuiltinPackNames(cityPath) {
+		bp, ok := builtinPackByName(name)
+		if !ok || !packContainsEmbeddedState(bp.fs, filepath.Join(systemRoot, name)) {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func builtinPackByName(name string) (builtinPack, bool) {
+	for _, bp := range builtinPacks {
+		if bp.name == name {
+			return bp, true
+		}
+	}
+	return builtinPack{}, false
+}
+
+func packContainsEmbeddedState(embedded fs.FS, dstDir string) bool {
+	manifest, err := embeddedPackManifest(embedded)
+	if err != nil {
+		return false
+	}
+	return packContainsEmbeddedManifest(manifest, dstDir)
+}
+
+func packContainsEmbeddedManifest(manifest map[string]builtinPackFile, dstDir string) bool {
+	fi, err := os.Stat(dstDir)
+	if err != nil || !fi.IsDir() {
+		return false
+	}
+	for rel, want := range manifest {
+		dstPath := filepath.Join(dstDir, filepath.FromSlash(rel))
+		info, err := os.Lstat(dstPath)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != want.perm {
+			return false
+		}
+		got, err := os.ReadFile(dstPath)
+		if err != nil || !bytes.Equal(got, want.data) {
+			return false
+		}
+	}
+	return true
+}
+
+func embeddedPackManifest(embedded fs.FS) (map[string]builtinPackFile, error) {
+	manifest := make(map[string]builtinPackFile)
+	err := fs.WalkDir(embedded, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, err := fs.ReadFile(embedded, path)
+		if err != nil {
+			return fmt.Errorf("reading embedded %s: %w", path, err)
+		}
+		manifest[filepath.ToSlash(path)] = builtinPackFile{
+			data: data,
+			perm: builtinPackFileMode(path),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func requiredBuiltinPackNames(cityPath string) []string {
+	required := []string{"core", "maintenance"}
+
+	provider := strings.TrimSpace(configuredBeadsProviderValue(cityPath))
+	normalizedProvider := normalizeRawBeadsProvider(cityPath, provider)
+	if providerUsesBdStoreContract(normalizedProvider) {
+		required = append(required, "bd")
+	}
+	usesDirectExecLifecycle := strings.HasPrefix(provider, "exec:") &&
+		execProviderBase(provider) == "gc-beads-bd" &&
+		normalizedProvider != "bd"
+	if usesDirectExecLifecycle {
+		required = append(required, "dolt")
+	}
+	return required
+}
+
+func emitBuiltinPackRefreshWarning(w io.Writer, err error) {
+	if w == nil || err == nil {
+		return
+	}
+	fmt.Fprintf(w, "warning: %v\n", err) //nolint:errcheck // best-effort warning emission
+}
+
 // builtinPackIncludes returns the system pack paths that should be
 // auto-included in config loading. These are appended as extraIncludes
 // to LoadWithIncludes so they go through normal pack expansion
@@ -77,30 +263,10 @@ func builtinPackIncludes(cityPath string) []string {
 	systemRoot := filepath.Join(cityPath, citylayout.SystemPacksRoot)
 
 	var includes []string
-	if corePath := filepath.Join(systemRoot, "core"); packExists(corePath) {
-		includes = append(includes, corePath)
-	}
-	if maintenancePath := filepath.Join(systemRoot, "maintenance"); packExists(maintenancePath) {
-		includes = append(includes, maintenancePath)
-	}
-
-	// bd is gated on the beads provider. The managed exec wrapper path is
-	// normalized back to "bd", so it only needs the bd pack. A direct
-	// exec:gc-beads-bd override outside the managed wrapper still includes
-	// dolt explicitly so config loading keeps the lifecycle helpers aligned.
-	provider := strings.TrimSpace(configuredBeadsProviderValue(cityPath))
-	normalizedProvider := normalizeRawBeadsProvider(cityPath, provider)
-	usesDirectExecLifecycle := strings.HasPrefix(provider, "exec:") &&
-		execProviderBase(provider) == "gc-beads-bd" &&
-		normalizedProvider != "bd"
-	if providerUsesBdStoreContract(normalizedProvider) {
-		if bdPath := filepath.Join(systemRoot, "bd"); packExists(bdPath) {
-			includes = append(includes, bdPath)
-		}
-	}
-	if usesDirectExecLifecycle {
-		if doltPath := filepath.Join(systemRoot, "dolt"); packExists(doltPath) {
-			includes = append(includes, doltPath)
+	for _, name := range requiredBuiltinPackNames(cityPath) {
+		packPath := filepath.Join(systemRoot, name)
+		if packExists(packPath) {
+			includes = append(includes, packPath)
 		}
 	}
 
@@ -165,10 +331,7 @@ func materializeFS(embedded fs.FS, root, dstDir string) (map[string]struct{}, er
 			return err
 		}
 
-		perm := os.FileMode(0o644)
-		if isExecutableScriptFilename(path) {
-			perm = 0o755
-		}
+		perm := builtinPackFileMode(path)
 		return fsys.WriteFileIfContentOrModeChangedAtomic(fsys.OSFS{}, dst, data, perm)
 	})
 	if err != nil {
@@ -189,6 +352,13 @@ func isExecutableScriptFilename(name string) bool {
 		}
 	}
 	return false
+}
+
+func builtinPackFileMode(name string) os.FileMode {
+	if isExecutableScriptFilename(name) {
+		return 0o755
+	}
+	return 0o644
 }
 
 // pruneLegacyEmbeddedOrders removes deprecated order directory layouts when the
@@ -220,6 +390,10 @@ func pruneLegacyEmbeddedOrders(embedded fs.FS, dstDir string) error {
 	return nil
 }
 
+// pruneStaleGeneratedPackFiles treats the current binary's embedded pack tree
+// as the source of truth for generated files. Concurrent older/newer binaries
+// can briefly prune each other's obsolete generated-only files, but the next
+// successful materialization self-heals the directory to the active binary.
 func pruneStaleGeneratedPackFiles(dstDir string, desired map[string]struct{}) error {
 	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
 		return nil
@@ -227,7 +401,8 @@ func pruneStaleGeneratedPackFiles(dstDir string, desired map[string]struct{}) er
 		return err
 	}
 
-	return filepath.WalkDir(dstDir, func(path string, d fs.DirEntry, err error) error {
+	dirsToPrune := make(map[string]struct{})
+	if err := filepath.WalkDir(dstDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -238,15 +413,50 @@ func pruneStaleGeneratedPackFiles(dstDir string, desired map[string]struct{}) er
 		if err != nil {
 			return err
 		}
-		if _, ok := desired[filepath.ToSlash(rel)]; ok {
+		rel = filepath.ToSlash(rel)
+		if _, ok := desired[rel]; ok {
+			return nil
+		}
+		// Ignore in-flight atomic temp files so concurrent refreshes do not
+		// delete each other's rename targets mid-write.
+		if isGeneratedPackAtomicTempRel(rel, func(path string) bool {
+			_, ok := desired[path]
+			return ok
+		}) {
 			return nil
 		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
-		pruneEmptyDirs(filepath.Dir(path), dstDir)
+		dirsToPrune[filepath.Dir(path)] = struct{}{}
 		return nil
+	}); err != nil {
+		return err
+	}
+
+	pruneDirs := make([]string, 0, len(dirsToPrune))
+	for dir := range dirsToPrune {
+		pruneDirs = append(pruneDirs, dir)
+	}
+	sort.Slice(pruneDirs, func(i, j int) bool {
+		left := filepath.Clean(pruneDirs[i])
+		right := filepath.Clean(pruneDirs[j])
+		leftDepth := strings.Count(left, string(filepath.Separator))
+		rightDepth := strings.Count(right, string(filepath.Separator))
+		if leftDepth != rightDepth {
+			return leftDepth > rightDepth
+		}
+		return left > right
 	})
+	for _, dir := range pruneDirs {
+		pruneEmptyDirs(dir, dstDir)
+	}
+	return nil
+}
+
+func isGeneratedPackAtomicTempRel(rel string, hasDesired func(string) bool) bool {
+	idx := strings.LastIndex(rel, ".tmp.")
+	return idx > 0 && hasDesired(rel[:idx])
 }
 
 func pruneEmptyDirs(dir, stop string) {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 func TestMaterializeBuiltinPacks(t *testing.T) {
@@ -630,9 +632,34 @@ func TestMaterializeBuiltinPacks_PrunesStaleGeneratedPackFiles(t *testing.T) {
 	}
 }
 
+func TestMaterializeBuiltinPacks_PruneIgnoresAtomicTempFilesForDesiredAssets(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	finalPath := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact", "run.sh")
+	tempPath := finalPath + ".tmp.foreign-writer"
+	if err := os.WriteFile(tempPath, []byte("#!/bin/sh\necho temp\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", tempPath, err)
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() second call error: %v", err)
+	}
+
+	if _, err := os.Stat(tempPath); err != nil {
+		t.Fatalf("atomic temp file was pruned: %v", err)
+	}
+	if _, err := os.Stat(finalPath); err != nil {
+		t.Fatalf("final embedded file missing after prune: %v", err)
+	}
+}
+
 func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -648,6 +675,364 @@ func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
 			t.Fatalf("builtin pack file missing after loadCityConfig: %v", err)
 		}
 	}
+}
+
+func TestLoadCityConfigSuppressDeprecatedOrderWarningsMaterializesBuiltinPacks(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadCityConfigSuppressDeprecatedOrderWarnings(dir); err != nil {
+		t.Fatalf("loadCityConfigSuppressDeprecatedOrderWarnings() error: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "bd", "pack.toml"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("builtin pack file missing after suppress-warnings load: %v", err)
+		}
+	}
+}
+
+func TestLoadCityConfigFSMaterializesBuiltinPacksForOSFS(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(dir, "city.toml")); err != nil {
+		t.Fatalf("loadCityConfigFS(OSFS) error: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "bd", "pack.toml"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("builtin pack file missing after loadCityConfigFS(OSFS): %v", err)
+		}
+	}
+}
+
+func TestLoadCityConfigWithoutBuiltinPackRefreshFSDoesNotMaterializeBuiltinPacks(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadCityConfigWithoutBuiltinPackRefreshFS(fsys.OSFS{}, filepath.Join(dir, "city.toml"))
+	if err != nil {
+		t.Fatalf("loadCityConfigWithoutBuiltinPackRefreshFS(OSFS) error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("loadCityConfigWithoutBuiltinPackRefreshFS returned nil config")
+	}
+	if _, err := os.Stat(filepath.Join(dir, citylayout.SystemPacksRoot)); !os.IsNotExist(err) {
+		t.Fatalf("builtin packs were materialized on read-only load path: %v", err)
+	}
+}
+
+func TestLoadCityConfigFallsBackToExistingBuiltinPacksWhenRefreshFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact")
+	targetFile := filepath.Join(targetDir, "run.sh")
+	wantContent, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("ReadFile(initial run.sh): %v", err)
+	}
+	staleContent := []byte("#!/bin/sh\necho stale\n")
+	if err := os.WriteFile(targetFile, staleContent, 0o755); err != nil {
+		t.Fatalf("WriteFile(stale run.sh): %v", err)
+	}
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(targetDir, 0o755)
+	})
+
+	var stderr bytes.Buffer
+	if _, err := loadCityConfig(dir, &stderr); err != nil {
+		t.Fatalf("loadCityConfig() fallback error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
+		t.Fatalf("expected suppressed refresh warning, got %q", stderr.String())
+	}
+
+	got, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("ReadFile(run.sh): %v", err)
+	}
+	if !bytes.Equal(got, staleContent) {
+		t.Fatalf("run.sh changed during read-only fallback; got %q", got)
+	}
+
+	if err := os.Chmod(targetDir, 0o755); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	stderr.Reset()
+	if _, err := loadCityConfig(dir, &stderr); err != nil {
+		t.Fatalf("loadCityConfig() retry error: %v", err)
+	}
+	got, err = os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("ReadFile(run.sh) after retry: %v", err)
+	}
+	if !bytes.Equal(got, wantContent) {
+		t.Fatalf("run.sh did not refresh after retry; got %q", got)
+	}
+	if strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
+		t.Fatalf("unexpected refresh warning after retry: %q", stderr.String())
+	}
+}
+
+func TestLoadCityConfigDeduplicatesBuiltinPackRefreshWarningsPerProcess(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact")
+	targetFile := filepath.Join(targetDir, "run.sh")
+	if err := os.WriteFile(targetFile, []byte("#!/bin/sh\necho stale\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(stale run.sh): %v", err)
+	}
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(targetDir, 0o755)
+	})
+
+	var stderr bytes.Buffer
+	for i := 0; i < 2; i++ {
+		if _, err := loadCityConfig(dir, &stderr); err != nil {
+			t.Fatalf("loadCityConfig() fallback attempt %d error: %v", i+1, err)
+		}
+	}
+
+	if got := strings.Count(stderr.String(), "builtin pack refresh incomplete"); got != 1 {
+		t.Fatalf("warning count = %d, want 1; stderr=%q", got, stderr.String())
+	}
+}
+
+func TestLoadCityConfigSuppressDeprecatedOrderWarningsDoesNotSuppressBuiltinPackRefreshWarnings(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact")
+	targetFile := filepath.Join(targetDir, "run.sh")
+	if err := os.WriteFile(targetFile, []byte("#!/bin/sh\necho stale\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(stale run.sh): %v", err)
+	}
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(targetDir, 0o755)
+	})
+
+	origDefaultWarningWriter := loadCityConfigDefaultWarningWriter
+	var stderr bytes.Buffer
+	loadCityConfigDefaultWarningWriter = func() io.Writer { return &stderr }
+	t.Cleanup(func() {
+		loadCityConfigDefaultWarningWriter = origDefaultWarningWriter
+	})
+
+	if _, err := loadCityConfigSuppressDeprecatedOrderWarnings(dir); err != nil {
+		t.Fatalf("loadCityConfigSuppressDeprecatedOrderWarnings() fallback error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
+		t.Fatalf("expected builtin pack refresh warning, got %q", stderr.String())
+	}
+}
+
+func TestLoadCityConfigFailsWhenRequiredBuiltinPackRefreshFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "bd")
+	targetFile := filepath.Join(targetDir, "pack.toml")
+	if err := os.Remove(targetFile); err != nil {
+		t.Fatalf("Remove(%s): %v", targetFile, err)
+	}
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(targetDir, 0o755)
+	})
+
+	if _, err := loadCityConfig(dir); err == nil {
+		t.Fatal("loadCityConfig() error = nil, want required builtin pack refresh failure")
+	} else if !strings.Contains(err.Error(), "materializing builtin packs") {
+		t.Fatalf("loadCityConfig() error = %v, want materialization failure", err)
+	}
+}
+
+func TestLoadCityConfigFailsWhenRequiredBuiltinPackRemainsPartiallyMaterialized(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts")
+	targetFile := filepath.Join(targetDir, "pool-worker.md")
+	if err := os.Remove(targetFile); err != nil {
+		t.Fatalf("Remove(%s): %v", targetFile, err)
+	}
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(targetDir, 0o755)
+	})
+
+	if _, err := loadCityConfig(dir); err == nil {
+		t.Fatal("loadCityConfig() error = nil, want partial required builtin pack failure")
+	} else if !strings.Contains(err.Error(), "required builtin packs remain unusable (core)") {
+		t.Fatalf("loadCityConfig() error = %v, want unusable core pack failure", err)
+	}
+}
+
+func TestLoadCityConfigFailsWhenRequiredBuiltinPackRefreshLeavesStaleContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	targetDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts")
+	targetFile := filepath.Join(targetDir, "pool-worker.md")
+	if err := os.WriteFile(targetFile, []byte("stale core prompt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", targetFile, err)
+	}
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", targetDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(targetDir, 0o755)
+	})
+
+	if _, err := loadCityConfig(dir); err == nil {
+		t.Fatal("loadCityConfig() error = nil, want stale required builtin pack failure")
+	} else if !strings.Contains(err.Error(), "required builtin packs remain unusable (core)") {
+		t.Fatalf("loadCityConfig() error = %v, want unusable core pack failure", err)
+	}
+}
+
+func TestLoadCityConfigFallsBackWhenRequiredBuiltinPackHasOnlyExtraStaleFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	staleDir := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "stale")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", staleDir, err)
+	}
+	staleFile := filepath.Join(staleDir, "leftover.txt")
+	if err := os.WriteFile(staleFile, []byte("obsolete\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", staleFile, err)
+	}
+	if err := os.Chmod(staleDir, 0o555); err != nil {
+		t.Fatalf("Chmod(%s): %v", staleDir, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(staleDir, 0o755)
+	})
+
+	var stderr bytes.Buffer
+	if _, err := loadCityConfig(dir, &stderr); err != nil {
+		t.Fatalf("loadCityConfig() fallback error = %v, want warning-only fallback", err)
+	}
+	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
+		t.Fatalf("expected builtin pack refresh warning, got %q", stderr.String())
+	}
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Fatalf("expected extra stale file to remain after fallback, got stat error %v", err)
+	}
+}
+
+func TestLoadCityConfigRevalidatesRequiredBuiltinPacksAfterReadyCacheSuccess(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadCityConfig(dir); err != nil {
+		t.Fatalf("loadCityConfig() initial error: %v", err)
+	}
+
+	targetFile := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml")
+	if err := os.Remove(targetFile); err != nil {
+		t.Fatalf("Remove(%s): %v", targetFile, err)
+	}
+
+	if _, err := loadCityConfig(dir); err != nil {
+		t.Fatalf("loadCityConfig() repair error: %v", err)
+	}
+	if _, err := os.Stat(targetFile); err != nil {
+		t.Fatalf("required pack file missing after ready-cache revalidation: %v", err)
+	}
+}
+
+func TestLoadCityConfigRevalidatesRequiredBuiltinPackContentsAfterReadyCacheSuccess(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadCityConfig(dir); err != nil {
+		t.Fatalf("loadCityConfig() initial error: %v", err)
+	}
+
+	targetFile := filepath.Join(dir, citylayout.SystemPacksRoot, "core", "assets", "prompts", "pool-worker.md")
+	if err := os.Remove(targetFile); err != nil {
+		t.Fatalf("Remove(%s): %v", targetFile, err)
+	}
+
+	if _, err := loadCityConfig(dir); err != nil {
+		t.Fatalf("loadCityConfig() repair error: %v", err)
+	}
+	if _, err := os.Stat(targetFile); err != nil {
+		t.Fatalf("required builtin asset missing after ready-cache content revalidation: %v", err)
+	}
+}
+
+func writeBuiltinPackLoadTestCity(dir string) error {
+	return os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test\"\n"), 0o644)
 }
 
 func TestBuiltinPackIncludes_DefaultProvider(t *testing.T) {

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -588,6 +588,68 @@ func TestMaterializeBuiltinPacks_PrunesLegacyOrderDirs(t *testing.T) {
 	}
 }
 
+func TestMaterializeBuiltinPacks_PrunesStaleGeneratedPackFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() error: %v", err)
+	}
+
+	stalePaths := []string{
+		filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "orders", "removed-order.toml"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "removed-command", "run.sh"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "maintenance", "assets", "scripts", "removed-helper.sh"),
+	}
+	for _, path := range stalePaths {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir stale path: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+			t.Fatalf("write stale path: %v", err)
+		}
+	}
+
+	if err := MaterializeBuiltinPacks(dir); err != nil {
+		t.Fatalf("MaterializeBuiltinPacks() second call error: %v", err)
+	}
+
+	for _, path := range stalePaths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("stale generated pack file still exists: %s", path)
+		}
+	}
+
+	for _, path := range []string{
+		filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact", "run.sh"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "orders", "mol-dog-compactor.toml"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "maintenance", "orders", "gate-sweep.toml"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("embedded pack file missing after stale prune: %v", err)
+		}
+	}
+}
+
+func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadCityConfig(dir); err != nil {
+		t.Fatalf("loadCityConfig() error: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(dir, citylayout.SystemPacksRoot, "core", "pack.toml"),
+		filepath.Join(dir, citylayout.SystemPacksRoot, "dolt", "commands", "compact", "run.sh"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("builtin pack file missing after loadCityConfig: %v", err)
+		}
+	}
+}
+
 func TestBuiltinPackIncludes_DefaultProvider(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/gc/fast_loop_helpers_test.go
+++ b/cmd/gc/fast_loop_helpers_test.go
@@ -45,19 +45,27 @@ func sanitizedBaseEnv(extra ...string) []string {
 // If stderrMsg is non-empty, the script writes it to stderr before exiting.
 func writeTestScript(t *testing.T, _ string, exitCode int, stderrMsg string) string {
 	t.Helper()
-	dir := t.TempDir()
-	script := filepath.Join(dir, "test-beads.sh")
-
 	content := "#!/bin/sh\n"
 	if stderrMsg != "" {
 		content += "echo '" + stderrMsg + "' >&2\n"
 	}
 	content += "exit " + itoa(exitCode) + "\n"
+	return writeNamedTestScript(t, "test-beads.sh", content)
+}
 
+func writeNamedTestScript(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, name)
 	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return script
+}
+
+func writeManagedBdTestScript(t *testing.T, content string) string {
+	t.Helper()
+	return writeNamedTestScript(t, "gc-beads-bd.sh", content)
 }
 
 func itoa(n int) string {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3302,20 +3302,36 @@ scale_check = "echo 3"
 		t.Errorf("ResolvedWorkspaceName = %q, want %q (should be overridden)", cfg.ResolvedWorkspaceName, "bright-lights")
 	}
 	explicit := explicitAgents(cfg.Agents)
-	if len(explicit) != 2 {
-		t.Fatalf("len(explicitAgents) = %d, want 2", len(explicit))
+	if len(explicit) != 3 {
+		t.Fatalf("len(explicitAgents) = %d, want 3", len(explicit))
 	}
-	if explicit[1].Name != "worker" {
-		t.Errorf("explicitAgents[1].Name = %q, want %q", explicit[1].Name, "worker")
+	explicitByName := make(map[string]config.Agent, len(explicit))
+	for _, agent := range explicit {
+		explicitByName[agent.Name] = agent
 	}
-	if explicit[1].MaxActiveSessions == nil {
-		t.Fatal("explicitAgents[1].MaxActiveSessions is nil, want non-nil")
+	mayor, ok := explicitByName["mayor"]
+	if !ok {
+		t.Fatalf("explicitAgents missing mayor: %+v", explicit)
 	}
-	if *explicit[1].MaxActiveSessions != 5 {
-		t.Errorf("explicitAgents[1].MaxActiveSessions = %d, want 5", *explicit[1].MaxActiveSessions)
+	worker, ok := explicitByName["worker"]
+	if !ok {
+		t.Fatalf("explicitAgents missing worker: %+v", explicit)
 	}
-	if !strings.HasSuffix(explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
-		t.Errorf("explicitAgents[0].PromptTemplate = %q, want suffix %q", explicit[0].PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
+	dog, ok := explicitByName["dog"]
+	if !ok {
+		t.Fatalf("explicitAgents missing builtin maintenance dog agent: %+v", explicit)
+	}
+	if worker.MaxActiveSessions == nil {
+		t.Fatal("worker.MaxActiveSessions is nil, want non-nil")
+	}
+	if *worker.MaxActiveSessions != 5 {
+		t.Errorf("worker.MaxActiveSessions = %d, want 5", *worker.MaxActiveSessions)
+	}
+	if !strings.HasSuffix(mayor.PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md")) {
+		t.Errorf("mayor.PromptTemplate = %q, want suffix %q", mayor.PromptTemplate, filepath.Join("agents", "mayor", "prompt.template.md"))
+	}
+	if !strings.HasSuffix(dog.PromptTemplate, filepath.Join(".gc", "system", "packs", "maintenance", "agents", "dog", "prompt.template.md")) {
+		t.Errorf("dog.PromptTemplate = %q, want maintenance dog prompt", dog.PromptTemplate)
 	}
 
 	packData, err := os.ReadFile(filepath.Join(cityPath, "pack.toml"))
@@ -5425,6 +5441,9 @@ prompt_template = "prompts/mayor.md"
 // rather than being reported as an error. Strict is for debugging typos
 // and template mistakes, not for rejecting valid minimal configs.
 func TestDoPrimeStrictAgentWithEmptyPromptTemplate(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5437,6 +5456,7 @@ name = "test-city"
 
 [[agent]]
 name = "mayor"
+max_active_sessions = 1
 `
 	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(toml), 0o644); err != nil {
 		t.Fatal(err)
@@ -5464,6 +5484,9 @@ name = "mayor"
 // silently swallows by returning "", which strict mode needs to surface
 // with the underlying stat reason.
 func TestDoPrimeStrictMissingTemplateFile(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5500,6 +5523,9 @@ prompt_template = "prompts/does-not-exist.md"
 }
 
 func TestDoPrimeStrictAbsoluteTemplatePath(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5545,6 +5571,9 @@ prompt_template = %q
 // substantial content. The absence of this test would let the missing-
 // file strict check quietly regress into a broader empty-render check.
 func TestDoPrimeStrictTemplateRendersLegitimatelyEmpty(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5597,6 +5626,9 @@ prompt_template = "prompts/mayor.md"
 // effects (persisting the session ID to .runtime/session_id) do NOT fire.
 // A failing strict invocation must not leave partial state behind.
 func TestDoPrimeStrictHookModeDoesNotPersistSessionOnFailure(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5639,6 +5671,9 @@ name = "mayor"
 // effects. A missing prompt_template is a strict failure, so it must not
 // leave behind a session id for the failed hook invocation.
 func TestDoPrimeStrictHookModeMissingTemplateDoesNotPersistSessionOnFailure(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5683,6 +5718,9 @@ prompt_template = "prompts/does-not-exist.md"
 // session-id persistence DOES fire — the deferral is not a regression of
 // hook behavior for the success path.
 func TestDoPrimeStrictHookModePersistsSessionOnSuccess(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -5797,6 +5835,9 @@ prompt_template = "prompts/mayor.md"
 // Without this guard, the strict deferral silently drops session-id
 // persistence on the suspended-agent success path.
 func TestDoPrimeStrictHookModeOnSuspendedAgentPersistsSessionID(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	gcDir := filepath.Join(dir, ".gc")
 	if err := os.MkdirAll(gcDir, 0o755); err != nil {
@@ -6010,6 +6051,9 @@ func materializeBuiltinPrompts(cityPath string) error {
 }
 
 func TestDoPrimeHookPersistsSessionID(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/gc/nudge_dispatcher_test.go
+++ b/cmd/gc/nudge_dispatcher_test.go
@@ -110,6 +110,9 @@ func TestStartNudgeWakeListenerStopsOnContextCancel(t *testing.T) {
 }
 
 func TestDispatchAllQueuedNudgesNoOpInLegacyMode(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "msg", "session", time.Now().Add(-time.Minute))); err != nil {
 		t.Fatalf("enqueueQueuedNudge: %v", err)
@@ -125,6 +128,9 @@ func TestDispatchAllQueuedNudgesNoOpInLegacyMode(t *testing.T) {
 }
 
 func TestDispatchAllQueuedNudgesEmptyQueue(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	delivered, err := dispatchAllQueuedNudges(dir, supervisorCfg(), nil, nil, newSessionBeadSnapshot(nil))
 	if err != nil {
@@ -136,6 +142,9 @@ func TestDispatchAllQueuedNudgesEmptyQueue(t *testing.T) {
 }
 
 func TestDispatchAllQueuedNudgesSkipsNotYetDue(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	future := time.Now().Add(5 * time.Minute)
 	item := newQueuedNudge("worker", "later", "session", time.Now())
@@ -163,6 +172,8 @@ func TestDispatchAllQueuedNudgesSkipsNotYetDue(t *testing.T) {
 }
 
 func TestDispatchAllQueuedNudgesDeliversAndAcks(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "file")
 	dir := t.TempDir()
 
@@ -220,6 +231,9 @@ func TestDispatchAllQueuedNudgesDeliversAndAcks(t *testing.T) {
 }
 
 func TestDispatchAllQueuedNudgesSkipsACPSession(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "msg", "session", time.Now().Add(-time.Minute))); err != nil {
 		t.Fatalf("enqueueQueuedNudge: %v", err)
@@ -257,6 +271,9 @@ func TestNudgeDispatcherIsSupervisor(t *testing.T) {
 }
 
 func TestDispatchAllQueuedNudgesNilCfg(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	dir := t.TempDir()
 	if err := enqueueQueuedNudge(dir, newQueuedNudge("worker", "msg", "session", time.Now().Add(-time.Minute))); err != nil {
 		t.Fatalf("enqueueQueuedNudge: %v", err)
@@ -300,6 +317,9 @@ func TestMaybeStartNudgePollerSkipsInSupervisorMode(t *testing.T) {
 }
 
 func TestEnqueuePingsWakeSocket(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	dir := t.TempDir()

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -921,7 +921,9 @@ source = "`+doltDir+`"
 		"mol-dog-backup":     "$PACK_DIR/assets/scripts/mol-dog-backup.sh",
 		"mol-dog-compactor":  "gc dolt compact",
 		"mol-dog-doctor":     "$PACK_DIR/assets/scripts/mol-dog-doctor.sh",
+		"mol-dog-jsonl":      "$PACK_DIR/assets/scripts/jsonl-export.sh",
 		"mol-dog-phantom-db": "$PACK_DIR/assets/scripts/mol-dog-phantom-db.sh",
+		"mol-dog-reaper":     "$PACK_DIR/assets/scripts/reaper.sh",
 	}
 	gotExecDogOrders := map[string]bool{}
 	const wantFormulaDogOrders = 1
@@ -943,7 +945,11 @@ source = "`+doltDir+`"
 			}
 			const packScriptPrefix = "$PACK_DIR/assets/scripts/"
 			if scriptName := strings.TrimPrefix(wantExec, packScriptPrefix); scriptName != wantExec {
-				scriptPath := filepath.Join(doltDir, "assets", "scripts", scriptName)
+				packDir := orderPoolSourceDirHint(a)
+				if packDir == "" {
+					t.Fatalf("%s pack dir hint is empty for script-backed exec order", a.Name)
+				}
+				scriptPath := filepath.Join(packDir, "assets", "scripts", scriptName)
 				if _, err := os.Stat(scriptPath); err != nil {
 					t.Fatalf("%s exec script missing: %v", a.Name, err)
 				}
@@ -964,8 +970,8 @@ source = "`+doltDir+`"
 		if err != nil {
 			t.Fatalf("qualifyOrderPool(%s): %v", a.Name, err)
 		}
-		if got != "ops.dog" {
-			t.Fatalf("qualifyOrderPool(%s) = %q, want ops.dog", a.Name, got)
+		if got != "dog" {
+			t.Fatalf("qualifyOrderPool(%s) = %q, want local maintenance dog", a.Name, got)
 		}
 	}
 	if gotFormulaDogOrders != wantFormulaDogOrders {
@@ -4029,8 +4035,15 @@ func loadImportedDogOrders(t *testing.T, cityDir string) (*config.City, []orders
 	if err != nil {
 		t.Fatalf("scanAllOrders: %v; stderr: %s", err, stderr.String())
 	}
-	if len(aa) != 1 {
-		t.Fatalf("scanAllOrders() len = %d, want 1 (%#v)", len(aa), aa)
+	found := false
+	for _, order := range aa {
+		if order.Name == "digest" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("scanAllOrders() missing digest order (%#v)", aa)
 	}
 	return cfg, aa
 }

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -18,12 +18,12 @@ import (
 // Helpers
 // ---------------------------------------------------------------------------
 
-// setupCity creates a minimal city directory with city.toml and .gc/.
+// setupCity creates a minimal city directory with city.toml and the runtime scaffold.
 // Returns the absolute path to the city root.
 func setupCity(t *testing.T, name string) string {
 	t.Helper()
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+	if err := ensureCityScaffold(dir); err != nil {
 		t.Fatal(err)
 	}
 	toml := "[workspace]\nname = \"" + name + "\"\n\n[[agent]]\nname = \"mayor\"\n"

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -31,6 +31,15 @@ func clearGCEnv(t *testing.T) {
 	}
 }
 
+func disableManagedDoltRecoveryForTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_DOLT_HOST", "")
+	t.Setenv("GC_DOLT_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+}
+
 var testProviderStubCommands = []string{
 	"claude",
 	"codex",


### PR DESCRIPTION
## Summary
- materialize and prune builtin system packs on shared config-load paths
- keep completion on the existing-pack read path so shell completion avoids refresh work on every invocation
- warn and retry when refresh falls back to existing materialized packs, with regression coverage for the fallback contract

Supersedes #1921.

Credit: Original fix by @julianknutsen.

## Tests
- `go test ./cmd/gc -run 'TestMaterializeBuiltinPacks_PrunesStaleGeneratedPackFiles|TestLoadCityConfigMaterializesBuiltinPacks|TestLoadCityConfigSuppressDeprecatedOrderWarningsMaterializesBuiltinPacks|TestLoadCityConfigFSMaterializesBuiltinPacksForOSFS|TestLoadCityConfigWithoutBuiltinPackRefreshFSDoesNotMaterializeBuiltinPacks|TestLoadCityConfigFallsBackToExistingBuiltinPacksWhenRefreshFails|TestLoadCityConfigFailsWhenRequiredBuiltinPackRefreshFails|TestNonTestLoadCityConfigCallersPassWarningWriter' -count=1`
- `go vet ./...`
- `git diff --check`

## Notes
- The original PR correctly identified the stale generated builtin-pack problem and is preserved here as the first commit in this branch.
- The repo's full `make test` sweep still hits unrelated lifecycle failures in `TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState` and `TestStartBeadsLifecycleSkipsProviderForExternalHost`.
