### PR TITLE
fix(dolt-health): exclude foreign-workspace dolts from zombie scan

### DIFF
--- a/examples/dolt/commands/health/run.sh
+++ b/examples/dolt/commands/health/run.sh
@@ -268,6 +268,28 @@ if [ "${GC_HEALTH_SKIP_ZOMBIE_SCAN:-0}" != "1" ]; then
       *sql-server*) ;;
       *) continue ;;
     esac
+    # Skip dolt servers whose --config path resolves outside this city's
+    # directory: they belong to a sibling workspace (another Gas City,
+    # Gas Town, or a standalone service like faultline) and are not
+    # zombies of ours. Servers with no explicit --config remain
+    # ambiguous and fall through to be evaluated as zombies.
+    #
+    # Without this guard, on a host running more than one Gas City /
+    # Gas Town / dolt-backed service, every workspace's zombie scan
+    # would flag every sibling's legitimately-running dolt — and the
+    # Gastown Deacon patrol formula instructs killing zombie PIDs.
+    config_arg=$(printf '%s\n' "$cmd" | awk '{
+      for (i=1; i<=NF; i++) {
+        if ($i == "--config" && i+1 <= NF) { print $(i+1); exit }
+        if (index($i, "--config=") == 1) { print substr($i, 10); exit }
+      }
+    }')
+    if [ -n "$config_arg" ]; then
+      case "$config_arg" in
+        "$GC_CITY_PATH"/*) ;;
+        *) continue ;;
+      esac
+    fi
     zombie_count=$((zombie_count + 1))
     zombie_pids="$zombie_pids $p"
   done

--- a/examples/dolt/health_test.go
+++ b/examples/dolt/health_test.go
@@ -823,6 +823,122 @@ func TestHealthScriptZombieScanExcludesRigLocalServers(t *testing.T) {
 	}
 }
 
+// TestHealthScriptZombieScanExcludesForeignConfigDolts verifies that
+// dolt sql-server processes whose `--config` argument resolves to a
+// path outside `$GC_CITY_PATH` are not flagged as zombies. This is the
+// multi-workspace case: on a developer machine running more than one
+// Gas City (or a Gas City alongside Gas Town / a faultline server),
+// each workspace's `gc dolt health` scan would previously flag every
+// sibling workspace's legitimately-running dolt as a "zombie." The
+// Gastown Deacon patrol formula then explicitly instructs killing
+// zombie PIDs, which would cross workspace boundaries and take down
+// unrelated cities.
+//
+// A dolt sql-server with no explicit `--config` falls through and is
+// still evaluated as a zombie, because its workspace is ambiguous.
+func TestHealthScriptZombieScanExcludesForeignConfigDolts(t *testing.T) {
+	cityPath := t.TempDir()
+	foreignPath := t.TempDir()
+	fakeBin := t.TempDir()
+
+	mainPort := "19911"
+
+	mainPID := "525201"
+	foreignPID := "525202"
+	noConfigPID := "525203"
+
+	// City .beads directory with metadata.
+	if err := os.MkdirAll(filepath.Join(cityPath, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, ".beads", "metadata.json"),
+		[]byte(`{"dolt_database":"city"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake gc: fail so metadata_files() falls back to find.
+	writeExecutable(t, filepath.Join(fakeBin, "gc"), "#!/bin/sh\nexit 1\n")
+
+	// Fake pgrep: returns main PID + a foreign dolt + a no-config dolt.
+	writeExecutable(t, filepath.Join(fakeBin, "pgrep"),
+		fmt.Sprintf("#!/bin/sh\necho %s\necho %s\necho %s\n", mainPID, foreignPID, noConfigPID))
+
+	// Fake lsof: only the main port is listening.
+	writeExecutable(t, filepath.Join(fakeBin, "lsof"),
+		fmt.Sprintf(`#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    -iTCP:%s) echo %s; exit 0 ;;
+  esac
+done
+exit 1
+`, mainPort, mainPID))
+
+	// Fake ps: handles pid_is_running (-o pid=) and zombie scan (-o args=).
+	// The foreign PID's --config points outside cityPath; the no-config PID
+	// runs sql-server with no --config at all (treated as ambiguous and
+	// still flagged as zombie under the current contract).
+	foreignConfig := filepath.Join(foreignPath, ".gc", "runtime", "packs", "dolt", "dolt-config.yaml")
+	writeExecutable(t, filepath.Join(fakeBin, "ps"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "-p" ] && [ "$3" = "-o" ]; then
+  case "$4" in
+    pid=) printf ' %%s\n' "$2"; exit 0 ;;
+    args=)
+      case "$2" in
+        %s) echo "dolt sql-server --config %s" ;;
+        %s) echo "dolt sql-server" ;;
+        *)  echo "dolt sql-server" ;;
+      esac
+      exit 0
+      ;;
+  esac
+fi
+exit 1
+`, foreignPID, foreignConfig, noConfigPID))
+
+	// Fake nc / dolt: unreachable (no real server).
+	writeExecutable(t, filepath.Join(fakeBin, "nc"), "#!/bin/sh\nexit 1\n")
+	writeExecutable(t, filepath.Join(fakeBin, "dolt"), "#!/bin/sh\nexit 1\n")
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, healthScript), "--json")
+	cmd.Env = append(
+		filteredEnv("GC_CITY_PATH", "GC_PACK_DIR", "GC_DOLT_HOST", "GC_DOLT_PORT",
+			"GC_DOLT_USER", "GC_DOLT_PASSWORD", "GC_HEALTH_SKIP_ZOMBIE_SCAN", "PATH"),
+		"GC_CITY_PATH="+cityPath,
+		"GC_PACK_DIR="+root,
+		"GC_DOLT_HOST=127.0.0.1",
+		"GC_DOLT_PORT="+mainPort,
+		"GC_DOLT_USER=root",
+		"GC_DOLT_PASSWORD=",
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("health.sh failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+
+	// The no-config dolt (525203) is still ambiguous and should be the
+	// only zombie reported.
+	if !strings.Contains(output, `"zombie_count": 1`) {
+		t.Errorf("expected zombie_count 1; got:\n%s", output)
+	}
+
+	// The foreign-config PID (525202) must NOT appear in zombie_pids.
+	if strings.Contains(output, foreignPID) {
+		t.Errorf("foreign-config dolt PID %s should not be in zombie_pids; got:\n%s", foreignPID, output)
+	}
+
+	// The no-config PID (525203) should appear, since its workspace is
+	// ambiguous and the current contract still flags it.
+	if !strings.Contains(output, noConfigPID) {
+		t.Errorf("no-config dolt PID %s should be in zombie_pids; got:\n%s", noConfigPID, output)
+	}
+}
+
 // TestHealthScriptJSONAlwaysExitsZero guards the JSON-mode exit
 // contract. Automation consumers (notably the deacon patrol formula)
 // parse the JSON payload and key health decisions off `server.reachable`.


### PR DESCRIPTION
## Summary

On a host running more than one Gas City — or a Gas City alongside Gas Town / a faultline server / any other dolt-backed service — every workspace's `gc dolt health` scan flags every sibling workspace's legitimately-running `dolt sql-server` as a **zombie**. The Gastown Deacon patrol formula (`examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml:276-280`) instructs `kill <zombie_pid>` for any zombie — which crosses workspace boundaries and can take down an unrelated city's bead store.

Real-world repro on a developer machine with five live dolts:

| PID | Owner |
|-----|-------|
| 890 | faultline (`--config ~/.faultline-data/config.yaml`) |
| 56977 | gt-greenwood (Gas Town) |
| 93162 | gc-vancouver (sibling Gas City) |
| 62161 | gc-greenwood (this city) |
| 26963 | switchyard rig's app DB |

`gc dolt health` from `gc-greenwood` reports: `Zombie processes: 3 (PIDs: 890 56977 93162)` — the three sibling-workspace dolts.

## Cause

The existing exclusion logic in `examples/dolt/commands/health/run.sh` (lines 247–274) only knows about *rig-local* dolts in this city (looked up via `dolt.port:` in `<rig>/.beads/config.yaml`). Anything else running `dolt sql-server` becomes a zombie. There's no consideration that the candidate process might belong to a different workspace entirely.

## Fix

Add a `--config` path check after the existing filters: if a candidate dolt's `--config` argument resolves outside `$GC_CITY_PATH`, skip it. Servers with no explicit `--config` remain ambiguous and still fall through to be evaluated as zombies (no behavior change for that case).

```diff
   for p in $(pgrep -x dolt 2>/dev/null || true); do
     [ "$p" = "$server_pid" ] && continue
     case "$rig_dolt_pids" in *" $p "*) continue ;; esac
     cmd=$(ps -p "$p" -o args= 2>/dev/null || true)
     case "$cmd" in
       *sql-server*) ;;
       *) continue ;;
     esac
+    # Skip foreign-config dolts (sibling workspaces).
+    config_arg=$(printf '%s\n' "$cmd" | awk '{ ... --config extraction ... }')
+    if [ -n "$config_arg" ]; then
+      case "$config_arg" in
+        "$GC_CITY_PATH"/*) ;;
+        *) continue ;;
+      esac
+    fi
     zombie_count=$((zombie_count + 1))
     zombie_pids="$zombie_pids $p"
   done
```

## Test plan

- [x] New `TestHealthScriptZombieScanExcludesForeignConfigDolts` (3-process scenario: city main + foreign-config sibling + no-config ambiguous) fails on `main`, passes after fix.
- [x] Existing `TestHealthScriptZombieScanExcludesRigLocalServers` still passes (no behavior change for rig-local case).
- [x] Full `examples/dolt` test suite still passes (`go test ./examples/dolt/`).
- [x] `go vet ./examples/dolt/` clean.

## Follow-up suggestion (separate PR)

`examples/gastown/packs/gastown/formulas/mol-deacon-patrol.toml:276-280` should grow a defense-in-depth check: verify any candidate zombie PID's `--config` is inside the city's own `$GC_CITY_PATH` before issuing `kill`. Even if the scanner regresses, the kill should never cross workspace boundaries. Happy to follow up if helpful.