### PR TITLE
test(cmd/gc): sync TestDoltStateInspectManagedCmdDetectsDeletedInodes on child readiness (ga-q42)

### DIFF
--- a/cmd/gc/cmd_dolt_state_test.go
+++ b/cmd/gc/cmd_dolt_state_test.go
@@ -898,20 +898,30 @@ func TestDoltStateInspectManagedCmdDetectsDeletedInodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveManagedDoltRuntimeLayout: %v", err)
 	}
+	// The child opens a file, unlinks it while the fd is still held, and
+	// blocks. inspect-managed sees the deleted inode by walking the child's
+	// open fds. The unlink must complete BEFORE inspect-managed runs, so
+	// the child signals readiness via a marker file and the parent polls
+	// for it. Without this sync the test races and sporadically observes
+	// the inode as still-linked. (ga-q42 flake.)
+	readyFile := filepath.Join(t.TempDir(), "deleted-inode.ready")
 	proc := exec.Command("python3", "-c", `
 import os, signal, sys, time
 path = sys.argv[1]
+ready_file = sys.argv[2]
 os.makedirs(path, exist_ok=True)
 stale = os.path.join(path, "stale-open.txt")
 f = open(stale, "w+")
 f.write("stale")
 f.flush()
 os.unlink(stale)
+with open(ready_file, "w", encoding="utf-8") as r:
+    r.write("ready\n")
 signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
 while True:
     time.sleep(1)
-`, layout.DataDir)
+`, layout.DataDir, readyFile)
 	if err := proc.Start(); err != nil {
 		t.Fatalf("start python: %v", err)
 	}
@@ -919,6 +929,16 @@ while True:
 		_ = proc.Process.Kill()
 		_, _ = proc.Process.Wait()
 	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("python child did not signal readiness within 5s: %v", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(layout.PIDFile), 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Picks off one flake from the `ga-q42` list: `TestDoltStateInspectManagedCmdDetectsDeletedInodes`.

The test spawns a `python3` helper that opens a file, unlinks it while the fd is still held, and blocks. The production code under test (`gc dolt-state inspect-managed`) detects the held-deleted inode by walking the child's open fds. **If `inspect-managed` runs before the child's `unlink()` call has landed, the inode is still linked and the test asserts the wrong outcome.** There was no synchronization between `proc.Start()` and the `inspect-managed` invocation, so this raced in practice.

## Fix

Apply the existing ready-file pattern already used elsewhere in this file (e.g. `startUnixSocketProcess`, the lock-and-listen helper):

- Pass a `readyFile` path as `sys.argv[2]`.
- Child writes `"ready\n"` to that path **after** the `os.unlink()` call.
- Parent polls for the file with a 5s deadline before running `inspect-managed`.

## Test plan

- [x] 50× sequential runs of the target test — all green
- [x] 20× runs under `-race` — all green
- [x] `go vet ./cmd/gc/` clean, `gofumpt -l` clean
- [x] Happy-path overhead is sub-50ms (poll interval is 25ms; child writes the marker immediately after unlink)
- [ ] CI runs the full gates

## Scope

This is one of the env-sensitive flakes in `ga-q42`'s list. The other entries (`TestRegisterCityWithSupervisorFailsFastWhenSupervisorStopsDuringWait`, `internal/mail/exec` concurrent timeout, etc.) are unrelated root causes and need their own per-flake PRs.

## Note on hooks

Committed with `--no-verify` per the workaround documented in `ga-q42` (other pre-existing flakes still block `make test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)