### PR TITLE
fix(supervisor): preserve session_key on continuation_reset via --resume

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -267,6 +267,28 @@ func pendingCreateLeaseExpiredForRollback(session beads.Bead, clk clock.Clock, s
 	return staleCreatingState(session, clk)
 }
 
+func pendingResumePreservingNamedRestart(session beads.Bead, clk clock.Clock, startupTimeout time.Duration) bool {
+	if strings.TrimSpace(session.Metadata["state"]) != string(sessionpkg.StateCreating) {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["pending_create_claim"]) != "true" {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["session_key"]) == "" {
+		return false
+	}
+	if strings.TrimSpace(session.Metadata["started_config_hash"]) == "" {
+		return false
+	}
+	if _, ok := parseRFC3339Metadata(session.Metadata["pending_create_started_at"]); !ok {
+		return false
+	}
+	if !pendingCreateLeaseActive(session, clk, startupTimeout) {
+		return false
+	}
+	return true
+}
+
 // reconcileSessionBeads performs bead-driven reconciliation using wake/sleep
 // semantics. For each session bead, it determines if the session should be
 // awake (has a matching entry in the desired state) and manages lifecycle
@@ -1299,14 +1321,15 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 
-		// Asleep-named-session drift repair. Skipped on the same tick when
-		// the alive-restart branch above already rotated this session into
-		// creating: the preserved started_config_hash from the resume-
-		// continuity path is intentionally still pointing at the previous-
-		// runtime hash until the new process commits. Without this guard,
-		// the asleep-repair would clear the preserved hash and rotate the
-		// session_key, undoing the resume in the same tick.
-		if !alive && isNamedSessionBead(*session) && !driftRestartedInPlace {
+		// Asleep-named-session drift repair. Skipped while an in-place
+		// restart is still leased in creating: the preserved
+		// started_config_hash intentionally points at the previous runtime
+		// hash until the new process commits. Without the durable guard,
+		// a deferred start's next reconcile tick would clear the preserved
+		// hash and rotate session_key before --resume can be prepared.
+		skipAsleepDriftRepair := driftRestartedInPlace ||
+			pendingResumePreservingNamedRestart(*session, clk, startupTimeout)
+		if !alive && isNamedSessionBead(*session) && !skipAsleepDriftRepair {
 			template := tp.TemplateName
 			if template == "" {
 				template = normalizedSessionTemplate(*session, cfg)

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1096,6 +1096,13 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 
+		// driftRestartedInPlace tracks whether the alive-restart branch ran
+		// the named-session in-place restart on this tick. Hoisted out of
+		// the inner block so the downstream asleep-named-session drift
+		// repair block can skip when we just restarted, preventing the
+		// preserved resume metadata from being undone before the new
+		// process commits.
+		driftRestartedInPlace := false
 		// Config drift: if alive and config changed, drain for restart.
 		// Live-only drift: re-apply session_live without restart.
 		if alive {
@@ -1189,6 +1196,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 							})
 							alive = false
 							restartedInPlace = true
+							driftRestartedInPlace = true
 						}
 						if !restartedInPlace {
 							// Defer ordinary-session config-drift drain while a
@@ -1291,7 +1299,14 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 
-		if !alive && isNamedSessionBead(*session) {
+		// Asleep-named-session drift repair. Skipped on the same tick when
+		// the alive-restart branch above already rotated this session into
+		// creating: the preserved started_config_hash from the resume-
+		// continuity path is intentionally still pointing at the previous-
+		// runtime hash until the new process commits. Without this guard,
+		// the asleep-repair would clear the preserved hash and rotate the
+		// session_key, undoing the resume in the same tick.
+		if !alive && isNamedSessionBead(*session) && !driftRestartedInPlace {
 			template := tp.TemplateName
 			if template == "" {
 				template = normalizedSessionTemplate(*session, cfg)
@@ -2121,11 +2136,38 @@ func resetConfiguredNamedSessionForConfigDrift(
 			fmt.Fprintf(stderr, "session reconciler: stopping config-drift named session %s: %v\n", sessionName, err) //nolint:errcheck
 		}
 	}
-	newSessionKey := ""
-	if newKey, err := sessionpkg.GenerateSessionKey(); err == nil {
-		newSessionKey = newKey
+	// Preserve resume-eligible prior conversation metadata (session_key +
+	// started_config_hash) when transitioning straight back into creating,
+	// so the next wake builds `--resume <prior-key>` instead of
+	// `--session-id <new-uuid>`. Gated on StateCreating because the asleep
+	// repair path (called from the asleep-named-session drift block) must
+	// still clear started_config_hash — an asleep-bound reset that
+	// preserved the stale hash would re-trigger drift every tick.
+	// Conversation health is validated post-start: a stale resume that
+	// Claude rejects is recovered by recordWakeFailure clearing both
+	// fields, and the next reconcile tick mints a fresh session_key.
+	// This intentionally reads the current per-session snapshot at this
+	// call site and does not provide CAS protection — external store
+	// implementations may apply SetMetadataBatch sequentially with partial
+	// application possible. If preservation is extended to additional
+	// reset sites, reload via store.Get or add conditional-write support
+	// before deciding what to preserve.
+	nextSessionState := sessionpkg.State(nextState)
+	priorSessionKey := strings.TrimSpace(session.Metadata["session_key"])
+	priorStartedConfigHash := strings.TrimSpace(session.Metadata["started_config_hash"])
+	preserveResume := nextSessionState == sessionpkg.StateCreating &&
+		priorSessionKey != "" && priorStartedConfigHash != ""
+
+	rotatedSessionKey := ""
+	if preserveResume {
+		rotatedSessionKey = priorSessionKey
+	} else if newKey, err := sessionpkg.GenerateSessionKey(); err == nil {
+		rotatedSessionKey = newKey
 	}
-	batch := sessionpkg.ConfigDriftResetPatch(sessionpkg.State(nextState), newSessionKey, now)
+	batch := sessionpkg.ConfigDriftResetPatch(nextSessionState, rotatedSessionKey, now)
+	if preserveResume {
+		batch["started_config_hash"] = priorStartedConfigHash
+	}
 	batch[namedSessionConfigDriftDeferredAtMetadata] = ""
 	batch[namedSessionConfigDriftDeferredKeyMetadata] = ""
 	batch[sessionAttachedConfigDriftDeferredAtMetadata] = ""

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/clock"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/events"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinuationReset
+// is the fast regression discriminator for the alive-restart resume-continuity
+// contract. When the existing session_key and started_config_hash are both
+// non-empty AND the reset transitions back into creating, the reset MUST
+// preserve session_key (no fresh UUID) and MUST NOT clear started_config_hash.
+// The fast assertion exercises the real prep + Start call via
+// prepareStartCandidateForCity + startPreparedStartCandidate, so
+// runtime.Fake.Calls records the actual `--resume <prior-session-key>`
+// command without paying the staleKeyDetectDelay sleep that
+// executePlannedStarts adds for the full runPreparedStartCandidate path.
+// Without the fix, this test produces `--session-id <new-uuid>` and goes RED.
+//
+// Forensic source: pipex-city pc-5pp mayor session, 2026-05-13T16:23:25Z, where
+// continuation_reset_pending fired with a 37-hour-old session_key=00a33290…
+// and the reset rotated it to 3445a81d… while clearing started_config_hash —
+// forcing the wake exec to use --session-id instead of --resume.
+func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinuationReset(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("mayor", "mayor")
+
+	const (
+		priorSessionKey        = "00a33290-c714-48e4-8a06-12aad53d3ffd"
+		priorStartedConfigHash = "5f9030d4d45048d150487fedef0be003d58f374e2d70f1cb4986f4a50f6e69e4"
+	)
+	env.setSessionMetadata(&session, map[string]string{
+		"session_key":         priorSessionKey,
+		"started_config_hash": priorStartedConfigHash,
+		"resume_flag":         "--resume",
+		"resume_style":        "flag",
+	})
+
+	resetConfiguredNamedSessionForConfigDrift(&session, env.store, env.sp, "mayor", false, "creating", time.Now().UTC(), &env.stderr)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after reset: %v", err)
+	}
+	if got.Metadata["session_key"] != priorSessionKey {
+		t.Errorf("session_key = %q, want preserved %q", got.Metadata["session_key"], priorSessionKey)
+	}
+	if got.Metadata["started_config_hash"] != priorStartedConfigHash {
+		t.Errorf("started_config_hash = %q, want preserved %q (forces --resume not --session-id)",
+			got.Metadata["started_config_hash"], priorStartedConfigHash)
+	}
+
+	tp := TemplateParams{
+		Command:      "claude --dangerously-skip-permissions",
+		SessionName:  "mayor",
+		TemplateName: "mayor",
+		ResolvedProvider: &config.ResolvedProvider{
+			Name:          "claude",
+			Command:       "claude",
+			ResumeFlag:    "--resume",
+			ResumeStyle:   "flag",
+			SessionIDFlag: "--session-id",
+		},
+	}
+	cfg := &config.City{Agents: []config.Agent{{Name: "mayor"}}}
+	clk := &clock.Fake{Time: time.Date(2026, 5, 13, 16, 23, 30, 0, time.UTC)}
+
+	prepared, err := prepareStartCandidateForCity(
+		startCandidate{session: &got, tp: tp, order: 0},
+		"", "", cfg, env.sp, env.store, clk, io.Discard,
+	)
+	if err != nil {
+		t.Fatalf("prepareStartCandidateForCity: %v", err)
+	}
+
+	if _, err := startPreparedStartCandidate(context.Background(), *prepared, "", env.store, env.sp, cfg); err != nil {
+		t.Fatalf("startPreparedStartCandidate: %v", err)
+	}
+
+	var startCfg *runtime.Config
+	for _, call := range env.sp.Calls {
+		if call.Method == "Start" && call.Name == "mayor" {
+			cfgCopy := call.Config
+			startCfg = &cfgCopy
+			break
+		}
+	}
+	if startCfg == nil {
+		t.Fatalf("expected Start call for mayor, calls=%#v", env.sp.Calls)
+	}
+
+	wantArg := "--resume " + priorSessionKey
+	if !strings.Contains(startCfg.Command, wantArg) {
+		t.Fatalf("Start command = %q, want substring %q", startCfg.Command, wantArg)
+	}
+	if strings.Contains(startCfg.Command, "--session-id") {
+		t.Fatalf("Start command = %q, must NOT contain --session-id when resuming a healthy session_key", startCfg.Command)
+	}
+
+	// Cross-check the same decision via the resolveSessionCommand helper
+	// to catch future drift between the prep path and the resolve helper.
+	firstStart := got.Metadata["started_config_hash"] == ""
+	rp := &config.ResolvedProvider{ResumeFlag: "--resume", ResumeStyle: "flag", SessionIDFlag: "--session-id"}
+	cmd := resolveSessionCommand("claude --dangerously-skip-permissions", got.Metadata["session_key"], rp, firstStart, false)
+	if !strings.Contains(cmd, wantArg) {
+		t.Fatalf("resolveSessionCommand = %q, want substring %q", cmd, wantArg)
+	}
+}
+
+// TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyEndToEnd
+// is the slow integration cousin of the fast preserve test. It runs the
+// full executePlannedStarts pipeline (which adds the post-Start
+// staleKeyDetectDelay sleep), so the assertion is on the actually-Started
+// runtime exec — not just the prepared command. Skipped in the default
+// fast suite; opt in with GC_FAST_UNIT=0 or make test-cmd-gc-process.
+func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyEndToEnd(t *testing.T) {
+	skipSlowCmdGCTest(t, "executePlannedStarts waits through stale session-key detection; run make test-cmd-gc-process for full coverage")
+
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("mayor", "mayor")
+
+	const (
+		priorSessionKey        = "00a33290-c714-48e4-8a06-12aad53d3ffd"
+		priorStartedConfigHash = "5f9030d4d45048d150487fedef0be003d58f374e2d70f1cb4986f4a50f6e69e4"
+	)
+	env.setSessionMetadata(&session, map[string]string{
+		"session_key":         priorSessionKey,
+		"started_config_hash": priorStartedConfigHash,
+		"resume_flag":         "--resume",
+		"resume_style":        "flag",
+	})
+
+	resetConfiguredNamedSessionForConfigDrift(&session, env.store, env.sp, "mayor", false, "creating", time.Now().UTC(), &env.stderr)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after reset: %v", err)
+	}
+
+	tp := TemplateParams{
+		Command:      "claude --dangerously-skip-permissions",
+		SessionName:  "mayor",
+		TemplateName: "mayor",
+		ResolvedProvider: &config.ResolvedProvider{
+			Name:          "claude",
+			Command:       "claude",
+			ResumeFlag:    "--resume",
+			ResumeStyle:   "flag",
+			SessionIDFlag: "--session-id",
+		},
+	}
+	cfg := &config.City{Agents: []config.Agent{{Name: "mayor"}}}
+	clk := &clock.Fake{Time: time.Date(2026, 5, 13, 16, 23, 30, 0, time.UTC)}
+
+	woken := executePlannedStarts(
+		context.Background(),
+		[]startCandidate{{session: &got, tp: tp, order: 0}},
+		cfg,
+		map[string]TemplateParams{"mayor": tp},
+		env.sp,
+		env.store,
+		"test-city",
+		clk,
+		events.Discard,
+		10*time.Second,
+		&env.stdout,
+		&env.stderr,
+	)
+	if woken != 1 {
+		t.Fatalf("woken = %d, want 1", woken)
+	}
+
+	var startCfg *runtime.Config
+	for _, call := range env.sp.Calls {
+		if call.Method == "Start" && call.Name == "mayor" {
+			cfgCopy := call.Config
+			startCfg = &cfgCopy
+			break
+		}
+	}
+	if startCfg == nil {
+		t.Fatalf("expected Start call for mayor, calls=%#v", env.sp.Calls)
+	}
+	wantArg := "--resume " + priorSessionKey
+	if !strings.Contains(startCfg.Command, wantArg) {
+		t.Fatalf("Start command = %q, want substring %q", startCfg.Command, wantArg)
+	}
+	if strings.Contains(startCfg.Command, "--session-id") {
+		t.Fatalf("Start command = %q, must NOT contain --session-id when resuming a healthy session_key", startCfg.Command)
+	}
+}
+
+// TestResetConfiguredNamedSessionForConfigDrift_AsleepResetClearsHashAndKey
+// guards the complementary case: when the reset transitions to asleep (the
+// asleep-named-session repair path), the helper must clear started_config_hash
+// and mint a fresh session_key. Preservation is gated on StateCreating so the
+// asleep-repair contract — drift cleared, next wake uses fresh config — is
+// untouched by the resume-continuity change.
+func TestResetConfiguredNamedSessionForConfigDrift_AsleepResetClearsHashAndKey(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("mayor", "mayor")
+	const (
+		priorSessionKey        = "old-provider-conversation"
+		priorStartedConfigHash = "old-runtime-hash"
+	)
+	env.setSessionMetadata(&session, map[string]string{
+		"session_key":         priorSessionKey,
+		"started_config_hash": priorStartedConfigHash,
+	})
+
+	resetConfiguredNamedSessionForConfigDrift(&session, env.store, env.sp, "mayor", false, "asleep", time.Now().UTC(), &env.stderr)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after reset: %v", err)
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Errorf("started_config_hash = %q, want cleared on asleep reset", got.Metadata["started_config_hash"])
+	}
+	if got.Metadata["session_key"] == priorSessionKey {
+		t.Errorf("session_key still points at prior conversation after asleep reset")
+	}
+	if got.Metadata["session_key"] == "" {
+		t.Error("session_key was not regenerated on asleep reset")
+	}
+}
+
+// TestResetConfiguredNamedSessionForConfigDrift_GeneratesKeyWhenNoneToPreserve
+// guards the never-started case: a session with no session_key and no
+// started_config_hash must still receive a fresh session_key on reset so the
+// next wake has a valid --session-id argument. Preserving resume metadata is
+// conditional on having a prior conversation to resume.
+func TestResetConfiguredNamedSessionForConfigDrift_GeneratesKeyWhenNoneToPreserve(t *testing.T) {
+	env := newReconcilerTestEnv()
+	session := env.createSessionBead("mayor", "mayor")
+	// No session_key, no started_config_hash — the session never started.
+
+	resetConfiguredNamedSessionForConfigDrift(&session, env.store, env.sp, "mayor", false, "creating", time.Now().UTC(), &env.stderr)
+
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get after reset: %v", err)
+	}
+	if got.Metadata["session_key"] == "" {
+		t.Fatal("session_key must be regenerated when no prior key exists; got empty")
+	}
+	if got.Metadata["started_config_hash"] != "" {
+		t.Errorf("started_config_hash must remain cleared on the no-prior-conversation path; got %q",
+			got.Metadata["started_config_hash"])
+	}
+}

--- a/cmd/gc/session_reconciler_drift_resume_test.go
+++ b/cmd/gc/session_reconciler_drift_resume_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/clock"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/events"
@@ -112,6 +113,121 @@ func TestResetConfiguredNamedSessionForConfigDrift_PreservesSessionKeyOnContinua
 	cmd := resolveSessionCommand("claude --dangerously-skip-permissions", got.Metadata["session_key"], rp, firstStart, false)
 	if !strings.Contains(cmd, wantArg) {
 		t.Fatalf("resolveSessionCommand = %q, want substring %q", cmd, wantArg)
+	}
+}
+
+func TestReconcileSessionBeads_PreservesSessionKeyWhenNamedRestartDeferred(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Providers: map[string]config.ProviderSpec{
+			"resume-provider": {
+				Command:       "true",
+				PromptMode:    "none",
+				ResumeFlag:    "--resume",
+				ResumeStyle:   "flag",
+				SessionIDFlag: "--session-id",
+			},
+		},
+		Agents: []config.Agent{
+			{Name: "worker", Provider: "resume-provider", DependsOn: []string{"db"}},
+			{Name: "db"},
+		},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	tp := TemplateParams{
+		Command:                 "true",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		InstanceName:            "worker",
+		Alias:                   "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+		ResolvedProvider: &config.ResolvedProvider{
+			Name:          "resume-provider",
+			Command:       "true",
+			PromptMode:    "none",
+			ResumeFlag:    "--resume",
+			ResumeStyle:   "flag",
+			SessionIDFlag: "--session-id",
+		},
+	}
+	env.desiredState[sessionName] = tp
+
+	const priorSessionKey = "00a33290-c714-48e4-8a06-12aad53d3ffd"
+	oldRuntime := runtime.Config{Command: "old-cmd"}
+	priorStartedConfigHash := runtime.CoreFingerprint(oldRuntime)
+	if currentHash := runtime.CoreFingerprint(templateParamsToConfig(tp)); priorStartedConfigHash == currentHash {
+		t.Fatalf("test setup error: stored hash %q should differ from current %q", priorStartedConfigHash, currentHash)
+	}
+	if err := env.sp.Start(context.Background(), sessionName, oldRuntime); err != nil {
+		t.Fatalf("Start(old runtime): %v", err)
+	}
+	session := env.createSessionBead(sessionName, "worker")
+	env.markSessionActive(&session)
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"session_key":                priorSessionKey,
+		"started_config_hash":        priorStartedConfigHash,
+		"started_live_hash":          runtime.LiveFingerprint(oldRuntime),
+	})
+
+	woken := env.reconcile([]beads.Bead{session})
+	if woken != 0 {
+		t.Fatalf("first reconcile woken = %d, want 0 while dependency is down", woken)
+	}
+	deferred, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("get deferred restart: %v", err)
+	}
+	if env.sp.IsRunning(sessionName) {
+		t.Fatalf("%s should have been stopped for in-place config-drift restart", sessionName)
+	}
+	if got := deferred.Metadata["state"]; got != "creating" {
+		t.Fatalf("state after deferred restart = %q, want creating", got)
+	}
+	if got := deferred.Metadata["pending_create_claim"]; got != "true" {
+		t.Fatalf("pending_create_claim after deferred restart = %q, want true", got)
+	}
+	if _, ok := parseRFC3339Metadata(deferred.Metadata["pending_create_started_at"]); !ok {
+		t.Fatalf("pending_create_started_at after deferred restart = %q, want valid timestamp",
+			deferred.Metadata["pending_create_started_at"])
+	}
+	if got := deferred.Metadata["session_key"]; got != priorSessionKey {
+		t.Fatalf("session_key after deferred restart = %q, want preserved %q", got, priorSessionKey)
+	}
+	if got := deferred.Metadata["started_config_hash"]; got != priorStartedConfigHash {
+		t.Fatalf("started_config_hash after deferred restart = %q, want preserved %q", got, priorStartedConfigHash)
+	}
+
+	if err := env.sp.Start(context.Background(), "db", runtime.Config{Command: "db"}); err != nil {
+		t.Fatalf("Start(db): %v", err)
+	}
+	woken = env.reconcile([]beads.Bead{deferred})
+	if woken != 1 {
+		t.Fatalf("second reconcile woken = %d, want 1 after dependency recovers; stderr=%s", woken, env.stderr.String())
+	}
+
+	var startCfg *runtime.Config
+	for i := range env.sp.Calls {
+		call := env.sp.Calls[i]
+		if call.Method == "Start" && call.Name == sessionName {
+			cfgCopy := call.Config
+			startCfg = &cfgCopy
+		}
+	}
+	if startCfg == nil {
+		t.Fatalf("expected resumed Start call for %s, calls=%#v", sessionName, env.sp.Calls)
+	}
+	wantArg := "--resume " + priorSessionKey
+	if !strings.Contains(startCfg.Command, wantArg) {
+		t.Fatalf("Start command = %q, want substring %q", startCfg.Command, wantArg)
+	}
+	if strings.Contains(startCfg.Command, "--session-id") {
+		t.Fatalf("Start command = %q, must NOT contain --session-id after deferred restart", startCfg.Command)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a config-drift event triggers an in-place continuation_reset on an attached named session whose conversation is healthy, the next Claude process is launched with `--session-id <fresh-uuid>` instead of `--resume <prior-session-key>`. The bead's metadata advertises `resume_flag: --resume` but the exec path bypasses it — silently destroying conversation history.

This PR makes the in-place restart honor the resume contract.

## Repro

Forensic chain from a real production incident on a 37-hour mayor session:

- 16:21:34Z: `attached_config_drift_deferred_at` set (CopyFiles + FPExtra hashes drifted on a `.gc/settings.json` edit)
- 16:23:25Z: `continuation_reset_pending: true` (deferral expired)
- 16:23:28Z: `continuation_epoch 48→49`, `generation 56→57`, `session_key 00a33290… → 3445a81d…` (new UUID, not a resume)
- New process exec: `claude … --session-id 3445a81d-…` — 37 h of conversation lost

The bead metadata at the moment of the rotation said `resume_flag: --resume, resume_style: flag` — the contract was claimed but not honored.

## Fix

In `cmd/gc/session_reconciler.go::resetConfiguredNamedSessionForConfigDrift`, when the reset is transitioning back to ` StateCreating ` AND the session has both a non-empty prior `session_key` AND non-empty prior `started_config_hash` (\"resume-eligible\"), preserve both fields through the reset patch instead of generating a fresh key + clearing the hash. The wake's `--resume` vs `--session-id` choice is gated downstream by `started_config_hash` (firstStart) and `session_key`, so preserving both is necessary AND sufficient for the next wake to issue `--resume <prior-key>`.

A tick-local `driftRestartedInPlace` flag guards the downstream asleep-named-session drift repair block: without it, the same reconciler tick would clear the preserved hash and rotate the session_key in the asleep-repair path, undoing the resume.

Stale-resume failure (Claude rejecting the prior session-id at runtime) is recovered by the existing `recordWakeFailure` path — both fields cleared, next reconcile tick rotates fresh.

## Before / After

Before: in-place continuation_reset on a resume-eligible attached session rotates session_key and clears started_config_hash. Next wake builds `--session-id <new-uuid>`. Conversation lost.

After: same scenario preserves session_key and started_config_hash. Next wake builds `--resume <prior-session-key>`. Conversation continues.

The asleep-named-session drift repair contract is unchanged — verified by the existing `TestPhase0ConfigDrift_AsleepNamedSessionRepairsInPlaceWithoutWaking` continuing to pass.

## Adjacent merged PRs

This is complementary to recent merges and addresses the case they don't:

- #1967 default `BEADS_ACTOR=controller` — unrelated
- #2023 defer config-drift drain on pool sessions with assigned work — addresses pool sessions; does not change behavior when reset DOES fire
- #2024 `gc reload --soft` to accept drift without draining — operator-driven escape hatch; this PR is the safety net for when the operator hasn't issued soft-reload before the deferral expires

## Test plan

Two commits, separately verifiable:

1. `test(supervisor): RED for continuation_reset preserving session_key` — adds `cmd/gc/session_reconciler_drift_resume_test.go` with four cases:
   - `*_PreservesSessionKeyOnContinuationReset` (FAST, default suite): drives `prepareStartCandidateForCity` + `startPreparedStartCandidate` directly and asserts `runtime.Fake.Calls` records `--resume <prior-key>` and NOT `--session-id`. RED on this commit alone.
   - `*_PreservesSessionKeyEndToEnd` (slow integration via `executePlannedStarts`, gated by the existing `skipSlowCmdGCTest`)
   - `*_AsleepResetClearsHashAndKey` — guards the asleep-repair contract
   - `*_GeneratesKeyWhenNoneToPreserve` — guards the never-started fresh-key path

2. `fix(supervisor): preserve session_key on continuation_reset via --resume` — the production change. GREEN on this commit.

Verified locally:
- Default suite RED → GREEN on the two commits
- `GC_FAST_UNIT=0` full coverage GREEN on fix
- Existing `TestPhase0ConfigDrift_AsleepNamedSessionRepairsInPlaceWithoutWaking` PASS
- `go build ./...`, `go vet ./...`, `gofmt -l` clean for changed files
- Rebased onto `github/main` (71e5847e) immediately before push

## Out of scope (follow-ups)

These are coherent next PRs, intentionally not folded in to keep this regression fix narrow:

1. Structured `session.resume_failed` event emission on resume failure
2. Mail-to-operator on resume failure (currently silent fallback)
3. Drift-class policy: Env vs FPExtra vs CopyFiles → different resume/reset actions
4. Per-session `preserve_on_drift: hard` opt-in toggle