### PR TITLE
fix(polecat): refuse to stamp worktree-setup persistent branch on submit

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -250,6 +250,57 @@ func TestPolecatFormulaTreatsMetadataBranchAsAuthoritative(t *testing.T) {
 	)
 }
 
+// TestPolecatPromptRejectsWorktreeSetupBranchOnSubmit guards against the
+// failure mode where the polecat's done sequence stamps the per-slot
+// persistent worktree branch (`gc-<agent>-<hash>`, created by
+// `worktree-setup.sh`) onto the work bead's `branch` metadata.
+//
+// The pool reuses slot identities — a new polecat in slot `furiosa` gets
+// the same worktree path and therefore the same `worktree-setup.sh`
+// branch as the previous occupant. If the agent skips the formula's
+// workspace-setup step (which would create a fresh `polecat/<issue>`
+// feature branch), `git branch --show-current` returns the persistent
+// `gc-furiosa-<hash>` branch. Stamping that on the work bead points the
+// refinery at the slot's branch — and every subsequent bead through that
+// slot stamps the same name, producing cross-bead branch collisions
+// where multiple work beads share one branch.
+//
+// The guard fails loud with `exit 1` rather than silently corrupting
+// downstream merge state. Codified after stg-b9di / events.jsonl
+// inspection of validate-l5-20260510-v3 confirmed two work beads
+// (vl2vr-73h, vl2vr-gcw) ended up sharing branch `gc-furiosa-14808603229f`
+// across two polecat sessions in the same `furiosa` slot, which matches
+// the `branch_name()` output of `worktree-setup.sh` for that worktree
+// path exactly.
+func TestPolecatPromptRejectsWorktreeSetupBranchOnSubmit(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "polecat", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading polecat prompt: %v", err)
+	}
+	prompt := string(data)
+
+	// The done-sequence guard must capture the current branch, refuse
+	// `gc-*` (the worktree-setup pattern), and stamp `branch=` from the
+	// captured variable rather than re-running `git branch --show-current`
+	// inside the metadata write.
+	assertContainsInOrder(t, prompt,
+		`CURRENT_BRANCH=$(git branch --show-current)`,
+		`case "$CURRENT_BRANCH" in`,
+		`gc-*)`,
+		`exit 1`,
+		`--set-metadata branch="$CURRENT_BRANCH"`,
+	)
+
+	// Guard against the prior shape that stamped `git branch
+	// --show-current` directly inside the `gc bd update` line — that's
+	// the bug this test exists to prevent recurring.
+	if strings.Contains(prompt, `--set-metadata branch=$(git branch --show-current)`) {
+		t.Fatalf("polecat prompt still pipes `git branch --show-current` straight into `--set-metadata branch=`; capture and validate against the `gc-*` worktree-setup pattern first")
+	}
+}
+
 func TestPolecatFormulaRecordsExistingPRMetadataOnSubmit(t *testing.T) {
 	dir := exampleDir()
 	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-polecat-work.toml")

--- a/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/polecat/prompt.template.md
@@ -197,8 +197,19 @@ Nudges from other agents may arrive via your hook. When working:
 
 ```bash
 git push origin HEAD
+CURRENT_BRANCH=$(git branch --show-current)
+case "$CURRENT_BRANCH" in
+  gc-*)
+    echo "ERROR: current branch '$CURRENT_BRANCH' is the per-slot worktree branch from worktree-setup," >&2
+    echo "       not a feature branch. Stamping it on the work bead would point the refinery at the" >&2
+    echo "       slot's persistent branch — which the next polecat in this slot will reuse — causing" >&2
+    echo "       cross-bead branch collisions. The formula's workspace-setup step creates the feature" >&2
+    echo "       branch ('polecat/{{ "{{issue}}" }}'); pour mol-polecat-work and walk it before resubmitting." >&2
+    exit 1
+    ;;
+esac
 gc bd update <work-bead> \
-  --set-metadata branch=$(git branch --show-current) \
+  --set-metadata branch="$CURRENT_BRANCH" \
   --set-metadata target={{ .DefaultBranch }} \
   --notes "Implemented: <brief summary>"
 REFINERY_TARGET="${GC_RIG:+$GC_RIG/}{{ .BindingPrefix }}refinery"
@@ -211,6 +222,16 @@ Your work is not complete until you run these commands. `gc runtime drain-ack`
 signals the reconciler to kill this session — it will only restart you if the
 pool check command finds more work. Sitting idle after finishing implementation
 is the "Idle Polecat heresy."
+
+The `gc-*` branch guard above catches the case where the agent skipped the
+formula's workspace-setup step and is still on the per-slot persistent branch
+that `worktree-setup.sh` creates (named `gc-<agent>-<hash>`, where `<agent>`
+is the polecat slot name). Stamping that branch on the work bead is the
+failure mode where the refinery sees two work beads pointing at the same
+branch — pool slot reuse means the next polecat in the slot inherits the same
+worktree-setup branch, and without a feature branch in between, every bead
+through that slot stamps the same name. The guard fails loud rather than
+silently corrupt downstream merge state.
 
 ---
 


### PR DESCRIPTION
## Summary

The polecat prompt's FINAL REMINDER done sequence stamps `branch=$(git
branch --show-current)` directly into the work bead's metadata. When
the agent skipped the formula's workspace-setup step (which would
create a fresh `polecat/<issue>` feature branch), `git branch
--show-current` returns the per-slot persistent branch that
`assets/scripts/worktree-setup.sh` creates — `gc-<agent>-<hash>`,
where `<agent>` is the polecat slot name (e.g. `furiosa`) and
`<hash>` is the worktree path's `git hash-object` value. That branch
is shared across every polecat session that reuses the slot, so
stamping it on a work bead points the refinery at a branch the next
polecat in the slot will reuse for an unrelated bead — producing the
failure where two work beads sit in the refinery queue pointing at
the same branch and only one merges cleanly.

This PR adds a `case "$CURRENT_BRANCH" in gc-*) ... exit 1 ;;` guard
in the FINAL REMINDER between the `git branch --show-current` capture
and the `gc bd update --set-metadata branch=` call. The error message
names the formula step that creates the correct feature branch so
the agent knows the recovery action.

Surface: pack-prompt edit only — no gascity Go code touched. Bug
class is agent-behavior, instruction-shape per the maintenance-fixer
solution-shape preference. The deeper architectural shape
(worktree-setup's persistent branch surviving across pool slot reuses)
is left untouched: that branch is correct as a stable per-slot
checkout target; the bug is the polecat prompt trusting `git branch
--show-current` for bead metadata without validating it is a feature
branch.

### Architecture surface confirmation

The change is at the canonical surface (the polecat prompt template
that polecat sessions actually read), not a wrong-way variant. The
formula's `workspace-setup` step already creates `polecat/<issue>`
feature branches correctly; the issue is that the prompt's FINAL
REMINDER is the path agents actually follow on the done sequence,
and it didn't validate the branch shape before stamping.

## Testing

- [x] `go test ./examples/gastown/...` — full scoped suite passes (146s,
      includes the new `TestPolecatPromptRejectsWorktreeSetupBranchOnSubmit`).
- [x] Command fixture (8/8 PASS): rejects `gc-furiosa-14808603229f`
      (the actual stg-b9di branch from `cities/validate-l5-20260510-v3`),
      `gc-nux-deadbeef`, `gc-polecat-a`; accepts `polecat/stg-b9di`,
      `polecat/vl2vr-gcw`, `feat/some-thing`, `main`. Verifies prompt
      contains the guard shape so a revert fails the fixture.
- [x] `TestPolecatPromptRejectsWorktreeSetupBranchOnSubmit` fails
      (assertion missing) when the prompt change is reverted via stash.
- [ ] `make check` — full gate not run; diff is one prompt-template
      file plus its scoped go test under `examples/gastown/`. Per
      `mol-pr-submit` step 3 isolated-package guidance, the scoped
      `go test ./examples/gastown/...` is the right gate; full-suite
      catch happens at CI time.
- [ ] `make check-docs` — no `docs/` or `engdocs/` files touched.
- [ ] `make test-integration` — current local policy: don't run
      (timeouts with no partial output).

### Forensic evidence (the bug actually fired)

`cities/validate-l5-20260510-v3/.gc/events.jsonl` shows two work
beads (`vl2vr-73h`, `vl2vr-gcw`) both stamped with
`branch=gc-furiosa-14808603229f` across two polecat sessions
(`polecat-vl2v-e1b`, `polecat-vl2v-037k`) in the same `furiosa`
slot. The hash `14808603229f` matches
`printf '%s' '<worktree-path>' | git hash-object --stdin | cut -c1-12`
exactly — i.e. it is `worktree-setup.sh`'s `branch_name()` output for
that worktree path, not a coincidental name collision.

### Pre-existing failures (unrelated)

Open EXPECT-FAIL beads against `gascity` on the local ladder:
`stg-bz3` (`TestStartLongSocketPathUsesShortSocketName` flake under
parallel load on macOS), `stg-7s03`
(`TestDoctorScriptIgnoresDocumentedSystemSchemasForBackupFreshness`
— no fix yet), `stg-f6o2`
(`TestCityRuntimeWatchReloadPanicRestoresDirty` flake under parallel
load — no fix yet), `stg-i7z3`
(`TestProjectIdentity/B10_write_concurrent_same_id_safe` flake under
parallel load — no fix yet). None of these touch the
`examples/gastown/...` package this PR's diff lives in, and the
scoped suite this PR runs from did not surface them.

## Checklist

- [x] Linked an issue (stg-b9di in our local bd).
- [x] Added a regression test
      (`TestPolecatPromptRejectsWorktreeSetupBranchOnSubmit`) that
      asserts the guard shape and explicitly rejects the prior
      direct-stamp shape so reverting the fix fails the test.
- [x] No user-facing docs change required — the prompt is
      agent-facing prose; the new guard's error message documents
      the recovery path inline.
- [x] No breaking changes. The guard fires only when the agent has
      gone straight to the FINAL REMINDER without creating a feature
      branch — the documented happy path is unaffected.

## Out of scope

- gascity#1925 (open) adds the `git branch -D "$BRANCH"` polecat
  cleanup that runs against the same `git branch --show-current`
  value. This guard layers cleanly on top: if `$BRANCH` matched
  `gc-*`, the FINAL REMINDER guard exits before the cleanup runs,
  surfacing the issue rather than letting the prior occupant's
  persistent worktree branch get silently deleted by a later
  polecat.
- The `worktree-setup.sh` `branch_name()` function and the
  `gc-<agent>-<hash>` naming scheme are unchanged — that is the
  canonical worktree-branch contract; the fix just teaches the
  polecat to recognize it and refuse to stamp it as a feature branch.
- The formula `mol-polecat-work.toml` `workspace-setup` step already
  creates the correct `polecat/<issue>` feature branch and stamps
  it. The guard catches the case where the agent goes straight to
  the prompt's done sequence without running workspace-setup; it
  does not modify the formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
