### PR TITLE
fix(beads): fail loud when CREATE DATABASE fails in gc-beads-bd init

### DIFF
--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2100,7 +2100,15 @@ op_init() {
     # IF NOT EXISTS both creates the on-disk directory and registers it in
     # the server's catalog. This is the upstream gastown pattern — when the
     # server is running, always go through SQL rather than dolt init on disk.
-    ensure_database_registered "$dolt_database" || true
+    #
+    # Failure here is a hard stop: bd init in server mode requires the
+    # database to exist on the server. The previous `|| true` swallowed
+    # CREATE DATABASE failures and let bd init fail later with a cryptic
+    # "database not found" error — root cause of the gascity-3 reproducer
+    # where the city's hq database was never created on first start.
+    if ! ensure_database_registered "$dolt_database"; then
+        die "failed to register Dolt database '$dolt_database' on running server (CREATE DATABASE failed); see warnings above. cannot proceed with bd init."
+    fi
 
     # Run bd init in server mode through the pinned wrapper so the fallback
     # path uses the same authenticated Dolt target as the rest of init.
@@ -2112,7 +2120,14 @@ op_init() {
     # and leave the pinned database schema-less.
     run_bd_init_pinned "$dir" "$prefix" "$dolt_database" "$host" "${bd_init_force:+true}"
 
-    ensure_database_registered "$dolt_database" || true
+    # Re-register post-init: if bd init didn't catalog-register the DB
+    # (server-mode quirk), do it now. After a successful bd init this is a
+    # no-op via the USE check inside ensure_database_registered. Failure
+    # here means bd init claimed success but the server can't see the DB —
+    # equally a hard stop, equally previously swallowed by `|| true`.
+    if ! ensure_database_registered "$dolt_database"; then
+        die "Dolt database '$dolt_database' is unreachable on the server after bd init reported success; see warnings above. probable causes: server crashed mid-init, port collision, or stale catalog state."
+    fi
 
     # GC owns canonical metadata/config normalization after this backend
     # bridge returns. Keep bd-specific config/migration here only.


### PR DESCRIPTION
## Symptom

On the gascity-3 reproducer:

\`\`\`
$ gc session attach mayor
gc session attach: resolving configured named session "mayor": ...
{"error": "failed to open database: database \"hq\" not found on Dolt server at 127.0.0.1:52539\n..."}
\`\`\`

The Dolt server runs, knows about \`hq\` per its connection metadata, but \`hq\` doesn't exist as a database in the data dir (\`ls ~/my-city/.beads/dolt/\` shows only \`si/\` from the rig, no \`hq/\`). Many minutes earlier, the supervisor's init for the city scope had silently failed to create \`hq\` — but the operator had no log trail pointing to that.

## Root cause

\`examples/bd/assets/scripts/gc-beads-bd.sh\` (the exec-provider script) calls \`ensure_database_registered "$dolt_database"\` twice during \`op_init\`:

\`\`\`bash
# Before bd init:
ensure_database_registered "$dolt_database" || true
run_bd_init_pinned "$dir" "$prefix" "$dolt_database" "$host" ...

# After bd init:
ensure_database_registered "$dolt_database" || true
\`\`\`

The \`|| true\` swallows CREATE DATABASE failures. If CREATE DATABASE fails for the city's \`hq\`, bd init then runs in \`--server --database hq\` mode against a database that doesn't exist on the server, and bd init fails with a generic error that propagates up via \`die\`. The original CREATE DATABASE warning scrolled by but the operator never sees the chain because:

1. The script exits at the wrong place (bd init's failure, not CREATE DATABASE's)
2. The supervisor log is invisible on systemd/launchd (see PR #2104)

## Fix

Replace both \`|| true\` swallows with explicit \`if ! ... then die\` guards. The first guard fails before bd init runs (so we don't waste time running bd init on a non-existent database). The second guard catches the rare case where bd init reports success but the server can't see the database (server crash mid-init, port collision, stale catalog state).

Both \`die\` messages name the specific database and operation, so the operator immediately knows what's broken.

## Behavior change

|                | Before                              | After                                              |
| ------         | ------                              | ------                                             |
| CREATE DATABASE fails  | Silent. bd init fails downstream with a cryptic error. | Script exits immediately with a clear message naming the database. |
| CREATE DATABASE succeeds       | Unchanged                           | Unchanged                                          |
| Post-bd-init re-register fails | Silent. Probably-broken DB left for downstream surprise. | Script exits with \"database unreachable after init\" message. |

Legitimate \`|| true\` patterns in the script (pkill best-effort, jq with default-empty fallback) are untouched.

## Tests

The shell script's behavior is exercised end-to-end by the integration test suite (\`test/integration/gc-live-contract\`). The change here is a 2-line semantic shift inside an existing code path; \`bash -n\` syntax check passes. No new unit-level test added because the failure path requires a real Dolt server in a transient bad state — better captured by integration tests than by mocking the SQL connection.

## Stack context

This is **PR 2/5** of the gascity-3 reproducer audit.

- PR 1 (#2104): supervisor log visibility on systemd/launchd ← unblocks debug for this
- PR 2 (this): drop \`|| true\` on CREATE DATABASE
- RC5: post-init validation that the database actually exists
- RC2: stop pre-writing \`metadata.json\` before init succeeds
- RC4: write \`.bd-dolt-ok\` marker after server-mode init

Independent of the others, but compounding effects with PR 1: once both merge, an operator hitting the gascity-3 failure mode would see a clear "CREATE DATABASE hq failed: <reason>" line in \`gc supervisor logs\` instead of the current invisible silent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)