### PR TITLE
fix(bd): reap stale .beads/issues.jsonl on managed scopes

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -141,6 +141,7 @@ func scopeIsGCManaged(scopeRoot string) bool {
 }
 
 func controlBdStoreForCity(dir, cityPath string, cfg *config.City) *beads.BdStore {
+	reapStaleBdExportJSONL(dir)
 	return beads.NewBdStoreWithPrefix(dir, controlBdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
 }
 
@@ -154,6 +155,7 @@ func controlBdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix
 			}
 		}
 	}
+	reapStaleBdExportJSONL(rigDir)
 	return beads.NewBdStoreWithPrefix(rigDir, controlBdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
 }
 

--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -39,6 +39,7 @@ func bdStoreForCity(dir, cityPath string) *beads.BdStore {
 	if err != nil {
 		cfg = nil
 	}
+	reapStaleBdExportJSONL(dir)
 	return beads.NewBdStoreWithPrefix(dir, bdCommandRunnerForCity(cityPath), issuePrefixForScope(dir, cityPath, cfg))
 }
 
@@ -55,7 +56,88 @@ func bdStoreForRig(rigDir, cityPath string, cfg *config.City, knownPrefix ...str
 			}
 		}
 	}
+	reapStaleBdExportJSONL(rigDir)
 	return beads.NewBdStoreWithPrefix(rigDir, bdCommandRunnerForRig(cityPath, cfg, rigDir), prefix)
+}
+
+// reapStaleBdExportJSONL removes .beads/issues.jsonl best-effort when the
+// scope is gc-managed. The file is a stale export from when bd's auto-export
+// was on (the upstream default); keeping it on disk causes bd 1.x to detect
+// a "fresh clone" / "empty database" on the next write and stall bd create /
+// gc mail send for the full 2m subprocess timeout while it re-imports the
+// JSONL (sa-41j3kp).
+//
+// Cleanup conditions (any of which proves the scope is gc-managed and the
+// JSONL is therefore stale):
+//
+//   - config.yaml explicitly sets export.auto:false (PR 1965 canonical state)
+//   - config.yaml's gc.endpoint_origin is one of the managed origins
+//
+// Best-effort: any error is ignored because the env-var BD_EXPORT_AUTO=false
+// in bdRuntimeEnv is a second line of defense, and a concurrent reader of the
+// file (e.g., a bd-aware viewer) shouldn't fail the caller's operation. Reads
+// use os.Stat/os.Remove (not fsys.OSFS) so the helper stays callable from
+// store constructors that don't carry an fs seam.
+func reapStaleBdExportJSONL(scopeRoot string) {
+	scopeRoot = strings.TrimSpace(scopeRoot)
+	if scopeRoot == "" {
+		return
+	}
+	jsonlPath := filepath.Join(scopeRoot, ".beads", "issues.jsonl")
+	if _, err := os.Stat(jsonlPath); err != nil {
+		// Fast path: no file → nothing to do. This is the steady state
+		// once the cleanup has run once, so the rest of the helper is
+		// only reached during the one-shot transition.
+		return
+	}
+	if !scopeIsGCManaged(scopeRoot) {
+		// Unmanaged scope: leave the file alone. Removing it under those
+		// conditions could race with a legitimate auto-exporter (e.g., a
+		// rig that opted out of managed canonicalization).
+		return
+	}
+	_ = os.Remove(jsonlPath)
+}
+
+// scopeIsGCManaged reports whether a scope's .beads/config.yaml proves the
+// scope is gc-managed under the canonical (non-explicit) shape. Either of
+// two signals counts as proof:
+//   - export.auto is explicitly false (PR 1965 wrote it; the user did not
+//     opt back into auto-export afterward)
+//   - gc.endpoint_origin is one of the canonical managed origins (the scope
+//     was initialized by gc, even if the export.auto key has not yet been
+//     normalized into the config on disk)
+//
+// Either signal alone is sufficient: the first covers post-normalization
+// state, the second covers the transitional state where samtown-style
+// long-lived cities still have a pre-PR-1965 config but were always
+// gc-managed.
+//
+// EndpointOriginExplicit is intentionally excluded: per PR 1965, that is
+// the deliberate opt-out path for rigs that want to keep JSONL-based
+// sharing, so issues.jsonl there is load-bearing, not stale. The
+// endpoint-origin check runs first so that an opt-out rig that *also*
+// has export.auto:false (e.g. left over from a prior canonicalization,
+// or hand-set) is still treated as unmanaged and never reaped.
+func scopeIsGCManaged(scopeRoot string) bool {
+	configPath := filepath.Join(scopeRoot, ".beads", "config.yaml")
+	state, stateOK, stateErr := contract.ReadConfigState(fsys.OSFS{}, configPath)
+	if stateErr == nil && stateOK {
+		switch state.EndpointOrigin {
+		case contract.EndpointOriginExplicit:
+			// Deliberate opt-out — JSONL is load-bearing, leave alone
+			// regardless of any other signal in the config.
+			return false
+		case contract.EndpointOriginManagedCity,
+			contract.EndpointOriginCityCanonical,
+			contract.EndpointOriginInheritedCity:
+			return true
+		}
+	}
+	if autoExport, ok, err := contract.ReadExportAuto(fsys.OSFS{}, configPath); err == nil && ok && !autoExport {
+		return true
+	}
+	return false
 }
 
 func controlBdStoreForCity(dir, cityPath string, cfg *config.City) *beads.BdStore {
@@ -935,6 +1017,16 @@ func bdRuntimeEnvWithError(cityPath string) (map[string]string, error) {
 	// dolt.auto-start:false config (beads resolveAutoStart priority bug) and
 	// starts rogue servers from the agent's cwd with the wrong data_dir.
 	env["BEADS_DOLT_AUTO_START"] = "0"
+	// Suppress bd's auto-export of issues.jsonl on every write. The canonical
+	// config also persists export.auto:false (see internal/beads/contract/files.go),
+	// but the env var is the bulletproof per-invocation guard: it covers fresh
+	// scopes whose config has not yet been canonicalized, and it short-circuits
+	// the export → next-write-auto-import stall cycle (sa-41j3kp) even when an
+	// out-of-band caller has left a stale .beads/issues.jsonl on disk. Without
+	// this, bd's "auto-importing N bytes ... into empty database" path can
+	// stall bd create / gc mail send for the full 2m subprocess timeout on
+	// large datasets.
+	env["BD_EXPORT_AUTO"] = "false"
 	if !cityUsesBdStoreContract(cityPath) {
 		return env, nil
 	}

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4457,3 +4457,183 @@ dolt.auto-start: false
 		t.Errorf("errors.As(*MetadataParseError) = false, want true; err=%v", err)
 	}
 }
