### PR TITLE
fix: preserve ralph retry fanouts

### DIFF
--- a/internal/dispatch/control.go
+++ b/internal/dispatch/control.go
@@ -569,6 +569,9 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 		"gc.step_id":  stepID,
 		"gc.step_ref": attemptPrefix,
 	}
+	if step.OnComplete != nil {
+		rootMeta["gc.output_json_required"] = "true"
+	}
 	// Ralph iterations need scope metadata for grouping.
 	if rootKind == "scope" {
 		rootMeta["gc.scope_role"] = "body"
@@ -592,6 +595,8 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 		Name:  attemptPrefix,
 		Steps: []formula.RecipeStep{rootStep},
 	}
+	var fanoutSteps []formula.RecipeStep
+	var fanoutDeps []formula.RecipeDep
 
 	// For steps with children (scoped ralph), add children as sub-steps.
 	// Children may have retry/ralph config — propagate their metadata
@@ -627,6 +632,9 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 				if _, exists := childMeta[k]; !exists {
 					childMeta[k] = v
 				}
+			}
+			if child.OnComplete != nil {
+				childMeta["gc.output_json_required"] = "true"
 			}
 			// Derive gc.kind and control metadata from retry/ralph config.
 			if child.Retry != nil {
@@ -673,6 +681,10 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 				childStep.Type = "task"
 			}
 			recipe.Steps = append(recipe.Steps, childStep)
+			if fanoutStep, fanoutDep, ok := buildAttemptRecipeFanoutControl(childStep, child.OnComplete); ok {
+				fanoutSteps = append(fanoutSteps, fanoutStep)
+				fanoutDeps = append(fanoutDeps, fanoutDep)
+			}
 			// No parent-child dep to the iteration scope — it creates a
 			// deadlock (scope waits for children, children wait for scope).
 			// Children are associated with the iteration via gc.scope_ref
@@ -691,8 +703,52 @@ func buildAttemptRecipe(step *formula.Step, control beads.Bead, attemptNum int) 
 	}
 
 	applyAttemptRecipeScopeChecks(recipe)
+	recipe.Steps = append(recipe.Steps, fanoutSteps...)
+	recipe.Deps = append(recipe.Deps, fanoutDeps...)
 
 	return recipe
+}
+
+func buildAttemptRecipeFanoutControl(source formula.RecipeStep, onComplete *formula.OnCompleteSpec) (formula.RecipeStep, formula.RecipeDep, bool) {
+	if onComplete == nil {
+		return formula.RecipeStep{}, formula.RecipeDep{}, false
+	}
+	sourceRef := source.Metadata["gc.step_ref"]
+	if sourceRef == "" {
+		sourceRef = source.ID
+	}
+	meta := map[string]string{
+		"gc.kind":        "fanout",
+		"gc.control_for": sourceRef,
+		"gc.for_each":    onComplete.ForEach,
+		"gc.bond":        onComplete.Bond,
+		"gc.fanout_mode": "parallel",
+	}
+	if onComplete.Sequential {
+		meta["gc.fanout_mode"] = "sequential"
+	}
+	if len(onComplete.Vars) > 0 {
+		if data, err := json.Marshal(onComplete.Vars); err == nil {
+			meta["gc.bond_vars"] = string(data)
+		}
+	}
+	for _, key := range []string{"gc.scope_ref", "gc.scope_role", "gc.on_fail", "gc.step_id", "gc.ralph_step_id", "gc.attempt"} {
+		if value := source.Metadata[key]; value != "" {
+			meta[key] = value
+		}
+	}
+	control := formula.RecipeStep{
+		ID:       source.ID + "-fanout",
+		Title:    "Expand fanout for " + source.Title,
+		Type:     "task",
+		Metadata: meta,
+	}
+	dep := formula.RecipeDep{
+		StepID:      control.ID,
+		DependsOnID: source.ID,
+		Type:        "blocks",
+	}
+	return control, dep, true
 }
 
 func applyAttemptRecipeScopeChecks(recipe *formula.Recipe) {

--- a/internal/dispatch/control_test.go
+++ b/internal/dispatch/control_test.go
@@ -2479,6 +2479,92 @@ func TestBuildAttemptRecipeComposeExpandFanout(t *testing.T) {
 	}
 }
 
