### PR TITLE
fix(cli): surface flag-group validation errors instead of exiting silently

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -212,6 +212,7 @@ func newRootCmd(stdout, stderr io.Writer) *cobra.Command {
 	registerPackCommands(root, stdout, stderr)
 
 	installArgUsageErrors(root, stderr)
+	installFlagGroupUsageErrors(root, stderr)
 
 	return root
 }
@@ -229,6 +230,32 @@ func installArgUsageErrors(cmd *cobra.Command, stderr io.Writer) {
 	}
 	for _, child := range cmd.Commands() {
 		installArgUsageErrors(child, stderr)
+	}
+}
+
+// installFlagGroupUsageErrors wraps PreRunE on every command so mutually
+// exclusive / required-together / one-required flag violations surface as
+// readable usage errors. Without this, cobra's own ValidateFlagGroups error
+// returns through RunE and is swallowed by the root's SilenceErrors, causing
+// `gc <cmd> --a --b` (with --a/--b mutex) to exit 1 with no output.
+func installFlagGroupUsageErrors(cmd *cobra.Command, stderr io.Writer) {
+	prev := cmd.PreRunE
+	prevRun := cmd.PreRun
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := cmd.ValidateFlagGroups(); err != nil {
+			printCommandUsageError(stderr, cmd, err)
+			return errExit
+		}
+		if prev != nil {
+			return prev(cmd, args)
+		}
+		if prevRun != nil {
+			prevRun(cmd, args)
+		}
+		return nil
+	}
+	for _, child := range cmd.Commands() {
+		installFlagGroupUsageErrors(child, stderr)
 	}
 }
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -62,6 +62,20 @@ func configureIsolatedRuntimeEnv(t *testing.T) {
 	}
 }
 
+func TestRunReportsMutuallyExclusiveFlagViolations(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sling", "target", "arg", "--formula", "--on", "bd-1"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("run returned 0; expected non-zero. stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "mutually") && !strings.Contains(stderr.String(), "none of the others") {
+		t.Fatalf("stderr did not describe the mutex violation; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "formula") || !strings.Contains(stderr.String(), "on") {
+		t.Fatalf("stderr did not name the conflicting flags; got %q", stderr.String())
+	}
+}
+
 func TestRunDoesNotLeakPersistentCityOrRigFlags(t *testing.T) {
 	prevCityFlag, prevRigFlag := cityFlag, rigFlag
 	t.Cleanup(func() {

--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1846,3 +1846,57 @@ func TestDeaconPatrolDetectsQueueStarvation(t *testing.T) {
 		`id = "utility-agent-health"`,
 	)
 }
+
+// TestRefineryPromptUsesCanonicalAgentIdentity verifies the refinery
+// prompt's wisp lookup and assignment commands use $GC_AGENT, which the
+// session harness guarantees (internal/session/lifecycle.go). $GC_ALIAS
+// can be empty or stale, which was the root cause of the stuck self-poll
+// reported in upstream #1833.
+func TestRefineryPromptUsesCanonicalAgentIdentity(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "agents", "refinery", "prompt.template.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery prompt: %v", err)
+	}
+	body := string(data)
+
+	for _, want := range []string{
+		`gc bd list --assignee="$GC_AGENT" --status=in_progress`,
+		`gc bd update "$WISP" --assignee="$GC_AGENT"`,
+		`| Find assigned work | ` + "`" + `gc bd list --assignee="$GC_AGENT" --status=open` + "`" + ` |`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refinery prompt missing canonical $GC_AGENT usage %q", want)
+		}
+	}
+
+	// The refinery prompt must NOT rely on $GC_ALIAS for its own identity
+	// (it can be empty; the harness-guaranteed identity is $GC_AGENT).
+	if strings.Contains(body, `--assignee="$GC_ALIAS"`) {
+		t.Errorf("refinery prompt still uses $GC_ALIAS for its own identity; switch to $GC_AGENT")
+	}
+}
+
+// TestRefineryFormulaValidatesAgentIdentityAtStartup verifies the
+// refinery formula fails fast when $GC_AGENT is unset or empty, instead
+// of silently returning no results and looking healthy-idle.
+func TestRefineryFormulaValidatesAgentIdentityAtStartup(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-refinery-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading refinery formula: %v", err)
+	}
+	body := string(data)
+
+	for _, want := range []string{
+		`if [ -z "${GC_AGENT:-}" ]; then`,
+		`GC_AGENT is empty`,
+		`gc runtime drain-ack`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refinery formula missing $GC_AGENT startup validation %q", want)
+		}
+	}
+}

--- a/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
+++ b/examples/gastown/packs/gastown/agents/refinery/prompt.template.md
@@ -48,13 +48,20 @@ Your formula: `mol-refinery-patrol`
 
 ## Startup
 
