### PR TITLE
Fix session bead adoption race

### DIFF
--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -51,6 +51,7 @@ var poolSlotPattern = regexp.MustCompile(`-(\d+)$`)
 // Returns the adoption result and whether the barrier passed (all running
 // sessions have beads).
 func runAdoptionBarrier(
+	cityPath string,
 	store beads.Store,
 	sp runtime.Provider,
 	cfg *config.City,
@@ -215,12 +216,30 @@ func runAdoptionBarrier(
 			continue
 		}
 
-		_, createErr := store.Create(beads.Bead{
-			Title:    detail.AgentName,
-			Type:     sessionBeadType,
-			Labels:   []string{sessionBeadLabel, "agent:" + detail.AgentName},
-			Metadata: meta,
+		alreadyHadBead := false
+		createErr := sessionpkg.WithCitySessionIdentifierLocks(cityPath, []string{sessionName, detail.AgentName}, func() error {
+			hasBead, err := openSessionBeadExists(store, sessionName)
+			if err != nil {
+				return err
+			}
+			if hasBead {
+				alreadyHadBead = true
+				return nil
+			}
+			_, err = store.Create(beads.Bead{
+				Title:    detail.AgentName,
+				Type:     sessionBeadType,
+				Labels:   []string{sessionBeadLabel, "agent:" + detail.AgentName},
+				Metadata: meta,
+			})
+			return err
 		})
+		if alreadyHadBead {
+			result.AlreadyHadBead++
+			detail.HasBead = true
+			result.Details = append(result.Details, detail)
+			continue
+		}
 		if createErr != nil {
 			fmt.Fprintf(stderr, "adoption barrier: creating bead for %s: %v\n", sessionName, createErr) //nolint:errcheck
 			result.Skipped++
@@ -233,6 +252,26 @@ func runAdoptionBarrier(
 	// Step 4: Barrier gate — all running sessions must have beads.
 	passed := result.Skipped == 0 && !partialList
 	return result, passed
+}
+
+func openSessionBeadExists(store beads.Store, sessionName string) (bool, error) {
+	existing, err := store.List(beads.ListQuery{
+		Label:    sessionBeadLabel,
+		Metadata: map[string]string{"session_name": sessionName},
+		Live:     true,
+	})
+	if err != nil {
+		return false, fmt.Errorf("listing session beads for %q: %w", sessionName, err)
+	}
+	for _, b := range existing {
+		if b.Status == "closed" {
+			continue
+		}
+		if sessionpkg.IsSessionBeadOrRepairable(b) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // resolvePoolBase attempts to match a pool instance session name back to its

--- a/cmd/gc/adoption_barrier.go
+++ b/cmd/gc/adoption_barrier.go
@@ -108,7 +108,7 @@ func runAdoptionBarrier(
 	st := cfg.Workspace.SessionTemplate
 	snapshot := &sessionBeadSnapshot{}
 	for _, b := range existing {
-		if b.Status != "closed" {
+		if b.Status != "closed" && sessionpkg.IsSessionBeadOrRepairable(b) {
 			snapshot.add(b)
 		}
 	}
@@ -123,8 +123,6 @@ func runAdoptionBarrier(
 		agentBySession[sn] = a
 		agentByQN[a.QualifiedName()] = a
 	}
-
-	now := clk.Now().UTC()
 
 	// Step 3: For each running session, adopt if no open bead exists.
 	for _, sessionName := range running {
@@ -163,7 +161,6 @@ func runAdoptionBarrier(
 			"generation":         strconv.Itoa(sessionpkg.DefaultGeneration),
 			"continuation_epoch": strconv.Itoa(sessionpkg.DefaultContinuationEpoch),
 			"instance_token":     sessionpkg.NewInstanceToken(),
-			"synced_at":          now.Format("2006-01-02T15:04:05Z07:00"),
 		}
 
 		detail := adoptionDetail{SessionName: sessionName}
@@ -217,6 +214,19 @@ func runAdoptionBarrier(
 		}
 
 		alreadyHadBead := false
+		createSessionBead := func() error {
+			meta["synced_at"] = clk.Now().UTC().Format("2006-01-02T15:04:05Z07:00")
+			_, err := store.Create(beads.Bead{
+				Title:    detail.AgentName,
+				Type:     sessionBeadType,
+				Labels:   []string{sessionBeadLabel, "agent:" + detail.AgentName},
+				Metadata: meta,
+			})
+			if err != nil {
+				return fmt.Errorf("creating session bead for %q: %w", sessionName, err)
+			}
+			return nil
+		}
 		createErr := sessionpkg.WithCitySessionIdentifierLocks(cityPath, []string{sessionName, detail.AgentName}, func() error {
 			hasBead, err := openSessionBeadExists(store, sessionName)
 			if err != nil {
@@ -226,13 +236,7 @@ func runAdoptionBarrier(
 				alreadyHadBead = true
 				return nil
 			}
-			_, err = store.Create(beads.Bead{
-				Title:    detail.AgentName,
-				Type:     sessionBeadType,
-				Labels:   []string{sessionBeadLabel, "agent:" + detail.AgentName},
-				Metadata: meta,
-			})
-			return err
+			return createSessionBead()
 		})
 		if alreadyHadBead {
 			result.AlreadyHadBead++
@@ -241,7 +245,7 @@ func runAdoptionBarrier(
 			continue
 		}
 		if createErr != nil {
-			fmt.Fprintf(stderr, "adoption barrier: creating bead for %s: %v\n", sessionName, createErr) //nolint:errcheck
+			fmt.Fprintf(stderr, "adoption barrier: %v\n", createErr) //nolint:errcheck
 			result.Skipped++
 			continue
 		}

--- a/cmd/gc/adoption_barrier_test.go
+++ b/cmd/gc/adoption_barrier_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
+	"github.com/gastownhall/gascity/internal/session"
 )
 
 // fakeAdoptionProvider implements runtime.Provider for adoption barrier tests.
@@ -17,6 +18,42 @@ type fakeAdoptionProvider struct {
 	running []string
 	alive   map[string]bool
 	listErr error
+}
+
+type adoptionLockProbeStore struct {
+	beads.Store
+
+	targetSessionName string
+	listed            chan struct{}
+	createAttempted   chan struct{}
+	allowCreate       <-chan struct{}
+}
+
+func (s *adoptionLockProbeStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	result, err := s.Store.List(query)
+	if query.Label == sessionBeadLabel {
+		select {
+		case s.listed <- struct{}{}:
+		default:
+		}
+	}
+	return result, err
+}
+
+func (s *adoptionLockProbeStore) Create(b beads.Bead) (beads.Bead, error) {
+	if b.Type == sessionBeadType && b.Metadata["session_name"] == s.targetSessionName {
+		select {
+		case s.createAttempted <- struct{}{}:
+		default:
+		}
+		<-s.allowCreate
+	}
+	return s.Store.Create(b)
+}
+
+type adoptionBarrierOutcome struct {
+	result adoptionResult
+	passed bool
 }
 
 func (f *fakeAdoptionProvider) ListRunning(_ string) ([]string, error) {
@@ -51,7 +88,7 @@ func TestAdoptionBarrier_NoRunning(t *testing.T) {
 	cfg := &config.City{}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Error("barrier should pass with no running sessions")
 	}
@@ -69,7 +106,7 @@ func TestAdoptionBarrier_PartialListUsesVisibleSessionsButFailsBarrier(t *testin
 	cfg := &config.City{Agents: []config.Agent{{Name: "worker"}}}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if passed {
 		t.Fatal("barrier should fail closed on partial session listing")
 	}
@@ -93,7 +130,7 @@ func TestAdoptionBarrier_AdoptsRunning(t *testing.T) {
 	var stderr bytes.Buffer
 	clk := &clock.Fake{Time: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clk, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clk, &stderr, false)
 	if !passed {
 		t.Errorf("barrier should pass, stderr: %s", stderr.String())
 	}
@@ -155,7 +192,7 @@ func TestAdoptionBarrier_SkipsExistingBead(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Error("barrier should pass")
 	}
@@ -190,7 +227,7 @@ func TestAdoptionBarrier_ClosedBeadDoesNotBlock(t *testing.T) {
 	cfg := &config.City{Agents: []config.Agent{{Name: "mayor", MaxActiveSessions: intPtr(1)}}}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Error("barrier should pass")
 	}
@@ -206,13 +243,13 @@ func TestAdoptionBarrier_Rerunnable(t *testing.T) {
 	var stderr bytes.Buffer
 
 	// First run: adopts.
-	r1, _ := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	r1, _ := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if r1.Adopted != 1 {
 		t.Fatalf("first run Adopted = %d, want 1", r1.Adopted)
 	}
 
 	// Second run: dedup prevents duplicates.
-	r2, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	r2, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Error("second run: barrier should pass")
 	}
@@ -221,6 +258,89 @@ func TestAdoptionBarrier_Rerunnable(t *testing.T) {
 	}
 	if r2.AlreadyHadBead != 1 {
 		t.Errorf("second run AlreadyHadBead = %d, want 1", r2.AlreadyHadBead)
+	}
+}
+
+func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T) {
+	const sessionName = "worker-3"
+	const agentName = "worker-3"
+	cityPath := t.TempDir()
+	baseStore := beads.NewMemStore()
+	allowCreate := make(chan struct{})
+	store := &adoptionLockProbeStore{
+		Store:             baseStore,
+		targetSessionName: sessionName,
+		listed:            make(chan struct{}, 1),
+		createAttempted:   make(chan struct{}, 1),
+		allowCreate:       allowCreate,
+	}
+	sp := &fakeAdoptionProvider{running: []string{sessionName}}
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)}}}
+	var stderr bytes.Buffer
+	done := make(chan adoptionBarrierOutcome, 1)
+
+	err := session.WithCitySessionAliasLock(cityPath, agentName, func() error {
+		go func() {
+			result, passed := runAdoptionBarrier(cityPath, store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+			done <- adoptionBarrierOutcome{result: result, passed: passed}
+		}()
+
+		select {
+		case <-store.listed:
+		case <-time.After(time.Second):
+			t.Fatal("adoption barrier did not list existing session beads")
+		}
+
+		select {
+		case <-store.createAttempted:
+			close(allowCreate)
+			outcome := <-done
+			t.Fatalf("adoption barrier created while session_name lock was held; outcome=%+v stderr=%q", outcome, stderr.String())
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		_, createErr := baseStore.Create(beads.Bead{
+			Title:  agentName,
+			Type:   sessionBeadType,
+			Labels: []string{sessionBeadLabel, "agent:" + agentName},
+			Metadata: map[string]string{
+				"agent_name":   agentName,
+				"session_name": sessionName,
+				"state":        "active",
+			},
+		})
+		return createErr
+	})
+	if err != nil {
+		t.Fatalf("holding session identifier lock: %v", err)
+	}
+	close(allowCreate)
+
+	var outcome adoptionBarrierOutcome
+	select {
+	case outcome = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("adoption barrier did not finish after session_name lock released")
+	}
+	if !outcome.passed {
+		t.Fatalf("barrier should pass, stderr: %s", stderr.String())
+	}
+	if outcome.result.Adopted != 0 {
+		t.Fatalf("Adopted = %d, want 0 after locked peer created the bead", outcome.result.Adopted)
+	}
+	if outcome.result.AlreadyHadBead != 1 {
+		t.Fatalf("AlreadyHadBead = %d, want 1", outcome.result.AlreadyHadBead)
+	}
+
+	beadList, err := baseStore.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("listing session beads: %v", err)
+	}
+	if len(beadList) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(beadList))
+	}
+	if got := beadList[0].Metadata["session_name"]; got != sessionName {
+		t.Fatalf("session_name = %q, want %q", got, sessionName)
 	}
 }
 
@@ -235,7 +355,7 @@ func TestAdoptionBarrier_DryRun(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
 	if !passed {
 		t.Error("dry run barrier should pass")
 	}
@@ -267,7 +387,7 @@ func TestAdoptionBarrier_SkipsDeadSessions(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Fatalf("barrier should pass, stderr: %s", stderr.String())
 	}
@@ -291,7 +411,7 @@ func TestAdoptionBarrier_NilStore(t *testing.T) {
 	cfg := &config.City{}
 	var stderr bytes.Buffer
 
-	_, passed := runAdoptionBarrier(nil, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	_, passed := runAdoptionBarrier("", nil, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if passed {
 		t.Error("nil store: barrier should not pass")
 	}
@@ -309,7 +429,7 @@ func TestAdoptionBarrier_PoolSlotDetection(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, _ := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
+	result, _ := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
 	// Pool instance "worker-3" should resolve to config agent "worker"
 	// via resolvePoolBase, with pool slot 3. AgentName should be the
 	// expanded instance name "worker-3" (matching syncSessionBeads).
@@ -336,7 +456,7 @@ func TestAdoptionBarrier_PoolOutOfBounds(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, _ := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
+	result, _ := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, true)
 	found := false
 	for _, d := range result.Details {
 		if d.SessionName == "worker-7" && d.PoolSlot == 7 && d.OutOfBounds {
@@ -378,7 +498,7 @@ func TestAdoptionBarrier_SingletonWithNumericSuffix(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Errorf("barrier should pass, stderr: %s", stderr.String())
 	}
@@ -434,7 +554,7 @@ func TestAdoptionBarrier_UnknownSession(t *testing.T) {
 	cfg := &config.City{} // no agents configured
 	var stderr bytes.Buffer
 
-	result, passed := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if !passed {
 		t.Error("barrier should pass (adopt permissively)")
 	}

--- a/cmd/gc/adoption_barrier_test.go
+++ b/cmd/gc/adoption_barrier_test.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
@@ -29,6 +33,17 @@ type adoptionLockProbeStore struct {
 	allowCreate       <-chan struct{}
 }
 
+type adoptionListFailureStore struct {
+	beads.Store
+}
+
+type adoptionClockAdvanceStore struct {
+	beads.Store
+
+	advance  func()
+	advanced bool
+}
+
 func (s *adoptionLockProbeStore) List(query beads.ListQuery) ([]beads.Bead, error) {
 	result, err := s.Store.List(query)
 	if query.Label == sessionBeadLabel {
@@ -36,6 +51,22 @@ func (s *adoptionLockProbeStore) List(query beads.ListQuery) ([]beads.Bead, erro
 		case s.listed <- struct{}{}:
 		default:
 		}
+	}
+	return result, err
+}
+
+func (s *adoptionListFailureStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	if strings.TrimSpace(query.Metadata["session_name"]) != "" {
+		return nil, errors.New("live list failed")
+	}
+	return s.Store.List(query)
+}
+
+func (s *adoptionClockAdvanceStore) List(query beads.ListQuery) ([]beads.Bead, error) {
+	result, err := s.Store.List(query)
+	if strings.TrimSpace(query.Metadata["session_name"]) != "" && !s.advanced {
+		s.advanced = true
+		s.advance()
 	}
 	return result, err
 }
@@ -261,12 +292,62 @@ func TestAdoptionBarrier_Rerunnable(t *testing.T) {
 	}
 }
 
+func TestAdoptionBarrier_IgnoresNonRepairableSessionBeadsInConfigSnapshot(t *testing.T) {
+	store := beads.NewMemStore()
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MaxActiveSessions: intPtr(1)}}}
+	sessionName := agent.SessionNameFor("test-city", "worker", cfg.Workspace.SessionTemplate)
+	if _, err := store.Create(beads.Bead{
+		Title:  "stale malformed worker",
+		Type:   "task",
+		Labels: []string{sessionBeadLabel},
+		Metadata: map[string]string{
+			"agent_name":   "worker",
+			"session_name": "stale-worker",
+			"template":     "worker",
+			"state":        "active",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sp := &fakeAdoptionProvider{running: []string{sessionName}}
+	var stderr bytes.Buffer
+
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	if !passed {
+		t.Fatalf("barrier should pass, result=%+v stderr=%q", result, stderr.String())
+	}
+	beadList, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("listing session beads: %v", err)
+	}
+	for _, b := range beadList {
+		if b.Type != sessionBeadType {
+			continue
+		}
+		if got := b.Metadata["agent_name"]; got != "worker" {
+			t.Fatalf("adopted bead agent_name = %q, want configured agent name", got)
+		}
+		if got := b.Metadata["session_name"]; got != sessionName {
+			t.Fatalf("adopted bead session_name = %q, want %q", got, sessionName)
+		}
+		return
+	}
+	t.Fatalf("adopted session bead not found; beads=%+v", beadList)
+}
+
 func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T) {
-	const sessionName = "worker-3"
 	const agentName = "worker-3"
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)}}}
+	sessionName := agent.SessionNameFor("test-city", "worker", cfg.Workspace.SessionTemplate) + "-3"
 	cityPath := t.TempDir()
 	baseStore := beads.NewMemStore()
 	allowCreate := make(chan struct{})
+	var releaseCreate sync.Once
+	t.Cleanup(func() {
+		releaseCreate.Do(func() {
+			close(allowCreate)
+		})
+	})
 	store := &adoptionLockProbeStore{
 		Store:             baseStore,
 		targetSessionName: sessionName,
@@ -275,7 +356,6 @@ func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T)
 		allowCreate:       allowCreate,
 	}
 	sp := &fakeAdoptionProvider{running: []string{sessionName}}
-	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MinActiveSessions: intPtr(1), MaxActiveSessions: intPtr(5)}}}
 	var stderr bytes.Buffer
 	done := make(chan adoptionBarrierOutcome, 1)
 
@@ -289,14 +369,6 @@ func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T)
 		case <-store.listed:
 		case <-time.After(time.Second):
 			t.Fatal("adoption barrier did not list existing session beads")
-		}
-
-		select {
-		case <-store.createAttempted:
-			close(allowCreate)
-			outcome := <-done
-			t.Fatalf("adoption barrier created while session_name lock was held; outcome=%+v stderr=%q", outcome, stderr.String())
-		case <-time.After(100 * time.Millisecond):
 		}
 
 		_, createErr := baseStore.Create(beads.Bead{
@@ -314,7 +386,9 @@ func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T)
 	if err != nil {
 		t.Fatalf("holding session identifier lock: %v", err)
 	}
-	close(allowCreate)
+	releaseCreate.Do(func() {
+		close(allowCreate)
+	})
 
 	var outcome adoptionBarrierOutcome
 	select {
@@ -331,6 +405,11 @@ func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T)
 	if outcome.result.AlreadyHadBead != 1 {
 		t.Fatalf("AlreadyHadBead = %d, want 1", outcome.result.AlreadyHadBead)
 	}
+	select {
+	case <-store.createAttempted:
+		t.Fatalf("adoption barrier attempted a duplicate create; outcome=%+v stderr=%q", outcome, stderr.String())
+	default:
+	}
 
 	beadList, err := baseStore.ListByLabel(sessionBeadLabel, 0)
 	if err != nil {
@@ -341,6 +420,56 @@ func TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock(t *testing.T)
 	}
 	if got := beadList[0].Metadata["session_name"]; got != sessionName {
 		t.Fatalf("session_name = %q, want %q", got, sessionName)
+	}
+}
+
+func TestAdoptionBarrier_ReportsInLockListFailuresAsChecks(t *testing.T) {
+	store := &adoptionListFailureStore{Store: beads.NewMemStore()}
+	sp := &fakeAdoptionProvider{running: []string{"test-city-worker"}}
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MaxActiveSessions: intPtr(1)}}}
+	var stderr bytes.Buffer
+
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	if passed {
+		t.Fatal("barrier should fail when the in-lock bead check fails")
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("Skipped = %d, want 1", result.Skipped)
+	}
+	log := stderr.String()
+	if !strings.Contains(log, `listing session beads for "test-city-worker"`) {
+		t.Fatalf("stderr %q does not mention the failing session-bead check", log)
+	}
+	if strings.Contains(log, "creating bead for") {
+		t.Fatalf("stderr %q should not report a list failure as a create failure", log)
+	}
+}
+
+func TestAdoptionBarrier_StampsSyncedAtAtCreateTime(t *testing.T) {
+	fakeClock := &clock.Fake{Time: time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC)}
+	store := &adoptionClockAdvanceStore{
+		Store: beads.NewMemStore(),
+		advance: func() {
+			fakeClock.Advance(time.Hour)
+		},
+	}
+	sp := &fakeAdoptionProvider{running: []string{"test-city-worker"}}
+	cfg := &config.City{Agents: []config.Agent{{Name: "worker", MaxActiveSessions: intPtr(1)}}}
+	var stderr bytes.Buffer
+
+	result, passed := runAdoptionBarrier("", store, sp, cfg, "test-city", fakeClock, &stderr, false)
+	if !passed {
+		t.Fatalf("barrier should pass, result=%+v stderr=%q", result, stderr.String())
+	}
+	beadList, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("listing session beads: %v", err)
+	}
+	if len(beadList) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(beadList))
+	}
+	if got, want := beadList[0].Metadata["synced_at"], "2026-05-15T09:00:00Z"; got != want {
+		t.Fatalf("synced_at = %q, want %q", got, want)
 	}
 }
 
