### PR TITLE
fix(supervisor): default BEADS_ACTOR=controller in process env at startup

### DIFF
--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -381,9 +381,15 @@ API server.`,
 	}
 }
 
+// runSupervisorFunc is the run-loop entry point invoked by
+// doSupervisorRun. Indirection enables tests to substitute a no-op
+// loop so pre-loop setup (defaultSupervisorBeadsActor) is observable
+// without launching the real long-running supervisor.
+var runSupervisorFunc = runSupervisor
+
 func doSupervisorRun(stdout, stderr io.Writer) int {
 	defaultSupervisorBeadsActor()
-	return runSupervisor(stdout, stderr)
+	return runSupervisorFunc(stdout, stderr)
 }
 
 // defaultSupervisorBeadsActor sets BEADS_ACTOR=controller in this

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -382,7 +382,33 @@ API server.`,
 }
 
 func doSupervisorRun(stdout, stderr io.Writer) int {
+	defaultSupervisorBeadsActor()
 	return runSupervisor(stdout, stderr)
+}
+
+// defaultSupervisorBeadsActor sets BEADS_ACTOR=controller in this
+// process's env when the operator has not already set a value.
+//
+// bd hooks (.beads/hooks/on_create, on_update, on_close) are spawned
+// from the supervisor process and forward events via `gc event emit`
+// subprocesses that inherit this process's env. Without this default,
+// eventActor() walks the GC_ALIAS → GC_AGENT → GC_SESSION_ID →
+// BEADS_ACTOR chain (all unset in a fresh supervisor) and lands on the
+// "human" fallback, mis-attributing every dispatcher-issued
+// tracking-bead create/update/close.
+//
+// applyControllerBdEnv (cmd/gc/bd_env.go) covers BEADS_ACTOR for the
+// env map handed to spawned bd commands; this covers the
+// process-env path the hook subprocesses inherit. The two paths are
+// independent and both are required for full controller attribution.
+//
+// Order-exec subprocesses still override BEADS_ACTOR to "order:<name>"
+// via orderExecEnv (cmd/gc/order_store.go) before exec, so per-order
+// attribution is preserved.
+func defaultSupervisorBeadsActor() {
+	if strings.TrimSpace(os.Getenv("BEADS_ACTOR")) == "" {
+		_ = os.Setenv("BEADS_ACTOR", "controller")
+	}
 }
 
 func doSupervisorStart(stdout, stderr io.Writer) int {

--- a/cmd/gc/cmd_supervisor_lifecycle_actor_test.go
+++ b/cmd/gc/cmd_supervisor_lifecycle_actor_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDefaultSupervisorBeadsActor verifies that the supervisor's process
+// env defaults BEADS_ACTOR=controller when the operator has not set it.
+//
+// Without this default, bd hooks (which spawn `gc event emit`
+// subprocesses inheriting the supervisor's ambient process env) fall
+// through eventActor()'s GC_ALIAS → GC_AGENT → GC_SESSION_ID → BEADS_ACTOR
+// chain and land on the literal "human" fallback, mis-attributing every
+// dispatcher-issued tracking-bead create/update/close to "human".
+//
+// applyControllerBdEnv (cmd/gc/bd_env.go) sets BEADS_ACTOR=controller in
+// the env *map* used when spawning bd commands, but bd hooks are
+// spawned from the supervisor's own process — they inherit the process
+// env, not that map — so the helper here ensures the hook path resolves
+// to "controller" as well.
+//
+// Order-exec subprocesses still override BEADS_ACTOR to "order:<name>"
+// via orderExecEnv (cmd/gc/order_store.go), which beats the inherited
+// process env, so per-order attribution is preserved.
+func TestDefaultSupervisorBeadsActor(t *testing.T) {
+	t.Run("unset env defaults to controller", func(t *testing.T) {
+		t.Setenv("BEADS_ACTOR", "")
+		_ = os.Unsetenv("BEADS_ACTOR")
+		defaultSupervisorBeadsActor()
+		if got := os.Getenv("BEADS_ACTOR"); got != "controller" {
+			t.Fatalf("BEADS_ACTOR = %q, want %q", got, "controller")
+		}
+	})
+
+	t.Run("whitespace-only treated as unset", func(t *testing.T) {
+		t.Setenv("BEADS_ACTOR", "   ")
+		defaultSupervisorBeadsActor()
+		if got := os.Getenv("BEADS_ACTOR"); got != "controller" {
+			t.Fatalf("BEADS_ACTOR = %q, want %q", got, "controller")
+		}
+	})
+
+	t.Run("operator-set value is respected", func(t *testing.T) {
+		t.Setenv("BEADS_ACTOR", "custom-operator")
+		defaultSupervisorBeadsActor()
+		if got := os.Getenv("BEADS_ACTOR"); got != "custom-operator" {
+			t.Fatalf("BEADS_ACTOR = %q, want %q", got, "custom-operator")
+		}
+	})
+}
+
+// TestEventActorAfterSupervisorDefault verifies the end-to-end effect:
+// once defaultSupervisorBeadsActor has run with an empty ambient env,
+// eventActor() — the function bd-hook-forwarded `gc event emit`
+// subprocesses use to determine the event Actor — returns "controller"
+// instead of falling through to "human".
+func TestEventActorAfterSupervisorDefault(t *testing.T) {
+	// Clear every env var eventActor() consults so the discriminator
+	// isolates the BEADS_ACTOR path that the supervisor default touches.
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT", "GC_SESSION_ID", "BEADS_ACTOR"} {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
+	}
+	if got := eventActor(); got != "human" {
+		t.Fatalf("eventActor() = %q before supervisor default, want %q (parent-RED baseline)", got, "human")
+	}
+
+	defaultSupervisorBeadsActor()
+
+	if got := eventActor(); got != "controller" {
+		t.Fatalf("eventActor() = %q after supervisor default, want %q", got, "controller")
+	}
+}

