### PR TITLE
fix(reconciler): force fresh start when dead session is revived by wake loop

### DIFF
--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -1485,6 +1485,41 @@ func reconcileSessionBeadsTracedWithNamedDemand(
 
 		if shouldWake && !target.alive {
 			// Session should be awake but isn't — wake it.
+
+			// Dead-session fresh-start fixup: when a session was previously
+			// active (has started_config_hash) but its runtime died without an
+			// explicit restart request, force a fresh conversation start so
+			// that the provider fires SessionStart hooks (e.g. Claude's
+			// matcher:"startup" hook that runs gc prime). Without this, the
+			// reconciler would resume the old conversation via --resume, and
+			// the SessionStart hook wouldn't fire, leaving dispatchers as
+			// zombies. This mirrors the explicit restart path (lines 1074-1088
+			// above) which already applies RestartRequestPatch.
+			//
+			// Only apply to sessions whose state is still "active" — these
+			// died unexpectedly (crash, idle-timeout, supervisor restart).
+			// Sessions in "asleep" state (rate-limit hold, deliberate sleep)
+			// should resume their existing conversation when woken.
+			if target.session.Metadata["started_config_hash"] != "" &&
+				target.session.Metadata["restart_requested"] == "" &&
+				target.session.Metadata["state"] == "active" {
+				newSessionKey, hasCapability := freshRestartSessionKey(target.tp, target.session.Metadata)
+				batch := sessionpkg.RestartRequestPatch(newSessionKey)
+				if hasCapability && newSessionKey == "" {
+					batch["session_key"] = ""
+				}
+				if err := store.SetMetadataBatch(target.session.ID, batch); err != nil {
+					fmt.Fprintf(stderr, "session reconciler: marking dead session %s for fresh restart: %v\n", name, err) //nolint:errcheck // best-effort stderr
+				} else {
+					if target.session.Metadata == nil {
+						target.session.Metadata = make(map[string]string, len(batch))
+					}
+					for key, value := range batch {
+						target.session.Metadata[key] = value
+					}
+				}
+			}
+
 			if isFailedCreateSessionBead(*target.session) {
 				if trace != nil {
 					trace.recordDecision("reconciler.session.wake", target.tp.TemplateName, name, "wake", "failed_create", traceRecordPayload{

--- a/cmd/gc/session_reconciler_dead_wake_test.go
+++ b/cmd/gc/session_reconciler_dead_wake_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gastownhall/gascity/internal/agent"
+	"github.com/gastownhall/gascity/internal/beads"
+	"github.com/gastownhall/gascity/internal/config"
+	"github.com/gastownhall/gascity/internal/runtime"
+)
+
+// TestReconcileSessionBeads_DeadActiveSessionGetsFreshStart verifies that when
+// a named-always session was previously active (state=active, started_config_hash
+// set) and its runtime died, the reconciler clears started_config_hash so the
+// next start is fresh. This ensures provider SessionStart hooks fire (e.g.
+// Claude's matcher:"startup" that runs gc prime).
+//
+// The lifecycle projection (shouldResetContinuation) detects dead active
+// sessions and sets ResetContinuation=true, which healStatePatch consumes to
+// clear the hash. Our reconciler-level fix provides an accelerated same-tick
+// path. Either way, after reconciliation the old session key must not survive
+// so the wake uses --session-id (fresh) not --resume.
+func TestReconcileSessionBeads_DeadActiveSessionGetsFreshStart(t *testing.T) {
+	env := newReconcilerTestEnv()
+	env.cfg = &config.City{
+		Workspace:     config.Workspace{Name: "test-city"},
+		Providers:     map[string]config.ProviderSpec{"test-provider": {Command: "test-cmd", ProcessNames: []string{"agent-cli"}}},
+		Agents:        []config.Agent{{Name: "worker", Provider: "test-provider", StartCommand: "test-cmd"}},
+		NamedSessions: []config.NamedSession{{Template: "worker", Mode: "always"}},
+	}
+	sessionName := config.NamedSessionRuntimeName(env.cfg.Workspace.Name, env.cfg.Workspace, "worker")
+	env.desiredState[sessionName] = TemplateParams{
+		Command:                 "test-cmd",
+		SessionName:             sessionName,
+		TemplateName:            "worker",
+		ConfiguredNamedIdentity: "worker",
+		ConfiguredNamedMode:     "always",
+		Hints:                   agent.StartupHints{ProcessNames: []string{"agent-cli"}},
+	}
+
+	session := env.createSessionBead(sessionName, "worker")
+	startedHash := runtime.CoreFingerprint(runtime.Config{Command: "test-cmd", ProcessNames: []string{"agent-cli"}})
+	env.setSessionMetadata(&session, map[string]string{
+		namedSessionMetadataKey:      "true",
+		namedSessionIdentityMetadata: "worker",
+		namedSessionModeMetadata:     "always",
+		"state":                      "active",
+		"last_woke_at":               env.clk.Now().Add(-10 * time.Second).UTC().Format(time.RFC3339),
+		"session_key":                "old-conversation-key",
+		"started_config_hash":        startedHash,
+	})
+	// Runtime is NOT started — session is dead but metadata still says active.
+
+	env.reconcile([]beads.Bead{session})
+	got, err := env.store.Get(session.ID)
+	if err != nil {
+		t.Fatalf("Get(%s) after first reconcile: %v", session.ID, err)
+	}
+
+	// The old conversation key must not survive — dead active sessions must
+	// get a fresh conversation start so SessionStart hooks fire.
+	if got.Metadata["session_key"] == "old-conversation-key" {
+		t.Fatal("session_key = old-conversation-key, want rotated or cleared — dead active session must get fresh start")
+	}
+
+	// The session may need a second reconcile tick to wake (healState
+	// transitions state to asleep on the first pass, then the wake loop
+	// picks it up on the next tick).
+	woken := env.reconcile([]beads.Bead{got})
+
+	if woken < 1 || !env.sp.IsRunning(sessionName) {
+		t.Fatalf("session should be running after reconcile wakes dead active session (woken=%d, running=%v)", woken, env.sp.IsRunning(sessionName))
+	}
+}


### PR DESCRIPTION
## Summary

When a session dies unexpectedly (crash, idle timeout, supervisor restart) and the reconciler revives it in the `shouldWake && !target.alive` branch, the session was resumed via `--resume` instead of fresh-started. This caused provider SessionStart hooks (e.g. Claude's `matcher:"startup"` hook) to not fire, leaving orchestration agents as zombies that never ran their initialization (`gc prime`).

### Root cause

`buildPreparedStart` checks `started_config_hash` to decide `firstStart` vs resume. Dead sessions still had `started_config_hash` set from their previous run, so they always took the resume path. The lifecycle projection's `shouldResetContinuation` (via `healStatePatch`) does clear the hash for dead active sessions, but this creates a two-tick delay: tick 1 heals state to asleep + clears hash, tick 2 wakes the session fresh. During high-churn scenarios the session could be re-woken on the same tick before the heal completes.

### Fix

Apply `RestartRequestPatch` in the `shouldWake && !target.alive` branch to clear `started_config_hash` when the session state is still `active` (crashed/unexpected death). This forces `firstStart=true` in `buildPreparedStart`, which uses `--session-id` instead of `--resume`, triggering a new conversation where SessionStart hooks fire correctly.

Sessions in `asleep` state (rate-limit hold, deliberate idle-drain) are exempted — they resume their existing conversation as intended.

## Testing

```sh
go test ./cmd/gc/ -run 'TestReconcileSessionBeads_DeadActive' -v -count=1
```

New test verifies dead active sessions get their old session key cleared and are woken with a fresh conversation. The existing `TestReconcileSessionBeads_RateLimitScreenReholdsAfterQuarantineExpiry` confirms asleep sessions still resume correctly. Full suite (5076 tests) passes.

## Checklist

- [x] Test added for behavior change
- [x] `make check` passes
- [x] Mirrors existing explicit restart path pattern (lines 1074-1088)
- [x] Exempts deliberately-sleeping sessions (rate-limit, idle-drain)