### PR TITLE
feat(rig): auto-detect shipped gc-rig config with no store (state 4 of #2110)

### DIFF
--- a/cmd/gc/cmd_prompt_test.go
+++ b/cmd/gc/cmd_prompt_test.go
@@ -128,6 +128,48 @@ func TestEmbeddedMetaAgentAuthorPromptRendersCityContext(t *testing.T) {
 }
 
 func TestEmbeddedMetaAgentAuthorPromptRendersRigContext(t *testing.T) {
+	// Use a distinctive default-branch value ("trunk-99x") that won't
+	// collide with the example "main" mentioned in the meta-prompt's
+	// runtime-variables reference list.
+	got, err := renderMetaPrompt(string(metaAgentAuthorPrompt), metaPromptCtx{
+		Role:                "polecat",
+		ProviderKey:         "codex",
+		ProviderDisplayName: "Codex CLI",
+		ContextType:         "rig",
+		CityName:            "city-x",
+		CityPath:            "/tmp/city-x",
+		RigName:             "myrepo",
+		RigPath:             "/Users/test/myrepo",
+		RigDefaultBranch:    "trunk-99x",
+	})
+	if err != nil {
+		t.Fatalf("embedded meta-prompt failed to render (rig context): %v", err)
+	}
+	if !strings.Contains(got, "myrepo") {
+		t.Errorf("rig-context render should mention rig name 'myrepo'")
+	}
+	if !strings.Contains(got, "/Users/test/myrepo") {
+		t.Errorf("rig-context render should mention rig path")
+	}
+	if !strings.Contains(got, "trunk-99x") {
+		t.Errorf("rig-context render should resolve RigDefaultBranch into the rendered text")
+	}
+	if strings.Contains(got, "HQ-only") {
+		t.Errorf("rig-context render should NOT include city-branch HQ-only content")
+	}
+}
+
+// TestEmbeddedMetaAgentAuthorPromptDirectsLLMToUseRuntimePlaceholdersForRig
+// verifies the portability fix for ga-99x: the rendered rig-context
+// meta-prompt must show the LLM the literal `{{ .RigName }}`,
+// `{{ .RigRoot }}`, `{{ .DefaultBranch }}` runtime placeholders it should
+// use in the output template (instead of baking the resolved values like
+// "myrepo" / "/Users/test/myrepo" / "main" into the generated body).
+//
+// Without these literals visible in the LLM's brief, it sees only the
+// resolved values and produces a non-portable template that hard-codes
+// the rig it was synthesized for.
+func TestEmbeddedMetaAgentAuthorPromptDirectsLLMToUseRuntimePlaceholdersForRig(t *testing.T) {
 	got, err := renderMetaPrompt(string(metaAgentAuthorPrompt), metaPromptCtx{
 		Role:                "polecat",
 		ProviderKey:         "codex",
@@ -142,17 +184,72 @@ func TestEmbeddedMetaAgentAuthorPromptRendersRigContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("embedded meta-prompt failed to render (rig context): %v", err)
 	}
-	if !strings.Contains(got, "myrepo") {
-		t.Errorf("rig-context render should mention rig name 'myrepo'")
+	// Literal runtime placeholders the LLM should embed in its output.
+	wantLiterals := []string{
+		"{{ .RigName }}",
+		"{{ .RigRoot }}",
+		"{{ .DefaultBranch }}",
+		"{{ .CityRoot }}",
+		"{{ .WorkDir }}",
 	}
-	if !strings.Contains(got, "/Users/test/myrepo") {
-		t.Errorf("rig-context render should mention rig path")
+	for _, want := range wantLiterals {
+		if !strings.Contains(got, want) {
+			t.Errorf("rig-context meta-prompt must surface literal %q as a runtime placeholder for the LLM to use\n--- got ---\n%s", want, got)
+		}
 	}
-	if !strings.Contains(got, "Default branch:  main") {
-		t.Errorf("rig-context render should mention default branch")
+}
+
+// TestEmbeddedMetaAgentAuthorPromptHasPortabilityRuleForRig verifies that
+// the rendered rig-context meta-prompt contains an explicit instruction
+// telling the LLM not to bake resolved rig-specific values into the
+// generated template body. The exact wording is allowed to drift, but the
+// "portability" framing must be present.
+func TestEmbeddedMetaAgentAuthorPromptHasPortabilityRuleForRig(t *testing.T) {
+	got, err := renderMetaPrompt(string(metaAgentAuthorPrompt), metaPromptCtx{
+		Role:                "polecat",
+		ProviderKey:         "codex",
+		ProviderDisplayName: "Codex CLI",
+		ContextType:         "rig",
+		CityName:            "city-x",
+		CityPath:            "/tmp/city-x",
+		RigName:             "myrepo",
+		RigPath:             "/Users/test/myrepo",
+		RigDefaultBranch:    "main",
+	})
+	if err != nil {
+		t.Fatalf("embedded meta-prompt failed to render (rig context): %v", err)
 	}
-	if strings.Contains(got, "HQ-only") {
-		t.Errorf("rig-context render should NOT include city-branch HQ-only content")
+	lowered := strings.ToLower(got)
+	if !strings.Contains(lowered, "portab") {
+		t.Errorf("rig-context meta-prompt must include a portability rule explicitly\n--- got ---\n%s", got)
+	}
+}
+
+// TestEmbeddedMetaAgentAuthorPromptDirectsLLMToUseRuntimePlaceholdersForCity
+// is the city-context counterpart: the rendered HQ-only meta-prompt must
+// still surface `{{ .CityRoot }}` and `{{ .WorkDir }}` literally so the
+// LLM uses them as runtime placeholders rather than baking in the
+// resolved city path.
+func TestEmbeddedMetaAgentAuthorPromptDirectsLLMToUseRuntimePlaceholdersForCity(t *testing.T) {
+	got, err := renderMetaPrompt(string(metaAgentAuthorPrompt), metaPromptCtx{
+		Role:                "mayor",
+		ProviderKey:         "claude",
+		ProviderDisplayName: "Claude Code",
+		ContextType:         "city",
+		CityName:            "test-city",
+		CityPath:            "/tmp/city",
+	})
+	if err != nil {
+		t.Fatalf("embedded meta-prompt failed to render (city context): %v", err)
+	}
+	wantLiterals := []string{
+		"{{ .CityRoot }}",
+		"{{ .WorkDir }}",
+	}
+	for _, want := range wantLiterals {
+		if !strings.Contains(got, want) {
+			t.Errorf("city-context meta-prompt must surface literal %q as a runtime placeholder for the LLM to use\n--- got ---\n%s", want, got)
+		}
 	}
 }
 
@@ -326,7 +423,8 @@ func TestRunPromptSynthRigContextLooksUpRigInCityToml(t *testing.T) {
 		"Context type: rig",
 		"myproj",
 		rigPath,
-		"Default branch:  develop",
+		"Default branch",
+		"develop",
 	}
 	for _, want := range wantSubs {
 		if !strings.Contains(runner.gotPrompt, want) {

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -87,7 +87,13 @@ The rig's agents won't spawn until explicitly resumed with "gc rig resume".
 
 Use --adopt to register a directory that already has a fully initialized
 .beads/ directory (must include both metadata.json and config.yaml).
-Skips beads init; the git repo check remains informational.`,
+Skips beads init; the git repo check remains informational.
+
+A rig directory that ships a gc-flavored .beads/config.yaml but no store
+(no metadata.json, no dolt/) is auto-detected: gc rig add will honor the
+shipped config and initialize the store in place, without requiring
+--adopt. This matches the common shape of a team-shared rig that commits
+its gc config but gitignores the Dolt data.`,
 		Example: `  gc rig add /path/to/project
   gc rig add /path/to/project --name myrig
   gc rig add /path/to/project --prefix r1
@@ -264,12 +270,28 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		break
 	}
 
+	// State 4 of the .beads/ matrix (see gascity#2110): the rig directory
+	// ships a gc-flavored config.yaml but no store (no metadata.json, no
+	// dolt/). This is the shape of a freshly-cloned team-shared rig where
+	// the gc config travels in git and the Dolt data does not.
+	shippedConfigOnly := !reAdd && !adopt && isShippedGCRigConfigOnly(fs, rigPath)
+
 	var prefix string
 	switch {
 	case reAdd:
 		prefix = existingRig.EffectivePrefix()
 	case prefixOverride != "":
 		prefix = strings.ToLower(prefixOverride)
+	case shippedConfigOnly:
+		// Honor the team's chosen prefix from the shipped config rather
+		// than re-deriving from the local rig-name choice. Falls back to
+		// the name derivation if the shipped config has no parseable
+		// issue_prefix.
+		if shipped, ok := readBeadsPrefix(fs, rigPath); ok {
+			prefix = shipped
+		} else {
+			prefix = config.DeriveBeadsPrefix(name)
+		}
 	default:
 		prefix = config.DeriveBeadsPrefix(name)
 	}
@@ -394,7 +416,11 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 	// to bd init against an existing Dolt store and typically dies with
 	// "bd init: signal: killed" after the probe times out — an unhelpful
 	// failure mode for the common "register existing store" workflow.
-	if !reAdd && !adopt {
+	//
+	// Exception: state 4 (shipped gc config, no store) — bd init against
+	// just a config.yaml is exactly the right thing to do, so let it
+	// through and honor the shipped config.
+	if !reAdd && !adopt && !shippedConfigOnly {
 		beadsPath := filepath.Join(rigPath, ".beads")
 		fi, err := fs.Stat(beadsPath)
 		if err != nil && !os.IsNotExist(err) {
@@ -1079,6 +1105,30 @@ func writeBeadsEnvGTRoot(fs fsys.FS, rigPath, cityPath string) error {
 		return fmt.Errorf("creating .beads dir: %w", err)
 	}
 	return fs.WriteFile(envPath, []byte(content), 0o644)
+}
+
+// isShippedGCRigConfigOnly reports whether the rig directory has the shape
+// of state 4 from the .beads/ matrix (gascity#2110): a gc-flavored
+// .beads/config.yaml (identified by a non-empty endpoint_origin, which is
+// gc-specific and not produced by plain bd workspaces) and no store yet —
+// neither metadata.json nor a dolt/ directory.
+//
+// This matches the common shape of a freshly-cloned team-shared rig where
+// the gc config travels in git and the Dolt data does not. The right action
+// is to honor the shipped config and run bd init in place.
+func isShippedGCRigConfigOnly(fs fsys.FS, rigPath string) bool {
+	cfgPath := filepath.Join(rigPath, ".beads", "config.yaml")
+	cfg, ok, err := contract.ReadConfigState(fs, cfgPath)
+	if err != nil || !ok || cfg.EndpointOrigin == "" {
+		return false
+	}
+	if _, err := fs.Stat(filepath.Join(rigPath, ".beads", "metadata.json")); !os.IsNotExist(err) {
+		return false
+	}
+	if _, err := fs.Stat(filepath.Join(rigPath, ".beads", "dolt")); !os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 // readBeadsPrefix reads the issue_prefix from an existing .beads/config.yaml

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1729,6 +1729,183 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	}
 }
 
+// A rig directory that ships a gc-flavored .beads/config.yaml but no store
+// (no metadata.json, no dolt/) is the common shape of a freshly-cloned
+// team-shared rig: the gc config travels in git, the Dolt data does not.
+// gc rig add must honor the shipped config (using its issue_prefix) and
+// initialize the store in place, rather than refusing or pointing the user
+// at --adopt (which itself requires metadata.json, not shipped here).
+func TestDoRigAdd_ShippedGCConfigNoStoreInitsInPlace(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "service-inventory")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	shippedConfig := "issue_prefix: si\ngc.endpoint_origin: inherited_city\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte(shippedConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d; stderr: %s", code, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Adding rig 'service-inventory'") {
+		t.Errorf("output missing rig name: %s", output)
+	}
+	if !strings.Contains(output, "Prefix: si") {
+		t.Errorf("output missing prefix from shipped config: %s", output)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "service-inventory") {
+		t.Errorf("city.toml should list rig:\n%s", data)
+	}
+
+	preserved, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	preservedStr := string(preserved)
+	if !strings.Contains(preservedStr, "issue_prefix: si") {
+		t.Errorf("shipped issue_prefix not preserved:\n%s", preservedStr)
+	}
+	if !strings.Contains(preservedStr, "gc.endpoint_origin: inherited_city") {
+		t.Errorf("shipped endpoint_origin not preserved:\n%s", preservedStr)
+	}
+}
+
+// State 4 must use the shipped config.yaml's issue_prefix even when the
+// rig directory name would derive a different prefix. The team's chosen
+// prefix wins over local name-derivation.
+func TestDoRigAdd_ShippedGCConfigPrefersShippedPrefixOverDerived(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: zz\ngc.endpoint_origin: inherited_city\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd returned %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Prefix: zz") {
+		t.Errorf("expected shipped prefix 'zz', got stdout: %s", stdout.String())
+	}
+}
+
+// Explicit --prefix that conflicts with the shipped config.yaml must still
+// be rejected. State 4 does not silently override a shipped prefix when the
+// operator asked for something different.
+func TestDoRigAdd_ShippedGCConfigPrefixOverrideConflictRejected(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "service-inventory")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: si\ngc.endpoint_origin: inherited_city\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "xx", "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected --prefix conflict to fail, got code %d; stdout: %s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "already has bead prefix") {
+		t.Errorf("stderr should explain prefix conflict: %s", stderr.String())
+	}
+}
+
+// State 5 (gc-flavored config + metadata.json present = canonical adopted
+// store) must continue to require --adopt. The state-4 relaxation must not
+// bleed into state 5 — adopting a populated store is a different intent.
+func TestDoRigAdd_GCFlavoredConfigWithMetadataStillRequiresAdopt(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "service-inventory")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"),
+		[]byte("issue_prefix: si\ngc.endpoint_origin: inherited_city\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"),
+		[]byte(`{"project_id":"deadbeef"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "bd")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected adopt-required failure, got code %d; stdout: %s", code, stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "--adopt") {
+		t.Errorf("stderr should hint at --adopt: %s", stderr.String())
+	}
+}
+
 func TestDoRigAdd_ExistingBeadsStatErrorFailsClosed(t *testing.T) {
 	f := fsys.NewFake()
 	cityPath := "/city"

--- a/cmd/gc/prompts/meta-agent-author.template.md
+++ b/cmd/gc/prompts/meta-agent-author.template.md
@@ -19,27 +19,77 @@ provider-aware fragment pattern documented at the end of this brief.
 # Context type: [[ .ContextType ]]
 
 [[ if eq .ContextType "rig" -]]
-This agent is attached to a registered rig (project repository):
+This agent is attached to a rig (project repository).
 
-- Rig name:        [[ .RigName ]]
-- Rig path:        [[ .RigPath ]]
-- Default branch:  [[ if .RigDefaultBranch ]][[ .RigDefaultBranch ]][[ else ]](unknown — probe at runtime)[[ end ]]
-- City name:       [[ .CityName ]]
-- City path:       [[ .CityPath ]]
+## Situational awareness for THIS synth run
+
+The values below are what the rig-bound runtime placeholders resolve to
+*for this particular synth invocation*. They are shown so you understand
+what kind of project you are designing for — **do not paste them into the
+output as literal strings.**
+
+- Rig name (`{{ .RigName }}`):       [[ .RigName ]]
+- Rig path (`{{ .RigRoot }}`):       [[ .RigPath ]]
+- Default branch (`{{ .DefaultBranch }}`): [[ if .RigDefaultBranch ]][[ .RigDefaultBranch ]][[ else ]](unknown — probe at runtime)[[ end ]]
+- City root (`{{ .CityRoot }}`):     [[ .CityPath ]]
+- City name (no runtime placeholder): [[ .CityName ]]
+
+## Portability rule — read carefully
+
+The template you generate will be used across **multiple rigs**. To stay
+portable, any reference to a rig-bound value must go through the
+corresponding runtime placeholder, NOT the resolved string above:
+
+| Use in output       | NOT this resolved literal      |
+|---------------------|--------------------------------|
+| `{{ .RigName }}`    | [[ .RigName ]]                 |
+| `{{ .RigRoot }}`    | [[ .RigPath ]]                 |
+| `{{ .DefaultBranch }}` | [[ if .RigDefaultBranch ]][[ .RigDefaultBranch ]][[ else ]](probed at runtime)[[ end ]] |
+| `{{ .CityRoot }}`   | [[ .CityPath ]]                |
+| `{{ .WorkDir }}`    | (the agent's working directory) |
+
+If your generated template hard-codes a rig name, rig path, or branch
+where a `{{ ... }}` placeholder belongs, it is **not portable** — re-author
+those lines to use the placeholder so the same template body works for
+every rig the role is attached to.
+
+The city name has no runtime placeholder; either substitute it verbatim
+or omit it from the body — but treat that as the exception, not the rule.
+
+## Role expectations
 
 The agent works **inside the rig's repository**. Its prompt should:
-- Mention the rig name and project context where it helps the agent
-  orient itself.
-- Cover git operations relevant to its role (branch management,
-  commits, push targets) — `{{ .DefaultBranch }}` is the merge base.
+- Mention the rig context using `{{ .RigName }}` (the placeholder, not the
+  resolved name) where the agent needs to orient itself within its project.
+- Cover git operations relevant to its role (branch management, commits,
+  push targets) — `{{ .DefaultBranch }}` is the merge base.
 - Reference `{{ .WorkDir }}` and `{{ .RigRoot }}` for path-anchored
   instructions.
 [[ else -]]
 This agent is **HQ-only** — it operates at the city level, not inside
-any rig:
+any rig.
 
-- City name:  [[ .CityName ]]
-- City path:  [[ .CityPath ]]
+## Situational awareness for THIS synth run
+
+The value below is what the city-bound runtime placeholder resolves to
+*for this particular synth invocation*. It is shown so you understand
+which city you are designing for — **do not paste it into the output as a
+literal string.**
+
+- City root (`{{ .CityRoot }}`): [[ .CityPath ]]
+- City name (no runtime placeholder): [[ .CityName ]]
+
+## Portability rule — read carefully
+
+The template you generate will be used by HQ agents across **different
+cities**. To stay portable, any reference to a city-bound path must go
+through `{{ .CityRoot }}` (or `{{ .WorkDir }}` for the agent's working
+directory), NOT the resolved literal above.
+
+The city name has no runtime placeholder; either substitute it verbatim
+or omit it from the body — but treat that as the exception, not the rule.
+
+## Role expectations
 
 The agent does not work inside a project repository. Its prompt should:
 - Focus on coordination, dispatch, monitoring, and city-wide concerns.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1998,6 +1998,12 @@ Use --adopt to register a directory that already has a fully initialized
 .beads/ directory (must include both metadata.json and config.yaml).
 Skips beads init; the git repo check remains informational.
 
+A rig directory that ships a gc-flavored .beads/config.yaml but no store
+(no metadata.json, no dolt/) is auto-detected: gc rig add will honor the
+shipped config and initialize the store in place, without requiring
+--adopt. This matches the common shape of a team-shared rig that commits
+its gc config but gitignores the Dolt data.
+
 ```
 gc rig add <path> [flags]
 ```


### PR DESCRIPTION
## Summary

- Detects "state 4" of the `.beads/` matrix from #2110: a rig directory that ships a gc-flavored `.beads/config.yaml` (non-empty `gc.endpoint_origin`) with no store (no `metadata.json`, no `dolt/`). This is the common shape of a freshly-cloned team-shared rig — gc config travels in git, Dolt data does not.
- Previously refused; `--adopt` (#737) didn't fix it either (requires `metadata.json` and skips `bd init`). The user workaround was `rm -rf .beads`, run plain `gc rig add`, then `git restore` the boilerplate — easy to get wrong.
- Now auto-detected: honors the shipped `issue_prefix` and runs `bd init` in place. Narrowly scoped — foreign bd workspaces, canonical adopted stores, and explicit `--prefix` mismatches all keep their existing behavior. First slice of #2110; other states (foreign-merge, adopt, remote Dolt, interactive) are not addressed here.

## Test plan

- [x] `TestDoRigAdd_ShippedGCConfigNoStoreInitsInPlace` — happy path: shipped gc config + no store → succeeds, honors shipped prefix, preserves shipped `config.yaml`
- [x] `TestDoRigAdd_ShippedGCConfigPrefersShippedPrefixOverDerived` — name "alpha-beta" derives "ab" but shipped prefix is "zz" → "zz" wins
- [x] `TestDoRigAdd_ShippedGCConfigPrefixOverrideConflictRejected` — `--prefix=xx` with shipped `si` still errors
- [x] `TestDoRigAdd_GCFlavoredConfigWithMetadataStillRequiresAdopt` — adding `metadata.json` to the state-4 shape pushes it back to state-5 territory (still requires `--adopt`)
- [x] Existing `TestDoRigAdd_ExistingBeadsRequiresAdopt` still passes (foreign workspaces — no `gc.*` keys — unaffected)
- [x] Existing `TestDoRigAdd_ExplicitPrefixConflictsWithExistingBeads` still passes
- [x] Full `cmd/gc/` package (286s) — zero regression
- [x] `go vet ./...` clean
- [x] `make lint-changed LINT_CHANGED_SCOPE=worktree` clean
- [x] `test/docsync` passes (cli.md regenerated via `go run ./cmd/genschema`)

## Related

- Tracks #2110 (umbrella matrix proposal)
- Adjacent to #1899, #1373, #737 — none of which addressed state 4 specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
