### PR TITLE
docs: propose user-docs overhaul plan

### DIFF
--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -262,8 +262,7 @@ Each issue cites the finding(s) it addresses by shortcode (F1, F2,
 
 **Issue 1 — Architecture overview page + diagrams.** Addresses
 F1(a).
-- New page: `docs/concepts/architecture-overview.md` (path TBD —
-  see open question).
+- New page: `docs/concepts/architecture-overview.md`.
 - Top-down prose: what Gas City is, how the parts hang together,
   how work flows, how agents are kept alive and communicate.
 - At least two diagrams (Mermaid, so they live in source):
@@ -275,7 +274,7 @@ F1(a).
 
 **Issue 2 — Primitives reference page.** Addresses F1(b). Lands in
 lockstep with Issue 1.
-- New page: `docs/concepts/primitives.md` (path TBD).
+- New page: `docs/concepts/primitives.md`.
 - Promote and rewrite `engdocs/architecture/nine-concepts.md` and
   `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.
@@ -402,7 +401,9 @@ F9.
 ## 6. Open questions
 
 - **IA placement of the architecture overview and primitives
-  reference.** Top-level `docs/concepts/`? Under `getting-started/`
+  reference.** ~~Top-level `docs/concepts/`? Under `getting-started/`
   so they're encountered before tutorials? Some hybrid (overview
-  in getting-started, primitives in concepts)? Resolving this also
-  determines the final file paths used in Issues 1 and 2.
+  in getting-started, primitives in concepts)?~~ **Resolved: both
+  pages land under top-level `docs/concepts/`.** Final paths:
+  `docs/concepts/architecture-overview.md` (Issue 1) and
+  `docs/concepts/primitives.md` (Issue 2).

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -8,412 +8,239 @@ status: Proposed
 
 **Status:** Proposed — first draft, expected to evolve before issues are cut.
 
-**Audience this plan targets:** engineers who want to *use* Gas City (not
-contribute to it). The motivating persona is a Gas Town user evaluating or
-executing a switch to Gas City.
+**Audience this plan targets:** engineers who want to *use* Gas City (not contribute to it). The motivating persona is a Gas Town user evaluating or executing a switch to Gas City.
 
-**Scope:** `docs/` (the Mintlify site). Contributor material in `engdocs/`
-is in scope only as a *source* — content that should be promoted, adapted,
-or referenced from `docs/`.
+**Scope:** `docs/` (the Mintlify site). Contributor material in `engdocs/` is in scope only as a *source* — content that should be promoted, adapted, or referenced from `docs/`.
 
-**Out of scope:** contributor-facing docs in `engdocs/`, CLAUDE/AGENTS
-files, internal architecture rewrites.
+**Out of scope:** contributor-facing docs in `engdocs/`, CLAUDE/AGENTS files, internal architecture rewrites.
 
 ---
 
 ## 1. Premise
 
-The current `docs/` tree is roughly 75% solid: installation, quickstart,
-and the seven tutorials work and are progressive. But the conceptual
-foundation lives in `engdocs/` (contributor docs), tutorials are split
-between PackV1 and PackV2 syntax, and several user-facing pages still
-send users into `engdocs/`. A new user — especially a Gas Town migrator —
-will bounce between conflicting sources.
+The current `docs/` tree is roughly 75% solid: installation, quickstart, and the seven tutorials work and are progressive. But the conceptual foundation lives in `engdocs/` (contributor docs), tutorials are split between PackV1 and PackV2 syntax, and several user-facing pages still send users into `engdocs/`. A new user — especially a Gas Town migrator — will bounce between conflicting sources.
 
-The goal of this overhaul is to make `docs/` self-sufficient for users:
-no link to `engdocs/` from a user-facing page should be required to
-understand or operate Gas City.
+The goal of this overhaul is to make `docs/` self-sufficient for users: no link to `engdocs/` from a user-facing page should be required to understand or operate Gas City.
 
 ---
 
 ## 2. Findings
 
-Each finding is tagged **P0** (blocks user onboarding), **P1** (significant
-friction), or **P2** (polish / longer-term). Findings carry a shortcode
-(**F1**, **F2**, …, **F12**) used throughout the rest of this document —
-in particular, work-plan issues in §4 cite the findings they address by
-shortcode.
+Each finding is tagged **P0** (blocks user onboarding), **P1** (significant friction), or **P2** (polish / longer-term). Findings carry a shortcode (**F1**, **F2**, …, **F12**) used throughout the rest of this document — in particular, work-plan issues in §4 cite the findings they address by shortcode.
 
 ### 2.1 F1 — No top-down view of how Gas City works (P0)
 
-`docs/` has no high-level explanation of Gas City as an orchestrator.
-An engineer arriving cold cannot answer "what is this system, how do its
-parts hang together, how does a piece of work flow through it, how are
-agents spawned and kept alive, how do they talk to each other" from
-user docs alone.
+`docs/` has no high-level explanation of Gas City as an orchestrator. An engineer arriving cold cannot answer "what is this system, how do its parts hang together, how does a piece of work flow through it, how are agents spawned and kept alive, how do they talk to each other" from user docs alone.
 
 What's needed is two pages, both currently absent from `docs/`:
 
-**(a) An architecture overview** — top-down prose plus at least two
-diagrams:
+**(a) An architecture overview** — top-down prose plus at least two diagrams:
 
-- **Structural diagram:** the components that exist (city → rigs →
-  agents → sessions; beads store; event bus; controller) and how they
-  connect.
-- **Interactional / lifecycle diagram:** how a piece of work flows
-  through the system — e.g. `gc sling` → bead created → agent
-  selected → session spawned → prompt rendered → nudge → completion
-  → events emitted. A health/keepalive flow (patrol → stall detection
-  → restart with backoff) is a strong candidate for a third diagram.
+- **Structural diagram:** the components that exist (city → rigs → agents → sessions; beads store; event bus; controller) and how they connect.
+- **Interactional / lifecycle diagram:** how a piece of work flows through the system — e.g. `gc sling` → bead created → agent selected → session spawned → prompt rendered → nudge → completion → events emitted. A health/keepalive flow (patrol → stall detection → restart with backoff) is a strong candidate for a third diagram.
 
-This is the page a user needs *first*, both to evaluate fit and to
-form a working mental model.
+This is the page a user needs *first*, both to evaluate fit and to form a working mental model.
 
-**(b) A primitives reference** — the Nine Concepts (Session, Task
-Store, Event Bus, Config, Prompt Templates, Messaging, Formulas,
-Dispatch, Health Patrol) rewritten in user tone and positioned as a
-deeper reference *introduced by* the overview, not as the entry
-point. The Nine Concepts are bottom-up building blocks; they do not
-teach the system on their own.
+**(b) A primitives reference** — the Nine Concepts (Session, Task Store, Event Bus, Config, Prompt Templates, Messaging, Formulas, Dispatch, Health Patrol) rewritten in user tone and positioned as a deeper reference *introduced by* the overview, not as the entry point. The Nine Concepts are bottom-up building blocks; they do not teach the system on their own.
 
-Both currently live only in `engdocs/architecture/` (contributor tone),
-and [docs/index.mdx](../../docs/index.mdx) plus
-[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
-send users there as required reading.
+Both currently live only in `engdocs/architecture/` (contributor tone), and [docs/index.mdx](../../docs/index.mdx) plus [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md) send users there as required reading.
 
 Relevant engdocs source material to adapt:
 
 - `engdocs/architecture/index.md` — overview seed
-- `engdocs/architecture/life-of-a-bead.md`,
-  `engdocs/architecture/life-of-a-molecule.md` — interactional diagram
-- `engdocs/architecture/session.md`, `controller.md`,
-  `health-patrol.md` — "how agents are kept alive"
-- `engdocs/architecture/nine-concepts.md`, `glossary.md` — primitives
-  reference
+- `engdocs/architecture/life-of-a-bead.md`, `engdocs/architecture/life-of-a-molecule.md` — interactional diagram
+- `engdocs/architecture/session.md`, `controller.md`, `health-patrol.md` — "how agents are kept alive"
+- `engdocs/architecture/nine-concepts.md`, `glossary.md` — primitives reference
 
 Existing published asset to cross-reference from the overview:
 
-- [`docs/tutorials/06-beads#bead-lifecycle`](../../docs/tutorials/06-beads.md#bead-lifecycle) —
-  already shows how a unit of work moves through states; link as
-  "dig deeper" from the interactional diagram section rather than
-  duplicating the content.
+- [`docs/tutorials/06-beads#bead-lifecycle`](../../docs/tutorials/06-beads.md#bead-lifecycle) — already shows how a unit of work moves through states; link as "dig deeper" from the interactional diagram section rather than duplicating the content.
 
 ### 2.2 F2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
 
-[Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and
-[Tutorial 03 — Sessions](../../docs/tutorials/03-sessions.md) still use
-the legacy `[[agent]]` TOML blocks, while
-[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
-and [guides/shareable-packs.md](../../docs/guides/shareable-packs.md)
-teach the PackV2 `agents/<name>/` directory layout. A user following
-tutorials in order will write config that contradicts the migration
-guide they hit next.
+[Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and [Tutorial 03 — Sessions](../../docs/tutorials/03-sessions.md) still use the legacy `[[agent]]` TOML blocks, while [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md) and [guides/shareable-packs.md](../../docs/guides/shareable-packs.md) teach the PackV2 `agents/<name>/` directory layout. A user following tutorials in order will write config that contradicts the migration guide they hit next.
 
-The project is currently at **v1.1.0**, well past the PackV2 cutover.
-PackV1 syntax in tutorials is unambiguous staleness, not a pre-release
-hedge.
+The project is currently at **v1.1.0**, well past the PackV2 cutover. PackV1 syntax in tutorials is unambiguous staleness, not a pre-release hedge.
 
 ### 2.3 F3 — Gas Town role recap missing (P1)
 
-[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
-maps Gas Town roles to Gas City equivalents without explaining what
-each role *did* operationally in Gas Town. A user who hasn't touched
-Gas Town recently — or who is *evaluating* whether to migrate at all —
-cannot recover operational meaning from a mapping alone. One paragraph
-per role (mayor, deacon, witness, refinery, polecat, crew, dog)
-describing its function in Gas Town is the minimum.
+[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md) maps Gas Town roles to Gas City equivalents without explaining what each role *did* operationally in Gas Town. A user who hasn't touched Gas Town recently — or who is *evaluating* whether to migrate at all — cannot recover operational meaning from a mapping alone. One paragraph per role (mayor, deacon, witness, refinery, polecat, crew, dog) describing its function in Gas Town is the minimum.
 
 ### 2.4 F4 — Migration Concept Map mixes domains (P1)
 
-The Concept Map table in `coming-from-gastown.md` jumbles at least
-four distinct domains into a single mapping:
+The Concept Map table in `coming-from-gastown.md` jumbles at least four distinct domains into a single mapping:
 
-- **Roles** — Mayor, Deacon, Witness, Refinery, Polecat, Crew, Dog
-  (things that *act*).
-- **Mechanisms / behaviors** — "Deacon watchdog logic", "Witness
-  lifecycle logic" (what those things *do*).
-- **Filesystem / state layout** — "Directory tree under `~/gt`"
-  (where state *lives*).
-- **Likely more** — commands, runtime artifacts, config file
-  shapes.
+- **Roles** — Mayor, Deacon, Witness, Refinery, Polecat, Crew, Dog (things that *act*).
+- **Mechanisms / behaviors** — "Deacon watchdog logic", "Witness lifecycle logic" (what those things *do*).
+- **Filesystem / state layout** — "Directory tree under `~/gt`" (where state *lives*).
+- **Likely more** — commands, runtime artifacts, config file shapes.
 
-Forcing the reader to disentangle domains while simultaneously
-learning the new system multiplies cognitive load. The fix is
-structural, not editorial: split into separate single-domain tables,
-each presented in a deliberate order (role recap → roles →
-mechanisms → filesystem/state → commands → workflows).
+Forcing the reader to disentangle domains while simultaneously learning the new system multiplies cognitive load. The fix is structural, not editorial: split into separate single-domain tables, each presented in a deliberate order (role recap → roles → mechanisms → filesystem/state → commands → workflows).
 
 ### 2.5 F5 — Workflow mapping missing (P1)
 
-The current migration guide is heavy on nouns (what *was* a mayor,
-what *is* an agent) and light on verbs (how do I *do* X in Gas City
-if I used to do it in Gas Town?). A workflow mapping table — e.g.
-"spin up a worker", "send a task", "inspect what's stuck", "restart a
-stalled agent", "share a config across teams" — is what a real
-migrator reaches for, and it does not exist today.
+The current migration guide is heavy on nouns (what *was* a mayor, what *is* an agent) and light on verbs (how do I *do* X in Gas City if I used to do it in Gas Town?). A workflow mapping table — e.g. "spin up a worker", "send a task", "inspect what's stuck", "restart a stalled agent", "share a config across teams" — is what a real migrator reaches for, and it does not exist today.
 
-Distinct from F9 (workflow gaps in the *general* user docs): F5 is
-about *translation* of existing Gas Town habits; F9 is about
-*operation* once on Gas City.
+Distinct from F9 (workflow gaps in the *general* user docs): F5 is about *translation* of existing Gas Town habits; F9 is about *operation* once on Gas City.
 
 ### 2.6 F6 — Migration guide points at files that aren't in the docs (P1)
 
-The "Fast Ramp Checklist" in
-[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
-references `examples/gastown/city.toml` and similar repo paths. These
-are not embedded in the rendered docs, nor linked as downloadable
-assets, nor guaranteed to exist at those paths. Users following the
-rendered site dead-end.
+The "Fast Ramp Checklist" in [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md) references `examples/gastown/city.toml` and similar repo paths. These are not embedded in the rendered docs, nor linked as downloadable assets, nor guaranteed to exist at those paths. Users following the rendered site dead-end.
 
 ### 2.7 F7 — Contributor material leaking into user docs (P1)
 
-- [docs/packv2/](../../docs/packv2/) holds 9 files; only
-  `migration.mdx` is in the user nav. The rest
-  (`doc-pack-v2.md`, `doc-agent-v2.md`, `doc-loader-v2.md`,
-  `doc-rig-binding-phases.md`, `doc-conformance-matrix.md`,
-  `doc-consistency-audit.md`, `doc-packman.md`, `doc-commands.md`,
-  `skew-analysis.md`) read as contributor scratch.
-- [docs/internals/](../../docs/internals/) is labeled "not required
-  reading" but `beads-topology.md` is exactly what an operator needs.
-- [docs/index.mdx](../../docs/index.mdx) literally states the tree is
-  "organized for external contributors first" — wrong primary
-  audience for `docs/`.
+- [docs/packv2/](../../docs/packv2/) holds 9 files; only `migration.mdx` is in the user nav. The rest (`doc-pack-v2.md`, `doc-agent-v2.md`, `doc-loader-v2.md`, `doc-rig-binding-phases.md`, `doc-conformance-matrix.md`, `doc-consistency-audit.md`, `doc-packman.md`, `doc-commands.md`, `skew-analysis.md`) read as contributor scratch.
+- [docs/internals/](../../docs/internals/) is labeled "not required reading" but `beads-topology.md` is exactly what an operator needs.
+- [docs/index.mdx](../../docs/index.mdx) literally states the tree is "organized for external contributors first" — wrong primary audience for `docs/`.
 
 ### 2.8 F8 — Reference docs are complete but not navigable (P1)
 
-- [reference/config.md](../../docs/reference/config.md): flat
-  auto-generated field dump, no grouped "Common Patterns".
-- [reference/formula.md](../../docs/reference/formula.md): mentions
-  conditions/loops/checks but never shows a working example.
-- [reference/api.md](../../docs/reference/api.md): points at OpenAPI
-  with no "how do I query my city" narrative.
-- [reference/cli.md](../../docs/reference/cli.md): comprehensive but
-  flat; no task-oriented entry points.
+- [reference/config.md](../../docs/reference/config.md): flat auto-generated field dump, no grouped "Common Patterns".
+- [reference/formula.md](../../docs/reference/formula.md): mentions conditions/loops/checks but never shows a working example.
+- [reference/api.md](../../docs/reference/api.md): points at OpenAPI with no "how do I query my city" narrative.
+- [reference/cli.md](../../docs/reference/cli.md): comprehensive but flat; no task-oriented entry points.
 
 ### 2.9 F9 — Significant workflow gaps in operating Gas City (P1)
 
 Things a real user will hit and not find:
 
-- How to write a first agent prompt from scratch (template variables,
-  prompt design).
-- Debugging a stuck or failing session (`gc session peek` output,
-  detection, kill/restart).
+- How to write a first agent prompt from scratch (template variables, prompt design).
+- Debugging a stuck or failing session (`gc session peek` output, detection, kill/restart).
 - Choosing between crew (persistent) and polecats (on-demand).
 - Hooks and external integrations.
 - Multi-machine / Kubernetes deployment.
 - Health monitoring; what `gc doctor [--fix]` actually does.
 
-Source material exists in `engdocs/architecture/` (e.g.
-`session.md`, `health-patrol.md`, `dispatch.md`,
-`prompt-templates.md`) and
-`engdocs/design/machine-wide-supervisor-v0.md` for scaling. None is
-promoted to user docs.
+Source material exists in `engdocs/architecture/` (e.g. `session.md`, `health-patrol.md`, `dispatch.md`, `prompt-templates.md`) and `engdocs/design/machine-wide-supervisor-v0.md` for scaling. None is promoted to user docs.
 
 ### 2.10 F10 — No full end-to-end example (P1)
 
-There is no canonical "minimal complete city" showing `pack.toml` +
-`city.toml` + `agents/<name>/agent.toml` + `prompt.md` + a formula +
-an order, together. Each piece is shown in isolation across different
-tutorials; assembly is left to the reader.
+There is no canonical "minimal complete city" showing `pack.toml` + `city.toml` + `agents/<name>/agent.toml` + `prompt.md` + a formula + an order, together. Each piece is shown in isolation across different tutorials; assembly is left to the reader.
 
 ### 2.11 F11 — Single-runbook troubleshooting catalog (P2)
 
-[docs/troubleshooting/](../../docs/troubleshooting/) holds one
-runbook (`dolt-bloat-recovery.md`). The Oh-My-Zsh `gc`-alias trap —
-a real blocker for affected users — is in
-[getting-started/troubleshooting.md](../../docs/getting-started/troubleshooting.md)
-but should be a prerequisite check at the top of Quickstart.
+[docs/troubleshooting/](../../docs/troubleshooting/) holds one runbook (`dolt-bloat-recovery.md`). The Oh-My-Zsh `gc`-alias trap — a real blocker for affected users — is in [getting-started/troubleshooting.md](../../docs/getting-started/troubleshooting.md) but should be a prerequisite check at the top of Quickstart.
 
 ### 2.12 F12 — Staleness signals (P2)
 
-- [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md)
-  shows version `v0.13.4` in sample output. Current tag is
-  **v1.1.0** — eight minor versions behind.
-- [docs/index.mdx](../../docs/index.mdx) opens with "organized for
-  external contributors first" — contradicts the goal of `docs/`.
-- General sweep needed for stale concept names (the former Agent
-  Protocol primitive was removed `dd90ac0a` on 2026-03-08; user docs
-  appear clean but worth a check).
+- [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md) shows version `v0.13.4` in sample output. Current tag is **v1.1.0** — eight minor versions behind.
+- [docs/index.mdx](../../docs/index.mdx) opens with "organized for external contributors first" — contradicts the goal of `docs/`.
+- General sweep needed for stale concept names (the former Agent Protocol primitive was removed `dd90ac0a` on 2026-03-08; user docs appear clean but worth a check).
 
 ---
 
 ## 3. Cross-cutting principles for the overhaul
 
-Before issues are cut, the following are non-negotiable so individual
-PRs stay coherent:
+Before issues are cut, the following are non-negotiable so individual PRs stay coherent:
 
-1. **`docs/` is user-first.** No user-facing page may link into
-   `engdocs/` as required reading. If `engdocs/` content is needed,
-   promote it (with rewrite) into `docs/`.
-2. **One pack syntax in tutorials.** PackV2 (`agents/<name>/`) is
-   canonical. PackV1 lives only in a clearly-labeled migration
-   appendix.
-3. **Every concept page has a runnable example.** No conceptual page
-   ships without at least one snippet a user can copy-paste.
-4. **Examples are versioned with the docs.** Reference output uses
-   the current release (v1.1.0 at time of writing).
-5. **`engdocs/` stays the source of truth for contributors.** When
-   content is promoted, the original stays as a deeper contributor
-   reference; the user-doc version links *back* (one-way).
+1. **`docs/` is user-first.** No user-facing page may link into `engdocs/` as required reading. If `engdocs/` content is needed, promote it (with rewrite) into `docs/`.
+2. **One pack syntax in tutorials.** PackV2 (`agents/<name>/`) is canonical. PackV1 lives only in a clearly-labeled migration appendix.
+3. **Every concept page has a runnable example.** No conceptual page ships without at least one snippet a user can copy-paste.
+4. **Examples are versioned with the docs.** Reference output uses the current release (v1.1.0 at time of writing).
+5. **`engdocs/` stays the source of truth for contributors.** When content is promoted, the original stays as a deeper contributor reference; the user-doc version links *back* (one-way).
 
 ---
 
 ## 4. Work plan (candidate GitHub issues)
 
-This is the first cut. Each item below is sized roughly to be a
-single PR / issue. Grouped by milestone so we can sequence cleanly.
-Each issue cites the finding(s) it addresses by shortcode (F1, F2,
-…); the mapping is not strictly 1:1.
+This is the first cut. Each item below is sized roughly to be a single PR / issue. Grouped by milestone so we can sequence cleanly. Each issue cites the finding(s) it addresses by shortcode (F1, F2, …); the mapping is not strictly 1:1.
 
 ### 4.1 Milestone 1 — Stop the bleeding (P0)
 
-**Issue 1 — Architecture overview page + diagrams.** Addresses
-F1(a). **Implemented:** [#2101](https://github.com/gastownhall/gascity/issues/2101)
-via [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
+**Issue 1 — Architecture overview page + diagrams.** Addresses F1(a). **Implemented:** [#2101](https://github.com/gastownhall/gascity/issues/2101) via [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
 - New page: `docs/concepts/architecture-overview.md`.
-- Top-down prose: what Gas City is, how the parts hang together,
-  how work flows, how agents are kept alive and communicate.
-- At least two diagrams (Excalidraw — see
-  [`engdocs/proposals/excalidraw-diagrams.md`](../proposals/excalidraw-diagrams.md)
-  for toolchain and authoring workflow):
-  structural and interactional. Health/keepalive a strong third.
-- Update `docs/index.mdx` and
-  `docs/getting-started/coming-from-gastown.md` to link to this
-  page instead of `engdocs/`.
+- Top-down prose: what Gas City is, how the parts hang together, how work flows, how agents are kept alive and communicate.
+- At least two diagrams (Excalidraw — see [`engdocs/proposals/excalidraw-diagrams.md`](../proposals/excalidraw-diagrams.md) for toolchain and authoring workflow): structural and interactional. Health/keepalive a strong third.
+- Update `docs/index.mdx` and `docs/getting-started/coming-from-gastown.md` to link to this page instead of `engdocs/`.
 - Add to `docs/docs.json` nav.
 
-**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in
-lockstep with Issue 1.
+**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in lockstep with Issue 1.
 - New page: `docs/concepts/primitives.md`.
-- Promote and rewrite `engdocs/architecture/nine-concepts.md` and
-  `glossary.md` for a user audience.
+- Promote and rewrite `engdocs/architecture/nine-concepts.md` and `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.
 
-**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.**
-Addresses F2.
+**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.** Addresses F2.
 - Rewrite the `agents/<name>/agent.toml` + `prompt.md` flow.
-- Verify all cross-references (Tutorial 04+, guides) stay
-  consistent.
-- Move existing PackV1 examples to a clearly-labeled appendix
-  inside `guides/migrating-to-pack-vnext.md` (or remove if
-  redundant with that guide).
+- Verify all cross-references (Tutorial 04+, guides) stay consistent.
+- Move existing PackV1 examples to a clearly-labeled appendix inside `guides/migrating-to-pack-vnext.md` (or remove if redundant with that guide).
 
-**Issue 4 — Refresh stale version strings and "contributors first"
-framing.** Addresses F12.
+**Issue 4 — Refresh stale version strings and "contributors first" framing.** Addresses F12.
 - Update Tutorial 01 sample output (and any others) to v1.1.0.
 - Update `docs/index.mdx` opening framing to "user-first".
 - Sweep for any other stale concept names.
 
 ### 4.2 Milestone 2 — Migration realism (P1)
 
-**Issue 5 — Restructure `coming-from-gastown.md`.** Addresses F3,
-F4, F5 in one coherent rewrite of the same file.
+**Issue 5 — Restructure `coming-from-gastown.md`.** Addresses F3, F4, F5 in one coherent rewrite of the same file.
 - Add "Gas Town role recap" — one paragraph per role.
-- Split the single Concept Map into domain-scoped tables: roles,
-  mechanisms, filesystem/state, commands (existing), workflows
-  (new).
-- Add the workflow mapping table ("how I used to do X → how I do
-  X now").
+- Split the single Concept Map into domain-scoped tables: roles, mechanisms, filesystem/state, commands (existing), workflows (new).
+- Add the workflow mapping table ("how I used to do X → how I do X now").
 
 **Issue 6 — Embed or link real example assets.** Addresses F6.
-- Replace dangling `examples/gastown/city.toml` references with
-  inline TOML blocks **or** downloadable links served by
-  Mintlify.
+- Replace dangling `examples/gastown/city.toml` references with inline TOML blocks **or** downloadable links served by Mintlify.
 - Ensure offline / PDF rendering works.
 
-**Issue 7 — Publish a "Complete Minimal City" example.**
-Addresses F10.
-- New page under `docs/guides/` (or top-level
-  `docs/examples/minimal-city.md`).
-- Full tree: `pack.toml`, `city.toml`, `agents/<name>/`, one
-  formula, one order — assembled, runnable end-to-end.
+**Issue 7 — Publish a "Complete Minimal City" example.** Addresses F10.
+- New page under `docs/guides/` (or top-level `docs/examples/minimal-city.md`).
+- Full tree: `pack.toml`, `city.toml`, `agents/<name>/`, one formula, one order — assembled, runnable end-to-end.
 - Link from index, quickstart, and Tutorial 07.
 
 ### 4.3 Milestone 3 — Reference & workflow gaps (P1)
 
-**Issue 8 — Add "Common Config Patterns" to
-`reference/config.md`.** Addresses F8.
-- Hand-written grouped patterns above the auto-generated field
-  dump: changing beads provider, adding a rig, configuring
-  pools, overriding an agent's provider, etc.
+**Issue 8 — Add "Common Config Patterns" to `reference/config.md`.** Addresses F8.
+- Hand-written grouped patterns above the auto-generated field dump: changing beads provider, adding a rig, configuring pools, overriding an agent's provider, etc.
 
-**Issue 9 — Expand `reference/formula.md` with conditions, loops,
-checks.** Addresses F8.
-- Working examples of each. Source:
-  `engdocs/architecture/formulas.md`,
-  `engdocs/design/formula-v2-transient-retries.md`.
+**Issue 9 — Expand `reference/formula.md` with conditions, loops, checks.** Addresses F8.
+- Working examples of each. Source: `engdocs/architecture/formulas.md`, `engdocs/design/formula-v2-transient-retries.md`.
 
-**Issue 10 — Narrative API guide in `reference/api.md`.**
-Addresses F8.
-- "How to query your city's state" walkthrough with curl + a tiny
-  client snippet. Keep the OpenAPI link.
+**Issue 10 — Narrative API guide in `reference/api.md`.** Addresses F8.
+- "How to query your city's state" walkthrough with curl + a tiny client snippet. Keep the OpenAPI link.
 
 **Issue 11 — "Debugging Sessions" guide.** Addresses F9.
-- `gc session peek` output, stuck-session detection, restart
-  flow.
-- Source: `engdocs/architecture/session.md`,
-  `engdocs/contributors/reconciler-debugging.md` (sanitized — the
-  trace artifact workflow stays contributor-only).
+- `gc session peek` output, stuck-session detection, restart flow.
+- Source: `engdocs/architecture/session.md`, `engdocs/contributors/reconciler-debugging.md` (sanitized — the trace artifact workflow stays contributor-only).
 
 **Issue 12 — "Choosing crew vs. polecats" guide.** Addresses F9.
 - Decision criteria and config snippets.
-- Source: `engdocs/architecture/session.md`,
-  `engdocs/design/agent-pools.md`.
+- Source: `engdocs/architecture/session.md`, `engdocs/design/agent-pools.md`.
 
-**Issue 13 — "Writing your first agent prompt" guide.** Addresses
-F9.
+**Issue 13 — "Writing your first agent prompt" guide.** Addresses F9.
 - Template variables, GUPP principle in user terms, examples.
 - Source: `engdocs/architecture/prompt-templates.md`.
 
 ### 4.4 Milestone 4 — IA cleanup (P1/P2)
 
 **Issue 14 — Audit and reclassify `docs/packv2/`.** Addresses F7.
-- For each of the unlinked files: promote into Guides/Reference
-  with a proper nav entry, or move to `engdocs/`.
+- For each of the unlinked files: promote into Guides/Reference with a proper nav entry, or move to `engdocs/`.
 - Update `docs/docs.json`.
 
-**Issue 15 — Rename `docs/internals/` → "How It Works" (or
-similar), promote `beads-topology.md` into the main IA.** Addresses
-F7.
+**Issue 15 — Rename `docs/internals/` → "How It Works" (or similar), promote `beads-topology.md` into the main IA.** Addresses F7.
 - Adjust framing from "not required" to operator-relevant.
 
-**Issue 16 — Move OMZ alias warning to top of Quickstart and
-expand troubleshooting catalog.** Addresses F11.
-- New runbooks (initial set): recovering from dolt corruption,
-  resetting a rig, debugging order triggers.
+**Issue 16 — Move OMZ alias warning to top of Quickstart and expand troubleshooting catalog.** Addresses F11.
+- New runbooks (initial set): recovering from dolt corruption, resetting a rig, debugging order triggers.
 
 ### 4.5 Milestone 5 — Scaling and integrations (P2)
 
-**Issue 17 — Multi-machine / Kubernetes deployment guide.**
-Addresses F9.
+**Issue 17 — Multi-machine / Kubernetes deployment guide.** Addresses F9.
 - Source: `engdocs/design/machine-wide-supervisor-v0.md`.
 
-**Issue 18 — Document hooks and external integrations.** Addresses
-F9.
-- Source: `engdocs/architecture/messaging.md`,
-  `engdocs/design/external-messaging-fabric.md`.
+**Issue 18 — Document hooks and external integrations.** Addresses F9.
+- Source: `engdocs/architecture/messaging.md`, `engdocs/design/external-messaging-fabric.md`.
 
 ---
 
 ## 5. Process
 
 1. Land this design doc as `Proposed`.
-2. Iterate on §2 (findings) and §4 (issue list) in this file until
-   the work plan is agreed.
+2. Iterate on §2 (findings) and §4 (issue list) in this file until the work plan is agreed.
 3. Cut the issues from §4. Each issue links back here for context.
 4. Flip status to `Accepted` once issues are filed.
 5. Flip individual items in §4 to checkboxes as their issues land.
-6. Flip the whole doc to `Implemented` when Milestones 1–3 are done.
-   Milestones 4–5 may continue independently.
+6. Flip the whole doc to `Implemented` when Milestones 1–3 are done. Milestones 4–5 may continue independently.
 
 ---
 
 ## 6. Open questions
 
-- **IA placement of the architecture overview and primitives
-  reference.** ~~Top-level `docs/concepts/`? Under `getting-started/`
-  so they're encountered before tutorials? Some hybrid (overview
-  in getting-started, primitives in concepts)?~~ **Resolved: both
-  pages land under top-level `docs/concepts/`.** Final paths:
-  `docs/concepts/architecture-overview.md` (Issue 1) and
-  `docs/concepts/primitives.md` (Issue 2).
+- **IA placement of the architecture overview and primitives reference.** ~~Top-level `docs/concepts/`? Under `getting-started/` so they're encountered before tutorials? Some hybrid (overview in getting-started, primitives in concepts)?~~ **Resolved: both pages land under top-level `docs/concepts/`.** Final paths: `docs/concepts/architecture-overview.md` (Issue 1) and `docs/concepts/primitives.md` (Issue 2).

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -268,7 +268,8 @@ Each issue cites the finding(s) it addresses by shortcode (F1, F2,
 ### 4.1 Milestone 1 — Stop the bleeding (P0)
 
 **Issue 1 — Architecture overview page + diagrams.** Addresses
-F1(a).
+F1(a). **Implemented:** [#2101](https://github.com/gastownhall/gascity/issues/2101)
+via [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
 - New page: `docs/concepts/architecture-overview.md`.
 - Top-down prose: what Gas City is, how the parts hang together,
   how work flows, how agents are kept alive and communicate.

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -154,7 +154,7 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 - Update `docs/index.mdx` and `docs/getting-started/coming-from-gastown.md` to link to this page instead of `engdocs/`.
 - Add to `docs/docs.json` nav.
 
-**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in lockstep with Issue 1. **Recorded:** [#3014](https://github.com/gastownhall/gascity/issues/3014). **Implemented:** TBD.
+**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in lockstep with Issue 1. **Recorded:** [#3014](https://github.com/gastownhall/gascity/issues/3014). **Implemented:** [PR #3034](https://github.com/gastownhall/gascity/pull/3034).
 - New page: `docs/concepts/primitives.md`.
 - Promote and rewrite `engdocs/architecture/nine-concepts.md` and `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.
@@ -164,7 +164,7 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 - Verify all cross-references (Tutorial 04+, guides) stay consistent.
 - Move existing PackV1 examples to a clearly-labeled appendix inside `guides/migrating-to-pack-vnext.md` (or remove if redundant with that guide).
 
-**Issue 4 — Refresh stale version strings and "contributors first" framing.** Addresses F12. **Recorded:** [#3015](https://github.com/gastownhall/gascity/issues/3015). **Implemented:** TBD.
+**Issue 4 — Refresh stale version strings and "contributors first" framing.** Addresses F12. **Recorded:** [#3015](https://github.com/gastownhall/gascity/issues/3015). **Implemented:** [PR #3044](https://github.com/gastownhall/gascity/pull/3044).
 - Update Tutorial 01 sample output (and any others) to v1.1.0.
 - Update `docs/index.mdx` opening framing to "user-first".
 - Sweep for any other stale concept names.

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -60,7 +60,7 @@ Existing published asset to cross-reference from the overview:
 
 [Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and [Tutorial 03 — Sessions](../../docs/tutorials/03-sessions.md) still use the legacy `[[agent]]` TOML blocks, while [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md) and [guides/shareable-packs.md](../../docs/guides/shareable-packs.md) teach the PackV2 `agents/<name>/` directory layout. A user following tutorials in order will write config that contradicts the migration guide they hit next.
 
-The project is currently at **v1.1.0**, well past the PackV2 cutover. PackV1 syntax in tutorials is unambiguous staleness, not a pre-release hedge.
+The project is currently at **v1.2.1**, well past the PackV2 cutover. PackV1 syntax in tutorials is unambiguous staleness, not a pre-release hedge.
 
 ### 2.3 F3 — Gas Town role recap missing (P1)
 
@@ -123,7 +123,7 @@ There is no canonical "minimal complete city" showing `pack.toml` + `city.toml` 
 
 ### 2.12 F12 — Staleness signals (P2)
 
-- [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md) shows version `v0.13.4` in sample output. Current tag is **v1.1.0** — eight minor versions behind.
+- [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md) shows version `v0.13.4` in sample output. Current tag is **v1.2.1** — eight minor versions behind.
 - [docs/index.mdx](../../docs/index.mdx) opens with "organized for external contributors first" — contradicts the goal of `docs/`.
 - General sweep needed for stale concept names (the former Agent Protocol primitive was removed `dd90ac0a` on 2026-03-08; user docs appear clean but worth a check).
 
@@ -136,7 +136,7 @@ Before issues are cut, the following are non-negotiable so individual PRs stay c
 1. **`docs/` is user-first.** No user-facing page may link into `engdocs/` as required reading. If `engdocs/` content is needed, promote it (with rewrite) into `docs/`.
 2. **One pack syntax in tutorials.** PackV2 (`agents/<name>/`) is canonical. PackV1 lives only in a clearly-labeled migration appendix.
 3. **Every concept page has a runnable example.** No conceptual page ships without at least one snippet a user can copy-paste.
-4. **Examples are versioned with the docs.** Reference output uses the current release (v1.1.0 at time of writing).
+4. **Examples are versioned with the docs.** Reference output uses the current release (v1.2.1 at time of writing).
 5. **`engdocs/` stays the source of truth for contributors.** When content is promoted, the original stays as a deeper contributor reference; the user-doc version links *back* (one-way).
 
 ---
@@ -165,7 +165,7 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 - Move existing PackV1 examples to a clearly-labeled appendix inside `guides/migrating-to-pack-vnext.md` (or remove if redundant with that guide).
 
 **Issue 4 — Refresh stale version strings and "contributors first" framing.** Addresses F12. **Recorded:** [#3015](https://github.com/gastownhall/gascity/issues/3015). **Implemented:** [PR #3044](https://github.com/gastownhall/gascity/pull/3044).
-- Update Tutorial 01 sample output (and any others) to v1.1.0.
+- Update Tutorial 01 sample output (and any others) to v1.2.1 .
 - Update `docs/index.mdx` opening framing to "user-first".
 - Sweep for any other stale concept names.
 

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -36,38 +36,60 @@ understand or operate Gas City.
 
 ---
 
-## 2. Findings (initial critical analysis)
+## 2. Findings
 
-Numbered for traceability into the work plan in §4. Severity:
-**P0** (blocks user onboarding), **P1** (significant friction), **P2**
-(polish / longer-term).
+Each finding is tagged **P0** (blocks user onboarding), **P1** (significant
+friction), or **P2** (polish / longer-term). Numbered for traceability
+into the work plan in §4.
 
-### F1 — Mental model lives in the wrong repo (P0)
+### 2.1 Finding 1 — No top-down view of how Gas City works (P0)
 
-The Nine Concepts (Session, Task Store, Event Bus, Config, Prompt
-Templates, Messaging, Formulas, Dispatch, Health Patrol) — the entire
-conceptual spine of the SDK — are documented in
-[engdocs/architecture/nine-concepts.md](../architecture/nine-concepts.md)
-and never explained in `docs/`.
+`docs/` has no high-level explanation of Gas City as an orchestrator.
+An engineer arriving cold cannot answer "what is this system, how do its
+parts hang together, how does a piece of work flow through it, how are
+agents spawned and kept alive, how do they talk to each other" from
+user docs alone.
 
-- [docs/index.mdx](../../docs/index.mdx) tells users to read `engdocs/`.
-- [docs/getting-started/coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
-  explicitly sends Gas Town migrators to
-  `engdocs/architecture/nine-concepts`.
+What's needed is two pages, both currently absent from `docs/`:
 
-Relevant engdocs source material that should be promoted/adapted:
+**(a) An architecture overview** — top-down prose plus at least two
+diagrams:
 
-- `engdocs/architecture/nine-concepts.md`
-- `engdocs/architecture/glossary.md`
-- `engdocs/architecture/life-of-a-bead.md`
-- `engdocs/architecture/life-of-a-molecule.md`
-- `engdocs/architecture/index.md`
+- **Structural diagram:** the components that exist (city → rigs →
+  agents → sessions; beads store; event bus; controller) and how they
+  connect.
+- **Interactional / lifecycle diagram:** how a piece of work flows
+  through the system — e.g. `gc sling` → bead created → agent
+  selected → session spawned → prompt rendered → nudge → completion
+  → events emitted. A health/keepalive flow (patrol → stall detection
+  → restart with backoff) is a strong candidate for a third diagram.
 
-These are written for contributors today; they need a user-tone
-rewrite (less "invariant" / "layer N", more "what this is and why
-you care").
+This is the page a user needs *first*, both to evaluate fit and to
+form a working mental model.
 
-### F2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
+**(b) A primitives reference** — the Nine Concepts (Session, Task
+Store, Event Bus, Config, Prompt Templates, Messaging, Formulas,
+Dispatch, Health Patrol) rewritten in user tone and positioned as a
+deeper reference *introduced by* the overview, not as the entry
+point. The Nine Concepts are bottom-up building blocks; they do not
+teach the system on their own.
+
+Both currently live only in `engdocs/architecture/` (contributor tone),
+and [docs/index.mdx](../../docs/index.mdx) plus
+[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
+send users there as required reading.
+
+Relevant engdocs source material to adapt:
+
+- `engdocs/architecture/index.md` — overview seed
+- `engdocs/architecture/life-of-a-bead.md`,
+  `engdocs/architecture/life-of-a-molecule.md` — interactional diagram
+- `engdocs/architecture/session.md`, `controller.md`,
+  `health-patrol.md` — "how agents are kept alive"
+- `engdocs/architecture/nine-concepts.md`, `glossary.md` — primitives
+  reference
+
+### 2.2 Finding 2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
 
 [Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and
 [Tutorial 03 — Sessions](../../docs/tutorials/03-sessions.md) still use
@@ -78,28 +100,63 @@ teach the PackV2 `agents/<name>/` directory layout. A user following
 tutorials in order will write config that contradicts the migration
 guide they hit next.
 
-Note: project is currently at **v1.1.0**, well past the PackV2 cutover.
+The project is currently at **v1.1.0**, well past the PackV2 cutover.
 PackV1 syntax in tutorials is unambiguous staleness, not a pre-release
 hedge.
 
-### F3 — Gas Town migration guide assumes you still remember Gas Town (P1)
+### 2.3 Finding 3 — Gas Town role recap missing (P1)
 
 [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
-maps roles ("Deacon watchdog logic → Controller and supervisor")
-without recalling what each Gas Town role actually *did*. A user who
-last touched Gas Town six months ago, or who is evaluating whether to
-migrate at all, cannot recover operational meaning from these mappings
-alone.
+maps Gas Town roles to Gas City equivalents without explaining what
+each role *did* operationally in Gas Town. A user who hasn't touched
+Gas Town recently — or who is *evaluating* whether to migrate at all —
+cannot recover operational meaning from a mapping alone. One paragraph
+per role (mayor, deacon, witness, refinery, polecat, crew, dog)
+describing its function in Gas Town is the minimum.
 
-### F4 — Migration guide points at files that aren't in the docs (P1)
+### 2.4 Finding 4 — Migration Concept Map mixes domains (P1)
 
-The "Fast Ramp Checklist" in `coming-from-gastown.md` references
-`examples/gastown/city.toml` and similar repo paths. These are not
-embedded in the rendered docs, nor linked as downloadable assets, nor
-guaranteed to exist at those paths. Users following the rendered site
-dead-end.
+The Concept Map table in `coming-from-gastown.md` jumbles at least
+four distinct domains into a single mapping:
 
-### F5 — Contributor material leaking into user docs (P1)
+- **Roles** — Mayor, Deacon, Witness, Refinery, Polecat, Crew, Dog
+  (things that *act*).
+- **Mechanisms / behaviors** — "Deacon watchdog logic", "Witness
+  lifecycle logic" (what those things *do*).
+- **Filesystem / state layout** — "Directory tree under `~/gt`"
+  (where state *lives*).
+- **Likely more** — commands, runtime artifacts, config file
+  shapes.
+
+Forcing the reader to disentangle domains while simultaneously
+learning the new system multiplies cognitive load. The fix is
+structural, not editorial: split into separate single-domain tables,
+each presented in a deliberate order (role recap → roles →
+mechanisms → filesystem/state → commands → workflows).
+
+### 2.5 Finding 5 — Workflow mapping missing (P1)
+
+The current migration guide is heavy on nouns (what *was* a mayor,
+what *is* an agent) and light on verbs (how do I *do* X in Gas City
+if I used to do it in Gas Town?). A workflow mapping table — e.g.
+"spin up a worker", "send a task", "inspect what's stuck", "restart a
+stalled agent", "share a config across teams" — is what a real
+migrator reaches for, and it does not exist today.
+
+Distinct from Finding 9 (workflow gaps in the *general* user docs):
+this finding is about *translation* of existing Gas Town habits;
+Finding 9 is about *operation* once on Gas City.
+
+### 2.6 Finding 6 — Migration guide points at files that aren't in the docs (P1)
+
+The "Fast Ramp Checklist" in
+[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
+references `examples/gastown/city.toml` and similar repo paths. These
+are not embedded in the rendered docs, nor linked as downloadable
+assets, nor guaranteed to exist at those paths. Users following the
+rendered site dead-end.
+
+### 2.7 Finding 7 — Contributor material leaking into user docs (P1)
 
 - [docs/packv2/](../../docs/packv2/) holds 9 files; only
   `migration.mdx` is in the user nav. The rest
@@ -113,7 +170,7 @@ dead-end.
   "organized for external contributors first" — wrong primary
   audience for `docs/`.
 
-### F6 — Reference docs are complete but not navigable (P1)
+### 2.8 Finding 8 — Reference docs are complete but not navigable (P1)
 
 - [reference/config.md](../../docs/reference/config.md): flat
   auto-generated field dump, no grouped "Common Patterns".
@@ -124,7 +181,7 @@ dead-end.
 - [reference/cli.md](../../docs/reference/cli.md): comprehensive but
   flat; no task-oriented entry points.
 
-### F7 — Significant workflow gaps (P1)
+### 2.9 Finding 9 — Significant workflow gaps in operating Gas City (P1)
 
 Things a real user will hit and not find:
 
@@ -135,21 +192,22 @@ Things a real user will hit and not find:
 - Choosing between crew (persistent) and polecats (on-demand).
 - Hooks and external integrations.
 - Multi-machine / Kubernetes deployment.
-- Health monitoring, what `gc doctor [--fix]` actually does.
+- Health monitoring; what `gc doctor [--fix]` actually does.
 
 Source material exists in `engdocs/architecture/` (e.g.
-`session.md`, `health-patrol.md`, `dispatch.md`, `prompt-templates.md`)
-and `engdocs/design/machine-wide-supervisor-v0.md` for scaling. None
-is promoted to user docs.
+`session.md`, `health-patrol.md`, `dispatch.md`,
+`prompt-templates.md`) and
+`engdocs/design/machine-wide-supervisor-v0.md` for scaling. None is
+promoted to user docs.
 
-### F8 — No full end-to-end example (P1)
+### 2.10 Finding 10 — No full end-to-end example (P1)
 
 There is no canonical "minimal complete city" showing `pack.toml` +
 `city.toml` + `agents/<name>/agent.toml` + `prompt.md` + a formula +
 an order, together. Each piece is shown in isolation across different
 tutorials; assembly is left to the reader.
 
-### F9 — Single-runbook troubleshooting catalog (P2)
+### 2.11 Finding 11 — Single-runbook troubleshooting catalog (P2)
 
 [docs/troubleshooting/](../../docs/troubleshooting/) holds one
 runbook (`dolt-bloat-recovery.md`). The Oh-My-Zsh `gc`-alias trap —
@@ -157,16 +215,16 @@ a real blocker for affected users — is in
 [getting-started/troubleshooting.md](../../docs/getting-started/troubleshooting.md)
 but should be a prerequisite check at the top of Quickstart.
 
-### F10 — Staleness signals (P2)
+### 2.12 Finding 12 — Staleness signals (P2)
 
 - [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md)
   shows version `v0.13.4` in sample output. Current tag is
-  **v1.1.0**.
-- [docs/index.mdx](../../docs/index.mdx): "organized for external
-  contributors first" — contradicts the goal of `docs/`.
-- General audit needed for stale concept names (the former Agent
+  **v1.1.0** — eight minor versions behind.
+- [docs/index.mdx](../../docs/index.mdx) opens with "organized for
+  external contributors first" — contradicts the goal of `docs/`.
+- General sweep needed for stale concept names (the former Agent
   Protocol primitive was removed `dd90ac0a` on 2026-03-08; user docs
-  appear clean but worth a sweep).
+  appear clean but worth a check).
 
 ---
 
@@ -184,9 +242,7 @@ PRs stay coherent:
 3. **Every concept page has a runnable example.** No conceptual page
    ships without at least one snippet a user can copy-paste.
 4. **Examples are versioned with the docs.** Reference output uses
-   the current release (v1.1.0 at time of writing). Add a CI check
-   that flags hard-coded version strings drifting from the current
-   tag (or use placeholder substitution at build time).
+   the current release (v1.1.0 at time of writing).
 5. **`engdocs/` stays the source of truth for contributors.** When
    content is promoted, the original stays as a deeper contributor
    reference; the user-doc version links *back* (one-way).
@@ -195,112 +251,137 @@ PRs stay coherent:
 
 ## 4. Work plan (candidate GitHub issues)
 
-This is the first cut. Each item below is sized roughly to be a single
-PR / issue. Grouped by milestone so we can sequence cleanly.
+This is the first cut. Each item below is sized roughly to be a
+single PR / issue. Grouped by milestone so we can sequence cleanly.
+Issue numbers track Finding numbers loosely but not strictly — some
+findings need multiple PRs, some PRs serve multiple findings.
 
-### Milestone 1 — Stop the bleeding (P0, blockers)
+### 4.1 Milestone 1 — Stop the bleeding (P0)
 
-**Issue 1.** *Add a user-facing "Mental Model" page to `docs/`.*
-- New page: `docs/concepts/mental-model.md` (or equivalent in IA).
-- Source: promote and rewrite `engdocs/architecture/nine-concepts.md`
-  and `glossary.md` for a user audience.
-- Update `docs/index.mdx` and `docs/getting-started/coming-from-gastown.md`
-  to link to the new page instead of `engdocs/`.
+**Issue 1 — Architecture overview page + diagrams.** Addresses
+Finding 1(a).
+- New page: `docs/concepts/architecture-overview.md` (path TBD —
+  see open question).
+- Top-down prose: what Gas City is, how the parts hang together,
+  how work flows, how agents are kept alive and communicate.
+- At least two diagrams (Mermaid, so they live in source):
+  structural and interactional. Health/keepalive a strong third.
+- Update `docs/index.mdx` and
+  `docs/getting-started/coming-from-gastown.md` to link to this
+  page instead of `engdocs/`.
 - Add to `docs/docs.json` nav.
 
-**Issue 2.** *Migrate Tutorials 02 and 03 to PackV2 syntax.*
-- Rewrite `agents/<name>/agent.toml` + `prompt.md` flow.
+**Issue 2 — Primitives reference page.** Addresses Finding 1(b).
+Lands in lockstep with Issue 1.
+- New page: `docs/concepts/primitives.md` (path TBD).
+- Promote and rewrite `engdocs/architecture/nine-concepts.md` and
+  `glossary.md` for a user audience.
+- Linked *from* the architecture overview, not the entry point.
+
+**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.**
+Addresses Finding 2.
+- Rewrite the `agents/<name>/agent.toml` + `prompt.md` flow.
 - Verify all cross-references (Tutorial 04+, guides) stay
   consistent.
-- Move the existing PackV1 examples to a clearly-labeled appendix
-  inside `guides/migrating-to-pack-vnext.md` (or kill if redundant
-  with that guide).
+- Move existing PackV1 examples to a clearly-labeled appendix
+  inside `guides/migrating-to-pack-vnext.md` (or remove if
+  redundant with that guide).
 
-**Issue 3.** *Refresh stale version strings and remove "contributors
-first" framing.*
+**Issue 4 — Refresh stale version strings and "contributors first"
+framing.** Addresses Finding 12.
 - Update Tutorial 01 sample output (and any others) to v1.1.0.
 - Update `docs/index.mdx` opening framing to "user-first".
-- Decide on version-substitution mechanism for future releases
-  (build-time replace vs. linting rule).
+- Sweep for any other stale concept names.
 
-### Milestone 2 — Migration realism (P1)
+### 4.2 Milestone 2 — Migration realism (P1)
 
-**Issue 4.** *Embed or link real example assets from
-`coming-from-gastown.md`.*
+**Issue 5 — Restructure `coming-from-gastown.md`.** Addresses
+Findings 3, 4, 5 in one coherent rewrite of the same file.
+- Add "Gas Town role recap" — one paragraph per role.
+- Split the single Concept Map into domain-scoped tables: roles,
+  mechanisms, filesystem/state, commands (existing), workflows
+  (new).
+- Add the workflow mapping table ("how I used to do X → how I do
+  X now").
+
+**Issue 6 — Embed or link real example assets.** Addresses
+Finding 6.
 - Replace dangling `examples/gastown/city.toml` references with
-  inline TOML blocks **or** downloadable links served by Mintlify.
+  inline TOML blocks **or** downloadable links served by
+  Mintlify.
 - Ensure offline / PDF rendering works.
 
-**Issue 5.** *Add a "Gas Town role recap" section to
-`coming-from-gastown.md`.*
-- One paragraph per Gas Town role (mayor, deacon, witness,
-  refinery, polecat, crew) explaining what it *did*, before the
-  mapping table.
-- Goal: usable as a standalone migration evaluation doc, not a
-  cheat sheet for people who already know.
-
-**Issue 6.** *Publish a "Complete Minimal City" example.*
-- New page under `docs/guides/` (or a top-level
+**Issue 7 — Publish a "Complete Minimal City" example.**
+Addresses Finding 10.
+- New page under `docs/guides/` (or top-level
   `docs/examples/minimal-city.md`).
 - Full tree: `pack.toml`, `city.toml`, `agents/<name>/`, one
   formula, one order — assembled, runnable end-to-end.
 - Link from index, quickstart, and Tutorial 07.
 
-### Milestone 3 — Reference & workflow gaps (P1)
+### 4.3 Milestone 3 — Reference & workflow gaps (P1)
 
-**Issue 7.** *Add "Common Config Patterns" to `reference/config.md`.*
+**Issue 8 — Add "Common Config Patterns" to
+`reference/config.md`.** Addresses Finding 8.
 - Hand-written grouped patterns above the auto-generated field
-  dump: changing beads provider, adding a rig, configuring pools,
-  overriding an agent's provider, etc.
+  dump: changing beads provider, adding a rig, configuring
+  pools, overriding an agent's provider, etc.
 
-**Issue 8.** *Expand `reference/formula.md` with conditions, loops,
-checks.*
-- Working examples of each. Source material:
+**Issue 9 — Expand `reference/formula.md` with conditions, loops,
+checks.** Addresses Finding 8.
+- Working examples of each. Source:
   `engdocs/architecture/formulas.md`,
   `engdocs/design/formula-v2-transient-retries.md`.
 
-**Issue 9.** *Add narrative API guide to `reference/api.md`.*
+**Issue 10 — Narrative API guide in `reference/api.md`.**
+Addresses Finding 8.
 - "How to query your city's state" walkthrough with curl + a tiny
   client snippet. Keep the OpenAPI link.
 
-**Issue 10.** *Add a "Debugging Sessions" guide.*
-- Cover `gc session peek` output, stuck-session detection, restart
+**Issue 11 — "Debugging Sessions" guide.** Addresses Finding 9.
+- `gc session peek` output, stuck-session detection, restart
   flow.
 - Source: `engdocs/architecture/session.md`,
-  `engdocs/contributors/reconciler-debugging.md` (sanitized for
-  users — the trace artifact workflow stays contributor-only).
+  `engdocs/contributors/reconciler-debugging.md` (sanitized — the
+  trace artifact workflow stays contributor-only).
 
-**Issue 11.** *Add a "Choosing crew vs. polecats" guide.*
+**Issue 12 — "Choosing crew vs. polecats" guide.** Addresses
+Finding 9.
 - Decision criteria and config snippets.
 - Source: `engdocs/architecture/session.md`,
   `engdocs/design/agent-pools.md`.
 
-**Issue 12.** *Add a "Writing your first agent prompt" guide.*
+**Issue 13 — "Writing your first agent prompt" guide.** Addresses
+Finding 9.
 - Template variables, GUPP principle in user terms, examples.
 - Source: `engdocs/architecture/prompt-templates.md`.
 
-### Milestone 4 — IA cleanup (P1/P2)
+### 4.4 Milestone 4 — IA cleanup (P1/P2)
 
-**Issue 13.** *Audit and reclassify `docs/packv2/`.*
-- For each of the 8 unlinked files: promote into Guides/Reference
-  with proper nav entry, or move to `engdocs/`.
+**Issue 14 — Audit and reclassify `docs/packv2/`.** Addresses
+Finding 7.
+- For each of the unlinked files: promote into Guides/Reference
+  with a proper nav entry, or move to `engdocs/`.
 - Update `docs/docs.json`.
 
-**Issue 14.** *Rename `docs/internals/` → "How It Works" (or
-similar), and promote `beads-topology.md` into the main IA.*
+**Issue 15 — Rename `docs/internals/` → "How It Works" (or
+similar), promote `beads-topology.md` into the main IA.** Addresses
+Finding 7.
 - Adjust framing from "not required" to operator-relevant.
 
-**Issue 15.** *Move OMZ alias warning to top of Quickstart and
-expand troubleshooting catalog.*
+**Issue 16 — Move OMZ alias warning to top of Quickstart and
+expand troubleshooting catalog.** Addresses Finding 11.
 - New runbooks (initial set): recovering from dolt corruption,
   resetting a rig, debugging order triggers.
 
-### Milestone 5 — Scaling and integrations (P2)
+### 4.5 Milestone 5 — Scaling and integrations (P2)
 
-**Issue 16.** *Add a multi-machine / Kubernetes deployment guide.*
+**Issue 17 — Multi-machine / Kubernetes deployment guide.**
+Addresses Finding 9.
 - Source: `engdocs/design/machine-wide-supervisor-v0.md`.
 
-**Issue 17.** *Document hooks and external integrations.*
+**Issue 18 — Document hooks and external integrations.** Addresses
+Finding 9.
 - Source: `engdocs/architecture/messaging.md`,
   `engdocs/design/external-messaging-fabric.md`.
 
@@ -309,26 +390,20 @@ expand troubleshooting catalog.*
 ## 5. Process
 
 1. Land this design doc as `Proposed`.
-2. Iterate on §4 (issue list) in this file until the work plan is
-   agreed.
+2. Iterate on §2 (findings) and §4 (issue list) in this file until
+   the work plan is agreed.
 3. Cut the issues from §4. Each issue links back here for context.
 4. Flip status to `Accepted` once issues are filed.
 5. Flip individual items in §4 to checkboxes as their issues land.
-6. Flip whole doc to `Implemented` when Milestones 1–3 are done.
+6. Flip the whole doc to `Implemented` when Milestones 1–3 are done.
    Milestones 4–5 may continue independently.
 
 ---
 
 ## 6. Open questions
 
-- Should the "Mental Model" page live under a new `concepts/` section
-  in the nav, or as `getting-started/mental-model.md` so it's
-  encountered earlier?
-- Do we want Mintlify "snippets" / includes for shared TOML
-  examples, so the minimal-city tree and tutorial examples don't
-  drift?
-- Is there a version-substitution mechanism already used in
-  `make check-docs`, or do we need to add one?
-- For Gas Town migration: do we keep `coming-from-gastown.md` as a
-  single long page, or split into "Concept Map" + "Command Cheat
-  Sheet" + "Fast Ramp Checklist"?
+- **IA placement of the architecture overview and primitives
+  reference.** Top-level `docs/concepts/`? Under `getting-started/`
+  so they're encountered before tutorials? Some hybrid (overview
+  in getting-started, primitives in concepts)? Resolving this also
+  determines the final file paths used in Issues 1 and 2.

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -39,10 +39,12 @@ understand or operate Gas City.
 ## 2. Findings
 
 Each finding is tagged **P0** (blocks user onboarding), **P1** (significant
-friction), or **P2** (polish / longer-term). Numbered for traceability
-into the work plan in §4.
+friction), or **P2** (polish / longer-term). Findings carry a shortcode
+(**F1**, **F2**, …, **F12**) used throughout the rest of this document —
+in particular, work-plan issues in §4 cite the findings they address by
+shortcode.
 
-### 2.1 Finding 1 — No top-down view of how Gas City works (P0)
+### 2.1 F1 — No top-down view of how Gas City works (P0)
 
 `docs/` has no high-level explanation of Gas City as an orchestrator.
 An engineer arriving cold cannot answer "what is this system, how do its
@@ -89,7 +91,7 @@ Relevant engdocs source material to adapt:
 - `engdocs/architecture/nine-concepts.md`, `glossary.md` — primitives
   reference
 
-### 2.2 Finding 2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
+### 2.2 F2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
 
 [Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and
 [Tutorial 03 — Sessions](../../docs/tutorials/03-sessions.md) still use
@@ -104,7 +106,7 @@ The project is currently at **v1.1.0**, well past the PackV2 cutover.
 PackV1 syntax in tutorials is unambiguous staleness, not a pre-release
 hedge.
 
-### 2.3 Finding 3 — Gas Town role recap missing (P1)
+### 2.3 F3 — Gas Town role recap missing (P1)
 
 [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
 maps Gas Town roles to Gas City equivalents without explaining what
@@ -114,7 +116,7 @@ cannot recover operational meaning from a mapping alone. One paragraph
 per role (mayor, deacon, witness, refinery, polecat, crew, dog)
 describing its function in Gas Town is the minimum.
 
-### 2.4 Finding 4 — Migration Concept Map mixes domains (P1)
+### 2.4 F4 — Migration Concept Map mixes domains (P1)
 
 The Concept Map table in `coming-from-gastown.md` jumbles at least
 four distinct domains into a single mapping:
@@ -134,7 +136,7 @@ structural, not editorial: split into separate single-domain tables,
 each presented in a deliberate order (role recap → roles →
 mechanisms → filesystem/state → commands → workflows).
 
-### 2.5 Finding 5 — Workflow mapping missing (P1)
+### 2.5 F5 — Workflow mapping missing (P1)
 
 The current migration guide is heavy on nouns (what *was* a mayor,
 what *is* an agent) and light on verbs (how do I *do* X in Gas City
@@ -143,11 +145,11 @@ if I used to do it in Gas Town?). A workflow mapping table — e.g.
 stalled agent", "share a config across teams" — is what a real
 migrator reaches for, and it does not exist today.
 
-Distinct from Finding 9 (workflow gaps in the *general* user docs):
-this finding is about *translation* of existing Gas Town habits;
-Finding 9 is about *operation* once on Gas City.
+Distinct from F9 (workflow gaps in the *general* user docs): F5 is
+about *translation* of existing Gas Town habits; F9 is about
+*operation* once on Gas City.
 
-### 2.6 Finding 6 — Migration guide points at files that aren't in the docs (P1)
+### 2.6 F6 — Migration guide points at files that aren't in the docs (P1)
 
 The "Fast Ramp Checklist" in
 [coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
@@ -156,7 +158,7 @@ are not embedded in the rendered docs, nor linked as downloadable
 assets, nor guaranteed to exist at those paths. Users following the
 rendered site dead-end.
 
-### 2.7 Finding 7 — Contributor material leaking into user docs (P1)
+### 2.7 F7 — Contributor material leaking into user docs (P1)
 
 - [docs/packv2/](../../docs/packv2/) holds 9 files; only
   `migration.mdx` is in the user nav. The rest
@@ -170,7 +172,7 @@ rendered site dead-end.
   "organized for external contributors first" — wrong primary
   audience for `docs/`.
 
-### 2.8 Finding 8 — Reference docs are complete but not navigable (P1)
+### 2.8 F8 — Reference docs are complete but not navigable (P1)
 
 - [reference/config.md](../../docs/reference/config.md): flat
   auto-generated field dump, no grouped "Common Patterns".
@@ -181,7 +183,7 @@ rendered site dead-end.
 - [reference/cli.md](../../docs/reference/cli.md): comprehensive but
   flat; no task-oriented entry points.
 
-### 2.9 Finding 9 — Significant workflow gaps in operating Gas City (P1)
+### 2.9 F9 — Significant workflow gaps in operating Gas City (P1)
 
 Things a real user will hit and not find:
 
@@ -200,14 +202,14 @@ Source material exists in `engdocs/architecture/` (e.g.
 `engdocs/design/machine-wide-supervisor-v0.md` for scaling. None is
 promoted to user docs.
 
-### 2.10 Finding 10 — No full end-to-end example (P1)
+### 2.10 F10 — No full end-to-end example (P1)
 
 There is no canonical "minimal complete city" showing `pack.toml` +
 `city.toml` + `agents/<name>/agent.toml` + `prompt.md` + a formula +
 an order, together. Each piece is shown in isolation across different
 tutorials; assembly is left to the reader.
 
-### 2.11 Finding 11 — Single-runbook troubleshooting catalog (P2)
+### 2.11 F11 — Single-runbook troubleshooting catalog (P2)
 
 [docs/troubleshooting/](../../docs/troubleshooting/) holds one
 runbook (`dolt-bloat-recovery.md`). The Oh-My-Zsh `gc`-alias trap —
@@ -215,7 +217,7 @@ a real blocker for affected users — is in
 [getting-started/troubleshooting.md](../../docs/getting-started/troubleshooting.md)
 but should be a prerequisite check at the top of Quickstart.
 
-### 2.12 Finding 12 — Staleness signals (P2)
+### 2.12 F12 — Staleness signals (P2)
 
 - [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md)
   shows version `v0.13.4` in sample output. Current tag is
@@ -253,13 +255,13 @@ PRs stay coherent:
 
 This is the first cut. Each item below is sized roughly to be a
 single PR / issue. Grouped by milestone so we can sequence cleanly.
-Issue numbers track Finding numbers loosely but not strictly — some
-findings need multiple PRs, some PRs serve multiple findings.
+Each issue cites the finding(s) it addresses by shortcode (F1, F2,
+…); the mapping is not strictly 1:1.
 
 ### 4.1 Milestone 1 — Stop the bleeding (P0)
 
 **Issue 1 — Architecture overview page + diagrams.** Addresses
-Finding 1(a).
+F1(a).
 - New page: `docs/concepts/architecture-overview.md` (path TBD —
   see open question).
 - Top-down prose: what Gas City is, how the parts hang together,
@@ -271,15 +273,15 @@ Finding 1(a).
   page instead of `engdocs/`.
 - Add to `docs/docs.json` nav.
 
-**Issue 2 — Primitives reference page.** Addresses Finding 1(b).
-Lands in lockstep with Issue 1.
+**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in
+lockstep with Issue 1.
 - New page: `docs/concepts/primitives.md` (path TBD).
 - Promote and rewrite `engdocs/architecture/nine-concepts.md` and
   `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.
 
 **Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.**
-Addresses Finding 2.
+Addresses F2.
 - Rewrite the `agents/<name>/agent.toml` + `prompt.md` flow.
 - Verify all cross-references (Tutorial 04+, guides) stay
   consistent.
@@ -288,15 +290,15 @@ Addresses Finding 2.
   redundant with that guide).
 
 **Issue 4 — Refresh stale version strings and "contributors first"
-framing.** Addresses Finding 12.
+framing.** Addresses F12.
 - Update Tutorial 01 sample output (and any others) to v1.1.0.
 - Update `docs/index.mdx` opening framing to "user-first".
 - Sweep for any other stale concept names.
 
 ### 4.2 Milestone 2 — Migration realism (P1)
 
-**Issue 5 — Restructure `coming-from-gastown.md`.** Addresses
-Findings 3, 4, 5 in one coherent rewrite of the same file.
+**Issue 5 — Restructure `coming-from-gastown.md`.** Addresses F3,
+F4, F5 in one coherent rewrite of the same file.
 - Add "Gas Town role recap" — one paragraph per role.
 - Split the single Concept Map into domain-scoped tables: roles,
   mechanisms, filesystem/state, commands (existing), workflows
@@ -304,15 +306,14 @@ Findings 3, 4, 5 in one coherent rewrite of the same file.
 - Add the workflow mapping table ("how I used to do X → how I do
   X now").
 
-**Issue 6 — Embed or link real example assets.** Addresses
-Finding 6.
+**Issue 6 — Embed or link real example assets.** Addresses F6.
 - Replace dangling `examples/gastown/city.toml` references with
   inline TOML blocks **or** downloadable links served by
   Mintlify.
 - Ensure offline / PDF rendering works.
 
 **Issue 7 — Publish a "Complete Minimal City" example.**
-Addresses Finding 10.
+Addresses F10.
 - New page under `docs/guides/` (or top-level
   `docs/examples/minimal-city.md`).
 - Full tree: `pack.toml`, `city.toml`, `agents/<name>/`, one
@@ -322,66 +323,64 @@ Addresses Finding 10.
 ### 4.3 Milestone 3 — Reference & workflow gaps (P1)
 
 **Issue 8 — Add "Common Config Patterns" to
-`reference/config.md`.** Addresses Finding 8.
+`reference/config.md`.** Addresses F8.
 - Hand-written grouped patterns above the auto-generated field
   dump: changing beads provider, adding a rig, configuring
   pools, overriding an agent's provider, etc.
 
 **Issue 9 — Expand `reference/formula.md` with conditions, loops,
-checks.** Addresses Finding 8.
+checks.** Addresses F8.
 - Working examples of each. Source:
   `engdocs/architecture/formulas.md`,
   `engdocs/design/formula-v2-transient-retries.md`.
 
 **Issue 10 — Narrative API guide in `reference/api.md`.**
-Addresses Finding 8.
+Addresses F8.
 - "How to query your city's state" walkthrough with curl + a tiny
   client snippet. Keep the OpenAPI link.
 
-**Issue 11 — "Debugging Sessions" guide.** Addresses Finding 9.
+**Issue 11 — "Debugging Sessions" guide.** Addresses F9.
 - `gc session peek` output, stuck-session detection, restart
   flow.
 - Source: `engdocs/architecture/session.md`,
   `engdocs/contributors/reconciler-debugging.md` (sanitized — the
   trace artifact workflow stays contributor-only).
 
-**Issue 12 — "Choosing crew vs. polecats" guide.** Addresses
-Finding 9.
+**Issue 12 — "Choosing crew vs. polecats" guide.** Addresses F9.
 - Decision criteria and config snippets.
 - Source: `engdocs/architecture/session.md`,
   `engdocs/design/agent-pools.md`.
 
 **Issue 13 — "Writing your first agent prompt" guide.** Addresses
-Finding 9.
+F9.
 - Template variables, GUPP principle in user terms, examples.
 - Source: `engdocs/architecture/prompt-templates.md`.
 
 ### 4.4 Milestone 4 — IA cleanup (P1/P2)
 
-**Issue 14 — Audit and reclassify `docs/packv2/`.** Addresses
-Finding 7.
+**Issue 14 — Audit and reclassify `docs/packv2/`.** Addresses F7.
 - For each of the unlinked files: promote into Guides/Reference
   with a proper nav entry, or move to `engdocs/`.
 - Update `docs/docs.json`.
 
 **Issue 15 — Rename `docs/internals/` → "How It Works" (or
 similar), promote `beads-topology.md` into the main IA.** Addresses
-Finding 7.
+F7.
 - Adjust framing from "not required" to operator-relevant.
 
 **Issue 16 — Move OMZ alias warning to top of Quickstart and
-expand troubleshooting catalog.** Addresses Finding 11.
+expand troubleshooting catalog.** Addresses F11.
 - New runbooks (initial set): recovering from dolt corruption,
   resetting a rig, debugging order triggers.
 
 ### 4.5 Milestone 5 — Scaling and integrations (P2)
 
 **Issue 17 — Multi-machine / Kubernetes deployment guide.**
-Addresses Finding 9.
+Addresses F9.
 - Source: `engdocs/design/machine-wide-supervisor-v0.md`.
 
 **Issue 18 — Document hooks and external integrations.** Addresses
-Finding 9.
+F9.
 - Source: `engdocs/architecture/messaging.md`,
   `engdocs/design/external-messaging-fabric.md`.
 

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -1,0 +1,334 @@
+---
+title: User Docs Overhaul
+description: Plan to make `docs/` usable for end users — especially Gas Town users migrating to Gas City — rather than a half-contributor half-user mix.
+status: Proposed
+---
+
+# User Docs Overhaul
+
+**Status:** Proposed — first draft, expected to evolve before issues are cut.
+
+**Audience this plan targets:** engineers who want to *use* Gas City (not
+contribute to it). The motivating persona is a Gas Town user evaluating or
+executing a switch to Gas City.
+
+**Scope:** `docs/` (the Mintlify site). Contributor material in `engdocs/`
+is in scope only as a *source* — content that should be promoted, adapted,
+or referenced from `docs/`.
+
+**Out of scope:** contributor-facing docs in `engdocs/`, CLAUDE/AGENTS
+files, internal architecture rewrites.
+
+---
+
+## 1. Premise
+
+The current `docs/` tree is roughly 75% solid: installation, quickstart,
+and the seven tutorials work and are progressive. But the conceptual
+foundation lives in `engdocs/` (contributor docs), tutorials are split
+between PackV1 and PackV2 syntax, and several user-facing pages still
+send users into `engdocs/`. A new user — especially a Gas Town migrator —
+will bounce between conflicting sources.
+
+The goal of this overhaul is to make `docs/` self-sufficient for users:
+no link to `engdocs/` from a user-facing page should be required to
+understand or operate Gas City.
+
+---
+
+## 2. Findings (initial critical analysis)
+
+Numbered for traceability into the work plan in §4. Severity:
+**P0** (blocks user onboarding), **P1** (significant friction), **P2**
+(polish / longer-term).
+
+### F1 — Mental model lives in the wrong repo (P0)
+
+The Nine Concepts (Session, Task Store, Event Bus, Config, Prompt
+Templates, Messaging, Formulas, Dispatch, Health Patrol) — the entire
+conceptual spine of the SDK — are documented in
+[engdocs/architecture/nine-concepts.md](../architecture/nine-concepts.md)
+and never explained in `docs/`.
+
+- [docs/index.mdx](../../docs/index.mdx) tells users to read `engdocs/`.
+- [docs/getting-started/coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
+  explicitly sends Gas Town migrators to
+  `engdocs/architecture/nine-concepts`.
+
+Relevant engdocs source material that should be promoted/adapted:
+
+- `engdocs/architecture/nine-concepts.md`
+- `engdocs/architecture/glossary.md`
+- `engdocs/architecture/life-of-a-bead.md`
+- `engdocs/architecture/life-of-a-molecule.md`
+- `engdocs/architecture/index.md`
+
+These are written for contributors today; they need a user-tone
+rewrite (less "invariant" / "layer N", more "what this is and why
+you care").
+
+### F2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
+
+[Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and
+[Tutorial 03 — Sessions](../../docs/tutorials/03-sessions.md) still use
+the legacy `[[agent]]` TOML blocks, while
+[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
+and [guides/shareable-packs.md](../../docs/guides/shareable-packs.md)
+teach the PackV2 `agents/<name>/` directory layout. A user following
+tutorials in order will write config that contradicts the migration
+guide they hit next.
+
+Note: project is currently at **v1.1.0**, well past the PackV2 cutover.
+PackV1 syntax in tutorials is unambiguous staleness, not a pre-release
+hedge.
+
+### F3 — Gas Town migration guide assumes you still remember Gas Town (P1)
+
+[coming-from-gastown.md](../../docs/getting-started/coming-from-gastown.md)
+maps roles ("Deacon watchdog logic → Controller and supervisor")
+without recalling what each Gas Town role actually *did*. A user who
+last touched Gas Town six months ago, or who is evaluating whether to
+migrate at all, cannot recover operational meaning from these mappings
+alone.
+
+### F4 — Migration guide points at files that aren't in the docs (P1)
+
+The "Fast Ramp Checklist" in `coming-from-gastown.md` references
+`examples/gastown/city.toml` and similar repo paths. These are not
+embedded in the rendered docs, nor linked as downloadable assets, nor
+guaranteed to exist at those paths. Users following the rendered site
+dead-end.
+
+### F5 — Contributor material leaking into user docs (P1)
+
+- [docs/packv2/](../../docs/packv2/) holds 9 files; only
+  `migration.mdx` is in the user nav. The rest
+  (`doc-pack-v2.md`, `doc-agent-v2.md`, `doc-loader-v2.md`,
+  `doc-rig-binding-phases.md`, `doc-conformance-matrix.md`,
+  `doc-consistency-audit.md`, `doc-packman.md`, `doc-commands.md`,
+  `skew-analysis.md`) read as contributor scratch.
+- [docs/internals/](../../docs/internals/) is labeled "not required
+  reading" but `beads-topology.md` is exactly what an operator needs.
+- [docs/index.mdx](../../docs/index.mdx) literally states the tree is
+  "organized for external contributors first" — wrong primary
+  audience for `docs/`.
+
+### F6 — Reference docs are complete but not navigable (P1)
+
+- [reference/config.md](../../docs/reference/config.md): flat
+  auto-generated field dump, no grouped "Common Patterns".
+- [reference/formula.md](../../docs/reference/formula.md): mentions
+  conditions/loops/checks but never shows a working example.
+- [reference/api.md](../../docs/reference/api.md): points at OpenAPI
+  with no "how do I query my city" narrative.
+- [reference/cli.md](../../docs/reference/cli.md): comprehensive but
+  flat; no task-oriented entry points.
+
+### F7 — Significant workflow gaps (P1)
+
+Things a real user will hit and not find:
+
+- How to write a first agent prompt from scratch (template variables,
+  prompt design).
+- Debugging a stuck or failing session (`gc session peek` output,
+  detection, kill/restart).
+- Choosing between crew (persistent) and polecats (on-demand).
+- Hooks and external integrations.
+- Multi-machine / Kubernetes deployment.
+- Health monitoring, what `gc doctor [--fix]` actually does.
+
+Source material exists in `engdocs/architecture/` (e.g.
+`session.md`, `health-patrol.md`, `dispatch.md`, `prompt-templates.md`)
+and `engdocs/design/machine-wide-supervisor-v0.md` for scaling. None
+is promoted to user docs.
+
+### F8 — No full end-to-end example (P1)
+
+There is no canonical "minimal complete city" showing `pack.toml` +
+`city.toml` + `agents/<name>/agent.toml` + `prompt.md` + a formula +
+an order, together. Each piece is shown in isolation across different
+tutorials; assembly is left to the reader.
+
+### F9 — Single-runbook troubleshooting catalog (P2)
+
+[docs/troubleshooting/](../../docs/troubleshooting/) holds one
+runbook (`dolt-bloat-recovery.md`). The Oh-My-Zsh `gc`-alias trap —
+a real blocker for affected users — is in
+[getting-started/troubleshooting.md](../../docs/getting-started/troubleshooting.md)
+but should be a prerequisite check at the top of Quickstart.
+
+### F10 — Staleness signals (P2)
+
+- [Tutorial 01 line ~26](../../docs/tutorials/01-cities-and-rigs.md)
+  shows version `v0.13.4` in sample output. Current tag is
+  **v1.1.0**.
+- [docs/index.mdx](../../docs/index.mdx): "organized for external
+  contributors first" — contradicts the goal of `docs/`.
+- General audit needed for stale concept names (the former Agent
+  Protocol primitive was removed `dd90ac0a` on 2026-03-08; user docs
+  appear clean but worth a sweep).
+
+---
+
+## 3. Cross-cutting principles for the overhaul
+
+Before issues are cut, the following are non-negotiable so individual
+PRs stay coherent:
+
+1. **`docs/` is user-first.** No user-facing page may link into
+   `engdocs/` as required reading. If `engdocs/` content is needed,
+   promote it (with rewrite) into `docs/`.
+2. **One pack syntax in tutorials.** PackV2 (`agents/<name>/`) is
+   canonical. PackV1 lives only in a clearly-labeled migration
+   appendix.
+3. **Every concept page has a runnable example.** No conceptual page
+   ships without at least one snippet a user can copy-paste.
+4. **Examples are versioned with the docs.** Reference output uses
+   the current release (v1.1.0 at time of writing). Add a CI check
+   that flags hard-coded version strings drifting from the current
+   tag (or use placeholder substitution at build time).
+5. **`engdocs/` stays the source of truth for contributors.** When
+   content is promoted, the original stays as a deeper contributor
+   reference; the user-doc version links *back* (one-way).
+
+---
+
+## 4. Work plan (candidate GitHub issues)
+
+This is the first cut. Each item below is sized roughly to be a single
+PR / issue. Grouped by milestone so we can sequence cleanly.
+
+### Milestone 1 — Stop the bleeding (P0, blockers)
+
+**Issue 1.** *Add a user-facing "Mental Model" page to `docs/`.*
+- New page: `docs/concepts/mental-model.md` (or equivalent in IA).
+- Source: promote and rewrite `engdocs/architecture/nine-concepts.md`
+  and `glossary.md` for a user audience.
+- Update `docs/index.mdx` and `docs/getting-started/coming-from-gastown.md`
+  to link to the new page instead of `engdocs/`.
+- Add to `docs/docs.json` nav.
+
+**Issue 2.** *Migrate Tutorials 02 and 03 to PackV2 syntax.*
+- Rewrite `agents/<name>/agent.toml` + `prompt.md` flow.
+- Verify all cross-references (Tutorial 04+, guides) stay
+  consistent.
+- Move the existing PackV1 examples to a clearly-labeled appendix
+  inside `guides/migrating-to-pack-vnext.md` (or kill if redundant
+  with that guide).
+
+**Issue 3.** *Refresh stale version strings and remove "contributors
+first" framing.*
+- Update Tutorial 01 sample output (and any others) to v1.1.0.
+- Update `docs/index.mdx` opening framing to "user-first".
+- Decide on version-substitution mechanism for future releases
+  (build-time replace vs. linting rule).
+
+### Milestone 2 — Migration realism (P1)
+
+**Issue 4.** *Embed or link real example assets from
+`coming-from-gastown.md`.*
+- Replace dangling `examples/gastown/city.toml` references with
+  inline TOML blocks **or** downloadable links served by Mintlify.
+- Ensure offline / PDF rendering works.
+
+**Issue 5.** *Add a "Gas Town role recap" section to
+`coming-from-gastown.md`.*
+- One paragraph per Gas Town role (mayor, deacon, witness,
+  refinery, polecat, crew) explaining what it *did*, before the
+  mapping table.
+- Goal: usable as a standalone migration evaluation doc, not a
+  cheat sheet for people who already know.
+
+**Issue 6.** *Publish a "Complete Minimal City" example.*
+- New page under `docs/guides/` (or a top-level
+  `docs/examples/minimal-city.md`).
+- Full tree: `pack.toml`, `city.toml`, `agents/<name>/`, one
+  formula, one order — assembled, runnable end-to-end.
+- Link from index, quickstart, and Tutorial 07.
+
+### Milestone 3 — Reference & workflow gaps (P1)
+
+**Issue 7.** *Add "Common Config Patterns" to `reference/config.md`.*
+- Hand-written grouped patterns above the auto-generated field
+  dump: changing beads provider, adding a rig, configuring pools,
+  overriding an agent's provider, etc.
+
+**Issue 8.** *Expand `reference/formula.md` with conditions, loops,
+checks.*
+- Working examples of each. Source material:
+  `engdocs/architecture/formulas.md`,
+  `engdocs/design/formula-v2-transient-retries.md`.
+
+**Issue 9.** *Add narrative API guide to `reference/api.md`.*
+- "How to query your city's state" walkthrough with curl + a tiny
+  client snippet. Keep the OpenAPI link.
+
+**Issue 10.** *Add a "Debugging Sessions" guide.*
+- Cover `gc session peek` output, stuck-session detection, restart
+  flow.
+- Source: `engdocs/architecture/session.md`,
+  `engdocs/contributors/reconciler-debugging.md` (sanitized for
+  users — the trace artifact workflow stays contributor-only).
+
+**Issue 11.** *Add a "Choosing crew vs. polecats" guide.*
+- Decision criteria and config snippets.
+- Source: `engdocs/architecture/session.md`,
+  `engdocs/design/agent-pools.md`.
+
+**Issue 12.** *Add a "Writing your first agent prompt" guide.*
+- Template variables, GUPP principle in user terms, examples.
+- Source: `engdocs/architecture/prompt-templates.md`.
+
+### Milestone 4 — IA cleanup (P1/P2)
+
+**Issue 13.** *Audit and reclassify `docs/packv2/`.*
+- For each of the 8 unlinked files: promote into Guides/Reference
+  with proper nav entry, or move to `engdocs/`.
+- Update `docs/docs.json`.
+
+**Issue 14.** *Rename `docs/internals/` → "How It Works" (or
+similar), and promote `beads-topology.md` into the main IA.*
+- Adjust framing from "not required" to operator-relevant.
+
+**Issue 15.** *Move OMZ alias warning to top of Quickstart and
+expand troubleshooting catalog.*
+- New runbooks (initial set): recovering from dolt corruption,
+  resetting a rig, debugging order triggers.
+
+### Milestone 5 — Scaling and integrations (P2)
+
+**Issue 16.** *Add a multi-machine / Kubernetes deployment guide.*
+- Source: `engdocs/design/machine-wide-supervisor-v0.md`.
+
+**Issue 17.** *Document hooks and external integrations.*
+- Source: `engdocs/architecture/messaging.md`,
+  `engdocs/design/external-messaging-fabric.md`.
+
+---
+
+## 5. Process
+
+1. Land this design doc as `Proposed`.
+2. Iterate on §4 (issue list) in this file until the work plan is
+   agreed.
+3. Cut the issues from §4. Each issue links back here for context.
+4. Flip status to `Accepted` once issues are filed.
+5. Flip individual items in §4 to checkboxes as their issues land.
+6. Flip whole doc to `Implemented` when Milestones 1–3 are done.
+   Milestones 4–5 may continue independently.
+
+---
+
+## 6. Open questions
+
+- Should the "Mental Model" page live under a new `concepts/` section
+  in the nav, or as `getting-started/mental-model.md` so it's
+  encountered earlier?
+- Do we want Mintlify "snippets" / includes for shared TOML
+  examples, so the minimal-city tree and tutorial examples don't
+  drift?
+- Is there a version-substitution mechanism already used in
+  `make check-docs`, or do we need to add one?
+- For Gas Town migration: do we keep `coming-from-gastown.md` as a
+  single long page, or split into "Concept Map" + "Command Cheat
+  Sheet" + "Fast Ramp Checklist"?

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -147,7 +147,7 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 
 ### 4.1 Milestone 1 — Stop the bleeding (P0)
 
-**Issue 1 — Architecture overview page + diagrams.** Addresses F1(a). **Implemented:** [#2101](https://github.com/gastownhall/gascity/issues/2101) via [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
+**Issue 1 — Architecture overview page + diagrams.** Addresses F1(a). **Recorded as** [#2101](https://github.com/gastownhall/gascity/issues/2101). **Implemented via** [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
 - New page: `docs/concepts/architecture-overview.md`.
 - Top-down prose: what Gas City is, how the parts hang together, how work flows, how agents are kept alive and communicate.
 - At least two diagrams (Excalidraw — see [`engdocs/proposals/excalidraw-diagrams.md`](../proposals/excalidraw-diagrams.md) for toolchain and authoring workflow): structural and interactional. Health/keepalive a strong third.
@@ -159,12 +159,12 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 - Promote and rewrite `engdocs/architecture/nine-concepts.md` and `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.
 
-**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.** Addresses F2.
+**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.** Addresses F2. **Recorded:** [#3013](https://github.com/gastownhall/gascity/issues/3013). **Implemented:** TBD.
 - Rewrite the `agents/<name>/agent.toml` + `prompt.md` flow.
 - Verify all cross-references (Tutorial 04+, guides) stay consistent.
 - Move existing PackV1 examples to a clearly-labeled appendix inside `guides/migrating-to-pack-vnext.md` (or remove if redundant with that guide).
 
-**Issue 4 — Refresh stale version strings and "contributors first" framing.** Addresses F12.
+**Issue 4 — Refresh stale version strings and "contributors first" framing.** Addresses F12. **Recorded:** [#3015](https://github.com/gastownhall/gascity/issues/3015). **Implemented:** TBD.
 - Update Tutorial 01 sample output (and any others) to v1.1.0.
 - Update `docs/index.mdx` opening framing to "user-first".
 - Sweep for any other stale concept names.

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -272,7 +272,9 @@ F1(a).
 - New page: `docs/concepts/architecture-overview.md`.
 - Top-down prose: what Gas City is, how the parts hang together,
   how work flows, how agents are kept alive and communicate.
-- At least two diagrams (Mermaid, so they live in source):
+- At least two diagrams (Excalidraw — see
+  [`engdocs/proposals/excalidraw-diagrams.md`](../proposals/excalidraw-diagrams.md)
+  for toolchain and authoring workflow):
   structural and interactional. Health/keepalive a strong third.
 - Update `docs/index.mdx` and
   `docs/getting-started/coming-from-gastown.md` to link to this

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -159,7 +159,7 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 - Promote and rewrite `engdocs/architecture/nine-concepts.md` and `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.
 
-**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.** Addresses F2. **Recorded:** [#3013](https://github.com/gastownhall/gascity/issues/3013). **Implemented:** TBD.
+**Issue 3 — Migrate Tutorials 02 and 03 to PackV2 syntax.** Addresses F2. **Recorded:** [#3013](https://github.com/gastownhall/gascity/issues/3013). **Implemented:** Tutorials 02/03 were already on the PackV2 `agents/<name>/` layout on `main` (legacy `[[agent]]` authoring deprecated in [#2117](https://github.com/gastownhall/gascity/pull/2117)); a cross-reference audit confirmed the full 01→07 tutorial path plus `coming-from-gastown.md` and `shareable-packs.md` are PackV1-free, and fixed the one remaining PackV1-as-canonical example in `docs/concepts/primitives.md`. [#3013](https://github.com/gastownhall/gascity/issues/3013) closed as completed.
 - Rewrite the `agents/<name>/agent.toml` + `prompt.md` flow.
 - Verify all cross-references (Tutorial 04+, guides) stay consistent.
 - Move existing PackV1 examples to a clearly-labeled appendix inside `guides/migrating-to-pack-vnext.md` (or remove if redundant with that guide).

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -91,6 +91,13 @@ Relevant engdocs source material to adapt:
 - `engdocs/architecture/nine-concepts.md`, `glossary.md` — primitives
   reference
 
+Existing published asset to cross-reference from the overview:
+
+- [`docs/tutorials/06-beads#bead-lifecycle`](../../docs/tutorials/06-beads.md#bead-lifecycle) —
+  already shows how a unit of work moves through states; link as
+  "dig deeper" from the interactional diagram section rather than
+  duplicating the content.
+
 ### 2.2 F2 — PackV1 / PackV2 contradiction in the tutorial path (P0)
 
 [Tutorial 02 — Agents](../../docs/tutorials/02-agents.md) and

--- a/engdocs/design/user-docs-overhaul.md
+++ b/engdocs/design/user-docs-overhaul.md
@@ -147,14 +147,14 @@ This is the first cut. Each item below is sized roughly to be a single PR / issu
 
 ### 4.1 Milestone 1 — Stop the bleeding (P0)
 
-**Issue 1 — Architecture overview page + diagrams.** Addresses F1(a). **Recorded as** [#2101](https://github.com/gastownhall/gascity/issues/2101). **Implemented via** [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
+**Issue 1 — Architecture overview page + diagrams.** Addresses F1(a). **Recorded:** [#2101](https://github.com/gastownhall/gascity/issues/2101). **Implemented:** [PR #2981](https://github.com/gastownhall/gascity/pull/2981).
 - New page: `docs/concepts/architecture-overview.md`.
 - Top-down prose: what Gas City is, how the parts hang together, how work flows, how agents are kept alive and communicate.
 - At least two diagrams (Excalidraw — see [`engdocs/proposals/excalidraw-diagrams.md`](../proposals/excalidraw-diagrams.md) for toolchain and authoring workflow): structural and interactional. Health/keepalive a strong third.
 - Update `docs/index.mdx` and `docs/getting-started/coming-from-gastown.md` to link to this page instead of `engdocs/`.
 - Add to `docs/docs.json` nav.
 
-**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in lockstep with Issue 1.
+**Issue 2 — Primitives reference page.** Addresses F1(b). Lands in lockstep with Issue 1. **Recorded:** [#3014](https://github.com/gastownhall/gascity/issues/3014). **Implemented:** TBD.
 - New page: `docs/concepts/primitives.md`.
 - Promote and rewrite `engdocs/architecture/nine-concepts.md` and `glossary.md` for a user audience.
 - Linked *from* the architecture overview, not the entry point.


### PR DESCRIPTION
## Summary

- Adds `engdocs/design/user-docs-overhaul.md` (status: **Proposed**) — a design doc with a critical analysis of `docs/` from the perspective of an engineer trying to *use* Gas City, with a Gas Town migrator as the motivating persona.
- §2 catalogues 12 findings (F1..F12) tagged P0/P1/P2, covering the missing top-down architecture overview, the PackV1/V2 contradiction in tutorials, structural problems in `coming-from-gastown.md`, IA leakage from contributor docs, reference-doc navigability, and staleness signals.
- §4 proposes 18 candidate GitHub issues across 5 milestones, each citing the finding(s) it addresses by shortcode.
- §6 leaves one open question (IA placement of the new architecture overview and primitives pages) intentionally for PR-review feedback.

Drafted because the plan is meant to evolve from reviewer feedback before any of the 18 issues are filed.

## Test plan

- [ ] Markdown renders cleanly (doc lives in `engdocs/`, not the Mintlify site, so no `make check-docs` impact)
- [ ] Reviewer feedback collected on findings (§2), work plan (§4), and the open question (§6) before flipping status from `Proposed` to `Accepted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>