### PR TITLE
ci(mac): consolidate outlier mac workflows onto Blacksmith

### DIFF
--- a/.github/workflows/homebrew-tap-smoke.yml
+++ b/.github/workflows/homebrew-tap-smoke.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tap-smoke:
     name: Tap install smoke
-    runs-on: macos-15
+    runs-on: blacksmith-12vcpu-macos-15
     timeout-minutes: 30
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,7 +56,7 @@ jobs:
 
   mac-inference:
     name: Mac / Tier B+C inference tests
-    runs-on: macos-15
+    runs-on: blacksmith-12vcpu-macos-15
     timeout-minutes: 180
     env:
       ANTHROPIC_BASE_URL: https://ollama.com


### PR DESCRIPTION
## Summary

Two workflows were the last ones pinned to GitHub-hosted `macos-15`:
- `.github/workflows/homebrew-tap-smoke.yml:18`
- `.github/workflows/nightly.yml:59`

Both fire on `push` / `schedule`, not `pull_request`, so the trusted-author gating that drives `runner_policy.py` doesn't apply. Following the `rc-gate.yml` precedent, hardcode both to `blacksmith-12vcpu-macos-15` so all push/schedule/manual Mac jobs run on Blacksmith.

## What stays on GitHub-hosted

`runner_policy.py:25` still falls back to `macos-15` for PRs opened by users outside the `julianknutsen` / `csells` / `sjarmak` / `quad341` allowlist. That's the deliberate security boundary, not a Mac consolidation gap.

## Test plan
- [ ] `grep -rn "runs-on: macos-15$" .github/` returns zero hits
- [ ] homebrew-tap-smoke and nightly next runs report `blacksmith-12vcpu-macos-15`
- [ ] No MacStadium references anywhere (verified — there were none to begin with)

🤖 Generated with [Claude Code](https://claude.com/claude-code)