### PR TITLE
fix(hooks): JSON-aware claude settings upgrade preserves customizations

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -293,7 +293,20 @@ func desiredClaudeSettings(fs fsys.FS, cityDir string) ([]byte, claudeSettingsSo
 		return base, claudeSettingsSourceNone, nil
 	}
 
-	merged, err := overlay.MergeSettingsJSON(base, overrideData)
+	// Apply targeted in-place upgrades to legacy forms of managed gascity
+	// hook commands and matchers in the user's override before merging with
+	// the embedded base. Custom hook events and custom commands are
+	// preserved verbatim. The previous "use base instead" path discarded
+	// user customizations along with stale managed-hook bytes; this path
+	// patches the managed bytes while keeping customizations intact.
+	upgradedOverride, _, upgradeErr := upgradeClaudeFile(overrideData)
+	if upgradeErr != nil {
+		// Upgrade failure (e.g., malformed JSON) — fall back to original
+		// override; better to keep the user file as-is than fail install.
+		upgradedOverride = overrideData
+	}
+
+	merged, err := overlay.MergeSettingsJSON(base, upgradedOverride)
 	if err != nil {
 		return nil, claudeSettingsSourceNone, fmt.Errorf("merging Claude settings from %s: %w", overridePath, err)
 	}
@@ -321,14 +334,16 @@ func readClaudeSettingsOverride(fs fsys.FS, cityDir string, base []byte) (string
 
 	hookExists := hookState == candidateFound
 	runtimeExists := runtimeState == candidateFound
-	if hookExists &&
-		(!runtimeExists || !bytes.Equal(hookData, runtimeData)) &&
-		!claudeFileNeedsUpgrade(hookData) {
+	// The previous !claudeFileNeedsUpgrade gates here forced cities whose
+	// settings.json had stale managed-hook commands AND user customizations
+	// to fall through to the "use base" branch, silently discarding their
+	// customizations. desiredClaudeSettings now patches stale managed
+	// commands in-place via upgradeClaudeFile before merging with base, so
+	// customizations survive while managed commands get upgraded.
+	if hookExists && (!runtimeExists || !bytes.Equal(hookData, runtimeData)) {
 		return hookPath, hookData, claudeSettingsSourceLegacyHook, nil
 	}
-	if runtimeExists &&
-		!bytes.Equal(runtimeData, base) &&
-		!claudeFileNeedsUpgrade(runtimeData) {
+	if runtimeExists && !bytes.Equal(runtimeData, base) {
 		return runtimePath, runtimeData, claudeSettingsSourceLegacyRuntime, nil
 	}
 	return "", nil, claudeSettingsSourceNone, nil
@@ -613,41 +628,134 @@ func writeManagedFile(fs fsys.FS, dst string, data []byte, policy writeManagedFi
 	return nil
 }
 
+// claudeFileNeedsUpgrade reports whether the existing settings.json contains
+// known legacy forms of managed gascity hook commands or matchers that would
+// be patched by upgradeClaudeFile. Used by isStaleHookFile to decide whether
+// to overwrite the legacy hook-file path; readClaudeSettingsOverride no
+// longer gates on this since desiredClaudeSettings applies the upgrade
+// in-place before merge.
+//
+// The previous implementation enumerated 16 byte-exact transforms of the
+// embedded template and matched the user's bytes against that set. Any
+// custom addition (e.g. an extra Stop hook entry) defeated every variant
+// match, so cities with customizations never received upstream fixes —
+// most notably the PreCompact `--auto` patch from commit 7b3b913a, which
+// landed weeks before this rewrite but never propagated to cities like
+// pipex-city that had drifted from the canonical embedded shape.
 func claudeFileNeedsUpgrade(existing []byte) bool {
-	current, err := readEmbedded("config/claude.json")
+	_, changed, err := upgradeClaudeFile(existing)
 	if err != nil {
 		return false
 	}
-	transforms := []func(string) string{
-		func(s string) string {
-			return strings.Replace(s, `gc handoff --auto \"context cycle\"`, `gc handoff \"context cycle\"`, 1)
-		},
-		func(s string) string {
-			return strings.Replace(s, `gc handoff --auto \"context cycle\"`, `gc prime --hook`, 1)
-		},
-		func(s string) string {
-			return strings.Replace(s, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, `gc prime --hook`, 1)
-		},
-		func(s string) string {
-			return strings.Replace(s, `"matcher": "startup"`, `"matcher": ""`, 1)
-		},
-	}
+	return changed
+}
 
-	known := make(map[string]struct{})
-	var enumerate func(int, string, bool)
-	enumerate = func(idx int, candidate string, changed bool) {
-		if idx == len(transforms) {
-			if changed {
-				known[candidate] = struct{}{}
-			}
-			return
+// upgradeClaudeFile parses the existing Claude settings.json and patches
+// known legacy forms of managed gascity hook commands and matchers to their
+// current shape. Walks the hook events so upgrades can be event-aware
+// (e.g. SessionStart matcher upgrade, PreCompact command upgrade); custom
+// hook events and custom commands are preserved verbatim.
+//
+// Returns the (possibly re-marshalled) JSON bytes and whether any patch
+// was applied.
+func upgradeClaudeFile(existing []byte) ([]byte, bool, error) {
+	var root any
+	if err := json.Unmarshal(existing, &root); err != nil {
+		return nil, false, err
+	}
+	rootMap, ok := root.(map[string]any)
+	if !ok {
+		return existing, false, nil
+	}
+	hooks, ok := rootMap["hooks"].(map[string]any)
+	if !ok {
+		return existing, false, nil
+	}
+	changed := false
+	for event, entries := range hooks {
+		entriesArr, ok := entries.([]any)
+		if !ok {
+			continue
 		}
-		enumerate(idx+1, candidate, changed)
-		next := transforms[idx](candidate)
-		enumerate(idx+1, next, changed || next != candidate)
+		for _, entry := range entriesArr {
+			entryMap, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if upgradeClaudeHookEntry(event, entryMap) {
+				changed = true
+			}
+		}
 	}
-	enumerate(0, string(current), false)
+	if !changed {
+		return existing, false, nil
+	}
+	data, err := overlay.MarshalCanonicalJSON(root)
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
 
-	_, ok := known[string(existing)]
-	return ok
+// upgradeClaudeHookEntry applies event-aware upgrades to a single
+// {matcher, hooks: [...]} entry under one of the hook event arrays.
+func upgradeClaudeHookEntry(event string, entry map[string]any) bool {
+	changed := false
+	if event == "SessionStart" {
+		if matcher, ok := entry["matcher"].(string); ok && matcher == "" {
+			entry["matcher"] = "startup"
+			changed = true
+		}
+	}
+	hookCmds, ok := entry["hooks"].([]any)
+	if !ok {
+		return changed
+	}
+	for _, h := range hookCmds {
+		hMap, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		cmd, ok := hMap["command"].(string)
+		if !ok {
+			continue
+		}
+		if upgraded, didUpgrade := upgradeClaudeHookCommand(event, cmd); didUpgrade {
+			hMap["command"] = upgraded
+			changed = true
+		}
+	}
+	return changed
+}
+
+// upgradeClaudeHookCommand returns the upgraded form of an event-scoped
+// command if it matches a known legacy shape. Returns ("", false) when no
+// upgrade applies.
+func upgradeClaudeHookCommand(event, command string) (string, bool) {
+	switch event {
+	case "PreCompact":
+		// Older legacy: PreCompact used `gc prime --hook` before
+		// `gc handoff` was introduced. Upgrade to the current
+		// `gc handoff --auto "context cycle"` form. Tested first
+		// because it changes the same trailing token the bare-handoff
+		// form would otherwise patch.
+		if strings.Contains(command, `gc prime --hook`) && !strings.Contains(command, `gc handoff`) {
+			return strings.Replace(command, `gc prime --hook`, `gc handoff --auto "context cycle"`, 1), true
+		}
+		// Legacy: bare `gc handoff "context cycle"` (no --auto)
+		// requests a controller restart on every Claude Code
+		// compaction event, killing the session (gc-flp1). Upstream
+		// fix landed in commit 7b3b913a; this patches existing cities.
+		if strings.Contains(command, `gc handoff "context cycle"`) && !strings.Contains(command, `--auto`) {
+			return strings.Replace(command, `gc handoff "context cycle"`, `gc handoff --auto "context cycle"`, 1), true
+		}
+	case "SessionStart":
+		// Legacy: bare `gc prime --hook` without the
+		// GC_MANAGED_SESSION_HOOK / GC_HOOK_EVENT_NAME env vars the
+		// current managed form expects.
+		if strings.Contains(command, `gc prime --hook`) && !strings.Contains(command, `GC_MANAGED_SESSION_HOOK=`) {
+			return strings.Replace(command, `gc prime --hook`, `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart gc prime --hook`, 1), true
+		}
+	}
+	return "", false
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -601,6 +601,83 @@ func TestInstallClaudeUpgradesGeneratedFileWithAllKnownDrift(t *testing.T) {
 	}
 }
 
+// TestInstallClaudeUpgradesPreCompactPreservingCustomHookEvent verifies that
+// a settings.json containing a stale managed PreCompact command (no --auto)
+// AND a custom user-added hook event (e.g. Stop) gets the managed command
+// upgraded while the custom hook event is preserved verbatim.
+//
+// Regression for the byte-enumerated claudeFileNeedsUpgrade brittleness
+// observed in pipex-city: the prior implementation matched files byte-exact
+// against 16 transforms of the embedded template; any custom addition
+// defeated every variant match, so the file fell through to "user override"
+// and never received upstream fixes (notably commit 7b3b913a's --auto patch).
+// The JSON-aware upgradeClaudeFile rewrite handles this case correctly.
+func TestInstallClaudeUpgradesPreCompactPreservingCustomHookEvent(t *testing.T) {
+	fs := fsys.NewFake()
+	current, err := readEmbedded("config/claude.json")
+	if err != nil {
+		t.Fatalf("readEmbedded: %v", err)
+	}
+	// Start from the canonical embedded shape, downgrade PreCompact to the
+	// bare-handoff legacy form, and inject a custom Stop hook event that
+	// is not part of the managed set.
+	stale := strings.Replace(string(current), `gc handoff --auto \"context cycle\"`, `gc handoff \"context cycle\"`, 1)
+	if stale == string(current) {
+		t.Fatal("PreCompact downgrade did not modify the fixture — check the legacy form pattern")
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(stale), &doc); err != nil {
+		t.Fatalf("parsing stale fixture: %v", err)
+	}
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("stale fixture has no hooks map")
+	}
+	hooks["Stop"] = []any{
+		map[string]any{
+			"matcher": "",
+			"hooks": []any{
+				map[string]any{
+					"type":    "command",
+					"command": `export PATH="$HOME/go/bin:$HOME/.local/bin:$PATH" && gc hook --inject`,
+				},
+			},
+		},
+	}
+	staleWithCustom, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("re-marshalling stale fixture: %v", err)
+	}
+	fs.Files["/city/.gc/settings.json"] = staleWithCustom
+
+	if err := Install(fs, "/city", "/work", []string{"claude"}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	runtime := fs.Files["/city/.gc/settings.json"]
+
+	// The managed PreCompact command must be upgraded to include --auto.
+	preCompactCmd := claudeHookCommand(t, runtime, "PreCompact")
+	if !strings.Contains(preCompactCmd, `gc handoff --auto "context cycle"`) {
+		t.Fatalf("PreCompact command not upgraded to include --auto:\n%s", preCompactCmd)
+	}
+
+	// The custom Stop hook must survive the upgrade verbatim.
+	stopCmd := claudeHookCommand(t, runtime, "Stop")
+	if !strings.Contains(stopCmd, `gc hook --inject`) {
+		t.Fatalf("custom Stop hook lost during upgrade — expected gc hook --inject in:\n%s", string(runtime))
+	}
+
+	// Sanity: the canonical SessionStart and UserPromptSubmit managed hooks
+	// must still be present (merged from base).
+	if !strings.Contains(string(runtime), "SessionStart") {
+		t.Fatalf("runtime lost SessionStart after upgrade:\n%s", string(runtime))
+	}
+	if !strings.Contains(string(runtime), "UserPromptSubmit") {
+		t.Fatalf("runtime lost UserPromptSubmit after upgrade:\n%s", string(runtime))
+	}
+}
+
 func TestInstallClaudeMergesCityDotClaudeSettings(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/.claude/settings.json"] = []byte(`{


### PR DESCRIPTION
## Summary

`claudeFileNeedsUpgrade` byte-enumerates 16 transforms of the embedded
template and matches the user's `settings.json` bytes against that set.
Any user-added customization (e.g. an extra `Stop` hook entry, a city-
specific UserPromptSubmit hook) defeats every variant match, so the
file falls through to "user override" and never receives upstream
patches.

The most visible effect: cities customized away from the canonical
shape **never received commit 7b3b913a's `gc handoff --auto` patch**
(PR #1825, weeks old), leaving every PreCompact event to kill the
session.

## What this PR changes

Replaces the byte-enumeration with a JSON-aware walker
(`upgradeClaudeFile`) that parses `settings.json`, iterates hook events,
and applies event-scoped command/matcher upgrades to managed gascity
commands while leaving any custom hook events or custom commands
verbatim.

`desiredClaudeSettings` now applies the upgrade to the user override
**before** merging with the embedded base, so customizations survive
while managed commands get upgraded. The previous
`!claudeFileNeedsUpgrade(...)` gates in `readClaudeSettingsOverride`
that forced legacy/customized files into a "use base instead" branch
(silently discarding the customizations) are removed.

### Currently known upgrades, all event-scoped

- `PreCompact`: pre-handoff `gc prime --hook` → `gc handoff --auto "context cycle"`
- `PreCompact`: bare `gc handoff "context cycle"` → adds `--auto` (this is the #1825 patch that previously didn't propagate)
- `SessionStart`: bare `gc prime --hook` → adds the `GC_MANAGED_SESSION_HOOK=1 GC_HOOK_EVENT_NAME=SessionStart` env prefix
- `SessionStart`: empty matcher → `"startup"`

Custom hook events (`Stop`, user-added hooks under any event) and any
non-managed commands within a hook entry are untouched.

## Test plan

- [x] `TestInstallClaudeUpgradesPreCompactPreservingCustomHookEvent` exercises pipex-city's exact shape (bare PreCompact `gc handoff` + extra `Stop` hook). Fails on parent (`gc handoff "context cycle"` stays bare), passes here.
- [x] Existing `TestInstallClaudeUpgradesGeneratedFileWithAllKnownDrift` and all other `internal/hooks` tests pass post-rebase.
- [x] RED→GREEN observed locally: test commit `54e765bd` fails the discriminator with `PreCompact command not upgraded to include --auto: ... gc handoff "context cycle"`; fix commit `70971d7f` passes.
- [x] `go vet ./internal/hooks/` and `gofmt -d internal/hooks/` both clean.

## How this was discovered

`pipex-city` was sitting on `gc handoff "context cycle"` (no `--auto`)
weeks after #1825 landed. Every PreCompact event would crash the
session because the cached PreCompact command was the bare form.
Bytes-match diagnosis: the city had an extra `Stop` hook for
`gc hook --inject`, which is not part of the embedded template
variants — so the byte enumeration produced 16 candidates, none
matched the user's bytes, and the file was classified "user override"
indefinitely.