### PR TITLE
fix(deacon): detect stuck sessions with assigned queue (#1833)

### DIFF
--- a/examples/gastown/gastown_test.go
+++ b/examples/gastown/gastown_test.go
@@ -1666,3 +1666,42 @@ func TestDoltHealthFormulasExist(t *testing.T) {
 		t.Error("no formula files found")
 	}
 }
+
+// TestDeaconPatrolDetectsQueueStarvation verifies the deacon formula
+// cross-checks assigned open beads against visible work signal, so a
+// stuck self-polling refinery is flagged even when its patrol wisp is
+// cycling fresh. See upstream #1833.
+func TestDeaconPatrolDetectsQueueStarvation(t *testing.T) {
+	dir := exampleDir()
+	path := filepath.Join(dir, "packs", "gastown", "formulas", "mol-deacon-patrol.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading deacon formula: %v", err)
+	}
+	body := string(data)
+
+	for _, want := range []string{
+		`id = "queue-starvation-check"`,
+		`needs = ["health-scan"]`,
+		"Cross-check assigned work against visible work signal",
+		"gc bd list --status=open --assignee=",
+		"bead.updated_at",
+		"30min",
+		`"gc.routed_to":"{{binding_prefix}}dog"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("deacon formula missing queue-starvation guidance %q", want)
+		}
+	}
+
+	// The new step must chain into the next one.
+	if !strings.Contains(body, `needs = ["queue-starvation-check"]`) {
+		t.Errorf("deacon formula step after queue-starvation-check must depend on it")
+	}
+
+	assertContainsInOrder(t, body,
+		`id = "health-scan"`,
+		`id = "queue-starvation-check"`,
+		`id = "utility-agent-health"`,
+	)
+}

--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -46,7 +46,7 @@ between patrol cycles.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-deacon-patrol"
-version = 12
+version = 13
 
 [vars]
 [vars.event_timeout]
@@ -172,9 +172,79 @@ patterns of failure).
 Close this step after assessment."""
 
 [[steps]]
+id = "queue-starvation-check"
+title = "Cross-check assigned work against visible work signal"
+needs = ["health-scan"]
+description = """
+Cross-check assigned work against visible work signal. A session can
+look healthy-idle in a patrol wisp view while its queue is silently
+starving — the refinery (upstream #1833) self-polled for 13h42m with
+seven beads in its queue and no visible work signal, because its poll
+filter resolved to an identity that didn't match its own.
+
+The deacon's wisp-freshness check catches "no patrol activity" but not
+"active polling, wrong filter, queue silently piling up." This step
+closes that gap.
+
+**Step 1: For each active coordination/merge session, compute the pair:**
+- `A` = count of open beads assigned to the session's agent identity
+- `B` = the most recent bead.updated_at across those beads (work signal)
+
+```bash
+gc agents list --json --active | jq -r '.[] | .agent_id' | while read -r AGENT; do
+    ASSIGNED=$(gc bd list --status=open --assignee="$AGENT" --json --limit=0 | jq 'length')
+    LATEST=$(gc bd list --status=open --assignee="$AGENT" --json --limit=0 \\
+        | jq -r '[.[].updated_at] | max // ""')
+    printf '%s\\t%s\\t%s\\n' "$AGENT" "$ASSIGNED" "$LATEST"
+done
+```
+
+The latest bead.updated_at is the cheapest proxy for "did this session
+move work recently?" — every claim, status transition, metadata update,
+or note bumps it.
+
+**Step 2: Flag when queue > 0 and signal is stale (judgment call,
+guideline ~30min):**
+
+If `A > 0` AND `now - B` has grown well past the patrol's natural
+cadence (default guideline: 30min — roughly 6x the 300s max patrol
+backoff), the session is holding work without making progress. This
+is exactly why an LLM does it, not Go code. Consider:
+- Coordination agents (refinery, witness) naturally cycle in seconds
+  when work is present; 30min is an eternity, not a lull.
+- Polecats may take longer per step; be more lenient before flagging.
+- A freshly-assigned bead with no prior activity gets `updated_at` at
+  assignment time; if it's hours old, the session picked it up but
+  never acted.
+
+**Step 3: For flagged sessions, nudge first, then warrant:**
+
+```bash
+gc session nudge "$STUCK_SESSION" "Queue has $ASSIGNED open beads, no bead activity for <duration>. Run gc hook."
+```
+
+If the nudge doesn't unstick within the next patrol cycle, escalate
+by filing a warrant for the dog pool:
+
+```bash
+gc bd create --type=task --label=warrant \\
+    --title="Stuck queue: <session> — $ASSIGNED beads, no activity $duration" \\
+    --metadata '{"target":"<session>","reason":"queue starvation: N beads, no bead.updated_at progress","requester":"deacon","gc.routed_to":"{{binding_prefix}}dog"}'
+```
+
+The dog runs `mol-shutdown-dance` and the controller respawns a fresh
+session that re-reads the queue with a correct filter.
+
+**Step 4: A genuinely-idle session (no assigned beads) is NOT flagged.**
+If `A == 0`, this step is a no-op for that session. Idle-but-ready
+refineries and witnesses are healthy.
+
+Close this step after the cross-check runs for every active session."""
+
+[[steps]]
 id = "utility-agent-health"
 title = "Check utility agent (dog) health"
-needs = ["health-scan"]
+needs = ["queue-starvation-check"]
 description = """
 Detect utility agents (dogs) that are alive but stuck on their work.
 


### PR DESCRIPTION
## Summary

Closes #1833. The deacon formula now cross-checks open assigned beads per agent against that agent's last bead-transition timestamp, so a session that is silently starving on its queue is flagged even while its own patrol wisp cycles fresh.

Concrete symptom this addresses: a refinery self-polled for 13h42m while seven queued beads accumulated. Health-scan's wisp-freshness signal looked green the whole time because the refinery kept burning its own patrol wisps — it was alive, it was just not processing the work assigned to it. Deacon had no cross-check that would notice the queue wasn't moving.

## Changes

New `queue-starvation-check` step in `mol-deacon-patrol.toml`, slotted between `health-scan` (wisp freshness) and `utility-agent-health`. For each active agent:

1. `gc bd list --status=open --assignee=<agent>` — count the queue.
2. Look at the latest `bead.updated_at` on that queue.
3. If there are open beads and the newest transition is > 30 min old, it's silent starvation. Nudge first; if persistent, file a warrant routed to `{{binding_prefix}}dog`.

Threshold is 30 min in the prompt text so it can be tuned without a code change.

## Test plan

- [x] `TestDeaconPatrolDetectsQueueStarvation` in `examples/gastown/gastown_test.go` asserts the new step exists with the right guidance, depends on `health-scan`, and is followed by `utility-agent-health`.
- [x] `go test ./examples/gastown -count=1` passes (verified on fresh `upstream/main` + cherry-pick).