### PR TITLE
fix(cmd/gc): findCity inspects starting dir when it equals discovery ceiling (closes ga-bi2)

### DIFF
--- a/cmd/gc/city_discovery.go
+++ b/cmd/gc/city_discovery.go
@@ -27,6 +27,22 @@ func findCityWithOptions(dir string, opts cityDiscoveryOptions) (string, error) 
 		return "", err
 	}
 
+	// When the starting dir is itself the discovery ceiling, the upward-walk
+	// loop below skips it entirely. Inspect it once so an explicit invocation
+	// from a city installed directly at the ceiling (e.g. user `gc` with city
+	// at `/home/gc`) succeeds. We still do not walk past the ceiling, and a
+	// stray runtime root at the ceiling that matches the configured supervisor
+	// root is ignored — preserving the "stray $HOME/.gc" guard.
+	if isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
+		if citylayout.HasCityConfig(dir) {
+			return dir, nil
+		}
+		if citylayout.HasRuntimeRoot(dir) && !isIgnoredLegacyRuntimeRoot(dir, opts.ignoredLegacyRuntime) {
+			return dir, nil
+		}
+		return "", fmt.Errorf("not in a city directory (no city.toml or .gc/ found)")
+	}
+
 	var legacy string
 	for !isCityDiscoveryCeiling(dir, opts.ceilingDirs) {
 		if citylayout.HasCityConfig(dir) {

--- a/cmd/gc/main_test.go
+++ b/cmd/gc/main_test.go
@@ -457,6 +457,62 @@ func TestFindCity(t *testing.T) {
 		}
 	})
 
+	t.Run("starting_at_ceiling_finds_city_toml", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		if err := os.WriteFile(filepath.Join(homeDir, "city.toml"), []byte("[workspace]\nname = \"home-city\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := findCity(homeDir)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", homeDir, err)
+		}
+		if got != homeDir {
+			t.Errorf("findCity(%q) = %q, want %q", homeDir, got, homeDir)
+		}
+	})
+
+	t.Run("starting_at_ceiling_finds_legacy_runtime_root", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		// Point the supervisor runtime root somewhere else so $HOME/.gc is a
+		// legitimate legacy city root rather than the ignored supervisor root.
+		t.Setenv("GC_HOME", filepath.Join(homeDir, "supervisor", ".gc"))
+
+		if err := os.MkdirAll(filepath.Join(homeDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := findCity(homeDir)
+		if err != nil {
+			t.Fatalf("findCity(%q) error: %v", homeDir, err)
+		}
+		if got != homeDir {
+			t.Errorf("findCity(%q) = %q, want %q", homeDir, got, homeDir)
+		}
+	})
+
+	t.Run("starting_at_ceiling_ignores_supervisor_runtime_root", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("GC_HOME", filepath.Join(homeDir, ".gc"))
+
+		if err := os.MkdirAll(filepath.Join(homeDir, ".gc"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := findCity(homeDir)
+		if err == nil {
+			t.Fatal("findCity() should fail when ceiling dir holds only the supervisor runtime root")
+		}
+		if !strings.Contains(err.Error(), "not in a city directory") {
+			t.Errorf("error = %q, want 'not in a city directory'", err)
+		}
+	})
+
 	t.Run("respects_gc_ceiling_directories", func(t *testing.T) {
 		root := t.TempDir()
 		parent := filepath.Join(root, "parent")


### PR DESCRIPTION
## Summary

Closes bead `ga-bi2`. `findCity`'s loop guard (`for !isCityDiscoveryCeiling(...)`) skipped the starting dir entirely when it equaled the ceiling (typically `$HOME`), so `gc doctor` run from a city installed directly at the ceiling — e.g. a dedicated user `gc` with city at `/home/gc` — reported *"not in a city directory"* even though `city.toml` was present. `gc start` worked because `resolveContextFromPath` calls `validateCityPath` first; only the implicit discovery path had the bug.

## Fix

Inspect the starting dir once when it equals the ceiling. The upward-walk semantics are **unchanged** — walking up to the ceiling still does not inspect it, preserving the existing *"stray $HOME/city.toml"* guard.

A runtime root at the ceiling that matches the configured supervisor root is still ignored at the starting-dir check, keeping the *"$HOME/.gc is the supervisor's runtime, not a legacy city"* guard intact.

## Test plan

- [x] New: `TestFindCity/starting_at_ceiling_finds_city_toml` — the canonical bead case
- [x] New: `TestFindCity/starting_at_ceiling_finds_legacy_runtime_root` — legacy `.gc/` at ceiling, supervisor root pointed elsewhere
- [x] New: `TestFindCity/starting_at_ceiling_ignores_supervisor_runtime_root` — supervisor-root guard at ceiling
- [x] Existing guards preserved: `not_found_ignores_stray_home_city_toml`, `not_found_ignores_supervisor_home_runtime_root`, `nested_city_below_home_boundary_still_found`, `respects_gc_ceiling_directories` — all green
- [x] `go vet ./cmd/gc/` clean, `gofumpt -l` clean
- [ ] CI runs the full gates

## Note on hooks

Committed with `--no-verify` per the workaround documented in `ga-q42` (pre-existing `make test` failures block polecat commits on isolated, verified changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)