### PR TITLE
feat(doctor): add provider capability parity check (#672)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -149,6 +149,7 @@ func doDoctor(fix, verbose bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewBuiltinPackFamilyCheck(cfg, cityPath))
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		d.Register(doctor.NewDurationRangeCheck(cfg))
+		d.Register(doctor.NewProviderParityCheck(cfg))
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		d.Register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))
 		d.Register(newMCPConfigDoctorCheck(cityPath, cfg, exec.LookPath))

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/migrate"
 )
 
 func registerV2DeprecationChecks(d *doctor.Doctor) {
@@ -25,9 +27,12 @@ func registerV2DeprecationChecks(d *doctor.Doctor) {
 
 type v2AgentFormatCheck struct{}
 
-func (v2AgentFormatCheck) Name() string                     { return "v2-agent-format" }
-func (v2AgentFormatCheck) CanFix() bool                     { return false }
-func (v2AgentFormatCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2AgentFormatCheck) Name() string { return "v2-agent-format" }
+func (v2AgentFormatCheck) CanFix() bool { return true }
+func (v2AgentFormatCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+}
+
 func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	files := legacyAgentFiles(ctx.CityPath)
 	if len(files) == 0 {
@@ -41,9 +46,12 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 
 type v2ImportFormatCheck struct{}
 
-func (v2ImportFormatCheck) Name() string                     { return "v2-import-format" }
-func (v2ImportFormatCheck) CanFix() bool                     { return false }
-func (v2ImportFormatCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2ImportFormatCheck) Name() string { return "v2-import-format" }
+func (v2ImportFormatCheck) CanFix() bool { return true }
+func (v2ImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+}
+
 func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
 	if !ok || len(cfg.Workspace.Includes) == 0 {
@@ -57,9 +65,12 @@ func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 
 type v2DefaultRigImportFormatCheck struct{}
 
-func (v2DefaultRigImportFormatCheck) Name() string                     { return "v2-default-rig-import-format" }
-func (v2DefaultRigImportFormatCheck) CanFix() bool                     { return false }
-func (v2DefaultRigImportFormatCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2DefaultRigImportFormatCheck) Name() string { return "v2-default-rig-import-format" }
+func (v2DefaultRigImportFormatCheck) CanFix() bool { return true }
+func (v2DefaultRigImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+}
+
 func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
 	if !ok || len(cfg.Workspace.DefaultRigIncludes) == 0 {
@@ -441,6 +452,34 @@ func warnCheck(name, message, hint string, details []string) *doctor.CheckResult
 func v2MigrationHint() string {
 	return `run "gc doctor --fix" to rewrite safe mechanical cases, then rerun "gc doctor"`
 }
+
+// runV2PackMigration applies the pack-shape migration (legacy [[agent]]
+// tables, workspace.includes, default_rig_includes) for a doctor --fix run.
+// It is safe to call from multiple checks: migrate.Apply is idempotent on a
+// city that has already been migrated (it returns an empty change set).
+//
+// migrate.Apply can return warnings about behavior-affecting fields it had
+// to drop (e.g. legacy [[agent]] entries with fallback = true — the
+// fallback field has no v2 counterpart and shadowing must be reviewed by
+// hand). doctor --fix must not silently swallow those, otherwise the next
+// gc doctor run reports a green check and the manual follow-up is lost
+// forever. The warnings are emitted to warnSink so they land in the same
+// stream as the doctor output (production: os.Stderr; tests: a buffer).
+func runV2PackMigration(ctx *doctor.CheckContext, warnSink io.Writer) error {
+	report, err := migrate.Apply(ctx.CityPath, migrate.Options{})
+	if err != nil {
+		return err
+	}
+	for _, w := range report.Warnings {
+		fmt.Fprintf(warnSink, "      gc doctor --fix: %s\n", w) //nolint:errcheck // best-effort diagnostic
+	}
+	return nil
+}
+
+// defaultV2MigrationWarnSink is the production warning sink for
+// runV2PackMigration. It is overridable for tests via the runV2PackMigration
+// signature; production callers always pass this.
+var defaultV2MigrationWarnSink io.Writer = os.Stderr
 
 func parseCityConfig(path string) (*config.City, bool) {
 	data, err := os.ReadFile(path)

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -30,7 +30,7 @@ type v2AgentFormatCheck struct{}
 func (v2AgentFormatCheck) Name() string { return "v2-agent-format" }
 func (v2AgentFormatCheck) CanFix() bool { return true }
 func (v2AgentFormatCheck) Fix(ctx *doctor.CheckContext) error {
-	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+	return runV2PackMigration(ctx, v2MigrationWarnSink(ctx))
 }
 
 func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
@@ -49,7 +49,7 @@ type v2ImportFormatCheck struct{}
 func (v2ImportFormatCheck) Name() string { return "v2-import-format" }
 func (v2ImportFormatCheck) CanFix() bool { return true }
 func (v2ImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
-	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+	return runV2PackMigration(ctx, v2MigrationWarnSink(ctx))
 }
 
 func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
@@ -68,7 +68,7 @@ type v2DefaultRigImportFormatCheck struct{}
 func (v2DefaultRigImportFormatCheck) Name() string { return "v2-default-rig-import-format" }
 func (v2DefaultRigImportFormatCheck) CanFix() bool { return true }
 func (v2DefaultRigImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
-	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+	return runV2PackMigration(ctx, v2MigrationWarnSink(ctx))
 }
 
 func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
@@ -78,7 +78,7 @@ func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.Check
 	}
 	return warnCheck("v2-default-rig-import-format",
 		"workspace.default_rig_includes is deprecated; migrate to root pack.toml [defaults.rig.imports.<binding>]",
-		`move each entry into root pack.toml [defaults.rig.imports.<binding>]`,
+		v2MigrationHint(),
 		cfg.Workspace.DefaultRigIncludes)
 }
 
@@ -463,12 +463,15 @@ func v2MigrationHint() string {
 // fallback field has no v2 counterpart and shadowing must be reviewed by
 // hand). doctor --fix must not silently swallow those, otherwise the next
 // gc doctor run reports a green check and the manual follow-up is lost
-// forever. The warnings are emitted to warnSink so they land in the same
-// stream as the doctor output (production: os.Stderr; tests: a buffer).
+// forever. The warnings are emitted to warnSink so Doctor.Run callers see
+// them in the same captured output stream as the check results.
 func runV2PackMigration(ctx *doctor.CheckContext, warnSink io.Writer) error {
 	report, err := migrate.Apply(ctx.CityPath, migrate.Options{})
 	if err != nil {
 		return err
+	}
+	if warnSink == nil {
+		warnSink = io.Discard
 	}
 	for _, w := range report.Warnings {
 		fmt.Fprintf(warnSink, "      gc doctor --fix: %s\n", w) //nolint:errcheck // best-effort diagnostic
@@ -476,9 +479,16 @@ func runV2PackMigration(ctx *doctor.CheckContext, warnSink io.Writer) error {
 	return nil
 }
 
+func v2MigrationWarnSink(ctx *doctor.CheckContext) io.Writer {
+	if ctx != nil && ctx.Output != nil {
+		return ctx.Output
+	}
+	return defaultV2MigrationWarnSink
+}
+
 // defaultV2MigrationWarnSink is the production warning sink for
-// runV2PackMigration. It is overridable for tests via the runV2PackMigration
-// signature; production callers always pass this.
+// direct Fix calls outside Doctor.Run. Doctor.Run sets CheckContext.Output,
+// and production doctor commands normally use that writer instead.
 var defaultV2MigrationWarnSink io.Writer = os.Stderr
 
 func parseCityConfig(path string) (*config.City, bool) {

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -539,6 +539,35 @@ fallback = true
 	}
 }
 
+func TestV2DeprecationDoctorFixSurfacesMigrateWarningsInOutput(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+fallback = true
+`)
+	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	d.Register(v2AgentFormatCheck{})
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
+
+	got := buf.String()
+	if !strings.Contains(got, "fallback") {
+		t.Fatalf("expected doctor --fix output to include migrate warning; got:\n%s", got)
+	}
+	if !strings.Contains(got, "✓ v2-agent-format") {
+		t.Fatalf("expected doctor --fix output to include fixed check result; got:\n%s", got)
+	}
+}
+
 // TestV2ImportFormatCheckFixMigratesIncludes runs v2ImportFormatCheck.Fix
 // in isolation against a city whose only legacy artifact is
 // workspace.includes — guards the per-Check Fix entry point that the
@@ -586,8 +615,12 @@ default_rig_includes = ["../packs/default-rig"]
 	if !check.CanFix() {
 		t.Fatal("v2DefaultRigImportFormatCheck should advertise CanFix()=true")
 	}
-	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusWarning {
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusWarning {
 		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	}
+	if !strings.Contains(got.FixHint, "gc doctor --fix") {
+		t.Fatalf("FixHint = %q, want gc doctor --fix hint", got.FixHint)
 	}
 	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
 		t.Fatalf("Fix: %v", err)

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -504,6 +504,163 @@ prompt_template = "prompts/mayor.md"
 	}
 }
 
+// TestV2DeprecationFixSurfacesMigrateWarnings guards the codex review
+// finding on PR #1880: when migrate.Apply emits warnings about
+// behavior-affecting fields it had to drop (e.g. legacy [[agent]] entries
+// with fallback = true), doctor --fix must surface them. Without this,
+// the next gc doctor run sees a green check and the manual follow-up is
+// lost forever.
+func TestV2DeprecationFixSurfacesMigrateWarnings(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+fallback = true
+`)
+	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
+
+	var sink bytes.Buffer
+	if err := runV2PackMigration(&doctor.CheckContext{CityPath: cityDir}, &sink); err != nil {
+		t.Fatalf("runV2PackMigration: %v", err)
+	}
+
+	got := sink.String()
+	if !strings.Contains(got, "fallback") {
+		t.Fatalf("expected migrate warnings about dropped fallback field to be surfaced; got:\n%s", got)
+	}
+	if !strings.Contains(got, "mayor") {
+		t.Fatalf("expected the agent name to appear in the warning; got:\n%s", got)
+	}
+}
+
+// TestV2ImportFormatCheckFixMigratesIncludes runs v2ImportFormatCheck.Fix
+// in isolation against a city whose only legacy artifact is
+// workspace.includes — guards the per-Check Fix entry point that the
+// bundled migration test does not exercise (the chained doctor.Run already
+// migrates everything via the first Fix call).
+func TestV2ImportFormatCheckFixMigratesIncludes(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/gastown"]
+`)
+
+	check := v2ImportFormatCheck{}
+	if !check.CanFix() {
+		t.Fatal("v2ImportFormatCheck should advertise CanFix()=true")
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusWarning {
+		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; message=%q", got.Status, got.Message)
+	}
+}
+
+// TestV2DefaultRigImportFormatCheckFixMigratesDefaults runs
+// v2DefaultRigImportFormatCheck.Fix in isolation, mirroring the
+// import-only test above for the default-rig-includes path.
+func TestV2DefaultRigImportFormatCheckFixMigratesDefaults(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+default_rig_includes = ["../packs/default-rig"]
+`)
+
+	check := v2DefaultRigImportFormatCheck{}
+	if !check.CanFix() {
+		t.Fatal("v2DefaultRigImportFormatCheck should advertise CanFix()=true")
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusWarning {
+		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; message=%q", got.Status, got.Message)
+	}
+}
+
+// TestV2DeprecationChecksFixMigratesPackShape exercises the doctor --fix
+// path for the v2 pack-shape checks (legacy [[agent]] tables,
+// workspace.includes, default_rig_includes). The hint shown in warning
+// states points users at "gc doctor --fix"; this test guards against the
+// regression where those checks declared CanFix()=false and the hint led
+// nowhere.
+func TestV2DeprecationChecksFixMigratesPackShape(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/gastown"]
+default_rig_includes = ["../packs/default rig"]
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 1
+
+[[agent]]
+name = "helper"
+scope = "city"
+`)
+	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	d.Register(v2AgentFormatCheck{})
+	d.Register(v2ImportFormatCheck{})
+	d.Register(v2DefaultRigImportFormatCheck{})
+	report := d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
+
+	if report.Fixed == 0 {
+		t.Fatalf("expected at least one v2 pack check to be auto-fixed, got Fixed=0; output:\n%s", buf.String())
+	}
+	if report.Warned > 0 {
+		t.Fatalf("expected v2 pack warnings to clear after --fix, got Warned=%d; output:\n%s", report.Warned, buf.String())
+	}
+
+	// Re-run without fix and confirm the city is now clean.
+	var verify bytes.Buffer
+	verifyDoctor := &doctor.Doctor{}
+	verifyDoctor.Register(v2AgentFormatCheck{})
+	verifyDoctor.Register(v2ImportFormatCheck{})
+	verifyDoctor.Register(v2DefaultRigImportFormatCheck{})
+	verifyDoctor.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &verify, false)
+	out := verify.String()
+	for _, line := range []string{
+		"✓ v2-agent-format",
+		"✓ v2-import-format",
+		"✓ v2-default-rig-import-format",
+	} {
+		if !strings.Contains(out, line) {
+			t.Fatalf("post-fix doctor output missing %q:\n%s", line, out)
+		}
+	}
+}
+
 func writeDoctorFile(t *testing.T, root, rel, contents string) {
 	t.Helper()
 	path := filepath.Join(root, rel)

--- a/internal/doctor/checks_provider_parity.go
+++ b/internal/doctor/checks_provider_parity.go
@@ -1,0 +1,131 @@
+package doctor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+// ProviderParityCheck flags providers used by configured agents whose
+// capability fields are likely to silently no-op at runtime. The signal
+// is structural — it inspects the resolved ProviderSpec for each
+// provider that at least one agent in the city references, and warns
+// when:
+//
+//   - ResumeFlag and ResumeCommand are both empty: every session restart
+//     will silently drop the session-id and start a fresh process
+//     (resolveResumeCommand short-circuits, gap 1 of #672).
+//
+// SupportsHooks=false is intentionally NOT flagged — many providers
+// genuinely lack a hook surface and Gas Town has an alternative drain
+// path (NeedsNudgePoller) for them. Flagging it would be noise.
+//
+// Each warning names the provider, what is missing, and the consequence.
+// Built-in providers reuse the canonical preset; city-defined providers
+// in cfg.Providers override or extend them.
+type ProviderParityCheck struct {
+	cfg *config.City
+}
+
+// NewProviderParityCheck creates a check that flags provider capability
+// gaps for every provider referenced by a configured agent.
+func NewProviderParityCheck(cfg *config.City) *ProviderParityCheck {
+	return &ProviderParityCheck{cfg: cfg}
+}
+
+// Name returns the check identifier.
+func (c *ProviderParityCheck) Name() string { return "provider-parity" }
+
+// Run inspects each provider referenced by at least one agent and
+// reports capability gaps as warnings.
+func (c *ProviderParityCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		r.Status = StatusOK
+		r.Message = "no config; nothing to check"
+		return r
+	}
+
+	specs := providersInUse(c.cfg)
+	if len(specs) == 0 {
+		r.Status = StatusOK
+		r.Message = "no providers referenced by configured agents"
+		return r
+	}
+
+	names := make([]string, 0, len(specs))
+	for name := range specs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var details []string
+	for _, name := range names {
+		spec := specs[name]
+		if spec.ResumeFlag == "" && spec.ResumeCommand == "" {
+			details = append(details, fmt.Sprintf(
+				"provider %q has no ResumeFlag or ResumeCommand: session restarts will silently drop the session-id and start a fresh process",
+				name))
+		}
+	}
+
+	if len(details) == 0 {
+		r.Status = StatusOK
+		r.Message = "provider capabilities look complete"
+		return r
+	}
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("%d provider capability gap(s)", len(details))
+	r.Details = details
+	r.FixHint = "populate resume_flag (or resume_command) in the provider spec; see internal/config/provider.go for the built-in presets and gastownhall/gascity#672 (non-Claude provider parity)"
+	return r
+}
+
+// CanFix returns false — provider capability fields are config-managed.
+func (c *ProviderParityCheck) CanFix() bool { return false }
+
+// Fix is a no-op.
+func (c *ProviderParityCheck) Fix(_ *CheckContext) error { return nil }
+
+// providersInUse returns the resolved ProviderSpec for every provider
+// that at least one agent in the city references (directly via
+// agent.Provider or implicitly via workspace.Provider). Resolution
+// follows the same order as ResolveProvider: city-defined overrides
+// extend built-ins. Agents that pin StartCommand are skipped because
+// they bypass ProviderSpec entirely.
+func providersInUse(cfg *config.City) map[string]config.ProviderSpec {
+	builtins := config.BuiltinProviders()
+	out := map[string]config.ProviderSpec{}
+
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if _, seen := out[name]; seen {
+			return
+		}
+		if city, ok := cfg.Providers[name]; ok {
+			if builtin, hasBuiltin := builtins[name]; hasBuiltin {
+				out[name] = config.MergeProviderOverBuiltin(builtin, city)
+				return
+			}
+			out[name] = city
+			return
+		}
+		if builtin, ok := builtins[name]; ok {
+			out[name] = builtin
+		}
+	}
+
+	for _, a := range cfg.Agents {
+		if a.StartCommand != "" {
+			continue
+		}
+		add(a.Provider)
+	}
+	add(cfg.Workspace.Provider)
+	return out
+}

--- a/internal/doctor/checks_provider_parity.go
+++ b/internal/doctor/checks_provider_parity.go
@@ -10,9 +10,8 @@ import (
 
 // ProviderParityCheck flags providers used by configured agents whose
 // capability fields are likely to silently no-op at runtime. The signal
-// is structural — it inspects the resolved ProviderSpec for each
-// provider that at least one agent in the city references, and warns
-// when:
+// is structural — it inspects each provider after applying the same
+// config resolution semantics used for runtime sessions, and warns when:
 //
 //   - ResumeFlag and ResumeCommand are both empty: every session restart
 //     will silently drop the session-id and start a fresh process
@@ -23,8 +22,6 @@ import (
 // path (NeedsNudgePoller) for them. Flagging it would be noise.
 //
 // Each warning names the provider, what is missing, and the consequence.
-// Built-in providers reuse the canonical preset; city-defined providers
-// in cfg.Providers override or extend them.
 type ProviderParityCheck struct {
 	cfg *config.City
 }
@@ -48,23 +45,23 @@ func (c *ProviderParityCheck) Run(_ *CheckContext) *CheckResult {
 		return r
 	}
 
-	specs := providersInUse(c.cfg)
-	if len(specs) == 0 {
+	providers := providersInUse(c.cfg)
+	if len(providers) == 0 {
 		r.Status = StatusOK
 		r.Message = "no providers referenced by configured agents"
 		return r
 	}
 
-	names := make([]string, 0, len(specs))
-	for name := range specs {
+	names := make([]string, 0, len(providers))
+	for name := range providers {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	var details []string
 	for _, name := range names {
-		spec := specs[name]
-		if spec.ResumeFlag == "" && spec.ResumeCommand == "" {
+		provider := providers[name]
+		if !provider.hasResume {
 			details = append(details, fmt.Sprintf(
 				"provider %q has no ResumeFlag or ResumeCommand: session restarts will silently drop the session-id and start a fresh process",
 				name))
@@ -89,43 +86,51 @@ func (c *ProviderParityCheck) CanFix() bool { return false }
 // Fix is a no-op.
 func (c *ProviderParityCheck) Fix(_ *CheckContext) error { return nil }
 
-// providersInUse returns the resolved ProviderSpec for every provider
-// that at least one agent in the city references (directly via
-// agent.Provider or implicitly via workspace.Provider). Resolution
-// follows the same order as ResolveProvider: city-defined overrides
-// extend built-ins. Agents that pin StartCommand are skipped because
-// they bypass ProviderSpec entirely.
-func providersInUse(cfg *config.City) map[string]config.ProviderSpec {
-	builtins := config.BuiltinProviders()
-	out := map[string]config.ProviderSpec{}
+type providerResumeState struct {
+	hasResume bool
+}
 
-	add := func(name string) {
-		name = strings.TrimSpace(name)
+// providersInUse returns resume capability state for every provider used by
+// at least one configured agent. It delegates provider inheritance and
+// agent-level overrides to config.ResolveProvider, using a PATH lookup stub
+// because provider-parity checks config semantics rather than host binaries.
+// Agents that pin StartCommand are skipped because they bypass ProviderSpec.
+func providersInUse(cfg *config.City) map[string]providerResumeState {
+	out := map[string]providerResumeState{}
+
+	addResolved := func(agent config.Agent) {
+		resolved, err := config.ResolveProvider(&agent, &cfg.Workspace, cfg.Providers, providerParityLookPath)
+		if err != nil {
+			return
+		}
+		name := strings.TrimSpace(resolved.Name)
 		if name == "" {
 			return
 		}
-		if _, seen := out[name]; seen {
-			return
-		}
-		if city, ok := cfg.Providers[name]; ok {
-			if builtin, hasBuiltin := builtins[name]; hasBuiltin {
-				out[name] = config.MergeProviderOverBuiltin(builtin, city)
-				return
-			}
-			out[name] = city
-			return
-		}
-		if builtin, ok := builtins[name]; ok {
-			out[name] = builtin
+		hasResume := strings.TrimSpace(resolved.ResumeFlag) != "" || strings.TrimSpace(resolved.ResumeCommand) != ""
+		current, seen := out[name]
+		if !seen || (current.hasResume && !hasResume) {
+			out[name] = providerResumeState{hasResume: hasResume}
 		}
 	}
 
+	checkedAgentProvider := false
 	for _, a := range cfg.Agents {
 		if a.StartCommand != "" {
 			continue
 		}
-		add(a.Provider)
+		if strings.TrimSpace(a.Provider) == "" && strings.TrimSpace(cfg.Workspace.Provider) == "" {
+			continue
+		}
+		checkedAgentProvider = true
+		addResolved(a)
 	}
-	add(cfg.Workspace.Provider)
+	if !checkedAgentProvider && len(cfg.Agents) == 0 && strings.TrimSpace(cfg.Workspace.Provider) != "" {
+		addResolved(config.Agent{})
+	}
 	return out
+}
+
+func providerParityLookPath(command string) (string, error) {
+	return command, nil
 }

--- a/internal/doctor/checks_provider_parity_test.go
+++ b/internal/doctor/checks_provider_parity_test.go
@@ -1,0 +1,131 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func TestProviderParityCheck_NoConfig(t *testing.T) {
+	c := NewProviderParityCheck(nil)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK", r.Status)
+	}
+}
+
+func TestProviderParityCheck_NoAgents(t *testing.T) {
+	cfg := &config.City{}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+	if !strings.Contains(r.Message, "no providers referenced") {
+		t.Errorf("Message = %q, want mention of no providers", r.Message)
+	}
+}
+
+func TestProviderParityCheck_ClaudeOnly(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "mayor", Provider: "claude"}},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_FlagsProviderWithoutResume(t *testing.T) {
+	// Inject a city-defined provider that explicitly opts out of resume
+	// (empty ResumeFlag + ResumeCommand) and reference it from an agent.
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "tester", Provider: "noresume"}},
+		Providers: map[string]config.ProviderSpec{
+			"noresume": {Command: "noresume"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], `"noresume"`) || !strings.Contains(r.Details[0], "ResumeFlag") {
+		t.Errorf("Details[0] missing provider name or ResumeFlag mention: %q", r.Details[0])
+	}
+	if r.FixHint == "" {
+		t.Error("expected non-empty FixHint")
+	}
+}
+
+func TestProviderParityCheck_BypassedWhenStartCommandSet(t *testing.T) {
+	// Agents that pin StartCommand bypass ProviderSpec entirely, so the
+	// provider parity warning should not fire.
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "raw", StartCommand: "raw --foo", Provider: "noresume"}},
+		Providers: map[string]config.ProviderSpec{
+			"noresume": {Command: "noresume"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_ChecksWorkspaceDefaultProvider(t *testing.T) {
+	cfg := &config.City{
+		Workspace: config.Workspace{Provider: "noresume"},
+		Providers: map[string]config.ProviderSpec{
+			"noresume": {Command: "noresume"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_CityOverrideExtendsBuiltin(t *testing.T) {
+	// City-defined "claude" overrides only DisplayName; ResumeFlag inherits
+	// from the builtin so the check should pass.
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "mayor", Provider: "claude"}},
+		Providers: map[string]config.ProviderSpec{
+			"claude": {DisplayName: "MyClaude"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_DeterministicOrdering(t *testing.T) {
+	// Multiple gaps must be reported in stable alphabetic order.
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "a1", Provider: "zproblem"},
+			{Name: "a2", Provider: "aproblem"},
+		},
+		Providers: map[string]config.ProviderSpec{
+			"zproblem": {Command: "z"},
+			"aproblem": {Command: "a"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 2 {
+		t.Fatalf("Details = %d, want 2: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], `"aproblem"`) {
+		t.Errorf("Details[0] should mention aproblem first: %q", r.Details[0])
+	}
+	if !strings.Contains(r.Details[1], `"zproblem"`) {
+		t.Errorf("Details[1] should mention zproblem second: %q", r.Details[1])
+	}
+}

--- a/internal/doctor/checks_provider_parity_test.go
+++ b/internal/doctor/checks_provider_parity_test.go
@@ -13,6 +13,9 @@ func TestProviderParityCheck_NoConfig(t *testing.T) {
 	if r.Status != StatusOK {
 		t.Fatalf("Status = %v, want StatusOK", r.Status)
 	}
+	if !strings.Contains(r.Message, "no config") {
+		t.Errorf("Message = %q, want mention of no config", r.Message)
+	}
 }
 
 func TestProviderParityCheck_NoAgents(t *testing.T) {
@@ -100,6 +103,67 @@ func TestProviderParityCheck_CityOverrideExtendsBuiltin(t *testing.T) {
 	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
 	if r.Status != StatusOK {
 		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_CustomProviderBaseInheritsBuiltinResume(t *testing.T) {
+	base := "builtin:codex"
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "coder", Provider: "wrapped-codex"}},
+		Providers: map[string]config.ProviderSpec{
+			"wrapped-codex": {Base: &base},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_CommandMatchInheritsBuiltinResume(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "helper", Provider: "fast-claude"}},
+		Providers: map[string]config.ProviderSpec{
+			"fast-claude": {Command: "claude"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_AgentResumeCommandSuppressesWarning(t *testing.T) {
+	cfg := &config.City{
+		Agents: []config.Agent{{
+			Name:          "tester",
+			Provider:      "noresume",
+			ResumeCommand: "noresume --continue {{.SessionKey}}",
+		}},
+		Providers: map[string]config.ProviderSpec{
+			"noresume": {Command: "noresume"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestProviderParityCheck_ExplicitStandaloneBuiltinNameWarns(t *testing.T) {
+	base := ""
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "standalone", Provider: "claude"}},
+		Providers: map[string]config.ProviderSpec{
+			"claude": {Base: &base, Command: "claude"},
+		},
+	}
+	r := NewProviderParityCheck(cfg).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 || !strings.Contains(r.Details[0], `"claude"`) {
+		t.Fatalf("Details = %v, want one warning for claude", r.Details)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -31,6 +31,15 @@ func (d *Doctor) Register(c Check) {
 // completes. When fix is true, fixable checks that fail are remediated
 // and re-run. Returns a summary report.
 func (d *Doctor) Run(ctx *CheckContext, w io.Writer, fix bool) *Report {
+	if ctx == nil {
+		ctx = &CheckContext{}
+	}
+	runCtx := *ctx
+	if runCtx.Output == nil {
+		runCtx.Output = w
+	}
+	ctx = &runCtx
+
 	r := &Report{}
 	for _, c := range d.checks {
 		result := c.Run(ctx)

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -3,6 +3,8 @@
 // output, optional --fix support, and a summary report.
 package doctor
 
+import "io"
+
 // CheckStatus represents the outcome of a health check.
 type CheckStatus int
 
@@ -35,6 +37,10 @@ type CheckContext struct {
 	CityPath string
 	// Verbose enables extra diagnostic output in check results.
 	Verbose bool
+	// Output is the writer used for doctor output during Doctor.Run.
+	// Checks that need to surface fix-time diagnostics should use this
+	// writer so captured doctor output includes the diagnostics.
+	Output io.Writer
 }
 
 // CheckResult holds the outcome of a single check execution.


### PR DESCRIPTION
## Summary

Closes Gap 8 of the non-Claude provider parity audit ([wasteland `w-c243404137`](https://wasteland.gastownhall.ai/) / [`gastownhall/gascity#672`](https://github.com/gastownhall/gascity/issues/672) / audit doc at [Rome-1/gastown](https://github.com/Rome-1/gastown/blob/main/docs/research/w-7ed35a727f-parity-audit-classification.md)).

`gc doctor` previously had no signal when an agent referenced a provider whose `ResumeFlag` / `ResumeCommand` were both empty — the consequence (`session_reconciler.resolveResumeCommand` silently dropping the session-id on every restart) was invisible until the user noticed their sessions losing context.

## Changes

Adds `ProviderParityCheck` in `internal/doctor/checks_provider_parity.go`:

- For every provider referenced by at least one configured agent (or by `workspace.provider`), resolve the effective `ProviderSpec` (city override merged over the built-in preset, mirroring `ResolveProvider`'s lookup order).
- Warn when both `ResumeFlag` and `ResumeCommand` are empty.
- Skip agents that pin `StartCommand` — they bypass `ProviderSpec` entirely, so the warning would be a false positive.

`SupportsHooks: false` is intentionally **not** flagged. Many providers genuinely lack a hook surface and Gas Town has a documented alternative drain path (`NeedsNudgePoller`) for them. Flagging it would be noise.

Registered alongside the other config-level checks in `cmd/gc/cmd_doctor.go` (only when the config loaded cleanly).

## Test plan

- [x] `go test ./internal/doctor/ -run "ProviderParityCheck"` passes (8 sub-tests covering nil config, no agents, claude-only happy path, missing resume flag, StartCommand bypass, workspace.provider, city-override merging, deterministic ordering)
- [x] gofumpt clean
- [ ] CI runs the full gates

Closes Gap 8 of #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)