### PR TITLE
fix(maintenance): retry mol-dog-jsonl push on concurrent ref-update race

### DIFF
--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -5993,6 +5993,7 @@ func TestJsonlExportPushFailureWritesLastPushStderr(t *testing.T) {
 	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
 	archiveRepo := filepath.Join(cityDir, "archive")
 	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	pushLog := filepath.Join(t.TempDir(), "git-push.log")
 
 	// Must have an origin remote — auto-detect mode skips push (and therefore
 	// the failure path) when origin is unset. An unreachable remote triggers
@@ -6000,10 +6001,29 @@ func TestJsonlExportPushFailureWritesLastPushStderr(t *testing.T) {
 	initSeedArchiveWithUnreachableRemote(t, archiveRepo)
 	writeMultiRecordDoltStub(t, binDir, 5)
 	writeJsonlExportGCStub(t, binDir)
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git): %v", err)
+	}
+	writeGitPushAttemptStub(t, binDir, realGit, "pass-through", pushLog)
 
 	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
 
-	runScript(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh should report push failure in summary without exiting non-zero: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "pushing archive main failed after 3 attempts") {
+		t.Fatalf("expected terminal retry message, got:\n%s", out)
+	}
+
+	pushData, err := os.ReadFile(pushLog)
+	if err != nil {
+		t.Fatalf("ReadFile(push log): %v", err)
+	}
+	if got := strings.Count(string(pushData), "\n"); got != 3 {
+		t.Fatalf("unreachable remote should be retried exactly 3 times, got %d:\n%s", got, pushData)
+	}
 
 	stateData, err := os.ReadFile(stateFile)
 	if err != nil {

--- a/examples/gastown/maintenance_scripts_test.go
+++ b/examples/gastown/maintenance_scripts_test.go
@@ -4352,21 +4352,23 @@ func mergeTestEnv(overrides map[string]string) []string {
 func jsonlExportEnv(t *testing.T, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog string) map[string]string {
 	t.Helper()
 	return map[string]string{
-		"GC_CALL_LOG":                gcLog,
-		"GC_MAIL_LOG":                mailLog,
-		"GC_CITY":                    cityDir,
-		"GC_CITY_PATH":               cityDir,
-		"GC_PACK_STATE_DIR":          stateDir,
-		"GC_DOLT_HOST":               "127.0.0.1",
-		"GC_DOLT_PORT":               "3307",
-		"GC_DOLT_USER":               "root",
-		"GC_DOLT_PASSWORD":           "",
-		"GC_JSONL_ARCHIVE_REPO":      archiveRepo,
-		"GC_JSONL_MAX_PUSH_FAILURES": "99",
-		"GC_JSONL_SCRUB":             "false",
-		"GIT_CONFIG_GLOBAL":          filepath.Join(t.TempDir(), "gitconfig"),
-		"GIT_CONFIG_NOSYSTEM":        "1",
-		"PATH":                       binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GC_CALL_LOG":                    gcLog,
+		"GC_MAIL_LOG":                    mailLog,
+		"GC_CITY":                        cityDir,
+		"GC_CITY_PATH":                   cityDir,
+		"GC_PACK_STATE_DIR":              stateDir,
+		"GC_DOLT_HOST":                   "127.0.0.1",
+		"GC_DOLT_PORT":                   "3307",
+		"GC_DOLT_USER":                   "root",
+		"GC_DOLT_PASSWORD":               "",
+		"GC_JSONL_ARCHIVE_REPO":          archiveRepo,
+		"GC_JSONL_MAX_PUSH_FAILURES":     "99",
+		"GC_JSONL_PUSH_RETRY_DELAY_MIN":  "0",
+		"GC_JSONL_PUSH_RETRY_DELAY_SPAN": "0",
+		"GC_JSONL_SCRUB":                 "false",
+		"GIT_CONFIG_GLOBAL":              filepath.Join(t.TempDir(), "gitconfig"),
+		"GIT_CONFIG_NOSYSTEM":            "1",
+		"PATH":                           binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 	}
 }
 
@@ -4544,6 +4546,46 @@ for arg in "$@"; do
 done
 exec '%s' "$@"
 `, subcommand, subcommand, realGit))
+}
+
+func writeGitPushAttemptStub(t *testing.T, binDir, realGit, mode, logFile string) {
+	t.Helper()
+	countFile := filepath.Join(t.TempDir(), "push-count")
+	writeExecutable(t, filepath.Join(binDir, "git"), fmt.Sprintf(`#!/bin/sh
+count_file=%s
+log_file=%s
+mode=%s
+real_git=%s
+for arg in "$@"; do
+    if [ "$arg" = "push" ]; then
+        count=0
+        if [ -f "$count_file" ]; then
+            count="$(cat "$count_file")"
+        fi
+        count=$((count + 1))
+        printf '%%s\n' "$count" > "$count_file"
+        printf '%%s\n' "$count" >> "$log_file"
+        if [ "$mode" = "fail-first" ] && [ "$count" -eq 1 ]; then
+            echo "simulated git push failure on attempt $count" >&2
+            exit 1
+        fi
+        if [ "$mode" = "always-fail" ]; then
+            echo "simulated git push failure on attempt $count" >&2
+            exit 1
+        fi
+        break
+    fi
+done
+exec "$real_git" "$@"
+`, strconv.Quote(countFile), strconv.Quote(logFile), strconv.Quote(mode), strconv.Quote(realGit)))
+}
+
+func writeSleepLogStub(t *testing.T, binDir, logFile string) {
+	t.Helper()
+	writeExecutable(t, filepath.Join(binDir, "sleep"), fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %s
+exit 0
+`, strconv.Quote(logFile)))
 }
 
 func initSeedArchiveWithoutLocalIdentity(t *testing.T, archiveRepo string, prevCount int) string {
@@ -5977,6 +6019,163 @@ func TestJsonlExportPushFailureWritesLastPushStderr(t *testing.T) {
 	stderrVal, ok := state["last_push_stderr"].(string)
 	if !ok || stderrVal == "" {
 		t.Fatalf("last_push_stderr missing from state after push failure:\n%s", stateData)
+	}
+}
+
+func TestJsonlExportPushRetriesAndRecordsSuccessAfterTransientFailure(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	pushLog := filepath.Join(t.TempDir(), "git-push.log")
+	sleepLog := filepath.Join(t.TempDir(), "sleep.log")
+
+	remoteRepo, priorHead := initSeedArchiveWithRemote(t, archiveRepo)
+	writeMultiRecordDoltStub(t, binDir, 100)
+	writeJsonlExportGCStub(t, binDir)
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git): %v", err)
+	}
+	writeGitPushAttemptStub(t, binDir, realGit, "fail-first", pushLog)
+	writeSleepLogStub(t, binDir, sleepLog)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["GC_JSONL_PUSH_RETRY_DELAY_MIN"] = "0"
+	env["GC_JSONL_PUSH_RETRY_DELAY_SPAN"] = "0"
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "push succeeded on retry attempt 2") {
+		t.Fatalf("expected successful retry to be operator-visible, got:\n%s", out)
+	}
+
+	pushData, err := os.ReadFile(pushLog)
+	if err != nil {
+		t.Fatalf("ReadFile(push log): %v", err)
+	}
+	if got := strings.Count(string(pushData), "\n"); got != 2 {
+		t.Fatalf("expected exactly 2 push attempts, got %d:\n%s", got, pushData)
+	}
+	sleepData, err := os.ReadFile(sleepLog)
+	if err != nil {
+		t.Fatalf("ReadFile(sleep log): %v", err)
+	}
+	if got := strings.TrimSpace(string(sleepData)); got != "0.00" {
+		t.Fatalf("retry delay override must produce one zero-second sleep, got %q", got)
+	}
+
+	remoteHeadOut, err := exec.Command("git", "--git-dir", remoteRepo, "rev-parse", "refs/heads/main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse remote main: %v\n%s", err, remoteHeadOut)
+	}
+	if got := strings.TrimSpace(string(remoteHeadOut)); got == priorHead {
+		t.Fatalf("expected retry success to advance remote main from %s", priorHead)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["consecutive_push_failures"]; got != float64(0) {
+		t.Fatalf("consecutive_push_failures = %v, want 0\nstate: %s", got, stateData)
+	}
+	if got := state["pending_archive_push"]; got == true {
+		t.Fatalf("pending_archive_push should clear after retry success\nstate: %s", stateData)
+	}
+	if _, ok := state["last_push_at"].(string); !ok {
+		t.Fatalf("last_push_at should be set after retry success:\n%s", stateData)
+	}
+	if _, has := state["last_push_stderr"]; has {
+		t.Fatalf("last_push_stderr should clear after retry success:\n%s", stateData)
+	}
+}
+
+func TestJsonlExportPushRetriesThreeTimesBeforeRecordingFailure(t *testing.T) {
+	cityDir := t.TempDir()
+	binDir := t.TempDir()
+	stateDir := t.TempDir()
+	gcLog := filepath.Join(t.TempDir(), "gc.log")
+	mailLog := filepath.Join(t.TempDir(), "gc-mail.log")
+	archiveRepo := filepath.Join(cityDir, "archive")
+	stateFile := filepath.Join(stateDir, "jsonl-export-state.json")
+	pushLog := filepath.Join(t.TempDir(), "git-push.log")
+	sleepLog := filepath.Join(t.TempDir(), "sleep.log")
+
+	remoteRepo, priorHead := initSeedArchiveWithRemote(t, archiveRepo)
+	writeMultiRecordDoltStub(t, binDir, 100)
+	writeJsonlExportGCStub(t, binDir)
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git): %v", err)
+	}
+	writeGitPushAttemptStub(t, binDir, realGit, "always-fail", pushLog)
+	writeSleepLogStub(t, binDir, sleepLog)
+
+	env := jsonlExportEnv(t, cityDir, binDir, stateDir, archiveRepo, gcLog, mailLog)
+	env["GC_JSONL_PUSH_RETRY_DELAY_MIN"] = "0"
+	env["GC_JSONL_PUSH_RETRY_DELAY_SPAN"] = "0"
+
+	out, err := runScriptResult(t, filepath.Join(exampleDir(), "packs", "maintenance", "assets", "scripts", "jsonl-export.sh"), env)
+	if err != nil {
+		t.Fatalf("jsonl-export.sh should report push failure in summary without exiting non-zero: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "pushing archive main failed after 3 attempts") {
+		t.Fatalf("expected terminal retry message, got:\n%s", out)
+	}
+
+	pushData, err := os.ReadFile(pushLog)
+	if err != nil {
+		t.Fatalf("ReadFile(push log): %v", err)
+	}
+	if got := strings.Count(string(pushData), "\n"); got != 3 {
+		t.Fatalf("expected exactly 3 push attempts, got %d:\n%s", got, pushData)
+	}
+	sleepData, err := os.ReadFile(sleepLog)
+	if err != nil {
+		t.Fatalf("ReadFile(sleep log): %v", err)
+	}
+	if got := strings.TrimSpace(string(sleepData)); got != "0.00\n0.00" {
+		t.Fatalf("retry delay override must produce two zero-second sleeps, got %q", got)
+	}
+
+	remoteHeadOut, err := exec.Command("git", "--git-dir", remoteRepo, "rev-parse", "refs/heads/main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse remote main: %v\n%s", err, remoteHeadOut)
+	}
+	if got := strings.TrimSpace(string(remoteHeadOut)); got != priorHead {
+		t.Fatalf("terminal push failure must leave remote unchanged: got %s want %s", got, priorHead)
+	}
+
+	stateData, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("ReadFile(state file): %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		t.Fatalf("Unmarshal(state file): %v\n%s", err, stateData)
+	}
+	if got := state["consecutive_push_failures"]; got != float64(1) {
+		t.Fatalf("consecutive_push_failures = %v, want 1\nstate: %s", got, stateData)
+	}
+	if got := state["pending_archive_push"]; got != true {
+		t.Fatalf("pending_archive_push = %v, want true\nstate: %s", got, stateData)
+	}
+	stderrVal, ok := state["last_push_stderr"].(string)
+	if !ok || !strings.Contains(stderrVal, "simulated git push failure on attempt 3") {
+		t.Fatalf("last_push_stderr should capture final push failure, got %q\nstate: %s", stderrVal, stateData)
+	}
+	if _, has := state["last_push_at"]; has {
+		t.Fatalf("last_push_at should not be set after terminal push failure:\n%s", stateData)
 	}
 }
 

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -29,6 +29,8 @@ SPIKE_THRESHOLD="${GC_JSONL_SPIKE_THRESHOLD:-20}"  # percentage (0-100)
 # this absolute floor — small-N percentages are noise. Set to 0 to disable.
 MIN_PREV_FOR_SPIKE_CHECK="${GC_JSONL_MIN_PREV_FOR_SPIKE:-10}"
 MAX_PUSH_FAILURES="${GC_JSONL_MAX_PUSH_FAILURES:-3}"
