### PR TITLE
fix(prompt): load template-fragments and prompts/shared from city root

### DIFF
--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -125,6 +125,16 @@ func renderPromptWithMeta(fs fsys.FS, cityPath, cityName, templatePath string, c
 		loadSharedTemplates(fs, tmpl, fragDir, stderr)
 	}
 
+	// Load shared templates from the city root itself. cfg.PackDirs is
+	// populated only from imported packs, so a root city pack with no
+	// [imports.*] blocks would otherwise silently ignore its own
+	// prompts/shared/ and template-fragments/ directories. Loaded after
+	// imported-pack fragments (so city-root wins on name collision with
+	// imports) but before sibling shared/ and per-agent fragments below
+	// (which keep their existing higher precedence).
+	loadSharedTemplates(fs, tmpl, filepath.Join(cityPath, "prompts", "shared"), stderr)
+	loadSharedTemplates(fs, tmpl, filepath.Join(cityPath, "template-fragments"), stderr)
+
 	// Load shared templates from sibling shared/ directory (highest priority —
 	// wins on name collision with cross-pack templates).
 	sharedDir := filepath.Join(filepath.Dir(sourcePath), "shared")

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -980,3 +980,69 @@ func TestProviderDisplayNameFallsBackToKeyForUnknownProvider(t *testing.T) {
 		t.Errorf("displayName = %q, want %q (unknown provider should fall back to key)", gotName, "totally-unknown")
 	}
 }
+
+// TestRenderPromptCityRootTemplateFragments verifies that template-fragments/
+// at the city root (the root pack itself) are loaded into the template set,
+// not just template-fragments/ inside imported pack dirs. Regression test for
+// rp-aew: a PackV2 root pack with no [imports.*] blocks (so cfg.PackDirs is
+// empty) must still be able to use its own template-fragments/.
+func TestRenderPromptCityRootTemplateFragments(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/template-fragments/recovery.template.md"] = []byte(
+		`{{ define "recovery" }}recover-from-city-root{{ end }}`)
+	f.Files["/city/agents/x/prompt.template.md"] = []byte(`{{ template "recovery" . }}`)
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md", PromptContext{},
+		"", io.Discard, nil, nil, nil)
+	if got != "recover-from-city-root" {
+		t.Errorf("renderPrompt(city-root template-fragments) = %q, want %q",
+			got, "recover-from-city-root")
+	}
+}
+
+// TestRenderPromptCityRootPromptsShared mirrors the test above for the
+// prompts/shared/ subdirectory at the city root.
+func TestRenderPromptCityRootPromptsShared(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/shared/greet.template.md"] = []byte(
+		`{{ define "greet" }}hello-from-city-root{{ end }}`)
+	f.Files["/city/agents/x/prompt.template.md"] = []byte(`{{ template "greet" . }}`)
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md", PromptContext{},
+		"", io.Discard, nil, nil, nil)
+	if got != "hello-from-city-root" {
+		t.Errorf("renderPrompt(city-root prompts/shared) = %q, want %q",
+			got, "hello-from-city-root")
+	}
+}
+
+// TestRenderPromptCityRootFragmentsPerAgentWins ensures the new city-root
+// fragment load does not displace per-agent fragments (which must still win
+// on name collision).
+func TestRenderPromptCityRootFragmentsPerAgentWins(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/template-fragments/footer.template.md"] = []byte(
+		`{{ define "footer" }}city-root{{ end }}`)
+	f.Files["/city/agents/x/template-fragments/footer.template.md"] = []byte(
+		`{{ define "footer" }}per-agent{{ end }}`)
+	f.Files["/city/agents/x/prompt.template.md"] = []byte(`{{ template "footer" . }}`)
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md", PromptContext{},
+		"", io.Discard, nil, nil, nil)
+	if got != "per-agent" {
+		t.Errorf("renderPrompt(per-agent overrides city-root) = %q, want %q",
+			got, "per-agent")
+	}
+}
+
+// TestRenderPromptCityRootFragmentsAbsentNoEffect is the regression-safety
+// check: when the city root has no template-fragments/ or prompts/shared/,
+// rendered output is byte-identical to pre-fix behavior (i.e. the new
+// directory probes silently no-op via the loadSharedTemplates ReadDir miss).
+func TestRenderPromptCityRootFragmentsAbsentNoEffect(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/agents/x/prompt.template.md"] = []byte("plain body {{ .AgentName }}")
+	got := renderPrompt(f, "/city", "", "agents/x/prompt.template.md",
+		PromptContext{AgentName: "x"}, "", io.Discard, nil, nil, nil)
+	want := "plain body x"
+	if got != want {
+		t.Errorf("renderPrompt(no city-root fragments) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

`renderPrompt` in `cmd/gc/prompt.go` iterates `cfg.PackDirs` to load `template-fragments/` and `prompts/shared/`. But `cfg.PackDirs` is populated only from *imported* packs (`workspace.includes` / `[imports.*]`). A PackV2 root city pack with no imports has nowhere to land its own `template-fragments/` — `gc` silently skips it, and `{{ template "name" . }}` in any agent prompt fails with `template "name" not defined`.

This contradicts [doc-pack-v2.md](https://github.com/gastownhall/gascity/blob/main/docs/packv2/doc-pack-v2.md) and [doc-directory-conventions.md](https://github.com/gastownhall/gascity/blob/main/docs/packv2/doc-directory-conventions.md), which describe `template-fragments/` as a standard top-level directory loaded by convention.

## Fix

After the `cfg.PackDirs` loop in `renderPrompt`, additionally load `template-fragments/` and `prompts/shared/` from `cityPath`. Placement chosen so:

- **Root pack wins over imports** on name collision (the importing city's own override beats an imported pack's fragment — sane "pack owns its own overrides" semantics).
- **Per-agent fragments still win over root** (existing higher-precedence loads run after this block).

## Tests

Adds four cases in `prompt_test.go`:

1. `TestRenderPromptCityRootTemplateFragments` — city-root `template-fragments/` is discovered.
2. `TestRenderPromptCityRootPromptsShared` — city-root `prompts/shared/` is discovered (symmetry).
3. `TestRenderPromptCityRootFragmentsPerAgentWins` — per-agent fragment overrides root on collision.
4. `TestRenderPromptCityRootFragmentsAbsentNoEffect` — packs with no city-root fragments render byte-identically to pre-patch (regression safety).

`go test ./cmd/gc/ -run "Render|Prompt|Template" -count=1` passes locally (46s).

## Scope

Single file behavioral change (`cmd/gc/prompt.go`) plus tests. No public API or config surface changes. No effect on packs that import others — those continue to work exactly as before.