### PR TITLE
fix: stabilize provider timeout cleanup tests

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -85,7 +85,11 @@ var resolveProviderLifecycleGCBinary = func() string {
 	return ""
 }
 
-var providerProbeTimeout = 10 * time.Second
+var (
+	providerProbeTimeout = 10 * time.Second
+	// Override only in tests that do not call t.Parallel while the hook is changed.
+	providerLifecycleContext = context.WithTimeout
+)
 
 var (
 	initDirIfReadyEnsureBeadsProvider = ensureBeadsProvider
@@ -1428,7 +1432,7 @@ func normalizeScopeDoltConfig(dir string, state contract.ConfigState) error {
 // available (exit 2) or on any error. Unlike runProviderOp, exit 2 means
 // "not running" rather than "not needed."
 func runProviderProbe(script, cityPath, provider string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), providerProbeTimeout)
+	ctx, cancel := providerLifecycleContext(context.Background(), providerProbeTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, script, "probe")
@@ -1534,7 +1538,7 @@ func acquireProviderSemaphore(ctx context.Context, cityPath string) (func(), err
 }
 
 func acquireProviderSemaphoreForOp(cityPath, op string) (func(), error) {
-	ctx, cancel := context.WithTimeout(context.Background(), providerOpTimeout(op))
+	ctx, cancel := providerLifecycleContext(context.Background(), providerOpTimeout(op))
 	release, err := acquireProviderSemaphore(ctx, cityPath)
 	if err != nil {
 		cancel()
@@ -1576,7 +1580,7 @@ func runProviderOpWithEnv(script string, environ []string, args ...string) error
 	if len(args) > 0 {
 		op = args[0]
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), providerOpTimeout(op))
+	ctx, cancel := providerLifecycleContext(context.Background(), providerOpTimeout(op))
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, script, args...)

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -3298,13 +3298,7 @@ func TestRunProviderOpSanitizesInheritedRuntimeEnv(t *testing.T) {
 }
 
 func TestRunProviderOpKillsProcessGroupOnTimeout(t *testing.T) {
-	oldProviderOpTimeout := providerOpTimeout
-	providerOpTimeout = func(string) time.Duration {
-		return 300 * time.Millisecond
-	}
-	t.Cleanup(func() {
-		providerOpTimeout = oldProviderOpTimeout
-	})
+	cancelCh := useCancelableProviderLifecycleContext(t)
 
 	dir := t.TempDir()
 	childPIDFile := filepath.Join(dir, "child.pid")
@@ -3317,39 +3311,37 @@ wait
 		t.Fatal(err)
 	}
 
-	err := runProviderOpWithEnv(script, append(os.Environ(), "GC_TEST_CHILD_PID="+childPIDFile), "health")
-	if err == nil {
-		t.Fatal("expected timeout error")
-	}
+	// Timeouts and explicit cancellation both drive exec.Cmd.Cancel; cancel only
+	// after the child PID is observable so the cleanup assertion cannot race setup.
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- runProviderOpWithEnv(script, append(os.Environ(), "GC_TEST_CHILD_PID="+childPIDFile), "health")
+	}()
 
-	pidBytes, readErr := os.ReadFile(childPIDFile)
-	if readErr != nil {
-		t.Fatalf("read child pid: %v", readErr)
-	}
-	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-	if convErr != nil {
-		t.Fatalf("parse child pid: %v", convErr)
-	}
+	cancel := waitForProviderLifecycleCancel(t, cancelCh)
+	t.Cleanup(cancel)
+	pid := waitForProviderTestChildPID(t, childPIDFile)
 	t.Cleanup(func() {
 		_ = syscall.Kill(pid, syscall.SIGKILL)
 	})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
-			return
-		}
-		time.Sleep(25 * time.Millisecond)
+	cancel()
+
+	var err error
+	select {
+	case err = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider op did not return after cancellation")
 	}
-	t.Fatalf("provider child pid %d survived provider op timeout", pid)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	waitForProviderTestPIDExit(t, pid, "provider op")
 }
 
 func TestRunProviderProbeKillsProcessGroupOnTimeout(t *testing.T) {
-	oldProviderProbeTimeout := providerProbeTimeout
-	providerProbeTimeout = 300 * time.Millisecond
-	t.Cleanup(func() {
-		providerProbeTimeout = oldProviderProbeTimeout
-	})
+	cancelCh := useCancelableProviderLifecycleContext(t)
 
 	dir := t.TempDir()
 	childPIDFile := filepath.Join(dir, "child.pid")
@@ -3363,22 +3355,95 @@ wait
 	}
 	t.Setenv("GC_TEST_CHILD_PID", childPIDFile)
 
-	if ok := runProviderProbe(script, "", ""); ok {
-		t.Fatal("expected timeout probe to return false")
-	}
+	// Timeouts and explicit cancellation both drive exec.Cmd.Cancel; cancel only
+	// after the child PID is observable so the cleanup assertion cannot race setup.
+	resultCh := make(chan bool, 1)
+	go func() {
+		resultCh <- runProviderProbe(script, "", "")
+	}()
 
-	pidBytes, readErr := os.ReadFile(childPIDFile)
-	if readErr != nil {
-		t.Fatalf("read child pid: %v", readErr)
-	}
-	pid, convErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-	if convErr != nil {
-		t.Fatalf("parse child pid: %v", convErr)
-	}
+	cancel := waitForProviderLifecycleCancel(t, cancelCh)
+	t.Cleanup(cancel)
+	pid := waitForProviderTestChildPID(t, childPIDFile)
 	t.Cleanup(func() {
 		_ = syscall.Kill(pid, syscall.SIGKILL)
 	})
 
