### PR TITLE
fix(witness): stop leaking patrol wisps from early-exit steps (#1884)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1246,6 +1246,60 @@ func TestWitnessPatrolStateClassificationCoversSessionStates(t *testing.T) {
 	}
 }
 
+// TestWitnessPatrolAllStepsContinueNotExit guards against the regression
+// in upstream #1884: every intermediate step in mol-witness-patrol must
+// tell the agent to continue rather than exit the wisp. The burn
+// primitive only lives in `next-iteration`, so any step that reads as
+// terminal ("Exit criteria: no orphans found.") leaks wisps when an LLM
+// treats the early-exit as a terminal instruction.
+func TestWitnessPatrolAllStepsContinueNotExit(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-witness-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading witness patrol formula: %v", err)
+	}
+
+	var parsed struct {
+		Steps []struct {
+			ID          string `toml:"id"`
+			Description string `toml:"description"`
+		} `toml:"steps"`
+	}
+	if _, err := toml.Decode(string(data), &parsed); err != nil {
+		t.Fatalf("parsing witness patrol formula: %v", err)
+	}
+
+	byID := make(map[string]string, len(parsed.Steps))
+	for _, s := range parsed.Steps {
+		byID[s.ID] = s.Description
+	}
+
+	intermediate := []string{
+		"check-inbox",
+		"recover-orphaned-beads",
+		"check-refinery",
+		"check-polecat-health",
+	}
+	for _, id := range intermediate {
+		desc, ok := byID[id]
+		if !ok {
+			t.Errorf("witness patrol formula missing step %q", id)
+			continue
+		}
+		if !strings.Contains(desc, "do NOT exit") {
+			t.Errorf("step %q missing continuation reminder 'do NOT exit' so an LLM can treat the step as terminal and leak the wisp:\n%s", id, desc)
+		}
+		if !strings.Contains(desc, "next-iteration") {
+			t.Errorf("step %q missing reference to `next-iteration` as the sole burn site:\n%s", id, desc)
+		}
+	}
+
+	if _, ok := byID["next-iteration"]; !ok {
+		t.Fatal("witness patrol formula missing `next-iteration` step — continuation clauses point at a non-existent target")
+	}
+}
+
 func TestAllFormulasExist(t *testing.T) {
 	dir := exampleDir()
 	formulaDir := filepath.Join(dir, "packs", "gastown", "formulas")

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -11,8 +11,11 @@ you left off from context (bead state, mail state, last action).
 Formula steps are NOT materialized as child beads. Read the step
 descriptions below and work through them in order.
 
-The loop mechanism: every exit path (happy or early) pours the next
-wisp before burning this one. The prompt only bootstraps the first wisp.
+The loop mechanism: EVERY step is one leg of the same wisp. Never exit
+the wisp from an intermediate step — either continue to the next step
+or jump directly to `next-iteration` to pour and burn. Exiting without
+burning leaks wisps (see #1884). The prompt only bootstraps the first
+wisp.
 
 ## Witness Role
 
@@ -55,7 +58,7 @@ the worktree. This makes the work schedulable again.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-witness-patrol"
-version = 8
+version = 9
 
 [vars]
 [vars.event_timeout]
@@ -117,7 +120,9 @@ Archive after reading.
 **Hygiene principle**: Archive messages after they're fully processed.
 Inbox should be near-empty after this step.
 
-Close this step and proceed."""
+Close this step and continue to `recover-orphaned-beads` — do NOT exit
+the wisp here. The `next-iteration` step is the only place that pours
+the next wisp and burns this one."""
 
 [[steps]]
 id = "recover-orphaned-beads"
@@ -353,7 +358,9 @@ gc bd update <bead> --set-metadata recovered=true
 ```
 
 **Exit criteria:** All orphaned beads recovered, worktrees cleaned.
-Or no orphans found."""
+Or no orphans found. Continue to `check-refinery` — do NOT exit the
+wisp here. The `next-iteration` step is the only place that pours the
+next wisp and burns this one."""
 
 [[steps]]
 id = "check-refinery"
@@ -395,7 +402,10 @@ Observation: <what you found>
 Recommendation: <what should happen>"
 ```
 
-Close this step after assessment."""
+**Exit criteria:** Queue health assessed; nudge sent or escalation
+filed if needed. Continue to `check-polecat-health` — do NOT exit the
+wisp here. The `next-iteration` step is the only place that pours the
+next wisp and burns this one."""
 
 [[steps]]
 id = "check-polecat-health"
@@ -450,7 +460,9 @@ system handles it. Only escalate if you see a pattern (many stuck
 polecats, systemic issue).
 
 **Exit criteria:** All active polecat work beads assessed. Warrants
-filed for stuck agents. Or no stuck polecats found."""
+filed for stuck agents. Or no stuck polecats found. Continue to
+`next-iteration` — do NOT exit the wisp here. The `next-iteration` step
+is the only place that pours the next wisp and burns this one."""
 
 [[steps]]
 id = "next-iteration"


### PR DESCRIPTION
## Summary

Closes #1884. `mol-witness-patrol` has 5 steps, but only `next-iteration` calls `gc bd mol burn`. The four intermediate steps (`check-inbox`, `recover-orphaned-beads`, `check-refinery`, `check-polecat-health`) end with bare `Exit criteria: …` lines that an LLM treats as terminal instructions. Result: witnesses exit without burning, and the reaper reports stale wisps climbing each cycle with `closed_wisps=0`.

The preamble even claims *"every exit path pours the next wisp before burning this one"* — but the step wording never enforced it. `mol-refinery-patrol` is the canonical counter-example: it repeats the pour-and-burn block at every exit path, so refinery wisps always burn.

## Changes

TOML-only (ZFC: behavior lives in prompts, not Go):

- **Preamble mandate.** Tightened the loop-mechanism paragraph into an explicit rule: *"EVERY step is one leg of the same wisp. Never exit the wisp from an intermediate step — either continue to the next step or jump directly to `next-iteration` to pour and burn. Exiting without burning leaks wisps (see #1884)."*
- **Intermediate step tails.** Each of the four intermediate steps now ends with: *"Continue to `<next-step>` — do NOT exit the wisp here. The `next-iteration` step is the only place that pours the next wisp and burns this one."*
- **Version bump** 8 → 9.

## Test plan

- [x] New test `TestWitnessPatrolAllStepsContinueNotExit` parses the formula TOML, extracts the four intermediate step descriptions by ID, and asserts each contains the `do NOT exit` anchor plus a reference to `next-iteration`. Verified it fails on unpatched formula.
- [x] `go test ./examples/gastown -count=1` — full gastown package green (106s).
- [x] `go vet ./examples/gastown` — clean.
- [ ] Behavioral verification (post-merge): pour a witness wisp on a live city, confirm it burns on cycle end, reaper `stale_wisps` stays at 0.

## Out of scope

- Closing the already-stranded wisps. Reaper will clean them up once the leak is fixed.
- Whether formula steps should enforce continuation via schema (Go-level guard). Separate design conversation; this PR just stops the bleeding.