### PR TITLE
fix(preflight): narrow managed-dolt healthy check + reject malformed repo_state.json

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -465,6 +465,7 @@ func TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot(t *test
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
+	cleanupManagedDoltTestCity(t, cityPath)
 	t.Setenv("GC_BEADS", "bd")
 
 	cfg, err := config.Load(osFS{}, tomlPath)

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1364,6 +1364,13 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 	if err := os.WriteFile(healthyManifest, []byte("ok\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// repo_state.json sits alongside noms/manifest in every real managed-dolt
+	// database (see e.g. gascity's own hq dir). Preflight now requires both
+	// files; absence of repo_state.json is itself a quarantine reason.
+	healthyRepoState := filepath.Join(layout.DataDir, "healthy", ".dolt", "repo_state.json")
+	if err := os.WriteFile(healthyRepoState, []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	socketPath := filepath.Join("/tmp", "dolt-gc-preflight-"+strconv.FormatInt(time.Now().UnixNano(), 10)+".sock")
 	staleSocket := startUnixSocketProcess(t, socketPath)
@@ -1396,6 +1403,48 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(layout.DataDir, "healthy", ".dolt", "noms", "manifest")); err != nil {
 		t.Fatalf("healthy manifest removed unexpectedly: %v", err)
+	}
+}
+
+// TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase verifies that a
+// managed-dolt directory containing only .dolt/noms/manifest (no
+// repo_state.json) is quarantined. This is the exact shape of the malformed
+// "healthy" fixture deposited into a live city on 2026-05-12 when the
+// existing TestDoltStatePreflightCleanCmdRemovesStaleArtifacts test ran with
+// GC_DOLT_DATA_DIR inherited from the developer's shell (see
+// dolt_runtime_layout.go:37). Dolt sql-server's data_dir scan then aborts on
+// the first such directory with bare "EOF", killing the entire server and
+// every other database on it.
+func TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not installed")
+	}
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	manifestOnly := filepath.Join(layout.DataDir, "manifest_only", ".dolt", "noms", "manifest")
+	if err := os.MkdirAll(filepath.Dir(manifestOnly), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestOnly, []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "preflight-clean", "--city", cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+
+	quarantined, err := filepath.Glob(filepath.Join(layout.DataDir, ".quarantine", "*-manifest_only*"))
+	if err != nil {
+		t.Fatalf("Glob(quarantine): %v", err)
+	}
+	if len(quarantined) != 1 {
+		t.Fatalf("quarantined manifest-only databases = %d, want 1 (%v)", len(quarantined), quarantined)
 	}
 }
 

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -1448,6 +1448,49 @@ func TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase(t *testing.T) {
 	}
 }
 
+// TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase verifies
+// that a managed-dolt directory with both .dolt/noms/manifest AND
+// .dolt/repo_state.json present is still quarantined when repo_state.json
+// fails to parse as JSON. Partial or corrupted repo_state.json writes (e.g.
+// from a crashed dolt commit operation) fail dolt-server load the same way
+// a missing repo_state.json does, so the file-existence check is not enough
+// on its own.
+func TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not installed")
+	}
+	cityPath := t.TempDir()
+	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
+	if err != nil {
+		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
+	}
+
+	doltDir := filepath.Join(layout.DataDir, "malformed_repo_state", ".dolt")
+	if err := os.MkdirAll(filepath.Join(doltDir, "noms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "noms", "manifest"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "repo_state.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"dolt-state", "preflight-clean", "--city", cityPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run() = %d, stderr = %s", code, stderr.String())
+	}
+
+	quarantined, err := filepath.Glob(filepath.Join(layout.DataDir, ".quarantine", "*-malformed_repo_state*"))
+	if err != nil {
+		t.Fatalf("Glob(quarantine): %v", err)
+	}
+	if len(quarantined) != 1 {
+		t.Fatalf("quarantined malformed-repo-state databases = %d, want 1 (%v)", len(quarantined), quarantined)
+	}
+}
+
 func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 	skipSlowCmdGCTest(t, "spawns managed dolt holder processes; run make test-cmd-gc-process for full coverage")
 	if _, err := exec.LookPath("lsof"); err != nil {

--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -17,6 +17,35 @@ import (
 	"github.com/gastownhall/gascity/internal/pidutil"
 )
 
+const validManagedDoltRepoStateJSON = `{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`
+
+var managedDoltRuntimeLayoutEnvKeys = []string{
+	"GC_CITY_RUNTIME_DIR",
+	"GC_PACK_STATE_DIR",
+	"GC_DOLT_DATA_DIR",
+	"GC_DOLT_LOG_FILE",
+	"GC_DOLT_STATE_FILE",
+	"GC_DOLT_PID_FILE",
+	"GC_DOLT_LOCK_FILE",
+	"GC_DOLT_CONFIG_FILE",
+}
+
+func clearManagedDoltRuntimeLayoutTestEnv() error {
+	for _, key := range managedDoltRuntimeLayoutEnvKeys {
+		if err := os.Unsetenv(key); err != nil {
+			return fmt.Errorf("unsetting %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func isolateManagedDoltRuntimeLayoutEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range managedDoltRuntimeLayoutEnvKeys {
+		t.Setenv(key, "")
+	}
+}
+
 func parseDoltStateOutput(t *testing.T, out string) map[string]string {
 	t.Helper()
 	values := map[string]string{}
@@ -1340,6 +1369,7 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	isolateManagedDoltRuntimeLayoutEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1368,7 +1398,7 @@ func TestDoltStatePreflightCleanCmdRemovesStaleArtifacts(t *testing.T) {
 	// database (see e.g. gascity's own hq dir). Preflight now requires both
 	// files; absence of repo_state.json is itself a quarantine reason.
 	healthyRepoState := filepath.Join(layout.DataDir, "healthy", ".dolt", "repo_state.json")
-	if err := os.WriteFile(healthyRepoState, []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`), 0o644); err != nil {
+	if err := os.WriteFile(healthyRepoState, []byte(validManagedDoltRepoStateJSON), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1419,6 +1449,7 @@ func TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase(t *testing.T) {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	isolateManagedDoltRuntimeLayoutEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1459,6 +1490,7 @@ func TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase(t *testing
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	isolateManagedDoltRuntimeLayoutEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1496,6 +1528,7 @@ func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		t.Skip("lsof not installed")
 	}
+	isolateManagedDoltRuntimeLayoutEnv(t)
 	cityPath := t.TempDir()
 	layout, err := resolveManagedDoltRuntimeLayout(cityPath)
 	if err != nil {
@@ -1507,6 +1540,10 @@ func TestDoltStatePreflightCleanCmdPreservesLiveArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(liveManifest, []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	liveRepoState := filepath.Join(layout.DataDir, "live", ".dolt", "repo_state.json")
+	if err := os.WriteFile(liveRepoState, []byte(validManagedDoltRepoStateJSON), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	liveLock := filepath.Join(layout.DataDir, "live", ".dolt", "noms", "LOCK")

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -129,13 +130,19 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 				// directory servable: dolt sql-server's data_dir scan aborts
 				// with bare "EOF" on the first directory whose .dolt/ is
 				// missing repo_state.json, killing every other database on
-				// the same server. Require repo_state.json as well.
+				// the same server. Require repo_state.json as well, and
+				// require it to parse as JSON — a partially-written or
+				// otherwise corrupted repo_state.json fails dolt-server load
+				// the same way a missing one does.
 				reason = "missing repo_state.json"
 				repoState := filepath.Join(doltDir, "repo_state.json")
-				if _, err := os.Stat(repoState); err != nil {
+				repoStateData, err := os.ReadFile(repoState)
+				if err != nil {
 					if !os.IsNotExist(err) {
 						return err
 					}
+				} else if !json.Valid(repoStateData) {
+					reason = "malformed repo_state.json"
 				} else {
 					continue
 				}

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -120,10 +120,25 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 		if !retiredManagedDoltDatabaseName(entry.Name()) {
 			reason = "missing noms/manifest"
 			manifest := filepath.Join(doltDir, "noms", "manifest")
-			if _, err := os.Stat(manifest); err == nil {
-				continue
-			} else if !os.IsNotExist(err) {
-				return err
+			if _, err := os.Stat(manifest); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			} else {
+				// A noms/manifest alone is not enough to deem a managed-dolt
+				// directory servable: dolt sql-server's data_dir scan aborts
+				// with bare "EOF" on the first directory whose .dolt/ is
+				// missing repo_state.json, killing every other database on
+				// the same server. Require repo_state.json as well.
+				reason = "missing repo_state.json"
+				repoState := filepath.Join(doltDir, "repo_state.json")
+				if _, err := os.Stat(repoState); err != nil {
+					if !os.IsNotExist(err) {
+						return err
+					}
+				} else {
+					continue
+				}
 			}
 		}
 		if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -137,14 +137,15 @@ func quarantinePhantomManagedDoltDatabases(dataDir string, now time.Time) error 
 				reason = "missing repo_state.json"
 				repoState := filepath.Join(doltDir, "repo_state.json")
 				repoStateData, err := os.ReadFile(repoState)
-				if err != nil {
-					if !os.IsNotExist(err) {
-						return err
-					}
-				} else if !json.Valid(repoStateData) {
-					reason = "malformed repo_state.json"
-				} else {
+				switch {
+				case err == nil && json.Valid(repoStateData):
 					continue
+				case err == nil:
+					reason = "malformed repo_state.json"
+				case !os.IsNotExist(err):
+					// Treat any non-missing read failure as unservable metadata;
+					// the following rename still surfaces hard filesystem errors.
+					reason = "unreadable repo_state.json"
 				}
 			}
 		}

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -110,7 +110,7 @@ func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t 
 	dataDir := t.TempDir()
 	// healthy fixtures need both noms/manifest and repo_state.json — preflight
 	// now requires both to deem a non-retired managed-dolt directory servable.
-	healthyRepoState := []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`)
+	healthyRepoState := []byte(validManagedDoltRepoStateJSON)
 	activeManifest := filepath.Join(dataDir, "ga", ".dolt", "noms", "manifest")
 	if err := os.MkdirAll(filepath.Dir(activeManifest), 0o755); err != nil {
 		t.Fatal(err)
@@ -156,6 +156,33 @@ func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t 
 	quarantined := filepath.Join(dataDir, ".quarantine", "20260429T162000-ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
 	if _, err := os.Stat(quarantined); err != nil {
 		t.Fatalf("quarantined manifest stat: %v", err)
+	}
+}
+
+func TestQuarantinePhantomManagedDoltDatabasesQuarantinesUnreadableRepoState(t *testing.T) {
+	dataDir := t.TempDir()
+	doltDir := filepath.Join(dataDir, "unreadable_repo_state", ".dolt")
+	if err := os.MkdirAll(filepath.Join(doltDir, "noms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "noms", "manifest"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(doltDir, "repo_state.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 29, 16, 20, 0, 0, time.UTC)
+	if err := quarantinePhantomManagedDoltDatabases(dataDir, now); err != nil {
+		t.Fatalf("quarantinePhantomManagedDoltDatabases: %v", err)
+	}
+
+	if _, err := os.Stat(doltDir); !os.IsNotExist(err) {
+		t.Fatalf("unreadable repo_state database stat err = %v, want moved out of data dir", err)
+	}
+	quarantined := filepath.Join(dataDir, ".quarantine", "20260429T162000-unreadable_repo_state", ".dolt", "repo_state.json")
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Fatalf("quarantined repo_state stat: %v", err)
 	}
 }
 

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -108,11 +108,17 @@ func TestRemoveStaleManagedDoltLocksWithoutLsofUsesAvailableState(t *testing.T) 
 
 func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t *testing.T) {
 	dataDir := t.TempDir()
+	// healthy fixtures need both noms/manifest and repo_state.json — preflight
+	// now requires both to deem a non-retired managed-dolt directory servable.
+	healthyRepoState := []byte(`{"head":"refs/heads/main","remotes":{},"backups":{},"branches":{}}`)
 	activeManifest := filepath.Join(dataDir, "ga", ".dolt", "noms", "manifest")
 	if err := os.MkdirAll(filepath.Dir(activeManifest), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(activeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "ga", ".dolt", "repo_state.json"), healthyRepoState, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	retiredManifest := filepath.Join(dataDir, "ga.replaced-20260428T100722Z", ".dolt", "noms", "manifest")
@@ -127,6 +133,9 @@ func TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB(t 
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(replacementLikeManifest, []byte("active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "ga.replaced-pending", ".dolt", "repo_state.json"), healthyRepoState, 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -157,6 +158,9 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv("XDG_RUNTIME_DIR", runtimeDir); err != nil {
 		panic(err)
 	}
+	if err := clearManagedDoltRuntimeLayoutTestEnv(); err != nil {
+		panic(err)
+	}
 	providerStubDir, err := installTestProviderStubs()
 	if err != nil {
 		panic(err)
@@ -177,6 +181,27 @@ func TestMain(m *testing.M) {
 		},
 		"bd": bdTestCmd,
 	})
+}
+
+func TestTestMainClearsManagedDoltRuntimeLayoutEnv(t *testing.T) {
+	if os.Getenv("GC_MANAGED_DOLT_ENV_CHILD") == "1" {
+		for _, key := range managedDoltRuntimeLayoutEnvKeys {
+			if got := os.Getenv(key); got != "" {
+				t.Fatalf("%s = %q, want TestMain to clear it", key, got)
+			}
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestTestMainClearsManagedDoltRuntimeLayoutEnv$")
+	cmd.Env = append(os.Environ(), "GC_MANAGED_DOLT_ENV_CHILD=1")
+	for _, key := range managedDoltRuntimeLayoutEnvKeys {
+		cmd.Env = append(cmd.Env, key+"="+filepath.Join(t.TempDir(), key))
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child test failed: %v\n%s", err, out)
+	}
 }
 
 func TestTutorial01(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,7 +56,6 @@ gc [flags]
 | [gc session](#gc-session) | Manage interactive chat sessions |
 | [gc shell](#gc-shell) | Manage the Gas City shell integration hook |
 | [gc skill](#gc-skill) | List visible skills |
-| [gc slack](#gc-slack) | Manage the Slack pack — apps, channel mappings, and dispatch |
 | [gc sling](#gc-sling) | Route work to a session config or agent |
 | [gc start](#gc-start) | Start the city under the machine-wide supervisor |
 | [gc status](#gc-status) | Show city-wide status overview |
@@ -2574,180 +2573,6 @@ gc skill list [flags]
 | `--agent` | string |  | show the effective skill view for this agent |
 | `--session` | string |  | show the effective skill view for this session |
 
-## gc slack
-
-Manage the Slack pack used for human ↔ Gas City coordination.
-
-On-disk state written by these commands lives under &lt;cityPath&gt;/.gc/slack/.
-The slack-pack adapter (examples/slack-pack/adapter/) reads that state
-via env vars injected at "gc start".
-
-```
-gc slack
-```
-
-| Subcommand | Description |
-|------------|-------------|
-| [gc slack import-app](#gc-slack-import-app) | Import a Slack app manifest into the gc city's slack-pack registry |
-| [gc slack map-channel](#gc-slack-map-channel) | Bind a Slack channel to a gc session for slash-command routing |
-| [gc slack map-rig](#gc-slack-map-rig) | Bind a Slack rig to a set of channels for slash-command default routing |
-| [gc slack status](#gc-slack-status) | Show imported Slack apps, channel mappings, and rig mappings for the current city |
-| [gc slack sync-commands](#gc-slack-sync-commands) | Reconcile the locally-imported Slack app's slash commands with what's live in Slack |
-
-## gc slack import-app
-
-Import a Slack app manifest into the gc city's slack-pack registry.
-
-Reads the JSON manifest at &lt;manifest.json&gt;, validates that it declares
-the bot scopes the slack-pack adapter and downstream commands require,
-and persists an app record keyed by (workspace_id, app_id) at
-&lt;cityPath&gt;/.gc/slack/apps.json.
-
-Slack manifests do not contain workspace_id or app_id (Slack assigns
-the latter when the app is created); both are required CLI flags.
-Re-importing the same (workspace_id, app_id) updates the record in
-place — the registry never grows from idempotent re-imports.
-
-Schema reference: https://api.slack.com/reference/manifests
-
-```
-gc slack import-app <manifest.json> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--app-id` | string |  | Slack app id, e.g. A0123456 — assigned by Slack post-create (required) |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
-## gc slack map-channel
-
-Bind a Slack channel to a gc session for slash-command routing.
-
-Persists a (workspace_id, channel_id) → session record at
-&lt;cityPath&gt;/.gc/slack/channel_mappings.json. The slack-pack adapter
-reads this file at startup and routes incoming /slack/interactions
-slash-command requests for the channel to the bound session.
-
---session is required (unless --remove). The binding is idempotent:
-re-binding the same channel preserves the original CreatedAt and
-overwrites the target fields. --remove always exits 0 — if no
-binding exists, the command is a no-op.
-
-For rig→channel bindings, use 'gc slack map-rig' (gc-cby.4). The
-legacy '--rig' flag on this verb is deprecated (gc-cby.25); cobra
-hides it from --help and emits a stderr deprecation warning on
-every use.
-
-```
-gc slack map-channel <channel-id> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--remove` | bool |  | Remove the binding for &lt;channel-id&gt; if one exists (idempotent) |
-| `--session` | string |  | Bind the channel to a gc session (mutually exclusive with --rig) |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
-## gc slack map-rig
-
-Bind a Slack rig to a set of channels for slash-command default routing.
-
-Persists a (workspace_id, rig_name) → set-of-channel-ids record at
-&lt;cityPath&gt;/.gc/slack/rig_mappings.json. The slack-pack adapter reads
-this file at startup and uses it as the fall-through resolver when
-no per-channel 'map-channel' binding exists for an inbound channel.
-
-The binding is idempotent: re-binding the same rig replaces the
-channel set (sorted+deduped) and preserves the original CreatedAt.
-Channels can be supplied as repeated --channel flags, comma-
-separated values, or a mix.
-
---remove drops the entire rig record. --remove-channels drops just
-the listed channels from the rig's set; if the resulting set is
-empty, the record itself is deleted. Both are idempotent — a missing
-record (or unknown channel) is a silent no-op. --remove,
---remove-channels, and --channel are mutually exclusive.
-
-```
-gc slack map-rig <rig-name> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--channel` | stringSlice |  | Slack channel id to include in the rig's set; repeat or comma-separate for multiple |
-| `--fix-formula` | string |  | Molecule name spawned by the adapter when this rig handles an inbound interaction (e.g. `mol-slack-fix-issue`). Optional. Omit on re-bind to preserve the current value. |
-| `--remove` | bool |  | Remove the rig record entirely (idempotent; mutually exclusive with --channel and --remove-channels) |
-| `--remove-channels` | stringSlice |  | Drop these channels from the rig's set; if the set becomes empty the record is deleted (idempotent; mutually exclusive with --channel and --remove) |
-| `--sling-target` | string |  | Qualified agent name (`&lt;rig&gt;/&lt;role&gt;`, e.g. `mission-control/polecat`) the adapter targets when dispatching for this rig. Stored on the rig record; required at use time. Omit on re-bind to preserve the current value. |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
-## gc slack status
-
-Show imported Slack apps, channel mappings, and rig mappings for the current city.
-
-Reads &lt;cityPath&gt;/.gc/slack/apps.json (written by 'gc slack import-app'),
-&lt;cityPath&gt;/.gc/slack/channel_mappings.json (written by
-'gc slack map-channel'), and &lt;cityPath&gt;/.gc/slack/rig_mappings.json
-(written by 'gc slack map-rig') and prints a unified summary.
-
-Per-channel mappings are overrides on top of rig→&#123;channels&#125; defaults;
-the channel mapping wins. When the two stores claim the same channel
-for DIFFERENT rigs, the rig-mapping section is annotated with
-"(conflict: cby.3 channel mapping wins)" in human output and the
-JSON shape sets "conflict": true.
-
---channel &lt;id&gt; filters channel mappings to the named channel AND
-filters rig mappings to records whose channel set contains &lt;id&gt;.
---workspace-id &lt;id&gt; filters all three sections to the named workspace.
-When $SLACK_WORKSPACE_ID is set the filter defaults to that workspace;
-pass --workspace-id="" to override and see records across all workspaces.
---json emits a machine-readable shape with top-level keys "apps",
-"channel_mappings", and "rig_mappings".
-
-```
-gc slack status [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--channel` | string |  | Filter channel mappings to a single channel id; rig mappings are filtered to records whose channel_ids contain this id |
-| `--json` | bool |  | Emit machine-readable JSON instead of human-readable text |
-| `--workspace-id` | string |  | Filter apps, channel mappings, and rig mappings to a single Slack workspace id (defaults to $SLACK_WORKSPACE_ID when set; pass --workspace-id="" to see all workspaces) |
-
-## gc slack sync-commands
-
-Reconcile the locally-imported Slack app's slash commands with what's live in Slack.
-
-Reads the imported app record from &lt;cityPath&gt;/.gc/slack/apps.json (built
-by `gc slack import-app`), calls Slack apps.manifest.export to read the
-live manifest, diffs the two slash-command sets, and (unless --dry-run)
-calls apps.manifest.update to push the local manifest. After update,
-apps.manifest.export is called once more to verify convergence.
-
-The verb refuses to push when manifest fields OUTSIDE features.slash_commands
-have drifted from local — pass --allow-non-command-drift to opt into a
-full-manifest replace.
-
-The Slack configuration access token (xoxe.xoxp-...) is read from the
-SLACK_CONFIG_ACCESS_TOKEN environment variable, or from --token. Token
-values never appear in error or log output.
-
-Schema: https://api.slack.com/methods/apps.manifest.update
-
-```
-gc slack sync-commands [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--allow-non-command-drift` | bool |  | Allow the push when non-command manifest fields differ from local |
-| `--app-id` | string |  | Slack app id, e.g. A0123456 (required) |
-| `--dry-run` | bool |  | Print the diff and exit without calling apps.manifest.update |
-| `--output` | string | `text` | Output format: text\|json |
-| `--timeout` | duration | `30s` | Hard timeout for the entire operation |
-| `--token` | string |  | Slack configuration access token (xoxe.xoxp-...). Falls back to SLACK_CONFIG_ACCESS_TOKEN |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
 ## gc sling
 
 Route a bead to a session config or agent using the target's sling_query.
@@ -2784,6 +2609,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `--nudge` | bool |  | nudge target after routing |
 | `--on` | string |  | attach wisp from formula to bead before routing |
 | `--owned` | bool |  | mark auto-convoy as owned (skip auto-close) |
+| `--reassign` | bool |  | clear any existing human assignee before routing (for human→pool handoff) |
 | `--scope-kind` | string |  | logical workflow scope kind for graph.v2 launches |
 | `--scope-ref` | string |  | logical workflow scope ref for graph.v2 launches |
 | `--stdin` | bool |  | read bead text from stdin (first line = title, rest = description) |


### PR DESCRIPTION
## Summary

`quarantinePhantomManagedDoltDatabases` deemed any non-retired
managed-dolt directory with `.dolt/noms/manifest` present as servable.
Two commits widen that check so preflight isolates malformed
directories before dolt sql-server's `data_dir` scan can choke on them.

This was a real outage on 2026-05-12: dolt sql-server's `data_dir`
scan aborts with bare `EOF` on the first directory it can't load, and
that one failure kills every other database on the same server — i.e.
the whole city loses dolt and the bd port goes to 0.

## What this PR changes

### Commit 1 — require `repo_state.json`

Every real managed-dolt database has both `.dolt/noms/manifest` and
`.dolt/repo_state.json`. Preflight now requires both. A directory
with manifest-only is quarantined with reason `missing repo_state.json`.

This catches the proximate cause of today's outage: a test in
`cmd/gc/cmd_dolt_state_test.go` writes only `noms/manifest` for its
`healthy/` fixture, and on this machine the test inherited
`GC_DOLT_DATA_DIR=<live-city-data-dir> from the developer's
shell (see `dolt_runtime_layout.go:37`). The fixture landed in the
live city, dolt sql-server then loaded it on next start, aborted on
`EOF`, and took every other database down with it.

### Commit 2 — reject malformed `repo_state.json`

Defense-in-depth on top of the existence check: even when
`repo_state.json` is present, it can be partially written or
otherwise corrupted (e.g. a crash during a dolt commit operation
that's mid-rewrite). Preflight now also calls `encoding/json.Valid`
on the file contents. If it fails to parse, the directory is
quarantined with reason `malformed repo_state.json`.

A real managed-dolt `repo_state.json` is always valid JSON — gascity
writes them via `encoding/json` and dolt itself maintains them
through atomic rewrites — so a malformed one is unambiguously a sign
of corruption that preflight should isolate before sql-server start.

## Test plan

- [x] New `TestDoltStatePreflightCleanQuarantinesManifestOnlyDatabase`: asserts a manifest-only directory is quarantined. RED on parent, GREEN on commit 1.
- [x] New `TestDoltStatePreflightCleanQuarantinesMalformedRepoStateDatabase`: asserts a `{not json` repo_state.json is quarantined. RED on commit 1's state, GREEN on commit 2.
- [x] Existing `TestDoltStatePreflightCleanCmdRemovesStaleArtifacts`: `healthy/` fixture updated to also write `repo_state.json` so it's genuinely healthy. Still passes.
- [x] Existing `TestQuarantinePhantomManagedDoltDatabasesQuarantinesRetiredReplacementDB`: `ga/` and `ga.replaced-pending/` fixtures updated to also write `repo_state.json` since the test asserts they survive. Still passes.
- [x] Full preflight + quarantine + retired-managed + remove-stale-managed regression suite: GREEN.
- [x] `go vet ./cmd/gc/` clean. `gofmt -d` clean.

All tests verified locally with `env -u GC_DOLT_*` to confirm
isolation under `t.TempDir()`. Test runs landed under
`/tmp/TestDoltStatePreflightClean…/` exclusively — no live-city
side-effects.

## Follow-up not addressed here

The `cmd/gc` dolt-state tests inherit `GC_DOLT_*` env vars from the
developer's shell because `resolveManagedDoltRuntimeLayout` consults
them before falling back to the cityPath-based default. Tests should
clear these env vars (`t.Setenv("GC_DOLT_DATA_DIR", "")`) so a
developer running `go test` against `cmd/gc` never deposits fixtures
into their live city's `.beads/dolt/`.

That's a separate test-isolation fix; this PR addresses the
production behavior so the preflight catches malformed fixtures even
when the env-leak happens.