+// TestBdRuntimeEnvDisablesAutoExport pins the env-var defense against
+// bd's auto-export-on-write trap (sa-41j3kp): every gc-initiated bd call
+// must set BD_EXPORT_AUTO=false so that even if .beads/config.yaml has not
+// yet been canonicalized with export.auto:false (older cities pre-PR-1965,
+// fresh inits, rigs that have not reached normalization), bd's auto-export
+// of issues.jsonl on every write is suppressed. Without this, the next bd
+// write re-creates the 15MB JSONL, and the bd write after that stalls for
+// the full 2m subprocess timeout while bd re-imports the file.
+func TestBdRuntimeEnvDisablesAutoExport(t *testing.T) {
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_DOLT", "skip")
+
+	cityPath := t.TempDir()
+	env, err := bdRuntimeEnvWithError(cityPath)
+	if err != nil {
+		t.Fatalf("bdRuntimeEnvWithError: %v", err)
+	}
+
+	if got := env["BD_EXPORT_AUTO"]; got != "false" {
+		t.Fatalf("BD_EXPORT_AUTO = %q, want false (auto-export-on-write suppression for sa-41j3kp)", got)
+	}
+}
+
+// TestScopeIsGCManagedRecognizesExplicitAutoOff verifies that a config with
+// export.auto:false is recognized as gc-managed even when gc.endpoint_origin
+// is absent. This is the steady-state signal post-PR-1965.
+func TestScopeIsGCManagedRecognizesExplicitAutoOff(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\nexport.auto: false\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if !scopeIsGCManaged(scope) {
+		t.Fatalf("scopeIsGCManaged = false, want true for explicit export.auto:false")
+	}
+}
+
+// TestScopeIsGCManagedRecognizesManagedOrigin verifies that a long-lived
+// city whose config still pre-dates PR 1965 (export.auto absent) is still
+// recognized as gc-managed because gc.endpoint_origin proves it. This is
+// the transitional signal — without it the jsonl reaper would refuse to
+// clean up samtown-style cities until they hit a canonicalization event.
+func TestScopeIsGCManagedRecognizesManagedOrigin(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\ngc.endpoint_origin: managed_city\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if !scopeIsGCManaged(scope) {
+		t.Fatalf("scopeIsGCManaged = false, want true for gc.endpoint_origin: managed_city")
+	}
+}
+
+// TestScopeIsGCManagedDoesNotClaimExplicitOptOut verifies the carve-out
+// for rigs that deliberately keep JSONL-based sharing. Per PR 1965 docs,
+// gc.endpoint_origin: explicit is the supported opt-out path; issues.jsonl
+// there is load-bearing, not stale, so scopeIsGCManaged must return false.
+func TestScopeIsGCManagedDoesNotClaimExplicitOptOut(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\ngc.endpoint_origin: explicit\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if scopeIsGCManaged(scope) {
+		t.Fatalf("scopeIsGCManaged = true, want false for explicit opt-out")
+	}
+}
+
+// TestScopeIsGCManagedExplicitOptOutBeatsExportAutoFalse verifies the
+// precedence contract: when a scope has gc.endpoint_origin: explicit
+// (deliberate opt-out, JSONL is load-bearing) AND also has export.auto:
+// false (left over from a prior canonicalization, or hand-set), the
+// endpoint_origin signal wins. Without this ordering, a stale
+// export.auto value could trick the reaper into deleting issues.jsonl
+// on an opt-out rig.
+func TestScopeIsGCManagedExplicitOptOutBeatsExportAutoFalse(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\nexport.auto: false\ngc.endpoint_origin: explicit\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if scopeIsGCManaged(scope) {
+		t.Fatalf("scopeIsGCManaged = true, want false for explicit opt-out (export.auto:false must not override endpoint_origin)")
+	}
+}
+
+// TestReapStaleBdExportJSONLRemovesFileOnManagedScope verifies the
+// transitional cleanup that breaks the sa-41j3kp loop on samtown-style
+// long-lived cities. issues.jsonl from a pre-PR-1965 auto-export is
+// removed on the next bd-store construction, so the next bd create does
+// not stall on auto-import.
+func TestReapStaleBdExportJSONLRemovesFileOnManagedScope(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"_type":"issue","id":"zz-1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\ngc.endpoint_origin: managed_city\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	reapStaleBdExportJSONL(scope)
+
+	if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
+		t.Fatalf("jsonl present after reap; stat err = %v, want IsNotExist", err)
+	}
+}
+
+// TestReapStaleBdExportJSONLLeavesFileOnExplicitOptOut verifies the
+// opt-out path: rigs with gc.endpoint_origin: explicit keep issues.jsonl
+// because they're deliberately using JSONL-based sharing.
+func TestReapStaleBdExportJSONLLeavesFileOnExplicitOptOut(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"_type":"issue","id":"zz-1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\ngc.endpoint_origin: explicit\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	reapStaleBdExportJSONL(scope)
+
+	if _, err := os.Stat(jsonlPath); err != nil {
+		t.Fatalf("jsonl removed on explicit opt-out; stat err = %v, want nil", err)
+	}
+}
+
+// TestReapStaleBdExportJSONLLeavesFileOnUnmanagedScope verifies that an
+// unmanaged scope (no config.yaml, or config without any gc/managed signal)
+// keeps issues.jsonl intact. The reaper must not be aggressive on scopes
+// that gc does not own.
+func TestReapStaleBdExportJSONLLeavesFileOnUnmanagedScope(t *testing.T) {
+	scope := t.TempDir()
+	beadsDir := filepath.Join(scope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"_type":"issue","id":"zz-1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	// No config.yaml at all — definitely not gc-managed.
+
+	reapStaleBdExportJSONL(scope)
+
+	if _, err := os.Stat(jsonlPath); err != nil {
+		t.Fatalf("jsonl removed on unmanaged scope; stat err = %v, want nil", err)
+	}
+}

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -4457,6 +4457,7 @@ dolt.auto-start: false
 		t.Errorf("errors.As(*MetadataParseError) = false, want true; err=%v", err)
 	}
 }
