### PR TITLE
fix(test): isolate CityRuntime preflight test from inherited gc env + dolt leak

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -466,6 +466,7 @@ func TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot(t *test
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
 	t.Setenv("GC_BEADS", "bd")
+	cleanupManagedDoltTestCity(t, cityPath)
 
 	cfg, err := config.Load(osFS{}, tomlPath)
 	if err != nil {

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -671,6 +671,13 @@ func TestGcBdRejectsGCBeadsFileOverride(t *testing.T) {
 	cityFlag = ""
 	rigFlag = ""
 
+	// Scrub inherited beads env (notably GC_BEADS_SCOPE_ROOT from a
+	// gc agent's outer city) so the explicit GC_BEADS override below
+	// is honored by configuredBeadsProviderValue. Without this, a leaked
+	// GC_BEADS_SCOPE_ROOT disqualifies the override and the provider
+	// resolution falls back to city.toml peek (which has no [beads]
+	// section here) → defaults to "bd" → rejection never fires.
+	clearInheritedBeadsEnv(t)
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
 name = "demo"

--- a/cmd/gc/rig_scope_resolution.go
+++ b/cmd/gc/rig_scope_resolution.go
@@ -30,7 +30,19 @@ func resolveRigForDir(cfg *config.City, cityPath, dir string) (config.Rig, bool,
 }
 
 func rigFromRedirectedBeadsDir(cfg *config.City, cityPath, dir string) (config.Rig, bool, error) {
+	// Redirect resolution is meaningful only when cwd lies inside cityPath.
+	// When tests or commands run with a cwd outside the declared city tree
+	// (e.g., a polecat worktree under a different gc city), walking up the
+	// cwd chain would pick up unrelated .beads/redirect files and either
+	// mis-route the command or hard-error against the test's fake cfg.
+	cityScope := normalizePathForCompare(cityPath)
+	if !pathWithinScope(normalizePathForCompare(dir), cityScope) {
+		return config.Rig{}, false, nil
+	}
 	for current := dir; current != "" && current != filepath.Dir(current); current = filepath.Dir(current) {
+		if !pathWithinScope(normalizePathForCompare(current), cityScope) {
+			break
+		}
 		redirectPath := filepath.Join(current, ".beads", "redirect")
 		redirectTarget, err := os.ReadFile(redirectPath)
 		if err != nil {


### PR DESCRIPTION
## Summary

Two related fixes for flaky pre-commit tests that leak gc environment + managed Dolt instances across test boundaries:

1. **`fix(cmd/gc): bound cwd-redirect walk to cityPath; scrub inherited beads env in test`** — `rigFromRedirectedBeadsDir`'s upward walk could traverse out of the test's cityPath into a foreign `.beads/redirect` (typical on polecat worktrees that sit under a parent city with its own redirects). The walk is now bounded to cityPath. The preflight test also scrubs inherited `GC_BEADS_*` / `GC_CITY_PATH` env vars so it runs deterministically regardless of where the developer (or polecat) invoked it from.

2. **`fix(test): clean up managed dolt sql-server in preflight test`** — `TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot` started a managed Dolt sql-server and never tore it down, leaving a leaked process + lock files. Added `cleanupManagedDoltTestCity(t, cityPath)` and called it from the test. Verified 3/3 isolated runs pass under `-race -count=3`.

## Why this matters

Polecats running pre-commit hooks from worktree subdirectories were hitting these tests as false positives — they couldn't push clean work even though their actual changes were unrelated. Memory note (feedback_gc_env_leak_pretest) tracks the symptom; this PR is the fix.

## Test plan

- [ ] `go test -race -count=3 ./cmd/gc -run TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot` passes locally
- [ ] CI passes (existing job exercises the same path)
- [ ] No managed-dolt processes leaked after the test run

Refs: ga-10qg locally.