### PR TITLE
feat(nix): add flake + contrib/nix packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ cmd/gc/.runtime/
 /genschema
 /bd
 /br
+/result
+/result-*
 /tmp/
 .runtime/
 *.test

--- a/contrib/nix/README.md
+++ b/contrib/nix/README.md
@@ -1,0 +1,93 @@
+# Nix packaging for Gas City
+
+## Quick start
+
+```bash
+# Run gc without installing
+nix run github:gastownhall/gascity
+
+# Or from a local checkout
+nix run .
+```
+
+## Install via flake input
+
+Add to your `flake.nix`:
+
+```nix
+inputs.gascity.url = "github:gastownhall/gascity";
+```
+
+Then add the package to your profile:
+
+```nix
+home.packages = [ inputs.gascity.packages.${system}.default ];
+```
+
+## Home Manager module
+
+```nix
+# flake.nix
+inputs = {
+  gascity.url = "github:gastownhall/gascity";
+  home-manager.url = "github:nix-community/home-manager";
+};
+
+outputs = { self, home-manager, gascity, ... }: {
+  homeConfigurations.yourhost = home-manager.lib.homeManagerConfiguration {
+    modules = [
+      gascity.homeManagerModules.default
+      {
+        programs.gascity.enable = true;
+      }
+    ];
+  };
+};
+```
+
+This installs `gc` and all required runtime dependencies.
+
+## Development shell
+
+```bash
+# Full dev environment with all runtime deps
+nix develop
+```
+
+## Runtime dependencies
+
+These are required at runtime but not bundled in the `gc` binary:
+
+| Dependency | Required for | Minimum version |
+|---|---|---|
+| tmux | Session runtime provider | any |
+| git | Repo operations | any |
+| jq | JSON processing | any |
+| pgrep | Process monitoring | any |
+| lsof | Port detection | any |
+| dolt | Beads backend (default) | 1.85.0 |
+| bd | Beads backend (default) | 0.61.0 |
+| flock | Beads backend (default) | any |
+
+Set `GC_BEADS=file` to skip dolt/bd/flock and use a file-based store.
+
+Note: `bd` (beads CLI) is not yet in nixpkgs. Install it from
+[github.com/gastownhall/beads/releases](https://github.com/gastownhall/beads/releases).
+
+## Update procedure
+
+When a new gc release is cut, update the derivation as follows:
+
+1. Bump `version` in `flake.nix` (project flake) or in the nixpkgs derivation.
+2. Reset `vendorHash` in `contrib/nix/package.nix` to `lib.fakeHash`.
+3. Run `nix build .#default`. The build will fail with a hash mismatch.
+4. Copy the `got: sha256-...` value from the error and replace `lib.fakeHash`.
+5. Re-run `nix build .#default` to confirm.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `package.nix` | Standalone derivation — usable from nixpkgs or any flake |
+| `hm-module.nix` | Home Manager module with `programs.gascity.enable` |
+| `../../flake.nix` | Root project flake — wires `src = self` into `package.nix` |

--- a/contrib/nix/hm-module.nix
+++ b/contrib/nix/hm-module.nix
@@ -1,0 +1,50 @@
+# Gas City — Home Manager module.
+#
+# Usage in your flake.nix:
+#
+#   inputs = {
+#     gascity.url = "github:gastownhall/gascity";
+#     beads.url = "github:gastownhall/beads";  # >=0.61.0; nixpkgs ships 0.42.0
+#   };
+#
+#   home-manager.sharedModules = [
+#     inputs.gascity.homeManagerModules.default
+#     { programs.gascity.enable = true; }
+#   ];
+#
+#   # In your home config, add bd from the beads flake:
+#   home.packages = [ inputs.beads.packages.${system}.default ];
+{ inputs, ... }:
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.gascity;
+  system = pkgs.stdenv.hostPlatform.system;
+  gcPkg = inputs.gascity.packages.${system}.default;
+in
+{
+  options.programs.gascity = {
+    enable = lib.mkEnableOption "Gas City multi-agent orchestration system";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      gcPkg
+
+      # Required runtime deps
+      pkgs.tmux
+      pkgs.git
+      pkgs.jq
+      pkgs.procps   # pgrep
+      pkgs.lsof
+
+      # Beads backend deps
+      pkgs.dolt       # >=1.85.0 per deps.env
+      pkgs.util-linux # flock
+
+      # bd (beads CLI) — nixpkgs ships 0.42.0 which is too old.
+      # Add inputs.beads.url = "github:gastownhall/beads" to your flake
+      # and include inputs.beads.packages.${system}.default here.
+    ];
+  };
+}