+PUSH_RETRY_DELAY_MIN="${GC_JSONL_PUSH_RETRY_DELAY_MIN:-1}"
+PUSH_RETRY_DELAY_SPAN="${GC_JSONL_PUSH_RETRY_DELAY_SPAN:-4}"
 SCRUB="${GC_JSONL_SCRUB:-true}"
 ARCHIVE_REPO="${GC_JSONL_ARCHIVE_REPO:-$PACK_STATE_DIR/jsonl-archive}"
 
@@ -39,6 +41,11 @@ ARCHIVE_REPO="${GC_JSONL_ARCHIVE_REPO:-$PACK_STATE_DIR/jsonl-archive}"
 # instead of being silently scored as zero rows.
 count_jsonl_rows() {
     jq -s -r 'if length == 0 then 0 else ((.[0].rows // []) | length) end' || echo "0"
+}
+
+push_retry_delay_seconds() {
+    awk -v seed="$RANDOM$$" -v min="$PUSH_RETRY_DELAY_MIN" -v span="$PUSH_RETRY_DELAY_SPAN" \
+        'BEGIN{srand(seed); printf "%.2f", min + rand() * span}'
 }
 
 # Scrub test-only rows and ephemeral system rows while preserving the JSON
@@ -574,17 +581,21 @@ ESCALATION
     # Retry-with-backoff for transient push failures. Concurrent rigs pushing
     # to the same local bare archive can race on the ref-update lock or produce
     # non-fast-forward (a sibling rig commits between our fetch and our push).
