### PR TITLE
fix(rig): suppress redundant rig imports covered by pack defaults

### DIFF
--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -319,13 +319,15 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		case len(includes) > 0:
 			rig.Includes = slices.Clone(includes)
 		default:
-			if len(rootDefaultRigImports) > 0 {
-				rig.Imports = make(map[string]config.Import, len(rootDefaultRigImports))
-				for _, bound := range rootDefaultRigImports {
-					rig.Imports[bound.Binding] = bound.Import
-				}
-			}
-			if len(defaultRigIncludes) > 0 {
+			// pack.toml's [defaults.rig.imports] is the single source of
+			// truth — applied to rigs at config-resolution time via
+			// applyDefaultRigImports. Avoid duplicating those entries into
+			// city.toml's [rigs.imports.*], which would cause the pack to
+			// be loaded twice (once via DefaultRigImports, once via the
+			// rig's explicit imports) and double-append session_live and
+			// other [global] arrays. The legacy default_rig_includes is
+			// only used as a fallback when no defaults.rig.imports exists.
+			if len(rootDefaultRigImports) == 0 && len(defaultRigIncludes) > 0 {
 				rig.Includes = slices.Clone(defaultRigIncludes)
 			}
 		}
@@ -438,8 +440,7 @@ func doRigAdd(fs fsys.FS, cityPath, rigPath string, includes []string, nameOverr
 		default:
 			if len(rootDefaultRigImports) > 0 {
 				w(fmt.Sprintf("  Import: %s (default)", formatBoundImports(rootDefaultRigImports)))
-			}
-			if len(defaultRigIncludes) > 0 {
+			} else if len(defaultRigIncludes) > 0 {
 				w(fmt.Sprintf("  Include: %s (default)", strings.Join(defaultRigIncludes, ", ")))
 			}
 		}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -1352,6 +1352,17 @@ source = "packs/a-pack"
 	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Stub the referenced packs so LoadWithIncludes can resolve them.
