### PR TITLE
fix(extmsg): cascade-cleanup on pool session close (#1939)

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1876,9 +1876,10 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 		return false
 	}
 	// Cascade extmsg cleanup. Pool retirement funnels through closeBead;
-	// named-session retirement calls this directly at retireNamedSession.
-	// Without it, pool respawn leaves zombie memberships and the successor
-	// never re-binds to slack (#1939).
+	// named-session retirement calls this directly at
+	// retireRemovedConfiguredNamedSessionBead. Without it, pool respawn
+	// leaves zombie memberships and the successor never re-binds to
+	// slack (#1939).
 	cancelStateAssignedToRetiredSessionBead(store, id, now, stderr)
 	return true
 }

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1599,6 +1599,10 @@ func closeFailedCreateBead(store beads.Store, id string, now time.Time, stderr i
 		fmt.Fprintf(stderr, "session beads: closing failed-create bead %s: %v\n", id, err) //nolint:errcheck
 		return false
 	}
+	// Defense in depth: a startup race between bead creation and an early
+	// bind could leave participant records behind. Cleanup helpers no-op
+	// when the session has no labeled state.
+	cancelStateAssignedToRetiredSessionBead(store, id, now, stderr)
 	return true
 }
 
@@ -1871,6 +1875,11 @@ func closeBead(store beads.Store, id, reason string, now time.Time, stderr io.Wr
 		fmt.Fprintf(stderr, "session beads: closing %s: %v\n", id, err) //nolint:errcheck
 		return false
 	}
