### PR TITLE
fix(cmd/gc): prefer rig binding over findCity legacy fallback for GC_DIR

### DIFF
--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -511,9 +511,18 @@ func resolveContext() (resolvedContext, error) {
 	// (e.g. rig at /Code/rigname and city at /Code/cityname), the walkup
 	// never reaches the real city and the stale ".gc/" inside the rig
 	// would otherwise win.
+	//
+	// Guard: only run the (potentially expensive) registry scan when GC_DIR
+	// actually shows the legacy-fallback misfire shape — a .gc/ directory
+	// without a sibling city.toml. When GC_DIR carries its own city.toml
+	// the walkup at step 8 finds the right city in O(1) and we don't pay
+	// for a full registry scan. When GC_DIR has neither, step 9 (cwd-based
+	// rig lookup) covers it.
 	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" {
-		if ctx, ok := lookupRigFromCwd(gcDir); ok {
-			return ctx, nil
+		if citylayout.HasRuntimeRoot(gcDir) && !citylayout.HasCityConfig(gcDir) {
+			if ctx, ok := lookupRigFromCwd(gcDir); ok {
+				return ctx, nil
+			}
 		}
 	}
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -445,10 +445,11 @@ func resolveCommandCity(args []string) (string, error) {
 //  4. Explicit city env (GC_CITY / GC_CITY_PATH / GC_CITY_ROOT) + GC_RIG
 //  5. Explicit city env only (city set, rig from GC_DIR/cwd if applicable)
 //  6. GC_RIG only (rig from registered city site bindings)
-//  7. GC_DIR-derived city path
-//  8. Registered rig binding lookup (cwd prefix match)
-//  9. Walk up from cwd looking for city.toml
-//  10. Fail
+//  7. Registered rig binding lookup using GC_DIR (rig with leftover .gc/)
+//  8. GC_DIR-derived city path (walk-up)
+//  9. Registered rig binding lookup (cwd prefix match)
+//  10. Walk up from cwd looking for city.toml
+//  11. Fail
 func resolveContext() (resolvedContext, error) {
 	city := cityFlag
 	rig := rigFlag
@@ -502,13 +503,27 @@ func resolveContext() (resolvedContext, error) {
 		return ctx, nil
 	}
 
-	// Step 7: GC_DIR-derived city path.
+	// Step 7: Registered rig binding lookup using GC_DIR. Must run before
+	// the GC_DIR walkup (step 8) so that a rig dir with a leftover ".gc/"
+	// runtime artifact does not get mistaken for a legacy city via
+	// findCity's HasRuntimeRoot fallback. Spawned rig agents have GC_DIR
+	// set to the rig path; when that path is a sibling of the city
+	// (e.g. rig at /Code/rigname and city at /Code/cityname), the walkup
+	// never reaches the real city and the stale ".gc/" inside the rig
+	// would otherwise win.
+	if gcDir := strings.TrimSpace(os.Getenv("GC_DIR")); gcDir != "" {
+		if ctx, ok := lookupRigFromCwd(gcDir); ok {
+			return ctx, nil
+		}
+	}
+
+	// Step 8: GC_DIR-derived city path.
 	if gcDirCity, ok := resolveCityPathFromGCDir(); ok {
 		rn := rigFromCwdDir(gcDirCity, strings.TrimSpace(os.Getenv("GC_DIR")))
 		return resolvedContext{CityPath: gcDirCity, RigName: rn}, nil
 	}
 
-	// Step 8: Registered rig binding lookup (cwd prefix match).
+	// Step 9: Registered rig binding lookup (cwd prefix match).
 	cwd, err := os.Getwd()
 	if err != nil {
 		return resolvedContext{}, err
@@ -517,7 +532,7 @@ func resolveContext() (resolvedContext, error) {
 		return ctx, nil
 	}
 
-	// Step 9: Walk up from cwd looking for city.toml.
+	// Step 10: Walk up from cwd looking for city.toml.
 	cityPath, err := findCity(cwd)
 	if err != nil {
 		return resolvedContext{}, err

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/runtime"
 	sessionpkg "github.com/gastownhall/gascity/internal/session"
+	"github.com/gastownhall/gascity/internal/supervisor"
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
@@ -840,6 +841,57 @@ func TestResolveCityFlag(t *testing.T) {
 			t.Errorf("resolveCity() = %q, want %q", got, cityDir)
 		}
 	})
+}
+
+// TestResolveCityRigSiblingWithLegacyGCDir covers the case where GC_DIR
+// points at a registered rig directory that happens to have a stale ".gc/"
+// runtime root left over from earlier supervisor activity. Without the rig
+// registry check, findCity's legacy ".gc/" fallback would return the rig
+// dir itself as the "city" — the subsequent loadCityConfig then fails with
+// `open .../city.toml: no such file or directory`, draining the agent
+// session on first wake. The fix consults the registered rig binding for
+// GC_DIR before falling back to walkup so the rig sibling resolves to its
+// city instead of a missing city.toml.
+func TestResolveCityRigSiblingWithLegacyGCDir(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	root := shortSocketTempDir(t, "gc-rig-sibling-")
+	cityDir := filepath.Join(root, "samtown")
+	rigDir := filepath.Join(root, "drops-of-jupyter")
+	for _, dir := range []string{cityDir, rigDir} {
+		if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"),
+		[]byte("[workspace]\nname = \"samtown\"\n\n[[rigs]]\nname = \"drops-of-jupyter\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := supervisor.NewRegistry(supervisor.RegistryPath()).Register(cityDir, "samtown"); err != nil {
+		t.Fatalf("register city: %v", err)
+	}
+	if err := config.PersistRigSiteBindings(fsys.OSFS{}, cityDir, []config.Rig{
+		{Name: "drops-of-jupyter", Path: rigDir},
+	}); err != nil {
+		t.Fatalf("persist rig binding: %v", err)
+	}
+
+	old := cityFlag
+	cityFlag = ""
+	t.Cleanup(func() { cityFlag = old })
+	t.Setenv("GC_CITY", "")
+	t.Setenv("GC_CITY_PATH", "")
+	t.Setenv("GC_CITY_ROOT", "")
+	t.Setenv("GC_RIG", "")
+	t.Setenv("GC_DIR", rigDir)
+
+	got, err := resolveCity()
+	if err != nil {
+		t.Fatalf("resolveCity() error: %v", err)
+	}
+	if canonicalTestPath(got) != canonicalTestPath(cityDir) {
+		t.Errorf("resolveCity() = %q, want %q (registered rig binding should win over rig's stale .gc/ legacy fallback)", got, cityDir)
+	}
 }
 
 // --- doRigAdd (with fsys.Fake) ---

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -876,9 +876,14 @@ func TestResolveCityRigSiblingWithLegacyGCDir(t *testing.T) {
 		t.Fatalf("persist rig binding: %v", err)
 	}
 
-	old := cityFlag
+	// Save & restore BOTH cityFlag and rigFlag. resolveContext prioritizes
+	// --rig at step 3, so a leftover rigFlag from another parallel-safe
+	// test would short-circuit the GC_DIR-based path under exercise here
+	// and silently invalidate the assertion.
+	oldCity, oldRig := cityFlag, rigFlag
 	cityFlag = ""
-	t.Cleanup(func() { cityFlag = old })
+	rigFlag = ""
+	t.Cleanup(func() { cityFlag, rigFlag = oldCity, oldRig })
 	t.Setenv("GC_CITY", "")
 	t.Setenv("GC_CITY_PATH", "")
 	t.Setenv("GC_CITY_ROOT", "")


### PR DESCRIPTION
Closes #2061.

## Summary

`resolveContext()` walked up from `GC_DIR` via `findCity()` **before** consulting the registered rig binding for that path. When a rig dir contained a stale `.gc/` runtime artifact (Claude Code projects `settings.json` under `<rig>/.gc/`; `events.jsonl` can land there too), `findCity`'s `HasRuntimeRoot` legacy fallback fired on the first inspected directory and returned the rig path as the city. `loadCityConfig` then failed with `open <rig>/city.toml: no such file or directory`. Sibling-pathed rig agents (rig at `/Code/<rig>`, city at `/Code/<city>`) drained on first wake because the `gc hook` step of their startup protocol errored out before `bd ready` could find their routed work.

Fix: when `GC_DIR` is set, consult the registered rig binding for that path before the `findCity` walk-up. The rig binding lookup is authoritative because it requires both the supervisor registry **and** the city's `.gc/site.toml` to agree the dir is a rig — neither stray `.gc/` artifacts nor partial init state can produce a false positive.

The cwd-based lookup (existing step 8) already handled the case where cwd happens to be a registered rig. The new step is the `GC_DIR` analogue and is placed earlier in the priority chain because the `GC_DIR` walk-up hit the legacy fallback first.

## Reproduction (before this PR)

```sh
# Rig at /Code/drops-of-jupyter is sibling of city /Code/samtown.
# Rig dir has a stale .gc/ from earlier supervisor activity.
cd /Code/drops-of-jupyter
env -u GC_CITY -u GC_CITY_PATH -u GC_CITY_RUNTIME_DIR -u GC_RIG -u GC_RIG_ROOT \
    GC_DIR=/Code/drops-of-jupyter \
    gc hook drops-of-jupyter/builder
# gc hook: loading config "/Code/drops-of-jupyter/city.toml":
#   open /Code/drops-of-jupyter/city.toml: no such file or directory
```

After this PR the same command resolves to the city's `samtown` workspace and the `gc hook` work query runs normally.

## Why this is the right fix

- The bug surfaces in `gc hook`, but the root resolution lives in `resolveContext`. Fixing at `resolveContext` repairs every `gc` subcommand for the same scenario (`gc bd`, `gc config`, `gc agent`, …) — `gc hook` happens to be the one that drains a session on failure, but it's not the only consumer.
- The rig binding lookup is already trusted enough to be the *cwd-based* path (existing step 8). Extending it to the `GC_DIR`-based case is a one-shape extension, not a new resolution semantics.
- Defense in depth complements #101 (root-cause: `GC_CITY` missing from spawned-session env). Even when env is propagated correctly, the rig-binding step now catches the broken state before `findCity`'s fallback misfires.

## Testing

- New `TestResolveCityRigSiblingWithLegacyGCDir` reproduces the bug on clean `1c5b6073` and passes after the fix. Sets up a tempdir city + sibling rig with stale `.gc/`, registers the city in the supervisor registry, persists the site binding, sets `GC_DIR`, and asserts `resolveCity()` returns the city, not the rig.
- Existing `TestResolveCityFlag` subtests pass unchanged when run with a clean env (`env -u GC_RIG -u GC_RIG_ROOT -u GC_CITY* …`).
- `go vet ./...` and `make lint` clean.
- Manual probe with the installed binary on samtown's `drops-of-jupyter` rig: `gc config show` now resolves the right workspace name (`samtown`) from inside the rig dir with no `GC_CITY*` env.

## Checklist

- [ ] `make check` — same pre-existing macOS-specific test flakes documented in #2060 (`TestResolveDoltConnectionTargetManagedCity_EnvOverride` fails to bind `127.0.0.2`; `TestControllerStateMutationRollsBackWhenRefreshFails` hangs at 5m) reproduce on clean `1c5b6073` before this change. CI on Linux should run cleanly. Flagging rather than papering over.
- [x] `make check-docs` — no docs / nav / links touched.
- [x] Added a regression test (`TestResolveCityRigSiblingWithLegacyGCDir`).
- [ ] `make test-integration` — I haven't run the integration suite; the change is contained to `resolveContext` and is exercised by the new unit test plus the manual probe above. Would value the reviewer's read on whether anything in the integration suite covers the `GC_DIR`-based rig resolution path.

## Why this is a draft

- Wanted to give maintainers a chance to weigh in on the priority ordering (new step is `7`, between `GC_RIG`-only and the existing `GC_DIR` walk-up) before flipping ready-for-review.
- The root-cause for sibling-rig sessions having missing `GC_CITY` (re-seeded `runtime.Config.Env` on session restart) is a separate, larger change. Happy to file or tackle a follow-up if maintainers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)