### PR TITLE
fix(refinery): enforce rejection_reason clearance on close in prompt

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -206,12 +206,18 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 		t.Fatalf("reading refinery formula: %v", err)
 	}
 	body := string(data)
+	normalizedBody := strings.Join(strings.Fields(body), " ")
+	unsetRationale := "`--unset-metadata rejection_reason` clears any stale rejection field"
+	if count := strings.Count(normalizedBody, unsetRationale); count != 2 {
+		t.Fatalf("refinery formula should explain rejection_reason cleanup in both close paths, found %d occurrences", count)
+	}
 
 	// Direct-merge path: metadata write must be chained into the close.
 	assertContainsInOrder(t, body,
 		"--set-metadata merge_result=merged",
 		"--set-metadata merged_sha=$MERGED_SHA",
-		"--set-metadata merged_target=$TARGET &&",
+		"--set-metadata merged_target=$TARGET",
+		"--unset-metadata rejection_reason &&",
 		`gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"`,
 	)
 
@@ -220,7 +226,8 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 		"--set-metadata merge_result=pull_request",
 		`--set-metadata pr_url="$PR_URL"`,
 		`--set-metadata pr_number="$PR_NUMBER"`,
-		`--set-metadata merged_target="$TARGET" &&`,
+		`--set-metadata merged_target="$TARGET"`,
+		"--unset-metadata rejection_reason &&",
 		`gc bd close $WORK --reason "Pull request ready: $PR_URL"`,
 	)
 }
@@ -234,11 +241,11 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 // abandoned" by reading metadata.
 //
 // The formula's `merge-push` step chains `--unset-metadata
-// rejection_reason` into the same `gc bd update` that records
-// `merged_sha` / `merged_target`, but the refinery prompt's "Rejection
-// Flow" section described only the set side of the lifecycle — the
-// LLM agent saw no closing-symmetry instruction in the prompt and
-// dropped the unset whenever it bypassed the formula's chained command.
+// rejection_reason` into the terminal `gc bd update`, but the refinery
+// prompt's "Rejection Flow" section described only the set side of the
+// lifecycle — the LLM agent saw no closing-symmetry instruction in the
+// prompt and dropped the unset whenever it bypassed the formula's chained
+// command.
 //
 // The fix adds a closing-symmetry note to the Rejection Flow section
 // naming the obligation: on merging a previously-rejected bead, clear
@@ -250,12 +257,12 @@ func TestRefineryPromptRejectionFlowEnforcesClearOnMerge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading refinery prompt: %v", err)
 	}
-	body := string(data)
+	body := strings.Join(strings.Fields(string(data)), " ")
 
 	assertContainsInOrder(t, body,
 		"## Rejection Flow",
-		"clear\n`rejection_reason` before `gc bd close`",
-		"--unset-metadata\nrejection_reason",
+		"clear `rejection_reason` before `gc bd close`",
+		"--unset-metadata rejection_reason",
 	)
 }
 

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -225,6 +225,40 @@ func TestRefineryFormulaChainsMergeMetadataWithClose(t *testing.T) {
 	)
 }
 
+// TestRefineryPromptRejectionFlowEnforcesClearOnMerge guards against
+// the regression observed in L5c (2026-05-10): the refinery agent
+// merged a previously-rejected work bead and closed it, but never ran
+// `gc bd update --unset-metadata rejection_reason`. The closed bead
+// retained the stale `rejection_reason` field, so downstream tooling
+// could not distinguish "rejected and resolved" from "rejected and
+// abandoned" by reading metadata.
+//
+// The formula's `merge-push` step chains `--unset-metadata
+// rejection_reason` into the same `gc bd update` that records
+// `merged_sha` / `merged_target`, but the refinery prompt's "Rejection
+// Flow" section described only the set side of the lifecycle — the
+// LLM agent saw no closing-symmetry instruction in the prompt and
+// dropped the unset whenever it bypassed the formula's chained command.
+//
+// The fix adds a closing-symmetry note to the Rejection Flow section
+// naming the obligation: on merging a previously-rejected bead, clear
+// `rejection_reason` before `gc bd close`.
+func TestRefineryPromptRejectionFlowEnforcesClearOnMerge(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "refinery", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery prompt: %v", err)
+	}
+	body := string(data)
+
+	assertContainsInOrder(t, body,
+		"## Rejection Flow",
+		"clear\n`rejection_reason` before `gc bd close`",
+		"--unset-metadata\nrejection_reason",
+	)
+}
+
 func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -115,6 +115,18 @@ On rebase conflict or test failure:
 A new polecat picks up the bead, sees `metadata.branch` and
 `metadata.rejection_reason`, rebases or redoes work, reassigns to refinery.
 
