### PR TITLE
fix(rig): allow gc rig add on dirs with non-store .beads/ subdir

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -413,8 +413,8 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 	// We treat .beads/ as a store only when metadata.json or config.yaml is
 	// present. A directory that happens to be named .beads/ but contains
 	// only unrelated content (e.g. the beads project's own .beads/formulas/
-	// convention for formula source files) is not a store; bd init will
-	// add the missing files alongside without disturbing the existing ones.
+	// convention for formula source files) is not a store, so the init path
+	// decides how to create the missing store files in place.
 	if !reAdd && !adopt {
 		beadsPath := filepath.Join(rigPath, ".beads")
 		fi, err := fs.Stat(beadsPath)
@@ -422,11 +422,18 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
 			return config.Rig{}, 1
 		}
-		if err == nil && fi.IsDir() && beadsDirContainsStore(fs, beadsPath) {
-			fmt.Fprintf(stderr, "gc rig add: %s/.beads already contains a beads store; "+ //nolint:errcheck // best-effort stderr
-				"use --adopt to register it, or remove %s/.beads to reinitialize\n",
-				rigPath, rigPath)
-			return config.Rig{}, 1
+		if err == nil && fi.IsDir() {
+			containsStore, containsErr := beadsDirContainsStore(fs, beadsPath)
+			if containsErr != nil {
+				fmt.Fprintf(stderr, "gc rig add: %v\n", containsErr) //nolint:errcheck // best-effort stderr
+				return config.Rig{}, 1
+			}
+			if containsStore {
+				fmt.Fprintf(stderr, "gc rig add: %s/.beads already contains a beads store; "+ //nolint:errcheck // best-effort stderr
+					"use --adopt to register it, or remove %s/.beads to reinitialize\n",
+					rigPath, rigPath)
+				return config.Rig{}, 1
+			}
 		}
 	}
 
@@ -1004,6 +1011,8 @@ func rigHasRunningAgent(cfg *config.City, rigName string) bool {
 }
 
 // rigBeadsStatus returns a human-readable beads status for a directory.
