### PR TITLE
feat(reconciler): spawn-storm safety net via drain-without-claim signal

### DIFF
--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -830,11 +830,6 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 		return counts, nil, nil
 	}
 
-	type scaleStoreGroup struct {
-		store     beads.Store
-		templates map[string]struct{}
-	}
-	groups := make(map[string]*scaleStoreGroup)
 	var errs []error
 	var partialTemplates map[string]bool
 	for _, target := range targets {
@@ -854,35 +849,38 @@ func defaultScaleCheckCounts(targets []defaultScaleCheckTarget) (map[string]int,
 			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
 			continue
 		}
-		key := strings.TrimSpace(target.storeKey)
-		if key == "" {
-			key = fmt.Sprintf("%p", target.store)
+		// Symmetric query: same predicate as the worker's pool-demand shell
+		// (`bd ready --metadata-field gc.routed_to=T --unassigned`). Routing
+		// through ReadyQuery (rather than scanning a cached set and filtering
+		// in Go) ensures defer_until and dep-blocking filtering match exactly
+		// — the reconciler cannot disagree with the worker about what counts
+		// as claimable demand. See fo-spawn-storm-mitigate.
+		query := beads.ReadyQuery{
+			Metadata:   map[string]string{"gc.routed_to": template},
+			Unassigned: true,
 		}
-		group := groups[key]
-		if group == nil {
-			group = &scaleStoreGroup{store: target.store, templates: make(map[string]struct{})}
-			groups[key] = group
-		}
-		group.templates[template] = struct{}{}
-	}
-
-	for key, group := range groups {
-		ready, err := readyForControllerDemand(group.store)
+		ready, err := readyForControllerDemandQuery(target.store, query)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
-			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
+			storeKey := strings.TrimSpace(target.storeKey)
+			if storeKey == "" {
+				storeKey = fmt.Sprintf("%p", target.store)
+			}
+			errs = append(errs, fmt.Errorf("default scale_check %s template=%s: Ready(): %w", storeKey, template, err))
+			partialTemplates = markScaleCheckPartialTemplate(partialTemplates, template)
 			if !beads.IsPartialResult(err) || len(ready) == 0 {
 				continue
 			}
 		}
 		for _, b := range ready {
+			// Defensive: store-side filters should already have applied these,
+			// but a partial-result fallback may have skipped some.
 			if strings.TrimSpace(b.Assignee) != "" {
 				continue
 			}
-			template := strings.TrimSpace(b.Metadata["gc.routed_to"])
-			if _, ok := group.templates[template]; ok {
-				counts[template]++
+			if strings.TrimSpace(b.Metadata["gc.routed_to"]) != template {
+				continue
 			}
+			counts[template]++
 		}
 	}
 	return counts, partialTemplates, errs
@@ -946,7 +944,14 @@ func defaultNamedSessionDemand(targets []defaultScaleCheckTarget, cfg *config.Ci
 	}
 
 	for key, group := range groups {
-		ready, err := readyForControllerDemand(group.store)
+		// Named-session demand uses a routed_to value that may be either a
+		// template (identitiesByTemplate path) or an identity (namedByIdentity
+		// path), so we cannot scope the query by exact metadata match. We
+		// still set Unassigned so the query bypasses the defer_until-blind
+		// cache (see readyForControllerDemandQuery comment) and inherits
+		// bd ready's defer/dep filtering. The match remains in Go.
+		query := beads.ReadyQuery{Unassigned: true}
+		ready, err := readyForControllerDemandQuery(group.store, query)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("default scale_check %s templates=%s: Ready(): %w", key, strings.Join(sortedStringSet(group.templates), ","), err))
 			partialTemplates = markScaleCheckPartialSet(partialTemplates, group.templates)
@@ -1103,6 +1108,17 @@ func readyForControllerDemand(store beads.Store) ([]beads.Bead, error) {
 }
 
 func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([]beads.Bead, error) {
+	// Spawn-demand queries (Metadata or Unassigned) must bypass CachedReady
+	// because the in-memory cache is defer_until-blind: it would return
+	// beads bd would have hidden for being scheduled in the future,
+	// producing phantom demand and spawn storms (fo-spawn-storm-mitigate).
+	// Such queries are the authoritative spawn-decision predicate and must
+	// be answered by the backing store, which routes through bd ready and
+	// gets defer/dep filtering by construction. Assignee/Limit-only queries
+	// do not depend on defer_until correctness, so they keep the cache path.
+	if len(query.Metadata) > 0 || query.Unassigned {
+		return store.Ready(query)
+	}
 	if cached, ok := store.(interface {
 		CachedReady() ([]beads.Bead, bool)
 	}); ok {
@@ -1114,13 +1130,28 @@ func readyForControllerDemandQuery(store beads.Store, query beads.ReadyQuery) ([
 }
 
 func filterReadyForControllerDemand(ready []beads.Bead, query beads.ReadyQuery) []beads.Bead {
-	if query == (beads.ReadyQuery{}) {
+	if query.IsZero() {
 		return ready
 	}
 	result := make([]beads.Bead, 0, len(ready))
 	for _, bead := range ready {
 		if query.Assignee != "" && bead.Assignee != query.Assignee {
 			continue
+		}
+		if query.Unassigned && strings.TrimSpace(bead.Assignee) != "" {
+			continue
+		}
+		if len(query.Metadata) > 0 {
+			ok := true
+			for k, v := range query.Metadata {
+				if bead.Metadata[k] != v {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
 		}
 		result = append(result, bead)
 		if query.Limit > 0 && len(result) >= query.Limit {

--- a/cmd/gc/build_desired_state.go
+++ b/cmd/gc/build_desired_state.go
@@ -349,6 +349,12 @@ func buildDesiredStateWithSessionBeads(
 		if len(scaleCheckPartialTemplates) > 0 {
 			fmt.Fprintf(stderr, "scaleCheck: PARTIAL — scale_check failed for %s, retaining affected sessions\n", strings.Join(sortedBoolMapKeys(scaleCheckPartialTemplates), ",")) //nolint:errcheck
 		}
+		// Spawn-storm safety net: suppress new spawns for any template
+		// currently in a detected storm. Affects pool sizing only; this
+		// gate has no path to in-flight workers. See fo-wmfem.
+		if throttled := applyThrottleToScaleCheckCounts(safetyNetForGating(), scaleCheckCounts, time.Now()); len(throttled) > 0 {
+			fmt.Fprintf(stderr, "spawn-storm safety net: throttling new spawns for %s (drain-without-claim threshold crossed)\n", strings.Join(sortedBoolMapKeys(throttled), ",")) //nolint:errcheck
+		}
 		poolWorkBeads := filterAssignedWorkBeadsForPoolDemand(cfg, cityPath, sessionBeads.Open(), assignedWorkBeads, assignedWorkStoreRefs)
 		bp.assignedWorkBeads = poolWorkBeads
 		poolDesiredStates := ComputePoolDesiredStatesTraced(cfg, poolWorkBeads, sessionBeads.Open(), scaleCheckCounts, trace)

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -165,7 +165,15 @@ func (s *controllerDemandPartialStore) Ready(query ...beads.ReadyQuery) ([]beads
 	if err != nil {
 		return nil, err
 	}
-	if len(query) == 0 {
+	q := beads.ReadyQuery{}
+	if len(query) > 0 {
+		q = query[0]
+	}
+	// Surface the partial only on spawn-demand reads (Metadata or Unassigned),
+	// matching the controller-demand path in defaultScaleCheckCounts /
+	// defaultNamedSessionDemand. Assignee-keyed reads (collectAssignedWorkBeads)
+	// stay clean so the partial is correctly scoped to scale_check failures.
+	if len(q.Metadata) > 0 || q.Unassigned {
 		return rows, &beads.PartialResultError{Op: "bd ready", Err: errors.New("skipped corrupt controller demand bead")}
 	}
 	return rows, nil
@@ -351,8 +359,8 @@ func TestCollectAssignedWorkBeads_ExcludesBlockedOpenAssignedHandoff(t *testing.
 	}
 }
 
-func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
-	backing := &readyFailStore{Store: beads.NewMemStore()}
+func TestDefaultScaleCheckCountsCountsReadyRoutedWork(t *testing.T) {
+	backing := beads.NewMemStore()
 	if _, err := backing.Create(beads.Bead{
 		Title:  "queued routed work",
 		Type:   "task",
@@ -378,9 +386,6 @@ func TestDefaultScaleCheckCountsUsesCachedReadyReadModel(t *testing.T) {
 	}
 	if got := counts["gascity/workflows.codex-min"]; got != 1 {
 		t.Fatalf("defaultScaleCheckCounts = %d, want 1", got)
-	}
-	if backing.readyCalls != 0 {
-		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
 	}
 }
 
@@ -417,8 +422,8 @@ func TestDefaultScaleCheckCountsIgnoresOpenMoleculeContainers(t *testing.T) {
 	}
 }
 
-func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.T) {
-	backing := &readyFailStore{Store: beads.NewMemStore()}
+func TestDefaultScaleCheckCountsExcludesBlockedWork(t *testing.T) {
+	backing := beads.NewMemStore()
 	blocker, err := backing.Create(beads.Bead{
 		Title:  "blocked earlier step",
 		Type:   "task",
@@ -457,8 +462,209 @@ func TestDefaultScaleCheckCountsHonorsCachedWriteThroughDependencies(t *testing.
 	if got := counts["gascity/workflows.codex-max"]; got != 0 {
 		t.Fatalf("defaultScaleCheckCounts = %d, want blocked future work excluded", got)
 	}
-	if backing.readyCalls != 0 {
-		t.Fatalf("backing Ready calls = %d, want cached demand read", backing.readyCalls)
+}
+
+// TestDefaultScaleCheckCountsIssuesSymmetricReadyQuery locks in the
+// structural defense against spawn storms (fo-spawn-storm-mitigate):
+// defaultScaleCheckCounts queries store.Ready with the same filters as
+// the worker's pool-demand shell predicate
+// (bd ready --metadata-field gc.routed_to=T --unassigned). The reconciler
+// cannot disagree with the worker about what counts as claimable demand
+// because both sides resolve it through the same query.
+func TestDefaultScaleCheckCountsIssuesSymmetricReadyQuery(t *testing.T) {
+	store := &readyQueryRecordingStore{MemStore: beads.NewMemStore()}
+	if _, err := store.Create(beads.Bead{
+		Title:  "queued routed work",
+		Type:   "task",
+		Status: "open",
+		Metadata: map[string]string{
+			"gc.routed_to": "foundations/worker",
+		},
+	}); err != nil {
+		t.Fatalf("create routed bead: %v", err)
+	}
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: "foundations/worker",
+		storeKey: "rig:foundations",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v", errs)
+	}
+	if got := counts["foundations/worker"]; got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	if len(store.readyQueries) != 1 {
+		t.Fatalf("Ready calls = %d, want 1", len(store.readyQueries))
+	}
+	q := store.readyQueries[0]
+	if !q.Unassigned {
+		t.Errorf("query.Unassigned = false, want true (matches worker shell predicate)")
+	}
+	if v := q.Metadata["gc.routed_to"]; v != "foundations/worker" {
+		t.Errorf("query.Metadata[gc.routed_to] = %q, want foundations/worker", v)
+	}
+}
+
+// readyDemandSimStore models a backing store whose Ready applies the same
+// filters as bd CLI's `bd ready` (defer_until, dep-blocking, --unassigned,
+// --metadata-field). The real BdStore inherits these by shelling out;
+// this fixture lets us assert spawn-decision behavior without a bd binary.
+type readyDemandSimStore struct {
+	*beads.MemStore
+	deferred map[string]bool // bead IDs that bd would hide as future-deferred
+}
+
+func (s *readyDemandSimStore) Ready(query ...beads.ReadyQuery) ([]beads.Bead, error) {
+	rows, err := s.MemStore.Ready(query...)
+	if err != nil {
+		return nil, err
+	}
+	if len(s.deferred) == 0 {
+		return rows, nil
+	}
+	out := make([]beads.Bead, 0, len(rows))
+	for _, b := range rows {
+		if s.deferred[b.ID] {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// TestClaimRateInvariant_StormResilience is the load-bearing acceptance test
+// for fo-spawn-storm-mitigate: regardless of bead-store state, the reconciler
+// must not see phantom demand that the worker won't claim. Each subtest seeds
+// a class of bead that is open + routed but not actually claimable, and
+// asserts that defaultScaleCheckCounts reports zero demand for the template.
+//
+// CRITICAL: each subtest must pass without operator-side cleanup (no clearing
+// assignees, closing stale session beads, removing routed_to metadata,
+// deferring beads). Bead-store state is INPUT, not config.
+func TestClaimRateInvariant_StormResilience(t *testing.T) {
+	const template = "foundations/worker"
+	cases := []struct {
+		name string
+		seed func(t *testing.T, store *readyDemandSimStore)
+	}{
+		{
+			name: "deferred_by_date",
+			seed: func(t *testing.T, store *readyDemandSimStore) {
+				b, err := store.Create(beads.Bead{
+					Title:  "future routed work",
+					Type:   "task",
+					Status: "open",
+					Metadata: map[string]string{
+						"gc.routed_to": template,
+					},
+				})
+				if err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				store.deferred[b.ID] = true
+			},
+		},
+		{
+			name: "blocked_by_deps",
+			seed: func(t *testing.T, store *readyDemandSimStore) {
+				blocker, err := store.Create(beads.Bead{
+					Title: "earlier step", Type: "task", Status: "open",
+				})
+				if err != nil {
+					t.Fatalf("create blocker: %v", err)
+				}
+				blocked, err := store.Create(beads.Bead{
+					Title: "blocked routed work", Type: "task", Status: "open",
+					Metadata: map[string]string{"gc.routed_to": template},
+				})
+				if err != nil {
+					t.Fatalf("create blocked: %v", err)
+				}
+				if err := store.DepAdd(blocked.ID, blocker.ID, "blocks"); err != nil {
+					t.Fatalf("DepAdd: %v", err)
+				}
+			},
+		},
+		{
+			name: "stale_assignee",
+			seed: func(t *testing.T, store *readyDemandSimStore) {
+				if _, err := store.Create(beads.Bead{
+					Title: "claimed by ghost", Type: "task", Status: "open",
+					Assignee: "worker-ghost-session",
+					Metadata: map[string]string{"gc.routed_to": template},
+				}); err != nil {
+					t.Fatalf("create stale: %v", err)
+				}
+			},
+		},
+		{
+			name: "mixed",
+			seed: func(t *testing.T, store *readyDemandSimStore) {
+				deferred, err := store.Create(beads.Bead{
+					Title: "future", Type: "task", Status: "open",
+					Metadata: map[string]string{"gc.routed_to": template},
+				})
+				if err != nil {
+					t.Fatalf("create deferred: %v", err)
+				}
+				store.deferred[deferred.ID] = true
+				if _, err := store.Create(beads.Bead{
+					Title: "claimed by ghost", Type: "task", Status: "open",
+					Assignee: "worker-ghost-session",
+					Metadata: map[string]string{"gc.routed_to": template},
+				}); err != nil {
+					t.Fatalf("create stale: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &readyDemandSimStore{
+				MemStore: beads.NewMemStore(),
+				deferred: map[string]bool{},
+			}
+			tc.seed(t, store)
+			counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+				template: template,
+				storeKey: "rig:foundations",
+				store:    store,
+			}})
+			if len(errs) != 0 {
+				t.Fatalf("errs = %v", errs)
+			}
+			if got := counts[template]; got != 0 {
+				t.Fatalf("count = %d, want 0 (would induce phantom demand → spawn storm)", got)
+			}
+		})
+	}
+}
+
+// TestClaimRateInvariant_ClaimableWorkStillCounted is the positive control
+// for TestClaimRateInvariant_StormResilience: a genuinely claimable bead
+// must produce demand of 1 through the same query path. Without this, a
+// regression that returned 0 for everything would silently pass the
+// resilience test.
+func TestClaimRateInvariant_ClaimableWorkStillCounted(t *testing.T) {
+	const template = "foundations/worker"
+	store := &readyDemandSimStore{MemStore: beads.NewMemStore(), deferred: map[string]bool{}}
+	if _, err := store.Create(beads.Bead{
+		Title: "ready routed work", Type: "task", Status: "open",
+		Metadata: map[string]string{"gc.routed_to": template},
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	counts, _, errs := defaultScaleCheckCounts([]defaultScaleCheckTarget{{
+		template: template,
+		storeKey: "rig:foundations",
+		store:    store,
+	}})
+	if len(errs) != 0 {
+		t.Fatalf("errs = %v", errs)
+	}
+	if got := counts[template]; got != 1 {
+		t.Fatalf("count = %d, want 1", got)
 	}
 }
 
@@ -533,13 +739,16 @@ func TestDefaultScaleCheckCountsReadyErrorNamesAffectedTemplates(t *testing.T) {
 		{template: "gascity/workflows.codex-min", storeKey: "rig:gascity", store: store},
 		{template: "gascity/workflows.codex-max", storeKey: "rig:gascity", store: store},
 	})
-	if len(errs) != 1 {
-		t.Fatalf("defaultScaleCheckCounts errs = %v, want one grouped Ready diagnostic", errs)
+	if len(errs) != 2 {
+		t.Fatalf("defaultScaleCheckCounts errs = %v, want one diagnostic per template", errs)
 	}
-	msg := errs[0].Error()
-	for _, want := range []string{"rig:gascity", "gascity/workflows.codex-min", "gascity/workflows.codex-max"} {
-		if !strings.Contains(msg, want) {
-			t.Fatalf("defaultScaleCheckCounts err = %q, want affected template %q", msg, want)
+	for _, e := range errs {
+		msg := e.Error()
+		if !strings.Contains(msg, "rig:gascity") {
+			t.Fatalf("defaultScaleCheckCounts err = %q, want store key", msg)
+		}
+		if !strings.Contains(msg, "gascity/workflows.codex-min") && !strings.Contains(msg, "gascity/workflows.codex-max") {
+			t.Fatalf("defaultScaleCheckCounts err = %q, want affected template", msg)
 		}
 	}
 	for _, want := range []string{"gascity/workflows.codex-min", "gascity/workflows.codex-max"} {

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -100,6 +100,13 @@ type CityRuntime struct {
 	managedDoltOwned    func(string) (bool, error)
 	managedDoltPort     func(string) string
 
+	// spawnStormSafetyNet is the defense-in-depth detector for pool
+	// spawn storms. Registered process-wide at the top of run() so the
+	// build_desired_state gate and the session-stop observation can
+	// consult the same instance. nil disables both — used by tests and
+	// non-controller code paths. See fo-wmfem.
+	spawnStormSafetyNet *SpawnStormSafetyNet
+
 	shutdownOnce             sync.Once
 	preserveSessionsShutdown atomic.Bool
 	forceStopShutdown        *atomic.Bool
@@ -151,6 +158,14 @@ type CityRuntimeParams struct {
 
 	LogPrefix      string // "gc start" or "gc supervisor"; defaults to "gc start"
 	Stdout, Stderr io.Writer
+
+	// SpawnStormSafetyNet is the optional storm detector this runtime
+	// owns. When nil, newCityRuntime constructs a default-config net
+	// (so production controllers always have one); pass a pre-built
+	// instance from tests that want to assert on detector state. The
+	// detector is registered process-wide during run() and unregistered
+	// on shutdown.
+	SpawnStormSafetyNet *SpawnStormSafetyNet
 }
 
 var (
@@ -267,15 +282,16 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 			}
 			return make(chan struct{}, 1)
 		}(),
-		nudgeWakeCh:       make(chan struct{}, 1),
-		onStarted:         p.OnStarted,
-		onStatus:          p.OnStatus,
-		managedDoltHealth: managedDoltHealth,
-		managedDoltOwned:  managedDoltOwned,
-		managedDoltPort:   managedDoltPort,
-		logPrefix:         logPrefix,
-		stdout:            p.Stdout,
-		stderr:            p.Stderr,
+		nudgeWakeCh:         make(chan struct{}, 1),
+		onStarted:           p.OnStarted,
+		onStatus:            p.OnStatus,
+		managedDoltHealth:   managedDoltHealth,
+		managedDoltOwned:    managedDoltOwned,
+		managedDoltPort:     managedDoltPort,
+		logPrefix:           logPrefix,
+		stdout:              p.Stdout,
+		stderr:              p.Stderr,
+		spawnStormSafetyNet: resolveSpawnStormSafetyNet(p.SpawnStormSafetyNet),
 	}
 	cr.svc = workspacesvc.NewManager(&serviceRuntime{cr: cr})
 	if err := cr.svc.Reload(); err != nil {
@@ -301,6 +317,14 @@ func (cr *CityRuntime) crashTrack() crashTracker {
 // wisp GC, and dispatches orders.
 func (cr *CityRuntime) run(ctx context.Context) {
 	defer cr.shutdown()
+
+	// Register the spawn-storm safety net so buildDesiredState can gate
+	// new spawns for any pool template the detector has flagged. Scoped
+	// to this run() invocation; restore runs on shutdown so subsequent
+	// city instances start clean. See fo-wmfem.
+	if cr.spawnStormSafetyNet != nil {
+		defer RegisterSpawnStormSafetyNetForCurrentController(cr.spawnStormSafetyNet)()
+	}
 
 	dirty := cr.configDirty
 	if dirty == nil {

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -720,6 +720,11 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 								Message: "drain acknowledged by agent",
 								Payload: api.SessionLifecyclePayloadJSON(session.ID, template, "drain acknowledged"),
 							})
+							// Spawn-storm safety net: contribute this
+							// drain outcome (claimed / unclaimed) so a
+							// sustained drain-without-claim pattern
+							// triggers the throttle. See fo-wmfem.
+							observeSessionStoppedForSafetyNet(cityPath, *session, name, template, store, rigStores, clk.Now().UTC(), stderr)
 							if hasAssignedWork {
 								batch := sessionpkg.CompleteDrainPatch(clk.Now().UTC(), "idle", session.Metadata["wake_mode"] == "fresh")
 								_ = store.SetMetadataBatch(session.ID, batch)

--- a/cmd/gc/spawn_storm_safety_net.go
+++ b/cmd/gc/spawn_storm_safety_net.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// SpawnStormSafetyNet is the defense-in-depth detector for pool spawn
+// storms. It observes worker drain outcomes; when too many workers drain
+// without claiming any bead within a sliding window, it declares a storm
+// for that template and gates further spawn decisions until the storm
+// subsides.
+//
+// The signal — "worker drained without ever claiming a bead" — is the
+// unambiguous trace of the contract mismatch this layer exists to catch:
+// when the reconciler's spawn-decision predicate disagrees with what a
+// worker can actually claim, the worker has no choice but to drain
+// without work. The L0 fix (symmetric ReadyQuery) eliminates the
+// asymmetry in the supported case; this safety net catches any future
+// asymmetry, regardless of where it originates.
+//
+// The safety net is a backstop, not the primary mechanism. In healthy
+// operation it should never fire.
+//
+// Effect scope: this layer ONLY suppresses NEW spawn decisions for the
+// affected template. It has no API for stopping or draining in-flight
+// workers. Workers already mid-execution complete their work normally
+// and close their beads; the throttle's blast radius is limited to
+// future spawn admissions.
+type SpawnStormSafetyNet struct {
+	cfg SpawnStormConfig
+
+	mu          sync.Mutex
+	perTemplate map[string]*templateStormState
+}
+
+// SpawnStormConfig tunes detection sensitivity and throttle behavior.
+// Zero values fall through to safe defaults (see effectiveConfig).
+type SpawnStormConfig struct {
+	// Window over which drain-without-claim outcomes accumulate. Outcomes
+	// older than now-Window are evicted before each detection check.
+	Window time.Duration
+
+	// DrainThreshold is the number of drain-without-claim outcomes within
+	// Window required to declare a storm. Set high enough that legitimate
+	// transients (a single failed worker, a quick test) don't trip it.
+	DrainThreshold int
+
+	// InitialBackoff is the throttle duration applied on the first
+	// detection of a storm episode. Subsequent drain-without-claim
+	// outcomes during the same episode double the backoff (capped at
+	// MaxBackoff).
+	InitialBackoff time.Duration
+
+	// MaxBackoff caps the exponential growth so a persistent
+	// misconfiguration doesn't lock out a pool indefinitely. When the
+	// backoff window passes with no further drain-without-claim
+	// outcomes, the episode resets and the next storm starts from
+	// InitialBackoff again.
+	MaxBackoff time.Duration
+}
+
+func (c SpawnStormConfig) effective() SpawnStormConfig {
+	if c.Window <= 0 {
+		c.Window = 5 * time.Minute
+	}
+	if c.DrainThreshold <= 0 {
+		c.DrainThreshold = 5
+	}
+	if c.InitialBackoff <= 0 {
+		c.InitialBackoff = 10 * time.Minute
+	}
+	if c.MaxBackoff <= 0 {
+		c.MaxBackoff = 60 * time.Minute
+	}
+	if c.MaxBackoff < c.InitialBackoff {
+		c.MaxBackoff = c.InitialBackoff
+	}
+	return c
+}
+
+type templateStormState struct {
+	// drains is the sliding-window history of drain-without-claim
+	// timestamps, kept in arrival order. Pruned on every observation
+	// and every IsThrottled call.
+	drains []time.Time
+
+	inStorm        bool
+	throttledUntil time.Time
+	currentBackoff time.Duration
+}
+
+// NewSpawnStormSafetyNet returns a safety net configured with cfg.
+// Zero-valued fields use built-in defaults.
+func NewSpawnStormSafetyNet(cfg SpawnStormConfig) *SpawnStormSafetyNet {
+	return &SpawnStormSafetyNet{
+		cfg:         cfg.effective(),
+		perTemplate: make(map[string]*templateStormState),
+	}
+}
+
+// RecordDrainOutcome reports that a worker session for the given template
+// has drained. claimed indicates whether the session ever claimed a bead
+// during its lifetime. Returns true exactly once per storm-episode
+// transition — i.e., when this outcome causes the safety net to declare
+// a NEW storm (so the caller can send a one-shot notification).
+//
+// A claimed=true outcome is healthy and does not contribute to the
+// sliding window. A claimed=false outcome is the storm signal.
+func (s *SpawnStormSafetyNet) RecordDrainOutcome(template, sessionName string, claimed bool, now time.Time) bool {
+	if s == nil {
+		return false
+	}
+	if claimed {
+		return false
+	}
+	template = trimTemplate(template)
+	if template == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	st := s.perTemplate[template]
+	if st == nil {
+		st = &templateStormState{}
+		s.perTemplate[template] = st
+	}
+
+	// Slide the window forward before counting.
+	st.drains = pruneBefore(st.drains, now.Add(-s.cfg.Window))
+	st.drains = append(st.drains, now)
+
+	if st.inStorm {
+		// Extend the throttle exponentially. Each additional
+		// drain-without-claim during an active episode signals the
+		// underlying condition is still firing.
+		st.currentBackoff = doublingCappedAt(st.currentBackoff, s.cfg.MaxBackoff)
+		st.throttledUntil = now.Add(st.currentBackoff)
+		return false
+	}
+
+	if len(st.drains) < s.cfg.DrainThreshold {
+		return false
+	}
+
+	// Threshold crossed: declare a new storm episode.
+	st.inStorm = true
+	st.currentBackoff = s.cfg.InitialBackoff
+	st.throttledUntil = now.Add(st.currentBackoff)
+	return true
+}
+
+// IsThrottled reports whether spawn decisions for template should be
+// suppressed at time now. As a side effect, it clears expired episodes
+// — once an episode's throttle window passes without further
+// drain-without-claim outcomes, the sliding window is reset so the next
+// storm starts from InitialBackoff rather than the elevated backoff of
+// the previous episode.
+func (s *SpawnStormSafetyNet) IsThrottled(template string, now time.Time) bool {
+	if s == nil {
+		return false
+	}
+	template = trimTemplate(template)
+	if template == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	st := s.perTemplate[template]
+	if st == nil {
+		return false
+	}
+
+	if !st.throttledUntil.IsZero() && now.Before(st.throttledUntil) {
+		return true
+	}
+
+	// Throttle window has elapsed. If the episode produced no new
+	// drain-without-claim outcomes during the window, transition out:
+	// the storm has subsided and the next episode (if any) starts
+	// fresh.
+	if st.inStorm {
+		st.inStorm = false
+		st.currentBackoff = 0
+		st.throttledUntil = time.Time{}
+		st.drains = nil
+	}
+	return false
+}
+
+// trimTemplate normalizes the template name. Templates passed through
+// untrusted call paths (CLI, config) can carry whitespace.
+func trimTemplate(t string) string {
+	// Inline strings.TrimSpace to avoid importing strings just for this
+	// — see also other minimal helpers in this package.
+	for len(t) > 0 && isSpace(t[0]) {
+		t = t[1:]
+	}
+	for len(t) > 0 && isSpace(t[len(t)-1]) {
+		t = t[:len(t)-1]
+	}
+	return t
+}
+
+func isSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r':
+		return true
+	}
+	return false
+}
+
+func pruneBefore(ts []time.Time, cutoff time.Time) []time.Time {
+	idx := 0
+	for idx < len(ts) && ts[idx].Before(cutoff) {
+		idx++
+	}
+	if idx == 0 {
+		return ts
+	}
+	return append(ts[:0], ts[idx:]...)
+}
+
+func doublingCappedAt(current, max time.Duration) time.Duration {
+	doubled := current * 2
+	if doubled <= 0 || doubled > max {
+		return max
+	}
+	return doubled
+}
+
+// applyThrottleToScaleCheckCounts zeroes out demand for any template the
+// safety net is currently throttling. Called from buildDesiredState
+// directly after defaultScaleCheckCounts populates the map so the
+// gate runs before ComputePoolDesiredStates sizes the pool. Returns
+// the set of templates whose demand was suppressed so the caller can
+// surface diagnostics on a tick that actually gated something.
+//
+// Safe to call with sn==nil (returns nil set, leaves the map alone) so
+// test paths that don't construct a safety net stay on the original
+// behavior.
+func applyThrottleToScaleCheckCounts(sn *SpawnStormSafetyNet, counts map[string]int, now time.Time) map[string]bool {
+	if sn == nil || len(counts) == 0 {
+		return nil
+	}
+	var throttled map[string]bool
+	for template, count := range counts {
+		if count == 0 {
+			continue
+		}
+		if sn.IsThrottled(template, now) {
+			counts[template] = 0
+			if throttled == nil {
+				throttled = make(map[string]bool)
+			}
+			throttled[template] = true
+		}
+	}
+	return throttled
+}
+
+// activeSpawnStormSafetyNet is the controller-scoped safety net registered
+// at city startup. buildDesiredState consults it when gating demand; the
+// session reconciler observes drain outcomes through it. Tests that don't
+// register one (the vast majority) operate as if the gate were absent.
+//
+// The pattern: at most one controller per process registers, via
+// RegisterSpawnStormSafetyNetForCurrentController; the deferred restore is
+// always run on shutdown so subsequent processes start clean. Read paths
+// hold the lock only long enough to copy the pointer.
+var (
+	activeSafetyNetMu sync.RWMutex
+	activeSafetyNet   *SpawnStormSafetyNet
+)
+
+// RegisterSpawnStormSafetyNetForCurrentController installs sn as the
+// active safety net for the lifetime of the returned restore function.
+// CityRuntime calls this at startup and defers the restore at shutdown.
+// Tests use it to inject a pre-loaded detector for gate-level assertions.
+func RegisterSpawnStormSafetyNetForCurrentController(sn *SpawnStormSafetyNet) (restore func()) {
+	activeSafetyNetMu.Lock()
+	prev := activeSafetyNet
+	activeSafetyNet = sn
+	activeSafetyNetMu.Unlock()
+	return func() {
+		activeSafetyNetMu.Lock()
+		activeSafetyNet = prev
+		activeSafetyNetMu.Unlock()
+	}
+}
+
+// safetyNetForGating returns the currently registered safety net, or nil
+// when no controller is running (tests, one-shot CLI invocations).
+func safetyNetForGating() *SpawnStormSafetyNet {
+	activeSafetyNetMu.RLock()
+	defer activeSafetyNetMu.RUnlock()
+	return activeSafetyNet
+}
+
+// resolveSpawnStormSafetyNet returns p when non-nil, otherwise a fresh
+// detector with default tuning. Production controllers (newCityRuntime)
+// call this so every controller has a working safety net without forcing
+// every callsite to construct one. Tests that want the gate disabled can
+// disable detection by passing a detector configured with a very high
+// threshold; the cleanest path is just to never register, which is
+// already handled by run() being a no-op when this returns nil — but for
+// production correctness we always want one.
+func resolveSpawnStormSafetyNet(p *SpawnStormSafetyNet) *SpawnStormSafetyNet {
+	if p != nil {
+		return p
+	}
+	return NewSpawnStormSafetyNet(SpawnStormConfig{})
+}

--- a/cmd/gc/spawn_storm_safety_net_observe.go
+++ b/cmd/gc/spawn_storm_safety_net_observe.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/mail/beadmail"
+	sessionpkg "github.com/gastownhall/gascity/internal/session"
+)
+
+const spawnStormMayorRecipient = "mayor"
+const spawnStormMailSender = "controller"
+
+// observeSessionStoppedForSafetyNet is the wiring entry point: invoked
+// after the session reconciler confirms a worker has stopped, it asks
+// the active safety net to record the outcome. If the outcome causes a
+// storm-episode transition, mayor is notified once.
+//
+// Inputs:
+//
+//   - session: the session bead being torn down.
+//   - sessionName: the runtime identifier the worker used as $GC_SESSION_NAME.
+//   - template: the resolved template name from the session bead. Empty
+//     when the template can't be determined (defensive: we skip).
+//   - store: the city bead store; nil-safe.
+//   - rigStores: rig-attached bead stores; nil-safe.
+//   - now: clock reading. Wall clock by default; tests pass a fixed time.
+//   - stderr: best-effort diagnostics sink.
+//
+// All steps are nil/empty-safe so this can be called from any drain
+// observation point without local pre-checks. The function never
+// returns an error — observation is best-effort and must not affect
+// the reconciler's primary teardown path.
+func observeSessionStoppedForSafetyNet(
+	cityPath string,
+	session beads.Bead,
+	sessionName, template string,
+	store beads.Store,
+	rigStores map[string]beads.Store,
+	now time.Time,
+	stderr io.Writer,
+) {
+	sn := safetyNetForGating()
+	if sn == nil || template == "" || sessionName == "" {
+		return
+	}
+	// Only pool-managed workers participate in the spawn-storm class
+	// the safety net exists to catch. Named singletons and one-shots
+	// drain on their own terms; recording their outcomes would
+	// accumulate per-template state that no gate ever consults.
+	if !isPoolManagedSessionBead(session) {
+		return
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	claimed, err := sessionEverClaimedAnyWork(store, rigStores, session)
+	if err != nil {
+		fmt.Fprintf(stderr, "spawn-storm safety net: claim lookup for %s failed: %v (treating as claimed; observation skipped)\n", sessionName, err) //nolint:errcheck
+		return
+	}
+	if !sn.RecordDrainOutcome(template, sessionName, claimed, now) {
+		return
+	}
+	// First transition into a new storm episode for this template.
+	// Mail mayor exactly once per episode.
+	if err := notifyMayorOfSpawnStorm(cityPath, store, template, sessionName, stderr); err != nil {
+		fmt.Fprintf(stderr, "spawn-storm safety net: notify mayor for %s: %v\n", template, err) //nolint:errcheck
+	}
+}
+
+// notifyMayorOfSpawnStorm sends mayor a mail describing the detected
+// storm and enqueues a nudge so the mail wakes mayor immediately rather
+// than waiting for the next inbox check.
+//
+// Mail-only when no cityPath is available (test paths, exec providers);
+// the nudge enqueue requires filesystem access under cityPath. A failed
+// nudge does not cause the function to error — the mail bead is the
+// durable signal.
+func notifyMayorOfSpawnStorm(cityPath string, store beads.Store, template, sessionName string, stderr io.Writer) error {
+	if store == nil {
+		return fmt.Errorf("no city store available")
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	provider := beadmail.New(store)
+	subject := fmt.Sprintf("[SAFETY NET] Spawn-storm detected for pool %s", template)
+	body := buildSpawnStormMailBody(template, sessionName)
+	if _, err := provider.Send(spawnStormMailSender, spawnStormMayorRecipient, subject, body); err != nil {
+		return fmt.Errorf("send mail to mayor: %w", err)
+	}
+	if cityPath == "" {
+		// Mail-only path. Mayor will see the message on its next inbox
+		// check; the wake-immediately property is lost. Diagnostics-
+		// only — not an error condition.
+		fmt.Fprintf(stderr, "spawn-storm safety net: nudge skipped (no city path)\n") //nolint:errcheck
+		return nil
+	}
+	nudgeMsg := fmt.Sprintf("Spawn-storm detected for pool %s — please investigate", template)
+	item := newQueuedNudge(spawnStormMayorRecipient, nudgeMsg, "spawn-storm-safety-net", time.Now())
+	if err := enqueueQueuedNudgeWithStore(cityPath, store, item); err != nil {
+		// Mail bead has been created — log but don't propagate.
+		fmt.Fprintf(stderr, "spawn-storm safety net: nudge enqueue failed: %v (mail bead created)\n", err) //nolint:errcheck
+	}
+	return nil
+}
+
+func buildSpawnStormMailBody(template, sessionName string) string {
+	return fmt.Sprintf(`The spawn-storm safety net detected a sustained pattern of pool
+workers draining without claiming any bead for template %q.
+Most recent observation: session %q drained without a claim.
+
+This pattern indicates the reconciler's spawn-decision predicate
+disagrees with what workers can actually claim (see fo-spawn-storm-
+mitigate / fo-wmfem for the class). The safety net has now suppressed
+new spawns for this template via exponential backoff; in-flight workers
+are NOT disturbed and complete normally.
+
+While the safety net's throttle decays automatically when the underlying
+condition clears, the root cause should be investigated.
+
+Useful starting points:
+
+  bd list --status=open --metadata gc.routed_to=%s
+  gc events --type session.stopped --since 10m
+  gc agents peek <worker> --tail 200
+
+If a sustained mismatch is found, file a bead capturing the predicate
+divergence — that's the durable fix layer; the safety net is only the
+backstop.
+`, template, sessionName, template)
+}
+
+// sessionEverClaimedAnyWork reports whether any non-session-bead in any
+// reachable store carries one of the session's assignment identifiers,
+// regardless of bead status (open, in_progress, closed). It is the
+// safety net's "did this worker do anything before draining?" probe.
+//
+// A worker that only enumerated `bd ready` and then drain-acked never
+// recorded itself as assignee on any bead, so this returns false. A
+// worker that ran `bd update <id> --claim` left assignee=<sessionName>
+// on the bead, which persists across status transitions (claimed,
+// in_progress, closed), so this returns true even after the worker
+// closes the bead and drains.
+//
+// Closed beads are intentionally included so we don't confuse "claimed
+// and finished cleanly" (the healthy case) with "never claimed" (the
+// storm signal). Without IncludeClosed we'd flag every successful
+// worker as drain-without-claim.
+func sessionEverClaimedAnyWork(store beads.Store, rigStores map[string]beads.Store, session beads.Bead) (bool, error) {
+	if store == nil && len(rigStores) == 0 {
+		// No store visibility — be conservative and treat as claimed
+		// (no observation) rather than blame the worker for a probe
+		// failure on our side.
+		return true, nil
+	}
+	identifiers := sessionAssignmentIdentifiers(session)
+	if len(identifiers) == 0 {
+		return true, nil
+	}
+	stores := workAssignmentStores(store, rigStores)
+	for _, s := range stores {
+		if s == nil {
+			continue
+		}
+		for _, id := range identifiers {
+			items, err := s.List(beads.ListQuery{
+				Assignee:      id,
+				IncludeClosed: true,
+				Limit:         1,
+			})
+			if err != nil {
+				if beads.IsPartialResult(err) && len(items) == 0 {
+					continue
+				}
+				return false, err
+			}
+			for _, item := range items {
+				// Don't count the session's own self-reference bead.
+				if sessionpkg.IsSessionBeadOrRepairable(item) {
+					continue
+				}
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/cmd/gc/spawn_storm_safety_net_observe_test.go
+++ b/cmd/gc/spawn_storm_safety_net_observe_test.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// Acceptance scenarios for the wiring layer that sits between the
+// session reconciler and the safety net. These tests run with a real
+// in-memory store so the "did this worker ever claim?" probe is
+// exercised end-to-end.
+
+func TestObserveSessionStopped_NoSafetyNet_Noop(t *testing.T) {
+	// With no safety net registered, the observation must be a clean
+	// no-op even with a store full of session-relevant beads.
+	store := beads.NewMemStore()
+	session := buildSessionBeadForSafetyNet(t, store, "worker-pool-1", true)
+	now := time.Now().UTC()
+	var buf bytes.Buffer
+	observeSessionStoppedForSafetyNet("", session, "worker-pool-1", "foundations/worker", store, nil, now, &buf)
+	if buf.Len() != 0 {
+		t.Fatalf("stderr non-empty with no safety net registered: %s", buf.String())
+	}
+}
+
+func TestObserveSessionStopped_NonPoolSession_Skipped(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 1, // trigger on a single drain to make detection easy
+		InitialBackoff: 10 * time.Minute,
+	})
+	restore := RegisterSpawnStormSafetyNetForCurrentController(sn)
+	defer restore()
+
+	store := beads.NewMemStore()
+	// Non-pool session: no pool_managed metadata, no pool_slot, not ephemeral.
+	session := buildSessionBeadForSafetyNet(t, store, "mayor-fixed", false)
+	now := time.Now().UTC()
+	observeSessionStoppedForSafetyNet("", session, "mayor-fixed", "foundations/mayor", store, nil, now, io.Discard)
+	if sn.IsThrottled("foundations/mayor", now.Add(1*time.Minute)) {
+		t.Fatal("non-pool session caused throttle: want non-pool drain to be ignored")
+	}
+}
+
+func TestObserveSessionStopped_PoolWorkerWithoutClaim_DrivesDetection(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+	})
+	restore := RegisterSpawnStormSafetyNetForCurrentController(sn)
+	defer restore()
+
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	// Three pool workers that drained without claiming any bead.
+	for i := 0; i < 3; i++ {
+		name := workerNameForIndex(i)
+		session := buildSessionBeadForSafetyNet(t, store, name, true)
+		observeSessionStoppedForSafetyNet("", session, name, "foundations/worker", store, nil, now.Add(time.Duration(i)*30*time.Second), io.Discard)
+	}
+	if !sn.IsThrottled("foundations/worker", now.Add(5*time.Minute)) {
+		t.Fatal("safety net not throttled after threshold of drain-without-claim")
+	}
+}
+
+func TestObserveSessionStopped_PoolWorkerWithClaim_DoesNotTrigger(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+	})
+	restore := RegisterSpawnStormSafetyNetForCurrentController(sn)
+	defer restore()
+
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	// Three pool workers that each claimed and closed a bead.
+	for i := 0; i < 3; i++ {
+		name := workerNameForIndex(i)
+		session := buildSessionBeadForSafetyNet(t, store, name, true)
+		// Simulate the worker having claimed and closed a routed bead.
+		workBead, err := store.Create(beads.Bead{
+			Title:    "claimed routed work",
+			Type:     "task",
+			Status:   "closed",
+			Assignee: name,
+			Metadata: map[string]string{"gc.routed_to": "foundations/worker"},
+		})
+		if err != nil {
+			t.Fatalf("create work bead: %v", err)
+		}
+		_ = workBead
+		observeSessionStoppedForSafetyNet("", session, name, "foundations/worker", store, nil, now.Add(time.Duration(i)*30*time.Second), io.Discard)
+	}
+	if sn.IsThrottled("foundations/worker", now.Add(5*time.Minute)) {
+		t.Fatal("healthy churn (workers claimed+closed) caused throttle")
+	}
+}
+
+func TestSessionEverClaimed_DetectsClosedBeads(t *testing.T) {
+	// The signal must survive the worker closing its bead. Without
+	// IncludeClosed, this would return false for every successful
+	// worker — false positive avalanche.
+	store := beads.NewMemStore()
+	session := buildSessionBeadForSafetyNet(t, store, "worker-a", true)
+	if _, err := store.Create(beads.Bead{
+		Title:    "claimed and closed",
+		Type:     "task",
+		Status:   "closed",
+		Assignee: "worker-a",
+		Metadata: map[string]string{"gc.routed_to": "foundations/worker"},
+	}); err != nil {
+		t.Fatalf("create closed bead: %v", err)
+	}
+	claimed, err := sessionEverClaimedAnyWork(store, nil, session)
+	if err != nil {
+		t.Fatalf("sessionEverClaimedAnyWork: %v", err)
+	}
+	if !claimed {
+		t.Fatal("sessionEverClaimedAnyWork = false, want true (closed bead with matching assignee)")
+	}
+}
+
+func TestSessionEverClaimed_NoMatchingBeads_ReturnsFalse(t *testing.T) {
+	store := beads.NewMemStore()
+	session := buildSessionBeadForSafetyNet(t, store, "worker-ghost", true)
+	// Bead with a DIFFERENT assignee — must not count.
+	if _, err := store.Create(beads.Bead{
+		Title:    "claimed by someone else",
+		Type:     "task",
+		Status:   "closed",
+		Assignee: "worker-real",
+		Metadata: map[string]string{"gc.routed_to": "foundations/worker"},
+	}); err != nil {
+		t.Fatalf("create unrelated bead: %v", err)
+	}
+	claimed, err := sessionEverClaimedAnyWork(store, nil, session)
+	if err != nil {
+		t.Fatalf("sessionEverClaimedAnyWork: %v", err)
+	}
+	if claimed {
+		t.Fatal("sessionEverClaimedAnyWork = true, want false (no beads with this session as assignee)")
+	}
+}
+
+func TestObserveSessionStopped_NewStorm_SendsMail(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 1,
+		InitialBackoff: 10 * time.Minute,
+	})
+	restore := RegisterSpawnStormSafetyNetForCurrentController(sn)
+	defer restore()
+
+	store := beads.NewMemStore()
+	session := buildSessionBeadForSafetyNet(t, store, "worker-mailtest", true)
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	observeSessionStoppedForSafetyNet("", session, "worker-mailtest", "foundations/worker", store, nil, now, io.Discard)
+
+	// Mailer must have produced a message bead for mayor.
+	mailBeads, err := store.List(beads.ListQuery{Type: "message", Assignee: spawnStormMayorRecipient, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("list mail beads: %v", err)
+	}
+	if len(mailBeads) != 1 {
+		t.Fatalf("mayor inbox = %d messages, want 1", len(mailBeads))
+	}
+	if !strings.Contains(mailBeads[0].Title, "Spawn-storm") {
+		t.Fatalf("mail title = %q, want spawn-storm subject", mailBeads[0].Title)
+	}
+	if !strings.Contains(mailBeads[0].Description, "foundations/worker") {
+		t.Fatalf("mail body missing template name: %q", mailBeads[0].Description)
+	}
+}
+
+func TestObserveSessionStopped_OneMailPerStormEpisode(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 1, // trigger on first drain
+		InitialBackoff: 10 * time.Minute,
+	})
+	restore := RegisterSpawnStormSafetyNetForCurrentController(sn)
+	defer restore()
+
+	store := beads.NewMemStore()
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	// Five subsequent drain-without-claim outcomes inside the same
+	// throttle window — only the first should produce a mail.
+	for i := 0; i < 5; i++ {
+		name := workerNameForIndex(i)
+		session := buildSessionBeadForSafetyNet(t, store, name, true)
+		observeSessionStoppedForSafetyNet("", session, name, "foundations/worker", store, nil, now.Add(time.Duration(i)*30*time.Second), io.Discard)
+	}
+	mailBeads, err := store.List(beads.ListQuery{Type: "message", Assignee: spawnStormMayorRecipient, IncludeClosed: true})
+	if err != nil {
+		t.Fatalf("list mail beads: %v", err)
+	}
+	if len(mailBeads) != 1 {
+		t.Fatalf("mayor inbox = %d messages across one storm episode, want 1", len(mailBeads))
+	}
+}
+
+func TestBuildDesiredState_GateSuppressesDemandForThrottledTemplate(t *testing.T) {
+	// End-to-end: a registered safety net in storm state must cause
+	// buildDesiredStateWithSessionBeads to report 0 demand for the
+	// throttled template, and consequently no pool sessions in the
+	// desired-state map. This is the production effect — workers stop
+	// being spawned for the affected pool.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "foundations/worker"
+
+	// Seed real demand: 3 routed beads ready to be claimed.
+	for i := 0; i < 3; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:    "queued routed work",
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{"gc.routed_to": template},
+		}); err != nil {
+			t.Fatalf("create routed work: %v", err)
+		}
+	}
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	cfg := buildPoolCfgForGateTest(template)
+
+	// Register a safety net that's already in a storm episode for this
+	// template. We achieve this by directly driving RecordDrainOutcome
+	// past the threshold; the gate then sees IsThrottled=true at build
+	// time.
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 2,
+		InitialBackoff: 30 * time.Minute,
+		MaxBackoff:     60 * time.Minute,
+	})
+	now := time.Now().UTC()
+	sn.RecordDrainOutcome(template, "w1", false, now)
+	sn.RecordDrainOutcome(template, "w2", false, now.Add(10*time.Second))
+	if !sn.IsThrottled(template, now.Add(20*time.Second)) {
+		t.Fatal("test scaffold: safety net failed to enter storm before build")
+	}
+	restore := RegisterSpawnStormSafetyNetForCurrentController(sn)
+	defer restore()
+
+	var stderr strings.Builder
+	dsResult := callBuildDesiredStateWithSessionBeads(t, cityPath, cfg, store, snapshot, &stderr)
+
+	if got := dsResult.ScaleCheckCounts[template]; got != 0 {
+		t.Fatalf("ScaleCheckCounts[%s] = %d, want 0 with safety net throttling", template, got)
+	}
+	if !strings.Contains(stderr.String(), "spawn-storm safety net") {
+		t.Fatalf("expected throttle diagnostic in stderr, got:\n%s", stderr.String())
+	}
+	for sessionName, tp := range dsResult.State {
+		if tp.TemplateName == template {
+			t.Fatalf("desired state materialized pool session %q while throttled; want empty pool", sessionName)
+		}
+	}
+}
+
+func TestBuildDesiredState_NoGateWhenSafetyNetUnregistered(t *testing.T) {
+	// Positive control: without a registered safety net, the same
+	// fixture must produce real demand. Ensures the gate is opt-in
+	// (process-wide registration) and doesn't accidentally gate when
+	// no controller installed one.
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "foundations/worker"
+
+	for i := 0; i < 3; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:    "queued routed work",
+			Type:     "task",
+			Status:   "open",
+			Metadata: map[string]string{"gc.routed_to": template},
+		}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	snapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	cfg := buildPoolCfgForGateTest(template)
+
+	var stderr strings.Builder
+	dsResult := callBuildDesiredStateWithSessionBeads(t, cityPath, cfg, store, snapshot, &stderr)
+
+	if got := dsResult.ScaleCheckCounts[template]; got != 3 {
+		t.Fatalf("ScaleCheckCounts[%s] = %d, want 3 (unsuppressed demand)", template, got)
+	}
+}
+
+func buildSessionBeadForSafetyNet(t *testing.T, store beads.Store, sessionName string, poolManaged bool) beads.Bead {
+	t.Helper()
+	metadata := map[string]string{
+		"session_name": sessionName,
+		"template":     "foundations/worker",
+	}
+	if poolManaged {
+		metadata["pool_managed"] = "true"
+		metadata["pool_slot"] = "1"
+	}
+	bead, err := store.Create(beads.Bead{
+		Title:    "session " + sessionName,
+		Type:     "session",
+		Status:   "closed",
+		Metadata: metadata,
+	})
+	if err != nil {
+		t.Fatalf("create session bead %q: %v", sessionName, err)
+	}
+	return bead
+}
+
+func workerNameForIndex(i int) string {
+	suffixes := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa"}
+	if i < len(suffixes) {
+		return "worker-pool-" + suffixes[i]
+	}
+	return "worker-pool-extra"
+}
+
+func buildPoolCfgForGateTest(template string) *config.City {
+	zero := 0
+	ten := 10
+	return &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              template,
+			StartCommand:      "true",
+			MinActiveSessions: &zero,
+			MaxActiveSessions: &ten,
+		}},
+	}
+}
+
+func callBuildDesiredStateWithSessionBeads(
+	t *testing.T,
+	cityPath string,
+	cfg *config.City,
+	store beads.Store,
+	snapshot *sessionBeadSnapshot,
+	stderr *strings.Builder,
+) DesiredStateResult {
+	t.Helper()
+	return buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		store, nil, snapshot, nil, stderr,
+	)
+}

--- a/cmd/gc/spawn_storm_safety_net_test.go
+++ b/cmd/gc/spawn_storm_safety_net_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Acceptance tests for the spawn-storm safety net.
+//
+// Scenarios map directly to bead fo-wmfem acceptance criteria:
+//
+//   - Real storm (drain-without-claim sustained) triggers detection.
+//   - Healthy churn (workers claim and finish) does NOT trigger.
+//   - Pre-claim exploration (worker takes time, then claims) does NOT trigger.
+//   - Throttle gates new spawns; in-flight workers untouched.
+//   - One-storm-one-mail (single transition signal).
+//   - Decay: throttle expires when storm stops; state resets.
+
+func TestSafetyNet_RealStormTriggersDetection(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 5,
+		InitialBackoff: 10 * time.Minute,
+		MaxBackoff:     60 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Five drain-without-claim outcomes spaced over ~4 minutes — within the
+	// sliding window. The fifth crosses the threshold and triggers detection.
+	var newStorm bool
+	for i := 0; i < 5; i++ {
+		now := base.Add(time.Duration(i) * 50 * time.Second)
+		got := sn.RecordDrainOutcome("foundations/worker", "worker-1", false, now)
+		if i == 4 {
+			newStorm = got
+		} else if got {
+			t.Fatalf("RecordDrainOutcome(i=%d): unexpected newStorm=true before threshold", i)
+		}
+	}
+	if !newStorm {
+		t.Fatal("RecordDrainOutcome at threshold: want newStorm=true, got false")
+	}
+
+	// Throttle is active right after detection.
+	if !sn.IsThrottled("foundations/worker", base.Add(5*time.Minute)) {
+		t.Fatal("IsThrottled just after detection: want true, got false")
+	}
+}
+
+func TestSafetyNet_HealthyChurnDoesNotTrigger(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 5,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Twenty workers spawn, claim, finish, recycle — all claimed=true.
+	for i := 0; i < 20; i++ {
+		now := base.Add(time.Duration(i) * 10 * time.Second)
+		if sn.RecordDrainOutcome("foundations/worker", "worker", true, now) {
+			t.Fatalf("RecordDrainOutcome(claimed=true, i=%d): unexpected newStorm=true", i)
+		}
+	}
+	if sn.IsThrottled("foundations/worker", base.Add(10*time.Minute)) {
+		t.Fatal("IsThrottled after healthy churn: want false, got true")
+	}
+}
+
+func TestSafetyNet_ExplorationThenClaimDoesNotTrigger(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 5,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Five workers each take a couple of minutes thinking before claim, but
+	// eventually claim and close. From the safety net's vantage these are
+	// claimed=true outcomes; pre-claim exploration is unobservable.
+	for i := 0; i < 5; i++ {
+		now := base.Add(time.Duration(i) * 2 * time.Minute)
+		if sn.RecordDrainOutcome("foundations/worker", "worker", true, now) {
+			t.Fatalf("RecordDrainOutcome(exploring worker i=%d): unexpected newStorm=true", i)
+		}
+	}
+	if sn.IsThrottled("foundations/worker", base.Add(15*time.Minute)) {
+		t.Fatal("IsThrottled after exploration-then-claim: want false, got true")
+	}
+}
+
+func TestSafetyNet_OneMailPerStormTransition(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	transitions := 0
+	// 10 drains within the window. Only the threshold-crossing one should
+	// report newStorm=true; subsequent ones within the same storm episode
+	// must not retrigger the mail.
+	for i := 0; i < 10; i++ {
+		now := base.Add(time.Duration(i) * 20 * time.Second)
+		if sn.RecordDrainOutcome("foundations/worker", "w", false, now) {
+			transitions++
+		}
+	}
+	if transitions != 1 {
+		t.Fatalf("transitions across single storm episode: want 1, got %d", transitions)
+	}
+}
+
+func TestSafetyNet_DecayAfterStormPasses(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+		MaxBackoff:     60 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Trigger one storm.
+	for i := 0; i < 3; i++ {
+		sn.RecordDrainOutcome("foundations/worker", "w", false, base.Add(time.Duration(i)*30*time.Second))
+	}
+
+	// Wait past the initial backoff with no further drain signals: throttle
+	// must release; subsequent storm starts from the base window (not from
+	// the elevated backoff of the previous episode).
+	postBackoff := base.Add(11 * time.Minute)
+	if sn.IsThrottled("foundations/worker", postBackoff) {
+		t.Fatal("IsThrottled after backoff window with no new drains: want false, got true")
+	}
+
+	// A new storm now: backoff starts from InitialBackoff, not 2*Initial.
+	// The threshold-crossing drain lands at base2+60s; throttle should
+	// expire at base2+60s+10m (and NOT at base2+60s+20m).
+	base2 := postBackoff
+	for i := 0; i < 3; i++ {
+		sn.RecordDrainOutcome("foundations/worker", "w", false, base2.Add(time.Duration(i)*30*time.Second))
+	}
+	thresholdAt := base2.Add(60 * time.Second)
+	// 1 minute inside the InitialBackoff window: throttle active.
+	if !sn.IsThrottled("foundations/worker", thresholdAt.Add(9*time.Minute)) {
+		t.Fatal("IsThrottled at threshold+9m: want true, got false (second storm)")
+	}
+	// 1 minute past the InitialBackoff window with no new drains: throttle
+	// clears. If the backoff had doubled from the prior episode (20m) this
+	// would still be inside it — proves the second storm starts fresh.
+	if sn.IsThrottled("foundations/worker", thresholdAt.Add(11*time.Minute)) {
+		t.Fatal("IsThrottled at threshold+11m: want false, got true (decay didn't reset)")
+	}
+}
+
+func TestSafetyNet_ExponentialBackoffDuringSustainedStorm(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+		MaxBackoff:     60 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Cross threshold -> InitialBackoff (10 min) -> throttledUntil = t0+10m
+	for i := 0; i < 3; i++ {
+		sn.RecordDrainOutcome("foundations/worker", "w", false, base.Add(time.Duration(i)*30*time.Second))
+	}
+	thrAt := base.Add(2*30*time.Second + 10*time.Minute)
+	if !sn.IsThrottled("foundations/worker", thrAt.Add(-time.Second)) {
+		t.Fatal("IsThrottled just before initial backoff expiry: want true")
+	}
+
+	// Another drain-without-claim WHILE throttled: backoff doubles to 20 min.
+	mid := base.Add(2 * time.Minute)
+	sn.RecordDrainOutcome("foundations/worker", "w2", false, mid)
+
+	// Throttle now extends to mid+20m, well past the original thrAt.
+	probe := mid.Add(19 * time.Minute)
+	if !sn.IsThrottled("foundations/worker", probe) {
+		t.Fatal("IsThrottled inside extended (2x) backoff: want true, got false")
+	}
+	// And expires after 20 min from `mid`.
+	probe2 := mid.Add(20*time.Minute + time.Second)
+	// Need to also be past the sliding window so old drains age out, otherwise
+	// IsThrottled-driven clear may not trigger. The sliding window is 5 min.
+	if sn.IsThrottled("foundations/worker", probe2) {
+		t.Fatal("IsThrottled past extended backoff: want false, got true")
+	}
+}
+
+func TestSafetyNet_BackoffCappedAtMax(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 2,
+		InitialBackoff: 30 * time.Minute,
+		MaxBackoff:     60 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Trigger storm: initial backoff = 30 min.
+	sn.RecordDrainOutcome("foundations/worker", "a", false, base)
+	sn.RecordDrainOutcome("foundations/worker", "b", false, base.Add(10*time.Second))
+
+	// 10 further drain-without-claim outcomes — backoff should double several
+	// times but cap at 60 min.
+	for i := 0; i < 10; i++ {
+		sn.RecordDrainOutcome("foundations/worker", "c", false, base.Add(time.Duration(i)*20*time.Second))
+	}
+
+	// At base + (10*20s) + 61 min, throttle MUST have expired (cap = 60m).
+	lastDrain := base.Add(10 * 20 * time.Second)
+	if sn.IsThrottled("foundations/worker", lastDrain.Add(61*time.Minute)) {
+		t.Fatal("IsThrottled past MaxBackoff cap: want false, got true")
+	}
+}
+
+func TestSafetyNet_PerTemplateIsolation(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Storm on template A.
+	for i := 0; i < 3; i++ {
+		sn.RecordDrainOutcome("templateA", "w", false, base.Add(time.Duration(i)*30*time.Second))
+	}
+	if !sn.IsThrottled("templateA", base.Add(5*time.Minute)) {
+		t.Fatal("templateA throttled after storm: want true, got false")
+	}
+
+	// templateB unaffected: no drains there.
+	if sn.IsThrottled("templateB", base.Add(5*time.Minute)) {
+		t.Fatal("templateB throttled by templateA's storm: want false, got true (cross-template leak)")
+	}
+}
+
+func TestApplyThrottleToScaleCheckCounts_NilSafetyNet(t *testing.T) {
+	counts := map[string]int{"templateA": 3, "templateB": 1}
+	throttled := applyThrottleToScaleCheckCounts(nil, counts, time.Now())
+	if throttled != nil {
+		t.Fatalf("throttled = %v, want nil with nil safety net", throttled)
+	}
+	if counts["templateA"] != 3 || counts["templateB"] != 1 {
+		t.Fatalf("counts mutated by nil safety net: %v", counts)
+	}
+}
+
+func TestApplyThrottleToScaleCheckCounts_GatesOnlyThrottled(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 3,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	// Storm on templateA only.
+	for i := 0; i < 3; i++ {
+		sn.RecordDrainOutcome("templateA", "w", false, base.Add(time.Duration(i)*30*time.Second))
+	}
+
+	counts := map[string]int{"templateA": 5, "templateB": 2}
+	throttled := applyThrottleToScaleCheckCounts(sn, counts, base.Add(2*time.Minute))
+	if len(throttled) != 1 || !throttled["templateA"] {
+		t.Fatalf("throttled = %v, want {templateA:true} only", throttled)
+	}
+	if counts["templateA"] != 0 {
+		t.Fatalf("counts[templateA] = %d, want 0 (gated)", counts["templateA"])
+	}
+	if counts["templateB"] != 2 {
+		t.Fatalf("counts[templateB] = %d, want 2 (unaffected)", counts["templateB"])
+	}
+}
+
+func TestApplyThrottleToScaleCheckCounts_SkipsZeroDemand(t *testing.T) {
+	// A template that already has zero demand should NOT appear in the
+	// throttled-set even if it's currently in a storm — there's nothing
+	// to suppress, and surfacing it in diagnostics would be noisy.
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 2,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	sn.RecordDrainOutcome("templateA", "w", false, base)
+	sn.RecordDrainOutcome("templateA", "w", false, base.Add(30*time.Second))
+
+	counts := map[string]int{"templateA": 0}
+	throttled := applyThrottleToScaleCheckCounts(sn, counts, base.Add(1*time.Minute))
+	if len(throttled) != 0 {
+		t.Fatalf("throttled = %v, want empty (zero demand has nothing to gate)", throttled)
+	}
+}
+
+func TestRegisterSpawnStormSafetyNet_RestoresOnRelease(t *testing.T) {
+	sn1 := NewSpawnStormSafetyNet(SpawnStormConfig{})
+	restore1 := RegisterSpawnStormSafetyNetForCurrentController(sn1)
+	if got := safetyNetForGating(); got != sn1 {
+		t.Fatalf("after register: got %p, want %p", got, sn1)
+	}
+
+	sn2 := NewSpawnStormSafetyNet(SpawnStormConfig{})
+	restore2 := RegisterSpawnStormSafetyNetForCurrentController(sn2)
+	if got := safetyNetForGating(); got != sn2 {
+		t.Fatalf("after second register: got %p, want %p", got, sn2)
+	}
+
+	restore2()
+	if got := safetyNetForGating(); got != sn1 {
+		t.Fatalf("after restore2: got %p, want %p (sn1)", got, sn1)
+	}
+
+	restore1()
+	if got := safetyNetForGating(); got != nil {
+		t.Fatalf("after restore1: got %p, want nil", got)
+	}
+}
+
+func TestSafetyNet_SlidingWindowExpiresOldDrains(t *testing.T) {
+	sn := NewSpawnStormSafetyNet(SpawnStormConfig{
+		Window:         5 * time.Minute,
+		DrainThreshold: 5,
+		InitialBackoff: 10 * time.Minute,
+	})
+	base := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+
+	// Four drains, spaced out wide enough that by the time the 5th arrives,
+	// the earliest has aged out of the 5-min window. Should NOT trigger.
+	sn.RecordDrainOutcome("foundations/worker", "w", false, base)
+	sn.RecordDrainOutcome("foundations/worker", "w", false, base.Add(1*time.Minute))
+	sn.RecordDrainOutcome("foundations/worker", "w", false, base.Add(2*time.Minute))
+	sn.RecordDrainOutcome("foundations/worker", "w", false, base.Add(3*time.Minute))
+	// At base+6m, the base drain has aged out. Window now contains 4 entries
+	// counting the new one — below threshold.
+	if got := sn.RecordDrainOutcome("foundations/worker", "w", false, base.Add(6*time.Minute)); got {
+		t.Fatal("RecordDrainOutcome at base+6m (with window expiry): want newStorm=false, got true")
+	}
+	if sn.IsThrottled("foundations/worker", base.Add(7*time.Minute)) {
+		t.Fatal("IsThrottled after below-threshold sustained low rate: want false, got true")
+	}
+}

--- a/internal/beads/bdstore.go
+++ b/internal/beads/bdstore.go
@@ -1094,6 +1094,19 @@ func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 	if q.Assignee != "" {
 		args = append(args, "--assignee", q.Assignee)
 	}
+	if q.Unassigned {
+		args = append(args, "--unassigned")
+	}
+	if len(q.Metadata) > 0 {
+		keys := make([]string, 0, len(q.Metadata))
+		for k := range q.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			args = append(args, "--metadata-field", k+"="+q.Metadata[k])
+		}
+	}
 	if q.Limit > 0 {
 		args = append(args, "--limit", strconv.Itoa(q.Limit))
 	} else {
@@ -1111,6 +1124,12 @@ func (s *BdStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 			continue
 		}
 		if q.Assignee != "" && bead.Assignee != q.Assignee {
+			continue
+		}
+		if q.Unassigned && strings.TrimSpace(bead.Assignee) != "" {
+			continue
+		}
+		if len(q.Metadata) > 0 && !matchesMetadata(bead, q.Metadata) {
 			continue
 		}
 		result = append(result, bead)

--- a/internal/beads/bdstore_test.go
+++ b/internal/beads/bdstore_test.go
@@ -1392,6 +1392,43 @@ func TestBdStoreReadyWithAssigneeAndLimit(t *testing.T) {
 	}
 }
 
+func TestBdStoreReadyForwardsMetadataAndUnassigned(t *testing.T) {
+	runner := fakeRunner(map[string]struct {
+		out []byte
+		err error
+	}{
+		`bd ready --json --unassigned --metadata-field gc.routed_to=foundations/worker --limit 0`: {
+			out: []byte(`[
+				{"id":"bd-route","title":"routed work","status":"open","issue_type":"task","metadata":{"gc.routed_to":"foundations/worker"},"created_at":"2025-01-15T10:30:00Z"},
+				{"id":"bd-claimed","title":"already claimed","status":"open","issue_type":"task","assignee":"someone","metadata":{"gc.routed_to":"foundations/worker"},"created_at":"2025-01-15T10:31:00Z"},
+				{"id":"bd-other-pool","title":"different route","status":"open","issue_type":"task","metadata":{"gc.routed_to":"foundations/refinery"},"created_at":"2025-01-15T10:32:00Z"}
+			]`),
+		},
+	})
+	s := beads.NewBdStore("/city", runner)
+	got, err := s.Ready(beads.ReadyQuery{
+		Metadata:   map[string]string{"gc.routed_to": "foundations/worker"},
+		Unassigned: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Ready returned %d beads, want 1; ids=%v", len(got), beadIDs(got))
+	}
+	if got[0].ID != "bd-route" {
+		t.Fatalf("Ready[0].ID = %q, want bd-route", got[0].ID)
+	}
+}
+
+func beadIDs(beads []beads.Bead) []string {
+	ids := make([]string, len(beads))
+	for i, b := range beads {
+		ids[i] = b.ID
+	}
+	return ids
+}
+
 func TestBdStoreReadyFiltersInfraTypes(t *testing.T) {
 	runner := fakeRunner(map[string]struct {
 		out []byte

--- a/internal/beads/caching_store_reads.go
+++ b/internal/beads/caching_store_reads.go
@@ -323,7 +323,7 @@ func (c *CachingStore) Get(id string) (Bead, error) {
 
 // Ready returns open beads whose blocking deps are all closed.
 func (c *CachingStore) Ready(query ...ReadyQuery) ([]Bead, error) {
-	if readyQueryFromArgs(query) != (ReadyQuery{}) {
+	if !readyQueryFromArgs(query).IsZero() {
 		return c.backing.Ready(query...)
 	}
 	c.mu.RLock()

--- a/internal/beads/memstore.go
+++ b/internal/beads/memstore.go
@@ -266,6 +266,12 @@ func (m *MemStore) Ready(query ...ReadyQuery) ([]Bead, error) {
 		if q.Assignee != "" && b.Assignee != q.Assignee {
 			continue
 		}
+		if q.Unassigned && strings.TrimSpace(b.Assignee) != "" {
+			continue
+		}
+		if len(q.Metadata) > 0 && !matchesMetadata(b, q.Metadata) {
+			continue
+		}
 		blocked := false
 		for _, dep := range m.deps {
 			if dep.IssueID != b.ID {

--- a/internal/beads/query.go
+++ b/internal/beads/query.go
@@ -46,9 +46,25 @@ type ListQuery struct {
 // ReadyQuery describes optional filters for ready-work lookup. A zero-value
 // query preserves Ready's historical behavior: all open, unblocked actionable
 // work.
+//
+// Metadata and Unassigned exist so the in-process spawn-decision path can
+// issue the *same* query as the worker's pool-demand shell predicate
+// (`bd ready --metadata-field gc.routed_to=T --unassigned`). Without that
+// symmetry the reconciler can spawn against beads the worker won't claim
+// (deferred-by-date, dep-blocked, stale-assignee), producing a spawn storm.
+// See bead fo-spawn-storm-mitigate.
 type ReadyQuery struct {
-	Assignee string
-	Limit    int
+	Assignee   string
+	Metadata   map[string]string
+	Unassigned bool
+	Limit      int
+}
+
+// IsZero reports whether q would request the historical default Ready set
+// (no filters). Maps with non-zero len count as a filter even if all values
+// are empty strings.
+func (q ReadyQuery) IsZero() bool {
+	return q.Assignee == "" && !q.Unassigned && len(q.Metadata) == 0 && q.Limit == 0
 }
 
 func readyQueryFromArgs(queries []ReadyQuery) ReadyQuery {


### PR DESCRIPTION
## Summary

Defense-in-depth safety net for pool spawn storms (fo-wmfem). When the
reconciler's spawn-decision predicate disagrees with what workers can
actually claim, workers drain without claiming and a livelock starts.
The L0 fix at the protocol level is in [PR #1064](https://github.com/gastownhall/gascity/pull/1064)
(fo-spawn-storm); this PR is the backstop that catches the *observable*
consequence — sustained drain-without-claim outcomes per pool template —
regardless of where the underlying mismatch comes from.

## What it does

- **Detect**: per-template sliding-window counter of drain-without-claim
  outcomes. 5 unclaimed drains in 5 minutes crosses the default threshold.
  Signal is unambiguous: "worker drained without ever claiming a bead",
  derived from existing bead-store state (`List(Assignee=session, IncludeClosed=true)`)
  so a worker that claimed-and-closed (healthy) is distinguished from one
  that never claimed (storm signal).

- **Throttle**: on detection, `defaultScaleCheckCounts` reports 0 demand
  for the affected template. Initial backoff 10 min, doubles with each
  subsequent drain-without-claim during the same episode, capped at 60
  min. Backoff clears when the window passes with no further unclaimed
  drains; next episode starts from `InitialBackoff` again (decay so a
  one-off transient doesn't suppress the pool indefinitely).

- **In-flight protection**: the gate only suppresses NEW spawn
  decisions. The safety net exposes no API that touches existing
  sessions — workers mid-claim complete and close normally.

- **Notify**: exactly one mail to mayor per transition-into-storm,
  delivered with a queued nudge for wake-immediately semantics. The
  mail bead is the durable signal; nudge failure doesn't fail the
  notification.

## Cherry-pick note

This PR is rooted on `cwalv:main` but includes one commit (`feat(reconciler):
symmetric ReadyQuery for spawn-decision predicate`) that's a re-pick of
the L0 fix in PR #1064. Tests in fo-wmfem's TDD loop require L0 in the
working tree to exercise the spawn-decision predicate. Once #1064 merges
to upstream main and propagates back, the cherry-picked commit can be
dropped from this branch (rebase --onto upstream/main).

## Design constraints (from bead fo-wmfem)

- **One detection mechanism, not several layered.** This bead deliberately
  leaves behind prior-art design choices (per-bead intersection detector,
  asymmetric cooldown) — the safety net is designed from the bead's goals
  rather than refactored from `cwalv:feat/reconciler-spawn-backoff`.
- **State is in-memory.** Loss on controller restart is acceptable; restart
  is the natural reset.
- **Detection signal is unambiguous.** "Drained without claim" survives
  changes to the reconciler/work-query model. Avoids signals that depend
  on inferring worker intent.

## Test plan

- [x] Unit tests for the detector (`spawn_storm_safety_net_test.go`): real
  storm triggers, healthy churn doesn't, exploration-then-claim doesn't,
  one-mail-per-episode, exponential backoff, MaxBackoff cap, per-template
  isolation, sliding-window expiry, decay reset across episodes.
- [x] Wiring tests (`spawn_storm_safety_net_observe_test.go`): non-pool
  sessions skipped, pool-without-claim drives detection, pool-with-claim
  does not, closed-bead claim detection, end-to-end gate through
  `buildDesiredStateWithSessionBeads`.
- [x] Gate diagnostic appears in stderr only when a template was actually
  throttled.
- [ ] **Manual smoke**: induce a contract mismatch in a test city, verify
  detection within 5 min, mayor receives one mail, throttle releases when
  mismatch is resolved.