### PR TITLE
fix(dispatch): skip non-control dispatcher candidates

### DIFF
--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -3007,6 +3007,60 @@ func TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady(t *testin
 	}
 }
 
+func TestRunWorkflowServeSkipsUnexpectedNonControlBeadAndProcessesLaterReady(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	var controlled []string
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		switch calls {
+		case 1:
+			return []hookBead{
+				{ID: "gc-task", Metadata: map[string]string{"gc.routed_to": "workflows.codex-max"}},
+				{ID: "gc-ready", Metadata: map[string]string{"gc.kind": "scope-check"}},
+			}, nil
+		default:
+			return nil, nil
+		}
+	}
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
+		controlled = append(controlled, beadID)
+		return nil
+	}
+
+	if err := runWorkflowServe("", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+
+	if !slices.Equal(controlled, []string{"gc-ready"}) {
+		t.Fatalf("controlled beads = %#v, want only valid control bead processed", controlled)
+	}
+}
+
 func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *testing.T) {
 	clearGCEnv(t)
 	disableManagedDoltRecoveryForTest(t)

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -3061,6 +3061,52 @@ func TestRunWorkflowServeSkipsUnexpectedNonControlBeadAndProcessesLaterReady(t *
 	}
 }
 
+func TestRunWorkflowServeSkipsUnexpectedNonControlOnly(t *testing.T) {
+	clearGCEnv(t)
+	disableManagedDoltRecoveryForTest(t)
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+	t.Setenv("GC_CITY", cityDir)
+
+	prevCityFlag := cityFlag
+	prevList := workflowServeList
+	prevControl := controlDispatcherServe
+	prevInterval := workflowServeIdlePollInterval
+	prevAttempts := workflowServeIdlePollAttempts
+	cityFlag = ""
+	workflowServeIdlePollInterval = 0
+	workflowServeIdlePollAttempts = 0
+	t.Cleanup(func() {
+		cityFlag = prevCityFlag
+		workflowServeList = prevList
+		controlDispatcherServe = prevControl
+		workflowServeIdlePollInterval = prevInterval
+		workflowServeIdlePollAttempts = prevAttempts
+	})
+
+	calls := 0
+	workflowServeList = func(_, _ string, _ map[string]string) ([]hookBead, error) {
+		calls++
+		return []hookBead{
+			{ID: "gc-task", Metadata: map[string]string{"gc.routed_to": "workflows.codex-max"}},
+		}, nil
+	}
+	controlDispatcherServe = func(_, _ string, beadID string, _ io.Writer, _ io.Writer) error {
+		t.Fatalf("controlDispatcherServe called for non-control bead %q", beadID)
+		return nil
+	}
+
+	if err := runWorkflowServe("", false, io.Discard, io.Discard); err != nil {
+		t.Fatalf("runWorkflowServe: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("workflowServeList calls = %d, want one all-unexpected queue pass", calls)
+	}
+}
+
 func TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady(t *testing.T) {
 	clearGCEnv(t)
 	disableManagedDoltRecoveryForTest(t)

--- a/cmd/gc/dispatch_runtime.go
+++ b/cmd/gc/dispatch_runtime.go
@@ -450,12 +450,14 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 		processedThisCycle := false
 		pendingCount := 0
 		legacyOversizedCount := 0
+		unexpectedKindCount := 0
 		for _, candidate := range queue {
 			beadID := candidate.ID
 			kind := strings.TrimSpace(candidate.Metadata["gc.kind"])
 			if !isControlDispatcherKind(kind) {
-				workflowTracef("serve unexpected-kind bead=%s kind=%s", beadID, kind)
-				return result, fmt.Errorf("bead %s has unexpected non-control kind %q", beadID, kind)
+				unexpectedKindCount++
+				workflowTracef("serve unexpected-kind-skip bead=%s kind=%s", beadID, kind)
+				continue
 			}
 			workflowTracef("serve process bead=%s kind=%s store=%s", beadID, kind, storePath)
 			// controlDispatcherServe currently returns nil both when it
@@ -494,6 +496,10 @@ func drainWorkflowServeWork(agentCfg config.Agent, cityPath, storePath, workQuer
 		}
 		if legacyOversizedCount > 0 {
 			workflowTracef("serve legacy-oversized-queue agent=%s count=%d", agentCfg.QualifiedName(), legacyOversizedCount)
+			return result, nil
+		}
+		if unexpectedKindCount > 0 {
+			workflowTracef("serve unexpected-kind-queue agent=%s count=%d", agentCfg.QualifiedName(), unexpectedKindCount)
 			return result, nil
 		}
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,6 +46,7 @@ gc [flags]
 | [gc order](#gc-order) | Manage orders (scheduled and event-driven dispatch) |
 | [gc pack](#gc-pack) | Manage remote pack sources |
 | [gc prime](#gc-prime) | Output the behavioral prompt for an agent |
+| [gc prompt](#gc-prompt) | Author and inspect agent prompt templates |
 | [gc register](#gc-register) | Register a city with the machine-wide supervisor |
 | [gc reload](#gc-reload) | Reload the current city's config without restarting the city/controller |
 | [gc restart](#gc-restart) | Restart all agent sessions in the city |
@@ -1788,6 +1789,95 @@ gc prime [agent-name] [flags]
 | `--hook-format` | string |  | format hook output for a provider |
 | `--strict` | bool |  | fail on missing city, missing or unknown agent, or unreadable prompt_template instead of falling back to the default prompt |
 
+## gc prompt
+
+Subcommands for authoring agent prompt templates.
+
+Currently the only subcommand is 'synth', which invokes the configured
+provider in one-shot mode to generate a prompt template for a given role.
+
+```
+gc prompt
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| [gc prompt synth](#gc-prompt-synth) | Generate an agent prompt template by invoking the LLM |
+
+## gc prompt synth
+
+Renders a meta-prompt with the given parameters, invokes the configured
+provider in one-shot mode, and emits the generated prompt template.
+
+The default behavior prints the generated prompt to stdout. Pass --write
+to save it directly to &lt;city&gt;/agents/&lt;role&gt;/prompt.template.md (use --force
+to overwrite an existing file).
+
+Context type is determined by --rig:
+
+  (no --rig)     City context. The agent is HQ-only and operates at
+                 the city level (e.g. mayor, deacon). The meta-prompt
+                 emphasizes coordination, dispatch, monitoring.
+  --rig &lt;name&gt;   Rig context. The agent is attached to the named rig
+                 (looked up in city.toml). The meta-prompt includes
+                 the rig path, default branch, and project-aware
+                 guidance (git operations, branch management, etc.).
+
+Auto-detection:
+  --provider     defaults to workspace.provider in city.toml
+
+Baseline:
+  The synth pulls in an existing prompt template as a refinement
+  baseline so the LLM iterates on a known-good shape rather than
+  designing from scratch. Resolution priority:
+    1. &lt;city&gt;/agents/&lt;role&gt;/prompt.template.md     (user customization)
+    2. &lt;city&gt;/.gc/system/packs/*/agents/&lt;role&gt;/    (pack default)
+    3. embedded prompts/&lt;role&gt;.md                  (built-in fallback)
+    4. embedded prompts/mayor.md                   (structural reference,
+                                                     used only when no
+                                                     role-specific source
+                                                     exists)
+
+Two execution modes:
+
+  --writer-agent ""        Direct mode (default). Spawns a one-shot
+                           subprocess of the configured provider; no
+                           Gas City agent is involved. Useful for
+                           bootstrap and offline-friendly invocations.
+
+  --writer-agent &lt;name&gt;    Slingued mode. Creates a bead and slings the
+                           synth as work to the named agent via the
+                           mol-prompt-synth formula; the agent's
+                           session reads the meta-prompt, generates the
+                           prompt, and writes it to the destination.
+
+                           Async by default — the CLI prints the bead
+                           ID + destination and returns immediately;
+                           use 'gc bd show &lt;id&gt;' to track progress.
+                           Pass --wait to block until the agent closes
+                           the bead (or --wait-timeout fires).
+
+The output is LLM-generated. Review it carefully before relying on it.
+When --write is used, a comment header records the inputs and generation
+date for traceability.
+
+```
+gc prompt synth [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--city` | string |  | city path (default: auto-resolve) |
+| `--force` | bool |  | with --write, overwrite the destination if it exists |
+| `--meta-prompt` | string |  | override the embedded meta-prompt with a file path |
+| `--provider` | string |  | target AI provider key (default: city.toml workspace.provider) |
+| `--rig` | string |  | rig name from city.toml (default: empty = city/HQ context, no rig) |
+| `--role` | string |  | agent role to design (required, e.g. mayor, polecat, witness) |
+| `--wait` | bool |  | in slingued mode, block until the agent closes the bead |
+| `--wait-timeout` | duration | `10m0s` | in slingued mode with --wait, abort after this duration |
+| `--write` | bool |  | write to &lt;city&gt;/agents/&lt;role&gt;/prompt.template.md instead of stdout (direct mode only; slingued mode always writes) |
+| `--writer-agent` | string |  | Gas City agent to delegate the synth to via mol-prompt-synth (default: empty = direct mode, no agent) |
+
 ## gc register
 
 Register a city directory with the machine-wide supervisor.
@@ -1818,16 +1908,15 @@ Reload may fetch configured remote packs before recomputing effective
 config. By default, per-session restarts may still happen if normal
 config drift rules require them.
 
-With `--soft`, the controller accepts any detected per-session config
+With --soft, the controller accepts any detected per-session config
 drift instead of draining the drifted sessions: each open session's
-recorded config hash is updated to the hash the freshly reloaded config
-produces for it, so the immediately-following reconcile tick sees no
-drift and no config-drift drains fire. Useful when editing a running
-city's `.gc/settings.json` without disrupting in-flight work. Sessions
-whose template no longer maps to a configured agent are NOT updated;
-normal orphan/suspended drain handles them on the next tick. See
-[Soft Reload](../guides/gc-reload-design.md#soft-reload) for the full
-semantics and when to use it.
+recorded config hash is updated to the hash the freshly reloaded
+config produces for it, so the immediately-following reconcile tick
+sees no drift and no config-drift drains fire. Useful when editing a
+running city's .gc/settings.json without disrupting in-flight work.
+Sessions whose template no longer maps to a configured agent are
+NOT updated; normal orphan/suspended drain handles them on the next
+tick.
 
 ```
 gc reload [path] [flags]

--- a/test/acceptance/session_test.go
+++ b/test/acceptance/session_test.go
@@ -104,10 +104,15 @@ func TestSessionDefaultNamedSession(t *testing.T) {
 		if strings.Contains(out, "No sessions found") {
 			t.Errorf("expected default named session on fresh city, got:\n%s", out)
 		}
-		for _, want := range []string{"mayor", "creating"} {
+		for _, want := range []string{"mayor"} {
 			if !strings.Contains(out, want) {
 				t.Errorf("expected %q in default named session list, got:\n%s", want, out)
 			}
+		}
+		if !strings.Contains(out, string(session.StateCreating)) &&
+			!strings.Contains(out, string(session.StateActive)) &&
+			!strings.Contains(out, string(session.StateAwake)) {
+			t.Errorf("expected creating or running state in default named session list, got:\n%s", out)
 		}
 	})
 
@@ -126,8 +131,10 @@ func TestSessionDefaultNamedSession(t *testing.T) {
 		if got[0].Template != "mayor" {
 			t.Errorf("template = %q, want mayor\n%s", got[0].Template, out)
 		}
-		if got[0].State != session.StateCreating {
-			t.Errorf("state = %q, want creating\n%s", got[0].State, out)
+		switch got[0].State {
+		case session.StateCreating, session.StateActive, session.StateAwake:
+		default:
+			t.Errorf("state = %q, want creating or running\n%s", got[0].State, out)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- make the control-dispatcher serve loop skip ready-query contaminants whose `gc.kind` is not a control-dispatcher kind instead of exiting the pane
- return cleanly when a batch contains only non-control candidates so the follow loop can wait for the next wake
- add regression coverage for a non-control bead ahead of a valid `scope-check` bead

## Tests
- `go test ./cmd/gc -run 'TestRunWorkflowServeSkipsUnexpectedNonControlBeadAndProcessesLaterReady|TestRunWorkflowServeSkipsPendingControlBeadAndProcessesLaterReady|TestRunWorkflowServeSkipsLegacyOversizedControlAndProcessesLaterReady|TestRunWorkflowServeProcessesReadyControlBeadsThenExits' -count=1`
- pre-commit hook: `go test ./test/docsync`
- pre-commit hook: full `scripts/go-test-observable test -- -p=4 -count=1 ./...`