### PR TITLE
fix(cmd/gc): filter unready hook work_query rows

### DIFF
--- a/cmd/gc/cmd_hook.go
+++ b/cmd/gc/cmd_hook.go
@@ -23,7 +23,7 @@ func newHookCmd(stdout, stderr io.Writer) *cobra.Command {
 		Short: "Check for available work",
 		Long: `Checks for available work using the agent's work_query config.
 
-Without --inject: prints raw output, exits 0 if work exists, 1 if empty.
+Without --inject: prints normalized ready-only output, exits 0 if work exists, 1 if empty.
 With --inject: silent legacy Stop-hook compatibility; skips the work query and always exits 0.
 
 		The agent is determined from $GC_AGENT or a positional argument.`,
@@ -55,7 +55,7 @@ func cmdHookWithFormat(args []string, inject bool, hookFormat string, stdout, st
 		return 0
 	}
 	// Accepted for compatibility with installed hook commands; non-inject
-	// gc hook output is intentionally raw regardless of provider format.
+	// gc hook output ignores provider-specific formatting.
 	_ = hookFormat
 
 	agentName := os.Getenv("GC_ALIAS")
@@ -227,8 +227,9 @@ func workQueryEnvForDir(env []string, dir string) []string {
 }
 
 // doHook is the pure logic for gc hook. Runs the work query and outputs
-// results based on mode. Without inject: prints raw output, returns 0 if
-// work, 1 if empty. With inject: skips the work query and returns 0.
+// results based on mode. Without inject: prints normalized ready-only output,
+// returns 0 if work exists, 1 if empty. With inject: skips the work query and
+// returns 0.
 func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, stderr io.Writer) int {
 	if inject {
 		return 0
@@ -245,9 +246,10 @@ func doHook(workQuery, dir string, inject bool, runner WorkQueryRunner, stdout, 
 
 	trimmed := strings.TrimSpace(output)
 	normalized := normalizeWorkQueryOutput(trimmed)
+	normalized = filterUnreadyHookCandidates(normalized, time.Now())
 	hasWork := workQueryHasReadyWork(normalized)
 
-	// Non-inject mode: print raw output. Return 0 only when work exists.
+	// Non-inject mode: print normalized, ready-only output. Return 0 only when work exists.
 	if !hasWork {
 		if normalized != "" {
 			fmt.Fprint(stdout, normalized) //nolint:errcheck // best-effort stdout
@@ -279,6 +281,84 @@ func workQueryHasReadyWork(output string) bool {
 		}
 	}
 	return true
+}
+
+// filterUnreadyHookCandidates strips beads from work_query output that fail
+// bd ready semantics: future defer_until, or any open blocking dep in the
+// row's blocked_by array. The work_query is expected to gate these, but
+// defensive filtering here prevents a single broken query from cascading
+// into agent action on a bead it cannot progress.
+// Pure function over JSON; takes time.Time so tests stay deterministic.
+func filterUnreadyHookCandidates(output string, now time.Time) string {
+	if output == "" {
+		return output
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		return output
+	}
+	arr, ok := decoded.([]any)
+	if !ok {
+		return output
+	}
+	filtered := make([]any, 0, len(arr))
+	for _, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if isFutureDeferredHookCandidate(obj, now) {
+			continue
+		}
+		if isDepBlockedHookCandidate(obj) {
+			continue
+		}
+		filtered = append(filtered, obj)
+	}
+	reencoded, err := json.Marshal(filtered)
+	if err != nil {
+		return output
+	}
+	return string(reencoded)
+}
+
+func isFutureDeferredHookCandidate(item map[string]any, now time.Time) bool {
+	raw, ok := item["defer_until"].(string)
+	if !ok {
+		return false
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	deferAt, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+	return deferAt.After(now)
+}
+
+func isDepBlockedHookCandidate(item map[string]any) bool {
+	blockedBy, ok := item["blocked_by"].([]any)
+	if !ok || len(blockedBy) == 0 {
+		return false
+	}
+	for _, b := range blockedBy {
+		dep, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		status, ok := dep["status"].(string)
+		if !ok {
+			continue
+		}
+		status = strings.TrimSpace(status)
+		if status != "" && !strings.EqualFold(status, "closed") {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeWorkQueryOutput(output string) string {

--- a/cmd/gc/hook_defer_blocked_test.go
+++ b/cmd/gc/hook_defer_blocked_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDoHookFiltersDeferredBeads(t *testing.T) {
+	future := "2099-01-01T00:00:00Z"
+	runner := func(_, _ string) (string, error) {
+		return `[
+			{"id":"yijh.3","status":"open","defer_until":"` + future + `"},
+			{"id":"ready-1","status":"open"}
+		]`, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "yijh.3") {
+		t.Errorf("future-deferred bead surfaced in hook output: %s", out)
+	}
+	if !strings.Contains(out, "ready-1") {
+		t.Errorf("ready bead missing from hook output: %s", out)
+	}
+}
+
+func TestDoHookFiltersDepBlockedBeads(t *testing.T) {
+	runner := func(_, _ string) (string, error) {
+		return `[
+			{"id":"a4b8.6.11","status":"open","blocked_by":[{"id":"a4b8.6.10","status":"open"}]},
+			{"id":"clear-1","status":"open"}
+		]`, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "a4b8.6.11") {
+		t.Errorf("dep-blocked bead surfaced in hook output: %s", out)
+	}
+	if !strings.Contains(out, "clear-1") {
+		t.Errorf("clear bead missing from hook output: %s", out)
+	}
+}
+
+func TestDoHookKeepsPastDeferredAndClosedBlockers(t *testing.T) {
+	past := "2000-01-01T00:00:00Z"
+	runner := func(_, _ string) (string, error) {
+		return `[
+			{"id":"past-deferred","status":"open","defer_until":"` + past + `"},
+			{"id":"closed-blocker","status":"open","blocked_by":[{"id":"blocker-1","status":"closed"}]}
+		]`, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doHook("bd ready", ".", false, runner, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("doHook() = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"past-deferred", "closed-blocker"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ready bead %q missing from hook output: %s", want, out)
+		}
+	}
+}

--- a/release-gates/ga-5uxids-hook-filter-gate.md
+++ b/release-gates/ga-5uxids-hook-filter-gate.md
@@ -1,0 +1,90 @@
+# Release Gate: ga-5uxids Hook Work Query Filtering
+
+Bead: `ga-a5i63b` (deploy review for `ga-5uxids`)
+Branch: `release/ga-a5i63b` from `fork/builder/ga-5uxids-1`
+Commit: `b9490bfe6b3a6fc34b978238e802c128589bb241`
+Gate date: 2026-05-14
+
+## Summary
+
+This gate evaluates the hook-side defensive filter that strips unready
+`work_query` rows before `gc hook` returns work to an agent. The patch is
+limited to `cmd/gc/cmd_hook.go` plus focused tests in
+`cmd/gc/hook_defer_blocked_test.go`.
+
+`docs/PROJECT_MANIFEST.md` is not present in this checkout or adjacent
+worktree parent; the gate uses the deployer release criteria and `TESTING.md`
+sharded-runner guidance.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | Review bead `ga-a5i63b` notes contain `Verdict: PASS - routing to gascity/deployer`; no request-changes findings were listed. |
+| 2 | Acceptance criteria met | PASS | `doHook` now calls `filterUnreadyHookCandidates` after `normalizeWorkQueryOutput` and before `workQueryHasReadyWork`; the filter strips future `defer_until` rows and open/non-closed `blocked_by` rows while preserving malformed/non-array JSON, past deferred rows, and closed blockers. `cmd/gc/hook_defer_blocked_test.go` covers the required RED/GREEN cases plus the past-deferred/closed-blocker preservation edge case. |
+| 3 | Tests pass | PASS | Focused hook regression tests pass; broader hook suite passes; `go vet ./...` is clean. `make test-fast-parallel` fails in unrelated `unit-core` and `cmd/gc` shards. The exact failing tests, `TestStartLongSocketPathUsesShortSocketName` and `TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag`, both reproduce on `origin/main`. No hook test failed. |
+| 4 | No high-severity review findings open | PASS | `bd list --status open --limit 0` search for this bead/original bead plus HIGH/request-changes markers found no open matching findings. Reviewer notes list no request-changes findings. |
+| 5 | Final branch is clean | PASS | After committing this gate file, the branch has no uncommitted tracked changes. A pre-existing untracked root `.gitkeep` was present before deployer work and is not part of the branch. |
+| 6 | Branch diverges cleanly from main | PASS | `git merge-tree --write-tree origin/main HEAD` produced a merged tree without conflicts. `git diff --check origin/main...HEAD` is clean. |
+
+## Commands Run
+
+```text
+bd show ga-a5i63b
+bd show ga-5uxids
+gh auth status
+git fetch origin main
+git fetch fork builder/ga-5uxids-1
+git show --check --stat b9490bfe
+git diff --name-status origin/main...b9490bfe
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
+git diff --check origin/main...HEAD
+env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deployer-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp go test ./cmd/gc/ -run 'TestDoHookFiltersDeferred|TestDoHookFiltersDepBlocked|TestDoHookKeepsPastDeferredAndClosedBlockers' -count=1
+env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deployer-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp go test ./cmd/gc/ -run 'TestHook|TestCmdHook|TestDoHook' -count=1
+env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deployer-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp go vet ./...
+env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deployer-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deployer-go-tmp make test-fast-parallel
+env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deployer-origin-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deployer-origin-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deployer-origin-go-tmp go test ./internal/runtime/acp -run '^TestStartLongSocketPathUsesShortSocketName$' -count=1
+env -u GC_AGENT -u GC_ALIAS -u GC_TEMPLATE GOCACHE=/home/jaword/.gotmp/gc-deployer-origin-go-cache GOTMPDIR=/home/jaword/.gotmp/gc-deployer-origin-go-tmp TMPDIR=/home/jaword/.gotmp/gc-deployer-origin-go-tmp go test ./cmd/gc/ -run '^TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag$' -count=1
+git merge-tree --write-tree origin/main HEAD
+git diff --check origin/main...HEAD
+git config core.hooksPath
+bd list --status open --limit 0 | rg -i -- 'ga-a5i63b|ga-5uxids|high|request-changes'
+```
+
+## Test Results
+
+```text
+go test ./cmd/gc/ -run 'TestDoHookFiltersDeferred|TestDoHookFiltersDepBlocked|TestDoHookKeepsPastDeferredAndClosedBlockers' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	0.095s
+
+go test ./cmd/gc/ -run 'TestHook|TestCmdHook|TestDoHook' -count=1
+ok  	github.com/gastownhall/gascity/cmd/gc	0.578s
+
+go vet ./...
+PASS
+
+make test-fast-parallel
+FAIL: unit-core
+  TestStartLongSocketPathUsesShortSocketName
+  acp_test.go:741: failed to construct path where legacy socket is too long but short socket fits
+
+FAIL: unit-cmd-gc-6-of-6
+  TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag
+  session_model_phase0_spec_test.go:189: resolving configured named session "mayor": session name already exists: "mayor" already active in runtime
+
+origin/main reproduction:
+  TestStartLongSocketPathUsesShortSocketName fails with the same path construction error.
+  TestPhase0CanonicalMetadata_NamedMaterializationWritesNamedOriginWithoutLegacyManualFlag
+  fails with the same active-runtime session-name conflict.
+```
+
+## Acceptance Mapping
+
+| Done-when item | Result | Evidence |
+|---|---|---|
+| `cmd/gc/hook_defer_blocked_test.go` exists with required tests | PASS | File added with future-deferred, dep-blocked, and preservation tests. |
+| Focused hook filter tests pass | PASS | `go test ./cmd/gc/ -run 'TestDoHookFiltersDeferred|TestDoHookFiltersDepBlocked|TestDoHookKeepsPastDeferredAndClosedBlockers' -count=1` passed. |
+| Existing hook behavior is unchanged | PASS | `go test ./cmd/gc/ -run 'TestHook|TestCmdHook|TestDoHook' -count=1` passed. |
+| `go vet ./cmd/gc/` / broader vet clean | PASS | `go vet ./...` passed. |
+| Fast baseline | PASS with baseline exception | `make test-fast-parallel` failures are pre-existing and outside this hook change; both exact failing tests reproduce on `origin/main`. |
+| Pre-commit hook active | PASS | `git config core.hooksPath` reports `.githooks`; pre-commit will run for the gate commit. |


### PR DESCRIPTION
## What this changes

`gc hook` now defensively filters normalized `work_query` JSON before deciding whether an agent has work and before printing the hook output. Rows for future-deferred beads and rows blocked by non-closed dependencies are removed, so a stale or overly broad query cannot hand an agent work that is not actually ready.

Malformed JSON, non-array output, past-deferred rows, and closed blockers keep the existing behavior. `gc hook --inject` remains silent compatibility mode.

## Review notes

- The runtime behavior change is limited to `cmd/gc/cmd_hook.go`; the new tests live in `cmd/gc/hook_defer_blocked_test.go`.
- The filter runs after `normalizeWorkQueryOutput`, keeping normalization and readiness filtering separate.
- This does not change the configured default work-query tiers; it only prevents unready rows from escaping through the hook output.

## Test plan

- [x] `go test ./cmd/gc/ -run 'TestDoHookFiltersDeferred|TestDoHookFiltersDepBlocked|TestDoHookKeepsPastDeferredAndClosedBlockers' -count=1`
- [x] `go test ./cmd/gc/ -run 'TestHook|TestCmdHook|TestDoHook' -count=1`
- [x] `go vet ./...`
- [x] `make test-fast-parallel` run; unrelated failures reproduce on `origin/main` and are documented in the gate checklist
- [x] Release gate: [`release-gates/ga-5uxids-hook-filter-gate.md`](release-gates/ga-5uxids-hook-filter-gate.md)
