### PR TITLE
ci(codeowners): assign /docs/ to @csells

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,6 @@
 /internal/buildimage/ @gastownhall/gascity-admin
 /cmd/gc/dashboard/web/package.json @gastownhall/gascity-admin
 /cmd/gc/dashboard/web/package-lock.json @gastownhall/gascity-admin
+
+# Public docs are owned by csells.
+/docs/ @csells


### PR DESCRIPTION
## Summary

`.github/CODEOWNERS` covered 17 admin-sensitive paths but had no entry for `/docs/`, so the public docs tree had no ownership signal in PR review routing. Add `@csells` as the owner of `/docs/`.

## Test plan
- [ ] PR CI passes
- [ ] Future PRs touching `/docs/**` auto-request review from @csells

🤖 Generated with [Claude Code](https://claude.com/claude-code)