### PR TITLE
perf(status): parallelize runtime probes; skip drain probe for stopped sessions

### DIFF
--- a/cmd/gc/city_status_snapshot.go
+++ b/cmd/gc/city_status_snapshot.go
@@ -7,12 +7,51 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/worker"
 )
+
+// statusObservationConcurrency caps how many agent observations gc status
+// runs in parallel. Observations are mostly tmux probes; the bound keeps the
+// command from fanning out to hundreds of goroutines on very large cities
+// while still cutting wall time on the common 10-30 agent case.
+const statusObservationConcurrency = 8
+
+// observeStatusTargetsParallel runs observeSessionTargetWithWarning for each
+// target concurrently with a bounded worker pool. Results are returned in
+// input order. stderr is shared safely across goroutines.
+func observeStatusTargetsParallel(
+	sp runtime.Provider,
+	cfg *config.City,
+	cityPath string,
+	store beads.Store,
+	targets []statusObservationTarget,
+	stderr io.Writer,
+) []worker.LiveObservation {
+	out := make([]worker.LiveObservation, len(targets))
+	if len(targets) == 0 {
+		return out
+	}
+	safeStderr := lockedStderr(stderr)
+	sem := make(chan struct{}, statusObservationConcurrency)
+	var wg sync.WaitGroup
+	for i, t := range targets {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, t statusObservationTarget) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			out[i] = observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, t, safeStderr)
+		}(i, t)
+	}
+	wg.Wait()
+	return out
+}
 
 type cityStatusSnapshot struct {
 	CityName      string
@@ -121,6 +160,18 @@ func collectCityStatusSnapshotFromStoreSnapshot(
 		}
 	}
 
