### PR TITLE
fix(formula): extract single resolver so loadFormula and ResolveFormulas agree on layer precedence

### DIFF
--- a/cmd/gc/formula_resolve.go
+++ b/cmd/gc/formula_resolve.go
@@ -22,49 +22,17 @@ import (
 // Idempotent: correct symlinks are left alone, stale ones are updated,
 // and symlinks for formulas no longer in any layer are removed. Real files
 // (non-symlinks) in the target directory are never overwritten.
+//
+// Per-name precedence (last-wins across layers, canonical-beats-legacy
+// within a layer) is delegated to formula.ResolveAll — the same source of
+// truth used by parser.loadFormula so the symlink view and the in-process
+// loader cannot disagree on which file wins.
 func ResolveFormulas(targetDir string, layers []string) error {
 	if len(layers) == 0 {
 		return nil
 	}
 
-	// Build winner map keyed by formula NAME (not filename). Later layers
-	// overwrite earlier ones (higher priority). Within a single layer, the
-	// canonical .toml form wins over the legacy .formula.toml form so a
-	// partially-migrated layer does not shadow its own canonical file.
-	winners := make(map[string]string)
-	for _, layerDir := range layers {
-		entries, err := os.ReadDir(layerDir)
-		if err != nil {
-			continue // Layer dir doesn't exist — skip (not an error).
-		}
-		// Resolve within-layer winners first so canonical beats legacy
-		// sibling regardless of ReadDir order, then merge into the
-		// cross-layer winners map (overwriting lower layers).
-		layerPick := make(map[string]string)
-		layerLegacy := make(map[string]bool)
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
-			}
-			name, ok := formula.TrimTOMLFilename(e.Name())
-			if !ok {
-				continue
-			}
-			legacy := e.Name() == name+formula.LegacyTOMLExt
-			if _, exists := layerPick[name]; exists && legacy && !layerLegacy[name] {
-				continue // Canonical already picked in this layer — skip legacy sibling.
-			}
-			abs, err := filepath.Abs(filepath.Join(layerDir, e.Name()))
-			if err != nil {
-				continue
-			}
-			layerPick[name] = abs
-			layerLegacy[name] = legacy
-		}
-		for name, abs := range layerPick {
-			winners[name] = abs
-		}
-	}
+	winners := formula.ResolveAll(layers)
 
 	// Build the set of formula link names we will emit. Each winning formula
 	// gets a canonical link plus a legacy compatibility alias.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,7 +56,6 @@ gc [flags]
 | [gc session](#gc-session) | Manage interactive chat sessions |
 | [gc shell](#gc-shell) | Manage the Gas City shell integration hook |
 | [gc skill](#gc-skill) | List visible skills |
-| [gc slack](#gc-slack) | Manage the Slack pack — apps, channel mappings, and dispatch |
 | [gc sling](#gc-sling) | Route work to a session config or agent |
 | [gc start](#gc-start) | Start the city under the machine-wide supervisor |
 | [gc status](#gc-status) | Show city-wide status overview |
@@ -2574,180 +2573,6 @@ gc skill list [flags]
 | `--agent` | string |  | show the effective skill view for this agent |
 | `--session` | string |  | show the effective skill view for this session |
 
-## gc slack
-
-Manage the Slack pack used for human ↔ Gas City coordination.
-
-On-disk state written by these commands lives under &lt;cityPath&gt;/.gc/slack/.
-The slack-pack adapter (examples/slack-pack/adapter/) reads that state
-via env vars injected at "gc start".
-
-```
-gc slack
-```
-
-| Subcommand | Description |
-|------------|-------------|
-| [gc slack import-app](#gc-slack-import-app) | Import a Slack app manifest into the gc city's slack-pack registry |
-| [gc slack map-channel](#gc-slack-map-channel) | Bind a Slack channel to a gc session for slash-command routing |
-| [gc slack map-rig](#gc-slack-map-rig) | Bind a Slack rig to a set of channels for slash-command default routing |
-| [gc slack status](#gc-slack-status) | Show imported Slack apps, channel mappings, and rig mappings for the current city |
-| [gc slack sync-commands](#gc-slack-sync-commands) | Reconcile the locally-imported Slack app's slash commands with what's live in Slack |
-
-## gc slack import-app
-
-Import a Slack app manifest into the gc city's slack-pack registry.
-
-Reads the JSON manifest at &lt;manifest.json&gt;, validates that it declares
-the bot scopes the slack-pack adapter and downstream commands require,
-and persists an app record keyed by (workspace_id, app_id) at
-&lt;cityPath&gt;/.gc/slack/apps.json.
-
-Slack manifests do not contain workspace_id or app_id (Slack assigns
-the latter when the app is created); both are required CLI flags.
-Re-importing the same (workspace_id, app_id) updates the record in
-place — the registry never grows from idempotent re-imports.
-
-Schema reference: https://api.slack.com/reference/manifests
-
-```
-gc slack import-app <manifest.json> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--app-id` | string |  | Slack app id, e.g. A0123456 — assigned by Slack post-create (required) |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
-## gc slack map-channel
-
-Bind a Slack channel to a gc session for slash-command routing.
-
-Persists a (workspace_id, channel_id) → session record at
-&lt;cityPath&gt;/.gc/slack/channel_mappings.json. The slack-pack adapter
-reads this file at startup and routes incoming /slack/interactions
-slash-command requests for the channel to the bound session.
-
---session is required (unless --remove). The binding is idempotent:
-re-binding the same channel preserves the original CreatedAt and
-overwrites the target fields. --remove always exits 0 — if no
-binding exists, the command is a no-op.
-
-For rig→channel bindings, use 'gc slack map-rig' (gc-cby.4). The
-legacy '--rig' flag on this verb is deprecated (gc-cby.25); cobra
-hides it from --help and emits a stderr deprecation warning on
-every use.
-
-```
-gc slack map-channel <channel-id> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--remove` | bool |  | Remove the binding for &lt;channel-id&gt; if one exists (idempotent) |
-| `--session` | string |  | Bind the channel to a gc session (mutually exclusive with --rig) |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
-## gc slack map-rig
-
-Bind a Slack rig to a set of channels for slash-command default routing.
-
-Persists a (workspace_id, rig_name) → set-of-channel-ids record at
-&lt;cityPath&gt;/.gc/slack/rig_mappings.json. The slack-pack adapter reads
-this file at startup and uses it as the fall-through resolver when
-no per-channel 'map-channel' binding exists for an inbound channel.
-
-The binding is idempotent: re-binding the same rig replaces the
-channel set (sorted+deduped) and preserves the original CreatedAt.
-Channels can be supplied as repeated --channel flags, comma-
-separated values, or a mix.
-
---remove drops the entire rig record. --remove-channels drops just
-the listed channels from the rig's set; if the resulting set is
-empty, the record itself is deleted. Both are idempotent — a missing
-record (or unknown channel) is a silent no-op. --remove,
---remove-channels, and --channel are mutually exclusive.
-
-```
-gc slack map-rig <rig-name> [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--channel` | stringSlice |  | Slack channel id to include in the rig's set; repeat or comma-separate for multiple |
-| `--fix-formula` | string |  | Molecule name spawned by the adapter when this rig handles an inbound interaction (e.g. `mol-slack-fix-issue`). Optional. Omit on re-bind to preserve the current value. |
-| `--remove` | bool |  | Remove the rig record entirely (idempotent; mutually exclusive with --channel and --remove-channels) |
-| `--remove-channels` | stringSlice |  | Drop these channels from the rig's set; if the set becomes empty the record is deleted (idempotent; mutually exclusive with --channel and --remove) |
-| `--sling-target` | string |  | Qualified agent name (`&lt;rig&gt;/&lt;role&gt;`, e.g. `mission-control/polecat`) the adapter targets when dispatching for this rig. Stored on the rig record; required at use time. Omit on re-bind to preserve the current value. |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
-## gc slack status
-
-Show imported Slack apps, channel mappings, and rig mappings for the current city.
-
-Reads &lt;cityPath&gt;/.gc/slack/apps.json (written by 'gc slack import-app'),
-&lt;cityPath&gt;/.gc/slack/channel_mappings.json (written by
-'gc slack map-channel'), and &lt;cityPath&gt;/.gc/slack/rig_mappings.json
-(written by 'gc slack map-rig') and prints a unified summary.
-
-Per-channel mappings are overrides on top of rig→&#123;channels&#125; defaults;
-the channel mapping wins. When the two stores claim the same channel
-for DIFFERENT rigs, the rig-mapping section is annotated with
-"(conflict: cby.3 channel mapping wins)" in human output and the
-JSON shape sets "conflict": true.
-
---channel &lt;id&gt; filters channel mappings to the named channel AND
-filters rig mappings to records whose channel set contains &lt;id&gt;.
---workspace-id &lt;id&gt; filters all three sections to the named workspace.
-When $SLACK_WORKSPACE_ID is set the filter defaults to that workspace;
-pass --workspace-id="" to override and see records across all workspaces.
---json emits a machine-readable shape with top-level keys "apps",
-"channel_mappings", and "rig_mappings".
-
-```
-gc slack status [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--channel` | string |  | Filter channel mappings to a single channel id; rig mappings are filtered to records whose channel_ids contain this id |
-| `--json` | bool |  | Emit machine-readable JSON instead of human-readable text |
-| `--workspace-id` | string |  | Filter apps, channel mappings, and rig mappings to a single Slack workspace id (defaults to $SLACK_WORKSPACE_ID when set; pass --workspace-id="" to see all workspaces) |
-
-## gc slack sync-commands
-
-Reconcile the locally-imported Slack app's slash commands with what's live in Slack.
-
-Reads the imported app record from &lt;cityPath&gt;/.gc/slack/apps.json (built
-by `gc slack import-app`), calls Slack apps.manifest.export to read the
-live manifest, diffs the two slash-command sets, and (unless --dry-run)
-calls apps.manifest.update to push the local manifest. After update,
-apps.manifest.export is called once more to verify convergence.
-
-The verb refuses to push when manifest fields OUTSIDE features.slash_commands
-have drifted from local — pass --allow-non-command-drift to opt into a
-full-manifest replace.
-
-The Slack configuration access token (xoxe.xoxp-...) is read from the
-SLACK_CONFIG_ACCESS_TOKEN environment variable, or from --token. Token
-values never appear in error or log output.
-
-Schema: https://api.slack.com/methods/apps.manifest.update
-
-```
-gc slack sync-commands [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--allow-non-command-drift` | bool |  | Allow the push when non-command manifest fields differ from local |
-| `--app-id` | string |  | Slack app id, e.g. A0123456 (required) |
-| `--dry-run` | bool |  | Print the diff and exit without calling apps.manifest.update |
-| `--output` | string | `text` | Output format: text\|json |
-| `--timeout` | duration | `30s` | Hard timeout for the entire operation |
-| `--token` | string |  | Slack configuration access token (xoxe.xoxp-...). Falls back to SLACK_CONFIG_ACCESS_TOKEN |
-| `--workspace-id` | string |  | Slack workspace (team) id, e.g. T0123456 (required; defaults to $SLACK_WORKSPACE_ID when set) |
-
 ## gc sling
 
 Route a bead to a session config or agent using the target's sling_query.
@@ -2784,6 +2609,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `--nudge` | bool |  | nudge target after routing |
 | `--on` | string |  | attach wisp from formula to bead before routing |
 | `--owned` | bool |  | mark auto-convoy as owned (skip auto-close) |
+| `--reassign` | bool |  | clear any existing human assignee before routing (for human→pool handoff) |
 | `--scope-kind` | string |  | logical workflow scope kind for graph.v2 launches |
 | `--scope-ref` | string |  | logical workflow scope ref for graph.v2 launches |
 | `--stdin` | bool |  | read bead text from stdin (first line = title, rest = description) |

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -277,26 +277,20 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 	return merged, nil
 }
 
-// loadFormula loads a formula by name from search paths.
-// Tries canonical TOML first (.toml), then legacy infixed TOML, then JSON.
+// loadFormula loads a formula by name from search paths. Search paths are
+// ordered lowest→highest priority (matching ComputeFormulaLayers); the
+// highest-priority path containing the formula wins. Within a single path,
+// canonical .toml beats legacy .formula.toml beats legacy .formula.json.
 func (p *Parser) loadFormula(name string) (*Formula, error) {
-	// Check cache first
 	if cached, ok := p.cache[name]; ok {
 		return cached, nil
 	}
 
-	// Search for the formula file - try TOML first, then JSON
-	extensions := []string{FormulaExtTOML, FormulaLegacyExtTOML, FormulaExtJSON}
-	for _, dir := range p.searchPaths {
-		for _, ext := range extensions {
-			path := filepath.Join(dir, name+ext)
-			if _, err := os.Stat(path); err == nil {
-				return p.ParseFile(path)
-			}
-		}
+	path, ok := Resolve(p.searchPaths, name)
+	if !ok {
+		return nil, fmt.Errorf("formula %q not found in search paths", name)
 	}
-
-	return nil, fmt.Errorf("formula %q not found in search paths", name)
+	return p.ParseFile(path)
 }
 
 // LoadByName loads a formula by name from search paths.

--- a/internal/formula/resolve.go
+++ b/internal/formula/resolve.go
@@ -1,0 +1,77 @@
+package formula
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// extOrder is the within-layer extension precedence used by Resolve:
+// canonical TOML beats legacy infixed TOML beats legacy JSON. JSON is
+// included here because Resolve drives the in-process parser, which still
+// loads .formula.json formulas. ResolveAll deliberately excludes JSON
+// (its caller stages symlinks the bd CLI consumes — TOML-only).
+var extOrder = []string{CanonicalTOMLExt, LegacyTOMLExt, FormulaExtJSON}
+
+// Resolve returns the path of the highest-priority layer that contains a
+// formula by this name. layers are ordered lowest→highest priority,
+// matching ComputeFormulaLayers; the highest-priority layer present wins
+// (last-wins). Within a single layer, canonical .toml beats legacy
+// .formula.toml beats legacy .formula.json.
+//
+// Returns ("", false) if no layer contains the formula.
+func Resolve(layers []string, name string) (string, bool) {
+	for i := len(layers) - 1; i >= 0; i-- {
+		for _, ext := range extOrder {
+			path := filepath.Join(layers[i], name+ext)
+			if _, err := os.Stat(path); err == nil {
+				return path, true
+			}
+		}
+	}
+	return "", false
+}
+
+// ResolveAll returns name→winning-path for every TOML formula reachable
+// across layers. Same precedence rules as Resolve: layers ordered
+// lowest→highest priority (last-wins across layers), canonical beats
+// legacy within a layer.
+//
+// JSON formulas are excluded — they are loader-only fallback and not
+// suitable for symlink staging by callers that consume this map.
+func ResolveAll(layers []string) map[string]string {
+	winners := make(map[string]string)
+	for _, layerDir := range layers {
+		entries, err := os.ReadDir(layerDir)
+		if err != nil {
+			continue
+		}
+		// Resolve within-layer winners first so canonical beats legacy
+		// sibling regardless of ReadDir order, then merge into the
+		// cross-layer winners map (overwriting lower layers).
+		layerPick := make(map[string]string)
+		layerLegacy := make(map[string]bool)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name, ok := TrimTOMLFilename(e.Name())
+			if !ok {
+				continue
+			}
+			legacy := e.Name() == name+LegacyTOMLExt
+			if _, exists := layerPick[name]; exists && legacy && !layerLegacy[name] {
+				continue // Canonical already picked in this layer — skip legacy sibling.
+			}
+			abs, err := filepath.Abs(filepath.Join(layerDir, e.Name()))
+			if err != nil {
+				continue
+			}
+			layerPick[name] = abs
+			layerLegacy[name] = legacy
+		}
+		for name, abs := range layerPick {
+			winners[name] = abs
+		}
+	}
+	return winners
+}

--- a/internal/formula/resolve_test.go
+++ b/internal/formula/resolve_test.go
@@ -1,0 +1,238 @@
+package formula
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeLayerFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
+
+func TestResolve_MissingEverywhere(t *testing.T) {
+	dir := t.TempDir()
+	writeLayerFile(t, dir, "mol-a.toml", "")
+
+	if _, ok := Resolve([]string{dir}, "mol-missing"); ok {
+		t.Errorf("Resolve(mol-missing): expected not found")
+	}
+}
+
+func TestResolve_LastWinsAcrossLayers(t *testing.T) {
+	dir := t.TempDir()
+	layer1 := filepath.Join(dir, "layer1")
+	layer2 := filepath.Join(dir, "layer2")
+	writeLayerFile(t, layer1, "mol-a.toml", "lower")
+	want := writeLayerFile(t, layer2, "mol-a.toml", "higher")
+
+	got, ok := Resolve([]string{layer1, layer2}, "mol-a")
+	if !ok {
+		t.Fatalf("Resolve: not found")
+	}
+	if got != want {
+		t.Errorf("Resolve = %q, want layer2 path %q", got, want)
+	}
+}
+
+// TestResolve_ThreeLayersMiddleWins guards reverse-iteration off-by-one.
+// Real callers (ComputeFormulaLayers) build 3+ layers; two-layer tests
+// can pass with a `>` boundary as easily as `>=`.
+func TestResolve_ThreeLayersMiddleWins(t *testing.T) {
+	dir := t.TempDir()
+	low := filepath.Join(dir, "low")
+	mid := filepath.Join(dir, "mid")
+	high := filepath.Join(dir, "high")
+	writeLayerFile(t, low, "mol-a.toml", "low")
+	want := writeLayerFile(t, mid, "mol-a.toml", "mid")
+	if err := os.MkdirAll(high, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := Resolve([]string{low, mid, high}, "mol-a")
+	if !ok {
+		t.Fatalf("Resolve: not found")
+	}
+	if got != want {
+		t.Errorf("Resolve = %q, want mid layer path %q (highest layer with the formula)", got, want)
+	}
+}
+
+func TestResolve_CanonicalBeatsLegacyWithinLayer(t *testing.T) {
+	dir := t.TempDir()
+	want := writeLayerFile(t, dir, "mol-a.toml", "canonical")
+	writeLayerFile(t, dir, "mol-a.formula.toml", "legacy")
+
+	got, ok := Resolve([]string{dir}, "mol-a")
+	if !ok {
+		t.Fatalf("Resolve: not found")
+	}
+	if got != want {
+		t.Errorf("Resolve = %q, want canonical %q", got, want)
+	}
+}
+
+func TestResolve_JSONFallback(t *testing.T) {
+	dir := t.TempDir()
+	want := writeLayerFile(t, dir, "mol-a.formula.json", "")
+
+	got, ok := Resolve([]string{dir}, "mol-a")
+	if !ok {
+		t.Fatalf("Resolve: not found")
+	}
+	if got != want {
+		t.Errorf("Resolve = %q, want JSON path %q", got, want)
+	}
+}
+
+func TestResolve_HigherLayerLegacyWinsOverLowerCanonical(t *testing.T) {
+	dir := t.TempDir()
+	layer1 := filepath.Join(dir, "layer1")
+	layer2 := filepath.Join(dir, "layer2")
+	writeLayerFile(t, layer1, "mol-a.toml", "lower canonical")
+	want := writeLayerFile(t, layer2, "mol-a.formula.toml", "higher legacy")
+
+	got, ok := Resolve([]string{layer1, layer2}, "mol-a")
+	if !ok {
+		t.Fatalf("Resolve: not found")
+	}
+	if got != want {
+		t.Errorf("Resolve = %q, want %q (cross-layer priority outranks within-layer extension preference)", got, want)
+	}
+}
+
+func TestResolveAll_SingleLayer(t *testing.T) {
+	dir := t.TempDir()
+	a := writeLayerFile(t, dir, "mol-a.toml", "")
+	b := writeLayerFile(t, dir, "mol-b.formula.toml", "")
+
+	got := ResolveAll([]string{dir})
+	want := map[string]string{"mol-a": a, "mol-b": b}
+	if !maps.Equal(got, want) {
+		t.Errorf("ResolveAll = %v, want %v", got, want)
+	}
+}
+
+func TestResolveAll_LayerShadowing(t *testing.T) {
+	dir := t.TempDir()
+	layer1 := filepath.Join(dir, "layer1")
+	layer2 := filepath.Join(dir, "layer2")
+	writeLayerFile(t, layer1, "mol-a.toml", "lower")
+	bOnlyLow := writeLayerFile(t, layer1, "mol-b.toml", "lower-only")
+	aHigh := writeLayerFile(t, layer2, "mol-a.toml", "higher")
+	cOnlyHigh := writeLayerFile(t, layer2, "mol-c.toml", "higher-only")
+
+	got := ResolveAll([]string{layer1, layer2})
+	want := map[string]string{"mol-a": aHigh, "mol-b": bOnlyLow, "mol-c": cOnlyHigh}
+	if !maps.Equal(got, want) {
+		t.Errorf("ResolveAll = %v, want %v", got, want)
+	}
+}
+
+func TestResolveAll_CanonicalBeatsLegacyWithinLayer(t *testing.T) {
+	// ResolveAll re-implements within-layer canonical-beats-legacy
+	// independently of Resolve (it iterates entries from os.ReadDir, not
+	// the by-name Stat path). Keep this even though Resolve has the same
+	// invariant covered.
+	dir := t.TempDir()
+	canonical := writeLayerFile(t, dir, "mol-a.toml", "canonical")
+	writeLayerFile(t, dir, "mol-a.formula.toml", "legacy")
+
+	got := ResolveAll([]string{dir})
+	if got["mol-a"] != canonical {
+		t.Errorf("ResolveAll[mol-a] = %q, want canonical %q", got["mol-a"], canonical)
+	}
+}
+
+func TestResolveAll_ExcludesJSON(t *testing.T) {
+	// JSON formulas are loader-only fallback — they must not appear in the
+	// symlink staging map even when they are the only file present for a
+	// formula name.
+	dir := t.TempDir()
+	writeLayerFile(t, dir, "mol-json-only.formula.json", "")
+	writeLayerFile(t, dir, "mol-toml.toml", "")
+
+	got := ResolveAll([]string{dir})
+	if _, ok := got["mol-json-only"]; ok {
+		t.Errorf("ResolveAll picked up JSON-only formula: %v", got)
+	}
+	if _, ok := got["mol-toml"]; !ok {
+		t.Errorf("ResolveAll missing TOML formula: %v", got)
+	}
+}
+
+func TestResolveAll_EmptyAndMissing(t *testing.T) {
+	if got := ResolveAll(nil); len(got) != 0 {
+		t.Errorf("ResolveAll(nil) = %v, want empty", got)
+	}
+	if got := ResolveAll([]string{"/nonexistent"}); len(got) != 0 {
+		t.Errorf("ResolveAll(missing) = %v, want empty", got)
+	}
+}
+
+// TestResolveAndResolveAll_AgreeOnPath guards the whole point of this
+// package: two consumers must not see a different winning path for the
+// same name. Any divergence reintroduces the original bug class.
+func TestResolveAndResolveAll_AgreeOnPath(t *testing.T) {
+	dir := t.TempDir()
+	low := filepath.Join(dir, "low")
+	mid := filepath.Join(dir, "mid")
+	high := filepath.Join(dir, "high")
+	writeLayerFile(t, low, "shadowed.toml", "low")
+	writeLayerFile(t, low, "low-only.toml", "low-only")
+	writeLayerFile(t, mid, "shadowed.formula.toml", "mid")
+	writeLayerFile(t, high, "shadowed.toml", "high")
+	writeLayerFile(t, high, "high-only.formula.toml", "high-only")
+
+	layers := []string{low, mid, high}
+	all := ResolveAll(layers)
+	for name, allPath := range all {
+		resolvePath, ok := Resolve(layers, name)
+		if !ok {
+			t.Errorf("Resolve(%q) returned not-found, but ResolveAll has %q", name, allPath)
+			continue
+		}
+		if resolvePath != allPath {
+			t.Errorf("divergence on %q: Resolve=%q ResolveAll=%q", name, resolvePath, allPath)
+		}
+	}
+}
+
+// TestLoadByName_LastWinsAcrossLayers is the parser-level regression test
+// for the bug Resolve fixes: parser.loadFormula previously iterated layers
+// first-wins, inverting the lowest→highest priority contract that the
+// symlink staging path (cmd/gc/formula_resolve.go) and the producer
+// (config.ComputeFormulaLayers) both honor.
+func TestLoadByName_LastWinsAcrossLayers(t *testing.T) {
+	dir := t.TempDir()
+	layer1 := filepath.Join(dir, "layer1")
+	layer2 := filepath.Join(dir, "layer2")
+
+	const lower = `{"formula":"mol-x","version":2,"type":"workflow","steps":[{"id":"s","title":"lower"}]}`
+	const higher = `{"formula":"mol-x","version":2,"type":"workflow","steps":[{"id":"s","title":"higher"}]}`
+
+	writeLayerFile(t, layer1, "mol-x.formula.json", lower)
+	writeLayerFile(t, layer2, "mol-x.formula.json", higher)
+
+	p := NewParser(layer1, layer2)
+	got, err := p.LoadByName("mol-x")
+	if err != nil {
+		t.Fatalf("LoadByName(mol-x): %v", err)
+	}
+	if len(got.Steps) != 1 || got.Steps[0].Title != "higher" {
+		t.Errorf("LoadByName picked wrong layer: title=%q, want %q", got.Steps[0].Title, "higher")
+	}
+}


### PR DESCRIPTION
## Summary

`internal/formula/parser.go:loadFormula` (used by `gc formula show`/`cook` and the parser-driven `extends:` chain) iterated `searchPaths` first-wins, while `cmd/gc/formula_resolve.go:ResolveFormulas` (used to stage `.beads/formulas/` symlinks) iterated the same layer slice last-wins. Both consumed the slice produced by `internal/config/pack.go:ComputeFormulaLayers`, whose comment at line 814 documents the contract: *"Each layer slice is ordered lowest→highest priority."* Two consumers, opposite interpretations of one producer.

User-visible symptom: in a city whose `pack.toml` declares `[imports.gastown]`, dropping a same-name formula at `<city>/formulas/` (the documented override path) was silently shadowed by the imported pack's copy for `gc formula show`/`cook`, while the symlink staging path used the override correctly.

This PR extracts `internal/formula.Resolve` and `ResolveAll` as the single source of truth for layer-precedence decisions. Both consumers now route through them; future name-resolution sites pick up the canonical contract by default rather than risking a third inversion.

Within-layer precedence is preserved verbatim (canonical `.toml` > legacy `.formula.toml` > legacy `.formula.json` for `Resolve`; same minus JSON for `ResolveAll`'s symlink-staging caller).

Refs #2027 — the [followup comment](https://github.com/gastownhall/gascity/issues/2027#issuecomment-4428748715) walks the duplication-as-root-cause argument and proposes this shape (C). The original post floated the smaller (A) flip-the-loop and (B) reverse-the-producer-slice variants; happy to retreat to (A) if the abstraction lift isn't welcome — the core behavior change is the same.

## Why this shape (vs. just flipping the loop)

The two consumers were independently re-implementing layer iteration in the same way, but in opposite directions. Either of (A)/(B) closes *this* inversion but leaves the duplication; the next caller that needs name-resolution against `FormulaLayers` is one careless `for _, dir := range searchPaths { return on first }` away from reintroducing the same class of bug. Three peer name-discovery loops (`cmd/gc/cmd_formula.go:46-62`, `cmd/gc/cmd_config.go:389-414`, `internal/api/handler_formulas.go:262-287`) are *intentionally* not touched — they answer "what names exist", not "which file wins per name", so they're independent of the resolver bug. Happy to fold them into a separate cleanup if maintainers prefer symmetry.

> Surface: resolve a formula by name across layered search paths via the new `internal/formula.Resolve`/`ResolveAll` primitive; not via per-consumer inline reimplementation of layer iteration (the wrong-way pattern that produced the inversion).

## Notes on the diff

- **Two commits.** The first (`docs: regenerate cli.md`) is the pre-commit hook regenerating `docs/reference/cli.md` against the live binary — it caught a stale `gc slack` section on `main`. Landed standalone so the substantive fix commit's diff stays scoped.
- **`internal/formula/resolve.go`** is the new primitive (~75 lines).
- **`parser.go:loadFormula`** is now a `Resolve` call followed by the existing `ParseFile`. Cache check, error-message string, and order of operations preserved.
- **`cmd/gc/formula_resolve.go:ResolveFormulas`** consumes `formula.ResolveAll(layers)` instead of reimplementing the loop. Symlink-emit body, real-file-not-overwritten guard, and stale-cleanup are all unchanged.

## Testing

- [x] `make check` — passes for the changed packages (`go test ./internal/formula/... ./cmd/gc/...` clean; `golangci-lint run ./internal/formula/... ./cmd/gc/...` 0 issues; `gofmt` clean). Full `make check` run hit one pre-existing failure: `TestResolveDoltConnectionTargetManagedCity_EnvOverride` in `internal/beads/contract/connection_test.go:1146` — `listen tcp 127.0.0.2:0: bind: can't assign requested address` on macOS (loopback alias not configured). Unrelated package; not introduced by this change.
- [ ] `make check-docs` — n/a (no docs touched in the fix commit; the docs commit is pure regeneration).
- [ ] `make test-integration` — n/a per maintainer guidance.

Test additions cover the parser-level regression (`TestLoadByName_LastWinsAcrossLayers` would fail pre-fix), the new resolver primitive (last-wins across 2 and 3 layers, within-layer canonical > legacy > JSON precedence, JSON exclusion from `ResolveAll`), and a `Resolve`/`ResolveAll` consistency check that guards against future divergence reintroducing the original bug class.

## Checklist

- [x] Linked an issue (#2027)
- [x] Added tests for behavior changes (14 in `internal/formula/resolve_test.go`)
- [ ] Updated docs for user-facing changes — n/a (the loader's documented behavior at `docs/reference/formula.md:136` and `engdocs/architecture/formulas.md:156` already states last-wins; this PR makes the implementation match)
- [ ] Called out breaking changes — none. Callers depending on the previous first-wins behavior would already have been seeing the opposite behavior via the symlink staging path; no caller could have a coherent expectation.