### PR TITLE
fix(cmd/gc): bound cwd-redirect walk to cityPath

### DIFF
--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -686,6 +686,11 @@ name = "demo"
 	}
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("GC_BEADS", "file")
+	// Clear any inherited scope pin so the GC_BEADS override applies to
+	// this test's city. When run from a polecat session, the ambient
+	// GC_BEADS_SCOPE_ROOT points at the rig repo and would suppress the
+	// override before the provider check could fire.
+	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
 
 	var stdout, stderr bytes.Buffer
 	if got := doBd([]string{"list"}, &stdout, &stderr); got == 0 {

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -671,6 +671,13 @@ func TestGcBdRejectsGCBeadsFileOverride(t *testing.T) {
 	cityFlag = ""
 	rigFlag = ""
 
+	// Scrub inherited beads env (notably GC_BEADS_SCOPE_ROOT from a
+	// gc agent's outer city) so the explicit GC_BEADS override below
+	// is honored by configuredBeadsProviderValue. Without this, a leaked
+	// GC_BEADS_SCOPE_ROOT disqualifies the override and the provider
+	// resolution falls back to city.toml peek (which has no [beads]
+	// section here) → defaults to "bd" → rejection never fires.
+	clearInheritedBeadsEnv(t)
 	cityDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
 name = "demo"

--- a/cmd/gc/rig_scope_resolution.go
+++ b/cmd/gc/rig_scope_resolution.go
@@ -30,7 +30,19 @@ func resolveRigForDir(cfg *config.City, cityPath, dir string) (config.Rig, bool,
 }
 
 func rigFromRedirectedBeadsDir(cfg *config.City, cityPath, dir string) (config.Rig, bool, error) {
+	// Redirect resolution is meaningful only when cwd lies inside cityPath.
+	// When tests or commands run with a cwd outside the declared city tree
+	// (e.g., a polecat worktree under a different gc city), walking up the
+	// cwd chain would pick up unrelated .beads/redirect files and either
+	// mis-route the command or hard-error against the test's fake cfg.
+	cityScope := normalizePathForCompare(cityPath)
+	if !pathWithinScope(normalizePathForCompare(dir), cityScope) {
+		return config.Rig{}, false, nil
+	}
 	for current := dir; current != "" && current != filepath.Dir(current); current = filepath.Dir(current) {
+		if !pathWithinScope(normalizePathForCompare(current), cityScope) {
+			break
+		}
 		redirectPath := filepath.Join(current, ".beads", "redirect")
 		redirectTarget, err := os.ReadFile(redirectPath)
 		if err != nil {

--- a/cmd/gc/rig_scope_resolution_test.go
+++ b/cmd/gc/rig_scope_resolution_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// TestRigFromRedirectedBeadsDirIgnoresCwdOutsideCity verifies that when the
+// caller's cwd is outside cityPath, any .beads/redirect found while walking
+// the cwd's ancestor chain is ignored. The walk must be bounded by cityPath
+// so that a polecat worktree's foreign-rig redirect (e.g., the shared rig
+// repo checkout at /home/b/GIT/gascity/.beads) cannot bleed into rig
+// resolution against an unrelated city.
+func TestRigFromRedirectedBeadsDirIgnoresCwdOutsideCity(t *testing.T) {
+	foreignRoot := filepath.Join(t.TempDir(), "foreign")
+	if err := os.MkdirAll(filepath.Join(foreignRoot, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cwdRoot := t.TempDir()
+	cwd := filepath.Join(cwdRoot, "worktree", "polecat-1")
+	if err := os.MkdirAll(filepath.Join(cwd, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(cwd, ".beads", "redirect"),
+		[]byte(filepath.Join(foreignRoot, ".beads")+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(cityDir, "rigs", "frontend")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "demo"},
+		Rigs: []config.Rig{
+			{Name: "frontend", Path: filepath.Join("rigs", "frontend"), Prefix: "fr"},
+		},
+	}
+
+	rig, ok, err := rigFromRedirectedBeadsDir(cfg, cityDir, normalizePathForCompare(cwd))
+	if err != nil {
+		t.Fatalf("rigFromRedirectedBeadsDir() error = %v, want nil (cwd outside cityPath)", err)
+	}
+	if ok {
+		t.Fatalf("rigFromRedirectedBeadsDir() ok = true, want false; rig = %+v", rig)
+	}
+}


### PR DESCRIPTION
## Summary

`rigFromRedirectedBeadsDir` walked `filepath.Dir` from the caller's cwd without checking whether the walk had escaped `cityPath`. When a polecat worktree at `/home/b/gc/.gc/worktrees/<rig>/polecats/<name>` ran tests against a tempdir city, the walk eventually landed on the parent gc city's `.beads/redirect` and resolved a foreign rig — causing test failures unrelated to the actual change under test.

This fix bounds the upward walk to `cityPath`, so tests stay isolated regardless of where the developer (or polecat) invoked them from.

## Files

- `cmd/gc/rig_scope_resolution.go` — add cityPath bound to the upward walk
- `cmd/gc/cmd_bd_test.go` — adjusted test setup

## Test plan

- [ ] CI passes
- [ ] Running `cmd_bd` tests from inside a polecat worktree no longer hits the parent city's redirect

Refs: ga-chb6 locally. Replaces the broader test-isolation work from the closed PR#1990 — this PR keeps only the focused cwd-walk bound fix.