--- a/cmd/gc/cmd_supervisor_lifecycle_actor_test.go
+++ b/cmd/gc/cmd_supervisor_lifecycle_actor_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"testing"
 )
@@ -70,5 +71,36 @@ func TestEventActorAfterSupervisorDefault(t *testing.T) {
 
 	if got := eventActor(); got != "controller" {
 		t.Fatalf("eventActor() = %q after supervisor default, want %q", got, "controller")
+	}
+}
+
+// TestDoSupervisorRunInvokesDefaultBeadsActor verifies that
+// doSupervisorRun runs defaultSupervisorBeadsActor before delegating to
+// the run-loop, covering the call site that unit tests cannot exercise
+// directly (runSupervisor blocks until shutdown). The runSupervisorFunc
+// indirection lets the test substitute a no-op loop, observe the
+// pre-loop env state, and confirm the helper executed.
+func TestDoSupervisorRunInvokesDefaultBeadsActor(t *testing.T) {
+	for _, key := range []string{"GC_ALIAS", "GC_AGENT", "GC_SESSION_ID", "BEADS_ACTOR"} {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
+	}
+
+	origRun := runSupervisorFunc
+	called := false
+	runSupervisorFunc = func(io.Writer, io.Writer) int {
+		called = true
+		return 0
+	}
+	t.Cleanup(func() { runSupervisorFunc = origRun })
+
+	if rc := doSupervisorRun(io.Discard, io.Discard); rc != 0 {
+		t.Fatalf("doSupervisorRun = %d, want 0", rc)
+	}
+	if !called {
+		t.Fatal("runSupervisorFunc was not invoked")
+	}
+	if got := os.Getenv("BEADS_ACTOR"); got != "controller" {
+		t.Fatalf("BEADS_ACTOR after doSupervisorRun = %q, want %q", got, "controller")
 	}
 }


### PR DESCRIPTION
## Summary

bd hooks (`.beads/hooks/{on_create,on_update,on_close}`) are spawned from the supervisor process and forward events via `gc event emit` subprocesses that inherit the supervisor's ambient process env. With `BEADS_ACTOR` / `GC_ALIAS` / `GC_AGENT` / `GC_SESSION_ID` all unset (the default state when the supervisor is launched by systemd / launchd / `gc supervisor start`), `eventActor()` walks its fallback chain and lands on the literal `"human"` — mis-attributing every dispatcher-issued tracking-bead create/update/close.

This fix defaults `BEADS_ACTOR=controller` in `doSupervisorRun` when the operator hasn't set a value. It's independent of #1678 / its `/adopt-pr` empty-merge surface: `applyControllerBdEnv` (`cmd/gc/bd_env.go`) covers the env *map* passed to spawned bd commands; this PR covers the *process* env path bd hook subprocesses inherit. Both paths are required for full controller attribution.

## Empirical verification

On a fresh `gc supervisor run` against `46a14257`, the events log shows tracking-bead lifecycle attributed to `human`:

```json
{"type":"bead.created","actor":"human","subject":"pc-fhedx4","message":"order:gate-sweep","labels":null}
{"type":"bead.updated","actor":"human","subject":"pc-fhedx4","message":"order:gate-sweep","labels":["order-run:gate-sweep"]}
{"type":"bead.closed","actor":"human","subject":"pc-yv4jmn","message":"order:gate-sweep","labels":["exec","order-run:gate-sweep","order-tracking"]}
```

After setting `Environment=BEADS_ACTOR=controller` via a systemd drop-in (equivalent to this PR's change), a 30-second post-restart window captured **14 consecutive events, all attributed to `controller`, zero `human`**:

```
14 controller
 0 human
```

Sample:
```json
{"type":"bead.created","actor":"controller","message":"order:mol-dog-jsonl"}
{"type":"bead.updated","actor":"controller","message":"order:mol-dog-jsonl"}
```

## Order-exec subprocesses preserved

`orderExecEnv` in `cmd/gc/order_store.go:105` explicitly overrides `BEADS_ACTOR=order:<name>` in the env handed to spawned exec subprocesses, which beats this process-env default — so per-order attribution for the order's *own* bd writes is preserved unchanged. Only the supervisor's dispatcher-issued tracking-bead lifecycle (which runs in-process and thus uses the supervisor's ambient env via the hook subprocess) flips from `human` to `controller`.

## Discriminator

`cmd/gc/cmd_supervisor_lifecycle_actor_test.go`:

- `TestDefaultSupervisorBeadsActor` — verifies the helper sets `controller` when env is unset/whitespace and respects an operator-set value.
- `TestEventActorAfterSupervisorDefault` — verifies `eventActor()` returns `"human"` on a cleared env (parent-RED baseline) and `"controller"` after the helper runs (GREEN).

Parent-RED proof: on the test-only commit (`c9acc82e`), `go test ./cmd/gc/...` fails to compile with `undefined: defaultSupervisorBeadsActor`. After the fix commit (`0cc0df4a`), it passes.

## Test plan

- [x] `go test ./cmd/gc/ -run 'TestDefaultSupervisorBeadsActor|TestEventActorAfterSupervisorDefault'` — PASS
- [x] `go test ./cmd/gc/` filtered to supervisor / dispatch / event / bd-env tests — PASS, no collateral breakage
- [x] `gofmt` / `go vet` clean
- [x] Manual: systemd drop-in equivalent yields actor=controller in events.jsonl for 14/14 tracking-bead lifecycle events post-restart