### PR TITLE
fix(reconciler): wake named-always sessions when configured_named_identity is missing (#1493)

### DIFF
--- a/cmd/gc/compute_awake_bridge.go
+++ b/cmd/gc/compute_awake_bridge.go
@@ -53,12 +53,15 @@ func buildAwakeInputFromReconciler(
 	}
 
 	// Named sessions
+	cityName := config.EffectiveCityName(cfg, "")
 	for i := range cfg.NamedSessions {
 		ns := &cfg.NamedSessions[i]
+		identity := ns.QualifiedName()
 		input.NamedSessions = append(input.NamedSessions, AwakeNamedSession{
-			Identity: ns.QualifiedName(),
-			Template: ns.TemplateQualifiedName(),
-			Mode:     ns.Mode,
+			Identity:    identity,
+			Template:    ns.TemplateQualifiedName(),
+			Mode:        ns.Mode,
+			RuntimeName: config.NamedSessionRuntimeName(cityName, cfg.Workspace, identity),
 		})
 	}
 
@@ -88,18 +91,19 @@ func buildAwakeInputFromReconciler(
 			Now:      clk,
 		})
 		bead := AwakeSessionBead{
-			ID:             b.ID,
-			SessionName:    name,
-			Template:       b.Metadata["template"],
-			State:          string(lifecycle.CompatState),
-			SleepReason:    b.Metadata["sleep_reason"],
-			ManualSession:  isManualSessionBead(*b),
-			PendingCreate:  lifecycle.HasWakeCause(session.WakeCausePendingCreate),
-			DependencyOnly: b.Metadata["dependency_only"] == "true",
-			NamedIdentity:  lifecycle.NamedIdentity,
-			Pinned:         lifecycle.HasWakeCause(session.WakeCausePinned),
-			Drained:        lifecycle.BaseState == session.BaseStateDrained,
-			WaitHold:       b.Metadata["wait_hold"] == "true",
+			ID:                     b.ID,
+			SessionName:            name,
+			Template:               b.Metadata["template"],
+			State:                  string(lifecycle.CompatState),
+			SleepReason:            b.Metadata["sleep_reason"],
+			ManualSession:          isManualSessionBead(*b),
+			PendingCreate:          lifecycle.HasWakeCause(session.WakeCausePendingCreate),
+			DependencyOnly:         b.Metadata["dependency_only"] == "true",
+			NamedIdentity:          lifecycle.NamedIdentity,
+			ConfiguredNamedSession: isNamedSessionBead(*b),
+			Pinned:                 lifecycle.HasWakeCause(session.WakeCausePinned),
+			Drained:                lifecycle.BaseState == session.BaseStateDrained,
+			WaitHold:               b.Metadata["wait_hold"] == "true",
 		}
 		bead.HeldUntil = lifecycle.HeldUntil
 		bead.QuarantinedUntil = lifecycle.QuarantinedUntil

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -371,9 +371,12 @@ func findNamedSessionName(beads []AwakeSessionBead, identity string) string {
 // identity's deterministic runtime name AND its template matches.
 //
 // The fallback recovers a configured named session whose NamedIdentity is
-// missing or stale on its bead — for example, a bead minted before
-// configured_named_identity was added, or one whose identity metadata was
-// not migrated after a config change. Without this fallback, ComputeAwakeSet
+// MISSING on its bead — for example, a bead minted before
+// configured_named_identity was added. Beads with a non-empty NamedIdentity
+// that doesn't match any [[named_session]] identity are NOT recovered by
+// this fallback (those return "" at the bead.NamedIdentity != ns.Identity
+// check below); a config-change migration that leaves a stale NamedIdentity
+// must be handled separately. Without this fallback, ComputeAwakeSet
 // silently drops the bead from `desired` and the session stays asleep
 // forever even though the config says mode=always. See #1493.
 func resolveNamedSessionBeadName(beads []AwakeSessionBead, ns AwakeNamedSession) string {
@@ -417,7 +420,16 @@ func isNamedSessionTemplate(named []AwakeNamedSession, template string) bool {
 func collectActiveBeads(beads []AwakeSessionBead, template string) []AwakeSessionBead {
 	var result []AwakeSessionBead
 	for _, b := range beads {
-		if b.Template == template && b.State == "active" && b.NamedIdentity == "" && !b.ManualSession && !b.Drained && !b.DependencyOnly {
+		// Exclude both NamedIdentity-tagged beads AND ConfiguredNamedSession
+		// beads whose NamedIdentity happens to be missing — the latter are
+		// still configured named sessions (recovered via the runtime-name
+		// fallback in namedSessionMatches / resolveNamedSessionBeadName).
+		// Treating them as generic pool candidates would re-introduce the
+		// #1493 failure mode in a different shape: a configured named
+		// session getting woken by generic template scale_check demand.
+		if b.Template == template && b.State == "active" &&
+			b.NamedIdentity == "" && !b.ConfiguredNamedSession &&
+			!b.ManualSession && !b.Drained && !b.DependencyOnly {
 			result = append(result, b)
 		}
 	}
@@ -471,7 +483,11 @@ func namedSessionMatches(named []AwakeNamedSession, bead AwakeSessionBead, mode 
 func collectCreatingBeads(beads []AwakeSessionBead, template string) []AwakeSessionBead {
 	var result []AwakeSessionBead
 	for _, b := range beads {
-		if b.Template == template && b.State == "creating" && b.NamedIdentity == "" && !b.ManualSession && !b.Drained && !b.DependencyOnly {
+		// See collectActiveBeads above for why ConfiguredNamedSession beads
+		// must be excluded even when NamedIdentity is empty.
+		if b.Template == template && b.State == "creating" &&
+			b.NamedIdentity == "" && !b.ConfiguredNamedSession &&
+			!b.ManualSession && !b.Drained && !b.DependencyOnly {
 			result = append(result, b)
 		}
 	}

--- a/cmd/gc/compute_awake_set.go
+++ b/cmd/gc/compute_awake_set.go
@@ -41,28 +41,30 @@ type AwakeAgent struct {
 
 // AwakeNamedSession represents a [[named_session]] config entry.
 type AwakeNamedSession struct {
-	Identity string // qualified name, e.g. "hello-world/refinery"
-	Template string // agent template name
-	Mode     string // "always" or "on_demand"
+	Identity    string // qualified name, e.g. "hello-world/refinery"
+	Template    string // agent template name
+	Mode        string // "always" or "on_demand"
+	RuntimeName string // computed runtime session_name (e.g. "hello-world--refinery")
 }
 
 // AwakeSessionBead represents an open session bead from the store.
 type AwakeSessionBead struct {
-	ID               string
-	SessionName      string
-	Template         string
-	State            string // "creating", "active", "asleep", "drained", "closed"
-	SleepReason      string
-	ManualSession    bool
-	PendingCreate    bool      // controller claimed this bead for initial start
-	DependencyOnly   bool      // only wakeable via dependency gate
-	NamedIdentity    string    // non-empty for named session beads
-	Pinned           bool      // pin_awake durable wake reason
-	Drained          bool      // state=="drained" or sleep_reason=="drained"
-	WaitHold         bool      // user-issued gc wait in progress
-	HeldUntil        time.Time // zero = not held
-	QuarantinedUntil time.Time // zero = not quarantined
-	IdleSince        time.Time // zero = unknown/not idle
+	ID                     string
+	SessionName            string
+	Template               string
+	State                  string // "creating", "active", "asleep", "drained", "closed"
+	SleepReason            string
+	ManualSession          bool
+	PendingCreate          bool      // controller claimed this bead for initial start
+	DependencyOnly         bool      // only wakeable via dependency gate
+	NamedIdentity          string    // non-empty for named session beads
+	ConfiguredNamedSession bool      // configured_named_session metadata is true
+	Pinned                 bool      // pin_awake durable wake reason
+	Drained                bool      // state=="drained" or sleep_reason=="drained"
+	WaitHold               bool      // user-issued gc wait in progress
+	HeldUntil              time.Time // zero = not held
+	QuarantinedUntil       time.Time // zero = not quarantined
+	IdleSince              time.Time // zero = unknown/not idle
 }
 
 // AwakeWorkBead represents a work bead with an assignee.
@@ -119,7 +121,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 		}
 		switch ns.Mode {
 		case "always":
-			if sn := findNamedSessionName(input.SessionBeads, ns.Identity); sn != "" {
+			if sn := resolveNamedSessionBeadName(input.SessionBeads, ns); sn != "" {
 				bead := findBeadBySessionName(input.SessionBeads, sn)
 				if bead != nil && !bead.DependencyOnly {
 					desired[sn] = "named-always"
@@ -136,7 +138,7 @@ func ComputeAwakeSet(input AwakeInput) map[string]AwakeDecision {
 			if agent, ok := agentsByName[ns.Template]; ok && agent.Suspended {
 				continue
 			}
-			if sn := findNamedSessionName(input.SessionBeads, ns.Identity); sn != "" {
+			if sn := resolveNamedSessionBeadName(input.SessionBeads, ns); sn != "" {
 				bead := findBeadBySessionName(input.SessionBeads, sn)
 				if bead != nil && !bead.DependencyOnly && !bead.Drained && bead.State != "closed" {
 					desired[sn] = "named-demand"
@@ -362,6 +364,38 @@ func findNamedSessionName(beads []AwakeSessionBead, identity string) string {
 	return ""
 }
 
+// resolveNamedSessionBeadName locates the session_name of the bead that
+// represents a configured named session. The primary match is the bead's
+// NamedIdentity (configured_named_identity metadata). The fallback matches
+// a configured_named_session bead by its session_name when that matches the
+// identity's deterministic runtime name AND its template matches.
+//
+// The fallback recovers a configured named session whose NamedIdentity is
+// missing or stale on its bead — for example, a bead minted before
+// configured_named_identity was added, or one whose identity metadata was
+// not migrated after a config change. Without this fallback, ComputeAwakeSet
+// silently drops the bead from `desired` and the session stays asleep
+// forever even though the config says mode=always. See #1493.
+func resolveNamedSessionBeadName(beads []AwakeSessionBead, ns AwakeNamedSession) string {
+	if sn := findNamedSessionName(beads, ns.Identity); sn != "" {
+		return sn
+	}
+	if ns.RuntimeName == "" {
+		return ""
+	}
+	bead := findBeadBySessionName(beads, ns.RuntimeName)
+	if bead == nil || !bead.ConfiguredNamedSession {
+		return ""
+	}
+	if ns.Template != "" && bead.Template != ns.Template {
+		return ""
+	}
+	if bead.NamedIdentity != "" && bead.NamedIdentity != ns.Identity {
+		return ""
+	}
+	return bead.SessionName
+}
+
 func findBeadBySessionName(beads []AwakeSessionBead, name string) *AwakeSessionBead {
 	for i := range beads {
 		if beads[i].SessionName == name {
@@ -404,23 +438,30 @@ func sessionHasConcreteAssignedWork(workBeads []AwakeWorkBead, bead AwakeSession
 }
 
 func isOnDemandSession(named []AwakeNamedSession, bead AwakeSessionBead) bool {
-	if bead.NamedIdentity == "" {
-		return false
-	}
-	for _, ns := range named {
-		if ns.Identity == bead.NamedIdentity && ns.Mode == "on_demand" {
-			return true
-		}
-	}
-	return false
+	return namedSessionMatches(named, bead, "on_demand")
 }
 
 func isAlwaysNamedSession(named []AwakeNamedSession, bead AwakeSessionBead) bool {
-	if bead.NamedIdentity == "" {
-		return false
-	}
+	return namedSessionMatches(named, bead, "always")
+}
+
+// namedSessionMatches reports whether bead represents a configured named
+// session of the given mode. The fallback path (bead.ConfiguredNamedSession
+// + matching runtime name + template) mirrors resolveNamedSessionBeadName
+// so a bead with missing/stale NamedIdentity is still recognized as named —
+// otherwise idle-sleep suppression and on-demand keep-awake silently lose
+// their exemption for affected beads. See #1493.
+func namedSessionMatches(named []AwakeNamedSession, bead AwakeSessionBead, mode string) bool {
 	for _, ns := range named {
-		if ns.Identity == bead.NamedIdentity && ns.Mode == "always" {
+		if ns.Mode != mode {
+			continue
+		}
+		if bead.NamedIdentity != "" && ns.Identity == bead.NamedIdentity {
+			return true
+		}
+		if bead.NamedIdentity == "" && bead.ConfiguredNamedSession &&
+			ns.RuntimeName != "" && ns.RuntimeName == bead.SessionName &&
+			(ns.Template == "" || ns.Template == bead.Template) {
 			return true
 		}
 	}

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -113,6 +113,58 @@ func TestNamedAlways_Quarantined(t *testing.T) {
 	assertAsleep(t, result, "deacon")
 }
 
+// TestNamedAlways_MissingConfiguredIdentityWakesViaRuntimeNameFallback pins
+// the #1493 fallback: a configured_named_session bead whose NamedIdentity is
+// missing must still wake when its SessionName matches the deterministic
+// runtime name AND its Template matches the configured ns.Template.
+func TestNamedAlways_MissingConfiguredIdentityWakesViaRuntimeNameFallback(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{
+			Identity:    "hello-world/refinery",
+			Template:    "hello-world/refinery",
+			Mode:        "always",
+			RuntimeName: "hello-world--refinery",
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:                     "mc-1",
+			SessionName:            "hello-world--refinery",
+			Template:               "hello-world/refinery",
+			State:                  "asleep",
+			ConfiguredNamedSession: true,
+			// NamedIdentity intentionally empty — exercises the fallback path.
+		}},
+		Now: now,
+	})
+	assertAwake(t, result, "hello-world--refinery")
+	assertReason(t, result, "hello-world--refinery", "named-always")
+}
+
+// TestNamedAlways_MissingConfiguredIdentityIgnoredForUnrelatedTemplate pins
+// the guard rail on the #1493 fallback: it must NOT match a bead whose
+// template diverges from the configured ns.Template (avoids surfacing
+// unrelated beads as the named-session owner).
+func TestNamedAlways_MissingConfiguredIdentityIgnoredForUnrelatedTemplate(t *testing.T) {
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{
+			Identity:    "hello-world/refinery",
+			Template:    "hello-world/refinery",
+			Mode:        "always",
+			RuntimeName: "hello-world--refinery",
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:                     "mc-1",
+			SessionName:            "hello-world--refinery",
+			Template:               "hello-world/something-else", // mismatched template
+			State:                  "asleep",
+			ConfiguredNamedSession: true,
+		}},
+		Now: now,
+	})
+	assertAsleep(t, result, "hello-world--refinery")
+}
+
 func TestNamedAlways_TemplateRemoved(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{},

--- a/cmd/gc/compute_awake_set_test.go
+++ b/cmd/gc/compute_awake_set_test.go
@@ -165,6 +165,43 @@ func TestNamedAlways_MissingConfiguredIdentityIgnoredForUnrelatedTemplate(t *tes
 	assertAsleep(t, result, "hello-world--refinery")
 }
 
+// TestConfiguredNamedSessionExcludedFromPoolCandidatesEvenWhenIdentityMissing
+// guards the defensive fix from copilot review on PR #2034: a bead with
+// ConfiguredNamedSession=true but NamedIdentity="" must NOT be treated as a
+// generic pool candidate. The runtime-name fallback in namedSessionMatches
+// already recognizes such beads as named, so the pool-candidate collectors
+// (collectActiveBeads / collectCreatingBeads) must also exclude them — else
+// a configured named session could be woken by template scale_check demand,
+// re-introducing the #1493 failure shape from a different direction.
+func TestConfiguredNamedSessionExcludedFromPoolCandidatesEvenWhenIdentityMissing(t *testing.T) {
+	// Setup: an on_demand named session with a configured-but-identity-missing
+	// bead in state=active. No work demand is signaled. The bead should not
+	// be kept awake by template scale_check pressure.
+	result := ComputeAwakeSet(AwakeInput{
+		Agents: []AwakeAgent{{QualifiedName: "hello-world/refinery"}},
+		NamedSessions: []AwakeNamedSession{{
+			Identity:    "hello-world/refinery",
+			Template:    "hello-world/refinery",
+			Mode:        "on_demand",
+			RuntimeName: "hello-world--refinery",
+		}},
+		SessionBeads: []AwakeSessionBead{{
+			ID:                     "mc-1",
+			SessionName:            "hello-world--refinery",
+			Template:               "hello-world/refinery",
+			State:                  "active",
+			ConfiguredNamedSession: true,
+			// NamedIdentity intentionally empty — the fallback case.
+		}},
+		// Template demand is set, but the bead should NOT satisfy it because
+		// it's a configured named session, not a pool candidate.
+		ScaleCheckCounts: map[string]int{"hello-world/refinery": 1},
+		Now:              now,
+	})
+	// On-demand named session with no work demand should stay asleep.
+	assertAsleep(t, result, "hello-world--refinery")
+}
+
 func TestNamedAlways_TemplateRemoved(t *testing.T) {
 	result := ComputeAwakeSet(AwakeInput{
 		Agents:        []AwakeAgent{},

--- a/cmd/gc/session_reconciler_test.go
+++ b/cmd/gc/session_reconciler_test.go
@@ -1751,6 +1751,72 @@ func TestReconcileSessionBeads_AlwaysNamedSessionWakesAfterLiveChurnSequence(t *
 	}
 }
 
+// TestReconcileSessionBeads_AlwaysNamedSessionWakesPostChurnWithMissingConfiguredIdentity
+// pins the production-shaped failure described in #1493: a qualified
+// named-always session bead whose configured_named_identity metadata is
+// missing (legacy bead, unmigrated config change, or any path that lost
+// the identity tag) must still wake when its session_name matches the
+// deterministic runtime name for the configured identity.
+//
+// Without the fallback in ComputeAwakeSet, findNamedSessionName returns
+// "" because no bead has bead.NamedIdentity == ns.Identity, so the
+// awake-set pass keys `desired` by ns.Identity (the qualified name) while
+// the wake loop looks it up by bead.SessionName (the deterministic
+// runtime name). The two never match, ShouldWake stays false, no Start
+// is issued, and the session is stuck asleep forever even though
+// `gc session pin` (which keys off pin_awake, not identity) unsticks it.
+func TestReconcileSessionBeads_AlwaysNamedSessionWakesPostChurnWithMissingConfiguredIdentity(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Agents:        []config.Agent{{Name: "worker", Dir: "hello-world", StartCommand: "true"}},
+		NamedSessions: []config.NamedSession{{Dir: "hello-world", Template: "worker", Mode: "always"}},
+	}
+	identity := env.cfg.NamedSessions[0].QualifiedName()
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, identity)
+	if identity == sessionName {
+		t.Fatalf("test setup invalid: identity and sessionName both %q; the regression requires them to differ", identity)
+	}
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "hello-world/worker",
+		ConfiguredNamedIdentity: identity,
+		ConfiguredNamedMode:     "always",
+	}
+	session := env.createSessionBead(sessionName, "hello-world/worker")
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey: "true",
+		// configured_named_identity intentionally NOT set — this is the
+		// production-shaped failure mode the reporter hypothesized.
+		namedSessionModeMetadata:     "always",
+		"state":                      "asleep",
+		"sleep_reason":               "",
+		"state_reason":               "creation_complete",
+		"last_woke_at":               "",
+		"wake_attempts":              "0",
+		"churn_count":                "1",
+		"session_key":                "",
+		"continuation_reset_pending": "",
+		"pending_create_claim":       "",
+		"pin_awake":                  "",
+	})
+
+	env.reconcile([]beads.Bead{session})
+
+	if !env.sp.IsRunning(sessionName) {
+		final, _ := env.store.Get(session.ID)
+		t.Fatalf(
+			"named-always with missing configured_named_identity must wake (#1493); identity=%q sessionName=%q state=%q sleep_reason=%q churn_count=%q wake_attempts=%q",
+			identity, sessionName,
+			final.Metadata["state"],
+			final.Metadata["sleep_reason"],
+			final.Metadata["churn_count"],
+			final.Metadata["wake_attempts"],
+		)
+	}
+}
+
 // TestReconcileSessionBeads_QuarantinedNamedSessionStaysAsleepAfterChurn pins
 // the negative half of the post-churn invariant: when churn pushes the
 // session into quarantine, the session must stay asleep until the
@@ -5639,7 +5705,8 @@ func testHasRunningPoolSessionForTemplate(sessions []beads.Bead, sp *runtime.Fak
 func sessionBeadDebug(sessions []beads.Bead) []string {
 	out := make([]string, 0, len(sessions))
 	for _, sessionBead := range sessions {
-		out = append(out, fmt.Sprintf("%s:name=%s template=%s named=%t pool=%t state=%s status=%s",
+		out = append(out, fmt.Sprintf(
+			"%s:name=%s template=%s named=%t pool=%t state=%s status=%s",
 			sessionBead.ID,
 			sessionBead.Metadata["session_name"],
 			sessionBead.Metadata["template"],


### PR DESCRIPTION
## Summary

Wakes `named-always` sessions when `configured_named_identity` is missing from the runtime config but the session is otherwise eligible. Adds a runtime-name fallback so post-churn re-wakes don't depend on the configured-identity path staying populated through every reconcile tick.

Closes #1493.

## Test plan

- [x] `make build` clean
- [x] `go vet ./...` clean
- [x] `make lint` clean (golangci-lint)
- [x] Existing `cmd/gc` named/awake/reconciler-targeted tests pass
- [x] New regression tests:
  - `TestReconcileSessionBeads_AlwaysNamedSessionWakesPostChurnWithMissingConfiguredIdentity`
  - `TestNamedAlways_MissingConfiguredIdentityWakesViaRuntimeNameFallback`
  - `TestNamedAlways_MissingConfiguredIdentityIgnoredForUnrelatedTemplate`
- [x] Existing #1493 tests still pass:
  - `AlwaysNamedSessionWakesAfterLiveChurnSequence`
  - `QuarantinedNamedSessionStaysAsleepAfterChurn`
  - `AlwaysNamedSessionWakesFromDrainedCompatibilityState`
  - `BuildAwakeInputFromReconcilerNamedAlwaysPostChurnRewakes`
- Baseline noise: `TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot` fails identically on origin/main with this branch stashed (dolt sql-server leak; not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
