### PR TITLE
feat(config): rig-scoped formula var defaults (#1932)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,11 @@ Lesson test — it becomes LESS useful as models improve.
   in `cmd/gc/pool.go`. `TestAgentFieldSync` enforces this for the struct
   definitions; the apply functions and pool deep-copy must be checked
   manually.
+- **Adding rig config fields:** When adding a field to `config.Rig`, also
+  add the corresponding optional field to `RigPatch` and wire the merge
+  into `applyRigPatch` so layered configs (fragments, patches) can
+  override it. No field-sync test exists for Rig today; the patch path
+  must be checked manually.
 
 - `TESTING.md` — testing philosophy, tier boundaries, and sharded local
   runners. Read before writing any test. For broad local sweeps, prefer the

--- a/cmd/gc/cmd_formula.go
+++ b/cmd/gc/cmd_formula.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
@@ -89,9 +90,13 @@ func newFormulaShowCmd(stdout, stderr io.Writer) *cobra.Command {
 By default, shows the recipe with {{variable}} placeholders intact.
 Use --var to substitute variables and preview the resolved output.
 
+When --rig is set (or cwd is inside a rig), rig-scoped formula_vars from
+city.toml are shown as "(rig default=...)" alongside each applicable var.
+
 Examples:
   gc formula show mol-feature
-  gc formula show mol-feature --var title="Auth system" --var branch=main`,
+  gc formula show mol-feature --var title="Auth system" --var branch=main
+  gc formula show mol-polecat-work --rig mo`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
@@ -107,10 +112,20 @@ Examples:
 
 			compileVars := vars
 
-			searchPaths, err := formulaSearchPathsForScope(stderr)
+			cityPath, err := resolveCity()
 			if err != nil {
 				return err
 			}
+			cfg, err := loadCityConfig(cityPath, stderr)
+			if err != nil {
+				return err
+			}
+			scope, err := resolveFormulaScope(cfg, cityPath)
+			if err != nil {
+				return err
+			}
+			searchPaths := scope.searchPaths
+			rigVars := rigFormulaVarsForScope(cfg, cityPath)
 			recipe, err := formula.CompileWithoutRuntimeVarValidation(cmd.Context(), name, searchPaths, compileVars)
 			if err != nil {
 				return err
@@ -167,7 +182,15 @@ Examples:
 					_, _ = fmt.Fprintln(stdout, "\nRequired vars:")
 					for _, name := range requiredNames {
 						def := recipe.Vars[name]
-						_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s\n", name, def.Description)
+						var attrs []string
+						if v, ok := rigVars[name]; ok {
+							attrs = append(attrs, "rig default="+strconv.Quote(v))
+						}
+						attrStr := ""
+						if len(attrs) > 0 {
+							attrStr = " (" + strings.Join(attrs, ", ") + ")"
+						}
+						_, _ = fmt.Fprintf(stdout, "  {{%s}}: %s%s\n", name, def.Description, attrStr)
 					}
 				}
 				if len(optionalNames) > 0 {
@@ -179,7 +202,9 @@ Examples:
 					for _, name := range optionalNames {
 						def := recipe.Vars[name]
 						var attrs []string
-						if def != nil && def.Default != nil {
+						if v, ok := rigVars[name]; ok {
+							attrs = append(attrs, "rig default="+strconv.Quote(v))
+						} else if def != nil && def.Default != nil {
 							attrs = append(attrs, "default="+*def.Default)
 						}
 						attrStr := ""
@@ -418,23 +443,26 @@ func rigFormulaScope(cfg *config.City, cityPath string, rig config.Rig) formulaS
 	}
 }
 
-// formulaSearchPathsForScope resolves the active formula scope (honoring
-// --rig and cwd) and returns its search paths. Used by read-only commands
-// like `gc formula show` that don't need to open a store.
-func formulaSearchPathsForScope(warningWriter ...io.Writer) ([]string, error) {
-	cityPath, err := resolveCity()
-	if err != nil {
-		return nil, err
+// rigFormulaVarsForScope returns rig-scoped formula var defaults for the
+// active scope (honoring --rig and cwd). Returns an empty map when no rig
+// context is active so callers can treat the result as read-only
+// annotations without nil checks.
+func rigFormulaVarsForScope(cfg *config.City, cityPath string) map[string]string {
+	if cfg == nil {
+		return map[string]string{}
 	}
-	cfg, err := loadCityConfig(cityPath, warningWriter...)
-	if err != nil {
-		return nil, err
+	if name := strings.TrimSpace(rigFlag); name != "" {
+		if rig, ok := rigByName(cfg, name); ok {
+			return cloneStringMap(rig.FormulaVars)
+		}
+		return map[string]string{}
 	}
-	scope, err := resolveFormulaScope(cfg, cityPath)
-	if err != nil {
-		return nil, err
+	if cwd, err := os.Getwd(); err == nil {
+		if rig, ok, rerr := resolveRigForDir(cfg, cityPath, cwd); rerr == nil && ok {
+			return cloneStringMap(rig.FormulaVars)
+		}
 	}
-	return scope.searchPaths, nil
+	return map[string]string{}
 }
 
 // allFormulaSearchPaths returns the deduplicated union of formula search

--- a/cmd/gc/cmd_formula_test.go
+++ b/cmd/gc/cmd_formula_test.go
@@ -165,6 +165,56 @@ func TestResolveFormulaScope_UnboundRigErrors(t *testing.T) {
 	}
 }
 
+// TestRigFormulaVarsForScope verifies that rig-scoped formula_vars flow
+// through the scope resolver so `gc formula show --rig <name>` can surface
+// them as "(rig default=...)" annotations.
+func TestRigFormulaVarsForScope(t *testing.T) {
+	cityPath := t.TempDir()
+	rigPath := filepath.Join(cityPath, "mo")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	cfg := &config.City{
+		Rigs: []config.Rig{
+			{
+				Name: "mo",
+				Path: rigPath,
+				FormulaVars: map[string]string{
+					"test_command": "make test-fast",
+				},
+			},
+		},
+	}
+
+	t.Run("--rig populates FormulaVars via rigByName", func(t *testing.T) {
+		prev := rigFlag
+		t.Cleanup(func() { rigFlag = prev })
+		rigFlag = "mo"
+
+		r, ok := rigByName(cfg, "mo")
+		if !ok {
+			t.Fatalf("rigByName(mo) not found")
+		}
+		if got := r.FormulaVars["test_command"]; got != "make test-fast" {
+			t.Errorf("FormulaVars[test_command] = %q, want %q", got, "make test-fast")
+		}
+	})
+
+	t.Run("no --rig yields empty FormulaVars", func(t *testing.T) {
+		prev := rigFlag
+		t.Cleanup(func() { rigFlag = prev })
+		rigFlag = ""
+
+		t.Chdir(cityPath)
+		// Without --rig and outside a rig cwd, formula_vars are not injected.
+		vars := rigFormulaVarsForScope(cfg, cityPath)
+		if len(vars) != 0 {
+			t.Errorf("rigFormulaVarsForScope = %v, want empty (no rig context)", vars)
+		}
+	})
+}
+
 // TestResolveFormulaScope_RigFallsBackToCityLayers covers the case where a
 // rig is resolved but has no rig-specific FormulaLayers entry; SearchPaths
 // should fall back to city layers.

--- a/cmd/gc/cmd_sling.go
+++ b/cmd/gc/cmd_sling.go
@@ -951,73 +951,15 @@ func collectConflictErrors(err error, visit func(*sourceworkflow.ConflictError))
 }
 
 // buildSlingFormulaVars merges caller-provided vars with the runtime context
-// needed by common work formulas. Explicit --var entries always win.
+// needed by common work formulas. Delegates to the canonical implementation
+// in internal/sling so CLI dry-run previews match production routing, but
+// injects cliBranchResolver so live `git symbolic-ref origin/HEAD` probes
+// fire when neither bead metadata nor rig.DefaultBranch supply a branch.
 func buildSlingFormulaVars(formulaName, beadID string, userVars []string, a config.Agent, deps slingDeps) map[string]string {
-	vars := make(map[string]string, len(userVars)+6)
-	for _, v := range userVars {
-		key, value, ok := strings.Cut(v, "=")
-		if ok && key != "" {
-			vars[key] = value
-		}
-	}
-	addVar := func(key, value string) {
-		if value == "" {
-			return
-		}
-		if _, explicit := vars[key]; explicit {
-			return
-		}
-		vars[key] = value
-	}
-	addRoutingVar := func(key, value string) {
-		if _, explicit := vars[key]; explicit {
-			return
-		}
-		vars[key] = value
-	}
-
-	if beadID != "" {
-		// Attached work formulas conventionally expect issue=<bead-id>.
-		addVar("issue", beadID)
-	}
-	addRoutingVar("rig_name", a.Dir)
-	addRoutingVar("binding_name", a.BindingName)
-	addRoutingVar("binding_prefix", a.BindingPrefix())
-
-	autoBranch := slingFormulaTargetBranch(beadID, deps, a)
-	if slingFormulaUsesBaseBranch(formulaName) {
-		addVar("base_branch", autoBranch)
-	}
-	if slingFormulaUsesTargetBranch(formulaName) {
-		addVar("target_branch", autoBranch)
-	}
-
-	return vars
-}
-
-// slingFormulaSearchPaths returns the formula search paths for the current
-// sling context. Uses the target agent's rig to select rig-specific layers,
-// falling back to city-level layers via FormulaLayers.SearchPaths.
-//
-// slingFormulaTargetBranch resolves the branch used as base_branch /
-// target_branch in formula vars. Resolution order:
-//  1. metadata.target on the work bead (or convoy ancestor)
-//  2. DefaultBranch recorded on the bead's rig in city.toml
-//  3. DefaultBranch recorded on the agent's rig in city.toml
-//  4. Live probe of the rig repo (git symbolic-ref origin/HEAD)
-func slingFormulaTargetBranch(beadID string, deps slingDeps, a config.Agent) string {
 	if deps.Branches == nil {
 		deps.Branches = cliBranchResolver{}
 	}
-	return sling.SlingFormulaTargetBranch(beadID, deps, a)
-}
-
-func slingFormulaUsesBaseBranch(formula string) bool {
-	return strings.HasPrefix(formula, "mol-polecat-") || formula == "mol-scoped-work"
-}
-
-func slingFormulaUsesTargetBranch(formula string) bool {
-	return formula == "mol-refinery-patrol"
+	return sling.BuildSlingFormulaVars(formulaName, beadID, userVars, a, deps)
 }
 
 // resolveSlingEnv returns extra env vars for the sling command.

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -7048,6 +7048,100 @@ func TestBuildSlingFormulaVarsInjectsIssueAndBaseBranch(t *testing.T) {
 	}
 }
 
+// TestBuildSlingFormulaVarsRigDefaults covers rig-scoped formula var defaults
+// flowing into the final vars map, plus precedence:
+//
+//	--var > rig.formula_vars > routing-injected > formula default
+func TestBuildSlingFormulaVarsRigDefaults(t *testing.T) {
+	t.Run("rig defaults flow in when caller omits --var", func(t *testing.T) {
+		cfg := &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Rigs: []config.Rig{
+				{
+					Name: "mo",
+					Path: "/mo",
+					FormulaVars: map[string]string{
+						"test_command": "make test-fast",
+						"lint_command": "golangci-lint run",
+					},
+				},
+			},
+		}
+		deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+		vars := buildSlingFormulaVars("mol-polecat-work", "MO-1", nil,
+			config.Agent{Name: "polecat", Dir: "mo"}, deps)
+
+		if got, ok := findVarValue(vars, "test_command"); !ok || got != "make test-fast" {
+			t.Fatalf("test_command = %q, %v; want make test-fast (from rig defaults)", got, ok)
+		}
+		if got, ok := findVarValue(vars, "lint_command"); !ok || got != "golangci-lint run" {
+			t.Fatalf("lint_command = %q, %v; want golangci-lint run (from rig defaults)", got, ok)
+		}
+	})
+
+	t.Run("--var wins over rig defaults", func(t *testing.T) {
+		cfg := &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Rigs: []config.Rig{
+				{
+					Name:        "mo",
+					Path:        "/mo",
+					FormulaVars: map[string]string{"test_command": "make test-fast"},
+				},
+			},
+		}
+		deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+		vars := buildSlingFormulaVars("mol-polecat-work", "MO-1",
+			[]string{"test_command=go test -short ./..."},
+			config.Agent{Name: "polecat", Dir: "mo"}, deps)
+
+		if got, ok := findVarValue(vars, "test_command"); !ok || got != "go test -short ./..." {
+			t.Fatalf("test_command = %q, %v; want 'go test -short ./...' (--var override)", got, ok)
+		}
+	})
+
+	t.Run("no rig match is a no-op", func(t *testing.T) {
+		cfg := &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Rigs: []config.Rig{
+				{
+					Name:        "mo",
+					Path:        "/mo",
+					FormulaVars: map[string]string{"test_command": "make test-fast"},
+				},
+			},
+		}
+		deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+		vars := buildSlingFormulaVars("mol-polecat-work", "UNK-1", nil,
+			config.Agent{Name: "polecat", Dir: "other-rig"}, deps)
+
+		if _, ok := findVarValue(vars, "test_command"); ok {
+			t.Fatalf("test_command should not be set when agent rig does not match any rig with formula_vars")
+		}
+	})
+
+	t.Run("rig match by filesystem path resolves like Dir=rigName", func(t *testing.T) {
+		rigPath := "/abs/mo-path"
+		cfg := &config.City{
+			Workspace: config.Workspace{Name: "test-city"},
+			Rigs: []config.Rig{
+				{
+					Name:        "mo",
+					Path:        rigPath,
+					FormulaVars: map[string]string{"test_command": "make test-fast"},
+				},
+			},
+		}
+		deps, _, _ := testDeps(cfg, runtime.NewFake(), newFakeRunner().run)
+		vars := buildSlingFormulaVars("mol-polecat-work", "MO-1", nil,
+			config.Agent{Name: "polecat", Dir: rigPath}, deps)
+
+		if got, ok := findVarValue(vars, "test_command"); !ok || got != "make test-fast" {
+			t.Fatalf("test_command = %q, %v; want make test-fast (path-resolved rig lookup)", got, ok)
+		}
+	})
+}
+
 // --- 1-arg sling tests (via doSling, not cmdSling which needs a real city) ---
 
 func TestFindRigByPrefix(t *testing.T) {

--- a/cmd/gc/dashboard/web/src/generated/schema.d.ts
+++ b/cmd/gc/dashboard/web/src/generated/schema.d.ts
@@ -3544,6 +3544,9 @@ export interface components {
         };
         RigPatch: {
             DefaultBranch: string | null;
+            FormulaVars: {
+                [key: string]: string;
+            };
             Name: string;
             Path: string | null;
             Prefix: string | null;

--- a/cmd/gc/dashboard/web/src/generated/types.gen.ts
+++ b/cmd/gc/dashboard/web/src/generated/types.gen.ts
@@ -2178,6 +2178,9 @@ export type RigCreatedOutputBody = {
 
 export type RigPatch = {
     DefaultBranch: string | null;
+    FormulaVars: {
+        [key: string]: string;
+    };
     Name: string;
     Path: string | null;
     Prefix: string | null;

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1092,9 +1092,13 @@ Compile and display a formula recipe.
 By default, shows the recipe with &#123;&#123;variable&#125;&#125; placeholders intact.
 Use --var to substitute variables and preview the resolved output.
 
+When --rig is set (or cwd is inside a rig), rig-scoped formula_vars from
+city.toml are shown as "(rig default=...)" alongside each applicable var.
+
 Examples:
   gc formula show mol-feature
   gc formula show mol-feature --var title="Auth system" --var branch=main
+  gc formula show mol-polecat-work --rig mo
 
 ```
 gc formula show <formula-name> [flags]

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -538,6 +538,7 @@ Rig defines an external project registered in the city.
 | `session_sleep` | SessionSleepConfig |  |  | SessionSleep overrides workspace-level idle sleep defaults for agents in this rig. |
 | `dolt_host` | string |  |  | DoltHost overrides the city-level Dolt host for this rig's beads. Use when the rig's database lives on a different Dolt server (e.g., shared from another city). |
 | `dolt_port` | string |  |  | DoltPort overrides the city-level Dolt port for this rig's beads. When set, controller commands (scale_check, work_query) prefix their shell invocations with BEADS_DOLT_SERVER_PORT=&lt;port&gt; so bd connects to the correct server instead of the city-level default. |
+| `formula_vars` | map[string]string |  |  | FormulaVars provides rig-scoped defaults for formula vars. Keys match var names declared in formula `[vars.&lt;name&gt;]` blocks. Values are used when a formula runs in this rig and the caller did not pass an explicit --var override. Takes precedence over formula-level defaults but loses to --var flags. |
 
 ## RigPatch
 
@@ -550,6 +551,7 @@ RigPatch modifies an existing rig identified by Name.
 | `prefix` | string |  |  | Prefix overrides the bead ID prefix. |
 | `default_branch` | string |  |  | DefaultBranch overrides the rig's recorded mainline branch. |
 | `suspended` | boolean |  |  | Suspended overrides the rig's suspended state. |
+| `formula_vars` | map[string]string |  |  | FormulaVars adds or overrides rig-scoped formula var defaults. Additive merge: patch keys win over existing rig keys, unspecified keys are preserved. |
 
 ## Service
 

--- a/docs/schema/city-schema.json
+++ b/docs/schema/city-schema.json
@@ -1922,6 +1922,13 @@
         "dolt_port": {
           "type": "string",
           "description": "DoltPort overrides the city-level Dolt port for this rig's beads.\nWhen set, controller commands (scale_check, work_query) prefix their\nshell invocations with BEADS_DOLT_SERVER_PORT=\u003cport\u003e so bd connects to the\ncorrect server instead of the city-level default."
+        },
+        "formula_vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "FormulaVars provides rig-scoped defaults for formula vars. Keys match\nvar names declared in formula `[vars.\u003cname\u003e]` blocks. Values are used\nwhen a formula runs in this rig and the caller did not pass an\nexplicit --var override. Takes precedence over formula-level defaults\nbut loses to --var flags."
         }
       },
       "additionalProperties": false,
@@ -1952,6 +1959,13 @@
         "suspended": {
           "type": "boolean",
           "description": "Suspended overrides the rig's suspended state."
+        },
+        "formula_vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "FormulaVars adds or overrides rig-scoped formula var defaults.\nAdditive merge: patch keys win over existing rig keys, unspecified\nkeys are preserved."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/city-schema.txt
+++ b/docs/schema/city-schema.txt
@@ -1922,6 +1922,13 @@
         "dolt_port": {
           "type": "string",
           "description": "DoltPort overrides the city-level Dolt port for this rig's beads.\nWhen set, controller commands (scale_check, work_query) prefix their\nshell invocations with BEADS_DOLT_SERVER_PORT=\u003cport\u003e so bd connects to the\ncorrect server instead of the city-level default."
+        },
+        "formula_vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "FormulaVars provides rig-scoped defaults for formula vars. Keys match\nvar names declared in formula `[vars.\u003cname\u003e]` blocks. Values are used\nwhen a formula runs in this rig and the caller did not pass an\nexplicit --var override. Takes precedence over formula-level defaults\nbut loses to --var flags."
         }
       },
       "additionalProperties": false,
@@ -1952,6 +1959,13 @@
         "suspended": {
           "type": "boolean",
           "description": "Suspended overrides the rig's suspended state."
+        },
+        "formula_vars": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "FormulaVars adds or overrides rig-scoped formula var defaults.\nAdditive merge: patch keys win over existing rig keys, unspecified\nkeys are preserved."
         }
       },
       "additionalProperties": false,

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -5365,6 +5365,12 @@
               "null"
             ]
           },
+          "FormulaVars": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "Name": {
             "type": "string"
           },
@@ -5392,7 +5398,8 @@
           "Path",
           "Prefix",
           "DefaultBranch",
-          "Suspended"
+          "Suspended",
+          "FormulaVars"
         ],
         "type": "object"
       },

--- a/docs/schema/openapi.txt
+++ b/docs/schema/openapi.txt
@@ -5365,6 +5365,12 @@
               "null"
             ]
           },
+          "FormulaVars": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "Name": {
             "type": "string"
           },
@@ -5392,7 +5398,8 @@
           "Path",
           "Prefix",
           "DefaultBranch",
-          "Suspended"
+          "Suspended",
+          "FormulaVars"
         ],
         "type": "object"
       },

--- a/engdocs/architecture/formulas.md
+++ b/engdocs/architecture/formulas.md
@@ -204,6 +204,31 @@ Formula layers are assembled from:
 - rig packs
 - `[[rigs]].formulas_dir`
 
+Rig-scoped formula var defaults live on the rig entry itself:
+
+```toml
+[[rigs]]
+name = "mo"
+path = "/home/me/projects/mo"
+
+[rigs.formula_vars]
+test_command = "make test-fast"
+lint_command = "golangci-lint run"
+```
+
+When a formula runs with an agent bound to a rig (via `dir = "mo"` or an
+absolute filesystem path), `BuildSlingFormulaVars` folds these entries into
+the final var map. Precedence (highest wins):
+
+1. Explicit `--var key=value` on the CLI
+2. `rigs.<name>.formula_vars[key]`
+3. Routing-injected defaults (`issue`, `rig_name`, `base_branch`, `target_branch`, ...)
+4. Formula-declared `[vars.<name>].default`
+
+`gc formula show --rig <name>` surfaces active rig defaults as
+`(rig default="...")` next to the var description so operators can verify
+what will actually substitute before dispatch.
+
 Wisp cleanup is configured in `city.toml`:
 
 ```toml

--- a/internal/api/genclient/client_gen.go
+++ b/internal/api/genclient/client_gen.go
@@ -2109,11 +2109,12 @@ type RigCreatedOutputBody struct {
 
 // RigPatch defines model for RigPatch.
 type RigPatch struct {
-	DefaultBranch *string `json:"DefaultBranch"`
-	Name          string  `json:"Name"`
-	Path          *string `json:"Path"`
-	Prefix        *string `json:"Prefix"`
-	Suspended     *bool   `json:"Suspended"`
+	DefaultBranch *string           `json:"DefaultBranch"`
+	FormulaVars   map[string]string `json:"FormulaVars"`
+	Name          string            `json:"Name"`
+	Path          *string           `json:"Path"`
+	Prefix        *string           `json:"Prefix"`
+	Suspended     *bool             `json:"Suspended"`
 }
 
 // RigPatchSetInputBody defines model for RigPatchSetInputBody.

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -5365,6 +5365,12 @@
               "null"
             ]
           },
+          "FormulaVars": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "Name": {
             "type": "string"
           },
@@ -5392,7 +5398,8 @@
           "Path",
           "Prefix",
           "DefaultBranch",
-          "Suspended"
+          "Suspended",
+          "FormulaVars"
         ],
         "type": "object"
       },

--- a/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-polecat-base.toml
@@ -13,11 +13,11 @@ then add a terminal step (submit, commit, etc).
 |----------|--------|-------------|
 | issue | caller | The work bead ID assigned to this polecat |
 | base_branch | caller | Base branch to rebase on (default: main) |
-| setup_command | rig config | Setup/install command. Empty = skip. |
-| typecheck_command | rig config | Type check command. Empty = skip. |
-| test_command | rig config | Test command. Empty = skip. |
-| lint_command | rig config | Lint command. Empty = skip. |
-| build_command | rig config | Build command. Empty = skip. |"""
+| setup_command | rig `formula_vars` | Setup/install command. Empty = skip. |
+| typecheck_command | rig `formula_vars` | Type check command. Empty = skip. |
+| test_command | rig `formula_vars` | Test command. Empty = skip. |
+| lint_command | rig `formula_vars` | Lint command. Empty = skip. |
+| build_command | rig `formula_vars` | Build command. Empty = skip. |"""
 formula = "mol-polecat-base"
 version = 1
 
@@ -31,23 +31,23 @@ description = "The base branch to rebase on and compare against (e.g., main, int
 default = "main"
 
 [vars.setup_command]
-description = "Setup/install command (e.g., pnpm install). Empty = skip."
+description = "Setup/install command (e.g., pnpm install). From rig `formula_vars` or empty to skip."
 default = ""
 
 [vars.typecheck_command]
-description = "Type check command (e.g., tsc --noEmit). Empty = skip."
+description = "Type check command (e.g., tsc --noEmit). From rig `formula_vars` or empty to skip."
 default = ""
 
 [vars.test_command]
-description = "Command to run tests (auto-detected from rig settings)"
+description = "Command to run tests. From rig `formula_vars` or empty to skip."
 default = ""
 
 [vars.lint_command]
-description = "Command to run linting. Empty = skip."
+description = "Command to run linting. From rig `formula_vars` or empty to skip."
 default = ""
 
 [vars.build_command]
-description = "Command to run build. Empty = skip."
+description = "Command to run build. From rig `formula_vars` or empty to skip."
 default = ""
 
 [[steps]]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -508,6 +508,12 @@ type Rig struct {
 	// shell invocations with BEADS_DOLT_SERVER_PORT=<port> so bd connects to the
 	// correct server instead of the city-level default.
 	DoltPort string `toml:"dolt_port,omitempty"`
+	// FormulaVars provides rig-scoped defaults for formula vars. Keys match
+	// var names declared in formula `[vars.<name>]` blocks. Values are used
+	// when a formula runs in this rig and the caller did not pass an
+	// explicit --var override. Takes precedence over formula-level defaults
+	// but loses to --var flags.
+	FormulaVars map[string]string `toml:"formula_vars,omitempty"`
 }
 
 // AgentOverride modifies a pack-stamped agent for a specific rig.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2766,6 +2766,76 @@ func TestRigsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRigFormulaVarsRoundTrip verifies that rigs.<name>.formula_vars survives
+// TOML marshal/unmarshal so city.toml can declare rig-scoped formula defaults.
+func TestRigFormulaVarsRoundTrip(t *testing.T) {
+	c := City{
+		Workspace: Workspace{Name: "test"},
+		Agents:    []Agent{{Name: "mayor"}},
+		Rigs: []Rig{
+			{
+				Name: "mo",
+				Path: "/home/user/mo",
+				FormulaVars: map[string]string{
+					"test_command": "make test-fast",
+					"lint_command": "golangci-lint run",
+				},
+			},
+		},
+	}
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse(Marshal output): %v", err)
+	}
+	if len(got.Rigs) != 1 {
+		t.Fatalf("len(Rigs) after round-trip = %d, want 1", len(got.Rigs))
+	}
+	if v := got.Rigs[0].FormulaVars["test_command"]; v != "make test-fast" {
+		t.Errorf("FormulaVars[test_command] = %q, want %q", v, "make test-fast")
+	}
+	if v := got.Rigs[0].FormulaVars["lint_command"]; v != "golangci-lint run" {
+		t.Errorf("FormulaVars[lint_command] = %q, want %q", v, "golangci-lint run")
+	}
+}
+
+// TestRigFormulaVarsParsing verifies the expected TOML surface — a
+// [rigs.formula_vars] table inside a [[rigs]] entry — decodes into the
+// FormulaVars map on the rig.
+func TestRigFormulaVarsParsing(t *testing.T) {
+	input := `
+[workspace]
+name = "my-city"
+
+[[agent]]
+name = "mayor"
+
+[[rigs]]
+name = "mo"
+path = "/home/user/mo"
+
+[rigs.formula_vars]
+test_command = "make test-fast"
+build_command = "make build"
+`
+	cfg, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(cfg.Rigs) != 1 {
+		t.Fatalf("len(Rigs) = %d, want 1", len(cfg.Rigs))
+	}
+	if got := cfg.Rigs[0].FormulaVars["test_command"]; got != "make test-fast" {
+		t.Errorf("FormulaVars[test_command] = %q, want %q", got, "make test-fast")
+	}
+	if got := cfg.Rigs[0].FormulaVars["build_command"]; got != "make build" {
+		t.Errorf("FormulaVars[build_command] = %q, want %q", got, "make build")
+	}
+}
+
 // --- DeriveBeadsPrefix tests ---
 
 func TestDeriveBeadsPrefix(t *testing.T) {

--- a/internal/config/patch.go
+++ b/internal/config/patch.go
@@ -171,6 +171,10 @@ type RigPatch struct {
 	DefaultBranch *string `toml:"default_branch,omitempty"`
 	// Suspended overrides the rig's suspended state.
 	Suspended *bool `toml:"suspended,omitempty"`
+	// FormulaVars adds or overrides rig-scoped formula var defaults.
+	// Additive merge: patch keys win over existing rig keys, unspecified
+	// keys are preserved.
+	FormulaVars map[string]string `toml:"formula_vars,omitempty"`
 }
 
 // ProviderPatch modifies an existing provider identified by Name.
@@ -482,6 +486,14 @@ func applyRigPatch(cfg *City, patch *RigPatch) error {
 			}
 			if patch.Suspended != nil {
 				r.Suspended = *patch.Suspended
+			}
+			if len(patch.FormulaVars) > 0 {
+				if r.FormulaVars == nil {
+					r.FormulaVars = make(map[string]string, len(patch.FormulaVars))
+				}
+				for k, v := range patch.FormulaVars {
+					r.FormulaVars[k] = v
+				}
 			}
 			return nil
 		}

--- a/internal/config/patch_test.go
+++ b/internal/config/patch_test.go
@@ -407,6 +407,64 @@ func TestApplyPatches_RigSuspend(t *testing.T) {
 	}
 }
 
