### PR TITLE
feat(prompt): expose provider context vars + add templateFirst helper

### DIFF
--- a/cmd/gc/cmd_prime.go
+++ b/cmd/gc/cmd_prime.go
@@ -273,6 +273,7 @@ func doPrimeWithHookFormat(args []string, stdout, stderr io.Writer, hookMode boo
 		var ctx PromptContext
 		if a.PromptTemplate != "" || hookMode || sessionTemplateContext {
 			ctx = buildPrimeContext(cityPath, cityName, &a, cfg.Rigs, stderr)
+			ctx.ProviderKey, ctx.ProviderDisplayName = providerInfoForAgent(&a, &cfg.Workspace, cfg.Providers)
 		}
 		if a.PromptTemplate != "" {
 			fragments := effectivePromptFragments(

--- a/cmd/gc/prompt.go
+++ b/cmd/gc/prompt.go
@@ -34,10 +34,20 @@ type PromptContext struct {
 	WorkDir       string
 	IssuePrefix   string
 	Branch        string
-	DefaultBranch string            // e.g. "main" — from git symbolic-ref origin/HEAD
-	WorkQuery     string            // command to find available work (from Agent.EffectiveWorkQuery)
-	SlingQuery    string            // command template to route work to this agent (from Agent.EffectiveSlingQuery)
-	Env           map[string]string // from Agent.Env — custom vars
+	DefaultBranch string // e.g. "main" — from git symbolic-ref origin/HEAD
+	WorkQuery     string // command to find available work (from Agent.EffectiveWorkQuery)
+	SlingQuery    string // command template to route work to this agent (from Agent.EffectiveSlingQuery)
+	// ProviderKey is the resolved provider name for this agent (e.g. "claude",
+	// "codex", or a custom provider name from the city's [providers] section).
+	// Templates can branch on this via {{ .ProviderKey }} or feed it to
+	// {{ templateFirst }} for per-provider fragment selection.
+	ProviderKey string
+	// ProviderDisplayName is the human-readable name for the resolved provider
+	// (e.g. "Claude Code", "Codex CLI"). Resolved from city providers, then
+	// builtins, then the builtin family of a custom provider; falls back to
+	// ProviderKey when nothing else matches.
+	ProviderDisplayName string
+	Env                 map[string]string // from Agent.Env — custom vars
 }
 
 // PromptRenderResult holds the rendered text plus the version and rendered
@@ -95,8 +105,13 @@ func renderPromptWithMeta(fs fsys.FS, cityPath, cityName, templatePath string, c
 		}
 	}
 
-	tmpl := template.New("prompt").
-		Funcs(promptFuncMap(cityName, sessionTemplate, store)).
+	// templateFirst (registered via promptFuncMap) needs to call tmpl.Lookup
+	// at execute time. The closure captures &tmpl by reference so the func
+	// observes the parsed template (with all fragments registered) rather
+	// than nil at funcmap-construction time.
+	var tmpl *template.Template
+	tmpl = template.New("prompt").
+		Funcs(promptFuncMap(cityName, sessionTemplate, store, func() *template.Template { return tmpl })).
 		Option("missingkey=zero")
 
 	// Load shared templates from pack dirs (lower priority).
@@ -274,6 +289,8 @@ func buildTemplateData(ctx PromptContext) map[string]string {
 	m["DefaultBranch"] = ctx.DefaultBranch
 	m["WorkQuery"] = ctx.WorkQuery
 	m["SlingQuery"] = ctx.SlingQuery
+	m["ProviderKey"] = ctx.ProviderKey
+	m["ProviderDisplayName"] = ctx.ProviderDisplayName
 	return m
 }
 
@@ -320,8 +337,11 @@ func defaultBranchForRig(rigName string, rigs []config.Rig, dir string) string {
 // promptFuncMap returns template functions available in prompt templates.
 // sessionTemplate is the custom session naming template (empty = default).
 // store is used by the "session" function to look up bead-derived session
-// names; nil falls back to legacy naming.
-func promptFuncMap(cityName, sessionTemplate string, store beads.Store) template.FuncMap {
+// names; nil falls back to legacy naming. parentTmpl is a getter for the
+// template being rendered; it is invoked at execute time (not at funcmap
+// construction time) so functions can look up fragments parsed after the
+// funcmap was wired.
+func promptFuncMap(cityName, sessionTemplate string, store beads.Store, parentTmpl func() *template.Template) template.FuncMap {
 	return template.FuncMap{
 		"cmd": func() string {
 			return filepath.Base(os.Args[0])
@@ -333,5 +353,74 @@ func promptFuncMap(cityName, sessionTemplate string, store beads.Store) template
 			_, name := config.ParseQualifiedName(qualifiedName)
 			return name
 		},
+		// templateFirst executes the first registered template fragment whose
+		// name matches one of the provided candidates, using `data` as the
+		// template context. Returns "" when no candidate is registered (silent
+		// fallback — pass a guaranteed-present "default" name last to enforce
+		// a match). Empty candidate names are skipped.
+		//
+		// Typical use:
+		//   {{ templateFirst . (printf "slash-note-%s" .ProviderKey) "slash-note-default" }}
+		"templateFirst": func(data any, names ...string) (string, error) {
+			t := parentTmpl()
+			if t == nil {
+				return "", nil
+			}
+			for _, name := range names {
+				if name == "" {
+					continue
+				}
+				frag := t.Lookup(name)
+				if frag == nil {
+					continue
+				}
+				var buf bytes.Buffer
+				if err := frag.Execute(&buf, data); err != nil {
+					return "", err
+				}
+				return buf.String(), nil
+			}
+			return "", nil
+		},
 	}
+}
+
+// providerInfoForAgent returns the resolved provider key and human-readable
+// display name for an agent, without performing PATH lookups (which the full
+// config.ResolveProvider performs and which are inappropriate for prompt
+// rendering). Resolution chain: agent.Provider > workspace.Provider. Returns
+// empty strings when no provider name is configured.
+func providerInfoForAgent(a *config.Agent, ws *config.Workspace, cityProviders map[string]config.ProviderSpec) (key, displayName string) {
+	if a == nil {
+		return "", ""
+	}
+	name := a.Provider
+	if name == "" && ws != nil {
+		name = ws.Provider
+	}
+	if name == "" {
+		return "", ""
+	}
+	return name, providerDisplayNameFor(name, cityProviders)
+}
+
+// providerDisplayNameFor returns the human-readable name for a provider.
+// Resolution: city providers (explicit DisplayName) > builtin spec for the
+// raw name > builtin spec for the BuiltinFamily ancestor > the name itself.
+func providerDisplayNameFor(name string, cityProviders map[string]config.ProviderSpec) string {
+	if name == "" {
+		return ""
+	}
+	if spec, ok := cityProviders[name]; ok && spec.DisplayName != "" {
+		return spec.DisplayName
+	}
+	if spec, ok := config.BuiltinProviders()[name]; ok && spec.DisplayName != "" {
+		return spec.DisplayName
+	}
+	if family := config.BuiltinFamily(name, cityProviders); family != "" && family != name {
+		if spec, ok := config.BuiltinProviders()[family]; ok && spec.DisplayName != "" {
+			return spec.DisplayName
+		}
+	}
+	return name
 }

--- a/cmd/gc/prompt_test.go
+++ b/cmd/gc/prompt_test.go
@@ -800,3 +800,183 @@ func TestEffectivePromptFragmentsDedupsAcrossLayers(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderPromptProviderContextVarsExposed(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/test.template.md"] = []byte(
+		"key={{ .ProviderKey }} display={{ .ProviderDisplayName }}")
+	ctx := PromptContext{ProviderKey: "claude", ProviderDisplayName: "Claude Code"}
+	got := renderPrompt(f, "/city", "", "prompts/test.template.md", ctx, "", io.Discard, nil, nil, nil)
+	want := "key=claude display=Claude Code"
+	if got != want {
+		t.Errorf("provider vars = %q, want %q", got, want)
+	}
+}
+
+func TestRenderPromptTemplateFirstPicksFirstRegistered(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/shared/frags.template.md"] = []byte(
+		`{{ define "note-claude" }}CLAUDE{{ end }}{{ define "note-default" }}DEFAULT{{ end }}`)
+	f.Files["/city/prompts/test.template.md"] = []byte(
+		`{{ templateFirst . "note-claude" "note-default" }}`)
+	got := renderPrompt(f, "/city", "", "prompts/test.template.md", PromptContext{}, "", io.Discard, nil, nil, nil)
+	if got != "CLAUDE" {
+		t.Errorf("templateFirst first-wins = %q, want %q", got, "CLAUDE")
+	}
+}
+
+func TestRenderPromptTemplateFirstFallsBackWhenFirstMissing(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/shared/frags.template.md"] = []byte(
+		`{{ define "note-default" }}DEFAULT{{ end }}`)
+	f.Files["/city/prompts/test.template.md"] = []byte(
+		`{{ templateFirst . "note-codex" "note-default" }}`)
+	got := renderPrompt(f, "/city", "", "prompts/test.template.md", PromptContext{}, "", io.Discard, nil, nil, nil)
+	if got != "DEFAULT" {
+		t.Errorf("templateFirst fallback = %q, want %q", got, "DEFAULT")
+	}
+}
+
+func TestRenderPromptTemplateFirstReturnsEmptyWhenNoneRegistered(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/test.template.md"] = []byte(
+		`prefix:{{ templateFirst . "note-codex" "note-claude" }}:suffix`)
+	got := renderPrompt(f, "/city", "", "prompts/test.template.md", PromptContext{}, "", io.Discard, nil, nil, nil)
+	want := "prefix::suffix"
+	if got != want {
+		t.Errorf("templateFirst all-missing = %q, want %q", got, want)
+	}
+}
+
+func TestRenderPromptTemplateFirstComposesWithProviderKey(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/shared/frags.template.md"] = []byte(
+		`{{ define "note-claude" }}slash commands{{ end }}` +
+			`{{ define "note-codex" }}subcommands{{ end }}` +
+			`{{ define "note-default" }}commands{{ end }}`)
+	f.Files["/city/prompts/test.template.md"] = []byte(
+		`{{ templateFirst . (printf "note-%s" .ProviderKey) "note-default" }}`)
+
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"claude", "slash commands"},
+		{"codex", "subcommands"},
+		{"gemini", "commands"}, // falls through to default
+		{"", "commands"},       // empty key skipped, falls through
+	}
+	for _, tc := range cases {
+		got := renderPrompt(f, "/city", "", "prompts/test.template.md",
+			PromptContext{ProviderKey: tc.key}, "", io.Discard, nil, nil, nil)
+		if got != tc.want {
+			t.Errorf("ProviderKey=%q: got %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestRenderPromptTemplateFirstSkipsEmptyName(t *testing.T) {
+	f := fsys.NewFake()
+	f.Files["/city/prompts/shared/frags.template.md"] = []byte(
+		`{{ define "winner" }}WIN{{ end }}`)
+	f.Files["/city/prompts/test.template.md"] = []byte(
+		`{{ templateFirst . "" "winner" }}`)
+	got := renderPrompt(f, "/city", "", "prompts/test.template.md", PromptContext{}, "", io.Discard, nil, nil, nil)
+	if got != "WIN" {
+		t.Errorf("templateFirst skip-empty = %q, want %q", got, "WIN")
+	}
+}
+
+func TestProviderInfoForAgentResolvesAgentOverWorkspace(t *testing.T) {
+	ws := &config.Workspace{Provider: "codex"}
+	a := &config.Agent{Provider: "claude"}
+	gotKey, gotName := providerInfoForAgent(a, ws, nil)
+	if gotKey != "claude" {
+		t.Errorf("key = %q, want %q (agent.Provider should win over workspace.Provider)", gotKey, "claude")
+	}
+	if gotName != "Claude Code" {
+		t.Errorf("displayName = %q, want %q", gotName, "Claude Code")
+	}
+}
+
+func TestProviderInfoForAgentFallsBackToWorkspace(t *testing.T) {
+	ws := &config.Workspace{Provider: "codex"}
+	a := &config.Agent{}
+	gotKey, gotName := providerInfoForAgent(a, ws, nil)
+	if gotKey != "codex" {
+		t.Errorf("key = %q, want %q", gotKey, "codex")
+	}
+	if gotName != "Codex CLI" {
+		t.Errorf("displayName = %q, want %q", gotName, "Codex CLI")
+	}
+}
+
+func TestProviderInfoForAgentEmptyWhenNoneSet(t *testing.T) {
+	gotKey, gotName := providerInfoForAgent(&config.Agent{}, &config.Workspace{}, nil)
+	if gotKey != "" || gotName != "" {
+		t.Errorf("got (%q, %q), want both empty", gotKey, gotName)
+	}
+}
+
+func TestEmbeddedMayorPromptRendersProviderSpecificSlashNote(t *testing.T) {
+	// Round-trip the embedded mayor.md source through the renderer the same
+	// way `gc init` will (copy verbatim to agents/mayor/prompt.template.md,
+	// then render). Verifies the {{ templateFirst }} mechanism resolves the
+	// per-provider variant from the inline {{ define }} blocks at the top
+	// of the file.
+	source, err := defaultPrompts.ReadFile("prompts/mayor.md")
+	if err != nil {
+		t.Fatalf("read embedded mayor.md: %v", err)
+	}
+
+	cases := []struct {
+		key            string
+		wantContains   string
+		wantNotContain string
+	}{
+		{
+			key:            "claude",
+			wantContains:   "Claude Code slash commands",
+			wantNotContain: "provider's command",
+		},
+		{
+			key:            "codex",
+			wantContains:   "provider's command",
+			wantNotContain: "Claude Code",
+		},
+		{
+			key:            "", // no provider configured → fallback default
+			wantContains:   "provider's command",
+			wantNotContain: "Claude Code",
+		},
+	}
+
+	for _, tc := range cases {
+		f := fsys.NewFake()
+		f.Files["/city/agents/mayor/prompt.template.md"] = source
+		got := renderPrompt(f, "/city", "test-city",
+			"agents/mayor/prompt.template.md",
+			PromptContext{ProviderKey: tc.key},
+			"", io.Discard, nil, nil, nil)
+		if !strings.Contains(got, tc.wantContains) {
+			t.Errorf("ProviderKey=%q: rendered prompt missing %q\n--- got ---\n%s",
+				tc.key, tc.wantContains, got)
+		}
+		if tc.wantNotContain != "" && strings.Contains(got, tc.wantNotContain) {
+			t.Errorf("ProviderKey=%q: rendered prompt should not contain %q\n--- got ---\n%s",
+				tc.key, tc.wantNotContain, got)
+		}
+	}
+}
+
+func TestProviderDisplayNameFallsBackToKeyForUnknownProvider(t *testing.T) {
+	ws := &config.Workspace{Provider: "totally-unknown"}
+	a := &config.Agent{}
+	gotKey, gotName := providerInfoForAgent(a, ws, nil)
+	if gotKey != "totally-unknown" {
+		t.Errorf("key = %q, want %q", gotKey, "totally-unknown")
+	}
+	if gotName != "totally-unknown" {
+		t.Errorf("displayName = %q, want %q (unknown provider should fall back to key)", gotName, "totally-unknown")
+	}
+}

--- a/cmd/gc/prompts/mayor.md
+++ b/cmd/gc/prompts/mayor.md
@@ -8,13 +8,23 @@ manage rigs and agents, dispatch tasks, and monitor progress.
 Use `/gc-work`, `/gc-dispatch`, `/gc-agents`, `/gc-rigs`, `/gc-mail`,
 or `/gc-city` to load command reference for any topic.
 
+{{ define "mayor-slash-note-claude" -}}
 Note: those `/gc-*` entries are Claude Code slash commands (skill references),
-not bash commands — do not invent `gc mail list`, `gc city status`, etc. from
-them. For bead work use `gc bd ...`, for city-level status use `gc status`,
-and for mail use `gc mail <subcommand>` where subcommands are `inbox`, `send`,
-`check`, `read`, `peek`, `reply`, `mark-read`, `mark-unread`, `thread`,
-`count`, `archive`, `delete`. If unsure of exact subcommand shape, run
-`gc <cmd> --help` rather than guessing.
+not bash commands.
+{{- end }}
+{{ define "mayor-slash-note-default" -}}
+Note: those `/gc-*` entries name skills exposed by your provider's command
+palette, not bash commands.
+{{- end }}
+
+{{ templateFirst . (printf "mayor-slash-note-%s" .ProviderKey) "mayor-slash-note-default" }}
+
+Do not invent `gc mail list`, `gc city status`, etc. from them. For bead work
+use `gc bd ...`, for city-level status use `gc status`, and for mail use
+`gc mail <subcommand>` where subcommands are `inbox`, `send`, `check`, `read`,
+`peek`, `reply`, `mark-read`, `mark-unread`, `thread`, `count`, `archive`,
+`delete`. If unsure of exact subcommand shape, run `gc <cmd> --help` rather
+than guessing.
 
 ## How to work
 

--- a/cmd/gc/template_resolve.go
+++ b/cmd/gc/template_resolve.go
@@ -293,20 +293,23 @@ func resolveTemplate(p *agentBuildParams, cfgAgent *config.Agent, qualifiedName 
 		cfgAgent.InheritedAppendFragments,
 		p.appendFragments,
 	)
+	providerKey, providerDisplayName := providerInfoForAgent(cfgAgent, p.workspace, p.providers)
 	prompt = renderPrompt(p.fs, p.cityPath, p.cityName, cfgAgent.PromptTemplate, PromptContext{
-		CityRoot:      p.cityPath,
-		AgentName:     qualifiedName,
-		TemplateName:  cfgAgent.Name,
-		BindingName:   cfgAgent.BindingName,
-		BindingPrefix: cfgAgent.BindingPrefix(),
-		RigName:       rigName,
-		RigRoot:       rigRoot,
-		WorkDir:       workDir,
-		IssuePrefix:   findRigPrefix(rigName, p.rigs),
-		DefaultBranch: defaultBranchForRig(rigName, p.rigs, workDir),
-		WorkQuery:     expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQuery(), p.stderr),
-		SlingQuery:    expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
-		Env:           cfgAgent.Env,
+		CityRoot:            p.cityPath,
+		AgentName:           qualifiedName,
+		TemplateName:        cfgAgent.Name,
+		BindingName:         cfgAgent.BindingName,
+		BindingPrefix:       cfgAgent.BindingPrefix(),
+		RigName:             rigName,
+		RigRoot:             rigRoot,
+		WorkDir:             workDir,
+		IssuePrefix:         findRigPrefix(rigName, p.rigs),
+		DefaultBranch:       defaultBranchForRig(rigName, p.rigs, workDir),
+		WorkQuery:           expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "work_query", cfgAgent.EffectiveWorkQuery(), p.stderr),
+		SlingQuery:          expandAgentCommandTemplate(p.cityPath, p.cityName, cfgAgent, p.rigs, "sling_query", cfgAgent.EffectiveSlingQuery(), p.stderr),
+		ProviderKey:         providerKey,
+		ProviderDisplayName: providerDisplayName,
+		Env:                 cfgAgent.Env,
 	}, p.sessionTemplate, p.stderr, p.packDirs, fragments, p.beadStore)
 	hasHooks := config.AgentHasHooks(cfgAgent, p.workspace, resolved.Name, p.providers)
 	beacon := runtime.FormatBeaconAt(p.cityName, qualifiedName, !hasHooks, p.beaconTime)


