### PR TITLE
fix(hooks): disable Claude Code away-summary in default settings template

### DIFF
--- a/internal/hooks/config/claude.json
+++ b/internal/hooks/config/claude.json
@@ -1,6 +1,7 @@
 {
   "skipDangerousModePermissionPrompt": true,
   "editorMode": "normal",
+  "awaySummaryEnabled": false,
   "hooks": {
     "SessionStart": [
       {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -137,6 +137,9 @@ func TestInstallClaude(t *testing.T) {
 	if !strings.Contains(s, `"editorMode": "normal"`) {
 		t.Error("claude settings should contain editorMode")
 	}
+	if !strings.Contains(s, `"awaySummaryEnabled": false`) {
+		t.Error("claude settings should disable awaySummaryEnabled to prevent idle stalls (gh-1962)")
+	}
 	if !strings.Contains(s, `$HOME/go/bin`) {
 		t.Error("claude hook commands should include PATH export")
 	}


### PR DESCRIPTION
## Summary

Chain-agent sessions spawned by Gas City stall indefinitely after ~3 min idle because Claude Code v2.1.108+'s "recap" / away-summary feature fires and waits for operator input that never arrives. Supervisor reports `running`, mayor inbox is empty, no escalation — the chain halts silently.

Add `"awaySummaryEnabled": false` to the default Claude settings template (`internal/hooks/config/claude.json`) that `gc init` ships and pack-supplied agents inherit. Pack authors who want recaps for some reason can override per-pack.

Equivalent to env var `CLAUDE_CODE_ENABLE_AWAY_SUMMARY=false` per https://code.claude.com/docs/en/settings — config-file form keeps the surface in one place.

## Changes

- `internal/hooks/config/claude.json` — add `"awaySummaryEnabled": false` (one line)
- `internal/hooks/hooks_test.go` — add assertion in `TestInstallClaude` that the new key is present

## Test plan

- [x] `go test ./internal/hooks/... -run TestInstallClaude` passes
- [ ] CI green

Fixes #1962