+func TestApplyRigPatchFormulaVars(t *testing.T) {
+	t.Run("adds keys to a rig with no existing formula_vars", func(t *testing.T) {
+		cfg := &City{Rigs: []Rig{{Name: "mo", Path: "/mo"}}}
+		err := ApplyPatches(cfg, Patches{
+			Rigs: []RigPatch{{
+				Name:        "mo",
+				FormulaVars: map[string]string{"test_command": "make test-fast"},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("ApplyPatches: %v", err)
+		}
+		if got := cfg.Rigs[0].FormulaVars["test_command"]; got != "make test-fast" {
+			t.Errorf("FormulaVars[test_command] = %q, want %q", got, "make test-fast")
+		}
+	})
+
+	t.Run("patch keys win over existing rig keys", func(t *testing.T) {
+		cfg := &City{Rigs: []Rig{{
+			Name:        "mo",
+			Path:        "/mo",
+			FormulaVars: map[string]string{"test_command": "go test ./...", "lint_command": "golangci-lint"},
+		}}}
+		err := ApplyPatches(cfg, Patches{
+			Rigs: []RigPatch{{
+				Name:        "mo",
+				FormulaVars: map[string]string{"test_command": "make test-fast"},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("ApplyPatches: %v", err)
+		}
+		if got := cfg.Rigs[0].FormulaVars["test_command"]; got != "make test-fast" {
+			t.Errorf("FormulaVars[test_command] = %q, want %q (patch overrides)", got, "make test-fast")
+		}
+		if got := cfg.Rigs[0].FormulaVars["lint_command"]; got != "golangci-lint" {
+			t.Errorf("FormulaVars[lint_command] = %q, want %q (untouched)", got, "golangci-lint")
+		}
+	})
+
+	t.Run("empty patch leaves existing formula_vars unchanged", func(t *testing.T) {
+		cfg := &City{Rigs: []Rig{{
+			Name:        "mo",
+			Path:        "/mo",
+			FormulaVars: map[string]string{"test_command": "go test ./..."},
+		}}}
+		err := ApplyPatches(cfg, Patches{
+			Rigs: []RigPatch{{Name: "mo", Suspended: ptrBool(true)}},
+		})
+		if err != nil {
+			t.Fatalf("ApplyPatches: %v", err)
+		}
+		if got := cfg.Rigs[0].FormulaVars["test_command"]; got != "go test ./..." {
+			t.Errorf("FormulaVars[test_command] = %q, want %q (untouched)", got, "go test ./...")
+		}
+	})
+}
+
 func TestApplyPatches_RigNotFound(t *testing.T) {
 	cfg := &City{
 		Rigs: []Rig{{Name: "hw", Path: "/path"}},

--- a/internal/sling/sling.go
+++ b/internal/sling/sling.go
@@ -912,6 +912,8 @@ func rigStoredDefaultBranch(cfg *config.City, beadID string, a config.Agent) str
 }
 
 // BuildSlingFormulaVars builds the variable map for formula instantiation.
+// Precedence (highest wins): explicit --var > rig.formula_vars > routing-injected
+// defaults (issue/rig_name/base_branch/...) > formula-level [vars.*].default.
 func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a config.Agent, deps SlingDeps) map[string]string {
 	vars := make(map[string]string, len(userVars)+6)
 	for _, v := range userVars {
@@ -920,6 +922,7 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 			vars[key] = value
 		}
 	}
+	mergeRigFormulaVars(vars, deps.Cfg, a)
 	addVar := func(key, value string) {
 		if value == "" {
 			return
@@ -952,6 +955,32 @@ func BuildSlingFormulaVars(formulaName, beadID string, userVars []string, a conf
 	}
 
 	return vars
+}
+
+// mergeRigFormulaVars folds rig-scoped formula_vars defaults into vars.
+// Explicit --var entries already in vars are preserved. The lookup uses
+// rigNameForAgent so agents whose Dir is a filesystem path still resolve
+// to the correct rig.
+func mergeRigFormulaVars(vars map[string]string, cfg *config.City, a config.Agent) {
+	if cfg == nil {
+		return
+	}
+	rigName := rigNameForAgent(cfg, a)
+	if rigName == "" {
+		return
+	}
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name != rigName {
+			continue
+		}
+		for k, v := range cfg.Rigs[i].FormulaVars {
+			if _, explicit := vars[k]; explicit {
+				continue
+			}
+			vars[k] = v
+		}
+		return
+	}
 }
 
 // ResolveSlingEnv returns extra env vars for the sling command.


### PR DESCRIPTION
## Summary
- Adds `rigs.<name>.formula_vars` so polecat-family formulas (and any other formula declaring optional vars) pick up per-rig commands without repeating `--var` at every sling.
- Precedence (highest wins): explicit `--var` > `rig.formula_vars` > routing-injected defaults > formula-level `[vars.*].default`.
- `gc formula show --rig <name>` surfaces active rig defaults as `(rig default="...")` next to each applicable var so operators can verify before dispatch.
- polecat-base formula var descriptions stop claiming "auto-detected from rig settings" and now point at `formula_vars`.

Closes #1932. Partially addresses #1813 (rig defaults silently satisfy `required = true` vars for `gc order run`).

## Test plan
- [x] `go test ./internal/config/ ./internal/sling/` — new tests for round-trip, patch merge, and rig-defaults flow
- [x] `go test -run "^TestBuildSling|^TestRigFormula|^TestApplyPatches|^TestRigs|^TestOpenAPISpecInSync|^TestResolveFormulaScope" ./cmd/gc/ ./internal/config/ ./internal/sling/ ./internal/api/` — all green
- [x] Manual end-to-end: `gc formula show mol-polecat-base --rig mo` renders `(rig default="make test-fast")` on vars the rig has set; without `--rig` it falls back to formula `(default=...)`
- [x] OpenAPI spec regenerated via `go run ./cmd/genspec`; `TestOpenAPISpecInSync` passes
- [x] `go vet ./...` clean