### PR DESCRIPTION
## Summary

Lets agent prompt templates vary per CLI provider (claude, codex, gemini, …) without hardcoding the provider name in the template body.

- **New context vars** `{{ .ProviderKey }}` and `{{ .ProviderDisplayName }}` exposed to every prompt template. Resolution: `agent.Provider` → `workspace.Provider`; DisplayName looked up via city providers → builtin spec → `BuiltinFamily` ancestor → falls back to the key.
- **New template func** `{{ templateFirst data name1 name2 ... }}` returns the output of the first registered fragment whose name matches one of the candidates. Returns `""` when none exist (silent fallback — pass a default name last to enforce a match). Compose with `printf` for per-provider selection:
  ```go-tmpl
  {{ templateFirst . (printf "note-%s" .ProviderKey) "note-default" }}
  ```
- **Wiring**: `renderPromptWithMeta` now wires the funcmap with a closure that captures the parsed `*template.Template` by reference, so `templateFirst` can call `tmpl.Lookup` at execute time (after fragments are parsed). Both render call sites — `cmd/gc/template_resolve.go` and `cmd/gc/cmd_prime.go` — populate the new context fields via a shared `providerInfoForAgent` helper that does no PATH lookup (`config.ResolveProvider`'s PATH check is inappropriate for prompt rendering).
- **Demo**: `cmd/gc/prompts/mayor.md` migrates the slash-commands note to the new mechanism. Claude Code wording stays for `claude`; a generic "skills exposed by your provider's command palette" wording ships as the default fallback for `codex` / `gemini` / unknown providers.

## Why

The bundled mayor prompt hardcoded "Claude Code slash commands" in prose, which is wrong/misleading when the city's `[workspace]` provider is `codex`, `gemini`, etc. There was no template-side mechanism to vary text by provider — neither the existing `{{ cmd }}` (returns the gc binary name, not the AI CLI) nor the `template-fragments/` infra (no provider-aware fallback chain) covered this case.

The chosen approach reuses the existing fragment pipeline (rather than introducing a parallel file-based include) — fragments already get pre-parsed once, deduplicated, and layered with priority pack→agent. Adding `templateFirst` extends that vocabulary instead of cloning it. See discussion in commit message for the trade-offs that ruled out a path-based `includeFirst` alternative.

## Caveats

- Cities already initialized with `gc init` keep their existing `agents/<name>/prompt.template.md` untouched (`writeInitFile` preserves existing). Users either re-init or manually port the new `{{ define }}` blocks + `templateFirst` call into their own prompt template to pick up the new wording.
- Substituting just the provider name resolves the cosmetic mismatch but not the semantic one — slash-commands-as-skill-loader is a Claude Code concept; codex CLI / gemini CLI / copilot CLI do not implement it the same way. The new helper opens the door to per-provider fragments that can substitute the entire paragraph rather than one noun, which is the right direction for prompts that talk about provider-specific UX.

## Test plan

- [x] `go vet ./cmd/gc/... ./internal/...` clean
- [x] New unit tests in `cmd/gc/prompt_test.go`:
  - `TestRenderPromptProviderContextVarsExposed`
  - `TestRenderPromptTemplateFirstPicksFirstRegistered`
  - `TestRenderPromptTemplateFirstFallsBackWhenFirstMissing`
  - `TestRenderPromptTemplateFirstReturnsEmptyWhenNoneRegistered`
  - `TestRenderPromptTemplateFirstComposesWithProviderKey` (table-driven for claude / codex / gemini / unset)
  - `TestRenderPromptTemplateFirstSkipsEmptyName`
  - `TestEmbeddedMayorPromptRendersProviderSpecificSlashNote` (round-trip on the embedded mayor.md content)
  - `TestProviderInfoForAgentResolvesAgentOverWorkspace`
  - `TestProviderInfoForAgentFallsBackToWorkspace`
  - `TestProviderInfoForAgentEmptyWhenNoneSet`
  - `TestProviderDisplayNameFallsBackToKeyForUnknownProvider`
- [x] Targeted re-run of prompt-adjacent suites passes locally: `go test ./cmd/gc/ -run "TestRender|TestProvider|TestEmbedded|TestPrime|TestBuildDesired|TestMigrate|TestDoctor|TestTemplateResolve" -count=1` → ok in 26s
- [ ] **Note on pre-commit:** local `go test ./...` fails on `TestResolveDoltConnectionTargetManagedCity_EnvOverride` (`bind: 127.0.0.2:0 — can't assign requested address`). This is an environmental gap on my machine (`lo0` lacks the `127.0.0.2` alias the test expects); it reproduces on `origin/main` and is unrelated to this diff. Ran the full sharded suite via `make test-fast-parallel` — same single environmental failure plus a few timing-sensitive supervisor tests under load that pass when re-run in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)