### PR TITLE
fix(beads): keep gc-beads-bd init gate on metadata.json file, not project_id

### DIFF
--- a/cmd/gc/dolt_start_managed_test.go
+++ b/cmd/gc/dolt_start_managed_test.go
@@ -152,6 +152,39 @@ func TestGCBeadsBDScript_DoesNotMutateDoltInternals(t *testing.T) {
 	}
 }
 
+// TestGCBeadsBDScript_InitForcesReinitOverPreSeededMetadata guards the
+// fresh-init regression where `gc init` / `gc rig add` aborted at provider
+// readiness with bd's "This workspace is already initialized" error. GC
+// pre-seeds .beads/metadata.json (dolt_database/dolt_mode) before invoking
+// gc-beads-bd init; bd (>= 1.0.x) treats any present metadata.json as proof
+// the workspace is already initialized and bails unless `bd init` is given
+// --force. op_init's "already initialized on disk" branch must therefore key
+// on the metadata.json file itself (not on a project_id, which a fresh
+// pre-seeded stub never has) so the schema-missing path can set --force.
+func TestGCBeadsBDScript_InitForcesReinitOverPreSeededMetadata(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	scriptPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "examples", "bd", "assets", "scripts", "gc-beads-bd.sh")
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptPath, err)
+	}
+	script := string(data)
+
+	guard := `if [ -f "$dir/.beads/metadata.json" ]; then
+        if ensure_database_registered "$dolt_database"; then`
+	if !strings.Contains(script, guard) {
+		t.Fatalf("gc-beads-bd.sh op_init must gate the already-initialized branch on the metadata.json file, not on project_id; " +
+			"gating on project_id leaves --force unset for gc-pre-seeded metadata and bd init aborts")
+	}
+	if strings.Contains(script, `if metadata_has_project_id "$dir/.beads/metadata.json"; then
+        if ensure_database_registered`) {
+		t.Fatal("gc-beads-bd.sh op_init must not gate the already-initialized branch on metadata_has_project_id (fresh-init regression)")
+	}
+}
+
 func TestManagedDoltStartFields(t *testing.T) {
 	report := managedDoltStartReport{
 		Ready:        true,

--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -2135,10 +2135,17 @@ op_init() {
     # beads (#1039). Must match doctor.RequiredCustomTypes.
     local custom_types="${GC_BEADS_CUSTOM_TYPES:-molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step}"
 
-    # If already initialized on disk and the server has a bd schema, ensure the
-    # database is also registered with the running server. Local metadata can be
-    # written before bd init seeds tables, so require the server-side schema
-    # before taking the fast path.
+    # If already initialized on disk, ensure the database is also registered
+    # with the running server. gc's normalizeCanonicalBdScopeFilesForInit
+    # writes metadata.json (dolt_database/dolt_mode) BEFORE invoking us, so a
+    # fresh init also reaches this branch — that is intentional. The branch
+    # does NOT blindly skip init: it only exits early when the server already
+    # has a live bd schema (bd_runtime_schema_ready). Otherwise it sets
+    # bd_init_force="--force" so the fall-through bd init reinitializes over
+    # the gc-pre-seeded metadata stub instead of aborting with bd's "This
+    # workspace is already initialized" guard. Gating this branch on project_id
+    # instead breaks fresh init: gc-pre-seeded metadata has no project_id, so
+    # --force is never set and bd init aborts.
     if [ -f "$dir/.beads/metadata.json" ]; then
         if ensure_database_registered "$dolt_database"; then
             if bd_runtime_schema_ready "$dolt_database"; then


### PR DESCRIPTION
## Problem

`gc init` and `gc rig add` abort at provider readiness with bd's
**"This workspace is already initialized"** error on any fresh city or rig.

This PR previously *introduced* the regression: it changed `op_init`'s
"already initialized on disk" branch from `[ -f metadata.json ]` to
`metadata_has_project_id`. This commit reverts that and adds a guard test.

## Root cause

That branch does **not** just short-circuit init. When the server has no
live bd schema it sets `bd_init_force="--force"`, and that `--force` is
what lets the fall-through `bd init` reinitialize over the gc-pre-seeded
`metadata.json` instead of aborting.

`gc`'s `normalizeCanonicalBdScopeFilesForInit` writes `metadata.json`
(`dolt_database`/`dolt_mode`) **before** invoking the script, and a freshly
pre-seeded stub never carries `project_id` — only a successful `bd init`
writes that. Under the `project_id` gate the branch is skipped on every
fresh init, `--force` is never set, and `bd init` aborts.

## Fix

Gate the branch on the `metadata.json` file itself (the pre-regression
behavior). The original concern behind the `project_id` gate — a
half-initialized scope with `metadata.json` but no Dolt database — is
already covered downstream by the hard-stop on `CREATE DATABASE` failure
and the post-init database-existence validation, so keying on the file is
both correct and sufficient.

Adds `TestGCBeadsBDScript_InitForcesReinitOverPreSeededMetadata` to lock
the gate condition in and prevent recurrence.

## Verification

- `go vet` clean
- targeted `gc-beads-bd` init tests pass
- end-to-end: `gc init` reaches `[8/8]` and `gc rig add` succeeds against a
  running managed Dolt server, with `project_id` backfilled into
  `metadata.json` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)