### PR TITLE
fix(doctor): scrub inherited beads env in custom-types test

### DIFF
--- a/internal/doctor/checks_custom_types_test.go
+++ b/internal/doctor/checks_custom_types_test.go
@@ -17,6 +17,19 @@ func TestCustomTypesCheck_NoBeadsDir(t *testing.T) {
 }
 
 func TestCustomTypesCheck_MissingTypes(t *testing.T) {
+	// Scrub inherited beads env (BEADS_DIR / BEADS_ACTOR /
+	// GC_BEADS_SCOPE_ROOT) so the `bd config get` subprocess below
+	// resolves to the empty .beads/ in the temp dir instead of an
+	// outer gc city's beads database that a polecat/refinery worktree
+	// passes down via the environment. Without this, bd finds the
+	// outer city's store, reports all required types as present, and
+	// the check returns StatusOK — defeating the test's assertion.
+	// Same root cause class as ga-10qg / ga-766q; leak vector here is
+	// BEADS_DIR into a bd subprocess.
+	for _, key := range []string{"BEADS_DIR", "BEADS_ACTOR", "GC_BEADS_SCOPE_ROOT"} {
+		t.Setenv(key, "")
+	}
+
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o700); err != nil {


### PR DESCRIPTION
## Summary

`TestCustomTypesCheck_MissingTypes` in `internal/doctor/checks_custom_types_test.go` invokes `bd config get --json types.custom` as a subprocess in a temp dir with an empty `.beads/`. When `make test` runs from inside a gc polecat/refinery worktree, the outer city's `BEADS_DIR` (and `BEADS_ACTOR` / `GC_BEADS_SCOPE_ROOT`) leaks into the subprocess and `bd` resolves to that outer store instead of the empty temp dir. `bd` reports the required types as present, the check returns `StatusOK`, and the assertion fires.

The fix scrubs the three vars with `t.Setenv("", ...)` before constructing the check, matching `cmd/gc`'s `clearInheritedBeadsEnv` pattern from ga-10qg's broader scope fix (`14b03fa5`).

## Repro

```bash
go test -run 'TestCustomTypesCheck_MissingTypes' ./internal/doctor/
```

Reproduced on `origin/main @ 14b03fa5` (after ga-10qg landed) and on `46a14257` (before ga-10qg). Same root-cause class as ga-10qg / ga-766q (env leak), but vector is `BEADS_DIR` instead of `GC_BEADS_SCOPE_ROOT` and the code path is a `bd` subprocess instead of internal Go config resolution.

Fixes: bd ga-b3t6
Refs: bd ga-10qg, ga-766q

## Test plan

- [x] `go test -run 'TestCustomTypesCheck_MissingTypes' ./internal/doctor/` passes inside polecat worktree (where `BEADS_DIR` is set in env)
- [x] Existing assertions in the test still hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)