### PR TITLE
fix(formulas): replace event-watch hot-loop with fixed sleep in patrol formulas

### DIFF
--- a/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml
@@ -46,12 +46,12 @@ between patrol cycles.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-deacon-patrol"
-version = 13
+version = 14
 
 [vars]
 [vars.event_timeout]
-description = "Seconds to wait for events before re-checking (exponential backoff)"
-default = "30"
+description = "Seconds to sleep before re-checking. Replaces former event-watch loop which hot-spun on cache-reconcile firehose."
+default = "60"
 
 [[steps]]
 id = "check-inbox"
@@ -412,15 +412,12 @@ NEXT=$(gc bd mol wisp mol-deacon-patrol --root-only --var binding_prefix='{{bind
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
-**4. Wait for activity (exponential backoff):**
+**4. Wait before next cycle:**
 ```bash
-SEQ=$(gc events --seq)
-gc events --watch --type=bead.updated \
-  --after=$SEQ --timeout {{event_timeout}}s
+sleep {{event_timeout}}
 ```
 
-On event: proceed immediately.
-On timeout: double the timeout (cap 300s) and proceed anyway.
+Previous implementation watched `gc events --type=bead.updated` for fast wake-up, but cache-reconcile fires that event constantly, turning the watch into a tight loop with no useful backoff. Fixed sleep gives predictable idle cost.
 
 **5. Burn this wisp:**
 ```bash

--- a/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml
@@ -29,7 +29,7 @@ closes the bead once the PR is verified.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-refinery-patrol"
-version = 3
+version = 4
 contract = "graph.v2"
 
 [vars]
@@ -70,8 +70,8 @@ description = "Auto-create work beads to land completed integration branches"
 default = "false"
 
 [vars.event_timeout]
-description = "Seconds to wait for events before re-checking (exponential backoff)"
-default = "30"
+description = "Seconds to sleep before re-checking for work. Replaces former event-watch loop which hot-spun on cache-reconcile firehose."
+default = "60"
 
 [[steps]]
 id = "check-inbox"
@@ -122,15 +122,14 @@ gc bd show $WORK --json | jq '.[0].metadata'
 The bead MUST have `metadata.branch`. If `metadata.target` is missing,
 use {{target_branch}} as default. Note the work bead ID and close this step.
 
-If NO work found: wait for assignment:
+If NO work found: sleep before re-checking:
 ```bash
-SEQ=$(gc events --seq)
-gc events --watch --type=bead.updated \
-  --after=$SEQ --timeout {{event_timeout}}s
+sleep {{event_timeout}}
 ```
 
-On event: re-check for assigned work. If found, close this step.
-On timeout: re-check anyway, then wait again with doubled timeout (cap 300s).
+Re-check for assigned work. If found, close this step. Otherwise repeat the sleep.
+
+Note: previous implementation watched `gc events --type=bead.updated` for fast wake-up, but cache-reconcile fires that event constantly, turning the watch into a tight loop with no useful backoff. Fixed sleep gives predictable idle cost (~$0 vs ~$3.46/15min hot-loop measured 2026-04-29).
 
 **Do not close this step until you have a work bead with branch metadata.**"""
 

--- a/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
+++ b/examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml
@@ -58,12 +58,12 @@ the worktree. This makes the work schedulable again.
 
 Read each step's description before acting — Config values override defaults."""
 formula = "mol-witness-patrol"
-version = 9
+version = 10
 
 [vars]
 [vars.event_timeout]
-description = "Seconds to wait for events before re-checking (exponential backoff)"
-default = "30"
+description = "Seconds to sleep before re-checking. Replaces former event-watch loop which hot-spun on cache-reconcile firehose."
+default = "60"
 
 [[steps]]
 id = "check-inbox"
@@ -488,17 +488,12 @@ NEXT=$(gc bd mol wisp mol-witness-patrol --root-only --var binding_prefix='{{bin
 gc bd update "$NEXT" --assignee=$GC_AGENT
 ```
 
-**3. Wait for activity (exponential backoff):**
+**3. Wait before next cycle:**
 ```bash
-SEQ=$(gc events --seq)
-gc events --watch --type=bead.updated \
-  --after=$SEQ --timeout {{event_timeout}}s
+sleep {{event_timeout}}
 ```
 
-`--timeout` makes this command self-terminating — it exits on its own when an event arrives or the timeout fires. Do not add `&`, pipe to another command, or wrap in a background process.
-
-On event: proceed immediately.
-On timeout: double the timeout (cap 300s) and proceed anyway.
+Previous implementation watched `gc events --type=bead.updated` for fast wake-up, but cache-reconcile fires that event constantly, turning the watch into a tight loop with no useful backoff. Fixed sleep gives predictable idle cost.
 
 **4. Burn this wisp:**
 ```bash


### PR DESCRIPTION
## Summary

Three patrol formulas (refinery, deacon, witness) wait on \`gc events --watch --type=bead.updated\` between iterations. Cache-reconcile fires that event constantly, so the watch returns immediately every cycle and the patrol agents spin at ~7-10 LLM round-trips/min doing no real work.

Measured cost on intervaltree/refinery 2026-04-29: ~\$3.46/15min sustained idle bleed, multiplied across all patrol agents (~5 active in a typical city).

## Change

Replace \`gc events --watch ...\` block with \`sleep {{event_timeout}}\`. Bump default timeout 30s → 60s.

Trade fast event-driven wake-up for predictable idle cost. Wake-on-event was the desired UX but the firehose ruined it; fixing the watch filter properly (e.g. \`--type=bead.created --assignee=\$GC_AGENT\`) is a follow-up.

## Files

- \`examples/gastown/packs/gastown/formulas/mol-refinery-patrol.toml\` (v3 → v4)
- \`examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml\`   (v13 → v14)
- \`examples/gastown/packs/gastown/formulas/mol-witness-patrol.toml\`  (v9 → v10)

## Refs

- hq-f01p8 (P1 bug, 2 weeks open) — describes the hot-loop and original cost measurement

## Test plan

- [ ] CI green
- [ ] Local main merge: confirm patrol agents sleep instead of spinning (check connection ID growth in dolt logs drops dramatically)