--- a/contrib/nix/package.nix
+++ b/contrib/nix/package.nix
@@ -1,0 +1,99 @@
+# Gas City — Nix package derivation.
+#
+# Used two ways:
+#   1. From the project flake (src = self, version from flake outputs)
+#   2. From nixpkgs (src = fetchFromGitHub { ... }, version pinned there)
+#
+# To update for a new release:
+#   - Bump version and rev in the fetchFromGitHub call (nixpkgs usage)
+#   - Reset vendorHash to lib.fakeHash, run `nix build`, fill in the hash
+#     from the error output.
+#
+# Build mirrors the Makefile `build` target:
+#   go build -ldflags "..." -o bin/gc ./cmd/gc
+# We replicate the ldflags rather than calling `make` because the Makefile
+# uses `git describe` for VERSION, which is unavailable in the Nix sandbox.
+{
+  lib,
+  buildGoModule,
+  makeWrapper,
+  src,
+  version,
+}:
+
+let
+  gcBase = buildGoModule {
+    pname = "gascity";
+    inherit src version;
+
+    vendorHash = "sha256-59k7xFBaLZJ50KWNhwIzttE8j7GXZPneq6o4eUTlvBI=";
+
+    # Upstream does not commit vendor/. proxyVendor tells buildGoModule to
+    # fetch dependencies via the Go module proxy using go.mod + go.sum,
+    # validated against vendorHash. If upstream ever starts committing
+    # vendor/ again, this can be removed.
+    proxyVendor = true;
+
+    doCheck = false;
+
+    subPackages = [ "cmd/gc" ];
+
+    postPatch = ''
+      goVer="$(go env GOVERSION | sed 's/^go//')"
+      go mod edit -go="$goVer"
+    '';
+    env.GOTOOLCHAIN = "auto";
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X main.version=${version}"
+    ];
+
+    meta = {
+      description = "Orchestration-builder SDK for multi-agent systems";
+      longDescription = ''
+        Gas City provides a configurable multi-agent orchestration toolkit:
+        declarative city.toml configuration, runtime providers (tmux, subprocess,
+        exec, ACP, Kubernetes), beads-backed work routing, formula dispatch, and
+        a controller/supervisor reconciliation loop.
+
+        Runtime dependencies (not managed by this derivation):
+          Required:  tmux, git, jq, pgrep, lsof
+          Beads backend (default): dolt (>=1.85.0), bd/beads (>=0.61.0), flock
+          Set GC_BEADS=file to skip the beads backend deps.
+      '';
+      homepage = "https://github.com/gastownhall/gascity";
+      changelog = "https://github.com/gastownhall/gascity/releases/tag/v${version}";
+      license = lib.licenses.mit;
+      maintainers = [ ];
+      mainProgram = "gc";
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  };
+in
+
+# Wrap gc with a runtime check for bd (beads CLI).
+# If bd is not in PATH and GC_BEADS=file is not set, gc exits immediately
+# with a clear message rather than failing cryptically mid-command.
+#
+# nixpkgs ships beads 0.42.0 which is too old (gc requires >=0.61.0).
+# Install a compatible version via: nix shell github:gastownhall/beads
+gcBase.overrideAttrs (prev: {
+  nativeBuildInputs = (prev.nativeBuildInputs or [ ]) ++ [ makeWrapper ];
+
+  postInstall = (prev.postInstall or "") + ''
+    wrapProgram $out/bin/gc \
+      --run '
+        if [ "''${GC_BEADS:-}" != "file" ] && ! command -v bd >/dev/null 2>&1; then
+          echo "gc: bd (beads CLI >=0.61.0) not found in PATH." >&2
+          echo "    nixpkgs ships beads 0.42.0 which is too old for gc." >&2
+          echo "    Install a compatible version:" >&2
+          echo "      nix shell github:gastownhall/beads" >&2
+          echo "    Or bypass the beads backend:" >&2
+          echo "      GC_BEADS=file gc ..." >&2
+          exit 1
+        fi
+      '
+  '';
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "Gas City — orchestration-builder SDK for multi-agent systems";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      version = "0.13.4";
+
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            pkgs = nixpkgs.legacyPackages.${system};
+            inherit system self;
+          }
+        );
+    in
+    {
+      packages = forAllSystems (
+        { pkgs, ... }:
+        let
+          gc = pkgs.callPackage ./contrib/nix/package.nix {
+            inherit version;
+            src = self;
+          };
+        in
+        {
+          default = gc;
+          gascity = gc;
+        }
+      );
+
+      apps = forAllSystems (
+        { self, system, ... }:
+        {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/gc";
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        { pkgs, ... }:
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.go
+              pkgs.tmux
+              pkgs.git
+              pkgs.jq
+              pkgs.procps # pgrep
+              pkgs.lsof
+              pkgs.dolt
+              pkgs.util-linux # flock
+              # bd (beads CLI >=0.61.0) — nixpkgs ships 0.42.0 which is too old.
+              # Add to your shell via: nix shell github:gastownhall/beads
+            ];
+
+            shellHook = ''
+              echo "Gas City dev shell"
+              echo "  build:   go build ./cmd/gc"
+              echo "  test:    go test ./..."
+              echo "  install: make install"
+              if ! command -v bd >/dev/null 2>&1; then
+                echo ""
+                echo "  Warning: bd (beads CLI) not found."
+                echo "  Add it: nix shell github:gastownhall/beads"
+              fi
+            '';
+          };
+        }
+      );
+
+      homeManagerModules.default = import ./contrib/nix/hm-module.nix { inputs = { gascity = self; }; };
+      homeManagerModules.gascity = import ./contrib/nix/hm-module.nix { inputs = { gascity = self; }; };
+
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-rfc-style);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,12 @@
   outputs =
     { self, nixpkgs }:
     let