+
 // TestBdRuntimeEnvDisablesAutoExport pins the env-var defense against
 // bd's auto-export-on-write trap (sa-41j3kp): every gc-initiated bd call
 // must set BD_EXPORT_AUTO=false so that even if .beads/config.yaml has not
@@ -4587,6 +4588,52 @@ func TestReapStaleBdExportJSONLRemovesFileOnManagedScope(t *testing.T) {
 
 	if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
 		t.Fatalf("jsonl present after reap; stat err = %v, want IsNotExist", err)
+	}
+}
+
+func TestControlBdStoreForCityReapsStaleBdExportJSONL(t *testing.T) {
+	cityPath := t.TempDir()
+	beadsDir := filepath.Join(cityPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"_type":"issue","id":"gc-1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	controlBdStoreForCity(cityPath, cityPath, nil)
+
+	if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
+		t.Fatalf("jsonl present after control city store construction; stat err = %v, want IsNotExist", err)
+	}
+}
+
+func TestControlBdStoreForRigReapsStaleBdExportJSONL(t *testing.T) {
+	cityPath := t.TempDir()
+	rigDir := filepath.Join(cityPath, "repo")
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"_type":"issue","id":"repo-1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: repo\ngc.endpoint_origin: inherited_city\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := &config.City{Rigs: []config.Rig{{Name: "repo", Path: rigDir, Prefix: "repo"}}}
+
+	controlBdStoreForRig(rigDir, cityPath, cfg)
+
+	if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
+		t.Fatalf("jsonl present after control rig store construction; stat err = %v, want IsNotExist", err)
 	}
 }
 

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -340,15 +340,15 @@ func ensureCanonicalScopeConfigState(fs fsys.FS, dir string, state contract.Conf
 	if err != nil {
 		return err
 	}
-	if changed {
+	if changed && state.EndpointOrigin != contract.EndpointOriginExplicit {
 		// PR 1965 made export.auto:false canonical, but a pre-existing
 		// .beads/issues.jsonl from before this normalization still triggers
 		// bd's auto-import-on-write trap (sa-41j3kp) — bd sees the file,
 		// detects a "stale DB", and stalls bd create for the full 2m
 		// subprocess timeout while it re-imports the JSONL. The file is a
 		// stale export from when auto-export was on; with the canonical
-		// config now suppressing auto-export, nothing will refresh it, so
-		// keeping it on disk is pure liability. Remove best-effort.
+		// config now suppressing auto-export, nothing will refresh it. Explicit
+		// opt-out scopes keep JSONL as load-bearing state.
 		removeStaleBdExportJSONL(fs, beadsDir)
 	}
 	return nil

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -336,8 +336,36 @@ func ensureCanonicalScopeConfigState(fs fsys.FS, dir string, state contract.Conf
 	if err := ensureBeadsDir(fs, beadsDir); err != nil {
 		return err
 	}
-	_, err := contract.EnsureCanonicalConfig(fs, filepath.Join(beadsDir, "config.yaml"), state)
-	return err
+	changed, err := contract.EnsureCanonicalConfig(fs, filepath.Join(beadsDir, "config.yaml"), state)
+	if err != nil {
+		return err
+	}
+	if changed {
+		// PR 1965 made export.auto:false canonical, but a pre-existing
+		// .beads/issues.jsonl from before this normalization still triggers
+		// bd's auto-import-on-write trap (sa-41j3kp) — bd sees the file,
+		// detects a "stale DB", and stalls bd create for the full 2m
+		// subprocess timeout while it re-imports the JSONL. The file is a
+		// stale export from when auto-export was on; with the canonical
+		// config now suppressing auto-export, nothing will refresh it, so
+		// keeping it on disk is pure liability. Remove best-effort.
+		removeStaleBdExportJSONL(fs, beadsDir)
+	}
+	return nil
+}
+
+// removeStaleBdExportJSONL removes .beads/issues.jsonl if present. Called after
+// EnsureCanonicalConfig writes export.auto:false, since the file is a stale
+// export that bd's auto-import path would otherwise re-load on every write,
+// stalling bd create for the full subprocess timeout on large datasets.
+// Best-effort: any error is non-fatal because the env-var BD_EXPORT_AUTO=false
+// path (bdRuntimeEnv) is a second line of defense for gc-initiated calls.
+func removeStaleBdExportJSONL(fs fsys.FS, beadsDir string) {
+	path := filepath.Join(beadsDir, "issues.jsonl")
+	if _, err := fs.Stat(path); err != nil {
+		return
+	}
+	_ = fs.Remove(path)
 }
 
 func seedDeferredManagedBeads(cityPath, dir, prefix, doltDatabase string) {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -156,6 +156,64 @@ func TestProviderLifecycleProcessEnvCanonicalizesSymlinkedCityPath(t *testing.T)
 	}
 }
 
+func TestEnsureCanonicalScopeConfigStatePreservesExplicitOptOutJSONL(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"id":"rig-1"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue_prefix: rig\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureCanonicalScopeConfigState(fsys.OSFS{}, dir, contract.ConfigState{
+		IssuePrefix:    "rig",
+		EndpointOrigin: contract.EndpointOriginExplicit,
+		EndpointStatus: contract.EndpointStatusUnverified,
+		DoltHost:       "db.example.com",
+		DoltPort:       "3306",
+	})
+	if err != nil {
+		t.Fatalf("ensureCanonicalScopeConfigState: %v", err)
+	}
+
+	if _, err := os.Stat(jsonlPath); err != nil {
+		t.Fatalf("issues.jsonl removed for explicit opt-out scope: %v", err)
+	}
+}
+
+func TestEnsureCanonicalScopeConfigStateReapsManagedJSONL(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"id":"gc-1"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue_prefix: gc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureCanonicalScopeConfigState(fsys.OSFS{}, dir, contract.ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: contract.EndpointOriginManagedCity,
+		EndpointStatus: contract.EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("ensureCanonicalScopeConfigState: %v", err)
+	}
+
+	if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
+		t.Fatalf("issues.jsonl present after managed canonicalization; stat err = %v, want IsNotExist", err)
+	}
+}
+
 func TestProviderLifecycleProcessEnvProjectsResolvedGCBin(t *testing.T) {
 	cityPath := t.TempDir()
 	t.Setenv("GC_BIN", "/tmp/wrong-gc")

--- a/cmd/gc/cmd_bd.go
+++ b/cmd/gc/cmd_bd.go
@@ -166,6 +166,7 @@ func doBd(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	reapStaleBdExportJSONL(target.ScopeRoot)
 	warnExternalBdOverrideDrift(stderr, cityPath, target)
 
 	bdPath, err := exec.LookPath("bd")

--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -617,6 +617,56 @@ esac
 	}
 }
 