+	cancel()
+
+	var ok bool
+	select {
+	case ok = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider probe did not return after cancellation")
+	}
+	if ok {
+		t.Fatal("expected timeout probe to return false")
+	}
+
+	waitForProviderTestPIDExit(t, pid, "provider probe")
+}
+
+func useCancelableProviderLifecycleContext(t *testing.T) <-chan context.CancelFunc {
+	t.Helper()
+	oldProviderLifecycleContext := providerLifecycleContext
+	cancelCh := make(chan context.CancelFunc, 1)
+	providerLifecycleContext = func(parent context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(parent)
+		select {
+		case cancelCh <- cancel:
+		default:
+		}
+		return ctx, cancel
+	}
+	t.Cleanup(func() {
+		providerLifecycleContext = oldProviderLifecycleContext
+	})
+	return cancelCh
+}
+
+func waitForProviderLifecycleCancel(t *testing.T, cancelCh <-chan context.CancelFunc) context.CancelFunc {
+	t.Helper()
+	select {
+	case cancel := <-cancelCh:
+		return cancel
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider lifecycle context was not created")
+		return nil
+	}
+}
+
+func waitForProviderTestChildPID(t *testing.T, path string) int {
+	t.Helper()
+	pidText := waitForProviderTestNonEmptyFile(t, path, 5*time.Second)
+	pid, err := strconv.Atoi(pidText)
+	if err != nil {
+		t.Fatalf("parse child pid: %v", err)
+	}
+	return pid
+}
+
+func waitForProviderTestNonEmptyFile(t *testing.T, path string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pidBytes, err := os.ReadFile(path)
+		if err == nil {
+			pid := strings.TrimSpace(string(pidBytes))
+			if pid != "" {
+				return pid
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read child pid: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child pid was not written within %s", timeout)
+	return ""
+}
+
+func waitForProviderTestPIDExit(t *testing.T, pid int, label string) {
+	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
@@ -3386,7 +3451,7 @@ wait
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	t.Fatalf("provider child pid %d survived provider probe timeout", pid)
+	t.Fatalf("provider child pid %d survived %s cancellation", pid, label)
 }
 
 func TestStartBeadsLifecycleDoesNotMutateProcessDoltEnv(t *testing.T) {

--- a/cmd/gc/provider_op_process_unix.go
+++ b/cmd/gc/provider_op_process_unix.go
@@ -10,7 +10,10 @@ import (
 )
 
 func prepareProviderOpCommand(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
 	cmd.Cancel = func() error {
 		if cmd == nil || cmd.Process == nil {
 			return nil
@@ -18,7 +21,6 @@ func prepareProviderOpCommand(cmd *exec.Cmd) {
 		pgid, err := syscall.Getpgid(cmd.Process.Pid)
 		if err == nil {
 			if killErr := syscall.Kill(-pgid, syscall.SIGKILL); killErr != nil &&
-				!errors.Is(killErr, os.ErrProcessDone) &&
 				!errors.Is(killErr, syscall.ESRCH) {
 				return killErr
 			}

--- a/cmd/gc/provider_op_process_windows.go
+++ b/cmd/gc/provider_op_process_windows.go
@@ -5,6 +5,7 @@ package main
 import "os/exec"
 
 func prepareProviderOpCommand(cmd *exec.Cmd) {
+	// Windows provider cleanup remains direct-process-only until provider ops use job objects.
 	cmd.Cancel = func() error {
 		if cmd == nil || cmd.Process == nil {
 			return nil


### PR DESCRIPTION
Maintainer follow-up for #1715.

Original PR:
- URL: https://github.com/gastownhall/gascity/pull/1715
- Title: bd-npxnm.10.10: Fix provider lifecycle process cleanup on timeout
- State: MERGED
- Configured base: main
- Original GitHub base: main
- Base mismatch: none
- Original contributor: @fengning-starsend
- Original head SHA: 2d9969b354d2308ec46c7bfc3611fab7903d2fb6

Why this follow-up exists:
The original PR merged before the adoption workflow could push the approved maintainer-side stabilization fix. This PR carries only that maintainer follow-up commit; the contributor's original commit remains preserved in the already-merged PR.

Changes:
- Stabilize the provider op/probe timeout cleanup tests by cancelling only after the background child PID is observable.
- Preserve existing Unix `SysProcAttr` values while enabling provider process-group cleanup.
- Keep the Windows provider cleanup limitation explicit in code.

Validation before opening:
- `adopt_pr_approval_summary.py --issue ga-80pl9e --repo-slug gastownhall/gascity --pr-number 1715` passed after base refresh.
- `adopt_pr_base_refresh.py --issue ga-80pl9e --repo-slug gastownhall/gascity --pr-number 1715 --base-branch main --upstream-url https://github.com/gastownhall/gascity.git` returned `status=already_current` with unchanged patch-id.
- `go test ./cmd/gc -run 'TestRunProvider(Op|Probe)KillsProcessGroupOnTimeout' -count=1` passed.

Local note:
`make test` was attempted, but this environment reproduces a current `origin/main` failure in `TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot` that leaks a managed Dolt test server. The same focused test fails on a clean `origin/main` worktree, so this follow-up relies on the visible GitHub CI surface for the final merge-ready gate.
