### PR TITLE
fix(beads): skip cached no-op updates

### DIFF
--- a/internal/beads/caching_store_writes.go
+++ b/internal/beads/caching_store_writes.go
@@ -35,6 +35,9 @@ func (c *CachingStore) Create(b Bead) (Bead, error) {
 
 // Update passes through to the backing store and refreshes the cache.
 func (c *CachingStore) Update(id string, opts UpdateOpts) error {
+	if c.updateAlreadyMatchesCached(id, opts) {
+		return nil
+	}
 	if err := c.backing.Update(id, opts); err != nil {
 		return err
 	}
@@ -62,6 +65,24 @@ func (c *CachingStore) Update(id string, opts UpdateOpts) error {
 
 	c.notifyChange("bead.updated", fresh)
 	return nil
+}
+
+// updateAlreadyMatchesCached returns true when the cache holds a primed copy of
+// the bead and applying opts would leave every cached bead field unchanged.
+// Cache misses fall through because they cannot prove the backing write is a
+// no-op.
+func (c *CachingStore) updateAlreadyMatchesCached(id string, opts UpdateOpts) bool {
+	if id == "" {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	b, ok := c.beads[id]
+	if !ok {
+		return false
+	}
+	updated := applyUpdateOptsToBead(cloneBead(b), opts)
+	return !beadChanged(b, updated)
 }
 
 // Close marks a bead as closed in the backing store and cache.

--- a/internal/beads/caching_store_writes_internal_test.go
+++ b/internal/beads/caching_store_writes_internal_test.go
@@ -2,16 +2,22 @@ package beads
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
-// countingBackingStore wraps a Store and counts SetMetadata /
-// SetMetadataBatch invocations so tests can assert when CachingStore
-// short-circuits a no-op write before the backing call.
+// countingBackingStore wraps a Store and counts write invocations so tests can
+// assert when CachingStore short-circuits a no-op write before the backing call.
 type countingBackingStore struct {
 	Store
+	updateCalls           int
 	setMetadataCalls      int
 	setMetadataBatchCalls int
+}
+
+func (c *countingBackingStore) Update(id string, opts UpdateOpts) error {
+	c.updateCalls++
+	return c.Store.Update(id, opts)
 }
 
 func (c *countingBackingStore) SetMetadata(id, key, value string) error {
@@ -22,6 +28,97 @@ func (c *countingBackingStore) SetMetadata(id, key, value string) error {
 func (c *countingBackingStore) SetMetadataBatch(id string, kvs map[string]string) error {
 	c.setMetadataBatchCalls++
 	return c.Store.SetMetadataBatch(id, kvs)
+}
+
+func testStringPtr(s string) *string { return &s }
+
+func testIntPtr(i int) *int { return &i }
+
+// TestCachingStoreUpdateSkipsBackingAndNotificationWhenCachedBeadMatches
+// verifies that Update short-circuits before the backing write and cache
+// notification when applying opts would leave the cached bead unchanged.
+func TestCachingStoreUpdateSkipsBackingAndNotificationWhenCachedBeadMatches(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	priority := 2
+	bead, err := backing.Create(Bead{
+		Title:       "identity",
+		Type:        "session",
+		Priority:    &priority,
+		Description: "already current",
+		Assignee:    "agent/one",
+		ParentID:    "gc-parent",
+		Labels:      []string{"gc:session", "agent:one"},
+		Metadata:    map[string]string{"heartbeat": "123", "state": "ready"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var notifications []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		notifications = append(notifications, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.updateCalls = 0
+
+	if err := cache.Update(bead.ID, UpdateOpts{
+		Title:        testStringPtr("identity"),
+		Status:       testStringPtr("open"),
+		Type:         testStringPtr("session"),
+		Priority:     testIntPtr(2),
+		Description:  testStringPtr("already current"),
+		ParentID:     testStringPtr("gc-parent"),
+		Assignee:     testStringPtr("agent/one"),
+		Labels:       []string{"gc:session"},
+		RemoveLabels: []string{"missing"},
+		Metadata:     map[string]string{"heartbeat": "123"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if backing.updateCalls != 0 {
+		t.Errorf("backing.Update called %d times; want 0 (identity update must short-circuit)",
+			backing.updateCalls)
+	}
+	if len(notifications) != 0 {
+		t.Errorf("notifications = %v; want none for no-op Update", notifications)
+	}
+}
+
+// TestCachingStoreUpdateFallsThroughOnCachedMismatch verifies that a real field
+// change still propagates to the backing store and emits bead.updated.
+func TestCachingStoreUpdateFallsThroughOnCachedMismatch(t *testing.T) {
+	t.Parallel()
+
+	backing := &countingBackingStore{Store: NewMemStore()}
+	bead, err := backing.Create(Bead{Title: "before"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var notifications []string
+	cache := NewCachingStoreForTest(backing, func(eventType, beadID string, _ json.RawMessage) {
+		notifications = append(notifications, eventType+":"+beadID)
+	})
+	if err := cache.Prime(context.Background()); err != nil {
+		t.Fatalf("Prime: %v", err)
+	}
+	backing.updateCalls = 0
+
+	if err := cache.Update(bead.ID, UpdateOpts{Title: testStringPtr("after")}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if backing.updateCalls != 1 {
+		t.Errorf("backing.Update called %d times; want 1 (real change must propagate)",
+			backing.updateCalls)
+	}
+	want := "bead.updated:" + bead.ID
+	if len(notifications) != 1 || notifications[0] != want {
+		t.Errorf("notifications = %v; want [%s]", notifications, want)
+	}
 }
 
 // TestCachingStoreSetMetadataSkipsBackingWhenCachedValueMatches verifies that


### PR DESCRIPTION
## Summary
- skip CachingStore.Update backing writes when cached state already matches requested UpdateOpts
- avoid emitting bead.updated notifications for identity updates
- add tests covering both no-op Update suppression and real Update propagation

## Root cause
CachingStore.Update always called backing.Update, so bd on_update hooks emitted bead.updated and woke controllers even when the requested fields were identical to the cached bead.

## Validation
- go test ./internal/beads -run 'TestCachingStoreUpdate(SkipsBackingAndNotificationWhenCachedBeadMatches|FallsThroughOnCachedMismatch)' -count=1
- go test ./internal/beads -run 'TestCachingStoreSetMetadata|TestCachingStoreUpdate' -count=1
- go test ./internal/beads -count=1
- go vet ./...
- make test-fast-parallel
- pre-commit hook: make vet and make test