+// It reports only fully initialized stores; the rig-add guard below uses a
+// broader "dangerous to initialize over" check for partial store evidence.
 func rigBeadsStatus(fs fsys.FS, dir string) string {
 	metaPath := filepath.Join(dir, ".beads", "metadata.json")
 	if _, err := fs.Stat(metaPath); err == nil {
@@ -1344,19 +1353,20 @@ func writeBeadsEnvGTRoot(fs fsys.FS, rigPath, cityPath string) error {
 	return fs.WriteFile(envPath, []byte(content), 0o644)
 }
 
-// beadsDirContainsStore reports whether beadsPath looks like an existing
-// beads store. A directory is treated as a store when it contains either
-// metadata.json or config.yaml — the two files bd init always writes.
-// Other contents (e.g. the beads project's own .beads/formulas/ convention
-// for formula source files) are not treated as a store, so gc rig add can
-// safely initialize alongside them.
-func beadsDirContainsStore(fs fsys.FS, beadsPath string) bool {
+// beadsDirContainsStore reports whether beadsPath contains evidence that it
+// would be dangerous to initialize over. Either canonical marker is enough to
+// stop fresh initialization because partial stores should fail closed; only
+// missing marker files are ignored.
+func beadsDirContainsStore(fs fsys.FS, beadsPath string) (bool, error) {
 	for _, name := range [...]string{"metadata.json", "config.yaml"} {
-		if _, err := fs.Stat(filepath.Join(beadsPath, name)); err == nil {
-			return true
+		path := filepath.Join(beadsPath, name)
+		if _, err := fs.Stat(path); err == nil {
+			return true, nil
+		} else if !os.IsNotExist(err) {
+			return false, fmt.Errorf("checking %s: %w", path, err)
 		}
 	}
-	return false
+	return false, nil
 }
 
 // readBeadsPrefix reads the issue_prefix from an existing .beads/config.yaml

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -406,10 +406,15 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 	}
 
 	// Guard: on a fresh add (not a re-add) without --adopt, refuse to run
-	// if .beads/ is already present. Without this, doRigAdd falls through
-	// to bd init against an existing Dolt store and typically dies with
-	// "bd init: signal: killed" after the probe times out — an unhelpful
-	// failure mode for the common "register existing store" workflow.
+	// if .beads/ already holds a beads store. Without this, doRigAdd falls
+	// through to bd init against an existing Dolt store and typically dies
+	// with "bd init: signal: killed" after the probe times out.
+	//
+	// We treat .beads/ as a store only when metadata.json or config.yaml is
+	// present. A directory that happens to be named .beads/ but contains
+	// only unrelated content (e.g. the beads project's own .beads/formulas/
+	// convention for formula source files) is not a store; bd init will
+	// add the missing files alongside without disturbing the existing ones.
 	if !reAdd && !adopt {
 		beadsPath := filepath.Join(rigPath, ".beads")
 		fi, err := fs.Stat(beadsPath)
@@ -417,9 +422,9 @@ func doRigAddWithResult(fs fsys.FS, cityPath, rigPath string, includes []string,
 			fmt.Fprintf(stderr, "gc rig add: checking %s: %v\n", beadsPath, err) //nolint:errcheck // best-effort stderr
 			return config.Rig{}, 1
 		}
-		if err == nil && fi.IsDir() {
-			fmt.Fprintf(stderr, "gc rig add: %s/.beads already exists; "+ //nolint:errcheck // best-effort stderr
-				"use --adopt to register the existing store, or remove %s/.beads to reinitialize\n",
+		if err == nil && fi.IsDir() && beadsDirContainsStore(fs, beadsPath) {
+			fmt.Fprintf(stderr, "gc rig add: %s/.beads already contains a beads store; "+ //nolint:errcheck // best-effort stderr
+				"use --adopt to register it, or remove %s/.beads to reinitialize\n",
 				rigPath, rigPath)
 			return config.Rig{}, 1
 		}
@@ -1337,6 +1342,21 @@ func writeBeadsEnvGTRoot(fs fsys.FS, rigPath, cityPath string) error {
 		return fmt.Errorf("creating .beads dir: %w", err)
 	}
 	return fs.WriteFile(envPath, []byte(content), 0o644)
+}
+
+// beadsDirContainsStore reports whether beadsPath looks like an existing
+// beads store. A directory is treated as a store when it contains either
+// metadata.json or config.yaml — the two files bd init always writes.
+// Other contents (e.g. the beads project's own .beads/formulas/ convention
+// for formula source files) are not treated as a store, so gc rig add can
+// safely initialize alongside them.
+func beadsDirContainsStore(fs fsys.FS, beadsPath string) bool {
+	for _, name := range [...]string{"metadata.json", "config.yaml"} {
+		if _, err := fs.Stat(filepath.Join(beadsPath, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // readBeadsPrefix reads the issue_prefix from an existing .beads/config.yaml

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2060,10 +2060,10 @@ func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 	}
 }
 
-// A fresh "gc rig add" against a pre-existing .beads/ directory must fail
-// fast and point the user at --adopt — even when the existing prefix would
-// have matched the derived one. Falling through to bd init on a populated
-// Dolt store produces confusing "signal: killed" failures (see fo-5zeij).
+// A fresh "gc rig add" against a pre-existing .beads/ store must fail fast
+// and point the user at --adopt — even when the existing prefix would have
+// matched the derived one. Falling through to bd init on a populated Dolt
+// store produces confusing "signal: killed" failures (see fo-5zeij).
 func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	cityPath := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
@@ -2075,8 +2075,8 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	}
 
 	// Rig "alpha-beta" derives prefix "ab", and .beads already has "ab"
-	// — so the prefix-conflict guard does not trip and we reach the new
-	// "exists without --adopt" guard.
+	// — so the prefix-conflict guard does not trip and we reach the
+	// "store already exists without --adopt" guard.
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
 	beadsDir := filepath.Join(rigPath, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
@@ -2093,14 +2093,103 @@ func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
-		t.Fatalf("expected failure for pre-existing .beads/ without --adopt, got code %d; stdout: %s", code, stdout.String())
+		t.Fatalf("expected failure for pre-existing .beads/ store without --adopt, got code %d; stdout: %s", code, stdout.String())
 	}
 	errMsg := stderr.String()
-	if !strings.Contains(errMsg, ".beads already exists") {
-		t.Errorf("stderr should mention pre-existing .beads/: %s", errMsg)
+	if !strings.Contains(errMsg, "already contains a beads store") {
+		t.Errorf("stderr should identify existing store: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "--adopt") {
 		t.Errorf("stderr should hint at --adopt: %s", errMsg)
+	}
+}
+
+// A .beads/ directory containing only metadata.json (no config.yaml) is
+// still recognized as an existing store — bd init creates both files,
+// and either one is sufficient evidence that a real store is present.
+func TestDoRigAdd_ExistingBeadsMetadataOnlyRequiresAdopt(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"),
+		[]byte(`{"name":"alpha-beta","issue_prefix":"ab"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected failure for pre-existing .beads/ store without --adopt, got code %d; stdout: %s", code, stdout.String())
+	}
+	errMsg := stderr.String()
+	if !strings.Contains(errMsg, "already contains a beads store") {
+		t.Errorf("stderr should identify existing store: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "--adopt") {
+		t.Errorf("stderr should hint at --adopt: %s", errMsg)
+	}
+}
+
+// A target directory whose .beads/ subdir contains only unrelated content
+// (no metadata.json or config.yaml) is NOT a beads store. Common in the
+// wild: the beads project itself uses .beads/formulas/ for unrelated
+// formula source files. gc rig add must proceed in this case, initializing
+// the store alongside the existing content without disturbing it.
+func TestDoRigAdd_BeadsDirWithUnrelatedContentSucceeds(t *testing.T) {
+	cityPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigPath := filepath.Join(t.TempDir(), "beads-project")
+	formulasDir := filepath.Join(rigPath, ".beads", "formulas")
+	if err := os.MkdirAll(formulasDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	formulaPath := filepath.Join(formulasDir, "example.toml")
+	if err := os.WriteFile(formulaPath, []byte("# unrelated formula source\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doRigAdd should succeed when .beads/ has only unrelated content, got code %d; stderr: %s", code, stderr.String())
+	}
+
+	// Pre-existing unrelated content must be left untouched.
+	if _, err := os.Stat(formulaPath); err != nil {
+		t.Errorf(".beads/formulas/example.toml should be preserved: %v", err)
+	}
+
+	// city.toml must list the new rig.
+	cityTomlBytes, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(cityTomlBytes), "beads-project") {
+		t.Errorf("city.toml should contain rig name: %s", cityTomlBytes)
 	}
 }
 

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1370,10 +1370,10 @@ ref = "v1.2.3"
 func TestNewRigAddCmdIncludeFlagIsRepeatable(t *testing.T) {
 	cmd := newRigAddCmd(&bytes.Buffer{}, &bytes.Buffer{})
 	flag := cmd.Flags().Lookup("include")
-	if flag == nil {
+	switch {
+	case flag == nil:
 		t.Fatal("include flag not registered")
-	}
-	if flag.Value.Type() != "stringArray" {
+	case flag.Value.Type() != "stringArray":
 		t.Fatalf("include flag type = %q, want stringArray", flag.Value.Type())
 	}
 }
@@ -2131,7 +2131,7 @@ func TestDoRigAdd_ExistingBeadsMetadataOnlyRequiresAdopt(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("expected failure for pre-existing .beads/ store without --adopt, got code %d; stdout: %s", code, stdout.String())
 	}
@@ -2173,7 +2173,7 @@ func TestDoRigAdd_BeadsDirWithUnrelatedContentSucceeds(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	var stdout, stderr bytes.Buffer
-	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", false, false, &stdout, &stderr)
+	code := doRigAdd(fsys.OSFS{}, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doRigAdd should succeed when .beads/ has only unrelated content, got code %d; stderr: %s", code, stderr.String())
 	}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -2221,6 +2221,36 @@ func TestDoRigAdd_ExistingBeadsStatErrorFailsClosed(t *testing.T) {
 	}
 }
 
+func TestDoRigAdd_ExistingBeadsMarkerStatErrorFailsClosed(t *testing.T) {
+	f := fsys.NewFake()
+	cityPath := "/city"
+	rigPath := "/alpha-beta"
+	beadsPath := filepath.Join(rigPath, ".beads")
+	markerPath := filepath.Join(beadsPath, "metadata.json")
+
+	f.Dirs[filepath.Join(cityPath, ".gc")] = true
+	f.Dirs[rigPath] = true
+	f.Dirs[beadsPath] = true
+	f.Files[filepath.Join(cityPath, "city.toml")] = []byte("[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n")
+	f.Errors[markerPath] = os.ErrPermission
+
+	t.Setenv("GC_DOLT", "skip")
+	t.Setenv("GC_BEADS", "file")
+
+	var stdout, stderr bytes.Buffer
+	code := doRigAdd(f, cityPath, rigPath, nil, "", "", "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected failure for .beads marker stat error, got code %d; stdout: %s", code, stdout.String())
+	}
+	errMsg := stderr.String()
+	if !strings.Contains(errMsg, "checking "+markerPath) {
+		t.Fatalf("stderr should identify the marker stat failure, got: %s", errMsg)
+	}
+	if _, ok := f.Files[filepath.Join(cityPath, "city.toml")]; !ok {
+		t.Fatal("city.toml missing from fake filesystem")
+	}
+}
+
 func TestReadBeadsPrefix(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

`gc rig add <path>` previously refused to register any directory whose `.beads/` subdir already existed, without checking whether the existing `.beads/` actually held a beads store. This broke the realistic case of projects (like beads itself) that use `.beads/<something>/` as an unrelated subdir.

## Change

Detect a real beads store by presence of `.beads/metadata.json` or `.beads/config.yaml`. A `.beads/` subdir with only unrelated content (e.g. `.beads/formulas/`) no longer trips the guard.

## Tests

- `TestDoRigAdd_ExistingBeadsMetadataOnlyRequiresAdopt`
- `TestDoRigAdd_BeadsDirWithUnrelatedContentSucceeds`

Pre-existing unrelated test failures (`TestDoRigAddRouteFailureRollsBackConfig`, `TestDoRigAdd_DoesNotWritePortFileForFileBackedExternalRig`) exist on base branch.

## Tracking

Closes ga-8mo (gascity rig beads tracker).