+**On the next merge of a previously-rejected bead, clear
+`rejection_reason` before `gc bd close`.** A bead carrying both a
+"closed merged" status and a stale `rejection_reason` is internally
+contradictory — downstream tooling that reads `metadata.rejection_reason`
+to surface "this bead failed" can't tell the rejection has been
+resolved. The formula's `merge-push` step chains `--unset-metadata
+rejection_reason` into the same `gc bd update` that records
+`merged_sha` / `merged_target`; do not split the chain, and do not
+skip the unset because the bead's previous rejection looks like
+ancient history. The cost of the unset is one CLI flag; the cost of
+leaving it set is a permanent contradictory record on the bead.
+
 ## Merge Strategy
 
 `metadata.merge_strategy` controls the terminal handoff:

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -121,11 +121,11 @@ A new polecat picks up the bead, sees `metadata.branch` and
 contradictory — downstream tooling that reads `metadata.rejection_reason`
 to surface "this bead failed" can't tell the rejection has been
 resolved. The formula's `merge-push` step chains `--unset-metadata
-rejection_reason` into the same `gc bd update` that records
-`merged_sha` / `merged_target`; do not split the chain, and do not
-skip the unset because the bead's previous rejection looks like
-ancient history. The cost of the unset is one CLI flag; the cost of
-leaving it set is a permanent contradictory record on the bead.
+rejection_reason` into each terminal `gc bd update` before `gc bd
+close`; do not split the chain, and do not skip the unset because the
+bead's previous rejection looks like ancient history. The cost of the
+unset is one CLI flag; the cost of leaving it set is a permanent
+contradictory record on the bead.
 
 ## Merge Strategy
 

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -398,7 +398,9 @@ Run as a single chained command so the metadata write cannot be skipped
 when the close-reason already names the SHA. Both the `--set-metadata`
 write and the `gc bd close` are required — `merged_sha` and
 `merged_target` are the only forensic breadcrumbs tying a closed bead
-to its merge commit on `$TARGET`.
+to its merge commit on `$TARGET`. `--unset-metadata rejection_reason`
+clears any stale rejection field from an earlier rejected/reworked
+attempt before the successful close.
 
 ```bash
 MERGED_SHA=$(git rev-parse HEAD) && \
@@ -406,7 +408,8 @@ MERGED_SHORT=$(git rev-parse --short HEAD) && \
 gc bd update $WORK \
   --set-metadata merge_result=merged \
   --set-metadata merged_sha=$MERGED_SHA \
-  --set-metadata merged_target=$TARGET && \
+  --set-metadata merged_target=$TARGET \
+  --unset-metadata rejection_reason && \
 gc bd close $WORK --reason "Merged to $TARGET at $MERGED_SHORT"
 ```
 
@@ -535,14 +538,17 @@ Run as a single chained command so the metadata write cannot be skipped
 when the close-reason already names the PR. Both the `--set-metadata`
 write and the `gc bd close` are required — `pr_url` and `pr_number`
 are the only forensic breadcrumbs tying a closed bead to its pull
-request.
+request. `--unset-metadata rejection_reason` clears any stale rejection
+field from an earlier rejected/reworked attempt before the successful
+close.
 
 ```bash
 gc bd update $WORK \
   --set-metadata merge_result=pull_request \
   --set-metadata pr_url="$PR_URL" \
   --set-metadata pr_number="$PR_NUMBER" \
-  --set-metadata merged_target="$TARGET" && \
+  --set-metadata merged_target="$TARGET" \
+  --unset-metadata rejection_reason && \
 gc bd close $WORK --reason "Pull request ready: $PR_URL"
 ```
 


### PR DESCRIPTION
## Summary

When a polecat resolves a previously-rejected work bead and the refinery
merges it, `metadata.rejection_reason` must be cleared before close so
the closed bead doesn't carry an internally-contradictory "closed merged
+ stale rejection_reason" pair. This branch now carries both layers of
the fix: the formula's `merge-push` step chains
`--unset-metadata rejection_reason` into the same `gc bd update` that
records `merged_sha` / `merged_target`, and the refinery prompt's
"Rejection Flow" section explains the closing-symmetry obligation. The
formula hunk overlaps the rejection cleanup portion of still-open #1916;
if this PR lands first, #1916 should drop that overlapping cleanup hunk
and keep its separate wake/nudge changes. The LLM agent saw no
prompt-level closing-symmetry instruction and dropped the unset whenever
it bypassed the formula's chained command — the same shape as #1935
(stg-a1st) for `merged_sha`.

