### PR TITLE
fix(pool): alias-aware identity resolution prevents dual-claim spawns

### DIFF
--- a/cmd/gc/assigned_work_scope.go
+++ b/cmd/gc/assigned_work_scope.go
@@ -50,12 +50,8 @@ func filterAssignedWorkBeadsForPoolDemand(
 		if template != "" {
 			sessionBeadTemplate[sb.ID] = template
 		}
-		assigneeToSessionBeadID[sb.ID] = sb.ID
-		if sessionName := strings.TrimSpace(sb.Metadata["session_name"]); sessionName != "" {
-			assigneeToSessionBeadID[sessionName] = sb.ID
-		}
-		if identity := strings.TrimSpace(sb.Metadata["configured_named_identity"]); identity != "" {
-			assigneeToSessionBeadID[identity] = sb.ID
+		for _, id := range sessionBeadAssigneeIdentities(sb) {
+			assigneeToSessionBeadID[id] = sb.ID
 		}
 	}
 	filtered := make([]beads.Bead, 0, len(assignedWorkBeads))
@@ -131,9 +127,9 @@ func filterAssignedWorkBeadsForSessionWake(
 			continue
 		}
 		storeRef := assignedWorkStoreRefForAgent(cityPath, cfg, agentCfg)
-		add(sb.ID, storeRef)
-		add(sb.Metadata["session_name"], storeRef)
-		add(sb.Metadata["configured_named_identity"], storeRef)
+		for _, id := range sessionBeadAssigneeIdentities(sb) {
+			add(id, storeRef)
+		}
 		add(template, storeRef)
 	}
 

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -734,14 +734,10 @@ func expandSkipAssigneesWithSessionIdentities(skip map[string]struct{}, sessionB
 		return
 	}
 	for _, session := range sessionBeads.Open() {
-		ids := []string{
-			session.ID,
-			session.Metadata["session_name"],
-			session.Metadata["configured_named_identity"],
-		}
+		ids := sessionBeadAssigneeIdentities(session)
 		matched := false
 		for _, id := range ids {
-			if _, ok := skip[strings.TrimSpace(id)]; ok {
+			if _, ok := skip[id]; ok {
 				matched = true
 				break
 			}
@@ -750,10 +746,7 @@ func expandSkipAssigneesWithSessionIdentities(skip map[string]struct{}, sessionB
 			continue
 		}
 		for _, id := range ids {
-			id = strings.TrimSpace(id)
-			if id != "" {
-				skip[id] = struct{}{}
-			}
+			skip[id] = struct{}{}
 		}
 	}
 }
@@ -780,9 +773,9 @@ func readyAssignedWorkAssignees(cfg *config.City, sessionBeads *sessionBeadSnaps
 			if session.Status == "closed" {
 				continue
 			}
-			add(session.ID)
-			add(session.Metadata["session_name"])
-			add(session.Metadata["configured_named_identity"])
+			for _, id := range sessionBeadAssigneeIdentities(session) {
+				add(id)
+			}
 		}
 	}
 	if cfg != nil {

--- a/cmd/gc/pool_desired_state.go
+++ b/cmd/gc/pool_desired_state.go
@@ -83,7 +83,11 @@ func computePoolDesiredStates(
 	trace *sessionReconcilerTraceCycle,
 ) []PoolDesiredState {
 	// Build reverse lookup: any identifier → session bead ID.
-	// Assignee on work beads may be a bead ID, session name, or alias.
+	// Assignee on work beads may be a bead ID, session name, alias, or
+	// a prior alias preserved in alias_history. Resume-tier dispatch
+	// drops in-progress work whose owning session can't be resolved
+	// from this map, so missing identities cause live sessions to look
+	// orphaned and let a duplicate spawn for the same bead.
 	assigneeToSessionBeadID := make(map[string]string)
 	sessionBeadTemplate := make(map[string]string)
 	for _, sb := range sessionBeads {
@@ -94,12 +98,8 @@ func computePoolDesiredStates(
 		if template != "" {
 			sessionBeadTemplate[sb.ID] = template
 		}
-		assigneeToSessionBeadID[sb.ID] = sb.ID
-		if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" {
-			assigneeToSessionBeadID[sn] = sb.ID
-		}
-		if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" {
-			assigneeToSessionBeadID[ni] = sb.ID
+		for _, id := range sessionBeadAssigneeIdentities(sb) {
+			assigneeToSessionBeadID[id] = sb.ID
 		}
 	}
 

--- a/cmd/gc/pool_desired_state_test.go
+++ b/cmd/gc/pool_desired_state_test.go
@@ -139,6 +139,80 @@ func TestComputePoolDesiredStates_ResumeBeatsNew(t *testing.T) {
 	}
 }
 
+func TestComputePoolDesiredStates_ResumeResolvesAssigneeByAlias(t *testing.T) {
+	// Regression: a polecat session bead has its human-readable alias in
+	// Metadata["alias"], and the work bead's assignee is typically the
+	// alias. The resume-tier lookup must resolve alias→session so the
+	// active session stays alive — otherwise the pool sees the work as
+	// unowned and spawns a second polecat for the same bead.
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "rig/claude", "nux", "in_progress", 5),
+	}
+	sessions := []beads.Bead{{
+		ID:     "sess-vi6hhp",
+		Status: "open",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "polecat-sess-vi6hhp",
+			"alias":                "nux",
+			"template":             "rig/claude",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, nil)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	reqs := result[0].Requests
+	if len(reqs) != 1 {
+		t.Fatalf("len(requests) = %d, want 1 resume for alias-assigned work", len(reqs))
+	}
+	if reqs[0].Tier != "resume" {
+		t.Errorf("tier = %q, want resume", reqs[0].Tier)
+	}
+	if reqs[0].SessionBeadID != "sess-vi6hhp" {
+		t.Errorf("SessionBeadID = %q, want sess-vi6hhp", reqs[0].SessionBeadID)
+	}
+}
+
+func TestComputePoolDesiredStates_ResumeResolvesAssigneeByAliasHistory(t *testing.T) {
+	// Regression: alias rotation preserves prior aliases in alias_history.
+	// Work assigned under a prior alias must still resolve to its owning
+	// session.
+	cfg := &config.City{
+		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},
+	}
+	work := []beads.Bead{
+		workBead("w1", "rig/claude", "nux", "in_progress", 5),
+	}
+	sessions := []beads.Bead{{
+		ID:     "sess-vi6hhp",
+		Status: "open",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "polecat-sess-vi6hhp",
+			"alias":                "rictus",
+			"alias_history":        "nux",
+			"template":             "rig/claude",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	}}
+
+	result := ComputePoolDesiredStates(cfg, work, sessions, nil)
+
+	reqs := result[0].Requests
+	if len(reqs) != 1 || reqs[0].SessionBeadID != "sess-vi6hhp" {
+		t.Fatalf("requests = %+v, want 1 resume for sess-vi6hhp", reqs)
+	}
+}
+
 func TestComputePoolDesiredStates_MaxCapsTotal(t *testing.T) {
 	cfg := &config.City{
 		Agents: []config.Agent{poolAgent("claude", "rig", intPtr(2), 0)},

--- a/cmd/gc/pool_session_name.go
+++ b/cmd/gc/pool_session_name.go
@@ -9,7 +9,37 @@ import (
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/session"
 )
+
+// sessionBeadAssigneeIdentities returns every identifier under which a work
+// bead could be assigned to this session: the session bead ID, session_name,
+// configured_named_identity, current alias, and any prior aliases preserved
+// in alias_history. Pool polecat aliases (e.g. "nux") are first-class
+// assignment identities, so leaving them out of orphan-detection causes
+// in-progress work to be reset under a live owner — see the
+// SkipsLiveSessionAssignedByAlias regression tests.
+func sessionBeadAssigneeIdentities(sb beads.Bead) []string {
+	identities := make([]string, 0, 5)
+	if id := strings.TrimSpace(sb.ID); id != "" {
+		identities = append(identities, id)
+	}
+	if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" {
+		identities = append(identities, sn)
+	}
+	if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" {
+		identities = append(identities, ni)
+	}
+	if al := strings.TrimSpace(sb.Metadata["alias"]); al != "" {
+		identities = append(identities, al)
+	}
+	for _, prior := range session.AliasHistory(sb.Metadata) {
+		if prior = strings.TrimSpace(prior); prior != "" {
+			identities = append(identities, prior)
+		}
+	}
+	return identities
+}
 
 type releasedPoolAssignment struct {
 	ID    string
@@ -91,19 +121,13 @@ func releaseOrphanedPoolAssignments(
 	}
 
 	openIdentifiers := makeOpenSessionStoreRefIndex(cityPath, cfg, openSessionBeads, storeRefAware)
-	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionBeads)*3)
+	legacyOpenIdentifiers := make(map[string]struct{}, len(openSessionBeads)*5)
 	for _, sb := range openSessionBeads {
 		if sb.Status == "closed" {
 			continue
 		}
-		if id := strings.TrimSpace(sb.ID); id != "" {
+		for _, id := range sessionBeadAssigneeIdentities(sb) {
 			legacyOpenIdentifiers[id] = struct{}{}
-		}
-		if sn := strings.TrimSpace(sb.Metadata["session_name"]); sn != "" {
-			legacyOpenIdentifiers[sn] = struct{}{}
-		}
-		if ni := strings.TrimSpace(sb.Metadata["configured_named_identity"]); ni != "" {
-			legacyOpenIdentifiers[ni] = struct{}{}
 		}
 	}
 
@@ -168,7 +192,7 @@ func releaseOrphanedPoolAssignments(
 const unresolvedOpenSessionStoreRef = "\x00unresolved"
 
 func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSessionBeads []beads.Bead, storeRefAware bool) map[string]map[string]struct{} {
-	index := make(map[string]map[string]struct{}, len(openSessionBeads)*3)
+	index := make(map[string]map[string]struct{}, len(openSessionBeads)*5)
 	if !storeRefAware {
 		return index
 	}
@@ -180,9 +204,9 @@ func makeOpenSessionStoreRefIndex(cityPath string, cfg *config.City, openSession
 		if !ok {
 			storeRef = unresolvedOpenSessionStoreRef
 		}
-		addOpenSessionStoreRef(index, sb.ID, storeRef)
-		addOpenSessionStoreRef(index, sb.Metadata["session_name"], storeRef)
-		addOpenSessionStoreRef(index, sb.Metadata["configured_named_identity"], storeRef)
+		for _, id := range sessionBeadAssigneeIdentities(sb) {
+			addOpenSessionStoreRef(index, id, storeRef)
+		}
 	}
 	return index
 }
@@ -289,10 +313,10 @@ func liveOpenSessionAssignmentExists(store beads.Store, assignee string) bool {
 		if sb.Status == "closed" || !isSessionBead(sb) {
 			continue
 		}
-		if assignee == strings.TrimSpace(sb.ID) ||
-			assignee == strings.TrimSpace(sb.Metadata["session_name"]) ||
-			assignee == strings.TrimSpace(sb.Metadata["configured_named_identity"]) {
-			return true
+		for _, id := range sessionBeadAssigneeIdentities(sb) {
+			if assignee == id {
+				return true
+			}
 		}
 	}
 	return false
@@ -304,11 +328,13 @@ func liveSessionBeadExistsByIdentity(store beads.Store, assignee string) bool {
 		if err != nil {
 			continue
 		}
-		if sb.Status != "closed" && isSessionBead(sb) &&
-			(assignee == strings.TrimSpace(sb.ID) ||
-				assignee == strings.TrimSpace(sb.Metadata["session_name"]) ||
-				assignee == strings.TrimSpace(sb.Metadata["configured_named_identity"])) {
-			return true
+		if sb.Status == "closed" || !isSessionBead(sb) {
+			continue
+		}
+		for _, candidate := range sessionBeadAssigneeIdentities(sb) {
+			if assignee == candidate {
+				return true
+			}
 		}
 	}
 	return false

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -7,6 +7,101 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 )
 
+func TestSessionBeadAssigneeIdentities(t *testing.T) {
+	tests := []struct {
+		name string
+		bead beads.Bead
+		want []string
+	}{
+		{
+			name: "empty bead produces no identities",
+			bead: beads.Bead{},
+			want: []string{},
+		},
+		{
+			name: "id only",
+			bead: beads.Bead{ID: "mc-xyz"},
+			want: []string{"mc-xyz"},
+		},
+		{
+			name: "session_name only",
+			bead: beads.Bead{Metadata: map[string]string{"session_name": "worker-mc-live"}},
+			want: []string{"worker-mc-live"},
+		},
+		{
+			name: "configured_named_identity only",
+			bead: beads.Bead{Metadata: map[string]string{"configured_named_identity": "reviewer"}},
+			want: []string{"reviewer"},
+		},
+		{
+			name: "alias only",
+			bead: beads.Bead{Metadata: map[string]string{"alias": "nux"}},
+			want: []string{"nux"},
+		},
+		{
+			name: "alias_history single entry",
+			bead: beads.Bead{Metadata: map[string]string{"alias_history": "previous"}},
+			want: []string{"previous"},
+		},
+		{
+			name: "alias_history multiple entries",
+			bead: beads.Bead{Metadata: map[string]string{"alias_history": "first,second,third"}},
+			want: []string{"first", "second", "third"},
+		},
+		{
+			name: "all fields populated",
+			bead: beads.Bead{
+				ID: "mc-xyz",
+				Metadata: map[string]string{
+					"session_name":              "worker-mc-live",
+					"configured_named_identity": "reviewer",
+					"alias":                     "rictus",
+					"alias_history":             "nux",
+				},
+			},
+			want: []string{"mc-xyz", "worker-mc-live", "reviewer", "rictus", "nux"},
+		},
+		{
+			name: "whitespace-only values are trimmed and skipped",
+			bead: beads.Bead{
+				ID: "  ",
+				Metadata: map[string]string{
+					"session_name":              "   ",
+					"configured_named_identity": "\t",
+					"alias":                     " ",
+					"alias_history":             "  ,  , real ,  ",
+				},
+			},
+			want: []string{"real"},
+		},
+		{
+			name: "values with surrounding whitespace are trimmed",
+			bead: beads.Bead{
+				ID: "  mc-xyz  ",
+				Metadata: map[string]string{
+					"session_name":              "  worker-mc-live  ",
+					"configured_named_identity": "  reviewer  ",
+					"alias":                     "  nux  ",
+				},
+			},
+			want: []string{"mc-xyz", "worker-mc-live", "reviewer", "nux"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sessionBeadAssigneeIdentities(tt.bead)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d identities %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i, id := range got {
+				if id != tt.want[i] {
+					t.Errorf("identity[%d] = %q, want %q (full got=%v, want=%v)", i, id, tt.want[i], got, tt.want)
+				}
+			}
+		})
+	}
+}
+
 func TestPoolSessionName(t *testing.T) {
 	tests := []struct {
 		template string

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -324,6 +324,175 @@ func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionWhenLiveSessionListMisse
 	}
 }
 
+func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionAssignedByAlias(t *testing.T) {
+	// Regression: polecat pool sessions carry their human-readable identity
+	// in Metadata["alias"] (e.g. "nux"), separate from session_name
+	// ("polecat-gc-vi6hhp"). Work claimed by a polecat is often assigned
+	// under the alias, so orphan-release must recognize alias-owned work as
+	// belonging to a live session.
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "polecat-gc-vi6hhp",
+			"alias":                "nux",
+			"template":             "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		[]beads.Bead{sessionBead},
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — live polecat owns work via alias", released)
+	}
+
+	got, err := store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Get work bead: %v", err)
+	}
+	if got.Status != "in_progress" {
+		t.Fatalf("status = %q, want in_progress", got.Status)
+	}
+	if got.Assignee != "nux" {
+		t.Fatalf("assignee = %q, want nux", got.Assignee)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionAssignedByAliasHistory(t *testing.T) {
+	// Regression: a polecat may have been rebranded (alias rotated) while
+	// retaining ownership of work assigned under the prior alias. The
+	// previous alias is preserved in Metadata["alias_history"], so
+	// orphan-release must consult history before deciding the assignee is
+	// dead.
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "polecat",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "polecat-gc-vi6hhp",
+			"alias":                "rictus",
+			"alias_history":        "nux",
+			"template":             "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		[]beads.Bead{sessionBead},
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — live polecat owns work via prior alias", released)
+	}
+}
+
+func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionByAliasViaLiveList(t *testing.T) {
+	// Even without an upstream session snapshot, the fallback live-list
+	// path must recognize alias-owned work. This covers ticks where the
+	// session snapshot is missing or stale (e.g. partial reads).
+	store := beads.NewMemStore()
+	_, err := store.Create(beads.Bead{
+		Title:  "polecat",
+		Type:   sessionBeadType,
+		Status: "open",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":         "polecat-gc-vi6hhp",
+			"alias":                "nux",
+			"template":             "worker",
+			poolManagedMetadataKey: boolMetadata(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	work, err := store.Create(beads.Bead{
+		Title:    "claimed pool work",
+		Assignee: "nux",
+		Metadata: map[string]string{"gc.routed_to": "worker"},
+	})
+	if err != nil {
+		t.Fatalf("Create work bead: %v", err)
+	}
+	if err := store.Update(work.ID, beads.UpdateOpts{Status: stringPtr("in_progress")}); err != nil {
+		t.Fatalf("Set work status: %v", err)
+	}
+	work, err = store.Get(work.ID)
+	if err != nil {
+		t.Fatalf("Reload work bead: %v", err)
+	}
+
+	released := releaseOrphanedPoolAssignments(
+		store,
+		&config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(0), MaxActiveSessions: intPtr(2)}}},
+		"",
+		nil,
+		[]beads.Bead{work},
+		[]beads.Store{store},
+		nil,
+		nil,
+	)
+	if len(released) != 0 {
+		t.Fatalf("released = %v, want none — live-list fallback must resolve alias", released)
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_SkipsWorkReassignedAfterCandidateSnapshot(t *testing.T) {
 	store := beads.NewMemStore()
 	work, err := store.Create(beads.Bead{

--- a/cmd/gc/pool_session_name_test.go
+++ b/cmd/gc/pool_session_name_test.go
@@ -299,6 +299,73 @@ func (s sessionListMissStore) List(query beads.ListQuery) ([]beads.Bead, error) 
 	return s.Store.List(query)
 }
 
+func TestLiveSessionBeadExistsByIdentity_SkipsClosedSessionBead(t *testing.T) {
+	// Regression: directSessionBeadIDCandidates can resolve to a session
+	// bead that has since been closed. liveSessionBeadExistsByIdentity must
+	// skip closed beads via the early continue so the caller falls through
+	// to the live-list fallback instead of claiming the dead session is alive.
+	base := beads.NewMemStore()
+	closed, err := base.Create(beads.Bead{
+		Title:  "closed session",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+	})
+	if err != nil {
+		t.Fatalf("Create session bead: %v", err)
+	}
+	if err := base.Close(closed.ID); err != nil {
+		t.Fatalf("Close session bead: %v", err)
+	}
+	closed, err = base.Get(closed.ID)
+	if err != nil {
+		t.Fatalf("Reload closed session: %v", err)
+	}
+	if closed.Status != "closed" {
+		t.Fatalf("closed status = %q, want closed", closed.Status)
+	}
+
+	store := sessionListMissStore{
+		Store:          base,
+		directSessions: map[string]beads.Bead{"worker-mc-dead": closed},
+	}
+
+	if liveSessionBeadExistsByIdentity(store, "worker-mc-dead") {
+		t.Error("liveSessionBeadExistsByIdentity = true, want false for closed session bead")
+	}
+}
+
+func TestLiveSessionBeadExistsByIdentity_SkipsNonSessionBead(t *testing.T) {
+	// Regression: directSessionBeadIDCandidates can resolve to a bead that
+	// is not a session (e.g. a work bead whose ID collides with the
+	// assignee string). liveSessionBeadExistsByIdentity must skip such
+	// beads instead of treating them as live session owners.
+	base := beads.NewMemStore()
+	notSession, err := base.Create(beads.Bead{
+		Title: "not a session",
+		Type:  "task",
+	})
+	if err != nil {
+		t.Fatalf("Create non-session bead: %v", err)
+	}
+	if notSession.Type == sessionBeadType {
+		t.Fatalf("test setup: bead type = %q, want non-session", notSession.Type)
+	}
+	for _, label := range notSession.Labels {
+		if label == sessionBeadLabel {
+			t.Fatalf("test setup: bead has session label %q", label)
+		}
+	}
+
+	store := sessionListMissStore{
+		Store:          base,
+		directSessions: map[string]beads.Bead{"worker-mc-task": notSession},
+	}
+
+	if liveSessionBeadExistsByIdentity(store, "worker-mc-task") {
+		t.Error("liveSessionBeadExistsByIdentity = true, want false for non-session bead")
+	}
+}
+
 func TestReleaseOrphanedPoolAssignments_SkipsLiveSessionMissingFromSnapshot(t *testing.T) {
 	store := beads.NewMemStore()
 	sessionBead, err := store.Create(beads.Bead{


### PR DESCRIPTION
## Summary

Fixes a pool reconciler bug where bead assignments made via a pool slot's alias (e.g. `cashmaster/gastown.nux`) were not recognized by `releaseOrphanedPoolAssignments` and `ComputePoolDesiredStates`, causing the reconciler to drop the live polecat's claim and spawn a new polecat for the same bead — leading to duplicate claims and clobbered work.

## Root cause

Pool dispatch paths compared bead assignees against the canonical session-name identity only. When a session held a stable pool alias as its public identity (the normal case for named-pool members), the assignee string carried the alias while the live-session identity used the canonical session name. The mismatch made live work look orphaned.

## What changed

- Centralized identity resolution via new `sessionBeadAssigneeIdentities()` helper that builds the candidate set from session-name + `Metadata["alias"]` + `alias_history`.
- `releaseOrphanedPoolAssignments` and `ComputePoolDesiredStates` now use the helper so a polecat's assignment under any of its known identities counts as live.
- 5 new regression tests covering the alias / alias_history / mixed cases.

## Related upstream

- #1424 (pool session exits without clean drain leaves IN_PROGRESS work assigned)
- #855 (reconciler stuck in drain-log loop with orphaned in-progress work)
- #1181 (Implicit pool agents share one working tree — parallel dispatch can clobber)

This PR addresses the alias-resolution facet of that cluster; the others remain valid against separate root causes.

## Test plan

- [ ] CI passes
- [ ] In a multi-rig city: route a bead to a pool, observe the assigned polecat keep the claim across reconciler patrols (no duplicate spawn)
- [ ] Regression tests in `internal/dispatch/*_test.go` cover alias / alias_history paths

Refs: closes ga-ofmf locally.