### PR TITLE
fix(git): probe origin/{main,master} when origin/HEAD is unset

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -52,18 +52,32 @@ func (g *Git) CurrentBranchCtx(ctx context.Context) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-// DefaultBranch returns the default branch name via the origin HEAD symref.
-// Falls back to "main" if no remote is configured.
+// DefaultBranch returns the default branch name via the origin HEAD symref,
+// with a candidate-ref fallback when origin/HEAD is unset.
+//
+// Resolution order:
+//  1. refs/remotes/origin/HEAD symref (the configured default)
+//  2. refs/remotes/origin/main when it exists locally
+//  3. refs/remotes/origin/master when it exists locally
+//  4. "main" as a last resort
+//
+// The candidate-ref pass at step 2-3 prevents master-default rigs from
+// silently inheriting "main" when origin/HEAD has not been wired by the
+// clone (e.g., rigs added before gc rig add auto-detected the default
+// branch). See gc-8cowk / gc-ao9t.
 func (g *Git) DefaultBranch() (string, error) {
-	out, err := g.run("symbolic-ref", "refs/remotes/origin/HEAD")
-	if err != nil {
-		return "main", nil
+	if out, err := g.run("symbolic-ref", "refs/remotes/origin/HEAD"); err == nil {
+		ref := strings.TrimSpace(out)
+		if branch := strings.TrimPrefix(ref, "refs/remotes/origin/"); branch != "" {
+			return branch, nil
+		}
 	}
-	// Output is like "refs/remotes/origin/main" or
-	// "refs/remotes/origin/user/feature". Strip the full prefix so branch
-	// names containing slashes are preserved.
-	ref := strings.TrimSpace(out)
-	return strings.TrimPrefix(ref, "refs/remotes/origin/"), nil
+	for _, candidate := range []string{"main", "master"} {
+		if _, err := g.run("show-ref", "--verify", "--quiet", "refs/remotes/origin/"+candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "main", nil
 }
 
 // ProbeDefaultBranch returns the repo's mainline branch name with a richer

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -125,6 +125,77 @@ func TestDefaultBranch_FromOriginHEAD(t *testing.T) {
 	}
 }
 
+// TestDefaultBranch_OriginHEADUnsetWithMasterRef covers the master-default
+// rig case from gc-8cowk: a clone where refs/remotes/origin/HEAD is not set
+// but refs/remotes/origin/master exists. The hardcoded "main" fallback
+// strands polecats on master-default rigs (added before PR#1554) with
+// metadata.target=main, causing refinery rejection loops.
+func TestDefaultBranch_OriginHEADUnsetWithMasterRef(t *testing.T) {
+	tests := []struct {
+		name        string
+		remoteRefs  []string
+		wantBranch  string
+		description string
+	}{
+		{
+			name:        "origin/master only",
+			remoteRefs:  []string{"master"},
+			wantBranch:  "master",
+			description: "master-default rig: must detect master without origin/HEAD",
+		},
+		{
+			name:        "origin/main only",
+			remoteRefs:  []string{"main"},
+			wantBranch:  "main",
+			description: "main-default rig with unset origin/HEAD must still detect main",
+		},
+		{
+			name:        "both main and master",
+			remoteRefs:  []string{"main", "master"},
+			wantBranch:  "main",
+			description: "when ambiguous, prefer main (matches the hardcoded historical default)",
+		},
+		{
+			name:        "neither candidate exists",
+			remoteRefs:  []string{"develop"},
+			wantBranch:  "main",
+			description: "last-resort fallback remains main when no known candidate is on origin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bare := t.TempDir()
+			runGit(t, bare, "init", "--bare")
+
+			clone := t.TempDir()
+			runGit(t, clone, "clone", bare, ".")
+			runGit(t, clone, "config", "user.email", "test@test.com")
+			runGit(t, clone, "config", "user.name", "Test")
+			runGit(t, clone, "commit", "--allow-empty", "-m", "init")
+
+			// Populate refs/remotes/origin/<name> for each requested ref
+			// but DO NOT wire refs/remotes/origin/HEAD. This mirrors the
+			// state of rig clones added before gc rig add auto-detected
+			// the default branch.
+			for _, ref := range tt.remoteRefs {
+				runGit(t, clone, "update-ref", "refs/remotes/origin/"+ref, "HEAD")
+			}
+			// Defensive: ensure no origin/HEAD symref lingers from clone.
+			_ = exec.Command("git", "-C", clone, "symbolic-ref", "--delete", "refs/remotes/origin/HEAD").Run()
+
+			g := New(clone)
+			got, err := g.DefaultBranch()
+			if err != nil {
+				t.Fatalf("DefaultBranch: %v", err)
+			}
+			if got != tt.wantBranch {
+				t.Errorf("%s: DefaultBranch() = %q, want %q",
+					tt.description, got, tt.wantBranch)
+			}
+		})
+	}
+}
+
 func TestProbeDefaultBranch_FromOriginHEAD(t *testing.T) {
 	bare := t.TempDir()
 	runGit(t, bare, "init", "--bare")


### PR DESCRIPTION
## Summary

Fixes residual case of #1724 / #1554 (`gc rig add` default_branch auto-detect) for rigs that were registered before #1554 landed and have no `default_branch` field in `city.toml`. Those rigs fall through to the runtime probe, which previously hardcoded `"main"` when `refs/remotes/origin/HEAD` is unset — causing master-default polecats to write `metadata.target=main` and get rejected by the refinery on master-branched repos.

## What changed

- `internal/git/git.go:DefaultBranch()` now probes `refs/remotes/origin/main` and `refs/remotes/origin/master` before falling back to `"main"`.
- One-place fix covers both call sites:
  - prompt `.DefaultBranch`: `cmd/gc/prompt.go:defaultBranchFor` → `git.DefaultBranch`
  - formula `{{base_branch}}`: `internal/sling/sling.go:SlingFormulaTargetBranch` → `deps.Branches.DefaultBranch` → `cliBranchResolver` → `defaultBranchFor`

## Tests

- New `TestDefaultBranch_OriginHEADUnsetWithMasterRef` (table-driven, 4 cases) covering: only-main, only-master, both (prefers main), neither (falls back to "main").
- All `internal/git` package tests pass; `go vet` clean; build clean.

## Out of scope

Existing rigs registered pre-#1554 still have no `default_branch` in `city.toml`. They now resolve correctly at runtime via this fix, but a follow-up `gc rig refresh` (or one-time backfill) would let them be canonical in `city.toml`. Not blocking.

## Test plan

- [ ] CI passes
- [ ] On a fresh checkout: `git update-ref -d refs/remotes/origin/HEAD && go test ./internal/git/...` passes
- [ ] In a city with master-branch rigs lacking `default_branch`: polecats submit with `metadata.target=master` instead of `main`

Refs: closes ga-ao9t locally; addresses residual gap not covered by upstream #1724 + #1554.