### PR TITLE
fix(beads): post-init validation that the canonical database actually exists

### DIFF
--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -441,6 +441,19 @@ func initAndHookDir(cityPath, dir, prefix string) error {
 		if err := initAndHookDirWaitForScopeReady(dir, cityPath, time.Now().Add(10*time.Second)); err != nil {
 			return fmt.Errorf("waiting for initialized bead scope readiness: %w", err)
 		}
+		// Strong post-init validation: confirm the canonical database
+		// actually exists on the running Dolt server. The scope-ready
+		// check above pings via the bead store, which has historically
+		// returned ok against a server that knows the database name in
+		// metadata but doesn't have it in its catalog (gascity-3
+		// reproducer where bd init's CREATE DATABASE was silently
+		// swallowed and the city's hq was never created). An explicit
+		// SHOW DATABASES check fails fast at the actual init step
+		// instead of leaking the failure to a downstream "database not
+		// found" at gc session attach time.
+		if err := verifyManagedDoltDatabaseExistsAfterInit(cityPath, dir, doltDatabase); err != nil {
+			return fmt.Errorf("verifying canonical scope database after init: %w", err)
+		}
 	}
 	// Non-fatal: hooks are convenience (event forwarding), not critical.
 	if err := installBeadHooks(dir); err != nil {
@@ -499,6 +512,56 @@ func allowLegacyDoltMetadataRepair(fs fsys.FS, path string, err error) bool {
 		strings.TrimSpace(raw.PostgresPort) == "" &&
 		strings.TrimSpace(raw.PostgresUser) == "" &&
 		strings.TrimSpace(raw.PostgresDatabase) == ""
+}
+
+// verifyManagedDoltDatabaseExistsAfterInit confirms the named database is
+// present in the running managed Dolt server's catalog. Used as a post-init
+// guardrail to catch the silent-init failure mode where bd init reports
+// success but the database was never actually created. Returns nil when
+// the database is found, or an actionable error otherwise.
+//
+// The function is a no-op (returns nil) when the city does not use the bd
+// store contract or when no managed Dolt port is published — the caller
+// already gates on those conditions, but we double-check defensively so
+// the helper is safe to call from new sites without re-checking.
+var verifyManagedDoltDatabaseExistsAfterInit = func(cityPath, dir, dbName string) error {
+	if !cityUsesBdStoreContract(cityPath) {
+		return nil
+	}
+	port := currentManagedDoltPort(cityPath)
+	if port == "" {
+		return nil
+	}
+	dbName = strings.TrimSpace(dbName)
+	if dbName == "" {
+		return nil
+	}
+
+	host, user := managedDoltConnectHost(""), "root"
+	db, err := managedDoltOpenDB(host, port, user)
+	if err != nil {
+		return fmt.Errorf("connect to managed Dolt at %s:%s: %w", host, port, err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection to managed Dolt: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	dbs, err := managedDoltSelectUserDatabasesFromConn(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("list databases on managed Dolt: %w", err)
+	}
+	for _, d := range dbs {
+		if strings.EqualFold(d, dbName) {
+			return nil
+		}
+	}
+	return fmt.Errorf("database %q not found in managed Dolt server catalog after init for scope %s (server-visible: %v); bd init reported success but the database was never created — usually means CREATE DATABASE was swallowed (see gc-beads-bd.sh)", dbName, dir, dbs)
 }
 
 func shouldRetryExecBdInit(err error) bool {

--- a/cmd/gc/beads_provider_lifecycle.go
+++ b/cmd/gc/beads_provider_lifecycle.go
@@ -536,25 +536,15 @@ var verifyManagedDoltDatabaseExistsAfterInit = func(cityPath, dir, dbName string
 	if dbName == "" {
 		return nil
 	}
-
-	host, user := managedDoltConnectHost(""), "root"
-	db, err := managedDoltOpenDB(host, port, user)
-	if err != nil {
-		return fmt.Errorf("connect to managed Dolt at %s:%s: %w", host, port, err)
+	if isLegacyManagedDoltProbeDatabase(dbName) {
+		// Startup normalization preserves this one legacy reserved database
+		// when existing metadata already uses it as the real bead store.
+		return nil
 	}
-	defer db.Close() //nolint:errcheck
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	conn, err := db.Conn(ctx)
+	dbs, err := managedDoltListUserDatabasesAfterInit(port)
 	if err != nil {
-		return fmt.Errorf("acquire connection to managed Dolt: %w", err)
-	}
-	defer conn.Close() //nolint:errcheck
-
-	dbs, err := managedDoltSelectUserDatabasesFromConn(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("list databases on managed Dolt: %w", err)
+		return err
 	}
 	for _, d := range dbs {
 		if strings.EqualFold(d, dbName) {
@@ -562,6 +552,29 @@ var verifyManagedDoltDatabaseExistsAfterInit = func(cityPath, dir, dbName string
 		}
 	}
 	return fmt.Errorf("database %q not found in managed Dolt server catalog after init for scope %s (server-visible: %v); bd init reported success but the database was never created — usually means CREATE DATABASE was swallowed (see gc-beads-bd.sh)", dbName, dir, dbs)
+}
+
+var managedDoltListUserDatabasesAfterInit = func(port string) ([]string, error) {
+	host, user := managedDoltConnectHost(""), "root"
+	db, err := managedDoltOpenDB(host, port, user)
+	if err != nil {
+		return nil, fmt.Errorf("connect to managed Dolt at %s:%s: %w", host, port, err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire connection to managed Dolt: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	dbs, err := managedDoltSelectUserDatabasesFromConn(ctx, conn)
+	if err != nil {
+		return nil, fmt.Errorf("list databases on managed Dolt: %w", err)
+	}
+	return dbs, nil
 }
 
 func shouldRetryExecBdInit(err error) bool {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -9245,8 +9245,8 @@ func TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState(t *testing
 	// server. This test wires only a bare TCP listener as the "managed
 	// Dolt port", which is enough for the rest of the lifecycle but not
 	// for SHOW DATABASES. Stub the verifier — coverage for the verifier
-	// itself lives in TestVerifyManagedDoltDatabaseExistsAfterInitNoOps
-	// (unit-level guards) and the integration suite (full path).
+	// itself lives in focused unit tests below; this lifecycle test only
+	// needs to prove startup does not require pre-existing runtime state.
 	originalVerifier := verifyManagedDoltDatabaseExistsAfterInit
 	verifyManagedDoltDatabaseExistsAfterInit = func(_, _, _ string) error { return nil }
 	t.Cleanup(func() { verifyManagedDoltDatabaseExistsAfterInit = originalVerifier })
@@ -9981,24 +9981,125 @@ exit 2
 // these conditions but the helper double-checks defensively so it's
 // safe to call from new sites.
 func TestVerifyManagedDoltDatabaseExistsAfterInitNoOps(t *testing.T) {
-	// Capture the production verifier and restore at end of test.
 	original := verifyManagedDoltDatabaseExistsAfterInit
-	t.Cleanup(func() { verifyManagedDoltDatabaseExistsAfterInit = original })
 
-	tmp := t.TempDir()
-	// City without the bd store contract → no-op.
-	if err := original(tmp, tmp, "hq"); err != nil {
-		t.Errorf("city without bd contract should be no-op, got %v", err)
-	}
+	t.Run("non bd contract", func(t *testing.T) {
+		cityPath := setupFileProviderCityForTest(t)
+		stop := publishRejectingManagedDoltRuntimeForTest(t, cityPath)
+		defer stop()
 
-	// Empty db name → no-op (defensive).
+		if err := original(cityPath, cityPath, "hq"); err != nil {
+			t.Errorf("city without bd contract should be no-op, got %v", err)
+		}
+	})
+
+	t.Run("no managed port", func(t *testing.T) {
+		cityPath := setupBdContractCityForTest(t)
+
+		if err := original(cityPath, cityPath, "hq"); err != nil {
+			t.Errorf("city without managed Dolt port should be no-op, got %v", err)
+		}
+	})
+
+	t.Run("empty db name", func(t *testing.T) {
+		cityPath := setupBdContractCityForTest(t)
+		stop := publishRejectingManagedDoltRuntimeForTest(t, cityPath)
+		defer stop()
+
+		if err := original(cityPath, cityPath, ""); err != nil {
+			t.Errorf("empty dbName should be no-op, got %v", err)
+		}
+		if err := original(cityPath, cityPath, "  "); err != nil {
+			t.Errorf("whitespace dbName should be no-op, got %v", err)
+		}
+	})
+}
+
+func TestVerifyManagedDoltDatabaseExistsAfterInitSkipsLegacyProbeDatabase(t *testing.T) {
+	original := verifyManagedDoltDatabaseExistsAfterInit
+
 	cityPath := setupBdContractCityForTest(t)
-	if err := original(cityPath, cityPath, ""); err != nil {
-		t.Errorf("empty dbName should be no-op, got %v", err)
+	metadataPath := filepath.Join(cityPath, ".beads", "metadata.json")
+	if _, err := contract.EnsureCanonicalMetadata(fsys.OSFS{}, metadataPath, contract.MetadataState{
+		Database:     "dolt",
+		Backend:      "dolt",
+		DoltMode:     "server",
+		DoltDatabase: strings.ToUpper(managedDoltProbeDatabase),
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalMetadata: %v", err)
 	}
-	if err := original(cityPath, cityPath, "  "); err != nil {
-		t.Errorf("whitespace dbName should be no-op, got %v", err)
+	stop := publishRejectingManagedDoltRuntimeForTest(t, cityPath)
+	defer stop()
+
+	if err := original(cityPath, cityPath, strings.ToUpper(managedDoltProbeDatabase)); err != nil {
+		t.Fatalf("legacy probe database should be accepted without catalog lookup, got %v", err)
 	}
+}
+
+func TestVerifyManagedDoltDatabaseExistsAfterInitCatalogMatch(t *testing.T) {
+	original := verifyManagedDoltDatabaseExistsAfterInit
+	originalListDatabases := managedDoltListUserDatabasesAfterInit
+	t.Cleanup(func() { managedDoltListUserDatabasesAfterInit = originalListDatabases })
+
+	cityPath := setupBdContractCityForTest(t)
+	stop := publishRejectingManagedDoltRuntimeForTest(t, cityPath)
+	defer stop()
+
+	called := false
+	managedDoltListUserDatabasesAfterInit = func(port string) ([]string, error) {
+		called = true
+		if strings.TrimSpace(port) == "" {
+			t.Fatal("managed Dolt port was empty")
+		}
+		return []string{"archive", "HQ"}, nil
+	}
+
+	if err := original(cityPath, filepath.Join(cityPath, "scope"), "hq"); err != nil {
+		t.Fatalf("catalog containing database should pass: %v", err)
+	}
+	if !called {
+		t.Fatal("catalog listing was not reached")
+	}
+}
+
+func TestVerifyManagedDoltDatabaseExistsAfterInitCatalogMiss(t *testing.T) {
+	original := verifyManagedDoltDatabaseExistsAfterInit
+	originalListDatabases := managedDoltListUserDatabasesAfterInit
+	t.Cleanup(func() { managedDoltListUserDatabasesAfterInit = originalListDatabases })
+
+	cityPath := setupBdContractCityForTest(t)
+	stop := publishRejectingManagedDoltRuntimeForTest(t, cityPath)
+	defer stop()
+
+	managedDoltListUserDatabasesAfterInit = func(port string) ([]string, error) {
+		if strings.TrimSpace(port) == "" {
+			t.Fatal("managed Dolt port was empty")
+		}
+		return []string{"archive", "other"}, nil
+	}
+
+	scopeDir := filepath.Join(cityPath, "rigs", "alpha")
+	err := original(cityPath, scopeDir, "hq")
+	if err == nil {
+		t.Fatal("catalog missing database should fail")
+	}
+	msg := err.Error()
+	for _, want := range []string{`database "hq"`, scopeDir, "archive", "other", "CREATE DATABASE was swallowed"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func setupFileProviderCityForTest(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir beads: %v", err)
+	}
+	return tmp
 }
 
 // setupBdContractCityForTest returns a temp city dir that satisfies
@@ -10006,6 +10107,8 @@ func TestVerifyManagedDoltDatabaseExistsAfterInitNoOps(t *testing.T) {
 func setupBdContractCityForTest(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
+	t.Setenv("GC_BEADS", "bd")
+	t.Setenv("GC_BEADS_SCOPE_ROOT", tmp)
 	beadsDir := filepath.Join(tmp, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
 		t.Fatalf("mkdir beads: %v", err)
@@ -10022,7 +10125,35 @@ func setupBdContractCityForTest(t *testing.T) string {
 	return tmp
 }
 
-// (Integration-level coverage of the full verifier path — connect to a
-// running Dolt server and resolve SHOW DATABASES — lives in the
-// integration test suite. Unit tests here cover the no-op early-return
-// guards, which is what the helper's defensive contract requires.)
+func publishRejectingManagedDoltRuntimeForTest(t *testing.T, cityPath string) func() {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := writeDoltRuntimeStateFile(managedDoltStatePath(cityPath), doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   filepath.Join(cityPath, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("write managed Dolt runtime state: %v", err)
+	}
+	return func() {
+		_ = ln.Close()
+		<-done
+	}
+}

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -9241,6 +9241,16 @@ func TestStartBeadsLifecycleRegistersArchiveLevelOnlyDoltConfig(t *testing.T) {
 }
 
 func TestStartBeadsLifecycleManagedDeferredDoesNotRequireRuntimeState(t *testing.T) {
+	// The post-init Dolt catalog verifier needs a real MySQL-speaking
+	// server. This test wires only a bare TCP listener as the "managed
+	// Dolt port", which is enough for the rest of the lifecycle but not
+	// for SHOW DATABASES. Stub the verifier — coverage for the verifier
+	// itself lives in TestVerifyManagedDoltDatabaseExistsAfterInitNoOps
+	// (unit-level guards) and the integration suite (full path).
+	originalVerifier := verifyManagedDoltDatabaseExistsAfterInit
+	verifyManagedDoltDatabaseExistsAfterInit = func(_, _, _ string) error { return nil }
+	t.Cleanup(func() { verifyManagedDoltDatabaseExistsAfterInit = originalVerifier })
+
 	cityPath := t.TempDir()
 	rigPath := filepath.Join(cityPath, "rig")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {

--- a/cmd/gc/beads_provider_lifecycle_test.go
+++ b/cmd/gc/beads_provider_lifecycle_test.go
@@ -9963,3 +9963,56 @@ exit 2
 		t.Fatalf("health call count = %d, want 2; log:\n%s", got, data)
 	}
 }
+
+// TestVerifyManagedDoltDatabaseExistsAfterInitNoOps confirms the early
+// returns: when the city doesn't use the bd store contract, OR when no
+// managed Dolt port is published, OR when the database name is empty,
+// the verifier is a no-op (returns nil) — the caller already gates on
+// these conditions but the helper double-checks defensively so it's
+// safe to call from new sites.
+func TestVerifyManagedDoltDatabaseExistsAfterInitNoOps(t *testing.T) {
+	// Capture the production verifier and restore at end of test.
+	original := verifyManagedDoltDatabaseExistsAfterInit
+	t.Cleanup(func() { verifyManagedDoltDatabaseExistsAfterInit = original })
+
+	tmp := t.TempDir()
+	// City without the bd store contract → no-op.
+	if err := original(tmp, tmp, "hq"); err != nil {
+		t.Errorf("city without bd contract should be no-op, got %v", err)
+	}
+
+	// Empty db name → no-op (defensive).
+	cityPath := setupBdContractCityForTest(t)
+	if err := original(cityPath, cityPath, ""); err != nil {
+		t.Errorf("empty dbName should be no-op, got %v", err)
+	}
+	if err := original(cityPath, cityPath, "  "); err != nil {
+		t.Errorf("whitespace dbName should be no-op, got %v", err)
+	}
+}
+
+// setupBdContractCityForTest returns a temp city dir that satisfies
+// cityUsesBdStoreContract but has no published Dolt port.
+func setupBdContractCityForTest(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	beadsDir := filepath.Join(tmp, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir beads: %v", err)
+	}
+	// Minimum to make cityUsesBdStoreContract return true: the
+	// canonical config file presence is what's checked. Drop the file
+	// the function expects.
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue_prefix: tc\nissue-prefix: tc\n"), 0o644); err != nil {
+		t.Fatalf("seed config.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"hq","dolt_mode":"server"}`), 0o644); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	return tmp
+}
+
+// (Integration-level coverage of the full verifier path — connect to a
+// running Dolt server and resolve SHOW DATABASES — lives in the
+// integration test suite. Unit tests here cover the no-op early-return
+// guards, which is what the helper's defensive contract requires.)


### PR DESCRIPTION
## Symptom

On gascity-3, after \`gc start ~/my-city\` reported success and the supervisor stopped:

\`\`\`
$ gc session attach mayor
... database "hq" not found on Dolt server at 127.0.0.1:52539
\`\`\`

The Dolt server was running and \`metadata.json\` correctly named \`hq\` as the city's database — but \`hq\` had never been created in the server's catalog. Many minutes earlier, the supervisor's bd init for the city scope had silently failed.

## Why the existing readiness check missed it

\`initAndHookDir\` calls \`initAndHookDirWaitForScopeReady\` after \`initBeadsForDir\`, which pings via \`openStoreAtForCity\` + \`Ping()\`. That historically returned ok against a server that knows the database name in metadata but doesn't have it in its catalog — the connection succeeds at the protocol level even when the target database is missing, depending on driver behavior.

## Fix

Add an explicit \`SHOW DATABASES\` check immediately after the readiness ping. When the canonical scope database is absent from the server's catalog, return an actionable error that names the database, the scope, and the visible-databases list. The error makes it obvious that bd init reported success but the database was never actually created.

\`\`\`go
return fmt.Errorf("database %q not found in managed Dolt server catalog after init for scope %s (server-visible: %v); bd init reported success but the database was never created — usually means CREATE DATABASE was swallowed (see gc-beads-bd.sh)", dbName, dir, dbs)
\`\`\`

The verifier is exposed as a package-level \`var\` so tests can stub it without spinning a real Dolt server. The function itself short-circuits to nil when:
- The city doesn't use the bd store contract (file backend, etc.)
- The managed Dolt port isn't yet published (early init)
- The database name is empty

These guards match the caller's existing condition gates and make the helper safe to call from new sites without re-checking.

## Tests

- \`TestVerifyManagedDoltDatabaseExistsAfterInitNoOps\` — covers the three defensive early-returns.
- Full integration coverage (connect to running Dolt + \`SHOW DATABASES\`) lives in the integration test suite where a real Dolt server is available.

## Test plan

- [x] \`go vet ./cmd/gc/...\` clean
- [x] New unit tests pass

## Stack context

This is **PR 3/5** of the gascity-3 reproducer audit.

- PR 1 (#2104): supervisor log visibility on systemd/launchd
- PR 2 (#2105): drop \`|| true\` on CREATE DATABASE
- **PR 3 (this): post-init validation that the database actually exists**
- RC2: stop pre-writing \`metadata.json\` before init succeeds
- RC4: write \`.bd-dolt-ok\` marker after server-mode init

Compounding effect: with PR 1+2+3 merged, the gascity-3 failure mode either (a) doesn't happen because PR 2 fails fast on CREATE DATABASE, OR (b) is caught here at init time with a clear error visible in the supervisor log (PR 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)