### PR TITLE
fix(reconciler): defer config-drift drain on pool sessions with assigned work

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1206,6 +1206,32 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								}
 								continue
 							}
+							// Pool-routed sessions reach this branch when their
+							// config_hash drifts but they're not configured as
+							// named sessions (so restart-in-place at line 1173
+							// did not fire). If such a session is actively
+							// processing assigned work, draining mid-task would
+							// orphan the work bead (assignee still pointing at
+							// the dead session, status stuck at in_progress) and
+							// kill the agent before it can complete. Defer drain
+							// until the work completes; the next tick will see no
+							// assigned work and drain naturally. The same shape
+							// of protection is already applied to the
+							// orphan/suspended drain at line 754.
+							hasAssignedWork, assignedErr := sessionHasOpenAssignedWorkForReachableStore(cityPath, cfg, store, rigStores, *session)
+							if assignedErr != nil {
+								fmt.Fprintf(stderr, "session reconciler: checking assigned work before config-drift drain for %s: %v\n", name, assignedErr) //nolint:errcheck
+								continue
+							}
+							if hasAssignedWork {
+								if trace != nil {
+									trace.recordDecision("reconciler.session.config_drift", tp.TemplateName, name, "config_drift", string(TraceOutcomeDeferredActive), configDriftTracePayload(storedHash, currentHash, driftedFields, traceRecordPayload{
+										"active_reason": "live_assigned_work",
+									}), nil, "")
+								}
+								fmt.Fprintf(stdout, "Skipping config-drift drain for '%s': live assigned work found\n", name) //nolint:errcheck
+								continue
+							}
 							ddt := driftDrainTimeout
 							if ddt <= 0 {
 								ddt = defaultDrainTimeout

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -2462,6 +2462,51 @@ func TestReconcileSessionBeads_ConfigDriftInitiatesDrain(t *testing.T) {
 	}
 }
 
+// TestReconcileSessionBeads_ConfigDriftDeferredOnLiveAssignedWork verifies
+// that a pool session with live in-progress work assigned to it is NOT
+// drained when its config_hash drifts. Draining mid-work would orphan the
+// assigned bead (assignee still pointing at the dead session, status stuck
+// at in_progress) and kill the agent mid-task. The drain must wait until
+// the assigned work completes — the next reconcile tick will see no
+// assigned work and drain naturally.
+//
+// Regression for the 2026-05-12 live-edit drain cascade incident: editing
+// a city's .gc/settings.json on a running city flips the config hash and
+// triggers config-drift drains across the pool. The orphan/suspended
+// branch (line 754) already skips drain when sessionHasOpenAssignedWork
+// returns true; the config-drift branch did not. Pool sessions actively
+// processing work could be drained, orphaning their assignments. Named
+// sessions are protected separately via shouldDeferNamedSessionConfigDrift
+// (line 1161) so this case is specifically about pool-routed sessions
+// reaching the !restartedInPlace branch at line 1186.
+func TestReconcileSessionBeads_ConfigDriftDeferredOnLiveAssignedWork(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}
+	env.addRunningWorkerDesiredWithNewConfig()
+	session := env.createSessionBead("worker", "worker")
+	startedHash := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd"})
+	env.setSessionMetadata(&session, map[string]string{
+		"started_config_hash": startedHash,
+	})
+
+	// Assign live in-progress work to this session.
+	if _, err := env.store.Create(beads.Bead{
+		Title:    "in-flight work",
+		Type:     "task",
+		Status:   "in_progress",
+		Assignee: session.ID,
+	}); err != nil {
+		t.Fatalf("Create(work): %v", err)
+	}
+
+	env.reconcile([]beads.Bead{session})
+
+	if ds := env.dt.get(session.ID); ds != nil {
+		t.Fatalf("expected config-drift drain to be deferred for live assigned work, got drain=%+v stderr=%s",
+			ds, env.stderr.String())
+	}
+}
+
 func TestReconcileSessionBeads_NoDriftWhenHashMatches(t *testing.T) {
 	env := newReconcilerTestEnv()
 	env.cfg = &config.City{Agents: []config.Agent{{Name: "worker"}}}


### PR DESCRIPTION
## Summary

The pool-routed branch of config-drift handling drained any pool
session with stale `config_hash` as long as `pendingInteractionKeeps
Awake` returned false — without checking whether the session was
actively processing assigned work. This orphaned in-progress work
beads (assignee still pointing at the drained session, status stuck
at `in_progress`) and killed the agent mid-task.

The equivalent orphan/suspended branch at `session_reconciler.go:754`
already guards `beginSessionDrain` with
`sessionHasOpenAssignedWork`. This PR brings the config-drift branch
to parity.

## What this PR changes

In `session_reconciler.go` at the `!restartedInPlace` block (the
pool-routed branch of config-drift handling), adds a
`sessionHasOpenAssignedWorkForReachableStore` call before
`beginSessionDrain`. If the session has live in-progress work, the
drain is deferred with trace outcome `deferred_active` and active
reason `live_assigned_work`. The next reconcile tick will re-evaluate
and drain naturally once the work completes.

Named sessions are unaffected — they're already protected by
`shouldDeferNamedSessionConfigDrift` at line 1161 via the
`isNamedSessionBead` branch at line 1155.

## Test plan

- [x] New `TestReconcileSessionBeads_ConfigDriftDeferredOnLiveAssignedWork`: asserts a pool session with live in-progress work skips drain on config-drift. RED on parent (drain fires), GREEN here.
- [x] Existing `TestReconcileSessionBeads_ConfigDriftInitiatesDrain` still passes — drain still fires on config-drift when there's no live work.
- [x] Existing `TestReconcileSessionBeads_NoDriftWhenHashMatches` still passes.
- [x] Full `TestReconcileSessionBeads_*` suite GREEN.
- [x] `go vet ./cmd/gc/` clean. `gofmt -d` clean.

## How this was discovered

Observed during a live-edit drain cascade on 2026-05-12. An operator
edited the city's `.gc/settings.json` to fix an unrelated bug. The
~30s controller reconcile picked up the new config hash and triggered
drains across the entire pool. An ephemeral pool worker holding
`engine-polecat-2` (idle, no assigned work) was drained correctly. A
sibling worker `engine-polecat-1` happened to be actively processing
an assigned bead `en-dm4` (P0 fix) — it survived only because its
work bead routed through the orphan/suspended branch's existing
`sessionHasOpenAssignedWork` guard, NOT the config-drift branch.
Had the timing put it on the config-drift branch instead (different
shape of config edit, different ordering of checks), the bead would
have been stranded mid-fix.

This PR closes the symmetry gap so config-drift and orphan/suspended
treat live assigned work the same way.