### PR TITLE
fix(session): rollback stale pending creates for configured named sessions

### DIFF
--- a/cmd/gc/named_sessions.go
+++ b/cmd/gc/named_sessions.go
@@ -46,6 +46,18 @@ func namedSessionIdentity(b beads.Bead) string {
 	return session.NamedSessionIdentity(b)
 }
 
+func configuredNamedSessionBeadHasSpec(b beads.Bead, cfg *config.City, cityName string) bool {
+	if cfg == nil || !isNamedSessionBead(b) {
+		return false
+	}
+	identity := namedSessionIdentity(b)
+	if identity == "" {
+		return false
+	}
+	_, ok := findNamedSessionSpec(cfg, cityName, identity)
+	return ok
+}
+
 func namedSessionMode(b beads.Bead) string {
 	return session.NamedSessionMode(b)
 }

--- a/cmd/gc/session_lifecycle_chaos_test.go
+++ b/cmd/gc/session_lifecycle_chaos_test.go
@@ -40,6 +40,92 @@ func TestSessionLifecycleChaosInvariantsAllowFailedCreatePendingClaim(t *testing
 	h.assertInvariants()
 }
 
+func TestReconciler_RollsBackExpiredPendingCreateForConfiguredNamedSession(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260508)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	identity := "chaos-worker"
+	h.env.cfg.NamedSessions = []config.NamedSession{{
+		Name:     identity,
+		Template: h.template,
+	}}
+	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
+		"alias":                      identity,
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: identity,
+		namedSessionModeMetadata:     "on_demand",
+		"pending_create_started_at":  h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("mark named pending create stale: %v", err)
+	}
+	h.setDesired(false)
+	h.reconcileTick()
+
+	got, err := h.env.store.Get(h.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", h.sessionID, err)
+	}
+	if got.Status != "closed" {
+		t.Fatalf("status = %q, want closed after stale pending create rollback", got.Status)
+	}
+	if got.Metadata["state"] != "failed-create" {
+		t.Fatalf("state = %q, want failed-create", got.Metadata["state"])
+	}
+	if got.Metadata["pending_create_claim"] != "" {
+		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
+	}
+}
+
+func TestReconciler_DefersStalePendingCreateRollbackWhenStoreQueryPartial(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260514)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	identity := "chaos-worker"
+	h.env.cfg.NamedSessions = []config.NamedSession{{
+		Name:     identity,
+		Template: h.template,
+	}}
+	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
+		"alias":                      identity,
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: identity,
+		namedSessionModeMetadata:     "on_demand",
+		"pending_create_started_at":  h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("mark named pending create stale: %v", err)
+	}
+	h.setDesired(false)
+
+	sessions, err := loadSessionBeads(h.env.store)
+	if err != nil {
+		t.Fatalf("loadSessionBeads: %v", err)
+	}
+	poolDesired := make(map[string]int)
+	for _, tp := range h.env.desiredState {
+		if tp.TemplateName != "" {
+			poolDesired[tp.TemplateName]++
+		}
+	}
+	reconcileSessionBeads(
+		context.Background(), sessions, h.env.desiredState, configuredSessionNames(h.env.cfg, "", h.env.store),
+		h.env.cfg, h.env.sp, h.env.store, nil, nil, nil, h.env.dt, poolDesired, true, nil, "",
+		nil, h.env.clk, h.env.rec, 0, 0, &h.env.stdout, &h.env.stderr,
+	)
+
+	got, err := h.env.store.Get(h.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", h.sessionID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed, want rollback deferred when store query is partial")
+	}
+	if got.Metadata["pending_create_claim"] == "" {
+		t.Fatal("pending_create_claim was cleared, want preserved when store query is partial")
+	}
+}
+
 func TestSessionLifecycleChaosPendingInteractionDoesNotOverrideOrphanDrain(t *testing.T) {
 	h := newSessionChaosHarness(t, 20260415)
 	h.createSessionIntent()

--- a/cmd/gc/session_lifecycle_chaos_test.go
+++ b/cmd/gc/session_lifecycle_chaos_test.go
@@ -45,20 +45,9 @@ func TestReconciler_RollsBackExpiredPendingCreateForConfiguredNamedSession(t *te
 	h.createSessionIntent()
 	h.assertCreatingIntent()
 
-	identity := "chaos-worker"
-	h.env.cfg.NamedSessions = []config.NamedSession{{
-		Name:     identity,
-		Template: h.template,
-	}}
-	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
-		"alias":                      identity,
-		namedSessionMetadataKey:      "true",
-		namedSessionIdentityMetadata: identity,
-		namedSessionModeMetadata:     "on_demand",
-		"pending_create_started_at":  h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("mark named pending create stale: %v", err)
-	}
+	markConfiguredNamedPendingCreate(t, h, map[string]string{
+		"pending_create_started_at": h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
+	})
 	h.setDesired(false)
 	h.reconcileTick()
 
@@ -75,6 +64,87 @@ func TestReconciler_RollsBackExpiredPendingCreateForConfiguredNamedSession(t *te
 	if got.Metadata["pending_create_claim"] != "" {
 		t.Fatalf("pending_create_claim = %q, want cleared", got.Metadata["pending_create_claim"])
 	}
+	if got.Metadata["pending_create_started_at"] != "" {
+		t.Fatalf("pending_create_started_at = %q, want cleared", got.Metadata["pending_create_started_at"])
+	}
+}
+
+func TestReconciler_DefersStalePendingCreateRollbackWhenProviderAlive(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260515)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	markConfiguredNamedPendingCreate(t, h, map[string]string{
+		"pending_create_started_at": h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
+	})
+	if err := h.env.sp.Start(context.Background(), h.sessionName, runtime.Config{Command: h.command}); err != nil {
+		t.Fatalf("Start(%s): %v", h.sessionName, err)
+	}
+	h.setDesired(false)
+	h.reconcileTickWithoutPostInvariants(false)
+
+	got, err := h.env.store.Get(h.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", h.sessionID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed, want rollback deferred while provider is live")
+	}
+	if got.Metadata["pending_create_claim"] == "" {
+		t.Fatal("pending_create_claim was cleared, want preserved while provider is live")
+	}
+	if !h.env.sp.IsRunning(h.sessionName) {
+		t.Fatalf("runtime %q stopped, want still running", h.sessionName)
+	}
+}
+
+func TestReconciler_DefersStalePendingCreateRollbackForFreshLease(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260516)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	markConfiguredNamedPendingCreate(t, h, map[string]string{
+		"pending_create_started_at": h.env.clk.Now().UTC().Format(time.RFC3339),
+	})
+	h.setDesired(false)
+	h.reconcileTick()
+
+	got, err := h.env.store.Get(h.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", h.sessionID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed, want rollback deferred for fresh pending-create lease")
+	}
+	if got.Metadata["pending_create_claim"] == "" {
+		t.Fatal("pending_create_claim was cleared, want preserved for fresh pending-create lease")
+	}
+}
+
+func TestReconciler_DefersStalePendingCreateRollbackForRateLimit(t *testing.T) {
+	h := newSessionChaosHarness(t, 20260517)
+	h.createSessionIntent()
+	h.assertCreatingIntent()
+
+	stale := h.env.clk.Now().Add(-staleCreatingStateTimeout - time.Minute).UTC().Format(time.RFC3339)
+	markConfiguredNamedPendingCreate(t, h, map[string]string{
+		"last_woke_at":              stale,
+		"pending_create_started_at": stale,
+	})
+	h.env.sp.SetPeekOutput(h.sessionName, "You've hit your limit, Pro plan\n\n/rate-limit-options")
+	h.setDesired(false)
+	h.reconcileTick()
+
+	got, err := h.env.store.Get(h.sessionID)
+	if err != nil {
+		t.Fatalf("store.Get(%s): %v", h.sessionID, err)
+	}
+	if got.Status == "closed" {
+		t.Fatalf("status = closed, want rollback deferred for rate-limit screen")
+	}
+	if got.Metadata["sleep_reason"] != "rate_limit" {
+		t.Fatalf("sleep_reason = %q, want rate_limit", got.Metadata["sleep_reason"])
+	}
 }
 
 func TestReconciler_DefersStalePendingCreateRollbackWhenStoreQueryPartial(t *testing.T) {
@@ -82,37 +152,11 @@ func TestReconciler_DefersStalePendingCreateRollbackWhenStoreQueryPartial(t *tes
 	h.createSessionIntent()
 	h.assertCreatingIntent()
 
-	identity := "chaos-worker"
-	h.env.cfg.NamedSessions = []config.NamedSession{{
-		Name:     identity,
-		Template: h.template,
-	}}
-	if err := h.env.store.SetMetadataBatch(h.sessionID, map[string]string{
-		"alias":                      identity,
-		namedSessionMetadataKey:      "true",
-		namedSessionIdentityMetadata: identity,
-		namedSessionModeMetadata:     "on_demand",
-		"pending_create_started_at":  h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("mark named pending create stale: %v", err)
-	}
+	markConfiguredNamedPendingCreate(t, h, map[string]string{
+		"pending_create_started_at": h.env.clk.Now().Add(-pendingCreateNeverStartedTimeout - time.Minute).UTC().Format(time.RFC3339),
+	})
 	h.setDesired(false)
-
-	sessions, err := loadSessionBeads(h.env.store)
-	if err != nil {
-		t.Fatalf("loadSessionBeads: %v", err)
-	}
-	poolDesired := make(map[string]int)
-	for _, tp := range h.env.desiredState {
-		if tp.TemplateName != "" {
-			poolDesired[tp.TemplateName]++
-		}
-	}
-	reconcileSessionBeads(
-		context.Background(), sessions, h.env.desiredState, configuredSessionNames(h.env.cfg, "", h.env.store),
-		h.env.cfg, h.env.sp, h.env.store, nil, nil, nil, h.env.dt, poolDesired, true, nil, "",
-		nil, h.env.clk, h.env.rec, 0, 0, &h.env.stdout, &h.env.stderr,
-	)
+	h.reconcileTickWithoutPostInvariants(true)
 
 	got, err := h.env.store.Get(h.sessionID)
 	if err != nil {
@@ -123,6 +167,27 @@ func TestReconciler_DefersStalePendingCreateRollbackWhenStoreQueryPartial(t *tes
 	}
 	if got.Metadata["pending_create_claim"] == "" {
 		t.Fatal("pending_create_claim was cleared, want preserved when store query is partial")
+	}
+}
+
+func markConfiguredNamedPendingCreate(t *testing.T, h *sessionChaosHarness, metadata map[string]string) {
+	t.Helper()
+	const identity = "chaos-worker"
+	h.env.cfg.NamedSessions = []config.NamedSession{{
+		Name:     identity,
+		Template: h.template,
+	}}
+	batch := map[string]string{
+		"alias":                      identity,
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: identity,
+		namedSessionModeMetadata:     "on_demand",
+	}
+	for key, value := range metadata {
+		batch[key] = value
+	}
+	if err := h.env.store.SetMetadataBatch(h.sessionID, batch); err != nil {
+		t.Fatalf("mark named pending create: %v", err)
 	}
 }
 
@@ -994,6 +1059,25 @@ func (h *sessionChaosHarness) reconcileTick() {
 	woken := h.env.reconcile(sessions)
 	h.record("reconcile open=%d woken=%d", len(sessions), woken)
 	h.assertPostReconcileInvariants()
+}
+
+func (h *sessionChaosHarness) reconcileTickWithoutPostInvariants(storeQueryPartial bool) {
+	sessions, err := loadSessionBeads(h.env.store)
+	if err != nil {
+		h.failf("loadSessionBeads: %v", err)
+	}
+	poolDesired := make(map[string]int)
+	for _, tp := range h.env.desiredState {
+		if tp.TemplateName != "" {
+			poolDesired[tp.TemplateName]++
+		}
+	}
+	woken := reconcileSessionBeads(
+		context.Background(), sessions, h.env.desiredState, configuredSessionNames(h.env.cfg, "", h.env.store),
+		h.env.cfg, h.env.sp, h.env.store, nil, nil, nil, h.env.dt, poolDesired, storeQueryPartial, nil, "",
+		nil, h.env.clk, h.env.rec, 0, 0, &h.env.stdout, &h.env.stderr,
+	)
+	h.record("reconcile open=%d woken=%d", len(sessions), woken)
 }
 
 func (h *sessionChaosHarness) reconcileTickWithIdle(it idleTracker) {

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1655,7 +1655,20 @@ func rollbackPendingCreate(session *beads.Bead, store beads.Store, now time.Time
 			session.Metadata["session_name"] = ""
 		}
 	}
-	closeBead(store, session.ID, string(sessionpkg.StateFailedCreate), now, stderr)
+	if closeBead(store, session.ID, string(sessionpkg.StateFailedCreate), now, stderr) {
+		if setMeta(store, session.ID, "pending_create_claim", "", stderr) == nil {
+			if session.Metadata == nil {
+				session.Metadata = make(map[string]string)
+			}
+			session.Metadata["pending_create_claim"] = ""
+		}
+		if setMeta(store, session.ID, "pending_create_started_at", "", stderr) == nil {
+			if session.Metadata == nil {
+				session.Metadata = make(map[string]string)
+			}
+			session.Metadata["pending_create_started_at"] = ""
+		}
+	}
 }
 
 func executePlannedStarts(

--- a/cmd/gc/session_lifecycle_parallel.go
+++ b/cmd/gc/session_lifecycle_parallel.go
@@ -1655,20 +1655,33 @@ func rollbackPendingCreate(session *beads.Bead, store beads.Store, now time.Time
 			session.Metadata["session_name"] = ""
 		}
 	}
-	if closeBead(store, session.ID, string(sessionpkg.StateFailedCreate), now, stderr) {
-		if setMeta(store, session.ID, "pending_create_claim", "", stderr) == nil {
+	closeBead(store, session.ID, string(sessionpkg.StateFailedCreate), now, stderr)
+}
+
+func rollbackPendingCreateClearingClaim(session *beads.Bead, store beads.Store, now time.Time, stderr io.Writer) {
+	if session == nil || store == nil {
+		return
+	}
+	clearPendingStartInFlightLease(session, store, stderr)
+	if strings.TrimSpace(session.Metadata["session_name_explicit"]) == "true" {
+		if setMeta(store, session.ID, "session_name", "", stderr) == nil {
 			if session.Metadata == nil {
 				session.Metadata = make(map[string]string)
 			}
-			session.Metadata["pending_create_claim"] = ""
-		}
-		if setMeta(store, session.ID, "pending_create_started_at", "", stderr) == nil {
-			if session.Metadata == nil {
-				session.Metadata = make(map[string]string)
-			}
-			session.Metadata["pending_create_started_at"] = ""
+			session.Metadata["session_name"] = ""
 		}
 	}
+	if !closeFailedCreateBead(store, session.ID, now, stderr) {
+		return
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]string)
+	}
+	for key, value := range sessionpkg.ClosePatch(now.UTC(), string(sessionpkg.StateFailedCreate)) {
+		session.Metadata[key] = value
+	}
+	session.Metadata["pending_create_claim"] = ""
+	session.Metadata["pending_create_started_at"] = ""
 }
 
 func executePlannedStarts(

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -580,7 +580,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 	// remaining stale beads roll back on subsequent ticks.
 	const maxRollbacksPerTick = 5
 	rollbacksThisTick := 0
-	attemptRollbackPendingCreate := func(session *beads.Bead, templateName, name, action, detail string) {
+	attemptRollbackPendingCreate := func(session *beads.Bead, templateName, name, action, detail string, clearClaim bool) {
 		if rollbacksThisTick >= maxRollbacksPerTick {
 			fmt.Fprintf(stderr, "session reconciler: deferring rollback of %s (%s): rollback budget exhausted this tick\n", name, detail) //nolint:errcheck
 			if trace != nil {
@@ -595,6 +595,10 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 		fmt.Fprintf(stderr, "session reconciler: rolling back pending create %s: %s\n", name, detail) //nolint:errcheck
 		if trace != nil {
 			trace.recordDecision("reconciler.session.pending_create", templateName, name, action, "rollback", nil, nil, "")
+		}
+		if clearClaim {
+			rollbackPendingCreateClearingClaim(session, store, clk.Now().UTC(), stderr)
+			return
 		}
 		rollbackPendingCreate(session, store, clk.Now().UTC(), stderr)
 	}
@@ -629,6 +633,9 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if err != nil {
 				providerAlive = false
 			}
+			// Run this before configured named-session preservation. A stale
+			// state=creating bead with an expired pending-create lease would
+			// otherwise stay open and keep holding its alias forever.
 			if !storeQueryPartial && !providerAlive && shouldRollbackPendingCreate(session) {
 				var startupTimeout time.Duration
 				if cfg != nil {
@@ -644,7 +651,8 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 					if rateLimitHit || rateLimitErr != nil {
 						continue
 					}
-					attemptRollbackPendingCreate(session, template, name, "pending_create_lease_expired", "lease expired and no live runtime")
+					clearClaim := configuredNamedSessionBeadHasSpec(*session, cfg, cityName)
+					attemptRollbackPendingCreate(session, template, name, "pending_create_lease_expired", "lease expired and no live runtime", clearClaim)
 					continue
 				}
 			}
@@ -886,7 +894,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			}
 		}
 		if alive && shouldRollbackPendingCreate(session) && !runningSessionMatchesPendingCreate(session, name, sp) {
-			attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_rollback", "live runtime belongs to another session")
+			attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_rollback", "live runtime belongs to another session", false)
 			continue
 		}
 		// Desired-branch counterpart to pendingCreateSessionStillLeased: a
@@ -906,7 +914,7 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 				if rateLimitHit || rateLimitErr != nil {
 					continue
 				}
-				attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_lease_expired", "lease expired and no live runtime")
+				attemptRollbackPendingCreate(session, tp.TemplateName, name, "pending_create_lease_expired", "lease expired and no live runtime", false)
 				continue
 			}
 		}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -629,6 +629,25 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 			if err != nil {
 				providerAlive = false
 			}
+			if !storeQueryPartial && !providerAlive && shouldRollbackPendingCreate(session) {
+				var startupTimeout time.Duration
+				if cfg != nil {
+					startupTimeout = cfg.Session.StartupTimeoutDuration()
+				}
+				if pendingCreateLeaseExpiredForRollback(*session, clk, startupTimeout) {
+					template := normalizedSessionTemplate(*session, cfg)
+					if template == "" {
+						template = session.Metadata["template"]
+					}
+					peek := cachedSessionPeek(cityPath, store, sp, cfg, session.ID, nil)
+					rateLimitHit, rateLimitErr := checkRateLimitStability(session, cfg, providerAlive, dt, store, clk, peek)
+					if rateLimitHit || rateLimitErr != nil {
+						continue
+					}
+					attemptRollbackPendingCreate(session, template, name, "pending_create_lease_expired", "lease expired and no live runtime")
+					continue
+				}
+			}
 			preserveNamed := preserveConfiguredNamedSessionBead(*session, cfg, cityName)
 			var (
 				preservedTP  TemplateParams


### PR DESCRIPTION
## Summary

Configured named sessions can get stuck in a stale `pending_create` state after a failed or timed-out session creation. The reconciler's orphan-detection path handles generic sessions but does not cover named sessions whose pending-create lease has expired and whose runtime is dead.

This change adds rollback logic in the `!desired` orphan path for named sessions with expired pending-create leases, clearing `pending_create_claim` and `pending_create_started_at` so normal session lifecycle reconciliation can proceed.

Also fixes `rollbackPendingCreate` to clear the lease fields after closing the bead, preventing stale metadata from blocking subsequent create attempts.

## Testing

```sh
go test ./cmd/gc -run 'TestReconciler_RollsBackExpiredPendingCreateForConfiguredNamedSession' -v -count=1
```

Passes. `make check` passes.

## Checklist

- [x] Test added for behavior change (chaos harness test)
- [x] `make check` passes
- [x] Focused change — surgical fix in reconciler orphan path