### PR TITLE
Enforce remediable PackV1 surfaces and defer the rest explicitly

### DIFF
--- a/cmd/gc/api_state.go
+++ b/cmd/gc/api_state.go
@@ -72,10 +72,10 @@ var controllerStateInitRigDirIfReady = initDirIfReady
 var newControllerStateOpenCityStore = openCityStoreAt
 
 type configMutationSnapshot struct {
-	cityPath   string
-	files      map[string][]byte
-	existed    map[string]bool
-	agentFiles map[string]struct{}
+	cityPath  string
+	files     map[string][]byte
+	existed   map[string]bool
+	agentTree *fsys.TreeSnapshot
 }
 
 // newControllerState creates a controllerState with per-rig stores.
@@ -1040,10 +1040,9 @@ func (cs *controllerState) DeleteProviderPatch(name string) error {
 
 func captureConfigMutationSnapshot(cityPath string) (*configMutationSnapshot, error) {
 	snapshot := &configMutationSnapshot{
-		cityPath:   cityPath,
-		files:      make(map[string][]byte),
-		existed:    make(map[string]bool),
-		agentFiles: make(map[string]struct{}),
+		cityPath: cityPath,
+		files:    make(map[string][]byte),
+		existed:  make(map[string]bool),
 	}
 
 	capture := func(path string) error {
@@ -1069,16 +1068,11 @@ func captureConfigMutationSnapshot(cityPath string) (*configMutationSnapshot, er
 		}
 	}
 
-	agentFiles, err := filepath.Glob(filepath.Join(cityPath, "agents", "*", "agent.toml"))
+	agentTree, err := fsys.SnapshotTree(fsys.OSFS{}, filepath.Join(cityPath, "agents"))
 	if err != nil {
-		return nil, fmt.Errorf("listing agent overrides: %w", err)
+		return nil, fmt.Errorf("snapshotting agent scaffolds: %w", err)
 	}
-	for _, path := range agentFiles {
-		snapshot.agentFiles[path] = struct{}{}
-		if err := capture(path); err != nil {
-			return nil, err
-		}
-	}
+	snapshot.agentTree = agentTree
 
 	return snapshot, nil
 }
@@ -1086,17 +1080,9 @@ func captureConfigMutationSnapshot(cityPath string) (*configMutationSnapshot, er
 func (s *configMutationSnapshot) restore() error {
 	var restoreErr error
 
-	currentAgentFiles, err := filepath.Glob(filepath.Join(s.cityPath, "agents", "*", "agent.toml"))
-	if err != nil {
-		restoreErr = errors.Join(restoreErr, fmt.Errorf("listing current agent overrides: %w", err))
-	} else {
-		for _, path := range currentAgentFiles {
-			if _, existed := s.agentFiles[path]; existed {
-				continue
-			}
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				restoreErr = errors.Join(restoreErr, fmt.Errorf("removing %s: %w", path, err))
-			}
+	if s.agentTree != nil {
+		if err := s.agentTree.Restore(fsys.OSFS{}); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restoring agent scaffolds: %w", err))
 		}
 	}
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -22,6 +22,54 @@ import (
 	"github.com/gastownhall/gascity/internal/runtime"
 )
 
+type corruptCityAfterRemoveFS struct {
+	fsys.OSFS
+	triggerPath string
+	cityToml    string
+	fired       bool
+}
+
+func (f *corruptCityAfterRemoveFS) Remove(name string) error {
+	err := f.OSFS.Remove(name)
+	if err == nil && !f.fired && filepath.Clean(name) == filepath.Clean(f.triggerPath) {
+		f.fired = true
+		if writeErr := os.WriteFile(f.cityToml, []byte("["), 0o644); writeErr != nil {
+			return writeErr
+		}
+	}
+	return err
+}
+
+type corruptCityAfterRenameFS struct {
+	fsys.OSFS
+	triggerPath string
+	cityToml    string
+	fired       bool
+}
+
+func (f *corruptCityAfterRenameFS) Rename(oldpath, newpath string) error {
+	err := f.OSFS.Rename(oldpath, newpath)
+	if err == nil && !f.fired && filepath.Clean(newpath) == filepath.Clean(f.triggerPath) {
+		f.fired = true
+		if writeErr := os.WriteFile(f.cityToml, []byte("["), 0o644); writeErr != nil {
+			return writeErr
+		}
+	}
+	return err
+}
+
+type failAgentTomlRenameOSFS struct {
+	fsys.OSFS
+	target string
+}
+
+func (f *failAgentTomlRenameOSFS) Rename(oldpath, newpath string) error {
+	if filepath.Clean(newpath) == filepath.Clean(f.target) {
+		return errors.New("injected agent.toml write failure")
+	}
+	return f.OSFS.Rename(oldpath, newpath)
+}
+
 func TestControllerStateReadAccess(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
@@ -837,9 +885,6 @@ func TestControllerStateMutationRollsBackAgentOverrideWhenRefreshFails(t *testin
 	t.Setenv("GC_BEADS", "file")
 
 	cityDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cityDir, "broken.toml"), []byte("["), 0o644); err != nil {
-		t.Fatalf("write broken include: %v", err)
-	}
 	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
 		t.Fatalf("write pack.toml: %v", err)
 	}
@@ -851,7 +896,7 @@ func TestControllerStateMutationRollsBackAgentOverrideWhenRefreshFails(t *testin
 		t.Fatalf("write prompt template: %v", err)
 	}
 
-	original := []byte("include = [\"broken.toml\"]\n\n[workspace]\nname = \"city1\"\n")
+	original := []byte("[workspace]\nname = \"city1\"\n")
 	tomlPath := filepath.Join(cityDir, "city.toml")
 	if err := os.WriteFile(tomlPath, original, 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
@@ -860,6 +905,10 @@ func TestControllerStateMutationRollsBackAgentOverrideWhenRefreshFails(t *testin
 	cs := newControllerState(context.Background(), &config.City{
 		Workspace: config.Workspace{Name: "city1"},
 	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	cs.editor = configedit.NewEditor(&corruptCityAfterRenameFS{
+		triggerPath: filepath.Join(agentDir, "agent.toml"),
+		cityToml:    tomlPath,
+	}, tomlPath)
 	cs.pokeCh = make(chan struct{}, 1)
 	cs.configDirty = &atomic.Bool{}
 
@@ -880,6 +929,407 @@ func TestControllerStateMutationRollsBackAgentOverrideWhenRefreshFails(t *testin
 	}
 	if cs.configDirty.Load() {
 		t.Fatal("SuspendAgent should not mark config dirty after rollback")
+	}
+}
+
+func TestControllerStateMutationRestoresFullAgentScaffoldWhenRefreshFails(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	agentDir := filepath.Join(cityDir, "agents", "worker")
+	if err := os.MkdirAll(filepath.Join(agentDir, "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir agent skills: %v", err)
+	}
+	for rel, data := range map[string]string{
+		"agent.toml":         "provider = \"claude\"\n",
+		"prompt.template.md": "You are the worker.\n",
+		"skills/local.md":    "skill notes\n",
+	} {
+		if err := os.WriteFile(filepath.Join(agentDir, rel), []byte(data), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	original := []byte("[workspace]\nname = \"city1\"\n")
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, original, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	cs.editor = configedit.NewEditor(&corruptCityAfterRemoveFS{
+		triggerPath: agentDir,
+		cityToml:    tomlPath,
+	}, tomlPath)
+	cs.pokeCh = make(chan struct{}, 1)
+	cs.configDirty = &atomic.Bool{}
+
+	err := cs.DeleteAgent("worker")
+	if err == nil {
+		t.Fatal("DeleteAgent should fail when refreshing the updated snapshot fails")
+	}
+	if !strings.Contains(err.Error(), "refreshing updated city config") {
+		t.Fatalf("DeleteAgent error = %v, want refresh failure after mutation", err)
+	}
+
+	for rel, want := range map[string]string{
+		"agent.toml":         "provider = \"claude\"\n",
+		"prompt.template.md": "You are the worker.\n",
+		"skills/local.md":    "skill notes\n",
+	} {
+		got, readErr := os.ReadFile(filepath.Join(agentDir, rel))
+		if readErr != nil {
+			t.Fatalf("read restored %s: %v", rel, readErr)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %q, want restored %q", rel, got, want)
+		}
+	}
+	restored, readErr := os.ReadFile(tomlPath)
+	if readErr != nil {
+		t.Fatalf("read restored city.toml: %v", readErr)
+	}
+	if string(restored) != string(original) {
+		t.Fatalf("city.toml = %q, want rollback to %q", restored, original)
+	}
+	if cs.configDirty.Load() {
+		t.Fatal("DeleteAgent should not mark config dirty after rollback")
+	}
+}
+
+func TestControllerStateMutationAllowsSymlinkedAgentAssets(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+		Providers: map[string]config.ProviderSpec{
+			"codex-local": {Command: "codex"},
+		},
+	}
+	content, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, content, 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	agentDir := filepath.Join(cityDir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("provider = \"codex-local\"\n"), 0o644); err != nil {
+		t.Fatalf("write agent.toml: %v", err)
+	}
+	sharedSkills := filepath.Join(cityDir, "shared-skills")
+	if err := os.MkdirAll(sharedSkills, 0o755); err != nil {
+		t.Fatalf("mkdir shared skills: %v", err)
+	}
+	skillsLink := filepath.Join(agentDir, "skills")
+	if err := os.Symlink(sharedSkills, skillsLink); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), cfg, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	cs.pokeCh = make(chan struct{}, 1)
+	cs.configDirty = &atomic.Bool{}
+
+	if err := cs.UpdateProvider("codex-local", api.ProviderUpdate{Command: stringPtr("codex-wrapper")}); err != nil {
+		t.Fatalf("UpdateProvider with symlinked agent skills: %v", err)
+	}
+
+	info, err := os.Lstat(skillsLink)
+	if err != nil {
+		t.Fatalf("lstat skills symlink: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("skills path mode = %v, want symlink preserved", info.Mode())
+	}
+	if target, err := os.Readlink(skillsLink); err != nil || target != sharedSkills {
+		t.Fatalf("skills symlink target = %q, %v; want %q", target, err, sharedSkills)
+	}
+	got := cs.Config()
+	if got == nil {
+		t.Fatal("Config() = nil after UpdateProvider")
+	}
+	if got.Providers["codex-local"].Command != "codex-wrapper" {
+		t.Fatalf("provider after UpdateProvider = %+v, want command update", got.Providers["codex-local"])
+	}
+}
+
+func TestControllerStateSchema2CreateThenUpdateConventionAgent(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	cs.pokeCh = make(chan struct{}, 2)
+	cs.configDirty = &atomic.Bool{}
+
+	if err := cs.CreateAgent(config.Agent{Name: "helper", Provider: "claude", Scope: "city"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if err := cs.UpdateAgent("helper", api.AgentUpdate{
+		Provider:  "codex",
+		Scope:     "city",
+		Suspended: boolPtr(true),
+	}); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+
+	raw, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatalf("read city.toml: %v", err)
+	}
+	if strings.Contains(string(raw), "[[agent]]") {
+		t.Fatalf("city.toml = %q, want convention agent stored outside city.toml", raw)
+	}
+	data, err := os.ReadFile(filepath.Join(cityDir, "agents", "helper", "agent.toml"))
+	if err != nil {
+		t.Fatalf("read agent.toml: %v", err)
+	}
+	for _, want := range []string{
+		`provider = "codex"`,
+		`scope = "city"`,
+		`suspended = true`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("agent.toml = %q, want %s", data, want)
+		}
+	}
+	for _, agent := range cs.Config().Agents {
+		if agent.Name == "helper" {
+			if agent.Provider != "codex" || agent.Scope != "city" || !agent.Suspended {
+				t.Fatalf("agent = %+v, want updated provider/scope/suspended", agent)
+			}
+			return
+		}
+	}
+	t.Fatalf("Config() agents = %+v, want helper", cs.Config().Agents)
+}
+
+func TestControllerStateSchema2CreateRollsBackFreshConventionScaffoldWhenAgentTOMLWriteFails(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	agentDir := filepath.Join(cityDir, "agents", "helper")
+	cs.editor = configedit.NewEditor(&failAgentTomlRenameOSFS{target: filepath.Join(agentDir, "agent.toml")}, tomlPath)
+	cs.pokeCh = make(chan struct{}, 2)
+	cs.configDirty = &atomic.Bool{}
+
+	err := cs.CreateAgent(config.Agent{Name: "helper", Provider: "claude", Scope: "city"})
+	if err == nil {
+		t.Fatal("CreateAgent succeeded, want injected agent.toml write failure")
+	}
+	if _, statErr := os.Stat(agentDir); !os.IsNotExist(statErr) {
+		t.Fatalf("agent dir stat err = %v, want fresh scaffold removed", statErr)
+	}
+	cfg, _, loadErr := config.LoadWithIncludes(fsys.OSFS{}, tomlPath)
+	if loadErr != nil {
+		t.Fatalf("LoadWithIncludes: %v", loadErr)
+	}
+	for _, agent := range cfg.Agents {
+		if agent.Name == "helper" {
+			t.Fatalf("expanded agents include ghost helper after failed create: %+v", agent)
+		}
+	}
+	if cs.configDirty.Load() {
+		t.Fatal("CreateAgent should not mark config dirty after failed agent.toml write")
+	}
+}
+
+func TestControllerStateSchema2CreateRejectsSymlinkedConventionScaffoldPath(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		setup            func(t *testing.T, cityDir string) string
+		outsideWritePath string
+	}{
+		{
+			name: "agents root",
+			setup: func(t *testing.T, cityDir string) string {
+				t.Helper()
+				outsideAgentsDir := filepath.Join(t.TempDir(), "agents")
+				if err := os.MkdirAll(outsideAgentsDir, 0o755); err != nil {
+					t.Fatalf("mkdir outside agents: %v", err)
+				}
+				agentsLink := filepath.Join(cityDir, "agents")
+				if err := os.Symlink(outsideAgentsDir, agentsLink); err != nil {
+					t.Skipf("symlink unsupported: %v", err)
+				}
+				return agentsLink
+			},
+			outsideWritePath: filepath.Join("agents", "helper"),
+		},
+		{
+			name: "agent dir",
+			setup: func(t *testing.T, cityDir string) string {
+				t.Helper()
+				agentsDir := filepath.Join(cityDir, "agents")
+				if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+					t.Fatalf("mkdir agents: %v", err)
+				}
+				outsideAgentDir := filepath.Join(t.TempDir(), "helper")
+				if err := os.MkdirAll(outsideAgentDir, 0o755); err != nil {
+					t.Fatalf("mkdir outside agent: %v", err)
+				}
+				agentLink := filepath.Join(agentsDir, "helper")
+				if err := os.Symlink(outsideAgentDir, agentLink); err != nil {
+					t.Skipf("symlink unsupported: %v", err)
+				}
+				return agentLink
+			},
+			outsideWritePath: "helper",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GC_BEADS", "file")
+
+			cityDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+				t.Fatalf("write pack.toml: %v", err)
+			}
+			tomlPath := filepath.Join(cityDir, "city.toml")
+			if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+				t.Fatalf("write city.toml: %v", err)
+			}
+			linkPath := tc.setup(t, cityDir)
+			outsidePath := filepath.Join(filepath.Dir(linkPath), tc.outsideWritePath)
+
+			cs := newControllerState(context.Background(), &config.City{
+				Workspace: config.Workspace{Name: "city1"},
+			}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+			cs.pokeCh = make(chan struct{}, 1)
+			cs.configDirty = &atomic.Bool{}
+
+			err := cs.CreateAgent(config.Agent{Name: "helper", Provider: "claude", Scope: "city"})
+			if !errors.Is(err, configedit.ErrValidation) {
+				t.Fatalf("CreateAgent error = %v, want ErrValidation", err)
+			}
+			for _, path := range []string{
+				filepath.Join(outsidePath, "agent.toml"),
+				filepath.Join(outsidePath, "prompt.template.md"),
+			} {
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("%s stat err = %v, want no write through symlink", path, statErr)
+				}
+			}
+			info, statErr := os.Lstat(linkPath)
+			if statErr != nil {
+				t.Fatalf("lstat symlink: %v", statErr)
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("link mode = %v, want symlink preserved", info.Mode())
+			}
+			if cs.configDirty.Load() {
+				t.Fatal("CreateAgent should not mark config dirty after symlink rejection")
+			}
+		})
+	}
+}
+
+func TestControllerStateSchema2RejectsRigScopeConventionAgent(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+
+	if err := cs.CreateAgent(config.Agent{Name: "helper", Provider: "claude", Scope: "rig"}); !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("CreateAgent error = %v, want ErrValidation", err)
+	}
+	if err := cs.CreateAgent(config.Agent{Name: "helper", Provider: "claude", Scope: "city"}); err != nil {
+		t.Fatalf("CreateAgent city-scoped helper: %v", err)
+	}
+	if err := cs.UpdateAgent("helper", api.AgentUpdate{Scope: "rig"}); !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("UpdateAgent error = %v, want ErrValidation", err)
+	}
+	data, err := os.ReadFile(filepath.Join(cityDir, "agents", "helper", "agent.toml"))
+	if err != nil {
+		t.Fatalf("read agent.toml: %v", err)
+	}
+	if strings.Contains(string(data), `scope = "rig"`) {
+		t.Fatalf("agent.toml persisted rejected rig scope:\n%s", data)
+	}
+}
+
+func TestControllerStateSchema2CreateThenDeleteConventionAgent(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city1\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatalf("write pack.toml: %v", err)
+	}
+	tomlPath := filepath.Join(cityDir, "city.toml")
+	if err := os.WriteFile(tomlPath, []byte("[workspace]\nname = \"city1\"\n"), 0o644); err != nil {
+		t.Fatalf("write city.toml: %v", err)
+	}
+
+	cs := newControllerState(context.Background(), &config.City{
+		Workspace: config.Workspace{Name: "city1"},
+	}, runtime.NewFake(), events.NewFake(), "city1", cityDir)
+	cs.pokeCh = make(chan struct{}, 2)
+	cs.configDirty = &atomic.Bool{}
+
+	if err := cs.CreateAgent(config.Agent{Name: "helper", Provider: "claude", Scope: "city"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if err := cs.DeleteAgent("helper"); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cityDir, "agents", "helper", "agent.toml")); !os.IsNotExist(err) {
+		t.Fatalf("agent.toml stat err = %v, want removed file", err)
+	}
+	raw, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatalf("read city.toml: %v", err)
+	}
+	if strings.Contains(string(raw), "[[agent]]") {
+		t.Fatalf("city.toml = %q, want no inline helper", raw)
+	}
+	for _, agent := range cs.Config().Agents {
+		if agent.Name == "helper" {
+			t.Fatalf("Config() agents still include helper: %+v", agent)
+		}
 	}
 }
 

--- a/cmd/gc/api_state_test.go
+++ b/cmd/gc/api_state_test.go
@@ -1561,11 +1561,11 @@ func TestControllerStateOrdersIncludeVisibleCityRoot(t *testing.T) {
 	t.Setenv("GC_BEADS", "file")
 
 	cityDir := t.TempDir()
-	autoDir := filepath.Join(cityDir, "orders", "digest")
+	autoDir := filepath.Join(cityDir, "orders")
 	if err := os.MkdirAll(autoDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(autoDir, "order.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(autoDir, "digest.toml"), []byte(`
 [order]
 formula = "mol-digest"
 trigger = "cooldown"

--- a/cmd/gc/apiroute.go
+++ b/cmd/gc/apiroute.go
@@ -94,7 +94,10 @@ func apiClientFallbackReason(cityPath string) string {
 func resolveAgentForAPI(cityPath, name string) string {
 	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {
-		return name
+		cfg, err = loadCityConfigForEditFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+		if err != nil {
+			return name
+		}
 	}
 	resolved, ok := resolveAgentIdentity(cfg, name, currentRigContext(cfg))
 	if !ok {

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1501,15 +1501,20 @@ source = "./assets/sidecar"
 `,
 		filepath.Join(cityPath, "city.toml"): `
 [workspace]
-name = "import-regression"
 provider = "claude"
 
 [[rigs]]
 name = "repo"
-path = "./repo"
 
 [rigs.imports.gs]
 source = "./assets/sidecar"
+`,
+		filepath.Join(cityPath, ".gc", "site.toml"): `
+workspace_name = "import-regression"
+
+[[rig]]
+name = "repo"
+path = "./repo"
 `,
 		filepath.Join(cityPath, "assets", "sidecar", "pack.toml"): `
 [pack]

--- a/cmd/gc/cityinit_impl.go
+++ b/cmd/gc/cityinit_impl.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/api"
 	"github.com/gastownhall/gascity/internal/cityinit"
@@ -130,11 +132,19 @@ func cityInitDoInit(_ context.Context, req cityinit.InitRequest) error {
 }
 
 func cityInitFinalize(_ context.Context, req cityinit.InitRequest) error {
-	if code := finalizeInit(req.Dir, io.Discard, io.Discard, initFinalizeOptions{
+	var stdout, stderr bytes.Buffer
+	if code := finalizeInit(req.Dir, &stdout, &stderr, initFinalizeOptions{
 		skipProviderReadiness: req.SkipProviderReadiness,
 		showProgress:          false,
 		commandName:           "gc init",
 	}); code != 0 {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		if detail != "" {
+			return fmt.Errorf("finalize failed (exit %d): %s", code, detail)
+		}
 		return fmt.Errorf("finalize failed (exit %d)", code)
 	}
 	return nil

--- a/cmd/gc/cityinit_impl_test.go
+++ b/cmd/gc/cityinit_impl_test.go
@@ -257,8 +257,8 @@ func TestCityInitServiceScaffoldPreservesExistingDirectoryWhenRegisterFails(t *t
 
 func TestCityInitServiceInitScaffoldsAndFinalizes(t *testing.T) {
 	skipSlowCmdGCTest(t, "runs the full local init scaffold/finalize path; run make test-cmd-gc-process for full coverage")
-	configureTestDoltIdentityEnv(t)
-	configureRealBdAndDoltPath(t)
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
 	cityPath := filepath.Join(t.TempDir(), "init-city")
 	cleanupManagedDoltTestCity(t, cityPath)
 

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -721,15 +721,15 @@ replaced if they exit. Use "gc agent resume" to restore.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdAgentSuspend(args, io.Discard, stderr) != 0 {
-					return errExit
-				}
 				cityPath, err := resolveCity()
 				if err != nil {
 					fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
 				name, qualifiedName := agentJSONIdentity(cityPath, args[0])
+				if cmdAgentSuspend(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command:       commandName("agent", "suspend"),
 					Action:        "suspend",
@@ -795,15 +795,15 @@ names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
-				if cmdAgentResume(args, io.Discard, stderr) != 0 {
-					return errExit
-				}
 				cityPath, err := resolveCity()
 				if err != nil {
 					fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
 					return errExit
 				}
 				name, qualifiedName := agentJSONIdentity(cityPath, args[0])
+				if cmdAgentResume(args, io.Discard, stderr) != 0 {
+					return errExit
+				}
 				return writeManagementActionJSON(stdout, managementActionResult{
 					Command:       commandName("agent", "resume"),
 					Action:        "resume",

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -147,6 +147,9 @@ func isNonFatalLoadConfigWarning(warning string) bool {
 	if config.IsLegacyWorkspaceFieldWarning(warning) {
 		return true
 	}
+	if config.IsNonFatalSiteBindingWarning(warning) {
+		return true
+	}
 	if strings.Contains(warning, "[agents] is a deprecated compatibility alias for [agent_defaults]") {
 		return true
 	}

--- a/cmd/gc/cmd_agent.go
+++ b/cmd/gc/cmd_agent.go
@@ -43,29 +43,6 @@ func loadCityConfig(cityPath string, warningWriter ...io.Writer) (*config.City, 
 	return cfg, nil
 }
 
-// loadCityConfigSuppressDeprecatedOrderWarnings performs a full config load
-// while suppressing only legacy order-path migration warnings.
-func loadCityConfigSuppressDeprecatedOrderWarnings(cityPath string, warningWriter ...io.Writer) (*config.City, error) {
-	tomlPath := filepath.Join(cityPath, "city.toml")
-	resolvedWarningWriter := resolveLoadCityConfigWarningWriter(warningWriter...)
-	extras, err := builtinPackIncludesForConfigLoad(fsys.OSFS{}, tomlPath, resolvedWarningWriter)
-	if err != nil {
-		return nil, err
-	}
-	cfg, prov, err := config.LoadWithIncludesOptions(
-		fsys.OSFS{},
-		tomlPath,
-		config.LoadOptions{SuppressDeprecatedOrderWarnings: true},
-		extras...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	emitLoadCityConfigWarnings(resolvedWarningWriter, prov)
-	applyFeatureFlags(cfg)
-	return cfg, nil
-}
-
 // loadCityConfigFS is the testable variant of loadCityConfig that accepts a
 // filesystem implementation. Used by functions that take an fsys.FS parameter
 // for unit testing.
@@ -203,40 +180,12 @@ func loadCityConfigForEditFS(fs fsys.FS, tomlPath string) (*config.City, error) 
 	return cfg, nil
 }
 
-// writeCityConfigForEditFS writes the checked-in city.toml form (without
-// rig.path entries) and then persists machine-local rig bindings to
-// .gc/site.toml. Ordering matters: the reverse order would leave
-// .gc/site.toml with the new binding while city.toml retained the stale
-// legacy path, and the loader's "site wins" overlay would silently mask
-// the inconsistency. Writing city.toml first means a crash between the
-// two writes leaves an orphan-legacy-path state (rig has no effective
-// binding) which the loader surfaces via warnings (see
-// ApplySiteBindings in internal/config/site_binding.go).
-//
-// Both writes are skipped when the on-disk content already matches the
-// desired content. This keeps operations like repeated `gc rig add
-// <same-rig>` idempotent on the checked-in city.toml instead of
-// producing spurious diffs on every invocation.
+// writeCityConfigForEditFS writes the checked-in city.toml form and matching
+// machine-local rig bindings as a recoverable pair. Both writes are skipped
+// when on-disk content already matches the desired content, preserving
+// idempotency for repeated config-edit commands.
 func writeCityConfigForEditFS(fs fsys.FS, tomlPath string, cfg *config.City) error {
-	cityPath := filepath.Dir(tomlPath)
-	content, err := cfg.MarshalForWrite()
-	if err != nil {
-		return err
-	}
-	if err := fsys.WriteFileIfChangedAtomic(fs, tomlPath, content, 0o644); err != nil {
-		return err
-	}
-	if err := config.PersistRigSiteBindings(fs, cityPath, cfg.Rigs); err != nil {
-		// Surface the half-migrated state explicitly: city.toml has
-		// been written but the site binding was not, so any rig paths
-		// that would have been persisted to .gc/site.toml are now
-		// absent — declared rigs will load as unbound until recovered.
-		// Applies to every edit caller (rig add/remove/suspend/resume,
-		// agent suspend/resume, configedit via this shared helper),
-		// not just `gc doctor --fix`.
-		return fmt.Errorf("writing .gc/site.toml failed after city.toml was rewritten — rigs may be unbound; re-run the command or `gc doctor --fix` to retry: %w", err)
-	}
-	return nil
+	return config.WriteCityAndRigSiteBindingsForEdit(fs, tomlPath, cfg)
 }
 
 func loadCityPackConfigForEditFS(fs fsys.FS, packPath string) (*initPackConfig, error) {
@@ -582,11 +531,11 @@ agents/<name>/agent.toml. These files live in the city directory and do
 not append [[agent]] blocks to city.toml.
 
 Use --prompt-template to copy prompt content from an existing file into
-the canonical prompt.template.md location. Use --dir to record a rig or
-working-directory prefix in agent.toml. Use --suspended to scaffold the
-agent in a suspended state.`,
+the canonical prompt.template.md location. Schema-2 convention agents are
+city-scoped; define rig-scoped agents in pack config or [[patches.agent]].
+Use --suspended to scaffold the agent in a suspended state.`,
 		Example: `  gc agent add --name mayor
-  gc agent add --name polecat --dir my-project
+  gc agent add --name polecat
   gc agent add --name worker --prompt-template ./worker.md --suspended`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -611,7 +560,7 @@ agent in a suspended state.`,
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Name of the agent")
 	cmd.Flags().StringVar(&promptTemplate, "prompt-template", "", "Path to prompt template file (relative to city root)")
-	cmd.Flags().StringVar(&dir, "dir", "", "Working directory for the agent (relative to city root)")
+	cmd.Flags().StringVar(&dir, "dir", "", "Legacy working directory for schema-1 agents; schema-2 convention agents are city-scoped")
 	cmd.Flags().BoolVar(&suspended, "suspended", false, "Register the agent in suspended state")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSONL format")
 	return cmd
@@ -655,17 +604,40 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 		dir = inputDir
 		name = inputName
 	}
+	if err := config.ValidateAgents([]config.Agent{{Name: name}}); err != nil {
+		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	schema2Pack, err := configedit.HasSchema2RootPack(fs, cityPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if schema2Pack && dir != "" {
+		fmt.Fprintln(stderr, "gc agent add: schema-2 convention agents are city-scoped; create rig-scoped agents in pack config or use [[patches.agent]]") //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	candidateAgent := config.Agent{Name: name, Dir: dir}
+	candidateName := candidateAgent.QualifiedName()
 	for _, a := range cfg.Agents {
-		if a.Name == name {
-			fmt.Fprintf(stderr, "gc agent add: agent %q already exists\n", name) //nolint:errcheck // best-effort stderr
+		if a.QualifiedName() == candidateName {
+			fmt.Fprintf(stderr, "gc agent add: agent %q already exists\n", candidateName) //nolint:errcheck // best-effort stderr
 			return 1
 		}
 	}
 
-	agentDir := filepath.Join(cityPath, "agents", name)
-	if err := fs.MkdirAll(agentDir, 0o755); err != nil {
+	agentDir, agentDirExisted, err := configedit.EnsureLocalDiscoveredAgentDir(fs, cityPath, name)
+	if err != nil {
 		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
+	}
+	cleanupFreshScaffold := func() {
+		if agentDirExisted {
+			return
+		}
+		if err := fsys.RemoveAll(fs, agentDir); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "gc agent add: cleanup after failure: %v\n", err) //nolint:errcheck // best-effort stderr
+		}
 	}
 
 	var promptData []byte
@@ -678,6 +650,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 		promptData, err = fs.ReadFile(src)
 		if err != nil {
 			fmt.Fprintf(stderr, "gc agent add: reading prompt template %q: %v\n", promptTemplate, err) //nolint:errcheck // best-effort stderr
+			cleanupFreshScaffold()
 			return 1
 		}
 	} else {
@@ -687,10 +660,20 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 	promptPath := filepath.Join(agentDir, "prompt.template.md")
 	if err := fs.WriteFile(promptPath, promptData, 0o644); err != nil {
 		fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+		cleanupFreshScaffold()
 		return 1
 	}
 
-	if dir != "" || suspended {
+	if schema2Pack {
+		if err := configedit.WriteLocalDiscoveredAgentConfig(fs, cityPath, config.Agent{
+			Name:      name,
+			Suspended: suspended,
+		}); err != nil {
+			fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+			cleanupFreshScaffold()
+			return 1
+		}
+	} else if dir != "" || suspended {
 		var b strings.Builder
 		if dir != "" {
 			fmt.Fprintf(&b, "dir = %q\n", dir) //nolint:errcheck // best-effort strings.Builder
@@ -700,6 +683,7 @@ func doAgentAdd(fs fsys.FS, cityPath, name, promptTemplate, dir string, suspende
 		}
 		if err := fs.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(b.String()), 0o644); err != nil {
 			fmt.Fprintf(stderr, "gc agent add: %v\n", err) //nolint:errcheck // best-effort stderr
+			cleanupFreshScaffold()
 			return 1
 		}
 	}
@@ -721,6 +705,10 @@ replaced if they exit. Use "gc agent resume" to restore.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
+				if len(args) < 1 {
+					fmt.Fprintln(stderr, "gc agent suspend: missing agent name") //nolint:errcheck // best-effort stderr
+					return errExit
+				}
 				cityPath, err := resolveCity()
 				if err != nil {
 					fmt.Fprintf(stderr, "gc agent suspend: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -795,6 +783,10 @@ names (resolved via rig context) and qualified names (e.g. "myrig/worker").`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if jsonOutput {
+				if len(args) < 1 {
+					fmt.Fprintln(stderr, "gc agent resume: missing agent name") //nolint:errcheck // best-effort stderr
+					return errExit
+				}
 				cityPath, err := resolveCity()
 				if err != nil {
 					fmt.Fprintf(stderr, "gc agent resume: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -916,7 +908,12 @@ func doAgentSuspendOrResume(fs fsys.FS, cityPath, name string, suspended bool, s
 		fmt.Fprintln(stderr, agentNotFoundMsg("gc agent "+verb, name, expanded)) //nolint:errcheck // best-effort stderr
 		return 1
 	}
-	if configedit.LocalDiscoveredAgent(fs, cityPath, resolved) {
+	localDiscovered, err := configedit.LocalDiscoveredAgent(fs, cityPath, resolved)
+	if err != nil {
+		fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
+		return 1
+	}
+	if localDiscovered {
 		if err := configedit.WriteLocalDiscoveredAgentSuspended(fs, cityPath, resolved, suspended); err != nil {
 			fmt.Fprintf(stderr, "gc agent %s: %v\n", verb, err) //nolint:errcheck // best-effort stderr
 			return 1

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -246,7 +246,7 @@ append_fragments = ["footer"]
 	}
 }
 
-func TestLoadCityConfigFSEmitsLegacyV1SurfaceWarnings(t *testing.T) {
+func TestLoadCityConfigFSHardErrorsOnUnsupportedLegacyV1Surfaces(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Dirs["/city/legacy-pack"] = true
 	fs.Files["/city/legacy-pack/pack.toml"] = []byte(`[pack]
@@ -270,22 +270,19 @@ schema = 2
 `)
 
 	var stderr bytes.Buffer
-	cfg, err := loadCityConfigFS(fs, "/city/city.toml", &stderr)
-	if err != nil {
-		t.Fatalf("loadCityConfigFS: %v", err)
+	_, err := loadCityConfigFS(fs, "/city/city.toml", &stderr)
+	if err == nil {
+		t.Fatal("loadCityConfigFS unexpectedly accepted unsupported legacy PackV1 surfaces")
 	}
-	if cfg == nil {
-		t.Fatal("loadCityConfigFS returned nil config")
-	}
-	output := stderr.String()
+	output := err.Error()
 	for _, want := range []string{
-		"[[agent]] tables are deprecated",
-		"[packs] is deprecated",
-		"workspace.includes is deprecated",
-		"workspace.default_rig_includes is deprecated",
+		"unsupported PackV1 [[agent]] tables",
+		"unsupported PackV1 [packs] entries",
+		"unsupported PackV1 workspace.includes",
+		"unsupported PackV1 workspace.default_rig_includes",
 	} {
 		if !strings.Contains(output, want) {
-			t.Fatalf("stderr missing %q: %q", want, output)
+			t.Fatalf("error missing %q: %q", want, output)
 		}
 	}
 }

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -609,6 +610,11 @@ func TestDoAgentAddScaffoldsAgentDirectory(t *testing.T) {
 	if !strings.Contains(string(gotPrompt), "{{ .AgentName }}") {
 		t.Errorf("prompt scaffold = %q, want template placeholder", gotPrompt)
 	}
+	if got, ok := fs.Files["/city/agents/worker/agent.toml"]; !ok {
+		t.Fatal("agent.toml missing; gc agent add should use the shared convention scaffold writer")
+	} else if strings.TrimSpace(string(got)) != "" {
+		t.Fatalf("agent.toml = %q, want empty convention config for default scaffold", got)
+	}
 
 	cfg, err := loadCityConfigFS(fs, "/city/city.toml")
 	if err != nil {
@@ -648,20 +654,17 @@ func TestDoAgentAddCopiesPromptTemplate(t *testing.T) {
 	}
 }
 
-func TestDoAgentAddWritesAgentTomlForDirAndSuspended(t *testing.T) {
+func TestDoAgentAddWritesAgentTomlForSuspended(t *testing.T) {
 	fs := v2CityWithPack(t)
 
 	var stdout, stderr bytes.Buffer
-	code := doAgentAdd(fs, "/city", "hello-world/worker", "", "", true, &stdout, &stderr)
+	code := doAgentAdd(fs, "/city", "worker", "", "", true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, want 0; stderr: %s", code, stderr.String())
 	}
 	agentToml, ok := fs.Files["/city/agents/worker/agent.toml"]
 	if !ok {
 		t.Fatal("agent.toml missing")
-	}
-	if !strings.Contains(string(agentToml), "dir = \"hello-world\"") {
-		t.Errorf("agent.toml = %q, want dir", agentToml)
 	}
 	if !strings.Contains(string(agentToml), "suspended = true") {
 		t.Errorf("agent.toml = %q, want suspended", agentToml)
@@ -677,8 +680,8 @@ func TestDoAgentAddWritesAgentTomlForDirAndSuspended(t *testing.T) {
 			continue
 		}
 		found = true
-		if a.Dir != "hello-world" {
-			t.Errorf("Dir = %q, want hello-world", a.Dir)
+		if a.Dir != "" {
+			t.Errorf("Dir = %q, want empty", a.Dir)
 		}
 		if !a.Suspended {
 			t.Error("Suspended = false, want true")
@@ -686,6 +689,193 @@ func TestDoAgentAddWritesAgentTomlForDirAndSuspended(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("explicit agents = %#v, want worker", explicit)
+	}
+}
+
+type failAgentTomlRenameFS struct {
+	*fsys.Fake
+	target string
+}
+
+func (f *failAgentTomlRenameFS) Rename(oldpath, newpath string) error {
+	if filepath.Clean(newpath) == filepath.Clean(f.target) {
+		return errors.New("injected agent.toml write failure")
+	}
+	return f.Fake.Rename(oldpath, newpath)
+}
+
+func TestDoAgentAddRemovesFreshScaffoldWhenConventionConfigWriteFails(t *testing.T) {
+	fs := &failAgentTomlRenameFS{
+		Fake:   v2CityWithPack(t),
+		target: "/city/agents/worker/agent.toml",
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentAdd(fs, "/city", "worker", "", "", false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("code = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "injected agent.toml write failure") {
+		t.Fatalf("stderr = %q, want injected failure", stderr.String())
+	}
+	for _, path := range []string{
+		"/city/agents/worker/prompt.template.md",
+		"/city/agents/worker/agent.toml",
+	} {
+		if _, ok := fs.Files[path]; ok {
+			t.Fatalf("%s remains after failed add", path)
+		}
+	}
+	if fs.Dirs["/city/agents/worker"] {
+		t.Fatal("fresh agent scaffold directory remains after failed add")
+	}
+}
+
+func TestDoAgentAddRejectsSymlinkedScaffoldPathBeforeWriting(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		setup            func(t *testing.T, cityDir string) string
+		outsideWritePath string
+	}{
+		{
+			name: "agents root",
+			setup: func(t *testing.T, cityDir string) string {
+				t.Helper()
+				outsideAgentsDir := filepath.Join(t.TempDir(), "agents")
+				if err := os.MkdirAll(outsideAgentsDir, 0o755); err != nil {
+					t.Fatalf("mkdir outside agents: %v", err)
+				}
+				agentsLink := filepath.Join(cityDir, "agents")
+				if err := os.Symlink(outsideAgentsDir, agentsLink); err != nil {
+					t.Skipf("symlink unsupported: %v", err)
+				}
+				return agentsLink
+			},
+			outsideWritePath: filepath.Join("agents", "worker"),
+		},
+		{
+			name: "agent dir",
+			setup: func(t *testing.T, cityDir string) string {
+				t.Helper()
+				agentsDir := filepath.Join(cityDir, "agents")
+				if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+					t.Fatalf("mkdir agents: %v", err)
+				}
+				outsideAgentDir := filepath.Join(t.TempDir(), "worker")
+				if err := os.MkdirAll(outsideAgentDir, 0o755); err != nil {
+					t.Fatalf("mkdir outside agent: %v", err)
+				}
+				agentLink := filepath.Join(agentsDir, "worker")
+				if err := os.Symlink(outsideAgentDir, agentLink); err != nil {
+					t.Skipf("symlink unsupported: %v", err)
+				}
+				return agentLink
+			},
+			outsideWritePath: "worker",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n"), 0o644); err != nil {
+				t.Fatalf("write city.toml: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+				t.Fatalf("write pack.toml: %v", err)
+			}
+			linkPath := tc.setup(t, cityDir)
+			outsidePath := filepath.Join(filepath.Dir(linkPath), tc.outsideWritePath)
+
+			var stdout, stderr bytes.Buffer
+			code := doAgentAdd(fsys.OSFS{}, cityDir, "worker", "", "", false, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("code = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "not a symlink") {
+				t.Fatalf("stderr = %q, want symlink rejection", stderr.String())
+			}
+			for _, path := range []string{
+				filepath.Join(outsidePath, "prompt.template.md"),
+				filepath.Join(outsidePath, "agent.toml"),
+			} {
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatalf("%s stat err = %v, want no write through symlink", path, err)
+				}
+			}
+			info, err := os.Lstat(linkPath)
+			if err != nil {
+				t.Fatalf("lstat symlink: %v", err)
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("link mode = %v, want symlink preserved", info.Mode())
+			}
+		})
+	}
+}
+
+func TestDoAgentAddRejectsSchema2RigScopedConventionAgent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dir  string
+	}{
+		{name: "hello-world/worker"},
+		{name: "worker", dir: "hello-world"},
+	} {
+		t.Run(tc.name+" "+tc.dir, func(t *testing.T) {
+			fs := v2CityWithPack(t)
+
+			var stdout, stderr bytes.Buffer
+			code := doAgentAdd(fs, "/city", tc.name, "", tc.dir, false, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("code = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "schema-2 convention agents are city-scoped") {
+				t.Fatalf("stderr = %q, want schema-2 city-scoped validation message", stderr.String())
+			}
+			for _, path := range []string{
+				"/city/agents/worker/agent.toml",
+				"/city/agents/worker/prompt.template.md",
+			} {
+				if _, ok := fs.Files[path]; ok {
+					t.Fatalf("%s was created for rejected input", path)
+				}
+			}
+		})
+	}
+}
+
+func TestDoAgentAddAllowsCityLocalNameSharedWithImportedAgent(t *testing.T) {
+	fs := v2CityWithPack(t)
+	fs.Files["/city/city.toml"] = []byte(`[imports.helper]
+source = "../helper"
+`)
+	fs.Files["/helper/pack.toml"] = []byte(`[pack]
+name = "helper"
+schema = 2
+
+[[agent]]
+name = "worker"
+provider = "claude"
+scope = "city"
+`)
+
+	var stdout, stderr bytes.Buffer
+	code := doAgentAdd(fs, "/city", "worker", "", "", false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+	}
+
+	cfg, err := loadCityConfigFS(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("loadCityConfigFS: %v", err)
+	}
+	qualified := map[string]bool{}
+	for _, agent := range explicitAgents(cfg.Agents) {
+		qualified[agent.QualifiedName()] = true
+	}
+	for _, want := range []string{"helper.worker", "worker"} {
+		if !qualified[want] {
+			t.Fatalf("qualified agents = %v, want %q", qualified, want)
+		}
 	}
 }
 
@@ -703,6 +893,37 @@ func TestDoAgentAddDuplicateScaffold(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "already exists") {
 		t.Errorf("stderr = %q, want 'already exists'", stderr.String())
+	}
+}
+
+func TestDoAgentAddRejectsInvalidNamesBeforeFilesystemWrites(t *testing.T) {
+	for _, name := range []string{
+		"..",
+		".hidden",
+		"-worker",
+		"_worker",
+		"worker with space",
+		"worker.dotted",
+		"rig/worker.dotted",
+	} {
+		t.Run(name, func(t *testing.T) {
+			fs := v2CityWithPack(t)
+
+			var stdout, stderr bytes.Buffer
+			code := doAgentAdd(fs, "/city", name, "", "", false, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("code = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "name must match") {
+				t.Fatalf("stderr = %q, want validation message", stderr.String())
+			}
+			for _, call := range fs.Calls {
+				switch call.Method {
+				case "MkdirAll", "WriteFile":
+					t.Fatalf("unexpected filesystem mutation before validation: %#v", call)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/gc/cmd_agent_test.go
+++ b/cmd/gc/cmd_agent_test.go
@@ -572,12 +572,12 @@ func TestNonTestLoadCityConfigCallersPassWarningWriter(t *testing.T) {
 func v2CityWithPack(t *testing.T) *fsys.Fake {
 	t.Helper()
 	fs := fsys.NewFake()
-	fs.Files["/city/city.toml"] = []byte(`[workspace]
-name = "test-city"
-`)
+	fs.Files["/city/city.toml"] = []byte("")
 	fs.Files["/city/pack.toml"] = []byte(`[pack]
 name = "test-city"
 schema = 2
+`)
+	fs.Files["/city/.gc/site.toml"] = []byte(`workspace_name = "test-city"
 `)
 	return fs
 }

--- a/cmd/gc/cmd_config_validation_test.go
+++ b/cmd/gc/cmd_config_validation_test.go
@@ -56,7 +56,7 @@ func TestValidateLegacyFormulaConfigRoutes_RejectsTemplateAssignee(t *testing.T)
 	if err := os.MkdirAll(formulasDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, filepath.Join(formulasDir, "legacy.formula.toml"), `
+	writeFile(t, filepath.Join(formulasDir, "legacy.toml"), `
 formula = "legacy"
 version = 2
 
@@ -92,7 +92,7 @@ func TestValidateLegacyFormulaConfigRoutes_AllowsNamedSessionAssignee(t *testing
 	if err := os.MkdirAll(formulasDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, filepath.Join(formulasDir, "named.formula.toml"), `
+	writeFile(t, filepath.Join(formulasDir, "named.toml"), `
 formula = "named"
 version = 2
 

--- a/cmd/gc/cmd_convoy_dispatch_test.go
+++ b/cmd/gc/cmd_convoy_dispatch_test.go
@@ -687,11 +687,11 @@ formula_v2 = true
 
 [[rigs]]
 name = "alpha"
-path = "rigs/alpha"
 prefix = "BL"
 `), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
@@ -1788,9 +1788,10 @@ func TestRunWorkflowServeWarnsWhenLegacyRigTraceFileStillExists(t *testing.T) {
 	disableManagedDoltRecoveryForTest(t)
 
 	cityDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"alpha\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n")
 	rigRoot := filepath.Join(cityDir, "rigs", "alpha")
 	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
 		t.Fatalf("mkdir rig root: %v", err)
@@ -1839,9 +1840,10 @@ func TestRunWorkflowServeWarnsWhenLegacyEnvRigTraceFileStillExistsOutsideConfigu
 	disableManagedDoltRecoveryForTest(t)
 
 	cityDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"alpha\"\n"), 0o644); err != nil {
 		t.Fatalf("write city.toml: %v", err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n")
 	rigRoot := filepath.Join(cityDir, "rigs", "beta")
 	if err := os.MkdirAll(rigRoot, 0o755); err != nil {
 		t.Fatalf("mkdir rig root: %v", err)
@@ -2628,10 +2630,13 @@ func TestRunWorkflowServeOverridesInheritedCityBeadsDir(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityToml := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"myrig\"\npath = %q\n\n[[agent]]\nname = \"worker\"\ndir = \"myrig\"\n", rigDir)
+	cityToml := "[workspace]\nname = \"test-city\"\n\n[daemon]\nformula_v2 = true\n\n[[rigs]]\nname = \"myrig\"\n"
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeCatalogFile(t, cityDir, "pack.toml", "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeCatalogFile(t, cityDir, ".gc/site.toml", fmt.Sprintf("[[rig]]\nname = \"myrig\"\npath = %q\n", rigDir))
+	writeCatalogFile(t, cityDir, "agents/worker/agent.toml", "dir = \"myrig\"\n")
 
 	t.Setenv("GC_CITY", cityDir)
 	// Pollute parent env with a city-scoped BEADS_DIR. Without the fix,
@@ -2697,7 +2702,7 @@ func TestRunWorkflowServeProcessesControlBeadsInAgentStoreScope(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityToml := fmt.Sprintf(`[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [daemon]
@@ -2705,11 +2710,11 @@ formula_v2 = true
 
 [[rigs]]
 name = "myrig"
-path = %q
-`, rigDir)
+`
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", fmt.Sprintf("[[rig]]\nname = \"myrig\"\npath = %q\n", rigDir))
 	t.Setenv("GC_CITY", cityDir)
 
 	prevCityFlag := cityFlag
@@ -2970,19 +2975,13 @@ name = "test-city"
 
 [[rigs]]
 name = "rigrepo"
-path = "rigrepo"
-
-[[agent]]
-name = "polecat"
-dir = "rigrepo"
-
-[agent.pool]
-min = 0
-max = 5
 `
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeCatalogFile(t, cityDir, "pack.toml", "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"rigrepo\"\npath = \"rigrepo\"\n")
+	writeCatalogFile(t, cityDir, "agents/polecat/agent.toml", "dir = \"rigrepo\"\nmin_active_sessions = 0\nmax_active_sessions = 5\n")
 
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_ALIAS", "rigrepo/furiosa")
@@ -3681,18 +3680,15 @@ func TestRunWorkflowServeExpandsTemplateCommandsWithCityFallback(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityToml := fmt.Sprintf(`[[rigs]]
+	cityToml := `[[rigs]]
 name = "frontend"
-path = %q
-
-[[agent]]
-name = "worker"
-dir = "frontend"
-work_query = "bd {{.CityName}} {{.Rig}} {{.AgentBase}}"
-`, rigDir)
+`
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	writeCatalogFile(t, cityDir, "pack.toml", "[pack]\nname = \"demo-city\"\nschema = 2\n")
+	writeCatalogFile(t, cityDir, ".gc/site.toml", fmt.Sprintf("[[rig]]\nname = \"frontend\"\npath = %q\n", rigDir))
+	writeCatalogFile(t, cityDir, "agents/worker/agent.toml", "dir = \"frontend\"\nwork_query = \"bd {{.CityName}} {{.Rig}} {{.AgentBase}}\"\n")
 
 	prevList := workflowServeList
 	t.Cleanup(func() { workflowServeList = prevList })
@@ -4121,13 +4117,11 @@ name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "control-dispatcher"
-start_command = "echo hello"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
+	writeCatalogFile(t, cityPath, "pack.toml", "[pack]\nname = \"test-city\"\nschema = 2\n")
+	writeCatalogFile(t, cityPath, "agents/control-dispatcher/agent.toml", "start_command = \"echo hello\"\n")
 	t.Setenv("GC_CITY", cityPath)
 
 	store, err := openStoreAtForCity(cityPath, cityPath)
@@ -4272,11 +4266,11 @@ name = "test-city"
 
 [[rigs]]
 name = "alpha"
-path = "rigs/alpha"
 prefix = "BL"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
@@ -4391,11 +4385,11 @@ name = "test-city"
 
 [[rigs]]
 name = "alpha"
-path = "rigs/alpha"
 prefix = "BL"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")
@@ -4513,11 +4507,11 @@ name = "test-city"
 
 [[rigs]]
 name = "alpha"
-path = "rigs/alpha"
 prefix = "BL"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
+	writeCatalogFile(t, cityDir, ".gc/site.toml", "[[rig]]\nname = \"alpha\"\npath = \"rigs/alpha\"\n")
 	t.Setenv("GC_CITY", cityDir)
 	t.Setenv("GC_BEADS", "file")
 	t.Setenv("GC_BEADS_SCOPE_ROOT", "")

--- a/cmd/gc/cmd_doctor.go
+++ b/cmd/gc/cmd_doctor.go
@@ -139,6 +139,7 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 	d.Register(&doctor.CityStructureCheck{})
 	d.Register(&doctor.CityConfigCheck{})
 	registerV2DeprecationChecks(d)
+	d.Register(expandedConfigLoadCheck{})
 	d.Register(&doctor.ImplicitImportCacheCheck{})
 	d.Register(&doctor.DeprecatedAttachmentFieldsCheck{})
 
@@ -311,6 +312,26 @@ func doDoctor(fix, verbose, jsonOut bool, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+type expandedConfigLoadCheck struct{}
+
+func (expandedConfigLoadCheck) Name() string { return "expanded-config-load" }
+
+func (expandedConfigLoadCheck) CanFix() bool { return false }
+
+func (expandedConfigLoadCheck) WarmupEligible() bool { return false }
+
+func (expandedConfigLoadCheck) Fix(_ *doctor.CheckContext) error { return nil }
+
+func (expandedConfigLoadCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
+	if _, err := loadCityConfig(ctx.CityPath, io.Discard); err != nil {
+		return errorCheck("expanded-config-load",
+			fmt.Sprintf("expanded config load error: %v", err),
+			"fix the reported config, include, import, or pack-layout error and rerun gc doctor",
+			nil)
+	}
+	return okCheck("expanded-config-load", "expanded config loaded")
 }
 
 // doctorJSONResult mirrors doctor.CheckResult for JSON output. Keeping the

--- a/cmd/gc/cmd_doctor_test.go
+++ b/cmd/gc/cmd_doctor_test.go
@@ -33,6 +33,12 @@ func TestDoctorJSONSuccessIsParseableJSONOnly(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte("[workspace]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".gc", "site.toml"), []byte("workspace_name = \"demo\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("GC_BEADS", "file")
 	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
 

--- a/cmd/gc/cmd_formula_tutorial_regression_test.go
+++ b/cmd/gc/cmd_formula_tutorial_regression_test.go
@@ -275,6 +275,6 @@ func writeTutorialFormulaCity(t *testing.T, formulaName, formulaBody string) str
 	}
 
 	writeFile("city.toml", "[workspace]\nname = \"my-city\"\nprovider = \"claude\"\n")
-	writeFile("formulas/"+formulaName+".formula.toml", formulaBody)
+	writeFile("formulas/"+formulaName+".toml", formulaBody)
 	return cityDir
 }

--- a/cmd/gc/cmd_graph_test.go
+++ b/cmd/gc/cmd_graph_test.go
@@ -459,9 +459,7 @@ func TestOpenRigAwareStoreUsesProviderAwareRigStore(t *testing.T) {
 		t.Fatal(err)
 	}
 	toml := "[workspace]\nname = \"graph-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\nprefix = \"fe\"\npath = \"" + rigDir + "\"\n"
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigAnywhereCityToml(t, cityDir, toml)
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
 		t.Fatalf("ensureScopedFileStoreLayout: %v", err)
 	}

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -804,6 +804,15 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	rewriteInitPromptTemplates(cfg)
 	packCfg, cityCfg := splitInitConfig(cityName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
+	if hasInitRigSiteBindings(cityCfg.Rigs) {
+		if err := config.PersistRigSiteBindings(fs, cityPath, cityCfg.Rigs); err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		for i := range cityCfg.Rigs {
+			cityCfg.Rigs[i].Path = ""
+		}
+	}
 	wrotePack, err := writeInitPackTomlOpts(fs, cityPath, packCfg, preserveExisting)
 	if err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -860,6 +869,15 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		skipProviderReadiness: skipProviderReadiness,
 		commandName:           "gc init",
 	})
+}
+
+func hasInitRigSiteBindings(rigs []config.Rig) bool {
+	for _, rig := range rigs {
+		if strings.TrimSpace(rig.Path) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // doInit is the pure logic for "gc init". It creates the city directory

--- a/cmd/gc/cmd_init.go
+++ b/cmd/gc/cmd_init.go
@@ -804,11 +804,9 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 	rewriteInitPromptTemplates(cfg)
 	packCfg, cityCfg := splitInitConfig(cityName, cfg)
 	applyInitPackTemplateExtras(&packCfg, templatePack)
+	var rigSiteBindings []config.Rig
 	if hasInitRigSiteBindings(cityCfg.Rigs) {
-		if err := config.PersistRigSiteBindings(fs, cityPath, cityCfg.Rigs); err != nil {
-			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-			return 1
-		}
+		rigSiteBindings = append([]config.Rig(nil), cityCfg.Rigs...)
 		for i := range cityCfg.Rigs {
 			cityCfg.Rigs[i].Path = ""
 		}
@@ -827,24 +825,46 @@ func cmdInitFromTOMLFileWithOptions(fs fsys.FS, tomlSrc, cityPath, nameOverride 
 		fmt.Fprintf(stderr, "gc init: resolving formulas: %v\n", rfErr) //nolint:errcheck // best-effort stderr
 	}
 
-	// Re-marshal so the name and rewritten prompt paths are updated.
-	content, err := cityCfg.Marshal()
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-
 	// Write city.toml — preserved if --preserve-existing is set and a
 	// committed city.toml is already in place. Persist the workspace identity
 	// regardless so .gc/site.toml agrees with the preserved or newly-written
 	// config.
-	wroteCity, err := writeInitFile(fs, filepath.Join(cityPath, "city.toml"), content, preserveExisting)
-	if err != nil {
-		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
-		return 1
-	}
-	if !wroteCity {
-		fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
+	cityTomlPath := filepath.Join(cityPath, "city.toml")
+	if len(rigSiteBindings) > 0 {
+		wroteCity := true
+		if preserveExisting {
+			if _, err := fs.Stat(cityTomlPath); err == nil {
+				wroteCity = false
+			} else if !os.IsNotExist(err) {
+				fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		}
+		if wroteCity {
+			writeCfg := cityCfg
+			writeCfg.Rigs = append([]config.Rig(nil), rigSiteBindings...)
+			if err := config.WriteCityAndRigSiteBindingsForEdit(fs, cityTomlPath, &writeCfg); err != nil {
+				fmt.Fprintf(stderr, "gc init: %v\n", initSiteBindingPersistError(err)) //nolint:errcheck // best-effort stderr
+				return 1
+			}
+		} else {
+			fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
+		}
+	} else {
+		// Re-marshal so the name and rewritten prompt paths are updated.
+		content, err := cityCfg.Marshal()
+		if err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		wroteCity, err := writeInitFile(fs, cityTomlPath, content, preserveExisting)
+		if err != nil {
+			fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
+			return 1
+		}
+		if !wroteCity {
+			fmt.Fprintln(stdout, "Preserved existing city.toml.") //nolint:errcheck // best-effort stdout
+		}
 	}
 	if err := persistInitWorkspaceIdentity(fs, cityPath, filepath.Join(cityPath, "city.toml"), &cityCfg, cityName, cityPrefix); err != nil {
 		fmt.Fprintf(stderr, "gc init: %v\n", err) //nolint:errcheck // best-effort stderr
@@ -1386,18 +1406,37 @@ func rewriteCopiedInitFromIdentity(fs fsys.FS, cityPath, nameOverride string) (*
 	}
 	cfg.Workspace.Name = ""
 	cfg.Workspace.Prefix = ""
-
-	content, err := cfg.Marshal()
-	if err != nil {
-		return nil, "", "", false, err
+	var rigSiteBindings []config.Rig
+	if hasInitRigSiteBindings(cfg.Rigs) {
+		rigSiteBindings = append([]config.Rig(nil), cfg.Rigs...)
+		for i := range cfg.Rigs {
+			cfg.Rigs[i].Path = ""
+		}
 	}
-	if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
-		return nil, "", "", false, err
+
+	if len(rigSiteBindings) > 0 {
+		writeCfg := *cfg
+		writeCfg.Rigs = append([]config.Rig(nil), rigSiteBindings...)
+		if err := config.WriteCityAndRigSiteBindingsForEdit(fs, copiedToml, &writeCfg); err != nil {
+			return nil, "", "", false, initSiteBindingPersistError(err)
+		}
+	} else {
+		content, err := cfg.Marshal()
+		if err != nil {
+			return nil, "", "", false, err
+		}
+		if err := fs.WriteFile(copiedToml, content, 0o644); err != nil {
+			return nil, "", "", false, err
+		}
 	}
 	if err := rewriteCopiedInitPackName(fs, cityPath, cityName); err != nil {
 		return nil, "", "", false, err
 	}
 	return cfg, cityName, cityPrefix, true, nil
+}
+
+func initSiteBindingPersistError(err error) error {
+	return fmt.Errorf("writing .gc/site.toml failed while migrating rig paths; city.toml was restored, fix the site binding write error and retry: %w", err)
 }
 
 func rewriteCopiedInitPackName(fs fsys.FS, cityPath, cityName string) error {

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -154,7 +154,7 @@ func TestInternalMaterializeSkillsCityScopedDirMatchingRigDoesNotMaterializeRigS
 	if err := os.MkdirAll(helperDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(helper): %v", err)
 	}
-	cityToml := fmt.Sprintf(`[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
@@ -165,7 +165,7 @@ name = "fe"
 
 [rigs.imports.helper]
 source = "./assets/helper"
-`)
+`
 	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
 	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	writeMaterializeTestCityFile(t, filepath.Join(cityDir, ".gc"), "site.toml", fmt.Sprintf("[[rig]]\nname = \"fe\"\npath = %q\n", rigDir))

--- a/cmd/gc/cmd_internal_materialize_skills_test.go
+++ b/cmd/gc/cmd_internal_materialize_skills_test.go
@@ -23,28 +23,17 @@ func TestInternalMaterializeSkillsMaterializesClaude(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
 	// Pack.toml enables PackSkillsDir discovery. Without it, the
 	// materializer sees no shared city catalog and the sink stays empty.
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	writeSkillSource(t, filepath.Join(cityDir, "skills", "plan"))
 
 	workdir := t.TempDir()
@@ -103,26 +92,15 @@ func TestInternalMaterializeSkillsMaterializesImportedSharedSkills(t *testing.T)
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"city\"\nversion = \"0.1.0\"\nschema = 2\n\n[imports.helper]\nsource = \"../helper\"\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"city\"\nversion = \"0.1.0\"\nschema = 2\n\n[imports.helper]\nsource = \"../helper\"\n")
 	if err := os.MkdirAll(packDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(helper): %v", err)
 	}
@@ -184,24 +162,15 @@ provider = "file"
 
 [[rigs]]
 name = "fe"
-path = %q
 
 [rigs.imports.helper]
 source = "./assets/helper"
-
-[[agent]]
-name = "mayor"
-scope = "city"
-dir = "fe"
-provider = "claude"
-start_command = "echo"
-`, rigDir)
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(helperDir, "pack.toml"), []byte("[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(helper/pack.toml): %v", err)
-	}
+`)
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
+	writeMaterializeTestCityFile(t, filepath.Join(cityDir, ".gc"), "site.toml", fmt.Sprintf("[[rig]]\nname = \"fe\"\npath = %q\n", rigDir))
+	writeMaterializeTestMayor(t, cityDir, "scope = \"city\"\ndir = \"fe\"\nprovider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, helperDir, "pack.toml", "[pack]\nname = \"helper\"\nversion = \"0.1.0\"\nschema = 2\n")
 	writeSkillSource(t, filepath.Join(helperDir, "skills", "plan"))
 
 	workdir := t.TempDir()
@@ -227,26 +196,15 @@ func TestInternalMaterializeSkillsSharedCatalogFailurePrunesStaleSharedSymlink(t
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	skillsDir := filepath.Join(cityDir, "skills")
 	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
 
@@ -299,26 +257,15 @@ func TestInternalMaterializeSkillsUsesSharedCatalogSnapshotEnvWhenLiveCatalogFai
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	skillsDir := filepath.Join(cityDir, "skills")
 	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
 	sharedCat, err := materialize.LoadCityCatalog(skillsDir)
@@ -376,26 +323,15 @@ func TestInternalMaterializeSkillsUsesSharedCatalogSnapshotFile(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	skillsDir := filepath.Join(cityDir, "skills")
 	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
 	sharedCat, err := materialize.LoadCityCatalog(skillsDir)
@@ -459,26 +395,15 @@ func TestInternalMaterializeSkillsUsesDefaultSharedCatalogSnapshotFile(t *testin
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	skillsDir := filepath.Join(cityDir, "skills")
 	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
 	sharedCat, err := materialize.LoadCityCatalog(skillsDir)
@@ -538,26 +463,15 @@ func TestInternalMaterializeSkillsExplicitSnapshotFileOverridesInlineSnapshot(t 
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	skillsDir := filepath.Join(cityDir, "skills")
 	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
 	fileSnapshotCat, err := materialize.LoadCityCatalog(skillsDir)
@@ -615,26 +529,15 @@ func TestInternalMaterializeSkillsSnapshotFileMissingFallsBackToLiveCatalog(t *t
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	skillsDir := filepath.Join(cityDir, "skills")
 	writeSkillSource(t, filepath.Join(skillsDir, "plan"))
 
@@ -668,26 +571,15 @@ func TestInternalMaterializeSkillsInvalidSharedCatalogSnapshotFallsBackToLiveCat
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	writeSkillSource(t, filepath.Join(cityDir, "skills", "plan"))
 
 	workdir := t.TempDir()
@@ -728,28 +620,17 @@ func TestInternalMaterializeSkillsUnsupportedProvider(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "copilot"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"copilot\"\nstart_command = \"echo\"\n")
 	// Pack.toml enables PackSkillsDir discovery. Without it, the
 	// materializer sees no shared city catalog and the sink stays empty.
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 
 	workdir := t.TempDir()
 	var stdout, stderr bytes.Buffer
@@ -780,28 +661,17 @@ func TestInternalMaterializeSkillsUnknownAgent(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
 	// Pack.toml enables PackSkillsDir discovery. Without it, the
 	// materializer sees no shared city catalog and the sink stays empty.
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{
@@ -855,28 +725,17 @@ func TestInternalMaterializeSkillsSecondRunIsIdempotent(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	toml := `[workspace]
+	cityToml := `[workspace]
 name = "test-city"
 
 [beads]
 provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "claude"
-start_command = "echo"
-
-[[named_session]]
-template = "mayor"
 `
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "city.toml", cityToml)
+	writeMaterializeTestMayor(t, cityDir, "provider = \"claude\"\nstart_command = \"echo\"\n")
 	// Pack.toml enables PackSkillsDir discovery. Without it, the
 	// materializer sees no shared city catalog and the sink stays empty.
-	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(pack.toml): %v", err)
-	}
+	writeMaterializeTestCityFile(t, cityDir, "pack.toml", "[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n")
 	writeSkillSource(t, filepath.Join(cityDir, "skills", "plan"))
 	writeSkillSource(t, filepath.Join(cityDir, "skills", "code-review"))
 
@@ -921,5 +780,23 @@ func writeSkillSource(t *testing.T, dir string) {
 	body := "---\nname: " + filepath.Base(dir) + "\ndescription: test\n---\nbody\n"
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func writeMaterializeTestCityFile(t *testing.T, rootDir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(rootDir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", name, err)
+	}
+}
+
+func writeMaterializeTestMayor(t *testing.T, cityDir, body string) {
+	t.Helper()
+	agentDir := filepath.Join(cityDir, "agents", "mayor")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", agentDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", filepath.Join("agents", "mayor", "agent.toml"), err)
 	}
 }

--- a/cmd/gc/cmd_internal_project_mcp_test.go
+++ b/cmd/gc/cmd_internal_project_mcp_test.go
@@ -17,9 +17,11 @@ func TestInternalProjectMCPProjectsGeminiConfigWithIdentityExpansion(t *testing.
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "agents", "mayor"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(agents/mayor): %v", err)
+	}
 
 	cityToml := `[workspace]
-name = "test-city"
 provider = "gemini"
 
 [beads]
@@ -28,16 +30,18 @@ provider = "file"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "mayor"
-provider = "gemini"
 `
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".gc", "site.toml"), []byte("workspace_name = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(site.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "agents", "mayor", "agent.toml"), []byte("provider = \"gemini\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(agent.toml): %v", err)
 	}
 	writeMCPSource(t, filepath.Join(cityDir, "mcp", "notes.template.toml"), `
 name = "notes"

--- a/cmd/gc/cmd_internal_project_mcp_test.go
+++ b/cmd/gc/cmd_internal_project_mcp_test.go
@@ -110,9 +110,11 @@ func TestInternalProjectMCPProjectsCursorConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(cityDir, "agents", "worker"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(agents/worker): %v", err)
+	}
 
 	cityToml := `[workspace]
-name = "test-city"
 provider = "cursor"
 
 [beads]
@@ -121,16 +123,18 @@ provider = "file"
 [providers.cursor]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "worker"
-provider = "cursor"
 `
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, ".gc", "site.toml"), []byte("workspace_name = \"test-city\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(site.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "agents", "worker", "agent.toml"), []byte("provider = \"cursor\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(agent.toml): %v", err)
 	}
 	writeMCPSource(t, filepath.Join(cityDir, "mcp", "notes.toml"), `
 name = "notes"

--- a/cmd/gc/cmd_mcp_test.go
+++ b/cmd/gc/cmd_mcp_test.go
@@ -26,9 +26,7 @@ provider = "file"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "mayor"
+`, `
 provider = "gemini"
 scope = "city"
 max_active_sessions = 1
@@ -60,14 +58,10 @@ provider = "tmux"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
+`, `
+provider = "gemini"
+scope = "city"
 `)
-	agentDir := filepath.Join(cityDir, "agents", "mayor")
-	if err := os.MkdirAll(agentDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(agentDir): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("provider = \"gemini\"\nscope = \"city\"\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(agent.toml): %v", err)
-	}
 	writeCatalogFile(t, cityDir, "mcp/notes.toml", `
 name = "notes"
 command = "npx"
@@ -179,9 +173,7 @@ provider = "file"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "mayor"
+`, `
 provider = "gemini"
 scope = "city"
 max_active_sessions = 2
@@ -219,9 +211,7 @@ provider = "tmux"
 [providers.claude]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "mayor"
+`, `
 provider = "claude"
 scope = "city"
 max_active_sessions = 1
@@ -298,9 +288,7 @@ provider = "subprocess"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
-name = "mayor"
+`, `
 provider = "gemini"
 scope = "city"
 work_dir = "worktrees/mayor"
@@ -321,7 +309,7 @@ command = "npx"
 	}
 }
 
-func writeProjectedMCPCity(t *testing.T, dir, cityTOML string) {
+func writeProjectedMCPCity(t *testing.T, dir, cityTOML string, agentTOML ...string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
@@ -331,6 +319,9 @@ func writeProjectedMCPCity(t *testing.T, dir, cityTOML string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nversion = \"0.1.0\"\nschema = 2\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if len(agentTOML) > 0 && strings.TrimSpace(agentTOML[0]) != "" {
+		writeCatalogFile(t, dir, "agents/mayor/agent.toml", strings.TrimLeft(agentTOML[0], "\n"))
 	}
 }
 

--- a/cmd/gc/cmd_mcp_test.go
+++ b/cmd/gc/cmd_mcp_test.go
@@ -46,10 +46,7 @@ func TestMcpListAgentProjectedSummary(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeProjectedMCPCity(t, cityDir, `[workspace]
-name = "test-city"
-
-[beads]
+	writeProjectedMCPCity(t, cityDir, `[beads]
 provider = "file"
 
 [session]
@@ -98,10 +95,7 @@ func TestMcpListAgentJSON(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	writeProjectedMCPCity(t, cityDir, `[workspace]
-name = "test-city"
-
-[beads]
+	writeProjectedMCPCity(t, cityDir, `[beads]
 provider = "file"
 
 [session]

--- a/cmd/gc/cmd_order_test.go
+++ b/cmd/gc/cmd_order_test.go
@@ -302,7 +302,7 @@ func TestScanAllOrdersCityFlatFile(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, "formulas"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cityDir, "orders", "health-check.order.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "health-check.toml"), []byte(`
 [order]
 formula = "health-check"
 trigger = "cron"
@@ -325,8 +325,8 @@ schedule = "*/5 * * * *"
 	if aa[0].Name != "health-check" {
 		t.Fatalf("Name = %q, want %q", aa[0].Name, "health-check")
 	}
-	if aa[0].Source != filepath.Join(cityDir, "orders", "health-check.order.toml") {
-		t.Fatalf("Source = %q, want %q", aa[0].Source, filepath.Join(cityDir, "orders", "health-check.order.toml"))
+	if aa[0].Source != filepath.Join(cityDir, "orders", "health-check.toml") {
+		t.Fatalf("Source = %q, want %q", aa[0].Source, filepath.Join(cityDir, "orders", "health-check.toml"))
 	}
 }
 
@@ -351,7 +351,7 @@ schema = 1
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(repoDir, "orders", "health-check.order.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(repoDir, "orders", "health-check.toml"), []byte(`
 [order]
 formula = "health-check"
 trigger = "cron"
@@ -423,12 +423,12 @@ fetched = "2026-04-10T00:00:00Z"
 	if imported.Name != "health-check" {
 		t.Fatalf("Name = %q, want %q", imported.Name, "health-check")
 	}
-	if imported.Source != filepath.Join(cacheDir, "orders", "health-check.order.toml") {
-		t.Fatalf("Source = %q, want %q", imported.Source, filepath.Join(cacheDir, "orders", "health-check.order.toml"))
+	if imported.Source != filepath.Join(cacheDir, "orders", "health-check.toml") {
+		t.Fatalf("Source = %q, want %q", imported.Source, filepath.Join(cacheDir, "orders", "health-check.toml"))
 	}
 }
 
-func TestScanAllOrdersCityLegacyFormulaOrdersWarns(t *testing.T) {
+func TestScanAllOrdersCityLegacyFormulaOrdersRejects(t *testing.T) {
 	cityDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(cityDir, "formulas", "orders", "health-check"), 0o755); err != nil {
 		t.Fatal(err)
@@ -446,21 +446,15 @@ schedule = "*/5 * * * *"
 	cfg.FormulaLayers.City = []string{filepath.Join(cityDir, "formulas")}
 
 	var stderr bytes.Buffer
-	logs := captureCmdOrderLogs(t, func() {
-		aa, err := scanAllOrders(cityDir, cfg, &stderr, "gc order list")
-		if err != nil {
-			t.Fatalf("scanAllOrders: %v", err)
-		}
-		if len(aa) != 1 {
-			t.Fatalf("got %d orders, want 1", len(aa))
-		}
-		if aa[0].Source != filepath.Join(cityDir, "formulas", "orders", "health-check", "order.toml") {
-			t.Fatalf("Source = %q, want %q", aa[0].Source, filepath.Join(cityDir, "formulas", "orders", "health-check", "order.toml"))
-		}
-	})
-
-	if !strings.Contains(logs, "move to orders/health-check.toml") {
-		t.Fatalf("logs = %q, want move warning", logs)
+	_, err := scanAllOrders(cityDir, cfg, &stderr, "gc order list")
+	if err == nil {
+		t.Fatal("scanAllOrders succeeded, want PackV1 order layout rejection")
+	}
+	if !strings.Contains(err.Error(), "unsupported PackV1 order path") {
+		t.Fatalf("scanAllOrders error = %q, want PackV1 path rejection", err)
+	}
+	if !strings.Contains(err.Error(), "move to orders/health-check.toml") {
+		t.Fatalf("scanAllOrders error = %q, want migration hint", err)
 	}
 }
 
@@ -475,7 +469,7 @@ func TestOrderShow(t *testing.T) {
 			Trigger:     "cooldown",
 			Interval:    "24h",
 			Pool:        "dog",
-			Source:      "/city/formulas/orders/digest/order.toml",
+			Source:      "/city/orders/digest.toml",
 		},
 	}
 
@@ -485,7 +479,7 @@ func TestOrderShow(t *testing.T) {
 		t.Fatalf("doOrderShow = %d, want 0; stderr: %s", code, stderr.String())
 	}
 	out := stdout.String()
-	for _, want := range []string{"digest", "Generate daily digest", "mol-digest", "cooldown", "24h", "dog", "order.toml"} {
+	for _, want := range []string{"digest", "Generate daily digest", "mol-digest", "cooldown", "24h", "dog", "digest.toml"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout missing %q:\n%s", want, out)
 		}
@@ -520,7 +514,7 @@ func TestOrderShowExec(t *testing.T) {
 			Exec:        "$ORDER_DIR/scripts/poll.sh",
 			Trigger:     "cooldown",
 			Interval:    "2m",
-			Source:      "/city/formulas/orders/poll/order.toml",
+			Source:      "/city/orders/poll.toml",
 		},
 	}
 
@@ -1451,7 +1445,7 @@ id = "do-work"
 title = "Do work for {{target_id}}"
 description = "Target: {{target_id}}, workspace: {{workspace}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "order-required-vars.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "order-required-vars.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1509,7 +1503,7 @@ contract = "graph.v2"
 id = "step"
 title = "Do work"
 `
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2455,7 +2449,7 @@ func TestOrderCheckWithRig(t *testing.T) {
 
 func TestOrderShowWithRig(t *testing.T) {
 	aa := []orders.Order{
-		{Name: "db-health", Formula: "mol-db-health", Trigger: "cooldown", Interval: "5m", Rig: "demo-repo", Source: "/topo/orders/db-health/order.toml"},
+		{Name: "db-health", Formula: "mol-db-health", Trigger: "cooldown", Interval: "5m", Rig: "demo-repo", Source: "/topo/orders/db-health.toml"},
 	}
 
 	var stdout, stderr bytes.Buffer

--- a/cmd/gc/cmd_rig.go
+++ b/cmd/gc/cmd_rig.go
@@ -1449,7 +1449,7 @@ func cmdRigRemove(rigName string, stdout, stderr io.Writer) int {
 	cfg.Rigs = filtered
 
 	// Write updated config.
-	if err := writeCityConfigForEditFS(fsys.OSFS{}, tomlPath, cfg); err != nil {
+	if err := config.WriteCityAndRigSiteBindingsForEditRemovingRigs(fsys.OSFS{}, tomlPath, cfg, rigName); err != nil {
 		fmt.Fprintf(stderr, "gc rig remove: %v\n", err) //nolint:errcheck // best-effort stderr
 		return 1
 	}

--- a/cmd/gc/cmd_rig_endpoint_test.go
+++ b/cmd/gc/cmd_rig_endpoint_test.go
@@ -1639,7 +1639,16 @@ func writeRigEndpointCityConfig(t *testing.T, cityDir, rigDir string) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	content := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"frontend\"\npath = %q\nprefix = \"fe\"\n", rigDir)
+	if err := os.WriteFile(filepath.Join(cityDir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.PersistWorkspaceSiteBinding(fsys.OSFS{}, cityDir, "test-city", ""); err != nil {
+		t.Fatalf("PersistWorkspaceSiteBinding: %v", err)
+	}
+	if err := config.PersistRigSiteBindings(fsys.OSFS{}, cityDir, []config.Rig{{Name: "frontend", Path: rigDir}}); err != nil {
+		t.Fatalf("PersistRigSiteBindings: %v", err)
+	}
+	content := "[workspace]\n\n[[rigs]]\nname = \"frontend\"\nprefix = \"fe\"\n"
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -33,15 +33,47 @@ func (f mkdirAllErrorFS) MkdirAll(path string, perm os.FileMode) error {
 	return f.FS.MkdirAll(path, perm)
 }
 
-func TestDoRigAdd_Basic(t *testing.T) {
-	cityPath := t.TempDir()
+func writeSchema2RigCity(t *testing.T, cityPath, workspaceName, cityToml, siteToml string) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
+	packToml := fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", workspaceName)
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if cityToml == "" {
+		cityToml = "[workspace]\n"
+	}
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if siteToml == "" {
+		siteToml = fmt.Sprintf("workspace_name = %q\n", workspaceName)
+	}
+	if err := os.WriteFile(config.SiteBindingPath(cityPath), []byte(siteToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSchema2RigCityFS(t *testing.T, f *fsys.Fake, cityPath, workspaceName, cityToml, siteToml string) {
+	t.Helper()
+	f.Dirs[cityPath] = true
+	f.Dirs[filepath.Join(cityPath, ".gc")] = true
+	f.Files[filepath.Join(cityPath, "pack.toml")] = []byte(fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", workspaceName))
+	if cityToml == "" {
+		cityToml = "[workspace]\n"
+	}
+	f.Files[filepath.Join(cityPath, "city.toml")] = []byte(cityToml)
+	if siteToml == "" {
+		siteToml = fmt.Sprintf("workspace_name = %q\n", workspaceName)
+	}
+	f.Files[config.SiteBindingPath(cityPath)] = []byte(siteToml)
+}
+
+func TestDoRigAdd_Basic(t *testing.T) {
+	cityPath := t.TempDir()
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -109,13 +141,7 @@ func makeMasterRig(t *testing.T) string {
 
 func TestDoRigAdd_DetectsDefaultBranchFromOriginHEAD(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := makeMasterRig(t)
 
@@ -143,13 +169,7 @@ func TestDoRigAdd_DetectsDefaultBranchFromOriginHEAD(t *testing.T) {
 
 func TestDoRigAdd_DefaultBranchFlagOverridesProbe(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := makeMasterRig(t)
 
@@ -177,14 +197,14 @@ func TestDoRigAdd_DefaultBranchFlagOverridesProbe(t *testing.T) {
 
 func TestDoRigAdd_BackfillsExistingRigDefaultBranch(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	rigPath := makeMasterRig(t)
-	cityToml := fmt.Sprintf("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"master-rig\"\npath = %q\n", rigPath)
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"master-rig\"\n",
+		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"master-rig\"\npath = %q\n", rigPath),
+	)
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "bd")
@@ -206,13 +226,7 @@ func TestDoRigAdd_BackfillsExistingRigDefaultBranch(t *testing.T) {
 
 func TestDoRigAdd_NonGitDirOmitsDefaultBranch(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "no-git")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -287,13 +301,7 @@ func TestResolveRigAddPath(t *testing.T) {
 
 func TestDoRigAddWritesSiteBindingInsteadOfPath(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -328,30 +336,19 @@ func TestDoRigAddWritesSiteBindingInsteadOfPath(t *testing.T) {
 
 func TestDoRigAddRouteFailureRollsBackConfig(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	brokenRigFile := filepath.Join(t.TempDir(), "broken-rig")
 	if err := os.WriteFile(brokenRigFile, []byte("not a directory"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	cityToml := strings.Join([]string{
-		"[workspace]",
-		`name = "test-city"`,
-		"",
-		"[[agent]]",
-		`name = "mayor"`,
-		"",
-		"[[rigs]]",
-		`name = "broken"`,
-		`path = "` + brokenRigFile + `"`,
-		"",
-	}, "\n")
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"broken\"\n",
+		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"broken\"\npath = %q\n", brokenRigFile),
+	)
 
 	rigPath := filepath.Join(t.TempDir(), "new-rig")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -377,23 +374,24 @@ func TestDoRigAddRouteFailureRollsBackConfig(t *testing.T) {
 	if strings.Contains(string(cityData), "new-rig") {
 		t.Fatalf("city.toml should roll back the new rig after route failure:\n%s", cityData)
 	}
-	if !strings.Contains(string(cityData), brokenRigFile) {
-		t.Fatalf("city.toml should restore the original broken rig binding after rollback:\n%s", cityData)
+	siteData, err := os.ReadFile(config.SiteBindingPath(cityPath))
+	if err != nil {
+		t.Fatalf("reading .gc/site.toml after rollback: %v", err)
 	}
-	if _, err := os.Stat(config.SiteBindingPath(cityPath)); err == nil {
-		t.Fatalf(".gc/site.toml should not be left behind after rollback")
+	if !strings.Contains(string(siteData), brokenRigFile) {
+		t.Fatalf(".gc/site.toml should restore the original broken rig binding after rollback:\n%s", siteData)
 	}
 }
 
 func TestDoRigAdd_DuplicateNameDifferentPath(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"/some/path\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"frontend\"\n",
+		"workspace_name = \"test-city\"\n\n[[rig]]\nname = \"frontend\"\npath = \"/some/path\"\n",
+	)
 
 	rigPath := filepath.Join(t.TempDir(), "frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -419,9 +417,6 @@ func TestDoRigAdd_DuplicateNameDifferentPath(t *testing.T) {
 
 func TestDoRigAdd_IdempotentSameNameSamePath(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -429,10 +424,13 @@ func TestDoRigAdd_IdempotentSameNameSamePath(t *testing.T) {
 	}
 
 	// Config already has this rig at the same path.
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\n",
+		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath),
+	)
 
 	// Save original config content.
 	origData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
@@ -469,9 +467,6 @@ func TestDoRigAdd_IdempotentSameNameSamePath(t *testing.T) {
 
 func TestDoRigAdd_DoesNotWritePortFileForFileBackedExternalRig(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -490,10 +485,7 @@ func TestDoRigAdd_DoesNotWritePortFileForFileBackedExternalRig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "workspace_name = \"test-city\"\n")
 
 	rigPath := filepath.Join(t.TempDir(), "test-external")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -517,9 +509,6 @@ func TestDoRigAdd_DoesNotWritePortFileForFileBackedExternalRig(t *testing.T) {
 // Regression: re-add must use the rig's configured prefix, not re-derive it.
 func TestDoRigAdd_ReAddUsesExistingPrefix(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -527,10 +516,13 @@ func TestDoRigAdd_ReAddUsesExistingPrefix(t *testing.T) {
 	}
 
 	// Rig has explicit prefix "fe" (different from derived "mf").
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\nprefix = \"fe\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\nprefix = \"fe\"\n",
+		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath),
+	)
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -553,19 +545,19 @@ func TestDoRigAdd_ReAddUsesExistingPrefix(t *testing.T) {
 
 func TestDoRigAdd_ReAddMissingPathUsesCandidateConfig(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\n",
+		"workspace_name = \"test-city\"\n",
+	)
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -583,9 +575,6 @@ func TestDoRigAdd_ReAddMissingPathUsesCandidateConfig(t *testing.T) {
 
 func TestDoRigAdd_ReAddWarnsDifferingFlags(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -593,10 +582,13 @@ func TestDoRigAdd_ReAddWarnsDifferingFlags(t *testing.T) {
 	}
 
 	// Existing rig is NOT suspended.
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\n",
+		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath),
+	)
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -622,9 +614,6 @@ func TestDoRigAdd_ReAddWarnsDifferingFlags(t *testing.T) {
 func TestDoRigAdd_ReAddNoSpuriousWarning(t *testing.T) {
 	t.Setenv("GC_HOME", t.TempDir()) // isolate global rig registry
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -632,10 +621,13 @@ func TestDoRigAdd_ReAddNoSpuriousWarning(t *testing.T) {
 	}
 
 	// Existing rig IS suspended with includes.
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\nsuspended = true\nincludes = [\"packs/old\"]\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(
+		t,
+		cityPath,
+		"test-city",
+		"[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\nsuspended = true\nincludes = [\"packs/old\"]\n",
+		fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath),
+	)
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -653,13 +645,7 @@ func TestDoRigAdd_ReAddNoSpuriousWarning(t *testing.T) {
 
 func TestDoRigAdd_NotADirectory(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test", "[workspace]\n", "")
 
 	filePath := filepath.Join(t.TempDir(), "not-a-dir")
 	if err := os.WriteFile(filePath, []byte("nope"), 0o644); err != nil {
@@ -675,13 +661,7 @@ func TestDoRigAdd_NotADirectory(t *testing.T) {
 
 func TestDoRigAdd_RoutesGenerated(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "my-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -714,19 +694,18 @@ func TestDoRigAdd_RoutesGenerated(t *testing.T) {
 // creation fails. This prevents phantom rigs in config.
 func TestDoRigAdd_ConfigUnchangedOnInfraFailure(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	originalToml := "[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"
+	writeSchema2RigCity(t, cityPath, "test", "[workspace]\n", "")
 	tomlPath := filepath.Join(cityPath, "city.toml")
-	if err := os.WriteFile(tomlPath, []byte(originalToml), 0o644); err != nil {
+	originalBytes, err := os.ReadFile(tomlPath)
+	if err != nil {
 		t.Fatal(err)
 	}
+	originalToml := string(originalBytes)
 
 	// Use a fake FS that fails on beads init for the rig.
 	f := fsys.NewFake()
+	writeSchema2RigCityFS(t, f, cityPath, "test", originalToml, "")
 	f.Dirs["/fake-rig"] = true
-	f.Files[tomlPath] = []byte(originalToml)
 	f.Errors[filepath.Join("/fake-rig", ".beads")] = os.ErrPermission
 
 	var stdout, stderr bytes.Buffer
@@ -749,11 +728,8 @@ func TestDoRigAdd_RootPackDefaultRigImportsErrorDoesNotMutateRig(t *testing.T) {
 	f := fsys.NewFake()
 	cityPath := "/city"
 	rigPath := "/rigs/my-project"
-	originalToml := "[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"
-
-	f.Dirs[cityPath] = true
-	f.Dirs[filepath.Join(cityPath, ".gc")] = true
-	f.Files[filepath.Join(cityPath, "city.toml")] = []byte(originalToml)
+	writeSchema2RigCityFS(t, f, cityPath, "test", "[workspace]\n", "")
+	originalToml := string(f.Files[filepath.Join(cityPath, "city.toml")])
 	f.Errors[filepath.Join(cityPath, "pack.toml")] = errors.New("read denied")
 
 	t.Setenv("GC_DOLT", "skip")
@@ -816,14 +792,9 @@ func TestDoRigAdd_ExplicitIncludeSkipsUnusedDefaultRigImportErrors(t *testing.T)
 
 func TestDoRigAdd_CandidateValidationErrorDoesNotCreateMissingRig(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"registered\"\n"
+	cityToml := "[workspace]\n\n[[rigs]]\nname = \"registered\"\n"
+	writeSchema2RigCity(t, cityPath, "test-city", cityToml, "")
 	cityTomlPath := filepath.Join(cityPath, "city.toml")
-	if err := os.WriteFile(cityTomlPath, []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 
@@ -854,12 +825,10 @@ func TestDoRigAdd_CreateMissingRigDirectoryError(t *testing.T) {
 	base := fsys.NewFake()
 	cityPath := "/city"
 	rigPath := "/rigs/my-project"
-	originalToml := "[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"
+	writeSchema2RigCityFS(t, base, cityPath, "test", "[workspace]\n", "")
+	originalToml := string(base.Files[filepath.Join(cityPath, "city.toml")])
 	mkdirErr := errors.New("mkdir denied")
 
-	base.Dirs[cityPath] = true
-	base.Dirs[filepath.Join(cityPath, ".gc")] = true
-	base.Files[filepath.Join(cityPath, "city.toml")] = []byte(originalToml)
 	f := mkdirAllErrorFS{FS: base, path: rigPath, err: mkdirErr}
 
 	t.Setenv("GC_DOLT", "skip")
@@ -1047,10 +1016,8 @@ func TestResolveRigForAgent_TrailingSlash(t *testing.T) {
 
 func TestDoRigSuspend(t *testing.T) {
 	cityPath := t.TempDir()
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"/some/path\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	siteToml := "workspace_name = \"test-city\"\n\n[[rig]]\nname = \"frontend\"\npath = \"/some/path\"\n"
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n\n[[rigs]]\nname = \"frontend\"\n", siteToml)
 
 	var stdout, stderr bytes.Buffer
 	code := doRigSuspend(fsys.OSFS{}, cityPath, "frontend", &stdout, &stderr)
@@ -1072,9 +1039,8 @@ func TestDoRigSuspend(t *testing.T) {
 }
 
 func TestDoRigSuspendNotFound(t *testing.T) {
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
 	f := fsys.NewFake()
-	f.Files["/city/city.toml"] = []byte(cityToml)
+	writeSchema2RigCityFS(t, f, "/city", "test-city", "[workspace]\n", "")
 
 	var stdout, stderr bytes.Buffer
 	code := doRigSuspend(f, "/city", "nonexistent", &stdout, &stderr)
@@ -1088,10 +1054,9 @@ func TestDoRigSuspendNotFound(t *testing.T) {
 
 func TestDoRigSuspendAlreadySuspended(t *testing.T) {
 	cityPath := t.TempDir()
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"/some/path\"\nsuspended = true\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cityToml := "[workspace]\n\n[[rigs]]\nname = \"frontend\"\nsuspended = true\n"
+	siteToml := "workspace_name = \"test-city\"\n\n[[rig]]\nname = \"frontend\"\npath = \"/some/path\"\n"
+	writeSchema2RigCity(t, cityPath, "test-city", cityToml, siteToml)
 
 	var stdout, stderr bytes.Buffer
 	code := doRigSuspend(fsys.OSFS{}, cityPath, "frontend", &stdout, &stderr)
@@ -1102,10 +1067,9 @@ func TestDoRigSuspendAlreadySuspended(t *testing.T) {
 
 func TestDoRigResume(t *testing.T) {
 	cityPath := t.TempDir()
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"/some/path\"\nsuspended = true\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cityToml := "[workspace]\n\n[[rigs]]\nname = \"frontend\"\nsuspended = true\n"
+	siteToml := "workspace_name = \"test-city\"\n\n[[rig]]\nname = \"frontend\"\npath = \"/some/path\"\n"
+	writeSchema2RigCity(t, cityPath, "test-city", cityToml, siteToml)
 
 	var stdout, stderr bytes.Buffer
 	code := doRigResume(fsys.OSFS{}, cityPath, "frontend", &stdout, &stderr)
@@ -1127,9 +1091,8 @@ func TestDoRigResume(t *testing.T) {
 }
 
 func TestDoRigResumeNotFound(t *testing.T) {
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
 	f := fsys.NewFake()
-	f.Files["/city/city.toml"] = []byte(cityToml)
+	writeSchema2RigCityFS(t, f, "/city", "test-city", "[workspace]\n", "")
 
 	var stdout, stderr bytes.Buffer
 	code := doRigResume(f, "/city", "nonexistent", &stdout, &stderr)
@@ -1143,10 +1106,8 @@ func TestDoRigResumeNotFound(t *testing.T) {
 
 func TestDoRigResumeNotSuspended(t *testing.T) {
 	cityPath := t.TempDir()
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"frontend\"\npath = \"/some/path\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	siteToml := "workspace_name = \"test-city\"\n\n[[rig]]\nname = \"frontend\"\npath = \"/some/path\"\n"
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n\n[[rigs]]\nname = \"frontend\"\n", siteToml)
 
 	var stdout, stderr bytes.Buffer
 	code := doRigResume(fsys.OSFS{}, cityPath, "frontend", &stdout, &stderr)
@@ -1162,10 +1123,9 @@ func TestDoRigListShowsSuspended(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\nsuspended = true\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cityToml := "[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\nsuspended = true\n"
+	siteToml := fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath)
+	writeSchema2RigCity(t, cityPath, "test-city", cityToml, siteToml)
 
 	var stdout, stderr bytes.Buffer
 	code := doRigList(fsys.OSFS{}, cityPath, false, &stdout, &stderr)
@@ -1179,13 +1139,7 @@ func TestDoRigListShowsSuspended(t *testing.T) {
 
 func TestDoRigAdd_WithPack(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1276,13 +1230,7 @@ ref = "v1.2.3"
 
 func TestDoRigAdd_WithMultiplePacks(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1397,13 +1345,7 @@ func TestNewRigCmdRegistersSetEndpointSubcommand(t *testing.T) {
 
 func TestDoRigAdd_WithoutPack(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "my-project")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -1996,13 +1938,7 @@ func TestDoRigAdd_ExplicitPrefixResolvesCollision(t *testing.T) {
 // --prefix must be rejected when the rig's .beads/config.yaml has a different prefix.
 func TestDoRigAdd_ExplicitPrefixConflictsWithExistingBeads(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "my-city", "[workspace]\n", "")
 
 	// Rig already has .beads/config.yaml with prefix "ab".
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
@@ -2031,13 +1967,7 @@ func TestDoRigAdd_ExplicitPrefixConflictsWithExistingBeads(t *testing.T) {
 // Auto-derived prefix must also be rejected when it conflicts with existing .beads.
 func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "my-city", "[workspace]\n", "")
 
 	// Rig "alpha-beta" would derive prefix "ab", but .beads already has "zz".
 	rigPath := filepath.Join(t.TempDir(), "alpha-beta")
@@ -2069,13 +1999,7 @@ func TestDoRigAdd_DerivedPrefixConflictsWithExistingBeads(t *testing.T) {
 // store produces confusing "signal: killed" failures (see fo-5zeij).
 func TestDoRigAdd_ExistingBeadsRequiresAdopt(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "my-city", "[workspace]\n", "")
 
 	// Rig "alpha-beta" derives prefix "ab", and .beads already has "ab"
 	// — so the prefix-conflict guard does not trip and we reach the
@@ -2202,9 +2126,8 @@ func TestDoRigAdd_ExistingBeadsStatErrorFailsClosed(t *testing.T) {
 	rigPath := "/alpha-beta"
 	beadsPath := filepath.Join(rigPath, ".beads")
 
-	f.Dirs[filepath.Join(cityPath, ".gc")] = true
+	writeSchema2RigCityFS(t, f, cityPath, "my-city", "[workspace]\n", "")
 	f.Dirs[rigPath] = true
-	f.Files[filepath.Join(cityPath, "city.toml")] = []byte("[workspace]\nname = \"my-city\"\n\n[[agent]]\nname = \"mayor\"\n")
 	f.Errors[beadsPath] = os.ErrPermission
 
 	t.Setenv("GC_DOLT", "skip")
@@ -2308,19 +2231,15 @@ func TestReadBeadsPrefix(t *testing.T) {
 
 func TestDoRigAdd_ReAddWarnsDifferingPrefix(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-frontend")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"my-frontend\"\npath = \"" + rigPath + "\"\nprefix = \"mf\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cityToml := "[workspace]\n\n[[rigs]]\nname = \"my-frontend\"\nprefix = \"mf\"\n"
+	siteToml := fmt.Sprintf("workspace_name = \"test-city\"\n\n[[rig]]\nname = \"my-frontend\"\npath = %q\n", rigPath)
+	writeSchema2RigCity(t, cityPath, "test-city", cityToml, siteToml)
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -2339,19 +2258,13 @@ func TestDoRigAdd_ReAddWarnsDifferingPrefix(t *testing.T) {
 
 func TestDoRigAdd_PrefixCanonicalizedToLowercase(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	rigPath := filepath.Join(t.TempDir(), "my-rig")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -2393,17 +2306,11 @@ func TestDoRigAdd_PrefixCanonicalizedToLowercase(t *testing.T) {
 
 func TestDoRigAdd_PrefixAllowsHyphens(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	rigPath := filepath.Join(t.TempDir(), "my-rig")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	t.Setenv("GC_DOLT", "skip")
 	t.Setenv("GC_BEADS", "file")
@@ -2546,13 +2453,7 @@ name = "inline-agent"
 
 func TestDoRigAdd_AdoptExistingBeads(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "adopted-rig")
 	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0o755); err != nil {
@@ -2587,13 +2488,7 @@ func TestDoRigAdd_AdoptExistingBeads(t *testing.T) {
 
 func TestDoRigAdd_AdoptRequiresMetadataJSON(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "no-beads-rig")
 	if err := os.MkdirAll(rigPath, 0o755); err != nil {
@@ -2615,13 +2510,7 @@ func TestDoRigAdd_AdoptRequiresMetadataJSON(t *testing.T) {
 
 func TestDoRigAdd_AdoptRequiresExistingDir(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	rigPath := filepath.Join(t.TempDir(), "does-not-exist")
 
@@ -2640,13 +2529,7 @@ func TestDoRigAdd_AdoptRequiresExistingDir(t *testing.T) {
 
 func TestDoRigAdd_AdoptNonGitDirSucceeds(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	// Create rig without .git — should succeed with --adopt.
 	rigPath := filepath.Join(t.TempDir(), "no-git-rig")
@@ -2682,13 +2565,7 @@ func TestDoRigAdd_AdoptNonGitDirSucceeds(t *testing.T) {
 
 func TestDoRigAdd_AdoptRequiresConfigYaml(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	// Create rig with metadata.json but no config.yaml.
 	rigPath := filepath.Join(t.TempDir(), "no-config-rig")
@@ -2715,13 +2592,7 @@ func TestDoRigAdd_AdoptRequiresConfigYaml(t *testing.T) {
 
 func TestDoRigAdd_AdoptRejectsEmptyConfigYaml(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	// Create rig with config.yaml that has no issue_prefix key.
 	rigPath := filepath.Join(t.TempDir(), "empty-config-rig")
@@ -2752,13 +2623,7 @@ func TestDoRigAdd_AdoptRejectsEmptyConfigYaml(t *testing.T) {
 
 func TestDoRigAdd_AdoptWithoutPrefixMismatch(t *testing.T) {
 	cityPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	cityToml := "[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n"
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSchema2RigCity(t, cityPath, "test-city", "[workspace]\n", "")
 
 	// Create rig whose directory basename ("mismatch-rig") derives a prefix
 	// ("mismatchrig") that differs from config.yaml's prefix ("xr").

--- a/cmd/gc/cmd_rig_test.go
+++ b/cmd/gc/cmd_rig_test.go
@@ -56,7 +56,7 @@ func writeSchema2RigCity(t *testing.T, cityPath, workspaceName, cityToml, siteTo
 	}
 }
 
-func writeSchema2RigCityFS(t *testing.T, f *fsys.Fake, cityPath, workspaceName, cityToml, siteToml string) {
+func writeSchema2RigCityFS(t *testing.T, f *fsys.Fake, cityPath, workspaceName, cityToml string) {
 	t.Helper()
 	f.Dirs[cityPath] = true
 	f.Dirs[filepath.Join(cityPath, ".gc")] = true
@@ -65,10 +65,7 @@ func writeSchema2RigCityFS(t *testing.T, f *fsys.Fake, cityPath, workspaceName, 
 		cityToml = "[workspace]\n"
 	}
 	f.Files[filepath.Join(cityPath, "city.toml")] = []byte(cityToml)
-	if siteToml == "" {
-		siteToml = fmt.Sprintf("workspace_name = %q\n", workspaceName)
-	}
-	f.Files[config.SiteBindingPath(cityPath)] = []byte(siteToml)
+	f.Files[config.SiteBindingPath(cityPath)] = []byte(fmt.Sprintf("workspace_name = %q\n", workspaceName))
 }
 
 func TestDoRigAdd_Basic(t *testing.T) {
@@ -704,7 +701,7 @@ func TestDoRigAdd_ConfigUnchangedOnInfraFailure(t *testing.T) {
 
 	// Use a fake FS that fails on beads init for the rig.
 	f := fsys.NewFake()
-	writeSchema2RigCityFS(t, f, cityPath, "test", originalToml, "")
+	writeSchema2RigCityFS(t, f, cityPath, "test", originalToml)
 	f.Dirs["/fake-rig"] = true
 	f.Errors[filepath.Join("/fake-rig", ".beads")] = os.ErrPermission
 
@@ -728,7 +725,7 @@ func TestDoRigAdd_RootPackDefaultRigImportsErrorDoesNotMutateRig(t *testing.T) {
 	f := fsys.NewFake()
 	cityPath := "/city"
 	rigPath := "/rigs/my-project"
-	writeSchema2RigCityFS(t, f, cityPath, "test", "[workspace]\n", "")
+	writeSchema2RigCityFS(t, f, cityPath, "test", "[workspace]\n")
 	originalToml := string(f.Files[filepath.Join(cityPath, "city.toml")])
 	f.Errors[filepath.Join(cityPath, "pack.toml")] = errors.New("read denied")
 
@@ -825,7 +822,7 @@ func TestDoRigAdd_CreateMissingRigDirectoryError(t *testing.T) {
 	base := fsys.NewFake()
 	cityPath := "/city"
 	rigPath := "/rigs/my-project"
-	writeSchema2RigCityFS(t, base, cityPath, "test", "[workspace]\n", "")
+	writeSchema2RigCityFS(t, base, cityPath, "test", "[workspace]\n")
 	originalToml := string(base.Files[filepath.Join(cityPath, "city.toml")])
 	mkdirErr := errors.New("mkdir denied")
 
@@ -1040,7 +1037,7 @@ func TestDoRigSuspend(t *testing.T) {
 
 func TestDoRigSuspendNotFound(t *testing.T) {
 	f := fsys.NewFake()
-	writeSchema2RigCityFS(t, f, "/city", "test-city", "[workspace]\n", "")
+	writeSchema2RigCityFS(t, f, "/city", "test-city", "[workspace]\n")
 
 	var stdout, stderr bytes.Buffer
 	code := doRigSuspend(f, "/city", "nonexistent", &stdout, &stderr)
@@ -1092,7 +1089,7 @@ func TestDoRigResume(t *testing.T) {
 
 func TestDoRigResumeNotFound(t *testing.T) {
 	f := fsys.NewFake()
-	writeSchema2RigCityFS(t, f, "/city", "test-city", "[workspace]\n", "")
+	writeSchema2RigCityFS(t, f, "/city", "test-city", "[workspace]\n")
 
 	var stdout, stderr bytes.Buffer
 	code := doRigResume(f, "/city", "nonexistent", &stdout, &stderr)
@@ -2126,7 +2123,7 @@ func TestDoRigAdd_ExistingBeadsStatErrorFailsClosed(t *testing.T) {
 	rigPath := "/alpha-beta"
 	beadsPath := filepath.Join(rigPath, ".beads")
 
-	writeSchema2RigCityFS(t, f, cityPath, "my-city", "[workspace]\n", "")
+	writeSchema2RigCityFS(t, f, cityPath, "my-city", "[workspace]\n")
 	f.Dirs[rigPath] = true
 	f.Errors[beadsPath] = os.ErrPermission
 

--- a/cmd/gc/cmd_session_test.go
+++ b/cmd/gc/cmd_session_test.go
@@ -1973,23 +1973,27 @@ func writeNamedSessionCityTOML(t *testing.T, dir string) {
 	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
 		t.Fatalf("MkdirAll(.gc): %v", err)
 	}
-	data := []byte(`[workspace]
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte(`[pack]
 name = "test-city"
-
-[beads]
-provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "codex"
-start_command = "echo"
+schema = 2
 
 [[named_session]]
 template = "mayor"
-`)
-	if err := os.WriteFile(filepath.Join(dir, "city.toml"), data, 0o644); err != nil {
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pack.toml): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "city.toml"), []byte(`[workspace]
+
+[beads]
+provider = "file"
+`), 0o644); err != nil {
 		t.Fatalf("WriteFile(city.toml): %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, ".gc", "site.toml"), []byte(`workspace_name = "test-city"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(.gc/site.toml): %v", err)
+	}
+	writeCatalogFile(t, dir, "agents/mayor/agent.toml", "provider = \"codex\"\nstart_command = \"echo\"\n")
 }
 
 func writePoolSessionCityTOML(t *testing.T, dir string) {

--- a/cmd/gc/cmd_skill_test.go
+++ b/cmd/gc/cmd_skill_test.go
@@ -215,29 +215,10 @@ func TestSkillListAgentShowsFullCityCatalog(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
 	t.Setenv("GC_CITY", cityDir)
-	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
-		t.Fatalf("MkdirAll(.gc): %v", err)
-	}
+	writeNamedSessionCityTOML(t, cityDir)
 	// mayor declares an attachment list — this is a v0.15.0 tombstone and
 	// must be ignored; other-skill should still appear in the agent's view.
-	toml := `[workspace]
-name = "test-city"
-
-[beads]
-provider = "file"
-
-[[agent]]
-name = "mayor"
-provider = "codex"
-start_command = "echo"
-skills = ["attached-skill"]
-
-[[named_session]]
-template = "mayor"
-`
-	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(toml), 0o644); err != nil {
-		t.Fatalf("WriteFile(city.toml): %v", err)
-	}
+	writeCatalogFile(t, cityDir, "agents/mayor/agent.toml", "provider = \"codex\"\nstart_command = \"echo\"\nskills = [\"attached-skill\"]\n")
 	writeCatalogFile(t, cityDir, "skills/attached-skill/SKILL.md", "attached")
 	writeCatalogFile(t, cityDir, "skills/other-skill/SKILL.md", "other")
 	writeCatalogFile(t, cityDir, "agents/mayor/skills/private-workflow/SKILL.md", "agent-local")

--- a/cmd/gc/cmd_sling_routevars_test.go
+++ b/cmd/gc/cmd_sling_routevars_test.go
@@ -143,7 +143,7 @@ id = "work"
 title = "Do work"
 type = "task"
 `
-	if err := os.WriteFile(filepath.Join(formulaDir, "wf-test.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(formulaDir, "wf-test.toml"), []byte(formulaContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -350,7 +350,6 @@ func init() {
 	} {
 		content := fmt.Sprintf("formula = %q\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n", name)
 		_ = os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644)
-		_ = os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644)
 	}
 	sharedTestFormulaDir = dir
 

--- a/cmd/gc/cmd_sling_test.go
+++ b/cmd/gc/cmd_sling_test.go
@@ -349,6 +349,7 @@ func init() {
 		"my-formula", "convoy-formula",
 	} {
 		content := fmt.Sprintf("formula = %q\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n", name)
+		_ = os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644)
 		_ = os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644)
 	}
 	sharedTestFormulaDir = dir
@@ -3506,7 +3507,7 @@ func TestOnRootOnlyFormulaKeepsAttachedWispPrivate(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "root-only.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(dir, "root-only.toml"), []byte(`
 formula = "root-only"
 description = "Private attached root"
 version = 1
@@ -3566,7 +3567,7 @@ func TestFormulaRootOnlyRoutesRunnableWispRoot(t *testing.T) {
 	runner := newFakeRunner()
 	sp := runtime.NewFake()
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "root-only.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(dir, "root-only.toml"), []byte(`
 formula = "root-only"
 description = "Standalone root"
 version = 1
@@ -3704,7 +3705,7 @@ contract = "graph.v2"
 id = "step"
 title = "Do work"
 `
-	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3825,7 +3826,7 @@ contract = "graph.v2"
 id = "step"
 title = "Do work"
 `
-	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3883,7 +3884,7 @@ contract = "graph.v2"
 id = "step"
 title = "Do work"
 `
-	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3944,7 +3945,7 @@ contract = "graph.v2"
 id = "step"
 title = "Do work"
 `
-	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4215,7 +4216,7 @@ contract = "graph.v2"
 id = "step"
 title = "Do work"
 `
-	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.formula.toml"), []byte(graphFormula), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cfg.FormulaLayers.City[0], "graph-work.toml"), []byte(graphFormula), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4436,7 +4437,7 @@ id = "do-work"
 title = "Do work for {{target_id}}"
 description = "Target: {{target_id}}, workspace: {{workspace}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "repro.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "repro.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4485,7 +4486,7 @@ id = "do-work"
 title = "Do work for {{title}}"
 description = "Target: {{target_id}}, workspace: {{workspace}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "repro-mixed-vars.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "repro-mixed-vars.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4557,7 +4558,7 @@ required = true
 id = "do-work"
 title = "Work in {{workspace}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "requires-workspace.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "requires-workspace.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4799,7 +4800,7 @@ description = "Root title"
 id = "work"
 title = "Work"
 `
-	if err := os.WriteFile(filepath.Join(dir, "root-title-placeholder.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "root-title-placeholder.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4890,7 +4891,7 @@ required = true
 id = "work"
 title = "Work {{issue}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "requires-issue.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "requires-issue.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4934,7 +4935,7 @@ required = true
 id = "work"
 title = "Work {{workspace}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "batch-requires-workspace.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "batch-requires-workspace.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -5081,7 +5082,7 @@ id = "ship"
 title = "Ship"
 needs = ["prep"]
 `
-	if err := os.WriteFile(filepath.Join(dir, "multi-step.formula.toml"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "multi-step.toml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -6910,7 +6911,7 @@ required = true
 id = "do-work"
 title = "Work in {{workspace}}"
 `
-	if err := os.WriteFile(filepath.Join(dir, "default-requires-workspace.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "default-requires-workspace.toml"), []byte(formulaBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gc/completion_test.go
+++ b/cmd/gc/completion_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gastownhall/gascity/internal/beads"
 	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/fsys"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/runtime"
 	"github.com/gastownhall/gascity/internal/session"
@@ -357,12 +359,7 @@ func TestCompleteOrderNames_DistinguishesSameNameRigOrders(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	writeFile(t, filepath.Join(cityPath, "pack.toml"), `
-[pack]
-name = "orders-city"
-schema = 2
-`)
-	writeFile(t, filepath.Join(cityPath, "city.toml"), `
+	writeCompletionCity(t, cityPath, `
 [workspace]
 name = "orders-city"
 
@@ -438,7 +435,66 @@ func writeCompletionCity(t *testing.T, cityPath, cityToml string) {
 	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(cityToml), 0o644); err != nil {
+	cfg, err := config.Parse([]byte(cityToml))
+	if err != nil {
+		t.Fatalf("Parse(city.toml fixture): %v", err)
+	}
+	workspaceName := strings.TrimSpace(cfg.Workspace.Name)
+	if workspaceName == "" {
+		workspaceName = filepath.Base(cityPath)
+	}
+	workspacePrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	packToml := fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", workspaceName)
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.PersistWorkspaceSiteBinding(fsys.OSFS{}, cityPath, workspaceName, workspacePrefix); err != nil {
+		t.Fatalf("PersistWorkspaceSiteBinding: %v", err)
+	}
+	if err := config.PersistRigSiteBindings(fsys.OSFS{}, cityPath, cfg.Rigs); err != nil {
+		t.Fatalf("PersistRigSiteBindings: %v", err)
+	}
+	for _, agent := range cfg.Agents {
+		writeCompletionAgentToml(t, cityPath, agent)
+	}
+	cfg.Workspace.Name = ""
+	cfg.Workspace.Prefix = ""
+	cfg.Agents = nil
+	data, err := cfg.MarshalForWrite()
+	if err != nil {
+		t.Fatalf("MarshalForWrite: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeCompletionAgentToml(t *testing.T, cityPath string, agent config.Agent) {
+	t.Helper()
+	if strings.TrimSpace(agent.Name) == "" {
+		return
+	}
+	agentDir := filepath.Join(cityPath, "agents", agent.Name)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if agent.Provider != "" {
+		fmt.Fprintf(&b, "provider = %q\n", agent.Provider)
+	}
+	if agent.Session != "" {
+		fmt.Fprintf(&b, "session = %q\n", agent.Session)
+	}
+	if agent.Dir != "" {
+		fmt.Fprintf(&b, "dir = %q\n", agent.Dir)
+	}
+	if agent.WorkDir != "" {
+		fmt.Fprintf(&b, "work_dir = %q\n", agent.WorkDir)
+	}
+	if agent.StartCommand != "" {
+		fmt.Fprintf(&b, "start_command = %q\n", agent.StartCommand)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(b.String()), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/gc/doctor_mcp_checks_test.go
+++ b/cmd/gc/doctor_mcp_checks_test.go
@@ -10,21 +10,19 @@ import (
 func TestMCPConfigDoctorCheckReportsTemplateExpansionErrors(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
-	writeProjectedMCPCity(t, cityDir, `[workspace]
-name = "test-city"
-
+	writeProjectedMCPCity(t, cityDir, `
 [beads]
 provider = "file"
 
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
+`, `
 name = "mayor"
 provider = "gemini"
 scope = "city"
 `)
+
 	writeCatalogFile(t, cityDir, "mcp/remote.template.toml", `
 name = "remote"
 url = "https://example.com/{{.Missing}}"
@@ -49,9 +47,7 @@ url = "https://example.com/{{.Missing}}"
 func TestMCPConfigDoctorCheckReportsUndeliverableTargets(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
-	writeProjectedMCPCity(t, cityDir, `[workspace]
-name = "test-city"
-
+	writeProjectedMCPCity(t, cityDir, `
 [beads]
 provider = "file"
 
@@ -61,8 +57,7 @@ provider = "subprocess"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
+`, `
 name = "mayor"
 provider = "gemini"
 scope = "city"
@@ -89,9 +84,7 @@ command = "npx"
 func TestMCPSharedTargetDoctorCheckReportsConflicts(t *testing.T) {
 	clearGCEnv(t)
 	cityDir := t.TempDir()
-	writeProjectedMCPCity(t, cityDir, `[workspace]
-name = "test-city"
-
+	writeProjectedMCPCity(t, cityDir, `
 [beads]
 provider = "file"
 
@@ -101,13 +94,13 @@ provider = "tmux"
 [providers.gemini]
 command = "echo"
 prompt_mode = "none"
-
-[[agent]]
+`)
+	writeCatalogFile(t, cityDir, "agents/mayor/agent.toml", `
 name = "mayor"
 provider = "gemini"
 scope = "city"
-
-[[agent]]
+`)
+	writeCatalogFile(t, cityDir, "agents/deputy/agent.toml", `
 name = "deputy"
 provider = "gemini"
 scope = "city"

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -34,14 +34,26 @@ func (v2AgentFormatCheck) Fix(ctx *doctor.CheckContext) error {
 }
 
 func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
-	files := legacyAgentFiles(ctx.CityPath)
-	if len(files) == 0 {
+	cityHasLegacy, packHasLegacy := legacyAgentFiles(ctx.CityPath)
+	switch {
+	case !cityHasLegacy && !packHasLegacy:
 		return okCheck("v2-agent-format", "no legacy [[agent]] tables found")
+	case cityHasLegacy && packHasLegacy:
+		return errorCheck("v2-agent-format",
+			"unsupported PackV1 [[agent]] tables found in city.toml; pack.toml also still uses deferred legacy [[agent]] tables",
+			"move each city.toml [[agent]] definition into agents/<name>/agent.toml; pack.toml [[agent]] enforcement remains deferred until doctor/remediation support exists",
+			[]string{"city.toml", "pack.toml"})
+	case cityHasLegacy:
+		return errorCheck("v2-agent-format",
+			"unsupported PackV1 [[agent]] tables found in city.toml",
+			"move each city.toml [[agent]] definition into agents/<name>/agent.toml; gc doctor does not rewrite inline agents automatically in this wave",
+			[]string{"city.toml"})
+	default:
+		return warnCheck("v2-agent-format",
+			"legacy [[agent]] tables still present in pack.toml; enforcement is deferred until doctor/remediation support exists",
+			"leave this as-is for now or migrate to agents/<name>/agent.toml ahead of the follow-on enforcement pass",
+			[]string{"pack.toml"})
 	}
-	return warnCheck("v2-agent-format",
-		fmt.Sprintf("legacy [[agent]] tables found in %s", strings.Join(files, ", ")),
-		v2MigrationHint(),
-		files)
 }
 
 type v2ImportFormatCheck struct{}
@@ -57,9 +69,9 @@ func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	if !ok || len(cfg.Workspace.LegacyIncludes()) == 0 {
 		return okCheck("v2-import-format", "workspace.includes already migrated")
 	}
-	return warnCheck("v2-import-format",
-		"workspace.includes is deprecated; migrate this city to [imports] before gc can load it from pack.toml and city.toml",
-		v2MigrationHint(),
+	return errorCheck("v2-import-format",
+		"unsupported PackV1 workspace.includes found; migrate this city to [imports] before gc can load it",
+		"replace workspace.includes with [imports.<binding>] entries; gc doctor does not rewrite import bindings automatically in this wave",
 		cfg.Workspace.LegacyIncludes())
 }
 
@@ -76,9 +88,9 @@ func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.Check
 	if !ok || len(cfg.Workspace.LegacyDefaultRigIncludes()) == 0 {
 		return okCheck("v2-default-rig-import-format", "workspace.default_rig_includes already migrated")
 	}
-	return warnCheck("v2-default-rig-import-format",
-		"workspace.default_rig_includes is deprecated; migrate to root pack.toml [defaults.rig.imports.<binding>]",
-		v2MigrationHint(),
+	return errorCheck("v2-default-rig-import-format",
+		"unsupported PackV1 workspace.default_rig_includes found; migrate to root pack.toml [defaults.rig.imports.<binding>]",
+		`move each entry into root pack.toml [defaults.rig.imports.<binding>]`,
 		cfg.Workspace.LegacyDefaultRigIncludes())
 }
 
@@ -240,6 +252,12 @@ func (v2RigPathSiteBindingCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResu
 	}
 	if len(messages) == 0 {
 		return okCheck("v2-rig-path-site-binding", "rig paths already managed in .gc/site.toml")
+	}
+	if len(legacy) > 0 {
+		return errorCheck("v2-rig-path-site-binding",
+			strings.Join(messages, "; "),
+			strings.Join(hints, "; "),
+			details)
 	}
 	return warnCheck("v2-rig-path-site-binding",
 		strings.Join(messages, "; "),
@@ -413,7 +431,7 @@ func (v2WorkspaceNameCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	if rawPrefix != "" {
 		details = append(details, "workspace.prefix="+rawPrefix)
 	}
-	return warnCheck("v2-workspace-name",
+	return errorCheck("v2-workspace-name",
 		"workspace identity still lives in city.toml",
 		"run `gc doctor --fix` to migrate workspace.name/workspace.prefix into .gc/site.toml",
 		details)
@@ -449,8 +467,14 @@ func warnCheck(name, message, hint string, details []string) *doctor.CheckResult
 	}
 }
 
-func v2MigrationHint() string {
-	return `run "gc doctor" to inspect; use "gc doctor --fix" for the safe mechanical cases that currently have automatic rewrites, then rerun "gc doctor"`
+func errorCheck(name, message, hint string, details []string) *doctor.CheckResult {
+	return &doctor.CheckResult{
+		Name:    name,
+		Status:  doctor.StatusError,
+		Message: message,
+		FixHint: hint,
+		Details: details,
+	}
 }
 
 // runV2PackMigration applies the pack-shape migration (legacy [[agent]]
@@ -503,10 +527,9 @@ func parseCityConfig(path string) (*config.City, bool) {
 	return cfg, true
 }
 
-func legacyAgentFiles(cityPath string) []string {
-	var files []string
+func legacyAgentFiles(cityPath string) (cityHasLegacy, packHasLegacy bool) {
 	if cfg, ok := parseCityConfig(filepath.Join(cityPath, "city.toml")); ok && len(cfg.Agents) > 0 {
-		files = append(files, "city.toml")
+		cityHasLegacy = true
 	}
 	type rawPack struct {
 		Agents []config.Agent `toml:"agent"`
@@ -515,10 +538,10 @@ func legacyAgentFiles(cityPath string) []string {
 	if data, err := os.ReadFile(packPath); err == nil {
 		var pack rawPack
 		if _, err := toml.Decode(string(data), &pack); err == nil && len(pack.Agents) > 0 {
-			files = append(files, "pack.toml")
+			packHasLegacy = true
 		}
 	}
-	return files
+	return cityHasLegacy, packHasLegacy
 }
 
 func templatedMarkdownPrompts(cityPath string) []string {

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -34,7 +34,9 @@ func (v2AgentFormatCheck) Fix(ctx *doctor.CheckContext) error {
 }
 
 func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
-	cityHasLegacy, packHasLegacy := legacyAgentFiles(ctx.CityPath)
+	cityLegacy, packLegacy := legacyAgentFiles(ctx.CityPath)
+	cityHasLegacy := len(cityLegacy) > 0
+	packHasLegacy := len(packLegacy) > 0
 	switch {
 	case !cityHasLegacy && !packHasLegacy:
 		return okCheck("v2-agent-format", "no legacy [[agent]] tables found")
@@ -42,17 +44,17 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 		return errorCheck("v2-agent-format",
 			"unsupported PackV1 [[agent]] tables found in city.toml; pack.toml also still uses deferred legacy [[agent]] tables",
 			"move each city.toml [[agent]] definition into agents/<name>/agent.toml; pack.toml [[agent]] enforcement remains deferred until doctor/remediation support exists",
-			[]string{"city.toml", "pack.toml"})
+			append(cityLegacy, packLegacy...))
 	case cityHasLegacy:
 		return errorCheck("v2-agent-format",
 			"unsupported PackV1 [[agent]] tables found in city.toml",
 			"move each city.toml [[agent]] definition into agents/<name>/agent.toml; gc doctor does not rewrite inline agents automatically in this wave",
-			[]string{"city.toml"})
+			cityLegacy)
 	default:
 		return warnCheck("v2-agent-format",
 			"legacy [[agent]] tables still present in pack.toml; enforcement is deferred until doctor/remediation support exists",
 			"leave this as-is for now or migrate to agents/<name>/agent.toml ahead of the follow-on enforcement pass",
-			[]string{"pack.toml"})
+			packLegacy)
 	}
 }
 
@@ -65,14 +67,15 @@ func (v2ImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
 }
 
 func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
-	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
+	cityTomlPath := filepath.Join(ctx.CityPath, "city.toml")
+	cfg, ok := parseCityConfig(cityTomlPath)
 	if !ok || len(cfg.Workspace.LegacyIncludes()) == 0 {
 		return okCheck("v2-import-format", "workspace.includes already migrated")
 	}
 	return errorCheck("v2-import-format",
 		"unsupported PackV1 workspace.includes found; migrate this city to [imports] before gc can load it",
 		"replace workspace.includes with [imports.<binding>] entries; gc doctor does not rewrite import bindings automatically in this wave",
-		cfg.Workspace.LegacyIncludes())
+		doctorKeyDetails(cityTomlPath, "workspace", "includes", "workspace.includes", cfg.Workspace.LegacyIncludes()))
 }
 
 type v2DefaultRigImportFormatCheck struct{}
@@ -84,14 +87,15 @@ func (v2DefaultRigImportFormatCheck) Fix(ctx *doctor.CheckContext) error {
 }
 
 func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
-	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
+	cityTomlPath := filepath.Join(ctx.CityPath, "city.toml")
+	cfg, ok := parseCityConfig(cityTomlPath)
 	if !ok || len(cfg.Workspace.LegacyDefaultRigIncludes()) == 0 {
 		return okCheck("v2-default-rig-import-format", "workspace.default_rig_includes already migrated")
 	}
 	return errorCheck("v2-default-rig-import-format",
 		"unsupported PackV1 workspace.default_rig_includes found; migrate to root pack.toml [defaults.rig.imports.<binding>]",
 		`move each entry into root pack.toml [defaults.rig.imports.<binding>]`,
-		cfg.Workspace.LegacyDefaultRigIncludes())
+		doctorKeyDetails(cityTomlPath, "workspace", "default_rig_includes", "workspace.default_rig_includes", cfg.Workspace.LegacyDefaultRigIncludes()))
 }
 
 type v2RigPathSiteBindingCheck struct{}
@@ -180,15 +184,17 @@ func sameRigPath(cityPath, a, b string) bool {
 }
 
 func (v2RigPathSiteBindingCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
-	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
+	cityTomlPath := filepath.Join(ctx.CityPath, "city.toml")
+	cfg, ok := parseCityConfig(cityTomlPath)
 	if !ok {
 		return okCheck("v2-rig-path-site-binding", "rig path migration skipped until city.toml parses")
 	}
+	locator := newDoctorConfigLocator(cityTomlPath)
 
 	var legacy []string
 	for _, rig := range cfg.Rigs {
 		if strings.TrimSpace(rig.Path) != "" {
-			legacy = append(legacy, rig.Name)
+			legacy = append(legacy, doctorRigPathDetail(locator, rig.Name))
 		}
 	}
 
@@ -415,7 +421,8 @@ func (v2WorkspaceNameCheck) Fix(ctx *doctor.CheckContext) error {
 }
 
 func (v2WorkspaceNameCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
-	cfg, ok := parseCityConfig(filepath.Join(ctx.CityPath, "city.toml"))
+	cityTomlPath := filepath.Join(ctx.CityPath, "city.toml")
+	cfg, ok := parseCityConfig(cityTomlPath)
 	if !ok {
 		return okCheck("v2-workspace-name", "workspace identity migration skipped until city.toml parses")
 	}
@@ -425,11 +432,12 @@ func (v2WorkspaceNameCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 		return okCheck("v2-workspace-name", "workspace identity already absent from city.toml")
 	}
 	var details []string
+	locator := newDoctorConfigLocator(cityTomlPath)
 	if rawName != "" {
-		details = append(details, "workspace.name="+rawName)
+		details = append(details, doctorKeyDetail(locator, "workspace", "name", "workspace.name="+rawName))
 	}
 	if rawPrefix != "" {
-		details = append(details, "workspace.prefix="+rawPrefix)
+		details = append(details, doctorKeyDetail(locator, "workspace", "prefix", "workspace.prefix="+rawPrefix))
 	}
 	return errorCheck("v2-workspace-name",
 		"workspace identity still lives in city.toml",
@@ -527,9 +535,169 @@ func parseCityConfig(path string) (*config.City, bool) {
 	return cfg, true
 }
 
-func legacyAgentFiles(cityPath string) (cityHasLegacy, packHasLegacy bool) {
-	if cfg, ok := parseCityConfig(filepath.Join(cityPath, "city.toml")); ok && len(cfg.Agents) > 0 {
-		cityHasLegacy = true
+type doctorConfigLocator struct {
+	path  string
+	lines []string
+}
+
+func newDoctorConfigLocator(path string) doctorConfigLocator {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return doctorConfigLocator{path: path}
+	}
+	return doctorConfigLocator{path: path, lines: strings.Split(string(data), "\n")}
+}
+
+func (l doctorConfigLocator) source(line int) string {
+	source := filepath.Base(l.path)
+	if line <= 0 {
+		return source
+	}
+	return fmt.Sprintf("%s:%d", source, line)
+}
+
+func (l doctorConfigLocator) lineForTable(table string) int {
+	for i, line := range l.lines {
+		name, ok := parseDoctorTOMLTableHeader(line)
+		if ok && name == table {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (l doctorConfigLocator) lineForKey(table, key string) int {
+	var currentTable string
+	for i, line := range l.lines {
+		trimmed := trimDoctorTOMLLine(line)
+		if trimmed == "" {
+			continue
+		}
+		if name, ok := parseDoctorTOMLTableHeader(trimmed); ok {
+			currentTable = name
+			continue
+		}
+		if currentTable != table {
+			continue
+		}
+		gotKey, _, ok := strings.Cut(trimmed, "=")
+		if ok && strings.TrimSpace(gotKey) == key {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (l doctorConfigLocator) lineForRigPath(rigName string) int {
+	var inRig bool
+	var currentRigName string
+	var currentPathLine int
+
+	flushRig := func() int {
+		if !inRig || currentPathLine == 0 {
+			return 0
+		}
+		if rigName == "" || currentRigName == rigName {
+			return currentPathLine
+		}
+		return 0
+	}
+
+	for i, line := range l.lines {
+		trimmed := trimDoctorTOMLLine(line)
+		if trimmed == "" {
+			continue
+		}
+		if name, ok := parseDoctorTOMLTableHeader(trimmed); ok {
+			if line := flushRig(); line > 0 {
+				return line
+			}
+			inRig = name == "rigs"
+			currentRigName = ""
+			currentPathLine = 0
+			continue
+		}
+		if !inRig {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "name":
+			currentRigName = unquoteDoctorTOMLValue(value)
+		case "path":
+			currentPathLine = i + 1
+		}
+	}
+	return flushRig()
+}
+
+func doctorTableDetail(locator doctorConfigLocator, table, label string) string {
+	return fmt.Sprintf("%s: %s", locator.source(locator.lineForTable(table)), label)
+}
+
+func doctorKeyDetail(locator doctorConfigLocator, table, key, detail string) string {
+	return fmt.Sprintf("%s: %s", locator.source(locator.lineForKey(table, key)), detail)
+}
+
+func doctorKeyDetails(path, table, key, label string, values []string) []string {
+	locator := newDoctorConfigLocator(path)
+	if len(values) == 0 {
+		return []string{doctorKeyDetail(locator, table, key, label)}
+	}
+	details := make([]string, 0, len(values))
+	for _, value := range values {
+		details = append(details, doctorKeyDetail(locator, table, key, fmt.Sprintf("%s includes %q", label, value)))
+	}
+	return details
+}
+
+func doctorRigPathDetail(locator doctorConfigLocator, rigName string) string {
+	if strings.TrimSpace(rigName) == "" {
+		rigName = "<unnamed>"
+	}
+	return fmt.Sprintf("%s: rig %q path", locator.source(locator.lineForRigPath(rigName)), rigName)
+}
+
+func parseDoctorTOMLTableHeader(line string) (string, bool) {
+	trimmed := trimDoctorTOMLLine(line)
+	if strings.HasPrefix(trimmed, "[[") && strings.HasSuffix(trimmed, "]]") {
+		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "[["), "]]")), true
+	}
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")), true
+	}
+	return "", false
+}
+
+func trimDoctorTOMLLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return ""
+	}
+	if before, _, ok := strings.Cut(trimmed, "#"); ok {
+		trimmed = strings.TrimSpace(before)
+	}
+	return trimmed
+}
+
+func unquoteDoctorTOMLValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+	if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
+func legacyAgentFiles(cityPath string) (cityLegacy, packLegacy []string) {
+	cityTomlPath := filepath.Join(cityPath, "city.toml")
+	if cfg, ok := parseCityConfig(cityTomlPath); ok && len(cfg.Agents) > 0 {
+		cityLegacy = append(cityLegacy, doctorTableDetail(newDoctorConfigLocator(cityTomlPath), "agent", "city.toml [[agent]]"))
 	}
 	type rawPack struct {
 		Agents []config.Agent `toml:"agent"`
@@ -538,10 +706,10 @@ func legacyAgentFiles(cityPath string) (cityHasLegacy, packHasLegacy bool) {
 	if data, err := os.ReadFile(packPath); err == nil {
 		var pack rawPack
 		if _, err := toml.Decode(string(data), &pack); err == nil && len(pack.Agents) > 0 {
-			packHasLegacy = true
+			packLegacy = append(packLegacy, doctorTableDetail(newDoctorConfigLocator(packPath), "agent", "pack.toml [[agent]]"))
 		}
 	}
-	return cityHasLegacy, packHasLegacy
+	return cityLegacy, packLegacy
 }
 
 func templatedMarkdownPrompts(cityPath string) []string {

--- a/cmd/gc/doctor_v2_checks.go
+++ b/cmd/gc/doctor_v2_checks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/gastownhall/gascity/internal/citylayout"
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/doctor"
 	"github.com/gastownhall/gascity/internal/fsys"
@@ -19,7 +21,9 @@ func registerV2DeprecationChecks(d *doctor.Doctor) {
 	d.Register(v2AgentFormatCheck{})
 	d.Register(v2ImportFormatCheck{})
 	d.Register(v2DefaultRigImportFormatCheck{})
+	d.Register(v2PackSourcesCheck{})
 	d.Register(v2RigPathSiteBindingCheck{})
+	d.Register(v2LegacyOrderLayoutCheck{})
 	d.Register(v2ScriptsLayoutCheck{})
 	d.Register(v2WorkspaceNameCheck{})
 	d.Register(v2PromptTemplateSuffixCheck{})
@@ -43,12 +47,12 @@ func (v2AgentFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	case cityHasLegacy && packHasLegacy:
 		return errorCheck("v2-agent-format",
 			"unsupported PackV1 [[agent]] tables found in city.toml; pack.toml also still uses deferred legacy [[agent]] tables",
-			"move each city.toml [[agent]] definition into agents/<name>/agent.toml; pack.toml [[agent]] enforcement remains deferred until doctor/remediation support exists",
+			"run `gc doctor --fix` to move each city.toml [[agent]] definition into agents/<name>/agent.toml; pack.toml [[agent]] enforcement remains deferred until doctor/remediation support exists",
 			append(cityLegacy, packLegacy...))
 	case cityHasLegacy:
 		return errorCheck("v2-agent-format",
 			"unsupported PackV1 [[agent]] tables found in city.toml",
-			"move each city.toml [[agent]] definition into agents/<name>/agent.toml; gc doctor does not rewrite inline agents automatically in this wave",
+			"run `gc doctor --fix` to move each city.toml [[agent]] definition into agents/<name>/agent.toml",
 			cityLegacy)
 	default:
 		return warnCheck("v2-agent-format",
@@ -74,7 +78,7 @@ func (v2ImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
 	}
 	return errorCheck("v2-import-format",
 		"unsupported PackV1 workspace.includes found; migrate this city to [imports] before gc can load it",
-		"replace workspace.includes with [imports.<binding>] entries; gc doctor does not rewrite import bindings automatically in this wave",
+		"run `gc doctor --fix` to replace workspace.includes with [imports.<binding>] entries",
 		doctorKeyDetails(cityTomlPath, "workspace", "includes", "workspace.includes", cfg.Workspace.LegacyIncludes()))
 }
 
@@ -98,6 +102,26 @@ func (v2DefaultRigImportFormatCheck) Run(ctx *doctor.CheckContext) *doctor.Check
 		doctorKeyDetails(cityTomlPath, "workspace", "default_rig_includes", "workspace.default_rig_includes", cfg.Workspace.LegacyDefaultRigIncludes()))
 }
 
+type v2PackSourcesCheck struct{}
+
+func (v2PackSourcesCheck) Name() string { return "v2-pack-sources" }
+func (v2PackSourcesCheck) CanFix() bool { return true }
+func (v2PackSourcesCheck) Fix(ctx *doctor.CheckContext) error {
+	return runV2PackMigration(ctx, v2MigrationWarnSink(ctx))
+}
+
+func (v2PackSourcesCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
+	cityTomlPath := filepath.Join(ctx.CityPath, "city.toml")
+	cfg, ok := parseCityConfig(cityTomlPath)
+	if !ok || len(cfg.Packs) == 0 {
+		return okCheck("v2-pack-sources", "root [packs] entries already absent")
+	}
+	return errorCheck("v2-pack-sources",
+		"unsupported PackV1 [packs] entries found in city.toml",
+		"run `gc doctor --fix` to migrate entries referenced by workspace include lists; remove or rewrite any remaining [packs] entries manually as [imports]",
+		doctorPackSourceDetails(cityTomlPath, cfg))
+}
+
 type v2RigPathSiteBindingCheck struct{}
 
 func (v2RigPathSiteBindingCheck) Name() string { return "v2-rig-path-site-binding" }
@@ -111,7 +135,11 @@ func (v2RigPathSiteBindingCheck) Fix(ctx *doctor.CheckContext) error {
 	}
 	legacyByName := make(map[string]string, len(cfg.Rigs))
 	for _, rig := range cfg.Rigs {
-		legacyByName[rig.Name] = strings.TrimSpace(rig.Path)
+		name := strings.TrimSpace(rig.Name)
+		if name == "" {
+			continue
+		}
+		legacyByName[name] = strings.TrimSpace(rig.Path)
 	}
 	existing, err := config.LoadSiteBinding(fsys.OSFS{}, ctx.CityPath)
 	if err != nil {
@@ -124,6 +152,18 @@ func (v2RigPathSiteBindingCheck) Fix(ctx *doctor.CheckContext) error {
 			continue
 		}
 		existingByName[name] = strings.TrimSpace(rig.Path)
+	}
+	var orphans []string
+	for name, site := range existingByName {
+		if _, ok := legacyByName[name]; ok {
+			continue
+		}
+		orphans = append(orphans, fmt.Sprintf("rig %q: .gc/site.toml=%q", name, site))
+	}
+	if len(orphans) > 0 {
+		sort.Strings(orphans)
+		return fmt.Errorf("refusing to migrate rig paths because .gc/site.toml contains bindings for unknown rig names; remove or rename the stale entries and re-run `gc doctor --fix`:\n  %s",
+			strings.Join(orphans, "\n  "))
 	}
 	var conflicts []string
 	for name, legacy := range legacyByName {
@@ -144,16 +184,9 @@ func (v2RigPathSiteBindingCheck) Fix(ctx *doctor.CheckContext) error {
 	if _, err := config.ApplySiteBindingsForEdit(fsys.OSFS{}, ctx.CityPath, cfg); err != nil {
 		return err
 	}
-	content, err := cfg.MarshalForWrite()
-	if err != nil {
-		return err
-	}
 	cityTomlPath := filepath.Join(ctx.CityPath, "city.toml")
-	if err := fsys.WriteFileIfChangedAtomic(fsys.OSFS{}, cityTomlPath, content, 0o644); err != nil {
+	if err := config.WriteCityAndRigSiteBindingsForEdit(fsys.OSFS{}, cityTomlPath, cfg); err != nil {
 		return err
-	}
-	if err := config.PersistRigSiteBindings(fsys.OSFS{}, ctx.CityPath, cfg.Rigs); err != nil {
-		return fmt.Errorf("writing .gc/site.toml failed after city.toml was rewritten — rigs are now unbound; re-run `gc doctor --fix` to retry: %w", err)
 	}
 	return nil
 }
@@ -269,6 +302,376 @@ func (v2RigPathSiteBindingCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResu
 		strings.Join(messages, "; "),
 		strings.Join(hints, "; "),
 		details)
+}
+
+type v2LegacyOrderLayoutCheck struct{}
+
+func (v2LegacyOrderLayoutCheck) Name() string { return "v2-legacy-order-layout" }
+
+func (v2LegacyOrderLayoutCheck) CanFix() bool { return true }
+
+func (v2LegacyOrderLayoutCheck) WarmupEligible() bool { return false }
+
+func (v2LegacyOrderLayoutCheck) Fix(ctx *doctor.CheckContext) error {
+	if ctx == nil || strings.TrimSpace(ctx.CityPath) == "" {
+		return fmt.Errorf("city path is required")
+	}
+	return fixLegacyOrderLayouts(ctx.CityPath)
+}
+
+func (v2LegacyOrderLayoutCheck) Run(ctx *doctor.CheckContext) *doctor.CheckResult {
+	details := legacyOrderLayoutDetails(ctx.CityPath)
+	if len(details) == 0 {
+		return okCheck("v2-legacy-order-layout", "no PackV1 order subdirectory layouts found")
+	}
+	return errorCheck("v2-legacy-order-layout",
+		"unsupported PackV1 order subdirectory layouts found",
+		"run `gc doctor --fix` to migrate collision-free legacy order layouts, or rename each orders/<name>/order.toml or formulas/orders/<name>/order.toml file to the flat orders/<name>.toml layout manually",
+		details)
+}
+
+type legacyOrderRoot struct {
+	dir       string
+	targetDir string
+	hint      string
+	fixable   bool
+}
+
+func legacyOrderLayoutDetails(cityPath string) []string {
+	roots := legacyOrderLayoutRoots(cityPath)
+	var details []string
+	seen := make(map[string]bool)
+	for _, root := range roots {
+		for _, detail := range scanLegacyOrderRoot(root) {
+			if seen[detail] {
+				continue
+			}
+			seen[detail] = true
+			details = append(details, detail)
+		}
+	}
+	sort.Strings(details)
+	return details
+}
+
+func legacyOrderLayoutRoots(cityPath string) []legacyOrderRoot {
+	cityTomlPath := filepath.Join(cityPath, "city.toml")
+	cfg, cfgOK := parseCityConfig(cityTomlPath)
+	formulasDir := ""
+	if cfgOK {
+		formulasDir = cfg.FormulasDir()
+	}
+	orderDir := citylayout.OrdersPath(cityPath)
+	formulaOrderDir := filepath.Join(citylayout.ResolveFormulasDir(cityPath, formulasDir), "orders")
+	formulaOrderDirFixable := doctorPathWithinCity(cityPath, formulaOrderDir) && doctorPathWithinCity(cityPath, orderDir)
+	roots := []legacyOrderRoot{
+		{dir: orderDir, targetDir: orderDir, hint: "rename to orders/%s.toml", fixable: doctorPathWithinCity(cityPath, orderDir)},
+		{dir: formulaOrderDir, targetDir: orderDir, hint: legacyOrderRootHint(formulaOrderDirFixable, "move"), fixable: formulaOrderDirFixable},
+	}
+	if packDirs, err := config.LoadPackGraphDirsForDoctor(fsys.OSFS{}, cityTomlPath); err == nil {
+		return appendLegacyOrderRootsForPackDirs(roots, cityPath, packDirs)
+	}
+
+	seenPacks := map[string]bool{absDoctorPathKey(cityPath): true}
+	if cfgOK {
+		for _, ref := range cfg.Workspace.LegacyIncludes() {
+			if packDir, ok := localDoctorPackPath(cityPath, ref); ok {
+				roots = appendLegacyOrderRootsForPackGraph(roots, cityPath, packDir, seenPacks)
+			}
+		}
+		for _, imp := range cfg.Imports {
+			if packDir, ok := localDoctorPackPath(cityPath, imp.Source); ok {
+				roots = appendLegacyOrderRootsForPackGraph(roots, cityPath, packDir, seenPacks)
+			}
+		}
+		for _, rig := range cfg.Rigs {
+			for _, ref := range rig.Includes {
+				if packDir, ok := localDoctorPackPath(cityPath, ref); ok {
+					roots = appendLegacyOrderRootsForPackGraph(roots, cityPath, packDir, seenPacks)
+				}
+			}
+			for _, source := range sortedDoctorImportSources(rig.Imports) {
+				if packDir, ok := localDoctorPackPath(cityPath, source); ok {
+					roots = appendLegacyOrderRootsForPackGraph(roots, cityPath, packDir, seenPacks)
+				}
+			}
+		}
+	}
+	return appendLegacyOrderRootsForRootPackRefs(roots, cityPath, seenPacks)
+}
+
+func appendLegacyOrderRootsForPackDirs(roots []legacyOrderRoot, cityPath string, packDirs []string) []legacyOrderRoot {
+	seenPacks := map[string]bool{absDoctorPathKey(cityPath): true}
+	for _, packDir := range packDirs {
+		key := absDoctorPathKey(packDir)
+		if seenPacks[key] {
+			continue
+		}
+		seenPacks[key] = true
+		roots = append(roots, legacyOrderRootsForPack(cityPath, packDir)...)
+	}
+	return roots
+}
+
+func legacyOrderRootsForPack(cityPath, packDir string) []legacyOrderRoot {
+	orderDir := filepath.Join(packDir, "orders")
+	formulaOrderDir := filepath.Join(packDir, "formulas", "orders")
+	orderDirFixable := doctorPathWithinCity(cityPath, orderDir)
+	formulaOrderDirFixable := doctorPathWithinCity(cityPath, formulaOrderDir) && orderDirFixable
+	return []legacyOrderRoot{
+		{dir: orderDir, targetDir: orderDir, hint: legacyOrderRootHint(orderDirFixable, "rename"), fixable: orderDirFixable},
+		{dir: formulaOrderDir, targetDir: orderDir, hint: legacyOrderRootHint(formulaOrderDirFixable, "move"), fixable: formulaOrderDirFixable},
+	}
+}
+
+func legacyOrderRootHint(fixable bool, action string) string {
+	if fixable {
+		return action + " to orders/%s.toml"
+	}
+	return "manually " + action + " to orders/%s.toml; gc doctor --fix only changes files under the city"
+}
+
+func localDoctorPackPath(cityPath, ref string) (string, bool) {
+	return localDoctorPackPathFromBase(cityPath, ref)
+}
+
+func localDoctorPackPathFromBase(baseDir, ref string) (string, bool) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.Contains(ref, "://") || strings.HasPrefix(ref, "github.com/") || strings.HasPrefix(ref, "git@") {
+		return "", false
+	}
+	if filepath.IsAbs(ref) {
+		return filepath.Clean(ref), true
+	}
+	return filepath.Clean(filepath.Join(baseDir, ref)), true
+}
+
+type doctorPackRefsConfig struct {
+	Pack struct {
+		Includes []string `toml:"includes"`
+	} `toml:"pack"`
+	Imports  map[string]config.Import `toml:"imports"`
+	Defaults config.PackDefaults      `toml:"defaults"`
+}
+
+func appendLegacyOrderRootsForRootPackRefs(roots []legacyOrderRoot, cityPath string, seenPacks map[string]bool) []legacyOrderRoot {
+	return appendLegacyOrderRootsForPackRefs(roots, cityPath, cityPath, true, seenPacks)
+}
+
+func appendLegacyOrderRootsForPackGraph(roots []legacyOrderRoot, cityPath, packDir string, seenPacks map[string]bool) []legacyOrderRoot {
+	key := absDoctorPathKey(packDir)
+	if seenPacks[key] {
+		return roots
+	}
+	seenPacks[key] = true
+	roots = append(roots, legacyOrderRootsForPack(cityPath, packDir)...)
+	return appendLegacyOrderRootsForPackRefs(roots, cityPath, packDir, false, seenPacks)
+}
+
+func appendLegacyOrderRootsForPackRefs(roots []legacyOrderRoot, cityPath, packDir string, includeDefaultRigImports bool, seenPacks map[string]bool) []legacyOrderRoot {
+	cfg, ok := parseDoctorPackRefs(filepath.Join(packDir, "pack.toml"))
+	if !ok {
+		return roots
+	}
+	for _, ref := range doctorPackRefSources(cfg, includeDefaultRigImports) {
+		nextDir, ok := localDoctorPackPathFromBase(packDir, ref)
+		if !ok {
+			continue
+		}
+		roots = appendLegacyOrderRootsForPackGraph(roots, cityPath, nextDir, seenPacks)
+	}
+	return roots
+}
+
+func parseDoctorPackRefs(path string) (*doctorPackRefsConfig, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var cfg doctorPackRefsConfig
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return nil, false
+	}
+	return &cfg, true
+}
+
+func doctorPackRefSources(cfg *doctorPackRefsConfig, includeDefaultRigImports bool) []string {
+	var refs []string
+	refs = append(refs, cfg.Pack.Includes...)
+	refs = append(refs, sortedDoctorImportSources(cfg.Imports)...)
+	if includeDefaultRigImports {
+		refs = append(refs, sortedDoctorImportSources(cfg.Defaults.Rig.Imports)...)
+	}
+	return refs
+}
+
+func sortedDoctorImportSources(imports map[string]config.Import) []string {
+	if len(imports) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(imports))
+	for name := range imports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	sources := make([]string, 0, len(names))
+	for _, name := range names {
+		sources = append(sources, imports[name].Source)
+	}
+	return sources
+}
+
+func absDoctorPathKey(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(abs)
+}
+
+func doctorPathWithinCity(cityPath, path string) bool {
+	cityAbs := absDoctorPathKey(cityPath)
+	pathAbs := absDoctorPathKey(path)
+	if !cleanedPathWithin(cityAbs, pathAbs) {
+		return false
+	}
+	cityReal, cityErr := filepath.EvalSymlinks(cityAbs)
+	pathReal, pathErr := filepath.EvalSymlinks(pathAbs)
+	if cityErr == nil && pathErr == nil {
+		return cleanedPathWithin(filepath.Clean(cityReal), filepath.Clean(pathReal))
+	}
+	return true
+}
+
+func cleanedPathWithin(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel))
+}
+
+func scanLegacyOrderRoot(root legacyOrderRoot) []string {
+	entries, err := os.ReadDir(root.dir)
+	if err != nil {
+		return nil
+	}
+	var details []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		source := filepath.Join(root.dir, name, "order.toml")
+		if _, err := os.Stat(source); err != nil {
+			continue
+		}
+		details = append(details, fmt.Sprintf("%s; "+root.hint, source, name))
+	}
+	return details
+}
+
+type legacyOrderMove struct {
+	source string
+	target string
+}
+
+func fixLegacyOrderLayouts(cityPath string) error {
+	moves, err := planLegacyOrderMoves(legacyOrderLayoutRoots(cityPath))
+	if err != nil {
+		return err
+	}
+	var applied []legacyOrderMove
+	for _, move := range moves {
+		if err := os.MkdirAll(filepath.Dir(move.target), 0o755); err != nil {
+			return rollbackLegacyOrderMoves(applied, fmt.Errorf("creating %s: %w", filepath.Dir(move.target), err))
+		}
+		if _, err := os.Stat(move.target); err == nil {
+			return rollbackLegacyOrderMoves(applied, fmt.Errorf("target already exists: %s", move.target))
+		} else if !os.IsNotExist(err) {
+			return rollbackLegacyOrderMoves(applied, fmt.Errorf("checking target %s: %w", move.target, err))
+		}
+		if err := os.Rename(move.source, move.target); err != nil {
+			return rollbackLegacyOrderMoves(applied, fmt.Errorf("moving %s to %s: %w", move.source, move.target, err))
+		}
+		applied = append(applied, move)
+		_ = os.Remove(filepath.Dir(move.source))
+	}
+	return nil
+}
+
+func planLegacyOrderMoves(roots []legacyOrderRoot) ([]legacyOrderMove, error) {
+	targetSources := make(map[string]string)
+	var moves []legacyOrderMove
+	var problems []string
+	for _, root := range roots {
+		if !root.fixable {
+			continue
+		}
+		entries, err := os.ReadDir(root.dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			problems = append(problems, fmt.Sprintf("reading %s: %v", root.dir, err))
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			source := filepath.Join(root.dir, entry.Name(), "order.toml")
+			info, err := os.Stat(source)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				problems = append(problems, fmt.Sprintf("checking source %s: %v", source, err))
+				continue
+			}
+			if info.IsDir() {
+				problems = append(problems, fmt.Sprintf("source is a directory, not an order file: %s", source))
+				continue
+			}
+			target := filepath.Join(root.targetDir, entry.Name()+".toml")
+			if prior, ok := targetSources[target]; ok {
+				problems = append(problems, fmt.Sprintf("multiple legacy order files would migrate to %s: %s and %s", target, prior, source))
+				continue
+			}
+			targetSources[target] = source
+			if _, err := os.Stat(target); err == nil {
+				problems = append(problems, fmt.Sprintf("target already exists: %s", target))
+				continue
+			} else if !os.IsNotExist(err) {
+				problems = append(problems, fmt.Sprintf("checking target %s: %v", target, err))
+				continue
+			}
+			moves = append(moves, legacyOrderMove{source: source, target: target})
+		}
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return nil, fmt.Errorf("refusing to migrate legacy order layouts:\n  %s", strings.Join(problems, "\n  "))
+	}
+	return moves, nil
+}
+
+func rollbackLegacyOrderMoves(applied []legacyOrderMove, cause error) error {
+	var restoreErr error
+	for i := len(applied) - 1; i >= 0; i-- {
+		move := applied[i]
+		if err := os.MkdirAll(filepath.Dir(move.source), 0o755); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("recreating %s: %w", filepath.Dir(move.source), err))
+			continue
+		}
+		if err := os.Rename(move.target, move.source); err != nil && !os.IsNotExist(err) {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restoring %s to %s: %w", move.target, move.source, err))
+		}
+	}
+	if restoreErr != nil {
+		return errors.Join(cause, restoreErr)
+	}
+	return cause
 }
 
 type v2ScriptsLayoutCheck struct{}
@@ -536,8 +939,8 @@ func parseCityConfig(path string) (*config.City, bool) {
 }
 
 type doctorConfigLocator struct {
-	path  string
-	lines []string
+	path    string
+	locator config.DiagnosticLocator
 }
 
 func newDoctorConfigLocator(path string) doctorConfigLocator {
@@ -545,7 +948,7 @@ func newDoctorConfigLocator(path string) doctorConfigLocator {
 	if err != nil {
 		return doctorConfigLocator{path: path}
 	}
-	return doctorConfigLocator{path: path, lines: strings.Split(string(data), "\n")}
+	return doctorConfigLocator{path: path, locator: config.NewDiagnosticLocator(data)}
 }
 
 func (l doctorConfigLocator) source(line int) string {
@@ -557,81 +960,15 @@ func (l doctorConfigLocator) source(line int) string {
 }
 
 func (l doctorConfigLocator) lineForTable(table string) int {
-	for i, line := range l.lines {
-		name, ok := parseDoctorTOMLTableHeader(line)
-		if ok && name == table {
-			return i + 1
-		}
-	}
-	return 0
+	return l.locator.LineForTable(table)
 }
 
 func (l doctorConfigLocator) lineForKey(table, key string) int {
-	var currentTable string
-	for i, line := range l.lines {
-		trimmed := trimDoctorTOMLLine(line)
-		if trimmed == "" {
-			continue
-		}
-		if name, ok := parseDoctorTOMLTableHeader(trimmed); ok {
-			currentTable = name
-			continue
-		}
-		if currentTable != table {
-			continue
-		}
-		gotKey, _, ok := strings.Cut(trimmed, "=")
-		if ok && strings.TrimSpace(gotKey) == key {
-			return i + 1
-		}
-	}
-	return 0
+	return l.locator.LineForKey(table, key)
 }
 
 func (l doctorConfigLocator) lineForRigPath(rigName string) int {
-	var inRig bool
-	var currentRigName string
-	var currentPathLine int
-
-	flushRig := func() int {
-		if !inRig || currentPathLine == 0 {
-			return 0
-		}
-		if rigName == "" || currentRigName == rigName {
-			return currentPathLine
-		}
-		return 0
-	}
-
-	for i, line := range l.lines {
-		trimmed := trimDoctorTOMLLine(line)
-		if trimmed == "" {
-			continue
-		}
-		if name, ok := parseDoctorTOMLTableHeader(trimmed); ok {
-			if line := flushRig(); line > 0 {
-				return line
-			}
-			inRig = name == "rigs"
-			currentRigName = ""
-			currentPathLine = 0
-			continue
-		}
-		if !inRig {
-			continue
-		}
-		key, value, ok := strings.Cut(trimmed, "=")
-		if !ok {
-			continue
-		}
-		switch strings.TrimSpace(key) {
-		case "name":
-			currentRigName = unquoteDoctorTOMLValue(value)
-		case "path":
-			currentPathLine = i + 1
-		}
-	}
-	return flushRig()
+	return l.locator.LineForRigPath(rigName)
 }
 
 func doctorTableDetail(locator doctorConfigLocator, table, label string) string {
@@ -661,37 +998,52 @@ func doctorRigPathDetail(locator doctorConfigLocator, rigName string) string {
 	return fmt.Sprintf("%s: rig %q path", locator.source(locator.lineForRigPath(rigName)), rigName)
 }
 
-func parseDoctorTOMLTableHeader(line string) (string, bool) {
-	trimmed := trimDoctorTOMLLine(line)
-	if strings.HasPrefix(trimmed, "[[") && strings.HasSuffix(trimmed, "]]") {
-		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "[["), "]]")), true
+func doctorPackSourceDetails(path string, cfg *config.City) []string {
+	if cfg == nil || len(cfg.Packs) == 0 {
+		return nil
 	}
-	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")), true
+	locator := newDoctorConfigLocator(path)
+	names := make([]string, 0, len(cfg.Packs))
+	for name := range cfg.Packs {
+		names = append(names, name)
 	}
-	return "", false
-}
+	sort.Strings(names)
 
-func trimDoctorTOMLLine(line string) string {
-	trimmed := strings.TrimSpace(line)
-	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-		return ""
+	workspaceRefs := make(map[string]struct{})
+	for _, include := range cfg.Workspace.LegacyIncludes() {
+		workspaceRefs[include] = struct{}{}
 	}
-	if before, _, ok := strings.Cut(trimmed, "#"); ok {
-		trimmed = strings.TrimSpace(before)
+	for _, include := range cfg.Workspace.LegacyDefaultRigIncludes() {
+		workspaceRefs[include] = struct{}{}
 	}
-	return trimmed
-}
+	rigRefs := make(map[string]struct{})
+	for _, rig := range cfg.Rigs {
+		for _, include := range rig.Includes {
+			rigRefs[include] = struct{}{}
+		}
+	}
 
-func unquoteDoctorTOMLValue(value string) string {
-	value = strings.TrimSpace(value)
-	if len(value) < 2 {
-		return value
+	details := make([]string, 0, len(names))
+	for _, name := range names {
+		line := locator.locator.LineForTable("packs." + name)
+		if line == 0 {
+			line = locator.locator.LineForPacksTable()
+		}
+		remediation := "manual cleanup required"
+		if _, ok := workspaceRefs[name]; ok {
+			remediation = "gc doctor --fix can migrate this workspace/default-rig include reference"
+			if _, rigReferenced := rigRefs[name]; rigReferenced {
+				remediation = "manual cleanup required after gc doctor --fix because a rig include still references this pack"
+			}
+		}
+		src := strings.TrimSpace(cfg.Packs[name].Source)
+		if src == "" {
+			src = "<empty source>"
+		}
+		details = append(details, fmt.Sprintf("%s: [packs.%s] source=%q (%s)",
+			locator.source(line), name, src, remediation))
 	}
-	if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
-		return value[1 : len(value)-1]
-	}
-	return value
+	return details
 }
 
 func legacyAgentFiles(cityPath string) (cityLegacy, packLegacy []string) {

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -326,6 +326,40 @@ path = "`+rigPath+`"
 	}
 }
 
+func TestV2DeprecationChecksWarnOnDeferredPackAgentFormat(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+
+[[agent]]
+name = "helper"
+`)
+
+	var buf bytes.Buffer
+	d := &doctor.Doctor{}
+	registerV2DeprecationChecks(d)
+	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, false)
+
+	out := buf.String()
+	if !strings.Contains(out, "⚠ v2-agent-format") {
+		t.Fatalf("doctor output missing deferred pack agent warning:\n%s", out)
+	}
+	if !strings.Contains(out, "pack.toml") {
+		t.Fatalf("doctor output missing pack.toml detail:\n%s", out)
+	}
+	if !strings.Contains(out, "enforcement is deferred") {
+		t.Fatalf("doctor output missing deferral guidance:\n%s", out)
+	}
+}
+
 func TestV2DeprecationChecksWarnOnStaleSiteBindingName(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +50,9 @@ scope = "city"
 		"v2-agent-format",
 		"v2-import-format",
 		"v2-default-rig-import-format",
+		"v2-pack-sources",
 		"v2-rig-path-site-binding",
+		"v2-legacy-order-layout",
 		"v2-scripts-layout",
 		"v2-workspace-name",
 		"v2-prompt-template-suffix",
@@ -79,6 +82,618 @@ scope = "city"
 		if !strings.Contains(out, want) {
 			t.Fatalf("doctor output missing source coordinate %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestDoctorFixClearsExpandedConfigLoadAfterV2Migration(t *testing.T) {
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[agent]]
+name = "worker"
+prompt_template = "prompts/worker.md"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "prompts/worker.md", "You are the worker.\n")
+	t.Setenv("GC_CITY_PATH", cityDir)
+	t.Setenv("GC_BEADS", "file")
+	prependDoctorJSONStubBinaries(t, "tmux", "git", "jq", "pgrep", "lsof")
+
+	var stdout, stderr bytes.Buffer
+	code := doDoctor(true, false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gc doctor --fix = %d, want 0; stdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "✗ expanded-config-load") {
+		t.Fatalf("expanded-config-load reported stale pre-fix failure:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "✓ expanded-config-load") {
+		t.Fatalf("doctor output missing post-fix expanded-config-load success:\n%s", stdout.String())
+	}
+}
+
+func TestV2LegacyOrderLayoutCheckReportsSchema1NestedOrder(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 1
+`)
+	writeDoctorFile(t, cityDir, "orders/heartbeat/order.toml", `
+[order]
+exec = "scripts/heartbeat.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+
+	got := v2LegacyOrderLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; result=%+v", got.Status, got)
+	}
+	for _, want := range []string{
+		"unsupported PackV1 order subdirectory layouts",
+		"gc doctor --fix",
+		"orders/heartbeat/order.toml",
+		"orders/heartbeat.toml",
+	} {
+		if !strings.Contains(got.Message+strings.Join(got.Details, "\n")+got.FixHint, want) {
+			t.Fatalf("result %+v missing %q", got, want)
+		}
+	}
+	if !(v2LegacyOrderLayoutCheck{}).CanFix() {
+		t.Fatal("legacy order layout check should support automatic collision-free fixes")
+	}
+}
+
+func TestV2LegacyOrderLayoutFixMigratesSchema1NestedOrder(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 1
+`)
+	writeDoctorFile(t, cityDir, "orders/heartbeat/order.toml", `
+[order]
+exec = "scripts/heartbeat.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+	writeDoctorFile(t, cityDir, "formulas/orders/formula-heartbeat/order.toml", `
+[order]
+formula = "formula-heartbeat"
+trigger = "manual"
+`)
+
+	check := v2LegacyOrderLayoutCheck{}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	for _, rel := range []string{
+		"orders/heartbeat.toml",
+		"orders/formula-heartbeat.toml",
+	} {
+		if _, err := os.Stat(filepath.Join(cityDir, rel)); err != nil {
+			t.Fatalf("migrated %s stat: %v", rel, err)
+		}
+	}
+	for _, rel := range []string{
+		"orders/heartbeat/order.toml",
+		"formulas/orders/formula-heartbeat/order.toml",
+	} {
+		if _, err := os.Stat(filepath.Join(cityDir, rel)); !os.IsNotExist(err) {
+			t.Fatalf("legacy %s stat = %v, want removed", rel, err)
+		}
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; result=%+v", got.Status, got)
+	}
+}
+
+func TestV2LegacyOrderLayoutFixMigratesConfiguredFormulaDir(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "custom-formulas-city"
+
+[formulas]
+dir = "flows"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "custom-formulas-city"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "flows/orders/heartbeat/order.toml", `
+[order]
+formula = "heartbeat"
+trigger = "manual"
+`)
+
+	check := v2LegacyOrderLayoutCheck{}
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; result=%+v", got.Status, got)
+	}
+	resultText := got.Message + got.FixHint + strings.Join(got.Details, "\n")
+	for _, want := range []string{
+		"flows/orders/heartbeat/order.toml",
+		"orders/heartbeat.toml",
+	} {
+		if !strings.Contains(resultText, want) {
+			t.Fatalf("result %+v missing %q", got, want)
+		}
+	}
+
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, "orders/heartbeat.toml")); err != nil {
+		t.Fatalf("migrated orders/heartbeat.toml stat: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, "flows/orders/heartbeat/order.toml")); !os.IsNotExist(err) {
+		t.Fatalf("legacy flows/orders/heartbeat/order.toml stat = %v, want removed", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; result=%+v", got.Status, got)
+	}
+}
+
+func TestV2LegacyOrderLayoutFixMigratesRootPackReferencedOrders(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+includes = ["packs/root-include"]
+
+[imports.root-import]
+source = "packs/root-import"
+
+[defaults.rig.imports.root-default]
+source = "packs/root-default"
+`)
+	writeDoctorFile(t, cityDir, "packs/root-include/pack.toml", `
+[pack]
+name = "root-include"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "packs/root-import/pack.toml", `
+[pack]
+name = "root-import"
+schema = 2
+includes = ["../nested-import"]
+`)
+	writeDoctorFile(t, cityDir, "packs/root-default/pack.toml", `
+[pack]
+name = "root-default"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "packs/nested-import/pack.toml", `
+[pack]
+name = "nested-import"
+schema = 2
+`)
+	for _, rel := range []string{
+		"packs/root-include/orders/include-order/order.toml",
+		"packs/root-import/orders/import-order/order.toml",
+		"packs/root-default/orders/default-order/order.toml",
+		"packs/nested-import/orders/nested-order/order.toml",
+	} {
+		writeDoctorFile(t, cityDir, rel, `
+[order]
+trigger = "manual"
+`)
+	}
+
+	check := v2LegacyOrderLayoutCheck{}
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; result=%+v", got.Status, got)
+	}
+	for _, want := range []string{
+		"packs/root-include/orders/include-order/order.toml",
+		"packs/root-import/orders/import-order/order.toml",
+		"packs/root-default/orders/default-order/order.toml",
+		"packs/nested-import/orders/nested-order/order.toml",
+	} {
+		if !strings.Contains(strings.Join(got.Details, "\n"), want) {
+			t.Fatalf("details missing %q: %+v", want, got.Details)
+		}
+	}
+
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	for _, rel := range []string{
+		"packs/root-include/orders/include-order.toml",
+		"packs/root-import/orders/import-order.toml",
+		"packs/root-default/orders/default-order.toml",
+		"packs/nested-import/orders/nested-order.toml",
+	} {
+		if _, err := os.Stat(filepath.Join(cityDir, rel)); err != nil {
+			t.Fatalf("migrated %s stat: %v", rel, err)
+		}
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; result=%+v", got.Status, got)
+	}
+}
+
+func TestV2LegacyOrderLayoutReportsRemoteImportedPackEvaluatedByLoader(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	cityDir := t.TempDir()
+	source := "https://github.com/example/orders-pack.git"
+	repoDir := filepath.Join(t.TempDir(), "orders-pack")
+	writeDoctorFile(t, repoDir, "pack.toml", `
+[pack]
+name = "ops"
+schema = 1
+`)
+	writeDoctorFile(t, repoDir, "orders/nightly/order.toml", `
+[order]
+formula = "nightly"
+trigger = "manual"
+`)
+	mustGitImport(t, repoDir, "init")
+	mustGitImport(t, repoDir, "add", ".")
+	mustGitImport(t, repoDir, "commit", "-m", "initial")
+	commit := gitOutputImport(t, repoDir, "rev-parse", "HEAD")
+
+	cacheDir := filepath.Join(homeDir, ".gc", "cache", "repos", config.RepoCacheKey(source, commit))
+	if err := os.MkdirAll(filepath.Dir(cacheDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(repoDir, cacheDir); err != nil {
+		t.Fatal(err)
+	}
+
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "order-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "order-city"
+schema = 1
+
+[imports.ops]
+source = "https://github.com/example/orders-pack.git"
+version = "^1.2"
+`)
+	writeDoctorFile(t, cityDir, "packs.lock", fmt.Sprintf(`
+schema = 1
+
+[packs.%q]
+version = "1.2.3"
+commit = %q
+fetched = "2026-05-20T00:00:00Z"
+`, source, commit))
+
+	_, _, loadErr := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if loadErr == nil || !strings.Contains(loadErr.Error(), "unsupported PackV1 order path") {
+		t.Fatalf("LoadWithIncludes error = %v, want canonical legacy-order rejection", loadErr)
+	}
+
+	got := v2LegacyOrderLayoutCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error for remote imported legacy order; result=%+v", got.Status, got)
+	}
+	details := strings.Join(got.Details, "\n")
+	for _, want := range []string{
+		filepath.Join(cacheDir, "orders", "nightly", "order.toml"),
+		"gc doctor --fix only changes files under the city",
+	} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("details missing %q: %+v", want, got.Details)
+		}
+	}
+}
+
+func TestV2LegacyOrderLayoutFixMigratesRigPackReferencedOrders(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[rigs]]
+name = "frontend"
+includes = ["packs/rig-include"]
+
+[rigs.imports.rig-import]
+source = "packs/rig-import"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "packs/rig-include/pack.toml", `
+[pack]
+name = "rig-include"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "packs/rig-import/pack.toml", `
+[pack]
+name = "rig-import"
+schema = 2
+includes = ["../rig-nested"]
+`)
+	writeDoctorFile(t, cityDir, "packs/rig-nested/pack.toml", `
+[pack]
+name = "rig-nested"
+schema = 2
+`)
+	for _, rel := range []string{
+		"packs/rig-include/orders/include-order/order.toml",
+		"packs/rig-import/orders/import-order/order.toml",
+		"packs/rig-nested/orders/nested-order/order.toml",
+	} {
+		writeDoctorFile(t, cityDir, rel, `
+[order]
+trigger = "manual"
+`)
+	}
+
+	check := v2LegacyOrderLayoutCheck{}
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; result=%+v", got.Status, got)
+	}
+	for _, want := range []string{
+		"packs/rig-include/orders/include-order/order.toml",
+		"packs/rig-import/orders/import-order/order.toml",
+		"packs/rig-nested/orders/nested-order/order.toml",
+	} {
+		if !strings.Contains(strings.Join(got.Details, "\n"), want) {
+			t.Fatalf("details missing %q: %+v", want, got.Details)
+		}
+	}
+
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	for _, rel := range []string{
+		"packs/rig-include/orders/include-order.toml",
+		"packs/rig-import/orders/import-order.toml",
+		"packs/rig-nested/orders/nested-order.toml",
+	} {
+		if _, err := os.Stat(filepath.Join(cityDir, rel)); err != nil {
+			t.Fatalf("migrated %s stat: %v", rel, err)
+		}
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; result=%+v", got.Status, got)
+	}
+}
+
+func TestV2LegacyOrderLayoutFixLeavesExternalPackRefsForManualMigration(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cityDir := filepath.Join(root, "city")
+	absolutePackDir := filepath.Join(root, "shared-absolute")
+	parentPackDir := filepath.Join(root, "shared-parent")
+	writeDoctorFile(t, cityDir, "city.toml", fmt.Sprintf(`
+[workspace]
+name = "legacy-city"
+includes = ["../shared-parent"]
+
+[imports.absolute]
+source = %q
+`, absolutePackDir))
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "orders/local-order/order.toml", `
+[order]
+trigger = "manual"
+`)
+	for _, packDir := range []string{absolutePackDir, parentPackDir} {
+		writeDoctorFile(t, packDir, "pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+`)
+		writeDoctorFile(t, packDir, "orders/shared-order/order.toml", `
+[order]
+trigger = "manual"
+`)
+	}
+
+	check := v2LegacyOrderLayoutCheck{}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cityDir, "orders/local-order.toml")); err != nil {
+		t.Fatalf("city-local migrated order stat: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, "orders/local-order/order.toml")); !os.IsNotExist(err) {
+		t.Fatalf("city-local legacy order stat = %v, want removed", err)
+	}
+	for _, packDir := range []string{absolutePackDir, parentPackDir} {
+		if _, err := os.Stat(filepath.Join(packDir, "orders/shared-order/order.toml")); err != nil {
+			t.Fatalf("external legacy order was changed: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(packDir, "orders/shared-order.toml")); !os.IsNotExist(err) {
+			t.Fatalf("external flat order stat = %v, want absent", err)
+		}
+	}
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("post-fix status = %v, want error for external manual migration; result=%+v", got.Status, got)
+	}
+	details := strings.Join(got.Details, "\n")
+	for _, packDir := range []string{absolutePackDir, parentPackDir} {
+		if !strings.Contains(details, filepath.Join(packDir, "orders/shared-order/order.toml")) {
+			t.Fatalf("post-fix details missing external pack %s: %+v", packDir, got.Details)
+		}
+	}
+}
+
+func TestV2LegacyOrderLayoutFixLeavesExternalRigPackRefsForManualMigration(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cityDir := filepath.Join(root, "city")
+	includePackDir := filepath.Join(root, "shared-rig-include")
+	importPackDir := filepath.Join(root, "shared-rig-import")
+	writeDoctorFile(t, cityDir, "city.toml", fmt.Sprintf(`
+[workspace]
+name = "legacy-city"
+
+[[rigs]]
+name = "frontend"
+includes = ["../shared-rig-include"]
+
+[rigs.imports.shared]
+source = %q
+`, importPackDir))
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "orders/local-order/order.toml", `
+[order]
+trigger = "manual"
+`)
+	for _, packDir := range []string{includePackDir, importPackDir} {
+		writeDoctorFile(t, packDir, "pack.toml", `
+[pack]
+name = "shared"
+schema = 2
+`)
+		writeDoctorFile(t, packDir, "orders/shared-order/order.toml", `
+[order]
+trigger = "manual"
+`)
+	}
+
+	check := v2LegacyOrderLayoutCheck{}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(cityDir, "orders/local-order.toml")); err != nil {
+		t.Fatalf("city-local migrated order stat: %v", err)
+	}
+	for _, packDir := range []string{includePackDir, importPackDir} {
+		if _, err := os.Stat(filepath.Join(packDir, "orders/shared-order/order.toml")); err != nil {
+			t.Fatalf("external rig pack legacy order was changed: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(packDir, "orders/shared-order.toml")); !os.IsNotExist(err) {
+			t.Fatalf("external rig pack flat order stat = %v, want absent", err)
+		}
+	}
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("post-fix status = %v, want error for external manual migration; result=%+v", got.Status, got)
+	}
+	details := strings.Join(got.Details, "\n")
+	for _, packDir := range []string{includePackDir, importPackDir} {
+		if !strings.Contains(details, filepath.Join(packDir, "orders/shared-order/order.toml")) {
+			t.Fatalf("post-fix details missing external rig pack %s: %+v", packDir, got.Details)
+		}
+	}
+	if !strings.Contains(details, "gc doctor --fix only changes files under the city") {
+		t.Fatalf("post-fix details missing manual external-pack guidance: %+v", got.Details)
+	}
+}
+
+func TestV2LegacyOrderLayoutFixDeduplicatesRootPackSelfReference(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "legacy-city"
+schema = 2
+includes = ["."]
+`)
+	writeDoctorFile(t, cityDir, "orders/heartbeat/order.toml", `
+[order]
+trigger = "manual"
+`)
+
+	check := v2LegacyOrderLayoutCheck{}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, "orders/heartbeat.toml")); err != nil {
+		t.Fatalf("migrated order stat: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cityDir, "orders/heartbeat/order.toml")); !os.IsNotExist(err) {
+		t.Fatalf("legacy order stat = %v, want removed", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; result=%+v", got.Status, got)
+	}
+}
+
+func TestV2LegacyOrderLayoutFixRefusesTargetCollision(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", "[workspace]\nname = \"legacy-city\"\n")
+	writeDoctorFile(t, cityDir, "orders/heartbeat/order.toml", `
+[order]
+exec = "scripts/heartbeat.sh"
+trigger = "cooldown"
+interval = "5m"
+`)
+	writeDoctorFile(t, cityDir, "orders/heartbeat.toml", `
+[order]
+exec = "scripts/existing.sh"
+trigger = "manual"
+`)
+
+	err := (v2LegacyOrderLayoutCheck{}).Fix(&doctor.CheckContext{CityPath: cityDir})
+	if err == nil {
+		t.Fatal("Fix succeeded, want collision error")
+	}
+	if !strings.Contains(err.Error(), "target already exists") {
+		t.Fatalf("Fix error = %v, want target collision", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(cityDir, "orders/heartbeat/order.toml")); statErr != nil {
+		t.Fatalf("legacy source was changed despite collision: %v", statErr)
 	}
 }
 
@@ -339,6 +954,51 @@ path = "`+rigPath+`"
 	}
 }
 
+func TestV2DeprecationChecksFixLegacyRigPathRefusesOrphanSiteBinding(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	rigPath := filepath.Join(cityDir, "..", "frontend")
+	orphanPath := filepath.Join(cityDir, "..", "backend")
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "legacy-city"
+
+[[rigs]]
+name = "frontend"
+path = "`+rigPath+`"
+`)
+	writeDoctorFile(t, cityDir, ".gc/site.toml", `
+[[rig]]
+name = "backend"
+path = "`+orphanPath+`"
+`)
+
+	err := (v2RigPathSiteBindingCheck{}).Fix(&doctor.CheckContext{CityPath: cityDir})
+	if err == nil {
+		t.Fatal("Fix succeeded, want refusal for orphan site binding")
+	}
+	if !strings.Contains(err.Error(), "unknown rig names") || !strings.Contains(err.Error(), "backend") {
+		t.Fatalf("Fix error = %v, want orphan binding refusal", err)
+	}
+
+	rawData, readErr := os.ReadFile(filepath.Join(cityDir, "city.toml"))
+	if readErr != nil {
+		t.Fatalf("ReadFile(city.toml): %v", readErr)
+	}
+	if !strings.Contains(string(rawData), "path = ") {
+		t.Fatalf("city.toml should retain rig.path after refused migration:\n%s", rawData)
+	}
+
+	binding, err := config.LoadSiteBinding(fsys.OSFS{}, cityDir)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if len(binding.Rigs) != 1 || binding.Rigs[0].Name != "backend" || binding.Rigs[0].Path != orphanPath {
+		t.Fatalf("site binding should remain unchanged after refused migration; binding=%+v", binding.Rigs)
+	}
+}
+
 func TestV2DeprecationChecksWarnOnDeferredPackAgentFormat(t *testing.T) {
 	t.Parallel()
 
@@ -370,6 +1030,157 @@ name = "helper"
 	}
 	if !strings.Contains(out, "enforcement is deferred") {
 		t.Fatalf("doctor output missing deferral guidance:\n%s", out)
+	}
+}
+
+func TestExpandedConfigLoadCheckReportsSchema2FragmentErrors(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+include = ["fragments/legacy.toml"]
+
+[workspace]
+name = "fragment-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "fragment-city"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "fragments/legacy.toml", `
+[workspace]
+includes = ["legacy-pack"]
+`)
+
+	got := expandedConfigLoadCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; message=%q", got.Status, got.Message)
+	}
+	for _, want := range []string{
+		"expanded config load error",
+		"fragments/legacy.toml",
+		"unsupported PackV1 workspace.includes",
+	} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("message = %q, want substring %q", got.Message, want)
+		}
+	}
+}
+
+func TestExpandedConfigLoadCheckReportsImportedPackLegacyOrderPath(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+name = "order-city"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "order-city"
+schema = 2
+
+[imports.ops]
+source = "./packs/ops"
+`)
+	writeDoctorFile(t, cityDir, "packs/ops/pack.toml", `
+[pack]
+name = "ops"
+schema = 2
+`)
+	writeDoctorFile(t, cityDir, "packs/ops/orders/nightly/order.toml", `
+[order]
+formula = "nightly"
+trigger = "manual"
+`)
+
+	got := expandedConfigLoadCheck{}.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("status = %v, want error; message=%q", got.Status, got.Message)
+	}
+	for _, want := range []string{
+		"expanded config load error",
+		"unsupported PackV1 order path",
+		"packs/ops/orders/nightly/order.toml",
+	} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("message = %q, want substring %q", got.Message, want)
+		}
+	}
+}
+
+func TestV2PackSourcesCheckReportsAndFixesReferencedPacks(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+includes = ["legacy"]
+
+[packs.legacy]
+source = "../packs/legacy"
+
+[packs.unused]
+source = "../packs/unused"
+`)
+	writeDoctorFile(t, cityDir, "pack.toml", `
+[pack]
+name = "pack-source-city"
+schema = 2
+`)
+
+	check := v2PackSourcesCheck{}
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("pre-fix status = %v, want error", got.Status)
+	}
+	for _, want := range []string{
+		"city.toml:4: [packs.legacy]",
+		"city.toml:7: [packs.unused]",
+		"gc doctor --fix",
+		"manual",
+	} {
+		text := got.Message + "\n" + got.FixHint + "\n" + strings.Join(got.Details, "\n")
+		if !strings.Contains(text, want) {
+			t.Fatalf("check output missing %q:\n%+v", want, got)
+		}
+	}
+
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	after := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if after.Status != doctor.StatusError {
+		t.Fatalf("post-fix status = %v, want remaining error for unused pack", after.Status)
+	}
+	joined := strings.Join(after.Details, "\n")
+	if strings.Contains(joined, "[packs.legacy]") {
+		t.Fatalf("referenced pack should be removed after fix; details=%v", after.Details)
+	}
+	if !strings.Contains(joined, "[packs.unused]") {
+		t.Fatalf("unused pack should remain for manual cleanup; details=%v", after.Details)
+	}
+}
+
+func TestV2PackSourcesCheckFixClearsReferencedPacks(t *testing.T) {
+	t.Parallel()
+
+	cityDir := t.TempDir()
+	writeDoctorFile(t, cityDir, "city.toml", `
+[workspace]
+includes = ["legacy"]
+
+[packs.legacy]
+source = "../packs/legacy"
+`)
+
+	check := v2PackSourcesCheck{}
+	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusOK {
+		t.Fatalf("post-fix status = %v want OK; message=%q details=%v", got.Status, got.Message, got.Details)
 	}
 }
 

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -621,8 +621,12 @@ includes = ["../packs/gastown"]
 	if !check.CanFix() {
 		t.Fatal("v2ImportFormatCheck should advertise CanFix()=true")
 	}
-	if got := check.Run(&doctor.CheckContext{CityPath: cityDir}); got.Status != doctor.StatusWarning {
-		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
+	if got.Status != doctor.StatusError {
+		t.Fatalf("pre-fix status = %v, want error", got.Status)
+	}
+	if !strings.Contains(got.FixHint, "replace workspace.includes") {
+		t.Fatalf("FixHint = %q, want actionable workspace.includes guidance", got.FixHint)
 	}
 	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
 		t.Fatalf("Fix: %v", err)
@@ -650,11 +654,11 @@ default_rig_includes = ["../packs/default-rig"]
 		t.Fatal("v2DefaultRigImportFormatCheck should advertise CanFix()=true")
 	}
 	got := check.Run(&doctor.CheckContext{CityPath: cityDir})
-	if got.Status != doctor.StatusWarning {
-		t.Fatalf("pre-fix status = %v, want warning", got.Status)
+	if got.Status != doctor.StatusError {
+		t.Fatalf("pre-fix status = %v, want error", got.Status)
 	}
-	if !strings.Contains(got.FixHint, "gc doctor --fix") {
-		t.Fatalf("FixHint = %q, want gc doctor --fix hint", got.FixHint)
+	if !strings.Contains(got.FixHint, "move each entry") {
+		t.Fatalf("FixHint = %q, want actionable default rig import guidance", got.FixHint)
 	}
 	if err := check.Fix(&doctor.CheckContext{CityPath: cityDir}); err != nil {
 		t.Fatalf("Fix: %v", err)

--- a/cmd/gc/doctor_v2_checks_test.go
+++ b/cmd/gc/doctor_v2_checks_test.go
@@ -70,6 +70,16 @@ scope = "city"
 	if !strings.Contains(out, ".template.md") {
 		t.Fatalf("doctor output missing .template.md guidance:\n%s", out)
 	}
+	for _, want := range []string{
+		"city.toml:3: workspace.includes includes",
+		"city.toml:4: workspace.default_rig_includes includes",
+		"city.toml:6: city.toml [[agent]]",
+		"pack.toml:5: pack.toml [[agent]]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("doctor output missing source coordinate %q:\n%s", want, out)
+		}
+	}
 }
 
 func TestV2ScriptsLayoutWarnsForSymlinkOnlyDir(t *testing.T) {
@@ -298,6 +308,9 @@ path = "`+rigPath+`"
 	if !strings.Contains(out, ".gc/site.toml") {
 		t.Fatalf("doctor output missing site binding guidance:\n%s", out)
 	}
+	if !strings.Contains(out, "city.toml:6: rig \"frontend\" path") {
+		t.Fatalf("doctor output missing rig path source coordinate:\n%s", out)
+	}
 
 	buf.Reset()
 	d.Run(&doctor.CheckContext{CityPath: cityDir, Verbose: true}, &buf, true)
@@ -412,6 +425,14 @@ prefix = "lc"
 	}
 	if !strings.Contains(out, ".gc/site.toml") {
 		t.Fatalf("doctor output missing site binding guidance:\n%s", out)
+	}
+	for _, want := range []string{
+		"city.toml:2: workspace.name=legacy-city",
+		"city.toml:3: workspace.prefix=lc",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("doctor output missing source coordinate %q:\n%s", want, out)
+		}
 	}
 
 	buf.Reset()

--- a/cmd/gc/doctor_warmup_eligible.go
+++ b/cmd/gc/doctor_warmup_eligible.go
@@ -50,6 +50,10 @@ func (v2ImportFormatCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the
 // `gc start` warm-up scan.
+func (v2PackSourcesCheck) WarmupEligible() bool { return false }
+
+// WarmupEligible returns false; this check is not part of the
+// `gc start` warm-up scan.
 func (v2PromptTemplateSuffixCheck) WarmupEligible() bool { return false }
 
 // WarmupEligible returns false; this check is not part of the

--- a/cmd/gc/embed_builtin_packs_test.go
+++ b/cmd/gc/embed_builtin_packs_test.go
@@ -754,14 +754,14 @@ func TestLoadCityConfigMaterializesBuiltinPacks(t *testing.T) {
 	}
 }
 
-func TestLoadCityConfigSuppressDeprecatedOrderWarningsMaterializesBuiltinPacks(t *testing.T) {
+func TestLoadCityConfigForRegistryMaterializesBuiltinPacks(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := loadCityConfigSuppressDeprecatedOrderWarnings(dir); err != nil {
-		t.Fatalf("loadCityConfigSuppressDeprecatedOrderWarnings() error: %v", err)
+	if _, err := loadCityConfig(dir, io.Discard); err != nil {
+		t.Fatalf("loadCityConfig() error: %v", err)
 	}
 
 	for _, path := range []string{
@@ -906,7 +906,7 @@ func TestLoadCityConfigDeduplicatesBuiltinPackRefreshWarningsPerProcess(t *testi
 	}
 }
 
-func TestLoadCityConfigSuppressDeprecatedOrderWarningsDoesNotSuppressBuiltinPackRefreshWarnings(t *testing.T) {
+func TestLoadCityConfigForRegistryDoesNotSuppressBuiltinPackRefreshWarnings(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeBuiltinPackLoadTestCity(dir); err != nil {
 		t.Fatal(err)
@@ -934,8 +934,8 @@ func TestLoadCityConfigSuppressDeprecatedOrderWarningsDoesNotSuppressBuiltinPack
 		loadCityConfigDefaultWarningWriter = origDefaultWarningWriter
 	})
 
-	if _, err := loadCityConfigSuppressDeprecatedOrderWarnings(dir); err != nil {
-		t.Fatalf("loadCityConfigSuppressDeprecatedOrderWarnings() fallback error: %v", err)
+	if _, err := loadCityConfig(dir); err != nil {
+		t.Fatalf("loadCityConfig() fallback error: %v", err)
 	}
 	if !strings.Contains(stderr.String(), "builtin pack refresh incomplete") {
 		t.Fatalf("expected builtin pack refresh warning, got %q", stderr.String())

--- a/cmd/gc/init_identity_failure_test.go
+++ b/cmd/gc/init_identity_failure_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,27 @@ import (
 	"github.com/gastownhall/gascity/internal/config"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
+
+type recordingFS struct {
+	fsys.OSFS
+	Calls            []fsys.Call
+	failRenameTarget string
+	failedRename     bool
+}
+
+func (f *recordingFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	f.Calls = append(f.Calls, fsys.Call{Method: "WriteFile", Path: name})
+	return f.OSFS.WriteFile(name, data, perm)
+}
+
+func (f *recordingFS) Rename(oldpath, newpath string) error {
+	f.Calls = append(f.Calls, fsys.Call{Method: "Rename", Path: oldpath})
+	if !f.failedRename && f.failRenameTarget != "" && filepath.Clean(newpath) == filepath.Clean(f.failRenameTarget) {
+		f.failedRename = true
+		return errors.New("injected site binding failure")
+	}
+	return f.OSFS.Rename(oldpath, newpath)
+}
 
 type failSiteBindingRenameFS struct {
 	fsys.OSFS
@@ -122,5 +144,268 @@ func TestDoInitFromDirRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testing
 	}
 	if got := config.EffectiveHQPrefix(cfg); got != "dc" {
 		t.Fatalf("EffectiveHQPrefix() = %q, want %q", got, "dc")
+	}
+}
+
+func TestDoInitFromDirMigratesRigPathsToSiteBinding(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = "/srv/frontend"
+`)
+	fs.Files["/city/pack.toml"] = []byte("[pack]\nname = \"declared-city\"\nschema = 2\n")
+
+	cfg, _, _, persistSiteIdentity, err := rewriteCopiedInitFromIdentity(fs, "/city", "")
+	if err != nil {
+		t.Fatalf("rewriteCopiedInitFromIdentity: %v", err)
+	}
+	if !persistSiteIdentity {
+		t.Fatal("persistSiteIdentity = false, want true for copied pack city")
+	}
+
+	cityData := fs.Files["/city/city.toml"]
+	if strings.Contains(string(cityData), "path =") {
+		t.Fatalf("target city.toml still contains rig path:\n%s", cityData)
+	}
+	if len(cfg.Rigs) != 1 || cfg.Rigs[0].Path != "" {
+		t.Fatalf("rewritten cfg rigs = %#v, want path stripped", cfg.Rigs)
+	}
+
+	siteData := fs.Files["/city/.gc/site.toml"]
+	if !strings.Contains(string(siteData), `name = "frontend"`) || !strings.Contains(string(siteData), `path = "/srv/frontend"`) {
+		t.Fatalf("site.toml missing rig binding:\n%s", siteData)
+	}
+
+	loaded, _, err := config.LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes target city: %v", err)
+	}
+	if len(loaded.Rigs) != 1 || loaded.Rigs[0].Path != "/srv/frontend" {
+		t.Fatalf("loaded rigs = %#v, want frontend path from site binding", loaded.Rigs)
+	}
+}
+
+func TestDoInitFromFileWritesCityBeforeRigSiteBindings(t *testing.T) {
+	srcDir := t.TempDir()
+	rigPath := filepath.Join(srcDir, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcToml := filepath.Join(srcDir, "source.toml")
+	if err := os.WriteFile(srcToml, []byte(fmt.Sprintf(`[workspace]
+name = "declared-city"
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = %q
+`, rigPath)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	fs := &recordingFS{failRenameTarget: filepath.Join(cityPath, ".gc", "site.toml")}
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fs, srcToml, cityPath, "", &stdout, &stderr, true, false)
+	if code == 0 {
+		t.Fatal("cmdInitFromTOMLFileWithOptions = 0, want injected site binding failure")
+	}
+	if !strings.Contains(stderr.String(), "injected site binding failure") {
+		t.Fatalf("stderr = %q, want injected site binding failure", stderr.String())
+	}
+
+	cityWrite := firstCallIndex(fs.Calls, isCityConfigWriteCallFor(cityPath))
+	siteWrite := firstCallIndex(fs.Calls, isSiteBindingWriteCallFor(cityPath))
+	if cityWrite < 0 || siteWrite < 0 {
+		t.Fatalf("calls missing city or site write: %+v", fs.Calls)
+	}
+	if cityWrite > siteWrite {
+		t.Fatalf("write order = %+v, want city.toml before .gc/site.toml", fs.Calls)
+	}
+}
+
+func TestDoInitFromFileRestoresCityWhenRigSiteBindingWriteFails(t *testing.T) {
+	srcDir := t.TempDir()
+	rigPath := filepath.Join(srcDir, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcToml := filepath.Join(srcDir, "source.toml")
+	if err := os.WriteFile(srcToml, []byte(fmt.Sprintf(`[workspace]
+name = "declared-city"
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = %q
+`, rigPath)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	fs := &recordingFS{failRenameTarget: filepath.Join(cityPath, ".gc", "site.toml")}
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fs, srcToml, cityPath, "", &stdout, &stderr, true, false)
+	if code == 0 {
+		t.Fatal("cmdInitFromTOMLFileWithOptions = 0, want injected site binding failure")
+	}
+	for _, want := range []string{"injected site binding failure", "restored"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+	cityToml := filepath.Join(cityPath, "city.toml")
+	cityBytes, err := os.ReadFile(cityToml)
+	if err == nil && !strings.Contains(string(cityBytes), fmt.Sprintf("path = %q", rigPath)) {
+		t.Fatalf("city.toml = %q, want restored rig path or no city.toml", cityBytes)
+	}
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read city.toml after rollback: %v", err)
+	}
+}
+
+func TestDoInitFromFileMigratesRigPathsToSiteBinding(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+
+	srcDir := t.TempDir()
+	srcToml := filepath.Join(t.TempDir(), "source.toml")
+	rigPath := filepath.Join(srcDir, "frontend")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcToml, []byte(fmt.Sprintf(`[workspace]
+name = "declared-city"
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = %q
+`, rigPath)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cityPath := filepath.Join(t.TempDir(), "city")
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, srcToml, cityPath, "", &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want success; stderr=%s", code, stderr.String())
+	}
+
+	cityData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("read city.toml: %v", err)
+	}
+	if strings.Contains(string(cityData), "path =") {
+		t.Fatalf("target city.toml still contains rig path:\n%s", cityData)
+	}
+	siteData, err := os.ReadFile(filepath.Join(cityPath, ".gc", "site.toml"))
+	if err != nil {
+		t.Fatalf("read site.toml: %v", err)
+	}
+	if !strings.Contains(string(siteData), `name = "frontend"`) || !strings.Contains(string(siteData), fmt.Sprintf("path = %q", rigPath)) {
+		t.Fatalf("site.toml missing rig binding:\n%s", siteData)
+	}
+	loaded, _, err := config.LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("LoadWithIncludes target city: %v", err)
+	}
+	if len(loaded.Rigs) != 1 || loaded.Rigs[0].Path != rigPath {
+		t.Fatalf("loaded rigs = %#v, want frontend path from site binding", loaded.Rigs)
+	}
+}
+
+func TestDoInitFromDirWritesCityBeforeRigSiteBindings(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = "/srv/frontend"
+`)
+	fs.Files["/city/pack.toml"] = []byte("[pack]\nname = \"declared-city\"\nschema = 2\n")
+
+	if _, _, _, _, err := rewriteCopiedInitFromIdentity(fs, "/city", ""); err != nil {
+		t.Fatalf("rewriteCopiedInitFromIdentity: %v", err)
+	}
+
+	cityWrite := firstCallIndex(fs.Calls, isCityConfigWriteCallFor("/city"))
+	siteWrite := firstCallIndex(fs.Calls, isSiteBindingWriteCallFor("/city"))
+	if cityWrite < 0 || siteWrite < 0 {
+		t.Fatalf("calls missing city or site write: %+v", fs.Calls)
+	}
+	if cityWrite > siteWrite {
+		t.Fatalf("write order = %+v, want city.toml before .gc/site.toml", fs.Calls)
+	}
+}
+
+func TestRewriteCopiedInitFromIdentityRestoresRigPathsWhenSiteBindingFails(t *testing.T) {
+	cityPath := filepath.Join(t.TempDir(), "city")
+	fs := &recordingFS{failRenameTarget: filepath.Join(cityPath, ".gc", "site.toml")}
+	if err := fs.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(`[workspace]
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = "/srv/frontend"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte("[pack]\nname = \"declared-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, _, err := rewriteCopiedInitFromIdentity(fs, cityPath, "")
+	if err == nil {
+		t.Fatal("rewriteCopiedInitFromIdentity succeeded, want injected site binding failure")
+	}
+	for _, want := range []string{"injected site binding failure", "restored"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want %q", err, want)
+		}
+	}
+	cityBytes, readErr := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if readErr != nil {
+		t.Fatalf("read city.toml: %v", readErr)
+	}
+	cityData := string(cityBytes)
+	if !strings.Contains(cityData, `path = "/srv/frontend"`) {
+		t.Fatalf("city.toml = %q, want restored legacy rig path", cityData)
+	}
+}
+
+func firstCallIndex(calls []fsys.Call, match func(fsys.Call) bool) int {
+	for i, call := range calls {
+		if match(call) {
+			return i
+		}
+	}
+	return -1
+}
+
+func isSiteBindingWriteCallFor(cityPath string) func(fsys.Call) bool {
+	siteTempPrefix := filepath.Join(cityPath, ".gc", "site.toml.")
+	return func(call fsys.Call) bool {
+		if call.Method != "WriteFile" {
+			return false
+		}
+		return strings.HasPrefix(call.Path, siteTempPrefix)
+	}
+}
+
+func isCityConfigWriteCallFor(cityPath string) func(fsys.Call) bool {
+	cityTempPrefix := filepath.Join(cityPath, "city.toml.")
+	cityPath = filepath.Join(cityPath, "city.toml")
+	return func(call fsys.Call) bool {
+		if call.Method != "WriteFile" {
+			return false
+		}
+		return call.Path == cityPath || strings.HasPrefix(call.Path, cityTempPrefix)
 	}
 }

--- a/cmd/gc/init_identity_failure_test.go
+++ b/cmd/gc/init_identity_failure_test.go
@@ -93,12 +93,7 @@ func TestDoInitFromFileRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testin
 
 func TestDoInitFromDirRestoresLegacyIdentityWhenSiteBindingWriteFails(t *testing.T) {
 	srcDir := t.TempDir()
-	srcCfg := config.DefaultCity("declared-city")
-	srcCfg.Workspace.Prefix = "dc"
-	srcData, err := srcCfg.Marshal()
-	if err != nil {
-		t.Fatalf("marshal source config: %v", err)
-	}
+	srcData := []byte("[workspace]\nname = \"declared-city\"\nprefix = \"dc\"\n")
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"), srcData, 0o644); err != nil {
 		t.Fatalf("write source city.toml: %v", err)
 	}

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -892,6 +892,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
 	configureIsolatedRuntimeEnv(t)
+	stubInitHardDependenciesReady(t)
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer
@@ -1422,6 +1423,7 @@ func TestInitRunDoltConfigGetTreatsSilentEmptyExitAsMissingKey(t *testing.T) {
 func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip(t *testing.T) {
 	t.Setenv("GC_BEADS", "bd")
 	configureIsolatedRuntimeEnv(t)
+	stubInitDependencyChecks(t)
 	stubInitDoltAuthorIdentity(t, map[string]string{
 		"user.name":  "gc-test",
 		"user.email": "gc-test@test.local",
@@ -1475,6 +1477,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip
 func TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock(t *testing.T) {
 	configureIsolatedRuntimeEnv(t)
 	t.Setenv("GC_DOLT", "")
+	stubInitDependencyChecks(t)
 	stubInitDoltAuthorIdentity(t, map[string]string{
 		"user.name":  "gc-test",
 		"user.email": "gc-test@test.local",

--- a/cmd/gc/init_provider_readiness_test.go
+++ b/cmd/gc/init_provider_readiness_test.go
@@ -892,7 +892,7 @@ func TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock(t *testing
 	t.Setenv("GC_BEADS", "bd")
 	t.Setenv("GC_DOLT", "skip")
 	configureIsolatedRuntimeEnv(t)
-	stubInitHardDependenciesReady(t)
+	stubInitDependencyChecks(t)
 
 	cityPath := filepath.Join(t.TempDir(), "bright-lights")
 	var initStdout, initStderr bytes.Buffer

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -730,7 +730,7 @@ func lookupRigFromLocalCity(nameOrPath string) (resolvedContext, bool, error) {
 }
 
 func localCityRigBindings(cityPath string) ([]registeredRigBinding, error) {
-	cfg, err := loadCityConfigSuppressDeprecatedOrderWarnings(cityPath, io.Discard)
+	cfg, err := loadCityConfig(cityPath, io.Discard)
 	if err != nil {
 		if _, ok := missingRootCityTOML(err, cityPath); ok {
 			return nil, nil
@@ -899,7 +899,7 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 	var matched []registeredRigBinding
 	var loadErrors []string
 	for _, c := range cities {
-		cfg, err := loadCityConfigSuppressDeprecatedOrderWarnings(c.Path, io.Discard)
+		cfg, err := loadCityConfig(c.Path, io.Discard)
 		if err != nil {
 			// Tolerate stale registry entries whose city.toml has been
 			// deleted out from under the registry, but keep missing includes
@@ -908,12 +908,12 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 				stale = append(stale, staleRegisteredCity{Label: registeredCityLabel(c), Path: cityTOML})
 				continue
 			}
-			loadErrors = append(loadErrors, fmt.Sprintf("%s: %v", registeredCityLabel(c), err))
+			loadErrors = append(loadErrors, registeredCityLoadError(c, err))
 			continue
 		}
 		siteBinding, err := config.LoadSiteBinding(fsys.OSFS{}, c.Path)
 		if err != nil {
-			loadErrors = append(loadErrors, fmt.Sprintf("%s: %v", registeredCityLabel(c), err))
+			loadErrors = append(loadErrors, registeredCityLoadError(c, err))
 			continue
 		}
 		for _, binding := range siteBoundRigBindings(c, cfg, siteBinding) {
@@ -929,6 +929,17 @@ func registeredRigBindings(failOnLoadError bool, match func(registeredRigBinding
 		return matched, stale, nil, fmt.Errorf("loading registered city rig bindings: %s", strings.Join(loadErrors, "; "))
 	}
 	return matched, stale, nil, nil
+}
+
+func registeredCityLoadError(city supervisor.CityEntry, err error) string {
+	label := registeredCityLabel(city)
+	base := fmt.Sprintf("%s: %v", label, err)
+	if strings.Contains(err.Error(), "unsupported PackV1 order path") {
+		return base + fmt.Sprintf(
+			" (registered city %q still has a legacy order layout; run `gc --city %s doctor` for migration diagnostics, then rename legacy orders to flat orders/<name>.toml)",
+			label, label)
+	}
+	return base
 }
 
 func missingRootCityTOML(err error, cityPath string) (string, bool) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3870,6 +3870,75 @@ func TestCmdInitFromTOMLFilePreservesExistingFiles(t *testing.T) {
 	}
 }
 
+func TestCmdInitFromTOMLFilePreserveExistingLeavesRigSiteBindings(t *testing.T) {
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city")
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	preExistingPack := []byte("[pack]\nname = \"user-authored\"\nschema = 2\n")
+	preExistingCity := []byte(`[workspace]
+provider = "claude"
+
+[[rigs]]
+name = "backend"
+`)
+	preExistingSite := []byte(`[[rig]]
+name = "backend"
+path = "/existing/backend"
+`)
+	for _, f := range []struct {
+		path string
+		data []byte
+	}{
+		{filepath.Join(cityPath, "pack.toml"), preExistingPack},
+		{filepath.Join(cityPath, "city.toml"), preExistingCity},
+		{filepath.Join(cityPath, ".gc", "site.toml"), preExistingSite},
+	} {
+		if err := os.WriteFile(f.path, f.data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	src := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(src,
+		[]byte(`[workspace]
+name = "from-template"
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = "/template/frontend"
+`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, true)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	site, err := config.LoadSiteBinding(fsys.OSFS{}, cityPath)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if len(site.Rigs) != 1 || site.Rigs[0].Name != "backend" || site.Rigs[0].Path != "/existing/backend" {
+		t.Fatalf("site rig bindings = %#v, want preserved backend binding", site.Rigs)
+	}
+	siteData, err := os.ReadFile(filepath.Join(cityPath, ".gc", "site.toml"))
+	if err != nil {
+		t.Fatalf("reading site.toml: %v", err)
+	}
+	if strings.Contains(string(siteData), "/template/frontend") || strings.Contains(string(siteData), "frontend") {
+		t.Fatalf("site.toml picked up template rig binding:\n%s", siteData)
+	}
+}
+
 func TestCmdInitFromTOMLFilePreserveExistingBlockedByScaffold(t *testing.T) {
 	f := fsys.NewFake()
 	cityPath := "/city"
@@ -6849,41 +6918,21 @@ func TestCurrentRigContextUsesWorkingDirThroughSymlinkAlias(t *testing.T) {
 	}
 }
 
-// --- doAgentAdd with --dir and --suspended ---
+// --- doAgentAdd with schema-2 city-scoped scaffold metadata ---
 
-func TestDoAgentAddWithDir(t *testing.T) {
+func TestDoAgentAddWithDirRejectsSchema2ConventionAgent(t *testing.T) {
 	f := v2CityWithPack(t)
 
 	var stdout, stderr bytes.Buffer
 	code := doAgentAdd(f, "/city", "builder", "", "hello-world", false, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("doAgentAdd = %d, want 0; stderr: %s", code, stderr.String())
+	if code != 1 {
+		t.Fatalf("doAgentAdd = %d, want 1; stdout: %s stderr: %s", code, stdout.String(), stderr.String())
 	}
-
-	agentToml, ok := f.Files[filepath.Join("/city", "agents", "builder", "agent.toml")]
-	if !ok {
-		t.Fatal("agents/builder/agent.toml missing")
+	if !strings.Contains(stderr.String(), "schema-2 convention agents are city-scoped") {
+		t.Fatalf("stderr = %q, want schema-2 city-scoped validation message", stderr.String())
 	}
-	if !strings.Contains(string(agentToml), "dir = \"hello-world\"") {
-		t.Errorf("agent.toml = %q, want dir", agentToml)
-	}
-	got, err := loadCityConfigFS(f, filepath.Join("/city", "city.toml"))
-	if err != nil {
-		t.Fatalf("loadCityConfigFS: %v", err)
-	}
-	explicit := explicitAgents(got.Agents)
-	found := false
-	for _, a := range explicit {
-		if a.Name != "builder" {
-			continue
-		}
-		found = true
-		if a.Dir != "hello-world" {
-			t.Errorf("Agents[builder].Dir = %q, want %q", a.Dir, "hello-world")
-		}
-	}
-	if !found {
-		t.Fatalf("explicit agents = %#v, want builder", explicit)
+	if _, ok := f.Files[filepath.Join("/city", "agents", "builder", "agent.toml")]; ok {
+		t.Fatal("agents/builder/agent.toml was created for rejected input")
 	}
 }
 
@@ -6891,7 +6940,7 @@ func TestDoAgentAddWithSuspended(t *testing.T) {
 	f := v2CityWithPack(t)
 
 	var stdout, stderr bytes.Buffer
-	code := doAgentAdd(f, "/city", "builder", "", "hello-world", true, &stdout, &stderr)
+	code := doAgentAdd(f, "/city", "builder", "", "", true, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("doAgentAdd = %d, want 0; stderr: %s", code, stderr.String())
 	}
@@ -6917,8 +6966,8 @@ func TestDoAgentAddWithSuspended(t *testing.T) {
 		if !a.Suspended {
 			t.Error("Agents[builder].Suspended = false, want true")
 		}
-		if a.Dir != "hello-world" {
-			t.Errorf("Agents[builder].Dir = %q, want %q", a.Dir, "hello-world")
+		if a.Dir != "" {
+			t.Errorf("Agents[builder].Dir = %q, want empty", a.Dir)
 		}
 	}
 	if !found {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -3685,6 +3685,58 @@ scale_check = "echo 3"
 	}
 }
 
+func TestCmdInitFromTOMLFileMovesRigPathsToSiteBinding(t *testing.T) {
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("GC_DOLT", "skip")
+	configureIsolatedRuntimeEnv(t)
+
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "bright-lights")
+	if err := os.MkdirAll(cityPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	src := filepath.Join(dir, "my-config.toml")
+	tomlContent := []byte(`[workspace]
+name = "placeholder"
+
+[[rigs]]
+name = "frontend"
+path = "./frontend"
+`)
+	if err := os.WriteFile(src, tomlContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := cmdInitFromTOMLFileWithOptions(fsys.OSFS{}, src, cityPath, "", &stdout, &stderr, true, false)
+	if code != 0 {
+		t.Fatalf("cmdInitFromTOMLFileWithOptions = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	cityData, err := os.ReadFile(filepath.Join(cityPath, "city.toml"))
+	if err != nil {
+		t.Fatalf("reading city.toml: %v", err)
+	}
+	if strings.Contains(string(cityData), "path =") {
+		t.Fatalf("city.toml retained rig path:\n%s", cityData)
+	}
+
+	siteData, err := os.ReadFile(filepath.Join(cityPath, ".gc", "site.toml"))
+	if err != nil {
+		t.Fatalf("reading .gc/site.toml: %v", err)
+	}
+	for _, want := range []string{`workspace_name = "bright-lights"`, `name = "frontend"`, `path = "./frontend"`} {
+		if !strings.Contains(string(siteData), want) {
+			t.Fatalf(".gc/site.toml missing %q:\n%s", want, siteData)
+		}
+	}
+
+	if _, err := loadCityConfigFS(fsys.OSFS{}, filepath.Join(cityPath, "city.toml")); err != nil {
+		t.Fatalf("loading initialized config: %v", err)
+	}
+}
+
 func TestCmdInitFromTOMLFileNotFound(t *testing.T) {
 	f := fsys.NewFake()
 	var stderr bytes.Buffer

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -719,7 +719,7 @@ func TestResolveCityFlag(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(cityDir, "city.toml"),
-			[]byte("[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"), 0o644); err != nil {
+			[]byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.MkdirAll(filepath.Join(workDir, ".gc"), 0o755); err != nil {
@@ -910,7 +910,7 @@ func TestDoRigAddCreatesDirIfMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"),
-		[]byte("[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -974,7 +974,7 @@ func TestDoRigAddWithGit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"),
-		[]byte("[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1004,7 +1004,7 @@ func TestDoRigAddWithoutGit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(cityPath, "city.toml"),
-		[]byte("[workspace]\nname = \"test\"\n\n[[agent]]\nname = \"mayor\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1040,7 +1040,8 @@ func TestDoRigListConfigLoadFails(t *testing.T) {
 
 func TestDoRigListSuccess(t *testing.T) {
 	f := fsys.NewFake()
-	f.Files["/city/city.toml"] = []byte("[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"alpha\"\npath = \"/projects/alpha\"\n\n[[rigs]]\nname = \"beta\"\npath = \"/projects/beta\"\n")
+	f.Files["/city/city.toml"] = []byte("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"alpha\"\n\n[[rigs]]\nname = \"beta\"\n")
+	f.Files["/city/.gc/site.toml"] = []byte("[[rig]]\nname = \"alpha\"\npath = \"/projects/alpha\"\n\n[[rig]]\nname = \"beta\"\npath = \"/projects/beta\"\n")
 
 	var stdout, stderr bytes.Buffer
 	code := doRigList(f, "/city", false, &stdout, &stderr)
@@ -1058,7 +1059,8 @@ func TestDoRigListSuccess(t *testing.T) {
 
 func TestDoRigListJSON(t *testing.T) {
 	f := fsys.NewFake()
-	f.Files["/city/city.toml"] = []byte("[workspace]\nname = \"test-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"alpha\"\npath = \"/projects/alpha\"\n")
+	f.Files["/city/city.toml"] = []byte("[workspace]\nname = \"test-city\"\n\n[[rigs]]\nname = \"alpha\"\n")
+	f.Files["/city/.gc/site.toml"] = []byte("[[rig]]\nname = \"alpha\"\npath = \"/projects/alpha\"\n")
 
 	var stdout, stderr bytes.Buffer
 	code := doRigList(f, "/city", true, &stdout, &stderr)
@@ -4087,11 +4089,11 @@ func TestDoInitFromDirMaterializesPackOverlayClaudeSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\nincludes = [\"packs/demo\"]\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
-		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
+		[]byte("[pack]\nname = \"template\"\nschema = 2\n\n[imports.demo]\nsource = \"packs/demo\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "packs", "demo", "pack.toml"),
@@ -4176,18 +4178,22 @@ func TestInitNameFlagWithFrom(t *testing.T) {
 
 	// Create source template directory.
 	srcDir := filepath.Join(dir, "template")
-	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(srcDir, "agents", "mayor"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
 		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "agents", "mayor", "agent.toml"),
+		[]byte("prompt_template = \"agents/mayor/prompt.template.md\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "agents", "mayor", "prompt.template.md"), []byte("prompt"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -4302,18 +4308,22 @@ func TestInitFromDefaultsToTargetDirBasename(t *testing.T) {
 
 	// Source has workspace.name = "template" — should NOT propagate.
 	srcDir := filepath.Join(dir, "template")
-	if err := os.MkdirAll(filepath.Join(srcDir, "prompts"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(srcDir, "agents", "mayor"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "city.toml"),
-		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n\n[[agent]]\nname = \"mayor\"\nprompt_template = \"prompts/mayor.md\"\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"template\"\nprovider = \"claude\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "pack.toml"),
 		[]byte("[pack]\nname = \"template\"\nschema = 2\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "prompts", "mayor.md"), []byte("prompt"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "agents", "mayor", "agent.toml"),
+		[]byte("prompt_template = \"agents/mayor/prompt.template.md\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "agents", "mayor", "prompt.template.md"), []byte("prompt"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -5000,11 +5010,11 @@ func TestInitFromSkipForSource(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(v2IncludedPackShimDir, "city.toml"),
-		[]byte("[workspace]\nname = \"modern\"\nincludes = [\"packs/base\"]\n"), 0o644); err != nil {
+		[]byte("[workspace]\nname = \"modern\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(v2IncludedPackShimDir, "pack.toml"),
-		[]byte("[pack]\nname = \"modern\"\nschema = 2\n"), 0o644); err != nil {
+		[]byte("[pack]\nname = \"modern\"\nschema = 2\n\n[imports.base]\nsource = \"packs/base\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(v2IncludedPackShimDir, "packs", "base", "pack.toml"),

--- a/cmd/gc/management_json_test.go
+++ b/cmd/gc/management_json_test.go
@@ -208,6 +208,33 @@ func TestManagementJSONSuccessPayloadsValidateDeclaredSchemas(t *testing.T) {
 	}
 }
 
+func TestAgentManagementJSONMissingNameDoesNotPanic(t *testing.T) {
+	clearGCEnv(t)
+	cityPath := t.TempDir()
+	writeManagementJSONTestCity(t, cityPath, "[workspace]\nname = \"test-city\"\n")
+
+	for _, action := range []string{"suspend", "resume"} {
+		t.Run(action, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"--city", cityPath, "agent", action, "--json"}, &stdout, &stderr)
+			if code == 0 {
+				t.Fatalf("run agent %s --json without name = 0, want failure; stdout=%q", action, stdout.String())
+			}
+			payload := decodeOneJSONLine(t, &stdout)
+			if payload["ok"] != false {
+				t.Fatalf("payload ok = %#v, want false in JSON error payload", payload["ok"])
+			}
+			if _, ok := payload["error"].(map[string]any); !ok {
+				t.Fatalf("payload error = %#v, want structured error object", payload["error"])
+			}
+			want := "gc agent " + action + ": missing agent name"
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+			}
+		})
+	}
+}
+
 func TestAgentSuspendResumeJSONReportsResolvedIdentity(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/cmd/gc/order_dispatch.go
+++ b/cmd/gc/order_dispatch.go
@@ -25,14 +25,11 @@ import (
 	"github.com/gastownhall/gascity/internal/execenv"
 	"github.com/gastownhall/gascity/internal/formula"
 	"github.com/gastownhall/gascity/internal/fsys"
-	"github.com/gastownhall/gascity/internal/logutil"
 	"github.com/gastownhall/gascity/internal/molecule"
 	"github.com/gastownhall/gascity/internal/orderdiscovery"
 	"github.com/gastownhall/gascity/internal/orders"
 	"github.com/gastownhall/gascity/internal/processgroup"
 )
-
-var startDeprecatedOrderWarningDedup = logutil.NewDedup(logutil.DefaultDedupCapacity)
 
 const (
 	labelOrderTracking    = "order-tracking"
@@ -279,11 +276,7 @@ func buildOrderDispatcher(cityPath string, cfg *config.City, rec events.Recorder
 }
 
 func buildOrderDispatcherWithSnapshot(cityPath string, cfg *config.City, rec events.Recorder, stderr io.Writer, cmdName string) (orderDispatcher, orderSetSnapshot) {
-	snapshot, err := scanOrderSetSnapshotFSWithOptions(fsys.OSFS{}, cityPath, cfg, stderr, cmdName, orders.ScanOptions{
-		DeprecatedPathWarningDedup:    startDeprecatedOrderWarningDedup,
-		DeprecatedPathWarningWriter:   stderr,
-		VerboseDeprecatedPathWarnings: startVerboseMode,
-	})
+	snapshot, err := scanOrderSetSnapshotFS(fsys.OSFS{}, cityPath, cfg, stderr, cmdName)
 	if err != nil {
 		logDispatchError(stderr, "%s: %v", cmdName, err)
 		return nil, orderSetSnapshot{}
@@ -292,16 +285,11 @@ func buildOrderDispatcherWithSnapshot(cityPath string, cfg *config.City, rec eve
 }
 
 func scanOrderSetSnapshotFS(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer, cmdName string) (orderSetSnapshot, error) {
-	return scanOrderSetSnapshotFSWithOptions(fs, cityPath, cfg, stderr, cmdName, orders.ScanOptions{})
-}
-
-func scanOrderSetSnapshotFSWithOptions(fs fsys.FS, cityPath string, cfg *config.City, stderr io.Writer, cmdName string, opts orders.ScanOptions) (orderSetSnapshot, error) {
 	if cfg == nil {
 		cfg = &config.City{}
 	}
 	allAA, err := orderdiscovery.ScanAll(cityPath, cfg, orderdiscovery.ScanOptions{
-		FS:               fs,
-		OrderScanOptions: opts,
+		FS: fs,
 		OnRigScanError: func(rigName string, err error) error {
 			fmt.Fprintf(stderr, "%s: rig %s: %v\n", cmdName, rigName, err) //nolint:errcheck // best-effort stderr
 			return nil

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -1347,7 +1347,7 @@ func TestOrderDispatchExecDue(t *testing.T) {
 		Trigger:  "cooldown",
 		Interval: "2m",
 		Exec:     "$ORDER_DIR/scripts/poll.sh",
-		Source:   "/city/formulas/orders/wasteland-poll/order.toml",
+		Source:   "/city/orders/wasteland-poll.toml",
 	}}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, &rec)
 	if ad == nil {
@@ -1588,7 +1588,7 @@ func TestOrderDispatchReportsAllMissingRequiredVarsAtOnce(t *testing.T) {
 	var rec memRecorder
 
 	formulaDir := t.TempDir()
-	writeFile(t, filepath.Join(formulaDir, "order-required-vars.formula.toml"), `
+	writeFile(t, filepath.Join(formulaDir, "order-required-vars.toml"), `
 formula = "order-required-vars"
 version = 1
 
@@ -1909,7 +1909,7 @@ func TestOrderDispatchExecOrderDir(t *testing.T) {
 		Trigger:  "cooldown",
 		Interval: "1m",
 		Exec:     "$ORDER_DIR/scripts/poll.sh",
-		Source:   "/city/formulas/orders/poll/order.toml",
+		Source:   "/city/orders/poll.toml",
 	}}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 
@@ -1921,7 +1921,7 @@ func TestOrderDispatchExecOrderDir(t *testing.T) {
 	foundCityPath := false
 	foundRuntime := false
 	for _, e := range gotEnv {
-		if e == "ORDER_DIR=/city/formulas/orders/poll" {
+		if e == "ORDER_DIR=/city/orders" {
 			foundDir = true
 		}
 		if e == "GC_CITY=/city-root" {
@@ -1962,7 +1962,7 @@ func TestOrderDispatchExecPackDir(t *testing.T) {
 		Trigger:      "cooldown",
 		Interval:     "1m",
 		Exec:         "$PACK_DIR/scripts/gate-sweep.sh",
-		Source:       "/city/packs/maintenance/formulas/orders/gate-sweep/order.toml",
+		Source:       "/city/packs/maintenance/orders/gate-sweep.toml",
 		FormulaLayer: "/city/packs/maintenance/formulas",
 	}}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
@@ -1978,7 +1978,7 @@ func TestOrderDispatchExecPackDir(t *testing.T) {
 		if e == "PACK_DIR=/city/packs/maintenance" {
 			foundPackDir = true
 		}
-		if e == "ORDER_DIR=/city/packs/maintenance/formulas/orders/gate-sweep" {
+		if e == "ORDER_DIR=/city/packs/maintenance/orders" {
 			foundAutoDir = true
 		}
 		if e == "GC_PACK_NAME=maintenance" {
@@ -2051,7 +2051,7 @@ prefix = "ct"
 		Trigger:      "cooldown",
 		Interval:     "1m",
 		Exec:         "$PACK_DIR/scripts/gate-sweep.sh",
-		Source:       filepath.Join(cityDir, "packs", "maintenance", "formulas", "orders", "gate-sweep", "order.toml"),
+		Source:       filepath.Join(cityDir, "packs", "maintenance", "orders", "gate-sweep.toml"),
 		FormulaLayer: filepath.Join(cityDir, "packs", "maintenance", "formulas"),
 	}}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
@@ -2223,7 +2223,7 @@ func TestOrderDispatchExecPackDirEmpty(t *testing.T) {
 		Trigger:  "cooldown",
 		Interval: "1m",
 		Exec:     "scripts/test.sh",
-		Source:   "/city/formulas/orders/no-layer/order.toml",
+		Source:   "/city/orders/no-layer.toml",
 		// FormulaLayer intentionally empty.
 	}}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
@@ -2263,7 +2263,7 @@ func TestOrderDispatchExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
 		Trigger:  "cooldown",
 		Interval: "1m",
 		Exec:     "$ORDER_DIR/scripts/poll.sh",
-		Source:   "/city/formulas/orders/poll/order.toml",
+		Source:   "/city/orders/poll.toml",
 	}}
 	ad := buildOrderDispatcherFromListExec(aa, store, nil, fakeExec, nil)
 	mad := ad.(*memoryOrderDispatcher)
@@ -2291,7 +2291,7 @@ func TestOrderDispatchExecRigUsesScopedWorkdirAndStoreEnv(t *testing.T) {
 		"GC_BEADS_PREFIX": "fe",
 		"GC_RIG":          "frontend",
 		"GC_RIG_ROOT":     rigDir,
-		"ORDER_DIR":       "/city/formulas/orders/poll",
+		"ORDER_DIR":       "/city/orders",
 	}
 	for key, want := range checks {
 		entry := key + "=" + want
@@ -4296,12 +4296,15 @@ func orderDispatchTestEnv(t *testing.T, envCh <-chan []string) map[string]string
 func TestBuildOrderDispatcherWithRigs(t *testing.T) {
 	// Build a config with rig formula layers that include orders.
 	rigDir := t.TempDir()
+	rigLayer := filepath.Join(rigDir, "formulas")
 	// Create an order in the rig-exclusive layer.
-	orderDir := rigDir + "/orders/rig-health"
-	if err := mkdirAll(orderDir); err != nil {
-		t.Fatal(err)
+	orderDir := filepath.Join(rigDir, "orders")
+	for _, dir := range []string{rigLayer, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
 	}
-	writeFile(t, orderDir+"/order.toml", `[order]
+	writeFile(t, filepath.Join(orderDir, "rig-health.toml"), `[order]
 formula = "mol-rig-health"
 trigger = "cooldown"
 interval = "5m"
@@ -4312,7 +4315,7 @@ pool = "polecat"
 		FormulaLayers: config.FormulaLayers{
 			City: []string{"/nonexistent/city-layer"}, // no city orders
 			Rigs: map[string][]string{
-				"demo": {"/nonexistent/city-layer", rigDir},
+				"demo": {"/nonexistent/city-layer", rigLayer},
 			},
 		},
 	}
@@ -4542,21 +4545,23 @@ func TestBuildOrderDispatcherUsesProviderAwareFileStore(t *testing.T) {
 
 	cityDir := t.TempDir()
 	layerDir := filepath.Join(cityDir, "formulas")
-	orderDir := filepath.Join(layerDir, "orders", "file-order")
-	if err := mkdirAll(orderDir); err != nil {
-		t.Fatal(err)
+	orderDir := filepath.Join(cityDir, "orders")
+	for _, dir := range []string{layerDir, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
 	}
-	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+	writeFile(t, filepath.Join(orderDir, "file-order.toml"), `[order]
 formula = "test-formula"
 trigger = "cooldown"
 interval = "1m"
 pool = "worker"
 `)
-	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.toml"))
 	if err != nil {
 		t.Fatalf("ReadFile(test-formula): %v", err)
 	}
-	writeFile(t, filepath.Join(layerDir, "test-formula.formula.toml"), string(formulaText))
+	writeFile(t, filepath.Join(layerDir, "test-formula.toml"), string(formulaText))
 
 	cfg := &config.City{
 		FormulaLayers: config.FormulaLayers{
@@ -4591,23 +4596,23 @@ func TestBuildOrderDispatcherRigOrderUsesRigFileStore(t *testing.T) {
 	rigDir := filepath.Join(cityDir, "frontend")
 	cityLayer := filepath.Join(cityDir, "formulas")
 	rigLayer := filepath.Join(rigDir, "formulas")
-	orderDir := filepath.Join(rigDir, "orders", "rig-digest")
+	orderDir := filepath.Join(rigDir, "orders")
 	for _, dir := range []string{cityLayer, rigLayer, orderDir} {
 		if err := mkdirAll(dir); err != nil {
 			t.Fatal(err)
 		}
 	}
-	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+	writeFile(t, filepath.Join(orderDir, "rig-digest.toml"), `[order]
 formula = "test-formula"
 trigger = "cooldown"
 interval = "1m"
 pool = "worker"
 `)
-	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.toml"))
 	if err != nil {
 		t.Fatalf("ReadFile(test-formula): %v", err)
 	}
-	writeFile(t, filepath.Join(rigLayer, "test-formula.formula.toml"), string(formulaText))
+	writeFile(t, filepath.Join(rigLayer, "test-formula.toml"), string(formulaText))
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
 		t.Fatal(err)
 	}
@@ -4669,23 +4674,23 @@ func TestBuildOrderDispatcherRigOrderHonorsLegacyCityRunHistory(t *testing.T) {
 	rigDir := filepath.Join(cityDir, "frontend")
 	cityLayer := filepath.Join(cityDir, "formulas")
 	rigLayer := filepath.Join(rigDir, "formulas")
-	orderDir := filepath.Join(rigDir, "orders", "rig-digest")
+	orderDir := filepath.Join(rigDir, "orders")
 	for _, dir := range []string{cityLayer, rigLayer, orderDir} {
 		if err := mkdirAll(dir); err != nil {
 			t.Fatal(err)
 		}
 	}
-	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+	writeFile(t, filepath.Join(orderDir, "rig-digest.toml"), `[order]
 formula = "test-formula"
 trigger = "cooldown"
 interval = "24h"
 pool = "worker"
 `)
-	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.toml"))
 	if err != nil {
 		t.Fatalf("ReadFile(test-formula): %v", err)
 	}
-	writeFile(t, filepath.Join(rigLayer, "test-formula.formula.toml"), string(formulaText))
+	writeFile(t, filepath.Join(rigLayer, "test-formula.toml"), string(formulaText))
 	if err := ensureScopedFileStoreLayout(cityDir); err != nil {
 		t.Fatal(err)
 	}
@@ -4974,21 +4979,23 @@ func TestBuildOrderDispatcherReopensStoreForScopedFileReads(t *testing.T) {
 
 	cityDir := t.TempDir()
 	layerDir := filepath.Join(cityDir, "formulas")
-	orderDir := filepath.Join(layerDir, "orders", "file-order")
-	if err := mkdirAll(orderDir); err != nil {
-		t.Fatal(err)
+	orderDir := filepath.Join(cityDir, "orders")
+	for _, dir := range []string{layerDir, orderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
 	}
-	writeFile(t, filepath.Join(orderDir, "order.toml"), `[order]
+	writeFile(t, filepath.Join(orderDir, "file-order.toml"), `[order]
 formula = "test-formula"
 trigger = "cooldown"
 interval = "1m"
 pool = "worker"
 `)
-	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.toml"))
 	if err != nil {
 		t.Fatalf("ReadFile(test-formula): %v", err)
 	}
-	writeFile(t, filepath.Join(layerDir, "test-formula.formula.toml"), string(formulaText))
+	writeFile(t, filepath.Join(layerDir, "test-formula.toml"), string(formulaText))
 
 	cfg := &config.City{
 		FormulaLayers: config.FormulaLayers{
@@ -5031,24 +5038,31 @@ func TestBuildOrderDispatcherCityPackLayers(t *testing.T) {
 	// Simulate system formulas + pack formulas as two city layers.
 	sysDir := t.TempDir()
 	topoDir := t.TempDir()
+	sysLayer := filepath.Join(sysDir, "formulas")
+	topoLayer := filepath.Join(topoDir, "formulas")
+	for _, dir := range []string{sysLayer, topoLayer} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	// System dir: beads-health order.
-	sysAutoDir := sysDir + "/orders/beads-health"
-	if err := mkdirAll(sysAutoDir); err != nil {
+	sysOrderDir := filepath.Join(sysDir, "orders")
+	if err := mkdirAll(sysOrderDir); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, sysAutoDir+"/order.toml", `[order]
+	writeFile(t, filepath.Join(sysOrderDir, "beads-health.toml"), `[order]
 exec = "scripts/beads-health.sh"
 trigger = "cooldown"
 interval = "30s"
 `)
 
 	// Pack dir: wasteland-poll order.
-	topoAutoDir := topoDir + "/orders/wasteland-poll"
-	if err := mkdirAll(topoAutoDir); err != nil {
+	topoOrderDir := filepath.Join(topoDir, "orders")
+	if err := mkdirAll(topoOrderDir); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, topoAutoDir+"/order.toml", `[order]
+	writeFile(t, filepath.Join(topoOrderDir, "wasteland-poll.toml"), `[order]
 exec = "scripts/wasteland-poll.sh"
 trigger = "cooldown"
 interval = "2m"
@@ -5056,7 +5070,7 @@ interval = "2m"
 
 	cfg := &config.City{
 		FormulaLayers: config.FormulaLayers{
-			City: []string{sysDir, topoDir},
+			City: []string{sysLayer, topoLayer},
 		},
 	}
 
@@ -5087,22 +5101,29 @@ func TestBuildOrderDispatcherCityPackWithOverride(t *testing.T) {
 	// Same two-layer setup, plus a config override on wasteland-poll interval.
 	sysDir := t.TempDir()
 	topoDir := t.TempDir()
+	sysLayer := filepath.Join(sysDir, "formulas")
+	topoLayer := filepath.Join(topoDir, "formulas")
+	for _, dir := range []string{sysLayer, topoLayer} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-	sysAutoDir := sysDir + "/orders/beads-health"
-	if err := mkdirAll(sysAutoDir); err != nil {
+	sysOrderDir := filepath.Join(sysDir, "orders")
+	if err := mkdirAll(sysOrderDir); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, sysAutoDir+"/order.toml", `[order]
+	writeFile(t, filepath.Join(sysOrderDir, "beads-health.toml"), `[order]
 exec = "scripts/beads-health.sh"
 trigger = "cooldown"
 interval = "30s"
 `)
 
-	topoAutoDir := topoDir + "/orders/wasteland-poll"
-	if err := mkdirAll(topoAutoDir); err != nil {
+	topoOrderDir := filepath.Join(topoDir, "orders")
+	if err := mkdirAll(topoOrderDir); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, topoAutoDir+"/order.toml", `[order]
+	writeFile(t, filepath.Join(topoOrderDir, "wasteland-poll.toml"), `[order]
 exec = "scripts/wasteland-poll.sh"
 trigger = "cooldown"
 interval = "2m"
@@ -5111,7 +5132,7 @@ interval = "2m"
 	tenSec := "10s"
 	cfg := &config.City{
 		FormulaLayers: config.FormulaLayers{
-			City: []string{sysDir, topoDir},
+			City: []string{sysLayer, topoLayer},
 		},
 		Orders: config.OrdersConfig{
 			Overrides: []config.OrderOverride{
@@ -5217,12 +5238,14 @@ func TestBuildOrderDispatcherOverrideNotFoundNonFatal(t *testing.T) {
 	// Override targets wasteland-poll (nonexistent).
 	// Verify beads-health is still dispatched and stderr contains warning.
 	sysDir := t.TempDir()
-
-	sysAutoDir := sysDir + "/orders/beads-health"
-	if err := mkdirAll(sysAutoDir); err != nil {
-		t.Fatal(err)
+	sysLayer := filepath.Join(sysDir, "formulas")
+	sysOrderDir := filepath.Join(sysDir, "orders")
+	for _, dir := range []string{sysLayer, sysOrderDir} {
+		if err := mkdirAll(dir); err != nil {
+			t.Fatal(err)
+		}
 	}
-	writeFile(t, sysAutoDir+"/order.toml", `[order]
+	writeFile(t, filepath.Join(sysOrderDir, "beads-health.toml"), `[order]
 exec = "scripts/beads-health.sh"
 trigger = "cooldown"
 interval = "30s"
@@ -5231,7 +5254,7 @@ interval = "30s"
 	tenSec := "10s"
 	cfg := &config.City{
 		FormulaLayers: config.FormulaLayers{
-			City: []string{sysDir},
+			City: []string{sysLayer},
 		},
 		Orders: config.OrdersConfig{
 			Overrides: []config.OrderOverride{
@@ -5296,7 +5319,7 @@ scope = "city"
 	}
 	writeFile(t, filepath.Join(cityDir, "city.toml"), cityToml)
 
-	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.formula.toml"))
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "test-formula.toml"))
 	if err != nil {
 		t.Fatalf("ReadFile(test-formula): %v", err)
 	}
@@ -5334,7 +5357,7 @@ trigger = "cooldown"
 interval = "24h"
 pool = "dog"
 `)
-			writeFile(t, filepath.Join(packDir, "formulas", "test-formula.formula.toml"), string(formulaText))
+			writeFile(t, filepath.Join(packDir, "formulas", "test-formula.toml"), string(formulaText))
 		}
 		packToml.WriteString(`
 [imports.` + binding + `]

--- a/cmd/gc/order_dispatch_test.go
+++ b/cmd/gc/order_dispatch_test.go
@@ -5177,21 +5177,29 @@ func TestBuildOrderDispatcherOverrideDisablesDropsFromDispatcher(t *testing.T) {
 	sysDir := t.TempDir()
 	topoDir := t.TempDir()
 
-	sysAutoDir := sysDir + "/orders/beads-health"
-	if err := mkdirAll(sysAutoDir); err != nil {
+	sysFormulaDir := sysDir + "/formulas"
+	sysOrdersDir := sysDir + "/orders"
+	if err := mkdirAll(sysFormulaDir); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, sysAutoDir+"/order.toml", `[order]
+	if err := mkdirAll(sysOrdersDir); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, sysOrdersDir+"/beads-health.toml", `[order]
 exec = "scripts/beads-health.sh"
 trigger = "cooldown"
 interval = "30s"
 `)
 
-	topoAutoDir := topoDir + "/orders/wasteland-poll"
-	if err := mkdirAll(topoAutoDir); err != nil {
+	topoFormulaDir := topoDir + "/formulas"
+	topoOrdersDir := topoDir + "/orders"
+	if err := mkdirAll(topoFormulaDir); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, topoAutoDir+"/order.toml", `[order]
+	if err := mkdirAll(topoOrdersDir); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, topoOrdersDir+"/wasteland-poll.toml", `[order]
 exec = "scripts/wasteland-poll.sh"
 trigger = "cooldown"
 interval = "2m"
@@ -5200,7 +5208,7 @@ interval = "2m"
 	disabled := false
 	cfg := &config.City{
 		FormulaLayers: config.FormulaLayers{
-			City: []string{sysDir, topoDir},
+			City: []string{sysFormulaDir, topoFormulaDir},
 		},
 		Orders: config.OrdersConfig{
 			Overrides: []config.OrderOverride{

--- a/cmd/gc/pack_import_formula_order_test.go
+++ b/cmd/gc/pack_import_formula_order_test.go
@@ -118,6 +118,9 @@ func TestTransitiveGastownPackDigestOrderResolvesAndRuns(t *testing.T) {
 	if err := os.MkdirAll(wrapperPackDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	gastownRoot, err := filepath.Abs(filepath.Join("..", "..", "examples", "gastown"))
 	if err != nil {
@@ -129,11 +132,11 @@ func TestTransitiveGastownPackDigestOrderResolvesAndRuns(t *testing.T) {
 	digestFormulaFile := filepath.Join(digestFormulaLayer, "mol-digest-generate.toml")
 
 	writeFile(t, filepath.Join(cityDir, "city.toml"), `
-[workspace]
-name = "wrapper-city"
-
 [daemon]
 formula_v2 = true
+`)
+	writeFile(t, filepath.Join(cityDir, ".gc", "site.toml"), `
+workspace_name = "wrapper-city"
 `)
 	writeFile(t, filepath.Join(cityDir, "pack.toml"), `
 [pack]

--- a/cmd/gc/pack_import_formula_order_test.go
+++ b/cmd/gc/pack_import_formula_order_test.go
@@ -18,6 +18,7 @@ func TestPackV2ImportedFormulasAndOrdersVisibleToCityAndRig(t *testing.T) {
 	sidecarPackDir := filepath.Join(cityDir, "packs", "sidecar")
 
 	for _, dir := range []string{
+		filepath.Join(cityDir, ".gc"),
 		rigDir,
 		filepath.Join(opsPackDir, "formulas"),
 		filepath.Join(opsPackDir, "orders"),
@@ -39,14 +40,19 @@ source = "./packs/ops"
 `)
 	writeFile(t, filepath.Join(cityDir, "city.toml"), `
 [workspace]
-name = "testcity"
 
 [[rigs]]
 name = "frontend"
-path = "./frontend"
 
 [rigs.imports.sidecar]
 source = "./packs/sidecar"
+`)
+	writeFile(t, filepath.Join(cityDir, ".gc", "site.toml"), `
+workspace_name = "testcity"
+
+[[rig]]
+name = "frontend"
+path = "./frontend"
 `)
 	writeFile(t, filepath.Join(opsPackDir, "pack.toml"), `
 [pack]

--- a/cmd/gc/pack_import_formula_order_test.go
+++ b/cmd/gc/pack_import_formula_order_test.go
@@ -279,10 +279,12 @@ func TestPackV2OrdersOnlyPackVisibleToCity(t *testing.T) {
 [pack]
 name = "testcity"
 schema = 2
+
+[imports.pr_audit]
+source = "./packs/pr-audit"
 `)
 	writeFile(t, filepath.Join(cityDir, "city.toml"), `
 [workspace]
-includes = ["packs/pr-audit"]
 `)
 	writeFile(t, filepath.Join(packDir, "pack.toml"), `
 [pack]
@@ -322,6 +324,7 @@ func TestPackV2OrdersOnlyPackVisibleToRig(t *testing.T) {
 	packDir := filepath.Join(cityDir, "packs", "watcher")
 
 	for _, dir := range []string{
+		filepath.Join(cityDir, ".gc"),
 		rigDir,
 		filepath.Join(packDir, "orders"),
 	} {
@@ -341,10 +344,16 @@ name = "testcity"
 
 [[rigs]]
 name = "frontend"
-path = "./frontend"
 
 [rigs.imports.watcher]
 source = "./packs/watcher"
+`)
+	writeFile(t, filepath.Join(cityDir, ".gc", "site.toml"), `
+workspace_name = "testcity"
+
+[[rig]]
+name = "frontend"
+path = "./frontend"
 `)
 	writeFile(t, filepath.Join(packDir, "pack.toml"), `
 [pack]

--- a/cmd/gc/provider_store_resolution_test.go
+++ b/cmd/gc/provider_store_resolution_test.go
@@ -135,10 +135,10 @@ func TestCmdOrderHistoryUsesProviderAwareCityStore(t *testing.T) {
 	writeProviderAwareTestCity(t, cityDir, `[workspace]
 name = "demo"
 `)
-	if err := os.MkdirAll(filepath.Join(cityDir, "orders", "digest"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cityDir, "orders", "digest", "order.toml"), []byte(`[order]
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "digest.toml"), []byte(`[order]
 formula = "mol-digest"
 trigger = "manual"
 `), 0o644); err != nil {
@@ -249,10 +249,10 @@ func TestCmdOrderRunExecSkipsStoreOpenForScopedFileProvider(t *testing.T) {
 	writeProviderAwareTestCity(t, cityDir, `[workspace]
 name = "demo"
 `)
-	if err := os.MkdirAll(filepath.Join(cityDir, "orders", "poll"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cityDir, "orders", "poll", "order.toml"), []byte(`[order]
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "poll.toml"), []byte(`[order]
 exec = "printf 'exec ok\\n'"
 trigger = "manual"
 `), 0o644); err != nil {
@@ -281,10 +281,10 @@ func TestCmdOrderRunFormulaUsesProviderAwareCityStore(t *testing.T) {
 	writeProviderAwareTestCity(t, cityDir, `[workspace]
 name = "demo"
 `)
-	if err := os.MkdirAll(filepath.Join(cityDir, "orders", "digest"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cityDir, "orders"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cityDir, "orders", "digest", "order.toml"), []byte(`[order]
+	if err := os.WriteFile(filepath.Join(cityDir, "orders", "digest.toml"), []byte(`[order]
 formula = "mol-digest"
 trigger = "manual"
 pool = "dog"
@@ -294,11 +294,11 @@ pool = "dog"
 	if err := os.MkdirAll(filepath.Join(cityDir, "formulas"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "mol-digest.formula.toml"))
+	formulaText, err := os.ReadFile(filepath.Join(sharedTestFormulaDir, "mol-digest.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cityDir, "formulas", "mol-digest.formula.toml"), formulaText, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(cityDir, "formulas", "mol-digest.toml"), formulaText, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := ensurePersistedScopeLocalFileStore(cityDir); err != nil {

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -26,7 +26,7 @@ func setupCity(t *testing.T, name string) string {
 	if err := ensureCityScaffold(dir); err != nil {
 		t.Fatal(err)
 	}
-	toml := "[workspace]\nname = \"" + name + "\"\n\n[[agent]]\nname = \"mayor\"\n"
+	toml := "[workspace]\nname = \"" + name + "\"\n"
 	writeRigAnywhereCityToml(t, dir, toml)
 	return canonicalTestPath(dir)
 }
@@ -37,9 +37,27 @@ func writeRigAnywhereCityToml(t *testing.T, cityPath, toml string) {
 	if err != nil {
 		t.Fatalf("Parse(city.toml fixture): %v", err)
 	}
+	workspaceName := strings.TrimSpace(cfg.Workspace.Name)
+	if workspaceName == "" {
+		workspaceName = filepath.Base(cityPath)
+	}
+	workspacePrefix := strings.TrimSpace(cfg.Workspace.Prefix)
+	if err := os.MkdirAll(filepath.Join(cityPath, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	packToml := fmt.Sprintf("[pack]\nname = %q\nschema = 2\n", workspaceName)
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte(packToml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.PersistWorkspaceSiteBinding(fsys.OSFS{}, cityPath, workspaceName, workspacePrefix); err != nil {
+		t.Fatalf("PersistWorkspaceSiteBinding: %v", err)
+	}
 	if err := config.PersistRigSiteBindings(fsys.OSFS{}, cityPath, cfg.Rigs); err != nil {
 		t.Fatalf("PersistRigSiteBindings: %v", err)
 	}
+	cfg.Workspace.Name = ""
+	cfg.Workspace.Prefix = ""
+	cfg.Agents = nil
 	data, err := cfg.MarshalForWrite()
 	if err != nil {
 		t.Fatalf("MarshalForWrite: %v", err)
@@ -1265,11 +1283,14 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		if err := os.MkdirAll(rigDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		legacy := fmt.Sprintf("[workspace]\nname = \"legacy-city\"\n\n[[agent]]\nname = \"mayor\"\n\n[[rigs]]\nname = \"legacy-rig\"\npath = %q\n", rigDir)
+		legacy := fmt.Sprintf("[workspace]\nname = \"legacy-city\"\n\n[[rigs]]\nname = \"legacy-rig\"\npath = %q\n", rigDir)
 		if err := os.WriteFile(filepath.Join(cityPath, "city.toml"), []byte(legacy), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.Remove(config.SiteBindingPath(cityPath)); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if err := os.Remove(filepath.Join(cityPath, "pack.toml")); err != nil && !os.IsNotExist(err) {
 			t.Fatal(err)
 		}
 		registerCityForRigResolution(t, gcHome, cityPath, "legacy-city")
@@ -1870,9 +1891,6 @@ include = ["missing.toml"]
 
 [workspace]
 name = "missing-include-broken"
-
-[[agent]]
-name = "missing-include-agent"
 `), 0o644); err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/gc/rig_anywhere_test.go
+++ b/cmd/gc/rig_anywhere_test.go
@@ -1693,10 +1693,8 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 
 	// Companion to local_unregistered_city_uses_explicit_city_flag: the
 	// local-city fallback only fires when a real .gc/site.toml binding exists.
-	// A legacy city.toml with
-	// an inline `path = ...` (no site binding) must still be rejected so
-	// the legacy_city_toml_path_is_not_registered_binding invariant
-	// continues to apply at the cwd-walk level too.
+	// A legacy city.toml with inline PackV1/pre-1.0 surfaces must still be
+	// rejected at the cwd-walk level too.
 	t.Run("local_unregistered_city_legacy_path_still_rejected", func(t *testing.T) {
 		resetFlags(t)
 		gcHome := t.TempDir()
@@ -1720,8 +1718,8 @@ func TestRigAnywhere_ResolveRigToContext(t *testing.T) {
 		if err == nil {
 			t.Fatal("resolveRigToContext should reject a legacy city.toml even via the local-city fallback")
 		}
-		if !strings.Contains(err.Error(), "not registered") {
-			t.Fatalf("error = %q, want not registered", err)
+		if !strings.Contains(err.Error(), "PackV1 config surfaces are no longer supported") {
+			t.Fatalf("error = %q, want PackV1 surface rejection", err)
 		}
 	})
 
@@ -1909,6 +1907,64 @@ name = "missing-include-broken"
 		for _, s := range stale {
 			if strings.Contains(s.Label, "missing-include-broken") {
 				t.Fatalf("stale = %+v, missing include must not be reported as stale", stale)
+			}
+		}
+	})
+
+	t.Run("registered_city_with_legacy_order_layout_gets_migration_context", func(t *testing.T) {
+		gcHome := t.TempDir()
+		t.Setenv("GC_HOME", gcHome)
+
+		goodCity := setupCity(t, "legacy-order-good")
+		rigDir := filepath.Join(t.TempDir(), "legacy-order-rig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		registerRigBindingForResolution(t, gcHome, goodCity, "legacy-order-good", "legacy-order-rig", rigDir)
+
+		brokenCity := setupCity(t, "legacy-order-broken")
+		if err := os.Remove(filepath.Join(brokenCity, "pack.toml")); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		packDir := filepath.Join(brokenCity, "packs", "legacy")
+		if err := os.MkdirAll(filepath.Join(packDir, "orders", "heartbeat"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte("[pack]\nname = \"legacy\"\nschema = 1\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(packDir, "orders", "heartbeat", "order.toml"), []byte(`[order]
+exec = "scripts/heartbeat.sh"
+trigger = "cooldown"
+interval = "5m"
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(brokenCity, "city.toml"), []byte(`
+[workspace]
+includes = ["packs/legacy"]
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		registerCityForRigResolution(t, gcHome, brokenCity, "legacy-order-broken")
+
+		_, stale, err := registeredRigBindingsByPath(rigDir, true)
+		if err == nil {
+			t.Fatal("registeredRigBindingsByPath should fail closed on legacy order layout")
+		}
+		if len(stale) != 0 {
+			t.Fatalf("stale = %+v, legacy order layout must be a load error", stale)
+		}
+		errText := err.Error()
+		for _, want := range []string{
+			"loading registered city rig bindings",
+			"legacy-order-broken",
+			"unsupported PackV1 order path",
+			"registered city",
+			"gc --city legacy-order-broken doctor",
+		} {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error = %q, want substring %q", errText, want)
 			}
 		}
 	})

--- a/cmd/gc/session_beads_test.go
+++ b/cmd/gc/session_beads_test.go
@@ -353,15 +353,20 @@ source = "./assets/sidecar"
 `,
 		filepath.Join(cityPath, "city.toml"): `
 [workspace]
-name = "import-regression"
 provider = "claude"
 
 [[rigs]]
 name = "repo"
-path = "./repo"
 
 [rigs.imports.gs]
 source = "./assets/sidecar"
+`,
+		filepath.Join(cityPath, ".gc", "site.toml"): `
+workspace_name = "import-regression"
+
+[[rig]]
+name = "repo"
+path = "./repo"
 `,
 		filepath.Join(cityPath, "assets", "sidecar", "pack.toml"): `
 [pack]

--- a/cmd/gc/testdata/agent-suspend.txtar
+++ b/cmd/gc/testdata/agent-suspend.txtar
@@ -1,4 +1,4 @@
-# Agent suspend/resume and --dir tests with fake session provider.
+# Agent suspend/resume and city-scoped add tests with fake session provider.
 
 env GC_SESSION=fake
 env GC_BEADS=file
@@ -32,15 +32,15 @@ stdout 'Suspended agent'
 exec gc config show
 stdout 'suspended = true'
 
-# 7. gc agent add --dir --suspended registers correctly.
-exec gc agent add --name tester --dir other-project --suspended
+# 7. gc agent add --suspended registers a city-scoped agent correctly.
+exec gc agent add --name tester --suspended
 stdout 'Scaffolded agent'
 
 exec gc config show
 stdout 'tester'
 
-# 8. gc agent add --dir without --suspended.
-exec gc agent add --name reviewer --dir hello-world
+# 8. gc agent add without --suspended.
+exec gc agent add --name reviewer
 stdout 'Scaffolded agent'
 
 exec gc config show

--- a/cmd/gc/testdata/agent-suspend.txtar
+++ b/cmd/gc/testdata/agent-suspend.txtar
@@ -16,16 +16,16 @@ stdout 'mayor'
 stdout 'builder'
 stdout 'suspended = true'
 
-# 3. gc agent resume clears suspended (use qualified name).
-exec gc agent resume hello-world/builder
+# 3. gc agent resume clears suspended.
+exec gc agent resume builder
 stdout 'Resumed agent'
 
 # 4. After resume, gc start spawns the agent.
 exec gc start $WORK/city
 stdout 'City started.'
 
-# 5. gc agent suspend sets suspended (use qualified name).
-exec gc agent suspend hello-world/builder
+# 5. gc agent suspend sets suspended.
+exec gc agent suspend builder
 stdout 'Suspended agent'
 
 # 6. gc config show confirms suspended status.
@@ -55,21 +55,19 @@ stderr 'not found'
 stderr 'not found'
 
 -- city/.gc/.keep --
+-- city/.gc/site.toml --
+workspace_name = "bright-lights"
 -- city/rigs/.keep --
 -- city/city.toml --
 [workspace]
-name = "bright-lights"
-
-[[agent]]
-name = "mayor"
-start_command = "echo hello"
-
-[[agent]]
-name = "builder"
-dir = "hello-world"
-suspended = true
-start_command = "echo hello"
 -- city/pack.toml --
 [pack]
 name = "bright-lights"
 schema = 2
+-- city/agents/mayor/agent.toml --
+start_command = "echo hello"
+-- city/agents/builder/agent.toml --
+suspended = true
+start_command = "echo hello"
+-- city/agents/builder/prompt.template.md --
+You are the builder.

--- a/cmd/gc/testdata/config.txtar
+++ b/cmd/gc/testdata/config.txtar
@@ -22,9 +22,10 @@ exec gc config show --validate
 stdout 'Config valid.'
 
 # Add an agent and verify it appears in output.
-cp $WORK/city-with-agent $WORK/my-city/city.toml
+mkdir -p $WORK/my-city/agents/reviewer
+cp $WORK/agent-reviewer $WORK/my-city/agents/reviewer/agent.toml
 exec gc config show
-stdout 'name = "mayor"'
+stdout 'name = "reviewer"'
 stdout '\[\[agent\]\]'
 
 # Validate passes with valid agent config.
@@ -41,32 +42,28 @@ stderr 'gc config show'
 ! exec gc config show --validate
 stderr 'gc config show'
 
-# Invalid config (duplicate agents) fails --validate.
-cp $WORK/dup-agents $WORK/my-city/city.toml
+# Invalid legacy inline agents fail --validate.
+cp $WORK/legacy-inline-agent $WORK/my-city/city.toml
 cd $WORK/my-city
 ! exec gc config show --validate
-stderr 'duplicate name'
+stderr 'unsupported PackV1 \[\[agent\]\]'
 
-# Show mode prints validation warnings to stderr but still outputs config.
+# Show mode prints non-fatal migration warnings to stderr but still outputs config.
+cp $WORK/city-warning-name $WORK/my-city/city.toml
 exec gc config show
-stderr 'warning.*duplicate'
-stdout '\[\[agent\]\]'
+stderr 'workspace identity fields are deprecated'
+stdout '\[workspace\]'
 
 -- broken-city/.gc/.keep --
 -- bad-toml --
 {{invalid toml
--- city-with-agent --
+-- agent-reviewer --
+start_command = "echo reviewer"
+-- legacy-inline-agent --
+[workspace]
+
+[[agent]]
+name = "mayor"
+-- city-warning-name --
 [workspace]
 name = "my-city"
-
-[[agent]]
-name = "mayor"
--- dup-agents --
-[workspace]
-name = "my-city"
-
-[[agent]]
-name = "mayor"
-
-[[agent]]
-name = "mayor"

--- a/cmd/gc/testdata/init-from-dir.txtar
+++ b/cmd/gc/testdata/init-from-dir.txtar
@@ -17,8 +17,8 @@ exec grep 'workspace_name = "my-city"' $WORK/my-city/.gc/site.toml
 exec grep 'name = "my-city"' $WORK/my-city/pack.toml
 ! exec grep 'name = "template"' $WORK/my-city/pack.toml
 
-# Verify prompts were copied.
-exists $WORK/my-city/prompts/mayor.md
+# Verify agent prompt assets were copied.
+exists $WORK/my-city/agents/mayor/prompt.template.md
 
 # Verify .gc/ was created.
 exists $WORK/my-city/.gc
@@ -72,16 +72,12 @@ exists $WORK/v2-shim-city/pack.toml
 [workspace]
 provider = "claude"
 
-[[agent]]
-name = "mayor"
-prompt_template = "prompts/mayor.md"
-
 -- template/pack.toml --
 [pack]
 name = "template"
 schema = 2
 
--- template/prompts/mayor.md --
+-- template/agents/mayor/prompt.template.md --
 You are the mayor.
 
 -- template/example_test.go --
@@ -95,16 +91,12 @@ package test
 name = "mining"
 provider = "claude"
 
-[[agent]]
-name = "mayor"
-prompt_template = "prompts/mayor.md"
-
 -- named-template/pack.toml --
 [pack]
 name = "mining"
 schema = 2
 
--- named-template/prompts/mayor.md --
+-- named-template/agents/mayor/prompt.template.md --
 You are the mayor.
 
 -- v2-template/city.toml --

--- a/cmd/gc/testdata/pack-commands-doctor.txtar
+++ b/cmd/gc/testdata/pack-commands-doctor.txtar
@@ -47,7 +47,6 @@ stdout 'passed'
 
 -- city.toml.custom --
 [workspace]
-name = "testcity"
 
 [imports.ops]
 source = "../packs/ops"

--- a/cmd/gc/testdata/pack-v2-imports.txtar
+++ b/cmd/gc/testdata/pack-v2-imports.txtar
@@ -43,6 +43,12 @@ stdout 'sidecar:rig-check'
 stdout 'passed'
 
 -- city/.gc/.keep --
+-- city/.gc/site.toml --
+workspace_name = "testcity"
+
+[[rig]]
+name = "frontend"
+path = "./frontend"
 -- city/frontend/.keep --
 -- city/pack.toml --
 [pack]
@@ -53,11 +59,9 @@ schema = 2
 source = "./assets/ops"
 -- city/city.toml --
 [workspace]
-name = "testcity"
 
 [[rigs]]
 name = "frontend"
-path = "./frontend"
 
 [rigs.imports.sidecar]
 source = "./assets/sidecar"

--- a/cmd/gc/testenv_test.go
+++ b/cmd/gc/testenv_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -304,19 +303,4 @@ func configureTestDoltIdentityEnv(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(homeDir, ".gitconfig"))
 	t.Setenv("DOLT_ROOT_PATH", homeDir)
-}
-
-func configureRealBdAndDoltPath(t *testing.T) {
-	t.Helper()
-
-	bdPath := waitTestRealBDPath(t)
-	doltPath, err := exec.LookPath("dolt")
-	if err != nil {
-		t.Skip("dolt not installed")
-	}
-	t.Setenv("PATH", strings.Join([]string{
-		filepath.Dir(bdPath),
-		filepath.Dir(doltPath),
-		os.Getenv("PATH"),
-	}, string(os.PathListSeparator)))
 }

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -270,8 +270,27 @@ strips the optional `.order` infix when computing the symbolic order name, so
 exist for the same name in one directory, the plain `.toml` file wins.
 
 If your city still uses nested PackV1 order layouts such as
-`formulas/orders/.../order.toml`, migrate them now. Those shapes only
-load for compatibility and are headed toward hard deprecation.
+`orders/<name>/order.toml` or `formulas/orders/.../order.toml`, migrate them
+now. Gas City rejects those shapes for all pack schemas, including schema-1
+packs; use flat files under top-level `orders/` instead.
+
+For the Wave 2 hard-error rollout, the maintained pack inventory was checked
+on May 22, 2026 before enabling this behavior:
+
+| Repository or pack set | Legacy nested order paths found | Status |
+|---|---:|---|
+| `gastownhall/gascity` | 0 | In-tree fixtures and built-in packs use flat order files. |
+| `gastownhall/gascity-packs` | 0 | Public Gas City pack collection has no `orders/<name>/order.toml` or `formulas/orders/<name>/order.toml` files. |
+| `gascity/gas-city-inc` pack roots | 0 | Maintained internal workflow and role packs use flat order files. |
+
+If another imported pack still ships nested order files, upgrade that pack or
+vendor it and rename each `orders/<name>/order.toml` file to
+`orders/<name>.toml` before upgrading `gc`.
+
+Flat order files are also treated as load-bearing configuration. If Gas City
+finds `orders/<name>.toml` or `orders/<name>.order.toml` but cannot read it,
+config loading fails instead of silently skipping the file. Fix permissions,
+remove the file, or complete the migration before rerunning normal commands.
 
 ### Old shape
 
@@ -599,6 +618,11 @@ schema, plus the qualified rows that matter most during migration.
 > `workspace.prefix`) and `rigs.path` now live in `.gc/site.toml` for newly
 > written or migrated cities. `rigs.prefix` and `rigs.suspended` remain in
 > `city.toml` in this release.
+>
+> Migrate in two passes when a city uses included fragments: first resolve
+> hard errors in the root `city.toml`, then address fragment warnings. Fragment
+> paths and workspace identity often need a hand edit because their machine-local
+> target is the root city's `.gc/site.toml`.
 
 | 0.14.0 element | What it did | New home or action |
 |---|---|---|
@@ -617,7 +641,7 @@ schema, plus the qualified rows that matter most during migration.
 | `agent.namepool` | Path to names file | Move toward agent-local content such as `agents/<name>/namepool.txt` if retained. |
 | `[[named_session]]` | Named reusable sessions | Move to `[[named_session]]` in the root city `pack.toml`. |
 | `[[rigs]]` | Rig deployment entries | Keep in `city.toml`. |
-| `rigs.path` | Machine-local project binding | With the Phase A rig-binding slice, new writes stop persisting this in authored `city.toml`; older cities may still carry it until migrated. |
+| `rigs.path` | Machine-local project binding | Move to `.gc/site.toml`. Schema-2 root `city.toml` rejects this field; editor/init paths persist copied or edited bindings into `.gc/site.toml` and stop writing it back to authored `city.toml`. |
 | `rigs.prefix` | Derived rig prefix | Keep in `city.toml` in the current release wave. It is deployment state, but not yet extracted into separate site-binding storage. |
 | `rigs.suspended` | Operational toggle | Keep in `city.toml` in the current release wave. It remains deployment/runtime state rather than portable pack definition. |
 | `rigs.includes` | Rig-scoped pack composition | Move to rig-scoped imports in `city.toml`. |

--- a/docs/guides/migrating-to-pack-vnext.md
+++ b/docs/guides/migrating-to-pack-vnext.md
@@ -255,10 +255,19 @@ formulas/
 - stop treating formula location as configurable path wiring
 - move nested orders out of formula space
 
+Formula files may use either `formulas/<name>.toml` or
+`formulas/<name>.formula.toml`. In both cases, Gas City strips the optional
+`.formula` infix when computing the symbolic formula name, so
+`formulas/build-review.formula.toml` is named `build-review`. If both
+spellings exist for the same name in one directory, the plain `.toml` file wins.
+
 ## Orders
 
-Orders belong in top-level `orders/` and use flat files
-`orders/<name>.toml`.
+Orders belong in top-level `orders/` and use flat files. They may use either
+`orders/<name>.toml` or `orders/<name>.order.toml`. In both cases, Gas City
+strips the optional `.order` infix when computing the symbolic order name, so
+`orders/nightly-sync.order.toml` is named `nightly-sync`. If both spellings
+exist for the same name in one directory, the plain `.toml` file wins.
 
 If your city still uses nested PackV1 order layouts such as
 `formulas/orders/.../order.toml`, migrate them now. Those shapes only

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -99,9 +99,9 @@ agents/&lt;name&gt;/agent.toml. These files live in the city directory and do
 not append [[agent]] blocks to city.toml.
 
 Use --prompt-template to copy prompt content from an existing file into
-the canonical prompt.template.md location. Use --dir to record a rig or
-working-directory prefix in agent.toml. Use --suspended to scaffold the
-agent in a suspended state.
+the canonical prompt.template.md location. Schema-2 convention agents are
+city-scoped; define rig-scoped agents in pack config or [[patches.agent]].
+Use --suspended to scaffold the agent in a suspended state.
 
 ```
 gc agent add --name <name> [flags]
@@ -111,13 +111,13 @@ gc agent add --name <name> [flags]
 
 ```
 gc agent add --name mayor
-  gc agent add --name polecat --dir my-project
+  gc agent add --name polecat
   gc agent add --name worker --prompt-template ./worker.md --suspended
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--dir` | string |  | Working directory for the agent (relative to city root) |
+| `--dir` | string |  | Legacy working directory for schema-1 agents; schema-2 convention agents are city-scoped |
 | `--json` | bool |  | Output in JSONL format |
 | `--name` | string |  | Name of the agent |
 | `--prompt-template` | string |  | Path to prompt template file (relative to city root) |

--- a/internal/api/fake_state_test.go
+++ b/internal/api/fake_state_test.go
@@ -214,6 +214,9 @@ func (f *fakeMutatorState) ResumeRig(name string) error {
 func (f *fakeMutatorState) SuspendCity() error { f.cfg.Workspace.Suspended = true; return nil }
 func (f *fakeMutatorState) ResumeCity() error  { f.cfg.Workspace.Suspended = false; return nil }
 func (f *fakeMutatorState) CreateAgent(a config.Agent) error {
+	if err := config.ValidateAgents([]config.Agent{a}); err != nil {
+		return fmt.Errorf("%w: agent: %w", configedit.ErrValidation, err)
+	}
 	f.cfg.Agents = append(f.cfg.Agents, a)
 	return nil
 }

--- a/internal/api/handler_agent_crud_test.go
+++ b/internal/api/handler_agent_crud_test.go
@@ -232,6 +232,28 @@ func TestHandleAgentCreate_MissingName(t *testing.T) {
 	}
 }
 
+func TestHandleAgentCreate_InvalidScope(t *testing.T) {
+	fs := newFakeMutatorState(t)
+	h := newTestCityHandler(t, fs)
+
+	body := `{"name":"coder","provider":"claude","scope":"global"}`
+	req := newPostRequest(cityURL(fs, "/agents"), strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "created") {
+		t.Fatalf("response body looks successful: %s", w.Body.String())
+	}
+	for _, a := range fs.cfg.Agents {
+		if a.Name == "coder" {
+			t.Fatalf("invalid-scope agent was persisted: %+v", a)
+		}
+	}
+}
+
 func TestHandleAgentUpdate(t *testing.T) {
 	fs := newFakeMutatorState(t)
 	h := newTestCityHandler(t, fs)

--- a/internal/api/handler_sling_test.go
+++ b/internal/api/handler_sling_test.go
@@ -593,7 +593,7 @@ func TestSlingConflictReturns409ForExistingLiveWorkflow(t *testing.T) {
 		config.Agent{Name: config.ControlDispatcherAgentName, MaxActiveSessions: intPtr(1)},
 		config.Agent{Name: config.ControlDispatcherAgentName, Dir: "myrig", MaxActiveSessions: intPtr(1)},
 	)
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"

--- a/internal/buildimage/context_test.go
+++ b/internal/buildimage/context_test.go
@@ -114,7 +114,7 @@ name = "test-city"
 	writeFile(t, cityDir, filepath.Join(citylayout.CachePacksRoot, "remote", ".git", "HEAD"), "ref: refs/heads/main\n")
 	writeFile(t, cityDir, filepath.Join(citylayout.RuntimeRoot, "runtime", "artifact.txt"), "runtime")
 	writeFile(t, cityDir, filepath.Join(".gc", "prompts", "mayor.md"), "old prompt")
-	writeFile(t, cityDir, filepath.Join(".gc", "formulas", "legacy.formula.toml"), "name = \"legacy\"\n")
+	writeFile(t, cityDir, filepath.Join(".gc", "formulas", "legacy.toml"), "name = \"legacy\"\n")
 	writeFile(t, cityDir, filepath.Join(".gc", "settings.json"), "{}")
 	writeFile(t, cityDir, filepath.Join(".gc", "scripts", "setup.sh"), "#!/bin/sh\n")
 
@@ -131,7 +131,7 @@ name = "test-city"
 	assertFileNotExists(t, outputDir, filepath.Join("workspace", citylayout.CachePacksRoot, "remote", ".git", "HEAD"))
 	assertFileNotExists(t, outputDir, filepath.Join("workspace", citylayout.RuntimeRoot, "runtime", "artifact.txt"))
 	assertFileNotExists(t, outputDir, filepath.Join("workspace", ".gc", "prompts", "mayor.md"))
-	assertFileNotExists(t, outputDir, filepath.Join("workspace", ".gc", "formulas", "legacy.formula.toml"))
+	assertFileNotExists(t, outputDir, filepath.Join("workspace", ".gc", "formulas", "legacy.toml"))
 	assertFileNotExists(t, outputDir, filepath.Join("workspace", ".gc", "scripts", "setup.sh"))
 	assertFileNotExists(t, outputDir, filepath.Join("workspace", ".gc", "settings.json"))
 }

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -391,6 +391,9 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		prov.Warnings = append(prov.Warnings, fragWarnings...)
 		if legacyV1SurfaceWarningsEnabled {
+			if err := LegacyInlineAgentSurfaceError(frag, fragPath); err != nil {
+				return nil, nil, err
+			}
 			prov.Warnings = append(prov.Warnings, DetectLegacyV1Surfaces(frag, fragPath)...)
 			prov.Warnings = append(prov.Warnings, DetectLegacySiteBindingSurfaces(frag, fragPath)...)
 		}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -92,14 +92,12 @@ type Provenance struct {
 
 // LoadOptions controls optional config-loading behavior.
 type LoadOptions struct {
-	// SuppressDeprecatedOrderWarnings suppresses only legacy order-path
-	// migration warnings produced while discovering pack orders.
-	SuppressDeprecatedOrderWarnings bool
 	// AllowRootDefaultRigImports permits [defaults.rig.imports] only on the
 	// root pack.toml being loaded. Normal pack imports still reject it.
 	AllowRootDefaultRigImports bool
 	deferRigPatches            bool
 	deferredRigPatches         *[]deferredRigPatches
+	allowLegacyOrderLayouts    bool
 }
 
 // LoadWithIncludes loads a city.toml and merges all included fragments.
@@ -148,7 +146,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 	var rootPackRequires []PackRequirement
 	packPath := filepath.Join(cityRoot, packFile)
 	legacyV1SurfaceWarningsEnabled := false
-	if packData, pErr := fs.ReadFile(packPath); pErr == nil {
+	packData, pErr := fs.ReadFile(packPath)
+	if pErr != nil && !os.IsNotExist(pErr) {
+		return nil, nil, fmt.Errorf("loading city pack.toml: %w", pErr)
+	}
+	if pErr == nil {
 		packExists = true
 		pc, md, packWarnings, decErr := parsePackConfigWithMetadata(packData, packPath)
 		if decErr != nil {
@@ -391,11 +393,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		prov.Warnings = append(prov.Warnings, fragWarnings...)
 		if legacyV1SurfaceWarningsEnabled {
-			if err := LegacyInlineAgentSurfaceError(frag, fragPath, fragData); err != nil {
+			if err := LegacyV1SurfaceError(frag, fragPath, fragData); err != nil {
 				return nil, nil, err
 			}
-			prov.Warnings = append(prov.Warnings, DetectLegacyV1Surfaces(frag, fragPath)...)
-			prov.Warnings = append(prov.Warnings, DetectLegacySiteBindingSurfaces(frag, fragPath)...)
+			prov.Warnings = append(prov.Warnings, legacyWorkspaceIdentitySurfaceWarnings(frag, fragPath)...)
+			prov.Warnings = append(prov.Warnings, legacyRigPathSurfaceWarnings(frag, fragPath)...)
 		}
 
 		// Fragments cannot include other fragments.
@@ -1354,6 +1356,78 @@ func LoadRootPackDefaultRigImports(fs fsys.FS, cityRoot string) ([]BoundImport, 
 		return nil, fmt.Errorf("parsing city pack.toml: %s", strings.Join(warnings, "; "))
 	}
 	return defaultRigImportsFromPackDefaults(pc.Defaults, md)
+}
+
+// LoadPackGraphDirsForDoctor returns the pack directories the canonical city
+// loader would evaluate while allowing legacy PackV1 order layouts to remain
+// on disk for doctor diagnostics and migration.
+func LoadPackGraphDirsForDoctor(fs fsys.FS, cityTomlPath string) ([]string, error) {
+	cfg, _, err := LoadWithIncludesOptions(fs, cityTomlPath, LoadOptions{allowLegacyOrderLayouts: true})
+	if err != nil {
+		return nil, err
+	}
+
+	var dirs []string
+	dirs = appendUnique(dirs, cfg.PackDirs...)
+
+	rigNames := make([]string, 0, len(cfg.RigPackDirs))
+	for name := range cfg.RigPackDirs {
+		rigNames = append(rigNames, name)
+	}
+	sort.Strings(rigNames)
+	for _, name := range rigNames {
+		dirs = appendUnique(dirs, cfg.RigPackDirs[name]...)
+	}
+
+	defaultNames := make([]string, 0, len(cfg.DefaultRigImports))
+	seenDefaults := make(map[string]bool, len(cfg.DefaultRigImports))
+	for _, name := range cfg.DefaultRigImportOrder {
+		if _, ok := cfg.DefaultRigImports[name]; !ok || seenDefaults[name] {
+			continue
+		}
+		seenDefaults[name] = true
+		defaultNames = append(defaultNames, name)
+	}
+	var missingDefaults []string
+	for name := range cfg.DefaultRigImports {
+		if !seenDefaults[name] {
+			missingDefaults = append(missingDefaults, name)
+		}
+	}
+	sort.Strings(missingDefaults)
+	defaultNames = append(defaultNames, missingDefaults...)
+	if len(defaultNames) == 0 {
+		return dirs, nil
+	}
+
+	cityRoot := filepath.Dir(cityTomlPath)
+	cache := &packLoadCache{results: make(map[string]*packLoadResult)}
+	for _, name := range defaultNames {
+		imp := cfg.DefaultRigImports[name]
+		topoDirs, err := loadImportPackGraphDirsForDoctor(fs, imp, cityRoot, cityRoot, cache)
+		if err != nil {
+			return nil, fmt.Errorf("default rig import %q: %w", name, err)
+		}
+		dirs = appendUnique(dirs, topoDirs...)
+	}
+	return dirs, nil
+}
+
+func loadImportPackGraphDirsForDoctor(fs fsys.FS, imp Import, declDir, cityRoot string, cache *packLoadCache) ([]string, error) {
+	impDir, err := resolveImportPackRef(imp.Source, declDir, cityRoot)
+	if err != nil {
+		return nil, err
+	}
+	topoPath := filepath.Join(impDir, packFile)
+	_, _, _, _, topoDirs, _, _, err := loadPackWithCacheOptions(
+		fs, topoPath, impDir, cityRoot, "", nil, cache, LoadOptions{allowLegacyOrderLayouts: true})
+	if err != nil {
+		return nil, err
+	}
+	if !imp.ImportIsTransitive() {
+		return cachedPackLocalTopoDirs(cache, impDir), nil
+	}
+	return topoDirs, nil
 }
 
 func defaultRigImportsFromPackDefaults(defaults PackDefaults, md toml.MetaData) ([]BoundImport, error) {

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -171,6 +171,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 			if err := LegacyV1SurfaceError(root, path); err != nil {
 				return nil, nil, err
 			}
+			prov.Warnings = append(prov.Warnings, legacyWorkspaceIdentitySurfaceWarnings(root, path)...)
 			if err := LegacySiteBindingSurfaceError(root, path); err != nil {
 				return nil, nil, err
 			}

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -163,11 +163,17 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		legacyV1SurfaceWarningsEnabled = pc.Pack.Schema >= 2
 		if legacyV1SurfaceWarningsEnabled {
-			// Detect v1 surfaces on the freshly-parsed city.toml, before
-			// pack.toml merging or fragment processing can inject
-			// pack-discovered agents or pack-default rig includes into the
-			// same fields.
-			prov.Warnings = append(prov.Warnings, DetectLegacyV1Surfaces(root, path)...)
+			// Wave 2 hard-stop: schema=2 city packs no longer tolerate PackV1
+			// city.toml authoring surfaces. Check the freshly-parsed city.toml
+			// before pack merging or fragment processing can inject
+			// pack-discovered agents or pack-default rig includes into the same
+			// fields.
+			if err := LegacyV1SurfaceError(root, path); err != nil {
+				return nil, nil, err
+			}
+			if err := LegacySiteBindingSurfaceError(root, path); err != nil {
+				return nil, nil, err
+			}
 		}
 		// Preserve the city.toml agents so they can override pack-defined
 		// and convention-discovered agents.
@@ -385,6 +391,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		prov.Warnings = append(prov.Warnings, fragWarnings...)
 		if legacyV1SurfaceWarningsEnabled {
 			prov.Warnings = append(prov.Warnings, DetectLegacyV1Surfaces(frag, fragPath)...)
+			prov.Warnings = append(prov.Warnings, DetectLegacySiteBindingSurfaces(frag, fragPath)...)
 		}
 
 		// Fragments cannot include other fragments.

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -168,11 +168,11 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 			// before pack merging or fragment processing can inject
 			// pack-discovered agents or pack-default rig includes into the same
 			// fields.
-			if err := LegacyV1SurfaceError(root, path); err != nil {
+			if err := LegacyV1SurfaceError(root, path, data); err != nil {
 				return nil, nil, err
 			}
 			prov.Warnings = append(prov.Warnings, legacyWorkspaceIdentitySurfaceWarnings(root, path)...)
-			if err := LegacySiteBindingSurfaceError(root, path); err != nil {
+			if err := LegacySiteBindingSurfaceError(root, path, data); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -391,7 +391,7 @@ func LoadWithIncludesOptions(fs fsys.FS, path string, opts LoadOptions, extraInc
 		}
 		prov.Warnings = append(prov.Warnings, fragWarnings...)
 		if legacyV1SurfaceWarningsEnabled {
-			if err := LegacyInlineAgentSurfaceError(frag, fragPath); err != nil {
+			if err := LegacyInlineAgentSurfaceError(frag, fragPath, fragData); err != nil {
 				return nil, nil, err
 			}
 			prov.Warnings = append(prov.Warnings, DetectLegacyV1Surfaces(frag, fragPath)...)

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -70,7 +70,6 @@ func TestLoadWithIncludes_RootPackDefaultRigImportsPreserveOrder(t *testing.T) {
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
 name = "test"
-default_rig_includes = ["packs/city-local"]
 `)
 	fs.Files["/city/pack.toml"] = []byte(`
 [pack]
@@ -88,7 +87,7 @@ source = "packs/a-pack"
 	if err != nil {
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	want := []string{"packs/z-pack", "packs/a-pack", "packs/city-local"}
+	want := []string{"packs/z-pack", "packs/a-pack"}
 	if got := cfg.Workspace.LegacyDefaultRigIncludes(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("DefaultRigIncludes = %v, want %v", got, want)
 	}

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -306,8 +306,12 @@ name = "test"
 
 [[rigs]]
 name = "hw"
-path = "/tmp/hw"
 includes = ["packs/rigpack"]
+`)
+	fs.Files["/city/.gc/site.toml"] = []byte(`
+[[rig]]
+name = "hw"
+path = "/tmp/hw"
 `)
 	fs.Files["/city/pack.toml"] = []byte(`
 [pack]
@@ -324,9 +328,8 @@ schema = 2
 
 [agent_defaults]
 provider = "claude"
-
-[[agent]]
-name = "worker"
+`)
+	fs.Files["/city/packs/rigpack/agents/worker/agent.toml"] = []byte(`
 scope = "rig"
 `)
 

--- a/internal/config/diagnostic_locations.go
+++ b/internal/config/diagnostic_locations.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+const packV1MigrationDocsURL = "https://docs.gascityhall.com/guides/migrating-to-pack-vnext"
+
+type configDiagnosticLocator struct {
+	lines []string
+}
+
+func optionalConfigDiagnosticLocator(data [][]byte) configDiagnosticLocator {
+	if len(data) == 0 {
+		return configDiagnosticLocator{}
+	}
+	return newConfigDiagnosticLocator(data[0])
+}
+
+func newConfigDiagnosticLocator(data []byte) configDiagnosticLocator {
+	if len(data) == 0 {
+		return configDiagnosticLocator{}
+	}
+	return configDiagnosticLocator{lines: strings.Split(string(data), "\n")}
+}
+
+func (l configDiagnosticLocator) lineForTable(table string) int {
+	for i, line := range l.lines {
+		name, ok := parseTOMLTableHeader(line)
+		if ok && name == table {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (l configDiagnosticLocator) lineForPacksTable() int {
+	for i, line := range l.lines {
+		name, ok := parseTOMLTableHeader(line)
+		if ok && (name == "packs" || strings.HasPrefix(name, "packs.")) {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (l configDiagnosticLocator) lineForKey(table, key string) int {
+	var currentTable string
+	for i, line := range l.lines {
+		trimmed := trimTOMLDiagnosticLine(line)
+		if trimmed == "" {
+			continue
+		}
+		if name, ok := parseTOMLTableHeader(trimmed); ok {
+			currentTable = name
+			continue
+		}
+		if currentTable != table {
+			continue
+		}
+		gotKey, _, ok := parseTOMLDiagnosticKeyValue(trimmed)
+		if ok && gotKey == key {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (l configDiagnosticLocator) lineForRigPath(rigName string) int {
+	var inRig bool
+	var currentRigName string
+	var currentPathLine int
+
+	flushRig := func() int {
+		if !inRig || currentPathLine == 0 {
+			return 0
+		}
+		if rigName == "" || currentRigName == rigName {
+			return currentPathLine
+		}
+		return 0
+	}
+
+	for i, line := range l.lines {
+		trimmed := trimTOMLDiagnosticLine(line)
+		if trimmed == "" {
+			continue
+		}
+		if name, ok := parseTOMLTableHeader(trimmed); ok {
+			if line := flushRig(); line > 0 {
+				return line
+			}
+			inRig = name == "rigs"
+			currentRigName = ""
+			currentPathLine = 0
+			continue
+		}
+		if !inRig {
+			continue
+		}
+		key, value, ok := parseTOMLDiagnosticKeyValue(trimmed)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "name":
+			currentRigName = unquoteTOMLDiagnosticValue(value)
+		case "path":
+			currentPathLine = i + 1
+		}
+	}
+	return flushRig()
+}
+
+func sourceWithDiagnosticLine(source string, line int) string {
+	if line <= 0 {
+		return source
+	}
+	return fmt.Sprintf("%s:%d", source, line)
+}
+
+func configSurfaceError(title string, violations []string) error {
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s:\n  - %s\nsee %s for migration details",
+		title,
+		strings.Join(violations, "\n  - "),
+		packV1MigrationDocsURL)
+}
+
+func parseTOMLTableHeader(line string) (string, bool) {
+	trimmed := trimTOMLDiagnosticLine(line)
+	if strings.HasPrefix(trimmed, "[[") && strings.HasSuffix(trimmed, "]]") {
+		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "[["), "]]")), true
+	}
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")), true
+	}
+	return "", false
+}
+
+func trimTOMLDiagnosticLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return ""
+	}
+	if before, _, ok := strings.Cut(trimmed, "#"); ok {
+		trimmed = strings.TrimSpace(before)
+	}
+	return trimmed
+}
+
+func parseTOMLDiagnosticKeyValue(line string) (string, string, bool) {
+	before, after, ok := strings.Cut(line, "=")
+	if !ok {
+		return "", "", false
+	}
+	return strings.TrimSpace(before), strings.TrimSpace(after), true
+}
+
+func unquoteTOMLDiagnosticValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+	if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
+		return value[1 : len(value)-1]
+	}
+	return value
+}

--- a/internal/config/diagnostic_locations.go
+++ b/internal/config/diagnostic_locations.go
@@ -7,25 +7,40 @@ import (
 
 const packV1MigrationDocsURL = "https://docs.gascityhall.com/guides/migrating-to-pack-vnext"
 
-type configDiagnosticLocator struct {
+// DiagnosticLocator provides best-effort line numbers for TOML diagnostics.
+// It intentionally stays lightweight and line-oriented because it is used
+// after a successful decode to improve migration errors, not to validate TOML.
+type DiagnosticLocator struct {
 	lines []string
 }
 
+type configDiagnosticLocator = DiagnosticLocator
+
 func optionalConfigDiagnosticLocator(data [][]byte) configDiagnosticLocator {
 	if len(data) == 0 {
-		return configDiagnosticLocator{}
+		return DiagnosticLocator{}
 	}
 	return newConfigDiagnosticLocator(data[0])
 }
 
 func newConfigDiagnosticLocator(data []byte) configDiagnosticLocator {
-	if len(data) == 0 {
-		return configDiagnosticLocator{}
-	}
-	return configDiagnosticLocator{lines: strings.Split(string(data), "\n")}
+	return NewDiagnosticLocator(data)
 }
 
-func (l configDiagnosticLocator) lineForTable(table string) int {
+// NewDiagnosticLocator creates a locator for a TOML document.
+func NewDiagnosticLocator(data []byte) DiagnosticLocator {
+	if len(data) == 0 {
+		return DiagnosticLocator{}
+	}
+	return DiagnosticLocator{lines: strings.Split(string(data), "\n")}
+}
+
+func (l DiagnosticLocator) lineForTable(table string) int {
+	return l.LineForTable(table)
+}
+
+// LineForTable returns the 1-based line for a TOML table, or 0 when absent.
+func (l DiagnosticLocator) LineForTable(table string) int {
 	for i, line := range l.lines {
 		name, ok := parseTOMLTableHeader(line)
 		if ok && name == table {
@@ -35,7 +50,12 @@ func (l configDiagnosticLocator) lineForTable(table string) int {
 	return 0
 }
 
-func (l configDiagnosticLocator) lineForPacksTable() int {
+func (l DiagnosticLocator) lineForPacksTable() int {
+	return l.LineForPacksTable()
+}
+
+// LineForPacksTable returns the first 1-based line for [packs] or [packs.*].
+func (l DiagnosticLocator) LineForPacksTable() int {
 	for i, line := range l.lines {
 		name, ok := parseTOMLTableHeader(line)
 		if ok && (name == "packs" || strings.HasPrefix(name, "packs.")) {
@@ -45,7 +65,12 @@ func (l configDiagnosticLocator) lineForPacksTable() int {
 	return 0
 }
 
-func (l configDiagnosticLocator) lineForKey(table, key string) int {
+func (l DiagnosticLocator) lineForKey(table, key string) int {
+	return l.LineForKey(table, key)
+}
+
+// LineForKey returns the 1-based line for a key inside a TOML table.
+func (l DiagnosticLocator) LineForKey(table, key string) int {
 	var currentTable string
 	for i, line := range l.lines {
 		trimmed := trimTOMLDiagnosticLine(line)
@@ -67,7 +92,12 @@ func (l configDiagnosticLocator) lineForKey(table, key string) int {
 	return 0
 }
 
-func (l configDiagnosticLocator) lineForRigPath(rigName string) int {
+func (l DiagnosticLocator) lineForRigPath(rigName string) int {
+	return l.LineForRigPath(rigName)
+}
+
+// LineForRigPath returns the 1-based line for a [[rigs]] path field.
+func (l DiagnosticLocator) LineForRigPath(rigName string) int {
 	var inRig bool
 	var currentRigName string
 	var currentPathLine int
@@ -146,8 +176,23 @@ func trimTOMLDiagnosticLine(line string) string {
 	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 		return ""
 	}
-	if before, _, ok := strings.Cut(trimmed, "#"); ok {
-		trimmed = strings.TrimSpace(before)
+	inBasic := false
+	inLiteral := false
+	escaped := false
+	for i, r := range trimmed {
+		switch {
+		case escaped:
+			escaped = false
+		case inBasic && r == '\\':
+			escaped = true
+		case r == '"' && !inLiteral:
+			inBasic = !inBasic
+		case r == '\'' && !inBasic:
+			inLiteral = !inLiteral
+		case r == '#' && !inBasic && !inLiteral:
+			trimmed = strings.TrimSpace(trimmed[:i])
+			return trimmed
+		}
 	}
 	return trimmed
 }

--- a/internal/config/diagnostic_locations_test.go
+++ b/internal/config/diagnostic_locations_test.go
@@ -1,0 +1,18 @@
+package config
+
+import "testing"
+
+func TestDiagnosticLocatorLineForRigPathKeepsHashInsideQuotedName(t *testing.T) {
+	locator := NewDiagnosticLocator([]byte(`
+[workspace]
+name = "city"
+
+[[rigs]]
+name = "rig#one"
+path = "../rig-one"
+`))
+
+	if got := locator.LineForRigPath("rig#one"); got != 7 {
+		t.Fatalf("LineForRigPath = %d, want 7", got)
+	}
+}

--- a/internal/config/legacy_v1_surfaces.go
+++ b/internal/config/legacy_v1_surfaces.go
@@ -139,6 +139,8 @@ func LegacyInlineAgentSurfaceErrors(cfg *City, source string) []string {
 		source)}
 }
 
+// LegacyInlineAgentSurfaceError aggregates unsupported inline [[agent]]
+// surfaces into one load-time error for schema=2 enforcement paths.
 func LegacyInlineAgentSurfaceError(cfg *City, source string) error {
 	violations := LegacyInlineAgentSurfaceErrors(cfg, source)
 	if len(violations) == 0 {

--- a/internal/config/legacy_v1_surfaces.go
+++ b/internal/config/legacy_v1_surfaces.go
@@ -96,9 +96,7 @@ func LegacyV1SurfaceErrors(cfg *City, source string) []string {
 
 	var errors []string
 	if len(cfg.Agents) > 0 {
-		errors = append(errors, fmt.Sprintf(
-			"%s: unsupported PackV1 [[agent]] tables; move each agent to agents/<name>/agent.toml",
-			source))
+		errors = append(errors, LegacyInlineAgentSurfaceErrors(cfg, source)...)
 	}
 	if len(cfg.Packs) > 0 {
 		errors = append(errors, fmt.Sprintf(
@@ -126,5 +124,26 @@ func LegacyV1SurfaceError(cfg *City, source string) error {
 		return nil
 	}
 	return fmt.Errorf("PackV1 config surfaces are no longer supported:\n  - %s",
+		strings.Join(violations, "\n  - "))
+}
+
+// LegacyInlineAgentSurfaceErrors returns hard-error diagnostics for inline
+// [[agent]] tables. Unlike other fragment-level legacy surfaces, inline agents
+// have a direct portable replacement and do not require machine-local state.
+func LegacyInlineAgentSurfaceErrors(cfg *City, source string) []string {
+	if cfg == nil || len(cfg.Agents) == 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf(
+		"%s: unsupported PackV1 [[agent]] tables; move each agent to agents/<name>/agent.toml",
+		source)}
+}
+
+func LegacyInlineAgentSurfaceError(cfg *City, source string) error {
+	violations := LegacyInlineAgentSurfaceErrors(cfg, source)
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf("PackV1 inline agent tables are no longer supported:\n  - %s",
 		strings.Join(violations, "\n  - "))
 }

--- a/internal/config/legacy_v1_surfaces.go
+++ b/internal/config/legacy_v1_surfaces.go
@@ -89,63 +89,57 @@ func DetectLegacyV1Surfaces(cfg *City, source string) []string {
 // doctor and strict-warning filters still need stable warning strings while
 // the broader remediation messaging stays aligned. Load paths that are ready
 // to enforce should call LegacyV1SurfaceError instead.
-func LegacyV1SurfaceErrors(cfg *City, source string) []string {
+func LegacyV1SurfaceErrors(cfg *City, source string, data ...[]byte) []string {
 	if cfg == nil {
 		return nil
 	}
 
+	locator := optionalConfigDiagnosticLocator(data)
 	var errors []string
 	if len(cfg.Agents) > 0 {
-		errors = append(errors, LegacyInlineAgentSurfaceErrors(cfg, source)...)
+		errors = append(errors, LegacyInlineAgentSurfaceErrors(cfg, source, data...)...)
 	}
 	if len(cfg.Packs) > 0 {
 		errors = append(errors, fmt.Sprintf(
 			"%s: unsupported PackV1 [packs] entries; replace them with [imports] and regenerate packs.lock",
-			source))
+			sourceWithDiagnosticLine(source, locator.lineForPacksTable())))
 	}
 	if len(cfg.Workspace.Includes) > 0 {
 		errors = append(errors, fmt.Sprintf(
 			"%s: unsupported PackV1 workspace.includes; replace it with [imports.<binding>] entries",
-			source))
+			sourceWithDiagnosticLine(source, locator.lineForKey("workspace", "includes"))))
 	}
 	if len(cfg.Workspace.DefaultRigIncludes) > 0 {
 		errors = append(errors, fmt.Sprintf(
 			"%s: unsupported PackV1 workspace.default_rig_includes; move defaults into root pack.toml [defaults.rig.imports.<binding>]",
-			source))
+			sourceWithDiagnosticLine(source, locator.lineForKey("workspace", "default_rig_includes"))))
 	}
 	return errors
 }
 
 // LegacyV1SurfaceError aggregates legacy PackV1 surface violations into one
 // load-time error for Wave 2 enforcement paths.
-func LegacyV1SurfaceError(cfg *City, source string) error {
-	violations := LegacyV1SurfaceErrors(cfg, source)
-	if len(violations) == 0 {
-		return nil
-	}
-	return fmt.Errorf("PackV1 config surfaces are no longer supported:\n  - %s",
-		strings.Join(violations, "\n  - "))
+func LegacyV1SurfaceError(cfg *City, source string, data ...[]byte) error {
+	violations := LegacyV1SurfaceErrors(cfg, source, data...)
+	return configSurfaceError("PackV1 config surfaces are no longer supported", violations)
 }
 
 // LegacyInlineAgentSurfaceErrors returns hard-error diagnostics for inline
 // [[agent]] tables. Unlike other fragment-level legacy surfaces, inline agents
 // have a direct portable replacement and do not require machine-local state.
-func LegacyInlineAgentSurfaceErrors(cfg *City, source string) []string {
+func LegacyInlineAgentSurfaceErrors(cfg *City, source string, data ...[]byte) []string {
 	if cfg == nil || len(cfg.Agents) == 0 {
 		return nil
 	}
+	locator := optionalConfigDiagnosticLocator(data)
 	return []string{fmt.Sprintf(
 		"%s: unsupported PackV1 [[agent]] tables; move each agent to agents/<name>/agent.toml",
-		source)}
+		sourceWithDiagnosticLine(source, locator.lineForTable("agent")))}
 }
 
 // LegacyInlineAgentSurfaceError aggregates unsupported inline [[agent]]
 // surfaces into one load-time error for schema=2 enforcement paths.
-func LegacyInlineAgentSurfaceError(cfg *City, source string) error {
-	violations := LegacyInlineAgentSurfaceErrors(cfg, source)
-	if len(violations) == 0 {
-		return nil
-	}
-	return fmt.Errorf("PackV1 inline agent tables are no longer supported:\n  - %s",
-		strings.Join(violations, "\n  - "))
+func LegacyInlineAgentSurfaceError(cfg *City, source string, data ...[]byte) error {
+	violations := LegacyInlineAgentSurfaceErrors(cfg, source, data...)
+	return configSurfaceError("PackV1 inline agent tables are no longer supported", violations)
 }

--- a/internal/config/legacy_v1_surfaces.go
+++ b/internal/config/legacy_v1_surfaces.go
@@ -81,3 +81,50 @@ func DetectLegacyV1Surfaces(cfg *City, source string) []string {
 	}
 	return warnings
 }
+
+// LegacyV1SurfaceErrors returns hard-error diagnostics for legacy PackV1
+// surfaces that are no longer supported in Wave 2 enforcement paths.
+//
+// This intentionally does not replace DetectLegacyV1Surfaces: callers like
+// doctor and strict-warning filters still need stable warning strings while
+// the broader remediation messaging stays aligned. Load paths that are ready
+// to enforce should call LegacyV1SurfaceError instead.
+func LegacyV1SurfaceErrors(cfg *City, source string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	var errors []string
+	if len(cfg.Agents) > 0 {
+		errors = append(errors, fmt.Sprintf(
+			"%s: unsupported PackV1 [[agent]] tables; move each agent to agents/<name>/agent.toml",
+			source))
+	}
+	if len(cfg.Packs) > 0 {
+		errors = append(errors, fmt.Sprintf(
+			"%s: unsupported PackV1 [packs] entries; replace them with [imports] and regenerate packs.lock",
+			source))
+	}
+	if len(cfg.Workspace.Includes) > 0 {
+		errors = append(errors, fmt.Sprintf(
+			"%s: unsupported PackV1 workspace.includes; replace it with [imports.<binding>] entries",
+			source))
+	}
+	if len(cfg.Workspace.DefaultRigIncludes) > 0 {
+		errors = append(errors, fmt.Sprintf(
+			"%s: unsupported PackV1 workspace.default_rig_includes; move defaults into root pack.toml [defaults.rig.imports.<binding>]",
+			source))
+	}
+	return errors
+}
+
+// LegacyV1SurfaceError aggregates legacy PackV1 surface violations into one
+// load-time error for Wave 2 enforcement paths.
+func LegacyV1SurfaceError(cfg *City, source string) error {
+	violations := LegacyV1SurfaceErrors(cfg, source)
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf("PackV1 config surfaces are no longer supported:\n  - %s",
+		strings.Join(violations, "\n  - "))
+}

--- a/internal/config/legacy_v1_surfaces_test.go
+++ b/internal/config/legacy_v1_surfaces_test.go
@@ -197,7 +197,7 @@ source = "legacy-pack"
 	}
 }
 
-func TestLoadWithIncludesWarnsOnLegacyV1SurfacesInSchema2Fragments(t *testing.T) {
+func TestLoadWithIncludesRejectsInlineAgentInSchema2Fragments(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 include = ["fragments/legacy.toml"]
@@ -212,22 +212,59 @@ schema = 2
 name = "fragment-worker"
 `)
 
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want hard error for schema-2 fragment inline agent")
+	}
+	for _, want := range []string{
+		"PackV1 inline agent tables are no longer supported",
+		"/city/fragments/legacy.toml: unsupported PackV1 [[agent]] tables",
+		"move each agent to agents/<name>/agent.toml",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
+	}
+}
+
+func TestLoadWithIncludesWarnsOnNonAgentLegacyV1SurfacesInSchema2Fragments(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+include = ["fragments/legacy.toml"]
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "schema2-city"
+schema = 2
+`)
+	fs.Files["/city/fragments/legacy.toml"] = []byte(`
+[workspace]
+includes = ["legacy-pack"]
+default_rig_includes = ["default-pack"]
+
+[packs.legacy]
+source = "legacy-pack"
+`)
+
 	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
 	if err != nil {
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	if got := warningsExcludingV1Surfaces(prov.Warnings); len(got) != 0 {
-		t.Fatalf("unexpected unrelated warnings: %v", got)
-	}
-	var found bool
-	for _, warning := range prov.Warnings {
-		if strings.Contains(warning, "/city/fragments/legacy.toml: [[agent]] tables are deprecated") {
-			found = true
-			break
+	for _, want := range []string{
+		"/city/fragments/legacy.toml: [packs] is deprecated",
+		"/city/fragments/legacy.toml: workspace.includes is deprecated",
+		"/city/fragments/legacy.toml: workspace.default_rig_includes is deprecated",
+	} {
+		var found bool
+		for _, warning := range prov.Warnings {
+			if strings.Contains(warning, want) {
+				found = true
+				break
+			}
 		}
-	}
-	if !found {
-		t.Fatalf("warnings = %v, want schema-2 fragment legacy surface guidance", prov.Warnings)
+		if !found {
+			t.Fatalf("warnings = %v, want substring %q", prov.Warnings, want)
+		}
 	}
 }
 

--- a/internal/config/legacy_v1_surfaces_test.go
+++ b/internal/config/legacy_v1_surfaces_test.go
@@ -218,8 +218,9 @@ name = "fragment-worker"
 	}
 	for _, want := range []string{
 		"PackV1 inline agent tables are no longer supported",
-		"/city/fragments/legacy.toml: unsupported PackV1 [[agent]] tables",
+		"/city/fragments/legacy.toml:2: unsupported PackV1 [[agent]] tables",
 		"move each agent to agents/<name>/agent.toml",
+		packV1MigrationDocsURL,
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want substring %q", err, want)
@@ -293,10 +294,11 @@ schema = 2
 		t.Fatal("LoadWithIncludes succeeded, want hard error for schema-2 city legacy surfaces")
 	}
 	for _, want := range []string{
-		"unsupported PackV1 [[agent]] tables",
-		"unsupported PackV1 [packs] entries",
-		"unsupported PackV1 workspace.includes",
-		"unsupported PackV1 workspace.default_rig_includes",
+		"/city/city.toml:7: unsupported PackV1 [[agent]] tables",
+		"/city/city.toml:10: unsupported PackV1 [packs] entries",
+		"/city/city.toml:4: unsupported PackV1 workspace.includes",
+		"/city/city.toml:5: unsupported PackV1 workspace.default_rig_includes",
+		packV1MigrationDocsURL,
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want substring %q", err, want)
@@ -360,6 +362,16 @@ func TestDetectLegacyV1Surfaces_PointsAtDoctorWithoutPromisingInPlaceUpgrade(t *
 }
 
 func TestLegacyV1SurfaceErrorAggregatesViolations(t *testing.T) {
+	data := []byte(`[workspace]
+includes = ["./inc"]
+default_rig_includes = ["./drig"]
+
+[[agent]]
+name = "a"
+
+[packs.p]
+source = "./pack"
+`)
 	cfg := &City{
 		Agents: []Agent{{Name: "a"}},
 		Packs:  map[string]PackSource{"p": {}},
@@ -369,19 +381,22 @@ func TestLegacyV1SurfaceErrorAggregatesViolations(t *testing.T) {
 		},
 	}
 
-	err := LegacyV1SurfaceError(cfg, "city.toml")
+	err := LegacyV1SurfaceError(cfg, "city.toml", data)
 	if err == nil {
 		t.Fatal("LegacyV1SurfaceError returned nil, want aggregated error")
 	}
 	for _, want := range []string{
 		"PackV1 config surfaces are no longer supported",
-		"city.toml: unsupported PackV1 [[agent]] tables",
-		"city.toml: unsupported PackV1 [packs] entries",
-		"city.toml: unsupported PackV1 workspace.includes",
-		"city.toml: unsupported PackV1 workspace.default_rig_includes",
+		"city.toml:5: unsupported PackV1 [[agent]] tables",
+		"city.toml:8: unsupported PackV1 [packs] entries",
+		"city.toml:2: unsupported PackV1 workspace.includes",
+		"city.toml:3: unsupported PackV1 workspace.default_rig_includes",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want substring %q", err, want)
 		}
+	}
+	if got := strings.Count(err.Error(), packV1MigrationDocsURL); got != 1 {
+		t.Fatalf("error = %v, want one docs pointer, got %d", err, got)
 	}
 }

--- a/internal/config/legacy_v1_surfaces_test.go
+++ b/internal/config/legacy_v1_surfaces_test.go
@@ -197,13 +197,10 @@ source = "legacy-pack"
 	}
 }
 
-func TestLoadWithIncludesDetectsLegacyV1SurfacesInSchema2Fragments(t *testing.T) {
+func TestLoadWithIncludesWarnsOnLegacyV1SurfacesInSchema2Fragments(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 include = ["fragments/legacy.toml"]
-
-[workspace]
-name = "schema2-city"
 `)
 	fs.Files["/city/pack.toml"] = []byte(`
 [pack]
@@ -219,15 +216,54 @@ name = "fragment-worker"
 	if err != nil {
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
+	if got := warningsExcludingV1Surfaces(prov.Warnings); len(got) != 0 {
+		t.Fatalf("unexpected unrelated warnings: %v", got)
+	}
 	var found bool
-	for _, w := range prov.Warnings {
-		if strings.Contains(w, "/city/fragments/legacy.toml: [[agent]] tables are deprecated") {
+	for _, warning := range prov.Warnings {
+		if strings.Contains(warning, "/city/fragments/legacy.toml: [[agent]] tables are deprecated") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("fragment legacy agent warning missing from %v", prov.Warnings)
+		t.Fatalf("warnings = %v, want schema-2 fragment legacy surface guidance", prov.Warnings)
+	}
+}
+
+func TestLoadWithIncludesRejectsLegacyV1SurfacesInSchema2City(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "schema2-city"
+includes = ["legacy-pack"]
+default_rig_includes = ["default-pack"]
+
+[[agent]]
+name = "worker"
+
+[packs.legacy]
+source = "legacy-pack"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "schema2-city"
+schema = 2
+`)
+
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want hard error for schema-2 city legacy surfaces")
+	}
+	for _, want := range []string{
+		"unsupported PackV1 [[agent]] tables",
+		"unsupported PackV1 [packs] entries",
+		"unsupported PackV1 workspace.includes",
+		"unsupported PackV1 workspace.default_rig_includes",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
 	}
 }
 
@@ -253,7 +289,7 @@ func TestIsLegacyV1SurfaceWarning(t *testing.T) {
 	}
 }
 
-func TestDetectLegacyV1Surfaces_MentionsActionableMigrationCommand(t *testing.T) {
+func TestDetectLegacyV1Surfaces_PointsAtDoctorWithoutPromisingInPlaceUpgrade(t *testing.T) {
 	cfg := &City{
 		Agents: []Agent{{Name: "a"}},
 		Packs:  map[string]PackSource{"p": {}},
@@ -282,6 +318,33 @@ func TestDetectLegacyV1Surfaces_MentionsActionableMigrationCommand(t *testing.T)
 		}
 		if strings.Contains(w, "gc import migrate") {
 			t.Errorf("warning %d = %q, should not recommend gc import migrate", i, w)
+		}
+	}
+}
+
+func TestLegacyV1SurfaceErrorAggregatesViolations(t *testing.T) {
+	cfg := &City{
+		Agents: []Agent{{Name: "a"}},
+		Packs:  map[string]PackSource{"p": {}},
+		Workspace: Workspace{
+			Includes:           []string{"./inc"},
+			DefaultRigIncludes: []string{"./drig"},
+		},
+	}
+
+	err := LegacyV1SurfaceError(cfg, "city.toml")
+	if err == nil {
+		t.Fatal("LegacyV1SurfaceError returned nil, want aggregated error")
+	}
+	for _, want := range []string{
+		"PackV1 config surfaces are no longer supported",
+		"city.toml: unsupported PackV1 [[agent]] tables",
+		"city.toml: unsupported PackV1 [packs] entries",
+		"city.toml: unsupported PackV1 workspace.includes",
+		"city.toml: unsupported PackV1 workspace.default_rig_includes",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
 		}
 	}
 }

--- a/internal/config/legacy_v1_surfaces_test.go
+++ b/internal/config/legacy_v1_surfaces_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -197,6 +198,26 @@ source = "legacy-pack"
 	}
 }
 
+func TestLoadWithIncludesReturnsRootPackReadErrors(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "city"
+`)
+	fs.Errors["/city/pack.toml"] = os.ErrPermission
+
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want root pack.toml read error")
+	}
+	if !strings.Contains(err.Error(), "loading city pack.toml") {
+		t.Fatalf("error = %q, want loading context", err)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("error = %q, want permission error", err)
+	}
+}
+
 func TestLoadWithIncludesRejectsInlineAgentInSchema2Fragments(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
@@ -217,7 +238,7 @@ name = "fragment-worker"
 		t.Fatal("LoadWithIncludes succeeded, want hard error for schema-2 fragment inline agent")
 	}
 	for _, want := range []string{
-		"PackV1 inline agent tables are no longer supported",
+		"PackV1 config surfaces are no longer supported",
 		"/city/fragments/legacy.toml:2: unsupported PackV1 [[agent]] tables",
 		"move each agent to agents/<name>/agent.toml",
 		packV1MigrationDocsURL,
@@ -228,7 +249,7 @@ name = "fragment-worker"
 	}
 }
 
-func TestLoadWithIncludesWarnsOnNonAgentLegacyV1SurfacesInSchema2Fragments(t *testing.T) {
+func TestLoadWithIncludesRejectsNonAgentLegacyV1SurfacesInSchema2Fragments(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 include = ["fragments/legacy.toml"]
@@ -247,24 +268,19 @@ default_rig_includes = ["default-pack"]
 source = "legacy-pack"
 `)
 
-	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err != nil {
-		t.Fatalf("LoadWithIncludes: %v", err)
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want hard error for schema-2 fragment legacy surfaces")
 	}
 	for _, want := range []string{
-		"/city/fragments/legacy.toml: [packs] is deprecated",
-		"/city/fragments/legacy.toml: workspace.includes is deprecated",
-		"/city/fragments/legacy.toml: workspace.default_rig_includes is deprecated",
+		"PackV1 config surfaces are no longer supported",
+		"/city/fragments/legacy.toml:6: unsupported PackV1 [packs] entries",
+		"/city/fragments/legacy.toml:3: unsupported PackV1 workspace.includes",
+		"/city/fragments/legacy.toml:4: unsupported PackV1 workspace.default_rig_includes",
+		packV1MigrationDocsURL,
 	} {
-		var found bool
-		for _, warning := range prov.Warnings {
-			if strings.Contains(warning, want) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("warnings = %v, want substring %q", prov.Warnings, want)
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
 		}
 	}
 }

--- a/internal/config/order_discovery_test.go
+++ b/internal/config/order_discovery_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"bytes"
-	"log"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,7 +8,7 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-func TestLoadWithIncludes_WarnsForDeprecatedPackOrderDirectory(t *testing.T) {
+func TestLoadWithIncludes_RejectsDeprecatedPackOrderDirectory(t *testing.T) {
 	dir := t.TempDir()
 	packDir := filepath.Join(dir, "mypk")
 	writeTestFile(t, packDir, "pack.toml", `
@@ -32,14 +30,12 @@ name = "test"
 includes = ["../mypk"]
 `)
 
-	logs := captureConfigLogs(t, func() {
-		if _, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml")); err != nil {
-			t.Fatalf("LoadWithIncludes: %v", err)
-		}
-	})
-
-	if !strings.Contains(logs, "rename to orders/health-check.toml") {
-		t.Fatalf("logs = %q, want rename warning", logs)
+	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want hard error for deprecated order directory")
+	}
+	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
+		t.Fatalf("error = %v, want rename guidance", err)
 	}
 }
 
@@ -65,33 +61,7 @@ name = "test"
 includes = ["../mypk"]
 `)
 
-	logs := captureConfigLogs(t, func() {
-		if _, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml")); err != nil {
-			t.Fatalf("LoadWithIncludes: %v", err)
-		}
-	})
-
-	if strings.Contains(logs, "health-check.toml") {
-		t.Fatalf("logs = %q, want no order deprecation warning", logs)
+	if _, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml")); err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-}
-
-func captureConfigLogs(t *testing.T, fn func()) string {
-	t.Helper()
-
-	var buf bytes.Buffer
-	origWriter := log.Writer()
-	origFlags := log.Flags()
-	origPrefix := log.Prefix()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	log.SetPrefix("")
-	defer func() {
-		log.SetOutput(origWriter)
-		log.SetFlags(origFlags)
-		log.SetPrefix(origPrefix)
-	}()
-
-	fn()
-	return buf.String()
 }

--- a/internal/config/order_discovery_test.go
+++ b/internal/config/order_discovery_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -8,34 +9,38 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-func TestLoadWithIncludes_RejectsDeprecatedPackOrderDirectory(t *testing.T) {
-	dir := t.TempDir()
-	packDir := filepath.Join(dir, "mypk")
-	writeTestFile(t, packDir, "pack.toml", `
+func TestLoadWithIncludes_RejectsDeprecatedPackOrderDirectoryForAllPackSchemas(t *testing.T) {
+	for _, schema := range []int{1, 2} {
+		t.Run(fmt.Sprintf("schema-%d", schema), func(t *testing.T) {
+			dir := t.TempDir()
+			packDir := filepath.Join(dir, "mypk")
+			writeTestFile(t, packDir, "pack.toml", fmt.Sprintf(`
 [pack]
 name = "mypk"
-schema = 1
-`)
-	writeTestFile(t, filepath.Join(packDir, "orders", "health-check"), "order.toml", `
+schema = %d
+`, schema))
+			writeTestFile(t, filepath.Join(packDir, "orders", "health-check"), "order.toml", `
 [order]
 formula = "health-check"
 trigger = "cron"
 schedule = "*/5 * * * *"
 `)
 
-	cityDir := filepath.Join(dir, "city")
-	writeTestFile(t, cityDir, "city.toml", `
+			cityDir := filepath.Join(dir, "city")
+			writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test"
 includes = ["../mypk"]
 `)
 
-	_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
-	if err == nil {
-		t.Fatal("LoadWithIncludes succeeded, want hard error for deprecated order directory")
-	}
-	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
-		t.Fatalf("error = %v, want rename guidance", err)
+			_, _, err := LoadWithIncludes(fsys.OSFS{}, filepath.Join(cityDir, "city.toml"))
+			if err == nil {
+				t.Fatal("LoadWithIncludes succeeded, want hard error for deprecated order directory")
+			}
+			if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
+				t.Fatalf("error = %v, want rename guidance", err)
+			}
+		})
 	}
 }
 

--- a/internal/config/pack.go
+++ b/internal/config/pack.go
@@ -1431,13 +1431,16 @@ func loadPackWithCacheOptionsLocked(fs fsys.FS, topoPath, topoDir, cityRoot, rig
 	}
 
 	// V2 convention-based order discovery: top-level orders/ flat files are the
-	// standard layout. Deprecated locations are still discovered so pack loads
-	// surface migration warnings consistently.
-	if _, err := orders.ScanRootsWithOptions(fs, []orders.ScanRoot{{
-		Dir:          filepath.Join(topoDir, "orders"),
-		FormulaLayer: filepath.Join(topoDir, "formulas"),
-	}}, nil, orders.ScanOptions{SuppressDeprecatedPathWarnings: opts.SuppressDeprecatedOrderWarnings}); err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+	// standard layout. Deprecated subdirectory order paths are a filesystem
+	// layout cutover, not a city.toml PackV1 authoring surface, so they are
+	// rejected for all pack schemas.
+	if !opts.allowLegacyOrderLayouts {
+		if _, err := orders.ScanRoots(fs, []orders.ScanRoot{{
+			Dir:          filepath.Join(topoDir, "orders"),
+			FormulaLayer: filepath.Join(topoDir, "formulas"),
+		}}, nil); err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, err
+		}
 	}
 
 	// Stamp parent agents: set dir = rigName (unless already set), adjust paths.

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -2358,13 +2358,11 @@ prompt_flag = "--message"
 	writeTestFile(t, cityDir, "city.toml", `
 [workspace]
 name = "test-city"
-
-[[agent]]
-name = "mayor"
+`)
+	writeTestFile(t, cityDir, filepath.Join("agents", "mayor", "agent.toml"), `
 provider = "claude"
-
-[[agent]]
-name = "worker"
+`)
+	writeTestFile(t, cityDir, filepath.Join("agents", "worker", "agent.toml"), `
 provider = "codex"
 `)
 

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -54,6 +54,16 @@ func DetectLegacySiteBindingSurfaces(cfg *City, source string) []string {
 		return nil
 	}
 
+	warnings := legacyWorkspaceIdentitySurfaceWarnings(cfg, source)
+	warnings = append(warnings, legacyRigPathSurfaceWarnings(cfg, source)...)
+	return warnings
+}
+
+func legacyWorkspaceIdentitySurfaceWarnings(cfg *City, source string) []string {
+	if cfg == nil {
+		return nil
+	}
+
 	var warnings []string
 	var workspaceFields []string
 	if strings.TrimSpace(cfg.Workspace.Name) != "" {
@@ -71,6 +81,15 @@ func DetectLegacySiteBindingSurfaces(cfg *City, source string) []string {
 		))
 	}
 
+	return warnings
+}
+
+func legacyRigPathSurfaceWarnings(cfg *City, source string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	var warnings []string
 	for _, rig := range cfg.Rigs {
 		if strings.TrimSpace(rig.Path) == "" {
 			continue
@@ -99,21 +118,6 @@ func LegacySiteBindingSurfaceErrors(cfg *City, source string) []string {
 	}
 
 	var errors []string
-	var workspaceFields []string
-	if strings.TrimSpace(cfg.Workspace.Name) != "" {
-		workspaceFields = append(workspaceFields, "workspace.name")
-	}
-	if strings.TrimSpace(cfg.Workspace.Prefix) != "" {
-		workspaceFields = append(workspaceFields, "workspace.prefix")
-	}
-	if len(workspaceFields) > 0 {
-		errors = append(errors, fmt.Sprintf(
-			"%s: unsupported pre-1.0 workspace identity fields (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand)",
-			source,
-			strings.Join(workspaceFields, ", "),
-		))
-	}
-
 	for _, rig := range cfg.Rigs {
 		if strings.TrimSpace(rig.Path) == "" {
 			continue

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -16,12 +16,16 @@ import (
 const (
 	legacyRigPathSiteBindingWarningFragment = "still declares path in city.toml; move it to .gc/site.toml"
 	unknownRigSiteBindingWarningPrefix      = ".gc/site.toml declares a binding for unknown rig "
+	legacyWorkspaceIdentityWarningFragment  = "workspace identity fields are deprecated in v2; move them to .gc/site.toml"
+	legacyRigPathSurfaceWarningFragment     = "rig.path is deprecated in v2; move it to .gc/site.toml"
 )
 
 // IsNonFatalSiteBindingWarning reports whether warning is migration guidance
 // that should stay non-fatal in strict mode.
 func IsNonFatalSiteBindingWarning(warning string) bool {
 	return strings.Contains(warning, legacyRigPathSiteBindingWarningFragment) ||
+		strings.Contains(warning, legacyWorkspaceIdentityWarningFragment) ||
+		strings.Contains(warning, legacyRigPathSurfaceWarningFragment) ||
 		strings.HasPrefix(warning, unknownRigSiteBindingWarningPrefix)
 }
 
@@ -39,6 +43,104 @@ func missingRigSiteBindingWarning(name string) string {
 
 func unknownRigSiteBindingWarning(name string) string {
 	return fmt.Sprintf("%s%q", unknownRigSiteBindingWarningPrefix, name)
+}
+
+// DetectLegacySiteBindingSurfaces returns migration warnings for pre-1.0
+// workspace identity and rig-path declarations that still appear in city
+// fragments. Wave 2 defers hard-errors for fragments until the remediation
+// story is real, but we still want the loader to surface what needs work.
+func DetectLegacySiteBindingSurfaces(cfg *City, source string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	var warnings []string
+	var workspaceFields []string
+	if strings.TrimSpace(cfg.Workspace.Name) != "" {
+		workspaceFields = append(workspaceFields, "workspace.name")
+	}
+	if strings.TrimSpace(cfg.Workspace.Prefix) != "" {
+		workspaceFields = append(workspaceFields, "workspace.prefix")
+	}
+	if len(workspaceFields) > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: %s (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand)",
+			source,
+			legacyWorkspaceIdentityWarningFragment,
+			strings.Join(workspaceFields, ", "),
+		))
+	}
+
+	for _, rig := range cfg.Rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		rigName := strings.TrimSpace(rig.Name)
+		if rigName == "" {
+			rigName = "<unnamed>"
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: %s for rig %q; move it to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; otherwise add the binding manually and remove rig.path from the fragment)",
+			source,
+			legacyRigPathSurfaceWarningFragment,
+			rigName,
+		))
+	}
+
+	return warnings
+}
+
+// LegacySiteBindingSurfaceErrors returns hard-error diagnostics for pre-1.0
+// workspace identity and rig-path declarations that should now live in
+// .gc/site.toml instead of city config.
+func LegacySiteBindingSurfaceErrors(cfg *City, source string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	var errors []string
+	var workspaceFields []string
+	if strings.TrimSpace(cfg.Workspace.Name) != "" {
+		workspaceFields = append(workspaceFields, "workspace.name")
+	}
+	if strings.TrimSpace(cfg.Workspace.Prefix) != "" {
+		workspaceFields = append(workspaceFields, "workspace.prefix")
+	}
+	if len(workspaceFields) > 0 {
+		errors = append(errors, fmt.Sprintf(
+			"%s: unsupported pre-1.0 workspace identity fields (%s); move them to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; fragments must be updated by hand)",
+			source,
+			strings.Join(workspaceFields, ", "),
+		))
+	}
+
+	for _, rig := range cfg.Rigs {
+		if strings.TrimSpace(rig.Path) == "" {
+			continue
+		}
+		rigName := strings.TrimSpace(rig.Name)
+		if rigName == "" {
+			rigName = "<unnamed>"
+		}
+		errors = append(errors, fmt.Sprintf(
+			"%s: unsupported pre-1.0 rig.path for rig %q; move it to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; otherwise add the binding manually and remove rig.path from the fragment)",
+			source,
+			rigName,
+		))
+	}
+
+	return errors
+}
+
+// LegacySiteBindingSurfaceError aggregates unsupported pre-1.0 site-binding
+// surfaces into one load-time error for schema=2 enforcement paths.
+func LegacySiteBindingSurfaceError(cfg *City, source string) error {
+	violations := LegacySiteBindingSurfaceErrors(cfg, source)
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf("pre-1.0 site-binding fields are no longer supported:\n  - %s",
+		strings.Join(violations, "\n  - "))
 }
 
 // SiteBindingPath returns the machine-local site binding file for a city.

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -112,11 +112,12 @@ func legacyRigPathSurfaceWarnings(cfg *City, source string) []string {
 // LegacySiteBindingSurfaceErrors returns hard-error diagnostics for pre-1.0
 // workspace identity and rig-path declarations that should now live in
 // .gc/site.toml instead of city config.
-func LegacySiteBindingSurfaceErrors(cfg *City, source string) []string {
+func LegacySiteBindingSurfaceErrors(cfg *City, source string, data ...[]byte) []string {
 	if cfg == nil {
 		return nil
 	}
 
+	locator := optionalConfigDiagnosticLocator(data)
 	var errors []string
 	for _, rig := range cfg.Rigs {
 		if strings.TrimSpace(rig.Path) == "" {
@@ -128,7 +129,7 @@ func LegacySiteBindingSurfaceErrors(cfg *City, source string) []string {
 		}
 		errors = append(errors, fmt.Sprintf(
 			"%s: unsupported pre-1.0 rig.path for rig %q; move it to .gc/site.toml (run `gc doctor --fix` if this is the root city.toml; otherwise add the binding manually and remove rig.path from the fragment)",
-			source,
+			sourceWithDiagnosticLine(source, locator.lineForRigPath(rigName)),
 			rigName,
 		))
 	}
@@ -138,13 +139,9 @@ func LegacySiteBindingSurfaceErrors(cfg *City, source string) []string {
 
 // LegacySiteBindingSurfaceError aggregates unsupported pre-1.0 site-binding
 // surfaces into one load-time error for schema=2 enforcement paths.
-func LegacySiteBindingSurfaceError(cfg *City, source string) error {
-	violations := LegacySiteBindingSurfaceErrors(cfg, source)
-	if len(violations) == 0 {
-		return nil
-	}
-	return fmt.Errorf("pre-1.0 site-binding fields are no longer supported:\n  - %s",
-		strings.Join(violations, "\n  - "))
+func LegacySiteBindingSurfaceError(cfg *City, source string, data ...[]byte) error {
+	violations := LegacySiteBindingSurfaceErrors(cfg, source, data...)
+	return configSurfaceError("pre-1.0 site-binding fields are no longer supported", violations)
 }
 
 // SiteBindingPath returns the machine-local site binding file for a city.

--- a/internal/config/site_binding.go
+++ b/internal/config/site_binding.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,9 +47,9 @@ func unknownRigSiteBindingWarning(name string) string {
 }
 
 // DetectLegacySiteBindingSurfaces returns migration warnings for pre-1.0
-// workspace identity and rig-path declarations that still appear in city
-// fragments. Wave 2 defers hard-errors for fragments until the remediation
-// story is real, but we still want the loader to surface what needs work.
+// workspace identity and rig-path declarations. Schema-2 root-city compose
+// paths now promote rig.path to a hard error, but callers that intentionally
+// need advisory-only diagnostics can still use this helper.
 func DetectLegacySiteBindingSurfaces(cfg *City, source string) []string {
 	if cfg == nil {
 		return nil
@@ -285,30 +286,174 @@ func applyWorkspaceIdentityBinding(cityRoot string, binding *SiteBinding, cfg *C
 }
 
 // PersistRigSiteBindings writes the current machine-local rig bindings to
-// .gc/site.toml. Rigs without paths are left unbound and omitted.
+// .gc/site.toml. Rigs without paths are left unbound and omitted. Existing
+// bindings for rig names not represented by the current city config are
+// preserved so non-doctor edits do not silently delete orphan bindings.
 func PersistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig) error {
+	return persistRigSiteBindings(fs, cityRoot, rigs, nil)
+}
+
+func persistRigSiteBindings(fs fsys.FS, cityRoot string, rigs []Rig, removedRigNames map[string]struct{}) error {
 	existing, err := LoadSiteBinding(fs, cityRoot)
 	if err != nil {
 		return err
 	}
+	declaredNames := make(map[string]struct{}, len(rigs))
 	binding := SiteBinding{
 		WorkspaceName:   strings.TrimSpace(existing.WorkspaceName),
 		WorkspacePrefix: strings.TrimSpace(existing.WorkspacePrefix),
-		Rigs:            make([]RigSiteBinding, 0, len(rigs)),
+		Rigs:            make([]RigSiteBinding, 0, len(rigs)+len(existing.Rigs)),
 	}
 	for _, rig := range rigs {
+		name := strings.TrimSpace(rig.Name)
+		path := strings.TrimSpace(rig.Path)
+		if name == "" {
+			continue
+		}
+		declaredNames[name] = struct{}{}
+		if path == "" {
+			continue
+		}
+		binding.Rigs = append(binding.Rigs, RigSiteBinding{Name: name, Path: path})
+	}
+	for _, rig := range existing.Rigs {
 		name := strings.TrimSpace(rig.Name)
 		path := strings.TrimSpace(rig.Path)
 		if name == "" || path == "" {
 			continue
 		}
+		if _, removed := removedRigNames[name]; removed {
+			continue
+		}
+		if _, ok := declaredNames[name]; ok {
+			continue
+		}
 		binding.Rigs = append(binding.Rigs, RigSiteBinding{Name: name, Path: path})
 	}
 	sort.Slice(binding.Rigs, func(i, j int) bool {
-		return binding.Rigs[i].Name < binding.Rigs[j].Name
+		if binding.Rigs[i].Name != binding.Rigs[j].Name {
+			return binding.Rigs[i].Name < binding.Rigs[j].Name
+		}
+		return binding.Rigs[i].Path < binding.Rigs[j].Path
 	})
 
 	return persistSiteBinding(fs, cityRoot, binding)
+}
+
+// WriteCityAndRigSiteBindingsForEdit writes the checked-in city.toml form and
+// the matching machine-local rig bindings as a recoverable pair. If the site
+// binding write fails after city.toml is changed, the previous city.toml and
+// .gc/site.toml contents are restored before returning the error.
+func WriteCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City) error {
+	return writeCityAndRigSiteBindingsForEdit(fs, tomlPath, cfg, nil)
+}
+
+// WriteCityAndRigSiteBindingsForEditRemovingRigs writes city.toml and
+// .gc/site.toml while removing bindings for rig names that were intentionally
+// deleted from the city config.
+func WriteCityAndRigSiteBindingsForEditRemovingRigs(fs fsys.FS, tomlPath string, cfg *City, removedRigNames ...string) error {
+	return writeCityAndRigSiteBindingsForEdit(fs, tomlPath, cfg, rigNameSet(removedRigNames))
+}
+
+func writeCityAndRigSiteBindingsForEdit(fs fsys.FS, tomlPath string, cfg *City, removedRigNames map[string]struct{}) error {
+	cityRoot := filepath.Dir(tomlPath)
+	content, err := cfg.MarshalForWrite()
+	if err != nil {
+		return err
+	}
+	snapshot, err := snapshotCityAndSiteFiles(fs, tomlPath, SiteBindingPath(cityRoot))
+	if err != nil {
+		return err
+	}
+	if err := fsys.WriteFileIfChangedAtomic(fs, tomlPath, content, 0o644); err != nil {
+		return err
+	}
+	if err := persistRigSiteBindings(fs, cityRoot, cfg.Rigs, removedRigNames); err != nil {
+		if restoreErr := snapshot.restore(fs); restoreErr != nil {
+			return fmt.Errorf("writing .gc/site.toml failed and restoring city.toml/site binding failed: %w", errors.Join(err, restoreErr))
+		}
+		return fmt.Errorf("writing .gc/site.toml failed; restored city.toml and previous site binding, fix the site binding write error and retry: %w", err)
+	}
+	return nil
+}
+
+func rigNameSet(names []string) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		set[name] = struct{}{}
+	}
+	return set
+}
+
+type configFileRestoreSnapshot struct {
+	files map[string]configFileSnapshot
+}
+
+type configFileSnapshot struct {
+	data    []byte
+	mode    os.FileMode
+	existed bool
+}
+
+func snapshotCityAndSiteFiles(fs fsys.FS, paths ...string) (*configFileRestoreSnapshot, error) {
+	snapshot := &configFileRestoreSnapshot{files: make(map[string]configFileSnapshot, len(paths))}
+	for _, path := range paths {
+		fileSnapshot, err := snapshotConfigFile(fs, path)
+		if err != nil {
+			return nil, err
+		}
+		snapshot.files[path] = fileSnapshot
+	}
+	return snapshot, nil
+}
+
+func snapshotConfigFile(fs fsys.FS, path string) (configFileSnapshot, error) {
+	data, err := fs.ReadFile(path)
+	switch {
+	case err == nil:
+		mode := os.FileMode(0o644)
+		if info, statErr := fs.Stat(path); statErr == nil {
+			mode = info.Mode().Perm()
+		}
+		return configFileSnapshot{data: data, mode: mode, existed: true}, nil
+	case os.IsNotExist(err):
+		return configFileSnapshot{}, nil
+	default:
+		return configFileSnapshot{}, fmt.Errorf("snapshotting %s: %w", path, err)
+	}
+}
+
+func (s *configFileRestoreSnapshot) restore(fs fsys.FS) error {
+	var restoreErr error
+	paths := make([]string, 0, len(s.files))
+	for path := range s.files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		file := s.files[path]
+		if !file.existed {
+			if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
+				restoreErr = errors.Join(restoreErr, fmt.Errorf("removing %s: %w", path, err))
+			}
+			continue
+		}
+		if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("creating %s: %w", filepath.Dir(path), err))
+			continue
+		}
+		if err := fsys.WriteFileAtomic(fs, path, file.data, file.mode); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restoring %s: %w", path, err))
+		}
+	}
+	return restoreErr
 }
 
 // PersistWorkspaceSiteBinding writes machine-local workspace identity to

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -180,12 +180,19 @@ func TestLegacySiteBindingSurfaceErrorAggregatesViolations(t *testing.T) {
 	}
 	for _, want := range []string{
 		"pre-1.0 site-binding fields are no longer supported",
-		"city.toml: unsupported pre-1.0 workspace identity fields (workspace.name, workspace.prefix)",
 		`city.toml: unsupported pre-1.0 rig.path for rig "frontend"`,
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want substring %q", err, want)
 		}
+	}
+
+	warnings := legacyWorkspaceIdentitySurfaceWarnings(cfg, "city.toml")
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one workspace identity warning", warnings)
+	}
+	if !strings.Contains(warnings[0], "workspace identity fields are deprecated in v2; move them to .gc/site.toml (workspace.name, workspace.prefix)") {
+		t.Fatalf("warning = %q, want workspace identity guidance", warnings[0])
 	}
 }
 
@@ -211,7 +218,7 @@ schema = 2
 	}
 }
 
-func TestLoadWithIncludes_RejectsLegacyWorkspaceIdentityInSchema2City(t *testing.T) {
+func TestLoadWithIncludes_WarnsOnLegacyWorkspaceIdentityInSchema2City(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 [workspace]
@@ -224,12 +231,19 @@ name = "city"
 schema = 2
 `)
 
-	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
-	if err == nil {
-		t.Fatal("LoadWithIncludes succeeded, want hard error for legacy workspace identity")
+	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unsupported pre-1.0 workspace identity fields (workspace.name, workspace.prefix)") {
-		t.Fatalf("error = %v, want legacy workspace identity guidance", err)
+	var found bool
+	for _, warning := range prov.Warnings {
+		if strings.Contains(warning, "workspace identity fields are deprecated in v2; move them to .gc/site.toml (workspace.name, workspace.prefix)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %v, want legacy workspace identity guidance", prov.Warnings)
 	}
 }
 

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -165,6 +165,114 @@ workspace_prefix = "sc"
 	}
 }
 
+func TestLegacySiteBindingSurfaceErrorAggregatesViolations(t *testing.T) {
+	cfg := &City{
+		Workspace: Workspace{Name: "legacy-city", Prefix: "lc"},
+		Rigs: []Rig{{
+			Name: "frontend",
+			Path: "/legacy/frontend",
+		}},
+	}
+
+	err := LegacySiteBindingSurfaceError(cfg, "city.toml")
+	if err == nil {
+		t.Fatal("LegacySiteBindingSurfaceError returned nil, want aggregated error")
+	}
+	for _, want := range []string{
+		"pre-1.0 site-binding fields are no longer supported",
+		"city.toml: unsupported pre-1.0 workspace identity fields (workspace.name, workspace.prefix)",
+		`city.toml: unsupported pre-1.0 rig.path for rig "frontend"`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
+	}
+}
+
+func TestLoadWithIncludes_RejectsLegacyRigPathInSchema2City(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[[rigs]]
+name = "frontend"
+path = "/legacy/frontend"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "city"
+schema = 2
+`)
+
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want hard error for legacy rig.path")
+	}
+	if !strings.Contains(err.Error(), `unsupported pre-1.0 rig.path for rig "frontend"`) {
+		t.Fatalf("error = %v, want legacy rig.path guidance", err)
+	}
+}
+
+func TestLoadWithIncludes_RejectsLegacyWorkspaceIdentityInSchema2City(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+[workspace]
+name = "legacy-city"
+prefix = "lc"
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "city"
+schema = 2
+`)
+
+	_, _, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err == nil {
+		t.Fatal("LoadWithIncludes succeeded, want hard error for legacy workspace identity")
+	}
+	if !strings.Contains(err.Error(), "unsupported pre-1.0 workspace identity fields (workspace.name, workspace.prefix)") {
+		t.Fatalf("error = %v, want legacy workspace identity guidance", err)
+	}
+}
+
+func TestLoadWithIncludes_WarnsOnLegacySiteBindingSurfacesInSchema2Fragments(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+include = ["fragments/legacy.toml"]
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "city"
+schema = 2
+`)
+	fs.Files["/city/fragments/legacy.toml"] = []byte(`
+[workspace]
+name = "fragment-city"
+
+[[rigs]]
+name = "frontend"
+path = "/legacy/frontend"
+`)
+
+	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	for _, want := range []string{
+		"/city/fragments/legacy.toml: workspace identity fields are deprecated in v2; move them to .gc/site.toml (workspace.name)",
+		`/city/fragments/legacy.toml: rig.path is deprecated in v2; move it to .gc/site.toml for rig "frontend"`,
+	} {
+		var found bool
+		for _, warning := range prov.Warnings {
+			if strings.Contains(warning, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("warnings = %v, want substring %q", prov.Warnings, want)
+		}
+	}
+}
+
 func TestLoadWithIncludes_WarnsOnUnboundRig(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -1,11 +1,28 @@
 package config
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 )
+
+type failSiteRenameFS struct {
+	fsys.OSFS
+	target string
+	failed bool
+}
+
+func (f *failSiteRenameFS) Rename(oldpath, newpath string) error {
+	if !f.failed && filepath.Clean(newpath) == filepath.Clean(f.target) {
+		f.failed = true
+		return errors.New("injected site binding failure")
+	}
+	return f.OSFS.Rename(oldpath, newpath)
+}
 
 func TestMarshalForWrite_StripsRigPaths(t *testing.T) {
 	cfg := &City{
@@ -76,6 +93,90 @@ workspace_prefix = "sc"
 	}
 	if len(binding.Rigs) != 1 || binding.Rigs[0].Name != "frontend" {
 		t.Fatalf("binding.Rigs = %+v, want preserved workspace identity plus frontend rig", binding.Rigs)
+	}
+}
+
+func TestWriteCityAndRigSiteBindingsForEditRemovingRigsDropsDeletedBinding(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	if err := os.WriteFile(cityPath, []byte(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+path = "/srv/frontend"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(SiteBindingPath(dir), []byte(`[[rig]]
+name = "frontend"
+path = "/site/frontend"
+
+[[rig]]
+name = "archived"
+path = "/site/archived"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Rigs:      []Rig{{Name: "frontend", Path: "/site/frontend"}},
+	}
+	if err := WriteCityAndRigSiteBindingsForEditRemovingRigs(fsys.OSFS{}, cityPath, cfg, "archived"); err != nil {
+		t.Fatalf("WriteCityAndRigSiteBindingsForEditRemovingRigs: %v", err)
+	}
+
+	binding, err := LoadSiteBinding(fsys.OSFS{}, dir)
+	if err != nil {
+		t.Fatalf("LoadSiteBinding: %v", err)
+	}
+	if len(binding.Rigs) != 1 {
+		t.Fatalf("binding.Rigs = %+v, want only frontend", binding.Rigs)
+	}
+	if binding.Rigs[0].Name != "frontend" || binding.Rigs[0].Path != "/site/frontend" {
+		t.Fatalf("binding.Rigs[0] = %+v, want frontend binding", binding.Rigs[0])
+	}
+}
+
+func TestWriteCityAndRigSiteBindingsForEditRestoresCityWhenSiteBindingFails(t *testing.T) {
+	dir := t.TempDir()
+	cityPath := filepath.Join(dir, "city.toml")
+	original := []byte(`[workspace]
+name = "test-city"
+
+[[rigs]]
+name = "frontend"
+path = "/srv/frontend"
+`)
+	if err := os.WriteFile(cityPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &City{
+		Workspace: Workspace{Name: "test-city"},
+		Rigs:      []Rig{{Name: "frontend", Path: "/srv/frontend"}},
+	}
+	fs := &failSiteRenameFS{target: SiteBindingPath(dir)}
+
+	err := WriteCityAndRigSiteBindingsForEdit(fs, cityPath, cfg)
+	if err == nil {
+		t.Fatal("WriteCityAndRigSiteBindingsForEdit succeeded, want injected site binding failure")
+	}
+	if !strings.Contains(err.Error(), "restored city.toml") {
+		t.Fatalf("error = %v, want rollback guidance", err)
+	}
+	restored, readErr := os.ReadFile(cityPath)
+	if readErr != nil {
+		t.Fatalf("read city.toml: %v", readErr)
+	}
+	if string(restored) != string(original) {
+		t.Fatalf("city.toml = %q, want restored original %q", restored, original)
+	}
+	if _, statErr := os.Stat(SiteBindingPath(dir)); !os.IsNotExist(statErr) {
+		t.Fatalf("site.toml stat err = %v, want not exist", statErr)
 	}
 }
 
@@ -260,7 +361,7 @@ schema = 2
 	}
 }
 
-func TestLoadWithIncludes_WarnsOnLegacySiteBindingSurfacesInSchema2Fragments(t *testing.T) {
+func TestLoadWithIncludes_WarnsOnLegacyWorkspaceIdentityInSchema2Fragments(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/city/city.toml"] = []byte(`
 include = ["fragments/legacy.toml"]
@@ -273,7 +374,35 @@ schema = 2
 	fs.Files["/city/fragments/legacy.toml"] = []byte(`
 [workspace]
 name = "fragment-city"
+`)
 
+	_, prov, err := LoadWithIncludes(fs, "/city/city.toml")
+	if err != nil {
+		t.Fatalf("LoadWithIncludes: %v", err)
+	}
+	var found bool
+	for _, warning := range prov.Warnings {
+		if strings.Contains(warning, "/city/fragments/legacy.toml: workspace identity fields are deprecated in v2; move them to .gc/site.toml (workspace.name)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %v, want fragment workspace identity guidance", prov.Warnings)
+	}
+}
+
+func TestLoadWithIncludes_WarnsOnLegacyRigPathInSchema2Fragment(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`
+include = ["fragments/legacy.toml"]
+`)
+	fs.Files["/city/pack.toml"] = []byte(`
+[pack]
+name = "city"
+schema = 2
+`)
+	fs.Files["/city/fragments/legacy.toml"] = []byte(`
 [[rigs]]
 name = "frontend"
 path = "/legacy/frontend"
@@ -283,20 +412,15 @@ path = "/legacy/frontend"
 	if err != nil {
 		t.Fatalf("LoadWithIncludes: %v", err)
 	}
-	for _, want := range []string{
-		"/city/fragments/legacy.toml: workspace identity fields are deprecated in v2; move them to .gc/site.toml (workspace.name)",
-		`/city/fragments/legacy.toml: rig.path is deprecated in v2; move it to .gc/site.toml for rig "frontend"`,
-	} {
-		var found bool
-		for _, warning := range prov.Warnings {
-			if strings.Contains(warning, want) {
-				found = true
-				break
-			}
+	var found bool
+	for _, warning := range prov.Warnings {
+		if strings.Contains(warning, `/city/fragments/legacy.toml: rig.path is deprecated in v2; move it to .gc/site.toml for rig "frontend"`) {
+			found = true
+			break
 		}
-		if !found {
-			t.Fatalf("warnings = %v, want substring %q", prov.Warnings, want)
-		}
+	}
+	if !found {
+		t.Fatalf("warnings = %v, want fragment rig.path guidance", prov.Warnings)
 	}
 }
 

--- a/internal/config/site_binding_test.go
+++ b/internal/config/site_binding_test.go
@@ -166,6 +166,10 @@ workspace_prefix = "sc"
 }
 
 func TestLegacySiteBindingSurfaceErrorAggregatesViolations(t *testing.T) {
+	data := []byte(`[[rigs]]
+name = "frontend"
+path = "/legacy/frontend"
+`)
 	cfg := &City{
 		Workspace: Workspace{Name: "legacy-city", Prefix: "lc"},
 		Rigs: []Rig{{
@@ -174,17 +178,21 @@ func TestLegacySiteBindingSurfaceErrorAggregatesViolations(t *testing.T) {
 		}},
 	}
 
-	err := LegacySiteBindingSurfaceError(cfg, "city.toml")
+	err := LegacySiteBindingSurfaceError(cfg, "city.toml", data)
 	if err == nil {
 		t.Fatal("LegacySiteBindingSurfaceError returned nil, want aggregated error")
 	}
 	for _, want := range []string{
 		"pre-1.0 site-binding fields are no longer supported",
-		`city.toml: unsupported pre-1.0 rig.path for rig "frontend"`,
+		`city.toml:3: unsupported pre-1.0 rig.path for rig "frontend"`,
+		packV1MigrationDocsURL,
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want substring %q", err, want)
 		}
+	}
+	if got := strings.Count(err.Error(), packV1MigrationDocsURL); got != 1 {
+		t.Fatalf("error = %v, want one docs pointer, got %d", err, got)
 	}
 
 	warnings := legacyWorkspaceIdentitySurfaceWarnings(cfg, "city.toml")
@@ -213,8 +221,13 @@ schema = 2
 	if err == nil {
 		t.Fatal("LoadWithIncludes succeeded, want hard error for legacy rig.path")
 	}
-	if !strings.Contains(err.Error(), `unsupported pre-1.0 rig.path for rig "frontend"`) {
-		t.Fatalf("error = %v, want legacy rig.path guidance", err)
+	for _, want := range []string{
+		`/city/city.toml:4: unsupported pre-1.0 rig.path for rig "frontend"`,
+		packV1MigrationDocsURL,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
 	}
 }
 

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -555,19 +555,60 @@ func (e *Editor) ResumeCity() error {
 	})
 }
 
-// CreateAgent adds a new agent to the config. Returns an error if an
+// CreateAgent adds a new city-local convention agent. Returns an error if an
 // agent with the same qualified name already exists.
 func (e *Editor) CreateAgent(a config.Agent) error {
-	return e.Edit(func(cfg *config.City) error {
+	return e.EditExpanded(func(_, expanded *config.City) error {
 		qn := a.QualifiedName()
-		for _, existing := range cfg.Agents {
+		for _, existing := range expanded.Agents {
 			if existing.QualifiedName() == qn {
 				return fmt.Errorf("%w: agent %q", ErrAlreadyExists, qn)
 			}
 		}
-		cfg.Agents = append(cfg.Agents, a)
-		return nil
+		if err := WriteLocalDiscoveredAgentConfig(e.fs, filepath.Dir(e.tomlPath), a); err != nil {
+			return err
+		}
+		return ErrUnmodified
 	})
+}
+
+// WriteLocalDiscoveredAgentConfig writes the durable config for a city-local
+// convention agent under agents/<name>/agent.toml.
+func WriteLocalDiscoveredAgentConfig(fs fsys.FS, cityRoot string, agent config.Agent) error {
+	if agent.Name == "" {
+		return fmt.Errorf("%w: agent name is required", ErrValidation)
+	}
+
+	agentDir := filepath.Join(cityRoot, "agents", agent.Name)
+	if err := fs.MkdirAll(agentDir, 0o755); err != nil {
+		return fmt.Errorf("creating agents/%s: %w", agent.Name, err)
+	}
+
+	values := make(map[string]any)
+	if agent.Description != "" {
+		values["description"] = agent.Description
+	}
+	if agent.Dir != "" {
+		values["dir"] = agent.Dir
+	}
+	if agent.Scope != "" {
+		values["scope"] = agent.Scope
+	}
+	if agent.Provider != "" {
+		values["provider"] = agent.Provider
+	}
+	if agent.Suspended {
+		values["suspended"] = true
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
+		return fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err)
+	}
+	if err := fsys.WriteFileAtomic(fs, filepath.Join(agentDir, "agent.toml"), buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err)
+	}
+	return nil
 }
 
 // AgentUpdate holds optional fields for a partial agent update.

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"
@@ -98,20 +99,8 @@ func (e *Editor) Edit(fn func(cfg *config.City) error) error {
 		return err
 	}
 
-	if err := config.ValidateAgents(cfg.Agents); err != nil {
-		return fmt.Errorf("%w: agents: %w", ErrValidation, err)
-	}
-	if err := config.ValidateRigs(cfg.Rigs, config.EffectiveHQPrefix(cfg)); err != nil {
-		return fmt.Errorf("%w: rigs: %w", ErrValidation, err)
-	}
-	if err := config.ValidateServices(cfg.Services); err != nil {
-		return fmt.Errorf("%w: services: %w", ErrValidation, err)
-	}
-	if err := workspacesvc.ValidateRuntimeSupport(cfg.Services); err != nil {
-		return fmt.Errorf("%w: services: %w", ErrValidation, err)
-	}
-	if err := validateProviders(cfg.Providers); err != nil {
-		return fmt.Errorf("%w: providers: %w", ErrValidation, err)
+	if err := validateCityForEdit(cfg); err != nil {
+		return err
 	}
 
 	return e.write(cfg)
@@ -146,23 +135,30 @@ func (e *Editor) EditExpanded(fn func(raw, expanded *config.City) error) error {
 		return err
 	}
 
-	if err := config.ValidateAgents(raw.Agents); err != nil {
-		return fmt.Errorf("%w: agents: %w", ErrValidation, err)
-	}
-	if err := config.ValidateRigs(raw.Rigs, config.EffectiveHQPrefix(raw)); err != nil {
-		return fmt.Errorf("%w: rigs: %w", ErrValidation, err)
-	}
-	if err := config.ValidateServices(raw.Services); err != nil {
-		return fmt.Errorf("%w: services: %w", ErrValidation, err)
-	}
-	if err := workspacesvc.ValidateRuntimeSupport(raw.Services); err != nil {
-		return fmt.Errorf("%w: services: %w", ErrValidation, err)
-	}
-	if err := validateProviders(raw.Providers); err != nil {
-		return fmt.Errorf("%w: providers: %w", ErrValidation, err)
+	if err := validateCityForEdit(raw); err != nil {
+		return err
 	}
 
 	return e.write(raw)
+}
+
+func validateCityForEdit(cfg *config.City) error {
+	if err := config.ValidateAgents(cfg.Agents); err != nil {
+		return fmt.Errorf("%w: agents: %w", ErrValidation, err)
+	}
+	if err := config.ValidateRigs(cfg.Rigs, config.EffectiveHQPrefix(cfg)); err != nil {
+		return fmt.Errorf("%w: rigs: %w", ErrValidation, err)
+	}
+	if err := config.ValidateServices(cfg.Services); err != nil {
+		return fmt.Errorf("%w: services: %w", ErrValidation, err)
+	}
+	if err := workspacesvc.ValidateRuntimeSupport(cfg.Services); err != nil {
+		return fmt.Errorf("%w: services: %w", ErrValidation, err)
+	}
+	if err := validateProviders(cfg.Providers); err != nil {
+		return fmt.Errorf("%w: providers: %w", ErrValidation, err)
+	}
+	return nil
 }
 
 func (e *Editor) loadForEdit() (*config.City, error) {
@@ -187,22 +183,11 @@ func (e *Editor) loadForEdit() (*config.City, error) {
 // writeCityConfigForEditFS so repeated no-op mutations don't churn
 // watcher mtime or break debounce.
 func (e *Editor) write(cfg *config.City) error {
-	cityPath := filepath.Dir(e.tomlPath)
-	content, err := cfg.MarshalForWrite()
-	if err != nil {
-		return fmt.Errorf("marshaling config: %w", err)
-	}
-	if err := fsys.WriteFileIfChangedAtomic(e.fs, e.tomlPath, content, 0o644); err != nil {
-		return err
-	}
-	if err := config.PersistRigSiteBindings(e.fs, cityPath, cfg.Rigs); err != nil {
-		// Surface the half-migrated state: city.toml has been rewritten
-		// without rig paths, but the site binding wasn't persisted, so
-		// any previously-bound rigs whose path came only from city.toml
-		// are now unbound.
-		return fmt.Errorf("writing .gc/site.toml failed after city.toml was rewritten — rigs may be unbound; re-run the command or `gc doctor --fix` to retry: %w", err)
-	}
-	return nil
+	return config.WriteCityAndRigSiteBindingsForEdit(e.fs, e.tomlPath, cfg)
+}
+
+func (e *Editor) writeRemovingRigs(cfg *config.City, removedRigNames ...string) error {
+	return config.WriteCityAndRigSiteBindingsForEditRemovingRigs(e.fs, e.tomlPath, cfg, removedRigNames...)
 }
 
 // AgentOrigin determines whether an agent is defined inline in the raw
@@ -326,7 +311,11 @@ func mutateAgentSuspended(fs fsys.FS, cityRoot string, raw, expanded *config.Cit
 	case OriginInline:
 		return SetAgentSuspended(raw, name, suspended)
 	case OriginDerived:
-		if agent, ok := findLocalDiscoveredAgent(fs, expanded, cityRoot, name); ok {
+		agent, ok, err := findLocalDiscoveredAgent(fs, expanded, cityRoot, name)
+		if err != nil {
+			return err
+		}
+		if ok {
 			if err := WriteLocalDiscoveredAgentSuspended(fs, cityRoot, agent, suspended); err != nil {
 				return err
 			}
@@ -350,24 +339,28 @@ func mutateAgentSuspended(fs fsys.FS, cityRoot string, raw, expanded *config.Cit
 	return fmt.Errorf("agent %q: unknown origin", name)
 }
 
-func findLocalDiscoveredAgent(fs fsys.FS, expanded *config.City, cityRoot, name string) (config.Agent, bool) {
+func findLocalDiscoveredAgent(fs fsys.FS, expanded *config.City, cityRoot, name string) (config.Agent, bool, error) {
 	cityRoot = filepath.Clean(cityRoot)
 	for _, a := range expanded.Agents {
 		if !config.AgentMatchesIdentity(&a, name) {
 			continue
 		}
-		if !LocalDiscoveredAgent(fs, cityRoot, a) {
+		local, err := LocalDiscoveredAgent(fs, cityRoot, a)
+		if err != nil {
+			return config.Agent{}, false, err
+		}
+		if !local {
 			continue
 		}
-		return a, true
+		return a, true, nil
 	}
-	return config.Agent{}, false
+	return config.Agent{}, false, nil
 }
 
 // LocalDiscoveredAgent reports whether an agent's durable configuration
-// lives in agents/<name>/agent.toml. Such agents are scaffolded purely by
-// the convention layout (a prompt file under agents/<name>/) and are not
-// declared in either city.toml [[agent]] or the city's pack.toml [[agent]].
+// lives in agents/<name>/agent.toml. Such agents are scaffolded by the
+// convention layout or created through the schema-2 API, and are not declared
+// in either city.toml [[agent]] or the city's pack.toml [[agent]].
 //
 // Pack-declared [[agent]] entries that happen to point at a conventional
 // prompt template are intentionally excluded — for those, [[patches.agent]]
@@ -375,10 +368,14 @@ func findLocalDiscoveredAgent(fs fsys.FS, expanded *config.City, cityRoot, name 
 // precedence over agent.toml during composition. The pack-declared check
 // matches on the agent's full (Dir, Name) identity so that a city-scoped
 // discovered agent and a pack rig-scoped agent that happen to share a
-// bare Name remain distinct.
-func LocalDiscoveredAgent(fs fsys.FS, cityRoot string, agent config.Agent) bool {
+// bare Name remain distinct. The agent.toml marker is sufficient for
+// city-scoped convention ownership even when the prompt template lives at a
+// custom path. If the city's pack.toml exists but cannot be read or decoded,
+// the error is returned instead of treating the pack declaration check as
+// positive ownership evidence.
+func LocalDiscoveredAgent(fs fsys.FS, cityRoot string, agent config.Agent) (bool, error) {
 	if agent.BindingName != "" {
-		return false
+		return false, nil
 	}
 	// Convention discovery scans <cityRoot>/agents/<Name>/, which is
 	// strictly city-scoped (Agent.Dir == ""). A rig-scoped agent that
@@ -387,19 +384,31 @@ func LocalDiscoveredAgent(fs fsys.FS, cityRoot string, agent config.Agent) bool 
 	// as local-discovered — writing agent.toml there would corrupt the
 	// city agent's durable state.
 	if agent.Dir != "" {
-		return false
+		return false, nil
 	}
 	cityRoot = filepath.Clean(cityRoot)
 	agentDir := filepath.Join(cityRoot, "agents", agent.Name)
+	declared, err := agentDeclaredInCityPack(fs, cityRoot, agent.Dir, agent.Name)
+	if err != nil {
+		return false, err
+	}
+	if declared {
+		return false, nil
+	}
+	if _, err := fs.Stat(filepath.Join(agentDir, "agent.toml")); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, nil
+	}
 	switch filepath.Clean(agent.PromptTemplate) {
 	case filepath.Join(agentDir, "prompt.template.md"),
 		filepath.Join(agentDir, "prompt.md.tmpl"),
 		filepath.Join(agentDir, "prompt.md"):
-		// Conventional layout — eligible unless explicitly declared.
+		// Conventional prompt layout — eligible unless explicitly declared.
 	default:
-		return false
+		return false, nil
 	}
-	return !agentDeclaredInCityPack(fs, cityRoot, agent.Dir, agent.Name)
+	return true, nil
 }
 
 // agentDeclaredInCityPack reports whether (dir, name) appears as an
@@ -408,11 +417,14 @@ func LocalDiscoveredAgent(fs fsys.FS, cityRoot string, agent config.Agent) bool 
 // Matching uses the full (Dir, Name) identity so that, for example, a
 // rig-scoped pack agent (dir="rig", name="worker") does not shadow a
 // city-scoped discovered agent of the same bare name.
-func agentDeclaredInCityPack(fs fsys.FS, cityRoot, dir, name string) bool {
+func agentDeclaredInCityPack(fs fsys.FS, cityRoot, dir, name string) (bool, error) {
 	packPath := filepath.Join(cityRoot, "pack.toml")
 	data, err := fs.ReadFile(packPath)
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", packPath, err)
 	}
 	var pc struct {
 		Agents []struct {
@@ -421,14 +433,14 @@ func agentDeclaredInCityPack(fs fsys.FS, cityRoot, dir, name string) bool {
 		} `toml:"agent"`
 	}
 	if _, err := toml.Decode(string(data), &pc); err != nil {
-		return false
+		return false, fmt.Errorf("parsing %s: %w", packPath, err)
 	}
 	for _, a := range pc.Agents {
 		if a.Dir == dir && a.Name == name {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // StripAgentPatchSuspended clears the Suspended override from any
@@ -448,6 +460,57 @@ func StripAgentPatchSuspended(cfg *config.City, name string) bool {
 			if isAgentPatchOnlyIdentity(p) {
 				continue
 			}
+		}
+		kept = append(kept, p)
+	}
+	if modified {
+		cfg.Patches.Agents = kept
+	}
+	return modified
+}
+
+func stripAgentPatchUpdate(cfg *config.City, name string, patch AgentUpdate) bool {
+	dir, base := config.ParseQualifiedName(name)
+	modified := false
+	kept := cfg.Patches.Agents[:0:0]
+	for _, p := range cfg.Patches.Agents {
+		patchModified := false
+		if p.Dir == dir && p.Name == base {
+			if patch.Provider != "" && p.Provider != nil {
+				p.Provider = nil
+				patchModified = true
+			}
+			if patch.Scope != "" && p.Scope != nil {
+				p.Scope = nil
+				patchModified = true
+			}
+			if patch.Suspended != nil && p.Suspended != nil {
+				p.Suspended = nil
+				patchModified = true
+			}
+		}
+		if patchModified {
+			modified = true
+			if isAgentPatchOnlyIdentity(p) {
+				continue
+			}
+		}
+		kept = append(kept, p)
+	}
+	if modified {
+		cfg.Patches.Agents = kept
+	}
+	return modified
+}
+
+func removeAgentPatch(cfg *config.City, name string) bool {
+	dir, base := config.ParseQualifiedName(name)
+	modified := false
+	kept := cfg.Patches.Agents[:0:0]
+	for _, p := range cfg.Patches.Agents {
+		if p.Dir == dir && p.Name == base {
+			modified = true
+			continue
 		}
 		kept = append(kept, p)
 	}
@@ -525,6 +588,17 @@ func WriteLocalDiscoveredAgentSuspended(fs fsys.FS, cityRoot string, agent confi
 	return nil
 }
 
+func removeLocalDiscoveredAgentConfig(fs fsys.FS, cityRoot string, agent config.Agent) error {
+	agentDir, err := LocalDiscoveredAgentDir(cityRoot, agent.Name)
+	if err != nil {
+		return err
+	}
+	if err := fsys.RemoveAll(fs, agentDir); err != nil {
+		return fmt.Errorf("removing agents/%s: %w", agent.Name, err)
+	}
+	return nil
+}
+
 // SuspendRig suspends a rig by setting suspended=true in city.toml.
 func (e *Editor) SuspendRig(name string) error {
 	return e.Edit(func(cfg *config.City) error {
@@ -567,7 +641,7 @@ func (e *Editor) CreateAgent(a config.Agent) error {
 		}
 
 		cityRoot := filepath.Dir(e.tomlPath)
-		schema2Pack, err := hasSchema2RootPack(e.fs, cityRoot)
+		schema2Pack, err := HasSchema2RootPack(e.fs, cityRoot)
 		if err != nil {
 			return err
 		}
@@ -583,7 +657,9 @@ func (e *Editor) CreateAgent(a config.Agent) error {
 	})
 }
 
-func hasSchema2RootPack(fs fsys.FS, cityRoot string) (bool, error) {
+// HasSchema2RootPack reports whether cityRoot contains a root pack.toml with
+// [pack].schema set to 2 or later.
+func HasSchema2RootPack(fs fsys.FS, cityRoot string) (bool, error) {
 	data, err := fs.ReadFile(filepath.Join(cityRoot, "pack.toml"))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -603,24 +679,39 @@ func hasSchema2RootPack(fs fsys.FS, cityRoot string) (bool, error) {
 	return header.Pack.Schema >= 2, nil
 }
 
-// WriteLocalDiscoveredAgentConfig writes the durable config for a city-local
-// convention agent under agents/<name>/agent.toml.
+// WriteLocalDiscoveredAgentConfig writes the supported durable config for a
+// city-local convention agent under agents/<name>/agent.toml. The scaffold's
+// directory name is the agent identity; the file intentionally persists only
+// description, scope, provider, and suspended. Richer config.Agent fields must
+// come from pack config or [[patches.agent]] so the scaffold writer cannot
+// silently become a partial full-agent serializer. It returns ErrValidation
+// when agent.Dir is set; rig-scoped agents must also come from pack config or
+// [[patches.agent]].
 func WriteLocalDiscoveredAgentConfig(fs fsys.FS, cityRoot string, agent config.Agent) error {
-	if agent.Name == "" {
-		return fmt.Errorf("%w: agent name is required", ErrValidation)
+	if err := validateLocalDiscoveredAgent(agent); err != nil {
+		return err
+	}
+	if unsupported := unsupportedLocalDiscoveredAgentFields(agent); len(unsupported) > 0 {
+		return fmt.Errorf("%w: schema-2 convention agent config only persists description, scope, provider, and suspended; unsupported fields: %s", ErrValidation, strings.Join(unsupported, ", "))
 	}
 
-	agentDir := filepath.Join(cityRoot, "agents", agent.Name)
-	if err := fs.MkdirAll(agentDir, 0o755); err != nil {
-		return fmt.Errorf("creating agents/%s: %w", agent.Name, err)
+	agentDir, agentDirExisted, err := EnsureLocalDiscoveredAgentDir(fs, cityRoot, agent.Name)
+	if err != nil {
+		return err
+	}
+	cleanupFreshScaffold := func(err error) error {
+		if agentDirExisted {
+			return err
+		}
+		if removeErr := fsys.RemoveAll(fs, agentDir); removeErr != nil {
+			return errors.Join(err, fmt.Errorf("removing fresh agents/%s scaffold: %w", agent.Name, removeErr))
+		}
+		return err
 	}
 
 	values := make(map[string]any)
 	if agent.Description != "" {
 		values["description"] = agent.Description
-	}
-	if agent.Dir != "" {
-		values["dir"] = agent.Dir
 	}
 	if agent.Scope != "" {
 		values["scope"] = agent.Scope
@@ -634,12 +725,153 @@ func WriteLocalDiscoveredAgentConfig(fs fsys.FS, cityRoot string, agent config.A
 
 	var buf bytes.Buffer
 	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
-		return fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err)
+		return cleanupFreshScaffold(fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err))
 	}
 	if err := fsys.WriteFileAtomic(fs, filepath.Join(agentDir, "agent.toml"), buf.Bytes(), 0o644); err != nil {
+		return cleanupFreshScaffold(fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err))
+	}
+	return nil
+}
+
+// EnsureLocalDiscoveredAgentDir creates the agents/<name> scaffold directory
+// without following a symlink at the agents root or final agent directory.
+// It returns whether the final agent directory existed before the call.
+func EnsureLocalDiscoveredAgentDir(fs fsys.FS, cityRoot, name string) (string, bool, error) {
+	agentsDir := filepath.Join(cityRoot, "agents")
+	if _, err := ensureExistingDirectoryIsNotSymlink(fs, agentsDir, "agents"); err != nil {
+		return "", false, err
+	}
+
+	agentDir, err := LocalDiscoveredAgentDir(cityRoot, name)
+	if err != nil {
+		return "", false, err
+	}
+	agentDirExisted, err := ensureExistingDirectoryIsNotSymlink(fs, agentDir, filepath.Join("agents", name))
+	if err != nil {
+		return "", false, err
+	}
+	if err := fs.MkdirAll(agentDir, 0o755); err != nil {
+		return "", false, fmt.Errorf("creating agents/%s: %w", name, err)
+	}
+	return agentDir, agentDirExisted, nil
+}
+
+func ensureExistingDirectoryIsNotSymlink(fs fsys.FS, path, label string) (bool, error) {
+	info, err := fs.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking %s: %w", label, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("%w: %s must be a real directory, not a symlink", ErrValidation, label)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("%w: %s must be a directory", ErrValidation, label)
+	}
+	return true, nil
+}
+
+func writeLocalDiscoveredAgentUpdate(fs fsys.FS, cityRoot string, agent config.Agent, patch AgentUpdate) error {
+	if err := validateLocalDiscoveredAgent(agent); err != nil {
+		return err
+	}
+
+	agentTomlPath := filepath.Join(cityRoot, "agents", agent.Name, "agent.toml")
+	values := make(map[string]any)
+	data, err := fs.ReadFile(agentTomlPath)
+	switch {
+	case err == nil:
+		if len(bytes.TrimSpace(data)) > 0 {
+			if _, decodeErr := toml.Decode(string(data), &values); decodeErr != nil {
+				return fmt.Errorf("reading agents/%s/agent.toml: %w", agent.Name, decodeErr)
+			}
+		}
+	case os.IsNotExist(err):
+	default:
+		return fmt.Errorf("reading agents/%s/agent.toml: %w", agent.Name, err)
+	}
+
+	if patch.Provider != "" {
+		values["provider"] = patch.Provider
+	}
+	if patch.Scope != "" {
+		values["scope"] = patch.Scope
+	}
+	if patch.Suspended != nil {
+		values["suspended"] = *patch.Suspended
+	}
+
+	// An empty merged convention config means there is no durable agent.toml
+	// content to preserve; the prompt scaffold still defines the agent.
+	if len(values) == 0 {
+		if err := fs.Remove(agentTomlPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing agents/%s/agent.toml: %w", agent.Name, err)
+		}
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(values); err != nil {
+		return fmt.Errorf("encoding agents/%s/agent.toml: %w", agent.Name, err)
+	}
+	if err := fsys.WriteFileAtomic(fs, agentTomlPath, buf.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("writing agents/%s/agent.toml: %w", agent.Name, err)
 	}
 	return nil
+}
+
+func validateLocalDiscoveredAgent(agent config.Agent) error {
+	if agent.Dir != "" || agent.Scope == "rig" {
+		return fmt.Errorf("%w: schema-2 convention agents are city-scoped; create rig-scoped agents in pack config or use [[patches.agent]]", ErrValidation)
+	}
+	if err := config.ValidateAgents([]config.Agent{agent}); err != nil {
+		return fmt.Errorf("%w: agent: %w", ErrValidation, err)
+	}
+	return nil
+}
+
+func unsupportedLocalDiscoveredAgentFields(agent config.Agent) []string {
+	allowed := map[string]bool{
+		"Name":        true,
+		"Description": true,
+		"Scope":       true,
+		"Provider":    true,
+		"Suspended":   true,
+	}
+	v := reflect.ValueOf(agent)
+	t := v.Type()
+	var unsupported []string
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if allowed[field.Name] {
+			continue
+		}
+		if strings.Split(field.Tag.Get("toml"), ",")[0] == "-" {
+			continue
+		}
+		if !v.Field(i).IsZero() {
+			unsupported = append(unsupported, field.Name)
+		}
+	}
+	return unsupported
+}
+
+// LocalDiscoveredAgentDir returns the agents/<name> scaffold directory for a
+// city-local convention agent. It returns ErrValidation if name would resolve
+// outside the city's agents directory.
+func LocalDiscoveredAgentDir(cityRoot, name string) (string, error) {
+	agentsDir := filepath.Join(cityRoot, "agents")
+	agentDir := filepath.Join(agentsDir, name)
+	rel, err := filepath.Rel(agentsDir, agentDir)
+	if err != nil {
+		return "", fmt.Errorf("resolving agents/%s: %w", name, err)
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: agent name %q resolves outside agents directory", ErrValidation, name)
+	}
+	return agentDir, nil
 }
 
 // AgentUpdate holds optional fields for a partial agent update.
@@ -649,54 +881,158 @@ type AgentUpdate struct {
 	Suspended *bool
 }
 
-// UpdateAgent partially updates an existing agent. Uses EditExpanded for
-// provenance detection — pack-derived agents return a clear error.
-func (e *Editor) UpdateAgent(name string, patch AgentUpdate) error {
-	return e.EditExpanded(func(raw, expanded *config.City) error {
-		origin := AgentOrigin(raw, expanded, name)
-		switch origin {
-		case OriginDerived:
-			return fmt.Errorf("%w: agent %q cannot be updated directly (use patches)", ErrPackDerived, name)
-		case OriginNotFound:
-			return fmt.Errorf("%w: agent %q", ErrNotFound, name)
+func (e *Editor) loadExpandedForEdit() (*config.City, *config.City, error) {
+	raw, err := e.loadForEdit()
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading raw config: %w", err)
+	}
+	expanded, _, err := config.LoadWithIncludes(e.fs, e.tomlPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading expanded config: %w", err)
+	}
+	return raw, expanded, nil
+}
+
+func (e *Editor) commitLocalDiscoveredAgentMutation(cityRoot string, agent config.Agent, mutateLocal func() error, commit func() error) error {
+	agentDir, err := LocalDiscoveredAgentDir(cityRoot, agent.Name)
+	if err != nil {
+		return err
+	}
+	snapshot, err := fsys.SnapshotTree(e.fs, agentDir)
+	if err != nil {
+		return err
+	}
+	if err := mutateLocal(); err != nil {
+		if restoreErr := snapshot.Restore(e.fs); restoreErr != nil {
+			return fmt.Errorf("updating agents/%s: %w", agent.Name, errors.Join(err, fmt.Errorf("restoring agents/%s: %w", agent.Name, restoreErr)))
 		}
-		for i := range raw.Agents {
-			if config.AgentMatchesIdentity(&raw.Agents[i], name) {
-				if patch.Provider != "" {
-					raw.Agents[i].Provider = patch.Provider
-				}
-				if patch.Scope != "" {
-					raw.Agents[i].Scope = patch.Scope
-				}
-				if patch.Suspended != nil {
-					raw.Agents[i].Suspended = *patch.Suspended
-				}
-				return nil
-			}
+		return err
+	}
+	if commit == nil {
+		return nil
+	}
+	if err := commit(); err != nil {
+		if restoreErr := snapshot.Restore(e.fs); restoreErr != nil {
+			return fmt.Errorf("writing config after updating agents/%s: %w", agent.Name, errors.Join(err, fmt.Errorf("restoring agents/%s: %w", agent.Name, restoreErr)))
 		}
-		return fmt.Errorf("%w: agent %q", ErrNotFound, name)
+		return err
+	}
+	return nil
+}
+
+func (e *Editor) commitLocalDiscoveredAgentUpdate(cityRoot string, agent config.Agent, mutateLocal func() error, raw *config.City) error {
+	return e.commitLocalDiscoveredAgentMutation(cityRoot, agent, mutateLocal, func() error {
+		return e.write(raw)
 	})
+}
+
+// UpdateAgent partially updates an existing agent. It loads raw and expanded
+// config for provenance detection; pack-derived agents return a clear error.
+func (e *Editor) UpdateAgent(name string, patch AgentUpdate) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	raw, expanded, err := e.loadExpandedForEdit()
+	if err != nil {
+		return err
+	}
+
+	cityRoot := filepath.Dir(e.tomlPath)
+	switch AgentOrigin(raw, expanded, name) {
+	case OriginDerived:
+		agent, ok, err := findLocalDiscoveredAgent(e.fs, expanded, cityRoot, name)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("%w: agent %q cannot be updated directly (use patches)", ErrPackDerived, name)
+		}
+		updated := agent
+		applyAgentUpdate(&updated, patch)
+		if err := validateLocalDiscoveredAgent(updated); err != nil {
+			return err
+		}
+		if !stripAgentPatchUpdate(raw, agent.QualifiedName(), patch) {
+			return writeLocalDiscoveredAgentUpdate(e.fs, cityRoot, updated, patch)
+		}
+		if err := validateCityForEdit(raw); err != nil {
+			return err
+		}
+		return e.commitLocalDiscoveredAgentUpdate(cityRoot, agent, func() error {
+			return writeLocalDiscoveredAgentUpdate(e.fs, cityRoot, updated, patch)
+		}, raw)
+	case OriginNotFound:
+		return fmt.Errorf("%w: agent %q", ErrNotFound, name)
+	}
+	for i := range raw.Agents {
+		if config.AgentMatchesIdentity(&raw.Agents[i], name) {
+			applyAgentUpdate(&raw.Agents[i], patch)
+			if err := validateCityForEdit(raw); err != nil {
+				return err
+			}
+			return e.write(raw)
+		}
+	}
+	return fmt.Errorf("%w: agent %q", ErrNotFound, name)
+}
+
+func applyAgentUpdate(agent *config.Agent, patch AgentUpdate) {
+	if patch.Provider != "" {
+		agent.Provider = patch.Provider
+	}
+	if patch.Scope != "" {
+		agent.Scope = patch.Scope
+	}
+	if patch.Suspended != nil {
+		agent.Suspended = *patch.Suspended
+	}
 }
 
 // DeleteAgent removes an inline agent from the config.
 // Returns an error if the agent is not found.
 func (e *Editor) DeleteAgent(name string) error {
-	return e.EditExpanded(func(raw, expanded *config.City) error {
-		origin := AgentOrigin(raw, expanded, name)
-		switch origin {
-		case OriginDerived:
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	raw, expanded, err := e.loadExpandedForEdit()
+	if err != nil {
+		return err
+	}
+
+	cityRoot := filepath.Dir(e.tomlPath)
+	switch AgentOrigin(raw, expanded, name) {
+	case OriginDerived:
+		agent, ok, err := findLocalDiscoveredAgent(e.fs, expanded, cityRoot, name)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			return fmt.Errorf("%w: agent %q cannot be deleted (use patches to override)", ErrPackDerived, name)
-		case OriginNotFound:
-			return fmt.Errorf("%w: agent %q", ErrNotFound, name)
 		}
-		for i := range raw.Agents {
-			if config.AgentMatchesIdentity(&raw.Agents[i], name) {
-				raw.Agents = append(raw.Agents[:i], raw.Agents[i+1:]...)
-				return nil
-			}
+		if !removeAgentPatch(raw, agent.QualifiedName()) {
+			return e.commitLocalDiscoveredAgentMutation(cityRoot, agent, func() error {
+				return removeLocalDiscoveredAgentConfig(e.fs, cityRoot, agent)
+			}, nil)
 		}
+		if err := validateCityForEdit(raw); err != nil {
+			return err
+		}
+		return e.commitLocalDiscoveredAgentUpdate(cityRoot, agent, func() error {
+			return removeLocalDiscoveredAgentConfig(e.fs, cityRoot, agent)
+		}, raw)
+	case OriginNotFound:
 		return fmt.Errorf("%w: agent %q", ErrNotFound, name)
-	})
+	}
+	for i := range raw.Agents {
+		if config.AgentMatchesIdentity(&raw.Agents[i], name) {
+			raw.Agents = append(raw.Agents[:i], raw.Agents[i+1:]...)
+			if err := validateCityForEdit(raw); err != nil {
+				return err
+			}
+			return e.write(raw)
+		}
+	}
+	return fmt.Errorf("%w: agent %q", ErrNotFound, name)
 }
 
 // CreateRig adds a new rig to the config. Returns an error if a rig with
@@ -751,28 +1087,39 @@ func (e *Editor) UpdateRig(name string, patch RigUpdate) error {
 // DeleteRig removes a rig and all its scoped agents from the config.
 // Returns an error if the rig is not found.
 func (e *Editor) DeleteRig(name string) error {
-	return e.Edit(func(cfg *config.City) error {
-		found := false
-		for i := range cfg.Rigs {
-			if cfg.Rigs[i].Name == name {
-				cfg.Rigs = append(cfg.Rigs[:i], cfg.Rigs[i+1:]...)
-				found = true
-				break
-			}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	cfg, err := e.loadForEdit()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i := range cfg.Rigs {
+		if cfg.Rigs[i].Name == name {
+			cfg.Rigs = append(cfg.Rigs[:i], cfg.Rigs[i+1:]...)
+			found = true
+			break
 		}
-		if !found {
-			return fmt.Errorf("%w: rig %q", ErrNotFound, name)
+	}
+	if !found {
+		return fmt.Errorf("%w: rig %q", ErrNotFound, name)
+	}
+	// Remove rig-scoped agents.
+	var kept []config.Agent
+	for _, a := range cfg.Agents {
+		if a.Dir != name {
+			kept = append(kept, a)
 		}
-		// Remove rig-scoped agents.
-		var kept []config.Agent
-		for _, a := range cfg.Agents {
-			if a.Dir != name {
-				kept = append(kept, a)
-			}
-		}
-		cfg.Agents = kept
-		return nil
-	})
+	}
+	cfg.Agents = kept
+
+	if err := validateCityForEdit(cfg); err != nil {
+		return err
+	}
+
+	return e.writeRemovingRigs(cfg, name)
 }
 
 // ProviderUpdate holds optional fields for a partial provider update.

--- a/internal/configedit/configedit.go
+++ b/internal/configedit/configedit.go
@@ -558,18 +558,49 @@ func (e *Editor) ResumeCity() error {
 // CreateAgent adds a new city-local convention agent. Returns an error if an
 // agent with the same qualified name already exists.
 func (e *Editor) CreateAgent(a config.Agent) error {
-	return e.EditExpanded(func(_, expanded *config.City) error {
+	return e.EditExpanded(func(raw, expanded *config.City) error {
 		qn := a.QualifiedName()
 		for _, existing := range expanded.Agents {
 			if existing.QualifiedName() == qn {
 				return fmt.Errorf("%w: agent %q", ErrAlreadyExists, qn)
 			}
 		}
-		if err := WriteLocalDiscoveredAgentConfig(e.fs, filepath.Dir(e.tomlPath), a); err != nil {
+
+		cityRoot := filepath.Dir(e.tomlPath)
+		schema2Pack, err := hasSchema2RootPack(e.fs, cityRoot)
+		if err != nil {
+			return err
+		}
+		if !schema2Pack {
+			raw.Agents = append(raw.Agents, a)
+			return nil
+		}
+
+		if err := WriteLocalDiscoveredAgentConfig(e.fs, cityRoot, a); err != nil {
 			return err
 		}
 		return ErrUnmodified
 	})
+}
+
+func hasSchema2RootPack(fs fsys.FS, cityRoot string) (bool, error) {
+	data, err := fs.ReadFile(filepath.Join(cityRoot, "pack.toml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading pack.toml: %w", err)
+	}
+
+	var header struct {
+		Pack struct {
+			Schema int `toml:"schema"`
+		} `toml:"pack"`
+	}
+	if _, err := toml.Decode(string(data), &header); err != nil {
+		return false, fmt.Errorf("parsing pack.toml: %w", err)
+	}
+	return header.Pack.Schema >= 2, nil
 }
 
 // WriteLocalDiscoveredAgentConfig writes the durable config for a city-local

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -815,7 +815,10 @@ suspended = true
 
 func TestCreateAgent(t *testing.T) {
 	dir := t.TempDir()
-	path := writeTOML(t, dir, minimalCity())
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ed := configedit.NewEditor(fsys.OSFS{}, path)
 
 	err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude"})
@@ -823,10 +826,13 @@ func TestCreateAgent(t *testing.T) {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 
-	cfg := readTOML(t, path)
+	if _, err := os.Stat(filepath.Join(dir, "agents", "coder", "agent.toml")); err != nil {
+		t.Fatalf("agent.toml stat: %v", err)
+	}
+	cfg := readExpandedTOML(t, path)
 	found := false
 	for _, a := range cfg.Agents {
-		if a.Name == "coder" {
+		if a.Name == "coder" && a.Provider == "claude" {
 			found = true
 		}
 	}

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -1,6 +1,7 @@
 package configedit_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,32 @@ import (
 	"github.com/gastownhall/gascity/internal/configedit"
 	"github.com/gastownhall/gascity/internal/fsys"
 )
+
+type failRenameFS struct {
+	fsys.OSFS
+	target string
+	failed bool
+}
+
+func (f *failRenameFS) Rename(oldpath, newpath string) error {
+	if !f.failed && filepath.Clean(newpath) == filepath.Clean(f.target) {
+		f.failed = true
+		return errors.New("injected rename failure")
+	}
+	return f.OSFS.Rename(oldpath, newpath)
+}
+
+type failRemoveFakeFS struct {
+	*fsys.Fake
+	target string
+}
+
+func (f *failRemoveFakeFS) Remove(name string) error {
+	if filepath.Clean(name) == filepath.Clean(f.target) {
+		return errors.New("permission denied")
+	}
+	return f.Fake.Remove(name)
+}
 
 // minimalCity returns a minimal valid city.toml with one agent.
 func minimalCity() string {
@@ -697,7 +724,11 @@ schema = 2
 		Name:           "worker",
 		PromptTemplate: filepath.Join(dir, "agents", "worker", "prompt.template.md"),
 	}
-	if configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, rigAgent) {
+	local, err := configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, rigAgent)
+	if err != nil {
+		t.Fatalf("LocalDiscoveredAgent rig-scoped: %v", err)
+	}
+	if local {
 		t.Fatal("rig-scoped agent must not be classified as local-discovered even when prompt_template points at the city's agents/<name>/ tree")
 	}
 
@@ -706,8 +737,104 @@ schema = 2
 		Name:           "worker",
 		PromptTemplate: filepath.Join(dir, "agents", "worker", "prompt.template.md"),
 	}
-	if !configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, cityAgent) {
+	local, err = configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, cityAgent)
+	if err != nil {
+		t.Fatalf("LocalDiscoveredAgent city-scoped: %v", err)
+	}
+	if !local {
 		t.Fatal("city-scoped scaffolded agent should be classified as local-discovered")
+	}
+}
+
+func TestLocalDiscoveredAgent_AgentTOMLDefinesCityScopedConventionContract(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "agents", "worker")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cityAgent := config.Agent{
+		Name:           "worker",
+		PromptTemplate: filepath.Join(dir, "custom", "worker.md"),
+	}
+	local, err := configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, cityAgent)
+	if err != nil {
+		t.Fatalf("LocalDiscoveredAgent without agent.toml: %v", err)
+	}
+	if local {
+		t.Fatal("custom prompt path without agent.toml should not be classified as local-discovered")
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte("provider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	local, err = configedit.LocalDiscoveredAgent(fsys.OSFS{}, dir, cityAgent)
+	if err != nil {
+		t.Fatalf("LocalDiscoveredAgent with agent.toml: %v", err)
+	}
+	if !local {
+		t.Fatal("agents/<name>/agent.toml should classify a city-scoped agent as local-discovered even with a custom prompt path")
+	}
+}
+
+func TestLocalDiscoveredAgent_StatErrorIsNotPositiveEvidence(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Dirs["/city"] = true
+	fs.Dirs["/city/agents"] = true
+	fs.Dirs["/city/agents/worker"] = true
+	fs.Files["/city/pack.toml"] = []byte("[pack]\nname = \"test-city\"\nschema = 2\n")
+	fs.Errors["/city/agents/worker/agent.toml"] = errors.New("injected stat failure")
+
+	agent := config.Agent{
+		Name:           "worker",
+		PromptTemplate: "/city/custom/worker.md",
+	}
+	local, err := configedit.LocalDiscoveredAgent(fs, "/city", agent)
+	if err != nil {
+		t.Fatalf("LocalDiscoveredAgent: %v", err)
+	}
+	if local {
+		t.Fatal("agent.toml stat errors must not classify an agent as local-discovered")
+	}
+}
+
+func TestLocalDiscoveredAgent_PackTOMLReadErrorSurfacesError(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Dirs["/city"] = true
+	fs.Dirs["/city/agents"] = true
+	fs.Dirs["/city/agents/worker"] = true
+	fs.Files["/city/agents/worker/agent.toml"] = []byte("provider = \"claude\"\n")
+	fs.Errors["/city/pack.toml"] = os.ErrPermission
+
+	agent := config.Agent{Name: "worker"}
+	ok, err := configedit.LocalDiscoveredAgent(fs, "/city", agent)
+	if err == nil {
+		t.Fatal("LocalDiscoveredAgent error = nil, want pack.toml read error")
+	}
+	if ok {
+		t.Fatal("LocalDiscoveredAgent classified agent as local-discovered despite pack.toml read error")
+	}
+	if !strings.Contains(err.Error(), "reading /city/pack.toml") {
+		t.Fatalf("LocalDiscoveredAgent error = %v, want pack.toml read context", err)
+	}
+}
+
+func TestLocalDiscoveredAgent_MalformedPackTOMLSurfacesError(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Dirs["/city"] = true
+	fs.Dirs["/city/agents"] = true
+	fs.Dirs["/city/agents/worker"] = true
+	fs.Files["/city/pack.toml"] = []byte("[[agent]\nname = \"worker\"\n")
+	fs.Files["/city/agents/worker/agent.toml"] = []byte("provider = \"claude\"\n")
+
+	agent := config.Agent{Name: "worker"}
+	ok, err := configedit.LocalDiscoveredAgent(fs, "/city", agent)
+	if err == nil {
+		t.Fatal("LocalDiscoveredAgent error = nil, want pack.toml parse error")
+	}
+	if ok {
+		t.Fatal("LocalDiscoveredAgent classified agent as local-discovered despite malformed pack.toml")
+	}
+	if !strings.Contains(err.Error(), "parsing /city/pack.toml") {
+		t.Fatalf("LocalDiscoveredAgent error = %v, want pack.toml parse context", err)
 	}
 }
 
@@ -841,6 +968,138 @@ func TestCreateAgent(t *testing.T) {
 	}
 }
 
+func TestCreateAgentSchema2RollsBackFreshConventionScaffoldWhenAgentTOMLWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "coder")
+	ed := configedit.NewEditor(&failRenameFS{target: filepath.Join(agentDir, "agent.toml")}, path)
+
+	err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude", Scope: "city"})
+	if err == nil {
+		t.Fatal("CreateAgent succeeded, want injected agent.toml write failure")
+	}
+	if _, statErr := os.Stat(agentDir); !os.IsNotExist(statErr) {
+		t.Fatalf("agent dir stat err = %v, want fresh scaffold removed", statErr)
+	}
+	for _, agent := range readExpandedTOML(t, path).Agents {
+		if agent.Name == "coder" {
+			t.Fatalf("expanded agents include ghost coder after failed create: %+v", agent)
+		}
+	}
+}
+
+func TestWriteLocalDiscoveredAgentConfigWritesConventionFields(t *testing.T) {
+	fs := fsys.NewFake()
+
+	err := configedit.WriteLocalDiscoveredAgentConfig(fs, "/city", config.Agent{
+		Name:        "coder",
+		Description: "Writes code.",
+		Provider:    "claude",
+		Scope:       "city",
+		Suspended:   true,
+	})
+	if err != nil {
+		t.Fatalf("WriteLocalDiscoveredAgentConfig: %v", err)
+	}
+
+	got := string(fs.Files["/city/agents/coder/agent.toml"])
+	for _, want := range []string{
+		`description = "Writes code."`,
+		`provider = "claude"`,
+		`scope = "city"`,
+		`suspended = true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("agent.toml = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestLocalDiscoveredAgentDirRejectsEscapes(t *testing.T) {
+	got, err := configedit.LocalDiscoveredAgentDir("/city", "coder")
+	if err != nil {
+		t.Fatalf("LocalDiscoveredAgentDir valid name: %v", err)
+	}
+	if got != filepath.Join("/city", "agents", "coder") {
+		t.Fatalf("LocalDiscoveredAgentDir = %q, want /city/agents/coder", got)
+	}
+
+	if _, err := configedit.LocalDiscoveredAgentDir("/city", "../escape"); !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("LocalDiscoveredAgentDir escape error = %v, want ErrValidation", err)
+	}
+}
+
+func TestCreateAgentSchema2RejectsInvalidNameBeforeWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.CreateAgent(config.Agent{Name: "..", Provider: "claude"})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("CreateAgent error = %v, want ErrValidation", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "agent.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("escaped agent.toml stat err = %v, want not exist", statErr)
+	}
+}
+
+func TestCreateAgentSchema2RejectsInvalidScopeBeforeWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude", Scope: "global"})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("CreateAgent error = %v, want ErrValidation", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "agents", "coder", "agent.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("agent.toml stat err = %v, want not exist", statErr)
+	}
+}
+
+func TestCreateAgentSchema2RejectsRigScopedConventionAgentBeforeWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.CreateAgent(config.Agent{Name: "coder", Dir: "rig-a", Provider: "claude", Scope: "city"})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("CreateAgent error = %v, want ErrValidation", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "agents", "coder", "agent.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("agent.toml stat err = %v, want not exist", statErr)
+	}
+}
+
+func TestCreateAgentSchema2RejectsRigScopeConventionAgentBeforeWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude", Scope: "rig"})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("CreateAgent error = %v, want ErrValidation", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "agents", "coder", "agent.toml")); !os.IsNotExist(statErr) {
+		t.Fatalf("agent.toml stat err = %v, want not exist", statErr)
+	}
+}
+
 func TestCreateAgentLegacyNoPackAppendsInline(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, "[workspace]\n")
@@ -912,6 +1171,145 @@ suspended = true
 	}
 }
 
+func TestUpdateAgentSchema2LocalConventionAgentWritesAgentTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	if err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude", Scope: "city"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if err := ed.UpdateAgent("coder", configedit.AgentUpdate{
+		Provider:  "gemini",
+		Scope:     "city",
+		Suspended: boolPtrTest(true),
+	}); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+
+	raw := readTOML(t, path)
+	if len(raw.Agents) != 0 {
+		t.Fatalf("raw city.toml agents = %+v, want schema-2 convention agent outside city.toml", raw.Agents)
+	}
+	data := string(mustReadFile(t, filepath.Join(dir, "agents", "coder", "agent.toml")))
+	for _, want := range []string{
+		`provider = "gemini"`,
+		`scope = "city"`,
+		`suspended = true`,
+	} {
+		if !strings.Contains(data, want) {
+			t.Fatalf("agent.toml = %q, want %s", data, want)
+		}
+	}
+	agent := findAgent(t, readExpandedTOML(t, path), "coder")
+	if agent.Provider != "gemini" || agent.Scope != "city" || !agent.Suspended {
+		t.Fatalf("expanded agent = %+v, want updated provider/scope/suspended", agent)
+	}
+}
+
+func TestUpdateAgentSchema2RejectsRigScopeConventionAgentBeforeWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	if err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude", Scope: "city"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	agentTomlPath := filepath.Join(dir, "agents", "coder", "agent.toml")
+	before := string(mustReadFile(t, agentTomlPath))
+
+	err := ed.UpdateAgent("coder", configedit.AgentUpdate{Scope: "rig"})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("UpdateAgent error = %v, want ErrValidation", err)
+	}
+	after := string(mustReadFile(t, agentTomlPath))
+	if after != before {
+		t.Fatalf("agent.toml changed after rejected rig scope:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestUpdateAgentSchema2LocalConventionRollsBackAgentTOMLWhenCityWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+
+[[patches.agent]]
+name = "coder"
+provider = "legacy"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "coder")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the coder.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentTomlPath := filepath.Join(agentDir, "agent.toml")
+	if err := os.WriteFile(agentTomlPath, []byte("provider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(&failRenameFS{target: path}, path)
+
+	err := ed.UpdateAgent("coder", configedit.AgentUpdate{Provider: "gemini"})
+	if err == nil {
+		t.Fatal("UpdateAgent succeeded, want injected city write failure")
+	}
+	agentToml := string(mustReadFile(t, agentTomlPath))
+	if agentToml != "provider = \"claude\"\n" {
+		t.Fatalf("agent.toml = %q, want original after rollback", agentToml)
+	}
+	raw := string(mustReadFile(t, path))
+	if !strings.Contains(raw, `provider = "legacy"`) {
+		t.Fatalf("city.toml patch was stripped despite failed write:\n%s", raw)
+	}
+}
+
+func TestUpdateAgentSchema2LocalConventionValidatesRawBeforeWritingAgentTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+
+[[rigs]]
+name = "frontend"
+
+[[patches.agent]]
+name = "coder"
+provider = "legacy"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "coder")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the coder.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentTomlPath := filepath.Join(agentDir, "agent.toml")
+	if err := os.WriteFile(agentTomlPath, []byte("provider = \"claude\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.UpdateAgent("coder", configedit.AgentUpdate{Provider: "gemini"})
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("UpdateAgent error = %v, want ErrValidation", err)
+	}
+	agentToml := string(mustReadFile(t, agentTomlPath))
+	if strings.Contains(agentToml, "gemini") || !strings.Contains(agentToml, `provider = "claude"`) {
+		t.Fatalf("agent.toml = %q, want original provider preserved after validation failure", agentToml)
+	}
+}
+
 func TestUpdateAgent_NotFound(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, minimalCity())
@@ -937,6 +1335,282 @@ func TestDeleteAgent(t *testing.T) {
 		if a.Name == "mayor" {
 			t.Error("agent 'mayor' still exists after delete")
 		}
+	}
+}
+
+func TestDeleteAgentSchema2LocalConventionAgentRemovesAgentTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	if err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude", Scope: "city"}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if err := ed.DeleteAgent("coder"); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "agents", "coder", "agent.toml")); !os.IsNotExist(err) {
+		t.Fatalf("agent.toml stat err = %v, want removed file", err)
+	}
+	raw := readTOML(t, path)
+	if len(raw.Agents) != 0 {
+		t.Fatalf("raw city.toml agents = %+v, want schema-2 convention agent outside city.toml", raw.Agents)
+	}
+	for _, agent := range readExpandedTOML(t, path).Agents {
+		if agent.Name == "coder" {
+			t.Fatalf("expanded agents still include deleted coder: %+v", agent)
+		}
+	}
+}
+
+func TestDeleteAgentSchema2PromptBackedConventionAgentRemovesScaffold(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "coder")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "prompt.template.md"), []byte("You are the coder.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	if err := ed.DeleteAgent("coder"); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	if _, err := os.Stat(agentDir); !os.IsNotExist(err) {
+		t.Fatalf("agent scaffold stat err = %v, want removed directory", err)
+	}
+	for _, agent := range readExpandedTOML(t, path).Agents {
+		if agent.Name == "coder" {
+			t.Fatalf("expanded agents still include deleted coder: %+v", agent)
+		}
+	}
+}
+
+func TestDeleteAgentSchema2LocalConventionRollsBackScaffoldWhenCityWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+
+[[patches.agent]]
+name = "coder"
+provider = "legacy"
+`)
+	if err := os.WriteFile(filepath.Join(dir, "pack.toml"), []byte("[pack]\nname = \"test-city\"\nschema = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(dir, "agents", "coder")
+	if err := os.MkdirAll(filepath.Join(agentDir, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for rel, data := range map[string]string{
+		"agent.toml":         "provider = \"claude\"\n",
+		"prompt.template.md": "You are the coder.\n",
+		"skills/local.md":    "skill notes\n",
+	} {
+		if err := os.WriteFile(filepath.Join(agentDir, rel), []byte(data), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	ed := configedit.NewEditor(&failRenameFS{target: path}, path)
+
+	err := ed.DeleteAgent("coder")
+	if err == nil {
+		t.Fatal("DeleteAgent succeeded, want injected city write failure")
+	}
+	for rel, want := range map[string]string{
+		"agent.toml":         "provider = \"claude\"\n",
+		"prompt.template.md": "You are the coder.\n",
+		"skills/local.md":    "skill notes\n",
+	} {
+		got := string(mustReadFile(t, filepath.Join(agentDir, rel)))
+		if got != want {
+			t.Fatalf("%s = %q, want restored %q", rel, got, want)
+		}
+	}
+	raw := string(mustReadFile(t, path))
+	if !strings.Contains(raw, `provider = "legacy"`) {
+		t.Fatalf("city.toml patch was removed despite failed write:\n%s", raw)
+	}
+}
+
+func TestDeleteAgentSchema2LocalConventionRollsBackScaffoldWhenRemoveFails(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte(`[workspace]
+
+[[patches.agent]]
+name = "coder"
+provider = "legacy"
+`)
+	fs.Files["/city/pack.toml"] = []byte("[pack]\nname = \"test-city\"\nschema = 2\n")
+	if err := fs.MkdirAll("/city/agents/coder", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fs.Files["/city/agents/coder/agent.toml"] = []byte("suspended = true\n")
+	fs.Files["/city/agents/coder/prompt.template.md"] = []byte("You are the coder.\n")
+	fs.Files["/city/agents/coder/zz-blocked"] = []byte("keep me\n")
+	ed := configedit.NewEditor(&failRemoveFakeFS{
+		Fake:   fs,
+		target: "/city/agents/coder/zz-blocked",
+	}, "/city/city.toml")
+
+	err := ed.DeleteAgent("coder")
+	if err == nil {
+		t.Fatal("DeleteAgent succeeded, want removal error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("DeleteAgent error = %v, want permission denied", err)
+	}
+	if _, ok := fs.Files["/city/agents/coder/zz-blocked"]; !ok {
+		t.Fatal("blocked file was removed despite injected error")
+	}
+	for path, want := range map[string]string{
+		"/city/agents/coder/agent.toml":         "suspended = true\n",
+		"/city/agents/coder/prompt.template.md": "You are the coder.\n",
+	} {
+		if got, ok := fs.Files[path]; !ok || string(got) != want {
+			t.Fatalf("%s = %q, want restored %q", path, got, want)
+		}
+	}
+	if raw := string(fs.Files["/city/city.toml"]); !strings.Contains(raw, `provider = "legacy"`) {
+		t.Fatalf("city.toml patch was removed despite failed local mutation:\n%s", raw)
+	}
+}
+
+func TestDeleteAgentSchema2LocalConventionWithoutPatchRollsBackScaffoldWhenRemoveFails(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/city/city.toml"] = []byte("[workspace]\n")
+	fs.Files["/city/pack.toml"] = []byte("[pack]\nname = \"test-city\"\nschema = 2\n")
+	if err := fs.MkdirAll("/city/agents/coder", 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fs.Files["/city/agents/coder/agent.toml"] = []byte("provider = \"claude\"\n")
+	fs.Files["/city/agents/coder/prompt.template.md"] = []byte("You are the coder.\n")
+	fs.Files["/city/agents/coder/zz-blocked"] = []byte("keep me\n")
+	ed := configedit.NewEditor(&failRemoveFakeFS{
+		Fake:   fs,
+		target: "/city/agents/coder/zz-blocked",
+	}, "/city/city.toml")
+
+	err := ed.DeleteAgent("coder")
+	if err == nil {
+		t.Fatal("DeleteAgent succeeded, want removal error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("DeleteAgent error = %v, want permission denied", err)
+	}
+	for path, want := range map[string]string{
+		"/city/agents/coder/agent.toml":         "provider = \"claude\"\n",
+		"/city/agents/coder/prompt.template.md": "You are the coder.\n",
+		"/city/agents/coder/zz-blocked":         "keep me\n",
+	} {
+		if got, ok := fs.Files[path]; !ok || string(got) != want {
+			t.Fatalf("%s = %q, want restored %q", path, got, want)
+		}
+	}
+	if got := string(fs.Files["/city/city.toml"]); got != "[workspace]\n" {
+		t.Fatalf("city.toml = %q, want unchanged", got)
+	}
+}
+
+func TestWriteLocalDiscoveredAgentConfigRejectsUnsupportedRichFields(t *testing.T) {
+	fs := fsys.NewFake()
+
+	err := configedit.WriteLocalDiscoveredAgentConfig(fs, "/city", config.Agent{
+		Name:           "worker",
+		Provider:       "claude",
+		Scope:          "city",
+		PromptTemplate: "custom.md",
+		Args:           []string{"--danger"},
+	})
+
+	if !errors.Is(err, configedit.ErrValidation) {
+		t.Fatalf("WriteLocalDiscoveredAgentConfig error = %v, want ErrValidation", err)
+	}
+	for _, want := range []string{"PromptTemplate", "Args"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want unsupported field %s", err, want)
+		}
+	}
+	if len(fs.Files) != 0 {
+		t.Fatalf("files were written despite validation failure: %+v", fs.Files)
+	}
+}
+
+func TestWriteLocalDiscoveredAgentConfigRejectsUnsafeScaffoldPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		setup     func(*fsys.Fake)
+		wantError string
+	}{
+		{
+			name: "agents root symlink",
+			setup: func(fs *fsys.Fake) {
+				fs.Dirs["/outside/agents"] = true
+				fs.Symlinks["/city/agents"] = "/outside/agents"
+			},
+			wantError: "not a symlink",
+		},
+		{
+			name: "agents root file",
+			setup: func(fs *fsys.Fake) {
+				fs.Files["/city/agents"] = []byte("not a directory")
+			},
+			wantError: "must be a directory",
+		},
+		{
+			name: "agent dir symlink",
+			setup: func(fs *fsys.Fake) {
+				fs.Dirs["/city/agents"] = true
+				fs.Dirs["/outside/worker"] = true
+				fs.Symlinks["/city/agents/worker"] = "/outside/worker"
+			},
+			wantError: "not a symlink",
+		},
+		{
+			name: "agent dir file",
+			setup: func(fs *fsys.Fake) {
+				fs.Dirs["/city/agents"] = true
+				fs.Files["/city/agents/worker"] = []byte("not a directory")
+			},
+			wantError: "must be a directory",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := fsys.NewFake()
+			tc.setup(fs)
+
+			err := configedit.WriteLocalDiscoveredAgentConfig(fs, "/city", config.Agent{Name: "worker", Provider: "claude"})
+			if !errors.Is(err, configedit.ErrValidation) {
+				t.Fatalf("WriteLocalDiscoveredAgentConfig error = %v, want ErrValidation", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("WriteLocalDiscoveredAgentConfig error = %v, want %q", err, tc.wantError)
+			}
+			for _, path := range []string{
+				"/city/agents/worker/agent.toml",
+				"/outside/agents/worker/agent.toml",
+				"/outside/worker/agent.toml",
+			} {
+				if _, ok := fs.Files[path]; ok {
+					t.Fatalf("%s was written through rejected scaffold path", path)
+				}
+			}
+			for _, call := range fs.Calls {
+				if call.Method == "WriteFile" || call.Method == "Rename" {
+					t.Fatalf("unexpected write call after scaffold path rejection: %+v", call)
+				}
+			}
+		})
 	}
 }
 
@@ -1004,6 +1678,54 @@ func TestUpdateRig(t *testing.T) {
 	binding := readSiteBinding(t, dir)
 	if len(binding.Rigs) != 1 || binding.Rigs[0].Path != "/tmp/updated" {
 		t.Errorf("site binding = %+v, want updated path", binding.Rigs)
+	}
+}
+
+func TestUpdateRigPreservesOrphanSiteBinding(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "test-agent"
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = "/tmp/frontend"
+`)
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.SiteBindingPath(dir), []byte(`[[rig]]
+name = "frontend"
+path = "/site/frontend"
+
+[[rig]]
+name = "archived"
+path = "/site/archived"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	if err := ed.UpdateRig("frontend", configedit.RigUpdate{Path: "/site/updated"}); err != nil {
+		t.Fatalf("UpdateRig: %v", err)
+	}
+
+	binding := readSiteBinding(t, dir)
+	if len(binding.Rigs) != 2 {
+		t.Fatalf("site binding rigs = %+v, want frontend and archived", binding.Rigs)
+	}
+	got := map[string]string{}
+	for _, rig := range binding.Rigs {
+		got[rig.Name] = rig.Path
+	}
+	if got["frontend"] != "/site/updated" {
+		t.Fatalf("frontend binding = %q, want updated path", got["frontend"])
+	}
+	if got["archived"] != "/site/archived" {
+		t.Fatalf("archived binding = %q, want orphan preserved", got["archived"])
 	}
 }
 
@@ -1085,6 +1807,69 @@ path = "/tmp/my-rig"
 	}
 	if !found {
 		t.Error("city-scoped agent 'mayor' was incorrectly removed")
+	}
+}
+
+func TestDeleteRigRemovesDeletedSiteBindingAndPreservesOrphan(t *testing.T) {
+	dir := t.TempDir()
+	city := `[workspace]
+name = "test-city"
+
+[[agent]]
+name = "city-agent"
+provider = "claude"
+
+[[agent]]
+name = "rig-agent"
+dir = "frontend"
+provider = "claude"
+
+[[rigs]]
+name = "frontend"
+path = "/tmp/frontend"
+`
+	path := writeTOML(t, dir, city)
+	if err := os.MkdirAll(filepath.Join(dir, ".gc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.SiteBindingPath(dir), []byte(`[[rig]]
+name = "frontend"
+path = "/site/frontend"
+
+[[rig]]
+name = "archived"
+path = "/site/archived"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	if err := ed.DeleteRig("frontend"); err != nil {
+		t.Fatalf("DeleteRig: %v", err)
+	}
+
+	raw := readTOML(t, path)
+	for _, rig := range raw.Rigs {
+		if rig.Name == "frontend" {
+			t.Fatalf("deleted rig %q still exists in city.toml", rig.Name)
+		}
+	}
+	for _, agent := range raw.Agents {
+		if agent.Dir == "frontend" {
+			t.Fatalf("rig-scoped agent %q still exists in city.toml", agent.QualifiedName())
+		}
+	}
+
+	binding := readSiteBinding(t, dir)
+	got := map[string]string{}
+	for _, rig := range binding.Rigs {
+		got[rig.Name] = rig.Path
+	}
+	if _, ok := got["frontend"]; ok {
+		t.Fatalf("deleted rig site binding was preserved: %+v", binding.Rigs)
+	}
+	if got["archived"] != "/site/archived" {
+		t.Fatalf("orphan binding = %q, want preserved path %q", got["archived"], "/site/archived")
 	}
 }
 

--- a/internal/configedit/configedit_test.go
+++ b/internal/configedit/configedit_test.go
@@ -841,6 +841,22 @@ func TestCreateAgent(t *testing.T) {
 	}
 }
 
+func TestCreateAgentLegacyNoPackAppendsInline(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, "[workspace]\n")
+	ed := configedit.NewEditor(fsys.OSFS{}, path)
+
+	err := ed.CreateAgent(config.Agent{Name: "coder", Provider: "claude"})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	cfg := readTOML(t, path)
+	if len(cfg.Agents) != 1 || cfg.Agents[0].Name != "coder" || cfg.Agents[0].Provider != "claude" {
+		t.Fatalf("agents = %+v, want inline legacy coder", cfg.Agents)
+	}
+}
+
 func TestCreateAgent_Duplicate(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTOML(t, dir, minimalCity())

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -2126,7 +2126,7 @@ path = "check.sh"
 	})
 }
 
-func TestCompileRejectsLegacyFormulaFilename(t *testing.T) {
+func TestCompileAcceptsLegacyFormulaFilename(t *testing.T) {
 	dir := t.TempDir()
 	formulaContent := `
 formula = "legacy-name"
@@ -2140,12 +2140,12 @@ title = "Do work"
 		t.Fatal(err)
 	}
 
-	_, err := Compile(context.Background(), "legacy-name", []string{dir}, nil)
-	if err == nil {
-		t.Fatal("Compile succeeded, want hard error for legacy formula filename")
+	got, err := Compile(context.Background(), "legacy-name", []string{dir}, nil)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unsupported PackV1 formula path") || !strings.Contains(err.Error(), "rename to legacy-name.toml") {
-		t.Fatalf("error = %v, want legacy formula rename guidance", err)
+	if got.Name != "legacy-name" {
+		t.Fatalf("Name = %q, want legacy-name", got.Name)
 	}
 }
 

--- a/internal/formula/compile_test.go
+++ b/internal/formula/compile_test.go
@@ -1320,7 +1320,7 @@ func TestCompileBugReportFlowV2(t *testing.T) {
 	t.Cleanup(func() { SetFormulaV2Enabled(prev) })
 
 	const toolingPath = "/home/ubuntu/tooling/formulas"
-	if _, err := os.Stat(filepath.Join(toolingPath, "mol-bug-report-flow-v2.formula.toml")); err != nil {
+	if _, err := os.Stat(filepath.Join(toolingPath, "mol-bug-report-flow-v2.toml")); err != nil {
 		t.Skipf("tooling formula not present: %v", err)
 	}
 
@@ -2038,7 +2038,7 @@ contract = "graph.v2"
 id = "work"
 title = "Do work"
 `
-		if err := os.WriteFile(filepath.Join(dir, "needs-v2.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "needs-v2.toml"), []byte(formulaContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2060,7 +2060,7 @@ version = 8
 id = "work"
 title = "Do work"
 `
-		if err := os.WriteFile(filepath.Join(dir, "legacy-v8.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "legacy-v8.toml"), []byte(formulaContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2082,7 +2082,7 @@ version = 1
 id = "work"
 title = "Do work"
 `
-		if err := os.WriteFile(filepath.Join(dir, "still-v1.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "still-v1.toml"), []byte(formulaContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2108,7 +2108,7 @@ max_attempts = 1
 mode = "exec"
 path = "check.sh"
 `
-		if err := os.WriteFile(filepath.Join(dir, "legacy-check.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "legacy-check.toml"), []byte(formulaContent), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2124,6 +2124,29 @@ path = "check.sh"
 			t.Fatalf("root = %+v, want legacy molecule root", root)
 		}
 	})
+}
+
+func TestCompileRejectsLegacyFormulaFilename(t *testing.T) {
+	dir := t.TempDir()
+	formulaContent := `
+formula = "legacy-name"
+version = 1
+
+[[steps]]
+id = "work"
+title = "Do work"
+`
+	if err := os.WriteFile(filepath.Join(dir, "legacy-name.formula.toml"), []byte(formulaContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Compile(context.Background(), "legacy-name", []string{dir}, nil)
+	if err == nil {
+		t.Fatal("Compile succeeded, want hard error for legacy formula filename")
+	}
+	if !strings.Contains(err.Error(), "unsupported PackV1 formula path") || !strings.Contains(err.Error(), "rename to legacy-name.toml") {
+		t.Fatalf("error = %v, want legacy formula rename guidance", err)
+	}
 }
 
 func TestCompileValidatesRequiredVars(t *testing.T) {

--- a/internal/formula/filenames.go
+++ b/internal/formula/filenames.go
@@ -6,16 +6,13 @@ import "strings"
 // formulas/ directory (formulas/<name>.toml).
 const CanonicalTOMLExt = ".toml"
 
-// LegacyTOMLExt is the pre-canonicalization extension for formula TOML files
-// (formulas/<name>.formula.toml). Still recognized by discovery so existing
-// cities continue to load.
-//
-// PACKV2-CUTOVER: remove legacy formula filename support after the infix
-// migration window closes.
+// LegacyTOMLExt is the supported infixed extension for formula TOML files
+// (formulas/<name>.formula.toml). The exported name is retained for existing
+// internal callers, but this filename spelling is intentionally accepted.
 const LegacyTOMLExt = ".formula.toml"
 
-// IsTOMLFilename reports whether path names a TOML formula file in either the
-// canonical or legacy infixed form.
+// IsTOMLFilename reports whether path names a TOML formula file in either
+// supported TOML form.
 func IsTOMLFilename(path string) bool {
 	// Check legacy suffix first to stay symmetric with TrimTOMLFilename; the
 	// result is the same either way (both suffixes end in ".toml"), but the
@@ -24,6 +21,7 @@ func IsTOMLFilename(path string) bool {
 }
 
 // TrimTOMLFilename returns the formula name encoded in a TOML filename.
+// The optional ".formula" infix is not part of the symbolic formula name.
 func TrimTOMLFilename(path string) (string, bool) {
 	switch {
 	case strings.HasSuffix(path, LegacyTOMLExt):

--- a/internal/formula/filenames_test.go
+++ b/internal/formula/filenames_test.go
@@ -1,0 +1,29 @@
+package formula
+
+import "testing"
+
+func TestTrimTOMLFilenameStripsSupportedSuffixes(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want string
+		ok   bool
+	}{
+		{name: "plain TOML", file: "build-review.toml", want: "build-review", ok: true},
+		{name: "infixed TOML", file: "build-review.formula.toml", want: "build-review", ok: true},
+		{name: "JSON is not a TOML filename", file: "build-review.formula.json"},
+		{name: "not a formula file", file: "README.md"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := TrimTOMLFilename(tc.file)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Fatalf("name = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/formula/fragment_test.go
+++ b/internal/formula/fragment_test.go
@@ -448,7 +448,7 @@ contract = "graph.v2"
 id = "{target}.work"
 title = "Work"
 `
-	if err := os.WriteFile(filepath.Join(dir, "needs-v2-fragment.formula.toml"), []byte(expansion), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "needs-v2-fragment.toml"), []byte(expansion), 0o644); err != nil {
 		t.Fatalf("write expansion: %v", err)
 	}
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -81,14 +81,8 @@ func defaultSearchPaths() []string {
 }
 
 // ParseFile parses a formula from a file path.
-// Supported extensions are .toml and .formula.json. Legacy .formula.toml
-// paths hard-error with a migration hint.
+// Supported extensions are .toml, .formula.toml, and .formula.json.
 func (p *Parser) ParseFile(path string) (*Formula, error) {
-	if strings.HasSuffix(path, FormulaLegacyExtTOML) {
-		base := strings.TrimSuffix(filepath.Base(path), FormulaLegacyExtTOML)
-		return nil, fmt.Errorf("unsupported PackV1 formula path %s; rename to %s%s", path, base, FormulaExtTOML)
-	}
-
 	// Check cache first
 	absPath, err := filepath.Abs(path)
 	if err != nil {

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -12,12 +12,10 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// Formula file extensions. Canonical TOML is preferred, JSON is a legacy
-// fallback, and infixed TOML remains named here only so Wave 2 can emit clear
-// migration errors.
+// Formula file extensions. Canonical TOML is preferred, infixed TOML remains
+// supported at lower precedence, and JSON is a legacy fallback.
 const (
-	FormulaExtTOML = CanonicalTOMLExt
-	// PACKV2-CUTOVER: remove legacy formula filename support after the infix migration window closes.
+	FormulaExtTOML       = CanonicalTOMLExt
 	FormulaLegacyExtTOML = LegacyTOMLExt
 	FormulaExtJSON       = ".formula.json"
 	FormulaExt           = FormulaExtJSON // Legacy alias for backwards compatibility

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -82,6 +82,7 @@ func defaultSearchPaths() []string {
 
 // ParseFile parses a formula from a file path.
 // Supported extensions are .toml, .formula.toml, and .formula.json.
+// For .formula.toml, the ".formula" infix is stripped from the symbolic name.
 func (p *Parser) ParseFile(path string) (*Formula, error) {
 	// Check cache first
 	absPath, err := filepath.Abs(path)

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -12,7 +12,9 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// Formula file extensions. TOML is preferred, JSON is legacy fallback.
+// Formula file extensions. Canonical TOML is preferred, JSON is a legacy
+// fallback, and infixed TOML remains named here only so Wave 2 can emit clear
+// migration errors.
 const (
 	FormulaExtTOML = CanonicalTOMLExt
 	// PACKV2-CUTOVER: remove legacy formula filename support after the infix migration window closes.
@@ -79,8 +81,14 @@ func defaultSearchPaths() []string {
 }
 
 // ParseFile parses a formula from a file path.
-// Detects format from extension: .toml, .formula.toml, or .formula.json.
+// Supported extensions are .toml and .formula.json. Legacy .formula.toml
+// paths hard-error with a migration hint.
 func (p *Parser) ParseFile(path string) (*Formula, error) {
+	if strings.HasSuffix(path, FormulaLegacyExtTOML) {
+		base := strings.TrimSuffix(filepath.Base(path), FormulaLegacyExtTOML)
+		return nil, fmt.Errorf("unsupported PackV1 formula path %s; rename to %s%s", path, base, FormulaExtTOML)
+	}
+
 	// Check cache first
 	absPath, err := filepath.Abs(path)
 	if err != nil {
@@ -280,7 +288,7 @@ func (p *Parser) Resolve(formula *Formula) (*Formula, error) {
 // loadFormula loads a formula by name from search paths. Search paths are
 // ordered lowest→highest priority (matching ComputeFormulaLayers); the
 // highest-priority path containing the formula wins. Within a single path,
-// canonical .toml beats legacy .formula.toml beats legacy .formula.json.
+// plain .toml beats infixed .formula.toml beats legacy .formula.json.
 func (p *Parser) loadFormula(name string) (*Formula, error) {
 	if cached, ok := p.cache[name]; ok {
 		return cached, nil

--- a/internal/formula/resolve.go
+++ b/internal/formula/resolve.go
@@ -6,16 +6,16 @@ import (
 )
 
 // extOrder is the within-layer extension precedence used by Resolve:
-// canonical TOML beats legacy infixed TOML beats legacy JSON. JSON is
-// included here because Resolve drives the in-process parser, which still
-// loads .formula.json formulas. ResolveAll deliberately excludes JSON
-// (its caller stages symlinks the bd CLI consumes — TOML-only).
+// plain TOML beats infixed TOML beats legacy JSON. JSON is included here
+// because Resolve drives the in-process parser, which still loads
+// .formula.json formulas. ResolveAll deliberately excludes JSON (its caller
+// stages symlinks the bd CLI consumes — TOML-only).
 var extOrder = []string{CanonicalTOMLExt, LegacyTOMLExt, FormulaExtJSON}
 
 // Resolve returns the path of the highest-priority layer that contains a
 // formula by this name. layers are ordered lowest→highest priority,
 // matching ComputeFormulaLayers; the highest-priority layer present wins
-// (last-wins). Within a single layer, canonical .toml beats legacy
+// (last-wins). Within a single layer, plain .toml beats infixed
 // .formula.toml beats legacy .formula.json.
 //
 // Returns ("", false) if no layer contains the formula.
@@ -33,8 +33,8 @@ func Resolve(layers []string, name string) (string, bool) {
 
 // ResolveAll returns name→winning-path for every TOML formula reachable
 // across layers. Same precedence rules as Resolve: layers ordered
-// lowest→highest priority (last-wins across layers), canonical beats
-// legacy within a layer.
+// lowest→highest priority (last-wins across layers), plain .toml beats
+// infixed .formula.toml within a layer.
 //
 // JSON formulas are excluded — they are loader-only fallback and not
 // suitable for symlink staging by callers that consume this map.
@@ -45,7 +45,7 @@ func ResolveAll(layers []string) map[string]string {
 		if err != nil {
 			continue
 		}
-		// Resolve within-layer winners first so canonical beats legacy
+		// Resolve within-layer winners first so plain .toml beats an infixed
 		// sibling regardless of ReadDir order, then merge into the
 		// cross-layer winners map (overwriting lower layers).
 		layerPick := make(map[string]string)
@@ -60,7 +60,7 @@ func ResolveAll(layers []string) map[string]string {
 			}
 			legacy := e.Name() == name+LegacyTOMLExt
 			if _, exists := layerPick[name]; exists && legacy && !layerLegacy[name] {
-				continue // Canonical already picked in this layer — skip legacy sibling.
+				continue // Plain .toml already picked in this layer — skip infixed sibling.
 			}
 			abs, err := filepath.Abs(filepath.Join(layerDir, e.Name()))
 			if err != nil {

--- a/internal/fsys/fake.go
+++ b/internal/fsys/fake.go
@@ -27,7 +27,8 @@ type Fake struct {
 
 // Call records a single method invocation on [Fake].
 type Call struct {
-	Method string // "MkdirAll", "WriteFile", "ReadFile", "ReadRegularFile", "Stat", "ReadDir", "Rename", "Remove", or "Chmod"
+	// Method is the invoked filesystem method name.
+	Method string
 	Path   string // path argument
 }
 
@@ -197,6 +198,35 @@ func (f *Fake) Lstat(name string) (os.FileInfo, error) {
 	return nil, &os.PathError{Op: "lstat", Path: name, Err: os.ErrNotExist}
 }
 
+// Readlink records the call and returns the symlink target without following it.
+func (f *Fake) Readlink(name string) (string, error) {
+	f.Calls = append(f.Calls, Call{Method: "Readlink", Path: name})
+	if err, ok := f.Errors[name]; ok {
+		return "", err
+	}
+	if target, ok := f.Symlinks[name]; ok {
+		return target, nil
+	}
+	return "", &os.PathError{Op: "readlink", Path: name, Err: os.ErrInvalid}
+}
+
+// Symlink records the call and creates a symlink entry.
+func (f *Fake) Symlink(oldname, newname string) error {
+	f.Calls = append(f.Calls, Call{Method: "Symlink", Path: newname})
+	if err, ok := f.Errors[newname]; ok {
+		return err
+	}
+	if f.Symlinks == nil {
+		f.Symlinks = make(map[string]string)
+	}
+	f.Symlinks[newname] = oldname
+	delete(f.Files, newname)
+	delete(f.Dirs, newname)
+	delete(f.Modes, newname)
+	delete(f.ModTimes, newname)
+	return nil
+}
+
 // ReadDir records the call and returns entries from direct children.
 func (f *Fake) ReadDir(name string) ([]os.DirEntry, error) {
 	f.Calls = append(f.Calls, Call{Method: "ReadDir", Path: name})
@@ -225,6 +255,16 @@ func (f *Fake) ReadDir(name string) ([]os.DirEntry, error) {
 			if !seen[base] {
 				seen[base] = true
 				entries = append(entries, fakeDirEntry{name: base, size: int64(len(data)), mode: f.modeFor(p), id: fakeIdentity(p), hasID: true})
+			}
+		}
+	}
+	// Collect direct child symlinks.
+	for p := range f.Symlinks {
+		if filepath.Dir(p) == name {
+			base := filepath.Base(p)
+			if !seen[base] {
+				seen[base] = true
+				entries = append(entries, fakeDirEntry{name: base, symlink: true, id: fakeIdentity(p), hasID: true})
 			}
 		}
 	}
@@ -357,17 +397,21 @@ func (fi fakeFileInfo) Sys() any {
 // --- fake os.DirEntry ---
 
 type fakeDirEntry struct {
-	name  string
-	size  int64
-	mode  os.FileMode
-	id    fileIdentity
-	hasID bool
-	dir   bool
+	name    string
+	size    int64
+	mode    os.FileMode
+	id      fileIdentity
+	hasID   bool
+	dir     bool
+	symlink bool
 }
 
 func (de fakeDirEntry) Name() string { return de.name }
 func (de fakeDirEntry) IsDir() bool  { return de.dir }
 func (de fakeDirEntry) Type() fs.FileMode {
+	if de.symlink {
+		return fs.ModeSymlink
+	}
 	if de.dir {
 		return fs.ModeDir
 	}
@@ -375,7 +419,7 @@ func (de fakeDirEntry) Type() fs.FileMode {
 }
 
 func (de fakeDirEntry) Info() (fs.FileInfo, error) {
-	return fakeFileInfo{name: de.name, size: de.size, mode: de.mode, id: de.id, hasID: de.hasID, dir: de.dir}, nil
+	return fakeFileInfo{name: de.name, size: de.size, mode: de.mode, id: de.id, hasID: de.hasID, dir: de.dir, symlink: de.symlink}, nil
 }
 
 func fakeIdentity(name string) fileIdentity {

--- a/internal/fsys/fsys.go
+++ b/internal/fsys/fsys.go
@@ -70,6 +70,16 @@ func (OSFS) Lstat(name string) (os.FileInfo, error) {
 	return os.Lstat(name)
 }
 
+// Readlink delegates to [os.Readlink].
+func (OSFS) Readlink(name string) (string, error) {
+	return os.Readlink(name)
+}
+
+// Symlink delegates to [os.Symlink].
+func (OSFS) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
 // ReadDir delegates to [os.ReadDir].
 func (OSFS) ReadDir(name string) ([]os.DirEntry, error) {
 	return os.ReadDir(name)

--- a/internal/fsys/remove_all.go
+++ b/internal/fsys/remove_all.go
@@ -1,0 +1,47 @@
+package fsys
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// RemoveAll removes path and any children using the provided filesystem.
+// Missing paths are treated as already removed. Symlink paths are removed as
+// links and are not followed.
+func RemoveAll(fs FS, path string) error {
+	info, err := fs.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+
+	entries, err := fs.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var removeErr error
+	for _, entry := range entries {
+		if err := RemoveAll(fs, filepath.Join(path, entry.Name())); err != nil {
+			removeErr = errors.Join(removeErr, err)
+		}
+	}
+	if removeErr != nil {
+		return removeErr
+	}
+	if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/fsys/remove_all_test.go
+++ b/internal/fsys/remove_all_test.go
@@ -1,0 +1,69 @@
+package fsys
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRemoveAllRemovesNestedTree(t *testing.T) {
+	fs := NewFake()
+	fs.Dirs["/city"] = true
+	fs.Dirs["/city/agents"] = true
+	fs.Dirs["/city/agents/coder"] = true
+	fs.Dirs["/city/agents/coder/nested"] = true
+	fs.Files["/city/agents/coder/agent.toml"] = []byte("provider = \"claude\"\n")
+	fs.Files["/city/agents/coder/nested/prompt.template.md"] = []byte("You are the coder.\n")
+
+	if err := RemoveAll(fs, "/city/agents/coder"); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	for _, path := range []string{
+		"/city/agents/coder",
+		"/city/agents/coder/nested",
+		"/city/agents/coder/agent.toml",
+		"/city/agents/coder/nested/prompt.template.md",
+	} {
+		if fs.Dirs[path] {
+			t.Fatalf("directory %s remains after RemoveAll", path)
+		}
+		if _, ok := fs.Files[path]; ok {
+			t.Fatalf("file %s remains after RemoveAll", path)
+		}
+	}
+	if !fs.Dirs["/city/agents"] {
+		t.Fatal("RemoveAll removed parent directory")
+	}
+}
+
+func TestRemoveAllMissingPathIsNoop(t *testing.T) {
+	fs := NewFake()
+
+	if err := RemoveAll(fs, "/missing"); err != nil {
+		t.Fatalf("RemoveAll missing path: %v", err)
+	}
+}
+
+func TestRemoveAllDoesNotFollowSymlinks(t *testing.T) {
+	fs := NewFake()
+	fs.Symlinks["/city/agents/link"] = "/outside/target"
+	fs.Files["/outside/target"] = []byte("keep me\n")
+
+	if err := RemoveAll(fs, "/city/agents/link"); err != nil {
+		t.Fatalf("RemoveAll symlink: %v", err)
+	}
+	if _, ok := fs.Symlinks["/city/agents/link"]; ok {
+		t.Fatal("symlink remains after RemoveAll")
+	}
+	if got := string(fs.Files["/outside/target"]); got != "keep me\n" {
+		t.Fatalf("target file = %q, want preserved", got)
+	}
+}
+
+func TestRemoveAllReturnsUnexpectedStatError(t *testing.T) {
+	fs := NewFake()
+	fs.Errors["/city/agents/coder"] = os.ErrPermission
+
+	if err := RemoveAll(fs, "/city/agents/coder"); !os.IsPermission(err) {
+		t.Fatalf("RemoveAll error = %v, want permission", err)
+	}
+}

--- a/internal/fsys/tree_snapshot.go
+++ b/internal/fsys/tree_snapshot.go
@@ -1,0 +1,167 @@
+package fsys
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// TreeSnapshot captures the regular files and directories under one path so
+// they can be restored after a failed multi-file mutation.
+type TreeSnapshot struct {
+	root   string
+	exists bool
+	dirs   map[string]os.FileMode
+	files  map[string]treeSnapshotFile
+	links  map[string]string
+}
+
+type treeSnapshotFile struct {
+	data []byte
+	mode os.FileMode
+}
+
+type readlinkFS interface {
+	Readlink(name string) (string, error)
+}
+
+type symlinkFS interface {
+	Symlink(oldname, newname string) error
+}
+
+// SnapshotTree captures root using fs. Missing roots produce a snapshot whose
+// restore removes any later root created at the same path.
+func SnapshotTree(fs FS, root string) (*TreeSnapshot, error) {
+	snapshot := &TreeSnapshot{
+		root:  root,
+		dirs:  make(map[string]os.FileMode),
+		files: make(map[string]treeSnapshotFile),
+		links: make(map[string]string),
+	}
+	if err := snapshot.capture(fs, root); err != nil {
+		if os.IsNotExist(err) {
+			return snapshot, nil
+		}
+		return nil, err
+	}
+	snapshot.exists = true
+	return snapshot, nil
+}
+
+func (s *TreeSnapshot) capture(fs FS, path string) error {
+	info, err := fs.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkFS, ok := fs.(readlinkFS)
+		if !ok {
+			return fmt.Errorf("filesystem cannot preserve symlink in tree snapshot: %s", path)
+		}
+		target, err := linkFS.Readlink(path)
+		if err != nil {
+			return fmt.Errorf("reading symlink %s: %w", path, err)
+		}
+		s.links[path] = target
+		return nil
+	}
+	if !info.IsDir() {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("unsupported non-regular file in tree snapshot: %s", path)
+		}
+		data, err := fs.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		s.files[path] = treeSnapshotFile{data: data, mode: info.Mode().Perm()}
+		return nil
+	}
+
+	s.dirs[path] = info.Mode().Perm()
+	entries, err := fs.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("reading directory %s: %w", path, err)
+	}
+	for _, entry := range entries {
+		if err := s.capture(fs, filepath.Join(path, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Restore removes the current root and recreates the captured tree.
+func (s *TreeSnapshot) Restore(fs FS) error {
+	if s == nil {
+		return nil
+	}
+	var restoreErr error
+	if err := RemoveAll(fs, s.root); err != nil {
+		restoreErr = errors.Join(restoreErr, fmt.Errorf("removing current %s: %w", s.root, err))
+	}
+	if !s.exists {
+		return restoreErr
+	}
+
+	dirs := make([]string, 0, len(s.dirs))
+	for dir := range s.dirs {
+		dirs = append(dirs, dir)
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		if len(dirs[i]) == len(dirs[j]) {
+			return dirs[i] < dirs[j]
+		}
+		return len(dirs[i]) < len(dirs[j])
+	})
+	for _, dir := range dirs {
+		mode := s.dirs[dir]
+		if err := fs.MkdirAll(dir, mode); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("creating %s: %w", dir, err))
+			continue
+		}
+		if err := fs.Chmod(dir, mode); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("chmod %s: %w", dir, err))
+		}
+	}
+
+	files := make([]string, 0, len(s.files))
+	for path := range s.files {
+		files = append(files, path)
+	}
+	sort.Strings(files)
+	for _, path := range files {
+		file := s.files[path]
+		if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("creating %s: %w", filepath.Dir(path), err))
+			continue
+		}
+		if err := WriteFileAtomic(fs, path, file.data, file.mode); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restoring %s: %w", path, err))
+		}
+	}
+
+	links := make([]string, 0, len(s.links))
+	for path := range s.links {
+		links = append(links, path)
+	}
+	sort.Strings(links)
+	linkFS, linkCapable := fs.(symlinkFS)
+	for _, path := range links {
+		target := s.links[path]
+		if err := fs.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("creating %s: %w", filepath.Dir(path), err))
+			continue
+		}
+		if !linkCapable {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("filesystem cannot restore symlink %s", path))
+			continue
+		}
+		if err := linkFS.Symlink(target, path); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restoring symlink %s: %w", path, err))
+		}
+	}
+
+	return restoreErr
+}

--- a/internal/fsys/tree_snapshot_test.go
+++ b/internal/fsys/tree_snapshot_test.go
@@ -1,0 +1,113 @@
+package fsys
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTreeSnapshotRestoreRestoresNestedTree(t *testing.T) {
+	fs := NewFake()
+	fs.Dirs["/city/agents"] = true
+	fs.Dirs["/city/agents/worker"] = true
+	fs.Modes["/city/agents"] = 0o750
+	fs.Modes["/city/agents/worker"] = 0o700
+	fs.Files["/city/agents/worker/agent.toml"] = []byte("provider = \"codex\"\n")
+	fs.Modes["/city/agents/worker/agent.toml"] = 0o640
+
+	snapshot, err := SnapshotTree(fs, "/city/agents")
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+
+	if err := RemoveAll(fs, "/city/agents"); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	fs.Dirs["/city/agents"] = true
+	fs.Files["/city/agents/new.toml"] = []byte("stale\n")
+
+	if err := snapshot.Restore(fs); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if _, ok := fs.Files["/city/agents/new.toml"]; ok {
+		t.Fatalf("stale file still exists after restore")
+	}
+	if got := string(fs.Files["/city/agents/worker/agent.toml"]); got != "provider = \"codex\"\n" {
+		t.Fatalf("restored agent.toml = %q", got)
+	}
+	if got := fs.Modes["/city/agents/worker/agent.toml"]; got != 0o640 {
+		t.Fatalf("agent.toml mode = %#o, want 0640", got)
+	}
+	if got := fs.Modes["/city/agents/worker"]; got != 0o700 {
+		t.Fatalf("worker dir mode = %#o, want 0700", got)
+	}
+}
+
+func TestTreeSnapshotRestoreMissingRootRemovesCurrentRoot(t *testing.T) {
+	fs := NewFake()
+
+	snapshot, err := SnapshotTree(fs, "/city/agents")
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+
+	fs.Dirs["/city/agents"] = true
+	fs.Files["/city/agents/new.toml"] = []byte("new\n")
+
+	if err := snapshot.Restore(fs); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if fs.Dirs["/city/agents"] {
+		t.Fatalf("root dir still exists after restoring missing snapshot")
+	}
+	if _, ok := fs.Files["/city/agents/new.toml"]; ok {
+		t.Fatalf("file still exists after restoring missing snapshot")
+	}
+}
+
+func TestTreeSnapshotRestorePreservesSymlinks(t *testing.T) {
+	fs := NewFake()
+	fs.Dirs["/city/agents"] = true
+	fs.Dirs["/city/agents/worker"] = true
+	fs.Symlinks["/city/agents/worker/skills"] = "/shared/skills"
+
+	snapshot, err := SnapshotTree(fs, "/city/agents")
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+
+	if err := RemoveAll(fs, "/city/agents"); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	fs.Dirs["/city/agents"] = true
+	fs.Symlinks["/city/agents/stale"] = "/stale"
+
+	if err := snapshot.Restore(fs); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if _, ok := fs.Symlinks["/city/agents/stale"]; ok {
+		t.Fatal("stale symlink still exists after restore")
+	}
+	if got := fs.Symlinks["/city/agents/worker/skills"]; got != "/shared/skills" {
+		t.Fatalf("restored skills symlink = %q, want /shared/skills", got)
+	}
+}
+
+func TestTreeSnapshotRestoreReportsRemoveError(t *testing.T) {
+	fs := NewFake()
+	fs.Dirs["/city/agents"] = true
+	snapshot, err := SnapshotTree(fs, "/city/agents")
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+
+	removeErr := errors.New("busy")
+	fs.Errors["/city/agents"] = removeErr
+
+	err = snapshot.Restore(fs)
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("Restore error = %v, want remove error", err)
+	}
+}

--- a/internal/orderdiscovery/discovery.go
+++ b/internal/orderdiscovery/discovery.go
@@ -23,10 +23,9 @@ type OverrideErrorHandler func(err error) error
 
 // ScanOptions controls shared order discovery behavior.
 type ScanOptions struct {
-	FS               fsys.FS
-	OrderScanOptions orders.ScanOptions
-	OnRigScanError   RigScanErrorHandler
-	OnOverrideError  OverrideErrorHandler
+	FS              fsys.FS
+	OnRigScanError  RigScanErrorHandler
+	OnOverrideError OverrideErrorHandler
 }
 
 // ScanAll scans city-level and rig-exclusive order roots, stamps rig orders,
@@ -42,7 +41,7 @@ func ScanAll(cityPath string, cfg *config.City, opts ScanOptions) ([]orders.Orde
 	}
 
 	cityLayers := cityFormulaLayers(cityPath, cfg)
-	cityOrders, err := orders.ScanRootsWithOptions(fsysImpl, CityOrderRoots(cityPath, cfg), cfg.Orders.Skip, opts.OrderScanOptions)
+	cityOrders, err := orders.ScanRoots(fsysImpl, CityOrderRoots(cityPath, cfg), cfg.Orders.Skip)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +61,7 @@ func ScanAll(cityPath string, cfg *config.City, opts ScanOptions) ([]orders.Orde
 		if len(exclusive) == 0 && len(exclusivePackDirs) == 0 {
 			continue
 		}
-		aa, err := orders.ScanRootsWithOptions(fsysImpl, rigOrderRoots(exclusive, exclusivePackDirs, rigLocalFormulaLayer(exclusive, exclusivePackDirs)), cfg.Orders.Skip, opts.OrderScanOptions)
+		aa, err := orders.ScanRoots(fsysImpl, rigOrderRoots(exclusive, exclusivePackDirs, rigLocalFormulaLayer(exclusive, exclusivePackDirs)), cfg.Orders.Skip)
 		if err != nil {
 			if opts.OnRigScanError != nil {
 				if handlerErr := opts.OnRigScanError(rigName, err); handlerErr != nil {

--- a/internal/orderdiscovery/discovery_test.go
+++ b/internal/orderdiscovery/discovery_test.go
@@ -226,6 +226,36 @@ interval = "1h"
 	}
 }
 
+func TestScanAllRejectsSchema1PackLegacyOrderDirectory(t *testing.T) {
+	cityPath, cityLayer := orderDiscoveryCity(t)
+	if err := os.WriteFile(filepath.Join(cityPath, "pack.toml"), []byte("[pack]\nname = \"legacy-city\"\nschema = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	legacyOrderDir := filepath.Join(cityPath, "orders", "heartbeat")
+	if err := os.MkdirAll(legacyOrderDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyOrderDir, "order.toml"), []byte(`[order]
+exec = "scripts/heartbeat.sh"
+trigger = "cooldown"
+interval = "5m"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ScanAll(cityPath, &config.City{
+		FormulaLayers: config.FormulaLayers{
+			City: []string{cityLayer},
+		},
+	}, ScanOptions{})
+	if err == nil {
+		t.Fatal("ScanAll succeeded, want schema-1 legacy order directory rejection")
+	}
+	if !strings.Contains(err.Error(), "rename to orders/heartbeat.toml") {
+		t.Fatalf("ScanAll error = %v, want schema-1 flat-file migration guidance", err)
+	}
+}
+
 func TestCityOrderRootsUsesLocalAndPackFormulaLayersOnce(t *testing.T) {
 	cityPath, cityLayer := orderDiscoveryCity(t)
 	packLayer := filepath.Join(t.TempDir(), "formulas")

--- a/internal/orders/discovery.go
+++ b/internal/orders/discovery.go
@@ -10,9 +10,9 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-// discoverRoot discovers orders for one logical root. Wave 2 requires the
-// canonical flat orders/<name>.toml layout and hard-errors when older PackV1
-// order paths are still present.
+// discoverRoot discovers orders for one logical root. Wave 2 requires flat
+// order files and hard-errors when older PackV1 subdirectory order paths are
+// still present.
 func discoverRoot(fs fsys.FS, root ScanRoot) ([]Order, error) {
 	return discoverRootWithOptions(fs, root, ScanOptions{})
 }
@@ -57,22 +57,7 @@ func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Ord
 	return result, nil
 }
 
-func warnDeprecatedPath(opts ScanOptions, format string, args ...any) {
-	if opts.SuppressDeprecatedPathWarnings {
-		return
-	}
-	msg := fmt.Sprintf(format, args...)
-	if opts.DeprecatedPathWarningDedup != nil && !opts.VerboseDeprecatedPathWarnings && !opts.DeprecatedPathWarningDedup.First(msg) {
-		return
-	}
-	if opts.DeprecatedPathWarningWriter != nil {
-		fmt.Fprintln(opts.DeprecatedPathWarningWriter, msg) //nolint:errcheck // best-effort warning emission
-		return
-	}
-	log.Print(msg)
-}
-
-func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error, opts ScanOptions) error {
+func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error, _ ScanOptions) error {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -80,6 +65,7 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 		}
 		return fmt.Errorf("reading order root %s: %w", dir, err)
 	}
+	pickedInfixed := make(map[string]bool)
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -89,24 +75,24 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 		if !ok {
 			continue
 		}
-		legacy := fileName == name+LegacyFlatOrderSuffix
+		infixed := fileName == name+LegacyFlatOrderSuffix
 		source := filepath.Join(dir, fileName)
-		if legacy {
-			return fmt.Errorf("unsupported PackV1 order path %s; rename to orders/%s.toml", source, name)
-		}
 		if _, exists := found[name]; exists {
-			continue
+			if infixed || !pickedInfixed[name] {
+				continue
+			}
 		}
 		data, err := fs.ReadFile(source)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				warnUnreadablePath(opts, "warning: unreadable order path %s: %v", source, err)
+				log.Printf("warning: unreadable order path %s: %v", source, err)
 			}
 			continue
 		}
 		if err := add(name, source, data); err != nil {
 			return err
 		}
+		pickedInfixed[name] = infixed
 	}
 	return nil
 }
@@ -126,16 +112,12 @@ func rejectLegacySubdirectoryOrders(fs fsys.FS, dir, hintFmt string) error {
 		name := entry.Name()
 		source := filepath.Join(dir, name, orderFileName)
 		if _, err := fs.ReadFile(source); err == nil {
-			return fmt.Errorf("unsupported PackV1 order path %s; %s", source, fmt.Sprintf(hintFmt, name))
+			return fmt.Errorf("unsupported PackV1 order path %s; "+hintFmt, source, name)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("reading legacy order path %s: %w", source, err)
 		}
 	}
 	return nil
-}
-
-func warnUnreadablePath(_ ScanOptions, format string, args ...any) {
-	log.Printf(format, args...)
 }
 
 func legacyOrdersDir(formulaLayer string) string {

--- a/internal/orders/discovery.go
+++ b/internal/orders/discovery.go
@@ -3,21 +3,17 @@ package orders
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
 // discoverRoot discovers orders for one logical root. Wave 2 requires flat
-// order files and hard-errors when older PackV1 subdirectory order paths are
-// still present.
+// order files and treats selected flat order files as load-bearing config:
+// unreadable files and older PackV1 subdirectory paths are hard errors.
 func discoverRoot(fs fsys.FS, root ScanRoot) ([]Order, error) {
-	return discoverRootWithOptions(fs, root, ScanOptions{})
-}
-
-func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Order, error) {
 	found := make(map[string]Order)
 	var names []string
 
@@ -36,18 +32,24 @@ func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Ord
 		return nil
 	}
 
-	if err := discoverFlatFiles(fs, root.Dir, found, add, opts); err != nil {
+	if err := discoverFlatFiles(fs, root.Dir, add); err != nil {
 		return nil, err
 	}
-	if err := rejectLegacySubdirectoryOrders(fs, root.Dir, "rename to orders/%s.toml"); err != nil {
+	legacyFindings, err := findLegacySubdirectoryOrders(fs, root.Dir, "rename to orders/%s.toml")
+	if err != nil {
 		return nil, err
 	}
 
 	legacyDir := legacyOrdersDir(root.FormulaLayer)
 	if legacyDir != "" && filepath.Clean(legacyDir) != filepath.Clean(root.Dir) {
-		if err := rejectLegacySubdirectoryOrders(fs, legacyDir, "move to orders/%s.toml"); err != nil {
+		findings, err := findLegacySubdirectoryOrders(fs, legacyDir, "move to orders/%s.toml")
+		if err != nil {
 			return nil, err
 		}
+		legacyFindings = append(legacyFindings, findings...)
+	}
+	if len(legacyFindings) > 0 {
+		return nil, legacyOrderLayoutError{findings: legacyFindings}
 	}
 
 	result := make([]Order, 0, len(names))
@@ -57,7 +59,7 @@ func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Ord
 	return result, nil
 }
 
-func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error, _ ScanOptions) error {
+func discoverFlatFiles(fs fsys.FS, dir string, add func(name, source string, data []byte) error) error {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -65,7 +67,9 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 		}
 		return fmt.Errorf("reading order root %s: %w", dir, err)
 	}
-	pickedInfixed := make(map[string]bool)
+
+	selected := make(map[string]string)
+	var names []string
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -75,36 +79,60 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 		if !ok {
 			continue
 		}
-		infixed := fileName == name+LegacyFlatOrderSuffix
-		source := filepath.Join(dir, fileName)
-		if _, exists := found[name]; exists {
-			if infixed || !pickedInfixed[name] {
-				continue
-			}
+		if _, exists := selected[name]; !exists {
+			names = append(names, name)
+			selected[name] = fileName
+			continue
 		}
+		if fileName == name+CanonicalFlatOrderSuffix {
+			selected[name] = fileName
+		}
+	}
+
+	for _, name := range names {
+		fileName := selected[name]
+		source := filepath.Join(dir, fileName)
 		data, err := fs.ReadFile(source)
 		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				log.Printf("warning: unreadable order path %s: %v", source, err)
+			if errors.Is(err, os.ErrNotExist) {
+				continue
 			}
-			continue
+			return fmt.Errorf("reading order %s: %w", source, err)
 		}
 		if err := add(name, source, data); err != nil {
 			return err
 		}
-		pickedInfixed[name] = infixed
 	}
 	return nil
 }
 
-func rejectLegacySubdirectoryOrders(fs fsys.FS, dir, hintFmt string) error {
+type legacyOrderLayoutFinding struct {
+	source string
+	hint   string
+}
+
+type legacyOrderLayoutError struct {
+	findings []legacyOrderLayoutFinding
+}
+
+func (e legacyOrderLayoutError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "unsupported PackV1 order paths (%d); migrate all legacy order directories to flat orders/<name>.toml files before loading this city. This cutover applies to all pack schemas.", len(e.findings))
+	for _, finding := range e.findings {
+		fmt.Fprintf(&b, "\n- unsupported PackV1 order path %s; %s", finding.source, finding.hint)
+	}
+	return b.String()
+}
+
+func findLegacySubdirectoryOrders(fs fsys.FS, dir, hintFmt string) ([]legacyOrderLayoutFinding, error) {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("reading order root %s: %w", dir, err)
+		return nil, fmt.Errorf("reading order root %s: %w", dir, err)
 	}
+	var findings []legacyOrderLayoutFinding
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -112,12 +140,15 @@ func rejectLegacySubdirectoryOrders(fs fsys.FS, dir, hintFmt string) error {
 		name := entry.Name()
 		source := filepath.Join(dir, name, orderFileName)
 		if _, err := fs.ReadFile(source); err == nil {
-			return fmt.Errorf("unsupported PackV1 order path %s; "+hintFmt, source, name)
+			findings = append(findings, legacyOrderLayoutFinding{
+				source: source,
+				hint:   fmt.Sprintf(hintFmt, name),
+			})
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("reading legacy order path %s: %w", source, err)
+			return nil, fmt.Errorf("reading legacy order path %s: %w", source, err)
 		}
 	}
-	return nil
+	return findings, nil
 }
 
 func legacyOrdersDir(formulaLayer string) string {

--- a/internal/orders/discovery.go
+++ b/internal/orders/discovery.go
@@ -10,10 +10,9 @@ import (
 	"github.com/gastownhall/gascity/internal/fsys"
 )
 
-// discoverRoot discovers orders for one logical root. It prefers the canonical
-// flat .toml file format, then falls back to the deprecated infixed flat form,
-// then the deprecated subdirectory format, then the deprecated formulas/orders
-// legacy path.
+// discoverRoot discovers orders for one logical root. Wave 2 requires the
+// canonical flat orders/<name>.toml layout and hard-errors when older PackV1
+// order paths are still present.
 func discoverRoot(fs fsys.FS, root ScanRoot) ([]Order, error) {
 	return discoverRootWithOptions(fs, root, ScanOptions{})
 }
@@ -40,19 +39,13 @@ func discoverRootWithOptions(fs fsys.FS, root ScanRoot, opts ScanOptions) ([]Ord
 	if err := discoverFlatFiles(fs, root.Dir, found, add, opts); err != nil {
 		return nil, err
 	}
-	if err := discoverSubdirectoryOrders(fs, root.Dir, found, func(name, source string, data []byte) error {
-		warnDeprecatedPath(opts, "warning: deprecated order path %s; rename to orders/%s.toml", source, name)
-		return add(name, source, data)
-	}, opts); err != nil {
+	if err := rejectLegacySubdirectoryOrders(fs, root.Dir, "rename to orders/%s.toml"); err != nil {
 		return nil, err
 	}
 
 	legacyDir := legacyOrdersDir(root.FormulaLayer)
 	if legacyDir != "" && filepath.Clean(legacyDir) != filepath.Clean(root.Dir) {
-		if err := discoverSubdirectoryOrders(fs, legacyDir, found, func(name, source string, data []byte) error {
-			warnDeprecatedPath(opts, "warning: deprecated order path %s; move to orders/%s.toml", source, name)
-			return add(name, source, data)
-		}, opts); err != nil {
+		if err := rejectLegacySubdirectoryOrders(fs, legacyDir, "move to orders/%s.toml"); err != nil {
 			return nil, err
 		}
 	}
@@ -87,51 +80,38 @@ func discoverFlatFiles(fs fsys.FS, dir string, found map[string]Order, add func(
 		}
 		return fmt.Errorf("reading order root %s: %w", dir, err)
 	}
-	// Two-pass scan: canonical .toml files win over legacy .order.toml files
-	// regardless of ReadDir ordering. A legacy file is only consumed if no
-	// canonical file (in this call OR an earlier call via `found`) supplies
-	// the same name.
-	scan := func(wantLegacy bool) error {
-		for _, entry := range entries {
-			if entry.IsDir() {
-				continue
-			}
-			fileName := entry.Name()
-			name, ok := TrimFlatOrderFilename(fileName)
-			if !ok {
-				continue
-			}
-			legacy := fileName == name+LegacyFlatOrderSuffix
-			if legacy != wantLegacy {
-				continue
-			}
-			if _, exists := found[name]; exists {
-				continue
-			}
-			source := filepath.Join(dir, fileName)
-			data, err := fs.ReadFile(source)
-			if err != nil {
-				if !errors.Is(err, os.ErrNotExist) {
-					warnUnreadablePath(opts, "warning: unreadable order path %s: %v", source, err)
-				}
-				continue
-			}
-			if legacy {
-				warnDeprecatedPath(opts, "warning: deprecated order path %s; rename to orders/%s.toml", source, name)
-			}
-			if err := add(name, source, data); err != nil {
-				return err
-			}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
 		}
-		return nil
+		fileName := entry.Name()
+		name, ok := TrimFlatOrderFilename(fileName)
+		if !ok {
+			continue
+		}
+		legacy := fileName == name+LegacyFlatOrderSuffix
+		source := filepath.Join(dir, fileName)
+		if legacy {
+			return fmt.Errorf("unsupported PackV1 order path %s; rename to orders/%s.toml", source, name)
+		}
+		if _, exists := found[name]; exists {
+			continue
+		}
+		data, err := fs.ReadFile(source)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				warnUnreadablePath(opts, "warning: unreadable order path %s: %v", source, err)
+			}
+			continue
+		}
+		if err := add(name, source, data); err != nil {
+			return err
+		}
 	}
-	if err := scan(false); err != nil {
-		return err
-	}
-	return scan(true)
+	return nil
 }
 
-func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, add func(name, source string, data []byte) error, opts ScanOptions) error {
+func rejectLegacySubdirectoryOrders(fs fsys.FS, dir, hintFmt string) error {
 	entries, err := fs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -144,19 +124,11 @@ func discoverSubdirectoryOrders(fs fsys.FS, dir string, found map[string]Order, 
 			continue
 		}
 		name := entry.Name()
-		if _, exists := found[name]; exists {
-			continue
-		}
 		source := filepath.Join(dir, name, orderFileName)
-		data, err := fs.ReadFile(source)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				warnUnreadablePath(opts, "warning: unreadable order path %s: %v", source, err)
-			}
-			continue
-		}
-		if err := add(name, source, data); err != nil {
-			return err
+		if _, err := fs.ReadFile(source); err == nil {
+			return fmt.Errorf("unsupported PackV1 order path %s; %s", source, fmt.Sprintf(hintFmt, name))
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("reading legacy order path %s: %w", source, err)
 		}
 	}
 	return nil

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -85,7 +85,7 @@ schedule = "*/5 * * * *"
 	}
 }
 
-func TestDiscoverRootRejectsLegacyFlatOrderFilename(t *testing.T) {
+func TestDiscoverRootAcceptsLegacyFlatOrderFilename(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/pack/orders/health-check.order.toml"] = []byte(`
 [order]
@@ -94,15 +94,21 @@ trigger = "cron"
 schedule = "*/5 * * * *"
 `)
 
-	_, err := discoverRoot(fs, ScanRoot{
+	orders, err := discoverRoot(fs, ScanRoot{
 		Dir:          "/pack/orders",
 		FormulaLayer: "/pack/formulas",
 	})
-	if err == nil {
-		t.Fatal("discoverRoot succeeded, want hard error for legacy flat order filename")
+	if err != nil {
+		t.Fatalf("discoverRoot: %v", err)
 	}
-	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
-		t.Fatalf("error = %v, want rename guidance", err)
+	if len(orders) != 1 {
+		t.Fatalf("got %d orders, want 1", len(orders))
+	}
+	if orders[0].Name != "health-check" {
+		t.Fatalf("Name = %q, want health-check", orders[0].Name)
+	}
+	if orders[0].Source != "/pack/orders/health-check.order.toml" {
+		t.Fatalf("Source = %q, want legacy flat source", orders[0].Source)
 	}
 }
 

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/gastownhall/gascity/internal/fsys"
-	"github.com/gastownhall/gascity/internal/logutil"
 )
 
 func TestDiscoverRootPrefersFlatFiles(t *testing.T) {
@@ -85,7 +84,7 @@ schedule = "*/5 * * * *"
 	}
 }
 
-func TestDiscoverRootAcceptsLegacyFlatOrderFilename(t *testing.T) {
+func TestDiscoverRootAcceptsInfixedFlatOrderFilename(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/pack/orders/health-check.order.toml"] = []byte(`
 [order]
@@ -108,36 +107,41 @@ schedule = "*/5 * * * *"
 		t.Fatalf("Name = %q, want health-check", orders[0].Name)
 	}
 	if orders[0].Source != "/pack/orders/health-check.order.toml" {
-		t.Fatalf("Source = %q, want legacy flat source", orders[0].Source)
+		t.Fatalf("Source = %q, want infixed flat source", orders[0].Source)
 	}
 }
 
-func TestDiscoverRootDedupsDeprecatedPathWarnings(t *testing.T) {
+func TestDiscoverRootPlainFlatOrderBeatsInfixedSibling(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/pack/orders/health-check"] = true
-	fs.Files["/pack/orders/health-check/order.toml"] = []byte(`
-	[order]
-	formula = "health-check"
-	trigger = "cron"
-	schedule = "*/5 * * * *"
-	`)
+	fs.Files["/pack/orders/health-check.order.toml"] = []byte(`
+[order]
+formula = "infixed"
+trigger = "manual"
+`)
+	fs.Files["/pack/orders/health-check.toml"] = []byte(`
+[order]
+formula = "plain"
+trigger = "manual"
+`)
 
-	var logs bytes.Buffer
-	opts := ScanOptions{
-		DeprecatedPathWarningDedup:  logutil.NewDedup(10),
-		DeprecatedPathWarningWriter: &logs,
+	orders, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
+	})
+	if err != nil {
+		t.Fatalf("discoverRoot: %v", err)
 	}
-	for i := 0; i < 2; i++ {
-		if _, err := discoverRootWithOptions(fs, ScanRoot{
-			Dir:          "/pack/orders",
-			FormulaLayer: "/pack/formulas",
-		}, opts); err != nil {
-			t.Fatalf("discoverRootWithOptions: %v", err)
-		}
+	if len(orders) != 1 {
+		t.Fatalf("got %d orders, want 1", len(orders))
 	}
-
-	if got := strings.Count(logs.String(), "deprecated order path"); got != 1 {
-		t.Fatalf("deprecated warning count = %d, want 1; logs=%q", got, logs.String())
+	if orders[0].Name != "health-check" {
+		t.Fatalf("Name = %q, want health-check", orders[0].Name)
+	}
+	if orders[0].Formula != "plain" {
+		t.Fatalf("Formula = %q, want plain spelling to win", orders[0].Formula)
+	}
+	if orders[0].Source != "/pack/orders/health-check.toml" {
+		t.Fatalf("Source = %q, want plain flat source", orders[0].Source)
 	}
 }
 

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -1,9 +1,7 @@
 package orders
 
 import (
-	"bytes"
 	"errors"
-	"log"
 	"strings"
 	"testing"
 
@@ -59,6 +57,69 @@ schedule = "*/5 * * * *"
 	}
 	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
 		t.Fatalf("error = %v, want rename guidance", err)
+	}
+}
+
+func TestScanRootsRejectsSubdirectoryFormat(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Dirs["/pack/orders/health-check"] = true
+	fs.Files["/pack/orders/health-check/order.toml"] = []byte(`
+[order]
+formula = "health-check"
+trigger = "cron"
+schedule = "*/5 * * * *"
+`)
+
+	_, err := ScanRoots(fs, []ScanRoot{{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
+	}}, nil)
+	if err == nil {
+		t.Fatal("ScanRoots succeeded, want hard error for legacy subdirectory layout")
+	}
+	if !strings.Contains(err.Error(), "unsupported PackV1 order path /pack/orders/health-check/order.toml") {
+		t.Fatalf("error = %v, want PackV1 path rejection", err)
+	}
+	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
+		t.Fatalf("error = %v, want flat-file migration guidance", err)
+	}
+}
+
+func TestScanRootsAggregatesLegacyOrderLayoutGuidance(t *testing.T) {
+	fs := fsys.NewFake()
+	for _, dir := range []string{
+		"/base/orders/alpha",
+		"/base/formulas/orders/beta",
+		"/pack/orders/gamma",
+	} {
+		fs.Dirs[dir] = true
+		fs.Files[dir+"/order.toml"] = []byte(`
+[order]
+formula = "noop"
+trigger = "manual"
+`)
+	}
+
+	_, err := ScanRoots(fs, []ScanRoot{
+		{Dir: "/base/orders", FormulaLayer: "/base/formulas"},
+		{Dir: "/pack/orders", FormulaLayer: "/pack/formulas"},
+	}, nil)
+	if err == nil {
+		t.Fatal("ScanRoots succeeded, want hard error for legacy subdirectory layouts")
+	}
+	for _, want := range []string{
+		"unsupported PackV1 order paths",
+		"/base/orders/alpha/order.toml",
+		"rename to orders/alpha.toml",
+		"/base/formulas/orders/beta/order.toml",
+		"move to orders/beta.toml",
+		"/pack/orders/gamma/order.toml",
+		"rename to orders/gamma.toml",
+		"applies to all pack schemas",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want substring %q", err, want)
+		}
 	}
 }
 
@@ -145,34 +206,34 @@ trigger = "manual"
 	}
 }
 
-func TestDiscoverRootSkipsUnreadableFlatFile(t *testing.T) {
+func TestDiscoverRootPlainFlatOrderIgnoresMalformedInfixedSibling(t *testing.T) {
 	fs := fsys.NewFake()
+	fs.Files["/pack/orders/health-check.order.toml"] = []byte("[order\n")
 	fs.Files["/pack/orders/health-check.toml"] = []byte(`
 [order]
-formula = "health-check"
-trigger = "cron"
-schedule = "*/5 * * * *"
+formula = "plain"
+trigger = "manual"
 `)
-	fs.Errors["/pack/orders/health-check.toml"] = errors.New("boom")
 
-	logs := captureOrderLogs(t, func() {
-		orders, err := discoverRoot(fs, ScanRoot{
-			Dir:          "/pack/orders",
-			FormulaLayer: "/pack/formulas",
-		})
-		if err != nil {
-			t.Fatalf("discoverRoot: %v", err)
-		}
-		if len(orders) != 0 {
-			t.Fatalf("got %d orders, want 0", len(orders))
-		}
+	orders, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
 	})
-	if !strings.Contains(logs, "unreadable order path") {
-		t.Fatalf("logs = %q, want unreadable order path warning", logs)
+	if err != nil {
+		t.Fatalf("discoverRoot: %v", err)
+	}
+	if len(orders) != 1 {
+		t.Fatalf("got %d orders, want 1", len(orders))
+	}
+	if orders[0].Formula != "plain" {
+		t.Fatalf("Formula = %q, want plain spelling to win", orders[0].Formula)
+	}
+	if orders[0].Source != "/pack/orders/health-check.toml" {
+		t.Fatalf("Source = %q, want plain flat source", orders[0].Source)
 	}
 }
 
-func TestDiscoverRootLogsUnreadablePathWhenDeprecatedWarningsSuppressed(t *testing.T) {
+func TestDiscoverRootReturnsUnreadableFlatFileError(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Files["/pack/orders/health-check.toml"] = []byte(`
 [order]
@@ -182,20 +243,15 @@ schedule = "*/5 * * * *"
 `)
 	fs.Errors["/pack/orders/health-check.toml"] = errors.New("boom")
 
-	logs := captureOrderLogs(t, func() {
-		orders, err := discoverRootWithOptions(fs, ScanRoot{
-			Dir:          "/pack/orders",
-			FormulaLayer: "/pack/formulas",
-		}, ScanOptions{SuppressDeprecatedPathWarnings: true})
-		if err != nil {
-			t.Fatalf("discoverRootWithOptions: %v", err)
-		}
-		if len(orders) != 0 {
-			t.Fatalf("got %d orders, want 0", len(orders))
-		}
+	_, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
 	})
-	if !strings.Contains(logs, "unreadable order path") {
-		t.Fatalf("logs = %q, want unreadable order path warning", logs)
+	if err == nil {
+		t.Fatal("discoverRoot returned nil error for unreadable flat order file")
+	}
+	if !strings.Contains(err.Error(), "reading order /pack/orders/health-check.toml") {
+		t.Fatalf("error = %v, want flat order path context", err)
 	}
 }
 
@@ -213,24 +269,4 @@ func TestDiscoverRootReturnsUnreadableRootError(t *testing.T) {
 	if !strings.Contains(err.Error(), "reading order root") {
 		t.Fatalf("error = %v, want readable root context", err)
 	}
-}
-
-func captureOrderLogs(t *testing.T, fn func()) string {
-	t.Helper()
-
-	var buf bytes.Buffer
-	origWriter := log.Writer()
-	origFlags := log.Flags()
-	origPrefix := log.Prefix()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	log.SetPrefix("")
-	defer func() {
-		log.SetOutput(origWriter)
-		log.SetFlags(origFlags)
-		log.SetPrefix(origPrefix)
-	}()
-
-	fn()
-	return buf.String()
 }

--- a/internal/orders/discovery_test.go
+++ b/internal/orders/discovery_test.go
@@ -19,13 +19,6 @@ formula = "health-check"
 trigger = "cron"
 schedule = "*/5 * * * *"
 `)
-	fs.Dirs["/pack/orders/health-check"] = true
-	fs.Files["/pack/orders/health-check/order.toml"] = []byte(`
-[order]
-formula = "legacy-health-check"
-trigger = "cron"
-schedule = "0 * * * *"
-`)
 
 	orders, err := discoverRoot(fs, ScanRoot{
 		Dir:          "/pack/orders",
@@ -48,7 +41,7 @@ schedule = "0 * * * *"
 	}
 }
 
-func TestDiscoverRootFallsBackToSubdirectoryFormatWithWarning(t *testing.T) {
+func TestDiscoverRootRejectsSubdirectoryFormat(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Dirs["/pack/orders/health-check"] = true
 	fs.Files["/pack/orders/health-check/order.toml"] = []byte(`
@@ -58,28 +51,19 @@ trigger = "cron"
 schedule = "*/5 * * * *"
 `)
 
-	logs := captureOrderLogs(t, func() {
-		orders, err := discoverRoot(fs, ScanRoot{
-			Dir:          "/pack/orders",
-			FormulaLayer: "/pack/formulas",
-		})
-		if err != nil {
-			t.Fatalf("discoverRoot: %v", err)
-		}
-		if len(orders) != 1 {
-			t.Fatalf("got %d orders, want 1", len(orders))
-		}
-		if orders[0].Source != "/pack/orders/health-check/order.toml" {
-			t.Fatalf("Source = %q, want %q", orders[0].Source, "/pack/orders/health-check/order.toml")
-		}
+	_, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
 	})
-
-	if !strings.Contains(logs, "rename to orders/health-check.toml") {
-		t.Fatalf("logs = %q, want rename warning", logs)
+	if err == nil {
+		t.Fatal("discoverRoot succeeded, want hard error for legacy subdirectory layout")
+	}
+	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
+		t.Fatalf("error = %v, want rename guidance", err)
 	}
 }
 
-func TestDiscoverRootFallsBackToLegacyFormulaOrdersWithWarning(t *testing.T) {
+func TestDiscoverRootRejectsLegacyFormulaOrders(t *testing.T) {
 	fs := fsys.NewFake()
 	fs.Dirs["/pack/formulas/orders/health-check"] = true
 	fs.Files["/pack/formulas/orders/health-check/order.toml"] = []byte(`
@@ -89,24 +73,36 @@ trigger = "cron"
 schedule = "*/5 * * * *"
 `)
 
-	logs := captureOrderLogs(t, func() {
-		orders, err := discoverRoot(fs, ScanRoot{
-			Dir:          "/pack/orders",
-			FormulaLayer: "/pack/formulas",
-		})
-		if err != nil {
-			t.Fatalf("discoverRoot: %v", err)
-		}
-		if len(orders) != 1 {
-			t.Fatalf("got %d orders, want 1", len(orders))
-		}
-		if orders[0].Source != "/pack/formulas/orders/health-check/order.toml" {
-			t.Fatalf("Source = %q, want %q", orders[0].Source, "/pack/formulas/orders/health-check/order.toml")
-		}
+	_, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
 	})
+	if err == nil {
+		t.Fatal("discoverRoot succeeded, want hard error for legacy formulas/orders path")
+	}
+	if !strings.Contains(err.Error(), "move to orders/health-check.toml") {
+		t.Fatalf("error = %v, want move guidance", err)
+	}
+}
 
-	if !strings.Contains(logs, "move to orders/health-check.toml") {
-		t.Fatalf("logs = %q, want move warning", logs)
+func TestDiscoverRootRejectsLegacyFlatOrderFilename(t *testing.T) {
+	fs := fsys.NewFake()
+	fs.Files["/pack/orders/health-check.order.toml"] = []byte(`
+[order]
+formula = "health-check"
+trigger = "cron"
+schedule = "*/5 * * * *"
+`)
+
+	_, err := discoverRoot(fs, ScanRoot{
+		Dir:          "/pack/orders",
+		FormulaLayer: "/pack/formulas",
+	})
+	if err == nil {
+		t.Fatal("discoverRoot succeeded, want hard error for legacy flat order filename")
+	}
+	if !strings.Contains(err.Error(), "rename to orders/health-check.toml") {
+		t.Fatalf("error = %v, want rename guidance", err)
 	}
 }
 

--- a/internal/orders/filenames.go
+++ b/internal/orders/filenames.go
@@ -6,22 +6,20 @@ import "strings"
 // files under an orders/ directory (orders/<name>.toml).
 const CanonicalFlatOrderSuffix = ".toml"
 
-// LegacyFlatOrderSuffix is the pre-canonicalization extension for flat order
-// TOML files (orders/<name>.order.toml). Still recognized by discovery so
-// existing cities continue to load.
-//
-// PACKV2-CUTOVER: remove legacy flat order filename support after the infix
-// migration window closes.
+// LegacyFlatOrderSuffix is the supported infixed extension for flat order TOML
+// files (orders/<name>.order.toml). The exported name is retained for existing
+// internal callers, but this filename spelling is intentionally accepted.
 const LegacyFlatOrderSuffix = ".order.toml"
 
-// IsFlatOrderFilename reports whether a basename uses the canonical or legacy
-// flat order filename form.
+// IsFlatOrderFilename reports whether a basename uses either supported flat
+// order filename form.
 func IsFlatOrderFilename(name string) bool {
 	// Check legacy suffix first to stay symmetric with TrimFlatOrderFilename.
 	return strings.HasSuffix(name, LegacyFlatOrderSuffix) || strings.HasSuffix(name, CanonicalFlatOrderSuffix)
 }
 
 // TrimFlatOrderFilename returns the order name encoded in a flat filename.
+// The optional ".order" infix is not part of the symbolic order name.
 func TrimFlatOrderFilename(name string) (string, bool) {
 	switch {
 	case strings.HasSuffix(name, LegacyFlatOrderSuffix):

--- a/internal/orders/filenames_test.go
+++ b/internal/orders/filenames_test.go
@@ -1,0 +1,28 @@
+package orders
+
+import "testing"
+
+func TestTrimFlatOrderFilenameStripsSupportedSuffixes(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want string
+		ok   bool
+	}{
+		{name: "plain TOML", file: "health-check.toml", want: "health-check", ok: true},
+		{name: "infixed TOML", file: "health-check.order.toml", want: "health-check", ok: true},
+		{name: "not an order file", file: "README.md"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := TrimFlatOrderFilename(tc.file)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Fatalf("name = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/orders/order.go
+++ b/internal/orders/order.go
@@ -1,6 +1,7 @@
 // Package orders provides parsing, scanning, and trigger evaluation for Gas City
-// orders. Orders are discovered from top-level orders/<name>.toml files, with
-// deprecated fallback support for older flat and directory layouts.
+// orders. Orders are discovered from flat top-level orders/<name>.toml files,
+// with optional legacy-infix orders/<name>.order.toml support. Older PackV1
+// subdirectory layouts are rejected with migration guidance.
 package orders
 
 import (

--- a/internal/orders/scanner.go
+++ b/internal/orders/scanner.go
@@ -1,11 +1,10 @@
 package orders
 
 import (
-	"io"
+	"errors"
 	"path/filepath"
 
 	"github.com/gastownhall/gascity/internal/fsys"
-	"github.com/gastownhall/gascity/internal/logutil"
 )
 
 // orderDir is the subdirectory name within formula layers that contains orders.
@@ -21,31 +20,11 @@ type ScanRoot struct {
 	FormulaLayer string
 }
 
-// ScanOptions controls optional order discovery behavior.
-type ScanOptions struct {
-	// SuppressDeprecatedPathWarnings skips migration warnings for legacy order
-	// file layouts while preserving all other diagnostics.
-	SuppressDeprecatedPathWarnings bool
-	// DeprecatedPathWarningDedup suppresses repeated deprecated-path warnings
-	// within the caller's process. Nil leaves warnings unfiltered.
-	DeprecatedPathWarningDedup *logutil.Dedup
-	// DeprecatedPathWarningWriter receives deprecated-path warnings when set.
-	// Nil preserves the historical package logger output.
-	DeprecatedPathWarningWriter io.Writer
-	// VerboseDeprecatedPathWarnings bypasses DeprecatedPathWarningDedup.
-	VerboseDeprecatedPathWarnings bool
-}
-
 // Scan discovers orders across formula layers. Wave 2 requires top-level flat
 // order files; older PackV1 directory layouts now hard-error. Higher-priority
 // layers (later in the slice) override lower ones by order name. Disabled
 // orders and those in the skip list are excluded.
 func Scan(fs fsys.FS, formulaLayers []string, skip []string) ([]Order, error) {
-	return ScanWithOptions(fs, formulaLayers, skip, ScanOptions{})
-}
-
-// ScanWithOptions discovers orders across formula layers with the supplied options.
-func ScanWithOptions(fs fsys.FS, formulaLayers []string, skip []string, opts ScanOptions) ([]Order, error) {
 	roots := make([]ScanRoot, 0, len(formulaLayers))
 	for _, layer := range formulaLayers {
 		roots = append(roots, ScanRoot{
@@ -53,17 +32,12 @@ func ScanWithOptions(fs fsys.FS, formulaLayers []string, skip []string, opts Sca
 			FormulaLayer: layer,
 		})
 	}
-	return ScanRootsWithOptions(fs, roots, skip, opts)
+	return ScanRoots(fs, roots, skip)
 }
 
 // ScanRoots discovers orders across explicit order roots. Higher-priority
 // roots (later in the slice) override lower ones by order name.
 func ScanRoots(fs fsys.FS, roots []ScanRoot, skip []string) ([]Order, error) {
-	return ScanRootsWithOptions(fs, roots, skip, ScanOptions{})
-}
-
-// ScanRootsWithOptions discovers orders across explicit order roots with the supplied options.
-func ScanRootsWithOptions(fs fsys.FS, roots []ScanRoot, skip []string, opts ScanOptions) ([]Order, error) {
 	skipSet := make(map[string]bool, len(skip))
 	for _, s := range skip {
 		skipSet[s] = true
@@ -72,10 +46,16 @@ func ScanRootsWithOptions(fs fsys.FS, roots []ScanRoot, skip []string, opts Scan
 	// Scan layers lowest → highest priority. Later entries override earlier ones.
 	found := make(map[string]Order) // name → order
 	var order []string              // preserve discovery order
+	var legacyFindings []legacyOrderLayoutFinding
 
 	for _, root := range roots {
-		discovered, err := discoverRootWithOptions(fs, root, opts)
+		discovered, err := discoverRoot(fs, root)
 		if err != nil {
+			var legacyErr legacyOrderLayoutError
+			if errors.As(err, &legacyErr) {
+				legacyFindings = append(legacyFindings, legacyErr.findings...)
+				continue
+			}
 			return nil, err
 		}
 		for _, a := range discovered {
@@ -85,6 +65,9 @@ func ScanRootsWithOptions(fs fsys.FS, roots []ScanRoot, skip []string, opts Scan
 			}
 			found[name] = a // higher-priority layer overwrites
 		}
+	}
+	if len(legacyFindings) > 0 {
+		return nil, legacyOrderLayoutError{findings: legacyFindings}
 	}
 
 	// Collect results, excluding disabled and skipped orders.

--- a/internal/orders/scanner.go
+++ b/internal/orders/scanner.go
@@ -36,10 +36,10 @@ type ScanOptions struct {
 	VerboseDeprecatedPathWarnings bool
 }
 
-// Scan discovers orders across formula layers. Wave 2 requires top-level
-// orders/<name>.toml files; older PackV1 flat and directory layouts now
-// hard-error. Higher-priority layers (later in the slice) override lower ones
-// by order name. Disabled orders and those in the skip list are excluded.
+// Scan discovers orders across formula layers. Wave 2 requires top-level flat
+// order files; older PackV1 directory layouts now hard-error. Higher-priority
+// layers (later in the slice) override lower ones by order name. Disabled
+// orders and those in the skip list are excluded.
 func Scan(fs fsys.FS, formulaLayers []string, skip []string) ([]Order, error) {
 	return ScanWithOptions(fs, formulaLayers, skip, ScanOptions{})
 }

--- a/internal/orders/scanner.go
+++ b/internal/orders/scanner.go
@@ -36,11 +36,10 @@ type ScanOptions struct {
 	VerboseDeprecatedPathWarnings bool
 }
 
-// Scan discovers orders across formula layers. It prefers top-level
-// orders/<name>.toml files, with backward-compatible fallback to older flat
-// and directory layouts. Higher-priority layers (later in the slice) override
-// lower ones by order name. Disabled orders and those in the skip list are
-// excluded.
+// Scan discovers orders across formula layers. Wave 2 requires top-level
+// orders/<name>.toml files; older PackV1 flat and directory layouts now
+// hard-error. Higher-priority layers (later in the slice) override lower ones
+// by order name. Disabled orders and those in the skip list are excluded.
 func Scan(fs fsys.FS, formulaLayers []string, skip []string) ([]Order, error) {
 	return ScanWithOptions(fs, formulaLayers, skip, ScanOptions{})
 }

--- a/internal/orders/scanner_test.go
+++ b/internal/orders/scanner_test.go
@@ -8,23 +8,21 @@ import (
 
 func TestScan(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/layer1/orders/digest"] = true
-	fs.Files["/layer1/orders/digest/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/digest.toml"] = []byte(`
 [order]
 formula = "mol-digest"
 trigger = "cooldown"
 interval = "24h"
 pool = "dog"
 `)
-	fs.Dirs["/layer1/orders/cleanup"] = true
-	fs.Files["/layer1/orders/cleanup/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/cleanup.toml"] = []byte(`
 [order]
 formula = "mol-cleanup"
 trigger = "cron"
 schedule = "0 3 * * *"
 `)
 
-	orders, err := Scan(fs, []string{"/layer1"}, nil)
+	orders, err := Scan(fs, []string{"/layer1/formulas"}, nil)
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -43,9 +41,9 @@ schedule = "0 3 * * *"
 
 func TestScanEmpty(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/layer1"] = true
+	fs.Dirs["/layer1/formulas"] = true
 
-	orders, err := Scan(fs, []string{"/layer1"}, nil)
+	orders, err := Scan(fs, []string{"/layer1/formulas"}, nil)
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -57,8 +55,7 @@ func TestScanEmpty(t *testing.T) {
 func TestScanLayerOverride(t *testing.T) {
 	fs := fsys.NewFake()
 	// Layer 1 (lower priority): digest with 24h.
-	fs.Dirs["/layer1/orders/digest"] = true
-	fs.Files["/layer1/orders/digest/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/digest.toml"] = []byte(`
 [order]
 formula = "mol-digest"
 trigger = "cooldown"
@@ -66,8 +63,7 @@ interval = "24h"
 pool = "dog"
 `)
 	// Layer 2 (higher priority): digest with 8h.
-	fs.Dirs["/layer2/orders/digest"] = true
-	fs.Files["/layer2/orders/digest/order.toml"] = []byte(`
+	fs.Files["/layer2/orders/digest.toml"] = []byte(`
 [order]
 formula = "mol-digest"
 trigger = "cooldown"
@@ -75,7 +71,7 @@ interval = "8h"
 pool = "dog"
 `)
 
-	orders, err := Scan(fs, []string{"/layer1", "/layer2"}, nil)
+	orders, err := Scan(fs, []string{"/layer1/formulas", "/layer2/formulas"}, nil)
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -89,21 +85,19 @@ pool = "dog"
 
 func TestScanSkip(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/layer1/orders/digest"] = true
-	fs.Files["/layer1/orders/digest/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/digest.toml"] = []byte(`
 [order]
 formula = "mol-digest"
 trigger = "cooldown"
 interval = "24h"
 `)
-	fs.Dirs["/layer1/orders/cleanup"] = true
-	fs.Files["/layer1/orders/cleanup/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/cleanup.toml"] = []byte(`
 [order]
 formula = "mol-cleanup"
 trigger = "manual"
 `)
 
-	orders, err := Scan(fs, []string{"/layer1"}, []string{"digest"})
+	orders, err := Scan(fs, []string{"/layer1/formulas"}, []string{"digest"})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -117,8 +111,7 @@ trigger = "manual"
 
 func TestScanDisabled(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/layer1/orders/digest"] = true
-	fs.Files["/layer1/orders/digest/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/digest.toml"] = []byte(`
 [order]
 formula = "mol-digest"
 trigger = "cooldown"
@@ -126,7 +119,7 @@ interval = "24h"
 enabled = false
 `)
 
-	orders, err := Scan(fs, []string{"/layer1"}, nil)
+	orders, err := Scan(fs, []string{"/layer1/formulas"}, nil)
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -137,8 +130,7 @@ enabled = false
 
 func TestScanFormulaLayer(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/pack/formulas/orders/health"] = true
-	fs.Files["/pack/formulas/orders/health/order.toml"] = []byte(`
+	fs.Files["/pack/orders/health.toml"] = []byte(`
 [order]
 exec = "$PACK_DIR/scripts/health.sh"
 trigger = "cooldown"
@@ -160,16 +152,14 @@ interval = "1m"
 func TestScanFormulaLayerOverride(t *testing.T) {
 	fs := fsys.NewFake()
 	// Layer 1: lower priority.
-	fs.Dirs["/base/formulas/orders/health"] = true
-	fs.Files["/base/formulas/orders/health/order.toml"] = []byte(`
+	fs.Files["/base/orders/health.toml"] = []byte(`
 [order]
 exec = "$PACK_DIR/scripts/health.sh"
 trigger = "cooldown"
 interval = "1h"
 `)
 	// Layer 2: higher priority overrides.
-	fs.Dirs["/pack/formulas/orders/health"] = true
-	fs.Files["/pack/formulas/orders/health/order.toml"] = []byte(`
+	fs.Files["/pack/orders/health.toml"] = []byte(`
 [order]
 exec = "$PACK_DIR/scripts/health.sh"
 trigger = "cooldown"
@@ -191,21 +181,20 @@ interval = "5m"
 
 func TestScanSourcePath(t *testing.T) {
 	fs := fsys.NewFake()
-	fs.Dirs["/layer1/orders/digest"] = true
-	fs.Files["/layer1/orders/digest/order.toml"] = []byte(`
+	fs.Files["/layer1/orders/digest.toml"] = []byte(`
 [order]
 formula = "mol-digest"
 trigger = "manual"
 `)
 
-	orders, err := Scan(fs, []string{"/layer1"}, nil)
+	orders, err := Scan(fs, []string{"/layer1/formulas"}, nil)
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
 	if len(orders) != 1 {
 		t.Fatalf("got %d orders, want 1", len(orders))
 	}
-	if orders[0].Source != "/layer1/orders/digest/order.toml" {
-		t.Errorf("Source = %q, want %q", orders[0].Source, "/layer1/orders/digest/order.toml")
+	if orders[0].Source != "/layer1/orders/digest.toml" {
+		t.Errorf("Source = %q, want %q", orders[0].Source, "/layer1/orders/digest.toml")
 	}
 }

--- a/internal/sling/sling_test.go
+++ b/internal/sling/sling_test.go
@@ -243,7 +243,7 @@ func init() {
 		"my-formula", "convoy-formula",
 	} {
 		content := fmt.Sprintf("formula = %q\nversion = 1\n\n[[steps]]\nid = \"work\"\ntitle = \"Work\"\n", name)
-		_ = os.WriteFile(filepath.Join(dir, name+".formula.toml"), []byte(content), 0o644)
+		_ = os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644)
 	}
 	sharedTestFormulaDir = dir
 
@@ -1953,7 +1953,7 @@ func TestSlingAttachFormulaForceStillRejectsMissingBead(t *testing.T) {
 
 func TestSlingAttachGraphFormulaRejectsExistingLiveRoot(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -2378,7 +2378,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaRejectsExistingLiveRootAcrossStores(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -2532,7 +2532,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaForceReplacesExistingLiveRootAcrossStores(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -2720,7 +2720,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaForceRestoresCrossStoreRootWhenFinalizeFails(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -2814,7 +2814,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaForceAllowsExistingLiveRoot(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -2896,7 +2896,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaForceRollsBackNewRootWhenSupersededCloseFails(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -2996,7 +2996,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaForceRestoresSupersededRootWhenFinalizeFails(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -3090,7 +3090,7 @@ title = "Do work"
 
 func TestSlingAttachGraphFormulaConcurrentLaunchCreatesSingleRoot(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -3170,7 +3170,7 @@ title = "Do work"
 
 func TestDoSlingBatchGraphFormulaForceAllowsAttachedWorkflow(t *testing.T) {
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -3265,7 +3265,7 @@ func TestDoSlingBatchPropagatesConflictErrorToCaller(t *testing.T) {
 	// instead of exit 3 and never saw the "gc workflow delete-source"
 	// cleanup hint — the whole user-facing point of the fix.
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -3355,7 +3355,7 @@ func TestDoSlingBatchPreflightEmitsConflictErrorForWorkflowAttachment(t *testing
 	// pre-check now emits a typed ConflictError alongside the legacy
 	// summary so errors.As succeeds at the CLI boundary.
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"
@@ -3442,7 +3442,7 @@ func TestDoSlingBatchPreflightEmitsPerChildConflictErrors(t *testing.T) {
 	// conflicted child via errors.Join so each child's blocking IDs
 	// stay correctly attributed.
 	formulaDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.formula.toml"), []byte(`
+	if err := os.WriteFile(filepath.Join(formulaDir, "graph-work.toml"), []byte(`
 formula = "graph-work"
 version = 2
 contract = "graph.v2"

--- a/test/acceptance/agent_env_test.go
+++ b/test/acceptance/agent_env_test.go
@@ -69,10 +69,7 @@ func TestConfigLoad_GastownWithRig(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	toml := c.ReadFile("city.toml")
-	toml += "\n[[rigs]]\nname = \"myrig\"\npath = \"" + rigDir + "\"\nincludes = [\"packs/gastown\"]\n"
-	c.WriteConfig(toml)
+	c.RigAdd(rigDir, "packs/gastown")
 
 	out, err := c.GC("config", "explain", "--city", c.Dir)
 	if err != nil && strings.Contains(out, "pack.toml: no such file") {
@@ -98,9 +95,7 @@ func TestConfigLoad_SwarmConfig(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	toml := c.ReadFile("city.toml")
-	toml += "\n[[rigs]]\nname = \"swarm\"\npath = \"" + rigDir + "\"\nincludes = [\"packs/swarm\"]\n"
-	c.WriteConfig(toml)
+	c.RigAdd(rigDir, "packs/swarm")
 
 	out, err := c.GC("config", "explain", "--city", c.Dir)
 	if err != nil && strings.Contains(out, "pack.toml: no such file") {
@@ -130,9 +125,7 @@ func TestConfigLoad_LifecycleWithRig(t *testing.T) {
 	if err := os.MkdirAll(rigDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	toml := c.ReadFile("city.toml")
-	toml += "\n[[rigs]]\nname = \"lifecycle\"\npath = \"" + rigDir + "\"\nincludes = [\"packs/lifecycle\"]\n"
-	c.WriteConfig(toml)
+	c.RigAdd(rigDir, "packs/lifecycle")
 
 	out, err := c.GC("config", "explain", "--city", c.Dir)
 	if err != nil && strings.Contains(out, "pack.toml: no such file") {

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -49,14 +49,18 @@ func setupGasTownCity(t *testing.T, guard *tmuxtest.Guard, agents []gasTownAgent
 	}
 
 	cityDir := filepath.Join(t.TempDir(), cityName)
-	configPath := filepath.Join(t.TempDir(), cityName+".toml")
-	if err := os.WriteFile(configPath, []byte(renderGasTownToml(cityName, agents)), 0o644); err != nil {
+	sourceDir := filepath.Join(t.TempDir(), cityName+"-source")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("creating init source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "city.toml"), []byte(renderGasTownToml(cityName, agents)), 0o644); err != nil {
 		t.Fatalf("writing init config: %v", err)
 	}
+	writeGasTownAgentFiles(t, sourceDir, agents)
 
-	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", "--file", configPath, cityDir)
+	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", "--from", sourceDir, cityDir)
 	if err != nil {
-		t.Fatalf("gc init --file failed: %v\noutput: %s", err, out)
+		t.Fatalf("gc init --from failed: %v\noutput: %s", err, out)
 	}
 	registerCityCommandEnv(cityDir, env)
 	waitForExpectedTmuxSessions(t, cityDir, gasTownExpectedSessions(agents))
@@ -106,28 +110,6 @@ func renderGasTownToml(cityName string, agents []gasTownAgent) string {
 	fmt.Fprintf(&b, "\n[daemon]\npatrol_interval = \"100ms\"\n")
 
 	for _, a := range agents {
-		fmt.Fprintf(&b, "\n[[agent]]\nname = %s\n", quote(a.Name))
-		fmt.Fprintf(&b, "start_command = %s\n", quote(a.StartCommand))
-		if a.Dir != "" {
-			fmt.Fprintf(&b, "dir = %s\n", quote(a.Dir))
-		}
-		if a.Suspended {
-			fmt.Fprintf(&b, "suspended = true\n")
-		}
-		if a.Pool != nil {
-			fmt.Fprintf(&b, "min_active_sessions = %d\n", a.Pool.Min)
-			fmt.Fprintf(&b, "max_active_sessions = %d\n", a.Pool.Max)
-			fmt.Fprintf(&b, "scale_check = %s\n", quote(a.Pool.Check))
-		}
-		if len(a.Env) > 0 {
-			b.WriteString("\n[agent.env]\n")
-			for k, v := range a.Env {
-				fmt.Fprintf(&b, "%s = %s\n", k, quote(v))
-			}
-		}
-	}
-
-	for _, a := range agents {
 		if a.Pool != nil {
 			continue
 		}
@@ -138,6 +120,41 @@ func renderGasTownToml(cityName string, agents []gasTownAgent) string {
 	}
 
 	return b.String()
+}
+
+func writeGasTownAgentFiles(t *testing.T, cityDir string, agents []gasTownAgent) {
+	t.Helper()
+	for _, a := range agents {
+		agentDir := filepath.Join(cityDir, "agents", a.Name)
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			t.Fatalf("creating agent dir %s: %v", a.Name, err)
+		}
+
+		var b strings.Builder
+		if a.StartCommand != "" {
+			fmt.Fprintf(&b, "start_command = %s\n", quote(a.StartCommand))
+		}
+		if a.Dir != "" {
+			fmt.Fprintf(&b, "dir = %s\n", quote(a.Dir))
+		}
+		if a.Suspended {
+			b.WriteString("suspended = true\n")
+		}
+		if a.Pool != nil {
+			fmt.Fprintf(&b, "min_active_sessions = %d\n", a.Pool.Min)
+			fmt.Fprintf(&b, "max_active_sessions = %d\n", a.Pool.Max)
+			fmt.Fprintf(&b, "scale_check = %s\n", quote(a.Pool.Check))
+		}
+		if len(a.Env) > 0 {
+			b.WriteString("\n[env]\n")
+			for k, v := range a.Env {
+				fmt.Fprintf(&b, "%s = %s\n", k, quote(v))
+			}
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(b.String()), 0o644); err != nil {
+			t.Fatalf("writing agent.toml for %s: %v", a.Name, err)
+		}
+	}
 }
 
 // waitForBeadStatus polls until a bead reaches the expected status or times out.

--- a/test/integration/gastown_helpers_test.go
+++ b/test/integration/gastown_helpers_test.go
@@ -56,6 +56,10 @@ func setupGasTownCity(t *testing.T, guard *tmuxtest.Guard, agents []gasTownAgent
 	if err := os.WriteFile(filepath.Join(sourceDir, "city.toml"), []byte(renderGasTownToml(cityName, agents)), 0o644); err != nil {
 		t.Fatalf("writing init config: %v", err)
 	}
+	pack := fmt.Sprintf("[pack]\nname = %s\nschema = 2\n", quote(cityName))
+	if err := os.WriteFile(filepath.Join(sourceDir, "pack.toml"), []byte(pack), 0o644); err != nil {
+		t.Fatalf("writing init pack: %v", err)
+	}
 	writeGasTownAgentFiles(t, sourceDir, agents)
 
 	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", "--from", sourceDir, cityDir)

--- a/test/integration/gastown_multirig_test.go
+++ b/test/integration/gastown_multirig_test.go
@@ -119,10 +119,28 @@ func setupMultiRigCity(t *testing.T, rigCount int) (cityDir string, rigDirs []st
 }
 
 // writeMultiRigToml writes a schema-2 city plus site bindings for the given
-// rig directories. Each rig gets a [[rigs]] entry and each agent is declared
-// under agents/<name>/agent.toml.
+// rig directories. City-scoped agents are declared under agents/<name>/agent.toml.
+// Rig-scoped agents come from a local pack imported by each rig so duplicate
+// agent names across rigs stay representable without legacy inline [[agent]].
 func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string, agents []gasTownAgent) {
 	t.Helper()
+
+	var cityAgents []gasTownAgent
+	rigAgentsByDir := make(map[string][]gasTownAgent)
+	rigPackAgentNames := make(map[string]gasTownAgent)
+	for _, a := range agents {
+		if a.Dir == "" {
+			cityAgents = append(cityAgents, a)
+			continue
+		}
+		rigAgentsByDir[a.Dir] = append(rigAgentsByDir[a.Dir], a)
+		if _, ok := rigPackAgentNames[a.Name]; !ok {
+			rigPackAgentNames[a.Name] = gasTownAgent{Name: a.Name}
+		}
+	}
+	if len(rigPackAgentNames) > 0 {
+		writeMultiRigAgentPack(t, cityDir, rigPackAgentNames)
+	}
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "[workspace]\nname = %s\n", quote(cityName))
@@ -132,21 +150,38 @@ func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string,
 	for i := range rigDirs {
 		rigName := fmt.Sprintf("rig-%d", i)
 		fmt.Fprintf(&b, "\n[[rigs]]\nname = %s\n", quote(rigName))
+		if rigAgents := rigAgentsByDir[rigName]; len(rigAgents) > 0 {
+			fmt.Fprintf(&b, "\n[rigs.imports.multirig_agents]\nsource = \"packs/multirig-agents\"\n")
+			for _, a := range rigAgents {
+				fmt.Fprintf(&b, "\n[[rigs.patches]]\nagent = %s\n", quote(a.Name))
+				if a.StartCommand != "" {
+					fmt.Fprintf(&b, "start_command = %s\n", quote(a.StartCommand))
+				}
+				if a.Suspended {
+					b.WriteString("suspended = true\n")
+				}
+			}
+		}
 	}
 
 	for _, a := range agents {
 		if a.Pool != nil {
 			continue
 		}
-		fmt.Fprintf(&b, "\n[[named_session]]\ntemplate = %s\nmode = \"always\"\n", quote(a.Name))
+		template := a.Name
 		if a.Dir != "" {
+			template = "multirig_agents." + a.Name
+		}
+		fmt.Fprintf(&b, "\n[[named_session]]\ntemplate = %s\nmode = \"always\"\n", quote(template))
+		if a.Dir != "" {
+			fmt.Fprintf(&b, "name = %s\n", quote(a.Name))
 			fmt.Fprintf(&b, "dir = %s\n", quote(a.Dir))
 		}
 	}
 
 	tomlPath := filepath.Join(cityDir, "city.toml")
 	require.NoError(t, os.WriteFile(tomlPath, []byte(b.String()), 0o644))
-	writeGasTownAgentFiles(t, cityDir, agents)
+	writeGasTownAgentFiles(t, cityDir, cityAgents)
 
 	var site strings.Builder
 	fmt.Fprintf(&site, "workspace_name = %s\n", quote(cityName))
@@ -156,6 +191,26 @@ func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string,
 	}
 	require.NoError(t, os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(cityDir, ".gc", "site.toml"), []byte(site.String()), 0o644))
+}
+
+func writeMultiRigAgentPack(t *testing.T, cityDir string, agents map[string]gasTownAgent) {
+	t.Helper()
+
+	packDir := filepath.Join(cityDir, "packs", "multirig-agents")
+	require.NoError(t, os.MkdirAll(packDir, 0o755))
+	pack := "[pack]\nname = \"multirig-agents\"\nschema = 2\n"
+	require.NoError(t, os.WriteFile(filepath.Join(packDir, "pack.toml"), []byte(pack), 0o644))
+
+	for _, a := range agents {
+		agentDir := filepath.Join(packDir, "agents", a.Name)
+		require.NoError(t, os.MkdirAll(agentDir, 0o755))
+		var b strings.Builder
+		b.WriteString("scope = \"rig\"\n")
+		if a.StartCommand != "" {
+			fmt.Fprintf(&b, "start_command = %s\n", quote(a.StartCommand))
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(agentDir, "agent.toml"), []byte(b.String()), 0o644))
+	}
 }
 
 func installFakeBDForCity(t *testing.T, cityDir string) {

--- a/test/integration/gastown_multirig_test.go
+++ b/test/integration/gastown_multirig_test.go
@@ -68,18 +68,27 @@ func waitForActiveSessionTargets(t *testing.T, cityDir string, targets []string,
 // directories under an isolated integration GC_HOME. Returns the city
 // directory and a slice of rig directory paths.
 //
-// The city starts with the default minimal scaffold. Callers overwrite
-// city.toml afterward and use gc restart/start against the isolated
-// supervisor-managed city registered for this path.
+// The city starts from a file-backed schema-2 source so config-only multi-rig
+// tests do not depend on the developer machine's bd/dolt toolchain before the
+// test overwrites city.toml with its scenario-specific fixture.
 func setupMultiRigCity(t *testing.T, rigCount int) (cityDir string, rigDirs []string) {
 	t.Helper()
 	env := newIsolatedCommandEnv(t, false)
 	cityName := uniqueCityName()
 	cityDir = filepath.Join(t.TempDir(), cityName)
+	sourceDir := filepath.Join(t.TempDir(), cityName+"-source")
+	require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+
+	var source strings.Builder
+	fmt.Fprintf(&source, "[workspace]\nname = %s\n", quote(cityName))
+	fmt.Fprintf(&source, "\n[beads]\nprovider = \"file\"\n")
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "city.toml"), []byte(source.String()), 0o644))
+	pack := fmt.Sprintf("[pack]\nname = %s\nschema = 2\n", quote(cityName))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "pack.toml"), []byte(pack), 0o644))
 
 	// Create the city scaffold inside an isolated supervisor env so
 	// multi-rig tests do not contend with the suite-global supervisor.
-	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", cityDir)
+	out, err := runGCWithEnv(env, "", "init", "--skip-provider-readiness", "--from", sourceDir, cityDir)
 	require.NoError(t, err, "gc init: %s", out)
 	registerCityCommandEnv(cityDir, env)
 
@@ -109,8 +118,9 @@ func setupMultiRigCity(t *testing.T, rigCount int) (cityDir string, rigDirs []st
 	return cityDir, rigDirs
 }
 
-// writeMultiRigToml writes a city.toml that references the given rig directories.
-// Each rig gets a [[rigs]] entry and a rig-scoped worker agent.
+// writeMultiRigToml writes a schema-2 city plus site bindings for the given
+// rig directories. Each rig gets a [[rigs]] entry and each agent is declared
+// under agents/<name>/agent.toml.
 func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string, agents []gasTownAgent) {
 	t.Helper()
 
@@ -119,32 +129,9 @@ func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string,
 	fmt.Fprintf(&b, "\n[beads]\nprovider = \"file\"\n")
 	fmt.Fprintf(&b, "\n[daemon]\npatrol_interval = \"100ms\"\n")
 
-	for i, rd := range rigDirs {
+	for i := range rigDirs {
 		rigName := fmt.Sprintf("rig-%d", i)
-		fmt.Fprintf(&b, "\n[[rigs]]\nname = %s\npath = %s\n",
-			quote(rigName), quote(rd))
-	}
-
-	for _, a := range agents {
-		fmt.Fprintf(&b, "\n[[agent]]\nname = %s\n", quote(a.Name))
-		fmt.Fprintf(&b, "start_command = %s\n", quote(a.StartCommand))
-		if a.Dir != "" {
-			fmt.Fprintf(&b, "dir = %s\n", quote(a.Dir))
-		}
-		if a.Suspended {
-			fmt.Fprintf(&b, "suspended = true\n")
-		}
-		if len(a.Env) > 0 {
-			b.WriteString("\n[agent.env]\n")
-			for k, v := range a.Env {
-				fmt.Fprintf(&b, "%s = %s\n", k, quote(v))
-			}
-		}
-		if a.Pool != nil {
-			fmt.Fprintf(&b, "min_active_sessions = %d\n", a.Pool.Min)
-			fmt.Fprintf(&b, "max_active_sessions = %d\n", a.Pool.Max)
-			fmt.Fprintf(&b, "scale_check = %s\n", quote(a.Pool.Check))
-		}
+		fmt.Fprintf(&b, "\n[[rigs]]\nname = %s\n", quote(rigName))
 	}
 
 	for _, a := range agents {
@@ -159,6 +146,16 @@ func writeMultiRigToml(t *testing.T, cityDir, cityName string, rigDirs []string,
 
 	tomlPath := filepath.Join(cityDir, "city.toml")
 	require.NoError(t, os.WriteFile(tomlPath, []byte(b.String()), 0o644))
+	writeGasTownAgentFiles(t, cityDir, agents)
+
+	var site strings.Builder
+	fmt.Fprintf(&site, "workspace_name = %s\n", quote(cityName))
+	for i, rd := range rigDirs {
+		rigName := fmt.Sprintf("rig-%d", i)
+		fmt.Fprintf(&site, "\n[[rig]]\nname = %s\npath = %s\n", quote(rigName), quote(rd))
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(cityDir, ".gc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cityDir, ".gc", "site.toml"), []byte(site.String()), 0o644))
 }
 
 func installFakeBDForCity(t *testing.T, cityDir string) {

--- a/test/integration/gc_live_contract_test.go
+++ b/test/integration/gc_live_contract_test.go
@@ -148,10 +148,9 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 		Agent  string `json:"agent"`
 	}](t, baseURL, validator, http.MethodPost, cityBase+"/agents", map[string]string{
 		"name":     "worker",
-		"dir":      rigName,
 		"provider": "contract-agent",
 	}, http.StatusCreated)
-	targetAgent := rigName + "/worker"
+	targetAgent := "worker"
 	waitForLiveContractAgent(t, baseURL, validator, cityBase, targetAgent, 30*time.Second)
 
 	publicProviders := liveContractJSON[struct {
@@ -167,7 +166,7 @@ func TestGCLiveContract_BeadsAndEvents(t *testing.T) {
 	cfg := liveContractJSON[struct {
 		Agents []contractConfigAgent `json:"agents"`
 	}](t, baseURL, validator, http.MethodGet, cityBase+"/config", nil, http.StatusOK)
-	if !liveContractConfigHasAgent(cfg.Agents, "worker", rigName) {
+	if !liveContractConfigHasAgent(cfg.Agents, "worker", "") {
 		t.Fatalf("GET config missing created agent %q; agents=%+v", targetAgent, cfg.Agents)
 	}
 
@@ -684,8 +683,12 @@ func createLiveContractAgentSession(t *testing.T, baseURL string, v openapivalid
 	if result.Session.Title != "real-world app contract "+label {
 		t.Fatalf("%s session title = %q", label, result.Session.Title)
 	}
-	if result.Session.Rig != rigName {
-		t.Fatalf("%s session rig = %q, want %q", label, result.Session.Rig, rigName)
+	expectedSessionRig := ""
+	if dir, _, ok := strings.Cut(targetAgent, "/"); ok {
+		expectedSessionRig = dir
+	}
+	if result.Session.Rig != expectedSessionRig {
+		t.Fatalf("%s session rig = %q, want %q", label, result.Session.Rig, expectedSessionRig)
 	}
 	if result.Session.Alias == "" {
 		t.Fatalf("%s session missing controller-managed alias", label)
@@ -1490,11 +1493,13 @@ func liveContractRigList(baseURL string, v openapivalidator.Validator, cityBase 
 
 func waitForLiveContractAgent(t *testing.T, baseURL string, v openapivalidator.Validator, cityBase, targetAgent string, timeout time.Duration) {
 	t.Helper()
-	dir, base, ok := strings.Cut(targetAgent, "/")
-	if !ok || dir == "" || base == "" {
-		t.Fatalf("target agent %q is not a qualified rig agent", targetAgent)
+	path := cityBase + "/agent/" + url.PathEscape(targetAgent)
+	if dir, base, ok := strings.Cut(targetAgent, "/"); ok {
+		if dir == "" || base == "" {
+			t.Fatalf("target agent %q has an empty qualifier", targetAgent)
+		}
+		path = cityBase + "/agent/" + url.PathEscape(dir) + "/" + url.PathEscape(base)
 	}
-	path := cityBase + "/agent/" + url.PathEscape(dir) + "/" + url.PathEscape(base)
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
## Context
This PR is the next enforcement step in the [post-PackV2 package work](https://github.com/gastownhall/gascity/issues/2120).

It hard-errors the remaining pre-1.0 / PackV1 surfaces that now have a credible remediation story, while explicitly leaving the still-unready surfaces in warning/deferred status instead of pretending they are ready for strict enforcement.

## Product Changes
- schema-2 cities now hard-error on unsupported root-city and included-fragment PackV1 import surfaces (`workspace.includes`, `workspace.default_rig_includes`, and legacy `[packs]`)
- schema-2 cities now hard-error when `city.toml` still stores machine-local rig bindings via `[[rigs]].path`; workspace name/prefix still warn and point users to `.gc/site.toml`
- schema-2 cities now hard-error on inline `[[agent]]` in root `city.toml` and included fragment files, with guidance to move agents to `agents/<name>/agent.toml`
- `gc doctor` surfaces those same root-city issues as errors and keeps `gc doctor --fix` as the supported path for the site-binding rewrite cases it can actually remediate
- nested PackV1 order layouts now fail with direct migration guidance instead of silently riding along as compatibility fallbacks
- flat `.formula.toml` and `.order.toml` filenames remain accepted; this PR does not require or forbid those suffixes
- `gc import migrate` remains hidden as a deprecated compatibility shim that points users to `gc doctor` / `gc doctor --fix`; it no longer rewrites PackV1 layouts in place
- deferred surfaces remain visible but non-fatal: fragment `rig.path`, fragment `workspace.name` / `workspace.prefix`, and legacy `pack.toml [[agent]]` usage are explicitly called out as deferred until remediation support exists

## Expected Submission Hard-Fail Constructs
| Construct family | Old construct | Replacement |
| --- | --- | --- |
| PackV1 agent definition | inline `[[agent]]` in schema-2 root `city.toml` or included fragment files (`include = [...]` targets) | `agents/<name>/agent.toml` |
| PackV1 import surface | `[packs]` in schema-2 root `city.toml` or included fragment files (`include = [...]` targets) | `[imports.<binding>]` plus `packs.lock` |
| PackV1 workspace import list | `workspace.includes` in schema-2 root `city.toml` or included fragment files (`include = [...]` targets) | `[imports.<binding>]` entries |
| PackV1 default rig imports | `workspace.default_rig_includes` in schema-2 root `city.toml` or included fragment files (`include = [...]` targets) | root `pack.toml` `[defaults.rig.imports.<binding>]` |
| Pre-1.0 site binding | `[[rigs]].path` in schema-2 root `city.toml` | `.gc/site.toml` rig binding |
| Legacy nested order layout | `orders/<name>/order.toml` | `orders/<name>.toml` |

## Expected Submission Deferred / Warning-Only Constructs
| Construct | Expected submission behavior | Why it stays non-fatal in this PR |
| --- | --- | --- |
| `workspace.name` / `workspace.prefix` in root `city.toml` | warning | These fields are machine-local identity, not portable pack/import structure. They already point at `.gc/site.toml`, but unlike root import surfaces they do not block canonical pack composition or file discovery, so this PR keeps them loud but non-fatal while migration continues. |
| `rig.path` in included fragment files (`include = [...]` targets) | warning | Fragment remediation is not mechanical yet. A fragment cannot safely rewrite `.gc/site.toml` on behalf of the root city, so the loader warns until doctor/manual remediation support is real. |
| `workspace.name` / `workspace.prefix` in included fragment files (`include = [...]` targets) | warning | Same reason as fragment `rig.path`: the fix target is `.gc/site.toml`, which is root-city machine-local state, so fragment-level rewrites are not safely automatable in this wave. |
| inline `[[agent]]` in `pack.toml` | deferred warning / doctor guidance | The product direction is to move away from this, but enforcement is explicitly deferred until doctor/remediation and config-edit flows can migrate pack-owned agent definitions safely. |
| flat `.formula.toml` and `.order.toml` filenames | accepted | These filenames are not PackV1 authoring surfaces we need to break for 2.0. Per review feedback, formula/order filenames should remain flexible unless and until a separate design explicitly narrows them. |

## Pending Work
- #2120 — umbrella tracking for the broader post-PackV2 package work
- #2123 — doctor/remediation support for legacy fragment surfaces before hard-errors
- #2125 — doctor/remediation support for legacy `pack.toml [[agent]]` surfaces before hard-errors
- #1096 — PackV2 docs / implementation reconciliation beyond this enforcement step
- #2119 — newer `gc pack` / `gc pack registry` design and follow-on implementation

## What this PR is in support of
This PR is in support of the broader PackV2 transition:
- make the PackV2 contract real, not advisory
- enforce legacy surfaces only when doctor can remediate them mechanically or the manual guidance is genuinely trivial
- leave deferred surfaces visible and tracked rather than silently tolerated
- keep clearing the way for the newer `gc pack` / `gc pack registry` surface without carrying PackV1 ambiguity forward

## Non-goal for this PR
This PR is not trying to:
- hard-error every remaining deferred PackV1 surface
- solve `pack.toml [[agent]]` remediation in this wave
- solve all included-fragment remediation in this wave
- land the new `gc pack` / `gc pack registry` command surface in this PR

## Validation
Follow-up validation for the agent creation / gastown fixture failure family:
- `go test ./internal/configedit -run 'TestCreateAgent' -count=1`
- `go test ./cmd/gc -run 'TestControllerStateMutationsPokeController|TestControllerStateCreatedAgentVisibleAfterStaleRuntimeInterleaving' -count=1`
- `make test-cmd-gc-process-shard CMD_GC_PROCESS_SHARD=5 CMD_GC_PROCESS_TOTAL=12`
- `./scripts/test-integration-shard packages-cmd-gc-5-of-6`
- `./scripts/test-integration-shard rest-smoke-2-of-2`
- `make lint`
- `git diff --check`

Follow-up validation for the multi-rig named-session fixture failure family:
- `go test ./test/integration -tags integration -run 'TestGastown_MultiRig_(AgentsIsolated|IndependentLifecycle)' -count=1`
- `make lint`
- `git diff --check`

Local caveat for broader REST slices:
- `./scripts/test-integration-shard rest-smoke-1-of-2` and `./scripts/test-integration-shard rest-full-3-of-16` now get past the gastown PackV2 fixture issue locally; remaining local failures are the machine's Dolt version mismatch (`dolt` 1.86.1 while the suite requires 1.86.2+).

Focused validation after the current contract adjustment:
- `make lint`
- `git diff --check`
- `go test ./internal/formula ./internal/orders ./internal/configedit -run 'TestCompileAcceptsLegacyFormulaFilename|TestDiscoverRoot|TestCreateAgent' -count=1`
- `go test ./cmd/gc -run 'TestBuildOrderDispatcherOverrideDisablesDropsFromDispatcher|TestDoRigAdd|TestNewRigAddCmd' -count=1`
- `go test ./test/acceptance -tags acceptance_a -run 'TestConfigLoad_(GastownWithRig|SwarmConfig|LifecycleWithRig)' -count=1`
- `go test ./test/integration -tags integration -run 'TestGastown_MultiRig_ConfigLoads' -count=1`

Earlier focused validation on the core Wave 2 enforcement path:
- `go test ./cmd/gc -run '^(TestDoImportMigrateIsDeprecatedShim|TestDoImportMigrateDryRunUsesSameGuidance|TestSplitStrictConfigWarnings_LegacyV1SurfaceWarningsAreNonFatal|TestV2ImportFormatCheckFixMigratesIncludes|TestV2DefaultRigImportFormatCheckFixMigratesDefaults|TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlock|TestFinalizeInitCanonicalizesBdStoreBeforeProviderReadinessBlockWithoutSkip|TestFinalizeInitDoesNotRunBdProviderBeforeProviderReadinessBlock)$' -count=1`
- `go test ./internal/config -run 'TestDetectLegacyV1Surfaces|TestLegacyV1SurfaceErrorAggregatesViolations|TestLoadWithIncludesRejectsLegacyV1SurfacesInSchema2City|TestLoadWithIncludesRejectsInlineAgentInSchema2Fragments|TestLoadWithIncludesWarnsOnNonAgentLegacyV1SurfacesInSchema2Fragments' -count=1`
- `GC_FAST_UNIT=0 go test ./cmd/gc -run 'TestTutorial01/migrate-v2' -count=1`
- `go test ./cmd/gc -run '^TestInternalProjectMCPProjects(CursorConfig|GeminiConfigWithIdentityExpansion)$' -count=1`

Broad local validation before the upmerge:
- `go test ./cmd/gc -count=1`

Local environment caveat:
- `TestGCLiveContract_BeadsAndEvents` now gets past the Wave 2 `POST /agents` failure; local execution then hits the machine's Dolt/bd setup (`dolt` 1.86.1 while the suite requires 1.86.2+) rather than the PackV1 enforcement path.


