### PR TITLE
fix(session): retry fresh start when resume_flag is empty (#1655)

### DIFF
--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -74,14 +74,22 @@ func (m *Manager) retryFreshStartAfterStaleKey(
 	if b.Metadata["session_key"] == "" {
 		return false, nil
 	}
-	freshCmd := stripResumeFlag(resumeCommand, b.Metadata["resume_flag"], b.Metadata["session_key"])
+	resumeFlag := b.Metadata["resume_flag"]
+	freshCmd := stripResumeFlag(resumeCommand, resumeFlag, b.Metadata["session_key"])
 	if err := m.clearStaleResumeMetadata(id, b); err != nil {
 		if unroute != nil {
 			unroute()
 		}
 		return false, err
 	}
-	if freshCmd == resumeCommand {
+	// An empty resume_flag means the command was never resume-capable
+	// (e.g. a named-always session whose start command carries no
+	// --resume-style flag). stripResumeFlag is intentionally a no-op in
+	// that case, so refusing to retry would leave the session stuck.
+	// Only treat the no-op as an error when resume_flag was non-empty
+	// but the strip still found nothing — that signals an inconsistency
+	// between the bead metadata and the actual resume command.
+	if resumeFlag != "" && freshCmd == resumeCommand {
 		if unroute != nil {
 			unroute()
 		}

--- a/internal/session/chat.go
+++ b/internal/session/chat.go
@@ -28,7 +28,13 @@ const waitIdleNudgeTimeout = 30 * time.Second
 var ErrStateSync = errors.New("session state sync failed")
 
 // stripResumeFlag removes the resume flag and session key from a command
-// string, returning a command suitable for a fresh start.
+// string, returning a command suitable for a fresh start. When the strip
+// is a no-op (the flag/key isn't in cmd, or either argument is empty),
+// the original cmd is returned exactly — TrimSpace only runs when a
+// replacement actually happened. Callers rely on exact equality with
+// the input to detect the no-op case; trimming on a non-replacement
+// path would corrupt that signal when cmd has leading/trailing
+// whitespace.
 func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
 	if resumeFlag == "" || sessionKey == "" {
 		return cmd
@@ -39,6 +45,9 @@ func stripResumeFlag(cmd, resumeFlag, sessionKey string) string {
 	if result == cmd {
 		// Try without the leading space (flag at start of args).
 		result = strings.Replace(cmd, target+" ", "", 1)
+	}
+	if result == cmd {
+		return cmd
 	}
 	return strings.TrimSpace(result)
 }

--- a/internal/session/chat_test.go
+++ b/internal/session/chat_test.go
@@ -89,6 +89,17 @@ func TestStripResumeFlag(t *testing.T) {
 			sessionKey: "",
 			want:       "claude --resume abc-123",
 		},
+		{
+			// PR #2035 review: callers rely on freshCmd == cmd to detect
+			// a no-op strip. TrimSpace on a non-replacement path would
+			// silently change the return value when cmd has padding,
+			// breaking that signal.
+			name:       "no strip preserves leading and trailing whitespace",
+			cmd:        "  claude --model sonnet  ",
+			resumeFlag: "--resume",
+			sessionKey: "abc-123",
+			want:       "  claude --model sonnet  ",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3440,6 +3440,71 @@ func TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata(t *test
 	}
 }
 
+// Issue #1655 — a named-always session whose start command carries no
+// resume flag (ProviderResume{} on Create) must still be able to recover
+// from a stale session_key. Previously retryFreshStartAfterStaleKey
+// refused the retry because stripResumeFlag is a no-op when resume_flag
+// is empty, and the function misclassified that as a strip failure.
+func TestEnsureRunning_RetriesWhenResumeFlagIsEmpty(t *testing.T) {
+	store := beads.NewMemStore()
+	base := runtime.NewFake()
+
+	sp := &startupDeathProvider{Fake: base}
+	mgr := NewManager(store, sp)
+
+	// Named-always-style Create: no resume capability declared.
+	info, err := mgr.Create(context.Background(), "worker", "", "fakecmd --follow worker", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	b, err := store.Get(info.ID)
+	if err != nil {
+		t.Fatalf("Get bead: %v", err)
+	}
+	if b.Metadata["resume_flag"] != "" {
+		t.Fatalf("expected empty resume_flag for ProviderResume{}, got %q", b.Metadata["resume_flag"])
+	}
+
+	// Simulate the post-run state described in #1655: the session ran
+	// once and a session_key landed in bead metadata even though the
+	// start command never accepted a resume flag.
+	if err := store.SetMetadata(info.ID, "session_key", "stale-key-1"); err != nil {
+		t.Fatalf("SetMetadata session_key: %v", err)
+	}
+	if err := store.SetMetadata(info.ID, "started_config_hash", "hash-before"); err != nil {
+		t.Fatalf("SetMetadata started_config_hash: %v", err)
+	}
+
+	if err := mgr.Suspend(info.ID); err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+
+	sp.armed = true
+
+	// The "resume command" for a named-always session is its original
+	// start command — there is no --resume flag to add or strip.
+	err = mgr.Send(context.Background(), info.ID, "hello", "fakecmd --follow worker", runtime.Config{WorkDir: "/tmp"})
+	if err != nil {
+		t.Fatalf("Send should retry fresh when resume_flag is empty but failed: %v", err)
+	}
+
+	if !base.IsRunning(info.SessionName) {
+		t.Fatal("session should be running after empty-resume_flag fresh retry")
+	}
+
+	b, _ = store.Get(info.ID)
+	if b.Metadata["session_key"] != "" {
+		t.Errorf("session_key should be cleared after empty-resume_flag retry, got %q", b.Metadata["session_key"])
+	}
+	if b.Metadata["started_config_hash"] != "" {
+		t.Errorf("started_config_hash should be cleared after empty-resume_flag retry, got %q", b.Metadata["started_config_hash"])
+	}
+	if b.Metadata["continuation_reset_pending"] != "true" {
+		t.Errorf("continuation_reset_pending should be set after empty-resume_flag retry, got %q", b.Metadata["continuation_reset_pending"])
+	}
+}
+
 func TestEnsureRunning_StartupDeathClearMetadataFailurePropagates(t *testing.T) {
 	store := failMetadataKeyStore{MemStore: beads.NewMemStore(), key: "session_key"}
 	base := runtime.NewFake()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3440,11 +3440,15 @@ func TestEnsureRunning_StartupDeathWithoutStrippableResumeClearsMetadata(t *test
 	}
 }
 
-// Issue #1655 — a named-always session whose start command carries no
-// resume flag (ProviderResume{} on Create) must still be able to recover
-// from a stale session_key. Previously retryFreshStartAfterStaleKey
-// refused the retry because stripResumeFlag is a no-op when resume_flag
-// is empty, and the function misclassified that as a strip failure.
+// Issue #1655 — a session created without resume capability
+// (ProviderResume{} on Create → empty resume_flag in bead metadata)
+// must still be able to recover from a stale session_key. The
+// named-always case in the issue body is one instance of this shape;
+// the invariant is general — any session whose start command was
+// never resume-capable should clear a stale key and start fresh
+// rather than bail. Previously retryFreshStartAfterStaleKey refused
+// the retry because stripResumeFlag is a no-op when resume_flag is
+// empty, and the function misclassified that as a strip failure.
 func TestEnsureRunning_RetriesWhenResumeFlagIsEmpty(t *testing.T) {
 	store := beads.NewMemStore()
 	base := runtime.NewFake()
@@ -3452,7 +3456,10 @@ func TestEnsureRunning_RetriesWhenResumeFlagIsEmpty(t *testing.T) {
 	sp := &startupDeathProvider{Fake: base}
 	mgr := NewManager(store, sp)
 
-	// Named-always-style Create: no resume capability declared.
+	// Create a session without resume capability — ProviderResume{}
+	// yields an empty resume_flag in bead metadata. The same shape
+	// arises for any configured-named-always session whose start
+	// command lacks a --resume-style flag.
 	info, err := mgr.Create(context.Background(), "worker", "", "fakecmd --follow worker", "/tmp", "claude", nil, ProviderResume{}, runtime.Config{})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -3482,8 +3489,9 @@ func TestEnsureRunning_RetriesWhenResumeFlagIsEmpty(t *testing.T) {
 
 	sp.armed = true
 
-	// The "resume command" for a named-always session is its original
-	// start command — there is no --resume flag to add or strip.
+	// For a session without resume capability the "resume command"
+	// passed to Send is just the original start command — there is no
+	// --resume flag to add or strip.
 	err = mgr.Send(context.Background(), info.ID, "hello", "fakecmd --follow worker", runtime.Config{WorkDir: "/tmp"})
 	if err != nil {
 		t.Fatalf("Send should retry fresh when resume_flag is empty but failed: %v", err)


### PR DESCRIPTION
## Summary

`retryFreshStartAfterStaleKey` bailed early when `resume_flag` was empty, leaving sessions stuck on a stale key path instead of retrying with a clean start. Fix retries fresh-start regardless of whether `resume_flag` carries a value.

Closes #1655.

## Test plan

- [x] `make build` clean
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] Touched-package tests pass
- [x] New regression test covers the empty-`resume_flag` retry path
- Baseline noise: `TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot` fails identically on origin/main (unrelated dolt sql-server leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
