### PR TITLE
test(beads): wrap parseIssuesTolerant errors with raw bd output (#2040)

### DIFF
--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -286,6 +286,17 @@ func extractJSON(data []byte) []byte {
 	}
 }
 
+// truncateRawOutput returns a trimmed slice of bd CLI output suitable for
+// embedding in error messages. Limits to maxBytes to keep error strings
+// bounded, marking truncation explicitly so the reader knows there's more.
+func truncateRawOutput(data []byte, maxBytes int) string {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) <= maxBytes {
+		return string(trimmed)
+	}
+	return string(trimmed[:maxBytes]) + "...(truncated)"
+}
+
 // envWithout returns a copy of environ with all entries for the given key removed.
 func envWithout(environ []string, key string) []string {
 	prefix := key + "="
@@ -415,7 +426,12 @@ func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
 	}
 	var raw []json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing JSON: %w", err)
+		// Include a snippet of the raw bd output so the failure surface is
+		// diagnosable. Historical case (gascity #1726): bd returned the
+		// literal string "None" and the unwrapped error was the opaque
+		// "invalid character 'N' looking for beginning of value" with no
+		// hint that the offending byte was a Python None text.
+		return nil, fmt.Errorf("parsing JSON: raw=%q: %w", truncateRawOutput(data, 200), err)
 	}
 	result := make([]bdIssue, 0, len(raw))
 	var parseErr error

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -422,7 +422,15 @@ func IsPartialResult(err error) bool {
 // This prevents a single bad bead from breaking all list operations.
 func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
-		return nil, nil
+		// Empty / whitespace-only stdout from `bd list --json` is not a
+		// valid empty list — bd is expected to emit at minimum "[]".
+		// Treating the empty case as success silently hid real bd
+		// failures (gascity #1726/#2040 family). Return the same
+		// diagnostic-context shape as the json.Unmarshal failure path
+		// so callers' raw-output assertions cover all four input
+		// shapes uniformly (literal None, plain text, truncated JSON,
+		// empty/whitespace).
+		return nil, fmt.Errorf("parsing JSON: raw=%q: bd stdout was empty or whitespace-only", truncateRawOutput(data, 200))
 	}
 	var raw []json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -422,15 +422,7 @@ func IsPartialResult(err error) bool {
 // This prevents a single bad bead from breaking all list operations.
 func parseIssuesTolerant(data []byte) ([]bdIssue, error) {
 	if len(bytes.TrimSpace(data)) == 0 {
-		// Empty / whitespace-only stdout from `bd list --json` is not a
-		// valid empty list — bd is expected to emit at minimum "[]".
-		// Treating the empty case as success silently hid real bd
-		// failures (gascity #1726/#2040 family). Return the same
-		// diagnostic-context shape as the json.Unmarshal failure path
-		// so callers' raw-output assertions cover all four input
-		// shapes uniformly (literal None, plain text, truncated JSON,
-		// empty/whitespace).
-		return nil, fmt.Errorf("parsing JSON: raw=%q: bd stdout was empty or whitespace-only", truncateRawOutput(data, 200))
+		return nil, nil
 	}
 	var raw []json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1214,6 +1214,64 @@ func TestBdStoreListReturnsHardErrorWithoutUsableSurvivors(t *testing.T) {
 	}
 }
 
+// TestBdStoreListErrorIncludesRawBdOutput is a regression net for the
+// gascity #1726 / #2040 failure mode: when `bd list --json` returns non-JSON
+// output, the resulting error must include the raw bd stdout so the failure
+// surface is diagnosable rather than the opaque json.Unmarshal message
+// (e.g. "invalid character 'N' looking for beginning of value" with no clue
+// what 'N' was). Historical example: bd shipped with Gas City v1.0.0
+// returned the literal string "None\n" instead of a JSON array.
+func TestBdStoreListErrorIncludesRawBdOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		out         []byte
+		wantInError string
+	}{
+		{
+			name:        "literal None (historical #1726 shape)",
+			out:         []byte("None\n"),
+			wantInError: "None",
+		},
+		{
+			name:        "plain text error accidentally on stdout",
+			out:         []byte("error: connection refused\n"),
+			wantInError: "connection refused",
+		},
+		{
+			name:        "truncated JSON",
+			out:         []byte(`[{"id":"bd-aaa","title":"first"`),
+			wantInError: `bd-aaa`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := fakeRunner(map[string]struct {
+				out []byte
+				err error
+			}{
+				`bd list --json --include-infra --include-gates --limit 0`: {out: tc.out},
+			})
+
+			s := beads.NewBdStore("/city", runner)
+			got, err := s.ListOpen()
+			if err == nil {
+				t.Fatalf("ListOpen() error = nil, want diagnostic parse error")
+			}
+			if len(got) != 0 {
+				t.Fatalf("ListOpen() returned %v, want no usable survivors", got)
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("ListOpen() error = %q; want substring %q so callers can see the raw bd output",
+					err.Error(), tc.wantInError)
+			}
+			if !strings.Contains(err.Error(), "bd list") {
+				t.Errorf("ListOpen() error = %q; want 'bd list' context prefix", err.Error())
+			}
+		})
+	}
+}
+
 func TestBdStoreReadyReturnsPartialResultErrorOnCorruptEntries(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1108,23 +1108,6 @@ func TestBdStoreListEmpty(t *testing.T) {
 	}
 }
 
