### PR TITLE
feat(reload): add --soft to accept config drift without draining sessions

### DIFF
--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1225,6 +1225,18 @@ func (cr *CityRuntime) reloadConfigTraced(
 		trace.syncArms(time.Now().UTC(), nextCfg)
 	}
 
+	if cr.activeReload != nil && cr.activeReload.soft {
+		cityName := cr.cityName
+		if cityName == "" {
+			cityName = config.EffectiveCityName(nextCfg, "")
+		}
+		desired := buildDesiredState(cityName, cr.cityPath, time.Now().UTC(), nextCfg, cr.sp, cr.cityBeadStore(), cr.stderr)
+		accepted := acceptConfigDriftAcrossSessions(cr.cityBeadStore(), desired.State, cr.stderr)
+		if accepted > 0 {
+			fmt.Fprintf(cr.stdout, "%s: soft reload: accepted config drift on %d session(s)\n", cr.logPrefix, accepted) //nolint:errcheck // best-effort stdout
+		}
+	}
+
 	message := fmt.Sprintf("Config reloaded: %s (rev %s)",
 		configReloadSummary(oldAgentCount, oldRigCount, len(nextCfg.Agents), len(nextCfg.Rigs)),
 		shortRev(result.Revision))

--- a/cmd/gc/cmd_reload.go
+++ b/cmd/gc/cmd_reload.go
@@ -48,6 +48,15 @@ var (
 type reloadControlRequest struct {
 	Wait    bool   `json:"wait"`
 	Timeout string `json:"timeout,omitempty"`
+	// Soft requests that the reload tick accept any detected per-session
+	// config drift instead of draining the drifted sessions. The
+	// controller updates each open session's started_config_hash to the
+	// hash that the freshly reloaded config produces for that session,
+	// so the immediately-following reconcile tick sees no drift and
+	// doesn't fire config-drift drains. Sessions whose template no
+	// longer maps to a configured agent are NOT updated; normal
+	// orphan/suspended drain handles them on the next tick.
+	Soft bool `json:"soft,omitempty"`
 }
 
 type reloadControlReply struct {
@@ -61,12 +70,14 @@ type reloadControlReply struct {
 type reloadRequest struct {
 	wait       bool
 	timeout    time.Duration
+	soft       bool
 	acceptedCh chan reloadControlReply
 	doneCh     chan reloadControlReply
 }
 
 func newReloadCmd(stdout, stderr io.Writer) *cobra.Command {
 	var async bool
+	var soft bool
 	var timeoutValue string
 	cmd := &cobra.Command{
 		Use:   "reload [path]",
@@ -75,23 +86,34 @@ func newReloadCmd(stdout, stderr io.Writer) *cobra.Command {
 process one reload tick without restarting the city/controller.
 
 Reload may fetch configured remote packs before recomputing effective
-config. Existing per-session restarts may still happen if normal config
-drift rules require them.`,
+config. By default, per-session restarts may still happen if normal
+config drift rules require them.
+
+With --soft, the controller accepts any detected per-session config
+drift instead of draining the drifted sessions: each open session's
+recorded config hash is updated to the hash the freshly reloaded
+config produces for it, so the immediately-following reconcile tick
+sees no drift and no config-drift drains fire. Useful when editing a
+running city's .gc/settings.json without disrupting in-flight work.
+Sessions whose template no longer maps to a configured agent are
+NOT updated; normal orphan/suspended drain handles them on the next
+tick.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			timeoutChanged := cmd.Flags().Changed("timeout")
-			if cmdReload(args, async, timeoutValue, timeoutChanged, stdout, stderr) != 0 {
+			if cmdReload(args, async, soft, timeoutValue, timeoutChanged, stdout, stderr) != 0 {
 				return errExit
 			}
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&async, "async", false, "Return after the controller accepts the reload request")
+	cmd.Flags().BoolVar(&soft, "soft", false, "Accept config drift on open sessions instead of draining them")
 	cmd.Flags().StringVar(&timeoutValue, "timeout", "5m", "How long to wait for reload completion")
 	return cmd
 }
 
-func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
+func cmdReload(args []string, async bool, soft bool, timeoutValue string, timeoutChanged bool, stdout, stderr io.Writer) int {
 	cityPath, err := resolveCommandCity(args)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc reload: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -103,7 +125,7 @@ func cmdReload(args []string, async bool, timeoutValue string, timeoutChanged bo
 		return 1
 	}
 
-	req := reloadControlRequest{Wait: !async}
+	req := reloadControlRequest{Wait: !async, Soft: soft}
 	if !async {
 		timeout, err := time.ParseDuration(timeoutValue)
 		if err != nil {

--- a/cmd/gc/cmd_reload_test.go
+++ b/cmd/gc/cmd_reload_test.go
@@ -51,7 +51,7 @@ func TestCmdReloadApplied(t *testing.T) {
 	reloadUnavailableMessageHook = func(string) string { return "" }
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, "30s", true, &stdout, &stderr); code != 0 {
+	if code := cmdReload([]string{dir}, false, false, "30s", true, &stdout, &stderr); code != 0 {
 		t.Fatalf("cmdReload = %d; stderr=%s", code, stderr.String())
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "Config reloaded: 1 agents, 0 rigs (rev abc123def456)" {
@@ -67,7 +67,7 @@ func TestCmdReloadAsyncExplicitTimeoutInvalid(t *testing.T) {
 	writeCityTOML(t, dir, "test", "mayor")
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, true, "30s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, true, false, "30s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "--async and --timeout cannot be used together") {
@@ -99,7 +99,7 @@ func TestCmdReloadControllerUnavailableUsesRicherMessage(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: city failed to start under supervisor: fetching packs: auth denied: connecting to controller: dial failed" {
@@ -130,7 +130,7 @@ func TestCmdReloadControllerUnresponsiveUsesRicherMessage(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: controller is running but not responding: reading response: i/o timeout" {
@@ -157,7 +157,7 @@ func TestCmdReloadPreservesProtocolErrors(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	if got := strings.TrimSpace(stderr.String()); got != "gc reload: parsing response: invalid character 'o' in literal null" {
@@ -188,7 +188,7 @@ func TestCmdReloadFailedReplyPrintsWarnings(t *testing.T) {
 	reloadUnavailableMessageHook = func(string) string { return "" }
 
 	var stdout, stderr bytes.Buffer
-	if code := cmdReload([]string{dir}, false, "5s", true, &stdout, &stderr); code != 1 {
+	if code := cmdReload([]string{dir}, false, false, "5s", true, &stdout, &stderr); code != 1 {
 		t.Fatalf("cmdReload = %d, want 1", code)
 	}
 	got := stderr.String()

--- a/cmd/gc/controller.go
+++ b/cmd/gc/controller.go
@@ -390,6 +390,7 @@ func handleReloadSocketCmd(conn net.Conn, payload string, ch chan reloadRequest)
 	req := reloadRequest{
 		wait:       wire.Wait,
 		timeout:    timeout,
+		soft:       wire.Soft,
 		acceptedCh: make(chan reloadControlReply, 1),
 		doneCh:     make(chan reloadControlReply, 1),
 	}

--- a/cmd/gc/soft_reload.go
+++ b/cmd/gc/soft_reload.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// acceptConfigDriftAcrossSessions writes the current per-session config
+// hash into every open session bead's started_config_hash metadata
+// whose desired-state entry produces a different hash than the one
+// recorded on the bead. After the function returns, the reconciler's
+// drift-detection check (storedHash != currentHash) sees no drift for
+// any updated session, so the immediately-following reconcile tick
+// proceeds without firing config-drift drains for those sessions.
+//
+// Used by `gc reload --soft` so an operator editing a running city's
+// .gc/settings.json doesn't drain every drifted session — the new
+// config is accepted in-place instead. The caller is expected to have
+// just rebuilt desired state from the freshly reloaded config.
+//
+// Sessions are skipped (no metadata write) when:
+//   - the session is closed
+//   - the session has no session_name metadata
+//   - the session has no started_config_hash yet (the existing drift
+//     check already skips these — the next first-start path will
+//     stamp the right value)
+//   - the session's name has no entry in desired (orphaned by the
+//     config edit; normal orphan/suspended drain handles them on the
+//     next tick)
+//   - the recomputed current hash already equals the stored hash
+//
+// The hash computation mirrors the canonical reconciler path:
+// templateParamsToConfig → applyTemplateOverridesToConfig →
+// runtime.CoreFingerprint. Any future change to that sequence in the
+// reconciler must be mirrored here, otherwise --soft will write a
+// stale hash and the next tick will still detect drift.
+//
+// Returns the number of session beads whose started_config_hash was
+// updated.
+func acceptConfigDriftAcrossSessions(
+	store beads.Store,
+	desired map[string]TemplateParams,
+	stderr io.Writer,
+) int {
+	if store == nil || len(desired) == 0 {
+		return 0
+	}
+	sessionBeads, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		fmt.Fprintf(stderr, "soft reload: listing session beads: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 0
+	}
+	open := sessionBeads.Open()
+	if len(open) == 0 {
+		return 0
+	}
+
+	updated := 0
+	for i := range open {
+		session := open[i]
+		if session.Status == "closed" {
+			continue
+		}
+		name := strings.TrimSpace(session.Metadata["session_name"])
+		if name == "" {
+			continue
+		}
+		storedHash := strings.TrimSpace(session.Metadata["started_config_hash"])
+		if storedHash == "" {
+			continue
+		}
+		tp, ok := desired[name]
+		if !ok {
+			continue
+		}
+		agentCfg := templateParamsToConfig(tp)
+		applyTemplateOverridesToConfig(&agentCfg, session, tp)
+		currentHash := runtime.CoreFingerprint(agentCfg)
+		if storedHash == currentHash {
+			continue
+		}
+		if err := store.SetMetadata(session.ID, "started_config_hash", currentHash); err != nil {
+			fmt.Fprintf(stderr, "soft reload: updating started_config_hash for %s: %v\n", name, err) //nolint:errcheck // best-effort stderr
+			continue
+		}
+		updated++
+	}
+	return updated
+}

--- a/cmd/gc/soft_reload_test.go
+++ b/cmd/gc/soft_reload_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+func TestAcceptConfigDriftAcrossSessions_UpdatesStaleHash(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": "stale-hash-deadbeef",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	desired := map[string]TemplateParams{
+		"worker": {
+			Command:      "new-cmd",
+			SessionName:  "worker",
+			TemplateName: "worker",
+		},
+	}
+	wantHash := runtime.CoreFingerprint(runtime.Config{Command: "new-cmd"})
+	if wantHash == "stale-hash-deadbeef" {
+		t.Fatalf("test setup: stale fixture coincidentally equals fresh hash %q", wantHash)
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
+	if got != 1 {
+		t.Fatalf("updated = %d, want 1 (stderr=%s)", got, stderr.String())
+	}
+
+	updated, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if updated.Metadata["started_config_hash"] != wantHash {
+		t.Errorf("started_config_hash = %q, want %q", updated.Metadata["started_config_hash"], wantHash)
+	}
+}
+
+// TestAcceptConfigDriftAcrossSessions_SkipsUnstartedSessions asserts that a
+// session that has never recorded a started_config_hash (still in the
+// startup window) is left alone. Stamping a hash on an unstarted session
+// would interfere with the reconciler's first-start path; the reconciler
+// already skips drift detection while started_config_hash is empty.
+func TestAcceptConfigDriftAcrossSessions_SkipsUnstartedSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name": "worker",
+			"template":     "worker",
+			// no started_config_hash — session hasn't reached started state yet
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	desired := map[string]TemplateParams{
+		"worker": {Command: "new-cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
+	if got != 0 {
+		t.Fatalf("updated = %d, want 0 for unstarted session (stderr=%s)", got, stderr.String())
+	}
+
+	unchanged, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if _, present := unchanged.Metadata["started_config_hash"]; present {
+		t.Errorf("started_config_hash unexpectedly written for unstarted session: %q", unchanged.Metadata["started_config_hash"])
+	}
+}
+
+// TestAcceptConfigDriftAcrossSessions_SkipsOrphanedSessions asserts that a
+// session whose name has no entry in the freshly-built desired state
+// (orphaned by the config edit — e.g. an agent was removed) is left
+// untouched. The orphan/suspended branch of the reconciler handles such
+// sessions on the next tick; soft-reload only updates sessions still
+// mapped to a configured agent.
+func TestAcceptConfigDriftAcrossSessions_SkipsOrphanedSessions(t *testing.T) {
+	store := beads.NewMemStore()
+	const staleHash = "stale-orphan-hash"
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "removed-agent",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "removed-agent",
+			"template":            "removed-agent",
+			"started_config_hash": staleHash,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	// Desired state has a different agent — the original session is orphaned.
+	desired := map[string]TemplateParams{
+		"surviving-agent": {Command: "cmd", SessionName: "surviving-agent", TemplateName: "surviving-agent"},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
+	if got != 0 {
+		t.Fatalf("updated = %d, want 0 for orphaned session (stderr=%s)", got, stderr.String())
+	}
+
+	unchanged, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if unchanged.Metadata["started_config_hash"] != staleHash {
+		t.Errorf("started_config_hash changed for orphan = %q, want %q", unchanged.Metadata["started_config_hash"], staleHash)
+	}
+}
+
+// TestAcceptConfigDriftAcrossSessions_LeavesNonDriftingSessionsAlone asserts
+// that a session whose stored hash already matches the recomputed current
+// hash is not rewritten — the function returns 0 and metadata is
+// untouched. This keeps soft-reload a no-op for the common no-drift case.
+func TestAcceptConfigDriftAcrossSessions_LeavesNonDriftingSessionsAlone(t *testing.T) {
+	store := beads.NewMemStore()
+	matchingHash := runtime.CoreFingerprint(runtime.Config{Command: "cmd"})
+	sessionBead, err := store.Create(beads.Bead{
+		Title:  "worker",
+		Type:   sessionBeadType,
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"session_name":        "worker",
+			"template":            "worker",
+			"started_config_hash": matchingHash,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create(session): %v", err)
+	}
+
+	desired := map[string]TemplateParams{
+		"worker": {Command: "cmd", SessionName: "worker", TemplateName: "worker"},
+	}
+
+	var stderr bytes.Buffer
+	got := acceptConfigDriftAcrossSessions(store, desired, &stderr)
+	if got != 0 {
+		t.Fatalf("updated = %d, want 0 (no drift) — stderr=%s", got, stderr.String())
+	}
+
+	unchanged, err := store.Get(sessionBead.ID)
+	if err != nil {
+		t.Fatalf("Get(session): %v", err)
+	}
+	if unchanged.Metadata["started_config_hash"] != matchingHash {
+		t.Errorf("started_config_hash rewritten unexpectedly = %q, want %q", unchanged.Metadata["started_config_hash"], matchingHash)
+	}
+}

--- a/docs/guides/gc-reload-design.md
+++ b/docs/guides/gc-reload-design.md
@@ -36,12 +36,14 @@ work.
 ### Command
 
 ```text
-gc reload [path] [--async] [--timeout <duration>]
+gc reload [path] [--async] [--soft] [--timeout <duration>]
 ```
 
 - `[path]` is optional and follows existing city-command resolution.
 - `--async` returns after the current city controller accepts the reload
   request.
+- `--soft` accepts per-session config drift instead of draining the
+  drifted sessions — see [Soft Reload](#soft-reload) below.
 - `--timeout` applies only to synchronous mode, must be strictly
   positive, and defaults to `5m`.
 - `--async --timeout ...` is invalid when `--timeout` is explicitly set.
@@ -124,10 +126,70 @@ CLI projection.
 
 - does not restart the city/controller
 - may still cause normal per-session restarts if the reconciler detects
-  config drift under the existing rules
+  config drift under the existing rules — unless `--soft` is passed, in
+  which case the detected drift is accepted in place (see [Soft Reload](#soft-reload))
 - preserves existing service-manager reload behavior
 - works while the city is suspended, as long as the controller is still
   running
+
+### Soft Reload
+
+Editing a running city's effective config — most often via
+`.gc/settings.json` or one of the materialized overlay files — changes
+each affected agent's `runtime.Config` and therefore its
+`runtime.CoreFingerprint`. The reconciler sees the stored
+`started_config_hash` no longer match what it would now produce and
+treats the session as drifted, normally triggering a
+`config-drift` drain. For idle pool slots this is fine; for sessions
+holding live in-flight work it can be disruptive even with the
+existing in-flight-work guards in place.
+
+`gc reload --soft` accepts the drift in place instead of draining:
+
+1. The CLI sends `{soft: true}` in the reload control request.
+2. The controller runs the normal config reload (remote pack fetch,
+   parse, validation, apply). If that fails, `--soft` is a no-op —
+   reload returns `failed` exactly as it would without `--soft`.
+3. Once the new config is live, the controller rebuilds desired state
+   and walks every open session bead. For each session whose
+   `session_name` has a desired-state entry and whose recorded
+   `started_config_hash` differs from the value the new config would
+   produce, the controller writes the new hash into
+   `started_config_hash`. Sessions that have not yet stamped a
+   `started_config_hash` (still in the startup window) are skipped —
+   they will record the right value once they finish starting.
+   Sessions whose `session_name` has no desired-state entry are
+   skipped — the orphan/suspended drain handles them on the next tick.
+4. The immediately-following reconcile tick sees no drift on the
+   updated sessions and does not fire `config-drift` drains for them.
+5. The CLI prints `soft reload: accepted config drift on N session(s)`
+   on stdout when one or more sessions were updated, alongside the
+   normal `Config reloaded: ...` line.
+
+Soft reload is **not** a substitute for restarting sessions when a
+config change requires a process restart to take effect (e.g.
+changing the binary path or command-line). It updates only the
+recorded hash so the reconciler stops trying to drain the session;
+the live session continues running with the *old* command for the
+rest of its life. Use `--soft` for changes that are cosmetic to a
+running session — hook commands, matchers, environment variables that
+the session reads via lookup rather than once-at-launch — or any time
+you want to absorb a config edit without disrupting in-flight work
+and intend to restart sessions naturally on the next idle moment.
+
+Recommended live-edit workflow:
+
+```bash
+# 1. Edit your city's .gc/settings.json (or any other configured file)
+$EDITOR ~/path/to/city/.gc/settings.json
+
+# 2. Apply the change without draining live sessions
+gc reload --soft
+
+# 3. (Optional) Force-cycle individual sessions later if their
+#    in-process state needs to pick up the new config
+gc session reset <name>
+```
 
 ### Remote Pack Behavior
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1812,8 +1812,19 @@ Force the current city controller to re-read effective config and
 process one reload tick without restarting the city/controller.
 
 Reload may fetch configured remote packs before recomputing effective
-config. Existing per-session restarts may still happen if normal config
-drift rules require them.
+config. By default, per-session restarts may still happen if normal
+config drift rules require them.
+
+With `--soft`, the controller accepts any detected per-session config
+drift instead of draining the drifted sessions: each open session's
+recorded config hash is updated to the hash the freshly reloaded config
+produces for it, so the immediately-following reconcile tick sees no
+drift and no config-drift drains fire. Useful when editing a running
+city's `.gc/settings.json` without disrupting in-flight work. Sessions
+whose template no longer maps to a configured agent are NOT updated;
+normal orphan/suspended drain handles them on the next tick. See
+[Soft Reload](../guides/gc-reload-design.md#soft-reload) for the full
+semantics and when to use it.
 
 ```
 gc reload [path] [flags]
@@ -1822,6 +1833,7 @@ gc reload [path] [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--async` | bool |  | Return after the controller accepts the reload request |
+| `--soft` | bool |  | Accept config drift on open sessions instead of draining them |
 | `--timeout` | string | `5m` | How long to wait for reload completion |
 
 ## gc restart


### PR DESCRIPTION
## Summary

Adds a `--soft` flag to `gc reload`. By default, `gc reload` runs the
standard reconcile pass against the freshly reloaded effective config
and may drain any session whose recorded `started_config_hash` no
longer matches what the new config would produce — live config-drift
behavior. With `--soft`, the controller accepts the drift in place:
each open session's recorded hash is updated to what the new config
would produce, so the immediately-following reconcile tick sees no
drift and no `config-drift` drains fire.

## How it works

1. CLI: `--soft` sets `Soft: true` on `reloadControlRequest`.
2. Controller: parses `wire.Soft` into the internal `reloadRequest`.
3. `reloadConfigTraced` runs the normal config reload. If that fails,
   `--soft` is a no-op — reload returns `failed` exactly as it would
   without `--soft`.
4. Once the new config is live, the controller calls
   `acceptConfigDriftAcrossSessions(...)` which:
   - rebuilds desired state from the new config
   - walks every open session bead
   - for each session with a desired-state entry and a recorded
     `started_config_hash` that differs from the value the new config
     would produce, writes the new hash via `store.SetMetadata`
5. The immediately-following reconcile tick sees no drift on the
   updated sessions and proceeds without firing drains.
6. CLI prints `soft reload: accepted config drift on N session(s)`
   alongside the normal `Config reloaded: ...` line.

## Edge cases (covered by unit tests)

- Sessions still in the startup window (no `started_config_hash`) are
  skipped — stamping a hash on an unstarted session would interfere
  with the first-start path.
- Sessions whose `session_name` has no desired-state entry (orphaned
  by the config edit) are skipped — orphan/suspended drain handles
  them on the next tick.
- Sessions whose recorded hash already matches the recomputed current
  hash are skipped — soft reload is a no-op for the common no-drift
  case.

## Backward compatibility

- `Soft` is `omitempty` in the wire format. Old clients (without
  `--soft`) serialize byte-identical requests to the pre-change wire
  format; new controllers see `false` and run the original path.
- Old controllers receiving a `--soft` request silently ignore the
  field and run the original code path. The CLI returns `applied` as
  before; the soft-reload behavior is silently degraded to a normal
  reload. No protocol error.

## Soft reload is NOT a substitute for restart

It updates only the recorded hash so the reconciler stops trying to
drain the session; the live session continues running with the
*old* command. Use `--soft` for changes that are cosmetic to a
running session (hook commands, matchers, env vars read via lookup)
or any time you want to absorb a config edit without disrupting
in-flight work and intend to recycle sessions naturally on the next
idle moment.

## Test plan

- [x] New `TestAcceptConfigDriftAcrossSessions_UpdatesStaleHash`: stale hash gets rewritten to the new value.
- [x] New `TestAcceptConfigDriftAcrossSessions_SkipsUnstartedSessions`: empty-hash session left alone.
- [x] New `TestAcceptConfigDriftAcrossSessions_SkipsOrphanedSessions`: session whose name isn't in desired is left alone.
- [x] New `TestAcceptConfigDriftAcrossSessions_LeavesNonDriftingSessionsAlone`: no-op when no drift.
- [x] Existing `TestCmdReload*` / `TestSendReload*` / `TestHandleReloadSocketCmd*` / `TestReloadControlRequest*` updated for new signature; all pass.
- [x] Full `TestReconcileSessionBeads_*` regression GREEN — soft-reload doesn't touch the reconciler.
- [x] `go vet ./cmd/gc/` clean. `gofmt -d` clean.

## How this was motivated

The 2026-05-12 live-edit incident: a single `.gc/settings.json` edit
flipped the city's config hash and triggered drains across every
pool slot. The in-flight-work guards (recently extended to the
config-drift branch) prevented stranding, but idle pool slots still
drained on every edit. `gc reload --soft` makes the safe
edit-and-reload pattern a single command instead of an
"edit → restart → restart-recovery" cycle.

## Docs

- `docs/guides/gc-reload-design.md`: new "Soft Reload" section
  describing semantics, the workflow it enables, and the live-edit
  hazard it addresses.
- `docs/reference/cli.md`: `--soft` added to the `gc reload` flag
  table with a summary and link to the design doc.