### PR TITLE
fix(beads): write .bd-dolt-ok marker after server-mode init

### DIFF
--- a/examples/bd/assets/scripts/gc-beads-bd.sh
+++ b/examples/bd/assets/scripts/gc-beads-bd.sh
@@ -386,6 +386,25 @@ metadata_has_project_id() {
     grep -q '"project_id"[[:space:]]*:' "$meta_file" 2>/dev/null
 }
 
+# write_bd_dolt_ok_marker ensures the .bd-dolt-ok marker exists in the
+# Dolt data directory for the given scope. bd 0.56+ writes this marker
+# itself when running its standalone (non-server) init path; in the
+# server-mode path used by gc, bd doesn't touch the on-disk data
+# directory directly (the SQL server owns it), so the marker never
+# gets written and bd doctor reports a permanent "Dolt Format: pre-0.56"
+# warning even on freshly initialized scopes. Touch it here once we've
+# confirmed the canonical Dolt database is reachable, so the format
+# declaration matches reality. Best-effort — failure is non-fatal because
+# the warning it suppresses is itself non-fatal.
+write_bd_dolt_ok_marker() {
+    local dir="$1"
+    local data_dir="$dir/.beads/dolt"
+    [ -d "$data_dir" ] || return 0
+    local marker="$data_dir/.bd-dolt-ok"
+    [ -f "$marker" ] && return 0
+    : > "$marker" 2>/dev/null || true
+}
+
 backfill_project_id_if_missing() {
     local dir="$1" meta_file gc_bin dolt_database host
     meta_file="$dir/.beads/metadata.json"
@@ -2150,6 +2169,7 @@ op_init() {
                 ensure_bd_runtime_custom_types "$dolt_database" "$custom_types"
                 ensure_bd_runtime_issue_prefix "$dolt_database" "$prefix"
                 backfill_project_id_if_missing "$dir"
+                write_bd_dolt_ok_marker "$dir"
                 exit 0
             fi
             echo "warning: database '$dolt_database' missing bd schema; re-initializing" >&2
@@ -2223,6 +2243,7 @@ op_init() {
     fi
 
     normalize_scope_after_init "$dir" "$prefix" "$dolt_database"
+    write_bd_dolt_ok_marker "$dir"
 }
 
 


### PR DESCRIPTION
## Symptom

Even on freshly initialized cities, \`bd doctor\` reports:

\`\`\`
⚠ Dolt Format: Dolt database from pre-0.56 bd version (missing .bd-dolt-ok marker)
  Path: /home/pa/my-city/.beads/dolt
  └─ Delete .beads/dolt/.dolt/ and re-run, or restart the Dolt server (auto-recovery will rebuild it)
\`\`\`

The suggested remediation (delete + recreate) doesn't work because the next init is also server-mode and also doesn't write the marker, so the warning persists.

## Root cause

bd 0.56+ writes \`.bd-dolt-ok\` into its Dolt data dir during **standalone** init, then checks for it in \`bd doctor\`. In **server-mode** init (the path used by \`gc-beads-bd\`), bd doesn't touch the on-disk data dir directly — the SQL server owns it — so the marker never gets written.

## Fix

Add a \`write_bd_dolt_ok_marker\` helper to \`gc-beads-bd.sh\` and call it at both exit points of \`op_init\` (fast path + full bd init fall-through).

\`\`\`bash
write_bd_dolt_ok_marker() {
    local dir=\"\$1\"
    local data_dir=\"\$dir/.beads/dolt\"
    [ -d \"\$data_dir\" ] || return 0
    local marker=\"\$data_dir/.bd-dolt-ok\"
    [ -f \"\$marker\" ] && return 0
    : > \"\$marker\" 2>/dev/null || true
}
\`\`\`

Best-effort: failure to write the marker is non-fatal because the warning it suppresses is itself non-fatal.

## Why gascity owns this fix (vs. filing upstream)

Ideally bd's server-mode init would write the marker itself. Worth filing a parallel issue at \`gastownhall/beads\`, but until that lands, gascity is the right place to fix it because:

1. gascity is the layer driving server-mode init
2. The fix is one helper + two call sites (~21 lines)
3. Operators following gascity-published tutorials hit this on every fresh install today

## Test plan

- [x] \`bash -n\` syntax check passes
- [x] All three call sites (helper definition + 2 invocations) verified by grep
- The user-facing impact (suppressing the warning) is exercised via the integration test suite that runs \`bd doctor\` post-init

## Stack context

This is **PR 5/5** of the gascity-3 reproducer audit.

- PR 1 (#2104): supervisor log visibility
- PR 2 (#2105): drop \`|| true\` on CREATE DATABASE
- PR 3 (#2106): post-init validation
- PR 4 (#2107): fast-path gates on project_id
- **PR 5 (this): write \`.bd-dolt-ok\` marker after server-mode init**

Cosmetic-but-confusing — closes the last diagnostic that operators see on first \`bd doctor\` after a clean init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)