### PR TITLE
fix(supervisor): tee log to ~/.gc/supervisor.log on systemd/launchd start

### DIFF
--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -129,34 +129,59 @@ func newSupervisorStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 }
 
 // openSupervisorLogForTee opens the supervisor log file in append mode for
-// runSupervisor to tee output into. Returns nil on any error (we never
-// fail supervisor startup just because the log file can't be opened —
-// operators still get journald/launchd-captured stdout/stderr).
-func openSupervisorLogForTee() *os.File {
+// runSupervisor to tee output into.
+func openSupervisorLogForTee() (*os.File, error) {
 	f, err := os.OpenFile(supervisorLogPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("opening supervisor log %s: %w", supervisorLogPath(), err)
 	}
-	return f
+	return f, nil
 }
 
-// shouldTeeSupervisorLog reports whether `w` is distinct from the
-// supervisor log file. When `gc supervisor start` spawns a backgrounded
-// `gc supervisor run` child, it pre-opens the log and points
-// child.Stdout/child.Stderr at it — the child's stdout/stderr are then
-// already the log file, so adding a MultiWriter would double-log every
-// line. By comparing the underlying file (Name() match), we avoid that
-// while still teeing for the systemd/launchd/container path where
-// stdout/stderr arrive as a journal/pipe and need explicit routing.
+// shouldTeeSupervisorLog reports whether w is distinct from supervisor.log.
+// Service managers and manual background start can hand this process
+// fd-backed stdout/stderr that already append to supervisor.log while still
+// carrying cosmetic names like /dev/stdout. Compare open file identity instead
+// of names so those paths do not double-log.
 func shouldTeeSupervisorLog(w io.Writer, logFile *os.File) bool {
 	if w == nil || logFile == nil {
 		return false
 	}
-	wf, ok := w.(*os.File)
+	wf, ok := fileWriterForSupervisorLog(w)
 	if !ok {
 		return true
 	}
-	return wf.Name() != logFile.Name()
+	same, err := sameOpenFile(wf, logFile)
+	if err != nil {
+		return true
+	}
+	return !same
+}
+
+func fileWriterForSupervisorLog(w io.Writer) (*os.File, bool) {
+	switch v := w.(type) {
+	case *os.File:
+		return v, true
+	case *switchableWriter:
+		if v == nil || v.target == nil {
+			return nil, false
+		}
+		return fileWriterForSupervisorLog(v.target)
+	default:
+		return nil, false
+	}
+}
+
+func sameOpenFile(a, b *os.File) (bool, error) {
+	aInfo, err := a.Stat()
+	if err != nil {
+		return false, err
+	}
+	bInfo, err := b.Stat()
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(aInfo, bInfo), nil
 }
 
 // acquireSupervisorLock takes an exclusive flock on the supervisor lock file.
@@ -245,6 +270,10 @@ const supervisorOmitProviderCredsEnv = "GC_SUPERVISOR_OMIT_PROVIDER_CREDS"
 var supervisorShutdownSettleDelay = 50 * time.Millisecond
 
 var supervisorSignalNotify = signal.Notify
+
+// supervisorLoadConfig follows the package's test-double convention; tests
+// that replace it must not run in parallel.
+var supervisorLoadConfig = supervisor.LoadConfig
 
 // supervisorHardExitCodeRepeatedShutdown is the exit code for repeated
 // destructive shutdown escalation. 130 approximates the shell SIGINT
@@ -983,8 +1012,10 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	// regardless of how the supervisor was invoked. We skip the tee when
 	// stdout/stderr already point at the same file (manual `gc supervisor
 	// start` path) to avoid double-logging.
-	if logFile := openSupervisorLogForTee(); logFile != nil {
-		defer logFile.Close() //nolint:errcheck // best-effort cleanup
+	if logFile, err := openSupervisorLogForTee(); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor: tee disabled: %v\n", err) //nolint:errcheck
+	} else {
+		defer logFile.Close() //nolint:errcheck // keep after later run-loop cleanup defers
 		if shouldTeeSupervisorLog(stdout, logFile) {
 			stdout = io.MultiWriter(stdout, logFile)
 		}
@@ -1034,7 +1065,7 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	}, stderr)
 
 	// Load supervisor config.
