### PR TITLE
fix(bd): force export.auto: false in managed config (#1965)

### DIFF
--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -219,6 +219,11 @@ func EnsureCanonicalConfig(fs fsys.FS, path string, state ConfigState) (bool, er
 		changed = setString(root, "issue-prefix", prefix) || changed
 	}
 	changed = setBool(root, "dolt.auto-start", false) || changed
+	// Managed beads are Dolt-backed; issues.jsonl auto-export is redundant and
+	// triggers a re-import cycle that stalls bd writes for minutes on large
+	// datasets. BD_EXPORT_AUTO env-var suppression only covers gc's own calls,
+	// so bake it into the on-disk config too.
+	changed = setBool(root, "export.auto", false) || changed
 	if state.EndpointOrigin != "" {
 		changed = setString(root, "gc.endpoint_origin", string(state.EndpointOrigin)) || changed
 	}
@@ -320,6 +325,7 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 
 	replacements := map[string]string{
 		"dolt.auto-start": "dolt.auto-start: false",
+		"export.auto":     "export.auto: false",
 	}
 	if prefix != "" {
 		replacements["issue_prefix"] = "issue_prefix: " + prefix
@@ -393,6 +399,7 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		"issue_prefix",
 		"issue-prefix",
 		"dolt.auto-start",
+		"export.auto",
 		"gc.endpoint_origin",
 		"gc.endpoint_status",
 		"dolt.host",

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -110,6 +110,7 @@ func TestEnsureCanonicalConfigCreatesManagedShape(t *testing.T) {
 		"issue_prefix: gc",
 		"issue-prefix: gc",
 		"dolt.auto-start: false",
+		"export.auto: false",
 		"gc.endpoint_origin: managed_city",
 		"gc.endpoint_status: verified",
 	} {
@@ -231,6 +232,77 @@ func TestEnsureCanonicalConfigCollapsesDuplicateManagedKeys(t *testing.T) {
 			t.Fatalf("config should scrub stale duplicate %q:%c%s", forbidden, 10, text)
 		}
 	}
+}
+
+func TestEnsureCanonicalConfigForcesAutoExportOff(t *testing.T) {
+	// bd's export.auto defaults to true and triggers a full-file import-then-export
+	// cycle on every write. Managed cities never consume issues.jsonl (Dolt is the
+	// source of truth), so this must be forced off at config time — not just via
+	// BD_EXPORT_AUTO env-var suppression, which leaks when bd is invoked outside
+	// the gc wrapper (agents, humans, bd setup).
+	t.Run("sets false when key is absent", func(t *testing.T) {
+		fs := fsys.OSFS{}
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		input := strings.Join([]string{
+			"issue-prefix: gc",
+			"dolt.auto-start: false",
+			"",
+		}, "\n")
+		if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: EndpointOriginManagedCity,
+			EndpointStatus: EndpointStatusVerified,
+		}); err != nil {
+			t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+		}
+
+		data, err := fs.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), "export.auto: false") {
+			t.Fatalf("config should force export.auto: false:\n%s", data)
+		}
+	})
+
+	t.Run("overrides explicit true", func(t *testing.T) {
+		fs := fsys.OSFS{}
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		input := strings.Join([]string{
+			"issue-prefix: gc",
+			"export.auto: true",
+			"",
+		}, "\n")
+		if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+			IssuePrefix:    "gc",
+			EndpointOrigin: EndpointOriginManagedCity,
+			EndpointStatus: EndpointStatusVerified,
+		}); err != nil {
+			t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+		}
+
+		data, err := fs.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		if strings.Contains(text, "export.auto: true") {
+			t.Fatalf("config should scrub export.auto: true:\n%s", text)
+		}
+		if !strings.Contains(text, "export.auto: false") {
+			t.Fatalf("config should force export.auto: false:\n%s", text)
+		}
+	})
 }
 
 func TestEnsureCanonicalConfigWritesExternalFields(t *testing.T) {


### PR DESCRIPTION
Closes #1965.

## Summary

- `bd`'s default `export.auto: true` regenerates `.beads/issues.jsonl` after every write.
- On the next bd write, that file triggers a full JSONL-into-Dolt re-import before appending — stalling for minutes on large datasets.
- `gc` already suppresses auto-export via `BD_EXPORT_AUTO=false` env var, but only on bd calls originating from the gc wrapper. Out-of-band bd processes (agents, humans, `bd setup`) re-enable it.
- Persist `export.auto: false` in `.beads/config.yaml` alongside the existing `dolt.auto-start: false` so every bd process sees it.

## Why this is safe

- The two callers of `EnsureCanonicalConfig` (`cmd/gc/beads_provider_lifecycle.go`, `cmd/gc/cmd_rig_endpoint.go`) pick the change up automatically — no API changes.
- Rigs that explicitly want JSONL-based sharing can still opt back in by setting `export.auto: true` in their config; the canonical writer will then overwrite it on next `gc` init, so those rigs will need a deliberate opt-out from managed canonicalization (existing mechanism via `gc.endpoint_origin: explicit`).
- The fallback non-YAML rewriter is also updated so misformatted configs get the same treatment.

## Test plan

- [x] Added `TestEnsureCanonicalConfigForcesAutoExportOff` covering the "key absent" and "explicit true → false" paths.
- [x] Updated `TestEnsureCanonicalConfigCreatesManagedShape` to assert `export.auto: false` is written.
- [x] Full `go test ./internal/beads/contract/...` green (unrelated `TestResolveDoltConnectionTargetManagedCity_EnvOverride` needs a `127.0.0.2` loopback alias, not caused by this change).
- [x] Verified in a live city: after removing `issues.jsonl` and setting `export.auto: false`, `gc session new` drops from 2m hang to ~7s. Without the persistence, an out-of-band `bd create` from a shell re-enables auto-export and the slow path returns. With this fix, that regression vector is closed.

## Risk

Low. The change only affects a config key that gc already manages in every other sense; the env-var suppression path remains as a second line of defense.