### PR TITLE
fix(cmd/gc): stop TestPhase0Hook tests from leaking dolt sql-servers (gs-dkxn)

### DIFF
--- a/cmd/gc/session_model_phase0_hook_spec_test.go
+++ b/cmd/gc/session_model_phase0_hook_spec_test.go
@@ -32,6 +32,11 @@ work_query = "printf 'pwd=%s|agent=%s|template=%s|session=%s|origin=%s' \"$PWD\"
 		t.Fatal(err)
 	}
 
+	// GC_DOLT=skip prevents cmdHook's env build from spawning a managed dolt
+	// server via the gc-beads-bd recovery path (default bd backend + empty
+	// .beads triggers applyResolvedCityDoltEnv(allowRecovery=true) which
+	// would otherwise leak a dolt sql-server process for every test run).
+	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_ALIAS", "mayor")
 	t.Setenv("GC_AGENT", "mayor")
@@ -90,6 +95,10 @@ work_query = "printf 'agent=%s|template=%s|session=%s|origin=%s' \"$GC_AGENT\" \
 		t.Fatal(err)
 	}
 
+	// See TestPhase0Hook_UsesGCTemplateForConfigLookupInSessionContext for
+	// why GC_DOLT=skip is required (prevents dolt-server leak via managed
+	// bd recovery path).
+	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_ALIAS", "")
 	t.Setenv("GC_AGENT", "s-gc-ordinary")
@@ -151,6 +160,11 @@ start_command = "true"
 
 	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPath)
+	// See TestPhase0Hook_UsesGCTemplateForConfigLookupInSessionContext for
+	// why GC_DOLT=skip is required (prevents dolt-server leak via managed
+	// bd recovery path; fake bd on PATH alone is insufficient because the
+	// leak path is gc-beads-bd.sh, not bd).
+	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_SESSION_ID", "mc-session-123")
 	t.Setenv("GC_SESSION_NAME", "test-city--mayor")


### PR DESCRIPTION
## Summary

Set `GC_DOLT=skip` in all three `TestPhase0Hook_*` tests so `cmdHook`'s env build skips the `gc-beads-bd` recovery path. Without it, the default bd backend + empty `.beads` trips `applyResolvedCityDoltEnv(allowRecovery=true)` into spawning a managed dolt sql-server per test that never gets stopped (deacon found 29 orphans, ~2.2 GB RSS).

The bug report's hypothesis (real `bd` invoked by tests spawning its own dolt) was incorrect — the leak path is `cmdHook` -> `controllerWorkQueryEnv` -> `bdRuntimeEnv` -> `applyResolvedCityDoltEnv(allowRecovery=true)` -> `healthBeadsProvider` -> `gc-beads-bd.sh recover` -> spawns managed dolt. That's why test 3's fake-bd-on-PATH didn't prevent the leak. `GC_DOLT=skip` short-circuits `healthBeadsProvider` before recovery runs.

Fixes gs-dkxn.

## Test plan

- [x] `go test ./cmd/gc -run TestPhase0Hook -count=10` — 30 runs pass in 0.5s total
- [x] `pgrep -af 'dolt sql-server.*TestPhase0Hook'` — zero TestPhase0Hook dolt processes left behind after the 30 runs
- [x] Tests run ~250× faster (0.02s each vs 4.7s) because the dolt-spawn timeout no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)