-    # Retry up to 3 times with 1-5s jitter; re-fetch and rebase before each
-    # retry to absorb any new commits.
+    # Retry up to 3 times with jitter; re-fetch and rebase before each retry to
+    # absorb any new commits. Delay bounds default to 1-5s and are overridden
+    # in tests to keep failure-path coverage fast.
     push_succeeded=false
     for push_attempt in 1 2 3; do
         if push_err=$(git push origin main -q 2>&1 >/dev/null); then
             push_succeeded=true
+            if [ "$push_attempt" -gt 1 ]; then
+                echo "jsonl-export: push succeeded on retry attempt $push_attempt" >&2
+            fi
             break
         fi
 
         if [ "$push_attempt" -lt 3 ]; then
-            sleep "$(awk 'BEGIN{srand(); printf "%.2f", 1 + rand() * 4}')"
+            sleep "$(push_retry_delay_seconds)"
 
             # Refresh origin tracking before retry — a sibling rig may have
             # moved the ref while we slept.

--- a/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
+++ b/examples/gastown/packs/maintenance/assets/scripts/jsonl-export.sh
@@ -474,6 +474,8 @@ push_archive_main() {
     local fetch_err
     local rebase_err
     local push_err
+    local push_attempt
+    local push_succeeded
 
     # Retain only the last ~20 lines of stderr so an extremely chatty failure
     # doesn't drown the escalation body.
@@ -569,9 +571,43 @@ ESCALATION
         fi
     fi
 
-    if ! push_err=$(git push origin main -q 2>&1 >/dev/null); then
+    # Retry-with-backoff for transient push failures. Concurrent rigs pushing
+    # to the same local bare archive can race on the ref-update lock or produce
+    # non-fast-forward (a sibling rig commits between our fetch and our push).
+    # Retry up to 3 times with 1-5s jitter; re-fetch and rebase before each
+    # retry to absorb any new commits.
+    push_succeeded=false
+    for push_attempt in 1 2 3; do
+        if push_err=$(git push origin main -q 2>&1 >/dev/null); then
+            push_succeeded=true
+            break
+        fi
+
+        if [ "$push_attempt" -lt 3 ]; then
+            sleep "$(awk 'BEGIN{srand(); printf "%.2f", 1 + rand() * 4}')"
+
+            # Refresh origin tracking before retry — a sibling rig may have
+            # moved the ref while we slept.
+            if fetch_err=$(git fetch origin main -q 2>&1 >/dev/null); then
+                if git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1 \
+                    && ! git merge-base --is-ancestor refs/remotes/origin/main HEAD >/dev/null 2>&1; then
+                    if ! rebase_err=$(git rebase refs/remotes/origin/main 2>&1 >/dev/null); then
+                        git rebase --abort >/dev/null 2>&1 || true
+                        record_archive_push_failure \
+                            "jsonl-export: rebase onto origin/main failed during retry $push_attempt" \
+                            "$rebase_err"
+                        return 1
+                    fi
+                fi
+            fi
+            # If fetch failed, fall through and retry the push anyway —
+            # origin may just be momentarily unavailable.
+        fi
+    done
+
+    if [ "$push_succeeded" != "true" ]; then
         record_archive_push_failure \
-            "jsonl-export: pushing archive main failed" \
+            "jsonl-export: pushing archive main failed after 3 attempts" \
             "$push_err"
         return 1
     fi


### PR DESCRIPTION
## Summary

- Add retry-with-backoff (3 attempts, 1-5s jitter) to `push_archive_main()` in `jsonl-export.sh`
- Re-fetch + re-rebase before each retry to absorb commits from sibling rigs
- Preserves existing `consecutive_push_failures` / `MAX_PUSH_FAILURES` escalation semantic — one *cycle* still counts as one failure, not three

## Background

`mol-dog-jsonl` runs in parallel across all rigs in a city (HQ + co_store + co_shipping + co_auth + hello-world). All rigs push to the same local bare repo `.gc/jsonl-archive.git`. When two or more rigs land in the push step within ~1 second of each other, the second/third push gets `cannot lock ref 'refs/heads/main'` (atomic ref-update collision) or `non-fast-forward` (sibling moved `origin/main` between our fetch and our push), and exits 1.

Local evidence from a 5-rig city (`mc-w9iua4`):

```
12:35:08  commit 638d000 records=21735   (sibling push succeeded)
12:35:26  commit dc96cf6 records=21738   (sibling push succeeded — same second as failure)
12:35:26  order.failed mol-dog-jsonl:rig:hello-world (exit status 1)
```

```
06:57:45  commit bc6603b records=24087
06:58:56  order.failed mol-dog-jsonl:rig:co_shipping  (exit status 1)
06:59:01  commit a97eb0e records=24104   (sibling A succeeded 5s later)
06:59:02  commit 191e3fb records=24099   (sibling B succeeded 1s after A)
```

The existing `push_archive_main()` already handles non-fast-forward proactively by rebasing onto `origin/main` before the push. But the race between rebase and push is unhandled — and that's where the failures land. This patch adds a retry loop around the push itself.

Rate is low (~1-2 failures per day per 5-rig city) and self-healing (next cycle catches up the archive), so the failure mode is annoying rather than damaging. But every failure triggers `set_pending_archive_push` + `consecutive_push_failures++`, and three consecutive failures escalate to the mayor — so a string of unlucky races could noisily false-alarm.

## Why these defaults

- **3 attempts:** matches the existing `MAX_PUSH_FAILURES=3` escalation threshold. If 3 retries can't get a push through, the contention is real (or origin is genuinely down) and the existing escalation should fire.
- **1-5s jitter:** the race window is sub-second; 1-5s gaps reliably break tied attempts. Jitter via `awk rand()` avoids 5 rigs synchronizing on `sleep 1`.
- **Re-fetch + re-rebase between retries:** if the original failure was non-fast-forward (a sibling pushed first), the second attempt has to be on top of the new tip. Without re-rebase, retry #2 would fail the same way.

## Test plan

- [x] `go test ./examples/gastown/... -run "Jsonl|PushArchive|PushFailure"` — passes (104s)
- [x] `go vet ./...` — clean
- [ ] `make check` — running
- [ ] 24h soak in the originating city (Day-25 reads result) — expected: zero `mol-dog-jsonl exit 1` events in `events.jsonl` over the soak window

## Out of scope

- **No new unit test for the retry loop itself.** Existing tests in `maintenance_scripts_test.go` already exercise the push path (`initSeedArchiveWithUnreachableRemote`, `advanceArchiveRemoteMain`). A new test that races two concurrent pushes against a local bare repo is plausible but complex — happy to add it if reviewers prefer; otherwise the 24h soak is the canonical validator.
- **No change to escalation semantic.** `consecutive_push_failures` still counts one increment per failed *cycle*, not per failed attempt.

Filed downstream in the originating city as `mc-w9iua4` (P3 BUG). See that bead for the full evidence chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
