### PR TITLE
test: stabilize reload and managed dolt cleanup

### DIFF
--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -466,6 +466,7 @@ func TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot(t *test
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
 	t.Setenv("GC_BEADS", "bd")
+	cleanupManagedDoltTestCity(t, cityPath)
 
 	cfg, err := config.Load(osFS{}, tomlPath)
 	if err != nil {

--- a/cmd/gc/controller_test.go
+++ b/cmd/gc/controller_test.go
@@ -1898,13 +1898,12 @@ func TestControllerReloadCityNameChange(t *testing.T) {
 	// Change the city name.
 	writeCityTOML(t, dir, "different-city", "mayor")
 
-	// Wait for tick.
-	target := reconcileCount.Load() + 2
 	deadline := time.After(3 * time.Second)
-	for reconcileCount.Load() < target {
+	for !strings.Contains(stderr.String(), "workspace.name changed") {
 		select {
 		case <-deadline:
-			t.Fatal("timed out waiting for tick after name change")
+			t.Fatalf("timed out waiting for city name change rejection; reconciles=%d stdout=%q stderr=%q",
+				reconcileCount.Load(), stdout.String(), stderr.String())
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}

--- a/cmd/gc/path_helpers_test.go
+++ b/cmd/gc/path_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -167,5 +168,48 @@ func cleanupManagedDoltTestCity(t *testing.T, cityPath string) {
 		if err := shutdownBeadsProvider(cityPath); err != nil {
 			t.Logf("shutdownBeadsProvider(%s): %v", cityPath, err)
 		}
+		stopManagedDoltProcessesUnderTestCity(t, cityPath)
 	})
+}
+
+func stopManagedDoltProcessesUnderTestCity(t *testing.T, cityPath string) {
+	t.Helper()
+	procs, err := discoverDoltProcesses()
+	if err != nil {
+		t.Fatalf("discoverDoltProcesses: %v", err)
+	}
+	for _, p := range procs {
+		configPath := extractConfigPath(p.Argv)
+		if !pathutil.PathWithin(cityPath, configPath) {
+			continue
+		}
+		stopManagedDoltTestPID(t, p.PID)
+	}
+}
+
+func stopManagedDoltTestPID(t *testing.T, pid int) {
+	t.Helper()
+	if pid <= 0 || !managedStopPIDAlive(pid) {
+		return
+	}
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+		t.Fatalf("signal dolt test pid %d with SIGTERM: %v", pid, err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for managedStopPIDAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !managedStopPIDAlive(pid) {
+		return
+	}
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		t.Fatalf("signal dolt test pid %d with SIGKILL: %v", pid, err)
+	}
+	deadline = time.Now().Add(time.Second)
+	for managedStopPIDAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if managedStopPIDAlive(pid) {
+		t.Fatalf("dolt test pid %d still alive after SIGKILL", pid)
+	}
 }


### PR DESCRIPTION
## Summary
- stabilize TestControllerReloadCityNameChange by waiting for the actual workspace.name rejection log instead of a fixed reconcile tick count
- add cleanup for managed Dolt sql-server processes scoped to the test city temp directory

## Notes
- The original job page showed Preflight / unit cover failed with exit code 2. The corrupt bead messages were partial-result warnings; the failing assertion was the city-name reload test missing the rejection log before timeout.

## Verification
- make test-cover
- go test ./cmd/gc -run ^TestControllerReloadCityNameChange$ -count=50
- go test ./cmd/gc -run ^TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot$ -count=3 -v
- go test ./cmd/gc -run ^TestControllerReloadCityNameChange$ -count=20
- go test ./cmd/gc -run ^TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot$ -count=1 -v