### PR TITLE
fix(contract): repair malformed .beads/config.yaml after bd init

### DIFF
--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -550,6 +550,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		return false, err
 	}
 
+	repairedLines, repaired := repairMalformedConfigLines(strings.Split(string(data), "\n"))
+	if repaired {
+		data = []byte(strings.Join(repairedLines, "\n"))
+	}
+
 	prefix := strings.TrimSpace(state.IssuePrefix)
 	if prefix == "" {
 		if existing, ok := scanConfigLineValueFromData(data, "issue_prefix:", "issue-prefix:"); ok {
@@ -599,9 +604,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	lines := strings.Split(string(data), "\n")
 	out := make([]string, 0, len(lines)+len(replacements))
 	seen := make(map[string]bool, len(replacements))
-	changed := false
+	changed := repaired
 
-	for _, line := range lines {
+	lastTopLevelIndex := lastTopLevelKeyIndex(lines)
+
+	for i, line := range lines {
 		key, _, ok := topLevelConfigLine(line)
 		if !ok {
 			out = append(out, line)
@@ -613,6 +620,13 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		}
 		want, manage := replacements[key]
 		if !manage {
+			// Per YAML semantics, last-write-wins for duplicate top-level
+			// keys. Drop earlier occurrences so the canonical writer
+			// converges on a single entry per key.
+			if i != lastTopLevelIndex[key] {
+				changed = true
+				continue
+			}
 			out = append(out, line)
 			continue
 		}
@@ -910,4 +924,106 @@ func trimmedString(value any) string {
 		return ""
 	}
 	return trimmed
+}
+
+// repairMalformedConfigLines splits top-level config lines that have been
+// glued together by an upstream writer that forgot a trailing newline.
+// Returns the (possibly-expanded) line slice and a flag indicating whether
+// any line was split.
+//
+// Concretely this handles the ga-um7 reproducer: `bd init` against a git
+// repo can leave a line like
+//
+//	sync.remote: "<url>"types.custom: <value>
+//
+// which would otherwise trip the YAML parser and survive the line-based
+// fallback unchanged.
+func repairMalformedConfigLines(lines []string) ([]string, bool) {
+	out := make([]string, 0, len(lines))
+	changed := false
+	for _, line := range lines {
+		parts := splitGluedConfigLine(line)
+		if len(parts) > 1 {
+			changed = true
+		}
+		out = append(out, parts...)
+	}
+	return out, changed
+}
+
+// splitGluedConfigLine recursively splits a top-level config line that
+// contains a quoted-string value immediately followed by another top-level
+// key. Returns the original line as a one-element slice when no split is
+// possible.
+func splitGluedConfigLine(line string) []string {
+	if strings.TrimLeft(line, " \t") != line {
+		return []string{line}
+	}
+	colon := strings.Index(line, ":")
+	if colon <= 0 {
+		return []string{line}
+	}
+	rest := line[colon+1:]
+	quoteStart := strings.Index(rest, `"`)
+	if quoteStart < 0 {
+		return []string{line}
+	}
+	quoteEnd := strings.Index(rest[quoteStart+1:], `"`)
+	if quoteEnd < 0 {
+		return []string{line}
+	}
+	afterQuote := quoteStart + 1 + quoteEnd + 1
+	tail := rest[afterQuote:]
+	if !looksLikeTopLevelKeyStart(tail) {
+		return []string{line}
+	}
+	head := line[:colon+1+afterQuote]
+	// The tail may itself glue another key; recurse so chains of
+	// missing-newline writes all get split apart.
+	return append([]string{head}, splitGluedConfigLine(tail)...)
+}
+
+// looksLikeTopLevelKeyStart reports whether s begins with a YAML-style
+// top-level key followed by a colon (e.g. `types.custom: value`).
+func looksLikeTopLevelKeyStart(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == ':' {
+			return i > 0
+		}
+		if !isYamlKeyRune(r) {
+			return false
+		}
+	}
+	return false
+}
+
+func isYamlKeyRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '.' || r == '-' || r == '_':
+		return true
+	default:
+		return false
+	}
+}
+
+// lastTopLevelKeyIndex returns a map from top-level key name to the index
+// of its final occurrence in lines. Used by the fallback writer to drop
+// earlier duplicates so YAML last-write-wins semantics survive a rewrite.
+func lastTopLevelKeyIndex(lines []string) map[string]int {
+	last := make(map[string]int, len(lines))
+	for i, line := range lines {
+		if key, _, ok := topLevelConfigLine(line); ok {
+			last[key] = i
+		}
+	}
+	return last
 }

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -373,6 +373,111 @@ func TestEnsureCanonicalConfigIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine guards against the
+// ga-um7 reproducer: `bd init` against a git repo with a remote can leave
+// `.beads/config.yaml` with the `sync.remote:` line lacking a trailing
+// newline, so the next emitted key gets glued onto its value. The next
+// EnsureCanonicalConfig call must restructure the file into valid YAML
+// rather than silently passing the corrupt line through.
+func TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: si",
+		"issue-prefix: si",
+		"dolt.auto-start: false",
+		"export.auto: false",
+		"gc.endpoint_origin: inherited_city",
+		"gc.endpoint_status: verified",
+		"",
+		`sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step`,
+		"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "si",
+		EndpointOrigin: EndpointOriginInheritedCity,
+		EndpointStatus: EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() should report changes when repairing glued line")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+
+	// The repaired file must parse as YAML.
+	if _, err := readConfigDoc(fs, path); err != nil {
+		t.Fatalf("repaired config must parse as YAML, got error %v\n%s", err, text)
+	}
+
+	// sync.remote line must be a standalone key/value, not glued to anything.
+	if !strings.Contains(text, `sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"`+"\n") &&
+		!strings.Contains(text, "sync.remote: git+ssh://git@example.com/foo/service-inventory.git\n") {
+		t.Fatalf("sync.remote line must be standalone, got:\n%s", text)
+	}
+	if strings.Contains(text, `"types.custom`) {
+		t.Fatalf("types.custom must not be glued to a quoted value:\n%s", text)
+	}
+
+	// types.custom must appear at most once.
+	if got := countLineOccurrences(text, "types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step"); got != 1 {
+		t.Fatalf("types.custom should appear exactly once, found %d:\n%s", got, text)
+	}
+}
+
+// TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair ensures
+// that when fallback repairs are needed, duplicate top-level keys are
+// collapsed even when they aren't in the managed set. YAML semantics say
+// last-write-wins; the canonical writer should match.
+func TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	// Include a malformed marker so the fallback path runs.
+	input := strings.Join([]string{
+		"issue_prefix: gc",
+		"types.custom: first-value",
+		"types.custom: second-value",
+		": not yaml",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Contains(text, "types.custom: first-value") {
+		t.Fatalf("first duplicate value should be dropped:\n%s", text)
+	}
+	if count := countLineOccurrences(text, "types.custom: second-value"); count != 1 {
+		t.Fatalf("expected exactly one types.custom line, found %d:\n%s", count, text)
+	}
+}
+
 func TestEnsureCanonicalConfigFallsBackToLineRewriteOnMalformedYAML(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

`gc rig add` was producing a malformed `.beads/config.yaml` when the rig had a git remote — the file was missing a trailing newline and contained a duplicate `types.custom` section. Existing broken rigs self-heal via the post-init normalization pass.

## Tracking

Closes ga-um7 (gascity rig beads tracker).