### PR TITLE
test(cmd/gc): cut managed-dolt + stale-key delay overhead in city runtime tests

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -66,6 +66,11 @@ type controllerState struct {
 
 var controllerStateInitRigDirIfReady = initDirIfReady
 
+// newControllerStateOpenCityStore opens the city-level bead store for
+// newControllerState. Test code can swap this to return an in-memory store
+// and skip spawning managed dolt (~12s per call).
+var newControllerStateOpenCityStore = openCityStoreAt
+
 type configMutationSnapshot struct {
 	cityPath   string
 	files      map[string][]byte
@@ -100,7 +105,7 @@ func newControllerState(
 	}
 	cs.beadStores = cs.buildStores(cfg)
 	// Open city-level store for session beads and mail (best-effort).
-	if store, err := openCityStoreAt(cityPath); err != nil {
+	if store, err := newControllerStateOpenCityStore(cityPath); err != nil {
 		fmt.Fprintf(os.Stderr, "api: city bead store: %v (session/mail endpoints disabled)\n", err)
 	} else {
 		cs.cityBeadStore = wrapWithCachingStore(ctx, store, ep)

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -29,6 +29,11 @@ import (
 	"github.com/gastownhall/gascity/internal/workspacesvc"
 )
 
+// newCityRuntimeOpenSweepStore opens the city store used for the orphaned
+// order-tracking sweep in newCityRuntime. Test code can swap this to return
+// an in-memory store and skip spawning managed dolt.
+var newCityRuntimeOpenSweepStore = openStoreAtForCity
+
 // reloadOrderDrainTimeout bounds how long config reload will wait for
 // the outgoing order dispatcher's in-flight goroutines before replacing
 // it. Reload runs on the tick loop, so a larger budget would stall all
@@ -228,7 +233,7 @@ func newCityRuntime(p CityRuntimeParams) *CityRuntime {
 	// (goroutines killed on restart, or silent Close failures).
 	// Retry with backoff as defense-in-depth against transient store
 	// errors immediately after ensureBeadsProvider returns (#753).
-	if sweepStore, err := openStoreAtForCity(p.CityPath, p.CityPath); err != nil {
+	if sweepStore, err := newCityRuntimeOpenSweepStore(p.CityPath, p.CityPath); err != nil {
 		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep: %v\n", err) //nolint:errcheck // best-effort stderr
 	} else if n, err := sweepOrphanedOrderTrackingRetry(sweepStore, 3, time.Second); err != nil {
 		fmt.Fprintf(p.Stderr, "gc start: order tracking sweep (closed %d): %v\n", n, err) //nolint:errcheck // best-effort stderr

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -457,6 +457,9 @@ func TestCityRuntimeTickPreflightsManagedDoltBeforeSessionSnapshot(t *testing.T)
 	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "bd")
 
+	cityPath := t.TempDir()
+	cleanupManagedDoltTestCity(t, cityPath)
+
 	orderEvents := &orderedRuntimeEvents{}
 	store := &managedDoltPreflightOrderStore{
 		Store:  beads.NewMemStore(),
@@ -693,7 +696,7 @@ func TestNewCityRuntimePreflightsManagedDoltPublicationBeforeStartupStoreWork(t 
 
 	healthCalls := 0
 	cityPath := t.TempDir()
-	requireNoLeakedDoltAfterForPaths(t, cityPath)
+	cleanupManagedDoltTestCity(t, cityPath)
 	sp := runtime.NewFake()
 	_ = newCityRuntime(CityRuntimeParams{
 		CityPath: cityPath,

--- a/cmd/gc/city_runtime_test.go
+++ b/cmd/gc/city_runtime_test.go
@@ -71,6 +71,31 @@ func TestSweepUndesiredPoolSessionBeads_KeepsRunningSessionsOpen(t *testing.T) {
 	}
 }
 
+// stubManagedDoltStoreOpeners replaces the two package-level store openers
+// used during newCityRuntime + newControllerState startup with in-memory
+// stubs. This prevents tests from spawning real managed dolt servers (~12s
+// each). The original openers are restored via t.Cleanup.
+//
+// Tests that verify the managed-dolt preflight ordering invariant still
+// install their own fake managedDoltHealth/Owned/Port hooks to record events;
+// this helper only handles the side-effects from sweepStore / city store
+// opening which otherwise force a real dolt spawn.
+func stubManagedDoltStoreOpeners(t *testing.T) {
+	t.Helper()
+	prevCityStore := newControllerStateOpenCityStore
+	prevSweepStore := newCityRuntimeOpenSweepStore
+	newControllerStateOpenCityStore = func(string) (beads.Store, error) {
+		return beads.NewMemStore(), nil
+	}
+	newCityRuntimeOpenSweepStore = func(string, string) (beads.Store, error) {
+		return beads.NewMemStore(), nil
+	}
+	t.Cleanup(func() {
+		newControllerStateOpenCityStore = prevCityStore
+		newCityRuntimeOpenSweepStore = prevSweepStore
+	})
+}
+
 // newTestCityRuntime builds a CityRuntime and registers a cleanup that
 // cancels in-flight dispatched orders before invoking shutdown. Do NOT
 // add a duplicate t.Cleanup(cr.shutdown) in callers — t.Cleanup is LIFO,
@@ -456,6 +481,7 @@ func TestCityRuntimeEnsureManagedDoltPublishedForTickLogsOwnershipError(t *testi
 func TestCityRuntimeTickPreflightsManagedDoltBeforeSessionSnapshot(t *testing.T) {
 	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "bd")
+	stubManagedDoltStoreOpeners(t)
 
 	cityPath := t.TempDir()
 	cleanupManagedDoltTestCity(t, cityPath)
@@ -466,8 +492,6 @@ func TestCityRuntimeTickPreflightsManagedDoltBeforeSessionSnapshot(t *testing.T)
 		events: orderEvents,
 	}
 	sp := runtime.NewFake()
-	cityPath := t.TempDir()
-	requireNoLeakedDoltAfterForPaths(t, cityPath)
 	cr := &CityRuntime{
 		cityPath: cityPath,
 		cityName: "test-city",
@@ -579,7 +603,7 @@ func TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot(t *test
 	cityPath := t.TempDir()
 	tomlPath := filepath.Join(cityPath, "city.toml")
 	writeCityRuntimeConfig(t, tomlPath, "fake")
-	// This preflight starts a managed Dolt sql-server; clean it up even if the test fails.
+	stubManagedDoltStoreOpeners(t)
 	cleanupManagedDoltTestCity(t, cityPath)
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
@@ -644,6 +668,7 @@ func TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot(t *test
 func TestCityRuntimeControlDispatcherPreflightsManagedDoltBeforeSessionSnapshot(t *testing.T) {
 	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "bd")
+	stubManagedDoltStoreOpeners(t)
 
 	orderEvents := &orderedRuntimeEvents{}
 	store := &managedDoltPreflightOrderStore{
@@ -693,6 +718,7 @@ func TestCityRuntimeControlDispatcherPreflightsManagedDoltBeforeSessionSnapshot(
 func TestNewCityRuntimePreflightsManagedDoltPublicationBeforeStartupStoreWork(t *testing.T) {
 	disableManagedDoltRecoveryForTest(t)
 	t.Setenv("GC_BEADS", "bd")
+	stubManagedDoltStoreOpeners(t)
 
 	healthCalls := 0
 	cityPath := t.TempDir()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,6 +7,7 @@
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--city` | string |  | path to the city directory (default: walk up from cwd) |
+| `--json-schema` | string |  | emit JSON Schema for this command; optional value: result or failure |
 | `--rig` | string |  | rig name or path (default: discover from cwd) |
 
 ## gc
@@ -20,6 +21,7 @@ gc [flags]
 | Subcommand | Description |
 |------------|-------------|
 | [gc agent](#gc-agent) | Manage agent configuration |
+| [gc analyze](#gc-analyze) | Read-only analysis over events and beads |
 | [gc bd](#gc-bd) | Run bd in the correct rig directory |
 | [gc beads](#gc-beads) | Manage the beads provider |
 | [gc build-image](#gc-build-image) | Build a prebaked agent container image |
@@ -139,6 +141,54 @@ replaced if they exit. Use "gc agent resume" to restore.
 ```
 gc agent suspend <name>
 ```
+
+## gc analyze
+
+Analyze produces correlated reports over the events log and
+bead state. All subcommands are read-only and safe to run alongside a
+live controller.
+
+```
+gc analyze
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc analyze reliability](#gc-analyze-reliability) | Correlate session-lifecycle events with model/version/rig |
+
+## gc analyze reliability
+
+Reliability reports per-(model, prompt_version, rig) counts of
+the tracked session-lifecycle events:
+
+  session.crashed
+  session.quarantined (reserved; current production paths do not emit it)
+  session.idle_killed
+  session.draining
+
+Worker.operation events from #1252 supply the (model, prompt_version,
+agent_name) tuple per session. Lifecycle events get attributed via the
+session id or producer aliases from worker.operation payloads. Sessions
+with worker.operation events but no lifecycle events count toward the
+per-group total — they're the denominator side of crash-rate
+calculations. Model and prompt_version are best-effort dimensions; the
+report warns when the source event stream is missing them.
+
+Read-only: this command never writes events or beads.
+
+```
+gc analyze reliability [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--city` | string |  | city directory (default: discover from cwd) |
+| `--events` | string |  | explicit events.jsonl path (overrides city discovery) |
+| `--json` | bool |  | emit JSON instead of a table |
+| `--model` | string |  | filter to a specific model |
+| `--rig` | string |  | filter to a specific rig |
+| `--since` | string | `7d` | start of the analysis window — duration (1h, 7d) or RFC3339 timestamp |
+| `--until` | string |  | end of the analysis window — duration (0s = now, 30m = 30 minutes ago) or RFC3339 timestamp |
 
 ## gc bd
 
@@ -507,12 +557,14 @@ gc config show [flags]
 gc config show
   gc config show --validate
   gc config show --provenance
+  gc config show --json
   gc config show -f overlay.toml
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-f`, `--file` | stringArray |  | additional config files to layer (can be repeated) |
+| `--json` | bool |  | emit JSON |
 | `--provenance` | bool |  | show where each config element originated |
 | `--validate` | bool |  | validate config and exit (0 = valid, 1 = errors) |
 
@@ -897,7 +949,9 @@ Run diagnostic health checks on the city workspace.
 Checks city structure, config validity, binary dependencies (tmux, git,
 bd, dolt), controller status, agent sessions, zombie/orphan sessions,
 bead stores, Dolt server health, event log integrity, and per-rig
-health. Use --fix to attempt automatic repairs.
+health. Use --fix for the canonical remediation path, including any
+safe mechanical PackV1-to-PackV2 rewrites that are available on this
+branch.
 
 ```
 gc doctor [flags]
@@ -909,11 +963,13 @@ gc doctor [flags]
 gc doctor
   gc doctor --fix
   gc doctor --verbose
+  gc doctor --json
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--fix` | bool |  | attempt to fix issues automatically |
+| `--fix` | bool |  | attempt automatic repairs and safe mechanical migrations |
+| `--json` | bool |  | emit structured JSON instead of human-readable output |
 | `-v`, `--verbose` | bool |  | show extra diagnostic details |
 
 ## gc dolt-cleanup
@@ -1036,6 +1092,33 @@ gc events
 | `--timeout` | string | `30s` | Max wait duration for --watch (e.g. 30s, 5m) |
 | `--type` | string |  | Filter by event type (e.g. bead.created) |
 | `--watch` | bool |  | Block until matching events arrive (exits after first match or buffered replay) |
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc events rotate](#gc-events-rotate) | Force rotate the city event log |
+
+## gc events rotate
+
+Force rotate the city event log through the running supervisor.
+
+Output is one JSON line. Empty active logs are successful no-ops.
+
+```
+gc events rotate [flags]
+```
+
+**Example:**
+
+```
+gc events rotate
+  gc events rotate --wait
+  gc --city /path/to/city events rotate --api http://127.0.0.1:8080
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--api` | string |  | GC API server URL override (auto-discovered by default) |
+| `--wait` | bool |  | Wait for archive compression to complete before returning |
 
 ## gc formula
 
@@ -1200,7 +1283,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.
@@ -1227,7 +1310,6 @@ gc import
 | [gc import check](#gc-import-check) | Validate installed pack import state |
 | [gc import install](#gc-import-install) | Install imports from pack.toml and packs.lock |
 | [gc import list](#gc-import-list) | List imported packs |
-| [gc import migrate](#gc-import-migrate) | Migrate a V1 city layout to the V2 pack shape |
 | [gc import remove](#gc-import-remove) | Remove a pack import |
 | [gc import upgrade](#gc-import-upgrade) | Upgrade imported packs within their constraints |
 | [gc import why](#gc-import-why) | Explain why an import is present |
@@ -1272,22 +1354,6 @@ gc import list [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--tree` | bool |  | Show the import dependency tree |
-
-## gc import migrate
-
-Rewrite a legacy city into the V2 migration shape.
-
-Moves workspace.includes into pack imports, converts [[agent]] tables
-into agents/&lt;name&gt;/ directories, and stages prompt/overlay/namepool
-assets into their V2 locations.
-
-```
-gc import migrate [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--dry-run` | bool |  | print what would change without writing |
 
 ## gc import remove
 
@@ -1911,12 +1977,13 @@ config drift rules require them.
 With --soft, the controller accepts any detected per-session config
 drift instead of draining the drifted sessions: each open session's
 recorded config hash is updated to the hash the freshly reloaded
-config produces for it, so the immediately-following reconcile tick
-sees no drift and no config-drift drains fire. Useful when editing a
-running city's .gc/settings.json without disrupting in-flight work.
-Sessions whose template no longer maps to a configured agent are
-NOT updated; normal orphan/suspended drain handles them on the next
-tick.
+config produces for it, the matching hash breakdown is refreshed, and
+any already queued config-drift drain for that session is canceled. The
+immediately-following reconcile tick sees no drift and no config-drift
+drains fire. Useful when editing a running city's .gc/settings.json
+without disrupting in-flight work. Sessions whose template no longer
+maps to a configured agent are NOT updated; normal orphan/suspended
+drain handles them on the next tick.
 
 ```
 gc reload [path] [flags]
@@ -1982,8 +2049,9 @@ Register an external project directory as a rig.
 Initializes beads database, installs agent hooks if configured,
 generates cross-rig routes, and appends the rig to city.toml.
 If the target directory doesn't exist, it is created. Use --include
-to apply a pack directory that defines the rig's agent configuration;
-repeat the flag to compose multiple packs for one rig.
+to apply a pack source that defines the rig's agent configuration;
+repeat the flag to compose multiple packs for one rig. The flag is
+compatibility sugar: gc rig add writes canonical rig imports.
 
 Use --name to set the rig name explicitly (default: directory basename).
 Use --prefix to set the bead ID prefix explicitly (default: derived from name).
@@ -2019,7 +2087,7 @@ gc rig add /path/to/project
 |------|------|---------|-------------|
 | `--adopt` | bool |  | adopt existing .beads/ directory (skip init) |
 | `--default-branch` | string |  | mainline branch (default: auto-detect from origin/HEAD or current branch) |
-| `--include` | stringArray |  | pack directory for rig agents (repeatable) |
+| `--include` | stringArray |  | pack source for rig agents (repeatable; writes canonical rig imports) |
 | `--name` | string |  | rig name (default: directory basename) |
 | `--prefix` | string |  | bead ID prefix (default: derived from name) |
 | `--start-suspended` | bool |  | add rig in suspended state (dormant-by-default) |
@@ -2708,6 +2776,7 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `-n`, `--dry-run` | bool |  | show what would be done without executing |
 | `--force` | bool |  | suppress warnings, allow cross-rig routing, allow graph workflow replacement, and for direct bead routes dispatch even if the bead does not resolve in the local store |
 | `-f`, `--formula` | bool |  | treat argument as formula name |
+| `--json` | bool |  | Output dispatch result in JSON format |
 | `--merge` | string |  | merge strategy: direct, mr, or local |
 | `--no-convoy` | bool |  | skip auto-convoy creation |
 | `--no-formula` | bool |  | suppress default formula (route raw bead) |
@@ -2746,6 +2815,8 @@ gc start
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-n`, `--dry-run` | bool |  | preview what agents would start without starting them |
+| `--no-auto-restart` | bool |  | detect supervisor binary drift but do not auto-restart; exits non-zero on drift |
+| `--verbose` | bool |  | disable warning deduplication and print every supervisor warning |
 
 ## gc status
 
@@ -2869,8 +2940,12 @@ gc supervisor start
 Check if the supervisor is running
 
 ```
-gc supervisor status
+gc supervisor status [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | emit JSON |
 
 ## gc supervisor stop
 
@@ -3084,8 +3159,12 @@ gc wait cancel <wait-id>
 Show details for a wait
 
 ```
-gc wait inspect <wait-id>
+gc wait inspect <wait-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | bool |  | emit JSON |
 
 ## gc wait list
 
@@ -3097,6 +3176,7 @@ gc wait list [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--json` | bool |  | emit JSON |
 | `--session` | string |  | filter by session ID |
 | `--state` | string |  | filter by wait state |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,6 @@
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--city` | string |  | path to the city directory (default: walk up from cwd) |
-| `--json-schema` | string |  | emit JSON Schema for this command; optional value: result or failure |
 | `--rig` | string |  | rig name or path (default: discover from cwd) |
 
 ## gc
@@ -21,7 +20,6 @@ gc [flags]
 | Subcommand | Description |
 |------------|-------------|
 | [gc agent](#gc-agent) | Manage agent configuration |
-| [gc analyze](#gc-analyze) | Read-only analysis over events and beads |
 | [gc bd](#gc-bd) | Run bd in the correct rig directory |
 | [gc beads](#gc-beads) | Manage the beads provider |
 | [gc build-image](#gc-build-image) | Build a prebaked agent container image |
@@ -141,54 +139,6 @@ replaced if they exit. Use "gc agent resume" to restore.
 ```
 gc agent suspend <name>
 ```
-
-## gc analyze
-
-Analyze produces correlated reports over the events log and
-bead state. All subcommands are read-only and safe to run alongside a
-live controller.
-
-```
-gc analyze
-```
-
-| Subcommand | Description |
-|------------|-------------|
-| [gc analyze reliability](#gc-analyze-reliability) | Correlate session-lifecycle events with model/version/rig |
-
-## gc analyze reliability
-
-Reliability reports per-(model, prompt_version, rig) counts of
-the tracked session-lifecycle events:
-
-  session.crashed
-  session.quarantined (reserved; current production paths do not emit it)
-  session.idle_killed
-  session.draining
-
-Worker.operation events from #1252 supply the (model, prompt_version,
-agent_name) tuple per session. Lifecycle events get attributed via the
-session id or producer aliases from worker.operation payloads. Sessions
-with worker.operation events but no lifecycle events count toward the
-per-group total — they're the denominator side of crash-rate
-calculations. Model and prompt_version are best-effort dimensions; the
-report warns when the source event stream is missing them.
-
-Read-only: this command never writes events or beads.
-
-```
-gc analyze reliability [flags]
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--city` | string |  | city directory (default: discover from cwd) |
-| `--events` | string |  | explicit events.jsonl path (overrides city discovery) |
-| `--json` | bool |  | emit JSON instead of a table |
-| `--model` | string |  | filter to a specific model |
-| `--rig` | string |  | filter to a specific rig |
-| `--since` | string | `7d` | start of the analysis window — duration (1h, 7d) or RFC3339 timestamp |
-| `--until` | string |  | end of the analysis window — duration (0s = now, 30m = 30 minutes ago) or RFC3339 timestamp |
 
 ## gc bd
 
@@ -557,14 +507,12 @@ gc config show [flags]
 gc config show
   gc config show --validate
   gc config show --provenance
-  gc config show --json
   gc config show -f overlay.toml
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-f`, `--file` | stringArray |  | additional config files to layer (can be repeated) |
-| `--json` | bool |  | emit JSON |
 | `--provenance` | bool |  | show where each config element originated |
 | `--validate` | bool |  | validate config and exit (0 = valid, 1 = errors) |
 
@@ -949,9 +897,7 @@ Run diagnostic health checks on the city workspace.
 Checks city structure, config validity, binary dependencies (tmux, git,
 bd, dolt), controller status, agent sessions, zombie/orphan sessions,
 bead stores, Dolt server health, event log integrity, and per-rig
-health. Use --fix for the canonical remediation path, including any
-safe mechanical PackV1-to-PackV2 rewrites that are available on this
-branch.
+health. Use --fix to attempt automatic repairs.
 
 ```
 gc doctor [flags]
@@ -963,13 +909,11 @@ gc doctor [flags]
 gc doctor
   gc doctor --fix
   gc doctor --verbose
-  gc doctor --json
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--fix` | bool |  | attempt automatic repairs and safe mechanical migrations |
-| `--json` | bool |  | emit structured JSON instead of human-readable output |
+| `--fix` | bool |  | attempt to fix issues automatically |
 | `-v`, `--verbose` | bool |  | show extra diagnostic details |
 
 ## gc dolt-cleanup
@@ -1092,33 +1036,6 @@ gc events
 | `--timeout` | string | `30s` | Max wait duration for --watch (e.g. 30s, 5m) |
 | `--type` | string |  | Filter by event type (e.g. bead.created) |
 | `--watch` | bool |  | Block until matching events arrive (exits after first match or buffered replay) |
-
-| Subcommand | Description |
-|------------|-------------|
-| [gc events rotate](#gc-events-rotate) | Force rotate the city event log |
-
-## gc events rotate
-
-Force rotate the city event log through the running supervisor.
-
-Output is one JSON line. Empty active logs are successful no-ops.
-
-```
-gc events rotate [flags]
-```
-
-**Example:**
-
-```
-gc events rotate
-  gc events rotate --wait
-  gc --city /path/to/city events rotate --api http://127.0.0.1:8080
-```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--api` | string |  | GC API server URL override (auto-discovered by default) |
-| `--wait` | bool |  | Wait for archive compression to complete before returning |
 
 ## gc formula
 
@@ -1283,7 +1200,7 @@ gc help [command]
 
 Checks for available work using the agent's work_query config.
 
-Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
+Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.
@@ -1310,6 +1227,7 @@ gc import
 | [gc import check](#gc-import-check) | Validate installed pack import state |
 | [gc import install](#gc-import-install) | Install imports from pack.toml and packs.lock |
 | [gc import list](#gc-import-list) | List imported packs |
+| [gc import migrate](#gc-import-migrate) | Migrate a V1 city layout to the V2 pack shape |
 | [gc import remove](#gc-import-remove) | Remove a pack import |
 | [gc import upgrade](#gc-import-upgrade) | Upgrade imported packs within their constraints |
 | [gc import why](#gc-import-why) | Explain why an import is present |
@@ -1354,6 +1272,22 @@ gc import list [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--tree` | bool |  | Show the import dependency tree |
+
+## gc import migrate
+
+Rewrite a legacy city into the V2 migration shape.
+
+Moves workspace.includes into pack imports, converts [[agent]] tables
+into agents/&lt;name&gt;/ directories, and stages prompt/overlay/namepool
+assets into their V2 locations.
+
+```
+gc import migrate [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dry-run` | bool |  | print what would change without writing |
 
 ## gc import remove
 
@@ -1977,13 +1911,12 @@ config drift rules require them.
 With --soft, the controller accepts any detected per-session config
 drift instead of draining the drifted sessions: each open session's
 recorded config hash is updated to the hash the freshly reloaded
-config produces for it, the matching hash breakdown is refreshed, and
-any already queued config-drift drain for that session is canceled. The
-immediately-following reconcile tick sees no drift and no config-drift
-drains fire. Useful when editing a running city's .gc/settings.json
-without disrupting in-flight work. Sessions whose template no longer
-maps to a configured agent are NOT updated; normal orphan/suspended
-drain handles them on the next tick.
+config produces for it, so the immediately-following reconcile tick
+sees no drift and no config-drift drains fire. Useful when editing a
+running city's .gc/settings.json without disrupting in-flight work.
+Sessions whose template no longer maps to a configured agent are
+NOT updated; normal orphan/suspended drain handles them on the next
+tick.
 
 ```
 gc reload [path] [flags]
@@ -2049,9 +1982,8 @@ Register an external project directory as a rig.
 Initializes beads database, installs agent hooks if configured,
 generates cross-rig routes, and appends the rig to city.toml.
 If the target directory doesn't exist, it is created. Use --include
-to apply a pack source that defines the rig's agent configuration;
-repeat the flag to compose multiple packs for one rig. The flag is
-compatibility sugar: gc rig add writes canonical rig imports.
+to apply a pack directory that defines the rig's agent configuration;
+repeat the flag to compose multiple packs for one rig.
 
 Use --name to set the rig name explicitly (default: directory basename).
 Use --prefix to set the bead ID prefix explicitly (default: derived from name).
@@ -2087,7 +2019,7 @@ gc rig add /path/to/project
 |------|------|---------|-------------|
 | `--adopt` | bool |  | adopt existing .beads/ directory (skip init) |
 | `--default-branch` | string |  | mainline branch (default: auto-detect from origin/HEAD or current branch) |
-| `--include` | stringArray |  | pack source for rig agents (repeatable; writes canonical rig imports) |
+| `--include` | stringArray |  | pack directory for rig agents (repeatable) |
 | `--name` | string |  | rig name (default: directory basename) |
 | `--prefix` | string |  | bead ID prefix (default: derived from name) |
 | `--start-suspended` | bool |  | add rig in suspended state (dormant-by-default) |
@@ -2776,7 +2708,6 @@ gc sling [target] <bead-or-formula-or-text> [flags]
 | `-n`, `--dry-run` | bool |  | show what would be done without executing |
 | `--force` | bool |  | suppress warnings, allow cross-rig routing, allow graph workflow replacement, and for direct bead routes dispatch even if the bead does not resolve in the local store |
 | `-f`, `--formula` | bool |  | treat argument as formula name |
-| `--json` | bool |  | Output dispatch result in JSON format |
 | `--merge` | string |  | merge strategy: direct, mr, or local |
 | `--no-convoy` | bool |  | skip auto-convoy creation |
 | `--no-formula` | bool |  | suppress default formula (route raw bead) |
@@ -2815,8 +2746,6 @@ gc start
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `-n`, `--dry-run` | bool |  | preview what agents would start without starting them |
-| `--no-auto-restart` | bool |  | detect supervisor binary drift but do not auto-restart; exits non-zero on drift |
-| `--verbose` | bool |  | disable warning deduplication and print every supervisor warning |
 
 ## gc status
 
@@ -2940,12 +2869,8 @@ gc supervisor start
 Check if the supervisor is running
 
 ```
-gc supervisor status [flags]
+gc supervisor status
 ```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--json` | bool |  | emit JSON |
 
 ## gc supervisor stop
 
@@ -3159,12 +3084,8 @@ gc wait cancel <wait-id>
 Show details for a wait
 
 ```
-gc wait inspect <wait-id> [flags]
+gc wait inspect <wait-id>
 ```
-
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `--json` | bool |  | emit JSON |
 
 ## gc wait list
 
@@ -3176,7 +3097,6 @@ gc wait list [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--json` | bool |  | emit JSON |
 | `--session` | string |  | filter by session ID |
 | `--state` | string |  | filter by wait state |
 


### PR DESCRIPTION
## Summary

Cuts managed-dolt spawn + stale-key wait overhead across several `cmd/gc` tests.

Three commits, all test-only changes (one tiny `var`-instead-of-`const` swap in production code so tests can rebind):

### 1. `test: cleanup managed-dolt in city runtime tests` (7e09c8f)

Two tests in `cmd/gc/city_runtime_test.go` built `CityRuntime` directly instead of going through `newTestCityRuntime`, skipping the `t.Cleanup` that tears down the managed dolt sql-server. Even with stub `ManagedDoltHealth/Owned/Port` callbacks, `ensureManagedDoltPublishedForRuntime` ran unconditionally and spawned a real `dolt sql-server` rooted at the test's temp city. Every run left an orphan.

Fix: register `cleanupManagedDoltTestCity(t, cityPath)` for both, matching the pattern in `TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot`.

### 2. `test(cmd/gc): stub managed-dolt store openers to skip dolt spawn` (ec04dd6)

Three more city-runtime tests still spawn real managed dolt sql-servers via the controllerState bead store + the order-tracking sweep store opened during `newCityRuntime`. Each spawn costs ~12s and leaks a child until the test's cleanup runs.

Extract two package-level vars (`newControllerStateOpenCityStore`, `newCityRuntimeOpenSweepStore`) so tests can swap in in-memory stores. Add `stubManagedDoltStoreOpeners` helper and apply to:

- `TestCityRuntimeEnsureManagedDoltPublishedForTickLogsOwnershipError`
- `TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot`
- `TestCityRuntimeControlDispatcherPreflightsManagedDoltBeforeSessionSnapshot`

Production behavior unchanged; only test code rebinds the vars. The managed-dolt preflight ordering invariant is still verified via the existing fake `managedDoltHealth/Owned/Port` hooks installed by each test.

### 3. `test(reconciler): shorten stale-key detect delay in circuit-breaker tests` (2132a72)

Five circuit-breaker reconciler tests loop through the start path many times. Each iteration paid 2s on the `cmd/gc`-layer `staleKeyDetectDelay` plus another 2s on the matching `internal/session` constant, which dominated wall-time despite the Fake runtime being synchronous (the post-start `IsRunning` check always succeeds, so no wait is actually needed).

Promote both constants to package-level vars and add `session.SetStaleKeyDetectDelayForTest`, then introduce `shortenStaleKeyDetectDelayForTest` in `cmd/gc` that zeroes both delays for the duration of `t`. Applied to five `TestReconciler_Circuit*` tests.

## Repro

```
pgrep -fl 'dolt sql-server'
```

Before: 10+ orphans with config paths like `/var/folders/.../TestCityRuntime*` accumulate after the suite.

After: only the legit managed dolt for the active city remains.

## Test plan

- [x] Targeted tests pass: `go test -run 'TestCityRuntimeEnsureManagedDoltPublished|TestCityRuntimeRunStartupPreflightsManagedDoltBeforeSessionSnapshot|TestCityRuntimeControlDispatcherPreflightsManagedDoltBeforeSessionSnapshot|TestReconciler_Circuit' ./cmd/gc/...`
- [x] `pgrep -fl 'dolt sql-server'` after run — only legit dolt survives
- [x] `make test` — green

Refs hq-bgb3v