+	// Phase 1: walk the agent config and materialize a row + observation
+	// target per (agent or pool instance) without contacting the runtime.
+	// Each plan entry remembers everything needed to stitch the observation
+	// result back in once it arrives.
+	type agentPlan struct {
+		row       cityStatusAgentRow
+		target    statusObservationTarget
+		suspended bool
+		rigDir    string
+	}
+	var plans []agentPlan
+
 	for _, a := range cfg.Agents {
 		suspended := a.Suspended || (a.Dir != "" && suspendedRigs[a.Dir])
 		sp0 := scaleParamsFor(&a)
@@ -138,15 +189,12 @@ func collectCityStatusSnapshotFromStoreSnapshot(
 			headerShown := false
 			for _, qualifiedInstance := range discoverPoolInstances(a.Name, a.Dir, sp0, &a, snapshot.CityName, cfg.Workspace.SessionTemplate, sp) {
 				target := statusObservationTargetForIdentity(statusSnapshot, snapshot.CityName, qualifiedInstance, cfg.Workspace.SessionTemplate)
-				obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, target, stderr)
 				_, instanceName := config.ParseQualifiedName(qualifiedInstance)
 				row := cityStatusAgentRow{
 					Agent: StatusAgentJSON{
 						Name:          instanceName,
 						QualifiedName: qualifiedInstance,
 						Scope:         scope,
-						Running:       obs.Running,
-						Suspended:     suspended || obs.Suspended || target.suspended,
 						Pool:          nil,
 					},
 					SessionName: target.runtimeSessionName,
@@ -157,35 +205,46 @@ func collectCityStatusSnapshotFromStoreSnapshot(
 					row.ScaleLabel = scaleLabel
 					headerShown = true
 				}
-				snapshot.Agents = append(snapshot.Agents, row)
-				snapshot.Summary.TotalAgents++
-				if obs.Running {
-					snapshot.Summary.RunningAgents++
-				}
-				addRigCount(a.Dir, suspended || obs.Suspended || target.suspended)
+				plans = append(plans, agentPlan{row: row, target: target, suspended: suspended, rigDir: a.Dir})
 			}
 			continue
 		}
 
 		target := statusObservationTargetForIdentity(statusSnapshot, snapshot.CityName, a.QualifiedName(), cfg.Workspace.SessionTemplate)
-		obs := observeSessionTargetWithWarning("gc status", cityPath, store, sp, cfg, target, stderr)
-		snapshot.Agents = append(snapshot.Agents, cityStatusAgentRow{
+		row := cityStatusAgentRow{
 			Agent: StatusAgentJSON{
 				Name:          a.Name,
 				QualifiedName: a.QualifiedName(),
 				Scope:         scope,
-				Running:       obs.Running,
-				Suspended:     suspended || obs.Suspended || target.suspended,
 			},
 			SessionName: target.runtimeSessionName,
 			GroupName:   a.QualifiedName(),
 			Expanded:    false,
-		})
+		}
+		plans = append(plans, agentPlan{row: row, target: target, suspended: suspended, rigDir: a.Dir})
+	}
+
+	// Phase 2: fan out runtime observations across the worker pool. This is
+	// the long pole on multi-rig cities; running the probes serially used to
+	// dominate gc status wall time.
+	targets := make([]statusObservationTarget, len(plans))
+	for i, p := range plans {
+		targets[i] = p.target
+	}
+	observations := observeStatusTargetsParallel(sp, cfg, cityPath, store, targets, stderr)
+
+	// Phase 3: stitch observation results back into rows and tallies in the
+	// original order to keep output deterministic.
+	for i, p := range plans {
+		obs := observations[i]
+		p.row.Agent.Running = obs.Running
+		p.row.Agent.Suspended = p.suspended || obs.Suspended || p.target.suspended
+		snapshot.Agents = append(snapshot.Agents, p.row)
 		snapshot.Summary.TotalAgents++
 		if obs.Running {
 			snapshot.Summary.RunningAgents++
 		}
-		addRigCount(a.Dir, suspended || obs.Suspended || target.suspended)
+		addRigCount(p.rigDir, p.suspended || obs.Suspended || p.target.suspended)
 	}
 
 	for _, r := range cfg.Rigs {

--- a/cmd/gc/city_status_snapshot_test.go
+++ b/cmd/gc/city_status_snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/worker"
 )
 
 func TestCityStatusNamedSessionsUseProvidedStore(t *testing.T) {
@@ -499,5 +501,67 @@ func TestCityStatusNamedSessionsUseLoadedSnapshotWithoutGet(t *testing.T) {
 	out := stdout.String()
 	if strings.Contains(out, "lookup error:") || strings.Contains(out, "store offline") {
 		t.Fatalf("stdout = %q, want snapshot-backed named status without store lookup error", out)
+	}
+}
+
+// TestCityStatusObservationsRunInParallel guards against regression of the
+// serial per-agent observation loop that made `gc status` ~1.4s on multi-rig
+// cities. With N agents and an observer that blocks briefly, wall time should
+// be close to a single observation, not N times it.
+func TestCityStatusObservationsRunInParallel(t *testing.T) {
+	const observerDelay = 60 * time.Millisecond
+	const agentCount = 12
+
+	var mu sync.Mutex
+	inflight := 0
+	maxConcurrent := 0
+	totalCalls := 0
+
+	oldObserve := observeSessionTargetForStatus
+	observeSessionTargetForStatus = func(string, beads.Store, runtime.Provider, *config.City, string) (worker.LiveObservation, error) {
+		mu.Lock()
+		inflight++
+		totalCalls++
+		if inflight > maxConcurrent {
+			maxConcurrent = inflight
+		}
+		mu.Unlock()
+
+		time.Sleep(observerDelay)
+
+		mu.Lock()
+		inflight--
+		mu.Unlock()
+		return worker.LiveObservation{Running: true}, nil
+	}
+	t.Cleanup(func() { observeSessionTargetForStatus = oldObserve })
+
+	agents := make([]config.Agent, agentCount)
+	for i := range agents {
+		agents[i] = config.Agent{Name: fmt.Sprintf("a%d", i), MaxActiveSessions: intPtr(1)}
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city"},
+		Agents:    agents,
+	}
+
+	start := time.Now()
+	snapshot := collectCityStatusSnapshot(runtime.NewFake(), cfg, "/tmp/city", nil, io.Discard)
+	elapsed := time.Since(start)
+
+	if got := len(snapshot.Agents); got != agentCount {
+		t.Fatalf("agents = %d, want %d", got, agentCount)
+	}
+	if totalCalls != agentCount {
+		t.Fatalf("totalCalls = %d, want %d", totalCalls, agentCount)
+	}
+	if maxConcurrent < 2 {
+		t.Fatalf("maxConcurrent = %d, want >= 2 (observations ran serially)", maxConcurrent)
+	}
+	// Serial would be agentCount * observerDelay = 720ms. Allow generous
+	// slack for CI scheduling but well below the serial bound.
+	maxAllowed := time.Duration(agentCount) * observerDelay / 2
+	if elapsed > maxAllowed {
+		t.Fatalf("elapsed = %v, want < %v (likely serial); maxConcurrent = %d", elapsed, maxAllowed, maxConcurrent)
 	}
 }

--- a/cmd/gc/cmd_status.go
+++ b/cmd/gc/cmd_status.go
@@ -131,17 +131,18 @@ func doRigStatusWithStoreAndSnapshot(
 }
 
 // agentStatusLine returns a human-readable status string for an agent session.
+// The drain probe is a runtime metadata lookup (tmux show-environment) per
+// session; skip it when the session is not running because the draining flag
+// is meaningless then and the probe dominates wall time on idle cities.
 func agentStatusLine(running bool, dops drainOps, sn string, suspended bool) string {
-	draining, _ := dops.isDraining(sn)
-
-	switch {
-	case running && draining:
-		return "running  (draining)"
-	case running:
-		return "running"
-	case suspended:
-		return "stopped  (suspended)"
-	default:
+	if !running {
+		if suspended {
+			return "stopped  (suspended)"
+		}
 		return "stopped"
 	}
+	if draining, _ := dops.isDraining(sn); draining {
+		return "running  (draining)"
+	}
+	return "running"
 }


### PR DESCRIPTION
Fixes #2054.

`gc status` in a multi-rig city (`~/gc` with gastown + intervaltree + focuster rigs, 16 agents) took 5+ seconds because per-agent tmux probes ran serially **twice**:

1. Inside `collectCityStatusSnapshotFromStoreSnapshot`, one `observeSessionTargetWithWarning` per agent (16 sequential tmux `has-session` / `list-sessions` round-trips).
2. Inside `agentStatusLine`, one `dops.isDraining(sn)` per agent during text rendering — another full set of tmux `show-environment` probes.

## Changes

**1. Parallelize observations.** `collectCityStatusSnapshotFromStoreSnapshot` now:
   - builds a `(row, target)` plan serially,
   - fans observations out across a bounded worker pool (`statusObservationConcurrency = 8`),
   - stitches results back in input order so output stays deterministic.

   Stderr writes from concurrent goroutines are funneled through the existing `lockedStderr` so observation timeout warnings can't interleave bytes.

**2. Skip drain probe for stopped sessions.** `agentStatusLine` only consumes the `draining` flag inside the `running && draining` branch — for stopped sessions the result was always discarded, so the per-agent `tmux show-environment` was pure overhead.

## Test

`TestCityStatusObservationsRunInParallel` exercises a 12-agent config with a 60ms-blocking observer stub and asserts:
- max concurrent in-flight observations >= 2 (would be 1 with the old serial loop),
- wall time < `agentCount * delay / 2` (serial would be `12 * 60ms = 720ms`).

Existing 82 status tests still pass.

## Benchmark

Measured on `~/gc` (16 agents, 4 running) with binaries built from origin/main (baseline) and this branch (after).

| Metric | Baseline | After  |
| ------ | -------- | ------ |
| Min    | 4.74s    | 1.24s  |
| Median | 5.28s    | 1.41s  |
| Max    | 6.54s    | 1.94s  |

**~3.7× faster, ~3.9s saved per call.**

## Follow-ups (not in this PR)

- Add `Provider.ObserveMany(ctx, names) []LiveObservation` with a single batched `tmux list-sessions -F …` in the tmux provider — would drop the remaining serial-tmux overhead for the rare path that still falls through. Tracked as part of #2054.
- Short-circuit the `controllerAliveWithin` 250ms poll when the supervisor registry has no entry for the city.

Also regenerates `docs/reference/cli.md` (drift from prior changes; pre-commit hook re-staged it).