-func TestBdStoreListEmptyOutputMeansNoBeads(t *testing.T) {
-	runner := fakeRunner(map[string]struct {
-		out []byte
-		err error
-	}{
-		`bd list --json --include-infra --include-gates --limit 0`: {out: []byte(" \n\t")},
-	})
-	s := beads.NewBdStore("/city", runner)
-	got, err := s.ListOpen()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Errorf("List() returned %d beads, want 0", len(got))
-	}
-}
-
 func TestBdStoreListError(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1")
@@ -1241,6 +1224,24 @@ func TestBdStoreListErrorIncludesRawBdOutput(t *testing.T) {
 			name:        "truncated JSON",
 			out:         []byte(`[{"id":"bd-aaa","title":"first"`),
 			wantInError: `bd-aaa`,
+		},
+		{
+			// PR #2042 review (copilot): bd list returning empty stdout
+			// should surface as a parse error with raw=%q context, not
+			// silently as an empty list — bd is expected to emit at
+			// minimum "[]". Without this, real bd failures (process
+			// died after partial write, stdout closed prematurely) are
+			// indistinguishable from a legitimately-empty work queue.
+			name:        "empty stdout",
+			out:         []byte(""),
+			wantInError: "empty or whitespace-only",
+		},
+		{
+			// PR #2042 review (copilot): all-whitespace stdout shares
+			// the empty-stdout failure shape after bytes.TrimSpace.
+			name:        "whitespace only",
+			out:         []byte("   \n\n  \n"),
+			wantInError: "empty or whitespace-only",
 		},
 	}
 

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1108,6 +1108,23 @@ func TestBdStoreListEmpty(t *testing.T) {
 	}
 }
 
+func TestBdStoreListEmptyOutputMeansNoBeads(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd list --json --include-infra --include-gates --limit 0`: {out: []byte(" \n\t")},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.ListOpen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List() returned %d beads, want 0", len(got))
+	}
+}
+
 func TestBdStoreListError(t *testing.T) {
 	runner := func(_, _ string, _ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("exit status 1")
@@ -1224,24 +1241,6 @@ func TestBdStoreListErrorIncludesRawBdOutput(t *testing.T) {
 			name:        "truncated JSON",
 			out:         []byte(`[{"id":"bd-aaa","title":"first"`),
 			wantInError: `bd-aaa`,
-		},
-		{
-			// PR #2042 review (copilot): bd list returning empty stdout
-			// should surface as a parse error with raw=%q context, not
-			// silently as an empty list — bd is expected to emit at
-			// minimum "[]". Without this, real bd failures (process
-			// died after partial write, stdout closed prematurely) are
-			// indistinguishable from a legitimately-empty work queue.
-			name:        "empty stdout",
-			out:         []byte(""),
-			wantInError: "empty or whitespace-only",
-		},
-		{
-			// PR #2042 review (copilot): all-whitespace stdout shares
-			// the empty-stdout failure shape after bytes.TrimSpace.
-			name:        "whitespace only",
-			out:         []byte("   \n\n  \n"),
-			wantInError: "empty or whitespace-only",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Adds a parse-tolerance regression net to `internal/beads/bdstore.go` so future failures in `bd list --json` parsing surface with the raw bd output in the error message, instead of an opaque `invalid character N looking for beginning of value`-shaped message.

Follow-up to #1726 (gc init JSON-parse failure on older bd, dead on current toolchain but worth a defensive net for the next time bd output drifts).

Closes #2040.

## Changes

- `internal/beads/bdstore.go` (+11/-1): `parseIssuesTolerant` wraps the top-level `json.Unmarshal` error with `parsing JSON: raw=%q: %w`, including a 200-byte snippet of bd stdout via new `truncateRawOutput` helper. Existing outer `bd list` prefix preserved by the caller wrapper.
- `internal/beads/bdstore_test.go` (+64): new `TestBdStoreListErrorIncludesRawBdOutput` table test covers 3 shapes — `None\n`, plain text, truncated JSON. RED → GREEN with the wrap.

## Test plan

- [x] `go test -race ./internal/beads/...` pass
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] `make lint` 0 issues
- [x] Existing `TestBdStoreListReturnsHardErrorWithoutUsableSurvivors` still passes (outer "bd list" prefix preserved)
- [x] New test asserts error format includes raw bd output snippet for diagnostic context

## Context

Issue #1726 was filed against gc v1.0.0 + an older bd that emitted literal `None\n` for empty results. The bug is dead on current toolchain (gc v1.1.1 + bd v1.0.4) — `bd list --json` returns valid JSON. But the parse path was silently fail-opening when it should have surfaced the raw output. This PR doesn't change behavior on the happy path; it only improves error diagnostics for whichever flavor of malformed bd output appears next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
