### PR TITLE
fix(dolt): align mol-dog-doctor backup scope with mol-dog-backup

### DIFF
--- a/examples/dolt/assets/scripts/mol-dog-doctor.sh
+++ b/examples/dolt/assets/scripts/mol-dog-doctor.sh
@@ -116,14 +116,28 @@ if [ "${ORPHAN_COUNT:-0}" -gt 0 ]; then
 fi
 
 # Backup freshness: check newest backup artifact per database.
+# Scope mirrors mol-dog-backup.sh: only DBs with a configured <db>-backup
+# remote are eligible. Cities with user DBs but no backup remotes
+# (legitimate config) must not get false stale-backup alarms.
+BACKUP_ELIGIBLE_DBS=""
+for db in $USER_DBS; do
+    db_dir="$DOLT_DATA_DIR/$db"
+    if [ -d "$db_dir/.dolt" ]; then
+        if (cd "$db_dir" && dolt backup 2>/dev/null | awk '{print $1}' | grep -qx "${db}-backup"); then
+            BACKUP_ELIGIBLE_DBS="$BACKUP_ELIGIBLE_DBS $db"
+        fi
+    fi
+done
+BACKUP_ELIGIBLE_DBS=$(printf '%s\n' "$BACKUP_ELIGIBLE_DBS" | tr ' ' '\n' | grep -v '^$' || true)
+
 BACKUP_STALE=""
-if [ -n "$USER_DBS" ]; then
+if [ -n "$BACKUP_ELIGIBLE_DBS" ]; then
     if [ ! -d "$BACKUP_ARTIFACT_DIR" ]; then
         BACKUP_STALE=" [WARN: backup artifact dir missing]"
     else
         BACKUP_STALE_ITEMS=""
         NOW_S=$(date +%s)
-        for db in $USER_DBS; do
+        for db in $BACKUP_ELIGIBLE_DBS; do
             NEWEST_BACKUP_MTIME=$(newest_backup_mtime_for_db "$db")
             if [ "$NEWEST_BACKUP_MTIME" -le 0 ]; then
                 append_backup_stale "$db backup missing"

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2291,6 +2291,68 @@ exit 0
 	}
 }
 
+// TestDoctorBackupOnlyChecksDBsWithBackupRemote asserts mol-dog-doctor's backup
+// freshness scope mirrors mol-dog-backup.sh — only DBs with a configured
+// "<db>-backup" remote are eligible. Cities with user DBs but no backup
+// remotes (legitimate config) get no false stale-backup alarms.
+//
+// Companion to TestBackupScriptIgnoresDocumentedSystemSchemasForAutoDiscovery:
+// backup.sh already filters by remote presence; doctor.sh must use the same
+// gate so the two scripts agree on what "backup-eligible" means.
+func TestDoctorBackupOnlyChecksDBsWithBackupRemote(t *testing.T) {
+	cityPath := t.TempDir()
+	dataDir := filepath.Join(cityPath, "dolt-data")
+	artifactDir := filepath.Join(cityPath, ".dolt-backup")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	for _, db := range []string{"prod", "archive"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
+	}
+
+	binDir := t.TempDir()
+	gcLogPath := writeDogFakeGC(t, binDir)
+	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  backup)
+    if [ "$(basename "$PWD")" = "prod" ]; then
+      printf 'prod-backup\n'
+    fi
+    exit 0
+    ;;
+esac
+case "$*" in
+  *"COUNT(*) FROM information_schema.PROCESSLIST"*)
+    printf 'COUNT(*)\n1\n'
+    exit 0
+    ;;
+  *"SHOW DATABASES"*)
+    printf 'Database\nprod\narchive\n'
+    exit 0
+    ;;
+esac
+exit 0
+`)
+
+	out := runDogScript(t, "mol-dog-doctor.sh", binDir, cityPath, dataDir, "GC_DOCTOR_BACKUP_STALE_S=1")
+	if !strings.Contains(out, "server: ok") {
+		t.Fatalf("unexpected doctor output:\n%s", out)
+	}
+	gcLog, err := os.ReadFile(gcLogPath)
+	if err != nil {
+		t.Fatalf("read gc log: %v", err)
+	}
+	if strings.Contains(string(gcLog), "archive backup missing") {
+		t.Fatalf("doctor warned about archive (no <db>-backup remote configured); should be filtered out:\n%s", gcLog)
+	}
+	if !strings.Contains(string(gcLog), "prod backup missing") {
+		t.Fatalf("doctor did not warn about prod (eligible: has prod-backup remote, no artifact); scope filter should not exclude it:\n%s", gcLog)
+	}
+}
+
 func TestDoctorScriptDetectsDoctestOrphansWithBSDGrep(t *testing.T) {
 	cityPath := t.TempDir()
 	dataDir := filepath.Join(cityPath, "dolt-data")

--- a/examples/dolt/dog_exec_scripts_test.go
+++ b/examples/dolt/dog_exec_scripts_test.go
@@ -2193,8 +2193,10 @@ func TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase(t *testing.T) {
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		t.Fatalf("mkdir artifact dir: %v", err)
 	}
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
-		t.Fatalf("mkdir data dir: %v", err)
+	for _, db := range []string{"prod", "archive"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
 	}
 	freshBackup := filepath.Join(artifactDir, "prod.backup")
 	writeTestFile(t, freshBackup, "backup")
@@ -2213,6 +2215,15 @@ func TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase(t *testing.T) {
 	gcLogPath := writeDogFakeGC(t, binDir)
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
 set -euo pipefail
+case "$1" in
+  backup)
+    case "$(basename "$PWD")" in
+      prod) printf 'prod-backup\n' ;;
+      archive) printf 'archive-backup\n' ;;
+    esac
+    exit 0
+    ;;
+esac
 case "$*" in
   *"COUNT(*) FROM information_schema.PROCESSLIST"*)
     printf 'COUNT(*)\n1\n'
@@ -2402,8 +2413,10 @@ func TestDoctorScriptDoesNotCreditSharedPrefixBackupToDatabase(t *testing.T) {
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		t.Fatalf("mkdir artifact dir: %v", err)
 	}
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
-		t.Fatalf("mkdir data dir: %v", err)
+	for _, db := range []string{"prod", "prod_dev"} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", db, err)
+		}
 	}
 	freshSiblingBackup := filepath.Join(artifactDir, "prod_dev.backup")
 	writeTestFile(t, freshSiblingBackup, "backup")
@@ -2416,6 +2429,15 @@ func TestDoctorScriptDoesNotCreditSharedPrefixBackupToDatabase(t *testing.T) {
 	gcLogPath := writeDogFakeGC(t, binDir)
 	writeExecutable(t, filepath.Join(binDir, "dolt"), `#!/usr/bin/env bash
 set -euo pipefail
