### PR TITLE
feat(doctor): flag missing-but-recoverable InstructionsFile per rig (#672)

### DIFF
--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -158,6 +158,7 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 		d.Register(doctor.NewConfigSemanticsCheck(cfg, filepath.Join(cityPath, "city.toml")))
 		d.Register(doctor.NewDurationRangeCheck(cfg))
 		d.Register(doctor.NewProviderParityCheck(cfg))
+		d.Register(doctor.NewInstructionsFileCheck(cfg, cityPath))
 		d.Register(doctor.NewSkillCollisionCheck(cfg, cityPath))
 		d.Register(doctor.NewOrderFiringCurrentCheck(cfg, cityPath))
 		d.Register(newCodexHooksDriftCheck(codexHookWorkDirs(cityPath, cfg)))

--- a/internal/doctor/checks_instructions_file.go
+++ b/internal/doctor/checks_instructions_file.go
@@ -1,0 +1,225 @@
+package doctor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
+)
+
+// instructionsFileFallbacks lists the common project-instruction filenames
+// in priority order. Providers point at one canonical name via
+// `ProviderSpec.InstructionsFile` (defaulting to "AGENTS.md" via
+// ResolveProvider). When the canonical file is missing but a fallback is
+// present in the rig, the agent silently starts without project context;
+// this check surfaces that mismatch.
+var instructionsFileFallbacks = []string{
+	"AGENTS.md",
+	"CLAUDE.md",
+	"INSTRUCTIONS.md",
+}
+
+// InstructionsFileCheck warns when a rig hosts an agent whose provider's
+// `InstructionsFile` is missing from the rig directory while a known
+// fallback file (CLAUDE.md ↔ AGENTS.md ↔ INSTRUCTIONS.md) exists in the
+// same directory. Silently starting an agent with no project instructions
+// is one of the show-stoppers from the non-Claude provider parity audit
+// (Gap 7 in docs/research/w-7ed35a727f-parity-audit-classification.md /
+// gastownhall/gascity#672).
+//
+// The check is read-only by default. `gc doctor --fix` symlinks the
+// existing fallback to the expected name — symlink rather than copy so
+// the source of truth stays in one place.
+//
+// Scope:
+//   - One warning per (rig × expected filename). The agent providers
+//     populate the "expected filenames" set; the actual content of those
+//     files is not inspected.
+//   - Rigs with no Path are skipped (covered by the site-binding migration
+//     work; this check fires once the binding lands).
+//   - Empty fallback files are treated as present — if a user intentionally
+//     ships empty AGENTS.md and CLAUDE.md, the check should not nag.
+type InstructionsFileCheck struct {
+	cfg      *config.City
+	cityPath string
+}
+
+// NewInstructionsFileCheck creates a check that surfaces missing
+// per-provider instruction files in each rig.
+func NewInstructionsFileCheck(cfg *config.City, cityPath string) *InstructionsFileCheck {
+	return &InstructionsFileCheck{cfg: cfg, cityPath: cityPath}
+}
+
+// Name returns the check identifier.
+func (c *InstructionsFileCheck) Name() string { return "instructions-file" }
+
+// Run reports any (rig, expected-filename) pairs where the file is missing
+// but a known fallback exists. The fix hint is shown when at least one
+// pair is auto-repairable via symlinking.
+func (c *InstructionsFileCheck) Run(_ *CheckContext) *CheckResult {
+	r := &CheckResult{Name: c.Name()}
+	if c.cfg == nil {
+		r.Status = StatusOK
+		r.Message = "no config; nothing to check"
+		return r
+	}
+	gaps := c.collectGaps()
+	if len(gaps) == 0 {
+		r.Status = StatusOK
+		r.Message = "instructions files look complete"
+		return r
+	}
+	details := make([]string, 0, len(gaps))
+	for _, g := range gaps {
+		details = append(details, fmt.Sprintf(
+			"rig %q (%s): expected %s for provider %q is missing; %s is present",
+			g.rigName, g.rigPath, g.expected, g.provider, g.fallback,
+		))
+	}
+	r.Status = StatusWarning
+	r.Message = fmt.Sprintf("%d instructions-file gap(s)", len(gaps))
+	r.Details = details
+	r.FixHint = "run `gc doctor --fix` to symlink the present fallback to the expected filename, or copy the file manually"
+	return r
+}
+
+// CanFix reports that the check can symlink the fallback to the expected
+// name when --fix is requested.
+func (c *InstructionsFileCheck) CanFix() bool { return true }
+
+// Fix symlinks the existing fallback to the expected filename for each
+// recorded gap. Symlink failures are aggregated and returned as a single
+// error; partial success is preserved (we do not roll back files that
+// linked successfully).
+func (c *InstructionsFileCheck) Fix(_ *CheckContext) error {
+	if c.cfg == nil {
+		return nil
+	}
+	gaps := c.collectGaps()
+	var errs []error
+	for _, g := range gaps {
+		target := filepath.Join(g.rigPath, g.expected)
+		// Re-check existence in case another check already fixed it.
+		if _, err := os.Lstat(target); err == nil {
+			continue
+		}
+		if err := os.Symlink(g.fallback, target); err != nil {
+			errs = append(errs, fmt.Errorf("rig %q: symlink %s -> %s: %w", g.rigName, g.fallback, target, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// instructionsFileGap is one missing-but-recoverable expected file in a
+// rig.
+type instructionsFileGap struct {
+	rigName  string
+	rigPath  string
+	provider string
+	expected string // canonical filename the provider wants
+	fallback string // name of a sibling file actually present in rigPath
+}
+
+// collectGaps walks every rig × provider-in-use combination and records
+// the gaps. Output is sorted (rig, expected, provider) so warnings are
+// stable across runs.
+func (c *InstructionsFileCheck) collectGaps() []instructionsFileGap {
+	specs := providersInUse(c.cfg)
+	if len(specs) == 0 {
+		return nil
+	}
+	// Map each provider in use to the InstructionsFile name it expects,
+	// applying the same "default to AGENTS.md when empty" rule that
+	// ResolveProvider uses at runtime.
+	expectedByProvider := make(map[string]string, len(specs))
+	for name, spec := range specs {
+		want := strings.TrimSpace(spec.InstructionsFile)
+		if want == "" {
+			want = "AGENTS.md"
+		}
+		expectedByProvider[name] = want
+	}
+
+	type rigEntry struct {
+		name string
+		path string
+	}
+	var rigs []rigEntry
+	for _, r := range c.cfg.Rigs {
+		p := strings.TrimSpace(r.Path)
+		if p == "" {
+			continue
+		}
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(c.cityPath, p)
+		}
+		rigs = append(rigs, rigEntry{name: r.Name, path: filepath.Clean(p)})
+	}
+	if len(rigs) == 0 {
+		return nil
+	}
+
+	var gaps []instructionsFileGap
+	seen := map[string]struct{}{}
+	for _, rig := range rigs {
+		for prov, want := range expectedByProvider {
+			if instructionsFileExists(rig.path, want) {
+				continue
+			}
+			fb := firstFallback(rig.path, want)
+			if fb == "" {
+				continue
+			}
+			key := rig.name + "|" + want
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			gaps = append(gaps, instructionsFileGap{
+				rigName:  rig.name,
+				rigPath:  rig.path,
+				provider: prov,
+				expected: want,
+				fallback: fb,
+			})
+		}
+	}
+	sort.Slice(gaps, func(i, j int) bool {
+		if gaps[i].rigName != gaps[j].rigName {
+			return gaps[i].rigName < gaps[j].rigName
+		}
+		return gaps[i].expected < gaps[j].expected
+	})
+	return gaps
+}
+
+// instructionsFileExists reports whether name (a filename, not a path)
+// exists as a regular file or symlink inside dir. Empty files count as
+// present — users sometimes ship empty placeholders intentionally.
+func instructionsFileExists(dir, name string) bool {
+	info, err := fsys.OSFS{}.Stat(filepath.Join(dir, name))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// firstFallback returns the name of the first known instruction file
+// present in dir that is NOT want, in priority order. Empty string when
+// no fallback is present.
+func firstFallback(dir, want string) string {
+	for _, name := range instructionsFileFallbacks {
+		if name == want {
+			continue
+		}
+		if instructionsFileExists(dir, name) {
+			return name
+		}
+	}
+	return ""
+}

--- a/internal/doctor/checks_instructions_file.go
+++ b/internal/doctor/checks_instructions_file.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/gastownhall/gascity/internal/config"
-	"github.com/gastownhall/gascity/internal/fsys"
+	workdirutil "github.com/gastownhall/gascity/internal/workdir"
 )
 
 // instructionsFileFallbacks lists the common project-instruction filenames
@@ -37,11 +38,13 @@ var instructionsFileFallbacks = []string{
 // the source of truth stays in one place.
 //
 // Scope:
-//   - One warning per (rig × expected filename). The agent providers
-//     populate the "expected filenames" set; the actual content of those
-//     files is not inspected.
-//   - Rigs with no Path are skipped (covered by the site-binding migration
-//     work; this check fires once the binding lands).
+//   - One warning per (scope root × expected filename). The agent providers
+//     associated with each root populate that root's "expected filenames"
+//     set; the actual content of those files is not inspected.
+//   - Agents with no dir or work_dir check the city root. Agents with only
+//     work_dir check the same resolved root runtime uses. Rigs with no Path
+//     are skipped (covered by the site-binding migration work; this check
+//     fires once the binding lands).
 //   - Empty fallback files are treated as present — if a user intentionally
 //     ships empty AGENTS.md and CLAUDE.md, the check should not nag.
 type InstructionsFileCheck struct {
@@ -77,8 +80,8 @@ func (c *InstructionsFileCheck) Run(_ *CheckContext) *CheckResult {
 	details := make([]string, 0, len(gaps))
 	for _, g := range gaps {
 		details = append(details, fmt.Sprintf(
-			"rig %q (%s): expected %s for provider %q is missing; %s is present",
-			g.rigName, g.rigPath, g.expected, g.provider, g.fallback,
+			"%s: expected %s for %s is missing; %s is present",
+			instructionsScopeDescription(g), g.expected, formatInstructionProviders(g.providers), g.fallback,
 		))
 	}
 	r.Status = StatusWarning
@@ -104,52 +107,187 @@ func (c *InstructionsFileCheck) Fix(_ *CheckContext) error {
 	var errs []error
 	for _, g := range gaps {
 		target := filepath.Join(g.rigPath, g.expected)
-		// Re-check existence in case another check already fixed it.
-		if _, err := os.Lstat(target); err == nil {
+		// Re-check target state in case another check already fixed it.
+		info, err := os.Lstat(target)
+		if err == nil {
+			if info.IsDir() {
+				errs = append(errs, fmt.Errorf("%s: %s exists as a directory; remove it or replace it with a file before symlinking %s", instructionsScopeDescription(g), target, g.fallback))
+			}
+			continue
+		}
+		if !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("%s: inspect %s: %w", instructionsScopeDescription(g), target, err))
 			continue
 		}
 		if err := os.Symlink(g.fallback, target); err != nil {
-			errs = append(errs, fmt.Errorf("rig %q: symlink %s -> %s: %w", g.rigName, g.fallback, target, err))
+			errs = append(errs, fmt.Errorf("%s: symlink %s -> %s: %w", instructionsScopeDescription(g), g.fallback, target, err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
 // instructionsFileGap is one missing-but-recoverable expected file in a
-// rig.
+// city or rig scope root.
 type instructionsFileGap struct {
-	rigName  string
-	rigPath  string
-	provider string
-	expected string // canonical filename the provider wants
-	fallback string // name of a sibling file actually present in rigPath
+	rigName   string
+	rigPath   string
+	scopeName string
+	providers []string
+	expected  string // canonical filename the provider wants
+	fallback  string // name of a sibling file actually present in rigPath
 }
 
-// collectGaps walks every rig × provider-in-use combination and records
-// the gaps. Output is sorted (rig, expected, provider) so warnings are
-// stable across runs.
+type instructionsProviderExpectation struct {
+	rigName   string
+	rigPath   string
+	scopeName string
+	provider  string
+	expected  string
+}
+
+type instructionsRigEntry struct {
+	name      string
+	path      string
+	scopeName string
+}
+
+// collectGaps walks every agent-to-scope provider association and records
+// the gaps. Output is sorted (scope, expected) and provider names are sorted
+// inside each gap so warnings are stable across runs.
 func (c *InstructionsFileCheck) collectGaps() []instructionsFileGap {
-	specs := providersInUse(c.cfg)
-	if len(specs) == 0 {
+	expectations := c.instructionsProviderExpectations()
+	if len(expectations) == 0 {
 		return nil
 	}
-	// Map each provider in use to the InstructionsFile name it expects,
-	// applying the same "default to AGENTS.md when empty" rule that
-	// ResolveProvider uses at runtime.
-	expectedByProvider := make(map[string]string, len(specs))
-	for name, spec := range specs {
-		want := strings.TrimSpace(spec.InstructionsFile)
-		if want == "" {
-			want = "AGENTS.md"
+
+	gapsByKey := map[string]*instructionsFileGap{}
+	for _, exp := range expectations {
+		if instructionsFileExists(exp.rigPath, exp.expected) {
+			continue
 		}
-		expectedByProvider[name] = want
+		fb := firstFallback(exp.rigPath, exp.expected)
+		if fb == "" {
+			continue
+		}
+		key := exp.rigPath + "\x00" + exp.expected
+		g, ok := gapsByKey[key]
+		if !ok {
+			g = &instructionsFileGap{
+				rigName:   exp.rigName,
+				rigPath:   exp.rigPath,
+				scopeName: exp.scopeName,
+				expected:  exp.expected,
+				fallback:  fb,
+			}
+			gapsByKey[key] = g
+		}
+		if !slices.Contains(g.providers, exp.provider) {
+			g.providers = append(g.providers, exp.provider)
+		}
+	}
+	if len(gapsByKey) == 0 {
+		return nil
 	}
 
-	type rigEntry struct {
-		name string
-		path string
+	gaps := make([]instructionsFileGap, 0, len(gapsByKey))
+	for _, gap := range gapsByKey {
+		sort.Strings(gap.providers)
+		gaps = append(gaps, *gap)
 	}
-	var rigs []rigEntry
+	sort.Slice(gaps, func(i, j int) bool {
+		if gaps[i].rigName != gaps[j].rigName {
+			return gaps[i].rigName < gaps[j].rigName
+		}
+		if gaps[i].rigPath != gaps[j].rigPath {
+			return gaps[i].rigPath < gaps[j].rigPath
+		}
+		return gaps[i].expected < gaps[j].expected
+	})
+	return gaps
+}
+
+func (c *InstructionsFileCheck) instructionsProviderExpectations() []instructionsProviderExpectation {
+	rigs := c.rigsByName()
+	var out []instructionsProviderExpectation
+	for _, a := range c.cfg.Agents {
+		if a.StartCommand != "" {
+			continue
+		}
+		if strings.TrimSpace(a.Provider) == "" && strings.TrimSpace(c.cfg.Workspace.Provider) == "" {
+			continue
+		}
+		rig, ok := c.instructionsAgentScope(a, rigs)
+		if !ok {
+			continue
+		}
+		resolved, err := config.ResolveProvider(&a, &c.cfg.Workspace, c.cfg.Providers, providerParityLookPath)
+		if err != nil {
+			continue
+		}
+		provider := strings.TrimSpace(resolved.Name)
+		expected, ok := safeInstructionsFilename(resolved.InstructionsFile)
+		if provider == "" || !ok {
+			continue
+		}
+		out = append(out, instructionsProviderExpectation{
+			rigName:   rig.name,
+			rigPath:   rig.path,
+			scopeName: rig.scopeName,
+			provider:  provider,
+			expected:  expected,
+		})
+	}
+	return out
+}
+
+func (c *InstructionsFileCheck) instructionsAgentScope(a config.Agent, rigs map[string]instructionsRigEntry) (instructionsRigEntry, bool) {
+	if strings.TrimSpace(a.Scope) == "city" {
+		return instructionsRigEntry{path: filepath.Clean(c.cityPath), scopeName: "city root"}, true
+	}
+	if strings.TrimSpace(a.Dir) == "" && strings.TrimSpace(a.WorkDir) == "" {
+		return instructionsRigEntry{path: filepath.Clean(c.cityPath), scopeName: "city root"}, true
+	}
+	if strings.TrimSpace(a.Dir) == "" {
+		workDir, err := workdirutil.ResolveWorkDirPathStrict(
+			c.cityPath,
+			workdirutil.CityName(c.cityPath, c.cfg),
+			a.QualifiedName(),
+			a,
+			c.cfg.Rigs,
+		)
+		if err != nil {
+			return instructionsRigEntry{}, false
+		}
+		return c.scopeForResolvedPath(filepath.Clean(workDir), rigs), true
+	}
+	rigName := workdirutil.ConfiguredRigName(c.cityPath, a, c.cfg.Rigs)
+	if rigName == "" {
+		return instructionsRigEntry{}, false
+	}
+	rig, ok := rigs[rigName]
+	return rig, ok
+}
+
+func (c *InstructionsFileCheck) scopeForResolvedPath(path string, rigs map[string]instructionsRigEntry) instructionsRigEntry {
+	if filepath.Clean(path) == filepath.Clean(c.cityPath) {
+		return instructionsRigEntry{path: filepath.Clean(c.cityPath), scopeName: "city root"}
+	}
+	names := make([]string, 0, len(rigs))
+	for name := range rigs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		rig := rigs[name]
+		if filepath.Clean(rig.path) == filepath.Clean(path) {
+			return rig
+		}
+	}
+	return instructionsRigEntry{path: filepath.Clean(path), scopeName: "work_dir"}
+}
+
+func (c *InstructionsFileCheck) rigsByName() map[string]instructionsRigEntry {
+	rigs := map[string]instructionsRigEntry{}
 	for _, r := range c.cfg.Rigs {
 		p := strings.TrimSpace(r.Path)
 		if p == "" {
@@ -158,51 +296,26 @@ func (c *InstructionsFileCheck) collectGaps() []instructionsFileGap {
 		if !filepath.IsAbs(p) {
 			p = filepath.Join(c.cityPath, p)
 		}
-		rigs = append(rigs, rigEntry{name: r.Name, path: filepath.Clean(p)})
-	}
-	if len(rigs) == 0 {
-		return nil
-	}
-
-	var gaps []instructionsFileGap
-	seen := map[string]struct{}{}
-	for _, rig := range rigs {
-		for prov, want := range expectedByProvider {
-			if instructionsFileExists(rig.path, want) {
-				continue
-			}
-			fb := firstFallback(rig.path, want)
-			if fb == "" {
-				continue
-			}
-			key := rig.name + "|" + want
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-			gaps = append(gaps, instructionsFileGap{
-				rigName:  rig.name,
-				rigPath:  rig.path,
-				provider: prov,
-				expected: want,
-				fallback: fb,
-			})
+		name := strings.TrimSpace(r.Name)
+		if name == "" {
+			continue
 		}
+		rigs[name] = instructionsRigEntry{name: name, path: filepath.Clean(p)}
 	}
-	sort.Slice(gaps, func(i, j int) bool {
-		if gaps[i].rigName != gaps[j].rigName {
-			return gaps[i].rigName < gaps[j].rigName
-		}
-		return gaps[i].expected < gaps[j].expected
-	})
-	return gaps
+	return rigs
 }
 
 // instructionsFileExists reports whether name (a filename, not a path)
 // exists as a regular file or symlink inside dir. Empty files count as
-// present — users sometimes ship empty placeholders intentionally.
+// present — users sometimes ship empty placeholders intentionally. This
+// deliberately uses Lstat so an existing expected-name symlink, even if
+// dangling, is treated as user-owned state rather than a missing file.
 func instructionsFileExists(dir, name string) bool {
-	info, err := fsys.OSFS{}.Stat(filepath.Join(dir, name))
+	name, ok := safeInstructionsFilename(name)
+	if !ok {
+		return false
+	}
+	info, err := os.Lstat(filepath.Join(dir, name))
 	if err != nil {
 		return false
 	}
@@ -211,15 +324,65 @@ func instructionsFileExists(dir, name string) bool {
 
 // firstFallback returns the name of the first known instruction file
 // present in dir that is NOT want, in priority order. Empty string when
-// no fallback is present.
+// no fallback is present. Fallbacks must resolve to usable files because
+// Fix links the missing expected name to the fallback.
 func firstFallback(dir, want string) string {
+	want, ok := safeInstructionsFilename(want)
+	if !ok {
+		return ""
+	}
 	for _, name := range instructionsFileFallbacks {
 		if name == want {
 			continue
 		}
-		if instructionsFileExists(dir, name) {
+		if instructionsFallbackUsable(dir, name) {
 			return name
 		}
 	}
 	return ""
+}
+
+func instructionsFallbackUsable(dir, name string) bool {
+	name, ok := safeInstructionsFilename(name)
+	if !ok {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(dir, name))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func safeInstructionsFilename(name string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return "", false
+	}
+	if filepath.IsAbs(name) || strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return "", false
+	}
+	return name, true
+}
+
+func instructionsScopeDescription(g instructionsFileGap) string {
+	if g.rigName == "" {
+		scopeName := g.scopeName
+		if scopeName == "" {
+			scopeName = "city root"
+		}
+		return fmt.Sprintf("%s (%s)", scopeName, g.rigPath)
+	}
+	return fmt.Sprintf("rig %q (%s)", g.rigName, g.rigPath)
+}
+
+func formatInstructionProviders(providers []string) string {
+	if len(providers) == 1 {
+		return fmt.Sprintf("provider %q", providers[0])
+	}
+	quoted := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		quoted = append(quoted, fmt.Sprintf("%q", provider))
+	}
+	return "providers " + strings.Join(quoted, ", ")
 }

--- a/internal/doctor/checks_instructions_file_test.go
+++ b/internal/doctor/checks_instructions_file_test.go
@@ -1,0 +1,165 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/config"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func TestInstructionsFileCheck_NilConfig(t *testing.T) {
+	r := NewInstructionsFileCheck(nil, "").Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK", r.Status)
+	}
+}
+
+func TestInstructionsFileCheck_NoRigs(t *testing.T) {
+	cfg := &config.City{Agents: []config.Agent{{Name: "a", Provider: "claude"}}}
+	r := NewInstructionsFileCheck(cfg, t.TempDir()).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestInstructionsFileCheck_AllFilesPresent(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	writeFile(t, filepath.Join(rig, "AGENTS.md"), "agent instructions\n")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Provider: "claude"}},
+		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestInstructionsFileCheck_FlagsMissingButRecoverable(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	// Rig only ships CLAUDE.md; an agent on a non-Claude provider that
+	// expects AGENTS.md should be flagged.
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], `rig "demo"`) || !strings.Contains(r.Details[0], "AGENTS.md") || !strings.Contains(r.Details[0], "CLAUDE.md") {
+		t.Errorf("Details[0] missing expected components: %q", r.Details[0])
+	}
+	if !NewInstructionsFileCheck(cfg, city).CanFix() {
+		t.Error("expected CanFix() = true")
+	}
+}
+
+func TestInstructionsFileCheck_NoFallbackNoWarning(t *testing.T) {
+	// A rig with no instruction files at all should not be flagged —
+	// we cannot recover, and emitting a warning that the user cannot
+	// act on is noise.
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "bare")
+	if err := os.MkdirAll(rig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "bare", Path: rig}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestInstructionsFileCheck_FixSymlinksFallback(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
+	}
+	c := NewInstructionsFileCheck(cfg, city)
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix() error: %v", err)
+	}
+	link, err := os.Readlink(filepath.Join(rig, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("AGENTS.md not symlinked: %v", err)
+	}
+	if link != "CLAUDE.md" {
+		t.Errorf("AGENTS.md link target = %q, want CLAUDE.md", link)
+	}
+	// Re-run: check now passes.
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Errorf("after Fix, Status = %v, want StatusOK; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestInstructionsFileCheck_RelativeRigPathResolves(t *testing.T) {
+	city := t.TempDir()
+	rigRel := filepath.Join("rigs", "rel")
+	writeFile(t, filepath.Join(city, rigRel, "CLAUDE.md"), "x")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "rel", Path: rigRel}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+}
+
+func TestInstructionsFileCheck_DeterministicOrdering(t *testing.T) {
+	city := t.TempDir()
+	for _, name := range []string{"alpha", "zulu"} {
+		writeFile(t, filepath.Join(city, "rigs", name, "CLAUDE.md"), "x")
+	}
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Rigs: []config.Rig{
+			{Name: "zulu", Path: filepath.Join(city, "rigs", "zulu")},
+			{Name: "alpha", Path: filepath.Join(city, "rigs", "alpha")},
+		},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 2 {
+		t.Fatalf("Details = %d, want 2: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], `rig "alpha"`) {
+		t.Errorf("Details[0] should mention alpha first: %q", r.Details[0])
+	}
+	if !strings.Contains(r.Details[1], `rig "zulu"`) {
+		t.Errorf("Details[1] should mention zulu second: %q", r.Details[1])
+	}
+}

--- a/internal/doctor/checks_instructions_file_test.go
+++ b/internal/doctor/checks_instructions_file_test.go
@@ -41,7 +41,7 @@ func TestInstructionsFileCheck_AllFilesPresent(t *testing.T) {
 	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
 
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "a", Provider: "claude"}},
+		Agents: []config.Agent{{Name: "a", Dir: "demo", Provider: "claude"}},
 		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
 	}
 	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
@@ -58,7 +58,7 @@ func TestInstructionsFileCheck_FlagsMissingButRecoverable(t *testing.T) {
 	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
 
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Agents: []config.Agent{{Name: "a", Dir: "demo", Provider: "codex"}},
 		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
 	}
 	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
@@ -86,7 +86,7 @@ func TestInstructionsFileCheck_NoFallbackNoWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Agents: []config.Agent{{Name: "a", Dir: "bare", Provider: "codex"}},
 		Rigs:   []config.Rig{{Name: "bare", Path: rig}},
 	}
 	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
@@ -101,7 +101,7 @@ func TestInstructionsFileCheck_FixSymlinksFallback(t *testing.T) {
 	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
 
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Agents: []config.Agent{{Name: "a", Dir: "demo", Provider: "codex"}},
 		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
 	}
 	c := NewInstructionsFileCheck(cfg, city)
@@ -122,13 +122,46 @@ func TestInstructionsFileCheck_FixSymlinksFallback(t *testing.T) {
 	}
 }
 
+func TestInstructionsFileCheck_FixReportsExpectedDirectoryCollision(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
+	if err := os.MkdirAll(filepath.Join(rig, "AGENTS.md"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(AGENTS.md): %v", err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "a", Dir: "demo", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
+	}
+	c := NewInstructionsFileCheck(cfg, city)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	err := c.Fix(&CheckContext{})
+	if err == nil {
+		t.Fatal("Fix() error = nil, want directory collision error")
+	}
+	if !strings.Contains(err.Error(), "AGENTS.md exists as a directory") {
+		t.Fatalf("Fix() error = %v, want AGENTS.md directory collision", err)
+	}
+	info, statErr := os.Lstat(filepath.Join(rig, "AGENTS.md"))
+	if statErr != nil {
+		t.Fatalf("Lstat(AGENTS.md): %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("AGENTS.md is not a directory after Fix")
+	}
+}
+
 func TestInstructionsFileCheck_RelativeRigPathResolves(t *testing.T) {
 	city := t.TempDir()
 	rigRel := filepath.Join("rigs", "rel")
 	writeFile(t, filepath.Join(city, rigRel, "CLAUDE.md"), "x")
 
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Agents: []config.Agent{{Name: "a", Dir: "rel", Provider: "codex"}},
 		Rigs:   []config.Rig{{Name: "rel", Path: rigRel}},
 	}
 	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
@@ -143,7 +176,10 @@ func TestInstructionsFileCheck_DeterministicOrdering(t *testing.T) {
 		writeFile(t, filepath.Join(city, "rigs", name, "CLAUDE.md"), "x")
 	}
 	cfg := &config.City{
-		Agents: []config.Agent{{Name: "a", Provider: "codex"}},
+		Agents: []config.Agent{
+			{Name: "z", Dir: "zulu", Provider: "codex"},
+			{Name: "a", Dir: "alpha", Provider: "codex"},
+		},
 		Rigs: []config.Rig{
 			{Name: "zulu", Path: filepath.Join(city, "rigs", "zulu")},
 			{Name: "alpha", Path: filepath.Join(city, "rigs", "alpha")},
@@ -161,5 +197,173 @@ func TestInstructionsFileCheck_DeterministicOrdering(t *testing.T) {
 	}
 	if !strings.Contains(r.Details[1], `rig "zulu"`) {
 		t.Errorf("Details[1] should mention zulu second: %q", r.Details[1])
+	}
+}
+
+func TestInstructionsFileCheck_CityScopedAgentChecksCityRootOnly(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "unrelated")
+	writeFile(t, filepath.Join(city, "CLAUDE.md"), "city instructions\n")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "rig instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "city-worker", Scope: "city", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "unrelated", Path: rig}},
+	}
+	c := NewInstructionsFileCheck(cfg, city)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], "city root") {
+		t.Fatalf("Details[0] = %q, want city root warning", r.Details[0])
+	}
+	if strings.Contains(r.Details[0], `rig "unrelated"`) {
+		t.Fatalf("Details[0] = %q, should not warn for unrelated rig", r.Details[0])
+	}
+
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix() error: %v", err)
+	}
+	if link, err := os.Readlink(filepath.Join(city, "AGENTS.md")); err != nil || link != "CLAUDE.md" {
+		t.Fatalf("city AGENTS.md link = %q, err=%v; want CLAUDE.md symlink", link, err)
+	}
+	if _, err := os.Lstat(filepath.Join(rig, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("unrelated rig AGENTS.md exists after Fix; err=%v", err)
+	}
+}
+
+func TestInstructionsFileCheck_DefaultAgentChecksCityRoot(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "unrelated")
+	writeFile(t, filepath.Join(city, "CLAUDE.md"), "city instructions\n")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "rig instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "default-worker", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "unrelated", Path: rig}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], "city root") {
+		t.Fatalf("Details[0] = %q, want city root warning", r.Details[0])
+	}
+	if strings.Contains(r.Details[0], `rig "unrelated"`) {
+		t.Fatalf("Details[0] = %q, should not warn for unrelated rig", r.Details[0])
+	}
+}
+
+func TestInstructionsFileCheck_WorkDirOnlyAgentChecksWorkDirRoot(t *testing.T) {
+	city := t.TempDir()
+	workDir := filepath.Join("worktrees", "solo")
+	workRoot := filepath.Join(city, workDir)
+	rig := filepath.Join(city, "rigs", "unrelated")
+	writeFile(t, filepath.Join(workRoot, "CLAUDE.md"), "workdir instructions\n")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "rig instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "workdir-worker", WorkDir: workDir, Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "unrelated", Path: rig}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want 1: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], "work_dir") || !strings.Contains(r.Details[0], workRoot) {
+		t.Fatalf("Details[0] = %q, want work_dir warning for %s", r.Details[0], workRoot)
+	}
+	if strings.Contains(r.Details[0], `rig "unrelated"`) {
+		t.Fatalf("Details[0] = %q, should not warn for unrelated rig", r.Details[0])
+	}
+}
+
+func TestInstructionsFileCheck_DanglingExpectedSymlinkCountsPresent(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
+	if err := os.Symlink("missing.md", filepath.Join(rig, "AGENTS.md")); err != nil {
+		t.Fatalf("Symlink() setup error: %v", err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker", Dir: "demo", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
+	}
+	c := NewInstructionsFileCheck(cfg, city)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK for preexisting symlink; details=%v", r.Status, r.Details)
+	}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix() error = %v, want nil for preexisting symlink", err)
+	}
+	link, err := os.Readlink(filepath.Join(rig, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("Readlink(AGENTS.md): %v", err)
+	}
+	if link != "missing.md" {
+		t.Fatalf("AGENTS.md link = %q, want existing missing.md link unchanged", link)
+	}
+}
+
+func TestInstructionsFileCheck_DanglingFallbackSymlinkNotRecoverable(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	if err := os.MkdirAll(rig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("missing.md", filepath.Join(rig, "CLAUDE.md")); err != nil {
+		t.Fatalf("Symlink() setup error: %v", err)
+	}
+
+	cfg := &config.City{
+		Agents: []config.Agent{{Name: "worker", Dir: "demo", Provider: "codex"}},
+		Rigs:   []config.Rig{{Name: "demo", Path: rig}},
+	}
+	c := NewInstructionsFileCheck(cfg, city)
+	r := c.Run(&CheckContext{})
+	if r.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK for unusable fallback; details=%v", r.Status, r.Details)
+	}
+	if err := c.Fix(&CheckContext{}); err != nil {
+		t.Fatalf("Fix() error = %v, want nil for unusable fallback", err)
+	}
+	if _, err := os.Lstat(filepath.Join(rig, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("AGENTS.md exists after Fix with unusable fallback; err=%v", err)
+	}
+}
+
+func TestInstructionsFileCheck_MergesProvidersForSameGap(t *testing.T) {
+	city := t.TempDir()
+	rig := filepath.Join(city, "rigs", "demo")
+	writeFile(t, filepath.Join(rig, "CLAUDE.md"), "claude instructions\n")
+
+	cfg := &config.City{
+		Agents: []config.Agent{
+			{Name: "gemini-worker", Dir: "demo", Provider: "gemini"},
+			{Name: "codex-worker", Dir: "demo", Provider: "codex"},
+		},
+		Rigs: []config.Rig{{Name: "demo", Path: rig}},
+	}
+	r := NewInstructionsFileCheck(cfg, city).Run(&CheckContext{})
+	if r.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning; details=%v", r.Status, r.Details)
+	}
+	if len(r.Details) != 1 {
+		t.Fatalf("Details = %d, want one merged warning: %v", len(r.Details), r.Details)
+	}
+	if !strings.Contains(r.Details[0], `providers "codex", "gemini"`) {
+		t.Fatalf("Details[0] = %q, want sorted plural provider list", r.Details[0])
 	}
 }

--- a/internal/doctor/checks_provider_parity.go
+++ b/internal/doctor/checks_provider_parity.go
@@ -61,10 +61,11 @@ func (c *ProviderParityCheck) Run(_ *CheckContext) *CheckResult {
 	var details []string
 	for _, name := range names {
 		provider := providers[name]
-		if !provider.hasResume {
+		if strings.TrimSpace(provider.ResumeFlag) == "" && strings.TrimSpace(provider.ResumeCommand) == "" {
 			details = append(details, fmt.Sprintf(
 				"provider %q has no ResumeFlag or ResumeCommand: session restarts will silently drop the session-id and start a fresh process",
-				name))
+				name,
+			))
 		}
 	}
 
@@ -86,17 +87,18 @@ func (c *ProviderParityCheck) CanFix() bool { return false }
 // Fix is a no-op.
 func (c *ProviderParityCheck) Fix(_ *CheckContext) error { return nil }
 
-type providerResumeState struct {
-	hasResume bool
-}
-
-// providersInUse returns resume capability state for every provider used by
-// at least one configured agent. It delegates provider inheritance and
-// agent-level overrides to config.ResolveProvider, using a PATH lookup stub
-// because provider-parity checks config semantics rather than host binaries.
-// Agents that pin StartCommand are skipped because they bypass ProviderSpec.
-func providersInUse(cfg *config.City) map[string]providerResumeState {
-	out := map[string]providerResumeState{}
+// providersInUse returns the fully resolved provider for every provider
+// used by at least one configured agent. It delegates provider inheritance
+// and agent-level overrides to config.ResolveProvider, using a PATH lookup
+// stub because provider-parity checks config semantics rather than host
+// binaries. Agents that pin StartCommand are skipped because they bypass
+// ProviderSpec.
+//
+// When the same provider name is referenced by multiple agents, the result
+// prefers the entry whose resume capability is *missing* — that is the
+// signal worth surfacing.
+func providersInUse(cfg *config.City) map[string]config.ResolvedProvider {
+	out := map[string]config.ResolvedProvider{}
 
 	addResolved := func(agent config.Agent) {
 		resolved, err := config.ResolveProvider(&agent, &cfg.Workspace, cfg.Providers, providerParityLookPath)
@@ -109,8 +111,9 @@ func providersInUse(cfg *config.City) map[string]providerResumeState {
 		}
 		hasResume := strings.TrimSpace(resolved.ResumeFlag) != "" || strings.TrimSpace(resolved.ResumeCommand) != ""
 		current, seen := out[name]
-		if !seen || (current.hasResume && !hasResume) {
-			out[name] = providerResumeState{hasResume: hasResume}
+		currentHasResume := strings.TrimSpace(current.ResumeFlag) != "" || strings.TrimSpace(current.ResumeCommand) != ""
+		if !seen || (currentHasResume && !hasResume) {
+			out[name] = *resolved
 		}
 	}
 

--- a/internal/doctor/warmup_eligible.go
+++ b/internal/doctor/warmup_eligible.go
@@ -94,6 +94,10 @@ func (c *ImplicitImportCacheCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (c *InstructionsFileCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (c *NestedWorktreePruneCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the


### PR DESCRIPTION
## Summary

Closes Gap 7 of the non-Claude provider parity audit ([wasteland `w-c243404137`](https://wasteland.gastownhall.ai/) / [`gastownhall/gascity#672`](https://github.com/gastownhall/gascity/issues/672) / audit doc at [Rome-1/gastown](https://github.com/Rome-1/gastown/blob/main/docs/research/w-7ed35a727f-parity-audit-classification.md)).

The audit notes that `InstructionsFile` is consulted when *generating* quality-gate hints but is never materialized in the agent's workdir — so a non-Claude agent on a rig that only ships `CLAUDE.md` silently starts with no project instructions.

This PR ships the **doctor-half** of the fix (the auditable, low-risk, side-effect-free half). Materializing the file at session-start remains a separate, higher-risk change because it touches user worktrees during a live runtime.

## Changes

Adds `InstructionsFileCheck` in `internal/doctor/checks_instructions_file.go`:

- For every (rig × provider-in-use) combination, resolve the provider's expected `InstructionsFile` (default `AGENTS.md` per `ResolveProvider`) and check the rig's path on disk.
- Warn when the canonical file is missing but a known fallback (`AGENTS.md` ↔ `CLAUDE.md` ↔ `INSTRUCTIONS.md`) is present — recoverable cases only, no noise when the rig ships nothing.
- **`--fix` symlinks** the existing fallback to the expected name, so both providers read the same canonical file. Symlink (not copy) keeps a single source of truth.
- Rigs with no `Path` are skipped — that lives under the site-binding migration; this check kicks in once a rig is bound.
- Warnings are stable-ordered by rig name then expected filename.

Registered alongside the other config-level checks in `cmd/gc/cmd_doctor.go` (only when the config loaded cleanly).

## Test plan

- [x] `go test ./internal/doctor/ -run "InstructionsFileCheck"` passes (7 sub-tests: nil config, no rigs, all-files-present, missing-but-recoverable, no-fallback-no-noise, --fix symlink, relative rig path, deterministic ordering)
- [x] gofumpt clean
- [ ] CI runs the full gates

Closes Gap 7 of #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)