### PR TITLE
docs(convoy): clarify --help text re: workflows vs convoys

### DIFF
--- a/cmd/gc/cmd_convoy.go
+++ b/cmd/gc/cmd_convoy.go
@@ -23,9 +23,12 @@ func newConvoyCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Manage convoys — graphs of related work",
 		Long: `Manage convoys — graphs of related work beads.
 
-A convoy is a named graph of beads with dependencies. Simple convoys
-group related issues via parent-child relationships. Complex convoys
-use formula-compiled DAGs with control beads for orchestration.`,
+A convoy is a named graph of beads with dependencies. Convoys
+group related issues via parent-child relationships.
+
+Convoys are distinct from workflows (graph.v2 formula-compiled
+DAGs managed by the dispatch subsystem) — gc convoy commands do
+not operate on workflow roots.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -683,9 +683,12 @@ gc converge test-gate <bead-id>
 
 Manage convoys — graphs of related work beads.
 
-A convoy is a named graph of beads with dependencies. Simple convoys
-group related issues via parent-child relationships. Complex convoys
-use formula-compiled DAGs with control beads for orchestration.
+A convoy is a named graph of beads with dependencies. Convoys
+group related issues via parent-child relationships.
+
+Convoys are distinct from workflows (graph.v2 formula-compiled
+DAGs managed by the dispatch subsystem) — gc convoy commands do
+not operate on workflow roots.
 
 ```
 gc convoy


### PR DESCRIPTION
## Summary

Clarifies the `gc convoy --help` text by removing the misleading "Complex convoys use formula-compiled DAGs with control beads for orchestration" sentence and adding an explicit disambiguation: convoys (`type:convoy` beads) and workflows (`gc.kind=workflow` formula-compiled DAGs) are distinct primitives, and `gc convoy` commands do not operate on workflow roots.

## Motivation (empirical)

Running `gc convoy status <workflow-root-id>` returns:

```
gc convoy status: bead mc-1r8kbz is not a convoy
```

The prior help text led at least one operator (me) to expect `gc convoy` commands to manage workflow roots. They don't. The two primitives are distinct at every layer:

| Aspect | Convoy | Workflow |
|---|---|---|
| Bead type | `type:convoy` | `type:task` |
| Identifying metadata | (parent-child edges to children) | `gc.kind=workflow` + `gc.formula_contract=graph.v2` |
| Created by | `gc convoy create` (user-initiated) | Auto, when a v2-contract formula dispatches |
| Operator commands | `gc convoy create/add/status/list/land/check/close/delete` | none direct — observed through `bd` queries on the root bead's metadata |
| Verifiable via | `gc convoy status <id>` succeeds | `gc convoy status <id>` returns "bead X is not a convoy" |
| Internal package | `internal/convoy/` | `internal/sourceworkflow/` + sling layer |

The fix is the smallest one that removes the confusion: replace the "Complex convoys" sentence with an explicit "convoys are distinct from workflows" disambiguation line.

## Testing

- [ ] `make check` — started locally on macOS (Go 1.26.3); still in-flight in the `lint-full` golangci-lint phase at the time of PR submission (>22 min wall clock; large codebase + full lint pass). Will follow up with confirmation when it completes.
- [ ] `make check-docs` — N/A (no docs/ changes)
- [ ] `make test-integration` — N/A (docstring-only change; no Go logic touched)

The change is purely a docstring within a `cobra.Command.Long` field; it cannot fail Go compilation or affect runtime behavior.

## Checklist

- [ ] Linked an issue — none; surfaced during personal manual-writing of the convoy subsystem.
- [ ] Added or updated tests — none needed (docstring-only).
- [x] Updated docs — this IS the docs update.
- [x] Called out breaking changes — none. `Short:` text unchanged; `Long:` text reworded but conveys equivalent operator-facing semantics with clearer disambiguation.

## Discovery context

Surfaced during the convoys-subsystem tour (a long-running personal manual; full discussion in my study notes' §29). The empirical falsifier (`gc convoy status` returning "not a convoy" for a workflow root) prompted the disambiguation; the existing help text appeared to promise something the command surface doesn't deliver.

Happy to iterate on the wording if maintainers prefer a different framing.
