### PR TITLE
fix(doctor): wire --fix to migrate legacy v1 pack shape

### DIFF
--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
+	"github.com/gastownhall/gascity/internal/migrate"
 )
 
 func registerV2DeprecationChecks(d *doctor.Doctor) {
@@ -25,9 +27,12 @@ func registerV2DeprecationChecks(d *doctor.Doctor) {
 
 type v2AgentFormatCheck struct{}
 
-func (v2AgentFormatCheck) Name() string                     { return "v2-agent-format" }
-func (v2AgentFormatCheck) CanFix() bool                     { return false }
-func (v2AgentFormatCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2AgentFormatCheck) Name() string { return "v2-agent-format" }
+func (v2AgentFormatCheck) CanFix() bool { return true }
+func (v2AgentFormatCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+}
+
 func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	files := legacyAgentFiles(ctx.CityPath)
 	if len(files) == 0 {
@@ -41,9 +46,12 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 
 type v2ImportFormatCheck struct{}
 
-func (v2ImportFormatCheck) Name() string                     { return "v2-import-format" }
-func (v2ImportFormatCheck) CanFix() bool                     { return false }
-func (v2ImportFormatCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2ImportFormatCheck) Name() string { return "v2-import-format" }
+func (v2ImportFormatCheck) CanFix() bool { return true }
+func (v2ImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+}
+
 func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
 	if !ok || len(cfg.Workspace.Includes) == 0 {
@@ -57,9 +65,12 @@ func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 
 type v2DefaultRigImportFormatCheck struct{}
 
-func (v2DefaultRigImportFormatCheck) Name() string                     { return "v2-default-rig-import-format" }
-func (v2DefaultRigImportFormatCheck) CanFix() bool                     { return false }
-func (v2DefaultRigImportFormatCheck) Fix(_ *doctor.CheckContext) error { return nil }
+func (v2DefaultRigImportFormatCheck) Name() string { return "v2-default-rig-import-format" }
+func (v2DefaultRigImportFormatCheck) CanFix() bool { return true }
+func (v2DefaultRigImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, defaultV2MigrationWarnSink)
+}
+
 func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
 	if !ok || len(cfg.Workspace.DefaultRigIncludes) == 0 {
@@ -441,6 +452,34 @@ func warnCheck(name, message, hint string, details []string) *doctor.CheckResult
 func v2MigrationHint() string {
 	return `run "gc doctor --fix" to rewrite safe mechanical cases, then rerun "gc doctor"`
 }
+
+// runV2PackMigration applies the pack-shape migration (legacy [[agent]]
+// tables, workspace.includes, default_rig_includes) for a doctor --fix run.
+// It is safe to call from multiple checks: migrate.Apply is idempotent on a
+// city that has already been migrated (it returns an empty change set).
+//
+// migrate.Apply can return warnings about behavior-affecting fields it had
+// to drop (e.g. legacy [[agent]] entries with fallback = true — the
+// fallback field has no v2 counterpart and shadowing must be reviewed by
+// hand). doctor --fix must not silently swallow those, otherwise the next
+// gc doctor run reports a green check and the manual follow-up is lost
+// forever. The warnings are emitted to warnSink so they land in the same
+// stream as the doctor output (production: os.Stderr; tests: a buffer).
+func runV2PackMigration(ctx *doctor.CheckContext, warnSink io.Writer) error {
+	report, err := migrate.Apply(ctx.CityPath, migrate.Options{})
+	if err != nil {
+		return err
+	}
+	for _, w := range report.Warnings {
+		fmt.Fprintf(warnSink, "      gc doctor --fix: %s\n", w) //nolint:errcheck // best-effort diagnostic
+	}
+	return nil
+}
+
+// defaultV2MigrationWarnSink is the production warning sink for
+// runV2PackMigration. It is overridable for tests via the runV2PackMigration
+// signature; production callers always pass this.
+var defaultV2MigrationWarnSink io.Writer = os.Stderr
 
 func parseCityConfig(path string) (*config.City, bool) {
 	data, err := os.ReadFile(path)

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -504,6 +504,163 @@ prompt_template = "prompts/mayor.md"
 	}
 }
 
+// TestV2DeprecationFixSurfacesMigrateWarnings guards the codex review
+// finding on PR #1880: when migrate.Apply emits warnings about
+// behavior-affecting fields it had to drop (e.g. legacy [[agent]] entries
+// with fallback = true), doctor --fix must surface them. Without this,
+// the next gc doctor run sees a green check and the manual follow-up is
+// lost forever.
+func TestV2DeprecationFixSurfacesMigrateWarnings(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+fallback = true
+`)
+	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
+
+	var sink bytes.Buffer
+	if err := runV2PackMigration(&doctor.CheckContext{CityPath: cityDir}, &sink); err != nil {
+		t.Fatalf("runV2PackMigration: %v", err)
+	}
+
+	got := sink.String()
+	if !strings.Contains(got, "fallback") {
+		t.Fatalf("expected migrate warnings about dropped fallback field to be surfaced; got:\n%s", got)
+	}
+	if !strings.Contains(got, "mayor") {
+		t.Fatalf("expected the agent name to appear in the warning; got:\n%s", got)
+	}
+}
+
+// TestV2ImportFormatCheckFixMigratesIncludes runs v2ImportFormatCheck.Fix
+// in isolation against a city whose only legacy artifact is
+// workspace.includes — guards the per-Check Fix entry point that the
+// bundled migration test does not exercise (the chained doctor.Run already
+// migrates everything via the first Fix call).
+func TestV2ImportFormatCheckFixMigratesIncludes(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/gastown"]
+`)
+
+	check := v2ImportFormatCheck{}
+	if !check.CanFix() {
+		t.Fatal("v2ImportFormatCheck should advertise CanFix()=true")
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusWarning {
+		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; message=%q", got.Status, got.Message)
+	}
+}
+
+// TestV2DefaultRigImportFormatCheckFixMigratesDefaults runs
+// v2DefaultRigImportFormatCheck.Fix in isolation, mirroring the
+// import-only test above for the default-rig-includes path.
+func TestV2DefaultRigImportFormatCheckFixMigratesDefaults(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+default_rig_includes = ["../packs/default-rig"]
+`)
+
+	check := v2DefaultRigImportFormatCheck{}
+	if !check.CanFix() {
+		t.Fatal("v2DefaultRigImportFormatCheck should advertise CanFix()=true")
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusWarning {
+		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; message=%q", got.Status, got.Message)
+	}
+}
+
+// TestV2DeprecationChecksFixMigratesPackShape exercises the doctor --fix
+// path for the v2 pack-shape checks (legacy [[agent]] tables,
+// workspace.includes, default_rig_includes). The hint shown in warning
+// states points users at "gc doctor --fix"; this test guards against the
+// regression where those checks declared CanFix()=false and the hint led
+// nowhere.
+func TestV2DeprecationChecksFixMigratesPackShape(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+includes = ["../packs/gastown"]
+default_rig_includes = ["../packs/default rig"]
+
+[[agent]]
+name = "mayor"
+prompt_template = "prompts/mayor.md"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 1
+
+[[agent]]
+name = "helper"
+scope = "city"
+`)
+	writeDoctorFile(t, cityDir, "prompts/mayor.md", "Hello {{.Agent}}\n")
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	d.Register(v2AgentFormatCheck{})
+	d.Register(v2ImportFormatCheck{})
+	d.Register(v2DefaultRigImportFormatCheck{})
+	report := d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
+
+	if report.Fixed == 0 {
+		t.Fatalf("expected at least one v2 pack check to be auto-fixed, got Fixed=0; output:\n%s", buf.String())
+	}
+	if report.Warned > 0 {
+		t.Fatalf("expected v2 pack warnings to clear after --fix, got Warned=%d; output:\n%s", report.Warned, buf.String())
+	}
+
+	// Re-run without fix and confirm the city is now clean.
+	var verify bytes.Buffer
+	verifyDoctor := &doctor.Doctor{}
+	verifyDoctor.Register(v2AgentFormatCheck{})
+	verifyDoctor.Register(v2ImportFormatCheck{})
+	verifyDoctor.Register(v2DefaultRigImportFormatCheck{})
+	verifyDoctor.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &verify, false)
+	out := verify.String()
+	for _, line := range []string{
+		"✓ v2-agent-format",
+		"✓ v2-import-format",
+		"✓ v2-default-rig-import-format",
+	} {
+		if !strings.Contains(out, line) {
+			t.Fatalf("post-fix doctor output missing %q:\n%s", line, out)
+		}
+	}
+}
+
 func writeDoctorFile(t *testing.T, root, rel, contents string) {
 	t.Helper()
 	path := filepath.Join(root, rel)


### PR DESCRIPTION
## Summary

Split out from #1998 per review feedback — this is the code-fix half that was previously co-mingled with a docs-only PR.

The `v2-agent-format`, `v2-import-format`, and `v2-default-rig-import-format` doctor checks all reported their `FixHint` as *"run gc doctor --fix to rewrite safe mechanical cases"*, but their `CanFix()` returned `false` — so the hint led nowhere and the warnings could only be cleared by manually running `gc import migrate`.

## Changes

- Each of the three v2-deprecation checks now declares `CanFix() = true`.
- `Fix()` is routed through a shared `runV2PackMigration` helper that calls `migrate.Apply`.
- `migrate.Apply` is idempotent on a city that has already been migrated, so chaining the three `Fix()` calls in one `doctor --fix` invocation is safe — the second and third calls are no-ops on the partially-rewritten city.

## Test plan

- [x] New test: `TestV2DeprecationChecksFixMigratesPackShape` covers the three checks running in one `--fix` pass on a legacy v1 city.
- [ ] `make test` for the touched package
- [ ] Manual: run `gc doctor --fix` on a v1 city, confirm warnings clear without separately invoking `gc import migrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)