+	// Cascade extmsg cleanup. Pool retirement funnels through closeBead;
+	// named-session retirement calls this directly at retireNamedSession.
+	// Without it, pool respawn leaves zombie memberships and the successor
+	// never re-binds to slack (#1939).
+	cancelStateAssignedToRetiredSessionBead(store, id, now, stderr)
 	return true
 }
 

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5458,9 +5458,10 @@ func countOpenMembershipsForSession(t *testing.T, fabric extmsg.Services, caller
 
 // TestCloseBeadCascadesExtmsgState verifies the cascade fires from the pool
 // close path. Named-session retirement already calls
-// cancelStateAssignedToRetiredSessionBead at retireNamedSession; pool
-// retirement funnels through closeBead, so the cascade must fire here too
-// (regression for #1939, follow-up to #1865).
+// cancelStateAssignedToRetiredSessionBead at
+// retireRemovedConfiguredNamedSessionBead; pool retirement funnels through
+// closeBead, so the cascade must fire here too (regression for #1939,
+// follow-up to #1865).
 func TestCloseBeadCascadesExtmsgState(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, session.StateActive)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5408,7 +5408,7 @@ func TestCloseBeadIsNoopOnAlreadyClosedBead(t *testing.T) {
 // participant in a group, which also writes the matching membership via
 // ensureMembershipLocked. Returns the session bead, fabric, and caller so
 // the test can verify cleanup via TranscriptService.ListConversationsBySession.
-func setupSessionWithExtmsgMembership(t *testing.T, store beads.Store, state string) (beads.Bead, extmsg.Services, extmsg.Caller) {
+func setupSessionWithExtmsgMembership(t *testing.T, store beads.Store, state session.State) (beads.Bead, extmsg.Services, extmsg.Caller) {
 	t.Helper()
 	sessionBead, err := store.Create(beads.Bead{
 		Title:  "worker",
@@ -5416,7 +5416,7 @@ func setupSessionWithExtmsgMembership(t *testing.T, store beads.Store, state str
 		Labels: []string{sessionBeadLabel},
 		Metadata: map[string]string{
 			"session_name": "worker-1",
-			"state":        state,
+			"state":        string(state),
 		},
 	})
 	if err != nil {
@@ -5447,7 +5447,7 @@ func setupSessionWithExtmsgMembership(t *testing.T, store beads.Store, state str
 	return sessionBead, fabric, caller
 }
 
-func openMembershipsForSession(t *testing.T, fabric extmsg.Services, caller extmsg.Caller, sessionID string) int {
+func countOpenMembershipsForSession(t *testing.T, fabric extmsg.Services, caller extmsg.Caller, sessionID string) int {
 	t.Helper()
 	members, err := fabric.Transcript.ListConversationsBySession(context.Background(), caller, sessionID)
 	if err != nil {
@@ -5463,9 +5463,9 @@ func openMembershipsForSession(t *testing.T, fabric extmsg.Services, caller extm
 // (regression for #1939, follow-up to #1865).
 func TestCloseBeadCascadesExtmsgState(t *testing.T) {
 	store := beads.NewMemStore()
-	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, "active")
+	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, session.StateActive)
 
-	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
+	if got := countOpenMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
 		t.Fatalf("open memberships before close = %d, want 1 (setup precondition)", got)
 	}
 
@@ -5475,7 +5475,7 @@ func TestCloseBeadCascadesExtmsgState(t *testing.T) {
 		t.Fatalf("closeBead returned false; want true: stderr=%s", stderr.String())
 	}
 
-	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
+	if got := countOpenMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
 		t.Errorf("open memberships after closeBead = %d, want 0 (cascade should have closed the membership bead)", got)
 	}
 }
@@ -5486,9 +5486,9 @@ func TestCloseBeadCascadesExtmsgState(t *testing.T) {
 // both pool-close entry points need the cleanup (B23 fix scope completeness).
 func TestCloseFailedCreateBeadCascadesExtmsgState(t *testing.T) {
 	store := beads.NewMemStore()
-	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, string(session.StateFailedCreate))
+	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, session.StateFailedCreate)
 
-	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
+	if got := countOpenMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
 		t.Fatalf("open memberships before close = %d, want 1 (setup precondition)", got)
 	}
 
@@ -5498,7 +5498,7 @@ func TestCloseFailedCreateBeadCascadesExtmsgState(t *testing.T) {
 		t.Fatalf("closeFailedCreateBead returned false; want true: stderr=%s", stderr.String())
 	}
 
-	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
+	if got := countOpenMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
 		t.Errorf("open memberships after closeFailedCreateBead = %d, want 0 (cascade should have closed the membership bead)", got)
 	}
 }

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -5404,6 +5404,105 @@ func TestCloseBeadIsNoopOnAlreadyClosedBead(t *testing.T) {
 	}
 }
 
+// setupSessionWithExtmsgMembership creates a session bead and registers a
+// participant in a group, which also writes the matching membership via
+// ensureMembershipLocked. Returns the session bead, fabric, and caller so
+// the test can verify cleanup via TranscriptService.ListConversationsBySession.
+func setupSessionWithExtmsgMembership(t *testing.T, store beads.Store, state string) (beads.Bead, extmsg.Services, extmsg.Caller) {
+	t.Helper()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker-1",
+			"state":        state,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create session bead: %v", err)
+	}
+	fabric := extmsg.NewServices(store)
+	caller := extmsg.Caller{Kind: extmsg.CallerController, ID: "test"}
+	group, err := fabric.Groups.EnsureGroup(context.Background(), caller, extmsg.EnsureGroupInput{
+		RootConversation: extmsg.ConversationRef{
+			ScopeID:        "ds-research",
+			Provider:       "slack",
+			AccountID:      "T0WORKSPACE",
+			ConversationID: "C0CHANNEL",
+			Kind:           extmsg.ConversationRoom,
+		},
+		Mode: extmsg.GroupModeLauncher,
+	})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if _, err := fabric.Groups.UpsertParticipant(context.Background(), caller, extmsg.UpsertParticipantInput{
+		GroupID:   group.ID,
+		Handle:    "worker",
+		SessionID: sessionBead.ID,
+	}); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	return sessionBead, fabric, caller
+}
+
+func openMembershipsForSession(t *testing.T, fabric extmsg.Services, caller extmsg.Caller, sessionID string) int {
+	t.Helper()
+	members, err := fabric.Transcript.ListConversationsBySession(context.Background(), caller, sessionID)
+	if err != nil {
+		t.Fatalf("ListConversationsBySession: %v", err)
+	}
+	return len(members)
+}
+
+// TestCloseBeadCascadesExtmsgState verifies the cascade fires from the pool
+// close path. Named-session retirement already calls
+// cancelStateAssignedToRetiredSessionBead at retireNamedSession; pool
+// retirement funnels through closeBead, so the cascade must fire here too
+// (regression for #1939, follow-up to #1865).
+func TestCloseBeadCascadesExtmsgState(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, "active")
+
+	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
+		t.Fatalf("open memberships before close = %d, want 1 (setup precondition)", got)
+	}
+
+	var stderr bytes.Buffer
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	if !closeBead(store, sessionBead.ID, "drained", now, &stderr) {
+		t.Fatalf("closeBead returned false; want true: stderr=%s", stderr.String())
+	}
+
+	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
+		t.Errorf("open memberships after closeBead = %d, want 0 (cascade should have closed the membership bead)", got)
+	}
+}
+
+// TestCloseFailedCreateBeadCascadesExtmsgState mirrors the cascade check on
+// the failed-create path. A startup race between session-bead creation and
+// an early bind attempt could leave a participant referencing the bead, so
+// both pool-close entry points need the cleanup (B23 fix scope completeness).
+func TestCloseFailedCreateBeadCascadesExtmsgState(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, string(session.StateFailedCreate))
+
+	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
+		t.Fatalf("open memberships before close = %d, want 1 (setup precondition)", got)
+	}
+
+	var stderr bytes.Buffer
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	if !closeFailedCreateBead(store, sessionBead.ID, now, &stderr) {
+		t.Fatalf("closeFailedCreateBead returned false; want true: stderr=%s", stderr.String())
+	}
+
+	if got := openMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
+		t.Errorf("open memberships after closeFailedCreateBead = %d, want 0 (cascade should have closed the membership bead)", got)
+	}
+}
+
 func TestCloseSessionBeadIfUnassignedRefusesWhenRigStoreWorkAssignedBySessionName(t *testing.T) {
 	store := beads.NewMemStore()
 	rigStore := beads.NewMemStore()


### PR DESCRIPTION
Closes #1939.

## Summary

`closeBead` and `closeFailedCreateBead` in `cmd/gc/session_beads.go` close pool session beads via `store.Close()` but never call `extmsg.CloseSessionBindings`. Only named-session retirement at `retireNamedSession` (`session_beads.go:492`) cascades through `cancelStateAssignedToRetiredSessionBead`. So every pool respawn (supervisor restart, idle timeout, drain) leaks the session's bindings, participants, and memberships.

`#1865` made the cascade primitive correct; the cascade just wasn't wired into the pool close-paths. The `extmsg: notify <closed-id> failed: session is closed` log noise from #1939 is one symptom — the more important effect (observed today on `#gascity-maintenance` / C0B25SS12CD) is that the live successor never re-binds and slack delivery silently fails until manual `/extmsg/{unbind,bind}` recovery.

## Fix

Wire `cancelStateAssignedToRetiredSessionBead` (which fires both `session.CancelWaits` and `extmsg.CloseSessionBindings`) into both pool-close entry points so every close-path mirrors named-session retirement's cleanup. The pre-existing idempotence guard at the top of `closeBead` means the cascade fires exactly once per session — on the open→closed transition.

Net diff: +13 LOC in production, +99 LOC in tests, no new imports (extmsg was already imported).

This unifies #1939's two fix candidates into one: cascade-on-close at the right call site.

## Test plan

- [x] `go test ./cmd/gc/ -run 'TestCloseBead|TestCloseFailedCreateBead' -count=1 -v` — all pass, including 2 new regression tests
- [x] `go test ./internal/extmsg/ -count=1` — full suite passes
- [x] `go build ./...` clean
- [x] Multi-model review (3 Anthropic + Codex gpt-5.4 + Copilot gpt-5.3-codex), zero blockers/majors, all correctness claims grounded against source
- [x] 29-rule codebase audit passes (B23 fix-scope-completeness verified across all 13 callers of the two close helpers)

### Regression test shape

```go
func TestCloseBeadCascadesExtmsgState(t *testing.T) {
    store := beads.NewMemStore()
    sessionBead, fabric, caller := setupSessionWithExtmsgMembership(t, store, session.StateActive)

    if got := countOpenMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 1 {
        t.Fatalf("open memberships before close = %d, want 1 (setup precondition)", got)
    }

    var stderr bytes.Buffer
    now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
    if !closeBead(store, sessionBead.ID, "drained", now, &stderr) {
        t.Fatalf("closeBead returned false; want true: stderr=%s", stderr.String())
    }

    if got := countOpenMembershipsForSession(t, fabric, caller, sessionBead.ID); got != 0 {
        t.Errorf("open memberships after closeBead = %d, want 0 (cascade should have closed the membership bead)", got)
    }
}
```

`TestCloseFailedCreateBeadCascadesExtmsgState` mirrors the same shape on the failed-create path (B23 fix-scope-completeness — defense in depth against the startup race where a session bead exists briefly before bind).

The tests verify cascade firing through `Transcript.ListConversationsBySession`, which filters on membership bead status (`transcript_service.go:494`) and does NOT consult the session bead's status — so "count 0 after close" cannot be explained by anything other than the cascade.

## Validation in production

`#gascity-maintenance` (C0B25SS12CD) bound to closed `gc-156882` while live PL was `gc-164103` — manual `unbind+bind` via the API restored delivery and verified the cascade-call's effect end-to-end. This PR makes that recovery automatic on the next session-close event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)