-	supCfg, err := supervisor.LoadConfig(supervisor.ConfigPath())
+	supCfg, err := supervisorLoadConfig(supervisor.ConfigPath())
 	if err != nil {
 		fmt.Fprintf(stderr, "gc supervisor: config: %v\n", err) //nolint:errcheck
 		return 1

--- a/cmd/gc/cmd_supervisor.go
+++ b/cmd/gc/cmd_supervisor.go
@@ -128,6 +128,37 @@ func newSupervisorStatusCmd(stdout, stderr io.Writer) *cobra.Command {
 	return cmd
 }
 
+// openSupervisorLogForTee opens the supervisor log file in append mode for
+// runSupervisor to tee output into. Returns nil on any error (we never
+// fail supervisor startup just because the log file can't be opened —
+// operators still get journald/launchd-captured stdout/stderr).
+func openSupervisorLogForTee() *os.File {
+	f, err := os.OpenFile(supervisorLogPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil
+	}
+	return f
+}
+
+// shouldTeeSupervisorLog reports whether `w` is distinct from the
+// supervisor log file. When `gc supervisor start` spawns a backgrounded
+// `gc supervisor run` child, it pre-opens the log and points
+// child.Stdout/child.Stderr at it — the child's stdout/stderr are then
+// already the log file, so adding a MultiWriter would double-log every
+// line. By comparing the underlying file (Name() match), we avoid that
+// while still teeing for the systemd/launchd/container path where
+// stdout/stderr arrive as a journal/pipe and need explicit routing.
+func shouldTeeSupervisorLog(w io.Writer, logFile *os.File) bool {
+	if w == nil || logFile == nil {
+		return false
+	}
+	wf, ok := w.(*os.File)
+	if !ok {
+		return true
+	}
+	return wf.Name() != logFile.Name()
+}
+
 // acquireSupervisorLock takes an exclusive flock on the supervisor lock file.
 func acquireSupervisorLock() (*os.File, error) {
 	dir := supervisor.RuntimeDir()
@@ -937,6 +968,29 @@ func runSupervisor(stdout, stderr io.Writer) int {
 	if pid := supervisorAlive(); pid != 0 {
 		fmt.Fprintf(stderr, "gc supervisor: supervisor already running (PID %d)\n", pid) //nolint:errcheck
 		return 1
+	}
+
+	// Ensure ~/.gc/ exists. doSupervisorStart does this when invoked
+	// manually (mkdir + open log file before spawning the child), but the
+	// systemd/launchd/container paths jump straight to `gc supervisor run`
+	// without that prep — which leaves operators with `gc supervisor logs`
+	// reporting "log file not found" and no way to see startup errors.
+	if err := os.MkdirAll(supervisor.DefaultHome(), 0o700); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor: ensuring home dir %s: %v\n", supervisor.DefaultHome(), err) //nolint:errcheck
+		return 1
+	}
+	// Always tee to ~/.gc/supervisor.log so `gc supervisor logs` works
+	// regardless of how the supervisor was invoked. We skip the tee when
+	// stdout/stderr already point at the same file (manual `gc supervisor
+	// start` path) to avoid double-logging.
+	if logFile := openSupervisorLogForTee(); logFile != nil {
+		defer logFile.Close() //nolint:errcheck // best-effort cleanup
+		if shouldTeeSupervisorLog(stdout, logFile) {
+			stdout = io.MultiWriter(stdout, logFile)
+		}
+		if shouldTeeSupervisorLog(stderr, logFile) {
+			stderr = io.MultiWriter(stderr, logFile)
+		}
 	}
 
 	lock, err := acquireSupervisorLock()

--- a/cmd/gc/cmd_supervisor_lifecycle.go
+++ b/cmd/gc/cmd_supervisor_lifecycle.go
@@ -669,6 +669,14 @@ func supervisorLogPath() string {
 	return filepath.Join(supervisor.DefaultHome(), "supervisor.log")
 }
 
+func ensureSupervisorServiceLogDir(logPath string) error {
+	dir := filepath.Dir(logPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating supervisor log dir %s: %w", dir, err)
+	}
+	return nil
+}
+
 type supervisorServiceData struct {
 	GCPath        string
 	LogPath       string
@@ -1464,6 +1472,10 @@ func installSupervisorLaunchd(data *supervisorServiceData, stdout, stderr io.Wri
 		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}
+	if err := ensureSupervisorServiceLogDir(data.LogPath); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
 	if err := writeSupervisorServiceFile(path, []byte(content)); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: writing plist: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
@@ -1603,6 +1615,10 @@ func installSupervisorSystemd(data *supervisorServiceData, stdout, stderr io.Wri
 		return 1
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if err := ensureSupervisorServiceLogDir(data.LogPath); err != nil {
 		fmt.Fprintf(stderr, "gc supervisor install: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -5699,6 +5699,94 @@ func TestInstallSupervisorSystemdBailsCleanlyWhenUserManagerMissing(t *testing.T
 	}
 }
 
+func TestInstallSupervisorSystemdCreatesLogDirBeforeStartingService(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("systemd path only applies on linux")
+	}
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "fresh-gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	stubSupervisorSystemctlUserAvailable(t, true)
+	oldRun := supervisorSystemctlRun
+	oldActive := supervisorSystemctlActive
+	var calls []string
+	supervisorSystemctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if args[len(args)-1] == supervisorSystemdServiceName() {
+			if _, err := os.Stat(filepath.Dir(supervisorLogPath())); err != nil {
+				t.Fatalf("log dir missing before systemctl %s: %v", strings.Join(args, " "), err)
+			}
+		}
+		return nil
+	}
+	supervisorSystemctlActive = func(string) bool { return false }
+	t.Cleanup(func() {
+		supervisorSystemctlRun = oldRun
+		supervisorSystemctlActive = oldActive
+	})
+
+	data := &supervisorServiceData{
+		GCPath:        "/tmp/gc-new",
+		LogPath:       filepath.Join(gcHome, "supervisor.log"),
+		GCHome:        gcHome,
+		XDGRuntimeDir: "",
+		Path:          "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorSystemd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorSystemd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Dir(data.LogPath)); err != nil {
+		t.Fatalf("log dir was not created: %v", err)
+	}
+	if !slices.Contains(calls, "--user start "+supervisorSystemdServiceName()) {
+		t.Fatalf("systemctl calls = %v, want service start", calls)
+	}
+}
+
+func TestInstallSupervisorLaunchdCreatesLogDirBeforeLoadingService(t *testing.T) {
+	homeDir := t.TempDir()
+	gcHome := filepath.Join(t.TempDir(), "fresh-gc-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("GC_HOME", gcHome)
+
+	label := supervisorLaunchdLabel()
+	oldRun := supervisorLaunchctlRun
+	var calls []string
+	supervisorLaunchctlRun = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		if args[0] == "load" {
+			if _, err := os.Stat(filepath.Dir(supervisorLogPath())); err != nil {
+				t.Fatalf("log dir missing before launchctl load: %v", err)
+			}
+		}
+		return nil
+	}
+	t.Cleanup(func() { supervisorLaunchctlRun = oldRun })
+
+	data := &supervisorServiceData{
+		GCPath:       "/tmp/gc-new",
+		LogPath:      filepath.Join(gcHome, "supervisor.log"),
+		GCHome:       gcHome,
+		LaunchdLabel: label,
+		Path:         "/usr/local/bin:/usr/bin:/bin",
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := installSupervisorLaunchd(data, &stdout, &stderr); code != 0 {
+		t.Fatalf("installSupervisorLaunchd code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Dir(data.LogPath)); err != nil {
+		t.Fatalf("log dir was not created: %v", err)
+	}
+	if !slices.Contains(calls, "load "+supervisorLaunchdPlistPath()) {
+		t.Fatalf("launchctl calls = %v, want plist load", calls)
+	}
+}
+
 // TestCurrentUsernameForSystemdHintFallback covers the fallback branch of
 // currentUsernameForSystemdHint: when osuser.Current returns an error or
 // an empty username, the diagnostic still has a placeholder a user can
@@ -5750,31 +5838,20 @@ func TestRunSupervisorEnsuresHomeDirAndWritesLog(t *testing.T) {
 		t.Fatalf("precondition: %s must not exist yet, got err=%v", gcHome, err)
 	}
 
-	// Stub the long-running loop so the test exits as soon as the early
-	// setup (MkdirAll + log open + lock acquire) is exercised. We use
-	// runSupervisorFunc to substitute, but since runSupervisor itself does
-	// the setup BEFORE calling any loop, just invoking it and letting the
-	// lock-acquire fail is enough to test the early path.
-	//
-	// Force lock acquisition to fail fast by pre-creating a held lock.
-	if err := os.MkdirAll(gcHome, 0o700); err != nil {
-		t.Fatalf("seed home dir: %v", err)
+	oldLoadConfig := supervisorLoadConfig
+	supervisorLoadConfig = func(string) (supervisor.Config, error) {
+		return supervisor.Config{}, errors.New("stop after log setup")
 	}
-	preheld, err := os.OpenFile(filepath.Join(gcHome, "supervisor.lock"), os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		t.Fatalf("seed lock file: %v", err)
-	}
-	defer preheld.Close() //nolint:errcheck
-	if err := syscall.Flock(int(preheld.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		t.Fatalf("hold lock: %v", err)
-	}
-	// Now blow away the home dir to truly simulate the fresh-install state.
-	if err := os.RemoveAll(gcHome); err != nil {
-		t.Fatalf("reset home dir: %v", err)
-	}
+	t.Cleanup(func() { supervisorLoadConfig = oldLoadConfig })
 
 	var stdout, stderr bytes.Buffer
-	_ = runSupervisor(&stdout, &stderr) // exits with 1 because no lock; that's fine
+	code := runSupervisor(&stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runSupervisor code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "stop after log setup") {
+		t.Fatalf("stderr = %q, want stubbed config failure", stderr.String())
+	}
 
 	// The home dir must now exist (created by runSupervisor's MkdirAll).
 	if info, err := os.Stat(gcHome); err != nil || !info.IsDir() {
@@ -5786,13 +5863,46 @@ func TestRunSupervisorEnsuresHomeDirAndWritesLog(t *testing.T) {
 	if _, err := os.Stat(logPath); err != nil {
 		t.Fatalf("after runSupervisor, %s should exist; err=%v", logPath, err)
 	}
+	logContent, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read supervisor log: %v", err)
+	}
+	if !strings.Contains(string(logContent), "stop after log setup") {
+		t.Fatalf("supervisor log = %q, want stubbed config failure", string(logContent))
+	}
 }
 
-// TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart confirms the
+func TestRunSupervisorWarnsWhenLogTeeOpenFails(t *testing.T) {
+	gcHome := t.TempDir()
+	t.Setenv("GC_HOME", gcHome)
+	if err := os.Mkdir(filepath.Join(gcHome, "supervisor.log"), 0o700); err != nil {
+		t.Fatalf("seed log path as directory: %v", err)
+	}
+
+	oldLoadConfig := supervisorLoadConfig
+	supervisorLoadConfig = func(string) (supervisor.Config, error) {
+		return supervisor.Config{}, errors.New("stop after log setup")
+	}
+	t.Cleanup(func() { supervisorLoadConfig = oldLoadConfig })
+
+	var stdout, stderr bytes.Buffer
+	code := runSupervisor(&stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("runSupervisor code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "gc supervisor: tee disabled: opening supervisor log") {
+		t.Fatalf("stderr = %q, want tee-open warning", got)
+	}
+	if !strings.Contains(got, "stop after log setup") {
+		t.Fatalf("stderr = %q, want stubbed config failure", got)
+	}
+}
+
+// TestShouldTeeSupervisorLogAvoidsDoubleLoggingForRedirectedFDs confirms the
 // guard that prevents double-writes when stdout/stderr are already the
-// supervisor log file (the manual `gc supervisor start` path opens the
-// file in the parent and points the child's stdout/stderr at it).
-func TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart(t *testing.T) {
+// supervisor log file, even when the fd carries a cosmetic /dev/stdout name.
+func TestShouldTeeSupervisorLogAvoidsDoubleLoggingForRedirectedFDs(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "supervisor.log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0o644)
@@ -5801,17 +5911,25 @@ func TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart(t *testing.T) {
 	}
 	defer logFile.Close() //nolint:errcheck
 
-	// Same path = the manual-start case. Must not tee.
-	sameFile, err := os.OpenFile(logPath, os.O_RDWR, 0o644)
+	// A duped fd with a cosmetic name models os.Stdout/os.Stderr after a
+	// service manager or parent process already redirected fd 1/2 to the log.
+	dupFD, err := syscall.Dup(int(logFile.Fd()))
 	if err != nil {
-		t.Fatalf("reopen log: %v", err)
+		t.Fatalf("dup log fd: %v", err)
 	}
-	defer sameFile.Close() //nolint:errcheck
-	if shouldTeeSupervisorLog(sameFile, logFile) {
-		t.Errorf("manual-start case (same file path): shouldTeeSupervisorLog should return false")
+	redirectedStdout := os.NewFile(uintptr(dupFD), "/dev/stdout")
+	if redirectedStdout == nil {
+		t.Fatal("os.NewFile returned nil for duplicated log fd")
+	}
+	defer redirectedStdout.Close() //nolint:errcheck
+	if shouldTeeSupervisorLog(redirectedStdout, logFile) {
+		t.Errorf("redirected stdout fd: shouldTeeSupervisorLog should return false")
+	}
+	if shouldTeeSupervisorLog(&switchableWriter{target: redirectedStdout}, logFile) {
+		t.Errorf("switchable writer wrapping redirected stdout fd: shouldTeeSupervisorLog should return false")
 	}
 
-	// Different file = systemd/launchd case. Must tee.
+	// Different file = terminal/container output. Must tee.
 	otherPath := filepath.Join(dir, "other.log")
 	otherFile, err := os.Create(otherPath)
 	if err != nil {
@@ -5819,12 +5937,12 @@ func TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart(t *testing.T) {
 	}
 	defer otherFile.Close() //nolint:errcheck
 	if !shouldTeeSupervisorLog(otherFile, logFile) {
-		t.Errorf("systemd/launchd case (different file): shouldTeeSupervisorLog should return true")
+		t.Errorf("different file: shouldTeeSupervisorLog should return true")
 	}
 
 	// Non-file writer (a buffer simulating a journal pipe). Must tee.
 	if !shouldTeeSupervisorLog(&bytes.Buffer{}, logFile) {
-		t.Errorf("non-file writer (pipe/journal): shouldTeeSupervisorLog should return true")
+		t.Errorf("non-file writer: shouldTeeSupervisorLog should return true")
 	}
 
 	// Nil safety.

--- a/cmd/gc/cmd_supervisor_test.go
+++ b/cmd/gc/cmd_supervisor_test.go
@@ -5734,3 +5734,104 @@ func TestCurrentUsernameForSystemdHintFallback(t *testing.T) {
 		}
 	})
 }
+
+// TestRunSupervisorEnsuresHomeDirAndWritesLog confirms the fix for the
+// "Supervisor logs: log file not found" symptom seen on first start under
+// systemd/launchd/container — where the original `gc supervisor start`
+// mkdir+open codepath is bypassed. runSupervisor now creates ~/.gc/ and
+// opens the log file itself before doing any work.
+func TestRunSupervisorEnsuresHomeDirAndWritesLog(t *testing.T) {
+	gcHome := filepath.Join(t.TempDir(), "fresh-home")
+	t.Setenv("GC_HOME", gcHome)
+
+	// Sanity: the home dir does NOT exist yet — this is the systemd/launchd
+	// fresh-install scenario.
+	if _, err := os.Stat(gcHome); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist yet, got err=%v", gcHome, err)
+	}
+
+	// Stub the long-running loop so the test exits as soon as the early
+	// setup (MkdirAll + log open + lock acquire) is exercised. We use
+	// runSupervisorFunc to substitute, but since runSupervisor itself does
+	// the setup BEFORE calling any loop, just invoking it and letting the
+	// lock-acquire fail is enough to test the early path.
+	//
+	// Force lock acquisition to fail fast by pre-creating a held lock.
+	if err := os.MkdirAll(gcHome, 0o700); err != nil {
+		t.Fatalf("seed home dir: %v", err)
+	}
+	preheld, err := os.OpenFile(filepath.Join(gcHome, "supervisor.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("seed lock file: %v", err)
+	}
+	defer preheld.Close() //nolint:errcheck
+	if err := syscall.Flock(int(preheld.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	// Now blow away the home dir to truly simulate the fresh-install state.
+	if err := os.RemoveAll(gcHome); err != nil {
+		t.Fatalf("reset home dir: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_ = runSupervisor(&stdout, &stderr) // exits with 1 because no lock; that's fine
+
+	// The home dir must now exist (created by runSupervisor's MkdirAll).
+	if info, err := os.Stat(gcHome); err != nil || !info.IsDir() {
+		t.Fatalf("after runSupervisor, %s should exist as a directory; err=%v", gcHome, err)
+	}
+
+	// The log file must exist (created by runSupervisor's openSupervisorLogForTee).
+	logPath := filepath.Join(gcHome, "supervisor.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("after runSupervisor, %s should exist; err=%v", logPath, err)
+	}
+}
+
+// TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart confirms the
+// guard that prevents double-writes when stdout/stderr are already the
+// supervisor log file (the manual `gc supervisor start` path opens the
+// file in the parent and points the child's stdout/stderr at it).
+func TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "supervisor.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer logFile.Close() //nolint:errcheck
+
+	// Same path = the manual-start case. Must not tee.
+	sameFile, err := os.OpenFile(logPath, os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("reopen log: %v", err)
+	}
+	defer sameFile.Close() //nolint:errcheck
+	if shouldTeeSupervisorLog(sameFile, logFile) {
+		t.Errorf("manual-start case (same file path): shouldTeeSupervisorLog should return false")
+	}
+
+	// Different file = systemd/launchd case. Must tee.
+	otherPath := filepath.Join(dir, "other.log")
+	otherFile, err := os.Create(otherPath)
+	if err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	defer otherFile.Close() //nolint:errcheck
+	if !shouldTeeSupervisorLog(otherFile, logFile) {
+		t.Errorf("systemd/launchd case (different file): shouldTeeSupervisorLog should return true")
+	}
+
+	// Non-file writer (a buffer simulating a journal pipe). Must tee.
+	if !shouldTeeSupervisorLog(&bytes.Buffer{}, logFile) {
+		t.Errorf("non-file writer (pipe/journal): shouldTeeSupervisorLog should return true")
+	}
+
+	// Nil safety.
+	if shouldTeeSupervisorLog(nil, logFile) {
+		t.Errorf("nil writer: shouldTeeSupervisorLog should return false")
+	}
+	if shouldTeeSupervisorLog(otherFile, nil) {
+		t.Errorf("nil logFile: shouldTeeSupervisorLog should return false")
+	}
+}


### PR DESCRIPTION
## Symptom

On a fresh install (Linux/macOS), after running \`gc start <city>\` the operator sees:

\`\`\`
$ gc supervisor logs
gc supervisor logs: log file not found: /home/pa/.gc/supervisor.log
\`\`\`

\`~/.gc/\` doesn't exist. \`gc supervisor status\` says "not running" (after the supervisor crashed or stopped). Operator has zero visibility into what happened during the brief window the supervisor ran.

This invisibility is the root cause that masks RC2/RC3/RC4/RC5 of the wider audit on the gascity-3 reproducer (where bd init for the city scope silently failed and \`gc session attach mayor\` then dies with \"database not found: hq\").

## Root cause

\`gc start <city>\` → \`ensureSupervisorRunning\` → \`doSupervisorInstall\` → systemd/launchd unit → \`gc supervisor run\` (the platform service manager invokes the run subcommand directly).

The mkdir + log-file-open happens in \`doSupervisorStart\` (the manual path, lines 444-451 of \`cmd/gc/cmd_supervisor_lifecycle.go\`), NOT in \`runSupervisor\`. So the systemd/launchd path never creates \`~/.gc/\` and never writes \`~/.gc/supervisor.log\`. Stdout/stderr go to journald/launchd's log facilities, but \`gc supervisor logs\` stubbornly reads from the file path.

## Fix

\`runSupervisor\` now:

1. \`MkdirAll(supervisor.DefaultHome(), 0o700)\` very early — fails fast with a clear error if it can't.
2. Opens \`~/.gc/supervisor.log\` in append mode and tees stdout/stderr through it via \`io.MultiWriter\`. \`shouldTeeSupervisorLog\` skips the tee when stdout/stderr already point at the same file (the manual-start path opens the file in the parent and pipes child stdout/stderr to it — adding a MultiWriter would double-log every line).

Result: \`gc supervisor logs\` works regardless of how the supervisor was invoked (manual, systemd, launchd, container PID 1).

## Tests

- \`TestRunSupervisorEnsuresHomeDirAndWritesLog\` — fresh-install scenario (\`~/.gc/\` doesn't exist); runSupervisor creates the dir and log file even when it exits early due to lock contention. Confirms the early setup runs unconditionally.
- \`TestShouldTeeSupervisorLogAvoidsDoubleLoggingOnManualStart\` — table covering same-file (no tee), different-file (tee), non-file writer like a journal pipe (tee), plus nil safety.

## Test plan

- [x] \`go vet ./cmd/gc/...\` clean
- [x] \`make lint-changed\` clean on changed files
- [x] New unit tests pass

## Stack context

This is **PR 1/5** of the gascity-3 reproducer audit. The five RCs are independent and target different failure modes; this one (visibility) unblocks the debug experience for the others.

Subsequent PRs:
- RC3: drop \`|| true\` swallowing \`CREATE DATABASE\` failures in gc-beads-bd.sh
- RC5: post-init validation that the database actually exists
- RC2: stop pre-writing \`metadata.json\` before init succeeds
- RC4: write \`.bd-dolt-ok\` marker after server-mode init

🤖 Generated with [Claude Code](https://claude.com/claude-code)