### PR TITLE
ci(release): move release.yml jobs to Blacksmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     name: Release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: write
     steps:
@@ -57,7 +57,7 @@ jobs:
     name: Attest release
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       attestations: write
       contents: write
@@ -110,7 +110,7 @@ jobs:
     name: Update Homebrew formula
     if: ${{ github.repository == 'gastownhall/gascity' && startsWith(github.ref, 'refs/tags/v') }}
     needs: [release, attest-release]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

The Release workflow was the last admin-only path still running on GitHub-hosted `ubuntu-latest`. `rc-gate.yml` already validates the same artifacts on Blacksmith; this PR makes the actual tag-triggered publish step match.

| Job | Old | New |
|---|---|---|
| `release` (GoReleaser cross-compile + publish) | ubuntu-latest | `blacksmith-32vcpu-ubuntu-2404` |
| `attest-release` (SBOM + cosign attestations) | ubuntu-latest | `blacksmith-8vcpu-ubuntu-2404` |
| `update-homebrew-formula` (clone tap + push) | ubuntu-latest | `blacksmith-2vcpu-ubuntu-2404` |

Release publishing only triggers on `push: tags/v*` (or manual workflow_dispatch by the maintainer), so this is purely a runner-vendor swap — no security boundary change.

## Test plan
- [ ] PR CI passes
- [ ] Next `v*` tag publish reports the three jobs on Blacksmith runners
- [ ] GoReleaser cross-compile completes faster on 32vcpu than on the 4-core GitHub-hosted default

🤖 Generated with [Claude Code](https://claude.com/claude-code)