### PR TITLE
fix(test/acp): make TestStartLongSocketPathUsesShortSocketName robust to TMPDIR-length variance

### DIFF
--- a/internal/runtime/acp/acp_test.go
+++ b/internal/runtime/acp/acp_test.go
@@ -724,21 +724,29 @@ func TestStartLongSocketPathUsesShortSocketName(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(root) })
 	const name = "control-dispatcher"
+	// Unix socket sun_path is 104 bytes on macOS / 108 on Linux. Use the
+	// macOS limit so the constructed path binds on either platform.
+	const sockPathLimit = 104
+	// Step by a single byte per iteration: the valid window (legacy too
+	// long, short fits) is only a few bytes wide, so a 10-byte step (as the
+	// original "deep-path-" repeater used) can skip past it entirely
+	// depending on len(root) — root length varies because os.MkdirTemp's
+	// random suffix is a uint32 stringified to a variable number of digits.
 	longDir := ""
-	for i := 1; i <= 32; i++ {
-		candidate := filepath.Join(root, strings.Repeat("deep-path-", i), "acp")
+	for i := 1; i <= 128; i++ {
+		candidate := filepath.Join(root, strings.Repeat("x", i), "acp")
 		p := NewProviderWithDir(candidate, Config{
 			HandshakeTimeout:  5 * time.Second,
 			NudgeBusyTimeout:  2 * time.Second,
 			OutputBufferLines: 100,
 		})
-		if len(p.legacySockPath(name)) > 108 && len(p.sockPath(name)) < 108 {
+		if len(p.legacySockPath(name)) > sockPathLimit && len(p.sockPath(name)) < sockPathLimit {
 			longDir = candidate
 			break
 		}
 	}
 	if longDir == "" {
-		t.Fatal("failed to construct path where legacy socket is too long but short socket fits")
+		t.Skipf("cannot construct path where legacy socket exceeds %d bytes but short socket fits; len(root)=%d (likely TMPDIR=%q too long)", sockPathLimit, len(root), os.TempDir())
 	}
 	if err := os.MkdirAll(longDir, 0o755); err != nil {
 		t.Fatalf("mkdir longDir: %v", err)


### PR DESCRIPTION
## Summary

`TestStartLongSocketPathUsesShortSocketName` in `internal/runtime/acp`
flakes on macOS under `make test-fast-parallel`. The bead-author
hypothesized "socket name collision under parallelism," but the real
cause is purely arithmetic: the test's valid-path window is ~8 bytes
wide, but the loop iterates in 10-byte steps and so can skip over the
window entirely depending on `len(root)`.

`root` is built from `os.MkdirTemp(\"\", \"gc-acp-sock-\")`, whose random
suffix is `itoa(rand.Uint32())` — a variable-length string of 1–10
digits. On default macOS (`$TMPDIR` = 49 bytes), most suffix lengths
land `root` at 70-71 (works), but ~2.3% of `rand.Uint32` values
stringify to 7-8 digits and produce `root = 68` or `69`, which lies in
a gap where no `i ∈ [1, 32]` satisfies both `legacy > 108` and
`short < 108`. The test then `t.Fatal`s at the very start (Elapsed=0.02s
matching the bead's observation).

Confirmed by reproduction simulating multiple root lengths — gaps at
roots 68, 69, 78, 79, ≥85 — and by direct repro with an elongated
`TMPDIR` that fast-failed before the fix and `Skip`s gracefully after.

## Fix

- Step by a single byte (`strings.Repeat(\"x\", i)`) so the loop can
  always land in the valid window for any reasonable `len(root)`.
- Compare against `104` (macOS `sun_path`) rather than `108` (Linux), so
  the constructed path actually binds on both platforms. (At 10-byte
  steps the slack was wide enough that this never bit; at 1-byte steps
  it could.)
- If `TMPDIR` is so long that no valid path can be constructed at all
  (root ≥ 85), `Skip` with a diagnostic. That state is the
  fundamental constraint — not a bug — and shouldn't appear as a Fail.

## Why this candidate

The bead description suggested \"use `t.TempDir()` / per-test unique
socket name\" as a likely fix. Neither matches the actual root cause:

- `t.TempDir()` produces *longer* paths (includes the test name), which
  pushes `root` further into the impossible region — would make the
  flake worse, not better.
- \"Per-test unique socket name\" doesn't apply: the test's `name =
  \"control-dispatcher\"` is intentional (it's exercising the path-length
  fallback for that exact name) and the socket lives in a unique
  `MkdirTemp` directory per run, so cross-test collision was never the
  issue.

Adjusting the loop's step size and the platform check is the smallest
change that actually fixes the failure mode.

## Repro

Before:

```
$ TMPDIR=/var/folders/.../T/extra-long-prefix-12345 \
    go test -count=1 -run TestStartLong -v ./internal/runtime/acp/
--- FAIL: TestStartLongSocketPathUsesShortSocketName (0.01s)
    acp_test.go:741: failed to construct path where legacy socket is
    too long but short socket fits
```

After:

```
$ TMPDIR=/var/folders/.../T/extra-long-prefix-12345 \
    go test -count=1 -run TestStartLong -v ./internal/runtime/acp/
--- SKIP: TestStartLongSocketPathUsesShortSocketName (0.05s)
    cannot construct path where legacy socket exceeds 104 bytes but
    short socket fits; len(root)=95 (likely TMPDIR=\"...\" too long)

$ GC_FAST_UNIT=1 go test -count=20 -p=8 -run TestStartLong \
    ./internal/runtime/acp/
ok  github.com/gastownhall/gascity/internal/runtime/acp  1.200s
```

Full package: `go test -count=1 -p=4 ./internal/runtime/acp/` → ok 3.443s.

## Trail

- PR #2063 (fix/macos-test-flakes) fixed one of the two reported macOS
  pre-commit flakes and identified this one (along with a sibling) as
  the actual underlying issues.
- Bead: `ga-urt` (gascity rig).
- Sibling beads from the same investigation: `ga-un5`, `ga-kkn`.

## Testing

- [x] `go test -count=1 ./internal/runtime/acp/...` (the affected
      package)
- [x] `go vet ./internal/runtime/acp/`
- [x] `-count=20 -p=8` stress, plus a forced-failure reproduction
      that now correctly Skips
- [ ] `make check` — the pre-commit hook surfaced one unrelated
      pre-existing flake (`TestResolveDoltConnectionTargetManagedCity_EnvOverride`
      in `internal/beads/contract`) that is the exact flake fixed by
      in-flight PR #2063. That fix is not yet on `origin/main` where
      this branch is based; only the acp test is changed here and the
      failing test is in a different package.

## Checklist

- [x] Linked an issue (bead `ga-urt`) and the trail PR (#2063); no
      upstream GitHub issue per bead guidance
- [x] Added/updated tests for behavior changes (the test under test is
      itself the change)
- [ ] Updated docs for user-facing changes (n/a — internal test fix)
- [ ] Called out breaking changes or migration notes (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)