@@ -531,7 +660,7 @@ func TestAdoptionBarrier_OrphanDashNSessionLogsWarning(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 
-	result, _ := runAdoptionBarrier(store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
+	result, _ := runAdoptionBarrier("", store, sp, cfg, "test-city", clock.Real{}, &stderr, false)
 	if result.Adopted != 1 {
 		t.Errorf("Adopted = %d, want 1", result.Adopted)
 	}

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -395,7 +395,7 @@ func (cr *CityRuntime) run(ctx context.Context) {
 			cr.onStatus("adopting_sessions")
 		}
 		if cr.cityBeadStore() != nil {
-			result, passed := runAdoptionBarrier(cr.cityBeadStore(), cr.sp, cr.cfg, cr.cityName, clock.Real{}, cr.stderr, false)
+			result, passed := runAdoptionBarrier(cr.cityPath, cr.cityBeadStore(), cr.sp, cr.cfg, cr.cityName, clock.Real{}, cr.stderr, false)
 			if result.Adopted > 0 {
 				fmt.Fprintf(cr.stdout, "Adopted %d running session(s) into bead store.\n", result.Adopted) //nolint:errcheck
 			}

--- a/cmd/gc/cmd_start.go
+++ b/cmd/gc/cmd_start.go
@@ -625,7 +625,7 @@ func doStartStandalone(args []string, controllerMode bool, stdout, stderr io.Wri
 		oneShotStore = store
 
 		// Run adoption barrier before sync.
-		result, passed := runAdoptionBarrier(store, sp, cfg, cityName, clock.Real{}, stderr, false)
+		result, passed := runAdoptionBarrier(cityPath, store, sp, cfg, cityName, clock.Real{}, stderr, false)
 		if result.Adopted > 0 {
 			fmt.Fprintf(stdout, "Adopted %d running session(s) into bead store.\n", result.Adopted) //nolint:errcheck
 		}

--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -1014,11 +1014,32 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 				})
 			}
 			var (
-				newBead   beads.Bead
-				createErr error
-				created   bool
-				blocked   bool
+				newBead            beads.Bead
+				createErr          error
+				finalizeErr        error
+				createdSessionName string
+				created            bool
+				blocked            bool
 			)
+			finalizeCreatedSessionName := func() {
+				createdSessionName = strings.TrimSpace(newBead.Metadata["session_name"])
+				if isPoolInstance {
+					createdSessionName = PoolSessionName(qualifiedTemplate, newBead.ID)
+					if err := store.SetMetadata(newBead.ID, "session_name", createdSessionName); err != nil {
+						finalizeErr = err
+						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck
+						closeFailedCreateBead(store, newBead.ID, now, stderr)
+						return
+					}
+					if newBead.Metadata == nil {
+						newBead.Metadata = make(map[string]string, 1)
+					}
+					newBead.Metadata["session_name"] = createdSessionName
+				}
+				if createdSessionName == "" {
+					createdSessionName = sn
+				}
+			}
 			if managedAlias != "" {
 				lockFn := func() error {
 					if err := session.EnsureAliasAvailableWithConfigForOwner(store, cfg, managedAlias, "", managedAlias); err != nil {
@@ -1041,6 +1062,9 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 					}
 					newBead, createErr = createBead()
 					created = true
+					if createErr == nil {
+						finalizeCreatedSessionName()
+					}
 					return nil
 				}
 				var lockErr error
@@ -1055,26 +1079,17 @@ func syncSessionBeadsWithSnapshotAndRigStores(
 			}
 			if !created && !blocked {
 				newBead, createErr = createBead()
+				created = true
+				if createErr == nil {
+					finalizeCreatedSessionName()
+				}
 			}
-			if createErr != nil {
+			switch {
+			case createErr != nil:
 				fmt.Fprintf(stderr, "session beads: creating bead for %s: %v\n", agentName, createErr) //nolint:errcheck
-			} else {
-				createdSessionName := strings.TrimSpace(newBead.Metadata["session_name"])
-				if isPoolInstance {
-					createdSessionName = PoolSessionName(qualifiedTemplate, newBead.ID)
-					if err := store.SetMetadata(newBead.ID, "session_name", createdSessionName); err != nil {
-						fmt.Fprintf(stderr, "session beads: setting pool session_name for %s: %v\n", agentName, err) //nolint:errcheck
-						closeFailedCreateBead(store, newBead.ID, now, stderr)
-						continue
-					}
-					if newBead.Metadata == nil {
-						newBead.Metadata = make(map[string]string, 1)
-					}
-					newBead.Metadata["session_name"] = createdSessionName
-				}
-				if createdSessionName == "" {
-					createdSessionName = sn
-				}
+			case finalizeErr != nil:
+				continue
+			default:
 				desiredNames[createdSessionName] = true
 				openIndex[createdSessionName] = newBead.ID
 				openBeads = append(openBeads, newBead)

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -3,17 +3,21 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/gastownhall/gascity/internal/agent"
 	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/extmsg"
@@ -124,6 +128,14 @@ type failingPoolSessionNameStore struct {
 	*beads.MemStore
 }
 
+type poolSessionNameLockProbeStore struct {
+	*beads.MemStore
+
+	cityPath string
+	alias    string
+	checked  bool
+}
+
 func (s *failingPoolSessionNameStore) SetMetadata(id, key, value string) error {
 	if key == "session_name" {
 		return errors.New("session_name metadata failed")
@@ -131,8 +143,41 @@ func (s *failingPoolSessionNameStore) SetMetadata(id, key, value string) error {
 	return s.MemStore.SetMetadata(id, key, value)
 }
 
+func (s *poolSessionNameLockProbeStore) SetMetadata(id, key, value string) error {
+	if key == "session_name" {
+		held, err := citySessionIdentifierLockHeld(s.cityPath, s.alias)
+		if err != nil {
+			return fmt.Errorf("checking session identifier lock for %q: %w", s.alias, err)
+		}
+		if !held {
+			return fmt.Errorf("session identifier lock for %q was not held while setting session_name", s.alias)
+		}
+		s.checked = true
+	}
+	return s.MemStore.SetMetadata(id, key, value)
+}
+
 func (s *failingPoolSessionNameStore) Close(_ string) error {
 	return errors.New("close failed")
+}
+
+func citySessionIdentifierLockHeld(cityPath, identifier string) (bool, error) {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(identifier)))
+	lockPath := filepath.Join(citylayout.SessionNameLocksDir(cityPath), hex.EncodeToString(sum[:])+".lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close() //nolint:errcheck
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		return false, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return true, nil
+	}
+	return false, err
 }
 
 func newCountingMetadataStore() *countingMetadataStore {
@@ -2851,6 +2896,42 @@ func TestSyncSessionBeads_StalePoolSnapshotReusesVisibleOwner(t *testing.T) {
 				t.Fatalf("new pool bead session_name = %q, want %q", got, want)
 			}
 		}
+	}
+}
+
+func TestSyncSessionBeads_FinalizesPoolSessionNameUnderAliasLock(t *testing.T) {
+	alias := "pack/worker-1"
+	store := &poolSessionNameLockProbeStore{
+		MemStore: beads.NewMemStore(),
+		cityPath: t.TempDir(),
+		alias:    alias,
+	}
+	clk := &clock.Fake{Time: time.Date(2026, 5, 15, 8, 30, 0, 0, time.UTC)}
+	sp := runtime.NewFake()
+	template := "pack/worker"
+	desired := map[string]TemplateParams{
+		"legacy-worker-1": {
+			TemplateName: template,
+			InstanceName: alias,
+			PoolSlot:     1,
+			Command:      "codex",
+		},
+	}
+
+	var stderr bytes.Buffer
+	syncSessionBeads(store.cityPath, store, desired, sp, allConfiguredDS(desired), nil, clk, &stderr, false)
+	if stderr.Len() > 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if !store.checked {
+		t.Fatal("pool session_name metadata was not finalized through SetMetadata")
+	}
+	all := allSessionBeads(t, store)
+	if len(all) != 1 {
+		t.Fatalf("session bead count = %d, want 1", len(all))
+	}
+	if got, want := all[0].Metadata["session_name"], PoolSessionName(template, all[0].ID); got != want {
+		t.Fatalf("session_name = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- serialize adoption barrier session bead creation with the city session identifier lock
- re-check for a live session bead inside the lock before creating
- pass cityPath into startup/controller adoption paths
- add regression coverage for the adoption/sync lock race

Fixes #1155

## Tests
- go test ./cmd/gc -run 'TestAdoptionBarrier_SerializesCreateWithSessionIdentifierLock|TestAdoptionBarrier' -count=1
- go test ./cmd/gc -run 'TestAdoptionBarrier|TestSyncSessionBeads_(CreatesNewBeads|DuplicatePoolSessionNameKeepsVisibleOwner|SetsManagedAlias|DoesNotRewriteOwnershipWhenAliasRepairFails|ValidatesPreStampedPoolAlias)' -count=1
- make test
- make check