### PR TITLE
Add GH-1654 pool demand regression

### DIFF
--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1902,6 +1902,96 @@ func TestBuildDesiredState_MinZeroDefaultScaleCheckRoutedWorkCreatesPoolSession(
 	}
 }
 
+func TestBuildDesiredState_GH1654PoolReadyWorkGrowsPastMinActiveSessions(t *testing.T) {
+	cityPath := t.TempDir()
+	store := beads.NewMemStore()
+	const template = "worker"
+
+	for i := 0; i < 6; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  fmt.Sprintf("queued work %d", i+1),
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": template,
+			},
+		}); err != nil {
+			t.Fatalf("create queued work: %v", err)
+		}
+	}
+
+	existingSessionNames := make(map[string]bool)
+	for slot := 1; slot <= 3; slot++ {
+		agentName := poolInstanceName(template, slot, nil)
+		session, err := store.Create(beads.Bead{
+			Title:  agentName,
+			Type:   sessionBeadType,
+			Status: "open",
+			Labels: []string{sessionBeadLabel, "agent:" + agentName},
+			Metadata: map[string]string{
+				"agent_name":           agentName,
+				"pool_slot":            strconv.Itoa(slot),
+				"state":                "active",
+				"template":             template,
+				poolManagedMetadataKey: boolMetadata(true),
+			},
+		})
+		if err != nil {
+			t.Fatalf("create active pool session: %v", err)
+		}
+		sessionName := PoolSessionName(template, session.ID)
+		if err := store.SetMetadata(session.ID, "session_name", sessionName); err != nil {
+			t.Fatalf("set session_name: %v", err)
+		}
+		existingSessionNames[sessionName] = true
+	}
+
+	sessionSnapshot, err := loadSessionBeadSnapshot(store)
+	if err != nil {
+		t.Fatalf("load session snapshot: %v", err)
+	}
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              template,
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(3),
+			MaxActiveSessions: intPtr(100),
+		}},
+	}
+
+	var stderr strings.Builder
+	dsResult := buildDesiredStateWithSessionBeads(
+		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),
+		store, nil, sessionSnapshot, nil, &stderr,
+	)
+
+	if got := dsResult.ScaleCheckCounts[template]; got != 6 {
+		t.Fatalf("ScaleCheckCounts[%s] = %d, want 6 queued ready beads", template, got)
+	}
+	desiredSessionNames := make(map[string]bool)
+	for _, tp := range dsResult.State {
+		if tp.TemplateName == template {
+			desiredSessionNames[tp.SessionName] = true
+		}
+	}
+	if got := len(desiredSessionNames); got != 6 {
+		t.Fatalf("%s desired sessions = %d, want 6 (3 retained min sessions + 3 new slots); stderr:\n%s", template, got, stderr.String())
+	}
+	for sessionName := range existingSessionNames {
+		if !desiredSessionNames[sessionName] {
+			t.Fatalf("existing min-floor session %s was not retained in desired state; desired=%#v", sessionName, desiredSessionNames)
+		}
+	}
+	sessions, err := store.ListByLabel(sessionBeadLabel, 0)
+	if err != nil {
+		t.Fatalf("list session beads: %v", err)
+	}
+	if len(sessions) != 6 {
+		t.Fatalf("stored session beads = %d, want 6 total after growing past min_active_sessions; stderr:\n%s", len(sessions), stderr.String())
+	}
+}
+
 func TestBuildDesiredState_MinZeroDefaultScaleCheckNoWorkDropsPendingPoolCreate(t *testing.T) {
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()

--- a/cmd/gc/build_desired_state_test.go
+++ b/cmd/gc/build_desired_state_test.go
@@ -1906,6 +1906,16 @@ func TestBuildDesiredState_GH1654PoolReadyWorkGrowsPastMinActiveSessions(t *test
 	cityPath := t.TempDir()
 	store := beads.NewMemStore()
 	const template = "worker"
+	cfg := &config.City{
+		Workspace: config.Workspace{Name: "test-city"},
+		Agents: []config.Agent{{
+			Name:              template,
+			StartCommand:      "true",
+			MinActiveSessions: intPtr(3),
+			MaxActiveSessions: intPtr(100),
+		}},
+	}
+	cfgAgent := &cfg.Agents[0]
 
 	for i := 0; i < 6; i++ {
 		if _, err := store.Create(beads.Bead{
@@ -1922,44 +1932,31 @@ func TestBuildDesiredState_GH1654PoolReadyWorkGrowsPastMinActiveSessions(t *test
 
 	existingSessionNames := make(map[string]bool)
 	for slot := 1; slot <= 3; slot++ {
-		agentName := poolInstanceName(template, slot, nil)
-		session, err := store.Create(beads.Bead{
-			Title:  agentName,
-			Type:   sessionBeadType,
-			Status: "open",
-			Labels: []string{sessionBeadLabel, "agent:" + agentName},
-			Metadata: map[string]string{
-				"agent_name":           agentName,
-				"pool_slot":            strconv.Itoa(slot),
-				"state":                "active",
-				"template":             template,
-				poolManagedMetadataKey: boolMetadata(true),
-			},
+		_, qualifiedInstance := poolInstanceIdentity(cfgAgent, slot, io.Discard)
+		session, err := createPoolSessionBead(store, cfgAgent.QualifiedName(), nil, time.Now().UTC(), poolSessionCreateIdentity{
+			AgentName: qualifiedInstance,
+			Alias:     qualifiedInstance,
+			Slot:      slot,
 		})
 		if err != nil {
 			t.Fatalf("create active pool session: %v", err)
 		}
-		sessionName := PoolSessionName(template, session.ID)
-		if err := store.SetMetadata(session.ID, "session_name", sessionName); err != nil {
-			t.Fatalf("set session_name: %v", err)
+		if err := store.SetMetadata(session.ID, "state", "active"); err != nil {
+			t.Fatalf("set state: %v", err)
 		}
-		existingSessionNames[sessionName] = true
+		if err := store.SetMetadata(session.ID, "pending_create_claim", ""); err != nil {
+			t.Fatalf("clear pending_create_claim: %v", err)
+		}
+		if err := store.SetMetadata(session.ID, "pending_create_started_at", ""); err != nil {
+			t.Fatalf("clear pending_create_started_at: %v", err)
+		}
+		existingSessionNames[session.Metadata["session_name"]] = true
 	}
 
 	sessionSnapshot, err := loadSessionBeadSnapshot(store)
 	if err != nil {
 		t.Fatalf("load session snapshot: %v", err)
 	}
-	cfg := &config.City{
-		Workspace: config.Workspace{Name: "test-city"},
-		Agents: []config.Agent{{
-			Name:              template,
-			StartCommand:      "true",
-			MinActiveSessions: intPtr(3),
-			MaxActiveSessions: intPtr(100),
-		}},
-	}
-
 	var stderr strings.Builder
 	dsResult := buildDesiredStateWithSessionBeads(
 		"test-city", cityPath, time.Now().UTC(), cfg, runtime.NewFake(),

--- a/cmd/gc/city_runtime.go
+++ b/cmd/gc/city_runtime.go
@@ -1396,6 +1396,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 	// work_query remains the agent-side gc hook claim path; running every
 	// work_query here can block assigned-work resumes behind unrelated probes.
 	workSet := make(map[string]bool)
+	traceWorkRequested := traceWorkRequestedByTemplate(result.ScaleCheckCounts, result.NamedSessionDemand, workSet, cr.cfg)
 	if trace != nil {
 		templateNames := make(map[string]struct{})
 		openCounts := make(map[string]int)
@@ -1425,6 +1426,9 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 		for template := range workSet {
 			templateNames[template] = struct{}{}
 		}
+		for template := range traceWorkRequested {
+			templateNames[template] = struct{}{}
+		}
 		for _, template := range traceSetStrings(templateNames) {
 			status := TraceEvaluationEligible
 			reason := TraceReasonRetained
@@ -1436,7 +1440,7 @@ func (cr *CityRuntime) beadReconcileTick(ctx context.Context, result DesiredStat
 				"desired_count":  desiredCounts[template],
 				"open_count":     openCounts[template],
 				"pool_desired":   poolDesired[template],
-				"work_requested": workSet[template],
+				"work_requested": traceWorkRequested[template],
 			})
 		}
 		trace.RecordCycleInputSnapshot(map[string]any{
@@ -1565,6 +1569,34 @@ func filterReleasedAssignedWorkSnapshot(assignedWorkBeads []beads.Bead, assigned
 		filteredStoreRefs = assignedWorkStoreRefs
 	}
 	return filtered, filteredStoreRefs
+}
+
+func traceWorkRequestedByTemplate(scaleCheckCounts map[string]int, namedDemand map[string]bool, workSet map[string]bool, cfg *config.City) map[string]bool {
+	result := make(map[string]bool)
+	for template, requested := range workSet {
+		if requested {
+			result[template] = true
+		}
+	}
+	for template, count := range scaleCheckCounts {
+		if count > 0 {
+			result[template] = true
+		}
+	}
+	for identity, requested := range namedDemand {
+		if !requested {
+			continue
+		}
+		spec, ok := findNamedSessionSpec(cfg, "", identity)
+		if !ok {
+			continue
+		}
+		template := spec.Agent.QualifiedName()
+		if template != "" {
+			result[template] = true
+		}
+	}
+	return result
 }
 
 func (cr *CityRuntime) requestDeferredDrainFollowUpTick() {

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -74,14 +74,17 @@ func staleManagedDoltSocketPaths() []string {
 }
 
 func fileOpenedByAnyProcess(path string) (bool, error) {
-	if open, checked := fileOpenedByAnyProcessFromProc(path); checked {
+	ctx, cancel := context.WithTimeout(context.Background(), managedDoltLsofTimeout)
+	defer cancel()
+	if open, checked := fileOpenedByAnyProcessFromProc(ctx, path); checked {
 		return open, nil
+	}
+	if ctx.Err() != nil {
+		return false, errManagedDoltOpenStateUnknown
 	}
 	if _, err := exec.LookPath("lsof"); err != nil {
 		return false, errManagedDoltOpenStateUnknown
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), managedDoltLsofTimeout)
-	defer cancel()
 	cmd := exec.CommandContext(ctx, "lsof", path)
 	cmd.WaitDelay = 100 * time.Millisecond
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -108,13 +111,16 @@ func fileOpenedByAnyProcess(path string) (bool, error) {
 	return false, fmt.Errorf("lsof %s: %w: %s", path, err, strings.TrimSpace(string(out)))
 }
 
-func fileOpenedByAnyProcessFromProc(path string) (bool, bool) {
+func fileOpenedByAnyProcessFromProc(ctx context.Context, path string) (bool, bool) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return false, false
 	}
 	socketInodes, _ := unixSocketInodesForPath(path)
 	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return false, false
+		}
 		if !entry.IsDir() {
 			continue
 		}
@@ -127,6 +133,9 @@ func fileOpenedByAnyProcessFromProc(path string) (bool, bool) {
 			continue
 		}
 		for _, fd := range fds {
+			if ctx.Err() != nil {
+				return false, false
+			}
 			target, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
 			if err != nil {
 				continue

--- a/cmd/gc/dolt_preflight_cleanup.go
+++ b/cmd/gc/dolt_preflight_cleanup.go
@@ -16,7 +16,15 @@ import (
 
 var managedDoltPreflightCleanupFn = preflightManagedDoltCleanup
 
-const managedDoltLsofTimeout = 3 * time.Second
+const (
+	managedDoltProcTimeout = 1500 * time.Millisecond
+	managedDoltLsofTimeout = 3 * time.Second
+)
+
+var (
+	managedDoltProcDir         = "/proc"
+	managedDoltUnixSocketTable = "/proc/net/unix"
+)
 
 func preflightManagedDoltCleanup(_ string) error {
 	return removeStaleManagedDoltSockets()
@@ -74,18 +82,22 @@ func staleManagedDoltSocketPaths() []string {
 }
 
 func fileOpenedByAnyProcess(path string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), managedDoltLsofTimeout)
-	defer cancel()
-	if open, checked := fileOpenedByAnyProcessFromProc(ctx, path); checked {
+	procCtx, procCancel := context.WithTimeout(context.Background(), managedDoltProcTimeout)
+	open, checked := fileOpenedByAnyProcessFromProc(procCtx, path)
+	procErr := procCtx.Err()
+	procCancel()
+	if checked {
 		return open, nil
 	}
-	if ctx.Err() != nil {
-		return false, errManagedDoltOpenStateUnknown
-	}
 	if _, err := exec.LookPath("lsof"); err != nil {
+		if procErr != nil {
+			return false, fmt.Errorf("%w: proc probe timed out and lsof unavailable", errManagedDoltOpenStateUnknown)
+		}
 		return false, errManagedDoltOpenStateUnknown
 	}
-	cmd := exec.CommandContext(ctx, "lsof", path)
+	lsofCtx, lsofCancel := context.WithTimeout(context.Background(), managedDoltLsofTimeout)
+	defer lsofCancel()
+	cmd := exec.CommandContext(lsofCtx, "lsof", path)
 	cmd.WaitDelay = 100 * time.Millisecond
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
@@ -98,8 +110,8 @@ func fileOpenedByAnyProcess(path string) (bool, error) {
 		return nil
 	}
 	out, err := cmd.CombinedOutput()
-	if ctx.Err() != nil {
-		return false, errManagedDoltOpenStateUnknown
+	if lsofCtx.Err() != nil {
+		return false, fmt.Errorf("%w: lsof probe timed out", errManagedDoltOpenStateUnknown)
 	}
 	if err == nil {
 		return true, nil
@@ -112,11 +124,20 @@ func fileOpenedByAnyProcess(path string) (bool, error) {
 }
 
 func fileOpenedByAnyProcessFromProc(ctx context.Context, path string) (bool, bool) {
-	entries, err := os.ReadDir("/proc")
+	if ctx != nil && ctx.Err() != nil {
+		return false, false
+	}
+	entries, err := os.ReadDir(managedDoltProcDir)
 	if err != nil {
 		return false, false
 	}
-	socketInodes, _ := unixSocketInodesForPath(path)
+	if ctx != nil && ctx.Err() != nil {
+		return false, false
+	}
+	socketInodes, _ := unixSocketInodesForPath(ctx, path)
+	if ctx != nil && ctx.Err() != nil {
+		return false, false
+	}
 	for _, entry := range entries {
 		if ctx.Err() != nil {
 			return false, false
@@ -127,7 +148,7 @@ func fileOpenedByAnyProcessFromProc(ctx context.Context, path string) (bool, boo
 		if _, err := strconv.Atoi(entry.Name()); err != nil {
 			continue
 		}
-		fdDir := filepath.Join("/proc", entry.Name(), "fd")
+		fdDir := filepath.Join(managedDoltProcDir, entry.Name(), "fd")
 		fds, err := os.ReadDir(fdDir)
 		if err != nil {
 			continue
@@ -155,14 +176,23 @@ func fileOpenedByAnyProcessFromProc(ctx context.Context, path string) (bool, boo
 	return false, true
 }
 
-func unixSocketInodesForPath(path string) (map[string]struct{}, bool) {
-	data, err := os.ReadFile("/proc/net/unix")
+func unixSocketInodesForPath(ctx context.Context, path string) (map[string]struct{}, bool) {
+	if ctx != nil && ctx.Err() != nil {
+		return nil, false
+	}
+	data, err := os.ReadFile(managedDoltUnixSocketTable)
 	if err != nil {
+		return nil, false
+	}
+	if ctx != nil && ctx.Err() != nil {
 		return nil, false
 	}
 	inodes := map[string]struct{}{}
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	for scanner.Scan() {
+		if ctx != nil && ctx.Err() != nil {
+			return nil, false
+		}
 		fields := strings.Fields(scanner.Text())
 		if len(fields) < 8 {
 			continue
@@ -171,6 +201,9 @@ func unixSocketInodesForPath(path string) (map[string]struct{}, bool) {
 			continue
 		}
 		inodes[fields[6]] = struct{}{}
+	}
+	if scanner.Err() != nil {
+		return nil, false
 	}
 	return inodes, true
 }

--- a/cmd/gc/dolt_preflight_cleanup_test.go
+++ b/cmd/gc/dolt_preflight_cleanup_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os"
@@ -63,8 +64,9 @@ func TestFileOpenedByAnyProcessBoundsLsof(t *testing.T) {
 	if err := os.WriteFile(path, []byte("stale\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	withManagedDoltProcPaths(t, filepath.Join(t.TempDir(), "missing-proc"), filepath.Join(t.TempDir(), "missing-unix"))
 	binDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(binDir, "lsof"), []byte("#!/bin/sh\nexec sleep 10\n"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(binDir, "lsof"), []byte("#!/bin/sh\ntouch \"$1.ran\"\nexec sleep 10\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(lsof): %v", err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -77,8 +79,42 @@ func TestFileOpenedByAnyProcessBoundsLsof(t *testing.T) {
 	if open {
 		t.Fatal("fileOpenedByAnyProcess() = true, want false when lsof times out")
 	}
+	if _, err := os.Stat(path + ".ran"); err != nil {
+		t.Fatalf("fake lsof did not run: %v", err)
+	}
 	if elapsed := time.Since(start); elapsed > 4*time.Second {
 		t.Fatalf("fileOpenedByAnyProcess() took %s, want bounded timeout", elapsed)
+	}
+}
+
+func TestFileOpenedByAnyProcessFromProcHonorsCancelledContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "LOCK")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	open, checked := fileOpenedByAnyProcessFromProc(ctx, path)
+	if open || checked {
+		t.Fatalf("fileOpenedByAnyProcessFromProc(canceled) = (%v, %v), want false, false", open, checked)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("fileOpenedByAnyProcessFromProc(canceled) took %s, want immediate cancellation", elapsed)
+	}
+}
+
+func TestUnixSocketInodesForPathHonorsCancelledContext(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "dolt.sock")
+	unixTable := filepath.Join(t.TempDir(), "unix")
+	if err := os.WriteFile(unixTable, []byte("Num RefCount Protocol Flags Type St Inode Path\n0000000000000000: 00000002 00000000 00010000 0001 01 12345 "+socketPath+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(unix table): %v", err)
+	}
+	withManagedDoltProcPaths(t, t.TempDir(), unixTable)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	inodes, checked := unixSocketInodesForPath(ctx, socketPath)
+	if checked || len(inodes) != 0 {
+		t.Fatalf("unixSocketInodesForPath(canceled) = (%v, %v), want nil/empty, false", inodes, checked)
 	}
 }
 
@@ -100,4 +136,16 @@ func TestRemoveStaleManagedDoltSocketsWithoutLsofKeepsSocket(t *testing.T) {
 	if _, err := os.Stat(socketPath); err != nil {
 		t.Fatalf("socket stat err = %v, want preserved when lsof unavailable", err)
 	}
+}
+
+func withManagedDoltProcPaths(t *testing.T, procDir, unixSocketTable string) {
+	t.Helper()
+	oldProcDir := managedDoltProcDir
+	oldUnixSocketTable := managedDoltUnixSocketTable
+	managedDoltProcDir = procDir
+	managedDoltUnixSocketTable = unixSocketTable
+	t.Cleanup(func() {
+		managedDoltProcDir = oldProcDir
+		managedDoltUnixSocketTable = oldUnixSocketTable
+	})
 }

--- a/cmd/gc/session_reconciler_trace_integration_test.go
+++ b/cmd/gc/session_reconciler_trace_integration_test.go
@@ -463,6 +463,266 @@ func TestSessionReconcilerTraceStartAndDrainSubOps(t *testing.T) {
 	}
 }
 
+func TestSessionReconcilerTraceGH1654WorkRequestedStartCandidates(t *testing.T) {
+	now := time.Date(2026, 3, 8, 12, 20, 0, 0, time.UTC)
+
+	tests := []struct {
+		name                string
+		template            string
+		wantStartCandidates int
+		setup               func(t *testing.T, cityDir string, store beads.Store, sp runtime.Provider) (*config.City, DesiredStateResult, *sessionBeadSnapshot)
+	}{
+		{
+			name:                "named session post-kill",
+			template:            "dispatcher",
+			wantStartCandidates: 1,
+			setup: func(t *testing.T, cityDir string, store beads.Store, sp runtime.Provider) (*config.City, DesiredStateResult, *sessionBeadSnapshot) {
+				t.Helper()
+				cfg := &config.City{
+					Workspace: config.Workspace{Name: "trace-town"},
+					Session:   config.SessionConfig{Provider: "fake"},
+					Agents: []config.Agent{{
+						Name:              "dispatcher",
+						StartCommand:      "true",
+						MaxActiveSessions: intPtr(1),
+					}},
+					NamedSessions: []config.NamedSession{{
+						Template: "dispatcher",
+						Mode:     "on_demand",
+					}},
+				}
+				if _, err := store.Create(beads.Bead{
+					Title:  "queued dispatcher work",
+					Type:   "task",
+					Status: "open",
+					Metadata: map[string]string{
+						"gc.routed_to": "dispatcher",
+					},
+				}); err != nil {
+					t.Fatalf("Create named work: %v", err)
+				}
+				sessionName := config.NamedSessionRuntimeName("trace-town", cfg.Workspace, "dispatcher")
+				if _, err := store.Create(beads.Bead{
+					Title:  sessionName,
+					Type:   sessionBeadType,
+					Labels: []string{sessionBeadLabel},
+					Metadata: map[string]string{
+						"session_name":               sessionName,
+						"alias":                      "dispatcher",
+						"template":                   "dispatcher",
+						"state":                      "asleep",
+						"generation":                 "1",
+						"continuation_epoch":         "1",
+						"instance_token":             "named-token",
+						namedSessionMetadataKey:      boolMetadata(true),
+						namedSessionIdentityMetadata: "dispatcher",
+						namedSessionModeMetadata:     "on_demand",
+					},
+				}); err != nil {
+					t.Fatalf("Create named session: %v", err)
+				}
+				dsResult := buildDesiredState("trace-town", cityDir, now, cfg, sp, store, io.Discard)
+				if !dsResult.NamedSessionDemand["dispatcher"] {
+					t.Fatal("NamedSessionDemand[dispatcher] = false, want true")
+				}
+				snapshot, err := loadSessionBeadSnapshot(store)
+				if err != nil {
+					t.Fatalf("load session snapshot: %v", err)
+				}
+				return cfg, dsResult, snapshot
+			},
+		},
+		{
+			name:                "pool respawn after drain",
+			template:            "repo/worker",
+			wantStartCandidates: 1,
+			setup: func(t *testing.T, cityDir string, store beads.Store, sp runtime.Provider) (*config.City, DesiredStateResult, *sessionBeadSnapshot) {
+				t.Helper()
+				cfg := &config.City{
+					Workspace: config.Workspace{Name: "trace-town"},
+					Session:   config.SessionConfig{Provider: "fake"},
+					Agents: []config.Agent{{
+						Name:              "worker",
+						Dir:               "repo",
+						StartCommand:      "true",
+						MinActiveSessions: intPtr(0),
+						MaxActiveSessions: intPtr(5),
+					}},
+				}
+				createRoutedReadyWork(t, store, "repo/worker", 1)
+				dsResult := buildDesiredState("trace-town", cityDir, now, cfg, sp, store, io.Discard)
+				if got := dsResult.ScaleCheckCounts["repo/worker"]; got != 1 {
+					t.Fatalf("ScaleCheckCounts[repo/worker] = %d, want 1", got)
+				}
+				snapshot, err := loadSessionBeadSnapshot(store)
+				if err != nil {
+					t.Fatalf("load session snapshot: %v", err)
+				}
+				return cfg, dsResult, snapshot
+			},
+		},
+		{
+			name:                "pool grows past min active sessions",
+			template:            "repo/worker",
+			wantStartCandidates: 3,
+			setup: func(t *testing.T, cityDir string, store beads.Store, sp runtime.Provider) (*config.City, DesiredStateResult, *sessionBeadSnapshot) {
+				t.Helper()
+				cfg := &config.City{
+					Workspace: config.Workspace{Name: "trace-town"},
+					Session:   config.SessionConfig{Provider: "fake"},
+					Agents: []config.Agent{{
+						Name:              "worker",
+						Dir:               "repo",
+						StartCommand:      "true",
+						MinActiveSessions: intPtr(3),
+						MaxActiveSessions: intPtr(100),
+					}},
+				}
+				createRoutedReadyWork(t, store, "repo/worker", 6)
+				for slot := 1; slot <= 3; slot++ {
+					session := createCanonicalPoolSession(t, store, &cfg.Agents[0], now, slot)
+					if err := store.SetMetadata(session.ID, "state", "active"); err != nil {
+						t.Fatalf("set active state: %v", err)
+					}
+					if err := store.SetMetadata(session.ID, "pending_create_claim", ""); err != nil {
+						t.Fatalf("clear pending create claim: %v", err)
+					}
+					if err := store.SetMetadata(session.ID, "pending_create_started_at", ""); err != nil {
+						t.Fatalf("clear pending create timestamp: %v", err)
+					}
+					if err := sp.Start(context.Background(), session.Metadata["session_name"], runtime.Config{}); err != nil {
+						t.Fatalf("seed active runtime session: %v", err)
+					}
+				}
+				dsResult := buildDesiredState("trace-town", cityDir, now, cfg, sp, store, io.Discard)
+				if got := dsResult.ScaleCheckCounts["repo/worker"]; got != 6 {
+					t.Fatalf("ScaleCheckCounts[repo/worker] = %d, want 6", got)
+				}
+				snapshot, err := loadSessionBeadSnapshot(store)
+				if err != nil {
+					t.Fatalf("load session snapshot: %v", err)
+				}
+				return cfg, dsResult, snapshot
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cityDir := t.TempDir()
+			writeCityTOML(t, cityDir, "trace-town", "worker")
+			store := beads.NewMemStore()
+			sp := runtime.NewFake()
+			cfg, dsResult, sessionBeads := tc.setup(t, cityDir, store, sp)
+
+			tracer := newSessionReconcilerTracer(cityDir, "trace-town", io.Discard)
+			if !tracer.Enabled() {
+				t.Fatal("tracer should be enabled")
+			}
+			if _, err := tracer.armStore.upsertArm(TraceArm{
+				ScopeType:      TraceArmScopeTemplate,
+				ScopeValue:     tc.template,
+				Source:         TraceArmSourceManual,
+				Level:          TraceModeDetail,
+				ArmedAt:        now,
+				ExpiresAt:      now.Add(15 * time.Minute),
+				LastExtendedAt: now,
+				UpdatedAt:      now,
+			}); err != nil {
+				t.Fatalf("upsert arm: %v", err)
+			}
+			cycle := tracer.BeginCycle(TraceTickTriggerPatrol, "controller_tick", now, cfg)
+			if cycle == nil {
+				t.Fatal("BeginCycle returned nil")
+			}
+			cycle.syncArms(now, cfg)
+			cr := &CityRuntime{
+				cityPath:            cityDir,
+				cityName:            "trace-town",
+				cfg:                 cfg,
+				sp:                  sp,
+				trace:               tracer,
+				standaloneCityStore: store,
+				sessionDrains:       newDrainTracker(),
+				rec:                 events.NewFake(),
+				pokeCh:              make(chan struct{}, 1),
+				stdout:              io.Discard,
+				stderr:              io.Discard,
+			}
+			cr.beadReconcileTick(context.Background(), dsResult, sessionBeads, cycle)
+			if !cr.waitForAsyncStarts() {
+				t.Fatal("async starts did not finish")
+			}
+			if err := cycle.End(TraceCompletionCompleted, traceRecordPayload{"phase": "gh1654"}); err != nil {
+				t.Fatalf("cycle.End: %v", err)
+			}
+			if err := tracer.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			records, err := ReadTraceRecords(traceCityRuntimeDir(cityDir), TraceFilter{TraceID: cycle.traceID})
+			if err != nil {
+				t.Fatalf("ReadTraceRecords: %v", err)
+			}
+			var startCandidates int
+			haveWorkRequestedSummary := false
+			for _, rec := range records {
+				if rec.RecordType == TraceRecordTemplateTickSummary && rec.Template == tc.template {
+					if rec.EvaluationStatus != TraceEvaluationEligible {
+						t.Fatalf("template summary evaluation_status = %q, want eligible", rec.EvaluationStatus)
+					}
+					if !traceFieldBool(rec.Fields["work_requested"]) {
+						t.Fatalf("template summary work_requested = %#v, want true", rec.Fields["work_requested"])
+					}
+					haveWorkRequestedSummary = true
+				}
+				if rec.RecordType == TraceRecordDecision &&
+					rec.SiteCode == TraceSiteReconcilerWakeDecision &&
+					rec.Template == tc.template &&
+					rec.OutcomeCode == TraceOutcomeStartCandidate {
+					startCandidates++
+				}
+			}
+			if !haveWorkRequestedSummary {
+				t.Fatalf("missing work-requested template summary for %s", tc.template)
+			}
+			if startCandidates != tc.wantStartCandidates {
+				t.Fatalf("start_candidate decisions = %d, want %d", startCandidates, tc.wantStartCandidates)
+			}
+		})
+	}
+}
+
+func createRoutedReadyWork(t *testing.T, store beads.Store, template string, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		if _, err := store.Create(beads.Bead{
+			Title:  "queued work",
+			Type:   "task",
+			Status: "open",
+			Metadata: map[string]string{
+				"gc.routed_to": template,
+			},
+		}); err != nil {
+			t.Fatalf("Create routed work: %v", err)
+		}
+	}
+}
+
+func createCanonicalPoolSession(t *testing.T, store beads.Store, cfgAgent *config.Agent, now time.Time, slot int) beads.Bead {
+	t.Helper()
+	_, qualifiedInstance := poolInstanceIdentity(cfgAgent, slot, io.Discard)
+	session, err := createPoolSessionBead(store, cfgAgent.QualifiedName(), nil, now, poolSessionCreateIdentity{
+		AgentName: qualifiedInstance,
+		Alias:     qualifiedInstance,
+		Slot:      slot,
+	})
+	if err != nil {
+		t.Fatalf("create pool session: %v", err)
+	}
+	return session
+}
+
 func traceFieldInt(v any) int {
 	switch n := v.(type) {
 	case int:
@@ -492,4 +752,9 @@ func traceFieldInt(v any) int {
 	default:
 		return 0
 	}
+}
+
+func traceFieldBool(v any) bool {
+	b, ok := v.(bool)
+	return ok && b
 }


### PR DESCRIPTION
## Summary
- add a focused regression for GH-1654 min-active pool stall case
- assert routed ready work grows a pool past min_active_sessions while retaining existing floor sessions
- bound the managed Dolt open-file probe so the pre-commit timeout regression stays stable on process-heavy hosts

Closes #1654

## Tests
- go test ./cmd/gc -run TestBuildDesiredState_GH1654PoolReadyWorkGrowsPastMinActiveSessions -count=1
- go test ./cmd/gc -run TestFileOpenedByAnyProcessBoundsLsof -count=1
- make test