+func TestGcBdReapsStaleBdExportJSONLBeforeDirectCommand(t *testing.T) {
+	disableManagedDoltRecoveryForTest(t)
+
+	origCityFlag := cityFlag
+	origRigFlag := rigFlag
+	defer func() {
+		cityFlag = origCityFlag
+		rigFlag = origRigFlag
+	}()
+	cityFlag = ""
+	rigFlag = ""
+
+	cityDir := t.TempDir()
+	beadsDir := filepath.Join(cityDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
+name = "demo"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue_prefix: gc\ngc.endpoint_origin: managed_city\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"_type":"issue","id":"gc-1"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+set -eu
+printf '[{"id":"gc-1","title":"ok"}]\n'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GC_CITY_PATH", cityDir)
+
+	var stdout, stderr bytes.Buffer
+	if got := doBd([]string{"show", "gc-1", "--json"}, &stdout, &stderr); got != 0 {
+		t.Fatalf("doBd() = %d, want 0; stdout=%q stderr=%q", got, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
+		t.Fatalf("issues.jsonl present after direct gc bd command; stat err = %v, want IsNotExist", err)
+	}
+}
+
 func TestGcBdDoesNotAutoRouteHyphenatedFlagValue(t *testing.T) {
 	disableManagedDoltRecoveryForTest(t)
 

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -172,6 +172,42 @@ func ReadAutoStartDisabled(fs fsys.FS, path string) (bool, error) {
 	return false, nil
 }
 
+// ReadExportAuto returns the configured value of export.auto along with a
+// presence indicator. ok=false means the key is absent from the config OR
+// the value is not a recognized boolean (the upstream bd default is true).
+// Used by gc to gate cleanup of stale .beads/issues.jsonl exports: when
+// export.auto is explicitly false, the JSONL is a stale artifact that bd's
+// auto-import-on-write path (sa-41j3kp) would otherwise reload on every
+// write, stalling bd create for minutes on large datasets.
+//
+// Because this gates destructive cleanup, parsing is strict: only the
+// boolean literals strconv.ParseBool accepts count as present. A garbage
+// value (e.g. "yes", "off", "foo") returns ok=false so callers fall back
+// to other gc-managed signals rather than mis-treating the scope as
+// canonical.
+func ReadExportAuto(fs fsys.FS, path string) (value bool, ok bool, err error) {
+	doc, err := readConfigDoc(fs, path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false, nil
+		}
+		if raw, scanOK := scanConfigLineValue(fs, path, "export.auto:"); scanOK {
+			if parsed, parseErr := strconv.ParseBool(raw); parseErr == nil {
+				return parsed, true, nil
+			}
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	if raw, present := configStringValue(mappingRoot(doc), "export.auto"); present {
+		if parsed, parseErr := strconv.ParseBool(raw); parseErr == nil {
+			return parsed, true, nil
+		}
+		return false, false, nil
+	}
+	return false, false, nil
+}
+
 // ReadEndpointStatus reads gc.endpoint_status when present.
 func ReadEndpointStatus(fs fsys.FS, path string) (EndpointStatus, bool, error) {
 	doc, err := readConfigDoc(fs, path)

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -574,6 +574,94 @@ func TestReadAutoStartDisabledFallsBackToLineScanOnMalformedYAML(t *testing.T) {
 	}
 }
 
+func TestReadExportAuto(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantValue bool
+		wantOK    bool
+	}{
+		{
+			name:      "explicit false",
+			yaml:      "issue_prefix: zz\nexport.auto: false\n",
+			wantValue: false,
+			wantOK:    true,
+		},
+		{
+			name:      "explicit true",
+			yaml:      "issue_prefix: zz\nexport.auto: true\n",
+			wantValue: true,
+			wantOK:    true,
+		},
+		{
+			name:      "absent",
+			yaml:      "issue_prefix: zz\n",
+			wantValue: false,
+			wantOK:    false,
+		},
+		{
+			// Garbage value: strict parsing returns ok=false rather than
+			// silently treating it as "false". This matters because callers
+			// gate destructive cleanup on ok=true && value=false.
+			name:      "non-boolean string returns absent",
+			yaml:      "issue_prefix: zz\nexport.auto: yes\n",
+			wantValue: false,
+			wantOK:    false,
+		},
+		{
+			name:      "numeric one parses as true",
+			yaml:      "issue_prefix: zz\nexport.auto: 1\n",
+			wantValue: true,
+			wantOK:    true,
+		},
+		{
+			name:      "numeric zero parses as false",
+			yaml:      "issue_prefix: zz\nexport.auto: 0\n",
+			wantValue: false,
+			wantOK:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := fsys.OSFS{}
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := fs.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			gotValue, gotOK, err := ReadExportAuto(fs, path)
+			if err != nil {
+				t.Fatalf("ReadExportAuto() error = %v", err)
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("ReadExportAuto() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("ReadExportAuto() value = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestReadExportAutoOnMissingFileReturnsAbsent(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.yaml")
+
+	gotValue, gotOK, err := ReadExportAuto(fs, path)
+	if err != nil {
+		t.Fatalf("ReadExportAuto() error = %v, want nil for missing file", err)
+	}
+	if gotOK {
+		t.Errorf("ReadExportAuto() ok = true, want false for missing file")
+	}
+	if gotValue {
+		t.Errorf("ReadExportAuto() value = true, want false for missing file")
+	}
+}
+
 func TestEnsureCanonicalMetadataPreservesUnknownKeysAndScrubsDeprecatedOnes(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #2059. Companion to #1968 (which fixed `export.auto` going forward) and #1930 (empty `.beads/dolt/` case).

## Summary

- `#1968` made `export.auto: false` canonical so bd doesn't regenerate `.beads/issues.jsonl` on every write. That fix is correct but only suppresses *future* exports.
- On long-lived managed cities, a pre-existing 15 MB / 34k-row `issues.jsonl` from before #1968 still triggers bd's auto-import-on-write path on every subsequent bd write. The bd subprocess stalls at the 2m timeout re-importing all 34k rows into Dolt before the write completes.
- Symptom: `gc mail send` / `gc sling` / `gc session new` all time out at 2m on these cities. The user-visible workaround is manual `rm .beads/issues.jsonl` per scope, which is exactly what #1968 was supposed to eliminate.
- This PR adds the stale-file cleanup as a two-layer defense:
  1. `bdStoreFor{City,Rig}` (`cmd/gc/bd_env.go`) — best-effort reap when the scope is gc-managed (steady-state, every store construction).
  2. `ensureCanonicalScopeConfigState` (`cmd/gc/beads_provider_lifecycle.go`) — reap when canonicalization actually mutates config (transition-moment cleanup for newly-normalized scopes).
- Plus: tighten `bdRuntimeEnv` to set `BD_EXPORT_AUTO=false` on every gc-spawned bd subprocess. Belt to the canonical config's suspenders — covers fresh inits whose config hasn't been canonicalized yet, and short-circuits the export → next-write-import cycle even when an out-of-band caller left a stale JSONL on disk.

## Why this is safe

- The reaper only fires when the scope is provably gc-managed:
  - `.beads/config.yaml` has `export.auto: false` (steady-state post-#1968 signal), OR
  - `gc.endpoint_origin` is one of `managed_city`, `city_canonical`, or `inherited_city` (transitional signal for cities older than #1968 whose config hasn't been canonicalized yet).
- Rigs that deliberately keep JSONL-based sharing — those that set `gc.endpoint_origin: explicit` per #1968's escape hatch — are explicitly **not** treated as gc-managed, so their `issues.jsonl` is left alone.
- Unmanaged scopes (no `.beads/config.yaml`, or config without any gc-managed signal) are also left alone — the reaper is conservative by default.
- All operations are best-effort: `os.Stat` / `os.Remove` errors are swallowed because the env-var `BD_EXPORT_AUTO=false` in `bdRuntimeEnv` is a second line of defense for gc-initiated calls. A concurrent reader of the JSONL (e.g., a third-party bd-aware tool) won't fail the caller's operation.

## Verified locally

samtown (34k beads, 15 MB stale JSONL, dolt server healthy):

| command | before | after |
| --- | --- | --- |
| `gc mail send mayor "..." "..."` from rig | 120s (timeout) | **3.0s** |
| `gc mail count` | 2.5s | **1.7s** |
| `gc mail read <id>` | -- | **2.2s** |
| `gc bd list` | 0.3s | 0.3s |
| `gc bd --rig <r> list` | 0.3s | 0.3s |

After the patched binary handles a write, `.beads/issues.jsonl` does not reappear — confirming the env-var + canonical-config defenses together hold the line.

## Testing

- [x] Targeted unit tests (`TestBdRuntimeEnvDisablesAutoExport`, `TestScopeIsGCManaged*`, `TestReapStaleBdExportJSONL*`, `TestReadExportAuto*`, `TestEnsureCanonicalConfigForcesAutoExportOff*`) — all pass.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l` on touched files — clean.
- [x] `golangci-lint run --new-from-rev=main cmd/gc/... internal/beads/contract/...` — 0 issues.
- [x] Live end-to-end probe on samtown (numbers above).
- [ ] `make check` — there are pre-existing macOS-specific test flakes on main (`TestResolveDoltConnectionTargetManagedCity_EnvOverride` fails to bind 127.0.0.2; `TestControllerStateMutationRollsBackWhenRefreshFails` hangs at 5m) that I reproduce on clean `1c5b6073` before any of my changes. CI on Linux should run cleanly — flagging this for the reviewer rather than papering over it.
- [ ] `make check-docs` — no docs/nav/links touched.
- [ ] `make test-integration` — would appreciate the reviewer's read on whether the integration suite covers the canonicalize-then-write path I added a reaper to.

## Checklist

- [x] Linked an issue (#2059).
- [x] Added tests for behavior changes.
- [x] Updated docs — none required; the change is internal plumbing with no user-visible CLI or config surface.
- [x] Called out the macOS test-flake caveat above.

## Why this is a draft

CONTRIBUTING.md says to discuss in an issue first; #2059 is the issue. Marking as draft pending maintainer triage on:
1. Whether the two-layer defense is the right approach (vs. e.g. a one-shot migration in `gc doctor --fix`).
2. Whether the gc-managed signal set (`export.auto: false` OR managed endpoint origins, exclude `explicit`) matches the project's mental model.
3. Whether a `make check-docs` / `make test-integration` confirmation is required before un-drafting.

Happy to iterate on any of the above.