+func TestBuildAttemptRecipeRalphChildOnCompleteCreatesScopedFanout(t *testing.T) {
+	t.Parallel()
+
+	step := &formula.Step{
+		ID:    "review-loop",
+		Title: "Review loop",
+		Type:  "task",
+		Ralph: &formula.RalphSpec{MaxAttempts: 3},
+		Children: []*formula.Step{
+			{
+				ID:    "dc-members",
+				Title: "List design council members",
+				Type:  "task",
+				OnComplete: &formula.OnCompleteSpec{
+					ForEach:    "output.members",
+					Bond:       "review-member",
+					Sequential: true,
+					Vars: map[string]string{
+						"member": "{item.name}",
+					},
+				},
+			},
+		},
+	}
+	control := beads.Bead{
+		ID: "ctrl-fanout",
+		Metadata: map[string]string{
+			"gc.step_id":  "review-loop",
+			"gc.step_ref": "mol-review.review-loop",
+		},
+	}
+
+	recipe := buildAttemptRecipe(step, control, 2)
+	sourceID := "mol-review.review-loop.iteration.2.dc-members"
+	source := recipe.StepByID(sourceID)
+	if source == nil {
+		t.Fatal("missing dc-members source step")
+	}
+	if got := source.Metadata["gc.output_json_required"]; got != "true" {
+		t.Fatalf("source gc.output_json_required = %q, want true", got)
+	}
+
+	fanout := recipe.StepByID(sourceID + "-fanout")
+	if fanout == nil {
+		t.Fatal("missing dc-members fanout control")
+	}
+	if got := fanout.Metadata["gc.kind"]; got != "fanout" {
+		t.Fatalf("fanout gc.kind = %q, want fanout", got)
+	}
+	if got := fanout.Metadata["gc.control_for"]; got != sourceID {
+		t.Fatalf("fanout gc.control_for = %q, want %s", got, sourceID)
+	}
+	if got := fanout.Metadata["gc.scope_ref"]; got != "mol-review.review-loop.iteration.2" {
+		t.Fatalf("fanout gc.scope_ref = %q, want mol-review.review-loop.iteration.2", got)
+	}
+	if got := fanout.Metadata["gc.scope_role"]; got != "member" {
+		t.Fatalf("fanout gc.scope_role = %q, want member", got)
+	}
+	if got := fanout.Metadata["gc.attempt"]; got != "2" {
+		t.Fatalf("fanout gc.attempt = %q, want 2", got)
+	}
+	if got := fanout.Metadata["gc.for_each"]; got != "output.members" {
+		t.Fatalf("fanout gc.for_each = %q, want output.members", got)
+	}
+	if got := fanout.Metadata["gc.bond"]; got != "review-member" {
+		t.Fatalf("fanout gc.bond = %q, want review-member", got)
+	}
+	if got := fanout.Metadata["gc.fanout_mode"]; got != "sequential" {
+		t.Fatalf("fanout gc.fanout_mode = %q, want sequential", got)
+	}
+	if got := fanout.Metadata["gc.bond_vars"]; got != `{"member":"{item.name}"}` {
+		t.Fatalf("fanout gc.bond_vars = %q, want member binding", got)
+	}
+
+	foundFanoutDep := false
+	for _, dep := range recipe.Deps {
+		if dep.StepID == sourceID+"-fanout" && dep.DependsOnID == sourceID && dep.Type == "blocks" {
+			foundFanoutDep = true
+			break
+		}
+	}
+	if !foundFanoutDep {
+		t.Fatalf("missing fanout blocks dependency on source; deps = %+v", recipe.Deps)
+	}
+}
+
 func TestBuildAttemptRecipeScopeMetadataAndStepRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dispatch/ralph.go
+++ b/internal/dispatch/ralph.go
@@ -1170,6 +1170,9 @@ func rewriteRalphAttemptRef(ref string, oldAttempt, nextAttempt int) string {
 	if rewritten, ok := rewriteAttemptSegment(ref, "check", oldAttempt, nextAttempt); ok {
 		return rewritten
 	}
+	if rewritten, ok := rewriteAttemptSegment(ref, "iteration", oldAttempt, nextAttempt); ok {
+		return rewritten
+	}
 	return ref
 }
 

--- a/internal/dispatch/runtime_test.go
+++ b/internal/dispatch/runtime_test.go
@@ -3442,6 +3442,148 @@ func TestProcessRalphCheckRetriesNestedAttemptScope(t *testing.T) {
 	}
 }
 