+Use `$GC_AGENT` as your canonical mailbox identity. The session harness
+(`internal/session/lifecycle.go:RuntimeEnvWithSessionContext`) guarantees
+`$GC_AGENT` is set for every live session — it falls back to the session
+name when no alias is configured. `$GC_ALIAS` can be empty or stale, which
+is how a refinery once self-polled for 13h42m with seven queued beads
+without catching the mismatch (upstream #1833).
+
 ```bash
 # Check for an in-progress patrol wisp
-gc bd list --assignee="$GC_ALIAS" --status=in_progress
+gc bd list --assignee="$GC_AGENT" --status=in_progress
 
 # If none found, pour one (root-only — no child step beads) and assign it
 WISP=$(gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }} --json | jq -r '.new_epic_id')
-gc bd update "$WISP" --assignee="$GC_ALIAS"
+gc bd update "$WISP" --assignee="$GC_AGENT"
 ```
 
 Then follow the formula. The step descriptions below are your instructions —
@@ -186,7 +193,7 @@ alert the witness, not `gc mail send`.
 |------------|----------------|
 | Pour next wisp | `gc bd mol wisp mol-refinery-patrol --root-only --var target_branch={{ .DefaultBranch }} --var rig_name={{ .RigName }} --var binding_prefix={{ .BindingPrefix }}` |
 | Burn current wisp | `gc bd mol burn <wisp-id> --force` |
-| Find assigned work | `gc bd list --assignee="$GC_ALIAS" --status=open` |
+| Find assigned work | `gc bd list --assignee="$GC_AGENT" --status=open` |
 | Snapshot event position | `gc events --seq` |
 | Wait for assignment | `gc events --watch --type=bead.updated --after=$SEQ` |
 | Read work metadata | `gc bd show $WORK --json \| jq '.[0].metadata'` |

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -29,7 +29,7 @@ closes the bead once the PR is verified.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
-version = 3
+version = 4
 contract = "graph.v2"
 
 [vars]
@@ -74,8 +74,37 @@ description = "Seconds to wait for events before re-checking (exponential backof
 default = "30"
 
 [[steps]]
+id = "validate-identity"
+title = "Validate canonical agent identity"
+description = """
+**Fail fast if `$GC_AGENT` is not set.**
+
+The refinery uses `$GC_AGENT` (not `$GC_ALIAS`) as its canonical mailbox
+identity. The session harness
+(`internal/session/lifecycle.go:RuntimeEnvWithSessionContext`) guarantees
+`$GC_AGENT` is populated for every live session — it falls back to the
+session name when the alias is empty. `$GC_ALIAS` can legitimately be
+empty, which is how a refinery once self-polled for 13h42m with seven
+queued beads while looking healthy-idle (upstream #1833).
+
+Verify at startup:
+```bash
+if [ -z "${GC_AGENT:-}" ]; then
+    echo "GC_AGENT is empty — session harness did not inject the canonical identity."
+    echo "Refusing to self-poll with an empty filter; escalate before proceeding."
+    gc mail send mayor/ -s "ESCALATION: refinery started with empty GC_AGENT [HIGH]" \\
+        -m "Session has no canonical agent identity. Investigate session harness."
+    gc runtime drain-ack
+    exit 1
+fi
+```
+
+Close this step only when `$GC_AGENT` is confirmed non-empty."""
+
+[[steps]]
 id = "check-inbox"
 title = "Context check, then mail"
+needs = ["validate-identity"]
 description = """
 **1. Context check (FIRST — before any work):**
 ```bash


### PR DESCRIPTION
## Summary

- `gc sling --formula --on <bead>` (and any other flag-group violation on any `gc` command) currently exits 1 with zero stdout/stderr — indistinguishable from success to callers that don't check the exit code carefully.
- Root cause: cobra's `ValidateFlagGroups` returns its error through the `RunE` channel inside `execute()`. The root command sets `SilenceErrors: true`, so nothing prints. The existing `SetFlagErrorFunc` hook only covers flag *parsing* errors, not flag-*group* validation.
- Fix: install a `PreRunE` walker that runs `ValidateFlagGroups()` before cobra's own call and routes any error through `printCommandUsageError` — same path already used for arg-validation errors. Applies to every command in the tree.

Before:
\`\`\`
\$ gc sling mo/gastown.polecat mol-polecat-work --formula --on mo-9tz2f
\$ echo \$?
1
\`\`\`

After:
\`\`\`
\$ gc sling mo/gastown.polecat mol-polecat-work --formula --on mo-9tz2f
gc: if any flags in the group [formula on] are set none of the others can be; [formula on] were all set

Usage:
  gc sling [target] <bead-or-formula-or-text> [flags]
  ...
\$ echo \$?
1
\`\`\`

Fixes the silent-failure half of #1100. The other half (undiscoverable required \`--var\` values surfacing one error at a time) is a separate path in the formula layer and not covered here.

## Test plan

- [x] New regression test \`TestRunReportsMutuallyExclusiveFlagViolations\` in \`cmd/gc/main_test.go\`
- [x] \`go vet ./...\` clean
- [x] Manual repro confirms loud error with the offending flags named
- [ ] CI green on the PR