+	for _, name := range []string{"z-pack", "a-pack"} {
+		dir := filepath.Join(cityPath, "packs", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stub := fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", name)
+		if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(stub), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1371,8 +1382,10 @@ source = "packs/a-pack"
 	if !strings.Contains(output, "Import: z-pack=packs/z-pack, a-pack=packs/a-pack (default)") {
 		t.Errorf("output missing root pack default imports in declaration order: %s", output)
 	}
-	if !strings.Contains(output, "Include: packs/city-pack (default)") {
-		t.Errorf("output missing legacy default include fallback: %s", output)
+	// pack.toml's [defaults.rig.imports] suppresses the legacy
+	// default_rig_includes fallback so we don't write redundant entries.
+	if strings.Contains(output, "Include: packs/city-pack (default)") {
+		t.Errorf("output should not show legacy include fallback when defaults.rig.imports is set: %s", output)
 	}
 
 	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
@@ -1382,17 +1395,29 @@ source = "packs/a-pack"
 	if len(cfg.Rigs) != 1 {
 		t.Fatalf("expected 1 rig, got %d", len(cfg.Rigs))
 	}
-	if want := []string{"packs/city-pack"}; !reflect.DeepEqual(cfg.Rigs[0].Includes, want) {
-		t.Errorf("rig includes = %v, want %v", cfg.Rigs[0].Includes, want)
+	// gc rig add no longer writes [rigs.imports.*] for entries already
+	// covered by pack.toml's [defaults.rig.imports]; defaults are applied
+	// to rigs at config-resolution time instead.
+	if got := cfg.Rigs[0].Imports; len(got) != 0 {
+		t.Errorf("rig imports = %#v, want empty (covered by defaults.rig.imports)", got)
 	}
-	if len(cfg.Rigs[0].Imports) != 2 {
-		t.Fatalf("len(rig imports) = %d, want 2", len(cfg.Rigs[0].Imports))
+	if got := cfg.Rigs[0].Includes; len(got) != 0 {
+		t.Errorf("rig includes = %v, want empty (defaults.rig.imports replaces legacy default_rig_includes)", got)
 	}
-	if got := cfg.Rigs[0].Imports["z-pack"].Source; got != "packs/z-pack" {
-		t.Errorf("rig imports[z-pack] = %q, want packs/z-pack", got)
+
+	// Defaults must be applied at runtime via LoadWithIncludes.
+	resolved, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	if got := cfg.Rigs[0].Imports["a-pack"].Source; got != "packs/a-pack" {
-		t.Errorf("rig imports[a-pack] = %q, want packs/a-pack", got)
+	if got := resolved.Rigs[0].Imports; len(got) != 2 {
+		t.Fatalf("resolved rig imports = %#v, want 2 entries from defaults", got)
+	}
+	if got := resolved.Rigs[0].Imports["z-pack"].Source; got != "packs/z-pack" {
+		t.Errorf("resolved rig imports[z-pack] = %q, want packs/z-pack", got)
+	}
+	if got := resolved.Rigs[0].Imports["a-pack"].Source; got != "packs/a-pack" {
+		t.Errorf("resolved rig imports[a-pack] = %q, want packs/a-pack", got)
 	}
 }
 
@@ -1427,7 +1452,10 @@ func TestDoRigAdd_RealGastownExampleRootPackDefaultRigImport(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Import: gastown=packs/gastown (default)") {
 		t.Fatalf("output missing gastown default import: %s", stdout.String())
 	}
-	cfg, err := config.Load(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	// gc rig add no longer writes the default to city.toml's rig
+	// imports; the canonical source is pack.toml's [defaults.rig.imports],
+	// applied at config-resolution time via applyDefaultRigImports.
+	cfg, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/beads/contract/files.go
+++ b/internal/beads/contract/files.go
@@ -506,6 +506,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		return false, err
 	}
 
+	repairedLines, repaired := repairMalformedConfigLines(strings.Split(string(data), "\n"))
+	if repaired {
+		data = []byte(strings.Join(repairedLines, "\n"))
+	}
+
 	prefix := strings.TrimSpace(state.IssuePrefix)
 	if prefix == "" {
 		if existing, ok := scanConfigLineValueFromData(data, "issue_prefix:", "issue-prefix:"); ok {
@@ -555,9 +560,11 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 	lines := strings.Split(string(data), "\n")
 	out := make([]string, 0, len(lines)+len(replacements))
 	seen := make(map[string]bool, len(replacements))
-	changed := false
+	changed := repaired
 
-	for _, line := range lines {
+	lastTopLevelIndex := lastTopLevelKeyIndex(lines)
+
+	for i, line := range lines {
 		key, _, ok := topLevelConfigLine(line)
 		if !ok {
 			out = append(out, line)
@@ -569,6 +576,13 @@ func ensureCanonicalConfigFallback(fs fsys.FS, path string, state ConfigState) (
 		}
 		want, manage := replacements[key]
 		if !manage {
+			// Per YAML semantics, last-write-wins for duplicate top-level
+			// keys. Drop earlier occurrences so the canonical writer
+			// converges on a single entry per key.
+			if i != lastTopLevelIndex[key] {
+				changed = true
+				continue
+			}
 			out = append(out, line)
 			continue
 		}
@@ -866,4 +880,106 @@ func trimmedString(value any) string {
 		return ""
 	}
 	return trimmed
+}
+
+// repairMalformedConfigLines splits top-level config lines that have been
+// glued together by an upstream writer that forgot a trailing newline.
+// Returns the (possibly-expanded) line slice and a flag indicating whether
+// any line was split.
+//
+// Concretely this handles the ga-um7 reproducer: `bd init` against a git
+// repo can leave a line like
+//
+//	sync.remote: "<url>"types.custom: <value>
+//
+// which would otherwise trip the YAML parser and survive the line-based
+// fallback unchanged.
+func repairMalformedConfigLines(lines []string) ([]string, bool) {
+	out := make([]string, 0, len(lines))
+	changed := false
+	for _, line := range lines {
+		parts := splitGluedConfigLine(line)
+		if len(parts) > 1 {
+			changed = true
+		}
+		out = append(out, parts...)
+	}
+	return out, changed
+}
+
+// splitGluedConfigLine recursively splits a top-level config line that
+// contains a quoted-string value immediately followed by another top-level
+// key. Returns the original line as a one-element slice when no split is
+// possible.
+func splitGluedConfigLine(line string) []string {
+	if strings.TrimLeft(line, " \t") != line {
+		return []string{line}
+	}
+	colon := strings.Index(line, ":")
+	if colon <= 0 {
+		return []string{line}
+	}
+	rest := line[colon+1:]
+	quoteStart := strings.Index(rest, `"`)
+	if quoteStart < 0 {
+		return []string{line}
+	}
+	quoteEnd := strings.Index(rest[quoteStart+1:], `"`)
+	if quoteEnd < 0 {
+		return []string{line}
+	}
+	afterQuote := quoteStart + 1 + quoteEnd + 1
+	tail := rest[afterQuote:]
+	if !looksLikeTopLevelKeyStart(tail) {
+		return []string{line}
+	}
+	head := line[:colon+1+afterQuote]
+	// The tail may itself glue another key; recurse so chains of
+	// missing-newline writes all get split apart.
+	return append([]string{head}, splitGluedConfigLine(tail)...)
+}
+
+// looksLikeTopLevelKeyStart reports whether s begins with a YAML-style
+// top-level key followed by a colon (e.g. `types.custom: value`).
+func looksLikeTopLevelKeyStart(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == ':' {
+			return i > 0
+		}
+		if !isYamlKeyRune(r) {
+			return false
+		}
+	}
+	return false
+}
+
+func isYamlKeyRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '.' || r == '-' || r == '_':
+		return true
+	default:
+		return false
+	}
+}
+
+// lastTopLevelKeyIndex returns a map from top-level key name to the index
+// of its final occurrence in lines. Used by the fallback writer to drop
+// earlier duplicates so YAML last-write-wins semantics survive a rewrite.
+func lastTopLevelKeyIndex(lines []string) map[string]int {
+	last := make(map[string]int, len(lines))
+	for i, line := range lines {
+		if key, _, ok := topLevelConfigLine(line); ok {
+			last[key] = i
+		}
+	}
+	return last
 }

--- a/internal/beads/contract/files_test.go
+++ b/internal/beads/contract/files_test.go
@@ -373,6 +373,111 @@ func TestEnsureCanonicalConfigIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine guards against the
+// ga-um7 reproducer: `bd init` against a git repo with a remote can leave
+// `.beads/config.yaml` with the `sync.remote:` line lacking a trailing
+// newline, so the next emitted key gets glued onto its value. The next
+// EnsureCanonicalConfig call must restructure the file into valid YAML
+// rather than silently passing the corrupt line through.
+func TestEnsureCanonicalConfigRepairsGluedSyncRemoteLine(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	input := strings.Join([]string{
+		"issue_prefix: si",
+		"issue-prefix: si",
+		"dolt.auto-start: false",
+		"export.auto: false",
+		"gc.endpoint_origin: inherited_city",
+		"gc.endpoint_status: verified",
+		"",
+		`sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step`,
+		"types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "si",
+		EndpointOrigin: EndpointOriginInheritedCity,
+		EndpointStatus: EndpointStatusVerified,
+	})
+	if err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("EnsureCanonicalConfig() should report changes when repairing glued line")
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+
+	// The repaired file must parse as YAML.
+	if _, err := readConfigDoc(fs, path); err != nil {
+		t.Fatalf("repaired config must parse as YAML, got error %v\n%s", err, text)
+	}
+
+	// sync.remote line must be a standalone key/value, not glued to anything.
+	if !strings.Contains(text, `sync.remote: "git+ssh://git@example.com/foo/service-inventory.git"`+"\n") &&
+		!strings.Contains(text, "sync.remote: git+ssh://git@example.com/foo/service-inventory.git\n") {
+		t.Fatalf("sync.remote line must be standalone, got:\n%s", text)
+	}
+	if strings.Contains(text, `"types.custom`) {
+		t.Fatalf("types.custom must not be glued to a quoted value:\n%s", text)
+	}
+
+	// types.custom must appear at most once.
+	if got := countLineOccurrences(text, "types.custom: molecule,convoy,message,event,gate,merge-request,agent,role,rig,session,spec,convergence,step"); got != 1 {
+		t.Fatalf("types.custom should appear exactly once, found %d:\n%s", got, text)
+	}
+}
+
+// TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair ensures
+// that when fallback repairs are needed, duplicate top-level keys are
+// collapsed even when they aren't in the managed set. YAML semantics say
+// last-write-wins; the canonical writer should match.
+func TestEnsureCanonicalConfigDedupsUnmanagedKeysOnMalformedRepair(t *testing.T) {
+	fs := fsys.OSFS{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	// Include a malformed marker so the fallback path runs.
+	input := strings.Join([]string{
+		"issue_prefix: gc",
+		"types.custom: first-value",
+		"types.custom: second-value",
+		": not yaml",
+		"",
+	}, "\n")
+	if err := fs.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureCanonicalConfig(fs, path, ConfigState{
+		IssuePrefix:    "gc",
+		EndpointOrigin: EndpointOriginManagedCity,
+		EndpointStatus: EndpointStatusVerified,
+	}); err != nil {
+		t.Fatalf("EnsureCanonicalConfig() error = %v", err)
+	}
+
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Contains(text, "types.custom: first-value") {
+		t.Fatalf("first duplicate value should be dropped:\n%s", text)
+	}
+	if count := countLineOccurrences(text, "types.custom: second-value"); count != 1 {
+		t.Fatalf("expected exactly one types.custom line, found %d:\n%s", count, text)
+	}
+}
+
 func TestEnsureCanonicalConfigFallsBackToLineRewriteOnMalformedYAML(t *testing.T) {
 	fs := fsys.OSFS{}
 	dir := t.TempDir()

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -199,12 +199,26 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 				}
 			}
 		}
-		defaultRigIncludes, err := defaultRigIncludesFromPackDefaults(pc.Defaults, md)
+		defaultRigImports, err := defaultRigImportsFromPackDefaults(pc.Defaults, md)
 		if err != nil {
 			return nil, nil, fmt.Errorf("city pack.toml: %w", err)
 		}
-		if len(defaultRigIncludes) > 0 {
+		if len(defaultRigImports) > 0 {
+			defaultRigIncludes := make([]string, 0, len(defaultRigImports))
+			for _, bound := range defaultRigImports {
+				defaultRigIncludes = append(defaultRigIncludes, bound.Import.Source)
+			}
 			root.Workspace.DefaultRigIncludes = append(defaultRigIncludes, root.Workspace.DefaultRigIncludes...)
+			if root.DefaultRigImports == nil {
+				root.DefaultRigImports = make(map[string]Import, len(defaultRigImports))
+			}
+			for _, bound := range defaultRigImports {
+				if _, ok := root.DefaultRigImports[bound.Binding]; ok {
+					continue
+				}
+				root.DefaultRigImports[bound.Binding] = bound.Import
+				root.DefaultRigImportOrder = append(root.DefaultRigImportOrder, bound.Binding)
+			}
 		}
 		if len(pc.Defaults.Rig.Imports) > 0 {
 			defaultBindings = make(map[string]bool, len(pc.Defaults.Rig.Imports))
@@ -504,6 +518,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	}
 
 	// Expand rig packs after patches (pack agents get rig overrides).
+	// Apply pack.toml [defaults.rig.imports] to rigs before checking
+	// HasPackRigs so rigs that rely solely on defaults still expand.
+	applyDefaultRigImports(root)
 	rigFormulaDirs := make(map[string][]string)
 	if HasPackRigs(root.Rigs) {
 		if err := expandPacks(root, fs, cityRoot, rigFormulaDirs, opts); err != nil {
@@ -1310,18 +1327,6 @@ func defaultRigImportsFromPackDefaults(defaults packDefaults, md toml.MetaData) 
 		imports = append(imports, BoundImport{Binding: name, Import: imp})
 	}
 	return imports, nil
-}
-
-func defaultRigIncludesFromPackDefaults(defaults packDefaults, md toml.MetaData) ([]string, error) {
-	imports, err := defaultRigImportsFromPackDefaults(defaults, md)
-	if err != nil {
-		return nil, err
-	}
-	includes := make([]string, 0, len(imports))
-	for _, bound := range imports {
-		includes = append(includes, bound.Import.Source)
-	}
-	return includes, nil
 }
 
 func orderedDefaultRigImportNames(imports map[string]Import, md toml.MetaData) []string {

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -2096,23 +2096,79 @@ func legacyPackDoctors(fs fsys.FS, entries []PackDoctorEntry, packDir, packName 
 // applyPackGlobals appends [global].session_live commands from packs
 // to matching agents. City-level globals affect ALL agents. Rig-level
 // globals affect only agents in that rig.
+//
+// Packs declared at both city and rig scope (typical for packs with
+// agents on both sides) are deduped per-agent by pack name: each pack's
+// SessionLive applies at most once per agent, regardless of how many
+// scopes pull it in.
 func applyPackGlobals(cfg *City) {
+	// Track which packs have already applied their globals to each agent,
+	// keyed by agent index. Without this, a pack present at both city
+	// scope (PackGlobals) and rig scope (RigPackGlobals) would double-
+	// append its SessionLive to that rig's agents.
+	applied := make(map[int]map[string]bool, len(cfg.Agents))
+	for i := range cfg.Agents {
+		applied[i] = make(map[string]bool)
+	}
 	// City-level globals → all agents.
 	for _, g := range cfg.PackGlobals {
 		for i := range cfg.Agents {
+			if applied[i][g.PackName] {
+				continue
+			}
 			cfg.Agents[i].SessionLive = append(
 				cfg.Agents[i].SessionLive, g.SessionLive...)
+			applied[i][g.PackName] = true
 		}
 	}
 	// Rig-level globals → only that rig's agents.
 	for rigName, globals := range cfg.RigPackGlobals {
 		for _, g := range globals {
 			for i := range cfg.Agents {
-				if cfg.Agents[i].Dir == rigName {
-					cfg.Agents[i].SessionLive = append(
-						cfg.Agents[i].SessionLive, g.SessionLive...)
+				if cfg.Agents[i].Dir != rigName {
+					continue
 				}
+				if applied[i][g.PackName] {
+					continue
+				}
+				cfg.Agents[i].SessionLive = append(
+					cfg.Agents[i].SessionLive, g.SessionLive...)
+				applied[i][g.PackName] = true
 			}
+		}
+	}
+}
+
+// applyDefaultRigImports merges [defaults.rig.imports] entries into each
+// rig's Imports map for binding names the rig hasn't already declared
+// itself. The pack.toml [defaults.rig.imports] section is the single
+// source of truth for which packs apply to every rig — gc rig add no
+// longer needs to copy them into city.toml's [rigs.imports.*].
+//
+// A binding the rig already sets (with any source) wins, allowing per-rig
+// overrides.
+func applyDefaultRigImports(cfg *City) {
+	if len(cfg.DefaultRigImports) == 0 {
+		return
+	}
+	order := cfg.DefaultRigImportOrder
+	if len(order) == 0 {
+		order = make([]string, 0, len(cfg.DefaultRigImports))
+		for name := range cfg.DefaultRigImports {
+			order = append(order, name)
+		}
+		sort.Strings(order)
+	}
+	for i := range cfg.Rigs {
+		rig := &cfg.Rigs[i]
+		for _, name := range order {
+			if _, ok := rig.Imports[name]; ok {
+				continue
+			}
+			if rig.Imports == nil {
+				rig.Imports = make(map[string]Import)
+			}
+			rig.Imports[name] = cfg.DefaultRigImports[name]
 		}
 	}
 }

--- a/internal/config/pack_test.go
+++ b/internal/config/pack_test.go
@@ -4010,6 +4010,73 @@ session_live = ["echo global"]
 	}
 }
 
+// TestPackGlobal_DedupedAcrossScopes covers the case where a pack is loaded
+// at both city and rig scope (typical for packs with both city-scoped and
+// rig-scoped agents). Without dedup, applyPackGlobals would append the pack's
+// session_live twice to each rig agent — once for the city-level
+// PackGlobals entry, once for the rig-level RigPackGlobals entry.
+func TestPackGlobal_DedupedAcrossScopes(t *testing.T) {
+	cfg := &City{
+		PackGlobals: []ResolvedPackGlobal{
+			{PackName: "gastown", SessionLive: []string{"theme.sh", "keys.sh"}},
+		},
+		RigPackGlobals: map[string][]ResolvedPackGlobal{
+			"my-rig": {{PackName: "gastown", SessionLive: []string{"theme.sh", "keys.sh"}}},
+		},
+		Agents: []Agent{
+			{Name: "city-agent", Dir: ""},
+			{Name: "rig-agent", Dir: "my-rig"},
+		},
+	}
+	applyPackGlobals(cfg)
+	for _, a := range cfg.Agents {
+		if len(a.SessionLive) != 2 {
+			t.Errorf("agent %q: SessionLive = %v, want 2 entries (no dedup means double-application)", a.Name, a.SessionLive)
+		}
+	}
+}
+
+// TestApplyDefaultRigImports_AppliedToBareRigs verifies that
+// [defaults.rig.imports] entries get merged onto rigs that don't declare
+// the binding themselves.
+func TestApplyDefaultRigImports_AppliedToBareRigs(t *testing.T) {
+	cfg := &City{
+		DefaultRigImports: map[string]Import{
+			"gastown": {Source: "packs/gastown"},
+		},
+		DefaultRigImportOrder: []string{"gastown"},
+		Rigs: []Rig{
+			{Name: "alpha"},
+			{Name: "beta"},
+		},
+	}
+	applyDefaultRigImports(cfg)
+	for _, r := range cfg.Rigs {
+		if r.Imports["gastown"].Source != "packs/gastown" {
+			t.Errorf("rig %q: imports[gastown].Source = %q, want packs/gastown", r.Name, r.Imports["gastown"].Source)
+		}
+	}
+}
+
+// TestApplyDefaultRigImports_ExplicitWins verifies that an explicit
+// rig-level import overrides the default for the same binding name,
+// allowing per-rig overrides while preserving the dedup invariant.
+func TestApplyDefaultRigImports_ExplicitWins(t *testing.T) {
+	cfg := &City{
+		DefaultRigImports: map[string]Import{
+			"gastown": {Source: "packs/gastown-default"},
+		},
+		DefaultRigImportOrder: []string{"gastown"},
+		Rigs: []Rig{
+			{Name: "alpha", Imports: map[string]Import{"gastown": {Source: "packs/gastown-fork"}}},
+		},
+	}
+	applyDefaultRigImports(cfg)
+	if got := cfg.Rigs[0].Imports["gastown"].Source; got != "packs/gastown-fork" {
+		t.Errorf("explicit rig import overridden by default: got %q, want packs/gastown-fork", got)
+	}
+}
+
 func TestPackDefinesAgent_Found(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "packs/gastown/pack.toml", `


### PR DESCRIPTION
## Summary

`gc rig add <path> --name <rig>` previously appended a `[rigs.imports.<pack>]` block to city.toml for every pack that the rig would inherit, even when that pack was already declared in pack.toml's `[defaults.rig.imports]`. The result was double-application of the pack at config resolution time: once via `default_rig_includes`, once via `rigs.imports`.

This change suppresses the redundant `[rigs.imports.<pack>]` write when the pack is already covered by `defaults.rig.imports`, so both city and rig scope apply globals at most once per agent.

## Tests

- `internal/config/pack_test.go`: new coverage for the suppression logic in compose / pack resolution.
- `cmd/gc/cmd_rig_test.go`: extended to assert the no-redundant-write behavior.

## Tracking

Closes ga-lzd (gascity rig beads tracker).

## Note

This PR carries 2 commits. The first (`91de3572`) is the ga-um7 fix and is opened as a separate PR — once that lands on gastownhall:main, this PR's diff will collapse to the single ga-lzd commit. Order of merge: ga-um7 PR first, then this one.