### PR TITLE
test(cmd/gc): isolate cwd from ambient .beads/redirect in bd-scope tests (ga-q42)

### DIFF
--- a/cmd/gc/cmd_bd_test.go
+++ b/cmd/gc/cmd_bd_test.go
@@ -141,6 +141,13 @@ func TestExtractBdScopeFlags(t *testing.T) {
 }
 
 func TestResolveBdScopeTarget(t *testing.T) {
+	// Isolate cwd from any ambient `.beads/redirect` in the working tree
+	// (e.g. when `make test` runs from a polecat/crew worktree, the worktree's
+	// redirect resolves to a path outside the synthetic rig config below and
+	// `rigFromRedirectedBeadsDir` rejects it). t.TempDir's ancestry is /tmp,
+	// which is guaranteed to be free of city redirects.
+	setCwd(t, t.TempDir())
+
 	origProbe := bdBeadExists
 	defer func() { bdBeadExists = origProbe }()
 	bdBeadExists = func(_ string, _ execStoreTarget, beadID string) bool {
@@ -568,6 +575,9 @@ func TestGcBdSuppressesBdAutoExportInChildEnv(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	// See TestResolveBdScopeTarget for rationale: isolate cwd so any
+	// `.beads/redirect` in the ambient working tree doesn't surface here.
+	setCwd(t, cityDir)
 	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"), []byte(`[workspace]
 name = "demo"
 `), 0o644); err != nil {
@@ -700,6 +710,9 @@ prefix = "repo"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// See TestResolveBdScopeTarget for rationale: isolate cwd so any
+	// `.beads/redirect` in the ambient working tree doesn't surface here.
+	setCwd(t, cityDir)
 
 	binDir := t.TempDir()
 	capture := filepath.Join(t.TempDir(), "gc-bd-city-env.txt")
@@ -780,6 +793,9 @@ name = "demo"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// See TestResolveBdScopeTarget for rationale: isolate cwd so any
+	// `.beads/redirect` in the ambient working tree doesn't surface here.
+	setCwd(t, cityDir)
 	t.Setenv("GC_CITY_PATH", cityDir)
 	t.Setenv("GC_BEADS", "file")
 	// Clear any inherited scope pin so the GC_BEADS override applies to
@@ -816,6 +832,9 @@ provider = "file"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// See TestResolveBdScopeTarget for rationale: isolate cwd so any
+	// `.beads/redirect` in the ambient working tree doesn't surface here.
+	setCwd(t, cityDir)
 	t.Setenv("GC_CITY_PATH", cityDir)
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
## Summary

Resolves the redirect-test cluster called out in bead `ga-q42`. When `make test` runs from a polecat or crew worktree, the worktree's own `.beads/redirect` (typically `../../.beads`) sits in the ancestry of the test process's cwd. `resolveBdScopeTarget` → `bdRigFromCwd` → `rigFromRedirectedBeadsDir` walks up from cwd, finds the redirect, follows it to a path outside the test's *synthetic* rig config, and rejects with `cwd redirect <path> points outside declared city rigs` — a misleading-looking foreign-redirect error in tests that don't intend to exercise the redirect logic at all.

The bead's hypothesis was correct: the failing tests don't isolate cwd from the polecat-worktree layout.

## Reproducer (before fix)

```
$ go test ./cmd/gc/ -run TestResolveBdScopeTarget -count=1 -v
--- FAIL: TestResolveBdScopeTarget/no_rig_falls_back_to_city
    cmd_bd_test.go:236: resolveBdScopeTarget() error =
        cwd redirect /home/rome/gt/gascity/crew/marlowe/.beads/redirect
        points outside declared city rigs
```

## Fix

Add `setCwd(t, <isolated-dir>)` to each affected test:

- `TestResolveBdScopeTarget` — chdir to a fresh `t.TempDir()` (ancestry is `/tmp`, no `.beads/redirect`).
- `TestGcBdSuppressesBdAutoExportForJsonShowAndUpdate`
- `TestGcBdDoesNotAutoRouteHyphenatedFlagValue`
- `TestGcBdRejectsGCBeadsFileOverride`
- `TestGcBdRejectsNonBdProvider`

The four `TestGcBd*` tests chdir to their own `cityDir` (already a fresh tempdir), which is a more natural fit for tests that simulate \"run \`gc bd\` inside a city.\"

Existing redirect-specific tests (`TestResolveBdScopeTargetUsesRedirectedWorktreeRig`, `TestResolveBdScopeTargetErrorsOnForeignRedirect`) already call `setCwd` and continue to pass — they exercise the production logic deliberately and are unaffected.

## Test plan

- [x] Before: 6 subtests fail with the foreign-redirect message
- [x] After: all 12 tests in the affected file's redirect surface pass (`TestResolveBdScopeTarget` × 6, `TestResolveBdScopeTargetUsesRedirectedWorktreeRig`, `TestResolveBdScopeTargetErrorsOnForeignRedirect`, `TestGcBdSuppressesBdAutoExportForJsonShowAndUpdate`, `TestGcBdDoesNotAutoRouteHyphenatedFlagValue`, `TestGcBdRejectsGCBeadsFileOverride`, `TestGcBdRejectsNonBdProvider`)
- [x] `go vet ./cmd/gc/` clean, `gofumpt -l` clean
- [ ] CI runs the full gates

## Scope note

This closes the *redirect cluster* in `ga-q42`. The remaining `ga-q42` items (env-sensitive flakes in `internal/mail/exec` etc.) are unrelated root causes and need separate per-flake PRs.

## Note on hooks

Committed with \`--no-verify\` per the workaround documented in \`ga-q42\` (other pre-existing flakes still block \`make test\`). The redirect cluster this PR fixes was one of the things blocking the hook — once this lands the other flakes need to be picked off one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)