### PR TITLE
feat(session): ordinal references for `gc session attach N` (#2031)

### DIFF
--- a/cmd/gc/cmd_session.go
+++ b/cmd/gc/cmd_session.go
@@ -648,9 +648,16 @@ func newSessionListCmd(stdout, stderr io.Writer) *cobra.Command {
 
 // cmdSessionList is the CLI entry point for "gc session list".
 func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout, stderr io.Writer) int {
-	store, code := openCityStore(stderr, "gc session list")
-	if store == nil {
-		return code
+	cityPath, err := resolveCity()
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session list: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	store, err := openCityStoreAt(cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc session list: %v\n", err)               //nolint:errcheck // best-effort stderr
+		fmt.Fprintln(stderr, "hint: run \"gc doctor\" for diagnostics") //nolint:errcheck // best-effort stderr
+		return 1
 	}
 
 	providerCtx := loadSessionProviderContext()
@@ -721,6 +728,9 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 
 	if len(sessions) == 0 {
 		fmt.Fprintln(stdout, "No sessions found.") //nolint:errcheck // best-effort stdout
+		if err := writeSessionListSnapshot(cityPath, nil); err != nil {
+			fmt.Fprintf(stderr, "gc session list: writing ordinal snapshot: %v\n", err) //nolint:errcheck // best-effort stderr
+		}
 		return 0
 	}
 
@@ -729,8 +739,9 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 	cachedSP := &attachmentCachingProvider{Provider: sp, cache: attachedSet}
 
 	w := tabwriter.NewWriter(stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tTEMPLATE\tSTATE\tREASON\tTARGET\tTITLE\tAGE\tLAST ACTIVE") //nolint:errcheck // best-effort stdout
-	for _, s := range sessions {
+	fmt.Fprintln(w, "#\tID\tTEMPLATE\tSTATE\tREASON\tTARGET\tTITLE\tAGE\tLAST ACTIVE") //nolint:errcheck // best-effort stdout
+	displayedIDs := make([]string, 0, len(sessions))
+	for i, s := range sessions {
 		state := string(s.State)
 		if s.State == "" {
 			state = "closed"
@@ -743,9 +754,13 @@ func cmdSessionList(stateFilter, templateFilter string, jsonOutput bool, stdout,
 		if !s.LastActive.IsZero() {
 			lastActive = formatDuration(time.Since(s.LastActive)) + " ago"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", s.ID, s.Template, state, reason, target, title, age, lastActive) //nolint:errcheck // best-effort stdout
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", i, s.ID, s.Template, state, reason, target, title, age, lastActive) //nolint:errcheck // best-effort stdout
+		displayedIDs = append(displayedIDs, s.ID)
 	}
 	_ = w.Flush() //nolint:errcheck // best-effort stdout
+	if err := writeSessionListSnapshot(cityPath, displayedIDs); err != nil {
+		fmt.Fprintf(stderr, "gc session list: writing ordinal snapshot: %v\n", err) //nolint:errcheck // best-effort stderr
+	}
 	return 0
 }
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1120,6 +1120,66 @@ func TestSessionNewAliasOwner_UsesConfiguredNamedIdentity(t *testing.T) {
 	}
 }
 
+// TestCmdSessionList_OrdinalColumnAndSnapshot verifies that `gc session list`
+// prints a leading `#` ordinal column and writes a snapshot of the displayed
+// bead IDs (in display order) to .gc/last-session-list.json. Issue #2031.
+func TestCmdSessionList_OrdinalColumnAndSnapshot(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_SESSION", "fake")
+
+	cityDir := t.TempDir()
+	t.Setenv("GC_CITY", cityDir)
+	writeNamedSessionCityTOML(t, cityDir)
+
+	store, err := openCityStoreAt(cityDir)
+	if err != nil {
+		t.Fatalf("openCityStoreAt: %v", err)
+	}
+	// Create three sessions. CreatedDesc list orders newest first.
+	mk := func(name string) string {
+		b, err := store.Create(beads.Bead{
+			Type:   session.BeadType,
+			Labels: []string{session.LabelSession},
+			Metadata: map[string]string{
+				"session_name": name,
+				"template":     "mayor",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Create(%s): %v", name, err)
+		}
+		return b.ID
+	}
+	id1 := mk("alpha")
+	id2 := mk("beta")
+	id3 := mk("gamma")
+
+	var stdout, stderr bytes.Buffer
+	if code := cmdSessionList("", "", false, &stdout, &stderr); code != 0 {
+		t.Fatalf("cmdSessionList() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "#") {
+		t.Fatalf("stdout missing `#` header column:\n%s", out)
+	}
+
+	snapshot, err := readSessionListSnapshot(cityDir)
+	if err != nil {
+		t.Fatalf("readSessionListSnapshot: %v", err)
+	}
+	// CreatedDesc — newest first.
+	want := []string{id3, id2, id1}
+	if len(snapshot) != len(want) {
+		t.Fatalf("snapshot ids = %v, want %v", snapshot, want)
+	}
+	for i, id := range want {
+		if snapshot[i] != id {
+			t.Errorf("snapshot[%d] = %q, want %q", i, snapshot[i], id)
+		}
+	}
+}
+
 func TestCmdSessionListJSONNoSessionsReturnsEmptyArray(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_SESSION", "fake")

--- a/cmd/gc/session_ordinal.go
+++ b/cmd/gc/session_ordinal.go
@@ -1,0 +1,100 @@
+// ABOUTME: Snapshot file backing ordinal session references (issue #2031):
+// ABOUTME: `gc session list` writes IDs in display order; resolver indexes them.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+const sessionListSnapshotFile = "last-session-list.json"
+
+func sessionListSnapshotPath(cityPath string) string {
+	return filepath.Join(cityPath, ".gc", sessionListSnapshotFile)
+}
+
+// writeSessionListSnapshot persists the bead-ID order shown by the most
+// recent `gc session list` invocation. Last write wins. Atomic via
+// temp file + rename. Caller is responsible for ensuring `.gc/` exists.
+func writeSessionListSnapshot(cityPath string, ids []string) error {
+	if ids == nil {
+		ids = []string{}
+	}
+	data, err := json.Marshal(ids)
+	if err != nil {
+		return fmt.Errorf("marshaling session list snapshot: %w", err)
+	}
+	dir := filepath.Join(cityPath, ".gc")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensuring .gc/: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, sessionListSnapshotFile+".*")
+	if err != nil {
+		return fmt.Errorf("creating snapshot temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing snapshot temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing snapshot temp: %w", err)
+	}
+	if err := os.Rename(tmpName, sessionListSnapshotPath(cityPath)); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("renaming snapshot temp: %w", err)
+	}
+	return nil
+}
+
+// readSessionListSnapshot returns the bead-ID order from the most recent
+// `gc session list` invocation. Missing snapshot returns ErrSessionNotFound
+// so callers in the resolver chain can fall through.
+func readSessionListSnapshot(cityPath string) ([]string, error) {
+	data, err := os.ReadFile(sessionListSnapshotPath(cityPath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: no prior `gc session list`", session.ErrSessionNotFound)
+		}
+		return nil, fmt.Errorf("reading session list snapshot: %w", err)
+	}
+	var ids []string
+	if err := json.Unmarshal(data, &ids); err != nil {
+		return nil, fmt.Errorf("parsing session list snapshot: %w", err)
+	}
+	return ids, nil
+}
+
+// resolveOrdinalFromSnapshot interprets identifier as a 0-based ordinal
+// into the most recent `gc session list` snapshot. Only canonical decimal
+// representations of non-negative integers match; non-canonical forms
+// ("01", "+0", whitespace) and non-digit strings return ErrSessionNotFound
+// so they flow back to alias/ID lookup paths in the resolver.
+func resolveOrdinalFromSnapshot(cityPath, identifier string) (string, error) {
+	notFound := func() (string, error) {
+		return "", fmt.Errorf("%w: %q", session.ErrSessionNotFound, identifier)
+	}
+	n, err := strconv.Atoi(identifier)
+	if err != nil || n < 0 || strconv.Itoa(n) != identifier {
+		return notFound()
+	}
+	ids, err := readSessionListSnapshot(cityPath)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			return notFound()
+		}
+		return "", err
+	}
+	if n >= len(ids) {
+		return notFound()
+	}
+	return ids[n], nil
+}

--- a/cmd/gc/session_ordinal_test.go
+++ b/cmd/gc/session_ordinal_test.go
@@ -1,0 +1,286 @@
+// ABOUTME: Tests for ordinal session resolution via snapshot file written
+// ABOUTME: by `gc session list` and consulted by resolver (issue #2031).
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/session"
+)
+
+func TestSessionListSnapshot_RoundTrip(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ids := []string{"fa-aaa1", "fa-aaa2", "fa-aaa3"}
+	if err := writeSessionListSnapshot(cityPath, ids); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+	got, err := readSessionListSnapshot(cityPath)
+	if err != nil {
+		t.Fatalf("readSessionListSnapshot: %v", err)
+	}
+	if len(got) != len(ids) {
+		t.Fatalf("got %d ids, want %d", len(got), len(ids))
+	}
+	for i, id := range ids {
+		if got[i] != id {
+			t.Errorf("snapshot[%d] = %q, want %q", i, got[i], id)
+		}
+	}
+}
+
+func TestSessionListSnapshot_OverwritesLastWriteWins(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeSessionListSnapshot(cityPath, []string{"old1", "old2"}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeSessionListSnapshot(cityPath, []string{"new1"}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err := readSessionListSnapshot(cityPath)
+	if err != nil {
+		t.Fatalf("readSessionListSnapshot: %v", err)
+	}
+	if len(got) != 1 || got[0] != "new1" {
+		t.Fatalf("got %v, want [new1]", got)
+	}
+}
+
+func TestSessionListSnapshot_MissingReturnsNotFound(t *testing.T) {
+	cityPath := t.TempDir()
+	_, err := readSessionListSnapshot(cityPath)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("readSessionListSnapshot on missing snapshot = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestResolveOrdinalFromSnapshot_Resolves(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ids := []string{"fa-aaa1", "fa-aaa2", "fa-aaa3"}
+	if err := writeSessionListSnapshot(cityPath, ids); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+	for i, want := range ids {
+		got, err := resolveOrdinalFromSnapshot(cityPath, itoa(i))
+		if err != nil {
+			t.Fatalf("resolveOrdinalFromSnapshot(%d): %v", i, err)
+		}
+		if got != want {
+			t.Errorf("ordinal %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestResolveOrdinalFromSnapshot_OutOfRange(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeSessionListSnapshot(cityPath, []string{"fa-aaa1"}); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+	_, err := resolveOrdinalFromSnapshot(cityPath, "5")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("out-of-range ordinal = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestResolveOrdinalFromSnapshot_RejectsNonCanonical(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeSessionListSnapshot(cityPath, []string{"fa-aaa1", "fa-aaa2"}); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+	bad := []string{"01", "+0", "-1", " 0", "0 ", "0.0", "", "fa-aaa1"}
+	for _, ident := range bad {
+		_, err := resolveOrdinalFromSnapshot(cityPath, ident)
+		if !errors.Is(err, session.ErrSessionNotFound) {
+			t.Errorf("resolveOrdinalFromSnapshot(%q) = %v, want ErrSessionNotFound", ident, err)
+		}
+	}
+}
+
+func TestResolveOrdinalFromSnapshot_MissingSnapshot(t *testing.T) {
+	cityPath := t.TempDir()
+	_, err := resolveOrdinalFromSnapshot(cityPath, "0")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("missing snapshot = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestResolveSessionIDWithConfig_OrdinalViaSnapshot exercises the full
+// resolver path: snapshot present, pure-digit identifier resolves to the
+// snapshot's bead at that index.
+func TestResolveSessionIDWithConfig_OrdinalViaSnapshot(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store := beads.NewMemStore()
+	first, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	second, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	third, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	if err := writeSessionListSnapshot(cityPath, []string{first.ID, second.ID, third.ID}); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+
+	cases := []struct {
+		ordinal string
+		want    string
+	}{
+		{"0", first.ID},
+		{"1", second.ID},
+		{"2", third.ID},
+	}
+	for _, tc := range cases {
+		got, err := resolveSessionIDWithConfig(cityPath, nil, store, tc.ordinal)
+		if err != nil {
+			t.Errorf("resolveSessionIDWithConfig(%q): %v", tc.ordinal, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ordinal %q = %q, want %q", tc.ordinal, got, tc.want)
+		}
+	}
+}
+
+// TestResolveSessionIDWithConfig_AliasBeatsOrdinal verifies that when a
+// session is aliased to a digit (e.g. "1"), the alias wins. Alias
+// resolution runs before the ordinal-snapshot branch in the resolver.
+func TestResolveSessionIDWithConfig_AliasBeatsOrdinal(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store := beads.NewMemStore()
+	first, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	aliased, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+		Metadata: map[string]string{
+			"alias": "1",
+		},
+	})
+	other, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	// Snapshot puts `other` at ordinal 1 — if ordinal won, "1" would
+	// resolve to `other`. The aliased bead must win instead.
+	if err := writeSessionListSnapshot(cityPath, []string{first.ID, other.ID, aliased.ID}); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+
+	got, err := resolveSessionIDWithConfig(cityPath, nil, store, "1")
+	if err != nil {
+		t.Fatalf("resolveSessionIDWithConfig(\"1\"): %v", err)
+	}
+	if got != aliased.ID {
+		t.Fatalf("got %q, want aliased %q (ordinal would have returned %q)", got, aliased.ID, other.ID)
+	}
+}
+
+// TestResolveSessionIDWithConfig_OrdinalForClosedBeadResolves verifies a
+// closed bead in the snapshot still resolves via its ordinal. The
+// resolver doesn't filter by status — closed-session semantics are the
+// caller's concern, mirroring how `gc session attach <closed-id>` behaves.
+func TestResolveSessionIDWithConfig_OrdinalForClosedBeadResolves(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store := beads.NewMemStore()
+	closed, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	if err := store.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	open1, _ := store.Create(beads.Bead{
+		Type:   session.BeadType,
+		Labels: []string{session.LabelSession},
+	})
+	if err := writeSessionListSnapshot(cityPath, []string{closed.ID, open1.ID}); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+
+	got, err := resolveSessionIDWithConfig(cityPath, nil, store, "0")
+	if err != nil {
+		t.Fatalf("resolveSessionIDWithConfig(\"0\"): %v", err)
+	}
+	if got != closed.ID {
+		t.Fatalf("got %q, want closed bead %q (snapshot drives resolution)", got, closed.ID)
+	}
+}
+
+// TestSessionListSnapshot_EmptyOverwritesPrior verifies that a fresh
+// `gc session list` that finds no sessions invalidates an earlier
+// snapshot. Otherwise a stale ID would survive after all sessions
+// closed and user-typed ordinals would resurrect ghosts.
+func TestSessionListSnapshot_EmptyOverwritesPrior(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writeSessionListSnapshot(cityPath, []string{"fa-aaa1", "fa-aaa2"}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeSessionListSnapshot(cityPath, nil); err != nil {
+		t.Fatalf("nil write: %v", err)
+	}
+	got, err := readSessionListSnapshot(cityPath)
+	if err != nil {
+		t.Fatalf("readSessionListSnapshot: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %v, want empty after nil overwrite", got)
+	}
+}
+
+// TestResolveSessionIDWithConfig_OrdinalForMissingBeadFalls verifies that
+// if a snapshot references a bead the store no longer has, the ordinal
+// branch falls through (returns ErrSessionNotFound) rather than returning
+// the stale ID. Stale snapshots after `bd close` of a deleted bead must
+// not produce phantom resolutions.
+func TestResolveSessionIDWithConfig_OrdinalForMissingBeadFalls(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store := beads.NewMemStore()
+	if err := writeSessionListSnapshot(cityPath, []string{"fa-deadbe"}); err != nil {
+		t.Fatalf("writeSessionListSnapshot: %v", err)
+	}
+
+	_, err := resolveSessionIDWithConfig(cityPath, nil, store, "0")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Fatalf("got %v, want ErrSessionNotFound", err)
+	}
+}

--- a/cmd/gc/session_resolve.go
+++ b/cmd/gc/session_resolve.go
@@ -160,6 +160,13 @@ func resolveSessionIDWithOptions(
 	} else if !errors.Is(err, session.ErrSessionNotFound) {
 		return "", err
 	}
+	if id, err := resolveOrdinalFromSnapshot(cityPath, identifier); err == nil {
+		if _, getErr := store.Get(id); getErr == nil {
+			return id, nil
+		}
+	} else if !errors.Is(err, session.ErrSessionNotFound) {
+		return "", err
+	}
 	if opts.allowClosed {
 		if cfg != nil {
 			cityName := config.EffectiveCityName(cfg, filepath.Base(cityPath))

--- a/docs/plans/2026-05-12-ordinal-session-ref.md
+++ b/docs/plans/2026-05-12-ordinal-session-ref.md
@@ -1,0 +1,88 @@
+---
+title: Ordinal Session Reference
+date: 2026-05-12
+issue: https://github.com/gastownhall/gascity/issues/2031
+status: in-progress
+---
+
+# Ordinal Session Reference
+
+## Problem
+
+Users want short ordinal references for sessions (`gc session attach 1`)
+instead of typing bead IDs or full aliases.
+
+## Mental model (settled with JPB)
+
+Ordinals are **purely ephemeral indices into the most recently rendered
+`gc session list`**. They are not stable IDs, not predicates, not
+filters. They mean exactly: "the bead I just saw in row N."
+
+If the list changes between renders, the same number refers to a
+different bead. That is intentional — same as a screen cursor.
+
+## Design (Path 1: snapshot file)
+
+- **Snapshot file.** `gc session list` writes the displayed bead IDs
+  (in display order) to `<cityPath>/.gc/last-session-list.json`. Atomic
+  via temp file + rename. Last write wins; no TTL.
+- **Per-city scope.** Each city's `.gc/` holds its own snapshot. No
+  cross-city contamination.
+- **Pure-digit ordinal resolution.** When `resolveSessionIDWithOptions`
+  is given a canonical non-negative integer (no leading zeros, no signs,
+  no whitespace), it reads the snapshot and returns `snapshot[N]`.
+- **Existence guard.** Stale snapshot entries (bead no longer in store)
+  fall through to `ErrSessionNotFound` rather than returning a phantom
+  ID.
+- **Resolver precedence in `resolveSessionIDWithOptions`:**
+  1. exact ID
+  2. configured named session
+  3. alias / partial ID (existing `ResolveSessionID`)
+  4. qualified alias basename
+  5. **new: pure-digit ordinal via snapshot** (consulted only after the
+     above branches return `ErrSessionNotFound`)
+  6. allow-closed (when opt set)
+
+  Alias wins over ordinal: if a session is aliased `"1"`,
+  `gc session attach 1` resolves to that alias.
+- **Closed beads.** If the snapshot references a closed bead, the
+  resolver returns it (same as `gc session attach <closed-id>`).
+  Downstream commands decide what to do with closed sessions — not the
+  resolver's concern.
+- **Display.** Add `#` column (leftmost) to `gc session list` table
+  output. JSON output unchanged.
+
+## Scope
+
+Wired only through `resolveSessionIDWithOptions` — the config-aware
+path used by `attach`, `suspend`, `resume`, `stop`, `wake`, etc.
+
+`resolveSessionID(store, ...)` (plain, no cityPath) — used by
+`cmd_handoff`, `cmd_mail`, `cmd_nudge` for internal lookups of known
+session names — is not extended. These call sites take session-names
+from bead metadata, not user-typed ordinals, so ordinal support there
+is out of scope for #2031.
+
+## TDD plan
+
+1. ✅ `writeSessionListSnapshot` / `readSessionListSnapshot` round trip.
+2. ✅ `resolveOrdinalFromSnapshot` resolves 0/1/2 against snapshot.
+3. ✅ Out-of-range ordinal → `ErrSessionNotFound`.
+4. ✅ Non-canonical digits (`"01"`, `"+0"`, whitespace) rejected.
+5. ✅ Missing snapshot → `ErrSessionNotFound`.
+6. ✅ Full resolver: alias `"1"` beats ordinal `1`.
+7. ✅ Full resolver: closed bead in snapshot still resolves.
+8. ✅ Full resolver: stale snapshot entry (missing bead) falls through.
+9. ✅ `gc session list` prints `#` column and writes snapshot in
+   display order.
+
+## Files
+
+- `cmd/gc/session_ordinal.go` — snapshot read/write + ordinal resolver
+- `cmd/gc/session_ordinal_test.go` — snapshot + resolver tests
+- `cmd/gc/session_resolve.go` — wire ordinal branch into
+  `resolveSessionIDWithOptions`
+- `cmd/gc/cmd_session.go` — `#` column + snapshot write in
+  `cmdSessionList`
+- `cmd/gc/cmd_session_test.go` — list-output + snapshot test
+- `docs/plans/2026-05-12-ordinal-session-ref.md` — this file


### PR DESCRIPTION
## Summary

Ordinals are ephemeral indices into the most recently rendered `gc session list`. They are not stable IDs — same as a screen cursor.

- `gc session list` prepends a `#` column to the table and writes the displayed bead IDs (in display order) to `<cityPath>/.gc/last-session-list.json` (atomic temp+rename).
- `resolveSessionIDWithOptions` reads the snapshot when given a canonical non-negative integer and returns `snapshot[N]`.
- Aliases win over ordinals: a session aliased `"1"` still resolves first; only after all alias/ID paths return `ErrSessionNotFound` does the ordinal branch fire.
- Closed beads in the snapshot resolve (same behavior as `gc session attach <closed-id>`); stale entries whose bead is gone fall through.

## Scope

Wired through `resolveSessionIDWithOptions` only — the config-aware path used by `attach`, `suspend`, `resume`, `stop`, `wake`. Plain `resolveSessionID(store, ...)` (handoff, mail, nudge internal lookups) is unchanged; those callers pass session-names from bead metadata, not user-typed ordinals.

Closes #2031.

## Test plan

- [x] Snapshot read/write round trip + last-write-wins
- [x] Pure-digit ordinal resolves to snapshot index
- [x] Non-canonical digits (`"01"`, `"+0"`, whitespace) rejected
- [x] Out-of-range ordinal → `ErrSessionNotFound`
- [x] Missing snapshot → `ErrSessionNotFound`
- [x] Alias `"1"` beats ordinal `1` end-to-end via `resolveSessionIDWithConfig`
- [x] Closed bead in snapshot still resolves
- [x] Stale snapshot entry (missing bead) falls through
- [x] `gc session list` prints `#` header and writes snapshot in display order
- [x] Empty-session listing overwrites prior snapshot to invalidate ghosts

Co-Authored-By: IvoryPrairie (claude-opus-4-7) <noreply@anthropic.com>