### PR TITLE
feat(hooks): add preCompact hook for copilot (#672)

### DIFF
--- a/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
+++ b/internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json
@@ -8,6 +8,13 @@
         "timeoutSec": 30
       }
     ],
+    "preCompact": [
+      {
+        "type": "command",
+        "bash": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gc handoff --auto \"context cycle\"",
+        "timeoutSec": 30
+      }
+    ],
     "userPromptSubmitted": [
       {
         "type": "command",

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -980,6 +980,17 @@ func TestInstallOverlayManagedProviders(t *testing.T) {
 	if !strings.Contains(codexHooks, `gc handoff --auto --hook-format codex \"context cycle\"`) {
 		t.Error("codex PreCompact should use auto handoff with Codex hook output format")
 	}
+	// Copilot CLI documents preCompact (camelCase). The hook fires before
+	// context compaction starts so handoff can capture state; without it,
+	// long Copilot sessions silently lose context at compact boundaries.
+	// See gastownhall/gascity#672 gap 3.
+	copilotHooks := string(fs.Files["/work/.github/hooks/gascity.json"])
+	if !strings.Contains(copilotHooks, `"preCompact"`) {
+		t.Error("copilot hooks should include preCompact (closes #672 gap 3)")
+	}
+	if !strings.Contains(copilotHooks, `gc handoff --auto \"context cycle\"`) {
+		t.Error("copilot preCompact should use auto handoff")
+	}
 	for _, rel := range []string{
 		"/work/.codex/hooks.json",
 		"/work/.gemini/settings.json",


### PR DESCRIPTION
## Summary

Closes Gap 3 of the non-Claude provider parity audit ([wasteland `w-c243404137`](https://wasteland.gastownhall.ai/) / [`gastownhall/gascity#672`](https://github.com/gastownhall/gascity/issues/672) / audit doc at [Rome-1/gastown](https://github.com/Rome-1/gastown/blob/main/docs/research/w-7ed35a727f-parity-audit-classification.md)) for **copilot**.

Copilot CLI documents `preCompact` (camelCase per the [official hooks reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference)) as the hook event fired before context compaction starts. Without wiring it, long Copilot sessions silently lose context at compact boundaries — handoff never gets a chance to capture state.

## Changes

- `internal/bootstrap/packs/core/overlay/per-provider/copilot/.github/hooks/gascity.json` — add a `preCompact` entry that invokes the existing `gc handoff --auto "context cycle"` (same target as the claude / codex / cursor / gemini equivalents).
- `internal/hooks/hooks_test.go` — extend `TestInstallOverlayManagedProviders` to assert the new entry is materialized into the agent workdir.

## Re: codex

The audit doc listed codex as missing PreCompact, but codex's PreCompact had already been wired upstream (commit [2f3bf408](https://github.com/gastownhall/gascity/commit/2f3bf408), [PR #1811](https://github.com/gastownhall/gascity/pull/1811)) before this audit detail was actioned. The audit was authored against an older commit; codex is now done. This PR closes the remaining copilot half. **Gap 3 of #672 is now complete.**

## Test plan

- [x] `go test ./internal/hooks/ -run "TestInstallOverlayManagedProviders"` passes
- [ ] CI runs the full gates

Closes Gap 3 of #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)