+case "$1" in
+  backup)
+    case "$(basename "$PWD")" in
+      prod) printf 'prod-backup\n' ;;
+      prod_dev) printf 'prod_dev-backup\n' ;;
+    esac
+    exit 0
+    ;;
+esac
 case "$*" in
   *"COUNT(*) FROM information_schema.PROCESSLIST"*)
     printf 'COUNT(*)\n1\n'


### PR DESCRIPTION
## Summary

`mol-dog-doctor.sh` checked backup-freshness for ALL user DBs and emitted stale-backup MEDIUM advisories whenever any lacked an artifact. `mol-dog-backup.sh` uses a narrower scope: only DBs with a configured `<db>-backup` remote (auto-discovery via `dolt backup` listing).

Cities with user DBs but no backup remotes — a legitimate config — got permanent false stale-backup advisories every health-check tick.

## Repro

Observed in a managed city today: ~150 MEDIUM Dolt-health advisories accumulated over 24h from this exact mismatch. The city has 4 user DBs without configured backup remotes — `mol-dog-backup` correctly skips all four (logs `no databases with backup remotes found, skipping`), but `mol-dog-doctor` warns every 5 min that the backup artifact dir is missing.

## Fix

Reuse the same eligibility gate as `mol-dog-backup.sh`. Doctor now computes `BACKUP_ELIGIBLE_DBS` using:

- `.dolt/` subdir present in `$DOLT_DATA_DIR/$db`, AND
- `dolt backup` lists `<db>-backup`

Then iterates only that set for backup-freshness checks. The "backup artifact dir missing" warning is also gated on having at least one eligible DB, so cities without backup remotes produce no backup-related noise at all.

## Before / After

Before: 4 user DBs without backup remotes → warning fires every 5 min ("backup artifact dir missing"), or per-DB stale-backup warnings if the dir exists.

After: 4 user DBs without backup remotes → `BACKUP_ELIGIBLE_DBS` is empty → no backup-related warning at all. DBs that DO have backup remotes still get checked exactly as before.

## Test plan

Two commits, separately verifiable:

1. `test(dolt): RED for mol-dog-doctor scope alignment with mol-dog-backup` — adds `TestDoctorBackupOnlyChecksDBsWithBackupRemote`: 2 user DBs, only `prod` has the `prod-backup` remote, no artifacts. Doctor must warn about prod (in scope, no artifact) but NOT about archive (out of scope). RED on this commit.

2. `fix(dolt): align mol-dog-doctor backup scope with mol-dog-backup eligibility` — applies the eligibility filter. GREEN on this commit. Two existing doctor tests (`TestDoctorScriptChecksBackupArtifactFreshnessPerDatabase`, `TestDoctorScriptDoesNotCreditSharedPrefixBackupToDatabase`) updated to seed the `.dolt/` subdirs and mock `dolt backup` so they exercise the new scope.

Verified locally:
- Default `go test ./examples/dolt/... -run "TestDoctor.*Backup|TestBackupScript"` GREEN on fix
- RED proof: new test fails on test-only commit with "doctor warned about archive (no <db>-backup remote configured); should be filtered out"
- `bash -n examples/dolt/assets/scripts/mol-dog-doctor.sh` clean
- `gofmt -l` clean for changed files
- `go vet ./examples/dolt/...` clean
- Rebased onto `github/main` immediately before push

## Out of scope

- Wiring backup remotes for cities that need them (operator concern, not a doctor bug)
- Rate-limiting Dolt advisories upstream (separate concern; this fix removes the false-positive source so the rate-limit need goes away for affected cities)