-      version = "0.13.4";
+      # Version comes from the flake's git metadata: short commit SHA for clean
+      # builds, "-dirty" suffix for dirty trees, "dev" if no rev is available.
+      # The Makefile uses `git describe --tags --exact-match` instead, which the
+      # nix sandbox can't replicate (no .git access). For tagged-release builds
+      # via nixpkgs, override `version` at callPackage time.
+      version = self.shortRev or self.dirtyShortRev or "dev";
 
       systems = [
         "aarch64-darwin"


### PR DESCRIPTION
## Summary

Add a Nix flake at the repo root plus standalone derivation, Home
Manager module, and contributor README under `contrib/nix/`. Replaces
the conflated nix portion of closed PR #1352 with a focused,
audit-friendly change.

This adds packaging only — no functional change to `gc`.

## Files and rationale

- **`flake.nix`** — Flake-level entry point. Declares the `nixpkgs`
  input and exposes per-system `packages`, `apps`, and `devShells`.
  `packages.default = callPackage ./contrib/nix/package.nix { src = self; version; }`
  so the same derivation works from both the project flake and a
  future nixpkgs port. `apps.default` makes `nix run` invoke `gc`
  cleanly. `devShells.default` provides go, tmux, git, jq, procps,
  lsof, dolt, and util-linux for contributor workflows.
- **`flake.lock`** — Pins the exact nixpkgs revision the flake
  evaluates against. Regenerated by `nix flake update`.
- **`contrib/nix/package.nix`** — Standalone `buildGoModule`
  derivation. Two-mode: takes `src` and `version` as params so it
  works both from the project flake (`src = self`) and from nixpkgs
  (`src = fetchFromGitHub`). `proxyVendor = true` (upstream doesn't
  commit `vendor/`); `vendorHash` pinned for reproducibility;
  `postPatch` + `GOTOOLCHAIN = auto` to reconcile `go.mod`'s Go
  version with whatever Go nixpkgs ships; `ldflags` mirror the
  Makefile `build` target since the Nix sandbox has no
  `git describe`; `makeWrapper` adds a runtime PATH check that exits
  cleanly when `bd` is missing (bypassed when `GC_BEADS=file`).
- **`contrib/nix/hm-module.nix`** — Home Manager module. Exposes
  `programs.gascity.enable` and installs `gc` plus required runtime
  deps. Does **not** auto-install `bd` — the README instructs users
  to add `inputs.beads` as a separate flake input. Decoupling avoids
  the brittle `vendorHash` dance from depending on the beads flake
  directly (its `vendorHash` is frequently stale: beads PRs #2512,
  #2275, #2314).
- **`contrib/nix/README.md`** — Contributor-facing usage notes:
  `nix run github:gastownhall/gascity`, flake-input install,
  home-manager snippet, runtime deps table, and the `vendorHash`
  update procedure (reset to `lib.fakeHash`, rebuild, paste the
  error's hash).
- **`.gitignore`** — Adds `/result` and `/result-*` so `nix build`
  symlinks don't pollute `git status`.

## Why a runtime bd check instead of a flake input

The `gastownhall/beads` flake has a frequently-stale `vendorHash`.
Depending on it as a flake input is fragile, and nixpkgs ships beads
0.42.0 which is too old (`gc` requires >=0.61.0). Instead, the
`makeWrapper`-wrapped `gc` exits immediately with a clear actionable
message when `bd` is not in PATH and `GC_BEADS != file`. The check
is bypassed when `GC_BEADS = file` (file backend needs no `bd`).

## Audit reference

Re-derived cleanly off `upstream/main`. The earlier iteration lived
on fork `origin/main` in these commits (now only reachable via
reflog after that branch was reset):

- `cea7e695` feat(nix): add flake and Nix packaging in contrib/nix/
- `79441009` fix(nix): align with patterns from beads PR #2314
- `b460a1ab` fix(nix): runtime bd check via makeWrapper; drop beads
  flake input
- `4d155fb1` fix(nix): proxyVendor to handle upstream not committing
  vendor/

## Out of scope

- Auto-update wiring (renovate vs `update-flake-lock` workflow) —
  tracked separately.
- The `sessionDrains` salvage commit `5f62aefb` — separate bead.
- The hyphen-prefix fix — `gascity-2pv`, unrelated work.

## Test plan

- [x] `nix flake check` passes
- [x] `nix build .#default` produces a working `gc` binary
- [x] `GC_BEADS=file ./result/bin/gc help` runs cleanly
- [x] Without `bd` on PATH and without `GC_BEADS=file`, `gc` exits
      with the expected actionable message
- [x] `nix develop` drops into a usable shell with go, tmux, git, jq
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

Closes gascity-c1t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)