### PR TITLE
fix(orders): wisp roots stop blocking auto re-dispatch (ga-lo8c)

### DIFF
--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -778,9 +778,18 @@ func (m *memoryOrderDispatcher) rigSuspendedByName(rigName string) bool {
 	return false
 }
 
-// hasOpenWorkStrict reports whether any non-closed work or tracking bead
-// exists for this order. Open tracking beads represent in-flight dispatch and
-// must block condition/event orders that do not consult LastRun.
+// hasOpenWorkStrict reports whether an open tracking bead exists for this
+// order — i.e. a dispatchOne goroutine is still in flight. Tracking beads
+// carry both "order-run:<scoped>" and labelOrderTracking; dispatchOne closes
+// them via defer when dispatch returns.
+//
+// Wisp root beads also carry "order-run:<scoped>" (so gc order history and
+// the orders API feed can attribute the wisp to its order), but molecule
+// roots never auto-close when their step beads finish. A leftover open
+// root is not in-flight work and must not block re-dispatch — counting it
+// caused ga-jra/ga-lo8c, where formula+pool orders stalled indefinitely
+// after a city restart because the first auto-fire's wisp root permanently
+// tripped this check.
 func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName string) (bool, error) {
 	results, err := store.List(beads.ListQuery{
 		Label: "order-run:" + scopedName,
@@ -790,8 +799,13 @@ func (m *memoryOrderDispatcher) hasOpenWorkStrict(store beads.Store, scopedName 
 		return false, fmt.Errorf("listing order work beads: %w", err)
 	}
 	for _, b := range results {
-		if b.Status != "closed" {
-			return true, nil
+		if b.Status == "closed" {
+			continue
+		}
+		for _, lbl := range b.Labels {
+			if lbl == labelOrderTracking {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4334,6 +4334,52 @@ func TestOrderDispatchOpenWispRootDoesNotBlockRedispatch(t *testing.T) {
 	}
 }
 
+// listIncludingClosedStore forces List to include closed beads regardless of
+// the caller's IncludeClosed setting. Production stores honor IncludeClosed:
+// false, but hasOpenWorkStrict's defensive status check must still skip closed
+// beads if a store implementation (or a stale cache) returns them.
+type listIncludingClosedStore struct {
+	beads.Store
+}
+
+func (s listIncludingClosedStore) List(q beads.ListQuery) ([]beads.Bead, error) {
+	q.IncludeClosed = true
+	return s.Store.List(q)
+}
+
+// TestHasOpenWorkStrictSkipsClosedTrackingBead covers the defensive
+// status-closed branch in hasOpenWorkStrict (cmd/gc/order_dispatch.go:802-803).
+// The standard query passes IncludeClosed: false, so closed beads normally
+// don't reach the loop — but a misbehaving store (or a stale CachingStore
+// view) could leak one through. If hasOpenWorkStrict didn't skip closed
+// beads, a completed tracking bead would permanently block re-dispatch — the
+// same failure shape ga-lo8c hit with leftover wisp roots.
+func TestHasOpenWorkStrictSkipsClosedTrackingBead(t *testing.T) {
+	base := beads.NewMemStore()
+	store := listIncludingClosedStore{Store: base}
+
+	b, err := store.Create(beads.Bead{
+		Title:  "order:my-order",
+		Labels: []string{"order-run:my-order", labelOrderTracking},
+	})
+	if err != nil {
+		t.Fatalf("seed bead: %v", err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatalf("close seed bead: %v", err)
+	}
+
+	ad := &memoryOrderDispatcher{}
+	has, err := ad.hasOpenWorkStrict(store, "my-order")
+	if err != nil {
+		t.Fatalf("hasOpenWorkStrict: %v", err)
+	}
+	if has {
+		t.Fatal("closed tracking bead must not count as in-flight work; " +
+			"the defensive status filter at order_dispatch.go:802 should skip it")
+	}
+}
+
 // Unused but keep for future event assertion tests.
 var (
 	_ = (*memRecorder).hasSubject

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -4280,6 +4280,60 @@ func TestOrderDispatchFiresAfterWorkClosed(t *testing.T) {
 	}
 }
 
+// TestOrderDispatchOpenWispRootDoesNotBlockRedispatch reproduces the
+// formula+pool auto-dispatch failure tracked by ga-lo8c (continuation of
+// closed ga-jra). After a city restart, the wisp root bead from a previous
+// formula+pool dispatch persists in the store with status="open" and the
+// "order-run:<scoped>" label (stamped by dispatchWisp at order_dispatch.go:706).
+// Molecule roots are never auto-closed when their step beads complete, so
+// the leftover open root permanently tripped hasOpenWorkStrict and starved
+// the order's cooldown gate.
+//
+// In-flight dispatch is signaled by the tracking bead (carries both
+// "order-run:<scoped>" AND labelOrderTracking). Wisp roots carry only the
+// former — distinguishing the two is the fix.
+func TestOrderDispatchOpenWispRootDoesNotBlockRedispatch(t *testing.T) {
+	store := beads.NewMemStore()
+
+	// Simulate post-restart state: an open wisp root from the prior
+	// formula+pool dispatch. The tracking bead from that dispatch was
+	// already closed by dispatchOne's deferred Close, but the molecule
+	// root remains open because nothing in the dispatch path closes it.
+	wispRoot, err := store.Create(beads.Bead{
+		Title:  "mol-formula-pool-work",
+		Labels: []string{"order-run:my-pool-order"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wispRoot.Status == "closed" {
+		t.Fatalf("seed wisp root should be open, got status=%q", wispRoot.Status)
+	}
+
+	ran := false
+	fakeExec := func(_ context.Context, _, _ string, _ []string) ([]byte, error) {
+		ran = true
+		return nil, nil
+	}
+
+	aa := []orders.Order{{
+		Name:     "my-pool-order",
+		Trigger:  "cooldown",
+		Interval: "1s",
+		Exec:     "scripts/run.sh",
+	}}
+	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
+
+	// Future "now" so cooldown evaluates Due=true (LastRun = wispRoot.CreatedAt).
+	ad.dispatch(context.Background(), t.TempDir(), time.Now().Add(5*time.Second))
+	ad.drain(context.Background())
+
+	if !ran {
+		t.Fatal("exec should have run — an open wisp root (no labelOrderTracking) " +
+			"is leftover state, not in-flight work, and must not block re-dispatch")
+	}
+}
+
 // Unused but keep for future event assertion tests.
 var (
 	_ = (*memRecorder).hasSubject


### PR DESCRIPTION
## Summary

Fixes the formula+pool auto-dispatch stall: after a city restart, `mol-dog-stale-db`, `digest-generate`, and the formerly-formula `mol-dog-*` orders stalled silently for hours despite their cooldowns being well past due. Manual `gc order run <name>` worked because it bypasses the cooldown gate.

Closes #1440.

## Root cause

`memoryOrderDispatcher.hasOpenWorkStrict` treated any open bead carrying
the `order-run:<scoped>` label as in-flight work and short-circuited
re-dispatch. `dispatchWisp` (cmd/gc/order_dispatch.go:706) stamps that
same label on the **wisp root bead** so `gc order history` and the orders
API feed can attribute the wisp to its order — but molecule roots never
auto-close when their step beads finish. The first formula+pool auto-fire
therefore created a permanent open "work" record that blocked every
subsequent tick.

This was the "tracking-bead label leak" hypothesis. Confirmed.

## Fix

Restrict `hasOpenWorkStrict` to beads that **also** carry
`labelOrderTracking` — i.e. the synchronously-created tracking bead that
`dispatchOne` closes via defer once dispatch returns. Wisp roots still
carry `order-run:` for `gc order history` / API feed visibility but no
longer trip the in-flight gate.

## Test plan

- [x] New regression test
      `TestOrderDispatchOpenWispRootDoesNotBlockRedispatch` simulates the
      post-restart state: an open wisp root labeled `order-run:<scoped>`
      (no `labelOrderTracking`). On baseline (before the fix) the order
      stays gated; with the fix the cooldown trigger fires.
- [x] `TestOrderDispatchSkipsOpenTrackingBeadForConditionOrder` still
      passes — an open tracking bead (with `labelOrderTracking`) still
      blocks re-dispatch.
- [x] `TestOrderDispatchFiresAfterWorkClosed` still passes — closed wisp
      roots don't block re-dispatch.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] Stability of the new test: 20× `go test -count=20 -run …` all pass.
- [ ] Pre-commit `make test` aborted on **pre-existing** environmental
      failures unrelated to this change: `TestGcBdRejectsGCBeadsFileOverride`,
      `TestGcBdUsesEnclosingRigWhenNoFlag`, and several
      `TestResolveBdScopeTarget` subtests fail identically on `origin/main`
      when run from a polecat worktree (verified via `git stash`). The
      ambient `.beads/redirect` files in sibling polecat worktrees confuse
      the cwd-ancestor lookup these tests rely on. Filed as a separate
      concern; CI runs in a fresh checkout where these don't repro.

## Parallel work / supersedes

PR #1984 shipped the same fix on `fix/orders-wisp-roots-block-redispatch`
minutes earlier. That branch has since diverged from main and is marked
`CONFLICTING`. This PR is the conflict-free, focused-only-on-the-
dispatch-fix variant — close #1984 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)