### PR TITLE
test(cmd/gc): use fake session provider in Phase0 spec tests (ga-kkn)

### DIFF
--- a/cmd/gc/session_model_phase0_factory_namespace_spec_test.go
+++ b/cmd/gc/session_model_phase0_factory_namespace_spec_test.go
@@ -124,7 +124,7 @@ func TestResolveSessionTemplate_RigBindingQualifiedExactMatch(t *testing.T) {
 }
 
 func TestPhase0SessionTargeting_RejectsTemplateToken(t *testing.T) {
-	t.Setenv("GC_SESSION", "phase0")
+	t.Setenv("GC_SESSION", "fake")
 
 	store := beads.NewMemStore()
 	cfg := &config.City{

--- a/cmd/gc/session_model_phase0_spec_test.go
+++ b/cmd/gc/session_model_phase0_spec_test.go
@@ -84,7 +84,7 @@ func TestPhase0SessionResolution_ConfiguredNamedConflictFailsClosed(t *testing.T
 }
 
 func TestPhase0SessionResolution_DoesNotImplicitlyMaterializeSingletonConfig(t *testing.T) {
-	t.Setenv("GC_SESSION", "phase0")
+	t.Setenv("GC_SESSION", "fake")
 
 	store := beads.NewMemStore()
 	cfg := &config.City{
@@ -111,7 +111,7 @@ func TestPhase0SessionResolution_DoesNotImplicitlyMaterializeSingletonConfig(t *
 }
 
 func TestPhase0SessionResolution_RigScopedBareNamedIdentityRequiresAmbientRig(t *testing.T) {
-	t.Setenv("GC_SESSION", "phase0")
+	t.Setenv("GC_SESSION", "fake")
 	t.Setenv("GC_DIR", t.TempDir())
 
 	store := beads.NewMemStore()
@@ -170,7 +170,7 @@ func TestPhase0CanonicalMetadata_ManualCreateWritesSessionOrigin(t *testing.T) {
 }
 
 func TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag(t *testing.T) {
-	t.Setenv("GC_SESSION", "phase0")
+	t.Setenv("GC_SESSION", "fake")
 
 	store := beads.NewMemStore()
 	cfg := &config.City{
@@ -202,7 +202,7 @@ func TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLeg
 }
 
 func TestPhase0CanonicalMetadata_TemplateFactoryMaterializationWritesEphemeralOriginWithoutLegacyPoolFlags(t *testing.T) {
-	t.Setenv("GC_SESSION", "phase0")
+	t.Setenv("GC_SESSION", "fake")
 
 	store := beads.NewMemStore()
 	cfg := &config.City{


### PR DESCRIPTION
## Summary

Fixes the macOS test flake tracked as bead `ga-kkn`: five `TestPhase0*`
cases in `cmd/gc/session_model_phase0_spec_test.go` and one in
`cmd/gc/session_model_phase0_factory_namespace_spec_test.go` set
`t.Setenv("GC_SESSION", "phase0")`. The cmd/gc provider context
(`loadSessionProviderContext` in `cmd/gc/providers.go`) treats
`GC_SESSION` as the provider-name override. `"phase0"` is not a known
provider, so the runtime falls through to the default tmux provider.

When the developer's host already has a real tmux session named
`mayor` (or any matching named-session target), the provider's
`session-create` path returns `runtime.ErrSessionExists` and
`TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag`
fails with:

```
session name already exists: "mayor" already active in runtime
```

Switch the sentinel to `"fake"` so these tests use `runtime.NewFake()`
and never touch the host's tmux server, matching the convention
already established across `cmd_session_*_test.go`, `cmd_mail_test.go`,
`cmd_nudge_test.go`, etc. — every other test in the package that needs
to control the session-provider env var sets it to `"fake"`.

## Trail

- #2063 (gascity/flake-inv → sa-9sa3fn investigation) — fixed
  `TestResolveDoltConnectionTargetManagedCity_EnvOverride` and
  identified two real underlying flakes that PRs #2060/#2062 had
  misattributed.
- bead `ga-kkn` — this one.
- bead `ga-un5` (gascity/perf-inv) — the sibling cmd/gc perf flake.

## Fix choice (vs alternatives)

The bead listed candidate fixes; I picked the smallest-change option:
swap the sentinel value. Alternatives considered:

- **(picked) Use the existing `\"fake\"` sentinel.** 5-line diff, zero new
  helpers, aligns with prevailing convention. Root cause is that
  `\"phase0\"` was a typo'd sentinel that silently fell through to tmux.
- Inject a provider through the function signature
  (`resolveSessionIDMaterializingNamed`, friends) — much larger
  refactor; the lookup path already supports `\"fake\"` via env var.
- Build a separate test-only provider context — unnecessary; the
  `\"fake\"` path through `newSessionProvider` already exists for
  exactly this purpose.

## Repro

Before, with a host tmux session named \`mayor\`:
```
tmux new-session -d -s mayor
go test -count=1 -run TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag ./cmd/gc/
```
=> FAIL: `session name already exists: \"mayor\" already active in runtime`

After:
```
go test -count=1 -run TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag ./cmd/gc/
```
=> ok

Full `go test -count=1 ./cmd/gc/` passes locally with this change.

## Testing

- [x] `go test -count=1 ./cmd/gc/` — green
- [x] Bead's repro recipe — no longer fails
- [x] `go vet ./cmd/gc/...` — clean
- [x] `go build ./...` — clean

## Pre-commit hook note

The local `.githooks/pre-commit` `make test` gate trips on three
pre-existing failures on origin/main (`1c5b6073`) that are unrelated
to this change:

1. `internal/beads/contract.TestResolveDoltConnectionTargetManagedCity_EnvOverride`
   — the macOS `127.0.0.2` bind issue that PR #2063 fixes (still open).
2. `cmd/gc.TestCityRuntimeReloadDrainShortCircuitsOnTickContextCancel`
   — flaky under parallel `make test`, passes standalone. Forwarded
   to gascity/perf-inv as a sibling to ga-un5.
3. `internal/runtime/acp.TestStartLongSocketPathUsesShortSocketName`
   — flaky under parallel `make test`, passes standalone. Filed as
   bead `ga-urt`.

All three reproduce on a stashed-clean origin/main checkout in this
worktree; this PR touches only `*_test.go` files so it cannot affect
them. Verified via `git stash && go test -count=1 -run ... && git stash pop`.

## Checklist

- [x] Linked the bead (ga-kkn) and related PR (#2063) in the body
- [x] Test-only change; no production behavior changes
- [x] No docs to update (test sentinel rename)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)