Reproduced on validate-l5-20260510 L5c (city built from `local/integration`
1c2217ce, includes the formula's chained `--unset-metadata rejection_reason`):
bead `vlr-2gp` was rejected by refinery with `rejection_reason` set to a
rebase-conflict summary, picked back up by the polecat, conflict resolved,
resubmitted. The refinery merged and closed the bead — but the closed
bead still carried the stale `rejection_reason`. The refinery transcript
shows the agent ran:

```
gc bd close vlr-2gp --reason="Fast-forward merged ..."
```

without the preceding `gc bd update --unset-metadata rejection_reason`
that the formula's chain prescribes.

This is a sibling fix to #1935 (Merge Bookkeeping for `merged_sha` /
`merged_target`); same diagnosis, same prompt-level remediation pattern,
different metadata field.

### What changed

- `examples/gastown/packs/gastown/agents/refinery/prompt.template.md` —
  Rejection Flow section gains a closing-symmetry note: on the next
  merge of a previously-rejected bead, clear `rejection_reason` before
  `gc bd close`. Names the cost asymmetry (one CLI flag vs. a permanent
  contradictory record) and points back to the formula's chained
  `--unset-metadata rejection_reason` as the canonical implementation.

- `examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml` —
  both terminal close paths chain `--unset-metadata rejection_reason`
  before `gc bd close` and now explain that it clears stale rejection
  state from an earlier rejected/reworked attempt.

- `examples/gastown/gastown_test.go` — adds
  `TestRefineryPromptRejectionFlowEnforcesClearOnMerge`: substring-
  in-order assertion that the new closing-symmetry phrases are present
  in the Rejection Flow section. The existing formula close-chain test
  also checks that both terminal close paths explain the stale
  `rejection_reason` cleanup.

Surface: refinery rejection_reason clearance via prompt-level Rejection
Flow note (canonical agent prompt template), backstopped by the
formula's chained `--unset-metadata rejection_reason` in this branch;
not direct Dolt edits or per-call CLI wrappers.

Fixes: stg-e60b. Adjacent to: #1916 (overlapping formula cleanup plus
separate wake/nudge changes), #1935 (Merge Bookkeeping for
merged_sha/merged_target).

### Cross-PR ack

Interacts with #1934 — both PRs touch the same prompt file and the same
"Rejection Flow" section, but at non-overlapping concerns. #1934 fixes
the *set* side of the lifecycle (rejection bd update missing
`gc.routed_to`); this PR fixes the *clear* side (close path missing
`--unset-metadata rejection_reason`). The two diffs touch different
hunks of the section and merge order is independent — whichever lands
second will need a trivial textual rebase. Both share originating L5c
investigation context.

Interacts with #1916 — #1958 now intentionally subsumes the
`rejection_reason` formula cleanup that #1916 also contains, while #1916
still has independent wake/nudge work. Preferred merge order: land
#1958 first for the prompt plus formula close symmetry, then rebase
#1916 and drop its duplicate formula/test cleanup while preserving the
wake/nudge changes. If #1916 lands first, this PR should drop only the
overlapping formula/test cleanup and keep the prompt-level obligation.

## Testing

- [x] `go test ./examples/gastown/... -count=1` — PASS (39.4s
      on 2026-05-14 after the maintainer formula prose update; prior
      PR run also passed at 148s).
      Scoped gate per stg-v92z; full `make check` defers to CI. Diff
      is contained within `examples/gastown/...` (one prompt template,
      one formula, and one test file in the same package), no `cmd/gc/` or
      `internal/` reach.
- [ ] `make check-docs` — not needed; no `docs/` or `engdocs/` change.
- [ ] `make test-integration` — current policy: don't run (past
      attempts hit 30 min timeout with no saved partial output).

Pre-existing EXPECT-FAIL beads (none are exercised by the scoped gate
above; documented for completeness):

- `stg-bz3` gascity:TestStartLongSocketPathUsesShortSocketName flake
  (no fix yet)
- `stg-7s03` gascity:TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness
  (no fix yet)
- `stg-f6o2` gascity:TestCityRuntimeWatchReloadPanicRestoresDirty flake
  (no fix yet)
- `stg-i7z3` gascity:TestProjectIdentity/B10_write_concurrent_same_id_safe
  flake (no fix yet)

Verify-the-symptom (test inversion): with the prompt edit reverted,
`go test -run TestRefineryPromptRejectionFlowEnforcesClearOnMerge` fails
with `missing "clear\n\`rejection_reason\` before \`gc bd close\`"`. With
the prompt edit applied, it passes. Confirms the test is a true guard
for the regression and not a tautology.

## Checklist

- [x] Linked an issue (stg-e60b internal; same-shape sibling of #1935
      / stg-a1st). No upstream issue filed; behavior surfaced in our
      L-ladder validation.
- [x] Added regression test (`TestRefineryPromptRejectionFlowEnforcesClearOnMerge`).
- [ ] Updated docs — n/a; the edited file is itself an agent prompt
      template (the "doc" agents read at runtime).
- [ ] Breaking changes — none. The prompt addition is an obligation
      already satisfied by the formula; existing-but-incomplete LLM
      behavior is the regression being fixed.