+func TestAppendRalphRetryClonesIterationFanoutControls(t *testing.T) {
+	t.Parallel()
+
+	store := beads.NewMemStore()
+	workflow := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "workflow",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":             "workflow",
+			"gc.formula_contract": "graph.v2",
+		},
+	})
+	logical := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review loop",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":         "ralph",
+			"gc.step_id":      "review-loop",
+			"gc.step_ref":     "mol-review.review-loop",
+			"gc.max_attempts": "2",
+			"gc.root_bead_id": workflow.ID,
+		},
+	})
+	run1 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "review loop iteration 1",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "scope",
+			"gc.scope_role":      "body",
+			"gc.scope_name":      "review-loop",
+			"gc.step_ref":        "mol-review.review-loop.iteration.1",
+			"gc.step_id":         "review-loop",
+			"gc.ralph_step_id":   "review-loop",
+			"gc.attempt":         "1",
+			"gc.root_bead_id":    workflow.ID,
+			"gc.logical_bead_id": logical.ID,
+		},
+	})
+	source := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "List design council members",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.scope_ref":            "mol-review.review-loop.iteration.1",
+			"gc.scope_role":           "member",
+			"gc.step_ref":             "mol-review.review-loop.iteration.1.dc-members",
+			"gc.step_id":              "dc-members",
+			"gc.ralph_step_id":        "review-loop",
+			"gc.attempt":              "1",
+			"gc.root_bead_id":         workflow.ID,
+			"gc.output_json_required": "true",
+		},
+	})
+	fanout := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "Expand fanout for List design council members",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":          "fanout",
+			"gc.scope_ref":     "mol-review.review-loop.iteration.1",
+			"gc.scope_role":    "member",
+			"gc.step_ref":      "mol-review.review-loop.iteration.1.dc-members-fanout",
+			"gc.control_for":   "mol-review.review-loop.iteration.1.dc-members",
+			"gc.for_each":      "output.members",
+			"gc.bond":          "review-member",
+			"gc.fanout_mode":   "parallel",
+			"gc.step_id":       "dc-members",
+			"gc.ralph_step_id": "review-loop",
+			"gc.attempt":       "1",
+			"gc.root_bead_id":  workflow.ID,
+		},
+	})
+	check1 := mustCreateWorkflowBead(t, store, beads.Bead{
+		Title: "check review loop",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.kind":            "check",
+			"gc.step_id":         "review-loop",
+			"gc.ralph_step_id":   "review-loop",
+			"gc.attempt":         "1",
+			"gc.step_ref":        "mol-review.review-loop.check.1",
+			"gc.check_mode":      "exec",
+			"gc.check_path":      ".gc/scripts/check.sh",
+			"gc.check_timeout":   "30s",
+			"gc.max_attempts":    "2",
+			"gc.root_bead_id":    workflow.ID,
+			"gc.logical_bead_id": logical.ID,
+		},
+	})
+
+	mustDepAdd(t, store, fanout.ID, source.ID, "blocks")
+	mustDepAdd(t, store, run1.ID, fanout.ID, "blocks")
+	mustDepAdd(t, store, check1.ID, run1.ID, "blocks")
+	mustDepAdd(t, store, logical.ID, check1.ID, "blocks")
+
+	mapping, err := appendRalphRetry(store, logical.ID, run1, check1, 2, ProcessOptions{})
+	if err != nil {
+		t.Fatalf("appendRalphRetry: %v", err)
+	}
+	run2 := mustGetBead(t, store, mapping[run1.ID])
+	source2 := mustGetBead(t, store, mapping[source.ID])
+	fanout2 := mustGetBead(t, store, mapping[fanout.ID])
+
+	if got := run2.Metadata["gc.step_ref"]; got != "mol-review.review-loop.iteration.2" {
+		t.Fatalf("run2 gc.step_ref = %q, want mol-review.review-loop.iteration.2", got)
+	}
+	if got := source2.Metadata["gc.scope_ref"]; got != run2.Metadata["gc.step_ref"] {
+		t.Fatalf("source2 gc.scope_ref = %q, want %q", got, run2.Metadata["gc.step_ref"])
+	}
+	if got := source2.Metadata["gc.step_ref"]; got != "mol-review.review-loop.iteration.2.dc-members" {
+		t.Fatalf("source2 gc.step_ref = %q, want mol-review.review-loop.iteration.2.dc-members", got)
+	}
+	if got := source2.Metadata["gc.output_json_required"]; got != "true" {
+		t.Fatalf("source2 gc.output_json_required = %q, want true", got)
+	}
+	if got := fanout2.Metadata["gc.scope_ref"]; got != run2.Metadata["gc.step_ref"] {
+		t.Fatalf("fanout2 gc.scope_ref = %q, want %q", got, run2.Metadata["gc.step_ref"])
+	}
+	if got := fanout2.Metadata["gc.control_for"]; got != source2.Metadata["gc.step_ref"] {
+		t.Fatalf("fanout2 gc.control_for = %q, want %q", got, source2.Metadata["gc.step_ref"])
+	}
+	if got := fanout2.Metadata["gc.step_ref"]; got != "mol-review.review-loop.iteration.2.dc-members-fanout" {
+		t.Fatalf("fanout2 gc.step_ref = %q, want mol-review.review-loop.iteration.2.dc-members-fanout", got)
+	}
+	if got := fanout2.Metadata["gc.attempt"]; got != "2" {
+		t.Fatalf("fanout2 gc.attempt = %q, want 2", got)
+	}
+
+	deps, err := store.DepList(fanout2.ID, "down")
+	if err != nil {
+		t.Fatalf("fanout2 deps: %v", err)
+	}
+	foundSourceDep := false
+	for _, dep := range deps {
+		if dep.Type == "blocks" && dep.DependsOnID == source2.ID {
+			foundSourceDep = true
+			break
+		}
+	}
+	if !foundSourceDep {
+		t.Fatalf("fanout2 missing blocks dependency on source2; deps = %+v", deps)
+	}
+}
+
 func TestProcessRalphCheckRecoversPartialRetryAttempt(t *testing.T) {
 	t.Parallel()
 
@@ -6306,6 +6448,15 @@ func TestRewriteRalphAttemptRefRewritesInnermostMatchingAttempt(t *testing.T) {
 	got := rewriteRalphAttemptRef("outer.run.1.inner.run.1", 1, 2)
 	if got != "outer.run.1.inner.run.2" {
 		t.Fatalf("rewriteRalphAttemptRef() = %q, want innermost attempt rewritten", got)
+	}
+}
+
+func TestRewriteRalphAttemptRefRewritesIterationAttempt(t *testing.T) {
+	t.Parallel()
+
+	got := rewriteRalphAttemptRef("mol-review.review-loop.iteration.1", 1, 2)
+	if got != "mol-review.review-loop.iteration.2" {
+		t.Fatalf("rewriteRalphAttemptRef() = %q, want iteration attempt rewritten", got)
 	}
 }
 

--- a/internal/molecule/molecule.go
+++ b/internal/molecule/molecule.go
@@ -956,7 +956,7 @@ func stepToBead(step formula.RecipeStep, vars map[string]string, priorityOverrid
 
 	// Merge step metadata + notes into bead metadata.
 	if len(step.Metadata) > 0 || step.Notes != "" {
-		b.Metadata = make(map[string]string, len(step.Metadata)+1)
+		b.Metadata = make(map[string]string, len(step.Metadata))
 		for k, v := range step.Metadata {
 			b.Metadata[k] = formula.Substitute(v, vars)
 		}

--- a/internal/molecule/molecule_test.go
+++ b/internal/molecule/molecule_test.go
@@ -677,6 +677,27 @@ func TestInstantiateSequentialPathPreservesStepMetadata(t *testing.T) {
 	}
 }
 
+func TestStepToBeadSubstitutesMetadataAndNotes(t *testing.T) {
+	bead := stepToBead(formula.RecipeStep{
+		Title: "Work",
+		Type:  "task",
+		Metadata: map[string]string{
+			"gc.routed_to": "{{agent}}",
+		},
+		Notes: "retry {{attempt}}",
+	}, map[string]string{
+		"agent":   "worker",
+		"attempt": "1",
+	}, nil)
+
+	if got := bead.Metadata["gc.routed_to"]; got != "worker" {
+		t.Fatalf("gc.routed_to = %q, want worker", got)
+	}
+	if got := bead.Metadata["notes"]; got != "retry 1" {
+		t.Fatalf("notes = %q, want retry 1", got)
+	}
+}
+
 func TestInstantiateUsesGraphApplyStoreForRetryLogicalRefs(t *testing.T) {
 	store := &graphApplySpyStore{MemStore: beads.NewMemStore()}
 	prev := IsGraphApplyEnabled()


### PR DESCRIPTION
## Summary
- recreate per-iteration fanout controls when source-spec retry spawning builds Ralph attempts
- preserve scoped iteration refs when cloning Ralph retry beads, including fanout controls
- add regression coverage for issue #1658 and the iteration ref rewrite

## Tests
- go test ./internal/dispatch -run 'TestBuildAttemptRecipeRalphChildOnCompleteCreatesScopedFanout|TestAppendRalphRetryClonesIterationFanoutControls|TestRewriteRalphAttemptRefRewritesIterationAttempt' -count=1
- go test ./internal/dispatch -count=1
- make test
- pre-commit hook via git commit

Fixes #1658