### PR TITLE
fix(packs): fallback to dolt-provider-state.json

### DIFF
--- a/examples/dolt/assets/scripts/runtime.sh
+++ b/examples/dolt/assets/scripts/runtime.sh
@@ -26,7 +26,15 @@ fi
 
 DOLT_LOG_FILE="${GC_DOLT_LOG_FILE:-$DOLT_STATE_DIR/dolt.log}"
 DOLT_PID_FILE="${GC_DOLT_PID_FILE:-$DOLT_STATE_DIR/dolt.pid}"
-DOLT_STATE_FILE="${GC_DOLT_STATE_FILE:-$DOLT_STATE_DIR/dolt-state.json}"
+if [ -n "${GC_DOLT_STATE_FILE:-}" ]; then
+  DOLT_STATE_FILE="$GC_DOLT_STATE_FILE"
+elif [ -f "$DOLT_STATE_DIR/dolt-state.json" ]; then
+  DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-state.json"
+elif [ -f "$DOLT_STATE_DIR/dolt-provider-state.json" ]; then
+  DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-provider-state.json"
+else
+  DOLT_STATE_FILE="$DOLT_STATE_DIR/dolt-state.json"
+fi
 
 GC_BEADS_BD_SCRIPT="$GC_CITY_PATH/.gc/system/packs/bd/assets/scripts/gc-beads-bd.sh"
 

--- a/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/dolt-target.sh
@@ -143,7 +143,18 @@ managed_runtime_port() (
 )
 
 if [ -z "${GC_DOLT_PORT:-}" ]; then
-    DOLT_STATE_FILE="${GC_DOLT_STATE_FILE:-${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}/packs/dolt/dolt-state.json}"
+    if [ -n "${GC_DOLT_STATE_FILE:-}" ]; then
+        DOLT_STATE_FILE="$GC_DOLT_STATE_FILE"
+    else
+        DOLT_PACK_DIR="${GC_CITY_RUNTIME_DIR:-$GC_CITY_PATH/.gc/runtime}/packs/dolt"
+        if [ -f "$DOLT_PACK_DIR/dolt-state.json" ]; then
+            DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
+        elif [ -f "$DOLT_PACK_DIR/dolt-provider-state.json" ]; then
+            DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-provider-state.json"
+        else
+            DOLT_STATE_FILE="$DOLT_PACK_DIR/dolt-state.json"
+        fi
+    fi
     GC_DOLT_PORT="$(managed_runtime_port "$DOLT_STATE_FILE" "$GC_CITY_PATH/.beads/dolt")"
 fi
 


### PR DESCRIPTION
## Summary

The maintenance and dolt packs read `dolt-state.json` to discover the running dolt port. When the controller is invoking pack scripts it injects `GC_DOLT_STATE_FILE` via `providerLifecycleDoltPathEnv` (`cmd/gc/beads_provider_lifecycle.go:1381`) and everything works. When the env injection doesn't happen — e.g., a maintenance order while the supervisor is stopped, or after a fresh `bd dolt start` standalone — the script falls through to the hardcoded `dolt-state.json` default, which the controller may not have written yet. The `bd` pack has only written `dolt-provider-state.json` at that point. With no state file present, scripts get no port → fall back to `:=3307` → every dolt query fails silently because `jsonl-export.sh` swallows stderr with `2>/dev/null`.

This fixes the failure by extending the fallback chain in `dolt-target.sh` (`examples/gastown/packs/maintenance/...`) and `runtime.sh` (`examples/dolt/...`) to try the bd-pack-written file before giving up:

```
GC_DOLT_STATE_FILE env > dolt-state.json (canonical) > dolt-provider-state.json (bd-bridge) > legacy default
```

Both files have identical JSON shape (`running`, `pid`, `port`, `data_dir`, `started_at`), so `managed_runtime_port` parses either correctly. The canonical name is still preferred when both exist.

### Discovery context

Surfaced while triaging a local JSONL push-failure storm where `mol-dog-jsonl` reported `push: skipped` for every database. Root cause was the silent fallback to `:3307`, traced by re-running the underlying dolt query manually with stderr unmasked. Verified end-to-end locally: with `dolt-state.json` absent and a fresh `dolt-provider-state.json` matching the running server, sourcing `dolt-target.sh` resolves to the bd-bridge file and `dolt_sql` connects successfully.

The two-state-files design is documented by the commit message of `921cb29` ("fix: recover dolt-state.json from stale or missing provider state"), which makes clear `dolt-state.json` is the controller-managed canonical authority and `dolt-provider-state.json` is the bd-bridge state. This PR extends the read-side handling to match.

## Testing

- [x] `make check` — passed locally on macOS (Go 1.26.3)
- [ ] `make check-docs` — N/A (no docs changed)
- [ ] `make test-integration` — not run locally; change is shell-only with no Go logic touched

## Checklist

- [ ] Linked an issue — no upstream issue; discovered via local triage. Happy to file one separately if preferred.
- [ ] Added or updated tests — none. The change is a pure fallback-order extension in two shell scripts. Existing tests in `examples/gastown/maintenance_scripts_test.go` don't exercise the missing-state-file path (they all set up state files before running the scripts). Open to suggestions on where a regression test would land.
- [ ] Updated docs — none needed (internal pack-script behavior).
- [ ] Called out breaking changes — none. Behavior with a valid `GC_DOLT_STATE_FILE` env var or present `dolt-state.json` is unchanged; only the no-state-file fallback path is extended.
