### PR TITLE
docs(packs/core): fix dangling mol-polecat-work reference in mol-do-work

### DIFF
--- a/internal/bootstrap/packs/core/formulas/mol-do-work.toml
+++ b/internal/bootstrap/packs/core/formulas/mol-do-work.toml
@@ -7,8 +7,9 @@ description, implements the solution in the current working directory,
 and closes the bead when done.
 
 Use this for demos and simple single-agent workflows. For production
-multi-agent setups with branch isolation and merge review, use
-mol-polecat-work instead.
+multi-agent setups with worktree isolation, use mol-polecat-commit
+instead (or mol-polecat-work from the gastown pack for full refinery
+review).
 
 ## Variables
 


### PR DESCRIPTION
## Summary

- `internal/bootstrap/packs/core/formulas/mol-do-work.toml` told readers to use `mol-polecat-work` for production multi-agent setups, but that formula does not exist in the **core** pack — it lives in the **gastown** pack. A core-only city would chase a dangling reference.
- Repoint at `mol-polecat-commit`, the production sibling that actually ships in `core`, and note that `mol-polecat-work` is available from the `gastown` pack for full refinery review.
- Also drop "and merge review" from the suggestion: `mol-polecat-commit` pushes directly to `base_branch`, so the description was inaccurate for the in-pack alternative.

## Test plan

- [x] `go vet ./internal/bootstrap/...` clean
- [x] `go test ./examples/gastown/ -run TestAllPackTomlsParse` passes (the gating test for every pack TOML, added in #1926)
- [x] `go test ./internal/formula/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)